### PR TITLE
fix problem with s3 deletion of folders

### DIFF
--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -78,9 +78,15 @@ function map_aggregate_objects() {
 function map_key_with_prefix_delimiter() {
     /* jshint validthis: true */
     var suffix = this.key.slice(prefix.length);
-    var pos = suffix.indexOf(delimiter);
-    if (pos >= 0) {
-        emit(suffix.slice(0, pos), undefined);
+    if (delimiter && delimiter!==''){
+        var pos = suffix.indexOf(delimiter);
+        if (pos >= 0) {
+            emit(suffix.slice(0, pos), undefined);
+        }
+    }
+    else
+    {
+        emit(suffix,undefined);
     }
 }
 


### PR DESCRIPTION
In part of the cases, we can get “get_bucket” with prefix, but without
delimiter. In such case, we deleted all folders, as we didn’t take the
prefix into account.
