### PR TITLE
fix server secret return on OS X

### DIFF
--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -400,8 +400,7 @@ function read_server_secret() {
     } else if (os.type() === 'Darwin') {
         return fs.readFileAsync(config.CLUSTERING_PATHS.DARWIN_SECRET_FILE)
             .then(function(data) {
-                var sec = data.toString();
-                return sec.substring(0, sec.length - 1);
+                return data.toString();
             })
             .catch(err => {
                 //For Darwin only, if file does not exist, create it


### PR DESCRIPTION
### Purpose
- fix server secret return on OS X
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: 
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
  - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
