### PR TITLE
Support for bucket_lifecycle_configuration_rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dev-null": "~0.1.1",
     "diskspace": "~0.1.7",
     "dotenv": "~1.2.0",
-    "eslint": "^1.3.1",
+    "eslint": "2.7.0",
     "event-stream": "~3.3.1",
     "express": "~4.13.3",
     "forever": "^0.15.1",

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -139,7 +139,7 @@ module.exports = {
         update_bucket_s3_acl: {
             method: 'PUT',
             params: {
-                type: 'object', 
+                type: 'object',
                 required: ['name', 'access_control'],
                 properties: {
                     name: {
@@ -316,8 +316,180 @@ module.exports = {
             auth: {
                 system: 'admin'
             }
-        }
+        },
+        set_bucket_lifecycle_configuration_rules: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string'
+                    },
+                    rules: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            required: ['id', 'prefix', 'status', 'expiration'],
+                            properties: {
+                                id: {
+                                    type: 'string'
+                                },
+                                prefix: {
+                                    type: 'string'
+                                },
+                                status: {
+                                    type: 'string'
+                                },
+                                expiration: {
+                                    type: 'object',
+                                    properties: {
+                                        days: {
+                                            type: 'integer'
+                                        },
+                                        date: {
+                                            format: 'idate'
+                                        },
+                                        expired_object_delete_marker: {
+                                            type: 'boolean'
+                                        }
 
+                                    }
+                                },
+                                abort_incomplete_multipart_upload: {
+                                    type: 'object',
+                                    properties: {
+                                        days_after_initiation: {
+                                            type: 'integer'
+                                        },
+                                    }
+                                },
+                                transition: {
+                                    type: 'object',
+                                    properties: {
+                                        date: {
+                                            format: 'idate'
+                                        },
+                                        storage_class: {
+                                            $ref: '#/definitions/storage_class_enum'
+                                        }
+                                    }
+                                },
+                                noncurrent_version_expiration: {
+                                    type: 'object',
+                                    properties: {
+                                        noncurrent_days: {
+                                            type: 'integer'
+                                        },
+                                    }
+                                },
+                                noncurrent_version_transition: {
+                                    type: 'object',
+                                    properties: {
+                                        noncurrent_days: {
+                                            type: 'integer'
+                                        },
+                                        storage_class: {
+                                            $ref: '#/definitions/storage_class_enum'
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            },
+        },
+        get_bucket_lifecycle_configuration_rules: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string'
+                    }
+                }
+            },
+            reply: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    required: ['id', 'prefix', 'status', 'expiration'],
+                    properties: {
+                        id: {
+                            type: 'string'
+                        },
+                        prefix: {
+                            type: 'string'
+                        },
+                        status: {
+                            type: 'string'
+                        },
+                        last_sync: {
+                            format: 'idate'
+                        },
+                        expiration: {
+                            type: 'object',
+                            properties: {
+                                days: {
+                                    type: 'integer'
+                                },
+                                date: {
+                                    format: 'idate'
+                                },
+                                expired_object_delete_marker: {
+                                    type: 'boolean'
+                                }
+
+                            }
+                        },
+                        abort_incomplete_multipart_upload: {
+                            type: 'object',
+                            properties: {
+                                days_after_initiation: {
+                                    type: 'integer'
+                                },
+                            }
+                        },
+                        transition: {
+                            type: 'object',
+                            properties: {
+                                date: {
+                                    format: 'idate'
+                                },
+                                storage_class: {
+                                    $ref: '#/definitions/storage_class_enum'
+                                }
+                            }
+                        },
+                        noncurrent_version_expiration: {
+                            type: 'object',
+                            properties: {
+                                noncurrent_days: {
+                                    type: 'integer'
+                                },
+                            }
+                        },
+                        noncurrent_version_transition: {
+                            type: 'object',
+                            properties: {
+                                noncurrent_days: {
+                                    type: 'integer'
+                                },
+                                storage_class: {
+                                    $ref: '#/definitions/storage_class_enum'
+                                }
+                            }
+                        },
+                    },
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
     },
 
     definitions: {
@@ -397,6 +569,10 @@ module.exports = {
             enum: ['IDLE', 'SYNCING'],
             type: 'string',
         },
+        storage_class_enum: {
+            enum: ['STANDARD_IA', 'GLACIER'],
+            type: 'string'
+        }
 
     },
 

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -589,10 +589,25 @@ module.exports = {
                 system: 'admin'
             }
         },
