### PR TITLE
Phone Home internal status

### DIFF
--- a/config.js
+++ b/config.js
@@ -96,10 +96,11 @@ if (!is_windows) {
 config.central_stats = {
     send_stats: 'true',
     central_listener: 'http://104.155.41.235:9090/phdata',
-    send_time_cycle: 30 * 60000,
+    send_time_cycle: 30 * 60000, //min
     previous_diag_packs_dir: process.env.ProgramData + '/prev_diags',
     previous_diag_packs_count: 3 //TODO: We might want to split between agent and server
 };
+config.central_stats.send_time = 10 * (24 / (config.central_stats.send_time_cycle / 60000 / 60)); //10 days
 
 /*
   Clustering Defaults

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -703,7 +703,10 @@ module.exports = {
                         },
                         upgraded_cap_notification: {
                             type: 'boolean'
-                        }
+                        },
+                        phone_home_unable_comm: {
+                            type: 'boolean'
+                        },
                     }
                 },
                 remote_syslog_config: {

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -70,6 +70,9 @@ module.exports = {
                 phone_home_notified: {
                     type: 'boolean'
                 },
+                phone_home_unable_comm: {
+                    type: 'boolean'
+                },
                 cap_terabytes: {
                     type: 'number'
                 }

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -605,9 +605,9 @@ function background_worker() {
         .then(() => server_rpc.client.stats.get_all_stats({}))
         .then(payload => send_stats_payload(payload))
         .catch(err => {
-            successfuly_sent = 0;
             failed_sent++;
             if (failed_sent > 5) {
+                successfuly_sent = 0;
                 let updates = {
                     _id: system_store.data.systems[0]._id.toString()
                 };

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -351,6 +351,9 @@ function read_system(req) {
         if (system.phone_home_proxy_address) {
             phone_home_config.proxy_address = system.phone_home_proxy_address;
         }
+        if (system.freemium_cap.phone_home_unable_comm) {
+            phone_home_config.phone_home_unable_comm = true;
+        }
 
         // TODO use n2n_config.stun_servers ?
         // var stun_address = 'stun://' + ip_address + ':' + stun.PORT;


### PR DESCRIPTION
### Purpose
- Save internal status of phone home comm. This is used for freemium capacity upgrade. If PH ables to comm for 10 days, upgrade cap by 10TB.
### Checklist
- [x] Code Review - with someone besides myself:
  - [x] @dannyzaken 
- [x] Supportability:
  - [x] Phone Home info - added by read_system 
- [x] Code Comments - on non-trivial parts
- [x] Tests Coverage:
  - [x] Tested with `npm test`
