### PR TITLE
Nimrod Pools Mirror

### DIFF
--- a/src/server/object_mapper.js
+++ b/src/server/object_mapper.js
@@ -34,7 +34,7 @@ var P = require('../util/promise');
 var db = require('./db');
 var server_rpc = require('./server_rpc').server_rpc;
 var object_utils = require('./utils/object_mapper_utils');
-var block_allocator = require('./block_allocator');
+var policy_allocation = require('./utils/policy_allocation');
 var range_utils = require('../util/range_utils');
 var string_utils = require('../util/string_utils');
 var dbg = require('../util/debug_module')(__filename);
@@ -116,7 +116,7 @@ function allocate_object_parts(bucket, obj, parts) {
             var blocks_by_chunk_id = _.groupBy(blocks, 'chunk');
             _.each(digest_to_dup_chunk, function(chunk) {
                 chunk.all_blocks = blocks_by_chunk_id[chunk._id];
-                chunk.chunk_status = object_utils.analyze_chunk_status(chunk, chunk.all_blocks);
+                chunk.chunk_status = policy_allocation.analyze_chunk_status(chunk, chunk.all_blocks);
             });
             remove_parts = _.remove(existing_parts, function(existing_part) {
                 var chunk = existing_part.chunk;
@@ -124,7 +124,7 @@ function allocate_object_parts(bucket, obj, parts) {
                     return true; // remove it
                 }
                 chunk.all_blocks = blocks_by_chunk_id[chunk._id];
-                chunk.chunk_status = object_utils.analyze_chunk_status(chunk, chunk.all_blocks);
+                chunk.chunk_status = policy_allocation.analyze_chunk_status(chunk, chunk.all_blocks);
             });
 
             return P.map(parts, function(part, i) {
@@ -1006,7 +1006,7 @@ function chunks_and_objects_count(systemid) {
 // UTILS //////////////////////////////////////////////////////////
 
 function get_part_info(params) {
-    var chunk_status = object_utils.analyze_chunk_status(params.chunk, params.blocks);
+    var chunk_status = policy_allocation.analyze_chunk_status(params.chunk, params.blocks);
     var p = _.pick(params.part, 'start', 'end');
 
     p.chunk = _.pick(params.chunk,

--- a/src/server/utils/object_mapper_utils.js
+++ b/src/server/utils/object_mapper_utils.js
@@ -2,14 +2,13 @@
 
 module.exports = {
     build_chunks: build_chunks,
-    analyze_chunk_status: analyze_chunk_status,
     get_block_md: get_block_md,
 };
 
 var _ = require('lodash');
 var P = require('../../util/promise');
 var db = require('../db');
-var block_allocator = require('../block_allocator');
+var policy_allocation = require('./policy_allocation');
 var server_rpc = require('../server_rpc').server_rpc;
 var promise_utils = require('../../util/promise_utils');
 var js_utils = require('../../util/js_utils');
@@ -81,7 +80,7 @@ function build_chunks(chunks) {
             var blocks_to_remove = [];
             chunks_status = _.map(chunks, function(chunk) {
                 var chunk_blocks = blocks_by_chunk[chunk._id];
-                var chunk_status = analyze_chunk_status(chunk, chunk_blocks);
+                var chunk_status = policy_allocation.analyze_chunk_status(chunk, chunk_blocks);
                 js_utils.array_push_all(blocks_to_remove, chunk_status.blocks_to_remove);
                 return chunk_status;
             });
@@ -278,154 +277,10 @@ function build_chunks(chunks) {
         });
 }
 
-/**
- *
- * analyze_chunk_status
- *
- * compute the status in terms of availability
- * of the chunk blocks per fragment and as a whole.
- *
- */
-function analyze_chunk_status(chunk, all_blocks) {
-    var now = Date.now();
-    var blocks_by_frag_key = _.groupBy(all_blocks, get_frag_key);
-    var blocks_info_to_allocate;
-    var blocks_to_remove;
-    var chunk_health = 'available';
-
-    // TODO loop over parity fragments too
-    var frags = _.times(chunk.data_frags, function(frag) {
-
-        var fragment = {
-            layer: 'D',
-            frag: frag,
-        };
-
-        fragment.blocks = blocks_by_frag_key[get_frag_key(fragment)] || [];
-
-        // sorting the blocks by last node heartbeat time and by srvmode and building,
-        // so that reading will be served by most available node.
-        // TODO better randomize order of blocks for some time frame
-        // TODO need stable sorting here for parallel decision making...
-        fragment.blocks.sort(block_access_sort);
-
-        dbg.log1('analyze_chunk_status:', 'chunk', chunk._id,
-            'fragment', frag, 'num blocks', fragment.blocks.length);
-
-        _.each(fragment.blocks, function(block) {
-            var since_hb = now - block.node.heartbeat.getTime();
-            if (since_hb > config.LONG_GONE_THRESHOLD || block.node.srvmode === 'disabled') {
-                return js_utils.named_array_push(fragment, 'long_gone_blocks', block);
-            }
-            if (since_hb > config.SHORT_GONE_THRESHOLD) {
-                return js_utils.named_array_push(fragment, 'short_gone_blocks', block);
-            }
-            if (block.building) {
-                var since_bld = now - block.building.getTime();
-                if (since_bld > config.LONG_BUILD_THRESHOLD) {
-                    return js_utils.named_array_push(fragment, 'long_building_blocks', block);
-                } else {
-                    return js_utils.named_array_push(fragment, 'building_blocks', block);
-                }
-            }
-            if (!block.node.srvmode) {
-                js_utils.named_array_push(fragment, 'good_blocks', block);
-            }
-            // also keep list of blocks that we can use to replicate from
-            if (!block.node.srvmode || block.node.srvmode === 'decommissioning') {
-                js_utils.named_array_push(fragment, 'accessible_blocks', block);
-            }
-        });
-
-        var num_accessible_blocks = fragment.accessible_blocks ?
-            fragment.accessible_blocks.length : 0;
-        var num_good_blocks = fragment.good_blocks ?
-            fragment.good_blocks.length : 0;
-
-        if (!num_accessible_blocks) {
-            fragment.health = 'unavailable';
-            chunk_health = 'unavailable';
-        }
-
-        if (num_good_blocks > config.OPTIMAL_REPLICAS) {
-            blocks_to_remove = blocks_to_remove || [];
-
-            // remove all blocks that were building for too long
-            // as they most likely failed to build.
-            js_utils.array_push_all(blocks_to_remove, fragment.long_building_blocks);
-
-            // remove all long gone blocks
-            // defer the short gone blocks until either back to good or become long.
-            js_utils.array_push_all(blocks_to_remove, fragment.long_gone_blocks);
-
-            // remove extra good blocks when good blocks are above optimal
-            // and not just accesible blocks are above optimal
-            js_utils.array_push_all(blocks_to_remove, fragment.good_blocks.slice(config.OPTIMAL_REPLICAS));
-        }
-
-        if (num_good_blocks < config.OPTIMAL_REPLICAS && num_accessible_blocks) {
-            fragment.health = 'repairing';
-
-            // will allocate blocks for fragment to reach optimal count
-            blocks_info_to_allocate = blocks_info_to_allocate || [];
-            var round_rob = 0;
-            var num_blocks_to_add = Math.max(0, config.OPTIMAL_REPLICAS - num_good_blocks);
-            _.times(num_blocks_to_add, function() {
-                blocks_info_to_allocate.push({
-                    system_id: chunk.system,
-                    tier_id: chunk.tier,
-                    chunk_id: chunk._id,
-                    chunk: chunk,
-                    layer: 'D',
-                    frag: frag,
-                    source: fragment.accessible_blocks[
-                        round_rob % fragment.accessible_blocks.length]
-                });
-                round_rob += 1;
-            });
-        }
-
-        fragment.health = fragment.health || 'healthy';
-
-        return fragment;
-    });
-
-    return {
-        chunk: chunk,
-        all_blocks: all_blocks,
-        frags: frags,
-        blocks_info_to_allocate: blocks_info_to_allocate,
-        blocks_to_remove: blocks_to_remove,
-        chunk_health: chunk_health,
-    };
-}
 
 function get_block_md(block) {
     var b = _.pick(block, 'size', 'digest_type', 'digest_b64');
     b.id = block._id.toString();
     b.address = block.node.rpc_address;
     return b;
-}
-
-/**
- * sorting function for sorting blocks with most recent heartbeat first
- */
-function block_access_sort(block1, block2) {
-    if (block1.building) {
-        return 1;
-    }
-    if (block2.building) {
-        return -1;
-    }
-    if (block1.node.srvmode) {
-        return 1;
-    }
-    if (block2.node.srvmode) {
-        return -1;
-    }
-    return block2.node.heartbeat.getTime() - block1.node.heartbeat.getTime();
-}
-
-function get_frag_key(f) {
-    return f.layer + '-' + f.frag;
 }


### PR DESCRIPTION
Add the tiering policy object.
Aware of the tiering policy and the distribution policy per each tier, works with the block allocator to allocate on the needed pools (be that different tiers or mirrored pools), used by the object_mapper (and object_mapper_utils).
