### PR TITLE
Nimrod Keep last upgrade time

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -776,6 +776,9 @@ module.exports = {
                         },
                     },
                 },
+                last_upgrade: {
+                    format: 'idate'
+                },
                 cluster: {
                     $ref: '#/definitions/cluster_info'
                 },

--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -138,6 +138,11 @@ function upgrade_systems() {
             updates.access_keys = updated_access_keys;
         }
 
+        //Add last upgrade time if not exists
+        if (!system.upgrade_date) {
+            updates.upgrade_date = Date.now();
+        }
+
         // optional fix - convert to idate format from ISO date
         if (typeof(system.last_stats_report) !== 'number') {
             updates.last_stats_report = new Date(system.last_stats_report).getTime() || 0;

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -733,7 +733,7 @@ function upgrade_cluster(req) {
         .then(() => {
             let update = {
                 _id: system_store.data.systems[0]._id,
-                upgrade_data: Date.now(),
+                upgrade_date: Date.now(),
             };
             return system_store.make_changes({
                 update: {

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -730,6 +730,15 @@ function upgrade_cluster(req) {
                     throw err;
                 });
         }))
+        .then(() => {
+            let update = {
+                _id: req.system._id,
+                upgrade_data: Date.now(),
+            };
+            return system_store.make_changes({
+                update: update
+            });
+        })
         // after all secondaries are upgraded it is safe to upgrade the primary.
         // secondaries should wait (in upgrade.sh) for primary to complete upgrade and perform mongo_upgrade
         .then(() => {

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -736,7 +736,9 @@ function upgrade_cluster(req) {
                 upgrade_data: Date.now(),
             };
             return system_store.make_changes({
-                systems: update
+                update: {
+                    systems: [update]
+                }
             });
         })
         // after all secondaries are upgraded it is safe to upgrade the primary.

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -732,11 +732,11 @@ function upgrade_cluster(req) {
         }))
         .then(() => {
             let update = {
-                _id: req.system._id,
+                _id: system_store.data.systems[0]._id,
                 upgrade_data: Date.now(),
             };
             return system_store.make_changes({
-                update: update
+                systems: update
             });
         })
         // after all secondaries are upgraded it is safe to upgrade the primary.

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -114,7 +114,7 @@ module.exports = {
         },
 
         //Last upgrade date
-        upgrade_data: {
+        upgrade_date: {
             format: 'idate'
         }
 

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -113,5 +113,10 @@ module.exports = {
             type: 'integer'
         },
 
+        //Last upgrade date
+        upgrade_data: {
+            format: 'idate'
+        }
+
     }
 };

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -447,7 +447,7 @@ function read_system(req) {
             remote_syslog_config: system.remote_syslog_config,
             phone_home_config: phone_home_config,
             version: pkg.version,
-            last_upgrade: system.upgrade_data,
+            last_upgrade: system.upgrade_date,
             debug_level: debug_level,
             upgrade: upgrade,
             system_cap: system_cap,

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -447,6 +447,7 @@ function read_system(req) {
             remote_syslog_config: system.remote_syslog_config,
             phone_home_config: phone_home_config,
             version: pkg.version,
+            last_upgrade: system.upgrade_data,
             debug_level: debug_level,
             upgrade: upgrade,
             system_cap: system_cap,

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -122,7 +122,10 @@ function read_mac_linux_drives(include_all) {
         }, callback))
         .then(volumes => _.compact(_.map(volumes, function(vol) {
             //filter Azure temporary storage
-            if (vol.mount.indexOf('/mnt/resource') === 0) return;
+            if (vol.mount.indexOf('/mnt/resource') === 0) {
+                console.log('skipping /mnt/resource mount');
+                return;
+            }
             return linux_volume_to_drive(vol);
         })));
 }


### PR DESCRIPTION
### Purpose
- Save last upgrade time in the system and return it on read_system

### Checklist 
- Code:
 - [x] User Experience: Show last upgrade time in the GUI
 - [x] Failure handling and Comments on non trivial sections: N/A
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac** - N/A
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: Will be received with the read_system we save in the diag 
- Upgrade:
 - [x] Mongo Schema Upgrade: if upgrade_date doesn't exist we create it with Date.now()
 - [x] Agents changes, Server Platform changes and New packages added to package.json: none

### Fixed Issues References
- Relates to #925

