### PR TITLE
quick and very dirty fix for s3 and web server separation

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -320,7 +320,13 @@ module.exports = {
                     item: {
                         $ref: '/system_api/definitions/access_keys'
                     }
-                }
+                },
+                ssl_port: {
+                    type: 'string'
+                },
+                web_port: {
+                    type: 'string'
+                },
             }
         },
 
@@ -378,7 +384,5 @@ module.exports = {
                 }
             }
         }
-
-
     }
 };

--- a/src/client/nb_console.js
+++ b/src/client/nb_console.js
@@ -205,7 +205,10 @@ nb_console.controller('OverviewCtrl', [
         function rest_server_information() {
             var scope = $scope.$new();
             scope.access_keys = nbSystem.system.access_keys;
-            scope.rest_endpoint = $window.location.host + '/s3';
+
+            var rest_host = ($window.location.host).replace(':'+nbSystem.system.web_port,'').replace(':'+nbSystem.system.ssl_port,':443');
+            console.log('SYS3:'+nbSystem.system.web_port+' host:'+rest_host);
+            scope.rest_endpoint = rest_host ;
             scope.bucket_name = $scope.nbSystem.system.buckets[0].name;
             scope.rest_package = download_rest_server_package;
             console.log('rest_server_information', scope.rest_package, scope.rest_endpoint);
@@ -504,7 +507,7 @@ nb_console.controller('BucketViewCtrl', [
                     return init_only ? nbSystem.init_system : nbSystem.reload_system();
                 })
                 .then(function() {
-                    nbFiles.set_access_keys(nbSystem.system.access_keys);
+                    nbFiles.set_access_keys(nbSystem.system.access_keys,nbSystem.system.web_port,nbSystem.system.ssl_port);
                     $scope.bucket = _.find(nbSystem.system.buckets, function(bucket) {
                         return bucket.name === $routeParams.bucket_name;
                     });
@@ -553,7 +556,10 @@ nb_console.controller('BucketViewCtrl', [
         function rest_server_information() {
             var scope = $scope.$new();
             scope.access_keys = nbSystem.system.access_keys;
-            scope.rest_endpoint = $window.location.host + '/s3';
+            var rest_host = ($window.location.host).replace(':'+nbSystem.system.web_port,'').replace(':'+nbSystem.system.ssl_port,':443');
+            console.log('SYS2:'+nbSystem.system.web_port+' host:'+rest_host);
+
+            scope.rest_endpoint = rest_host;
             scope.bucket_name =  $routeParams.bucket_name;
             scope.rest_package = download_rest_server_package;
             console.log('rest_server_information', scope.rest_package, scope.rest_endpoint);
@@ -634,7 +640,7 @@ nb_console.controller('FileViewCtrl', [
                     //Setting access keys.
                     //TODO: consider separation to other object with only the keys
                     //      also, check better solution in terms of security.
-                    nbFiles.set_access_keys(nbSystem.system.access_keys);
+                    nbFiles.set_access_keys(nbSystem.system.access_keys,nbSystem.system.web_port,nbSystem.system.ssl_port);
 
                     $scope.bucket = _.find(nbSystem.system.buckets, function(bucket) {
                         return bucket.name === $routeParams.bucket_name;

--- a/src/client/nb_nodes.js
+++ b/src/client/nb_nodes.js
@@ -188,19 +188,21 @@ nb_api.factory('nbNodes', [
                 bucket: 'files',
                 root_path: './agent_storage/'
             };
-            config_json.address = 'wss://noobaa.local';
+
+            config_json.address = 'wss://noobaa.local:'+nbSystem.system.ssl_port;
             config_json.system = nbSystem.system.name;
             config_json.access_key = nbSystem.system.access_keys[0].access_key;
             config_json.secret_key = nbSystem.system.access_keys[0].secret_key;
             var encodedData = $window.btoa(JSON.stringify(config_json));
             scope.encodedData = encodedData;
-            config_json.address = 'wss://'+$window.location.host;
+            var secured_host = ($window.location.host).replace(':'+nbSystem.system.web_port,':'+nbSystem.system.ssl_port);
+            config_json.address = 'wss://'+secured_host;
             encodedData = $window.btoa(JSON.stringify(config_json));
             scope.encodedDataIP = encodedData;
             scope.current_host = $window.location.host;
             scope.typeOptions = [
                     { name: 'Use noobaa.local', value: scope.encodedData },
-                    { name: 'Use '+$window.location.host, value: scope.encodedDataIP },
+                    { name: 'Use '+secured_host, value: scope.encodedDataIP },
                 ];
             console.log('type options',scope.typeOptions);
             scope.encoding = {type : scope.typeOptions[0].value};

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -139,6 +139,9 @@ function setup_mongo {
 function general_settings {
 	iptables -I INPUT 1 -i eth0 -p tcp --dport 443 -j ACCEPT
 	iptables -I INPUT 1 -i eth0 -p tcp --dport 80 -j ACCEPT
+	iptables -I INPUT 1 -i eth0 -p tcp --dport 8080 -j ACCEPT
+	iptables -I INPUT 1 -i eth0 -p tcp --dport 8443 -j ACCEPT
+
 	/sbin/iptables -A INPUT -m limit --limit 15/minute -j LOG --log-level 2 --log-prefix "Dropped by firewall: "
 	/sbin/iptables -A OUTPUT -m limit --limit 15/minute -j LOG --log-level 2 --log-prefix "Dropped by firewall: "
 	service iptables save

--- a/src/deploy/NVA_build/env.orig
+++ b/src/deploy/NVA_build/env.orig
@@ -1,8 +1,8 @@
 DEV_MODE=false
 DEBUG_MODE=false
 
-PORT=80
-SSL_PORT=443
+PORT=8080
+SSL_PORT=8443
 ON_PREMISE=true
 
 # address means the address of the server as reachable from the internet

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -16,3 +16,7 @@ autorestart=true
 [program:webserver]
 directory=/root/node_modules/noobaa-core
 command=/usr/local/bin/node src/server/web_server.js
+
+[program:s3rver]
+directory=/root/node_modules/noobaa-core
+command=/usr/local/bin/node src/s3/s3rver_starter.js

--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -31,6 +31,10 @@ function restart_webserver {
     ${SUPERCTL} restart webserver
 }
 
+function restart_s3rver {
+    ${SUPERCTL} restart s3rver
+}
+
 
 function check_latest_version {
   local current=$(grep CURRENT_VERSION $ENV_FILE | sed 's:.*=\(.*\):\1:')
@@ -98,6 +102,7 @@ function do_upgrade {
   #workaround - from some reason, without sleep + restart, the server starts with odd behavior
   #TODO: understand why and fix.
   sleep 5;
+  restart_s3rver
   restart_webserver
   deploy_log "Upgrade finished successfully!"
 }

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -30,7 +30,7 @@ var browser_ws = global.window && global.window.WebSocket;
 // in the browser we take the address as the host of the web page
 // just like any ajax request. for development we take localhost.
 // for any other case the RPC objects can set the base_address property.
-var DEFAULT_BASE_ADDRESS = 'ws://127.0.0.1:5001';
+var DEFAULT_BASE_ADDRESS = 'ws://127.0.0.1:'+process.env.web_port;
 if (browser_location) {
     if (browser_ws) {
         // use ws/s address

--- a/src/s3/controllers.js
+++ b/src/s3/controllers.js
@@ -844,7 +844,7 @@ module.exports = function(params) {
                     dbg.log0('Init Multipart', req.originalUrl);
                     var key = (req.originalUrl).replace('/' + req.bucket + '/', '');
                     //TODO:Replace with s3 rest param, initiated from the constructor
-                    key = key.replace('/s3', '');
+                    //key = key.replace('/s3', '');
                     key = key.substring(0, key.indexOf('?uploads'));
                     key = decodeURIComponent(key);
 

--- a/src/s3/s3rver.js
+++ b/src/s3/s3rver.js
@@ -54,10 +54,12 @@ Q.nfcall(fs.readFile, 'agent_conf.json')
     .then(function(certificate_arg) {
         certificate = certificate_arg;
 
-        app.use('/s3', s3app(params));
-        app.use('/', function(req, res) {
-            res.redirect('/s3');
-        });
+        app.use('/', s3app(params));
+
+        // app.use('/s3', s3app(params));
+        // app.use('/', function(req, res) {
+        //     res.redirect('/s3');
+        // });
 
         return Q.Promise(function(resolve, reject) {
             dbg.log0('Starting HTTP', params.port);

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -36,7 +36,7 @@ var express_compress = require('compression');
 var config = require('../../config.js');
 var dbg = require('noobaa-util/debug_module')(__filename);
 var mongoose_logger = require('noobaa-util/mongoose_logger');
-var s3app = require('../s3/app');
+//var s3app = require('../s3/app');
 var pem = require('../util/pem');
 var multer  = require('multer');
 var fs = require('fs');
@@ -185,7 +185,7 @@ Q.fcall(function() {
 // S3 APP //
 ////////////
 
-app.use('/s3', s3app({}));
+//app.use('/s3', s3app({}));
 
 ////////////
 // ROUTES //

--- a/src/util/s3_utils.js
+++ b/src/util/s3_utils.js
@@ -50,8 +50,8 @@ function canonicalizedResource(request) {
     //Quick patch - add prefix for REST routing on top of MD server
     //TODO: Replace with s3 rest param, initiated from the constructor
 
-    path = '/s3'+path;
-    parts[0] = '/s3' +parts[0];
+    // path = '/s3'+path;
+    // parts[0] = '/s3' +parts[0];
     var resource = '';
 
     if (r.virtualHostedBucket)


### PR DESCRIPTION
1. Due to a problem (that we should be able to solve) we need to click
   on the shield for upload/download from the UI (https->http).
2. Separate s3 and web server.
   a. Comment all irrelevant path (TODO: redirect from insecure to
   secure path).
   b. Added the option to create  agent_conf.json for s3 up on system
   creation (on premise only).
   c. add reservation of agent_con.json in case of upgrade.
   d. added supervisorctl entry for server
   e. updated all relevant paths in config information, s3 rest
   information, etc
   f. modified upgrade to support separated services.
   g. changed s3 sign (avoid s3 path)
   h. added iptable settings to allow 8080 and 8443
   i. changed default web port and web ssl port to 8080 and 8443.
   TODO: redirect from S3 main page to 8443?
   j.
