### PR TITLE
Fixed #966 - ignore read only drives in agent_cli

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -104,7 +104,8 @@ AgentCLI.prototype.init = function() {
             if (self.params.address) {
                 self.client.options.address = self.params.address;
             }
-            return os_utils.read_drives();
+            return os_utils.read_drives()
+                .then(drives => os_utils.remove_linux_readonly_drives(drives));
         })
         .then(function(drives) {
             dbg.log0('drives:', drives, ' current location ', process.cwd());


### PR DESCRIPTION
### Purpose

ignore read only drives in agent_cli
- get read only drives from /proc/mounts
- filter out drives that are read only
### Checklist
- [x] Failure handling - describe how it behaves on failures:
  - **Return error to the user**
- [x] Platforms handling - describe how it behaves on different platforms:
  - **linux only** windows already filters out.
- [x] Code Comments - on non-trivial parts
### Issues References
- Fixed #966 
