### PR TITLE
Prevent creating a system with invalid DNS name

### DIFF
--- a/frontend/src/app/components/login/create-system-form/create-system-form.js
+++ b/frontend/src/app/components/login/create-system-form/create-system-form.js
@@ -42,7 +42,8 @@ class CreateSystemFormViewModel {
             ownerEmail: this.ownerEmail,
             ownerPassword: this.ownerPassword,
             confirmPassword: this.confirmPassword,
-            systemName: this.systemName
+            systemName: this.systemName,
+            systemDNS: this.systemDNS
         });            
 
     }


### PR DESCRIPTION
Preserving the option to create a system with no dos name specified
bug: #1213
