### PR TITLE
fix 3 read path bugs with large files (writes were not affected)

### DIFF
--- a/src/server/object_mapper.js
+++ b/src/server/object_mapper.js
@@ -1089,8 +1089,8 @@ function sanitize_object_range(obj, start, end) {
         end = obj.size;
     }
     // force integers
-    start = start | 0;
-    end = end | 0;
+    start = Math.floor(start);
+    end = Math.floor(end);
     // force positive
     if (start < 0) {
         start = 0;

--- a/src/test/nbcat.js
+++ b/src/test/nbcat.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var api = require('../api');
+var dbg = require('../util/debug_module')(__filename);
+dbg.set_level(5);
+
+var bkt = process.argv[2];
+var key = process.argv[3];
+var start = parseInt(process.argv[4], 10) || 0;
+var end = parseInt(process.argv[5], 10) || Infinity;
+var output = process.stderr;
+
+if (!bkt) {
+    init_api().then(function() {
+        return api.client.bucket.list_buckets();
+    }).then(function(res) {
+        output.write('\nLIST BUCKETS:\n\n');
+        res.buckets.forEach(function(bucket) {
+            output.write('> ' + bucket.name + '\n');
+        });
+        output.write('\n---\n\n');
+        api.rpc.disconnect_all();
+    });
+} else if (!key) {
+    init_api().then(function() {
+        return api.client.object.list_objects({
+            bucket: bkt
+        });
+    }).then(function(res) {
+        output.write('\nLIST OBJECTS:\n\n');
+        res.objects.forEach(function(obj) {
+            output.write('> ' + obj.key + ' ' + JSON.stringify(obj.info) + '\n');
+        });
+        output.write('\n---\n\n');
+        api.rpc.disconnect_all();
+    });
+} else {
+    init_api().then(function() {
+        return api.client.object_driver_lazy().open_read_stream({
+            bucket: bkt,
+            key: key,
+            start: start,
+            end: end
+        })
+        .on('end', function() {
+            api.rpc.disconnect_all();
+        })
+        .pipe(output);
+    });
+}
+
+
+function init_api() {
+    api.client = new api.Client();
+    api.rpc.base_address = 'ws://127.0.0.1:5001';
+    // api.rpc.register_n2n_transport();
+    return api.client.create_auth_token({
+        email: 'demo@noobaa.com',
+        password: 'DeMo',
+        system: 'demo',
+    });
+}

--- a/src/util/range_utils.js
+++ b/src/util/range_utils.js
@@ -5,9 +5,9 @@ var size_utils = require('./size_utils');
 
 module.exports = {
     intersection: intersection,
-    align_down_bitwise: align_down_bitwise,
-    align_up_bitwise: align_up_bitwise,
-    truncate_range_end_to_boundary_bitwise: truncate_range_end_to_boundary_bitwise,
+    align_down: align_down,
+    align_up: align_up,
+    truncate_range_end_to_boundary: truncate_range_end_to_boundary,
     human_range: human_range,
 };
 
@@ -26,30 +26,29 @@ function intersection(start1, end1, start2, end2) {
 
 
 /**
- * align the given offset down with boundary 1<<nbits
+ * align the given offset down with boundary
+ * NOTE! cannot use javascript bitwise on offsets as it is limited to 32bits
  */
-function align_down_bitwise(offset, nbits) {
-    var mask_up = ((~0) >>> nbits << nbits);
-    return offset & mask_up;
+function align_down(offset, boundary) {
+    return offset - (offset % boundary);
 }
 
 
 /**
- * align the given offset up with boundary 1<<nbits
+ * align the given offset up with boundary
+ * NOTE! cannot use javascript bitwise on offsets as it is limited to 32bits
  */
-function align_up_bitwise(offset, nbits) {
-    var mask_up = ((~0) >>> nbits << nbits);
-    var size = (1 << nbits);
-    return (offset + size - 1) & mask_up;
+function align_up(offset, boundary) {
+    return align_down(offset + boundary - 1, boundary);
 }
 
 
 /**
- * return the end of the range aligned down to the closest boundary of 1<<nbits
+ * return the end of the range aligned down to the closest boundary
  * but only if such boundary exists between start and end.
  */
-function truncate_range_end_to_boundary_bitwise(start, end, nbits) {
-    var new_end = align_down_bitwise(end, nbits);
+function truncate_range_end_to_boundary(start, end, boundary) {
+    var new_end = align_down(end, boundary);
     return (new_end > start) ? new_end : end;
 }
 


### PR DESCRIPTION
1. Incorrect end offset used for buffer slicing in
   combine_parts_buffers_in_range caused nodes buffer to return a 0 length
   buffer (weird behavior that was fixed in newer nodes versions)
2. Implementing offset alignment cannot use javascript bitwise which is
   limited to 32bits.
3. Mapper sanity used bitwise on offsets to make sure they are integers
   and have no fraction (just paranoia I guess).
