### PR TITLE
bug #154 - use reliable data channels

### DIFF
--- a/src/rpc/bwtest/client.js
+++ b/src/rpc/bwtest/client.js
@@ -108,10 +108,15 @@ function init_peer(msg) {
     var peer = new Peer({
         initiator: msg.initiator,
         config: {
+            // we use ordered channel to verify order of received sequences
             ordered: true,
-            reliable: true,
-            maxRetransmits: 0,
-            // maxRetransmitTime:
+
+            // default channel config is reliable
+            // passing either maxRetransmits or maxPacketLifeTime will
+            // set to unreliable mode (cant pass both).
+            // maxRetransmits: 0,
+            // maxPacketLifeTime: 3000,
+
             iceServers: [{
                 url: 'stun:23.21.150.121'
             }]

--- a/src/util/ice_lib.js
+++ b/src/util/ice_lib.js
@@ -799,9 +799,21 @@ function createPeerConnection(socket, requestId, config) {
         if (channelObj.isInitiator) {
             writeToLog(3,'Creating Data Channel req '+requestId);
             try {
-                // you can only specify maxRetransmits or maxRetransmitTime, not both
-                var dtConfig = {ordered: false, reliable: false, maxRetransmits: 2};//, maxRetransmitTime: 3000};
-                channelObj.dataChannel = channelObj.peerConn.createDataChannel("noobaa", dtConfig); // TODO  ? dtConfig
+                var dtConfig = {
+                    // we don't require strict ordering since we collect packets
+                    // and assmble the entire message anyhow for multiplexing.
+                    ordered: false,
+
+                    // you can only specify maxRetransmits or maxPacketLifeTime, not both,
+                    // and by passing any of these properties it will cause the channel to be
+                    // in unreliable mode.
+                    // we use a reliable channel to do retransmissions automagically
+                    // when a packet is not delivered and avoid waiting for timeouts
+                    // and sending the entire request from scratch.
+                    // maxRetransmits: 3,
+                    // maxPacketLifeTime: 3000,
+                };
+                channelObj.dataChannel = channelObj.peerConn.createDataChannel("noobaa", dtConfig);
                 onDataChannelCreated(socket, requestId, channelObj.dataChannel);
             } catch (ex) {
                 writeToLog(-1, 'Ex on Creating Data Channel ' + ex);


### PR DESCRIPTION
to use reliable data channel need to avoid passing both maxRetransmits
and maxPacketLifeTime according to webrtc spec.
