### PR TITLE
Danny diags

### DIFF
--- a/src/server/utils/server_diagnostics.js
+++ b/src/server/utils/server_diagnostics.js
@@ -3,36 +3,70 @@
 const fs = require('fs');
 const P = require('../../util/promise');
 const os_utils = require('../../util/os_utils');
-const fs_utils = require('../../util/fs_utils');
 const promise_utils = require('../../util/promise_utils');
 const base_diagnostics = require('../../util/base_diagnostics');
 const stats_aggregator = require('../system_services/stats_aggregator');
 const system_store = require('../system_services/system_store').get_instance();
 
 const TMP_WORK_DIR = '/tmp/diag';
-
+const DIAG_ERRORS_FILE = TMP_WORK_DIR + '/diagnostics_collection_errors.log';
+const LONG_EXEC_TIMEOUT = 60 * 1000;
+const SHORT_EXEC_TIMEOUT = 5 * 1000;
 
 //TODO: Add temp collection dir as param
 function collect_server_diagnostics(req) {
-    return P.fcall(function() {
-            let limit_logs_size = false;
-            let local_cluster = system_store.get_local_cluster_info();
-            return base_diagnostics.collect_basic_diagnostics(limit_logs_size, local_cluster && local_cluster.is_clusterized);
-        })
-        .then(function() {
+    let local_cluster = system_store.get_local_cluster_info();
+    return base_diagnostics.prepare_diag_dir(local_cluster && local_cluster.is_clusterized)
+        .then(() => base_diagnostics.collect_basic_diagnostics())
+        .then(() => {
 
             // operations for diagnostics that can take place in parallel
             const operations = [
-                () => collect_supervisor_logs(),
-                () => promise_utils.exec('cp -f /var/log/noobaa_deploy* ' + TMP_WORK_DIR, true),
-                () => promise_utils.exec('cp -f /var/log/noobaa.log* ' + TMP_WORK_DIR, true),
-                () => promise_utils.exec('cp -f ' + process.cwd() + '/.env ' + TMP_WORK_DIR + '/env', true),
-                () => os_utils.top_single(TMP_WORK_DIR + '/top.out'),
-                () => promise_utils.exec('cp -f /etc/noobaa* ' + TMP_WORK_DIR, true),
-                () => promise_utils.exec('lsof &> ' + TMP_WORK_DIR + '/lsof.out', true),
-                () => promise_utils.exec('chkconfig &> ' + TMP_WORK_DIR + '/chkconfig.out', true),
-                () => collect_ntp_diagnostics(),
-                () => collect_statistics.bind(this, req)
+                () => collect_supervisor_logs()
+                .then(() => diag_log('collected supervisor logs successfully'))
+                .catch(err => diag_log('collect_supervisor_logs failed with error: ' + err)),
+
+                () => promise_utils.exec('cp -f /var/log/noobaa_deploy* ' + TMP_WORK_DIR, false, false, LONG_EXEC_TIMEOUT)
+                .then(() => diag_log('collected noobaa_deploy logs successfully'))
+                .catch(err => diag_log('collecting noobaa_deploy.log failed with error: ' + err)),
+
+                () => promise_utils.exec('cp -f /var/log/noobaa.log* ' + TMP_WORK_DIR, false, false, LONG_EXEC_TIMEOUT)
+                .then(() => diag_log('collected noobaa.log files successfully'))
+                .catch(err => diag_log('collecting noobaa.log failed with error: ' + err)),
+
+                () => promise_utils.exec('cp -f ' + process.cwd() + '/.env ' + TMP_WORK_DIR + '/env', false, false, LONG_EXEC_TIMEOUT)
+                .then(() => diag_log('collected .env successfully'))
+                .catch(err => diag_log('collecting .env failed with error: ' + err)),
+
+                () => os_utils.top_single(TMP_WORK_DIR + '/top.out')
+                .then(() => diag_log('collected top.out successfully'))
+                .catch(err => diag_log('collecting top.out failed with error: ' + err)),
+
+
+                () => promise_utils.exec('cp -f /etc/noobaa* ' + TMP_WORK_DIR, false, false, LONG_EXEC_TIMEOUT)
+                .then(() => diag_log('collected /etc/noobaa files successfully'))
+                .catch(err => diag_log('collecting /etc/noobaa files failed with error: ' + err)),
+
+
+                () => promise_utils.exec('lsof &> ' + TMP_WORK_DIR + '/lsof.out', false, false, LONG_EXEC_TIMEOUT)
+                .then(() => diag_log('collected lsof.out successfully'))
+                .catch(err => diag_log('collecting lsof.out failed with error: ' + err)),
+
+
+                () => promise_utils.exec('chkconfig &> ' + TMP_WORK_DIR + '/chkconfig.out', false, false, LONG_EXEC_TIMEOUT)
+                .then(() => diag_log('collected chkconfig.out successfully'))
+                .catch(err => diag_log('collecting chkconfig.out failed with error: ' + err)),
+
+
+                () => collect_ntp_diagnostics()
+                .then(() => diag_log('collected ntp diagnostics successfully'))
+                .catch(err => diag_log('collect_ntp_diagnostics failed with error: ' + err)),
+
+
+                () => collect_statistics(req)
+                .then(() => diag_log('collected statistics successfully'))
+                .catch(err => diag_log('collect_statistics failed with error: ' + err)),
+
             ];
 
 
@@ -55,34 +89,40 @@ function write_agent_diag_file(data) {
 }
 
 function collect_ntp_diagnostics() {
+    if (process.platform !== 'linux') {
+        console.log('Skipping ntp diagnostics collection on non linux server');
+        return P.resolve();
+    }
     let ntp_diag = TMP_WORK_DIR + '/ntp.diag';
-    return promise_utils.exec('echo "### NTP diagnostics ###" >' + ntp_diag, true)
-        .then(() => promise_utils.exec('echo "\ncontent of /etc/ntp.conf:" &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('cat /etc/ntp.conf &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('echo "\n\n" &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('ls -l /etc/localtime &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('echo "\n\nntpstat:" &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('ntpstat &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('echo "\n\ndate:" &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('date &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('echo "\n\nntpdate:" &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('ntpdate &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('echo "\n\nntptime:" &>>' + ntp_diag, true))
-        .then(() => promise_utils.exec('ntptime &>>' + ntp_diag, true));
+    return promise_utils.exec('echo "### NTP diagnostics ###" >' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT)
+        .then(() => promise_utils.exec('echo "\ncontent of /etc/ntp.conf:" &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('cat /etc/ntp.conf &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('echo "\n\n" &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('ls -l /etc/localtime &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('echo "\n\nntpstat:" &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('ntpstat &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('echo "\n\ndate:" &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('date &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('echo "\n\nntpdate:" &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('ntpdate &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('echo "\n\nntptime:" &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT))
+        .then(() => promise_utils.exec('ntptime &>>' + ntp_diag, false, false, SHORT_EXEC_TIMEOUT));
 }
 
 //Collect supervisor logs, only do so on linux platforms and not on OSX (WA for local server run)
 function collect_supervisor_logs() {
-    if (process.platform === 'linux') {
-        return P.resolve()
-            .then(() => fs_utils.full_dir_copy('/tmp/supervisor', TMP_WORK_DIR))
-            .catch(function(err) {
-                console.error('Error in collecting supervisor logs', err);
-                throw new Error('Error in collecting supervisor logs ' + err);
-            });
-    } else {
-        console.log('Skipping supervisor logs collection on non linux server');
-    }
+    return P.resolve()
+        .then(() => {
+            if (process.platform === 'linux') {
+                return promise_utils.exec('cp -f /tmp/supervisor/* ' + TMP_WORK_DIR, false, false, LONG_EXEC_TIMEOUT)
+                    .catch(function(err) {
+                        console.error('Error in collecting supervisor logs', err);
+                        throw new Error('Error in collecting supervisor logs ' + err);
+                    });
+            } else {
+                console.log('Skipping supervisor logs collection on non linux server');
+            }
+        });
 }
 
 function collect_statistics(req) {
@@ -110,6 +150,10 @@ function collect_statistics(req) {
         });
 }
 
+
+function diag_log(msg) {
+    return fs.appendFileAsync(DIAG_ERRORS_FILE, msg + '\n\n');
+}
 
 // EXPORTS
 exports.collect_server_diagnostics = collect_server_diagnostics;

--- a/src/util/base_diagnostics.js
+++ b/src/util/base_diagnostics.js
@@ -17,7 +17,8 @@ const is_windows = (process.platform === "win32");
 
 const TMP_WORK_DIR = is_windows ? process.env.ProgramData + '/diag' : '/tmp/diag';
 
-function collect_basic_diagnostics(limit_logs_size, is_clusterized) {
+
+function prepare_diag_dir(is_clusterized) {
     return P.fcall(function() {
             if (!is_clusterized) {
                 return fs_utils.folder_delete(TMP_WORK_DIR);
@@ -33,27 +34,11 @@ function collect_basic_diagnostics(limit_logs_size, is_clusterized) {
                 return fs_utils.create_path(TMP_WORK_DIR);
             }
             return;
-        })
-        .then(function() {
-            if (fs.existsSync(process.cwd() + '/logs')) {
-                if (limit_logs_size) {
-                    //will take only noobaa.log and the first 9 zipped logs
-                    return fs_utils.full_dir_copy(process.cwd() + '/logs', TMP_WORK_DIR, 'noobaa?[1-9][0-9].log.gz');
-                } else {
-                    return fs_utils.full_dir_copy(process.cwd() + '/logs', TMP_WORK_DIR);
-                }
-            } else {
-                return;
-            }
-        })
-        .then(function() {
-            if (fs.existsSync('/var/log/noobaa_local_service.log')) {
-                return fs_utils.file_copy('/var/log/noobaa_local_service.log', TMP_WORK_DIR);
-            } else {
-                return;
-            }
-        })
-        .then(function() {
+        });
+}
+
+function collect_basic_diagnostics(limit_logs_size) {
+    return P.fcall(function() {
             return fs_utils.file_copy(process.cwd() + '/package.json', TMP_WORK_DIR);
         })
         .then(function() {
@@ -139,6 +124,7 @@ function archive_diagnostics_pack(dst) {
 
 
 // EXPORTS
+exports.prepare_diag_dir = prepare_diag_dir;
 exports.collect_basic_diagnostics = collect_basic_diagnostics;
 exports.write_agent_diag_file = write_agent_diag_file;
 exports.pack_diagnostics = pack_diagnostics;

--- a/src/util/promise_utils.js
+++ b/src/util/promise_utils.js
@@ -221,11 +221,12 @@ function spawn(command, args, options, ignore_rc) {
     });
 }
 
-function exec(command, ignore_rc, return_stdout) {
+function exec(command, ignore_rc, return_stdout, timeout) {
     return new P((resolve, reject) => {
         dbg.log2('promise exec', command, ignore_rc);
         child_process.exec(command, {
             maxBuffer: 5000 * 1024, //5MB, should be enough
+            timeout: timeout
         }, function(error, stdout, stderr) {
             if (!error || ignore_rc) {
                 if (error) {


### PR DESCRIPTION
### Purpose

Fixed #1572 diagnostics improvements:
- perform diagnostic collection in parallel for independent operations
- add time out of 60 seconds for each operation. 
- compress supervisor logs before copying (makes it faster)
- added diagnostics log to log success\failure of diagnostics operations
- refactored base\server\agent diagnostics (removed noobaa-core/logs collection in base - only relevant for agent)
### Checklist
- [x] Failure handling - describe how it behaves on failures:
  - write failure to log
- [x] Platforms handling - describe how it behaves on different platforms:
  - relevant to server only
- [X] Code Review - with someone besides myself:
  - [x]  @nimrod-becker - changed a bit from what we reviewed, please review changes in collect_supervisor in server_diagnostics.js
