### PR TITLE
Guym alpha - avoid wait for build_chunks too long

### DIFF
--- a/config.js
+++ b/config.js
@@ -28,6 +28,7 @@ config.REPLICATE_CONCURRENCY = 1;
 
 config.write_timeout = 30 * 1000;
 config.read_timeout = 30 * 1000;
+config.server_finalize_build_timeout = 20 * 1000;
 config.server_replicate_timeout = 29 * 1000;
 config.client_replicate_timeout = 300 * 1000;
 config.default_rpc_timeout = 120 * 1000;

--- a/src/api/object_client.js
+++ b/src/api/object_client.js
@@ -276,19 +276,20 @@ ObjectClient.prototype.upload_stream_parts = function(params) {
                             timeout: config.client_replicate_timeout,
                             retries: 3
                         })
-                        .then(function() {
-                            // push parts down the pipe
-                            for (var i = 0; i < parts.length; i++) {
-                                var part = parts[i];
-                                dbg.log0('upload_stream: finalize part offset', part.start);
-                                stream.push(part);
-                            }
-                        }, function(err) {
+                        .then(null, function(err) {
                             dbg.log0('upload_stream: FINALIZE FAILED',
                                 'leave it to background worker', err.stack || err);
                             // TODO temporary suppressing this error for the sake of user experience
                             // but we should fix this path
                         });
+                })
+                .then(function() {
+                    // push parts down the pipe
+                    for (var i = 0; i < parts.length; i++) {
+                        var part = parts[i];
+                        dbg.log0('upload_stream: finalize part offset', part.start);
+                        stream.push(part);
+                    }
                 });
             }
         }));

--- a/src/api/object_client.js
+++ b/src/api/object_client.js
@@ -255,37 +255,26 @@ ObjectClient.prototype.upload_stream_parts = function(params) {
                 var stream = this;
                 dbg.log0('upload_stream: finalize parts', parts.length);
                 // send parts to server
-                return Q.fcall(function() {
-                        // TODO currently not returning promise here in order to submit
-                        // the finalize and not wait for it
-                        // return self._finalize_sem.surround(function() {
-                        self._finalize_sem.surround(function() {
-                            return self.object_rpc_client.finalize_object_parts({
-                                    bucket: params.bucket,
-                                    key: params.key,
-                                    parts: _.map(parts, function(part) {
-                                        var p = _.pick(part, 'start', 'end');
-                                        if (!part.dedup) {
-                                            p.block_ids = _.flatten(
-                                                _.map(part.fragments, function(fragment) {
-                                                    return _.map(fragment.blocks, function(block) {
-                                                        return block.address.id;
-                                                    });
-                                                })
-                                            );
-                                        }
-                                        return p;
-                                    })
-                                }, {
-                                    timeout: config.client_replicate_timeout,
-                                    retries: 3
-                                })
-                                .then(null, function(err) {
-                                    dbg.log0('upload_stream: FINALIZE FAILED',
-                                        'leave it to background worker', err.stack || err);
-                                    // TODO temporary suppressing this error for the sake of user experience
-                                    // but we should fix this path
-                                });
+                return self._finalize_sem.surround(function() {
+                        return self.object_rpc_client.finalize_object_parts({
+                            bucket: params.bucket,
+                            key: params.key,
+                            parts: _.map(parts, function(part) {
+                                var p = _.pick(part, 'start', 'end');
+                                if (!part.dedup) {
+                                    p.block_ids = _.flatten(
+                                        _.map(part.fragments, function(fragment) {
+                                            return _.map(fragment.blocks, function(block) {
+                                                return block.address.id;
+                                            });
+                                        })
+                                    );
+                                }
+                                return p;
+                            })
+                        }, {
+                            timeout: config.client_replicate_timeout,
+                            retries: 3
                         });
                     })
                     .then(function() {

--- a/src/server/object_mapper.js
+++ b/src/server/object_mapper.js
@@ -295,7 +295,18 @@ function finalize_object_parts(bucket, obj, parts) {
             }
         })
         .then(function() {
-            return build_chunks(chunks);
+            // TODO currently not returning promise here in order to submit
+            // the build and not wait for it
+            // return Q.fcall(function() {
+            Q.fcall(function() {
+                    return build_chunks(chunks);
+                })
+                .then(null, function(err) {
+                    // TODO temporary suppressing this error for the sake of user experience
+                    // but we should fix this path
+                    dbg.log0('finalize_object_parts: BUILD FAILED',
+                        'leave it to background worker', err.stack || err);
+                });
         })
         .then(function() {
             var end = parts[parts.length - 1].end;

--- a/src/server/object_mapper.js
+++ b/src/server/object_mapper.js
@@ -295,15 +295,15 @@ function finalize_object_parts(bucket, obj, parts) {
             }
         })
         .then(function() {
-            // TODO currently not returning promise here in order to submit
-            // the build and not wait for it
-            // return Q.fcall(function() {
-            Q.fcall(function() {
+            // using a timeout to limit our wait here.
+            // in case of failure to build, we suppress the error for the
+            // sake of user experienceand leave it to the background worker.
+            // TODO dont suppress build errors, fix them.
+            return Q.fcall(function() {
                     return build_chunks(chunks);
                 })
+                .timeout(config.server_finalize_build_timeout, 'finalize build timeout')
                 .then(null, function(err) {
-                    // TODO temporary suppressing this error for the sake of user experience
-                    // but we should fix this path
                     dbg.log0('finalize_object_parts: BUILD FAILED',
                         'leave it to background worker', err.stack || err);
                 });


### PR DESCRIPTION
the client has to wait for finalize itself to handle the md changes consistently.
instead, moved the error suppressing and bg submit to server's finalize that now limits the wait for build_chunks.
