### PR TITLE
Fix noobaa_deploy log copy to stage dir

### DIFF
--- a/src/server/utils/server_diagnostics.js
+++ b/src/server/utils/server_diagnostics.js
@@ -25,7 +25,7 @@ function collect_server_diagnostics() {
             return collect_supervisor_logs();
         })
         .then(function() {
-            return promise_utils.promised_spawn('cp', ['-f', '/var/log/noobaa_deploy*', TMP_WORK_DIR], process.cwd());
+            return promise_utils.promised_exec('cp -f /var/log/noobaa_deploy* ' + TMP_WORK_DIR);
         })
         .then(function() {
             return promise_utils.promised_spawn('cp', ['-f', process.cwd() + '/.env', TMP_WORK_DIR + '/env'], process.cwd());


### PR DESCRIPTION
Spawn does not support wildcards, as opposed to exec.
