### PR TITLE
Eran alpha updates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -234,6 +234,21 @@ function pack(dest, name) {
             p.dirname = path.join('images', p.dirname);
         }));
 
+    var node_modules_stream = gulp
+        .src(['node_modules/**/*',
+             '!node_modules/gulp*/**/*',
+             '!node_modules/heapdump/**/*',
+             '!node_modules/bower/**/*',
+             '!node_modules/bcrypt/**/*',
+             '!node_modules/node-inspector/**/*' ], {
+            base: 'node_modules'
+        })
+        .pipe(gulp_rename(function(p) {
+            p.dirname = path.join('node_modules', p.dirname);
+        }));
+
+
+
     var basejs_stream = gulp
         .src(['bower.json', 'config.js', 'gulpfile.js', '.jshintrc'], {});
 
@@ -258,7 +273,7 @@ function pack(dest, name) {
 
     return event_stream
         .merge(pkg_stream, src_stream, images_stream, basejs_stream,
-            vendor_stream, agent_distro, build_stream)
+            vendor_stream, agent_distro, build_stream,node_modules_stream)
         .pipe(gulp_rename(function(p) {
             p.dirname = path.join('noobaa-core', p.dirname);
         }))
@@ -412,11 +427,11 @@ gulp.task('build_agent_distro', ['agent'], function() {
     if (build_on_premise === true) {
         build_params = ['--on_premise'];
     } else {
-        build_params = ['--access_key=2ad3ecd3f066d6f881c9e3c2b7044412',
-            '--secret_key=e168c0557f5d973d50ccd437209d6ad6a4271a21aed8e4a18109bd5b4b04eecb',
-            '--system_id=5558c06d3aa4700e008f68ba',
-            '--system=nesstest',
-            '--address=wss://noobaa-alpha.herokuapp.com:443'
+        build_params = ['--access_key=2a6ea085b0a0977a7caa7a59b77a698d',
+            '--secret_key=c8d1d9f1b1f4b50c762aefb0d4f8cc81c235a67c046f16f835e2e01475041ec3',
+            '--system_id=5562f0a1a715e5b107c2744d',
+            '--system=bankhapoalim',
+            '--address=wss://52.28.110.142'
         ];
     }
 

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -70,7 +70,10 @@ function setup_repos {
 	# Setup Repos
 	cp -f ${CORE_DIR}/src/deploy/NVA_build/env.orig ${CORE_DIR}/.env
 	cd ${CORE_DIR}
-	$(npm install -dd >> ${LOG_FILE})
+	deploy_log "setup_repos before deleted npm install"
+
+	#$(npm install -dd >> ${LOG_FILE})
+	deploy_log "setup_repos after deleted npm install"
 
 	deploy_log "setting up crontab"
 	# Setup crontab job for upgrade checks

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -4,7 +4,7 @@
 
 function pre_upgrade {
   #yum install -y lsof
-  
+
   #fix iptables
   #TODO: CHECK if rules already exist, is so skip this part
   iptables -I INPUT 1 -i eth0 -p tcp --dport 443 -j ACCEPT
@@ -21,7 +21,20 @@ function pre_upgrade {
   echo "alias less='less -R'" >> ~/.bashrc
   echo "alias zless='zless -R'" >> ~/.bashrc
   echo "export GREP_OPTIONS='--color=auto'" >> ~/.bashrc
-
+  if grep -Fxq "* hard nofile" /etc/security/limits.conf
+  then
+      echo "hard limit already exists"
+  else
+      echo "* hard nofile 102400" >> /etc/security/limits.conf
+  fi
+  if grep -Fxq "* soft nofile" /etc/security/limits.conf
+  then
+      echo "soft limit already exists"
+  else
+      echo "* soft nofile 102400" >> /etc/security/limits.conf
+  fi
+  sysctl -w fs.file-max=102400
+  sysctl -p
 }
 
 function post_upgrade {

--- a/src/deploy/build_atom_agent_win.sh
+++ b/src/deploy/build_atom_agent_win.sh
@@ -171,6 +171,7 @@ if [ ${ON_PREMISE} -eq 0 ]; then
       mkdir ../public/systems/
       mkdir ../public/systems/$SYSTEM_ID/
       cp noobaa-setup.exe ../public/systems/$SYSTEM_ID/
+      exit 1
   else
       s3cmd -P put noobaa-setup.exe s3://noobaa-core/systems/$SYSTEM_ID/noobaa-setup.exe
   fi


### PR DESCRIPTION
1. added node_modules
2. added logic that brings back specific modules built on linux
   (heapdump and bcrypt)
3. added ulimit as part of the upgrade
4. set permissions for upgrade_wrapper.sh
5. remove npm install (temporary)
