### PR TITLE
Add bucket statistics on get_bucket_info

### DIFF
--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -95,7 +95,30 @@ function upgrade_systems() {
 function upgrade_system(system) {
     print('\n*** upgrade_system ...', system.name);
 
-    print('\n*** CLOUD SYNC ***');
+    print('\n*** BUCKET STATS***');
+    db.bucket.find({
+        system: system._id,
+    }).forEach(function(bucket) {
+        var stats = {
+            reads: 0,
+            writes: 0,
+            last_read: 0,
+            last_write: 0,
+        };
+        if (bucket.stats) {
+            stats.reads = bucket.stats.reads ? bucket.stats.reads : 0;
+            stats.writes = bucket.stats.writes ? bucket.stats.writes : 0;
+            stats.last_read = bucket.stats.last_read ? bucket.stats.last_read : 0;
+            stats.last_write = bucket.stats.last_write ? bucket.stats.last_write : 0;
+        }
+        db.buckjets.update({
+            _id: bucket._id
+        }, {
+            $set: {
+                stats: stats
+            }
+        });
+    });
 
     db.buckets.find({
         system: system._id,
@@ -103,11 +126,10 @@ function upgrade_system(system) {
             $exists: true
         }
     }).forEach(function(bucket) {
-        print('\n*** update bucket with endpoint and target bucket', bucket.name);
+        print('\n*** CLOUD SYNC update bucket with endpoint and target bucket', bucket.name);
         if (bucket.cloud_sync.target_bucket) {
             print('\n*** nothing to upgrade for ', bucket.name);
         } else {
-
             var target_bucket = bucket.cloud_sync.endpoint;
             db.buckets.update({
                 _id: bucket._id

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -759,7 +759,7 @@ function get_bucket_info(bucket, nodes_aggregate_pool, num_of_objects, cloud_syn
         real: new BigInteger((bucket.storage_stats && bucket.storage_stats.chunks_capacity) || 0).multiply(tier_of_bucket.replicas).multiply(placement_mul)
     });
 
-    dbg.log0('ohadohad', bucket.name, placement_mul, tier_of_bucket.replicas, bucket.storage_stats.chunks_capacity);
+    info.stats = bucket.stats;
 
     info.cloud_sync = cloud_sync_policy ? (cloud_sync_policy.status ? cloud_sync_policy : undefined) : undefined;
     info.demo_bucket = Boolean(bucket.demo_bucket);


### PR DESCRIPTION
### Purpose
- Add bucket stats on get_bucket_info (#reads, #writes, last read and last write)
### Checklist
- [x] Failure handling - describe how it behaves on failures:
  Inited to zeroed stats, but always exist
- [x] Upgrade Conciderations:
  - [x] Mongo Schema Upgrade if needed
