### PR TITLE
warn on password reset when no sys exists

### DIFF
--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -180,8 +180,8 @@ function reset_password {
 
         local number_of_account=$(/usr/bin/mongo nbcore --eval 'db.accounts.count({_id: {$exists: true}})' --quiet)
         if [ ${number_of_account} -lt 2 ]; then
-          echo "Could not find any account. Please setup a system from the web management first"
-          return 0
+            dialog --colors --nocancel --backtitle "NooBaa First Install" --msgbox "Could not find any account. Please setup a system from the web management first" 8 40
+            return 0
         fi
 
         local user_name=$(/usr/bin/mongo nbcore --eval 'db.accounts.find({email:{$ne:"support@noobaa.com"}},{email:1,_id:0}).sort({_id:-1}).limit(1).map(function(u){return u.email})[0]' --quiet)


### PR DESCRIPTION
### Purpose
- warn on password reset when no sys exists in the dialog screen
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: NA
  - [x] Cross Platform: Server only - NA
- Testing:
  - [x] Unit/System Tests: NA
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
### Fixed Issues References
- Fixes #2015 
