### PR TITLE
Support password changed to be server secret

### DIFF
--- a/src/bg_workers/bg_workers_starter.js
+++ b/src/bg_workers/bg_workers_starter.js
@@ -30,7 +30,7 @@ var server_rpc = require('../server/server_rpc');
 var mongo_client = require('../util/mongo_client');
 var mongoose_utils = require('../util/mongoose_utils');
 var background_scheduler = require('../util/background_scheduler').get_instance();
-var config = require('../../config.js'); 
+var config = require('../../config.js');
 var lifecycle = require('./lifecycle');
 
 const MASTER_BG_WORKERS = [

--- a/src/bg_workers/lifecycle.js
+++ b/src/bg_workers/lifecycle.js
@@ -95,7 +95,7 @@ function background_worker() {
                     });
                 });
         })
-		.catch(err => {
+        .catch(err => {
             dbg.error('LIFECYCLE FAILED processing', err, err.stack);
         })
         .then(function() {

--- a/src/s3/s3_controller.js
+++ b/src/s3/s3_controller.js
@@ -788,7 +788,7 @@ class S3Controller {
                         if (rule.Expiration) {
                             current_rule.expiration = {};
                             if (rule.Expiration[0].Days) {
-                                current_rule.expiration.days = parseInt(rule.Expiration[0].Days[0]);
+                                current_rule.expiration.days = parseInt(rule.Expiration[0].Days[0], 10);
                                 if (rule.Expiration[0].Days < 1) {
                                     throw s3_errors.InvalidArgument;
                                 }
@@ -803,7 +803,8 @@ class S3Controller {
                         }
                         if (rule.AbortIncompleteMultipartUpload) {
                             current_rule.abort_incomplete_multipart_upload = {
-                                days_after_initiation: rule.AbortIncompleteMultipartUpload[0].DaysAfterInitiation ? parseInt(rule.AbortIncompleteMultipartUpload[0].DaysAfterInitiation[0]) : null
+                                days_after_initiation: rule.AbortIncompleteMultipartUpload[0].DaysAfterInitiation ?
+                                parseInt(rule.AbortIncompleteMultipartUpload[0].DaysAfterInitiation[0], 10) : null
                             };
                         }
                         if (rule.Transition) {
@@ -814,13 +815,16 @@ class S3Controller {
                         }
                         if (rule.NoncurrentVersionExpiration) {
                             current_rule.noncurrent_version_expiration = {
-                                noncurrent_days: rule.NoncurrentVersionExpiration[0].NoncurrentDays ? parseInt(rule.NoncurrentVersionExpiration[0].NoncurrentDays[0]) : null
+                                noncurrent_days: rule.NoncurrentVersionExpiration[0].NoncurrentDays ?
+                                    parseInt(rule.NoncurrentVersionExpiration[0].NoncurrentDays[0], 10) : null
                             };
                         }
                         if (rule.NoncurrentVersionTransition) {
                             current_rule.noncurrent_version_transition = {
-                                noncurrent_days: rule.NoncurrentVersionTransition[0].NoncurrentDays ? parseInt(rule.NoncurrentVersionTransition[0].NoncurrentDays[0]) : null,
-                                storage_class: rule.NoncurrentVersionTransition[0].StorageClass ? rule.NoncurrentVersionTransition[0].StorageClass[0] : 'STANDARD_IA'
+                                noncurrent_days: rule.NoncurrentVersionTransition[0].NoncurrentDays ?
+                                    parseInt(rule.NoncurrentVersionTransition[0].NoncurrentDays[0], 10) : null,
+                                storage_class: rule.NoncurrentVersionTransition[0].StorageClass ?
+                                    rule.NoncurrentVersionTransition[0].StorageClass[0] : 'STANDARD_IA'
                             };
                         }
 
@@ -857,10 +861,12 @@ class S3Controller {
                                     } : null,
                                     Expiration: rule.expiration ? (rule.expiration.days ? {
                                         Days: rule.expiration.days,
-                                        ExpiredObjectDeleteMarker: rule.expiration.expired_object_delete_marker ? rule.expiration.expired_object_delete_marker : null
+                                        ExpiredObjectDeleteMarker: rule.expiration.expired_object_delete_marker ?
+                                            rule.expiration.expired_object_delete_marker : null
                                     } : {
                                         Date: rule.expiration.date,
-                                        ExpiredObjectDeleteMarker: rule.expiration.expired_object_delete_marker ? rule.expiration.expired_object_delete_marker : null
+                                        ExpiredObjectDeleteMarker: rule.expiration.expired_object_delete_marker ?
+                                            rule.expiration.expired_object_delete_marker : null
                                     }) : null,
                                     NoncurrentVersionTransition: rule.noncurrent_version_transition ? {
                                         NoncurrentDays: rule.noncurrent_version_transition.noncurrent_days,

--- a/src/server/bg_services/cluster_master.js
+++ b/src/server/bg_services/cluster_master.js
@@ -64,7 +64,7 @@ function send_master_update(is_master) {
                 let system = system_store.data.systems[0];
                 let auth_params = {
                     email: 'support@noobaa.com',
-                    password: 'help',
+                    password: system_store.get_server_secret(),
                     system: system.name,
                 };
                 return server_rpc.client.create_auth_token(auth_params);

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -536,7 +536,7 @@ function ensure_support_account() {
                 _id: system_store.generate_id(),
                 name: 'Support',
                 email: 'support@noobaa.com',
-                password: process.env.SUPPORT_DEFAULT_PASSWORD || 'help',
+                password: system_store.get_server_secret(),
                 is_support: true
             };
             return bcrypt_password(support_account)

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -554,7 +554,7 @@ function background_worker() {
                 let system = system_store.data.systems[0];
                 let auth_params = {
                     email: 'support@noobaa.com',
-                    password: 'help',
+                    password: system_store.get_server_secret(),
                     system: system.name,
                 };
                 return server_rpc.client.create_auth_token(auth_params);


### PR DESCRIPTION
### Purpose
- Support password changed to be server secret
  This is not the final solution but a quick W/A for now.
  For GA we would have to set a better and more secure way of getting into shell (reverse ssh ?) and maybe support user (what do we need it for actually?) 
### Checklist
- Code:
  - [x] User Experience: NA
  - [x] Comments: NA
  - [x] Failure handling: NA
  - [x] Cross Platform: NA
  - [ ] Code Review: @tamireran  Please review and mark when done
  - [x] Technical Debt: NA
- Testing:
  - [x] Unit/System Tests: NA
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info: NA
  - [x] Phone Home info: NA
  - [x] ActivityLog events: NA
  - [x] External Syslog: NA
- Upgrade:
  - [x] Mongo Schema Upgrade - on upgrade, change current support password if still 'help'
  - [x] Server Platform changes
  - [x] Agents changes
  - [x] New packages added to package.json: NA
### Issues References
- Fixes #1932 
