### PR TITLE
moved setup_users to the beginning of upgrade.sh

### DIFF
--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -119,6 +119,7 @@ function extract_package {
 }
 
 function do_upgrade {
+  setup_users
   disable_supervisord
 
   unalias cp
@@ -151,7 +152,6 @@ function do_upgrade {
   deploy_log "Finished post upgrade"
 
   enable_supervisord
-  setup_users
   deploy_log "Enabling supervisor"
   #workaround - from some reason, without sleep + restart, the server starts with odd behavior
   #TODO: understand why and fix.


### PR DESCRIPTION
setup_users was called after starting supervisord, and in some cases
mongo wasn’t up yet so user creation failed
