### PR TITLE
pass JWT_SECRET in joint_to_cluster

### DIFF
--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -17,7 +17,7 @@ module.exports = {
             method: 'POST',
             params: {
                 type: 'object',
-                required: ['topology', 'cluster_id', 'secret', 'role', 'shard'],
+                required: ['topology', 'cluster_id', 'secret', 'role', 'shard', 'jwt_secret'],
                 properties: {
                     ip: {
                         type: 'string',
@@ -26,6 +26,9 @@ module.exports = {
                         type: 'string'
                     },
                     secret: {
+                        type: 'string'
+                    },
+                    jwt_secret: {
                         type: 'string'
                     },
                     role: {


### PR DESCRIPTION
### Purpose
- sync JWT_SECRET between all members of the cluster
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: 
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
  - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
### Fixed Issues References
- Fixes #1934 

sync JWT_SECRET between all members of the cluster
