### PR TITLE
Add debug / diagnostics in cluster mode

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1382,7 +1382,7 @@ export function downloadSystemDiagnosticPack() {
     logAction('downloadSystemDiagnosticPack');
 
     notify('Collecting data... might take a while');
-    api.system.diagnose_system()
+    api.cluster_server.diagnose_system()
         .catch(
             err => {
                 notify('Packing system diagnostic file failed', 'error');

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1363,6 +1363,21 @@ export function downloadNodeDiagnosticPack(nodeName) {
         .done();
 }
 
+export function downloadServerDiagnosticPack(secret) {
+    logAction('downloadServerDiagnosticPack', { secret });
+
+    notify('Collecting data... might take a while');
+    api.cluster_server.diagnose_system(secret)
+        .catch(
+            err => {
+                notify('Packing system diagnostic file failed', 'error');
+                throw err;
+            }
+        )
+        .then(downloadFile)
+        .done();
+}
+
 export function downloadSystemDiagnosticPack() {
     logAction('downloadSystemDiagnosticPack');
 
@@ -1403,6 +1418,24 @@ export function setNodeDebugLevel(node, level) {
         .then(
             () => loadNodeInfo(node)
         )
+        .done();
+}
+
+export function setServerDebugLevel(secret, hostname, level){
+    logAction('setServerDebugLevel', { secret, hostname, level });
+
+    api.cluster_server.set_debug_level({ secret, level })
+        .then(
+            () => notify(
+                `Debug level has been ${level === 0 ? 'lowered' : 'rasied'} for server ${hostname}`,
+                'success'
+            ),
+            () => notify(
+                `Cloud not ${level === 0 ? 'lower' : 'raise'} debug level for server ${hostname}`,
+                'error'
+            )
+        )
+        .then(loadSystemInfo)
         .done();
 }
 

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1363,11 +1363,11 @@ export function downloadNodeDiagnosticPack(nodeName) {
         .done();
 }
 
-export function downloadServerDiagnosticPack(secret) {
-    logAction('downloadServerDiagnosticPack', { secret });
+export function downloadServerDiagnosticPack(target_secret) {
+    logAction('downloadServerDiagnosticPack', { target_secret });
 
     notify('Collecting data... might take a while');
-    api.cluster_server.diagnose_system(secret)
+    api.cluster_server.diagnose_system(target_secret)
         .catch(
             err => {
                 notify('Packing system diagnostic file failed', 'error');
@@ -1421,10 +1421,10 @@ export function setNodeDebugLevel(node, level) {
         .done();
 }
 
-export function setServerDebugLevel(secret, hostname, level){
-    logAction('setServerDebugLevel', { secret, hostname, level });
+export function setServerDebugLevel(target_secret, hostname, level){
+    logAction('setServerDebugLevel', { target_secret, hostname, level });
 
-    api.cluster_server.set_debug_level({ secret, level })
+    api.cluster_server.set_debug_level({ target_secret, level })
         .then(
             () => notify(
                 `Debug level has been ${level === 0 ? 'lowered' : 'rasied'} for server ${hostname}`,

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1363,14 +1363,16 @@ export function downloadNodeDiagnosticPack(nodeName) {
         .done();
 }
 
-export function downloadServerDiagnosticPack(target_secret) {
-    logAction('downloadServerDiagnosticPack', { target_secret });
+export function downloadServerDiagnosticPack(targetSecret, targetHostname) {
+    logAction('downloadServerDiagnosticPack', { targetSecret });
 
     notify('Collecting data... might take a while');
-    api.cluster_server.diagnose_system(target_secret)
+    api.cluster_server.diagnose_system({
+        target_secret: targetSecret
+    })
         .catch(
             err => {
-                notify('Packing system diagnostic file failed', 'error');
+                notify(`Packing server diagnostic file for ${targetHostname} failed`, 'error');
                 throw err;
             }
         )
@@ -1421,17 +1423,20 @@ export function setNodeDebugLevel(node, level) {
         .done();
 }
 
-export function setServerDebugLevel(target_secret, hostname, level){
-    logAction('setServerDebugLevel', { target_secret, hostname, level });
+export function setServerDebugLevel(targetSecret, targetHostname, level){
+    logAction('setServerDebugLevel', { targetSecret, targetHostname, level });
 
-    api.cluster_server.set_debug_level({ target_secret, level })
+    api.cluster_server.set_debug_level({
+        target_secret: targetSecret,
+        level: level
+    })
         .then(
             () => notify(
-                `Debug level has been ${level === 0 ? 'lowered' : 'rasied'} for server ${hostname}`,
+                `Debug level has been ${level === 0 ? 'lowered' : 'rasied'} for server ${targetHostname}`,
                 'success'
             ),
             () => notify(
-                `Cloud not ${level === 0 ? 'lower' : 'raise'} debug level for server ${hostname}`,
+                `Cloud not ${level === 0 ? 'lower' : 'raise'} debug level for server ${targetHostname}`,
                 'error'
             )
         )

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1364,7 +1364,7 @@ export function downloadNodeDiagnosticPack(nodeName) {
 }
 
 export function downloadServerDiagnosticPack(targetSecret, targetHostname) {
-    logAction('downloadServerDiagnosticPack', { targetSecret });
+    logAction('downloadServerDiagnosticPack', { targetSecret, targetHostname });
 
     notify('Collecting data... might take a while');
     api.cluster_server.diagnose_system({

--- a/frontend/src/app/components/cluster/server-table/server-row.js
+++ b/frontend/src/app/components/cluster/server-table/server-row.js
@@ -98,7 +98,7 @@ export default class ServerRowViewModel extends Disposable {
     }
 
     toogleDebugLevel() {
-        let newDebugLevel = this.debuglevel() === 0 ? 5 : 0;
+        let newDebugLevel = this.debugLevel() === 0 ? 5 : 0;
         return setServerDebugLevel(this.secret(), this.hostname(), newDebugLevel);
     }
 

--- a/frontend/src/app/components/cluster/server-table/server-row.js
+++ b/frontend/src/app/components/cluster/server-table/server-row.js
@@ -1,6 +1,7 @@
 import Disposable from 'disposable';
 import ko from 'knockout';
-import { deepFreeze } from 'utils';
+import { downloadServerDiagnosticPack, setServerDebugLevel } from 'actions';
+import { deepFreeze, isUndefined } from 'utils';
 
 const stateIconMapping = deepFreeze({
     CONNECTED: {
@@ -75,5 +76,32 @@ export default class ServerRowViewModel extends Disposable {
                     'Using local serve time';
             }
         );
+
+        this.debugLevel = ko.pureComputed(
+            () => {
+                let level = server() && server().debug_level;
+                return isUndefined(level) ? 0 : level;
+            }
+        );
+
+        this.debugLevelText = ko.pureComputed(
+            () => this.debugLevel() > 0 ? 'High' : 'Low'
+        );
+
+        this.toogleDebugLevelButtonText = ko.pureComputed(
+            () => `${this.debugLevel() > 0 ? 'Lower' : 'Raise' } Debug Level`
+        );
+
+        this.debugLevelCss = ko.pureComputed(
+            () => ({ 'high-debug-level': this.debugLevel() > 0 })
+        );
+    }
+
+    toogleDebugLevel() {
+        setServerDebugLevel(this.secret(), this.hostname(), this.debugLevel() > 0 ? 0 : 5);
+    }
+
+    downloadDiagnosticPack() {
+        downloadServerDiagnosticPack(this.secret());
     }
 }

--- a/frontend/src/app/components/cluster/server-table/server-row.js
+++ b/frontend/src/app/components/cluster/server-table/server-row.js
@@ -98,10 +98,11 @@ export default class ServerRowViewModel extends Disposable {
     }
 
     toogleDebugLevel() {
-        setServerDebugLevel(this.secret(), this.hostname(), this.debugLevel() > 0 ? 0 : 5);
+        let newDebugLevel = this.debuglevel() === 0 ? 5 : 0;
+        return setServerDebugLevel(this.secret(), this.hostname(), newDebugLevel);
     }
 
     downloadDiagnosticPack() {
-        downloadServerDiagnosticPack(this.secret());
+        downloadServerDiagnosticPack(this.secret(), this.hostname());
     }
 }

--- a/frontend/src/app/components/cluster/server-table/server-table.html
+++ b/frontend/src/app/components/cluster/server-table/server-table.html
@@ -10,6 +10,7 @@
     <data-table params="
         columns: columns,
         rowFactory: rowFactory,
+        rowCssProp: 'debugLevelCss',
         sorting: sorting,
         data: servers,
         subRow: 'sub-row'
@@ -44,6 +45,29 @@
                         click: () => vm.showServerDNSSettingsModal(secret())
                     ">
                         Edit Enviorment DNS
+                    </button>
+                </li>
+                <li class="row">
+                    <span class="c2 push-next">Server Debug Level:</span>
+                    <span class="greedy" data-bind="
+                        text: debugLevelText,
+                        css: { warning: debugLevel() > 0 }
+                    "></span>
+
+                    <button class="link alt-colors no-outline" data-bind="
+                        click: toogleDebugLevel,
+                        text: toogleDebugLevelButtonText
+                    "></button>
+                    </button>
+                </li>
+                <li class="row">
+                    <span class="c2 push-next">Diagnostics:</span>
+                    <span class="greedy"></span>
+
+                    <button class="link alt-colors no-outline" data-bind="
+                        click: () => downloadDiagnosticPack()
+                    ">
+                        Download Diagnostic File
                     </button>
                 </li>
             </ul>

--- a/frontend/src/app/components/cluster/server-table/server-table.html
+++ b/frontend/src/app/components/cluster/server-table/server-table.html
@@ -7,7 +7,7 @@
 </section>
 
 <div data-bind="let: { vm: $component }">
-    <data-table params="
+    <data-table class="server-data-table" params="
         columns: columns,
         rowFactory: rowFactory,
         rowCssProp: 'debugLevelCss',

--- a/frontend/src/app/components/cluster/server-table/server-table.less
+++ b/frontend/src/app/components/cluster/server-table/server-table.less
@@ -1,7 +1,7 @@
 server-table {
     .column();
 
-    data-table {
+    .server-data-table {
         .header-row, .main-row, .sub-row {
             border-left: 4px solid transparent;
         }

--- a/frontend/src/app/components/cluster/server-table/server-table.less
+++ b/frontend/src/app/components/cluster/server-table/server-table.less
@@ -1,28 +1,38 @@
 server-table {
     .column();
 
-    .state-col {
-        min-width: 44px;
-    }
+    data-table {
+        .header-row, .main-row, .sub-row {
+            border-left: 4px solid transparent;
+        }
 
-    .hostname-col{
-        text-align: left;
-        width: 100%;
-    }
+        .main-row.high-debug-level {
+            border-color: @color11;
+        }
 
-    .address-col{
-        min-width: 110px;
-    }
+        .state-col {
+            min-width: 44px;
+        }
 
-    .memory-usage-col {
-        min-width: 110px;
-    }
+        .hostname-col{
+            text-align: left;
+            width: 100%;
+        }
 
-    .cpu-usage-col {
-        min-width: 110px;
-    }
+        .address-col{
+            min-width: 110px;
+        }
 
-    .version-col {
-        min-width: 80px;
+        .memory-usage-col {
+            min-width: 110px;
+        }
+
+        .cpu-usage-col {
+            min-width: 110px;
+        }
+
+        .version-col {
+            min-width: 80px;
+        }
     }
 }

--- a/frontend/src/app/components/cluster/server-table/server-table.less
+++ b/frontend/src/app/components/cluster/server-table/server-table.less
@@ -4,6 +4,7 @@ server-table {
     .server-data-table {
         .header-row, .main-row, .sub-row {
             border-left: 4px solid transparent;
+            transition: border-color 250ms ease;
         }
 
         .main-row.high-debug-level {

--- a/frontend/src/app/components/shared/data-table/data-table.html
+++ b/frontend/src/app/components/shared/data-table/data-table.html
@@ -1,6 +1,6 @@
 <table data-bind="css: tableCss, scroll: scroll, dataTable: rows">
     <thead>
-        <tr data-bind="foreach: columns">
+        <tr class="header-row" data-bind="foreach: columns">
             <th data-bind="css: css">
                 <span data-bind="text: label, css: sortCss, click: sortBy"></span>
             </th>


### PR DESCRIPTION
### Purpose

Add lower/raise debug and download diagnostics in cluster mode
### Checklist
- [x] Actions: 
  - Add: setServerDebugLevel - raises the debug level to one specific server
  - Add: downloadServerDiagnosticPack - download diagnostics of one specific server
  - Change: downloadSystemDiagnosticPack from 'system' to 'cluster_server' to fix wrong call
- [ ] Model: 
- [x] Components: 
  - Change: server-table: add raise/lower debug level and download diagnostic so each server sub row
  - Change: data-table: add class to header row
- [ ] Infrastructure: 
