### PR TITLE
Evgb vm world bug fixes

### DIFF
--- a/src/server/bg_services/cluster_master.js
+++ b/src/server/bg_services/cluster_master.js
@@ -46,10 +46,15 @@ function background_worker() {
             });
     } else if (!is_cluster_master) {
         dbg.log0('no local cluster info or server is not part of a cluster. therefore will be cluster master');
-        return send_master_update(true).then(() => {
-            bg_workers_starter.run_master_workers();
-            is_cluster_master = true;
-        });
+        return send_master_update(true)
+            .then(() => {
+                bg_workers_starter.run_master_workers();
+                is_cluster_master = true;
+            })
+            .catch(err => {
+                dbg.error('send_master_update had an error:', err.stack || err);
+                return;
+            });
     }
 }
 

--- a/src/server/bg_services/cluster_master.js
+++ b/src/server/bg_services/cluster_master.js
@@ -13,6 +13,11 @@ var is_cluster_master = false;
 exports.background_worker = background_worker;
 
 function background_worker() {
+    if (!system_store.is_finished_initial_load) {
+        dbg.log0('System did not finish initial load');
+        return;
+    }
+
     let current_clustering = system_store.get_local_cluster_info();
     if (current_clustering && current_clustering.is_clusterized) {
         // TODO: Currently checks the replica set master since we don't have shards
@@ -41,9 +46,10 @@ function background_worker() {
             });
     } else if (!is_cluster_master) {
         dbg.log0('no local cluster info or server is not part of a cluster. therefore will be cluster master');
-        bg_workers_starter.run_master_workers();
-        is_cluster_master = true;
-        return send_master_update(is_cluster_master);
+        return send_master_update(true).then(() => {
+            bg_workers_starter.run_master_workers();
+            is_cluster_master = true;
+        });
     }
 }
 

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -373,7 +373,7 @@ function set_debug_level(req) {
 
             return P.each(target_servers, function(server) {
                 return server_rpc.client.cluster_internal.apply_set_debug_level(debug_params, {
-                    address: 'ws://' + server.owner_address + ':8080',
+                    address: 'ws://' + server.owner_address + ':' + server_rpc.get_base_port(),
                     auth_token: req.auth_token
                 });
             });
@@ -469,7 +469,7 @@ function diagnose_system(req) {
         .then(() => {
             return P.each(target_servers, function(server) {
                 return server_rpc.client.cluster_internal.collect_server_diagnostics(req.rpc_params, {
-                        address: 'ws://' + server.owner_address + ':8080',
+                        address: 'ws://' + server.owner_address + ':' + server_rpc.get_base_port(),
                         auth_token: req.auth_token
                     })
                     .then((res_data) => {

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -432,7 +432,8 @@ function _set_debug_level_internal(req, level) {
                 // Only master can update the whole system debug mode level
                 // TODO: If master falls in the process and we already passed him
                 // It means that nobody will update the system in the DB, yet it will be in debug
-                if (!system_store.is_cluster_master) {
+                let current_clustering = system_store.get_local_cluster_info();
+                if ((current_clustering && current_clustering.is_clusterized) && !system_store.is_cluster_master) {
                     return;
                 }
 

--- a/src/server/utils/server_diagnostics.js
+++ b/src/server/utils/server_diagnostics.js
@@ -47,7 +47,8 @@ function collect_server_diagnostics(req) {
             return collect_ntp_diagnostics();
         })
         .then(function() {
-            if (stats_aggregator && system_store.is_cluster_master) {
+            let current_clustering = system_store.get_local_cluster_info();
+            if (stats_aggregator && !((current_clustering && current_clustering.is_clusterized) && !system_store.is_cluster_master)) {
                 return stats_aggregator.get_all_stats(req);
             } else {
                 return;


### PR DESCRIPTION
### Purpose
- Besides making the world a better place it also fixes #1505 
  and solves an issue with cluster master value in the system store, which was always false when we were not clusterized.
### Checklist

_Notice 1: you can create the PR and keep pushing commits until all relevant items are marked_  
_Notice 2: remove items below that are irrelevant_  
- [X] Failure handling - describe how it behaves on failures: Added additional catch and return in the cluster_master bg worker, for the case when the system store is not ready, or there is no system.
- [X] Platforms handling - describe how it behaves on different platforms: **Agnostic**
- [X] Issues opened on technical debt - We will need to check the cluster master algorithm, more. Seems like I've fixed an issue and I cannot see any other problems currently, but I don't trust it.
- [ ] **Does not support XXX - issue #xxxx**
- [x] Code Review - with someone besides myself:
  - [x] **Please review @nimrod-becker**
- [ ] Code Covered - by automatic tests: unit tests - rpc - set_debug_level
- [ ] Code Comments - on non-trivial parts
- [X] Diagnostics info - added: Changed the check of cluster master inside collect_server_diagnostics when we attempt to collect phone home details.
- [X] Phone Home info - added: The bg service of phone home will not run currently if the system store did not assign to itself the cluster master value correctly, or if there is no system (the bg doesn't run if there is no system).
- [ ] Tests added - **Links to unit-tests / system-tests**
- [ ] Tested with `npm test`
### Issues References
- Fixes #1505 
