### PR TITLE
Fix a lot of usability issues with dropdown

### DIFF
--- a/frontend/src/app/bindings/scroll-to.js
+++ b/frontend/src/app/bindings/scroll-to.js
@@ -1,10 +1,21 @@
 import ko from 'knockout';
 
-export default {
-    update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
-        let i = ko.unwrap(valueAccessor());
-        if ( -1 < i && i < element.children.length) {
-            element.scrollTop = element.children[i].offsetTop;
-        }
+function scroll(element, valueAccessor, allBindings, viewModel, bindingContext) {
+    let i = ko.unwrap(valueAccessor());
+    if ( -1 < i && i < element.children.length) {
+        let child = element.children[i];
+
+        element.scrollTop = Math.min(
+            child.offsetTop,
+            Math.max(
+                element.scrollTop, 
+                child.offsetTop + child.clientHeight - element.clientHeight
+            )
+        );
     }
+}
+
+export default {
+    init: scroll,
+    update: scroll
 }

--- a/frontend/src/app/components/shared/dropdown/dropdown.html
+++ b/frontend/src/app/components/shared/dropdown/dropdown.html
@@ -1,6 +1,6 @@
 <div class="dropdown-wrapper no-outline" data-bind="
-    click: () => active(true) && true,
-    event: { keypress: (_, evt) => scrollTo(evt) },
+    click: () => active.toggle(),
+    event: { keydown: (_, evt) => handleKeyPress(evt) },
     hasFocus: focused,
     attr: { tabindex: !ko.unwrap(disabled) && '0' },
     css: { disabled: disabled, active: active },
@@ -8,7 +8,7 @@
 ">
     <svg-icon class="pull-right" params="uri: '/fe/assets/icons.svg#expand'"></svg-icon>
     
-    <div type="text" class="value" data-bind="
+    <div type="text" class="value no-wrap" data-bind="
         value: selected, 
         text: selectedLabel,
         css: { placeholder: selected() == null }
@@ -16,7 +16,8 @@
 
     <div class="options" data-bind="
         visible: active(), 
-        event: { change: () => active(false) && true }
+        click: () => active(false) && true,
+        clickBubble: false
     ">
         <ul class="list-no-style" data-bind="foreach: options, scrollTo: selectedIndex">
             <li data-bind="css: { seperator: !$data }, if: $data">

--- a/frontend/src/app/components/shared/dropdown/dropdown.js
+++ b/frontend/src/app/components/shared/dropdown/dropdown.js
@@ -52,8 +52,49 @@ class DropdownViewModel {
         this.lastInput = 0;
     }
 
-    scrollTo({ which }) {
-        let char = String.fromCharCode(which).toLowerCase();
+    handleKeyPress({ which }) {
+        switch(which) {
+            case 9: /* tab */
+            case 13: /* enter */
+                this.searchInput = '';
+                this.active(false);
+
+                break;
+
+            case 38: /* up arrow */
+                this.active(true);
+                this.selectPrevOption();
+                break;
+
+            case 40: /* down arrow */
+                this.active(true);
+                this.selectNextOption()
+                break;
+
+            default:
+                this.sreachBy(which);
+                break;
+        }
+
+        return true;
+    }
+
+    selectPrevOption() {
+        let options = ko.unwrap(this.options);
+        let prev = options[Math.max(this.selectedIndex() - 1, 0)];
+        this.selected(prev.value);
+        this.searchInput = ''; 
+    }
+
+    selectNextOption() {
+        let options = ko.unwrap(this.options);
+        let next = options[Math.min(this.selectedIndex() + 1, options.length - 1)];
+        this.selected(next.value);
+        this.searchInput = '';
+    }
+
+    sreachBy(keyCode) {
+        let char = String.fromCharCode(keyCode).toLowerCase();
         this.searchInput = Date.now() - this.lastInput <= INPUT_THROTTLE ?
             this.searchInput + char : 
             char;


### PR DESCRIPTION
1. enter will select and close the current value
2. tab will close and move to the next field
3. up arrow will open the option box and will move to previous item in
   the option list
4. down arrow will open the option box and will move to next item in
   the option list
5. scroll will only happen if the option is not already in the visible
