### PR TITLE
fix node._id used as string when saved in blocks by map builder

### DIFF
--- a/src/server/node_services/node_allocator.js
+++ b/src/server/node_services/node_allocator.js
@@ -46,7 +46,7 @@ function refresh_pool_alloc(pool) {
             dbg.log0('refresh_pool_alloc: updated pool', pool._id,
                 'nodes', _.map(group.nodes, 'name'));
             _.each(alloc_group_by_pool_set, (g, pool_set) => {
-                if (_.includes(pool_set, pool._id.toString())) {
+                if (_.includes(pool_set, String(pool._id))) {
                     dbg.log0('invalidate alloc_group_by_pool_set for', pool_set,
                         'on change to pool', pool._id);
                     delete alloc_group_by_pool_set[pool_set];
@@ -71,7 +71,7 @@ function refresh_pool_alloc(pool) {
  *
  */
 function allocate_node(pools, avoid_nodes, content_tiering_params) {
-    let pool_set = _.map(pools, pool => pool._id.toString()).sort().join(',');
+    let pool_set = _.map(pools, pool => String(pool._id)).sort().join(',');
     let alloc_group =
         alloc_group_by_pool_set[pool_set] =
         alloc_group_by_pool_set[pool_set] || {
@@ -120,7 +120,7 @@ function allocate_from_list(nodes, avoid_nodes, use_nodes_with_errors) {
         var node = get_round_robin(nodes);
         if (Boolean(use_nodes_with_errors) ===
             Boolean(node.report_error_on_node_alloc) &&
-            !_.includes(avoid_nodes, node._id.toString())) {
+            !_.includes(avoid_nodes, String(node._id))) {
             dbg.log1('allocate_node: allocated node', node.name,
                 'avoid_nodes', avoid_nodes);
             return node;

--- a/src/server/object_services/map_allocator.js
+++ b/src/server/object_services/map_allocator.js
@@ -73,7 +73,7 @@ class MapAllocator {
                         if (map_utils.is_chunk_good(dup_chunk, this.bucket.tiering)) {
                             // we set the part's chunk_dedup to the chunk id
                             // so that the client will send it back to finalize
-                            part.chunk_dedup = dup_chunk._id.toString();
+                            part.chunk_dedup = String(dup_chunk._id);
                             delete part.chunk;
                             // returning explicit false to break from _.each
                             return false;
@@ -101,7 +101,7 @@ class MapAllocator {
                 block.node = node;
                 f.blocks = f.blocks || [];
                 f.blocks.push(map_utils.get_block_info(block));
-                avoid_nodes.push(node._id.toString());
+                avoid_nodes.push(String(node._id));
             });
         });
     }

--- a/src/server/object_services/map_deleter.js
+++ b/src/server/object_services/map_deleter.js
@@ -103,7 +103,8 @@ function delete_objects_from_agents(deleted_chunk_ids) {
         .then(deleted_blocks => {
             //TODO: If the overload of these calls is too big, we should protect
             //ourselves in a similar manner to the replication
-            var blocks_by_node = _.groupBy(deleted_blocks, block => block.node._id);
+            var blocks_by_node = _.groupBy(deleted_blocks,
+                block => String(block.node._id));
             return P.all(_.map(blocks_by_node, agent_delete_call));
         });
 }
@@ -115,7 +116,7 @@ function delete_objects_from_agents(deleted_chunk_ids) {
  */
 function agent_delete_call(del_blocks, node_id) {
     var address = del_blocks[0].node.rpc_address;
-    var block_ids = _.map(del_blocks, block => block._id.toString());
+    var block_ids = _.map(del_blocks, block => String(block._id));
     dbg.log0('agent_delete_call: node', node_id, address,
         'block_ids', block_ids.length);
     return server_rpc.client.block_store.delete_blocks({

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -397,20 +397,18 @@ function read_object_mappings(req) {
 function read_node_mappings(req) {
     var node;
     return nodes_client.instance().read_node_by_name(req.system._id, req.params.name)
-        .then(
-            node_arg => {
-                node = node_arg;
-                var params = _.pick(req.rpc_params, 'skip', 'limit');
-                params.node_id = node._id;
-                params.system = req.system;
-                return map_reader.read_node_mappings(params);
-            }
-        )
+        .then(node_arg => {
+            node = node_arg;
+            var params = _.pick(req.rpc_params, 'skip', 'limit');
+            params.node_id = node._id;
+            params.system = req.system;
+            return map_reader.read_node_mappings(params);
+        })
         .then(objects => {
             if (req.rpc_params.adminfo) {
                 return md_store.DataBlock.collection.count({
                         system: req.system._id,
-                        node: node._id,
+                        node: mongo_utils.make_object_id(node._id),
                         deleted: null
                     })
                     .then(count => ({

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -174,24 +174,20 @@ class SystemStoreData {
     }
 
     get_by_id(id) {
-        return id ? this.idmap[id.toString()] : null;
+        return id ? this.idmap[String(id)] : null;
     }
 
     get_by_id_include_deleted(id, name) {
-        var ret = id ? this.idmap[id.toString()] : null;
-        if (ret) {
-            return ret;
-        } else { //Query deleted !== null
-            return P.resolve(mongo_client.instance().db.collection(name).findOne({
-                    _id: id,
-                    deleted: {
-                        $ne: null
-                    }
-                }))
-                .then((item) => {
-                    return item;
-                });
-        }
+        const res = this.get_by_id(id);
+        if (res) return res;
+        //Query deleted !== null
+        const collection = mongo_client.instance().db.collection(name);
+        return P.resolve(collection.findOne({
+            _id: id,
+            deleted: {
+                $ne: null
+            }
+        }));
     }
 
     resolve_object_ids_paths(item, paths, allow_missing) {
@@ -214,7 +210,7 @@ class SystemStoreData {
         _.each(COLLECTIONS, col => {
             let items = this[col.name];
             _.each(items, item => {
-                let idstr = item._id.toString();
+                let idstr = String(item._id);
                 let existing = this.idmap[idstr];
                 if (existing) {
                     dbg.error('SystemStoreData: id collision', item, existing);

--- a/src/util/mongo_utils.js
+++ b/src/util/mongo_utils.js
@@ -34,7 +34,7 @@ function uniq_ids(docs, doc_path) {
     _.each(docs, doc => {
         const id = _.get(doc, doc_path);
         if (id) {
-            map[id.toString()] = id;
+            map[String(id)] = id;
         }
     });
     return _.values(map);
@@ -110,6 +110,15 @@ function make_object_id(id_str) {
     return new mongodb.ObjectId(id_str);
 }
 
+function fix_id_type(doc) {
+    if (_.isArray(doc)) {
+        _.each(doc, d => fix_id_type(d));
+    } else if (doc && doc._id) {
+        doc._id = make_object_id(doc._id);
+    }
+    return doc;
+}
+
 // apparently mongoose defined it's own class of ObjectID
 // instead of using the class from mongodb driver,
 // so we have to check both for now,
@@ -162,6 +171,7 @@ exports.populate = populate;
 exports.resolve_object_ids_recursive = resolve_object_ids_recursive;
 exports.resolve_object_ids_paths = resolve_object_ids_paths;
 exports.make_object_id = make_object_id;
+exports.fix_id_type = fix_id_type;
 exports.is_object_id = is_object_id;
 exports.is_err_duplicate_key = is_err_duplicate_key;
 exports.check_duplicate_key_conflict = check_duplicate_key_conflict;


### PR DESCRIPTION
which fixes read_node_mappings which was always returning empty.

this issue was introduced once node_allocator was changed to use node_monitor instead of directly from mongo, so any older database will not have this issue, and no db upgrade is needed.

also fixed in other queries and in general to avoid using node._id as string when not intended.
