### PR TITLE
Add retries on agent start() failure

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -15,6 +15,7 @@ var Semaphore = require('noobaa-util/semaphore');
 var api = require('../api');
 var Agent = require('./agent');
 var fs_utils = require('../util/fs_utils');
+var promise_utils = require('../util/promise_utils');
 // var config = require('../../config.js');
 var dbg = require('noobaa-util/debug_module')(__filename);
 var child_process = require('child_process');
@@ -287,7 +288,7 @@ AgentCLI.prototype.start = function(node_name) {
     }
 
     return Q.fcall(function() {
-        return agent.start();
+        return promise_utils.retry(100, 1000, 1000, agent.start());
     }).then(function(res) {
         dbg.log0('agent started', node_name);
         return res;

--- a/src/util/promise_utils.js
+++ b/src/util/promise_utils.js
@@ -105,9 +105,10 @@ function loop(times, func) {
  *
  * @param attempts number of attempts. can be Infinity.
  * @param delay number of milliseconds between retries
+ * @param delay_increment numbner of milliseconds to add to delay after each retry
  * @param func with signature function(attempts), passing remaining attempts just fyi
  */
-function retry(attempts, delay, func) {
+function retry(attempts, delay, delay_increment, func) {
 
     // call func and catch errors,
     // passing remaining attempts just fyi
@@ -122,7 +123,7 @@ function retry(attempts, delay, func) {
 
             // delay and retry next attempt
             return Q.delay(delay).then(function() {
-                return retry(attempts, delay, func);
+                return retry(attempts, delay+delay_increment, delay_increment, func);
             });
 
         });


### PR DESCRIPTION
Add retries on agent start() failure. 100 retries, 1s delay with back of of 1s. 
To a total of 5050s (=> ~1.5h)
