### PR TITLE
issue #2089 - using server_rpc in lifecycle instead of local rpc client

### DIFF
--- a/config.js
+++ b/config.js
@@ -79,6 +79,13 @@ config.REBUILD_NODE_OFFLINE_GRACE = 5 * 60000;
 config.SCRUBBER_ENABLED = true;
 config.SCRUBBER_RESTART_DELAY = 30000;
 
+//////////////////////
+// LIFECYCLE CONFIG //
+//////////////////////
+config.LIFECYCLE_INTERVAL = 15 * 60 * 1000;
+
+
+
 //////////////////
 // DEBUG CONFIG //
 //////////////////

--- a/src/bg_workers/bg_workers_starter.js
+++ b/src/bg_workers/bg_workers_starter.js
@@ -104,6 +104,7 @@ function run_master_workers() {
     if (config.LIFECYCLE_DISABLED !== 'true') {
         register_bg_worker({
             name: 'lifecycle',
+            delay: config.LIFECYCLE_INTERVAL,
         }, lifecycle.background_worker);
     }
 }

--- a/src/bg_workers/lifecycle.js
+++ b/src/bg_workers/lifecycle.js
@@ -2,15 +2,13 @@
 
 
 const _ = require('lodash');
-const P = require('../util/promise');
-const system_store = require('../server/system_services/system_store').get_instance();
-const api = require('../api');
-const dbg = require('../util/debug_module')(__filename);
 const moment = require('moment');
 
+const P = require('../util/promise');
+const system_store = require('../server/system_services/system_store').get_instance();
+const dbg = require('../util/debug_module')(__filename);
+const server_rpc = require('../server/server_rpc');
 
-let rpc = api.new_rpc();
-let rpc_client = rpc.new_client();
 
 
 //TODO: remove!!! handle BG RPC better asap
@@ -31,26 +29,6 @@ function background_worker() {
     return P.fcall(function() {
             dbg.log0('LIFECYCLE READ BUCKETS configuration:', 'BEGIN');
             return system_store.refresh()
-                .then(function() {
-                    //TODO:
-                    //Replace asap with bg call
-                    dbg.log0('sys store', system_store.data.accounts[1]);
-
-                    var basic_auth_params = {
-                        system: system_store.data.systems[0].name,
-                        role: 'admin'
-                    };
-                    var secret_key = system_store.data.accounts[1].access_keys[0].secret_key;
-                    var auth_params_str = JSON.stringify(basic_auth_params);
-                    var signature = s3.sign(secret_key, auth_params_str);
-                    var auth_params = {
-                        access_key: system_store.data.accounts[1].access_keys[0].access_key,
-                        string_to_sign: auth_params_str,
-                        signature: signature,
-                    };
-                    dbg.log0('create_access_key_auth', auth_params);
-                    return rpc_client.create_access_key_auth(auth_params);
-                })
                 .then(function() {
                     _.each(system_store.data.buckets, function(bucket, i) {
                         if (!bucket.lifecycle_configuration_rules) {
@@ -81,7 +59,7 @@ function background_worker() {
                                         deletion_params.create_time = moment().subtract(lifecycle_rule.expiration.days, 'minutes').unix();
                                         dbg.log0('LIFECYCLE DELETING bucket:', bucket.name, 'rule id(', i, ')', lifecycle_rule.id, ' Days:', lifecycle_rule.expiration.days, '==', deletion_params.create_time, '(', moment().subtract(lifecycle_rule.expiration.days, 'min'), ')');
                                     }
-                                    return rpc_client.object.delete_multiple_objects_by_prefix(deletion_params).then(function() {
+                                    return server_rpc.client.object.delete_multiple_objects_by_prefix(deletion_params).then(function() {
                                         bucket.lifecycle_configuration_rules[i].last_sync = Date.now();
                                         dbg.log0('LIFECYCLE Done bucket:', bucket.name, ' done deletion of objects per prefix ', lifecycle_rule.prefix, ' time:', bucket.lifecycle_configuration_rules[i].last_sync);
                                     });

--- a/src/bg_workers/lifecycle.js
+++ b/src/bg_workers/lifecycle.js
@@ -10,13 +10,6 @@ const dbg = require('../util/debug_module')(__filename);
 const server_rpc = require('../server/server_rpc');
 
 
-
-//TODO: remove!!! handle BG RPC better asap
-var S3Auth = require('aws-sdk/lib/signers/s3');
-var s3 = new S3Auth();
-
-
-
 var LIFECYCLE = {
     schedule_min: 1 //run every 5 minutes
 };


### PR DESCRIPTION
### Purpose
- issue #2089 - using server_rpc in lifecycle instead of local roc client
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: 
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
  - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
### Technical Debt Created
- Opened #xxxx
### Fixed Issues References
- Fixes #2089 
