### PR TITLE
s3 xml - always encode all string values, replace jstoxml with simple implementation that is x10 faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "istanbul": "^0.4.2",
     "jshint-stylish": "~2.0.1",
     "jsonwebtoken": "~5.0.5",
-    "jstoxml": "~0.2.3",
     "lodash": "^4.5.1",
     "method-override": "~2.3.5",
     "mime": "~1.3.4",

--- a/src/s3/s3_controller.js
+++ b/src/s3/s3_controller.js
@@ -8,7 +8,6 @@ let ObjectIO = require('../api/object_io');
 let s3_errors = require('./s3_errors');
 let xml2js = require('xml2js');
 let P = require('../util/promise');
-let string_utils = require('../util/string_utils');
 
 dbg.set_level(5);
 
@@ -54,12 +53,12 @@ class S3Controller {
                 return {
                     ListAllMyBucketsResult: {
                         Owner: DEFAULT_S3_USER,
-                        Buckets: if_not_empty(_.map(reply.buckets, bucket => ({
+                        Buckets: _.map(reply.buckets, bucket => ({
                             Bucket: {
                                 Name: bucket.name,
                                 CreationDate: date
                             }
-                        })))
+                        }))
                     }
                 };
             });
@@ -113,21 +112,21 @@ class S3Controller {
                             IsTruncated: false,
                             'Encoding-Type': req.query['encoding-type'],
                         },
-                        if_not_empty(_.map(reply.objects, obj => ({
+                        _.map(reply.objects, obj => ({
                             Contents: {
-                                Key: string_utils.encodeXML(obj.key),
+                                Key: obj.key,
                                 LastModified: to_s3_date(obj.info.create_time),
                                 ETag: obj.info.etag,
                                 Size: obj.info.size,
                                 Owner: DEFAULT_S3_USER,
                                 StorageClass: STORAGE_CLASS_STANDARD,
                             }
-                        }))),
-                        if_not_empty(_.map(reply.common_prefixes, prefix => ({
+                        })),
+                        _.map(reply.common_prefixes, prefix => ({
                             CommonPrefixes: {
-                                Prefix: string_utils.encodeXML(prefix) || ''
+                                Prefix: prefix || ''
                             }
-                        })))
+                        }))
                     ]
                 };
             });
@@ -165,9 +164,9 @@ class S3Controller {
                             // NextVersionIdMarker: ...
                             'Encoding-Type': req.query['encoding-type'],
                         },
-                        if_not_empty(_.map(reply.objects, obj => ({
+                        _.map(reply.objects, obj => ({
                             Version: {
-                                Key: string_utils.encodeXML(obj.key),
+                                Key: obj.key,
                                 VersionId: '',
                                 IsLatest: true,
                                 LastModified: to_s3_date(obj.info.create_time),
@@ -176,12 +175,12 @@ class S3Controller {
                                 Owner: DEFAULT_S3_USER,
                                 StorageClass: STORAGE_CLASS_STANDARD,
                             }
-                        }))),
-                        if_not_empty(_.map(reply.common_prefixes, prefix => ({
+                        })),
+                        _.map(reply.common_prefixes, prefix => ({
                             CommonPrefixes: {
-                                Prefix: string_utils.encodeXML(prefix) || ''
+                                Prefix: prefix || ''
                             }
-                        })))
+                        }))
                     ]
                 };
             });
@@ -216,21 +215,21 @@ class S3Controller {
                             IsTruncated: false,
                             'Encoding-Type': req.query['encoding-type'],
                         },
-                        if_not_empty(_.map(reply.objects, obj => ({
+                        _.map(reply.objects, obj => ({
                             Upload: {
-                                Key: string_utils.encodeXML(obj.key),
+                                Key: obj.key,
                                 UploadId: obj.info.version_id,
                                 Initiated: to_s3_date(obj.info.create_time),
                                 Initiator: DEFAULT_S3_USER,
                                 Owner: DEFAULT_S3_USER,
                                 StorageClass: STORAGE_CLASS_STANDARD,
                             }
-                        }))),
-                        if_not_empty(_.map(reply.common_prefixes, prefix => ({
+                        })),
+                        _.map(reply.common_prefixes, prefix => ({
                             CommonPrefixes: {
-                                Prefix: string_utils.encodeXML(prefix) || ''
+                                Prefix: prefix || ''
                             }
-                        })))
+                        }))
                     ]
                 };
             });
