### PR TITLE
Add the add_suffix option to create_multipart_upload

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -34,6 +34,17 @@ module.exports = {
                     xattr: {
                         $ref: '/object_api/definitions/xattr',
                     },
+                    add_suffix: {
+                        type: 'boolean',
+                    },
+                }
+            },
+            reply: {
+                required: [],
+                properties: {
+                    used_key: {
+                        type: 'string'
+                    },
                 }
             },
             auth: {

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -40,7 +40,7 @@ module.exports = {
                 }
             },
             reply: {
-                required: [],
+                type: 'object',
                 properties: {
                     used_key: {
                         type: 'string'

--- a/src/api/object_driver.js
+++ b/src/api/object_driver.js
@@ -135,12 +135,16 @@ function lazy_init_natives() {
  */
 ObjectDriver.prototype.upload_stream = function(params) {
     var self = this;
-    var create_params = _.pick(params, 'bucket', 'key', 'size', 'content_type');
+    var create_params = _.pick(params, 'bucket', 'key', 'size', 'content_type', 'add_suffix');
     var bucket_key_params = _.pick(params, 'bucket', 'key');
 
     dbg.log0('upload_stream: start upload', params.key);
     return self.client.object.create_multipart_upload(create_params)
-        .then(function() {
+        .then(function(res) {
+            if (res.used_key) { //add_suffix was sent and a suffix was added
+                params.key = res.used_key;
+                bucket_key_params.key = res.used_key;
+            }
             return self.upload_stream_parts(params);
         })
         .then(function() {

--- a/src/server/object_server.js
+++ b/src/server/object_server.js
@@ -49,7 +49,7 @@ module.exports = object_server;
  */
 function create_multipart_upload(req) {
     var info;
-    var reply;
+    var reply = {};
     return load_bucket(req)
         .then(function() {
             dbg.log0('create_multipart_upload xattr', req.rpc_params);

--- a/src/server/object_server.js
+++ b/src/server/object_server.js
@@ -48,10 +48,12 @@ module.exports = object_server;
  *
  */
 function create_multipart_upload(req) {
+    var info;
+    var reply;
     return load_bucket(req)
         .then(function() {
             dbg.log0('create_multipart_upload xattr', req.rpc_params);
-            var info = {
+            info = {
                 system: req.system.id,
                 bucket: req.bucket.id,
                 key: req.rpc_params.key,
@@ -62,8 +64,28 @@ function create_multipart_upload(req) {
                 xattr: req.rpc_params.xattr
             };
             return P.when(db.ObjectMD.create(info));
+        }).fail(function(err) {
+            if (db.is_err_exists(err) && req.rpc_params.add_suffix) {
+                return P.when(db.ObjectMD
+                        .count({
+                            system: req.system.id,
+                            bucket: req.bucket.id,
+                            key: new RegExp(req.rpc_params.key + '_copy*'),
+                            deleted: null
+                        }))
+                    .then(function(copies) {
+                        info.key = req.rpc_params.key + '_copy_' + (copies + 1);
+                        reply.used_key = info.key;
+                        return P.when(db.ObjectMD.create(info));
+                    });
+            } else {
+                throw err;
+            }
         }).then(function(data) {
             dbg.log0('after create_multipart_upload', data);
+            if (reply.used_key) {
+                return reply;
+            }
         });
 }
 


### PR DESCRIPTION
If add_suffix is provided, in case of key collision add a suffix of
_copyXYZ (according to current number of copies).

Return new key if suffix was added.
