### PR TITLE
fix for 1243 - Replication bug when using Cloud Pool

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -379,7 +379,6 @@ Agent.prototype._do_heartbeat = function() {
         params.cloud_pool_name = self.cloud_info.cloud_pool_name;
     }
 
-    params.is_internal_agent = self.is_internal_agent;
 
     params.debug_level = dbg.get_module_level('core');
 

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -249,9 +249,6 @@ module.exports = {
                     },
                     cloud_pool_name: {
                         type: 'string'
-                    },
-                    is_internal_agent: {
-                        type: 'boolean'
                     }
                 }
             },

--- a/src/server/node_services/node_model.js
+++ b/src/server/node_services/node_model.js
@@ -152,8 +152,9 @@ var node_schema = new Schema({
     latency_of_disk_read: [Number],
     latency_of_disk_write: [Number],
 
-    is_internal_agent: {
+    is_cloud_node: {
         type: Boolean,
+        required: true
     },
 
     error_since_hb: {

--- a/src/server/node_services/node_server.js
+++ b/src/server/node_services/node_server.js
@@ -42,9 +42,11 @@ function create_node(req) {
     var pool = {};
     if (req.rpc_params.cloud_pool_name) {
         pool = req.system.pools_by_name[req.rpc_params.cloud_pool_name];
+        node.is_cloud_node = true;
         dbg.log0('creating node in cloud pool', req.rpc_params.cloud_pool_name, pool);
     } else {
         pool = req.system.pools_by_name.default_pool;
+        node.is_cloud_node = false;
     }
 
     if (!pool) {

--- a/src/server/node_services/nodes_store.js
+++ b/src/server/node_services/nodes_store.js
@@ -23,6 +23,7 @@ const NODE_FIELDS_FOR_MAP = Object.freeze({
     rpc_address: 1,
     storage: 1,
     latency_of_disk_read: 1,
+    is_cloud_node: 1,
 });
 
 


### PR DESCRIPTION
when data placement policy was SPREAD, the blocks group passed to
check_blocks_group contained all blocks, including blocks on cloud
pools.
changed to partition blocks to and pass only blocks on regular pools