@@ -444,7 +443,7 @@ class S3Controller {
             start_index = 1;
             slash_index = copy_source.indexOf('/', 1);
         }
-        console.log('COPY OBJECT ',req.params.key);
+        console.log('COPY OBJECT ', req.params.key);
         let source_bucket = copy_source.slice(start_index, slash_index);
         let source_key = copy_source.slice(slash_index + 1);
         let params = {
@@ -616,14 +615,14 @@ class S3Controller {
                             NextPartNumberMarker: reply.next_part_number_marker,
                             IsTruncated: reply.is_truncated,
                         },
-                        if_not_empty(_.map(reply.upload_parts, part => ({
+                        _.map(reply.upload_parts, part => ({
                             Part: {
                                 PartNumber: part.part_number,
                                 Size: part.size,
                                 ETag: part.etag,
                                 LastModified: to_s3_date(part.last_modified),
                             }
-                        })))
+                        }))
                     ]
                 };
             });
@@ -761,10 +760,6 @@ function to_s3_date(input) {
     let date = input ? new Date(input) : new Date();
     date.setMilliseconds(0);
     return date.toISOString();
-}
-
-function if_not_empty(obj) {
-    return _.isEmpty(obj) ? undefined : obj;
 }
 
 function get_request_xattr(req) {

--- a/src/s3/s3_rest.js
+++ b/src/s3/s3_rest.js
@@ -6,17 +6,13 @@ let dbg = require('../util/debug_module')(__filename);
 let s3_util = require('../util/s3_utils');
 let s3_errors = require('./s3_errors');
 let express = require('express');
-let jstoxml = require('jstoxml');
 let moment = require('moment');
+let xml_utils = require('../util/xml_utils');
 //var S3Auth = require('aws-sdk/lib/signers/s3');
 //var s3_auth = new S3Auth();
 
 const S3_XML_ATTRS = Object.freeze({
     xmlns: 'http://doc.s3.amazonaws.com/2006-03-01'
-});
-const XML_OPTIONS = Object.freeze({
-    header: true,
-    indent: false
 });
 const BUCKET_QUERIES = Object.freeze([
     'acl',
@@ -124,12 +120,8 @@ function s3_rest(controller) {
                         res.status(200).end();
                     }
                 } else {
-                    let xml_root = _.map(reply, (val, key) => ({
-                        _name: key,
-                        _attrs: S3_XML_ATTRS,
-                        _content: val
-                    }));
-                    let xml_reply = jstoxml.toXML(xml_root, XML_OPTIONS);
+                    _.each(reply, val => val._attr = S3_XML_ATTRS);
+                    let xml_reply = xml_utils.encode_xml(reply);
                     dbg.log0('S3 XML REPLY', func_name, req.method, req.url,
                         JSON.stringify(req.headers), xml_reply);
                     res.status(200).send(xml_reply);

--- a/src/s3/s3_rest.js
+++ b/src/s3/s3_rest.js
@@ -120,8 +120,11 @@ function s3_rest(controller) {
                         res.status(200).end();
                     }
                 } else {
-                    _.each(reply, val => val._attr = S3_XML_ATTRS);
-                    let xml_reply = xml_utils.encode_xml(reply);
+                    let xml_root = _.mapValues(reply, val => ({
+                        _attr: S3_XML_ATTRS,
+                        _content: val
+                    }));
+                    let xml_reply = xml_utils.encode_xml(xml_root);
                     dbg.log0('S3 XML REPLY', func_name, req.method, req.url,
                         JSON.stringify(req.headers), xml_reply);
                     res.status(200).send(xml_reply);

--- a/src/util/string_utils.js
+++ b/src/util/string_utils.js
@@ -1,5 +1,5 @@
-// module targets: nodejs & browserify
 'use strict';
+
 /**
  *
  * string_utils
@@ -7,10 +7,8 @@
  * various string utils
  *
  */
-
 module.exports = {
     escapeRegExp: escapeRegExp,
-    encodeXML: encodeXML,
     toBinary: toBinary
 };
 
@@ -19,17 +17,10 @@ function escapeRegExp(str) {
     return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 }
 
-function encodeXML(instr) {
-    return instr.replace(/&/g, '&amp;')
-               .replace(/</g, '&lt;')
-               .replace(/>/g, '&gt;')
-               .replace(/"/g, '&quot;')
-               .replace(/'/g, '&apos;');
- }
- function toBinary (str) {
-     var result = '';
-     for (var i = 0, l = str.length; i < l; i += 2) {
-         result += String.fromCharCode(parseInt(str.substr(i, 2), 16));
-     }
-     return result;
- }
+function toBinary (str) {
+    var result = '';
+    for (var i = 0, l = str.length; i < l; i += 2) {
+        result += String.fromCharCode(parseInt(str.substr(i, 2), 16));
+    }
+    return result;
+}

--- a/src/util/xml_utils.js
+++ b/src/util/xml_utils.js
@@ -1,0 +1,85 @@
+'use strict';
+
+exports.encode_xml = encode_xml;
+exports.encode_xml_str = encode_xml_str;
+
+/**
+ *
+ * fast object to xml encoding, optimized for speed.
+ *
+ * the object will be traveresed recursively:
+ *  - any object will be encoded such that keys are xml tags.
+ *  - any array will be encode without introducing new keys, meaning items are flattened.
+ *  - string/number/boolean/date will be converted to strings.
+ *  - {key: null} will encode an empty tag - <key></key>
+ *  - {key: undefined} will not encode the tag at all.
+ *  - {key: {_attr:{k1=v1,k2=v2,...}} will encode xml attributes on the tag (_attr can be set on array values too)
+ *
+ * for example:
+ *   { root: [{a:1,b:2}, {a:3}, {b:4}, [[[[{z:42}]]]], {c:{_attr:{d:5}}} ] }
+ * will be encoded as (spaces are only for clarity):
+ *   <root> <a>1</a> <b>2</b> <a>3</a> <b>4</b> <z>42</z> <c d="5"></c> </root>
+ *
+ */
+function encode_xml(object) {
+    var output = '<?xml version="1.0" encoding="UTF-8"?>';
+    var append = function(s) {
+        output += s;
+    };
+    append_object(append, object);
+    return output;
+}
+
+function append_object(append, object) {
+    if (Array.isArray(object)) {
+        // arrays are encoded without adding new tags
+        // which allows repeating keys with the same name
+        for (let i = 0; i < object.length; ++i) {
+            append_object(append, object[i]);
+        }
+    } else {
+        for (let key in object) {
+            // skip any keys from the prototype
+            if (!object.hasOwnProperty(key)) continue;
+            // skip any internal key
+            if (key[0] === '_') continue;
+            let val = object[key];
+            let type = typeof(val);
+            // undefined values will skip encoding the key tag altogether
+            if (type === 'undefined') continue;
+            if (type === 'object') {
+                if (val && val._attr) {
+                    append('<' + key);
+                    for (let k in val._attr) {
+                        if (!val._attr.hasOwnProperty(k)) continue;
+                        append(' ' + k + '="' + encode_xml_str(val._attr[k]) + '"');
+                    }
+                    append('>');
+                } else {
+                    append('<' + key + '>');
+                }
+                if (val) {
+                    append_object(append, val);
+                }
+                append('</' + key + '>');
+            } else {
+                append('<' + key + '>');
+                append(encode_xml_str(val));
+                append('</' + key + '>');
+            }
+        }
+    }
+}
+
+// see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML
+const XML_CHAR_ENTITY_MAP = Object.freeze({
+    '"': '&quot;',
+    '&': '&amp;',
+    '\'': '&apos;',
+    '<': '&lt;',
+    '>': '&gt;'
+});
+
+function encode_xml_str(s) {
+    return String(s).replace(/(["&'<>])/g, (str, ch) => XML_CHAR_ENTITY_MAP[ch]);
+}


### PR DESCRIPTION
The following s3-tests that used to fail now pass:
s3tests.functional.test_s3.test_bucket_list_prefix_basic ... ok
s3tests.functional.test_s3.test_bucket_list_prefix_alt ... ok
s3tests.functional.test_s3.test_bucket_list_prefix_not_exist ... ok
s3tests.functional.test_s3.test_bucket_list_special_prefix ... ok
s3tests.functional.test_s3.test_bucket_create_special_key_names ... ok
