### PR TITLE
temporary fix for #886

### DIFF
--- a/src/server/node_monitor.js
+++ b/src/server/node_monitor.js
@@ -455,11 +455,20 @@ function collect_agent_diagnostics(req) {
 
 function set_debug_node(req) {
     var target = req.rpc_params.target;
-
+    dbg.log0('set_debug_node',req);
     return P.fcall(function() {
             return server_rpc.client.agent.set_debug_node({}, {
                 address: target,
             });
+        })
+        .then(function(){
+            var updates = {};
+            //TODO: use param and send it to the agent.
+            //Currently avoid it, due to multiple actors.
+            updates.debug_level = 5;
+            return db.Node.update({
+                rpc_address: target
+            }, updates).exec();
         })
         .then(null, function(err) {
             dbg.log0('Error on set_debug_node', err);

--- a/src/server/node_monitor.js
+++ b/src/server/node_monitor.js
@@ -455,7 +455,6 @@ function collect_agent_diagnostics(req) {
 
 function set_debug_node(req) {
     var target = req.rpc_params.target;
-    dbg.log0('set_debug_node',req);
     return P.fcall(function() {
             return server_rpc.client.agent.set_debug_node({}, {
                 address: target,


### PR DESCRIPTION
debug_level reflection for the UI.
Need to send it to the agent instead of duplicate the value in the
agent code and here. We have more than one way to activate it, so I
took the short path. We will need to change it.
