### PR TITLE
Fixing #673 - Generate unique JWT secret per server

### DIFF
--- a/src/deploy/NVA_build/env.orig
+++ b/src/deploy/NVA_build/env.orig
@@ -11,6 +11,5 @@ AGENTS_OVER_WS=true
 # address means the address of the server as reachable from the internet
 ADDRESS=http://localhost
 COOKIE_SECRET=iwqhofbq27ew5jbJb3cq87bukgyaw3or8
-JWT_SECRET=xoiaQih22y8wpq4t2e83awgLuwafeiur8923
 MONGOHQ_URL=mongodb://localhost/nbcore
 CURRENT_VERSION=0.2

--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -203,6 +203,13 @@ function end_wizard {
     sudo sed -i "s:No Server Secret.*:This server's secret is \x1b[0;32;40m${sec}\x1b[0m:" /etc/issue
   fi
 
+  #verify JWT_SECRET exists in .env, if not create it
+
+  if ! sudo -s grep -q JWT_SECRET /root/node_modules/noobaa-core/.env; then
+      local jwt=$(cat /etc/noobaa_sec | openssl sha512 -hmac | cut -c10-44)
+      echo "JWT_SECRET=${jwt}" | sudo tee -a /root/node_modules/noobaa-core/.env
+  fi
+
   sudo sed -i "s:Configured IP on this NooBaa Server.*:Configured IP on this NooBaa Server \x1b[0;32;40m${current_ip}\x1b[0m:" /etc/issue
 
   trap 2 20

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -300,6 +300,11 @@ function post_upgrade {
   # same as setup_repos in upgrade.sh. do we really need to perform it again?
   rm -f ${CORE_DIR}/.env
   cp -f ${CORE_DIR}/src/deploy/NVA_build/env.orig ${CORE_DIR}/.env
+  #fix JWT_SECRET from previous .env
+  if ! grep -q JWT_SECRET /backup/.env; then
+      local jwt=$(grep JWT_SECRET /backup/.env)
+      echo "${jwt}" > ${CORE_DIR}/.env
+  fi
 
   local AGENT_VERSION_VAR=$(grep AGENT_VERSION /backup/.env)
   if [ "${curmd}" != "${prevmd}" ]; then


### PR DESCRIPTION
### Purpose
- Generate unique JWT secret per server during the first install, if one does not exist already
### Checklist
- Code:
  - [x] User Experience: NA
  - [x] Comments: added
  - [x] Failure handling: NA
  - [x] Cross Platform: NA
  - [ ] Code Review: @tamireran Please review and mark when done
  - [x] Technical Debt:
    - Handle JWT in cluster mode - bug #1934
- Testing:
  - [x] Unit/System Tests: NA
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info: NA
  - [x] Phone Home info: NA
  - [x] ActivityLog events: NA
  - [x] External Syslog: NA
- Upgrade:
  - [x] Mongo Schema Upgrade NA
  - [x] Server Platform changes - Keep JWT secret in .env over upgrade
  - [x] Agents changes NA
  - [x] New packages added to package.json: NA
### Issues References
- Fixes #673 
