### PR TITLE
Nimrod bug79

### DIFF
--- a/src/server/object_mapper.js
+++ b/src/server/object_mapper.js
@@ -98,7 +98,8 @@ function allocate_object_parts(bucket, obj, parts) {
                     .find({
                         chunk: {
                             $in: query_chunks_ids
-                        }
+                        },
+                        deleted: null,
                     })
                     .populate('node')
                     .exec())

--- a/src/server/object_mapper.js
+++ b/src/server/object_mapper.js
@@ -132,13 +132,13 @@ function allocate_object_parts(bucket, obj, parts) {
                             break;
                         }
                     }
-                    //Chunk health is ok, we can mark it as dedup
                     if (merged_status) {
-                        dbg.log3('chunk ', dup_chunk , 'is dupped and available');
+                        //Chunk health is ok, we can mark it as dedup
+                        dbg.log3('chunk ', dup_chunk, 'is dupped and available');
                         reply.parts[i].dedup = true;
-                    //Chunk is not healthy, create a new fragment on it
                     } else {
-                        dbg.log3('chunk ', dup_chunk , 'is dupped but unavailable, allocating new blocks for it');
+                        //Chunk is not healthy, create a new fragment on it
+                        dbg.log3('chunk ', dup_chunk, 'is dupped but unavailable, allocating new blocks for it');
                         dupped_chunks.push(chunk);
                     }
                 } else {

--- a/src/server/object_mapper.js
+++ b/src/server/object_mapper.js
@@ -107,11 +107,11 @@ function allocate_object_parts(bucket, obj, parts) {
                 .then(function(queried_blocks) {
                     var blocks_by_chunk_id = _.groupBy(queried_blocks, 'chunk');
                     _.each(blocks_by_chunk_id, function(blocks, chunk_id) {
-                        for (var key in hash_val_to_dup_chunk) {
+                        _.each(hash_val_to_dup_chunk, function(key) {
                             if (hash_val_to_dup_chunk[key]._id.toString() === chunk_id) {
                                 hash_val_to_dup_chunk[key].all_blocks = blocks;
                             }
-                        }
+                        });
                     });
                     return hash_val_to_dup_chunk;
                 });

--- a/src/util/promise_utils.js
+++ b/src/util/promise_utils.js
@@ -14,6 +14,30 @@ module.exports = {
 
 /**
  *
+ * Iterate on an array, accumilate promises and return results of each
+ * invocation
+ *
+ */
+function iterate(array, func) {
+    var results = [];
+    results.length = array.legnth;
+    var i = 0;
+
+    function add_to_promise(promise, item) {
+        return promise.then(function() {
+            return Q.when(func(item))
+                .then(function(res) {
+                    results[i++] = res;
+                });
+        });
+    }
+
+    return _.reduce(array, add_to_promise, Q.resolve())
+        .thenResolve(results);
+}
+
+/**
+ *
  * simple promise loop, similar to _.times but ignores the return values,
  * and only returns a promise for completion or failure
  *


### PR DESCRIPTION
Bug79. When detecting dup chunks in allocate_object_parts, take under consideration the availability of the chunks. If a certain chunk is dup but unavailable, allocate new block for it.
