### PR TITLE
Fixing storage and adding read object md count 0 for Ohad

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1215,6 +1215,7 @@ class NodesMonitor extends EventEmitter {
                 has_issues += 1;
             }
 
+            item.node.storage.free = Math.max(item.node.storage.free, 0);
             // for internal agents set reserve to 0
             let reserve = item.node.is_internal_node ? 0 : config.NODES_FREE_SPACE_RESERVE;
 
@@ -1501,7 +1502,7 @@ class NodesMonitor extends EventEmitter {
 function get_storage_info(storage, ignore_reserve) {
     let reply = {
         total: storage.total || 0,
-        free: storage.free || 0,
+        free: Math.max(storage.free || 0, 0),
         used: storage.used || 0,
         alloc: storage.alloc || 0,
         limit: storage.limit || 0,

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -839,6 +839,9 @@ function get_object_info(md) {
         if (md.stats.last_read !== undefined) {
             info.stats.last_read = md.stats.last_read.getTime();
         }
+        if (_.isUndefined(md.stats.reads)) {
+            info.stats.reads = 0;
+        }
     }
     return info;
 }


### PR DESCRIPTION
### Purpose

Besides making the world a better place it also ... Fixes the storage calculations regarding agents who wrote more than their "free" space (which is kinda more than the logical limit) This bug occurred in internal demo nodes, because they are the only once that have a logical limit on their free. Also fixes for Ohad that include returning 0 and not undefined in objectmd.stats.count when called from list_objects.

**NOTICE THAT THIS IS A TEMPORARY FIX FOR THE STORAGE**
**I WILL UPDATE WITH DEBT ACCORDING TO THE WHOLE NODE STORAGE CALCULATIONS**
### Checklist

_Notice 1: you can create the PR and keep pushing commits until all relevant items are marked_  
_Notice 2: Mark N/A for irrelevant items below_  
- Code:
  - [ ] User Experience: **Taken a moment to think the effects on our user**
  - [ ] Comments: **Covered non-trivial decisions**
  - [ ] Failure handling: **"Anything that can go wrong will go wrong while Murphy is out of town" - _Mrs. Murphy's law_ -**
  - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
  - [ ] Code Review: @nb-ohad Please review and mark when done
  - [ ] Technical Debt: **Created issues for TODO's**
  - **Does not support XXX - issue #xxxx**
- Testing:
  - [ ] **Added tests ... / Already covered by existing tests ...**
  - [ ] Tested with `npm test`
- Supportability:
  - [ ] Diagnostics info if needed: **Logs / Files**
  - [ ] Phone Home info if needed: **Stats / Actions**
  - [ ] ActivityLog events if needed
  - [ ] External Syslog events if needed
- Upgrade:
  - [ ] Mongo Schema Upgrade if needed
  - [ ] Server Platform changes if needed
  - [ ] Agents changes if needed
### Issues References
- Fixes #1769 #1715 
- Fixes #yyyy

This is a temporary fix for the storage of internal nodes with limit
that got screwed up because we wrote more than the “free” value of the
nodes.
