### PR TITLE
renamed credentials cache api params to identity\secret

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -605,6 +605,7 @@ export function loadS3Connections() {
     logAction('loadS3Connections');
 
     api.account.get_account_sync_credentials_cache()
+        .then(conns => conns.map(conn => Object.assign(conn, {access_key: conn.identity})))
         .then(model.S3Connections)
         .done();
 }
@@ -1467,8 +1468,8 @@ export function checkS3Connection(endpoint, accessKey, secretKey) {
 
     let credentials = {
         endpoint: endpoint,
-        access_key: accessKey,
-        secret_key: secretKey
+        identity: accessKey,
+        secret: secretKey
     };
 
     api.account.check_account_sync_credentials(credentials)
@@ -1482,8 +1483,8 @@ export function addS3Connection(name, endpoint, accessKey, secretKey) {
     let credentials = {
         name: name,
         endpoint: endpoint,
-        access_key: accessKey,
-        secret_key: secretKey
+        identity: accessKey,
+        secret: secretKey
     };
 
     api.account.add_account_sync_credentials_cache(credentials)
@@ -1759,3 +1760,4 @@ export function recommissionNode(name) {
         .then(refresh)
         .done();
 }
+

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -248,7 +248,7 @@ module.exports = {
             method: 'PUT',
             params: {
                 type: 'object',
-                required: ['name', 'access_key', 'secret_key', 'endpoint'],
+                required: ['name', 'identity', 'secret', 'endpoint'],
                 properties: {
                     name: {
                         type: 'string'
@@ -256,12 +256,18 @@ module.exports = {
                     endpoint: {
                         type: 'string'
                     },
-                    access_key: {
+                    identity: {
                         type: 'string'
                     },
-                    secret_key: {
+                    secret: {
                         type: 'string'
+                    },
+
+                    endpoint_type: {
+                        type: 'string',
+                        enum: ['AWS', 'AZURE', 'S3_COMPATIBLE']
                     }
+
                 }
             },
             auth: {
@@ -282,8 +288,12 @@ module.exports = {
                         endpoint: {
                             type: 'string'
                         },
-                        access_key: {
+                        identity: {
                             type: 'string'
+                        },
+                        endpoint_type: {
+                            type: 'string',
+                            enum: ['AWS', 'AZURE', 'S3_COMPATIBLE']
                         }
                     }
                 }
@@ -297,17 +307,22 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
-                required: ['access_key', 'secret_key', 'endpoint'],
+                required: ['identity', 'secret', 'endpoint'],
                 properties: {
                     endpoint: {
                         type: 'string'
                     },
-                    access_key: {
+                    identity: {
                         type: 'string'
                     },
 
-                    secret_key: {
+                    secret: {
                         type: 'string'
+                    },
+
+                    endpoint_type: {
+                        type: 'string',
+                        enum: ['AWS', 'AZURE', 'S3_COMPATIBLE']
                     }
                 }
             },

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -406,7 +406,8 @@ function get_account_sync_credentials_cache(req) {
             return {
                 name: credentials.name || credentials.access_key,
                 endpoint: credentials.endpoint || 'https://s3.amazonaws.com',
-                access_key: credentials.access_key
+                identity: credentials.access_key,
+                endpoint_type: credentials.endpoint_type
             };
         }
     );
@@ -419,7 +420,9 @@ function get_account_sync_credentials_cache(req) {
  */
 
 function add_account_sync_credentials_cache(req) {
-    var info = _.pick(req.rpc_params, 'name', 'endpoint', 'access_key', 'secret_key');
+    var info = _.pick(req.rpc_params, 'name', 'endpoint', 'endpoint_type');
+    info.access_key = req.rpc_params.identity;
+    info.secret_key = req.rpc_params.secret;
     var updates = {
         _id: req.account._id,
         sync_credentials_cache: req.account.sync_credentials_cache || []
@@ -433,13 +436,13 @@ function add_account_sync_credentials_cache(req) {
 }
 
 function check_account_sync_credentials(req) {
-    var params = _.pick(req.rpc_params, 'endpoint', 'access_key', 'secret_key');
+    var params = _.pick(req.rpc_params, 'endpoint', 'identity', 'secret', 'endpoint_type');
 
     return P.fcall(function() {
         var s3 = new AWS.S3({
             endpoint: params.endpoint,
-            accessKeyId: params.access_key,
-            secretAccessKey: params.secret_key,
+            accessKeyId: params.identity,
+            secretAccessKey: params.secret,
             httpOptions: {
                 agent: new https.Agent({
                     rejectUnauthorized: false,

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -66,6 +66,10 @@ module.exports = {
                     },
                     endpoint: {
                         type: 'string'
+                    },
+                    endpoint_type: {
+                        type: 'string',
+                        enum: ['AWS', 'AZURE', 'S3_COMPATIBLE']
                     }
                 }
             }

--- a/src/test/system_tests/test_cloud_pools.js
+++ b/src/test/system_tests/test_cloud_pools.js
@@ -51,8 +51,8 @@ function main() {
         .then(() => client.account.add_account_sync_credentials_cache({
             name: 'aws',
             endpoint: 'https://s3.amazonaws.com',
-            access_key: 'AKIAIGLTF7IWOW4M3ZHQ',
-            secret_key: '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'
+            identity: 'AKIAIGLTF7IWOW4M3ZHQ',
+            secret: '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'
         }))
         .then(() => client.pool.create_cloud_pool({
             name: 'cloud-pool-aws',

--- a/src/test/system_tests/test_cloud_sync.js
+++ b/src/test/system_tests/test_cloud_sync.js
@@ -60,8 +60,8 @@ function set_cloud_sync(params) {
             () => client.account.add_account_sync_credentials_cache({
                 name: TEST_CTX.connection_name,
                 endpoint: TEST_CTX.target_ip,
-                access_key: '123',
-                secret_key: 'abc'
+                identity: '123',
+                secret: 'abc'
             })
         )
         .then(

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -269,8 +269,8 @@ mocha.describe('system_servers', function() {
             .then(() => client.account.add_account_sync_credentials_cache({
                 name: CLOUD_SYNC_CONNECTION,
                 endpoint: 'https://s3.amazonaws.com',
-                access_key: process.env.AWS_ACCESS_KEY_ID,
-                secret_key: process.env.AWS_SECRET_ACCESS_KEY
+                identity: process.env.AWS_ACCESS_KEY_ID,
+                secret: process.env.AWS_SECRET_ACCESS_KEY
             }))
             .then(() => client.bucket.set_cloud_sync({
                 name: BUCKET,


### PR DESCRIPTION
### Purpose
- rename of api params related to cloud credentials, to be more generic (for both S3 and Azure)
