### PR TITLE
Danny fixes

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const _ = require('lodash');
-const os = require('os');
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const config = require('../../../config');

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -190,8 +190,6 @@ function _delete_nodes_pool(system, pool, account) {
 function _delete_cloud_pool(system, pool, account) {
     dbg.log0('Deleting cloud pool', pool.name);
 
-    // construct the cloud node name according to convention
-    let cloud_node_name = 'noobaa-cloud-agent-' + os.hostname() + '-' + pool.name;
     return P.resolve()
         .then(function() {
             var reason = check_cloud_pool_deletion(pool);
@@ -207,8 +205,7 @@ function _delete_cloud_pool(system, pool, account) {
         .then(() => server_rpc.client.hosted_agents.remove_agent({
             name: pool.name
         }))
-        .then(() => nodes_client.instance().delete_node_by_name(system._id, cloud_node_name))
-        .then(res => {
+        .then(() => {
             Dispatcher.instance().activity({
                 event: 'pool.delete',
                 level: 'info',


### PR DESCRIPTION
### Purpose
- When removing a cloud resource, delete_node failed (not implemented yet) and a failure message appeared in UI.
- removed the call to delete_node (everything else, pool\agent, etc. is cleaned). 
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Comments: **Covered non-trivial decisions**
  - [x] Failure handling: **"Anything that can go wrong will go wrong while Murphy is out of town" - _Mrs. Murphy's law_ -**
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
  - [ ] Code Review: 
  - [x] Technical Debt: *_Created issues #1778  *_
  - *\* cloud node should be deleted when delete_node is implemented**
- Testing:
  - [ ] *\* tests should be added as part of cloud resources test**
  - [x] Tested with `npm test`
- Supportability:
### Issues References
- Fixes #1750 

delete_node is not implemented yet. removed delete_node when deleting
cloud pool to prevent the error.
this will leave the cloud node in the DB but the pool is deleted and
agent is removed. opened issue #1778
