### PR TITLE
#2068 - storing create_node_token in agent_conf.js

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -185,7 +185,7 @@ AgentCLI.prototype.init = function() {
                             });
                     })
                     .then(() => {
-                        dbg.log0('exit agent_cli. will restart with new agnet_storage');
+                        dbg.log0('exit agent_cli. will restart with new agent_storage');
                         process.exit(0);
                     })
                     .catch(err => {
@@ -278,6 +278,7 @@ AgentCLI.prototype.load = function() {
                         return self.start(node_name, node_path)
                             .catch(err => {
                                 if (err.message === 'INVALID_NODE') {
+                                    dbg.log0(`got INVALID_NODE for node_path ${node_path}`);
                                     return fs_utils.folder_delete(node_path)
                                         .then(() => 'INVALID_NODE');
                                 } else {
@@ -388,7 +389,7 @@ AgentCLI.prototype.create_node_helper = function(current_node_path_info, use_hos
 
         return fs_utils.file_must_not_exist(token_path)
             .then(function() {
-                if (self.create_node_token) return;
+                if (self.params.create_node_token) return;
                 // authenticate and create a token for new nodes
 
                 var basic_auth_params = _.pick(self.params,
@@ -411,14 +412,37 @@ AgentCLI.prototype.create_node_helper = function(current_node_path_info, use_hos
             .then(function(res) {
                 if (res) {
                     dbg.log0('result create:', res, 'node path:', node_path);
-                    self.create_node_token = res.token;
+                    self.params.create_node_token = res.token;
+                    if (!self.params.internal_agent) {
+                        return self.agent_conf_sem.surround(() => {
+                            // remove access_key and secret_key from agent_conf after a token was acquired and write create_token instead
+                            return fs.readFileAsync('agent_conf.json')
+                                .then(function(data) {
+                                    let agent_conf = JSON.parse(data);
+                                    delete agent_conf.access_key;
+                                    delete agent_conf.secret_key;
+                                    agent_conf.create_node_token = self.params.create_node_token;
+                                    agent_conf.host_id = self.params.host_id;
+                                    var write_data = JSON.stringify(agent_conf);
+                                    return fs.writeFileAsync('agent_conf.json', write_data);
+                                })
+                                .catch(function(err) {
+                                    if (err.code === 'ENOENT') {
+                                        console.warn('No agent_conf.json file exists');
+                                        return;
+                                    }
+                                    throw new Error(err);
+                                });
+                        });
+                    }
                 } else {
-                    dbg.log0('has token', self.create_node_token);
+                    dbg.log0('has token', self.params.create_node_token);
                 }
-                return fs_utils.create_path(node_path, fs_utils.PRIVATE_DIR_PERMISSIONS);
-            }).then(function() {
+            })
+            .then(() => fs_utils.create_path(node_path, fs_utils.PRIVATE_DIR_PERMISSIONS))
+            .then(function() {
                 dbg.log0('writing token', token_path);
-                return fs.writeFileAsync(token_path, self.create_node_token);
+                return fs.writeFileAsync(token_path, self.params.create_node_token);
             })
             .then(function() {
                 if (!fs.existsSync('./uninstall_noobaa_agent.sh')) return;
@@ -431,34 +455,14 @@ AgentCLI.prototype.create_node_helper = function(current_node_path_info, use_hos
                 return promise_utils.exec('echo rd /s /q ' + current_node_path + ' >> ./service_uninstaller.bat ');
             })
             .then(function() {
-                if (!self.params.internal_agent) {
-                    // remove access_key and secret_key from agent_conf after a token was acquired
-                    return fs.readFileAsync('agent_conf.json')
-                        .then(function(data) {
-                            let agent_conf = JSON.parse(data);
-                            delete agent_conf.access_key;
-                            delete agent_conf.secret_key;
-                            agent_conf.host_id = self.params.host_id;
-                            var write_data = JSON.stringify(agent_conf);
-                            return fs.writeFileAsync('agent_conf.json', write_data);
-                        })
-                        .catch(function(err) {
-                            if (err.code === 'ENOENT') {
-                                console.warn('No agent_conf.json file exists');
-                                return;
-                            }
-                            throw new Error(err);
-                        });
-
-                }
-            })
-            .then(function() {
                 dbg.log0('about to start node', node_path, 'with node name:', node_name);
                 return self.start(node_name, node_path);
-            }).then(function(res) {
+            })
+            .then(function(res) {
                 dbg.log0('created', node_name);
                 return res;
-            }).then(null, function(err) {
+            })
+            .then(null, function(err) {
                 dbg.log0('create failed', node_name, err, err.stack);
                 throw err;
             });
@@ -565,6 +569,7 @@ AgentCLI.prototype.start = function(node_name, node_path) {
             storage_limit: self.params.storage_limit,
             is_demo_agent: self.params.demo,
             agent_conf_sem: self.agent_conf_sem,
+            create_node_token: self.params.create_node_token
         });
 
         dbg.log0('agent inited', node_name, self.params.addres, self.params.port, self.params.secure_port, node_path);

--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -275,16 +275,7 @@ AgentCLI.prototype.load = function() {
                     return P.map(regular_node_names, node_name => {
                         dbg.log0('node_name', node_name, 'storage_path', storage_path);
                         var node_path = path.join(storage_path, node_name);
-                        return self.start(node_name, node_path)
-                            .catch(err => {
-                                if (err.message === 'INVALID_NODE') {
-                                    dbg.log0(`got INVALID_NODE for node_path ${node_path}`);
-                                    return fs_utils.folder_delete(node_path)
-                                        .then(() => 'INVALID_NODE');
-                                } else {
-                                    throw err;
-                                }
-                            });
+                        return self.start(node_name, node_path);
                     });
                 });
         }))
@@ -293,11 +284,9 @@ AgentCLI.prototype.load = function() {
             var number_of_new_paths = 0;
             var existing_nodes_count = 0;
             _.each(storage_path_nodes, function(nodes) {
-                // filter out invalid nodes, so new one will be created instead
-                let valid_nodes = nodes.filter(node => (node !== 'INVALID_NODE'));
                 // assumes same amount of nodes per each HD. we will take the last one.
-                if (valid_nodes.length) {
-                    existing_nodes_count = valid_nodes.length;
+                if (nodes.length) {
+                    existing_nodes_count = nodes.length;
                 } else {
                     number_of_new_paths += 1;
                 }

--- a/src/agent/agent_wrap.js
+++ b/src/agent/agent_wrap.js
@@ -31,7 +31,7 @@ fs.readFileAsync('./agent_conf.json')
     .catch(err => {
         if (err.code && err.code === DUPLICATE_RET_CODE) {
             dbg.log0('Duplicate token');
-            return promise_utils.fork('./src/agent/agent_cli', '--duplicate');
+            return promise_utils.fork('./src/agent/agent_cli', ['--duplicate']);
         }
         throw err;
     })

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -77,6 +77,9 @@ module.exports = {
                     cloud_pool_name: {
                         type: 'string'
                     },
+                    create_node_token: {
+                        type: 'string'
+                    }
                 }
             },
         },
@@ -88,6 +91,19 @@ module.exports = {
                 required: ['auth_token'],
                 properties: {
                     auth_token: {
+                        type: 'string'
+                    }
+                }
+            }
+        },
+
+        update_create_node_token: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['create_node_token'],
+                properties: {
+                    create_node_token: {
                         type: 'string'
                     }
                 }

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -240,27 +240,9 @@ class NodesMonitor extends EventEmitter {
 
     // test the passed node id, to verify that it's a valid node
     test_node_id(req) {
-        this._throw_if_not_started_and_loaded();
-        const extra = req.auth.extra || {};
-        const node_id = String(extra.node_id || '');
-        if (!node_id) {
-            dbg.log0('test_node_id: OK without node_id',
-                'auth', req.auth,
-                'from', req.connection.connid);
-            return true;
-        }
-        const item = this._map_node_id.get(String(node_id));
-        if (item) {
-            dbg.log0('test_node_id: OK node_id', node_id,
-                'node', item.node.name,
-                'auth', req.auth,
-                'from', req.connection.connid);
-            return true;
-        }
-        dbg.warn('test_node_id: INVALID node_id', node_id,
-            'auth', req.auth,
-            'from', req.connection.connid);
-        return false;
+        // Deprecated
+        // this case is handled in heartbeat flow. agent will clean itself when getting NODE_NOT_FOUND
+        return true;
     }
 
 
@@ -599,6 +581,7 @@ class NodesMonitor extends EventEmitter {
             P.resolve()
             .then(() => dbg.log0('_run_node:', item.node.name))
             .then(() => this._get_agent_info(item))
+            .then(() => this._update_create_node_token(item))
             .then(() => this._update_rpc_config(item))
             .then(() => this._test_store_perf(item))
             .then(() => this._test_network_perf(item))
@@ -650,12 +633,35 @@ class NodesMonitor extends EventEmitter {
                 }
                 _.extend(item.node, updates);
                 this._set_need_update.add(item);
+                item.create_node_token = info.create_node_token;
             })
             .catch(err => {
                 dbg.error('got error in _get_agent_info:', err);
                 throw err;
             });
     }
+
+    _update_create_node_token(item) {
+        if (item.create_node_token) {
+            dbg.log2(`_update_create_node_token: node already has a valid create_node_token. item.create_node_token = ${item.create_node_token}`);
+            return;
+        }
+        dbg.log0('node does not have a valid create_node_token. creating new one and sending to agent');
+        let auth_parmas = {
+            system_id: String(item.node.system),
+            account_id: system_store.data.get_by_id(item.node.system).owner._id,
+            role: 'admin'
+        };
+        let token = auth_server.make_auth_token(auth_parmas);
+        dbg.log0(`new create_node_token: ${token}`);
+
+        return this.client.agent.update_create_node_token({
+            create_node_token: token
+        }, {
+            connection: item.connection
+        });
+    }
+
 
     _update_rpc_config(item) {
         if (!item.connection) return;


### PR DESCRIPTION
### Purpose
- when deleting access_key and secret_key from agent_conf we want to
  store the original create_node_token, in case we want to create a new
  node in the future (e.g. on NODE_NOT_FOUND or DUPLICATE)
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: 
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
  - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
### Fixed Issues References
- Fixes #2068
