### PR TITLE
Add access and secret key support

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -161,7 +161,7 @@ Agent.prototype.start = function() {
             return self.send_heartbeat();
         })
         .then(null, function(err) {
-            console.error('AGENT server failed to start', err);
+            console.error('AGENT server failed to start', err,err.stack);
             self.stop();
             throw err;
         });
@@ -208,7 +208,7 @@ Agent.prototype._init_node = function() {
         .then(function(res) {
             dbg.log0('res:', res);
             // if we are already authorized with our specific node_id, use it
-            if (res.account && res.system &&
+            if (res.system &&
                 res.extra && res.extra.node_id) {
                 self.node_id = res.extra.node_id;
                 self.peer_id = res.extra.peer_id;
@@ -218,7 +218,7 @@ Agent.prototype._init_node = function() {
             }
 
             // if we have authorization to create a node, do it
-            if (res.account && res.system &&
+            if (res.system &&
                 _.contains(['admin', 'create_node'], res.role) &&
                 res.extra && res.extra.tier) {
                 dbg.log0('create node', self.node_name, 'tier', res.extra.tier);
@@ -238,6 +238,9 @@ Agent.prototype._init_node = function() {
                         return Q.nfcall(fs.writeFile, token_path, node.token);
                     }
                 });
+            }else
+            {
+                dbg.log0('failed:',res.system,_.contains(['admin', 'create_node'], res.role));
             }
 
             console.error('bad token', res);

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -238,9 +238,6 @@ Agent.prototype._init_node = function() {
                         return Q.nfcall(fs.writeFile, token_path, node.token);
                     }
                 });
-            }else
-            {
-                dbg.log0('failed:',res.system,_.contains(['admin', 'create_node'], res.role));
             }
 
             console.error('bad token', res);
@@ -439,7 +436,7 @@ Agent.prototype.send_heartbeat = function() {
 
         }, function(err) {
 
-            dbg.log0('HEARTBEAT FAILED', err, err.stack);
+            dbg.error('HEARTBEAT FAILED', err, err.stack);
 
             // schedule delay to retry on error
             self.heartbeat_delay_ms = 30000 * (1 + Math.random());

--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -98,7 +98,7 @@ AgentCLI.prototype.init = function() {
                 .then(function() {
                     dbg.log0('COMPLETED: load');
                 }, function(err) {
-                    dbg.log0('ERROR: load', self.params, err.stack);
+                    dbg.error('ERROR: load', self.params, err.stack);
                     throw new Error(err);
                 });
         });
@@ -428,7 +428,7 @@ function main() {
         populate_general_help(help.general);
         repl_srv.context.help = help;
     }, function(err) {
-        dbg.log0('init err:' + err);
+        dbg.error('init err:' + err);
 
     });
 }

--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -21,6 +21,7 @@ var config = require('../../config.js');
 var DebugModule = require('noobaa-util/debug_module');
 var dbg = require('noobaa-util/debug_module')(__filename);
 var child_process = require('child_process');
+var s3_auth = require('aws-sdk/lib/signers/s3');
 
 Q.longStackSupport = true;
 
