### PR TITLE
Nimrod bug73

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -77,7 +77,7 @@ function Agent(params) {
         write_block: self.write_block.bind(self),
         read_block: self.read_block.bind(self),
         replicate_block: self.replicate_block.bind(self),
-        delete_block: self.delete_block.bind(self),
+        delete_blocks: self.delete_blocks.bind(self),
         check_block: self.check_block.bind(self),
         kill_agent: self.kill_agent.bind(self),
         self_test_io: self.self_test_io.bind(self),
@@ -470,12 +470,12 @@ Agent.prototype.replicate_block = function(req) {
         });
 };
 
-Agent.prototype.delete_block = function(req) {
+Agent.prototype.delete_blocks = function(req) {
     var self = this;
-    var block_id = req.rest_params.block_id;
-    dbg.log0('AGENT delete_block', block_id);
-    self.store_cache.invalidate(block_id);
-    return self.store.delete_block(block_id);
+    var blocks = req.rest_params.blocks;
+    dbg.log0('AGENT delete_blocks', blocks);
+    self.store_cache.multi_invalidate(blocks);
+    return self.store.delete_blocks(blocks);
 };
 
 Agent.prototype.check_block = function(req) {

--- a/src/agent/agent_store.js
+++ b/src/agent/agent_store.js
@@ -202,17 +202,14 @@ AgentStore.prototype.delete_blocks = function(block_ids) {
             return call();
         }))
         .then(function(results) {
-            dbg.log0("  NB:: results", results);
             _.each(results, function(r) {
                 if (r.state === 'fulfilled') {
-                    dbg.log0("  NB:: fulfilled with size ", r.value, " r is ", r);
                     tmp_usage.size += r.value;
                     tmp_usage.count += 1;
                 } else {
                     ret = r.reason;
                 }
             });
-            dbg.log0("  NB:: updating size", tmp_usage.size, "count", tmp_usage.count);
             if (self._usage) {
                 self._usage.size -= tmp_usage.size;
                 self._usage.count -= tmp_usage.count;

--- a/src/agent/agent_store.js
+++ b/src/agent/agent_store.js
@@ -179,28 +179,47 @@ AgentStore.prototype.write_block = function(block_id, data) {
 
 /**
  *
- * DELETE_BLOCK
+ * DELETE_BLOCKS
  *
  */
-AgentStore.prototype.delete_block = function(block_id) {
+AgentStore.prototype.delete_blocks = function(block_ids) {
     var self = this;
-    var block_path = self._get_block_path(block_id);
-    var file_stats;
+    var ret = '';
+    var tmp_usage = {
+        size: 0,
+        count: 0,
+    };
+    var delete_funcs = [];
 
-    return self._stat_block_path(block_path, true)
-        .then(function(stats) {
-            file_stats = stats;
-            dbg.log0('delete block', block_path, file_stats);
-            if (file_stats) {
-                return Q.nfcall(fs.unlink(block_path));
-            }
-        })
-        .then(function() {
-            if (self._usage && file_stats) {
-                self._usage.size -= file_stats.size;
-                self._usage.count -= 1;
+    _.each(block_ids, function(block) {
+        delete_funcs.push(function() {
+            self._delete_block(block);
+        });
+    });
+
+    //TODO: use q.allSettled with 10 concurrency
+    Q.allSettled(_.map(delete_funcs, function(call) {
+            return call();
+        }))
+        .then(function(results) {
+            dbg.log0("  NB:: results", results);
+            _.each(results, function(r) {
+                if (r.state === 'fulfilled') {
+                    dbg.log0("  NB:: fulfilled with size ", r.value, " r is ", r);
+                    tmp_usage.size += r.value;
+                    tmp_usage.count += 1;
+                } else {
+                    ret = r.reason;
+                }
+            });
+            dbg.log0("  NB:: updating size", tmp_usage.size, "count", tmp_usage.count);
+            if (self._usage) {
+                self._usage.size -= tmp_usage.size;
+                self._usage.count -= tmp_usage.count;
             }
         });
+
+    //TODO: should we return ret here ?
 };
 
 
@@ -218,6 +237,30 @@ AgentStore.prototype.stat_block = function(block_id) {
 
 
 // PRIVATE //////////////////////////////////////////////////////////
+
+/**
+ *
+ * _delete_block
+ *
+ */
+AgentStore.prototype._delete_block = function(block_id) {
+    var self = this;
+    var block_path = self._get_block_path(block_id);
+    var file_stats;
+
+    return self._stat_block_path(block_path, true)
+        .then(function(stats) {
+            file_stats = stats;
+            dbg.log0('delete block', block_path, 'stats', file_stats);
+            if (file_stats) {
+                return Q.nfcall(fs.unlink(block_path));
+            }
+        })
+        .then(function() {
+            dbg.log0("  NB:: in _delete with size of ", file_stats.size);
+            return file_stats.size;
+        });
+};
 
 
 /**

--- a/src/agent/agent_store.js
+++ b/src/agent/agent_store.js
@@ -207,6 +207,7 @@ AgentStore.prototype.delete_blocks = function(block_ids) {
                     tmp_usage.size += r.value;
                     tmp_usage.count += 1;
                 } else {
+                    dbg.log0("delete block failed due to ", r.reason);
                     ret = r.reason;
                 }
             });

--- a/src/agent/agent_store.js
+++ b/src/agent/agent_store.js
@@ -193,7 +193,7 @@ AgentStore.prototype.delete_blocks = function(block_ids) {
 
     _.each(block_ids, function(block) {
         delete_funcs.push(function() {
-            self._delete_block(block);
+            return self._delete_block(block);
         });
     });
 
@@ -251,14 +251,12 @@ AgentStore.prototype._delete_block = function(block_id) {
     return self._stat_block_path(block_path, true)
         .then(function(stats) {
             file_stats = stats;
-            dbg.log0('delete block', block_path, 'stats', file_stats);
             if (file_stats) {
-                return Q.nfcall(fs.unlink(block_path));
+                return Q.nfcall(fs.unlink, block_path);
             }
         })
         .then(function() {
-            dbg.log0("  NB:: in _delete with size of ", file_stats.size);
-            return file_stats.size;
+            return file_stats ? file_stats.size : 0;
         });
 };
 

--- a/src/agent/agent_store.js
+++ b/src/agent/agent_store.js
@@ -198,7 +198,7 @@ AgentStore.prototype.delete_blocks = function(block_ids) {
     });
 
     //TODO: use q.allSettled with 10 concurrency
-    Q.allSettled(_.map(delete_funcs, function(call) {
+    return Q.allSettled(_.map(delete_funcs, function(call) {
             return call();
         }))
         .then(function(results) {

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -100,19 +100,30 @@ module.exports = {
             },
         },
 
-        delete_block: {
+        //NB:: turn into an array of block_ids
+        delete_blocks: {
             method: 'DELETE',
             path: '/block/:block_id',
             params: {
                 type: 'object',
-                required: ['block_id'],
+                required: ['blocks'],
                 properties: {
-                    block_id: {
-                        type: 'string',
-                    },
+                    blocks: {
+                        type: 'array',
+                        ids: {
+                            type: 'object',
+                            required: ['id'],
+                            properties: {
+                                id: {
+                                    type: 'string'
+                                }
+                            }
+                        }
+                    }
                 },
             },
         },
+
 
         self_test_io: {
             method: 'POST',

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -100,7 +100,6 @@ module.exports = {
             },
         },
 
-        //NB:: turn into an array of block_ids
         delete_blocks: {
             method: 'DELETE',
             path: '/block/:block_id',

--- a/src/util/lru_cache.js
+++ b/src/util/lru_cache.js
@@ -76,12 +76,7 @@ LRUCache.prototype.get = function(params, cache_miss) {
  */
 LRUCache.prototype.multi_invalidate = function(params) {
     var self = this;
-    var key;
-    var results = [];
-    _.each(params, function(p) {
-        key = self.make_key(p);
-        results.push(self.invalidate_key(key));
-    });
+    return _.map(params, function(p) { return self.invalidate(p); });
 };
 
 /**

--- a/src/util/lru_cache.js
+++ b/src/util/lru_cache.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var Q = require('q');
 var LRU = require('noobaa-util/lru');
+var dbg = require('noobaa-util/debug_module')(__filename);
 
 module.exports = LRUCache;
 
@@ -68,6 +69,19 @@ LRUCache.prototype.get = function(params, cache_miss) {
         .then(function(item) {
             return self.make_val(item.d, params);
         });
+};
+
+/**
+ * remove multiple keys from the cache
+ */
+LRUCache.prototype.multi_invalidate = function(params) {
+    var self = this;
+    var key;
+    var results = [];
+    _.each(params, function(p) {
+        key = self.make_key(p);
+        results.push(self.invalidate_key(key));
+    });
 };
 
 /**


### PR DESCRIPTION
Bug #73 . Actually delete blocks from the agent when deleting an object.
Change the delete API to contain an array of blocks (thus aggregating all blocks of the same agent in one request). 

Currently general success/failure is returned for the entire operation. Need to add error handling on the agent side (save the failed block deletions in stable state and retry periodically, will open a new bug).
