### PR TITLE
Fix n2n wrong connection url used on signal

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -341,7 +341,7 @@ AgentCLI.prototype.list = function() {
     var i = 1;
     _.each(self.agents, function(agent, node_name) {
         dbg.log0('#' + i, agent.is_started ? '<ok>' : '<STOPPED>',
-            'node', node_name, 'port', agent.http_port);
+            'node', node_name, 'address', agent.rpc_address);
         i++;
     });
 };

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -103,8 +103,14 @@ module.exports = {
             param_raw: 'data',
             params: {
                 type: 'object',
-                required: ['response_length'],
+                required: ['source', 'target', 'response_length'],
                 properties: {
+                    source: {
+                        type: 'string'
+                    },
+                    target: {
+                        type: 'string'
+                    },
                     response_length: {
                         type: 'integer'
                     },
@@ -128,8 +134,11 @@ module.exports = {
             method: 'POST',
             params: {
                 type: 'object',
-                required: ['target', 'request_length', 'response_length'],
+                required: ['source', 'target', 'request_length', 'response_length'],
                 properties: {
+                    source: {
+                        type: 'string'
+                    },
                     target: {
                         type: 'string'
                     },

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -304,7 +304,7 @@ module.exports = {
             },
             reply: {
                 type: 'object',
-                required: [ 'version', 'delay_ms'],
+                required: ['version', 'delay_ms'],
                 properties: {
                     auth_token: {
                         // auth token will only be sent back if new node was created
@@ -520,6 +520,9 @@ module.exports = {
             type: 'object',
             required: ['target', 'method_api', 'method_name'],
             properties: {
+                source: {
+                    type: 'string'
+                },
                 target: {
                     type: 'string'
                 },

--- a/src/bg_workers/redirector.js
+++ b/src/bg_workers/redirector.js
@@ -13,7 +13,7 @@ var bg_workers_rpc = require('./bg_workers_rpc').bg_workers_rpc;
 var dbg = require('../util/debug_module')(__filename);
 
 var REGISTERED_AGENTS = {
-    agents2srvs: {},
+    agents2srvs: new Map(),
 };
 
 /*
@@ -24,7 +24,7 @@ function redirect(req) {
 
     //Remove the leading n2n:// prefix from the address
     var target_agent = req.rpc_params.target.slice(6);
-    var entry = REGISTERED_AGENTS.agents2srvs[target_agent];
+    var entry = REGISTERED_AGENTS.agents2srvs.get(target_agent);
     if (entry) {
         dbg.log3('redirect found entry', entry);
         return P.when(bg_workers_rpc.client.node.redirect(req.rpc_params, {
@@ -39,24 +39,14 @@ function register_agent(req) {
     dbg.log2('Registering agent', req.rpc_params.peer_id, 'with server', req.connection.url.href);
 
     var agent = req.rpc_params.peer_id;
-    var entry = REGISTERED_AGENTS.agents2srvs[agent];
+    var entry = REGISTERED_AGENTS.agents2srvs.get(agent);
     if (entry) {
-        //Update data
-        REGISTERED_AGENTS.agents2srvs[agent] = {
+        // Update data
+        REGISTERED_AGENTS.agents2srvs.set(agent, {
             server: req.connection.url.href,
-        };
+        });
     } else {
-        REGISTERED_AGENTS.agents2srvs[agent] = {
-            server: req.connection.url.href,
-        };
-
-        //Save agent on connection for quick cleanup on close,
-        //Register on close handler to clean the agents form the agents2srvs map
-        if (!req.connection.agents) {
-            req.connection.agents = [];
-            req.connection.on('close', cleanup_on_close.bind(undefined, req.connection));
-        }
-        req.connection.agents.push(agent);
+        add_agent_to_connection(req.connection, agent);
     }
     return;
 }
@@ -65,39 +55,71 @@ function unregister_agent(req) {
     dbg.log2('Un-registering agent', req.rpc_params.peer_id, 'with server', req.connection.url);
 
     var agent = req.rpc_params.peer_id;
-    var entry = REGISTERED_AGENTS.agents2srvs[agent];
-    if (entry) {
-        if (req.connection.url === entry.server) {
-            //Remove agent
-            delete REGISTERED_AGENTS.agents2srvs[agent];
-        } else {
-            dbg.log0('Error: recieved unregister for', agent, 'on connection to', req.connection.url,
-                'while previously registered on', entry.server, ', ignoring');
-        }
-    }
-    return;
+    remove_agent_from_connection(req.connection, agent);
 }
 
 function resync_agents(req) {
-    dbg.log2('resync_agents of #', req.rpc_params.agents.length, 'agents with server', req.connection.url);
+    dbg.log0('resync_agents of #', req.rpc_params.agents.length,
+        'agents with server', req.connection.url.href,
+        'request timestamp', req.rpc_params.timestamp,
+        'last_resync', req.connection.last_resync);
+
     if (req.connection.last_resync &&
-        req.connection.last_resync < req.rpc_params.timestamp) {
-        cleanup_on_close(req.connection);
-        req.connection.last_resync = req.rpc_params.timestamp;
-        _.each(req.rpc_params.agents, function(a) {
-            REGISTERED_AGENTS.agents2srvs[a] = {
-                server: req.connection.url,
-            };
-            req.connection.agents.push(a);
-        });
-    } else {
-        dbg.log0('resync_agents recived old sync request, ignoring');
+        req.connection.last_resync >= req.rpc_params.timestamp) {
+        dbg.warn('resync_agents recived old sync request, ignoring');
+        return;
     }
+
+    cleanup_on_close(req.connection);
+    req.connection.last_resync = req.rpc_params.timestamp;
+    _.each(req.rpc_params.agents, function(agent) {
+        add_agent_to_connection(req.connection, agent);
+    });
 }
 
 function cleanup_on_close(connection) {
-    _.each(connection.agents, function(agent) {
-        delete REGISTERED_AGENTS.agents2srvs[agent];
+    if (connection.agents) {
+        dbg.log0('cleanup_on_close', connection.url.href,
+            '#', connection.agents.size, 'agents');
+        connection.agents.forEach(function(agent) {
+            remove_agent_from_connection(connection, agent);
+        });
+        if (connection.agents.size) {
+            dbg.warn('cleanup_on_close dangling agents in connection', connection.url.href,
+                '#', connection.agents.size, 'agents');
+        }
+    }
+}
+
+function add_agent_to_connection(connection, agent) {
+    REGISTERED_AGENTS.agents2srvs.set(agent, {
+        server: connection.url.href,
     });
-    connection.agents = null;
+
+    //Save agent on connection for quick cleanup on close,
+    //Register on close handler to clean the agents form the agents2srvs map
+    if (!connection.agents) {
+        connection.agents = new Set();
+        connection.on('close', function() {
+            cleanup_on_close(connection);
+        });
+    }
+    connection.agents.add(agent);
+}
+
+function remove_agent_from_connection(connection, agent) {
+    var entry = REGISTERED_AGENTS.agents2srvs.get(agent);
+    if (entry) {
+        if (connection.url.href === entry.server) {
+            //Remove agent
+            REGISTERED_AGENTS.agents2srvs.delete(agent);
+        } else {
+            dbg.warn('hmmm, recieved unregister for', agent, 'on connection to', connection.url.href,
+                'while previously registered on', entry.server, ', ignoring');
+        }
+    }
+    if (!connection.agents || !connection.agents.delete(agent)) {
+        dbg.warn('hmmm, recieved unregister for', agent, 'on connection to', connection.url.href,
+            'while the agent was not registered on this connection');
+    }
 }

--- a/src/client/nb_nodes.js
+++ b/src/client/nb_nodes.js
@@ -373,55 +373,9 @@ nb_api.factory('nbNodes', [
                         });
                 })
                 .then(function() {
-                    /*
-                    define_phase({
-                        name: 'write 0.5 MB from browser to ' + node.name,
-                        kind: ['full', 'rw'],
-                        func: function() {
-                            return self_test_io(node, 0.5 * 1024 * 1024, 0);
-                        }
-                    });
-                    define_phase({
-                        name: 'read 0.5 MB from ' + node.name + ' to browser',
-                        kind: ['full', 'rw'],
-                        func: function() {
-                            return self_test_io(node, 0, 0.5 * 1024 * 1024);
-                        }
-                    });
-                    define_phase({
-                        name: 'write 3 MB from browser to ' + node.name,
-                        kind: ['full', 'rw'],
-                        func: function() {
-                            return self_test_io(node, 3 * 1024 * 1024, 0);
-                        }
-                    });
-                    define_phase({
-                        name: 'read 3 MB from ' + node.name + ' to browser',
-                        kind: ['full', 'rw'],
-                        func: function() {
-                            return self_test_io(node, 0, 3 * 1024 * 1024);
-                        }
-                    });
-                    define_phase({
-                        name: 'connect from browser to test agent',
-                        kind: ['full', 'conn'],
-                        func: function() {
-                            return self_test_io(node);
-                        }
-                    });
                     _.each(online_nodes, function(target_node) {
                         define_phase({
-                            name: 'connect from browser to ' + target_node.name,
-                            kind: ['full', 'conn'],
-                            func: function() {
-                                return self_test_io(target_node);
-                            }
-                        });
-                    });
-                    */
-                    _.each(online_nodes, function(target_node) {
-                        define_phase({
-                            name: 'connect from ' + node.name + ' to ' + target_node.name,
+                            name: 'connect to ' + target_node.name,
                             kind: ['full', 'conn'],
                             func: function() {
                                 return self_test_to_node_via_web(node, target_node);
@@ -476,7 +430,7 @@ nb_api.factory('nbNodes', [
                     });
 
                     define_phase({
-                        name: 'transfer 100 MB between ' + node.name + ' and the other nodes',
+                        name: 'transfer 100 MB from this node to the other nodes',
                         kind: ['full', 'tx'],
                         total: 100 * 1024 * 1024,
                         position: 0,
@@ -494,26 +448,6 @@ nb_api.factory('nbNodes', [
                                 });
                         }
                     });
-
-                    /*
-                    define_phase({
-                        name: 'transfer 100 MB between browser and ' + node.name,
-                        kind: ['full', 'tx'],
-                        total: 100 * 1024 * 1024,
-                        position: 0,
-                        func: function() {
-                            var self = this;
-                            if (self.position >= self.total) return;
-                            return self_test_io(node, 512 * 1024, 512 * 1024)
-                                .then(function() {
-                                    self.position += 1024 * 1024;
-                                    self.progress = (100 * (self.position / self.total)).toFixed(0) + '%';
-                                    $rootScope.safe_apply();
-                                    return self.func();
-                                });
-                        }
-                    });
-                    */
 
                     return run_phases();
                 })

--- a/src/rpc/ice.js
+++ b/src/rpc/ice.js
@@ -1452,7 +1452,7 @@ function listen_on_port_range(port_range) {
         if (typeof(port_range) === 'object') {
             if (typeof(port_range.min) === 'number' &&
                 typeof(port_range.max) === 'number') {
-                if (attempts > port_range.max - port_range.min) {
+                if (attempts > Math.min(10, 10 * (port_range.max - port_range.min))) {
                     throw new Error('ICE PORT ALLOCATION EXHAUSTED');
                 }
                 port = chance.integer(port_range);
@@ -1464,7 +1464,7 @@ function listen_on_port_range(port_range) {
         } else {
             port = 0;
         }
-        dbg.log1('ICE listen_on_port_range', port, 'attempts', attempts);
+        dbg.log0('ICE listen_on_port_range', port, 'attempts', attempts, port_range);
         attempts += 1;
         server.listen(port);
         // wait for listen even, while also watching for error/close.

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -195,7 +195,7 @@ function start() {
 
             // register n2n and accept any peer_id
             var n2n_agent = rpc.register_n2n_transport();
-            n2n_agent.set_any_peer_id();
+            n2n_agent.set_any_rpc_address();
         })
         .then(function() {
 

--- a/src/rpc/rpc_n2n.js
+++ b/src/rpc/rpc_n2n.js
@@ -193,6 +193,7 @@ function RpcN2NAgent(options) {
             // send ice info to the peer over a relayed signal channel
             // in order to coordinate NAT traversal.
             return self.signaller({
+                source: self.rpc_address,
                 target: target,
                 info: info
             });
@@ -202,14 +203,14 @@ function RpcN2NAgent(options) {
 
 util.inherits(RpcN2NAgent, EventEmitter);
 
-RpcN2NAgent.prototype.reset_peer_id = function() {
-    this.peer_id = undefined;
+RpcN2NAgent.prototype.reset_rpc_address = function() {
+    this.rpc_address = undefined;
 };
-RpcN2NAgent.prototype.set_peer_id = function(peer_id) {
-    this.peer_id = peer_id;
+RpcN2NAgent.prototype.set_rpc_address = function(rpc_address) {
+    this.rpc_address = rpc_address;
 };
-RpcN2NAgent.prototype.set_any_peer_id = function() {
-    this.peer_id = '*';
+RpcN2NAgent.prototype.set_any_rpc_address = function() {
+    this.rpc_address = '*';
 };
 
 RpcN2NAgent.prototype.set_ssl_context = function(secure_context_params) {
@@ -217,7 +218,10 @@ RpcN2NAgent.prototype.set_ssl_context = function(secure_context_params) {
         tls.createSecureContext(secure_context_params);
 };
 
+var global_tcp_permanent_passive;
+
 RpcN2NAgent.prototype.update_ice_config = function(config) {
+    dbg.log0('UPDATE ICE CONFIG', config);
     var self = this;
     _.each(config, function(val, key) {
         if (key === 'tcp_permanent_passive') {
@@ -229,7 +233,10 @@ RpcN2NAgent.prototype.update_ice_config = function(config) {
                 if (conf.server) {
                     conf.server.close();
                 }
-                self.ice_config.tcp_permanent_passive = _.clone(val);
+                if (!global_tcp_permanent_passive) {
+                    global_tcp_permanent_passive = _.clone(val);
+                }
+                self.ice_config.tcp_permanent_passive = global_tcp_permanent_passive;
             }
         } else {
             self.ice_config[key] = val;
@@ -239,17 +246,18 @@ RpcN2NAgent.prototype.update_ice_config = function(config) {
 
 RpcN2NAgent.prototype.signal = function(params) {
     var self = this;
-    dbg.log0('N2N AGENT signal:', params);
+    dbg.log0('N2N AGENT signal:', params, 'my rpc_address', self.rpc_address);
 
-    // TODO target address is me, should use the source address but we don't send it ...
-    var target_url = url_utils.quick_parse(params.target);
-    // the special case if peer_id='*' allows testing code to accept for any peer_id
-    if (!self.peer_id || !target_url.hostname ||
-        (self.peer_id !== '*' && self.peer_id !== target_url.hostname)) {
+    // target address is me, source is you.
+    // the special case if rpc_address='*' allows testing code to accept for any target
+    var source = url_utils.quick_parse(params.source);
+    var target = url_utils.quick_parse(params.target);
+    if (!self.rpc_address || !target ||
+        (self.rpc_address !== '*' && self.rpc_address !== target.href)) {
         throw new Error('N2N MISMATCHING PEER ID ' + params.target +
-            ' my peer id ' + self.peer_id);
+            ' my rpc_address ' + self.rpc_address);
     }
-    var conn = new RpcN2NConnection(target_url, self);
+    var conn = new RpcN2NConnection(source, self);
     conn.once('connect', function() {
         self.emit('connection', conn);
     });

--- a/src/server/node_monitor.js
+++ b/src/server/node_monitor.js
@@ -205,12 +205,10 @@ function update_heartbeat(params, conn, reply_token) {
         version: process.env.AGENT_VERSION || '0',
         delay_ms: hb_delay_ms,
     };
-    
-    //0.4 backward compatible - reply with version and without rpc address.
-    if (!params.id)
-    {
-        reply.rpc_address =rpc_address;
 
+    //0.4 backward compatible - reply with version and without rpc address.
+    if (!params.id) {
+        reply.rpc_address = rpc_address;
     }
     if (reply_token) {
         reply.auth_token = reply_token;
@@ -383,6 +381,7 @@ function self_test_to_node_via_web(req) {
     console.log('SELF TEST', target, 'from', source);
 
     return server_rpc.client.agent.self_test_peer({
+        source: source,
         target: target,
         request_length: req.rpc_params.request_length || 1024,
         response_length: req.rpc_params.response_length || 1024,


### PR DESCRIPTION
added the source url to the signal and redirect calls,
so that the receiver can assign the new connection url to the source,
since this url is used as the key for the rpc connection map.

also refactored the redirector code to separate the add/remove agent functions
to be used from several paths and keep the global registry map and the connection set consistent.
