### PR TITLE
fixes

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -342,7 +342,7 @@ AgentCLI.prototype.create_node_helper = function(current_node_path_info, interna
 
     return P.fcall(function() {
         var current_node_path = current_node_path_info.mount;
-        var node_name = internal_node_name || os.hostname() + '-' + uuid();
+        var node_name = internal_node_name || os.hostname() + '-' + uuid().split('-')[0];
         var path_modification = current_node_path.replace('/agent_storage/', '').replace('/', '').replace('.', '');
         //windows
         path_modification = path_modification.replace('\\agent_storage\\', '');

--- a/src/s3/s3_errors.js
+++ b/src/s3/s3_errors.js
@@ -1,6 +1,7 @@
 'use strict';
 
 let _ = require('lodash');
+let xml_utils = require('../util/xml_utils');
 
 class S3Error {
 
@@ -14,13 +15,14 @@ class S3Error {
     }
 
     reply(resource, request_id) {
-        return `<?xml version="1.0" encoding="UTF-8"?>
-<Error>
- <Code>${this.code}</Code>
- <Message>${this.message}</Message>
- <Resource>${resource || ''}</Resource>
- <RequestId>${request_id || ''}</RequestId>
-</Error>`;
+        return xml_utils.encode_xml({
+            Error:{
+                Code:this.code,
+                Message:this.message,
+                Resource:resource ||'',
+                RequestId: request_id||''
+            }
+        });
     }
 
 }

--- a/src/server/mapper/map_builder.js
+++ b/src/server/mapper/map_builder.js
@@ -125,8 +125,6 @@ class MapBuilder {
                 block.system = chunk.system;
                 block.chunk = chunk;
                 alloc.block = block;
-                this.new_blocks = this.new_blocks || [];
-                this.new_blocks.push(block);
                 avoid_nodes.push(node._id.toString());
             });
         });
@@ -166,6 +164,8 @@ class MapBuilder {
                         address: target.address,
                     });
                 }).then(() => {
+                    this.new_blocks = this.new_blocks || [];
+                    this.new_blocks.push(block);
                     dbg.log1('MapBuilder.replicate_blocks: replicated block',
                         block._id, 'to', target.address, 'from', source.address);
                 }, err => {

--- a/src/server/mapper/map_deleter.js
+++ b/src/server/mapper/map_deleter.js
@@ -10,6 +10,7 @@ var dbg = require('../../util/debug_module')(__filename);
 
 
 exports.delete_object_mappings = delete_object_mappings;
+exports.agent_delete_call = agent_delete_call;
 
 
 /**

--- a/src/server/system_server.js
+++ b/src/server/system_server.js
@@ -186,13 +186,6 @@ function read_system(req) {
         // objects - size, count
         db.ObjectMD.aggregate_objects(by_system_id_undeleted),
 
-        // blocks
-        db.DataBlock.mapReduce({
-            query: by_system_id_undeleted,
-            map: mongo_functions.map_size,
-            reduce: mongo_functions.reduce_sum
-        }),
-
         promise_utils.all_obj(system.buckets_by_name, function(bucket) {
             // TODO this is a hacky "pseudo" rpc request. really should avoid.
             let new_req = _.defaults({
@@ -208,11 +201,9 @@ function read_system(req) {
     ).spread(function(
         nodes_aggregate_pool,
         objects_aggregate,
-        blocks,
         cloud_sync_by_bucket,
         time_status) {
 
-        blocks = _.mapValues(_.keyBy(blocks, '_id'), 'value');
         var nodes_sys = nodes_aggregate_pool[''] || {};
         var objects_sys = objects_aggregate[''] || {};
         var ip_address = ip_module.address();
@@ -263,7 +254,7 @@ function read_system(req) {
                 free: nodes_sys.free,
                 alloc: nodes_sys.alloc,
                 used: objects_sys.size,
-                real: blocks.size,
+                real: nodes_sys.used,
             }),
             nodes: {
                 count: nodes_sys.count || 0,


### PR DESCRIPTION
1. delete redundant blocks from agents in bg workers
2. avoid writing to database - allocated blocks that failed to write
3. make read system faster
4. shorten node name
5. encode s3 errors (client failed when got error on multipart)