-
+        delete_multiple_objects_by_prefix: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['bucket', 'prefix'],
+                properties: {
+                    bucket: {
+                        type: 'string',
+                    },
+                    prefix: {
+                        type: 'string',
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
     },
-
-
 
     definitions: {
 

--- a/src/bg_workers/bg_workers_starter.js
+++ b/src/bg_workers/bg_workers_starter.js
@@ -24,6 +24,7 @@ var cloud_sync = require('./cloud_sync');
 var system_store = require('../server/stores/system_store');
 var account_server = require('../server/account_server');
 var scrubber = require('./scrubber');
+var lifecycle = require('./lifecycle');
 var server_rpc = require('../server/server_rpc');
 var dbg = require('../util/debug_module')(__filename);
 var db = require('../server/db');
@@ -72,6 +73,11 @@ if (process.env.SCRUBBER_DISABLED !== 'true') {
         time_since_last_build: 60000, // TODO increase?
         building_timeout: 300000, // TODO increase?
     }, scrubber.background_worker);
+}
+if (process.env.LIFECYCLE_DISABLED !== 'true') {
+    register_bg_worker({
+        name: 'lifecycle',
+    }, lifecycle.background_worker);
 }
 
 dbg.log('BG Workers Server started');

--- a/src/bg_workers/lifecycle.js
+++ b/src/bg_workers/lifecycle.js
@@ -1,0 +1,112 @@
+'use strict';
+
+module.exports = {
+    background_worker: background_worker,
+};
+
+var _ = require('lodash');
+var P = require('../util/promise');
+var system_store = require('../server/stores/system_store');
+var api = require('../api');
+var dbg = require('../util/debug_module')(__filename);
+
+
+var rpc = api.new_rpc();
+var rpc_client = rpc.new_client();
+
+//TODO: remove!!! handle BG RPC better asap
+var S3Auth = require('aws-sdk/lib/signers/s3');
+var s3 = new S3Auth();
+
+
+
+var LIFECYCLE = {
+    schedule_min: 5 //run every 5 minutes
+};
+
+/*
+ *************** Cloud Sync Background Worker & Other Eports
+ */
+function background_worker() {
+    return P.fcall(function() {
+            dbg.log0('LIFECYCLE READ BUCKETS configuration:', 'BEGIN');
+            return system_store.refresh()
+                .then(function() {
+                    //TODO:
+                    //Replace asap with bg call
+                    dbg.log0('sys store', system_store.data.accounts[1]);
+
+                    var basic_auth_params = {
+                        system: system_store.data.systems[0].name,
+                        role: 'admin'
+                    };
+                    var secret_key = system_store.data.accounts[1].access_keys[0].secret_key;
+                    var auth_params_str = JSON.stringify(basic_auth_params);
+                    var signature = s3.sign(secret_key, auth_params_str);
+                    var auth_params = {
+                        access_key: system_store.data.accounts[1].access_keys[0].access_key,
+                        string_to_sign: auth_params_str,
+                        signature: signature,
+                    };
+                    dbg.log0('create_access_key_auth', auth_params);
+                    return rpc_client.create_access_key_auth(auth_params);
+                })
+                .then(function() {
+                    _.each(system_store.data.buckets, function(bucket, i) {
+                        if (!bucket.lifecycle_configuration_rules) {
+                            return;
+                        }
+                        P.all(_.map(bucket.lifecycle_configuration_rules, function(lifecycle_rule, i) {
+                            dbg.log0('LIFECYCLE HANDLING BUCKET:', bucket.name, 'BEGIN');
+                            var now = Date.now();
+                            //If refresh time
+                            if (!lifecycle_rule.last_sync) {
+                                dbg.log0('LIFECYCLE HANDLING bucket:', bucket.name, 'rule id', lifecycle_rule.id, 'status:', lifecycle_rule.status, ' setting yesterday time');
+                                lifecycle_rule.last_sync = now - 1000 * 60 * 60 * 24; //set yesterday as last sync
+                            }
+                            dbg.log0('LIFECYCLE HANDLING bucket:', bucket.name, 'rule id(', i, ')', lifecycle_rule.id, 'status:', lifecycle_rule.status, 'last_sync', Math.floor((now - lifecycle_rule.last_sync) / 1000 / 60), 'min ago.');
+
+                            if ((lifecycle_rule.status === 'Enabled') &&
+                                ((now - lifecycle_rule.last_sync) / 1000 / 60 > LIFECYCLE.schedule_min)) {
+                                dbg.log0('LIFECYCLE PROCESSING bucket:', bucket.name, 'rule id(', i, ')', lifecycle_rule.id);
+                                if ((lifecycle_rule.expiration.days === 0) ||
+                                    (lifecycle_rule.expiration.date < (new Date()).getTime())) {
+                                    dbg.log0('LIFECYCLE DELETING bucket:', bucket.name, 'rule id(', i, ')', lifecycle_rule.id);
+                                    return P.when(rpc_client.object.delete_multiple_objects_by_prefix({
+                                        bucket: bucket.name,
+                                        prefix: lifecycle_rule.prefix,
+                                    }).then(function() {
+                                        bucket.lifecycle_configuration_rules[i].last_sync = Date.now();
+                                        dbg.log0('LIFECYCLE Done bucket:', bucket.name, ' done deletion of objects per prefix ', lifecycle_rule.prefix, ' time:', bucket.lifecycle_configuration_rules[i].last_sync);
+                                    }));
+                                }
+                            } else {
+                                dbg.log0('LIFECYCLE NOTHING bucket:', bucket.name, 'rule id', lifecycle_rule.id, ' nothing to do');
+                            }
+                        })).then(() => {
+                            dbg.log('LIFECYCLE SYNC TIME bucket ', bucket.name, ' SAVE last sync', bucket.lifecycle_configuration_rules[0].last_sync);
+                            update_lifecycle_rules_last_sync(bucket, bucket.lifecycle_configuration_rules);
+                        });
+                    });
+                });
+        })
+        .fail(function(error) {
+            dbg.error('LIFECYCLE FAILED processing', error, error.stack);
+        })
+        .then(function() {
+            dbg.log0('LIFECYCLE:', 'END');
+            return;
+        });
+}
+
+
+function update_lifecycle_rules_last_sync(bucket, rules) {
+    return system_store.make_changes({
+        update: {
+            buckets: [{
+                _id: bucket._id,
+                lifecycle_configuration_rules: rules
+            }]
+        }
+    });
+}

--- a/src/s3/s3_controller.js
+++ b/src/s3/s3_controller.js
@@ -272,16 +272,16 @@ class S3Controller {
                     bucket: req.params.bucket,
                     keys: keys
                 }).then(reply => {
-                    var response =  {
+                    var response = {
                         DeleteResult: [{},
                             _.map(keys, obj => ({
                                 Deleted: {
                                     Key: obj,
                                 }
-                            }),{})
+                            }), {})
                         ]
                     };
-                return response;
+                    return response;
                 });
             });
     }
@@ -692,6 +692,124 @@ class S3Controller {
                     etag: etag
                 });
             });
+    }
+
+
+    put_bucket_lifecycle(req) {
+        // <Rule>
+        //     <ID>id2</ID>
+        //     <Prefix>logs/</Prefix>
+        //     <Status>Enabled</Status>
+        //    <Expiration>
+        //      <Days>365</Days>
+        //    </Expiration>
+        //  </Rule>
+
+        dbg.log0('ETET put_bucket_lifecycle', req.params, '::::', req.query, '::::', req.body);
+        return P.ninvoke(xml2js, 'parseString', req.body)
+            .then(function(data) {
+                dbg.log0('ETET put_bucket_lifecycle JSON', data.LifecycleConfiguration.Rule);
+                //var lifecycle_rules = data.LifecycleConfiguration.Rule;
+                var lifecycle_rules = [];
+                _.each(data.LifecycleConfiguration.Rule, rule => {
+                        let current_rule = {
+                            id: rule.ID[0],
+                            prefix: rule.Prefix[0],
+                            status: rule.Status[0]
+                        };
+                        if (rule.Expiration) {
+                            current_rule.expiration = {};
+                            if (rule.Expiration[0].Days) {
+                                current_rule.expiration.days = parseInt(rule.Expiration[0].Days[0]);
+                            } else {
+                                current_rule.expiration.date = (new Date(rule.Expiration[0].Date[0])).getTime();
+                            }
+
+                            if (rule.Expiration[0].ExpiredObjectDeleteMarker) {
+                                current_rule.expiration.expired_object_delete_marker = rule.Expiration[0].ExpiredObjectDeleteMarker[0] === 'true';
+                            }
+
+                        }
+                        if (rule.AbortIncompleteMultipartUpload) {
+                            current_rule.abort_incomplete_multipart_upload = {
+                                days_after_initiation: rule.AbortIncompleteMultipartUpload[0].DaysAfterInitiation ? parseInt(rule.AbortIncompleteMultipartUpload[0].DaysAfterInitiation[0]) : null
+                            };
+                        }
+                        if (rule.Transition) {
+                            dbg.log0('ETET lifecycle Transition', rule.Transition);
+                            current_rule.transition = {
+                                date: rule.Transition[0].Date ? (new Date(rule.Transition[0].Date[0])).getTime() : null,
+                                storage_class: rule.Transition[0].StorageClass ? rule.Transition[0].StorageClass[0] : 'STANDARD_IA'
+                            };
+                            dbg.log0('ETET lifecycle Transition(2)', current_rule.transition);
+                        }
+                        if (rule.NoncurrentVersionExpiration) {
+                            current_rule.noncurrent_version_expiration = {
+                                noncurrent_days: rule.NoncurrentVersionExpiration[0].NoncurrentDays ? parseInt(rule.NoncurrentVersionExpiration[0].NoncurrentDays[0]) : null
+                            };
+                        }
+                        if (rule.NoncurrentVersionTransition) {
+                            current_rule.noncurrent_version_transition = {
+                                noncurrent_days: rule.NoncurrentVersionTransition[0].NoncurrentDays ? parseInt(rule.NoncurrentVersionTransition[0].NoncurrentDays[0]) : null,
+                                storage_class: rule.NoncurrentVersionTransition[0].StorageClass ? rule.NoncurrentVersionTransition[0].StorageClass[0] : 'STANDARD_IA'
+                            };
+                        }
+
+                        lifecycle_rules.push(current_rule);
+                    }
+
+                );
+                let params = {
+                    name: req.params.bucket,
+                    rules: lifecycle_rules
+                };
+                dbg.log0('ETET params rules', lifecycle_rules);
+                return req.rpc_client.bucket.set_bucket_lifecycle_configuration_rules(params)
+                    .then(() => {
+                        dbg.log('set_bucket_lifecycle', req.params.rule);
+                    });
+            });
+    }
+    get_bucket_lifecycle(req) {
+        let params = {
+            name: req.params.bucket
+        };
+        return req.rpc_client.bucket.get_bucket_lifecycle_configuration_rules(params)
+            .then((reply) => {
+                    let res = {
+                        LifecycleConfiguration: [
+                            _.map(reply, rule => ({
+                                Rule: {
+                                    ID: rule.id,
+                                    Prefix: rule.prefix,
+                                    Status: rule.status,
+                                    Transition: rule.transition ? {
+                                        Days: rule.transition.days,
+                                        StorageClass: rule.transition.storage_class,
+                                    } : null,
+                                    Expiration: rule.expiration ? (rule.expiration.days ? {
+                                        Days: rule.expiration.days,
+                                        ExpiredObjectDeleteMarker: rule.expiration.expired_object_delete_marker ? rule.expiration.expired_object_delete_marker : null
+                                    } : {
+                                        Date: rule.expiration.date,
+                                        ExpiredObjectDeleteMarker: rule.expiration.expired_object_delete_marker ? rule.expiration.expired_object_delete_marker : null
+                                    }) : null,
+                                    NoncurrentVersionTransition: rule.noncurrent_version_transition ? {
+                                        NoncurrentDays: rule.noncurrent_version_transition.noncurrent_days,
+                                        StorageClass: rule.noncurrent_version_transition.storage_class,
+                                    } : null,
+                                    NoncurrentVersionExpiration: rule.noncurrent_version_expiration ? {
+                                        NoncurrentDays: rule.noncurrent_version_expiration.noncurrent_days,
+                                    } : null,
+                                }
+                            }))
+                        ]
+                    };
+                    return res;
+                }
+
+            );
+
     }
 
 

--- a/src/s3/s3_rest.js
+++ b/src/s3/s3_rest.js
@@ -395,7 +395,8 @@ function handle_options(req, res, next) {
 }
 
 function read_post_body(req, res, next) {
-    if (req.method === 'POST' &&
+    if ((req.method === 'POST' ||
+            req.method === 'PUT') &&
         (req.headers['content-type'] === 'application/xml' ||
             req.headers['content-type'] === 'application/octet-stream')) {
         let data = '';

--- a/src/server/stores/schemas/bucket_schema.js
+++ b/src/server/stores/schemas/bucket_schema.js
@@ -75,6 +75,84 @@ module.exports = {
                 }
             }
         },
+        //lifecycle rules if exist
+        lifecycle_configuration_rules: {
+            type: 'array',
+            items: {
+                type: 'object',
+                required: ['id', 'prefix', 'status', 'expiration'],
+                properties: {
+                    id: {
+                        type: 'string'
+                    },
+                    prefix: {
+                        type: 'string'
+                    },
+                    status: {
+                        type: 'string'
+                    },
+                    expiration: {
+                        type: 'object',
+                        properties: {
+                            days: {
+                                type: 'integer'
+                            },
+                            date: {
+                                format: 'idate'
+                            },
+                            expired_object_delete_marker: {
+                                type: 'boolean'
+                            }
+
+                        }
+                    },
+                    abort_incomplete_multipart_upload: {
+                        type: 'object',
+                        properties: {
+                            days_after_initiation: {
+                                type: 'integer'
+                            },
+                        }
+                    },
+                    transition: {
+                        type: 'object',
+                        properties: {
+                            date: {
+                                format: 'idate'
+                            },
+                            storage_class: {
+                                type: 'string',
+                                enum: ['STANDARD_IA', 'GLACIER'],
+                            }
+                        }
+                    },
+                    noncurrent_version_expiration: {
+                        type: 'object',
+                        properties: {
+                            noncurrent_days: {
+                                type: 'integer'
+                            },
+                        }
+                    },
+                    noncurrent_version_transition: {
+                        type: 'object',
+                        properties: {
+                            noncurrent_days: {
+                                type: 'integer'
+                            },
+                            storage_class: {
+                                type: 'string',
+                                enum: ['STANDARD_IA', 'GLACIER'],
+                            }
+                        }
+                    },
+                    last_sync: {
+                        format: 'idate'
+                    }
+                }
+            }
+        },
+
         stats: {
             type: 'object',
             // required: [],

--- a/src/server/stores/system_store.js
+++ b/src/server/stores/system_store.js
@@ -205,7 +205,7 @@ class SystemStoreData {
             // update all the accounts.
             if (account.allowed_buckets) {
                 account.allowed_buckets = _.filter(
-                    account.allowed_buckets, 
+                    account.allowed_buckets,
                     bucket => !!bucket._id
                 );
             }
@@ -284,16 +284,16 @@ class SystemStore extends EventEmitter {
 
     load() {
         if (this._load_promise) return this._load_promise;
-        dbg.log0('SystemStore: fetching ...');
+        dbg.log1('SystemStore: fetching ...');
         let new_data = new SystemStoreData();
         let millistamp = time_utils.millistamp();
         this._load_promise =
             P.fcall(() => this._register_for_changes())
             .then(() => this._read_data_from_db(new_data))
             .then(() => {
-                dbg.log0('SystemStore: fetch took', time_utils.millitook(millistamp));
-                dbg.log0('SystemStore: fetch size', size_utils.human_size(JSON.stringify(new_data).length));
-                dbg.log0('SystemStore: fetch data', util.inspect(new_data, {
+                dbg.log1('SystemStore: fetch took', time_utils.millitook(millistamp));
+                dbg.log1('SystemStore: fetch size', size_utils.human_size(JSON.stringify(new_data).length));
+                dbg.log1('SystemStore: fetch data', util.inspect(new_data, {
                     depth: 4
                 }));
                 millistamp = time_utils.millistamp();


### PR DESCRIPTION
set_bucket_lifecycle_configuration_rules
get_bucket_lifecycle_configuration_rules

RESTRICTIONS:

supports only expiration days equal to 0 or expiration date.

TODO:
1. Currently new lifecycle bg worker use rpc call to web server. Must
   be replaced asap with normal way.
2. Add validation checks.
