### PR TITLE
added servers storage to cluster information in read_system

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -878,6 +878,9 @@ module.exports = {
                 memory_usage: {
                     type: 'number'
                 },
+                storage: {
+                    $ref: 'common_api#/definitions/storage_info'
+                },
                 cpu_usage: {
                     type: 'number'
                 },

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -165,6 +165,10 @@ function get_cluster_info() {
         let time_epoch = moment().unix();
         let location = cinfo.location;
         let single_server = system_store.data.clusters.length === 1;
+        let storage = {
+            total: 0,
+            free: 0
+        };
         if (single_server) {
             is_connected = 'CONNECTED';
         }
@@ -176,6 +180,7 @@ function get_cluster_info() {
                 is_connected = 'CONNECTED';
             }
             hostname = cinfo.heartbeat.health.os_info.hostname;
+            storage = cinfo.heartbeat.health.storage;
         }
         let server_info = {
             version: version,
@@ -184,6 +189,7 @@ function get_cluster_info() {
             address: cinfo.owner_address,
             status: is_connected,
             memory_usage: memory_usage,
+            storage: storage,
             cpu_usage: cpu_usage,
             location: location,
             debug_level: cinfo.debug_level,


### PR DESCRIPTION
### Purpose
- added servers storage to cluster information in read_system. returning {free, total} in read_system
### Checklist
- Code:
  - [x] User Experience: **Taken a moment to think the effects on our user**
  - [x] Failure handling and Comments on non trivial sections: 
  - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
  - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
  - [x] Tested with: `npm test`
- Supportability:
  - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
  - [x] Mongo Schema Upgrade:
  - [x] Agents changes, Server Platform changes and New packages added to package.json:
