### PR TITLE
Fixed #1721 - demo nodes are down after upgrade

### DIFF
--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -187,6 +187,11 @@ function do_upgrade {
   deploy_log "Extracting new version"
   tar -xzvf ./${PACKAGE_FILE_NAME} >& /dev/null
 
+  # move existing internal agnets_storage to new dir
+  if [ -d /backup/agent_storage/ ]; then 
+    mv /backup/agent_storage/ ${CORE_DIR}
+  fi 
+
   # Re-setup Repos
   setup_repos
 

--- a/src/server/utils/supervisor_ctrl.js
+++ b/src/server/utils/supervisor_ctrl.js
@@ -140,6 +140,8 @@ SupervisorCtrl.prototype.add_agent = function(agent_name, args_str) {
     prog.stopsignal = config.SUPERVISOR_DEFAULTS.STOPSIGNAL;
     prog.command = '/usr/local/bin/node src/agent/agent_cli.js ' + args_str;
     prog.name = 'agent_' + agent_name;
+    prog.autostart = 'true';
+    prog.priority = '1100';
     return P.resolve(self.init())
         .then(() => {
             if (!self._supervised) {


### PR DESCRIPTION
### Purpose
- Fixed #1721 - after upgrade agent_storage of demo pools was moved to /backup. moved back after extraction of upgrade package.
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Comments: **Covered non-trivial decisions**
  - [x] Failure handling: **"Anything that can go wrong will go wrong while Murphy is out of town" - _Mrs. Murphy's law_ -**
  - [x] Cross Platform: N/A
  - [ ] Code Review: 
  - [x] Technical Debt: N/A
- Testing:
  - [ ] Upgrade tests needed
  - [x] Tested with `npm test`
- Supportability:
  - [x] Diagnostics info if needed: N/A
  - [x] Phone Home info if needed: N/A
  - [x] ActivityLog events if needed N/A
  - [x] External Syslog events if needed N/A
- Upgrade:
  - [x] Mongo Schema Upgrade if needed N/A
  - [x] Server Platform changes if needed
  - [x] Agents changes if needed
### Issues References
- Fixes #1721 
