### PR TITLE
Remove selenium dev dependencies from upgrade package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,7 +69,11 @@ function pack(dest, name) {
             'node_modules/**/*',
             '!node_modules/babel*/**/*',
             '!node_modules/gulp*/**/*',
-            '!node_modules/node-inspector/**/*'
+            '!node_modules/node-inspector/**/*',
+            '!node_modules/chromedriver/**/*',
+            '!node_modules/selenium-webdriver/**/*',
+            '!node_modules/selenium-standalone/**/*',
+            '!node_modules/phantomjs-prebuilt/**/*'
         ], {
             base: 'node_modules'
         })

--- a/src/server/object_services/map_reader.js
+++ b/src/server/object_services/map_reader.js
@@ -25,7 +25,7 @@ const system_store = require('../system_services/system_store').get_instance();
 function read_object_mappings(params) {
     var rng = map_utils.sanitize_object_range(params.obj, params.start, params.end);
     if (!rng) { // empty range
-        return P.fcall(function(){
+        return P.fcall(function() {
             return [];
         });
     }

--- a/src/test/qa/machine_killer.js
+++ b/src/test/qa/machine_killer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const promise_utils = require('../../util/promise_utils');
 var dotenv = require('dotenv');
 const gcops = require('../qa/gcops');


### PR DESCRIPTION
### Purpose
- Remove selenium dev dependencies from upgrade package, should reduce upgrade package footprint by ~70MB
### Checklist
- Code:
  - [x] User Experience: NA
  - [x] Comments: NA
  - [x] Failure handling: NA
  - [x] Cross Platform: NA
  - [x] Code Review: @guymguym 
  - [x] Technical Debt: NA
- Testing:
  - [x] Unit/System Tests: NA
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info: NA
  - [x] Phone Home info: NA
  - [x] ActivityLog events: NA
  - [x] External Syslog: NA
- Upgrade:
  - [x] Mongo Schema Upgrade: NA
  - [x] Server Platform changes: NA
  - [x] Agents changes: NA
  - [x] New packages added to package.json: Packages removed on upgrade package creation
