### PR TITLE
Fixed #890

### DIFF
--- a/src/server/bg_services/hosted_agents.js
+++ b/src/server/bg_services/hosted_agents.js
@@ -44,7 +44,7 @@ function create_agent(req) {
     }
 
     if (os_utils.is_supervised_env()) {
-        return supervisor.remove_program('agent_' +req.params.name).then(() => {
+        return supervisor.remove_program('agent_' + req.params.name).then(() => {
             dbg.log0('adding agent to supervior with arguments:', _.join(args, ' '));
             return supervisor.add_agent(req.params.name, _.join(args, ' '));
         });

--- a/src/test/system_tests/mongodb_defaults.js
+++ b/src/test/system_tests/mongodb_defaults.js
@@ -77,4 +77,4 @@ db.getSiblingDB("nbcore").accounts.updateMany({}, {
     $unset: {
         sync_credentials_cache: true
     }
-})
+});

--- a/src/test/system_tests/test_bucket_access.js
+++ b/src/test/system_tests/test_bucket_access.js
@@ -94,13 +94,13 @@ function setup() {
         }))
         // add new accounts:
         .then(() => client.account.create_account(full_access_user))
-//        .then(() => client.system.create_system({
-            // activation_code: '1111',
-            // name: full_access_user.name,
-            // email: full_access_user.email,
-            // password: full_access_user.password,
-            // access_keys: full_access_user.access_keys
-//         }))
+        //        .then(() => client.system.create_system({
+        // activation_code: '1111',
+        // name: full_access_user.name,
+        // email: full_access_user.email,
+        // password: full_access_user.password,
+        // access_keys: full_access_user.access_keys
+        //         }))
         .then(() => client.account.create_account(bucket1_user))
         .then(() => client.account.create_account(no_access_user));
 }
@@ -138,7 +138,7 @@ function run_test() {
         .then(() => {
             console.log('test_bucket_access PASSED');
             return;
-        })
+        });
 }
 
 

--- a/src/test/unit_tests/test_debug_module.js
+++ b/src/test/unit_tests/test_debug_module.js
@@ -95,7 +95,7 @@ mocha.describe('debug_module', function() {
             var dbg = new DebugModule('/web/noise/noobaa-core/src/blabla.asd/lll.asd');
             dbg.log0("test_debug_module: log0 should appear in the log");
             return file_content_verify("text", "test_debug_module: log0 should appear in the log");
-        })
+        });
     });
 
     mocha.it('should NOT log when level is lower', function() {

--- a/src/test/unit_tests/test_wait_queue.js
+++ b/src/test/unit_tests/test_wait_queue.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('lodash');
-var P = require('../../util/promise');
 var mocha = require('mocha');
 var assert = require('assert');
 var WaitQueue = require('../../util/wait_queue');

--- a/src/util/base_diagnostics.js
+++ b/src/util/base_diagnostics.js
@@ -38,16 +38,25 @@ function prepare_diag_dir(is_clusterized) {
 }
 
 function collect_basic_diagnostics(limit_logs_size) {
-    return P.fcall(function() {
-            return fs_utils.file_copy(process.cwd() + '/package.json', TMP_WORK_DIR);
+    return P.fcall(
+            () => fs_utils.file_copy(
+                process.cwd() + '/package.json',
+                TMP_WORK_DIR
+            )
+        )
+        .then(() => {
+            return os_utils.netstat_single(TMP_WORK_DIR + '/netstat.out')
+                .catch(err => {
+                    return P.fcall(() => {
+                            return os_utils.ss_single(TMP_WORK_DIR + '/ss.out');
+                        })
+                        .catch(err2 => {
+                            throw err;
+                        });
+                });
         })
-        .then(function() {
-            return os_utils.netstat_single(TMP_WORK_DIR + '/netstat.out');
-        })
-        .then(function() {
-            return 'ok';
-        })
-        .then(null, function(err) {
+        .then(() => 'ok')
+        .catch(err => {
             console.error('Error in collecting basic diagnostics', err);
             throw new Error('Error in collecting basic diagnostics ' + err);
         });

--- a/src/util/base_diagnostics.js
+++ b/src/util/base_diagnostics.js
@@ -46,7 +46,7 @@ function collect_basic_diagnostics(limit_logs_size) {
         )
         .then(() => {
             return os_utils.netstat_single(TMP_WORK_DIR + '/netstat.out')
-                .catch(err => {
+                .catch(err => { //netstat fails, soft trying ss instead
                     return P.fcall(() => {
                             return os_utils.ss_single(TMP_WORK_DIR + '/ss.out');
                         })

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -339,14 +339,12 @@ var LOG_FUNC_PER_LEVEL = {
 function syslog_formatter(self, level, args) {
     let msg = '';
     for (var i = 1; i < args.length; i++) {
-        if (msg.indexOf('%s')>0 && !(msg.indexOf('%d')>0 && msg.indexOf('%d')< msg.indexOf('%s'))){
-            msg = msg.replace('%s',util.format(args[i]));
-        }
-        else if (msg.indexOf('%d')>0){
-            msg = msg.replace('%d',util.format(args[i]));
-        }
-        else{
-            msg += util.format(args[i])+' ';
+        if (msg.indexOf('%s') > 0 && !(msg.indexOf('%d') > 0 && msg.indexOf('%d') < msg.indexOf('%s'))) {
+            msg = msg.replace('%s', util.format(args[i]));
+        } else if (msg.indexOf('%d') > 0) {
+            msg = msg.replace('%d', util.format(args[i]));
+        } else {
+            msg += util.format(args[i]) + ' ';
         }
     }
     let level_str = ((self._levels[level] === 0) ?

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -246,6 +246,11 @@ function netstat_single(dst) {
     }
 }
 
+function ss_single(dst) {
+    var file_redirect = dst ? ' &> ' + dst : '';
+    return promise_utils.exec('ss -nap' + file_redirect);
+}
+
 function set_manual_time(time_epoch, timez) {
     if (os.type() === 'Linux') {
         return _set_time_zone(timez)
@@ -441,6 +446,7 @@ exports.get_mount_of_path = get_mount_of_path;
 exports.get_drive_of_path = get_drive_of_path;
 exports.top_single = top_single;
 exports.netstat_single = netstat_single;
+exports.ss_single = ss_single;
 exports.set_manual_time = set_manual_time;
 exports.set_ntp = set_ntp;
 exports.get_time_config = get_time_config;


### PR DESCRIPTION
### Purpose
- Fixed issue #890.
  When creating diagnostics, in cases where netstat does not exist on the agent, instead of failing and crying we now run ss instead.
- Also fixed linter errors by running beautify
### Checklist
- [x] Failure handling - describe how it behaves on failures:
  - **Return error to the user**
- [x] Platforms handling - describe how it behaves on different platforms:
  - **Handled**
- [x] Technical debt - open issues and describe which gaps are postponed:
  - [x] **Does not support XXX - issue #xxxx** N\A
- [x] Code Review - with someone besides myself:
  - [x] **@dannyzaken**
- [x] Supportability:
  - [x] Diagnostics info - n/a
  - [x] Phone Home info - n/a
  - [x] ActivityLog new events - n/a
  - [x] External Syslog events - n/a
- [x] Upgrade Considerations:
  - [x] n/a
- [x] Code Comments - on non-trivial parts
- [x] Tests Coverage:
  - [x] **Required test**: Running diagnostics on Centos 7
  - [x] Tested with `npm test`
### Issues References
- Fixes #890 

netstat (part of net-tools package) may not exist in cents, making
diagnostics a sad panda. Now attempting to run ss instead on every
netstat failure.
