### PR TITLE
Agents failover

### DIFF
--- a/src/server/node_services/node_server.js
+++ b/src/server/node_services/node_server.js
@@ -14,6 +14,7 @@ const _ = require('lodash');
 const string_utils = require('../../util/string_utils');
 const system_store = require('../system_services/system_store').get_instance();
 const nodes_monitor = require('./nodes_monitor');
+const dbg = require('../../util/debug_module')(__filename);
 
 let monitor;
 
@@ -21,9 +22,12 @@ let monitor;
 function _init() {
     monitor = new nodes_monitor.NodesMonitor();
     //TODO:: return this once we enable HA
-    //if (system_store.is_cluster_master) {
-    return monitor.start();
-    //}
+    if (system_store.is_cluster_master) {
+        dbg.log0('this is master. starting nodes_monitor');
+        return monitor.start();
+    } else {
+        dbg.log0('this is not master. nodes_monitor iw not started');
+    }
 }
 
 function get_local_monitor() {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -35,6 +35,7 @@ const system_store = require('../system_services/system_store').get_instance();
 const promise_utils = require('../../util/promise_utils');
 const bucket_server = require('./bucket_server');
 const system_server_utils = require('../utils/system_server_utils');
+const node_server = require('../node_services/node_server');
 
 const SYS_STORAGE_DEFAULTS = Object.freeze({
     total: 0,
@@ -492,10 +493,10 @@ function set_webserver_master_state(req) {
                     auth_token: req.auth_token
                 }));
             //Going Master //TODO:: add this one we get back to HA
-            //node_server.start_monitor();
+            node_server.start_monitor();
         } else {
             //Stepping Down
-            //node_server.stop_monitor();
+            node_server.stop_monitor();
         }
     }
 }


### PR DESCRIPTION
### Purpose
- fixed agents failover on a clustered system
  - fixed format of potential masters from address to url
  - starting\stopping nodes_monitor on master change
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: 
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
  - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
### Technical Debt Created
- #1469  - existing issue - save servers list persistently and load on startup. currently when an agent restarts, it might loose the master if it will change while the agent is down.
