### PR TITLE
rpc_schema refactor

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    name: 'account_api',
+    id: 'account_api',
 
     methods: {
 
@@ -50,7 +50,7 @@ module.exports = {
             doc: 'Read the info of the authorized account',
             method: 'GET',
             reply: {
-                $ref: '/account_api/definitions/account_info'
+                $ref: '#/definitions/account_info'
             },
             auth: {
                 system: false,
@@ -101,7 +101,7 @@ module.exports = {
                     accounts: {
                         type: 'array',
                         items: {
-                            $ref: '/account_api/definitions/account_info'
+                            $ref: '#/definitions/account_info'
                         }
                     }
                 }
@@ -122,7 +122,7 @@ module.exports = {
                     accounts: {
                         type: 'array',
                         items: {
-                            $ref: '/account_api/definitions/account_info'
+                            $ref: '#/definitions/account_info'
                         }
                     }
                 }

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    name: 'agent_api',
+    id: 'agent_api',
 
     methods: {
 
@@ -21,7 +21,7 @@ module.exports = {
                 required: ['block_md', 'data'],
                 properties: {
                     block_md: {
-                        $ref: '/agent_api/definitions/block_md'
+                        $ref: '#/definitions/block_md'
                     },
                     data: {
                         type: 'buffer'
@@ -37,7 +37,7 @@ module.exports = {
                 required: ['block_md'],
                 properties: {
                     block_md: {
-                        $ref: '/agent_api/definitions/block_md'
+                        $ref: '#/definitions/block_md'
                     },
                 },
             },
@@ -46,7 +46,7 @@ module.exports = {
                 required: ['block_md', 'data'],
                 properties: {
                     block_md: {
-                        $ref: '/agent_api/definitions/block_md'
+                        $ref: '#/definitions/block_md'
                     },
                     data: {
                         type: 'buffer'
@@ -63,10 +63,10 @@ module.exports = {
                 required: ['target', 'source'],
                 properties: {
                     target: {
-                        $ref: '/agent_api/definitions/block_md'
+                        $ref: '#/definitions/block_md'
                     },
                     source: {
-                        $ref: '/agent_api/definitions/block_md'
+                        $ref: '#/definitions/block_md'
                     }
                 },
             },
@@ -91,10 +91,10 @@ module.exports = {
         n2n_signal: {
             method: 'POST',
             params: {
-                $ref: '/node_api/definitions/signal_params'
+                $ref: 'node_api#/definitions/signal_params'
             },
             reply: {
-                $ref: '/node_api/definitions/signal_reply'
+                $ref: 'node_api#/definitions/signal_reply'
             },
         },
 
@@ -133,10 +133,10 @@ module.exports = {
         self_test_peer: {
             method: 'POST',
             params: {
-                $ref: '/agent_api/definitions/self_test_params'
+                $ref: '#/definitions/self_test_params'
             },
             reply: {
-                $ref: '/agent_api/definitions/self_test_reply'
+                $ref: '#/definitions/self_test_reply'
             },
         },
 
@@ -164,7 +164,7 @@ module.exports = {
         update_n2n_config: {
             method: 'POST',
             params: {
-                $ref: '/common_api/definitions/n2n_config'
+                $ref: 'common_api#/definitions/n2n_config'
             }
         },
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -24,6 +24,7 @@ api_schema.register_api(require('./redirector_api'));
 api_schema.register_api(require('./tiering_policy_api'));
 api_schema.register_api(require('./pool_api'));
 api_schema.register_api(require('./cluster_api'));
+api_schema.compile();
 
 function new_rpc(options) {
     options = options || {};

--- a/src/api/auth_api.js
+++ b/src/api/auth_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    name: 'auth_api',
+    id: 'auth_api',
 
     methods: {
 

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    name: 'bucket_api',
+    id: 'bucket_api',
 
     methods: {
 
@@ -28,7 +28,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/bucket_api/definitions/bucket_info'
+                $ref: '#/definitions/bucket_info'
             },
             auth: {
                 system: 'admin'
@@ -47,7 +47,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/bucket_api/definitions/bucket_info'
+                $ref: '#/definitions/bucket_info'
             },
             auth: {
                 system: 'admin'
@@ -67,7 +67,7 @@ module.exports = {
                         type: 'string',
                     },
                     tiering: {
-                        $ref: '/tiering_policy_api/definitions/tiering_policy'
+                        $ref: 'tiering_policy_api#/definitions/tiering_policy'
                     }
                 }
             },
@@ -136,13 +136,13 @@ module.exports = {
                         type: 'string',
                     },
                     policy: {
-                        $ref: '/bucket_api/definitions/cloud_sync'
+                        $ref: '#/definitions/cloud_sync'
                     },
                     health: {
                         type: 'boolean'
                     },
                     status: {
-                        $ref: '/bucket_api/definitions/sync_status_enum'
+                        $ref: '#/definitions/sync_status_enum'
                     }
                 }
             },
@@ -163,13 +163,13 @@ module.exports = {
                             type: 'string',
                         },
                         policy: {
-                            $ref: '/bucket_api/definitions/cloud_sync'
+                            $ref: '#/definitions/cloud_sync'
                         },
                         health: {
                             type: 'boolean'
                         },
                         status: {
-                            $ref: '/bucket_api/definitions/sync_status_enum'
+                            $ref: '#/definitions/sync_status_enum'
                         }
                     }
                 }
@@ -205,7 +205,7 @@ module.exports = {
                         type: 'string',
                     },
                     policy: {
-                        $ref: '/bucket_api/definitions/cloud_sync'
+                        $ref: '#/definitions/cloud_sync'
                     }
                 }
             },
@@ -251,10 +251,10 @@ module.exports = {
                     type: 'string',
                 },
                 tiering: {
-                    $ref: '/tiering_policy_api/definitions/tiering_policy'
+                    $ref: 'tiering_policy_api#/definitions/tiering_policy'
                 },
                 storage: {
-                    $ref: '/common_api/definitions/storage_info'
+                    $ref: 'common_api#/definitions/storage_info'
                 },
                 num_objects: {
                     type: 'integer'
@@ -276,7 +276,7 @@ module.exports = {
                 access_keys: {
                     type: 'array',
                     item: {
-                        $ref: '/system_api/definitions/access_keys'
+                        $ref: 'system_api#/definitions/access_keys'
                     }
                 },
                 schedule: {

--- a/src/api/cloud_sync_api.js
+++ b/src/api/cloud_sync_api.js
@@ -8,7 +8,7 @@
  */
 module.exports = {
 
-    name: 'cloud_sync_api',
+    id: 'cloud_sync_api',
 
     methods: {
         get_policy_status: {
@@ -30,7 +30,7 @@ module.exports = {
                 required: ['status', 'health'],
                 properties: {
                     status: {
-                        $ref: '/bucket_api/definitions/sync_status_enum'
+                        $ref: 'bucket_api#/definitions/sync_status_enum'
                     },
                     health: {
                         type: 'boolean'

--- a/src/api/cluster_api.js
+++ b/src/api/cluster_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    name: 'cluster_api',
+    id: 'cluster_api',
 
     methods: {
 

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -9,9 +9,7 @@
  */
 module.exports = {
 
-    name: 'common_api',
-
-    methods: {},
+    id: 'common_api',
 
     definitions: {
 
@@ -20,23 +18,23 @@ module.exports = {
             // required: [],
             properties: {
                 total: {
-                    $ref: '/common_api/definitions/bigint'
+                    $ref: '#/definitions/bigint'
                 },
                 free: {
-                    $ref: '/common_api/definitions/bigint'
+                    $ref: '#/definitions/bigint'
                 },
                 used: {
-                    $ref: '/common_api/definitions/bigint'
+                    $ref: '#/definitions/bigint'
                 },
                 alloc: {
-                    $ref: '/common_api/definitions/bigint'
+                    $ref: '#/definitions/bigint'
                 },
                 limit: {
-                    $ref: '/common_api/definitions/bigint'
+                    $ref: '#/definitions/bigint'
                 },
                 // real - after calculating dedup reduction or redundancy overheads
                 real: {
-                    $ref: '/common_api/definitions/bigint'
+                    $ref: '#/definitions/bigint'
                 },
             }
         },
@@ -52,7 +50,7 @@ module.exports = {
                     type: 'string'
                 },
                 storage: {
-                    $ref: '/common_api/definitions/storage_info'
+                    $ref: '#/definitions/storage_info'
                 },
             }
         },
@@ -153,13 +151,13 @@ module.exports = {
                     type: 'boolean'
                 },
                 tcp_permanent_passive: {
-                    $ref: '/common_api/definitions/port_range_config'
+                    $ref: '#/definitions/port_range_config'
                 },
                 tcp_transient_passive: {
-                    $ref: '/common_api/definitions/port_range_config'
+                    $ref: '#/definitions/port_range_config'
                 },
                 tcp_simultaneous_open: {
-                    $ref: '/common_api/definitions/port_range_config'
+                    $ref: '#/definitions/port_range_config'
                 },
                 tcp_tls: {
                     type: 'boolean'

--- a/src/api/debug_api.js
+++ b/src/api/debug_api.js
@@ -8,7 +8,7 @@
  */
 module.exports = {
 
-    name: 'debug_api',
+    id: 'debug_api',
 
     methods: {
         set_debug_level: {

--- a/src/api/dedup_options.js
+++ b/src/api/dedup_options.js
@@ -1,5 +1,9 @@
+'use strict';
+
+var js_utils = require('../util/js_utils');
+
 // DO NOT CHANGE UNLESS YOU *KNOW* RABIN CHUNKING
-var dedup_config = {
+var dedup_config = js_utils.deep_freeze({
 
     // min_chunk bytes are skipped before looking for new boundary.
     // max_chunk is the length which will be chunked if not chunked by context.
@@ -19,9 +23,10 @@ var dedup_config = {
     window_len: 64,
 
     // using high gf_degree to allow high values of AVG_CHUNK_BITS
-    // gf_poly 0x3 is a representation of a primitive polynom in GF(2^63).
+    // gf_poly 0x3 is a representation of a primitive polynom in GF(2^63) - x^63 + x^1 + x^0
+    // http://web.eecs.utk.edu/~plank/plank/papers/CS-07-593/primitive-polynomial-table.txt
     gf_degree: 63,
     gf_poly: 0x3,
-};
+});
 
 module.exports = dedup_config;

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -12,14 +12,14 @@
  */
 module.exports = {
 
-    name: 'node_api',
+    id: 'node_api',
 
     methods: {
 
         create_node: {
             method: 'POST',
             params: {
-                $ref: '/node_api/definitions/node_config'
+                $ref: '#/definitions/node_config'
             },
             reply: {
                 type: 'object',
@@ -53,7 +53,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/node_api/definitions/node_full_info'
+                $ref: '#/definitions/node_full_info'
             },
             auth: {
                 system: 'admin'
@@ -63,7 +63,7 @@ module.exports = {
         update_node: {
             method: 'PUT',
             params: {
-                $ref: '/node_api/definitions/node_config'
+                $ref: '#/definitions/node_config'
             },
             auth: {
                 system: 'admin'
@@ -108,7 +108,7 @@ module.exports = {
                 required: ['node', 'objects'],
                 properties: {
                     node: {
-                        $ref: '/node_api/definitions/node_full_info'
+                        $ref: '#/definitions/node_full_info'
                     },
                     objects: {
                         type: 'array',
@@ -125,7 +125,7 @@ module.exports = {
                                 parts: {
                                     type: 'array',
                                     items: {
-                                        $ref: '/object_api/definitions/object_part_info'
+                                        $ref: 'object_api#/definitions/object_part_info'
                                     }
                                 }
                             }
@@ -196,7 +196,7 @@ module.exports = {
                     nodes: {
                         type: 'array',
                         items: {
-                            $ref: '/node_api/definitions/node_full_info'
+                            $ref: '#/definitions/node_full_info'
                         }
                     }
                 }
@@ -249,7 +249,7 @@ module.exports = {
                                     type: 'integer'
                                 },
                                 storage: {
-                                    $ref: '/common_api/definitions/storage_info'
+                                    $ref: 'common_api#/definitions/storage_info'
                                 },
                             }
                         }
@@ -305,25 +305,25 @@ module.exports = {
                         type: 'boolean'
                     },
                     storage: {
-                        $ref: '/common_api/definitions/storage_info'
+                        $ref: 'common_api#/definitions/storage_info'
                     },
                     drives: {
                         type: 'array',
                         items: {
-                            $ref: '/common_api/definitions/drive_info'
+                            $ref: 'common_api#/definitions/drive_info'
                         }
                     },
                     os_info: {
-                        $ref: '/common_api/definitions/os_info'
+                        $ref: 'common_api#/definitions/os_info'
                     },
                     latency_to_server: {
-                        $ref: '/node_api/definitions/latency_array'
+                        $ref: '#/definitions/latency_array'
                     },
                     latency_of_disk_write: {
-                        $ref: '/node_api/definitions/latency_array'
+                        $ref: '#/definitions/latency_array'
                     },
                     latency_of_disk_read: {
-                        $ref: '/node_api/definitions/latency_array'
+                        $ref: '#/definitions/latency_array'
                     },
                     debug_level: {
                         type: 'integer',
@@ -349,7 +349,7 @@ module.exports = {
                         type: 'string'
                     },
                     n2n_config: {
-                        $ref: '/common_api/definitions/n2n_config'
+                        $ref: 'common_api#/definitions/n2n_config'
                     },
                     version: {
                         type: 'string'
@@ -358,7 +358,7 @@ module.exports = {
                         type: 'integer'
                     },
                     storage: {
-                        $ref: '/common_api/definitions/storage_info'
+                        $ref: 'common_api#/definitions/storage_info'
                     },
                 }
             },
@@ -370,10 +370,10 @@ module.exports = {
         n2n_signal: {
             method: 'POST',
             params: {
-                $ref: '/node_api/definitions/signal_params'
+                $ref: '#/definitions/signal_params'
             },
             reply: {
-                $ref: '/node_api/definitions/signal_reply'
+                $ref: '#/definitions/signal_reply'
             },
             auth: {
                 system: false
@@ -383,10 +383,10 @@ module.exports = {
         redirect: {
             method: 'POST',
             params: {
-                $ref: '/node_api/definitions/signal_params'
+                $ref: '#/definitions/signal_params'
             },
             reply: {
-                $ref: '/node_api/definitions/signal_reply'
+                $ref: '#/definitions/signal_reply'
             },
             auth: {
                 system: false
@@ -396,10 +396,10 @@ module.exports = {
         self_test_to_node_via_web: {
             method: 'POST',
             params: {
-                $ref: '/agent_api/definitions/self_test_params'
+                $ref: 'agent_api#/definitions/self_test_params'
             },
             reply: {
-                $ref: '/agent_api/definitions/self_test_reply'
+                $ref: 'agent_api#/definitions/self_test_reply'
             },
             auth: {
                 system: ['admin', 'user']
@@ -499,7 +499,7 @@ module.exports = {
                     type: 'string',
                 },
                 srvmode: {
-                    $ref: '/node_api/definitions/srvmode'
+                    $ref: '#/definitions/srvmode'
                 }
             }
         },
@@ -538,7 +538,7 @@ module.exports = {
                     type: 'string'
                 },
                 srvmode: {
-                    $ref: '/node_api/definitions/srvmode'
+                    $ref: '#/definitions/srvmode'
                 },
                 rpc_address: {
                     type: 'string'
@@ -563,25 +563,25 @@ module.exports = {
                     type: 'string'
                 },
                 storage: {
-                    $ref: '/common_api/definitions/storage_info'
+                    $ref: 'common_api#/definitions/storage_info'
                 },
                 drives: {
                     type: 'array',
                     items: {
-                        $ref: '/common_api/definitions/drive_info'
+                        $ref: 'common_api#/definitions/drive_info'
                     }
                 },
                 os_info: {
-                    $ref: '/common_api/definitions/os_info'
+                    $ref: 'common_api#/definitions/os_info'
                 },
                 latency_to_server: {
-                    $ref: '/node_api/definitions/latency_array'
+                    $ref: '#/definitions/latency_array'
                 },
                 latency_of_disk_write: {
-                    $ref: '/node_api/definitions/latency_array'
+                    $ref: '#/definitions/latency_array'
                 },
                 latency_of_disk_read: {
-                    $ref: '/node_api/definitions/latency_array'
+                    $ref: '#/definitions/latency_array'
                 },
                 debug_level: {
                     type: 'integer',

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    name: 'object_api',
+    id: 'object_api',
 
     methods: {
 
@@ -32,7 +32,7 @@ module.exports = {
                         type: 'string',
                     },
                     xattr: {
-                        $ref: '/object_api/definitions/xattr',
+                        $ref: '#/definitions/xattr',
                     },
                 }
             },
@@ -217,12 +217,12 @@ module.exports = {
                                     type: 'integer',
                                 },
                                 chunk: {
-                                    $ref: '/object_api/definitions/chunk_info',
+                                    $ref: '#/definitions/chunk_info',
                                 },
                                 frags: {
                                     type: 'array',
                                     items: {
-                                        $ref: '/object_api/definitions/frag_info',
+                                        $ref: '#/definitions/frag_info',
                                     }
                                 },
                             }
@@ -244,7 +244,7 @@ module.exports = {
                                     type: 'boolean'
                                 },
                                 part: {
-                                    $ref: '/object_api/definitions/object_part_info'
+                                    $ref: '#/definitions/object_part_info'
                                 }
                             }
                         }
@@ -346,7 +346,7 @@ module.exports = {
                 // required: [],
                 properties: {
                     new_block: {
-                        $ref: '/agent_api/definitions/block_md'
+                        $ref: 'agent_api#/definitions/block_md'
                     }
                 }
             },
@@ -394,7 +394,7 @@ module.exports = {
                     parts: {
                         type: 'array',
                         items: {
-                            $ref: '/object_api/definitions/object_part_info'
+                            $ref: '#/definitions/object_part_info'
                         },
                     },
                 }
@@ -422,7 +422,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/object_api/definitions/object_info'
+                $ref: '#/definitions/object_info'
             },
             auth: {
                 system: ['admin', 'user', 'viewer']
@@ -445,7 +445,7 @@ module.exports = {
                         type: 'string',
                     },
                     xattr: {
-                        $ref: '/object_api/definitions/xattr',
+                        $ref: '#/definitions/xattr',
                     }
 
                 }
@@ -458,7 +458,7 @@ module.exports = {
         delete_object: {
             method: 'DELETE',
             params: {
-                $ref: '/object_api/definitions/object_path'
+                $ref: '#/definitions/object_path'
             },
             auth: {
                 system: ['admin', 'user']
@@ -525,7 +525,7 @@ module.exports = {
                                     type: 'string',
                                 },
                                 info: {
-                                    $ref: '/object_api/definitions/object_info'
+                                    $ref: '#/definitions/object_info'
                                 }
                             }
                         }
@@ -583,7 +583,7 @@ module.exports = {
                     type: 'string',
                 },
                 xattr: {
-                    $ref: '/object_api/definitions/xattr',
+                    $ref: '#/definitions/xattr',
                 },
                 stats: {
                     type: 'object',
@@ -624,13 +624,13 @@ module.exports = {
                     type: 'integer',
                 },
                 chunk: {
-                    $ref: '/object_api/definitions/chunk_info',
+                    $ref: '#/definitions/chunk_info',
                 },
                 // the fragments composing the data chunk
                 frags: {
                     type: 'array',
                     items: {
-                        $ref: '/object_api/definitions/frag_info',
+                        $ref: '#/definitions/frag_info',
                     }
                 }
             }
@@ -737,7 +737,7 @@ module.exports = {
                         required: ['block_md'],
                         properties: {
                             block_md: {
-                                $ref: '/agent_api/definitions/block_md'
+                                $ref: 'agent_api#/definitions/block_md'
                             },
                             adminfo: {
                                 type: 'object',
@@ -756,7 +756,7 @@ module.exports = {
                                         type: 'boolean'
                                     },
                                     srvmode: {
-                                        $ref: '/node_api/definitions/srvmode'
+                                        $ref: 'node_api#/definitions/srvmode'
                                     },
                                     building: {
                                         type: 'boolean',

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -7,14 +7,15 @@
  *
  */
 module.exports = {
-    name: 'pool_api',
+
+    id: 'pool_api',
 
     methods: {
         create_pool: {
             doc: 'Create Pool',
             method: 'POST',
             params: {
-                $ref: '/pool_api/definitions/pool_definition'
+                $ref: '#/definitions/pool_definition'
             },
             auth: {
                 system: 'admin'
@@ -54,7 +55,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/pool_api/definitions/pool_definition'
+                $ref: '#/definitions/pool_definition'
             },
             auth: {
                 system: 'admin'
@@ -74,7 +75,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/pool_api/definitions/pool_extended_info'
+                $ref: '#/definitions/pool_extended_info'
             },
             auth: {
                 system: 'admin'
@@ -193,10 +194,10 @@ module.exports = {
                     type: 'string'
                 },
                 nodes: {
-                    $ref: '/system_api/definitions/nodes_info'
+                    $ref: 'system_api#/definitions/nodes_info'
                 },
                 storage: {
-                    $ref: '/common_api/definitions/storage_info'
+                    $ref: 'common_api#/definitions/storage_info'
                 },
             },
         },

--- a/src/api/redirector_api.js
+++ b/src/api/redirector_api.js
@@ -7,17 +7,17 @@
  */
 module.exports = {
 
-    name: 'redirector_api',
+    id: 'redirector_api',
 
     methods: {
 
         redirect: {
             method: 'POST',
             params: {
-                $ref: '/node_api/definitions/redirect_params'
+                $ref: '#/definitions/redirect_params'
             },
             reply: {
-                $ref: '/node_api/definitions/redirect_reply'
+                $ref: '#/definitions/redirect_reply'
             },
             auth: {
                 system: false
@@ -27,7 +27,7 @@ module.exports = {
         register_agent: {
             method: 'POST',
             params: {
-                $ref: '/redirector_api/definitions/basic_registration_info'
+                $ref: '#/definitions/basic_registration_info'
             },
             auth: {
                 system: false
@@ -37,7 +37,7 @@ module.exports = {
         unregister_agent: {
             method: 'POST',
             params: {
-                $ref: '/redirector_api/definitions/basic_registration_info'
+                $ref: '#/definitions/basic_registration_info'
             },
             auth: {
                 system: false
@@ -86,10 +86,10 @@ module.exports = {
         publish_to_cluster: {
             method: 'POST',
             params: {
-                $ref: '/node_api/definitions/redirect_params'
+                $ref: '#/definitions/redirect_params'
             },
             reply: {
-                $ref: '/node_api/definitions/redirect_reply'
+                $ref: '#/definitions/redirect_reply'
             },
             auth: {
                 system: false

--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -8,14 +8,14 @@
  */
 module.exports = {
 
-    name: 'stats_api',
+    id: 'stats_api',
 
     methods: {
 
         get_systems_stats: {
             method: 'GET',
             reply: {
-                $ref: '/stats_api/definitions/systems_stats'
+                $ref: '#/definitions/systems_stats'
             },
             auth: {
                 system: 'admin'
@@ -25,7 +25,7 @@ module.exports = {
         get_nodes_stats: {
             method: 'GET',
             reply: {
-                $ref: '/stats_api/definitions/nodes_stats'
+                $ref: '#/definitions/nodes_stats'
             },
             auth: {
                 system: 'admin'
@@ -35,7 +35,7 @@ module.exports = {
         get_ops_stats: {
             method: 'GET',
             reply: {
-                $ref: '/stats_api/definitions/ops_stats'
+                $ref: '#/definitions/ops_stats'
             },
             auth: {
                 system: 'admin'
@@ -45,7 +45,7 @@ module.exports = {
         get_all_stats: {
             method: 'GET',
             reply: {
-                $ref: '/stats_api/definitions/all_stats'
+                $ref: '#/definitions/all_stats'
             },
             auth: {
                 system: 'admin'
@@ -198,19 +198,19 @@ module.exports = {
             equired: ['systems_stats', 'nodes_stats', 'ops_stats'],
             properties: {
                 systems_stats: {
-                    $ref: '/stats_api/definitions/systems_stats'
+                    $ref: '#/definitions/systems_stats'
                 },
                 nodes_stats: {
-                    $ref: '/stats_api/definitions/nodes_stats'
+                    $ref: '#/definitions/nodes_stats'
                 },
                 ops_stats: {
-                    $ref: '/stats_api/definitions/ops_stats'
+                    $ref: '#/definitions/ops_stats'
                 },
                 pools_stats: {
-                    $ref: '/stats_api/definitions/pools_stats'
+                    $ref: '#/definitions/pools_stats'
                 },
                 tier_stats: {
-                    $ref: '/stats_api/definitions/tier_stats'
+                    $ref: '#/definitions/tier_stats'
                 },
             }
         },

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    name: 'system_api',
+    id: 'system_api',
 
     methods: {
 
@@ -33,7 +33,7 @@ module.exports = {
                         type: 'string',
                     },
                     info: {
-                        $ref: '/system_api/definitions/system_info'
+                        $ref: '#/definitions/system_info'
                     },
                 }
             },
@@ -46,7 +46,7 @@ module.exports = {
             doc: 'Read the info of the authorized system',
             method: 'GET',
             reply: {
-                $ref: '/system_api/definitions/system_full_info'
+                $ref: '#/definitions/system_full_info'
             },
             auth: {
                 system: 'admin',
@@ -89,7 +89,7 @@ module.exports = {
                     systems: {
                         type: 'array',
                         items: {
-                            $ref: '/system_api/definitions/system_info'
+                            $ref: '#/definitions/system_info'
                         }
                     }
                 }
@@ -111,7 +111,7 @@ module.exports = {
                         type: 'string',
                     },
                     role: {
-                        $ref: '/system_api/definitions/role_enum'
+                        $ref: '#/definitions/role_enum'
                     },
                 }
             },
@@ -276,10 +276,10 @@ module.exports = {
         update_n2n_config: {
             method: 'POST',
             params: {
-                $ref: '/common_api/definitions/n2n_config'
+                $ref: 'common_api#/definitions/n2n_config'
             },
             reply: {
-                $ref: '/system_api/definitions/system_nodes_update_reply'
+                $ref: '#/definitions/system_nodes_update_reply'
             },
             auth: {
                 system: 'admin',
@@ -298,7 +298,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/system_api/definitions/system_nodes_update_reply'
+                $ref: '#/definitions/system_nodes_update_reply'
             },
             auth: {
                 system: 'admin',
@@ -347,31 +347,31 @@ module.exports = {
                 roles: {
                     type: 'array',
                     items: {
-                        $ref: '/system_api/definitions/role_info'
+                        $ref: '#/definitions/role_info'
                     }
                 },
                 tiers: {
                     type: 'array',
                     items: {
-                        $ref: '/tier_api/definitions/tier_info'
+                        $ref: 'tier_api#/definitions/tier_info'
                     }
                 },
                 storage: {
-                    $ref: '/common_api/definitions/storage_info'
+                    $ref: 'common_api#/definitions/storage_info'
                 },
                 nodes: {
-                    $ref: '/system_api/definitions/nodes_info'
+                    $ref: '#/definitions/nodes_info'
                 },
                 buckets: {
                     type: 'array',
                     items: {
-                        $ref: '/bucket_api/definitions/bucket_info'
+                        $ref: 'bucket_api#/definitions/bucket_info'
                     }
                 },
                 pools: {
                     type: 'array',
                     items: {
-                        $ref: '/pool_api/definitions/pool_extended_info'
+                        $ref: 'pool_api#/definitions/pool_extended_info'
                     },
                 },
                 objects: {
@@ -380,7 +380,7 @@ module.exports = {
                 access_keys: {
                     type: 'array',
                     item: {
-                        $ref: '/system_api/definitions/access_keys'
+                        $ref: '#/definitions/access_keys'
                     }
                 },
                 ssl_port: {
@@ -404,7 +404,7 @@ module.exports = {
                     }
                 },
                 n2n_config: {
-                    $ref: '/common_api/definitions/n2n_config'
+                    $ref: 'common_api#/definitions/n2n_config'
                 },
                 ip_address: {
                     type: 'string'
@@ -426,7 +426,7 @@ module.exports = {
                 roles: {
                     type: 'array',
                     items: {
-                        $ref: '/system_api/definitions/role_enum'
+                        $ref: '#/definitions/role_enum'
                     }
                 },
                 account: {

--- a/src/api/tier_api.js
+++ b/src/api/tier_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    name: 'tier_api',
+    id: 'tier_api',
 
     methods: {
 
@@ -24,10 +24,10 @@ module.exports = {
                         type: 'string',
                     },
                     pools: {
-                        $ref: '/tier_api/definitions/pool_info'
+                        $ref: '#/definitions/pool_info'
                     },
                     data_placement: {
-                        $ref: '/tier_api/definitions/data_placement_enum'
+                        $ref: '#/definitions/data_placement_enum'
                     },
                     replicas: {
                         type: 'integer',
@@ -41,7 +41,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/tier_api/definitions/tier_info'
+                $ref: '#/definitions/tier_info'
             },
             auth: {
                 system: 'admin'
@@ -61,7 +61,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/tier_api/definitions/tier_info'
+                $ref: '#/definitions/tier_info'
             },
             auth: {
                 system: 'admin'
@@ -82,10 +82,10 @@ module.exports = {
                         type: 'string',
                     },
                     pools: {
-                        $ref: '/tier_api/definitions/pool_info'
+                        $ref: '#/definitions/pool_info'
                     },
                     data_placement: {
-                        $ref: '/tier_api/definitions/data_placement_enum'
+                        $ref: '#/definitions/data_placement_enum'
                     },
                     replicas: {
                         type: 'integer',
@@ -140,10 +140,10 @@ module.exports = {
                     type: 'string',
                 },
                 pools: {
-                    $ref: '/tier_api/definitions/pool_info'
+                    $ref: '#/definitions/pool_info'
                 },
                 data_placement: {
-                    $ref: '/tier_api/definitions/data_placement_enum'
+                    $ref: '#/definitions/data_placement_enum'
                 },
                 replicas: {
                     type: 'integer',
@@ -155,7 +155,7 @@ module.exports = {
                     type: 'integer',
                 },
                 storage: {
-                    $ref: '/common_api/definitions/storage_info'
+                    $ref: 'common_api#/definitions/storage_info'
                 },
             }
         },

--- a/src/api/tiering_policy_api.js
+++ b/src/api/tiering_policy_api.js
@@ -7,17 +7,18 @@
  *
  */
 module.exports = {
-    name: 'tiering_policy_api',
+
+    id: 'tiering_policy_api',
 
     methods: {
         create_policy: {
             doc: 'Create Tiering Policy',
             method: 'POST',
             params: {
-                $ref: '/tiering_policy_api/definitions/tiering_policy'
+                $ref: '#/definitions/tiering_policy'
             },
             reply: {
-                $ref: '/tiering_policy_api/definitions/tiering_policy'
+                $ref: '#/definitions/tiering_policy'
             },
             auth: {
                 system: 'admin'
@@ -28,10 +29,10 @@ module.exports = {
             doc: 'Update Tiering Policy',
             method: 'POST',
             params: {
-                $ref: '/tiering_policy_api/definitions/tiering_policy'
+                $ref: '#/definitions/tiering_policy'
             },
             reply: {
-                $ref: '/tiering_policy_api/definitions/tiering_policy'
+                $ref: '#/definitions/tiering_policy'
             },
             auth: {
                 system: 'admin'
@@ -51,7 +52,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/tiering_policy_api/definitions/tiering_policy'
+                $ref: '#/definitions/tiering_policy'
             },
             auth: {
                 system: 'admin'
@@ -71,7 +72,7 @@ module.exports = {
                 }
             },
             reply: {
-                $ref: '/tiering_policy_api/definitions/tiering_policy'
+                $ref: '#/definitions/tiering_policy'
             },
             auth: {
                 system: 'admin'
@@ -106,8 +107,8 @@ module.exports = {
                     type: 'string',
                 },
                 storage: {
-                    $ref: '/common_api/definitions/storage_info'
-                },                
+                    $ref: 'common_api#/definitions/storage_info'
+                },
                 tiers: {
                     type: 'array',
                     items: {

--- a/src/client/nb_console.js
+++ b/src/client/nb_console.js
@@ -643,9 +643,11 @@ nb_console.controller('PoolsViewCtrl', [
                 .then(function(str) {
                     if (!str) return;
                     return nbNodes.create_pool(str)
-                        .then(function() {
+                        .then(() => {
+                            nbAlertify.log('Pool created.');
                             return reload_view();
-                        });
+                        })
+                        .catch(err => nbAlertify.error(err.message));
                 });
         }
     }

--- a/src/client/nb_nodes.js
+++ b/src/client/nb_nodes.js
@@ -33,15 +33,12 @@ nb_api.factory('nbNodes', [
         $scope.set_debug_node = set_debug_node;
 
         function create_pool(name) {
-            return $q.when()
-                .then(function() {
-                    return nbClient.client.pool.create_pool({
-                        name: name
-                    });
-                })
-                .then(function(res) {
-                    console.log('CREATED POOL', res);
+            return $q.when().then(function() {
+                return nbClient.client.pool.create_pool({
+                    name: name,
+                    nodes: []
                 });
+            });
         }
 
         function refresh_node_groups(selected_geo) {

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -83,10 +83,10 @@ RPC.prototype.register_service = function(api, server, options) {
     var self = this;
     options = options || {};
 
-    dbg.log0('RPC register_service', api.name);
+    dbg.log0('RPC register_service', api.id);
 
     _.each(api.methods, function(method_api, method_name) {
-        var srv = api.name + '.' + method_name;
+        var srv = api.id + '.' + method_name;
         assert(!self._services[srv],
             'RPC register_service: service already registered ' + srv);
         var func = server[method_name];
@@ -114,10 +114,10 @@ RPC.prototype.register_service = function(api, server, options) {
 
     //Service was registered, call _init (if exists)
     if (typeof(server._init) !== 'undefined') {
-        dbg.log0('RPC register_service: calling _int() for', api.name);
+        dbg.log0('RPC register_service: calling _init() for', api.id);
         server._init();
     } else {
-        dbg.log2('RPC register_service:', api.name, 'does not supply an _init() function');
+        dbg.log2('RPC register_service:', api.id, 'does not supply an _init() function');
     }
 };
 
@@ -151,7 +151,7 @@ RPC.prototype.create_client = function(api, default_options) {
     var client = {
         options: _.create(default_options)
     };
-    if (!api || !api.name || !api.methods) {
+    if (!api || !api.id) {
         throw new Error('RPC create_client: BAD API');
     }
 
@@ -771,7 +771,7 @@ RPC.prototype._connection_receive = function(conn, msg_buffer) {
 RPC.prototype._redirect = function(api, method, params, options) {
     var self = this;
     var req = {
-        method_api: api.name,
+        method_api: api.id,
         method_name: method.name,
         target: options.address,
         request_params: params

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -110,6 +110,7 @@ schema.register_api({
         }
     }
 });
+schema.compile();
 
 // create rpc
 var rpc = new RPC({

--- a/src/rpc/rpc_request.js
+++ b/src/rpc/rpc_request.js
@@ -36,7 +36,7 @@ RpcRequest.prototype.new_request = function(api, method_api, params, auth_token)
     this.method_api = method_api;
     this.params = params;
     this.auth_token = auth_token;
-    this.srv = api.name + '.' + method_api.name;
+    this.srv = api.id + '.' + method_api.name;
     try {
         this.method_api.validate_params(this.params, 'CLIENT');
     } catch (err) {
@@ -94,7 +94,7 @@ RpcRequest.prototype.export_request_buffers = function() {
     var header = {
         op: 'req',
         reqid: this.reqid,
-        api: this.api.name,
+        api: this.api.id,
         method: this.method_api.name,
         params: this.params,
     };
@@ -128,7 +128,7 @@ RpcRequest.prototype.import_request_message = function(msg, api, method_api) {
             throw this.rpc_error('BAD_REQUEST', err);
         }
     }
-    this.srv = (api ? api.name : '?') +
+    this.srv = (api ? api.id : '?') +
         '.' + (method_api ? method_api.name : '?');
 };
 

--- a/src/rpc/rpc_schema.js
+++ b/src/rpc/rpc_schema.js
@@ -1,33 +1,13 @@
 'use strict';
 
-module.exports = RpcSchema;
 
 var _ = require('lodash');
 var assert = require('assert');
 var Ajv = require('ajv');
-var genfun = require('generate-function');
 var dbg = require('../util/debug_module')(__filename);
+var schema_utils = require('../util/schema_utils');
 
-/**
- * a registry for api's
- */
-function RpcSchema() {
-    this._validator = new Ajv({
-        missingRefs: 'ignore',
-        // verbose: true,
-        formats: {
-            idate: function(val) {
-                var d = new Date(val);
-                return !isNaN(d.getTime());
-            },
-            buffer: function(val) {
-                return Buffer.isBuffer(val);
-            }
-        },
-    });
-}
-
-var VALID_HTTP_METHODS = {
+const VALID_HTTP_METHODS = {
     GET: 1,
     PUT: 1,
     POST: 1,
@@ -35,193 +15,96 @@ var VALID_HTTP_METHODS = {
 };
 
 /**
- *
- * register_api
- *
+ * a registry for api's
  */
-RpcSchema.prototype.register_api = function(api) {
-    var self = this;
+class RpcSchema {
 
-    assert(!self[api.name], 'RPC: api already registered ' + api.name);
+    constructor() {
+        this._ajv = new Ajv({
+            formats: {
+                idate: schema_utils.idate_format,
+                buffer: schema_utils.buffer_format
+            },
+        });
+    }
 
-    // add all definitions
-    _.each(api.definitions, function(schema, name) {
-        schema.id = '/' + api.name + '/definitions/' + name;
-        prepare_schema(schema);
+    /**
+     *
+     * register_api
+     *
+     */
+    register_api(api) {
+        assert(!this[api.id], 'RPC: api already registered ' + api.id);
+        _.each(api.definitions, schema => {
+            schema_utils.make_strict_schema(schema);
+            schema_utils.prepare_buffers_in_schema(schema);
+        });
+        _.each(api.methods, method_api => {
+            schema_utils.make_strict_schema(method_api.params);
+            schema_utils.make_strict_schema(method_api.reply);
+            schema_utils.prepare_buffers_in_schema(method_api.params);
+            schema_utils.prepare_buffers_in_schema(method_api.reply);
+        });
         try {
-            self._validator.addSchema(schema);
+            this._ajv.addSchema(api);
         } catch (err) {
-            dbg.error('register_api: failed compile definition schema',
-                schema, err.stack || err);
+            dbg.error('register_api: failed compile api schema', api, err.stack || err);
             throw err;
         }
-    });
-
-    // go over the api and check its validity
-    _.each(api.methods, function(method_api, method_name) {
-        // add the name to the info
-        method_api.api = api;
-        method_api.name = method_name;
-        method_api.fullname = '/' + api.name + '/methods/' + method_name;
-
-        if (method_api.params) {
-            method_api.params.id = method_api.fullname + '/params';
-            prepare_schema(method_api.params);
-            try {
-                method_api.params_validator = self._validator.compile(method_api.params);
-            } catch (err) {
-                dbg.error('register_api: failed compile params schema',
-                    method_api.params, err.stack || err);
-                throw err;
-            }
-        } else {
-            method_api.params_validator = validator_of_empty_schema;
-        }
-
-        if (method_api.reply) {
-            method_api.reply.id = method_api.fullname + '/reply';
-            prepare_schema(method_api.reply);
-            try {
-                method_api.reply_validator = self._validator.compile(method_api.reply);
-            } catch (err) {
-                dbg.error('register_api: failed compile reply schema',
-                    method_api.reply, err.stack || err);
-                throw err;
-            }
-        } else {
-            method_api.reply_validator = validator_of_empty_schema;
-        }
-
-        method_api.method = method_api.method || 'POST';
-        assert(method_api.method in VALID_HTTP_METHODS,
-            'RPC: unexpected http method: ' +
-            method_api.method + ' for ' + method_api.fullname);
-
-        method_api.validate_params = function(params, desc) {
-            var result = method_api.params_validator(params);
-            if (!result) {
-                dbg.error('INVALID PARAMS SCHEMA', desc, method_api.fullname,
-                    'ERRORS:', method_api.params_validator.errors,
-                    'PARAMS:', params);
-                throw new Error('INVALID PARAMS SCHEMA ' + desc + ' ' + method_api.fullname);
-            }
-        };
-
-        method_api.validate_reply = function(reply, desc) {
-            var result = method_api.reply_validator(reply);
-            if (!result) {
-                dbg.error('INVALID REPLY SCHEMA', desc, method_api.fullname,
-                    'ERRORS:', method_api.reply_validator.errors,
-                    'REPLY:', reply);
-                throw new Error('INVALID REPLY SCHEMA ' + desc + ' ' + method_api.fullname);
-            }
-        };
-    });
-
-    self[api.name] = api;
-
-    return api;
-};
-
-
-function prepare_schema(base, schema, path) {
-    if (!schema) {
-        schema = base;
-        path = [];
+        this[api.id] = api;
     }
 
-    if (schema.type === 'buffer') {
-        delete schema.type;
-        delete schema.additionalProperties;
-        schema.format = 'buffer';
-        base.buffers = base.buffers || [];
-        base.buffers.push({
-            path: path,
-            jspath: _.map(path, function(item) {
-                return '["' + item + '"]';
-            }).join('')
-        });
-    } else if (schema.type === 'array') {
-        if (schema.items) {
-            prepare_schema(base, schema.items, path.concat('[]'));
-        }
-    } else if (schema.type === 'object') {
-        // this is a temporary way to support banUnknownProperties - see above
-        if (!('additionalProperties' in schema)) {
-            schema.additionalProperties = false;
-        }
-        _.each(schema.properties, function(val, key) {
-            if (!val) return;
-            prepare_schema(base, val, path.concat(key));
-        });
-    } else if (!schema.type &&
-        !schema.$ref &&
-        !schema.oneOf &&
-        !schema.allOf &&
-        !schema.anyOf) {
-        console.error('RPC SCHEMA illegal schema, missing type/$ref/oneOf/anyOf',
-            base.id, 'path', path.join('.'), 'schema', JSON.stringify(schema));
-        throw new Error('RPC SCHEMA illegal schema ' + base.id);
-    }
+    compile() {
+        _.each(this, api => {
+            if (!api || !api.id || api.id[0] === '_') return;
+            _.each(api.methods, (method_api, method_name) => {
+                method_api.api = api;
+                method_api.name = method_name;
+                method_api.fullname = api.id + '#/methods/' + method_name;
+                method_api.method = method_api.method || 'POST';
+                assert(method_api.method in VALID_HTTP_METHODS,
+                    'RPC: unexpected http method: ' +
+                    method_api.method + ' for ' + method_api.fullname);
 
-    if (schema === base) {
-        /**
-         * generating functions to extract/combine the buffers from objects
-         *
-         * @param req the wrapping object holding the params/reply
-         * @param head either 'params' or 'reply'
-         *
-         * NOTE: this code only supports buffers under predefined properties
-         * so can't use array of buffers or a additionalProperties which is not listed
-         * in schema.properties while this preparation code runs.
-         */
-        var efn = genfun()('function export_buffers(obj) {');
-        if (base.buffers) {
-            // create a concatenated buffer from all the buffers
-            // and replace each of the original paths with the buffer length
-            efn('var buffers = [];');
-            efn('var buf;');
-            _.each(base.buffers, function(b) {
-                efn('var buf = obj%s;', b.jspath);
-                efn('if (buf) {');
-                efn(' buffers.push(buf);');
-                efn(' obj%s = buf.length;', b.jspath);
-                efn('}');
-            });
-            efn('return buffers;');
-        }
-        base.export_buffers = efn('}').toFunction();
+                try {
+                    method_api.params_validator = method_api.params ?
+                        this._ajv.compile({
+                            $ref: method_api.fullname + '/params'
+                        }) : schema_utils.empty_schema_validator;
+                    method_api.reply_validator = method_api.reply ?
+                        this._ajv.compile({
+                            $ref: method_api.fullname + '/reply'
+                        }) : schema_utils.empty_schema_validator;
+                } catch (err) {
+                    dbg.error('register_api: failed compile method params/reply refs',
+                        method_api, err.stack || err);
+                    throw err;
+                }
 
-        // the import_buffers counterpart
-        var ifn = genfun()('function import_buffers(obj, data) {');
-        if (base.buffers) {
-            ifn('var start = 0;');
-            ifn('var end = 0;');
-            ifn('var len;');
-            ifn('data = data || new Buffer(0);');
-            _.each(base.buffers, function(b, i) {
-                ifn('len = obj%s;', b.jspath);
-                ifn('if (typeof(len) === "number") {');
-                ifn(' start = end;');
-                ifn(' end = start + len;');
-                ifn(' obj%s = data.slice(start, end);', b.jspath);
-                ifn('}');
+                method_api.validate_params = (params, desc) => {
+                    var result = method_api.params_validator(params);
+                    if (!result) {
+                        dbg.error('INVALID PARAMS SCHEMA', desc, method_api.fullname,
+                            'ERRORS:', method_api.params_validator.errors,
+                            'PARAMS:', params);
+                        throw new Error('INVALID PARAMS SCHEMA ' + desc + ' ' + method_api.fullname);
+                    }
+                };
+
+                method_api.validate_reply = (reply, desc) => {
+                    var result = method_api.reply_validator(reply);
+                    if (!result) {
+                        dbg.error('INVALID REPLY SCHEMA', desc, method_api.fullname,
+                            'ERRORS:', method_api.reply_validator.errors,
+                            'REPLY:', reply);
+                        throw new Error('INVALID REPLY SCHEMA ' + desc + ' ' + method_api.fullname);
+                    }
+                };
             });
-        }
-        base.import_buffers = ifn('}').toFunction();
-        if (base.buffers) {
-            // dbg.log1('SCHEMA BUFFERS', base.id, base.buffers,
-            // base.export_buffers.toString(),
-            // base.import_buffers.toString());
-        }
+        });
     }
 }
 
-function validator_of_empty_schema(json) {
-    if (_.isEmpty(json)) {
-        return true;
-    } else {
-        validator_of_empty_schema.errors = "expected empty schema";
-        return false;
-    }
-}
+
+
+module.exports = RpcSchema;

--- a/src/test/measure_bind_perf.js
+++ b/src/test/measure_bind_perf.js
@@ -23,7 +23,7 @@ Clazz.prototype.measure = function() {
         }
         process.stdout.write('.');
         now = Date.now();
-        if (now - start > 5000) {
+        if (now - start > 2000) {
             process.stdout.write('\n');
             break;
         }
@@ -31,24 +31,24 @@ Clazz.prototype.measure = function() {
     console.log('Calls per second', (count * 1000 / (now - start)).toFixed(1));
 };
 
-console.log('BIND');
+console.log('\nBIND');
 var binded = new Clazz();
 binded.func = binded.func.bind(binded);
 binded.measure();
 
-console.log('LODASH');
+console.log('\nLODASH (_.bindAll)');
 var lodasher = new Clazz();
 _.bindAll(lodasher);
 binded.measure();
 
-console.log('CLOSURE');
+console.log('\nCLOSURE');
 var closure = new Clazz();
 closure.func = function() {
     return Clazz.prototype.func.apply(closure, arguments);
 };
 closure.measure();
 
-console.log('SELF BIND');
+console.log('\nSELF BIND (js_utils.self_bind)');
 var selfbind = new Clazz();
 js_utils.self_bind(selfbind);
 selfbind.measure();

--- a/src/test/test_rpc.js
+++ b/src/test/test_rpc.js
@@ -112,6 +112,7 @@ describe('RPC', function() {
     var ERROR_CODE = 'FORBIDDEN';
     var schema = new RpcSchema();
     schema.register_api(test_api);
+    schema.compile();
 
     describe('schema.register_api', function() {
 

--- a/src/util/schema_utils.js
+++ b/src/util/schema_utils.js
@@ -1,0 +1,136 @@
+'use strict';
+
+var _ = require('lodash');
+var genfun = require('generate-function');
+
+module.exports = {
+    idate_format: idate_format,
+    buffer_format: buffer_format,
+    make_strict_schema: make_strict_schema,
+    empty_schema_validator: empty_schema_validator,
+    prepare_buffers_in_schema: prepare_buffers_in_schema,
+};
+
+function idate_format(val) {
+    var d = new Date(val);
+    return !isNaN(d.getTime());
+}
+
+function buffer_format(val) {
+    return Buffer.isBuffer(val);
+}
+
+
+function make_strict_schema(schema, base) {
+    if (!schema) return;
+    if (!base) base = schema;
+    if (!_.isObject(schema)) return;
+    if (schema.type) {
+        if (schema.type === 'object') {
+            if (!('additionalProperties' in schema)) {
+                schema.additionalProperties = false;
+            }
+            _.each(schema.properties, val => make_strict_schema(val, base));
+        } else if (schema.type === 'array') {
+            make_strict_schema(schema.items, base);
+        }
+    } else if (schema.$ref) {
+        // noop
+    } else if (schema.oneOf) {
+        _.each(schema.oneOf, val => make_strict_schema(val, base));
+    } else if (schema.anyOf) {
+        _.each(schema.anyOf, val => make_strict_schema(val, base));
+    } else if (schema.allOf) {
+        _.each(schema.allOf, val => make_strict_schema(val, base));
+    } else {
+        console.error('ILLEGAL JSON SCHEMA, missing type/$ref/oneOf/allOf/anyOf',
+            'schema', schema, 'base', base);
+        throw new Error('ILLEGAL JSON SCHEMA ' + base.id);
+    }
+}
+
+function empty_schema_validator(json) {
+    if (_.isEmpty(json)) {
+        return true;
+    } else {
+        empty_schema_validator.errors = "expected empty schema";
+        return false;
+    }
+}
+
+
+function prepare_buffers_in_schema(schema, base, path) {
+    if (!schema) return;
+    if (!base) {
+        base = schema;
+        path = [];
+    }
+
+    if (schema.type === 'buffer') {
+        delete schema.type;
+        delete schema.additionalProperties;
+        schema.format = 'buffer';
+        base.buffers = base.buffers || [];
+        base.buffers.push({
+            path: path,
+            jspath: _.map(path, item => '["' + item + '"]').join('')
+        });
+    } else if (schema.type === 'object') {
+        _.each(schema.properties, (val, key) => {
+            if (!val) return;
+            prepare_buffers_in_schema(val, base, path.concat(key));
+        });
+    }
+
+    if (schema === base) {
+        /**
+         * generating functions to extract/combine the buffers from objects
+         *
+         * @param req the wrapping object holding the params/reply
+         * @param head either 'params' or 'reply'
+         *
+         * NOTE: this code only supports buffers under predefined properties
+         * so can't use array of buffers or a additionalProperties which is not listed
+         * in schema.properties while this preparation code runs.
+         */
+        var efn = genfun()('function export_buffers(obj) {');
+        if (base.buffers) {
+            // create a concatenated buffer from all the buffers
+            // and replace each of the original paths with the buffer length
+            efn('var buffers = [];');
+            efn('var buf;');
+            _.each(base.buffers, b => {
+                efn('buf = obj%s;', b.jspath);
+                efn('if (buf) {');
+                efn(' buffers.push(buf);');
+                efn(' obj%s = buf.length;', b.jspath);
+                efn('}');
+            });
+            efn('return buffers;');
+        }
+        base.export_buffers = efn('}').toFunction();
+
+        // the import_buffers counterpart
+        var ifn = genfun()('function import_buffers(obj, data) {');
+        if (base.buffers) {
+            ifn('var start = 0;');
+            ifn('var end = 0;');
+            ifn('var len;');
+            ifn('data = data || new Buffer(0);');
+            _.each(base.buffers, (b, i) => {
+                ifn('len = obj%s;', b.jspath);
+                ifn('if (typeof(len) === "number") {');
+                ifn(' start = end;');
+                ifn(' end = start + len;');
+                ifn(' obj%s = data.slice(start, end);', b.jspath);
+                ifn('}');
+            });
+        }
+        base.import_buffers = ifn('}').toFunction();
+        if (base.buffers) {
+            // dbg.log1('SCHEMA BUFFERS', base.id, base.buffers,
+            // base.export_buffers.toString(),
+            // base.import_buffers.toString());
+        }
+    }
+}


### PR DESCRIPTION
- rewrite as class
- use $refs in standard json pointer format
- extract util functions to schema_utils to prepare for use for mongodb validations
