### PR TITLE
Change is_connected to status- connected, disconnected, in-progress

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -845,8 +845,9 @@ module.exports = {
                 },
                 secret: {
                     type: 'string',
+                    enum: ['CONNECTED', 'DISCONNECTED', 'IN_PROGRESS']
                 },
-                is_connected: {
+                status: {
                     type: 'boolean'
                 },
                 hostname: {

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -16,7 +16,6 @@ const nodes_client = require('../node_services/nodes_client');
 const system_store = require('../system_services/system_store').get_instance();
 const system_server = require('../system_services/system_server');
 const object_server = require('../object_services/object_server');
-const md_store = require('../object_services/md_store');
 const bucket_server = require('../system_services/bucket_server');
 const auth_server = require('../common_services/auth_server');
 const server_rpc = require('../server_rpc');

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -163,7 +163,7 @@ function get_cluster_info() {
         let memory_usage = 0;
         let cpu_usage = 0;
         let version = '0';
-        let is_connected;
+        let is_connected = 'DISCONNECTED';
         let hostname = os.hostname();
         let time_epoch = moment().unix();
         let location = cinfo.location;

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -163,18 +163,23 @@ function get_cluster_info() {
         let memory_usage = 0;
         let cpu_usage = 0;
         let version = '0';
-        let single_server = system_store.data.clusters.length === 1;
-        let is_connected = single_server;
+        let is_connected;
         let hostname = os.hostname();
         let time_epoch = moment().unix();
         let location = cinfo.location;
+        let single_server = system_store.data.clusters.length === 1;
+        if (single_server) {
+            is_connected = 'CONNECTED';
+        }
         if (cinfo.heartbeat) {
             memory_usage = (1 - cinfo.heartbeat.health.os_info.freemem / cinfo.heartbeat.health.os_info.totalmem);
             cpu_usage = cinfo.heartbeat.health.os_info.loadavg[0];
             version = cinfo.heartbeat.version;
             let now = Date.now();
             let diff = now - cinfo.heartbeat.time;
-            is_connected = single_server || (diff < config.CLUSTER_NODE_MISSING_TIME);
+            if (diff < config.CLUSTER_NODE_MISSING_TIME) {
+                is_connected = 'CONNECTED';
+            }
             hostname = cinfo.heartbeat.health.os_info.hostname;
         }
         let server_info = {
@@ -182,7 +187,7 @@ function get_cluster_info() {
             hostname: hostname,
             secret: cinfo.owner_secret,
             address: cinfo.owner_address,
-            is_connected: is_connected,
+            status: is_connected,
             memory_usage: memory_usage,
             cpu_usage: cpu_usage,
             location: location,
@@ -198,7 +203,7 @@ function get_cluster_info() {
         if (shard.servers.length < 3) {
             shard.high_availabilty = false;
         } else {
-            let num_connected = shard.servers.filter(server => server.is_connected).length;
+            let num_connected = shard.servers.filter(server => server.status === 'CONNECTED').length;
             // to be highly available the cluster must be able to stand a failure and still
             // have a majority to vote for a master.
             shard.high_availabilty = num_connected > (shard.servers.length + 1) / 2;


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
### Purpose
- Change returned status per each server in cluster form boolean to enum - connected, disconnected, in progress
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: 
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
  - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
