### PR TITLE
Fix #2060 - multiple support accounts created

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -21,8 +21,6 @@ const system_store = require('../system_services/system_store').get_instance();
 const cloud_utils = require('../../util/cloud_utils');
 const azure = require('azure-storage');
 
-system_store.on('load', ensure_support_account);
-
 /**
  *
  * CREATE_ACCOUNT

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -47,11 +47,13 @@ const mongoose_utils = require('../util/mongoose_utils');
 const system_store = require('./system_services/system_store').get_instance();
 const promise_utils = require('../util/promise_utils');
 const SupervisorCtl = require('./utils/supervisor_ctrl');
+const account_server = require('./system_services/account_server');
 
 const rootdir = path.join(__dirname, '..', '..');
 const dev_mode = (process.env.DEV_MODE === 'true');
 const app = express();
 
+system_store.once('load', account_server.ensure_support_account);
 
 dbg.set_process_name('WebServer');
 mongoose_utils.mongoose_connect();


### PR DESCRIPTION
### Purpose
- Registering, just once, to the system_store load, in web_server. This makes sure there can't be a race condition.

### Checklist 
- Testing:
 - [x] Tested with: `npm test`

### Fixed Issues References
- Fixes #2060
