### PR TITLE
catching errors on update_work_list, to not abort all policies if one fails

### DIFF
--- a/src/bg_workers/cloud_sync.js
+++ b/src/bg_workers/cloud_sync.js
@@ -52,7 +52,11 @@ function background_worker() {
                         return;
                     }
                     should_update_time = true;
-                    return update_work_list(policy);
+                    return update_work_list(policy)
+                        .fail(function(error) {
+                            dbg.error('update_work_list failed for policy:', policy);
+                            return;
+                        });
                 }
             }));
         })


### PR DESCRIPTION
if one policy fails to update its work list, it caused all other cloud_sync policies to not work.
catching the error and returning  to continue with the rest.
