### PR TITLE
Add Agent Control testing framework module

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 var config = {};
 
 // TEST Mode
-config.marked_test = false;
+config.test_mode = false;
 
 // SIGNALING AND ICE
 config.address = 'wss://noobaa-signaling.herokuapp.com'; // (on heroku: wss://noobaa-signaling.herokuapp.com) ws://192.168.1.6:5002

--- a/config.js
+++ b/config.js
@@ -1,5 +1,8 @@
 var config = {};
 
+// TEST Mode
+config.marked_test = false;
+
 // SIGNALING AND ICE
 config.address = 'wss://noobaa-signaling.herokuapp.com'; // (on heroku: wss://noobaa-signaling.herokuapp.com) ws://192.168.1.6:5002
 config.alive_delay = 10 * 1000;

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -119,7 +119,7 @@ function Agent(params) {
     ]);
 
     //If test, add test APIs
-    if (config.marked_test) {
+    if (config.test_mode) {
         self._add_test_APIs();
     }
 

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -118,6 +118,11 @@ function Agent(params) {
         'Germany', 'England', 'France', 'Spain'
     ]);
 
+    //If test, add test APIs
+    if (config.marked_test) {
+        self._add_test_APIs();
+    }
+
 }
 
 
@@ -201,7 +206,7 @@ Agent.prototype._init_node = function() {
             return self.client.auth.read_auth();
         })
         .then(function(res) {
-            dbg.log0('res:',res);
+            dbg.log0('res:', res);
             // if we are already authorized with our specific node_id, use it
             if (res.account && res.system &&
                 res.extra && res.extra.node_id) {
@@ -326,7 +331,7 @@ Agent.prototype.send_heartbeat = function() {
 
     // chk if windows
     if (os.type().match(/win/i) && !os.type().match(/darwin/i)) {
-        drive ='c';
+        drive = 'c';
     }
 
     dbg.log0('send heartbeat by agent', self.node_id);
@@ -397,7 +402,7 @@ Agent.prototype.send_heartbeat = function() {
                 }
             }
 
-            dbg.log3('AGENT HB params: ',params);
+            dbg.log3('AGENT HB params: ', params);
 
             return self.client.node.heartbeat(params);
         })
@@ -465,9 +470,7 @@ Agent.prototype._start_stop_heartbeats = function() {
 };
 
 
-
 // AGENT API //////////////////////////////////////////////////////////////////
-
 
 
 Agent.prototype.read_block = function(req) {
@@ -574,4 +577,24 @@ Agent.prototype.self_test_peer = function(req) {
                 throw new Error('SELF TEST PEER response_length mismatch');
             }
         });
+};
+
+
+// AGENT TEST API /////////////////////////////////////////////////////////////
+
+Agent.prototype._add_test_APIs = function() {
+    console.warn("Adding test APIs for Agent prototype");
+
+    Agent.prototype.corrupt_blocks = function(req) {
+        var self = this;
+        var blocks = req.rest_params.blocks;
+        dbg.log0('AGENT TEST API corrupt_blocks', blocks);
+        return self.store.corrupt_blocks(blocks);
+    };
+
+    Agent.prototype.list_blocks = function() {
+        var self = this;
+        dbg.log0('AGENT TEST API list_blocks');
+        return self.store.list_blocks();
+    };
 };

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -2,7 +2,8 @@
 ===========
 ###Core Tests Table of Contents:
 
