### PR TITLE
Return system cap on read_system

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -739,6 +739,9 @@ module.exports = {
                 debug_level: {
                     type: 'integer'
                 },
+                system_cap: {
+                    type: 'integer'
+                },
                 upgrade: {
                     type: 'object',
                     properties: {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -356,6 +356,8 @@ function read_system(req) {
             phone_home_config.phone_home_unable_comm = true;
         }
 
+        let system_cap = system.freemium_cap.cap_terabytes ? system.freemium_cap.cap_terabytes : Number.MAX_SAFE_INTEGER;
+
         // TODO use n2n_config.stun_servers ?
         // var stun_address = 'stun://' + ip_address + ':' + stun.PORT;
         // var stun_address = 'stun://64.233.184.127:19302'; // === 'stun://stun.l.google.com:19302'
@@ -412,6 +414,7 @@ function read_system(req) {
             version: pkg.version,
             debug_level: debug_level,
             upgrade: upgrade,
+            system_cap: system_cap,
         };
 
         // fill cluster information if we have a cluster.


### PR DESCRIPTION
### Purpose
- Return system cap on read_system
### Checklist
- Upgrade:
  - [x] Mongo Schema Upgrade - Already handled on previous PR, if no value exists return MAX_SAFE_INTEGER
