### PR TITLE
Move "unable to activate" modal to "loading server info screen"

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -371,6 +371,7 @@ export function signOut(shouldRefresh = true) {
 export function loadServerInfo() {
     logAction('loadServerInfo');
 
+    model.serverInfo(null);
     api.account.accounts_status()
         .then(
             reply => reply.has_accounts ?

--- a/frontend/src/app/components/login/create-system-form/create-system-form.html
+++ b/frontend/src/app/components/login/create-system-form/create-system-form.html
@@ -85,7 +85,3 @@
     </div>
 </section>
 
-<!-- ko if: isUnableToActivateModalVisible -->
-<unable-to-activate-modal></unable-to-activate-modal>
-<!-- /ko -->
-

--- a/frontend/src/app/components/login/loading-server-information-from/loading-server-information-from.html
+++ b/frontend/src/app/components/login/loading-server-information-from/loading-server-information-from.html
@@ -4,3 +4,7 @@
     <svg-icon class="loading-icon icon-big spin"
         params="name: 'in-progress'"></svg-icon>
 </div>
+
+<!-- ko if: isUnableToActivateModalVisible -->
+<unable-to-activate-modal></unable-to-activate-modal>
+<!-- /ko -->

--- a/frontend/src/app/components/login/loading-server-information-from/loading-server-information-from.js
+++ b/frontend/src/app/components/login/loading-server-information-from/loading-server-information-from.js
@@ -1,5 +1,23 @@
 import template from './loading-server-information-from.html';
+import Disposable from 'disposable';
+import ko from 'knockout';
+import { serverInfo } from 'model';
+
+class LoadingServerInformationFromViewModel extends Disposable{
+    constructor() {
+        super();
+
+        this.isUnableToActivateModalVisible = ko.pureComputed(
+            () => Boolean(
+                serverInfo() &&
+                serverInfo().config &&
+                serverInfo().config.phone_home_connectivity_status !== 'CONNECTED'
+            )
+        );
+    }
+}
 
 export default {
+    viewModel: LoadingServerInformationFromViewModel,
     template: template
 };

--- a/frontend/src/app/components/login/login-layout/login-layout.js
+++ b/frontend/src/app/components/login/login-layout/login-layout.js
@@ -15,10 +15,19 @@ class LoginLayoutViewModel extends Disposable {
                     return 'unsupported-form';
                 }
 
-                if (serverInfo()) {
-                    return serverInfo().initialized ? 'signin-form' : 'create-system-form';
-                } else {
+                if (!serverInfo()) {
                     return 'loading-server-information-from';
+                }
+
+                let { initialized, config } = serverInfo();
+                if (initialized) {
+                    return 'signin-form';
+                }
+
+                if (config.phone_home_connectivity_status !== 'CONNECTED') {
+                    return 'loading-server-information-from';
+                } else {
+                    return 'create-system-form';
                 }
             }
         );


### PR DESCRIPTION
- [ ] Model:
- [x] Actions:
  - Reset serverInfo on every loadServerInfo invocation.
- [x] Components:
  - Change: create-system-form (remove 'unable-to-activate-modal')
  - Change: loading-server-information-from (add 'unable-to-activate-modal')
  - Change: login-layout (change from selection logic)
