### PR TITLE
Guym heartbeat - reduce some overhead

### DIFF
--- a/src/server/block_allocator.js
+++ b/src/server/block_allocator.js
@@ -80,7 +80,11 @@ function update_tier_alloc_nodes(system, tier) {
         nodes: [],
     };
 
-    if (info.last_refresh >= min_heartbeat) return Q.resolve(info.nodes);
+    // cache the nodes for 1 minutes and then refresh
+    if (info.last_refresh >= moment().subtract(1, 'minute').toDate()) {
+        return Q.resolve(info.nodes);
+    }
+
     if (info.promise) return info.promise;
 
     // refresh
@@ -100,6 +104,7 @@ function update_tier_alloc_nodes(system, tier) {
             // sorting with lowest used storage nodes first
             'storage.used': 1
         })
+        .limit(100)
         .exec()
         .then(function(nodes) {
             info.promise = null;

--- a/src/server/node_server.js
+++ b/src/server/node_server.js
@@ -323,6 +323,8 @@ var heartbeat_find_node_by_id_barrier = new Barrier({
                         $in: node_ids
                     },
                 })
+                // we are very selective to reduce overhead
+                .select('ip port storage geolocation device_info.last_update')
                 .exec())
             .then(function(res) {
                 var nodes_by_id = _.indexBy(res, '_id');


### PR DESCRIPTION
1. select only relevant node info on heartbeat query
2. save up to 100 nodes in memory of block-allocator, and refresh every minute. previously it was trying to hold ALL the nodes in memory which is heavy with 10k nodes.
