### PR TITLE
Nimrod Add linkable indication to activity log items

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -330,7 +330,10 @@ module.exports = {
                                     properties: {
                                         name: {
                                             type: 'string'
-                                        }
+                                        },
+                                        linkable: {
+                                            type: 'boolean'
+                                        },
                                     }
                                 },
                                 node: {
@@ -339,7 +342,10 @@ module.exports = {
                                     properties: {
                                         name: {
                                             type: 'string'
-                                        }
+                                        },
+                                        linkable: {
+                                            type: 'boolean'
+                                        },
                                     }
                                 },
                                 bucket: {
@@ -348,7 +354,10 @@ module.exports = {
                                     properties: {
                                         name: {
                                             type: 'string'
-                                        }
+                                        },
+                                        linkable: {
+                                            type: 'boolean'
+                                        },
                                     }
                                 },
                                 pool: {
@@ -357,7 +366,10 @@ module.exports = {
                                     properties: {
                                         name: {
                                             type: 'string'
-                                        }
+                                        },
+                                        linkable: {
+                                            type: 'boolean'
+                                        },
                                     }
                                 },
                                 obj: {

--- a/src/server/notifications/dispatcher.js
+++ b/src/server/notifications/dispatcher.js
@@ -120,7 +120,7 @@ class Dispatcher {
             .then(() => {
                 if (log_item.node) {
                     l.node = _.pick(log_item.node, 'name');
-                    l.node.linkable = true;
+                    l.node.linkable = true; //Currently node can't be deleted
                 }
 
                 if (log_item.obj) {
@@ -130,36 +130,35 @@ class Dispatcher {
             })
             .then(tier => {
                 if (tier) {
-                    l.tier = _.pick(tier.res, 'name');
+                    l.tier = _.pick(tier.record, 'name');
                     l.tier.linkable = tier.linkable;
                 }
                 return P.resolve(log_item.bucket && system_store.data.get_by_id_include_deleted(log_item.bucket, 'buckets'));
             })
             .then(bucket => {
                 if (bucket) {
-                    l.bucket = _.pick(bucket.res, 'name');
+                    l.bucket = _.pick(bucket.record, 'name');
                     l.bucket.linkable = bucket.linkable;
                 }
                 return P.resolve(log_item.pool && system_store.data.get_by_id_include_deleted(log_item.pool, 'pools'));
             })
             .then(pool => {
                 if (pool) {
-                    l.pool = _.pick(pool.res, 'name');
+                    l.pool = _.pick(pool.record, 'name');
                     l.pool.linkable = pool.linkable;
                 }
                 return P.resolve(log_item.account && system_store.data.get_by_id_include_deleted(log_item.account, 'accounts'));
             })
             .then(account => {
                 if (account) {
-                    l.account = _.pick(account.res, 'email');
+                    l.account = _.pick(account.record, 'email');
                 }
                 return P.resolve(log_item.actor && system_store.data.get_by_id_include_deleted(log_item.actor, 'accounts'));
             })
             .then(actor => {
                 if (actor) {
-                    l.actor = _.pick(actor.res, 'email');
+                    l.actor = _.pick(actor.record, 'email');
                 }
-                console.warn('NBNB:: log_item', log_item, 'NBNB:: l', l);
                 return log_item;
             });
     }

--- a/src/server/notifications/dispatcher.js
+++ b/src/server/notifications/dispatcher.js
@@ -120,6 +120,7 @@ class Dispatcher {
             .then(() => {
                 if (log_item.node) {
                     l.node = _.pick(log_item.node, 'name');
+                    l.node.linkable = true;
                 }
 
                 if (log_item.obj) {
@@ -129,34 +130,36 @@ class Dispatcher {
             })
             .then(tier => {
                 if (tier) {
-                    l.tier = _.pick(tier, 'name');
+                    l.tier = _.pick(tier.res, 'name');
+                    l.tier.linkable = tier.linkable;
                 }
                 return P.resolve(log_item.bucket && system_store.data.get_by_id_include_deleted(log_item.bucket, 'buckets'));
             })
             .then(bucket => {
                 if (bucket) {
-                    l.bucket = _.pick(bucket, 'name');
+                    l.bucket = _.pick(bucket.res, 'name');
+                    l.bucket.linkable = bucket.linkable;
                 }
                 return P.resolve(log_item.pool && system_store.data.get_by_id_include_deleted(log_item.pool, 'pools'));
             })
             .then(pool => {
                 if (pool) {
-                    l.pool = _.pick(pool, 'name');
+                    l.pool = _.pick(pool.res, 'name');
+                    l.pool.linkable = pool.linkable;
                 }
-
                 return P.resolve(log_item.account && system_store.data.get_by_id_include_deleted(log_item.account, 'accounts'));
             })
             .then(account => {
                 if (account) {
-                    l.account = _.pick(account, 'email');
+                    l.account = _.pick(account.res, 'email');
                 }
-
                 return P.resolve(log_item.actor && system_store.data.get_by_id_include_deleted(log_item.actor, 'accounts'));
             })
             .then(actor => {
                 if (actor) {
-                    l.actor = _.pick(actor, 'email');
+                    l.actor = _.pick(actor.res, 'email');
                 }
+                console.warn('NBNB:: log_item', log_item, 'NBNB:: l', l);
                 return log_item;
             });
     }

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -179,15 +179,30 @@ class SystemStoreData {
 
     get_by_id_include_deleted(id, name) {
         const res = this.get_by_id(id);
-        if (res) return res;
+        if (res) {
+            return {
+                res: res,
+                linkable: true
+            };
+        }
         //Query deleted !== null
         const collection = mongo_client.instance().db.collection(name);
         return P.resolve(collection.findOne({
-            _id: id,
-            deleted: {
-                $ne: null
-            }
-        }));
+                _id: id,
+                deleted: {
+                    $ne: null
+                }
+            }))
+            .then(res => {
+                if (res) {
+                    return {
+                        res: res,
+                        linkable: false
+                    };
+                } else {
+                    return;
+                }
+            });
     }
 
     resolve_object_ids_paths(item, paths, allow_missing) {

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -177,11 +177,14 @@ class SystemStoreData {
         return id ? this.idmap[String(id)] : null;
     }
 
+    //Return the mongo record (if found) and an indication if the
+    //object is linkable (not deleted) -> used in the activity log to link the
+    //various entities
     get_by_id_include_deleted(id, name) {
         const res = this.get_by_id(id);
         if (res) {
             return {
-                res: res,
+                record: res,
                 linkable: true
             };
         }
@@ -196,7 +199,7 @@ class SystemStoreData {
             .then(res => {
                 if (res) {
                     return {
-                        res: res,
+                        record: res,
                         linkable: false
                     };
                 } else {


### PR DESCRIPTION
### Purpose
- Nimrod Add linkable indication to activity log items for: node, pool, bucket, tier (placement policy)
### Checklist
- Code:
  - [x] User Experience: Links from activity log to the entities! Hooray!
  - [x] Failure handling and Comments on non trivial sections: NA
  - [x] Cross Platform: NA
- Testing:
  - [x] Unit/System Tests: NA 
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: NA
- Upgrade:
  - [x] Mongo Schema Upgrade: NA
  - [x] Agents changes, Server Platform changes and New packages added to package.json: NA
