### PR TITLE
Eran alpha updates

### DIFF
--- a/src/deploy/Linux/build_agent_linux.sh
+++ b/src/deploy/Linux/build_agent_linux.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#!/bin/sh
+# default - clean build
+CLEAN=true;
+#ON_PREMISE means that we are currently building the ON_PREMISE package
+#In this case, there is no point to create executable.
+#1 means building on-premise package
+ON_PREMISE=0
+#Upload to S3
+#1 means upload to S3
+UPLOAD_TO_S3=0
+
+
+#extract parms
+while [[ $# > 0 ]]; do
+  key=$(echo $1 | sed "s:\(.*\)=.*:\1:")
+  case $key in
+      --clean)
+      CLEAN=$(echo $1 | sed "s:.*=\(.*\):\1:")
+      ;;
+    --on_premise)
+      ON_PREMISE=1
+      ;;
+    --upload_to_s3)
+      UPLOAD_TO_S3=1
+      ;;
+    *)
+      usage
+      # unknown option
+      ;;
+  esac
+  shift
+done
+
+#TODO: automate - build and sign executable as well.
+
+if [ ${ON_PREMISE} -eq 1 ]; then
+    cd build/public/
+    s3cmd get --region eu-central-1 -f s3://noobaa-core/Alpha_v0.3.2/noobaa-setup ./noobaa-setup
+    echo "Done downloading noobaa-setup"
+else
+    if [ "$CLEAN" = true ] ; then
+        echo "delete old files"
+        rm -rf build/linux
+        mkdir build/linux
+        cd build/linux
+        echo "copy files"
+        cp ../../package.json ./package/
+        cp ../../config.js ./package/
+        mkdir ./package/src/
+        cp -R ../../src/agent ./package/src/
+        cp -R ../../src/util ./package/src/
+        cp -R ../../src/rpc ./package/src/
+        cp -R ../../src/api ./package/src/
+        #remove irrelevant packages
+        #TODO: create new package for that matter
+        cd package
+        echo "npm install"
+        sed -i '' '/gulp/d' package.json
+        sed -i '' '/bower/d' package.json
+        sed -i '' '/bootstrap/d' package.json
+        sed -i '' '/browserify"/d' package.json
+        sed -i '' '/rebuild/d' package.json
+        sed -i '' '/nodetime/d' package.json
+        sed -i '' '/newrelic/d' package.json
+        npm install -dd
+        cd ..
+        wget https://raw.githubusercontent.com/megastep/makeself/master/makeself-header.sh
+        wget https://raw.githubusercontent.com/megastep/makeself/master/makeself.sh
+        chmod 777 makeself.sh
+        #replace -- with /S in order to use exactly the same flags like windows.
+        sed -i s/'\--)'/'\/S)'/ makeself-header.sh
+
+        rm -rf ./node_modules/noobaa-util/node_modules/gulp*
+        rm -rf ./node_modules/noobaa-util/node_modules/node-gyp*/src ./config.js ./package.json ./agent_conf.json
+    else
+      cd build/linux
+    fi
+
+    echo "building installer"
+    cp noobaa_local_service.sh ./package/
+    mkdir ./dist
+    cp setup.sh ./dist/
+
+
+    ./makeself.sh ./package noobaa-installer 0.3.2 ./noobaa_local_service.sh
+    mv noobaa-installer ./dist/noobaa-installer
+    ./makeself.sh ./dist noobaa-setup 0.3.2 ./setup.sh
+
+    echo "noobaa-setup installer available under build/public/linux/"
+
+    if [ ${UPLOAD_TO_S3} -eq 1 ]; then
+        echo "uploading to S3"
+        s3cmd -P put noobaa-setup s3://noobaa-core/noobaa-setup
+    fi
+fi
+
+exit 0

--- a/src/deploy/Linux/noobaa_local_service.sh
+++ b/src/deploy/Linux/noobaa_local_service.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+function jsonval {
+    temp=`echo $json | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $prop`
+    echo ${temp##*|}
+}
+json=$(cat /usr/local/noobaa/agent_conf.json)
+prop='address'
+metadata_server_address=`jsonval`
+metadata_server_address=${metadata_server_address//wss/https}
+
+cd /usr/local/noobaa
+#cleanup of older setup
+rm -f noobaa-setup
+
+./node src/agent/agent_cli.js
+if [[ $? -eq 0 ]]; then
+   #upgrade
+   wget -t 2 --no-check-certificate $metadata_server_address/public/noobaa-setup
+   echo "Upgrading ..."
+   if [ ! -f ./noobaa-setup ]; then
+       echo "Failed to download upgrade package"
+   else
+       noobaa-setup
+   fi
+else
+   echo "Agent exited with error" $?
+fi

--- a/src/deploy/Linux/setup.sh
+++ b/src/deploy/Linux/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+CONFIG=false
+#if we have the folder and agent_conf.json, we will assume upgrade. Need to revisit in the future.
+
+if [ ! -d "/noobaa" ]; then
+   if [[ $# -lt 2 ]]; then
+  	echo "usage: noobaa-setup /S /Config <configuration string>"
+ 	exit 1
+    else
+       CONFIG=$2
+       mkdir /usr/local/noobaa
+       echo "config is:" ${CONFIG}
+       openssl enc -base64 -d -A <<<${CONFIG} >/usr/local/noobaa/agent_conf.json
+    fi
+else
+   if [ ! -f /usr/local/noobaa/agent_conf.json ]; then
+      #if we don't have the config, cleanup
+      rm -rf /usr/local/noobaa
+      echo "usage: noobaa-setup /S /Config <configuration string>"
+      exit 1
+   fi
+fi
+
+./noobaa-installer --keep --target /usr/local/noobaa

--- a/src/deploy/gcloud.js
+++ b/src/deploy/gcloud.js
@@ -533,7 +533,7 @@ function add_region_instances(region_name, count, is_docker_host, number_of_dock
                             machineType: machine_type,
                             disks: [{
                                 initializeParams: {
-                                    diskSizeGb: 20,
+                                    diskSizeGb: 50,
                                     //sourceImage:'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-trusty-14.04-amd64-server-20140927'
                                     sourceImage: source_image
                                 },


### PR DESCRIPTION
cloud hd size increased

First linux version. Not fully tested. tested on CentOS 6.6, Redhat 6 and
Ubuntu 14. Built on CentOS 6.6.

High level steps:

we use makeself, that creates self extractable binary that run on
redhead, centos, ubuntu.

in order to align it with windows, we replace its embedded script flags
with ‘/S’.

we create two installers:

1) Internal - includes the code + modules + noobaa_local_service.sh
(that actually run agent_cli).
2) noobaa-setup - Looks for /S /config <configuration> and run the
inner installer with —keep —target /usr/local/noobaa

NOTE: build script shouldn’t work (just includes the manual steps, but
no QA for this one).
