### PR TITLE
Nimrod autobuild upgrade

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -261,6 +261,7 @@ gulp.task('jshint', function() {
 
 gulp.task('agent', ['jshint'], function() {
     var DEST = 'build/public';
+    var BUILD_DEST = 'build/windows';
     var NAME = 'noobaa-agent.tar';
 
     var pkg_stream = gulp
@@ -279,7 +280,15 @@ gulp.task('agent', ['jshint'], function() {
                         'font-awesome',
                         'bootstrap',
                         'animate.css',
-                        'video.js'
+                        'video.js',
+                        'heapdump',
+                        'atom-shell',
+                        'gulp',
+                        'browserify',
+                        'rebuild',
+                        'nodetime',
+                        'newrelic',
+                        'memwatch'
                     ], key);
             });
             return {
@@ -298,6 +307,11 @@ gulp.task('agent', ['jshint'], function() {
         });
     // TODO bring back uglify .pipe(gulp_uglify());
 
+    event_stream.pipe(gulp_rename(function(p) {
+            p.dirname = path.join('package', p.dirname);
+        }))
+        .pipe(gulp.dest(BUILD_DEST));
+
     return event_stream
         .merge(pkg_stream, src_stream)
         .pipe(gulp_rename(function(p) {
@@ -309,7 +323,7 @@ gulp.task('agent', ['jshint'], function() {
         .pipe(gulp.dest(DEST));
 });
 
-gulp.task('build_agent_distro', function() {
+gulp.task('build_agent_distro', ['agent'], function() {
     var build_script = child_process.spawn('src/deploy/build_atom_agent_win.sh', ['--access_key=123', '--secret_key=abc'], {
         cwd: process.cwd()
     });

--- a/src/deploy/NVA_build/README.md
+++ b/src/deploy/NVA_build/README.md
@@ -17,7 +17,9 @@ noobaa-core/deploy/NVA_build
 - version_check.js - simple http request to the SaaS werbserver for version verification
 - mongo.repo - mongodb repo definitions
 - create_vm - Create the NVA machine using the VirtualBox CLI
-- build_release.js - Node script which runs on our EC2 building server
+- build_release.js - Node script which runs on our EC2 building server.
+                     DEPRECATED & NOT COMPLETE.
+- build_package.sh - shell script runs on our EC2 building server.
 
 
 * ###NVA_Build (NooBaa Virtual Appliance):

--- a/src/deploy/NVA_build/README.md
+++ b/src/deploy/NVA_build/README.md
@@ -1,10 +1,63 @@
 noobaa-core/deploy/NVA_build
 ===========
 
-deploy_base.sh - The master script for the NVA image creation.
-noobaa_supervisor.conf - Supervisord configuration for the NVA services (mongodb, webserver etc.)
-supervisord.orig - /etc/rc.d script for supervisord.
-upgrade - upgrade flow which runs from the crontab
-version_check.js - simple http request to the SaaS werbserver for version verification
-mongo.repo - mongodb repo definitions
-create_vm - Create the NVA machine using the VirtualBox CLI
+###src/deploy/NVA_build Table of Contents:
+
+* [Files](#Files) - List of files and short description.
+* [NVA_Build](#NVA_Build) - NooBaa Virtual Appliance building procedure.
+* [UpgradePack_Build](#UpgradePack_Build) - Upgrade pack building procedure.
+
+
+* ###Files
+
+- deploy_base.sh - The master script for the NVA image creation.
+- noobaa_supervisor.conf - Supervisord configuration for the NVA services (mongodb, webserver etc.)
+- supervisord.orig - /etc/rc.d script for supervisord.
+- upgrade - upgrade flow which runs from the crontab
+- version_check.js - simple http request to the SaaS werbserver for version verification
+- mongo.repo - mongodb repo definitions
+- create_vm - Create the NVA machine using the VirtualBox CLI
+- build_release.js - Node script which runs on our EC2 building server
+
+
+* ###NVA_Build (NooBaa Virtual Appliance):
+
+- Build Procedure:
+  1) Importing a base CentOS image (.OVA file).
+  2) Running the following:
+      2.1) yum -y update
+      2.2) passwd -> current pass reverse change to roonoobaa
+  3) In the core repo dir, run gulp NVA_build.
+  4) SCP src/deploy/NVA_build/* and build/public/noobaa-NVA.tar.gz to the machine at /tmp
+  5) run /tmp/deploy_base runinstall
+  6) Once done, export the machine to a .OVA file
+
+  The created OVA file is the NVA which needs to be imported by the admin.
+  create_vm is a script which automates this procedure. However, there are currently issues with
+  the network after the initial import from the CentOS so it's not functional yet.
+
+- NVA description:
+  Our NVA is a CentOS based machine running the following components: Web Server, STUN/TURN, REST, MongoDB.
+  It does not contain the entire repo, just the extracted package created by the gulp target NVA_build
+  (for example, the agent code is not there). It does contain all the files needed to run these services, the agent
+  distribution pack and the package.json for dependency installation.
+
+  The services are being run and monitored by the supervisord mechanism (look at /etc/noobaa_supervisor.conf for the definitions).
+  A crontab job which runs one a day between 00:00 to 03:00 checks against the NooBaa SaaS web server if the current version
+  installed is the latest one. If not, it receives a reply with a URL to an S3 bucket in which the upgrade package can be found.
+  It then downloads it, unpacks it and restart the services. Currently this is done automatically, in the future we would need to
+  consider giving an offline upgrade and scheduled time frames upgrades options.
+
+* ###UpgradePack_Build Upgrade package building and publishing:
+
+  General Flow: SnapCI -> EC2 Building Server -> Upload to S3
+                                              -> Create a new release in GitHub in the noobaa-core repo
+
+  Building the Upgrade pack and publishing it to a S3 bucket is initiated by our noobaa-core repo pipeline in our CI
+  environment SnapCI. It's a manual stage after running the tests (meaning it has to be invoked manually and can be done either if the tests
+  passed or failed. Needless to say, it should be invoked if the test phase passed). Once the stage is invoked, it sends a ssh command
+  to the EC2 Building Server indicating the hashtag of the desired repo version.
+
+  The Building Server receives the request, clones the repo at the requested hashtag and builds the package. It also build the
+  agent distribution package (which is a part of the upgrade package). After the package is build, it is uploaded to
+  s3://noobaa-download/on_premise/v_<VERSION_NUMBER> and an appropriate VERSION_NUMBER release is created in GitHub.

--- a/src/deploy/NVA_build/build_package.js
+++ b/src/deploy/NVA_build/build_package.js
@@ -1,0 +1,135 @@
+/* jshint node:true */
+'use strict';
+
+var request = require('request');
+var child_proc = require('child_process');
+var Q = require('q');
+//var npm = require("npm");
+
+var args = process.argv.slice(2);
+var current_hash = args[0];
+var increment = args[1];
+
+console.log('Got args hash', current_hash, ' increment', increment);
+
+//Auth
+var username = 'noobaa-dep';
+var token = '92a46eb3c399aaafb250a04633a9c3ee64f2396d';
+
+//Exec consts
+var cd_command = 'cd C:\\Users\\Administrator\\Documents\\GitHub\\noobaa-core ';
+var git_command = '&& "C:\\Program Files (x86)\\Git\\bin\\git.exe" ';
+
+var failed = false;
+var current_version, next_version;
+
+function advance_version(current_version, increment) {
+    var current_version_parts = current_version.toString().split('.');
+    var increment_version_parts = increment.toString().split('.');
+    var output_version = '';
+
+    var len = Math.min(current_version_parts.length, increment_version_parts.length);
+
+    var new_part;
+    for (var i = 0; i < len; i++) {
+        //if current part of increment is not 0, increment
+        if (increment_version_parts[i] !== '0') {
+            new_part = parseInt(current_version_parts[i]) + parseInt(increment_version_parts[i]);
+        } else {
+            new_part = current_version_parts[i];
+        }
+        output_version += new_part + '.';
+    }
+
+    //went over common part, now add tails if there are
+    if (current_version_parts.length > increment_version_parts.length) {
+        for (var j1 = len; j1 < current_version_parts.length; ++j1) {
+            output_version += current_version_parts[j1] + '.';
+        }
+    }
+
+    if (current_version_parts.length < increment_version_parts.length) {
+        for (var j2 = len; j2 < increment_version_parts.length; ++j2) {
+            output_version += increment_version_parts[j2] + '.';
+        }
+    }
+
+    //remove tailing .
+    output_version = output_version.slice(0, -1);
+
+    return output_version;
+}
+
+function get_latest_release() {
+
+}
+
+//Assuming git config credential.helper store was called and password is not required anymore
+function create_branch(next_version) {
+    var git_flags, out;
+
+    git_flags = 'pull';
+    out = child_proc.execSync(cd_command + git_command + git_flags);
+    process.stdout.write(out);
+
+    git_flags = 'checkout -b build_release_v' + next_version + ' ' + current_hash;
+    out = child_proc.execSync(cd_command + git_command + git_flags);
+    process.stdout.write(out);
+}
+
+/*function build_package() {
+	npm.load(function (err) {
+	  // catch errors
+	  npm.commands.install(["ffi"], function (er, data) {
+		// log the error or data
+	  });
+	  npm.on("log", function (message) {
+		// log the progress of the installation
+		console.log(message);
+	  });
+	});
+}*/
+
+
+request({
+        url: 'https://api.github.com/repos/noobaa/noobaa-core/releases/latest',
+        headers: {
+            'User-Agent': 'request'
+        },
+        auth: {
+            user: username,
+            pass: token
+        },
+    },
+    function(err, res, body) {
+        if (!err && res.statusCode === 200) {
+            //Create new version
+            var info = JSON.parse(body);
+            current_version = parseFloat(info.tag_name.substr(info.tag_name.indexOf('v') + 1));
+            next_version = advance_version(current_version, increment);
+            console.log('Current version', current_version, 'Will release', next_version);
+
+            //Create a branch a build the package
+            create_branch(next_version);
+
+            //Build upgrade package
+            //build_package();
+            //upload_package();
+
+            //Create new release
+            //create_release();
+        } else {
+            process.exit(1);
+        }
+    });
+
+
+/*
+git checkout -b build_release_v${newver} ${commit}
+npm install
+gulp NVA_build
+
+
+#aws s3 cp C:\Users\Administrator\Documents\GitHub\noobaa-core\build\public\noobaa-NVA.tar.gz s3://noobaa-download/on_premise/v_${newver}
+#git branch -D build_release_v${newver}
+exit 0*/

--- a/src/deploy/NVA_build/build_package.js
+++ b/src/deploy/NVA_build/build_package.js
@@ -3,7 +3,7 @@
 
 var request = require('request');
 var child_proc = require('child_process');
-var Q = require('q');
+
 //var npm = require("npm");
 
 var args = process.argv.slice(2);
@@ -20,7 +20,6 @@ var token = '92a46eb3c399aaafb250a04633a9c3ee64f2396d';
 var cd_command = 'cd C:\\Users\\Administrator\\Documents\\GitHub\\noobaa-core ';
 var git_command = '&& "C:\\Program Files (x86)\\Git\\bin\\git.exe" ';
 
-var failed = false;
 var current_version, next_version;
 
 function advance_version(current_version, increment) {
@@ -60,9 +59,6 @@ function advance_version(current_version, increment) {
     return output_version;
 }
 
-function get_latest_release() {
-
-}
 
 //Assuming git config credential.helper store was called and password is not required anymore
 function create_branch(next_version) {
@@ -77,18 +73,16 @@ function create_branch(next_version) {
     process.stdout.write(out);
 }
 
-/*function build_package() {
-	npm.load(function (err) {
-	  // catch errors
-	  npm.commands.install(["ffi"], function (er, data) {
-		// log the error or data
-	  });
-	  npm.on("log", function (message) {
-		// log the progress of the installation
-		console.log(message);
-	  });
-	});
-}*/
+function build_package() {
+	var out;
+	var orig = 'C:\\Users\\Administrator\\Documents\\GitHub\\noobaa-core\\src\\deploy\\NVA_build\\env.orig';
+	var dest = 'C:\\Users\\Administrator\\Documents\\GitHub\\noobaa-core\\.env';
+	out = child_proc.execSync('copy ' + orig + ' ' + dest);
+	process.stdout.write(out);
+
+	out = child_proc.execSync(cd_command + ' && gulp NVA_build');
+	process.stdout.write(out);
+}
 
 
 request({
@@ -113,7 +107,7 @@ request({
             create_branch(next_version);
 
             //Build upgrade package
-            //build_package();
+            build_package();
             //upload_package();
 
             //Create new release

--- a/src/deploy/NVA_build/build_package.js
+++ b/src/deploy/NVA_build/build_package.js
@@ -1,3 +1,5 @@
+//Depricated and NOT COMPLETE
+
 /* jshint node:true */
 'use strict';
 

--- a/src/deploy/NVA_build/build_package.sh
+++ b/src/deploy/NVA_build/build_package.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#Globals
+G_USER="noobaa-dep"
+G_TOK="92a46eb3c399aaafb250a04633a9c3ee64f2396d"
+
+#Return next version according to
+#current = X.Y.Z , increment = X2.Y2.Z2, new = X+X2.Y+Y2.Z+Z2
+#output param $3
+function get_next_version {
+  #Getting latest release from GitHub
+  local tmp_release=`curl -u ${G_USER}:${G_TOK} https://api.github.com/repos/noobaa/noobaa-core/releases/latest | `
+  local current=`echo $tmp_release | sed 's:.*tag_name"\: "v\(.*\)", "target_com.*:\1:'`
+  local increment=${VER_INCREMENT}
+
+  local cur_array=(${current//./ })
+  local inc_array=(${increment//./ })
+
+  #turn current version into full X.Y.Z notation
+  if [ ${#inc_array[@]} -eq 1 ]; then
+          inc_array[1]=0
+          inc_array[2]=0
+  elif [ ${#inc_array[@]} -eq 2 ]; then
+          inc_array[2]=0
+  fi
+
+  #turn increment version into full X.Y.Z notation
+  if [ ${#cur_array[@]} -eq 1 ]; then
+          cur_array[1]=0
+          cur_array[2]=0
+  elif [ ${#cur_array[@]} -eq 2 ]; then
+          cur_array[2]=0
+  fi
+
+  #add versions
+  local new="$((cur_array[0]+inc_array[0])).$((cur_array[1]+inc_array[1])).$((cur_array[2]+inc_array[2]))"
+  eval "$3=$new"
+}
+
+function build_package() {
+  #Clone repo accordig to commit hash, npm install and build package
+  cd /git
+  git clone https://${G_USER}:${G_TOK}@github.com/noobaa/noobaa-core.git
+  git checkout ${COMMIT}
+  cd /git/noobaa-core
+  npm install
+  gulp NVA_build
+}
+
+function publish_package() {
+  local newver=$1
+  aws s3 cp /git/noobaa-core/build/public/noobaa-NVA.tar.gz s3://noobaa-download/on_premise/v_${newver}
+}
+
+function release() {
+  local version=$1
+  API_JSON=$(printf '{"tag_name": "v%s","target_commitish": "master","name": "v%s","body": "New Release","draft": false,"prerelease": false}' $version $version)
+  curl --data "$API_JSON" -u ${G_USER}:${G_TOK} https://api.github.com/repos/noobaa/noobaa-core/releases
+}
+
+function cleanup() {
+
+}
+
+if [ "$1" == "" ]; then
+  echo "No commit hash"
+  exit 1;
+fi
+
+COMMIT=$1
+VER_INCREMENT="0.1"
+
+if [ "$2" != "" ]; then
+  VER_INCREMENT=$2
+else
+  VER_INCREMENT="0.0.1"
+fi
+
+next_version=""
+get_next_version $CURRENT_RELEASE $VER_INCREMENT next_version #get next version
+build_package           #build package
+publish_package         #publish package to S3
+release ${next_version} #create release in github
+cleanup ${next_version}  #cleanup leftovers


### PR DESCRIPTION
Autobuild upgrade packs. 

Have a Amazon build server waiting to be invoked via our CI env. (Currently SnapCI). 
On invocation, clone and checkout to the desired commithash, build upgrade package (including the agent distro in it), publish to S3 (downloaded later by our NVAs) and create a new release on GitHub.