-* [core_agent_control](#core_agent_control) - Agent Control Testing Infrastructure.
+* [core_agent_control](#core_agent_control) - Agent Control Testing Infrastructure
+* [coretest](#coretest) - Core Test Infrastructure
 
 
 * ###core_agent_control
@@ -32,3 +33,20 @@
   This API expects to receive the following parameters:
     utilitest - Reference to the utilitest module
     auth_token - The auth token for the agents to be crated with
+
+* ###coretest
+  This module will function as somewhat of a proxy to the different components control modules
+  (agents, clients etc.). It provides its own API:
+    1) account_credentials - Return the account credentials for the test
+    2) client - Return the allocated client (currently only 1 can be allocated)
+    3) new_client - Allocate and return a new client
+    4) init_test_nodes(count, system, tier) - Performs the following
+        1. Creates Auth Token for system & tier,
+        2. Sets the agent control to work locally (will be removed once we support remote),
+        3. Starts all stopped agents
+
+    5) clear_test_nodes - Stops all agents and then clears them
+
+  In addition, it exposes all the core_agent_control API.
+  
+  In the future, will expose all the client control API as well.

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -1,0 +1,33 @@
+#noobaa-core tests
+===========
+###Core Tests Table of Contents:
+
+* [core_agent_control](#core_agent_control) - Agent Control Testing Infrastructure.
+
+
+* ###core_agent_control
+  This module provides agent control API for our testing infrastructure.
+  Currently it holds the logic to work with local agents (with the MemoryStore), if the future
+  it will be expanded to work with remote clients (EC2) as well.
+
+  The module provides Control API:
+    1) create_agent(howmany) - Creates howmany new agents
+    2) stop_agent (agent_name) - Stops a specific agents
+    3) start_agent (agent_name) - Starts a specific agent
+    4) start_all_agents - Starts all agents
+    5) stop_all_agents - Stops all agents
+    6) cleanup_agents - Stops and clears all agents
+
+  I/O API:
+    1) read_block(node_name, block_id) - Reads and returns block_id on node_name
+    2) write_block(node_name, block_id, data) - Writes data to block_id on node_name
+    3) delete_blocks(node_name, block_ids) - Deletes all block_ids from node_name
+    4) corrupt_blocks(node_name, block_ids) - Corrupts (hash corruption) all block_ids on node_name
+
+  And Helpers:
+    1) get_agents_list - Return a list of the allocated agents and their status (started/stopped)
+
+  Using the module for local agents require initializing it with the use_local_agents() API.
+  This API expects to receive the following parameters:
+    utilitest - Reference to the utilitest module
+    auth_token - The auth token for the agents to be crated with

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -23,6 +23,7 @@
     2) write_block(node_name, block_id, data) - Writes data to block_id on node_name
     3) delete_blocks(node_name, block_ids) - Deletes all block_ids from node_name
     4) corrupt_blocks(node_name, block_ids) - Corrupts (hash corruption) all block_ids on node_name
+    5) list_blocks(node_name) - List all blocks for the given node_name
 
   And Helpers:
     1) get_agents_list - Return a list of the allocated agents and their status (started/stopped)

