### PR TITLE
Sending time in seconds (unix epoch) instead of milliseconds (javascr…

### DIFF
--- a/frontend/src/app/components/login/create-system-form/create-system-form.js
+++ b/frontend/src/app/components/login/create-system-form/create-system-form.js
@@ -2,6 +2,7 @@ import template from './create-system-form.html';
 import Disposable from 'disposable';
 import ko from 'knockout';
 import { createSystem } from 'actions';
+import moment from 'moment';
 
 class CreateSystemFormViewModel extends Disposable {
     constructor() {
@@ -115,7 +116,7 @@ class CreateSystemFormViewModel extends Disposable {
 
         let timeConfig = {
             timezone: Intl.DateTimeFormat().resolved.timeZone,
-            epoch: Date.now()
+            epoch: moment().unix()
         };
 
         if (this.validateStep(this.step())) {

--- a/frontend/src/app/components/management/server-time-form/server-time-form.js
+++ b/frontend/src/app/components/management/server-time-form/server-time-form.js
@@ -73,14 +73,7 @@ class ServerTimeFormViewModel extends Disposable{
 
     setManualTime() {
         let epoch = moment.tz(
-            {
-                years: this.year(),
-                months: this.month(),
-                date: this.day(),
-                hours: this.hour(),
-                minutes: this.minute(),
-                seconds: this.second()
-            },
+            this.time(),
             this.timezone()
         )
         .unix();


### PR DESCRIPTION
### Purpose
- Fixing a bug where epoch is sent to the server in milliseconds instead of seconds
- Technical debt:
  We decided that epoch time is always sent to the server in seconds (unix format)  for all api calls that uses epoch time (setting or getting epoch time)
### Issues References
- Fixes #1576
