### PR TITLE
cluster fixes - force sync cluster information after adding member

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -22,6 +22,7 @@ const url = require('url');
 const upgrade_utils = require('../../util/upgrade_utils');
 const request = require('request');
 const dns = require('dns');
+const cluster_hb = require('../bg_services/cluster_hb');
 
 function _init() {
     return P.resolve(MongoCtrl.init());
@@ -109,11 +110,14 @@ function add_member_to_cluster(req) {
             console.error('Failed adding members to cluster', req.rpc_params, 'with', err);
             throw new Error('Failed adding members to cluster');
         })
+        .delay(500)
         .then(function() {
             dbg.log0('Added member', req.rpc_params.address, 'to cluster. New topology',
                 cutil.pretty_topology(cutil.get_topology()));
-            return;
-        });
+            // reload system_store to update after new member HB
+            return system_store.load();
+        })
+        .return();
 }
 
 
@@ -173,6 +177,10 @@ function join_to_cluster(req) {
             //Mongo servers are up, update entire cluster with the new topology
             return _publish_to_cluster('news_updated_topology', topology_to_send);
         })
+        // ugly but works. perform first heartbeat after server is joined, so UI will present updated data
+        .then(() => cluster_hb.do_heartbeat())
+        // restart bg_workers and s3rver to fix stale data\connections issues. maybe we can do it in a more elgant way
+        .then(() => _restart_services())
         .return();
 }
 
@@ -414,6 +422,13 @@ function apply_set_debug_level(req) {
             }
         })
         .return();
+}
+
+function _restart_services() {
+    // set timeout to restart services in 1 second
+    setTimeout(() => {
+        promise_utils.exec('supervisorctl restart s3rver bg_workers');
+    }, 1000);
 }
 
 

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -110,6 +110,8 @@ function add_member_to_cluster(req) {
             console.error('Failed adding members to cluster', req.rpc_params, 'with', err);
             throw new Error('Failed adding members to cluster');
         })
+        // TODO: solve in a better way
+        // added this delay, otherwise the next system_store.load doesn't catch the new servers HB
         .delay(500)
         .then(function() {
             dbg.log0('Added member', req.rpc_params.address, 'to cluster. New topology',


### PR DESCRIPTION
### Purpose
- after adding a member to cluster the following read_system did not
  show updated data.
- after clusterization, existing RPC connections produced authentication errors. restarting bg and s3 services in joined server to force reinitialization. a bit ugly now, we might want to find a
  better solution.
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: 
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
  - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
### Technical Debt Created
- Opened #xxxx
### Fixed Issues References
- Fixes #xxxx
- Fixes #yyyy
- after adding a member to cluster the following read_system did not
  show updated data.
- after clusterization, existing RPC connections produced
  authentication errors. restarting bg and s3 services in joined server
  to force reinitialization. a bit ugly now, we might want to find a
  better solution.
