### PR TITLE
Activation and DNS Name setting improvements

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1751,8 +1751,28 @@ export function validateActivation(code, email) {
 
     api.system.validate_activation({ code, email })
         .then(
+            reply => waitFor(500, reply)
+        )
+        .then(
             ({ valid, reason }) => model.activationState({ code, email, valid, reason })
-        );
+        )
+
+        .done();
+}
+
+export function attemptResolveSystemName(name) {
+    logAction('attemptResolveServerName', { name });
+
+    api.system.attempt_dns_resolve({
+        dns_name: name
+    })
+        .then(
+            reply => waitFor(500, reply)
+        )
+        .then(
+            ({ valid, reason }) => model.nameResolutionState({ name, valid, reason })
+        )
+        .done();
 }
 
 export function dismissUpgradedCapacityNotification() {

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1236,11 +1236,18 @@ export function updateHostname(hostname) {
     logAction('updateHostname', { hostname });
 
     api.system.update_hostname({ hostname })
+        // The system changed it's name, reload to the new name
         .then(
-            () => notify('Hostname updated successfully', 'success'),
-            () => notify('Hostname update failed', 'error')
+            () => {
+                let { protocol, port } = window.location;
+                let baseAddress = `${protocol}//${hostname}:${port}`;
+
+                reloadTo(
+                    `${baseAddress}${routes.management}`,
+                    { tab: 'settings' }
+                );
+            }
         )
-        .then(loadSystemInfo)
         .done();
 }
 

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -4,7 +4,7 @@ import api from 'services/api';
 import config from 'config';
 import * as routes from 'routes';
 
-import { isDefined, last, makeArray, execInOrder, realizeUri,
+import { isDefined, last, makeArray, execInOrder, realizeUri, waitFor,
     downloadFile, generateAccessKeys, deepFreeze, flatMap } from 'utils';
 
 // TODO: resolve browserify issue with export of the aws-sdk module.
@@ -1746,33 +1746,13 @@ export function notify(message, severity = 'info') {
     model.lastNotification({ message, severity });
 }
 
-export function validateActivationCode(code) {
-    logAction('validateActivationCode', { code });
-
-    api.system.validate_activation({ code })
-        .then(
-            ({ valid, reason }) => model.activationCodeValid({
-                code: code,
-                isValid: valid,
-                reason: reason
-            })
-        )
-        .done();
-}
-
-export function validateActivationEmail(code, email) {
-    logAction('validateActivationEmail', { code, email });
+export function validateActivation(code, email) {
+    logAction('validateActivation', { code, email });
 
     api.system.validate_activation({ code, email })
         .then(
-            ({ valid, reason }) => model.activationEmailValid({
-                code: code,
-                email: email,
-                isValid: valid,
-                reason: reason
-            })
-        )
-        .done();
+            ({ valid, reason }) => model.activationState({ code, email, valid, reason })
+        );
 }
 
 export function dismissUpgradedCapacityNotification() {

--- a/frontend/src/app/bindings/register.js
+++ b/frontend/src/app/bindings/register.js
@@ -14,4 +14,5 @@ export default function register(ko) {
     ko.bindingHandlers.tooltip      = require('./tooltip');
     ko.bindingHandlers.scrollTo     = require('./scroll-to');
     ko.bindingHandlers.hover        = require('./hover');
+    ko.bindingHandlers.shakeOnClick = require('./shake-on-click');
 }

--- a/frontend/src/app/bindings/shake-on-click.js
+++ b/frontend/src/app/bindings/shake-on-click.js
@@ -1,0 +1,19 @@
+import ko from 'knockout';
+
+export default {
+    init: function(element, valueAccessor) {
+        let classList = element.classList;
+
+        ko.utils.registerEventHandler(
+            element,
+            'click',
+            () => ko.unwrap(ko.unwrap(valueAccessor())) && classList.add('shake')
+        );
+
+        ko.utils.registerEventHandler(
+            element,
+            'animationend',
+            evt => evt.animationName === 'shake' && classList.remove('shake')
+        );
+    }
+};

--- a/frontend/src/app/components/bucket/bucket-placement-policy-modal/bucket-placement-policy-modal.html
+++ b/frontend/src/app/components/bucket/bucket-placement-policy-modal/bucket-placement-policy-modal.html
@@ -38,8 +38,7 @@
         </button>
         <button class="btn" data-bind="
             click: save,
-            css: { shake: shake },
-            animation: { end: () => shake(false) }
+            shakeOnClick: errors().length
         ">
             Save
         </button>

--- a/frontend/src/app/components/bucket/bucket-placement-policy-modal/bucket-placement-policy-modal.js
+++ b/frontend/src/app/components/bucket/bucket-placement-policy-modal/bucket-placement-policy-modal.js
@@ -74,14 +74,11 @@ class BacketPlacementPolicyModalViewModel extends Disposable {
         });
 
         this.errors = ko.validation.group(this);
-
-        this.shake = ko.observable(false);
     }
 
     save() {
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
-            this.shake(true);
 
         } else {
             updateBucketPlacementPolicy(

--- a/frontend/src/app/components/bucket/set-cloud-sync-modal/set-cloud-sync-modal.html
+++ b/frontend/src/app/components/bucket/set-cloud-sync-modal/set-cloud-sync-modal.html
@@ -74,8 +74,7 @@
         </button>
         <button class="btn" data-bind="
             click: save,
-            css: { shake: shake },
-            animation: { end: () => shake(false) }
+            shakeOnClick: errors().length
         ">
             Save
         </button>

--- a/frontend/src/app/components/bucket/set-cloud-sync-modal/set-cloud-sync-modal.js
+++ b/frontend/src/app/components/bucket/set-cloud-sync-modal/set-cloud-sync-modal.js
@@ -139,8 +139,6 @@ class SetCloudSyncModalViewModel extends Disposable {
             this.targetBucket
         ]);
 
-        this.shake = ko.observable(false);
-
         loadCloudConnections();
     }
 
@@ -164,7 +162,6 @@ class SetCloudSyncModalViewModel extends Disposable {
     save() {
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
-            this.shake(true);
 
         } else {
             setCloudSyncPolicy(

--- a/frontend/src/app/components/cluster/attach-server-modal/attach-server-modal.html
+++ b/frontend/src/app/components/cluster/attach-server-modal/attach-server-modal.html
@@ -13,7 +13,15 @@
 
 
     <div class="row content-middle align-end">
-        <button class="link push-next" data-bind="click: cancel">Cancel</button>
-        <button class="btn" data-bind="click: attach">Attach</button>
+        <button class="link push-next" data-bind="click: cancel">
+            Cancel
+        </button>
+
+        <button class="btn" data-bind="
+            click: attach,
+            shakeOnClick: errors().length
+        ">
+            Attach
+        </button>
     </div>
 </modal>

--- a/frontend/src/app/components/cluster/attach-server-modal/attach-server-modal.js
+++ b/frontend/src/app/components/cluster/attach-server-modal/attach-server-modal.js
@@ -21,14 +21,9 @@ class AttachServerModalViewModel extends Disposable {
             });
 
         this.errors = ko.validation.group(this);
-
-        this.shake = ko.observable(false);
     }
 
     attach() {
-
-        this.shake(Boolean(this.errors().length));
-
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
 

--- a/frontend/src/app/components/cluster/server-dns-settings-modal/server-dns-settings-modal.html
+++ b/frontend/src/app/components/cluster/server-dns-settings-modal/server-dns-settings-modal.html
@@ -16,7 +16,15 @@
     </section>
 
     <div class="row content-middle align-end push-prev">
-        <button class="link push-next" data-bind="click: cancel">Cancel</button>
-        <button class="btn" data-bind="click: save">Save</button>
+        <button class="link push-next" data-bind="click: cancel">
+            Cancel
+        </button>
+
+        <button class="btn" data-bind="
+            click: save,
+            shakeOnClick: errors().length
+        ">
+            Save
+        </button>
     </div>
 </modal>

--- a/frontend/src/app/components/cluster/server-dns-settings-modal/server-dns-settings-modal.js
+++ b/frontend/src/app/components/cluster/server-dns-settings-modal/server-dns-settings-modal.js
@@ -21,8 +21,6 @@ class ServerDNSSettingsModalViewModel extends Disposable {
             () => server() ? server().dns_servers : []
         );
 
-
-
         this.primaryDNS = ko.observableWithDefault(
             () => dnsServers()[0]
         )

--- a/frontend/src/app/components/cluster/server-time-settings-modal/server-time-settings-modal.html
+++ b/frontend/src/app/components/cluster/server-time-settings-modal/server-time-settings-modal.html
@@ -24,7 +24,14 @@
     </div>
 
     <div class="row content-middle align-end push-prev">
-        <button class="link push-next" data-bind="click: cancel">Cancel</button>
-        <button class="btn" data-bind="click: save">save</button>
+        <button class="link push-next" data-bind="click: cancel">
+            Cancel
+        </button>
+        <button class="btn" data-bind="
+            click: save,
+            shakeOnClick: !isValid()
+        ">
+            save
+        </button>
     </div>
 </modal>

--- a/frontend/src/app/components/cluster/server-time-settings-modal/server-time-settings-modal.js
+++ b/frontend/src/app/components/cluster/server-time-settings-modal/server-time-settings-modal.js
@@ -67,6 +67,10 @@ class ServerTimeSettingsModalViewModel extends Disposable {
             this.ntpServer
         ]);
 
+        this.isValid = ko.pureComputed(
+            () => this.usingManualTime() || this.ntpErrors().length === 0
+        );
+
         loadServerTime(this.serverSecret);
     }
 

--- a/frontend/src/app/components/login/change-password-form/change-password-form.html
+++ b/frontend/src/app/components/login/change-password-form/change-password-form.html
@@ -34,8 +34,7 @@
 
         <button class="btn align-end push-prev" data-bind="
             click: change,
-            css: { shake: shake },
-            animation: { end: () => shake(false) }
+            shakeOnClick: errors().length
         ">
             Change
         </button>

--- a/frontend/src/app/components/login/change-password-form/change-password-form.js
+++ b/frontend/src/app/components/login/change-password-form/change-password-form.js
@@ -48,13 +48,12 @@ class ChangePasswordFormViewModel extends Disposable{
 
         this.errors = ko.validation.group(this);
 
-        this.shake = ko.observable(false);
     }
 
     change() {
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
-            this.shake(true);
+
         } else {
             updateAccountPassword(sessionInfo().user, this.newPassword());
         }

--- a/frontend/src/app/components/login/create-system-form/create-system-form.html
+++ b/frontend/src/app/components/login/create-system-form/create-system-form.html
@@ -20,7 +20,7 @@
                         data-bind="value: activationCode">
 
                     <svg-icon class="validating-indicator spin"
-                        data-bind="visible: activationCode.isValidating()"
+                        data-bind="visible: activationCode.isValidating"
                         params="name: 'in-progress'"></svg-icon>
                 </editor>
 
@@ -29,7 +29,7 @@
                         data-bind="value: email">
 
                     <svg-icon class="validating-indicator spin"
-                        data-bind="visible: email.isValidating()"
+                        data-bind="visible: email.isValidating"
                         params="name: 'in-progress'"></svg-icon>
                 </editor>
 
@@ -69,6 +69,11 @@
 
                 <editor params="label: 'Server DNS name'">
                     <input type="text" data-bind="value: serverDNSName">
+
+                    <svg-icon class="validating-indicator spin"
+                        data-bind="visible: serverDNSName.isValidating"
+                        params="name: 'in-progress'"></svg-icon>
+
                     <p class="hint">optional</p>
                 </editor>
 

--- a/frontend/src/app/components/login/create-system-form/create-system-form.js
+++ b/frontend/src/app/components/login/create-system-form/create-system-form.js
@@ -8,8 +8,8 @@ import { deepFreeze, calcPasswordStrength } from 'utils';
 
 const activationFaliureReasonMapping = deepFreeze({
     ACTIVATION_CODE_IN_USE: 'Activation code is already in use',
-    INVALID_ACTIVATION_CODE: 'Invalid activation code',
-    EMAIL_MISMATCH: 'Email does not match activation code'
+    MALFORMED_ACTIVATION_CODE: 'Invalid activation code',
+    ACTIVATION_CODE_EMAIL_MISMATCH: 'Email does not match activation code'
 });
 
 class CreateSystemFormViewModel extends Disposable {
@@ -42,7 +42,7 @@ class CreateSystemFormViewModel extends Disposable {
 
                         activationState.once(
                             ({ valid, reason }) => callback({
-                                isValid: valid || reason === 'EMAIL_MISMATCH',
+                                isValid: valid || reason === 'ACTIVATION_CODE_EMAIL_MISMATCH',
                                 message: reason && activationFaliureReasonMapping[reason]
                             })
                         );
@@ -65,7 +65,7 @@ class CreateSystemFormViewModel extends Disposable {
 
                         activationState.once(
                             ({ valid, reason }) => callback({
-                                isValid: valid || reason !== 'EMAIL_MISMATCH',
+                                isValid: valid || reason !== 'ACTIVATION_CODE_EMAIL_MISMATCH',
                                 message: reason && activationFaliureReasonMapping[reason]
                             })
                         );

--- a/frontend/src/app/components/login/create-system-form/create-system-form.less
+++ b/frontend/src/app/components/login/create-system-form/create-system-form.less
@@ -49,12 +49,6 @@
         display: none;
     }
 
-    .validating-indicator {
-        position: absolute;
-        top: @gutter/2;
-        right: @gutter/2;
-    }
-
     .remark {
         margin-top: auto;
     }

--- a/frontend/src/app/components/login/signin-form/signin-form.html
+++ b/frontend/src/app/components/login/signin-form/signin-form.html
@@ -32,8 +32,7 @@
             </p>
             <button class="btn" data-bind="
                 click: signIn,
-                css: { shake: shake },
-                animation: { end: () => shake(false) }
+                shakeOnClick: errors().length
             ">
                 Sign In
             </button>

--- a/frontend/src/app/components/login/signin-form/signin-form.js
+++ b/frontend/src/app/components/login/signin-form/signin-form.js
@@ -31,24 +31,15 @@ class SignInFormViewModel extends Disposable {
             () => !this.isDirty() && retryCount() > 0
         );
 
-        this.shake = ko.observable(false);
-
         this.errors = ko.validation.group([
             this.email,
             this.password
         ]);
-
-        this.addToDisposeList(
-            retryCount.subscribe(
-                () => this.shake(true)
-            )
-        );
     }
 
     signIn() {
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
-            this.shake(true);
 
         } else {
             this.isDirty(false);

--- a/frontend/src/app/components/management/phone-home-form/phone-home-form.html
+++ b/frontend/src/app/components/management/phone-home-form/phone-home-form.html
@@ -43,7 +43,10 @@
         "/>
    </editor>
 
-    <button class="btn align-start push-prev" data-bind="click: applyChanges">
+    <button class="btn align-start push-prev" data-bind="
+        click: applyChanges,
+        shakeOnClick: errors().length
+    ">
         Apply Changes
     </button>
 </section>

--- a/frontend/src/app/components/management/remote-syslog-form/remote-syslog-form.html
+++ b/frontend/src/app/components/management/remote-syslog-form/remote-syslog-form.html
@@ -50,7 +50,10 @@
         "/>
    </editor>
 
-    <button class="btn align-start push-prev" data-bind="click: applyChanges">
+    <button class="btn align-start push-prev" data-bind="
+        click: applyChanges,
+        shakeOnClick: errors().length
+    ">
         Apply Changes
     </button>
 </section>

--- a/frontend/src/app/components/management/remote-syslog-form/remote-syslog-form.js
+++ b/frontend/src/app/components/management/remote-syslog-form/remote-syslog-form.js
@@ -83,8 +83,10 @@ class RemoteSyslogFormViewModel extends Disposable {
     applyChanges() {
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
+
         } else if (this.enabled()) {
             enableRemoteSyslog(this.protocol(), this.address(), this.port());
+
         } else {
             disableRemoteSyslog();
         }

--- a/frontend/src/app/components/management/server-dns-form/server-dns-form.html
+++ b/frontend/src/app/components/management/server-dns-form/server-dns-form.html
@@ -70,7 +70,10 @@
         </p>
     </div>
 
-    <button class="btn align-start push-both" data-bind="click: applyChanges">
+    <button class="btn align-start push-both" data-bind="
+        click: applyChanges,
+        shakeOnClick: errors().length
+    ">
         Apply Changes
     </button>
 </div>

--- a/frontend/src/app/components/management/server-dns-form/server-dns-form.html
+++ b/frontend/src/app/components/management/server-dns-form/server-dns-form.html
@@ -30,6 +30,10 @@
 
         <editor params="label: 'DNS Name'" data-bind="visible: usingDNS">
             <input type="text" data-bind="textInput: dnsName" />
+
+            <svg-icon class="validating-indicator spin"
+                data-bind="visible: dnsName.isValidating"
+                params="name: 'in-progress'"></svg-icon>
         </editor>
     </div>
 
@@ -72,8 +76,15 @@
 
     <button class="btn align-start push-both" data-bind="
         click: applyChanges,
-        shakeOnClick: errors().length
+        shakeOnClick: errors().length,
     ">
         Apply Changes
     </button>
 </div>
+
+<!-- ko if: isUpdatingSystemNameModalVisible -->
+<updating-system-name-modal params="
+    name: baseAddress,
+    onClose: () => hideUpdatingSystemNameModal()
+"></updating-system-name-modal>
+<!-- /ko -->

--- a/frontend/src/app/components/management/server-dns-settings-form/server-dns-settings-form.html
+++ b/frontend/src/app/components/management/server-dns-settings-form/server-dns-settings-form.html
@@ -38,7 +38,10 @@
         <input type="text" data-bind="value: secondaryDNS" />
     </editor>
 
-    <button class="btn align-start push-prev" data-bind="click: applyChanges">
+    <button class="btn align-start push-prev" data-bind="
+        click: applyChanges,
+        shakeOnClick: errors().length
+    ">
         Apply Changes
     </button>
 </div>

--- a/frontend/src/app/components/management/server-dns-settings-form/server-dns-settings-form.js
+++ b/frontend/src/app/components/management/server-dns-settings-form/server-dns-settings-form.js
@@ -46,7 +46,6 @@ class ServerDnsSettingsFormViewModel extends Disposable{
                 isIPOrDNSName: true
             });
 
-
         this.errors = ko.validation.group(this);
     }
 
@@ -55,7 +54,6 @@ class ServerDnsSettingsFormViewModel extends Disposable{
             this.errors.showAllMessages();
 
         } else {
-            console.warn(this.serverSecret());
             updateServerDNSSettings(
                 this.serverSecret(), this.primaryDNS(), this.secondaryDNS()
             );

--- a/frontend/src/app/components/management/server-time-form/server-time-form.html
+++ b/frontend/src/app/components/management/server-time-form/server-time-form.html
@@ -37,7 +37,10 @@
     </div>
 
     <div class="row">
-        <button class="btn" data-bind="click: applyChanges">
+        <button class="btn" data-bind="
+            click: applyChanges,
+            shakeOnClick: !isValid()
+        ">
             Apply Changes
         </button>
     </div>

--- a/frontend/src/app/components/management/server-time-form/server-time-form.js
+++ b/frontend/src/app/components/management/server-time-form/server-time-form.js
@@ -74,6 +74,10 @@ class ServerTimeFormViewModel extends Disposable{
         this.ntpErrors = ko.validation.group([
             this.ntpServer
         ]);
+
+        this.isValid = ko.pureComputed(
+            () => this.usingManualTime() || this.ntpErrors().length === 0
+        );
     }
 
     applyChanges() {

--- a/frontend/src/app/components/management/start-maintenance-modal/start-maintenance-modal.html
+++ b/frontend/src/app/components/management/start-maintenance-modal/start-maintenance-modal.html
@@ -29,8 +29,7 @@
         </button>
         <button class="btn" data-bind="
             click: start,
-            css: { shake: shake },
-            animation: { end: () => shake(false) }
+            shakeOnClick: errors().length
         ">
             Start maintenance
         </button>

--- a/frontend/src/app/components/management/start-maintenance-modal/start-maintenance-modal.js
+++ b/frontend/src/app/components/management/start-maintenance-modal/start-maintenance-modal.js
@@ -36,7 +36,6 @@ class StartMaintenanceModalViewModel extends Disposable {
         );
 
         this.errors = ko.validation.group(this);
-        this.shake = ko.observable(false);
     }
 
     cancel() {
@@ -46,7 +45,6 @@ class StartMaintenanceModalViewModel extends Disposable {
     start() {
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
-            this.shake(true);
 
         } else {
             enterMaintenanceMode(this.durationInMin());

--- a/frontend/src/app/components/management/updating-system-name-modal/updating-system-name-modal.html
+++ b/frontend/src/app/components/management/updating-system-name-modal/updating-system-name-modal.html
@@ -1,0 +1,35 @@
+<modal class="modal-xsmall" params="
+    title: title,
+    allowBackdropClose: !restarting(),
+    addCloseButton: !restarting(),
+    onClose: () => no()
+">
+
+    <p class="highlight greedy push-next" data-bind="visible: !restarting()">
+        Updating the system name will cause a momentary restart of the NooBaa service.
+        <br>
+        Are you sure you want to continue?
+    </p>
+
+    <p class="highlight greedy push-next" data-bind="visible: restarting">
+        <svg-icon class="spin" params="name: 'in-progress'"></svg-icon>
+        Please wait while the system is restarting...
+    </p>
+
+    <div class="row content-middle align-end">
+        <button class="link alt-color push-next" data-bind="
+            click: no,
+            disable: restarting
+        ">
+            No
+        </button>
+
+        <button class="btn" data-bind="
+            click: yes,
+            disable: restarting
+        ">
+            Yes
+        </button>
+    </div>
+
+</modal>

--- a/frontend/src/app/components/management/updating-system-name-modal/updating-system-name-modal.js
+++ b/frontend/src/app/components/management/updating-system-name-modal/updating-system-name-modal.js
@@ -1,0 +1,33 @@
+import template from './updating-system-name-modal.html';
+import Disposable from 'disposable';
+import { updateHostname } from 'actions';
+import ko from 'knockout';
+
+class UpdatingSystemNameModalViewModel extends Disposable {
+    constructor({ name, onClose }) {
+        super();
+
+        this.name = name;
+        this.onClose = onClose;
+        this.restarting = ko.observable(false);
+
+        this.title = ko.pureComputed(
+            // () => this.restarting() ? null : 'Updating System Name'
+            () => 'Updating System Name'
+        );
+    }
+
+    yes() {
+        updateHostname(ko.unwrap(this.name));
+        this.restarting(true);
+    }
+
+    no() {
+        this.onClose();
+    }
+}
+
+export default {
+    viewModel: UpdatingSystemNameModalViewModel,
+    template: template
+};

--- a/frontend/src/app/components/management/updating-system-name-modal/updating-system-name-modal.less
+++ b/frontend/src/app/components/management/updating-system-name-modal/updating-system-name-modal.less
@@ -1,0 +1,3 @@
+updating-system-name-modal {
+    display: block;
+}

--- a/frontend/src/app/components/register.js
+++ b/frontend/src/app/components/register.js
@@ -128,6 +128,7 @@ export default function register(ko) {
     ko.components.register('server-ssl-form',           require('./management/server-ssl-form/server-ssl-form'));
     ko.components.register('server-time-form',          require('./management/server-time-form/server-time-form'));
     ko.components.register('server-dns-settings-form',  require('./management/server-dns-settings-form/server-dns-settings-form'));
+    ko.components.register('updating-system-name-modal', require('./management/updating-system-name-modal/updating-system-name-modal'));
     /** INJECT:management **/
 
     // -------------------------------

--- a/frontend/src/app/components/resources/add-cloud-resource-modal/add-cloud-resource-modal.html
+++ b/frontend/src/app/components/resources/add-cloud-resource-modal/add-cloud-resource-modal.html
@@ -44,8 +44,7 @@
         </button>
         <button class="btn" data-bind="
             click: add,
-            css: { shake: shake },
-            animation: { end: () => shake(false) }
+            shakeOnClick: errors().length
         ">
             Add
         </button>

--- a/frontend/src/app/components/resources/add-cloud-resource-modal/add-cloud-resource-modal.js
+++ b/frontend/src/app/components/resources/add-cloud-resource-modal/add-cloud-resource-modal.js
@@ -106,8 +106,6 @@ class AddCloudResourceModalViewModel extends Disposable {
             this.resourceName
         ]);
 
-        this.shake = ko.observable(false);
-
         loadCloudConnections();
     }
 
@@ -126,7 +124,6 @@ class AddCloudResourceModalViewModel extends Disposable {
     add() {
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
-            this.shake(true);
 
         } else {
             createCloudResource(this.resourceName(), this.connection().name, this.targetBucket());

--- a/frontend/src/app/components/shared/add-cloud-connection-modal/add-cloud-connection-modal.html
+++ b/frontend/src/app/components/shared/add-cloud-connection-modal/add-cloud-connection-modal.html
@@ -44,8 +44,7 @@
         </button>
         <button class="btn" data-bind="
             click: tryConnection,
-            css: { shake: shake },
-            animation: { end: () => shake(false) }
+            shakeOnClick: errors().length
         ">
             Save
         </button>

--- a/frontend/src/app/components/shared/add-cloud-connection-modal/add-cloud-connection-modal.js
+++ b/frontend/src/app/components/shared/add-cloud-connection-modal/add-cloud-connection-modal.js
@@ -175,14 +175,11 @@ class AddCloudConnectionModalViewModel extends Disposable {
             this.identity,
             this.secret
         ]);
-
-        this.shake = ko.observable(false);
     }
 
     tryConnection() {
         if (this.errors().length > 0) {
             this.errors.showAllMessages();
-            this.shake(true);
 
         } else {
             checkCloudConnection(

--- a/frontend/src/app/components/shared/modal/modal.html
+++ b/frontend/src/app/components/shared/modal/modal.html
@@ -4,7 +4,7 @@
     <h1 class="row heading2 modal-heading content-middle">
         <span class="greedy push-next" data-bind="text: title"></span>
 
-        <button class="close-btn icon-btn no-outline" data-bind="
+        <button class="close-btn icon-btn no-outline" tabindex="-1" data-bind="
             visible: addCloseButton,
             click: onClose
         ">

--- a/frontend/src/app/components/shared/wizard/wizard.html
+++ b/frontend/src/app/components/shared/wizard/wizard.html
@@ -17,15 +17,14 @@
 
     <div class="row buttons align-end content-middle">
         <button class="link alt-colors push-next" data-bind="
-            click: isFirstStep() ? cancel : prev,
-            text: isFirstStep() ? 'Cancel' : 'Previous'
+            click: prev,
+            text: prevText
         "></button>
 
         <button class="btn" data-bind="
-            click: isLastStep() ? done : next,
-            text: isLastStep() ? actionLabel : 'Next',
-            css: { shake: shake },
-            animation: { end: () => shake(false) }
+            click: next,
+            text: nextLabel,
+            shakeOnClick: !isStepValid()
         "></button>
     </div>
 </modal>

--- a/frontend/src/app/components/shared/wizard/wizard.js
+++ b/frontend/src/app/components/shared/wizard/wizard.js
@@ -18,7 +18,6 @@ class WizardViewModel extends Disposable {
         super();
 
         this.heading = heading;
-        this.actionLabel = actionLabel;
         this.step = ko.observable(skip);
         this.validateStep = validateStep;
         this.onCancel = onCancel;
@@ -41,41 +40,47 @@ class WizardViewModel extends Disposable {
         );
 
         this.isLastStep = ko.pureComputed(
-            () => this.step() === steps.length -1
+            () => this.step() === steps.length - 1
         );
 
-        this.shake = ko.observable(false);
+        this.prevText = ko.pureComputed(
+            () => this.isFirstStep() ? 'Cancel' : 'Previous'
+        );
+
+        this.nextLabel = ko.pureComputed(
+            () => this.isLastStep() ? ko.unwrap(actionLabel) : 'Next'
+        );
+
+        this.isStepValid = ko.pureComputed(
+            () => this.validateStep(this.step() + 1)
+        );
     }
 
     isInStep(stepNum) {
         return this.step() === stepNum;
     }
 
-    cancel() {
-        this.onCancel();
-        this.onClose();
-    }
-
     prev() {
-        if (this.step() > 0) {
+        if (this.isFirstStep()) {
+            this.onCancel();
+            this.onClose();
+
+        } else {
             this.step(this.step() - 1);
         }
     }
 
     next() {
-        if (!this.isLastStep() && this.validateStep(this.step() + 1)) {
-            this.step(this.step() + 1);
-        } else {
-            this.shake(true);
+        if (!this.isStepValid()) {
+            return;
         }
-    }
 
-    done() {
-        if (this.validateStep(this.step() + 1)) {
+        if (this.isLastStep()) {
             this.onComplete();
             this.onClose();
+
         } else {
-            this.shake(true);
+            this.step(this.step() + 1);
         }
     }
 }

--- a/frontend/src/app/config.json
+++ b/frontend/src/app/config.json
@@ -1,5 +1,5 @@
 {
-    "inputThrottle": 400,
+    "inputThrottle": 500,
     "paginationPageSize": 25,
     "infinitScrollPageSize": 25,
     "defaultPoolName": "default_pool",

--- a/frontend/src/app/knockout-extensions.js
+++ b/frontend/src/app/knockout-extensions.js
@@ -1,5 +1,5 @@
 import ko from 'knockout';
-import { isObject } from 'utils';
+import { isObject, deepFreeze } from 'utils';
 
 ko.subscribable.fn.is = function(value) {
     return ko.pureComputed(
@@ -87,6 +87,26 @@ if (ko.validation) {
             }
         );
     };
+
+    const validationGroupExtensions = deepFreeze({
+        validatingCount() {
+            return this.filter( obj => obj.isValidating() ).length;
+        }
+    });
+
+    const kvGroup = ko.validation.group;
+    ko.validation.group = function(obj, options) {
+        return Object.assign(
+            kvGroup(obj, options),
+            validationGroupExtensions
+        );
+    };
+
+    // ko.validation.isValidating = function (validationGroup) {
+    //     return Boolean(
+    //         validationGroup.filter( obs => obs.isValidating() ).length
+    //     );
+    // }
 }
 
 window.ko = ko;

--- a/frontend/src/app/model.js
+++ b/frontend/src/app/model.js
@@ -89,5 +89,4 @@ export const sslCertificateUploadStatus = ko.observable();
 export const serverTime = ko.observable();
 
 // Hold system activation information.
-export const activationCodeValid = ko.observable();
-export const activationEmailValid = ko.observable();
+export const activationState = ko.observable();

--- a/frontend/src/app/model.js
+++ b/frontend/src/app/model.js
@@ -90,3 +90,7 @@ export const serverTime = ko.observable();
 
 // Hold system activation information.
 export const activationState = ko.observable();
+
+// Hold system name resolution attempt
+export const nameResolutionState = ko.observable();
+

--- a/frontend/src/app/styles/input.less
+++ b/frontend/src/app/styles/input.less
@@ -213,3 +213,9 @@ input:not([type=checkbox]):not([type=radio]) {
     font-size: @font-size1;
     line-height: 1;
 }
+
+.validating-indicator {
+    position: absolute;
+    top: @gutter/2;
+    right: @gutter/2;
+}

--- a/frontend/src/app/utils.js
+++ b/frontend/src/app/utils.js
@@ -655,3 +655,22 @@ export function calcPasswordStrength(password) {
 
     return clamp(score/100, 0, 1);
 }
+
+// HTTP GET request as a promise.
+export function httpGetAsync(url) {
+    return new Promise(
+        (resolve, reject) =>  {
+            let xhr = new XMLHttpRequest();
+            xhr.open('GET', url, true);
+
+            xhr.onerror = reject;
+            xhr.onabort = reject;
+
+            xhr.onload = function(evt) {
+                xhr.status === 200 ? resolve(evt) : reject(evt);
+            };
+
+            xhr.send();
+        }
+    );
+}


### PR DESCRIPTION
### Purpose

Add async validation for DNS name, trying to resolve the names, in system creating and management/settings.
Also show a confirm dialog for service restart before changing the name.
### Checklist
- [x] Actions: 
  - Add:
    - validateActivation: merged version of validateActivationCode and validateActivationEmail
  - Change: 
    - updateHostname: wait for server restart after setting a new name.
  - Remove:
    - validateActivationEmail: repalced with validateActivation
    - validateActivationCode: repalced with validateActivation
- [x] Model: 
  - Add:
    - activationStat: hold state of last activation attempt.
    - nameResolutionState: hold state of last name resolution attempt
  - Remove:
    - activationCodeValid: replaced with activationState
    - activationEmailValid: replaced with activationState
- [x] Components: 
  - Add:
    - updating-system-name-modal: A confirmation modal for changing the system name that also double as a lock to the FE while the server is restarting (immediately after changing the name) 
  - Change:
    - bucket-placement-policy-modal: refactor button shake
    - set-cloud-sync-modal: refactor button shake
    - change-password-form: refactor button shake
    - signin-form: refactor button shake
    - start-maintenance-modal: refactor button shake
    - add-cloud-resource-modal: refactor button shake
    - add-cloud-connection-modal: refactor button shake
    - attach-server-modal: add button shake
    - server-dns-settings-moda: add button shake
    - server-time-settings-modal: add button shake
    - phone-home-form: add button shake
    - remote-syslog-form: add button shake
    - server-dns-settings-form: add button shake
    - server-time-form: add button shake
    - wizard: refactor button shake and button handlers (next/prev handlers)
    - modal: remove X button from keyboard navigation
    - server-dns-form: Add async validation to dns name and open a confirmation modal instead of sending the rpc call to update the name
    - create-system-form: refactor activation code and email async validation and add async validation to dns name (trying to resolve the name)
- [x] Infrastructure: 
  - Add: 
    - shakeOnClick binding: Shakes a button on click if passed condition is true, used in invalid form for get a better user reaction.
    - getHttpAsync util function: HTTP GET request returning a promise
    - validation-indicator class for general use (set on add a loader immediately after the input tag) 
