### PR TITLE
Disable bucket upload if bucket is not supported with enough nodes.

### DIFF
--- a/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.html
+++ b/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.html
@@ -4,11 +4,19 @@
         <span data-bind="text: objectCount"></span>
     </h3>
 
-    <input class="push-next" type="search" placeholder="Search by file name" data-bind="
-        textInput: filter
-    "/>
+    <div class="greedy push-next">
+        <input type="search" placeholder="Search by file name"
+            data-bind="textInput: filter" />
+    </div>
 
-    <button class="upload-btn btn3" data-bind="click: () => showUploadFilesModal()">Upload Files</button>
+    <div data-bind="tooltip: uploadTooltip">
+        <button class="upload-btn btn3" data-bind="
+            disable: uploadDisabled,
+            click: () => showUploadFilesModal()
+        ">
+            Upload Files
+        </button>
+    </div>
 </div>
 
 <div class="data-table greedy push-next">


### PR DESCRIPTION
### Purpose

Disabling bucket upload button if we know that the user will fail to upload
- Issues opened on technical debt -
  The decision about the state of the bucket in regard to uploading should be made in the server side.
### Issues References
- Fixes #874
