### PR TITLE
s3cmd multipart upload failure fix

### DIFF
--- a/src/s3/s3_controller.js
+++ b/src/s3/s3_controller.js
@@ -658,7 +658,7 @@ class S3Controller {
         let params = {
             bucket: req.params.bucket,
             key: req.params.key,
-            size: req.content_length,
+            size: req.content_length||0,
             content_type: req.headers['content-type'],
             xattr: get_request_xattr(req),
         };


### PR DESCRIPTION
s3cmd multipart upload doesn't send content length and fails our schema
as the value is NaN and not integer.
