### PR TITLE
fix server sec at init instead of relying later fix

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -6,7 +6,6 @@ ENV_FILE="${CORE_DIR}/.env"
 LOG_FILE="/var/log/noobaa_deploy.log"
 SUPERD="/usr/bin/supervisord"
 SUPERCTL="/usr/bin/supervisorctl"
-NOOBAASEC="/etc/noobaa_sec"
 NOOBAA_ROOTPWD="/etc/nbpwd"
 
 function deploy_log {
@@ -268,10 +267,6 @@ function fix_security_issues {
 	fi
 	echo ${rootpwd} | passwd root --stdin
 
-	# set noobaaroot password
-	secret=$(cat ${NOOBAASEC})
-	echo ${secret} | passwd noobaaroot --stdin
-
 	# disable root login from ssh
 	if ! grep -q 'PermitRootLogin no' /etc/ssh/sshd_config; then
 		echo 'PermitRootLogin no' >> /etc/ssh/sshd_config
@@ -282,6 +277,11 @@ function fix_security_issues {
 		echo 'Match User noobaa'  >> /etc/ssh/sshd_config
 		echo '	PasswordAuthentication no'  >> /etc/ssh/sshd_config
 	fi
+
+    # copy fix_server_sec to
+    if ! grep -q 'fix_server_sec' /etc/rc.local; then
+        echo "bash /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_sec.sh" >> /etc/rc.local
+    fi
 }
 
 function setup_supervisors {

--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -6,7 +6,6 @@ trap "" 2 20
 . /root/node_modules/noobaa-core/src/deploy/NVA_build/deploy_base.sh
 
 FIRST_INSTALL_MARK="/etc/first_install.mrk"
-NOOBAASEC="/etc/noobaa_sec"
 
 function clean_ifcfg() {
   sudo sed -i 's:.*IPADDR=.*::' /etc/sysconfig/network-scripts/ifcfg-eth0
@@ -228,20 +227,6 @@ function end_wizard {
   dialog --colors --nocancel --backtitle "NooBaa First Install" --title '\Z5\ZbNooBaa\Zn is Ready' --msgbox "\n\Z5\ZbNooBaa\Zn was configured and is ready to use. You can access \Z5\Zbhttp://${current_ip}:8080\Zn to start using your system." 7 65
   date | sudo tee -a ${FIRST_INSTALL_MARK}
   clear
-  if [ ! -f ${NOOBAASEC} ]; then
-    local sec=$(uuidgen | sudo cut -f 1 -d'-')
-    echo ${sec} |sudo tee -a ${NOOBAASEC}
-    #dev/null to avoid output with user name
-    echo ${sec} |sudo passwd noobaaroot --stdin >/dev/null
-    sudo sed -i "s:No Server Secret.*:This server's secret is \x1b[0;32;40m${sec}\x1b[0m:" /etc/issue
-  fi
-
-  #verify JWT_SECRET exists in .env, if not create it
-
-  if ! sudo -s grep -q JWT_SECRET /root/node_modules/noobaa-core/.env; then
-      local jwt=$(cat /etc/noobaa_sec | openssl sha512 -hmac | cut -c10-44)
-      echo "JWT_SECRET=${jwt}" | sudo tee -a /root/node_modules/noobaa-core/.env
-  fi
 
   sudo sed -i "s:Configured IP on this NooBaa Server.*:Configured IP on this NooBaa Server \x1b[0;32;40m${current_ip}\x1b[0m:" /etc/issue
 

--- a/src/deploy/NVA_build/fix_server_sec.sh
+++ b/src/deploy/NVA_build/fix_server_sec.sh
@@ -1,0 +1,16 @@
+NOOBAASEC="/etc/noobaa_sec"
+
+# If not sec file, fix it
+if [ ! -f ${NOOBAASEC} ]; then
+  sec=$(uuidgen | cut -f 1 -d'-')
+  echo ${sec} | tee -a ${NOOBAASEC}
+  #dev/null to avoid output with user name
+  echo ${sec} | passwd noobaaroot --stdin >/dev/null
+  sed -i "s:No Server Secret.*:This server's secret is \x1b[0;32;40m${sec}\x1b[0m:" /etc/issue
+
+  #verify JWT_SECRET exists in .env, if not create it
+  if ! grep -q JWT_SECRET /root/node_modules/noobaa-core/.env; then
+      jwt=$(cat /etc/noobaa_sec | openssl sha512 -hmac | cut -c10-44)
+      echo "JWT_SECRET=${jwt}" | tee -a /root/node_modules/noobaa-core/.env
+  fi
+fi

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -258,6 +258,11 @@ function pre_upgrade {
         deploy_log "$agent_conf not found."
     fi
 
+	# copy fix_server_sec to
+    if ! grep -q 'fix_server_sec' /etc/rc.local; then
+        echo "bash /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_sec.sh" >> /etc/rc.local
+    fi
+
 	#install nvm use v4.4.4
 	rm -rf ~/.nvm
 	mkdir ~/.nvm

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -395,16 +395,7 @@ function read_server_secret() {
                 return sec.trim();
             })
             .catch(err => {
-                //For Azure Market Place only, if file does not exist, create it
-                //The reason is that we don't run the first time wizard in the market place.
-                if (err.code === 'ENOENT') {
-                    var id = uuid().substring(0, 8);
-                    return fs.writeFileAsync(config.CLUSTERING_PATHS.SECRET_FILE,
-                            id)
-                        .then(() => id);
-                } else {
-                    throw new Error('Failed reading secret with ' + err);
-                }
+                throw new Error('Failed reading secret with ' + err);
             });
     } else if (os.type() === 'Darwin') {
         return fs.readFileAsync(config.CLUSTERING_PATHS.DARWIN_SECRET_FILE)


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)

### Purpose
- fix server sec at init instead of relying later fix (first install / os_utils_

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user** NA
 - [x] Failure handling and Comments on non trivial sections: NA
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac** NA
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade: NA
 - [x] Agents changes, Server Platform changes and New packages added to package.json: NA
 
### Fixed Issues References
- Fixes #2137 