### PR TITLE
Nimrod Fix basic_server_ops upgrade test function

### DIFF
--- a/src/test/system_tests/basic_server_ops.js
+++ b/src/test/system_tests/basic_server_ops.js
@@ -47,7 +47,6 @@ function upload_and_upgrade(ip, upgrade_pack) {
     };
 
     var version_match = filename.match(/noobaa-NVA-(.*)\.tar\.gz/);
-    var wait_for_version = version_match && version_match[1];
 
     return P.ninvoke(request, 'post', {
             url: 'http://' + ip + ':8080/upgrade',
@@ -56,7 +55,7 @@ function upload_and_upgrade(ip, upgrade_pack) {
         })
         .then(res => console.log('Upload package successful', res.statusCode))
         .then(() => P.delay(10000))
-        .then(() => wait_for_server(ip, wait_for_version))
+        .then(() => wait_for_server(ip))
         .then(() => P.delay(10000))
         .then(() => {
             var isNotListening = true;

--- a/src/test/system_tests/basic_server_ops.js
+++ b/src/test/system_tests/basic_server_ops.js
@@ -46,8 +46,6 @@ function upload_and_upgrade(ip, upgrade_pack) {
         }
     };
 
-    var version_match = filename.match(/noobaa-NVA-(.*)\.tar\.gz/);
-
     return P.ninvoke(request, 'post', {
             url: 'http://' + ip + ':8080/upgrade',
             formData: formData,


### PR DESCRIPTION
### Purpose
-   ignore wait_for_version on upgrade tests, will fail on private builds
### Checklist
- Code:
  - [x] User Experience: NA
  - [x] Failure handling and Comments on non trivial sections: NA
  - [x] Cross Platform: NA
- Testing:
  - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: NA
- Upgrade:
  - [x] Mongo Schema Upgrade: NA
  - [x] Agents changes, Server Platform changes and New packages added to package.json: NA