--- a/src/test/core_agent_control.js
+++ b/src/test/core_agent_control.js
@@ -81,7 +81,7 @@ function use_remote_agents() {
 
 function create_agent(howmany) {
     var count = howmany || 1;
-    return Q.allSettled(_.times(count, function(i) {
+    return Q.all(_.times(count, function(i) {
         return Q.fcall(function() {
                 var agent = new Agent({
                     address: 'http://localhost:' + agntCtlConfig.local_conf.utilitest.http_port(),
@@ -145,16 +145,16 @@ function stop_agent(node_name) {
 }
 
 function start_all_agents() {
-    return Q.allSettled(_.map(agntCtlConfig.allocated_agents,
-        function(data, id) {
-            if (data.started === false) {
-                return start_agent(id);
-            }
-        }));
+    return Q.all(_.map(agntCtlConfig.allocated_agents,
+            function(data, id) {
+                if (data.started === false) {
+                    return start_agent(id);
+                }
+            }));
 }
 
 function stop_all_agents() {
-    return Q.allSettled(_.map(agntCtlConfig.allocated_agents,
+    return Q.all(_.map(agntCtlConfig.allocated_agents,
         function(data, id) {
             if (data.started === true) {
                 return stop_agent(id);

--- a/src/test/core_agent_control.js
+++ b/src/test/core_agent_control.js
@@ -94,7 +94,7 @@ function create_agent(howmany) {
             })
             .then(function(agent) {
                 agntCtlConfig.allocated_agents[agent.node_name] = {
-                    ref: agent,
+                    agent: agent,
                     started: false
                 };
                 agntCtlConfig.num_allocated++;
@@ -109,7 +109,7 @@ function cleanup_agents() {
         })
         .then(function() {
             _.each(agntCtlConfig.allocated_agents, function(id) {
-                id.ref = null;
+                id.agent = null;
             });
             agntCtlConfig.allocated_agents = {};
             agntCtlConfig.num_allocated = 0;
@@ -120,7 +120,7 @@ function start_agent(node_name) {
     if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
         !agntCtlConfig.allocated_agents[node_name].started) {
         return Q.fcall(function() {
-                return agntCtlConfig.allocated_agents[node_name].ref.start();
+                return agntCtlConfig.allocated_agents[node_name].agent.start();
             })
             .then(function() {
                 agntCtlConfig.allocated_agents[node_name].started = true;
@@ -134,7 +134,7 @@ function stop_agent(node_name) {
     if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
         agntCtlConfig.allocated_agents[node_name].started) {
         return Q.fcall(function() {
-                return agntCtlConfig.allocated_agents[node_name].ref.stop();
+                return agntCtlConfig.allocated_agents[node_name].agent.stop();
             })
             .then(function() {
                 agntCtlConfig.allocated_agents[node_name].started = false;
@@ -188,7 +188,7 @@ function read_block(node_name, block_id) {
     if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
         agntCtlConfig.allocated_agents[node_name].started) {
         return Q.fcall(function() {
-            return agntCtlConfig.allocated_agents[node_name].ref.read_block(req);
+            return agntCtlConfig.allocated_agents[node_name].agent.read_block(req);
         });
     }
 
@@ -208,7 +208,7 @@ function write_block(node_name, block_id, data) {
     if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
         agntCtlConfig.allocated_agents[node_name].started) {
         return Q.fcall(function() {
-            return agntCtlConfig.allocated_agents[node_name].ref.write_block(req);
+            return agntCtlConfig.allocated_agents[node_name].agent.write_block(req);
         });
     }
 
@@ -229,7 +229,7 @@ function delete_blocks(node_name, block_ids) {
     if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
         agntCtlConfig.allocated_agents[node_name].started) {
         return Q.fcall(function() {
-            return agntCtlConfig.allocated_agents[node_name].ref.delete_blocks(req);
+            return agntCtlConfig.allocated_agents[node_name].agent.delete_blocks(req);
         });
     }
 
@@ -250,7 +250,7 @@ function corrupt_blocks(node_name, block_ids) {
     if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
         agntCtlConfig.allocated_agents[node_name].started) {
         return Q.fcall(function() {
-            return agntCtlConfig.allocated_agents[node_name].ref.corrupt_blocks(block_ids);
+            return agntCtlConfig.allocated_agents[node_name].agent.corrupt_blocks(block_ids);
         });
     }
 
@@ -261,7 +261,7 @@ function list_blocks(node_name) {
     if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
         agntCtlConfig.allocated_agents[node_name].started) {
         return Q.fcall(function() {
-            return agntCtlConfig.allocated_agents[node_name].ref.list_blocks();
+            return agntCtlConfig.allocated_agents[node_name].agent.list_blocks();
         });
     }
 

--- a/src/test/core_agent_control.js
+++ b/src/test/core_agent_control.js
@@ -1,0 +1,176 @@
+// make jshint ignore mocha globals
+/* global describe, it, before, after, beforeEach, afterEach */
+'use strict';
+
+var _ = require('lodash');
+var Q = require('q');
+var path = require('path');
+var mongoose = require('mongoose');
+var Semaphore = require('noobaa-util/semaphore');
+var api = require('../api');
+var db = require('../server/db');
+var Agent = require('../agent/agent');
+var config = require('../../config.js');
+var dbg = require('noobaa-util/debug_module')(__filename);
+
+var agntCtlConfig = {
+    use_local: true,
+    num_allocated: 0,
+    allocated_agents: {},
+    local_conf: {
+        utilitest: null,
+        auth: null,
+    },
+    remote_conf: {},
+};
+
+module.exports = {
+    show_ctl: show_ctl,
+    use_local_agents: use_local_agents,
+    use_remote_agents: use_remote_agents,
+
+    create_agent: create_agent,
+    cleanup_agents: cleanup_agents,
+    start_agent: start_agent,
+    stop_agent: stop_agent,
+    start_all_agents: start_all_agents,
+    stop_all_agents: stop_all_agents,
+    get_agents_list: get_agents_list,
+
+    /*TODO: add the following:
+     * delete_block: delete_block,
+     * corrupt_block: corrupt_block,
+     * comm_error_inject: comm_error_inject,
+     */
+};
+
+/*
+ *
+ * Switch between working locally and remotely
+ *
+ */
+
+function show_ctl() {
+    return agntCtlConfig;
+}
+
+function use_local_agents(utilitest, auth_token) {
+    if (!utilitest) {
+        throw Error('Must supply utilitest for local agents test run');
+    } else if (!auth_token) {
+        throw Error('Must supply auth_token for local agents test run');
+    }
+
+    agntCtlConfig.use_local = true;
+    agntCtlConfig.local_conf.utilitest = utilitest;
+    agntCtlConfig.local_conf.auth = _.clone(auth_token);
+}
+
+function use_remote_agents() {
+    //TODO: not supported yet
+    agntCtlConfig.use_local = true;
+}
+
+/*
+ *
+ * Agent(s) control path
+ *
+ */
+
+function create_agent(howmany) {
+    var count = howmany || 1;
+    return Q.all(_.times(count, function(i) {
+        return Q.fcall(function() {
+                var agent_a = new Agent({
+                    address: 'http://localhost:' + agntCtlConfig.local_conf.utilitest.http_port(),
+                    node_name: 'node' + (_num_allocated() + 1) + '_' + (Date.now() % 100000),
+                    // passing token instead of storage_path to use memory storage
+                    token: agntCtlConfig.local_conf.auth,
+                    use_http_server: true,
+                });
+                return agent_a;
+            })
+            .then(function(agent) {
+                agntCtlConfig.allocated_agents[agent.node_name] = {
+                    ref: agent,
+                    started: false
+                };
+                agntCtlConfig.num_allocated++;
+                return;
+            });
+    }));
+}
+
+function cleanup_agents() {
+    return Q.fcall(function() {
+            return stop_all_agents();
+        })
+        .then(function() {
+            agntCtlConfig.allocated_agents = {};
+            agntCtlConfig.num_allocated = 0;
+        });
+}
+
+function start_agent(node_name) {
+    if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
+        !agntCtlConfig.allocated_agents[node_name].started) {
+        return Q.fcall(function() {
+                return agntCtlConfig.allocated_agents[node_name].ref.start();
+            })
+            .then(function() {
+                agntCtlConfig.allocated_agents[node_name].started = true;
+            });
+    }
+
+    return Q.reject('No node_name supplied');
+}
+
+function stop_agent(node_name) {
+    if (agntCtlConfig.allocated_agents.hasOwnProperty(node_name) &&
+        agntCtlConfig.allocated_agents[node_name].started) {
+        return Q.fcall(function() {
+                return agntCtlConfig.allocated_agents[node_name].ref.stop();
+            })
+            .then(function() {
+                agntCtlConfig.allocated_agents[node_name].started = false;
+            });
+    }
+
+    return Q.reject('No node_name supplied');
+}
+
+function start_all_agents() {
+    return Q.all(_.map(agntCtlConfig.allocated_agents,
+        function(data, id) {
+            if (data.started === false) {
+                return start_agent(id);
+            }
+        }));
+}
+
+function stop_all_agents() {
+    return Q.all(_.map(agntCtlConfig.allocated_agents,
+        function(data, id) {
+            if (data.started === true) {
+                return stop_agent(id);
+            }
+        }));
+}
+
+function get_agents_list() {
+    return _.map(agntCtlConfig.allocated_agents, function(stat, id) {
+        return {
+            node_name: id,
+            started: stat.started
+        };
+    });
+}
+
+/*
+ *
+ * Internal Utilities
+ *
+ */
+function _num_allocated() {
+    return agntCtlConfig.num_allocated;
+}

--- a/src/test/coretest.js
+++ b/src/test/coretest.js
@@ -130,12 +130,8 @@ function clear_test_nodes() {
         });
 }
 
-// return all allocated agents and their status (started/not)
-function get_agents_list() {
-    return agentctl.get_agents_list();
-}
-
 module.exports = {
+    //Own API
     account_credentials: account_credentials,
     client: client,
 
@@ -145,5 +141,20 @@ module.exports = {
 
     init_test_nodes: init_test_nodes,
     clear_test_nodes: clear_test_nodes,
-    get_agents_list: get_agents_list,
+
+
+    //Expose Agent Control API
+    use_local_agents: agentctl.use_local_agents,
+    create_agent: agentctl.create_agent,
+    cleanup_agents: agentctl.cleanup_agents,
+    start_agent: agentctl.start_agent,
+    stop_agent: agentctl.stop_agent,
+    start_all_agents: agentctl.start_all_agents,
+    stop_all_agents: agentctl.stop_all_agents,
+    get_agents_list: agentctl.get_agents_list,
+    read_block: agentctl.read_block,
+    write_block: agentctl.write_block,
+    delete_blocks: agentctl.delete_blocks,
+    corrupt_blocks: agentctl.corrupt_blocks,
+    list_blocks: agentctl.list_blocks,
 };

--- a/src/test/coretest.js
+++ b/src/test/coretest.js
@@ -56,6 +56,8 @@ before(function(done) {
         config.use_ice_when_possible = false;
         client.options.port = utilitest.http_port();
 
+        config.marked_test = true;
+
         var account_params = _.clone(account_credentials);
         account_params.name = 'coretest';
         return client.account.create_account(account_params);

--- a/src/test/coretest.js
+++ b/src/test/coretest.js
@@ -91,13 +91,13 @@ function init_test_nodes(count, system, tier, storage_alloc) {
             agentctl.use_local_agents(utilitest, create_node_token);
             var sem = new Semaphore(3);
             return Q.all(_.times(count, function(i) {
-                return sem.surround(function() {
+                    return sem.surround(function() {
                         agentctl.create_agent(1);
-                    })
-                    .then(function() {
-                        return agentctl.start_all_agents();
                     });
-            }));
+                }))
+                .then(function() {
+                    return agentctl.start_all_agents();
+                });
         });
 }
 

--- a/src/test/coretest.js
+++ b/src/test/coretest.js
@@ -56,7 +56,7 @@ before(function(done) {
         config.use_ice_when_possible = false;
         client.options.port = utilitest.http_port();
 
-        config.marked_test = true;
+        config.test_mode = true;
 
         var account_params = _.clone(account_credentials);
         account_params.name = 'coretest';
@@ -141,20 +141,11 @@ module.exports = {
 
     init_test_nodes: init_test_nodes,
     clear_test_nodes: clear_test_nodes,
-
-
-    //Expose Agent Control API
-    use_local_agents: agentctl.use_local_agents,
-    create_agent: agentctl.create_agent,
-    cleanup_agents: agentctl.cleanup_agents,
-    start_agent: agentctl.start_agent,
-    stop_agent: agentctl.stop_agent,
-    start_all_agents: agentctl.start_all_agents,
-    stop_all_agents: agentctl.stop_all_agents,
-    get_agents_list: agentctl.get_agents_list,
-    read_block: agentctl.read_block,
-    write_block: agentctl.write_block,
-    delete_blocks: agentctl.delete_blocks,
-    corrupt_blocks: agentctl.corrupt_blocks,
-    list_blocks: agentctl.list_blocks,
 };
+
+//Expose Agent Control API via coretest
+_.each(agentctl, function(prop) {
+    if (agentctl.hasOwnProperty(prop)) {
+        module.exports[prop] = agentctl[prop];
+    }
+});


### PR DESCRIPTION
Add agent control testing module.
Instead of implementing the desired actions (create, start, stop etc.) in each test/place which needs them, provide a centralized module.

Currently providing the following abilities:
- working locally
- providing create,stop,start,stop_all,start_all, cleanup.

In the future, this module will also contain the ability to work on remote agents (amazon) thus providing a single point for agents testing API. Additional APIs (such as corrupt block, delete block etc.) will also be added.