@@ -38,6 +39,7 @@ Q.longStackSupport = true;
 function AgentCLI(params) {
     this.params = params;
     this.client = new api.Client();
+    this.s3 = new s3_auth();
     this.agents = {};
     // this._mod = dbg;
     // this.modules = this._mod.get_module_structure();
@@ -61,13 +63,13 @@ AgentCLI.prototype.init = function() {
             self.params = _.defaults(self.params, agent_conf);
         })
         .then(null, function(err) {
-            dbg.log0('cannot find configuration file. Using defaults.');
+            dbg.log0('cannot find configuration file. Using defaults.',err);
             self.params = _.defaults(self.params, {
                 root_path: './agent_storage/',
                 address: 'http://localhost:5001',
                 port: 0,
-                email: 'demo@noobaa.com',
-                password: 'DeMo',
+                access_key: '123',
+                secret_key: 'abc',
                 system: 'demo',
                 tier: 'nodes',
                 bucket: 'files'
@@ -189,30 +191,25 @@ AgentCLI.prototype.create = function() {
             if (self.create_node_token) return;
             // authenticate and create a token for new nodes
 
-            var auth_params = _.pick(self.params,
-                'email', 'password', 'system', 'role');
-            if (_.isEmpty(auth_params)) {
-                if (_.isEmpty(self.params.noobaa_access_key)) {
-                    dbg.log0('Exiting as there is no credential information.');
-
-                    throw new Error("No credentials");
-
-                } else {
-
-                    var access_res = {
-                        res: "Access Param",
-                        token: self.params.noobaa_access_key
-                    };
-                    return access_res;
-                }
-
+            var basic_auth_params = _.pick(self.params,
+                'system', 'role');
+            if (_.isEmpty(basic_auth_params)) {
+                throw new Error("No credentials");
             } else {
+                var secret_key = self.params.secret_key;
+                var auth_params_str = JSON.stringify(basic_auth_params);
+                var signature = self.s3.sign(secret_key, auth_params_str);
+                var auth_params = {
+                    'access_key': self.params.access_key,
+                    'string_to_sign': auth_params_str,
+                    'signature': signature
+                };
                 if (self.params.tier) {
                     auth_params.extra = {
                         tier: self.params.tier
                     };
                 }
-                return self.client.create_auth_token(auth_params);
+                return self.client.create_access_key_auth(auth_params);
             }
         })
         .then(function(res) {
@@ -458,6 +455,6 @@ function exitHandler() {
 // });
 
 process.on('uncaughtException', function(err) {
-    dbg.log0('Process Caught exception: ' , err , err.stack,require('util').inspect(err));
+    dbg.log0('Process Caught exception: ', err, err.stack, require('util').inspect(err));
     //exitHandler();
 });

--- a/src/api/auth_api.js
+++ b/src/api/auth_api.js
@@ -64,6 +64,50 @@ module.exports = {
             }
         },
 
+        create_access_key_auth: {
+            doc: 'Authenticate account with access key, ' +
+                'and returns an access token. ' +
+                'supply a system name to create a token for acting on the system.',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['access_key','string_to_sign','signature'],
+                properties: {
+                    access_key: {
+                        type: 'string',
+                    },
+                    string_to_sign: {
+                        doc: 'string used to sign with access key and secret key in order to verify the token',
+                        type: 'string',
+                    },
+                    signature: {
+                        type: 'string',
+                    },
+                    extra: {
+                        type: 'object',
+                        additionalProperties: true
+                    },
+                    expiry: {
+                        type: 'integer',
+                        doc: 'Number of seconds before the authentication expires',
+                    },
+                },
+            },
+            reply: {
+                type: 'object',
+                required: ['token'],
+                properties: {
+                    token: {
+                        type: 'string',
+                    },
+                }
+            },
+            auth: {
+                account: false,
+                system: false,
+            }
+        },
+
         read_auth: {
             doc: 'Get info about the authenticated token.',
             method: 'GET',

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -92,5 +92,11 @@ function Client(default_options) {
             return res;
         });
     };
+    self.create_access_key_auth = function(params) {
+        return self.auth.create_access_key_auth(params).then(function(res) {
+            self.options.auth_token = res.token;
+            return res;
+        });
+    };
 
 }

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -273,6 +273,7 @@ module.exports = {
                 'nodes',
                 'buckets',
                 'objects',
+                'access_keys'
             ],
             properties: {
                 name: {
@@ -305,6 +306,12 @@ module.exports = {
                 objects: {
                     type: 'integer'
                 },
+                access_keys: {
+                    type: 'array',
+                    item: {
+                        $ref: '/system_api/definitions/access_keys'
+                    }
+                }
             }
         },
 
@@ -349,6 +356,19 @@ module.exports = {
                 },
             }
         },
+        access_keys: {
+            type: 'object',
+            required: ['access_key','secret_key'],
+            peroperties: {
+                access_key : {
+                    type: String,
+
+                },
+                secret_key : {
+                    type: String,
+                }
+            }
+        }
 
 
     }

--- a/src/client/nb_console.js
+++ b/src/client/nb_console.js
@@ -559,6 +559,7 @@ nb_console.controller('BucketViewCtrl', [
                     return init_only ? nbSystem.init_system : nbSystem.reload_system();
                 })
                 .then(function() {
+                    nbFiles.set_keys(nbSystem.system.access_keys);
                     $scope.bucket = _.find(nbSystem.system.buckets, function(bucket) {
                         return bucket.name === $routeParams.bucket_name;
                     });
@@ -634,7 +635,8 @@ nb_console.controller('FileViewCtrl', [
                 redirectTo: 'parts'
             });
 
-        reload_view(true);
+            reload_view(true);
+
 
         function reload_view(init_only) {
             return $q.when()
@@ -642,6 +644,11 @@ nb_console.controller('FileViewCtrl', [
                     return init_only ? nbSystem.init_system : nbSystem.reload_system();
                 })
                 .then(function() {
+                    //Setting access keys.
+                    //TODO: consider separation to other object with only the keys
+                    //      also, check better solution in terms of security.
+                    nbFiles.set_keys(nbSystem.system.access_keys);
+
                     $scope.bucket = _.find(nbSystem.system.buckets, function(bucket) {
                         return bucket.name === $routeParams.bucket_name;
                     });
@@ -667,11 +674,10 @@ nb_console.controller('FileViewCtrl', [
                         rest_address + '/' +
                         $routeParams.bucket_name + '/' +
                         $routeParams.file_name + '?download=1');
-                    $scope.play_url = $sce.trustAsResourceUrl(
-                        rest_address + '/' +
-                        $routeParams.bucket_name + '/' +
-                        // (/^video\//.test($scope.file.content_type) ? 'video/' : 'o/') +
-                        $routeParams.file_name);
+
+                    //now we get s3 rest signed url
+                    console.log('url', $scope.file.url, $sce.trustAsResourceUrl($scope.file.url));
+                    $scope.play_url = $sce.trustAsResourceUrl($scope.file.url);
 
                     // TODO handle file parts pages
                     $scope.parts_num_pages = 9;

--- a/src/client/nb_files.js
+++ b/src/client/nb_files.js
@@ -201,7 +201,6 @@ nb_api.factory('nbFiles', [
                 Body: tx.input_file,
                 ContentType: tx.content_type
             };
-            try {
 
                 tx.promise = $q(function(resolve, reject, notify) {
                     console.log('starting');
@@ -240,9 +239,7 @@ nb_api.factory('nbFiles', [
                     });
 
                 });
-            } catch (err) {
-                console.log('ERRRRRRR:', err);
-            }
+            
             $scope.uploads.push(tx);
             $scope.transfers.push(tx);
             return tx.promise;

--- a/src/client/nb_files.js
+++ b/src/client/nb_files.js
@@ -9,8 +9,9 @@ var api = require('../api');
 var SliceReader = require('../util/slice_reader');
 var BrowserFileWriter = require('../util/browser_file_writer');
 var concat_stream = require('concat-stream');
-
+var AWS = require('aws-sdk');
 var nb_api = angular.module('nb_api');
+var streams = require('stream');
 
 
 nb_api.factory('nbFiles', [
@@ -28,17 +29,36 @@ nb_api.factory('nbFiles', [
         $scope.clear_download = clear_download;
         $scope.read_entire_object = read_entire_object;
         $scope.read_as_media_stream = read_as_media_stream;
-
+        $scope.set_keys = set_keys;
         $scope.uploads = [];
         $scope.downloads = [];
         $scope.transfers = [];
+
+        //TODO: move to ssl. disable certificate validation.
+        var ep = new AWS.Endpoint({
+            protocol: 'http',
+            port: 80,
+            hostname: '127.0.0.1'
+        });
+
+        //var access_key_id = 'd36e02598bf347148752';
+        //var secret_access_key = 'f25cd46a-e105-4518-ac75-0d033745b4e1';
+
+
+
+        var s3 = new AWS.S3({
+            endpoint: 'http://127.0.0.1',
+            s3ForcePathStyle: true,
+            sslEnabled: false,
+
+        });
 
         angular.element($window).on('beforeunload', function() {
             var num_uploads = 0;
             var num_downloads = 0;
             _.each($scope.transfers, function(tx) {
                 if (tx.running) {
-                    if (tx.type==='upload') {
+                    if (tx.type === 'upload') {
                         num_uploads += 1;
                     } else {
                         num_downloads += 1;
@@ -54,7 +74,22 @@ nb_api.factory('nbFiles', [
                 return 'Downloads are in progress. ' + warning;
             }
         });
+        //update access keys.
+        //TODO: find more secured approach
+        function set_keys(access_keys){
+            AWS.config.update({
+                accessKeyId: access_keys[0].access_key,
+                secretAccessKey: access_keys[0].secret_key,
+                sslEnabled: false
+            });
+            s3 = new AWS.S3({
+                endpoint: 'http://127.0.0.1',
+                s3ForcePathStyle: true,
+                sslEnabled: false,
 
+            });
+            console.log('updated keys',access_keys[0].access_key);
+        }
         function list_files(params) {
             return $q.when()
                 .then(function() {
@@ -74,10 +109,17 @@ nb_api.factory('nbFiles', [
                 })
                 .then(function(res) {
                     console.log('FILE', res);
-                    return make_file_info({
+                    var file_info = make_file_info({
                         key: params.key,
-                        info: res,
+                        info: res
                     });
+
+                    var url = s3.getSignedUrl('getObject', {
+                        Bucket: params.bucket,
+                        Key: params.key
+                    });
+                    file_info.url = url;
+                    return file_info;
                 });
         }
 
@@ -151,40 +193,56 @@ nb_api.factory('nbFiles', [
                 running: true,
             };
             console.log('upload', tx);
-            tx.promise = $q.when(nbClient.client.object_client.upload_stream({
-                    bucket: tx.bucket,
-                    key: tx.name,
-                    size: tx.size,
-                    content_type: tx.content_type,
-                    source_stream: new SliceReader(tx.input_file, {
-                        highWaterMark: size_utils.MEGABYTE,
-                        FileReader: $window.FileReader,
-                    }),
-                }))
-                .then(function() {
-                    _.pull($scope.transfers, tx);
-                    tx.done = true;
-                    tx.progress = 100;
-                    tx.running = false;
-                    tx.end_time = Date.now();
-                    var duration = (tx.end_time - tx.start_time) / 1000;
-                    var elapsed = duration.toFixed(1) + 'sec';
-                    var speed = $rootScope.human_size(tx.size / duration) + '/sec';
-                    console.log('upload completed', elapsed, speed);
-                    nbAlertify.success('upload completed');
-                }, function(err) {
-                    _.pull($scope.transfers, tx);
-                    tx.error = err;
-                    tx.running = false;
-                    console.error('upload failed', err);
-                    nbAlertify.error('upload failed. ' + err.toString());
-                }, function(progress) {
-                    if (progress.event === 'part:after') {
-                        var pos = progress.part && progress.part.end || 0;
-                        tx.progress = 100 * pos / tx.size;
-                    }
-                    return progress;
+
+
+            var params = {
+                Key: tx.name,
+                Bucket: tx.bucket,
+                Body: tx.input_file,
+                ContentType: tx.content_type
+            };
+            try {
+
+                tx.promise = $q(function(resolve, reject, notify) {
+                    console.log('starting');
+                    var s3req = s3.upload(params, function(err, data) {
+                        if (err) {
+                            console.error('upload failed', err);
+                            _.pull($scope.transfers, tx);
+                            tx.error = err;
+                            tx.running = false;
+                            nbAlertify.error('upload failed. ' + err.toString());
+                            reject(new Error('upload failed'));
+                            $rootScope.safe_apply();
+                        } else {
+                            // Success!
+                            console.log('upload done!!!!');
+                            _.pull($scope.transfers, tx);
+                            tx.done = true;
+                            tx.progress = 100;
+                            tx.running = false;
+                            tx.end_time = Date.now();
+                            var duration = (tx.end_time - tx.start_time) / 1000;
+                            var elapsed = duration.toFixed(1) + 'sec';
+                            var speed = $rootScope.human_size(tx.size / duration) + '/sec';
+                            console.log('upload completed', elapsed, speed);
+                            nbAlertify.success('upload completed');
+                            resolve();
+                            $rootScope.safe_apply();
+                        }
+                    }).on('httpUploadProgress', function(progress) {
+                        // Log Progress Information
+                        console.log(Math.round(progress.loaded / progress.total * 100) + '% done');
+                        console.log('prog info');
+                        var pos = progress.loaded && progress.total || 0;
+                        tx.progress = Math.round(progress.loaded / progress.total * 100);
+                        $rootScope.safe_apply();
+                    });
+
                 });
+            } catch (err) {
+                console.log('ERRRRRRR:', err);
+            }
             $scope.uploads.push(tx);
             $scope.transfers.push(tx);
             return tx.promise;
@@ -215,16 +273,17 @@ nb_api.factory('nbFiles', [
                         running: true
                     };
                     tx.promise = $q(function(resolve, reject, progress) {
+                        var params = {
+                            Bucket: bucket_name,
+                            Key: file.name,
+                        };
 
-                        var reader = nbClient.client.object_client.open_read_stream({
-                                bucket: bucket_name,
-                                key: file.name,
-                            })
-                            .once('error', on_error);
+                        var s3req = s3.getObject(params);
+                        var reader = createReadStream(s3req);
 
                         reader.pipe(res.writer)
                             .on('progress', function(pos) {
-
+                                console.log('progress', pos);
                                 tx.progress = (100 * pos / file.size);
                                 if (progress) {
                                     progress(pos);
@@ -267,12 +326,80 @@ nb_api.factory('nbFiles', [
                             $rootScope.safe_apply();
                         }
                     });
-                    console.log('DOWNLOAD', tx);
+                    console.log('DOWNLOAD', tx, tx.promise);
                     $scope.downloads.push(tx);
                     $scope.transfers.push(tx);
                     $rootScope.safe_apply();
                     return tx;
                 });
+        }
+        //copied code.
+        //TODO: replace or better understand how to use the standard amazon API
+        function createReadStream(req) {
+            var stream = null;
+            var legacyStreams = false;
+
+            if (AWS.HttpClient.streamsApiVersion === 2) {
+                stream = new streams.Readable();
+                stream._read = function() {};
+            } else {
+                stream = new streams.Stream();
+                stream.readable = true;
+            }
+
+            stream.sent = false;
+            stream.on('newListener', function(event) {
+                if (!stream.sent && (event === 'data' || event === 'readable')) {
+                    if (event === 'data') legacyStreams = true;
+                    stream.sent = true;
+                    process.nextTick(function() {
+                        req.send(function() {});
+                    });
+                }
+            });
+
+            req.on('httpHeaders', function streamHeaders(statusCode, headers, resp) {
+                if (statusCode < 300) {
+                    req.removeListener('httpData', AWS.EventListeners.Core.HTTP_DATA);
+                    req.removeListener('httpError', AWS.EventListeners.Core.HTTP_ERROR);
+                    req.on('httpError', function streamHttpError(error) {
+                        resp.error = error;
+                        resp.error.retryable = false;
+                    });
+
+                    var httpStream = resp.httpResponse.createUnbufferedStream();
+                    if (legacyStreams) {
+                        httpStream.on('data', function(arg) {
+                            stream.emit('data', arg);
+                        });
+                        httpStream.on('end', function() {
+                            stream.emit('end');
+                        });
+                    } else {
+                        httpStream.on('readable', function() {
+                            var chunk;
+                            do {
+                                chunk = httpStream.read();
+                                if (chunk !== null) stream.push(chunk);
+                            } while (chunk !== null);
+                            stream.read(0);
+                        });
+                        httpStream.on('end', function() {
+                            stream.push(null);
+                        });
+                    }
+
+                    httpStream.on('error', function(err) {
+                        stream.emit('error', err);
+                    });
+                }
+            });
+
+            req.on('error', function(err) {
+                stream.emit('error', err);
+            });
+
+            return stream;
         }
 
         function open_temp_file_write_stream() {

--- a/src/s3/app.js
+++ b/src/s3/app.js
@@ -67,14 +67,12 @@ function s3_app(params) {
                     dbg.log0('signed url');
                 }
                 if (authenticated_request) {
-
-
                     var s3 = new s3_auth(req);
                     params.string_to_sign = s3_util.noobaa_string_to_sign(req, res.headers);
                     // debug code.
                     // use it for faster detection of a problem in the signature calculation and verification
                     //
-                     //
+                    //
                     //  var s3_internal_signature = s3.sign(params.access_key, params.string_to_sign);
                     //  dbg.log0('s3 internal:::' + params.string_to_sign,req.query.Signature,req.headers.authorization);
                     //  if ((req.headers.authorization === 'AWS ' + params.access_key + ':' + s3_internal_signature) ||
@@ -82,7 +80,7 @@ function s3_app(params) {
                     //  {
                     //      dbg.log0('s3 internal authentication test passed!!!',s3_internal_signature);
                     //  } else {
-                     //
+                    //
                     //      dbg.error('s3 internal authentication test failed!!! Computed signature is ',s3_internal_signature, 'while the expected signature is:',req.headers.authorization || req.query.Signature);
                     //  }
 

--- a/src/s3/app.js
+++ b/src/s3/app.js
@@ -7,7 +7,8 @@ var https = require('https');
 var http = require('http');
 var dbg = require('noobaa-util/debug_module')(__filename);
 var pem = require('pem');
-
+var s3_auth = require('aws-sdk/lib/signers/s3');
+var _ = require('lodash');
 
 module.exports = s3_app;
 
@@ -15,46 +16,76 @@ module.exports = s3_app;
 function s3_app(params) {
 
 
-    var express = require('express'),
-        app = express(),
-        //logger = require('./logger')(false),
-        Controllers = require('./controllers'),
-        controllers = new Controllers(params),
-        concat = require('concat-stream');
-
-
-
-    // app.use(function(req, res, next) {
-    //
-    //     req.pipe(concat(function(data) {
-    //         req.body = data;
-    //         next();
-    //     }));
-    // });
+    var express = require('express');
+    var app = express();
+    //logger = require('./logger')(false),
+    var Controllers = require('./controllers');
+    var controllers = new Controllers(params);
 
     app.use(function(req, res, next) {
-        dbg.log0('S3 request. Time:', Date.now(), req.originalUrl,req.headers, req.query, req.query.prefix, req.query.delimiter);
-        if (req.headers.host) {
-            if (req.headers.host.indexOf(params.bucket) === 0) {
-                req.url = req.url.replace('/', '/' + params.bucket + '/');
-                dbg.log0('update path with bucket name', req.url, req.path, params.bucket);
-            }
-            if (req.query.prefix && req.query.delimiter) {
-                if (req.query.prefix.indexOf(req.query.delimiter) < 0) {
-                    req.url = req.url.replace(req.query.prefix, req.query.prefix + req.query.delimiter);
-                    dbg.log0('updated prefix', req.url, req.query.prefix);
-                    req.query.prefix = req.query.prefix + req.query.delimiter;
 
+        Q.fcall(function() {
+
+            dbg.log0('S3 request. Time:', Date.now(), req.originalUrl, req.headers, req.query, req.query.prefix, req.query.delimiter);
+
+
+            if (req.headers.authorization) {
+
+                var awsSecretKey = 'abc';
+                var awsAccessKey = '123';
+
+                var s3 = new s3_auth(req);
+                dbg.log0('s3 string:', s3.stringToSign());
+                var s3_signature = s3.sign(awsSecretKey, s3.stringToSign());
+                dbg.log0('s3:::' + s3_signature);
+                if (req.headers.authorization === 'AWS ' + awsAccessKey + ':' + s3_signature) {
+                    dbg.log0('s3 authentication test passed!!!');
+                } else {
+                    dbg.log0('s3 authentication test failed!!!');
                 }
+                var end_of_aws_key = req.headers.authorization.indexOf(':');
+                var req_access_key = req.headers.authorization.substring(4, end_of_aws_key);
+                req.params.aws_access_key = req_access_key;
+                params.aws_access_key = req_access_key;
+
+                dbg.log0('controller?', controllers, ' req - aws', req.params.aws_access_key, ' param - aws', params.aws_access_key, ' key ', req_access_key, end_of_aws_key);
+                return Q.fcall(function() {
+                    return controllers.is_system_client_exists(req_access_key);
+                }).then(function(is_exists) {
+                    if (!is_exists) {
+                        return controllers.add_new_system_client(params);
+                    }
+
+                });
+
+            } else {
+                req.unauthorized(403, 'unauthorized');
             }
-            if (req.url.indexOf('/' + params.bucket + '?') >= 0) {
-                //req.url = req.url.replace(params.bucket,params.bucket+'/');
-                dbg.log0('updated bucket name with delimiter', req.url);
-            }
+        }).then(function() {
+            if (req.headers.host) {
+                if (req.headers.host.indexOf(params.bucket) === 0) {
+                    req.url = req.url.replace('/', '/' + params.bucket + '/');
+                    dbg.log0('update path with bucket name', req.url, req.path, params.bucket);
+                }
+                if (req.query.prefix && req.query.delimiter) {
+                    if (req.query.prefix.indexOf(req.query.delimiter) < 0) {
+                        req.url = req.url.replace(req.query.prefix, req.query.prefix + req.query.delimiter);
+                        dbg.log0('updated prefix', req.url, req.query.prefix);
+                        req.query.prefix = req.query.prefix + req.query.delimiter;
+
+                    }
+                }
+                if (req.url.indexOf('/' + params.bucket + '?') >= 0) {
+                    //req.url = req.url.replace(params.bucket,params.bucket+'/');
+                    dbg.log0('updated bucket name with delimiter', req.url);
+                }
 
 
-        }
-        next();
+            }
+            next();
+
+        });
+
     });
 
     app.disable('x-powered-by');

--- a/src/s3/app.js
+++ b/src/s3/app.js
@@ -79,14 +79,14 @@ function s3_app(params) {
                         req.url = req.url.replace('/', '/' + params.bucket + '/');
                         dbg.log0('update path with bucket name', req.url, req.path, params.bucket);
                     }
-                    if (req.query.prefix && req.query.delimiter) {
-                        if (req.query.prefix.indexOf(req.query.delimiter) < 0) {
-                            req.url = req.url.replace(req.query.prefix, req.query.prefix + req.query.delimiter);
-                            dbg.log0('updated prefix', req.url, req.query.prefix);
-                            req.query.prefix = req.query.prefix + req.query.delimiter;
-
-                        }
-                    }
+                    // if (req.query.prefix && req.query.delimiter) {
+                    //     if (req.query.prefix.indexOf(req.query.delimiter) < 0) {
+                    //         req.url = req.url.replace(req.query.prefix, req.query.prefix + req.query.delimiter);
+                    //         dbg.log0('updated prefix', req.url, req.query.prefix);
+                    //         req.query.prefix = req.query.prefix + req.query.delimiter;
+                    //
+                    //     }
+                    // }
                 }
                 next();
 

--- a/src/s3/app.js
+++ b/src/s3/app.js
@@ -133,7 +133,7 @@ function s3_app(params) {
                         http.createServer(app.handle.bind(app))
                             .listen(params.port, function(err) {
                                 if (err) {
-                                    dbg.log0('HTTP listen', err);
+                                    dbg.err('HTTP listen', err);
                                     reject(err);
                                 } else {
                                     resolve();
@@ -150,7 +150,7 @@ function s3_app(params) {
                             }, app.handle.bind(app))
                             .listen(params.ssl_port, function(err) {
                                 if (err) {
-                                    dbg.log0('HTTPS listen', err);
+                                    dbg.err('HTTPS listen', err);
                                     reject(err);
                                 } else {
                                     resolve();

--- a/src/s3/controllers.js
+++ b/src/s3/controllers.js
@@ -62,7 +62,7 @@ module.exports = function(params) {
                     }
                     return res.status(200).end();
                 }, function(err) {
-                    dbg.log0('ERROR: upload:' + req.query.uploadId + ' err:' + util.inspect(err.stack));
+                    dbg.error('ERROR: upload:' + req.query.uploadId + ' err:' + util.inspect(err.stack));
                     return res.status(500).end();
                 });
 
@@ -117,7 +117,7 @@ module.exports = function(params) {
                         }).then(function() {
                             dbg.log0('Deleted old version of object "%s" in bucket "%s"', target_object.key, target_object.bucket);
                         }, function(err) {
-                            dbg.log0('Failure while trying to delete old version of object "%s"', target_object.key, err);
+                            dbg.error('Failure while trying to delete old version of object "%s"', target_object.key, err);
                         });
                     }
                 }
@@ -408,7 +408,7 @@ module.exports = function(params) {
             isBucketExists(bucketName, extract_access_key(req))
                 .then(function(exists) {
                     if (!exists) {
-                        dbg.log0('(1) No bucket found for "%s"', bucketName);
+                        dbg.error('(1) No bucket found for "%s"', bucketName);
                         var template = templateBuilder.buildBucketNotFound(bucketName);
                         return buildXmlResponse(res, 404, template);
                     }
@@ -419,7 +419,7 @@ module.exports = function(params) {
                 });
         },
         getBuckets: function(req, res) {
-            dbg.log0('getBuckets');
+            dbg.log0('getBuckets',req.params.bucket);
             var date = new Date();
             date.setMilliseconds(0);
             date = date.toISOString();
@@ -773,7 +773,7 @@ module.exports = function(params) {
                                 dbg.log0('Deleted old version of object "%s" in bucket "%s"', file_key_name, req.bucket);
                                 uploadObject(req, res, file_key_name);
                             }, function(err) {
-                                dbg.log0('Failure while trying to delete old version of object "%s"', file_key_name, err);
+                                dbg.error('Failure while trying to delete old version of object "%s"', file_key_name, err);
                                 var template = templateBuilder.buildKeyNotFound(file_key_name);
                                 return buildXmlResponse(res, 500, template);
 

--- a/src/s3/controllers.js
+++ b/src/s3/controllers.js
@@ -815,7 +815,7 @@ module.exports = function(params) {
                     }
                     return clients[access_key].object.create_multipart_upload(create_params)
                         .then(function(info) {
-                            template = templateBuilder.buildInitiateMultipartUploadResult(req.params.key);
+                            template = templateBuilder.buildInitiateMultipartUploadResult(req.params.key,req.bucket);
                             return buildXmlResponse(res, 200, template);
                         }).then(null, function(err) {
                             template = templateBuilder.buildKeyNotFound(req.query.uploadId);

--- a/src/s3/controllers.js
+++ b/src/s3/controllers.js
@@ -26,8 +26,15 @@ module.exports = function(params) {
     var clients = {};
 
     var extract_access_key = function(req) {
-        var end_of_aws_key = req.headers.authorization.indexOf(':');
-        var req_access_key = req.headers.authorization.substring(4, end_of_aws_key);
+        var req_access_key;
+        if (req.headers.authorization){
+            var end_of_aws_key = req.headers.authorization.indexOf(':');
+            req_access_key = req.headers.authorization.substring(4, end_of_aws_key);
+        }else{
+            if (req.query.AWSAccessKeyId){
+                req_access_key = req.query.AWSAccessKeyId;
+            }
+        }
         return req_access_key;
     };
 

--- a/src/s3/controllers.js
+++ b/src/s3/controllers.js
@@ -231,6 +231,7 @@ module.exports = function(params) {
             .then(function(results) {
                 var i = 0;
                 var folders = {};
+                dbg.log0('results:',results);
                 var objects = _.filter(results.objects, function(obj) {
                     try {
                         var date = new Date(obj.info.create_time);
@@ -242,13 +243,19 @@ module.exports = function(params) {
                         //we will keep the full path for CloudBerry online cloud backup tool
 
                         var obj_sliced_key = obj.key.slice(prefix.length);
-                        dbg.log3('obj.key:', obj.key, ' prefix ', prefix);
+                        dbg.log0('obj.key:', obj.key, ' prefix ', prefix,' sliced',obj_sliced_key);
                         if (obj_sliced_key.indexOf(delimiter) >= 0) {
                             var folder = obj_sliced_key.split(delimiter, 1)[0];
                             folders[prefix + folder + "/"] = true;
                             return false;
                         }
+
                         if (list_params.key === obj.key) {
+                            dbg.log0('LISTED KEY same as REQUIRED',obj.key);
+                            if (prefix===obj.key && prefix.substring(prefix.length-1)!==delimiter){
+                                return true;
+                            }
+
                             return false;
                         }
                         if (!obj.key) {
@@ -265,7 +272,7 @@ module.exports = function(params) {
                     objects: objects,
                     folders: folders
                 };
-                dbg.log3('About to return objects and folders:', objects_and_folders);
+                dbg.log0('About to return objects and folders:', objects_and_folders);
                 return objects_and_folders;
             }).then(null, function(err) {
                 dbg.error('failed to list object with prefix', err);

--- a/src/s3/controllers.js
+++ b/src/s3/controllers.js
@@ -25,7 +25,7 @@ module.exports = function(params) {
     var objects_avarage_part_size = {};
     var clients = {};
 
-    var extract_aws_access_key = function(req) {
+    var extract_access_key = function(req) {
         var end_of_aws_key = req.headers.authorization.indexOf(':');
         var req_access_key = req.headers.authorization.substring(4, end_of_aws_key);
         return req_access_key;
@@ -37,7 +37,7 @@ module.exports = function(params) {
             var template;
             var mydata = '';
             var content_length = req.headers['content-length'];
-            var aws_access_key = extract_aws_access_key(req);
+            var access_key = extract_access_key(req);
             var upload_part_info = {
                 bucket: req.bucket,
                 key: replaceSpaces(req.query.uploadId),
@@ -51,7 +51,7 @@ module.exports = function(params) {
             dbg.log0('upload info', _.pick(upload_part_info, 'bucket', 'key', 'size',
                 'content_type', 'upload_part_number'));
 
-            return clients[aws_access_key].object_client.upload_stream_parts(upload_part_info)
+            return clients[access_key].object_client.upload_stream_parts(upload_part_info)
                 .then(function() {
                     try {
                         dbg.log0('COMPLETED: upload', req.query.uploadId);
@@ -73,7 +73,7 @@ module.exports = function(params) {
             var template;
             var upload_id = req.query.uploadId;
             var max_parts = req.query['max-parts'] || 1000;
-            var aws_access_key = extract_aws_access_key(req);
+            var access_key = extract_access_key(req);
             var part_number_marker = req.query['part-number​-marker'] || '';
             dbg.log0('List part results for upload id:', upload_id, 'max parts', max_parts, 'part marker', part_number_marker);
             var list_options = {
@@ -82,7 +82,7 @@ module.exports = function(params) {
                 part_number_marker: 1,
                 max_parts: 1000
             };
-            return clients[aws_access_key].object.list_multipart_parts(list_options)
+            return clients[access_key].object.list_multipart_parts(list_options)
                 .then(function(list_result) {
                     list_options.NextPartNumberMarker = list_result.next_part_number_marker;
                     list_options.IsTruncated = list_result.next_part_number_marker > list_result.max_parts;
@@ -99,9 +99,9 @@ module.exports = function(params) {
         dbg.log2('template:', template);
         return res.send(template);
     };
-    var delete_if_exists = function(target_object, aws_access_key) {
+    var delete_if_exists = function(target_object, access_key) {
         dbg.log0('listing ', target_object.key, ' in bucket:', target_object.bucket);
-        return clients[aws_access_key].object.list_objects(target_object)
+        return clients[access_key].object.list_objects(target_object)
             .then(function(list_results) {
                 //object exists. Delete and write.
                 if (list_results.objects.length > 0) {
@@ -111,7 +111,7 @@ module.exports = function(params) {
                     //the current implementation of list_objects returns list of objects with key
                     // that starts with the provided name. we will validate it.
                     if (obj_index >= 0) {
-                        return clients[aws_access_key].object.delete_object({
+                        return clients[access_key].object.delete_object({
                             bucket: target_object.bucket,
                             key: target_object.key
                         }).then(function() {
@@ -123,7 +123,7 @@ module.exports = function(params) {
                 }
             });
     };
-    var copy_object = function(from_object, to_object, src_bucket, target_bucket, aws_access_key) {
+    var copy_object = function(from_object, to_object, src_bucket, target_bucket, access_key) {
         from_object = decodeURIComponent(from_object);
         var object_path = {
             bucket: src_bucket,
@@ -132,7 +132,7 @@ module.exports = function(params) {
         var create_params = {};
         var source_object_md;
         //read source object meta data. if doesn't exist, send error to the client.
-        return clients[aws_access_key].object_client.get_object_md(object_path)
+        return clients[access_key].object_client.get_object_md(object_path)
             .then(function(md) {
                 var target_object_path = {
                     bucket: target_bucket,
@@ -140,31 +140,31 @@ module.exports = function(params) {
                 };
                 source_object_md = md;
                 //check if target exists. if so, delete it (s3 overwrites objects)
-                return delete_if_exists(target_object_path, aws_access_key)
+                return delete_if_exists(target_object_path, access_key)
                     .then(function() {
                         //check if folder
                         if (source_object_md.size === 0) {
                             dbg.log0('Folder copy:', from_object, ' to ', to_object);
-                            list_objects_with_prefix(from_object, '/', src_bucket, aws_access_key)
+                            list_objects_with_prefix(from_object, '/', src_bucket, access_key)
                                 .then(function(objects_and_folders) {
                                     return Q.all(_.times(objects_and_folders.objects.length, function(i) {
                                         dbg.log0('copy inner objects:', objects_and_folders.objects[i].key, objects_and_folders.objects[i].key.replace(from_object, to_object));
                                         copy_object(objects_and_folders.objects[i].key,
                                             objects_and_folders.objects[i].key.replace(from_object, to_object),
-                                            src_bucket, target_bucket, aws_access_key);
+                                            src_bucket, target_bucket, access_key);
                                     })).then(function() {
                                         //                                dbg.log0('folders......',_.keys(objects_and_folders.folders));
                                         return Q.all(_.each(_.keys(objects_and_folders.folders), function(folder) {
                                             dbg.log0('copy inner folders:', folder, folder.replace(from_object, to_object));
                                             copy_object(folder, folder.replace(from_object, to_object),
-                                                src_bucket, target_bucket, aws_access_key);
+                                                src_bucket, target_bucket, access_key);
                                         }));
                                     });
                                 });
                         }
                         create_params.content_type = md.content_type;
                         create_params.size = md.size;
-                        return clients[aws_access_key].object.read_object_mappings({
+                        return clients[access_key].object.read_object_mappings({
                                 bucket: src_bucket,
                                 key: from_object,
                             })
@@ -191,13 +191,13 @@ module.exports = function(params) {
                                 create_params.bucket = target_bucket;
                                 create_params.key = to_object;
 
-                                return clients[aws_access_key].object.create_multipart_upload(create_params)
+                                return clients[access_key].object.create_multipart_upload(create_params)
                                     .then(function(info) {
-                                        return clients[aws_access_key].object.allocate_object_parts(new_obj_parts)
+                                        return clients[access_key].object.allocate_object_parts(new_obj_parts)
                                             .then(function(res) {
                                                 dbg.log0('complete multipart copy ', create_params);
                                                 var bucket_key_params = _.pick(create_params, 'bucket', 'key');
-                                                return clients[aws_access_key].object.complete_multipart_upload(bucket_key_params);
+                                                return clients[access_key].object.complete_multipart_upload(bucket_key_params);
                                             })
                                             .then(function(res) {
                                                 dbg.log0('COMPLETED: copy');
@@ -214,7 +214,7 @@ module.exports = function(params) {
             });
 
     };
-    var list_objects_with_prefix = function(prefix, delimiter, bucket_name, aws_access_key) {
+    var list_objects_with_prefix = function(prefix, delimiter, bucket_name, access_key) {
         var list_params = {
             bucket: bucket_name,
         };
@@ -226,8 +226,8 @@ module.exports = function(params) {
         if (delimiter) {
             delimiter = decodeURI(delimiter);
         }
-        dbg.log0('Listing objects with', list_params, delimiter,'key:',aws_access_key);
-        return clients[aws_access_key].object.list_objects(list_params)
+        dbg.log0('Listing objects with', list_params, delimiter, 'key:', access_key);
+        return clients[access_key].object.list_objects(list_params)
             .then(function(results) {
                 var i = 0;
                 var folders = {};
@@ -278,7 +278,7 @@ module.exports = function(params) {
 
     var uploadObject = function(req, res, file_key_name) {
         try {
-            var aws_access_key = extract_aws_access_key(req);
+            var access_key = extract_access_key(req);
             var md5 = 0;
             //
             // tranform stream that calculates md5 on-the-fly
@@ -290,7 +290,7 @@ module.exports = function(params) {
                 dbg.log3('MD5 data (end)', md5);
             });
 
-            return clients[aws_access_key].object_client.upload_stream({
+            return clients[access_key].object_client.upload_stream({
                 bucket: req.bucket,
                 key: file_key_name,
                 size: parseInt(req.headers['content-length']),
@@ -314,9 +314,9 @@ module.exports = function(params) {
         }
     };
 
-    var isBucketExists = function(bucketName, aws_access_key) {
-        dbg.log0('isBucketExists',bucketName,' key:',aws_access_key);
-        return clients[aws_access_key].bucket.list_buckets()
+    var isBucketExists = function(bucketName, access_key) {
+        dbg.log0('isBucketExists', bucketName, ' key:', access_key);
+        return clients[access_key].bucket.list_buckets()
             .then(function(reply) {
                 dbg.log3('trying to find', bucketName, 'in', reply.buckets);
                 if (_.findIndex(reply.buckets, {
@@ -337,37 +337,66 @@ module.exports = function(params) {
      * http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html
      */
     return {
-        is_system_client_exists: function(aws_access_key) {
-            Q.fcall(function() {
-                return _.has(clients, aws_access_key);
+        build_unauthorized_response: function(res, string_to_sign) {
+            var template = templateBuilder.buildSignatureDoesNotMatch(params.string_to_sign);
+            return buildXmlResponse(res, 401, template);
+        },
+        update_system_auth: function(access_key, params) {
+            return Q.fcall(function() {
+                if (clients[params.access_key].options.auth_token.indexOf('auth_token') > 0) {
+                    //update signature and string_to_sign
+                    //TODO: optimize this part. two converstions per request is a bit too much.
+
+                    var auth_token_obj = JSON.parse(clients[access_key].options.auth_token);
+                    auth_token_obj.signature = params.signature;
+                    auth_token_obj.string_to_sign = params.string_to_sign;
+                    clients[access_key].options.auth_token = JSON.stringify(auth_token_obj);
+
+                } else {
+                    params.auth_token = clients[params.access_key].options.auth_token;
+                    clients[access_key].options.auth_token = JSON.stringify(params);
+                }
+
+                dbg.log0('Update system auth', clients[access_key].options.auth_token);
+            });
+        },
+        is_system_client_exists: function(access_key) {
+            return Q.fcall(function() {
+                dbg.log0('check if system exists for key:', access_key, _.has(clients, access_key));
+                return _.has(clients, access_key);
             });
         },
         add_new_system_client: function(params) {
-            dbg.log0('add_new_system_client',params);
+            dbg.log0('add_new_system_client', params);
             return Q.fcall(function() {
-                if (_.isEmpty(params.aws_access_key)) {
+                if (_.isEmpty(params.access_key)) {
                     dbg.log0('Exiting as there is no credential information.');
                     throw new Error("No credentials");
 
                 } else {
                     dbg.log0('Adding new system client.', params);
-                    clients[params.aws_access_key] = new api.Client({
+                    clients[params.access_key] = new api.Client({
                         address: params.address,
                         bucket: params.bucket
                     });
-                    return clients[params.aws_access_key] ;
+                    return clients[params.access_key];
                 }
             }).then(function(new_client_system) {
-                dbg.log3('create auth',new_client_system);
-                return clients[params.aws_access_key].create_access_key_auth({
-                    'access_key': params.aws_access_key,
+                dbg.log3('create auth', new_client_system);
+                return clients[params.access_key].create_access_key_auth({
+                    'access_key': params.access_key,
                     'string_to_sign': params.string_to_sign,
                     'signature': params.signature,
                 });
-            }).then(function(token){
-                dbg.log0('Got Token:',token);
-            }).then(null,function(err){
-                dbg.error('failure while creating new client',err,err.stack);
+            }).then(function(token) {
+                dbg.log0('Got Token:', token);
+            }).then(null, function(err) {
+                dbg.error('failure while creating new client', err, err.stack);
+                //clients[params.access_key] =
+                throw {
+                    statusCode: 401,
+                    data: 'SignatureDoesNotMatch'
+                };
             });
         },
 
@@ -376,7 +405,7 @@ module.exports = function(params) {
          */
         bucketExists: function(req, res, next) {
             var bucketName = req.params.bucket;
-            isBucketExists(bucketName,extract_aws_access_key(req))
+            isBucketExists(bucketName, extract_access_key(req))
                 .then(function(exists) {
                     if (!exists) {
                         dbg.log0('(1) No bucket found for "%s"', bucketName);
@@ -398,29 +427,35 @@ module.exports = function(params) {
                 name: req.params.bucket,
                 creationDate: date
             }];
-            var aws_access_key = extract_aws_access_key(req);
-            dbg.log0('client2:::', aws_access_key, _.keys(clients));
+            var access_key = extract_access_key(req);
             var template;
 
-            return clients[aws_access_key].bucket.list_buckets()
+            clients[access_key].bucket.list_buckets()
                 .then(function(reply) {
-                    dbg.log0('list_buckets (A)', reply);
                     _.each(reply.buckets, function(bucket) {
                         bucket.creationDate = date;
                     });
                     dbg.log3('Fetched %d buckets', reply.buckets.length, ' b: ', reply.buckets);
                     var template = templateBuilder.buildBuckets(reply.buckets);
-                    dbg.log2('bucket response:', template);
+                    dbg.log3('bucket response:', template);
                     return buildXmlResponse(res, 200, template);
                 })
                 .then(null, function(err) {
-                    template = templateBuilder.buildBuckets({});
-                    dbg.log2('bucket response:', template);
-                    return buildXmlResponse(res, 200, template);
+                    dbg.error('Failed to get list of buckets',err);
+                    if (err.status) {
+                        if (err.status === 401) {
+                            template = templateBuilder.buildSignatureDoesNotMatch('');
+                            return buildXmlResponse(res, 401, template);
+                        } else {
+                            template = templateBuilder.buildBuckets({});
+                            return buildXmlResponse(res, err.status, template);
+                        }
 
+                    } else {
+                        template = templateBuilder.buildBuckets({});
+                        return buildXmlResponse(res, 500, template);
+                    }
                 });
-
-
         },
         getBucket: function(req, res) {
             var options = {
@@ -438,7 +473,7 @@ module.exports = function(params) {
 
             } else {
 
-                list_objects_with_prefix(options.prefix, options.delimiter, req.bucket, extract_aws_access_key(req))
+                list_objects_with_prefix(options.prefix, options.delimiter, req.bucket, extract_access_key(req))
                     .then(function(objects_and_folders) {
                         options.bucketName = req.bucket || params.bucket;
                         options.common_prefixes = _.isEmpty(objects_and_folders.folders) ? '' : _.keys(objects_and_folders.folders);
@@ -470,6 +505,19 @@ module.exports = function(params) {
                         dbg.log0('COMPLETED: list');
                     }).then(null, function(err) {
                         dbg.error('ERROR: list', err, err.stack, options);
+                        if (err.status) {
+                            if (err.status === 401) {
+                                template = templateBuilder.buildSignatureDoesNotMatch('');
+                                return buildXmlResponse(res, 401, template);
+                            } else {
+                                template = templateBuilder.buildBuckets({});
+                                return buildXmlResponse(res, err.status, template);
+                            }
+
+                        } else {
+                            template = templateBuilder.buildBuckets({});
+                            return buildXmlResponse(res, 500, template);
+                        }
                     });
             }
 
@@ -477,7 +525,7 @@ module.exports = function(params) {
         putBucket: function(req, res) {
             var bucketName = req.params.bucket;
             var template;
-            var aws_access_key = extract_aws_access_key(req);
+            var access_key = extract_access_key(req);
             /**
              * Derived from http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
              */
@@ -495,7 +543,7 @@ module.exports = function(params) {
                 return buildXmlResponse(res, 400, template);
             }
             Q.fcall(function() {
-                return isBucketExists(bucketName,extract_aws_access_key(req))
+                return isBucketExists(bucketName, extract_access_key(req))
                     .then(function(exists) {
                         if (exists) {
                             dbg.error('Error creating bucket. Bucket "%s" already exists', bucketName);
@@ -503,7 +551,7 @@ module.exports = function(params) {
                                 'The requested bucket already exists');
                             return buildXmlResponse(res, 409, template);
                         } else {
-                            clients[aws_access_key].bucket.create_bucket({
+                            clients[access_key].bucket.create_bucket({
                                     name: bucketName,
                                     tiering: ['nodes']
                                 })
@@ -538,7 +586,7 @@ module.exports = function(params) {
             var keyName = req.params.key;
             var acl = req.query.acl;
             var template;
-            var aws_access_key = extract_aws_access_key(req);
+            var access_key = extract_access_key(req);
             if (acl !== undefined) {
                 template = templateBuilder.buildAcl();
                 return buildXmlResponse(res, 200, template);
@@ -559,7 +607,7 @@ module.exports = function(params) {
                         key: keyName
                     };
                     dbg.log0('getObject', object_path, req.method);
-                    return clients[aws_access_key].object_client.get_object_md(object_path)
+                    return clients[access_key].object_client.get_object_md(object_path)
                         .then(function(object_md) {
                             var create_date = new Date(object_md.create_time);
                             create_date.setMilliseconds(0);
@@ -580,9 +628,9 @@ module.exports = function(params) {
                             } else {
                                 //read ranges
                                 if (req.header('range')) {
-                                    return clients[aws_access_key].object_client.serve_http_stream(req, res, object_path);
+                                    return clients[access_key].object_client.serve_http_stream(req, res, object_path);
                                 } else {
-                                    var stream = clients[aws_access_key].object_client.open_read_stream(object_path).pipe(res);
+                                    var stream = clients[access_key].object_client.open_read_stream(object_path).pipe(res);
 
                                 }
                             }
@@ -602,7 +650,7 @@ module.exports = function(params) {
                                 object_path.key = object_path.key + '/';
                             }
 
-                            return clients[aws_access_key].object_client.get_object_md(object_path)
+                            return clients[access_key].object_client.get_object_md(object_path)
                                 .then(function(object_md) {
                                     dbg.log3('obj_md2', object_md);
                                     var create_date = new Date(object_md.create_time);
@@ -615,7 +663,7 @@ module.exports = function(params) {
                                     if (req.method === 'HEAD') {
                                         return res.end();
                                     } else {
-                                        var stream = clients[aws_access_key].object_client.open_read_stream(object_path).pipe(res);
+                                        var stream = clients[access_key].object_client.open_read_stream(object_path).pipe(res);
                                     }
                                 }).then(null, function(err) {
                                     dbg.error('ERROR: while download from noobaa', err);
@@ -631,7 +679,7 @@ module.exports = function(params) {
             dbg.log0('put object');
             var template;
             var acl = req.query.acl;
-            var aws_access_key = extract_aws_access_key(req);
+            var access_key = extract_access_key(req);
             var delimiter = req.query.delimiter;
             if (acl !== undefined) {
                 template = templateBuilder.buildAcl();
@@ -662,7 +710,7 @@ module.exports = function(params) {
                 var srcBucket = srcObjectParams[0];
                 var srcObject = srcObjectParams.slice(1).join(delimiter);
                 dbg.log0('Attempt to copy object:', srcObject, ' from bucket:', srcBucket, ' to ', req.params.key, ' srcObjectParams: ', srcObjectParams, ' delimiter:', delimiter);
-                return isBucketExists(srcBucket,extract_aws_access_key(req))
+                return isBucketExists(srcBucket, extract_access_key(req))
                     .then(function(exists) {
                         if (!exists) {
                             dbg.error('No bucket found (2) for "%s"', srcBucket, delimiter, copy.indexOf(delimiter), copy.indexOf('/'), srcObjectParams, srcObject);
@@ -674,7 +722,7 @@ module.exports = function(params) {
                             return buildXmlResponse(res, 200, template);
                         } else {
                             copy_object(srcObject, req.params.key, srcBucket,
-                                    req.bucket, aws_access_key)
+                                    req.bucket, access_key)
                                 .then(function(is_copied) {
                                     if (is_copied) {
                                         template = templateBuilder.buildCopyObject(req.params.key);
@@ -705,7 +753,7 @@ module.exports = function(params) {
 
                 Q.fcall(function() {
                     dbg.log0('listing ', req.params.key, ' in bucket:', req.bucket);
-                    return clients[aws_access_key].object.list_objects({
+                    return clients[access_key].object.list_objects({
                         bucket: req.bucket,
                         key: file_key_name
                     });
@@ -718,7 +766,7 @@ module.exports = function(params) {
                         //the current implementation of list_objects returns list of objects with key
                         // that starts with the provided name. we will validate it.
                         if (obj_index >= 0) {
-                            return clients[aws_access_key].object.delete_object({
+                            return clients[access_key].object.delete_object({
                                 bucket: req.bucket,
                                 key: file_key_name
                             }).then(function() {
@@ -746,7 +794,7 @@ module.exports = function(params) {
         postMultipartObject: function(req, res) {
             Q.fcall(function() {
                 var template;
-                var aws_access_key = extract_aws_access_key(req);
+                var access_key = extract_access_key(req);
                 //init multipart upload
                 if (req.query.uploads === '') {
                     dbg.log0('Init Multipart', req.originalUrl);
@@ -765,7 +813,7 @@ module.exports = function(params) {
                         create_params.content_type = mime.lookup(key) || create_params.content_type;
                         dbg.log0('Init Multipart - create_multipart_upload - override mime ', create_params);
                     }
-                    return clients[aws_access_key].object.create_multipart_upload(create_params)
+                    return clients[access_key].object.create_multipart_upload(create_params)
                         .then(function(info) {
                             template = templateBuilder.buildInitiateMultipartUploadResult(req.params.key);
                             return buildXmlResponse(res, 200, template);
@@ -778,7 +826,7 @@ module.exports = function(params) {
                 //CompleteMultipartUpload
                 else if (!_.isUndefined(req.query.uploadId)) {
                     dbg.log0('request to complete ', req.query.uploadId);
-                    return clients[aws_access_key].object.complete_multipart_upload({
+                    return clients[access_key].object.complete_multipart_upload({
                         bucket: req.bucket,
                         key: replaceSpaces(req.query.uploadId),
                         fix_parts_size: true
@@ -807,9 +855,9 @@ module.exports = function(params) {
         deleteObject: function(req, res) {
             //this is also valid for the Abort Multipart Upload
             var key = req.params.key;
-            var aws_access_key = extract_aws_access_key(req);
+            var access_key = extract_access_key(req);
             Q.fcall(function() {
-                    return clients[aws_access_key].object.list_objects({
+                    return clients[access_key].object.list_objects({
                         bucket: req.bucket,
                         key: key
                     });
@@ -827,7 +875,7 @@ module.exports = function(params) {
                         dbg.log2('#' + i, obj.key, '\t', obj.info.size, 'bytes');
                         i++;
                     });
-                    return clients[aws_access_key].object.delete_object({
+                    return clients[access_key].object.delete_object({
                         bucket: req.bucket,
                         key: key
                     });

--- a/src/s3/s3rver_starter.js
+++ b/src/s3/s3rver_starter.js
@@ -24,11 +24,6 @@ Q.nfcall(fs.readFile, 'agent_conf.json')
         dbg.log0('cannot find configuration file. Using defaults.' + err);
         params = _.defaults(params, {
             address: 'http://localhost:5001',
-            email: 'demo@noobaa.com',
-            password: 'DeMo',
-            system: 'demo',
-            tier: 'nodes',
-            bucket: 'files',
             port: 80,
             ssl_port: 443,
         });

--- a/src/s3/s3rver_starter.js
+++ b/src/s3/s3rver_starter.js
@@ -29,8 +29,8 @@ Q.nfcall(fs.readFile, 'agent_conf.json')
             system: 'demo',
             tier: 'nodes',
             bucket: 'files',
-            port: 5005,
-            ssl_port: 5006,
+            port: 80,
+            ssl_port: 443,
         });
         return;
     }).then(function() {

--- a/src/s3/xml-template-builder.js
+++ b/src/s3/xml-template-builder.js
@@ -173,6 +173,23 @@ var xml = function() {
                 indent: '  '
             });
         },
+        buildSignatureDoesNotMatch: function(string_to_sign) {
+            return jstoxml.toXML({
+                Error: {
+                    Code: 'SignatureDoesNotMatch',
+                    Type: 'Sender',
+                    Message: 'The request signature we calculated does not match the signature you provided.'+
+                            ' Check your AWS Secret Access Key and signing method.'+
+                            'Consult the service documentation for details.The canonical string'+
+                            'for this request should have been '+'(no info)'+
+                            'The String - to - Sign should have been '+string_to_sign,
+                    RequestId: 1
+                }
+            }, {
+                header: true,
+                indent: ' '
+            });
+        },
         buildBucketNotEmpty: function(bucketName) {
             return jstoxml.toXML({
                 Error: {

--- a/src/s3/xml-template-builder.js
+++ b/src/s3/xml-template-builder.js
@@ -306,10 +306,10 @@ var xml = function() {
             }
 
         },
-        buildInitiateMultipartUploadResult: function(key) {
+        buildInitiateMultipartUploadResult: function(key,bucket) {
             return jstoxml.toXML({
                 InitiateMultipartUploadResult: {
-                    Bucket: 'files',
+                    Bucket: bucket,
                     Key: key,
                     UploadId: key
                 }

--- a/src/server/auth_server.js
+++ b/src/server/auth_server.js
@@ -187,17 +187,27 @@ function create_auth(req) {
     }
     /**
      *
-     * CREATE_AUTH
+     * CREATE_ACCESS_KEY_AUTH
      *
-     * authenticate and return an authorized token.
+     * Access and Secret key authentication.
      *
-     * the simplest usage is to send email & password, which will be verified
-     * to match the existing account, and will return an authorized token containing the account.
+     * We use it to authenticate requests from S3 REST server and Agents.
      *
-     * another usage is to get a system authorization by passing system_name.
-     * one option is to combine with email & password, and another is to call without
-     * email and password but with existing authorization token which contains
-     * a previously authenticated account.
+     * S3 REST requests
+     *
+     * The authorization header or query params includes the access key and
+     * a signature.The signature uses the secret key and a string that includes
+     * part of the request headers (string_to_sign).
+     * The REST server forwards this authorization information to the web server.
+     * The Server simply validate (by signing the string_to_sign and comparing
+     * to the provided signature).
+     * This allows us to avoid saving access key and secret key on the s3 rest.
+     * It also allows s3 rest server to serve more than one system.
+     *
+     * Agent
+     *
+     * The agent sends authorization information, we identify the system and
+     * returns token that will be used from now on (exactly like we used it before)
      *
      */
 function create_access_key_auth(req) {

--- a/src/server/auth_server.js
+++ b/src/server/auth_server.js
@@ -210,7 +210,6 @@ function create_access_key_auth(req) {
     var account;
     var system;
     var role;
-    dbg.log0('debdeb:',req.rpc_params);
     dbg.log3('create_access_key_auth', access_key, string_to_sign, signature);
     return Q.fcall(function() {
 
@@ -235,11 +234,11 @@ function create_access_key_auth(req) {
             }).then(function() {
                 var secret_key = _.result(_.find(system._doc.access_keys, 'access_key', access_key), 'secret_key');
                 var s3_signature = s3.sign(secret_key, string_to_sign);
-                dbg.log3('s3::: signature for access key:', access_key, 'string:', string_to_sign, ' is', s3_signature);
+                dbg.log3('signature for access key:', access_key, 'string:', string_to_sign, ' is', s3_signature);
                 if (signature === s3_signature) {
                     dbg.log3('s3 authentication test passed!!!');
                 } else {
-                    throw req.unauthorized('SignatureDoesNotMatch3');
+                    throw req.unauthorized('SignatureDoesNotMatch');
                 }
 
             }).then(function() {
@@ -330,7 +329,7 @@ function authorize(req, method_api) {
                         dbg.log3('Access key authentication (per request) test passed !!!');
                     } else {
                         dbg.error('Signature for access key:', auth_token_obj.access_key, 'computed:', s3_signature, 'expected:', auth_token_obj.signature);
-                        throw req.unauthorized('SignatureDoesNotMatch1');
+                        throw req.unauthorized('SignatureDoesNotMatch');
                     }
                 }
             });

--- a/src/server/auth_server.js
+++ b/src/server/auth_server.js
@@ -210,7 +210,7 @@ function create_access_key_auth(req) {
     var account;
     var system;
     var role;
-    dbg.log0('create_access_key_auth', access_key, string_to_sign, signature);
+    dbg.log3('create_access_key_auth', access_key, string_to_sign, signature);
     return Q.fcall(function() {
 
         // find system by name
@@ -225,7 +225,8 @@ function create_access_key_auth(req) {
             .exec()
             .then(function(system_arg) {
                 system = system_arg;
-                dbg.log0('system._doc.access_keys', system._doc.access_keys);
+                //TODO: replace _doc with a better valid path.
+                dbg.log3('system._doc.access_keys', system._doc.access_keys);
                 if (!system || system.deleted) {
                     throw req.unauthorized('system not found');
                 }
@@ -233,9 +234,9 @@ function create_access_key_auth(req) {
             }).then(function() {
                 var secret_key = _.result(_.find(system._doc.access_keys, 'access_key', access_key), 'secret_key');
                 var s3_signature = s3.sign(secret_key, string_to_sign);
-                dbg.log0('s3::: signature for access key:', access_key, 'string:', string_to_sign, ' is', s3_signature);
+                dbg.log3('s3::: signature for access key:', access_key, 'string:', string_to_sign, ' is', s3_signature);
                 if (signature === s3_signature) {
-                    dbg.log0('s3 authentication test passed!!!');
+                    dbg.log3('s3 authentication test passed!!!');
                 } else {
                     throw req.unauthorized('SignatureDoesNotMatch3');
                 }
@@ -419,7 +420,7 @@ function _prepare_auth_request(req) {
                     }
                     req.system = system;
                     req.role = req.auth.role;
-                    dbg.log3('load auth:', req.system);
+                    dbg.log3('load auth system:', req.system);
                 });
         });
     };

--- a/src/server/auth_server.js
+++ b/src/server/auth_server.js
@@ -210,6 +210,7 @@ function create_access_key_auth(req) {
     var account;
     var system;
     var role;
+    dbg.log0('debdeb:',req.rpc_params);
     dbg.log3('create_access_key_auth', access_key, string_to_sign, signature);
     return Q.fcall(function() {
 
@@ -246,7 +247,7 @@ function create_access_key_auth(req) {
                 var token = req.make_auth_token({
                     system_id: system && system.id,
                     role: 'admin',
-                    extra: req.rest_params.extra,
+                    extra: req.rpc_params.extra,
                 });
                 console.log('ACCESS TOKEN:', token);
                 return {

--- a/src/server/auth_server.js
+++ b/src/server/auth_server.js
@@ -316,7 +316,7 @@ function authorize(req, method_api) {
     }
 
     if (method_api.auth !== false) {
-        dbg.log0('authorize:', method_api.auth, method_api);
+        dbg.log3('authorize:', method_api.auth, method_api);
 
         return req.load_auth(method_api.auth)
             .then(function() {
@@ -332,10 +332,7 @@ function authorize(req, method_api) {
                     }
                 }
             });
-            // .then(null, function(err) {
-            //     dbg.error('Failure during s3 authentication', err, err.stack);
-            //     throw req.unauthorized('SignatureDoesNotMatch2');
-            // });
+
     }
 }
 
@@ -368,7 +365,7 @@ function _prepare_auth_request(req) {
         options = options || {};
 
         return Q.fcall(function() {
-            dbg.log0('options:', options, req.auth);
+            dbg.log3('options:', options, req.auth);
             // check that auth has account_id
             var ignore_missing_account = (options.account === false || _.isEmpty(options.account));
             if (!req.auth || !req.auth.account_id) {
@@ -422,7 +419,7 @@ function _prepare_auth_request(req) {
                     }
                     req.system = system;
                     req.role = req.auth.role;
-                    dbg.log0('load auth:', req.system);
+                    dbg.log3('load auth:', req.system);
                 });
         });
     };
@@ -455,7 +452,6 @@ function _prepare_auth_request(req) {
         if (options.expiry) {
             jwt_options.expiresInMinutes = options.expiry / 60;
         }
-        dbg.log0('tokenize:', auth);
         // create and return the signed token
         return jwt.sign(auth, process.env.JWT_SECRET, jwt_options);
     };

--- a/src/server/db/system.js
+++ b/src/server/db/system.js
@@ -28,6 +28,18 @@ var system_schema = new Schema({
         required: true,
     },
 
+    access_keys: [{
+        access_key : {
+            type: String,
+            required: true,
+        },
+        secret_key : {
+            type: String,
+            required: true,
+        }
+    }],
+
+
     // on delete set deletion time
     deleted: {
         type: Date,

--- a/src/server/node_server.js
+++ b/src/server/node_server.js
@@ -92,10 +92,13 @@ function create_node(req) {
                 event: 'node.create',
                 node: node,
             });
-
+            var account_id = '';
+            if (req.account){
+                account_id = req.account.id;
+            }
             // a token for the agent authorized to use the new node id.
             var token = req.make_auth_token({
-                account_id: req.account.id,
+                account_id: account_id,
                 system_id: req.system.id,
                 role: 'agent',
                 extra: {

--- a/src/server/system_server.js
+++ b/src/server/system_server.js
@@ -215,6 +215,7 @@ function read_system(req) {
 
             }),
             objects: objects_sys.count || 0,
+            access_keys: req.system.access_keys,
         };
     });
 }

--- a/src/server/system_server.js
+++ b/src/server/system_server.js
@@ -59,7 +59,7 @@ function create_system(req) {
                 }];
             } else {
                 info.access_keys = [{
-                    access_key: uuid.v4(),
+                    access_key: uuid.v4().replace(/-/g,'').substring(0,20),
                     secret_key: uuid.v4(),
                 }];
             }

--- a/src/server/system_server.js
+++ b/src/server/system_server.js
@@ -52,7 +52,7 @@ function create_system(req) {
 
     return Q.fcall(function() {
             var info = _.pick(req.rest_params, 'name');
-            if (info === 'demo') {
+            if (info.name === 'demo') {
                 info.access_keys = [{
                     access_key: '123',
                     secret_key: 'abc',

--- a/src/server/system_server.js
+++ b/src/server/system_server.js
@@ -13,6 +13,7 @@ var tier_server = require('./tier_server');
 var bucket_server = require('./bucket_server');
 var dbg = require('noobaa-util/debug_module')(__filename);
 var AWS = require('aws-sdk');
+var uuid = require('node-uuid');
 
 
 /**
@@ -51,7 +52,19 @@ function create_system(req) {
 
     return Q.fcall(function() {
             var info = _.pick(req.rest_params, 'name');
+            if (info === 'demo') {
+                info.access_keys = [{
+                    access_key: '123',
+                    secret_key: 'abc',
+                }];
+            } else {
+                info.access_keys = [{
+                    access_key: uuid.v4(),
+                    secret_key: uuid.v4(),
+                }];
+            }
             info.owner = req.account.id;
+
             return db.System.create(info);
         })
         .then(null, db.check_already_exists(req, 'system'))

--- a/src/util/s3_utils.js
+++ b/src/util/s3_utils.js
@@ -6,6 +6,10 @@ var Q = require('q');
 var dbg = require('noobaa-util/debug_module')(__filename);
 var s3_util = require('aws-sdk/lib/util');
 
+// The original s3 code doesn't work well with express and query string.
+// It expects to see query string as part of the request.path.
+// This is a copy of aws javascript sdk code, with minor modifications.
+
 module.exports = {
     noobaa_string_to_sign: noobaa_string_to_sign,
     canonicalizedResource: canonicalizedResource,
@@ -36,6 +40,7 @@ var subResources = {
     'website': 1
 };
 function canonicalizedResource (request) {
+    //handle path - modification on top of aws code.
     var r = request;
     var parts = r.url.split('?');
     var path = r.path;
@@ -59,6 +64,7 @@ function canonicalizedResource (request) {
                 var subresource = {
                     name: name
                 };
+                //another modification on top of aws code.
                 //fixed to isEmpty, instead of undefined comparison
                 if (!_.isEmpty(value)) {
                     if (subResources[name]) {
@@ -113,7 +119,7 @@ function noobaa_string_to_sign (request) {
     var r = request;
     var parts = [];
     parts.push(r.method);
-    //changed to lower case
+    //changed to lower case (on top of aws code)
     parts.push(r.headers['content-md5'] || '');
     parts.push(r.headers['content-type'] || '');
 
@@ -127,7 +133,6 @@ function noobaa_string_to_sign (request) {
     parts.push(canonicalizedResource(request));
 
     parts = parts.join('\n');
-    dbg.log('')
     return parts;
 
 }

--- a/src/util/s3_utils.js
+++ b/src/util/s3_utils.js
@@ -1,0 +1,133 @@
+// module targets: nodejs & browserify
+'use strict';
+
+var _ = require('lodash');
+var Q = require('q');
+var dbg = require('noobaa-util/debug_module')(__filename);
+var s3_util = require('aws-sdk/lib/util');
+
+module.exports = {
+    noobaa_string_to_sign: noobaa_string_to_sign,
+    canonicalizedResource: canonicalizedResource,
+    canonicalizedAmzHeaders: canonicalizedAmzHeaders
+};
+
+
+
+var subResources = {
+    'acl': 1,
+    'cors': 1,
+    'lifecycle': 1,
+    'delete': 1,
+    'location': 1,
+    'logging': 1,
+    'notification': 1,
+    'partNumber': 1,
+    'policy': 1,
+    'requestPayment': 1,
+    'restore': 1,
+    'tagging': 1,
+    'torrent': 1,
+    'uploadId': 1,
+    'uploads': 1,
+    'versionId': 1,
+    'versioning': 1,
+    'versions': 1,
+    'website': 1
+};
+function canonicalizedResource (request) {
+    var r = request;
+    var parts = r.url.split('?');
+    var path = r.path;
+    var querystring = parts[1];
+
+    var resource = '';
+
+    if (r.virtualHostedBucket)
+        resource += '/' + r.virtualHostedBucket;
+
+    resource += path;
+    if (querystring) {
+
+        // collect a list of sub resources and query params that need to be signed
+        var resources = [];
+
+        s3_util.arrayEach(querystring.split('&'), function(param) {
+            var name = param.split('=')[0];
+            var value = param.split('=')[1];
+            if (subResources[name]) {
+                var subresource = {
+                    name: name
+                };
+                //fixed to isEmpty, instead of undefined comparison
+                if (!_.isEmpty(value)) {
+                    if (subResources[name]) {
+                        subresource.value = value;
+                    } else {
+                        subresource.value = decodeURIComponent(value);
+                    }
+                }
+                resources.push(subresource);
+            }
+        });
+
+        resources.sort(function(a, b) {
+            return a.name < b.name ? -1 : 1;
+        });
+
+        if (resources.length) {
+            querystring = [];
+            s3_util.arrayEach(resources, function(res) {
+                if (res.value === undefined)
+                    querystring.push(res.name);
+                else
+                    querystring.push(res.name + '=' + res.value);
+            });
+
+            resource += '?' + querystring.join('&');
+        }
+
+    }
+    return resource;
+}
+function canonicalizedAmzHeaders (request) {
+    var amzHeaders = [];
+
+    s3_util.each(request.headers, function(name) {
+        if (name.match(/^x-amz-/i))
+            amzHeaders.push(name);
+    });
+
+    amzHeaders.sort(function(a, b) {
+        return a.toLowerCase() < b.toLowerCase() ? -1 : 1;
+    });
+
+    var parts = [];
+    s3_util.arrayEach( amzHeaders, function(name) {
+        parts.push(name.toLowerCase() + ':' + String(request.headers[name]));
+    });
+
+    return parts.join('\n');
+}
+function noobaa_string_to_sign (request) {
+    var r = request;
+    var parts = [];
+    parts.push(r.method);
+    //changed to lower case
+    parts.push(r.headers['content-md5'] || '');
+    parts.push(r.headers['content-type'] || '');
+
+    // This is the "Date" header, but we use X-Amz-Date.
+    // The S3 signing mechanism requires us to pass an empty
+    // string for this Date header regardless.
+    parts.push(r.headers['presigned-expires'] || '');
+
+    var headers = canonicalizedAmzHeaders(request);
+    if (headers) parts.push(headers);
+    parts.push(canonicalizedResource(request));
+
+    parts = parts.join('\n');
+    dbg.log('')
+    return parts;
+
+}

--- a/src/util/s3_utils.js
+++ b/src/util/s3_utils.js
@@ -126,7 +126,9 @@ function noobaa_string_to_sign (request) {
     // This is the "Date" header, but we use X-Amz-Date.
     // The S3 signing mechanism requires us to pass an empty
     // string for this Date header regardless.
-    parts.push(r.headers['presigned-expires'] || '');
+
+    //another noobaa addition - take into account signed urls
+    parts.push(r.headers['presigned-expires'] || ''||r.query.Expires);
 
     var headers = canonicalizedAmzHeaders(request);
     if (headers) parts.push(headers);


### PR DESCRIPTION
Currently Agent and browser uses access and secret key, similar to Amazon and Google. 

S3 REST uses it as well. It simply forward the details to the web server, that performs the actually verification. 

The SDK didn’t work well and required modification - done by adding s3_utils.

In order to use the keys, the agents should have "access_key" and "secret_key”in agent_conf.json 

TODO: revisit the need to download via stream instead of letting the
browser handle it. current implementation implements the same streaming download.
