### PR TITLE
Change redirect to navigate on table sorting/filtering/paging

### DIFF
--- a/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.js
+++ b/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.js
@@ -4,7 +4,7 @@ import ko from 'knockout';
 import { paginationPageSize, inputThrottle } from 'config';
 import { deepFreeze, throttle } from 'utils';
 import ObjectRowViewModel from './object-row';
-import { redirectTo, uploadFiles } from 'actions';
+import { navigateTo, uploadFiles } from 'actions';
 import { routeContext, systemInfo } from 'model';
 
 const columns = deepFreeze([
@@ -135,7 +135,7 @@ class BucketObjectsTableViewModel extends Disposable {
             this.sorting()
         );
 
-        redirectTo(undefined, undefined, params);
+        navigateTo(undefined, undefined, params);
     }
 
     filterObjects(phrase) {
@@ -147,7 +147,7 @@ class BucketObjectsTableViewModel extends Disposable {
             this.sorting()
         );
 
-        redirectTo(undefined, undefined, params);
+        navigateTo(undefined, undefined, params);
     }
 
     orderBy(sorting) {
@@ -159,7 +159,7 @@ class BucketObjectsTableViewModel extends Disposable {
             sorting
         );
 
-        redirectTo(undefined, undefined, params);
+        navigateTo(undefined, undefined, params);
     }
 }
 

--- a/frontend/src/app/components/buckets/buckets-table/buckets-table.js
+++ b/frontend/src/app/components/buckets/buckets-table/buckets-table.js
@@ -3,7 +3,7 @@ import BucketRowViewModel from './bucket-row';
 import Disposable from 'disposable';
 import ko from 'knockout';
 import { deepFreeze, createCompareFunc } from 'utils';
-import { redirectTo } from 'actions';
+import { navigateTo } from 'actions';
 import { systemInfo, routeContext } from 'model';
 
 const columns = deepFreeze([
@@ -69,7 +69,7 @@ class BucketsTableViewModel extends Disposable {
             }),
             write: value => {
                 this.deleteGroup(null);
-                redirectTo(undefined, undefined, value);
+                navigateTo(undefined, undefined, value);
             }
         });
 

--- a/frontend/src/app/components/cluster/server-dns-settings-modal/server-dns-settings-modal.html
+++ b/frontend/src/app/components/cluster/server-dns-settings-modal/server-dns-settings-modal.html
@@ -7,7 +7,7 @@
     </p>
 
     <section class="greedy">
-        <editor params="label: 'Pirmary DNS'" class="push-prev">
+        <editor params="label: 'Primary DNS'" class="push-prev">
             <input type="text" data-bind="value: primaryDNS" />
         </editor>
         <editor params="label: 'Secondary DNS'" class="push-next">

--- a/frontend/src/app/components/cluster/server-table/server-table.js
+++ b/frontend/src/app/components/cluster/server-table/server-table.js
@@ -3,7 +3,7 @@ import Disposable from 'disposable';
 import ko from 'knockout';
 import ServerRowViewModel from './server-row';
 import { createCompareFunc, deepFreeze } from 'utils';
-import { redirectTo } from 'actions';
+import { navigateTo } from 'actions';
 import { systemInfo, routeContext } from 'model';
 
 const columns = deepFreeze([
@@ -56,7 +56,7 @@ class ServerTableViewModel extends Disposable {
                 sortBy: routeContext().query.sortBy || 'hostname',
                 order: Number(routeContext().query.order) || 1
             }),
-            write: value => redirectTo(undefined, undefined, value)
+            write: value => navigateTo(undefined, undefined, value)
         });
 
         this.servers = ko.pureComputed(

--- a/frontend/src/app/components/management/server-dns-settings-form/server-dns-settings-form.html
+++ b/frontend/src/app/components/management/server-dns-settings-form/server-dns-settings-form.html
@@ -30,7 +30,7 @@
 <div class="column" data-bind="expand: expanded">
     <p>Setup the server to use the following DNS servers for name resolution</p>
 
-    <editor params="label: 'Pirmary DNS'">
+    <editor params="label: 'Primary DNS'">
         <input type="text" data-bind="value: primaryDNS" />
     </editor>
 

--- a/frontend/src/app/components/pool/pool-nodes-table/pool-nodes-table.js
+++ b/frontend/src/app/components/pool/pool-nodes-table/pool-nodes-table.js
@@ -4,7 +4,7 @@ import Disposable from 'disposable';
 import ko from 'knockout';
 import { paginationPageSize, inputThrottle } from 'config';
 import { deepFreeze, throttle} from 'utils';
-import { redirectTo } from 'actions';
+import { navigateTo } from 'actions';
 import { routeContext } from 'model';
 
 let columns = deepFreeze([
@@ -144,7 +144,7 @@ class PoolNodesTableViewModel extends Disposable {
             this.sorting()
         );
 
-        redirectTo(undefined, undefined, params);
+        navigateTo(undefined, undefined, params);
     }
 
     filterObjects(phrase) {
@@ -157,7 +157,7 @@ class PoolNodesTableViewModel extends Disposable {
             this.sorting()
         );
 
-        redirectTo(undefined, undefined, params);
+        navigateTo(undefined, undefined, params);
     }
 
     orderBy(sorting) {
@@ -170,7 +170,7 @@ class PoolNodesTableViewModel extends Disposable {
             sorting
         );
 
-        redirectTo(undefined, undefined, params);
+        navigateTo(undefined, undefined, params);
     }
 
     toggleIssues(value) {
@@ -183,7 +183,7 @@ class PoolNodesTableViewModel extends Disposable {
             this.sorting()
         );
 
-        redirectTo(undefined, undefined, params);
+        navigateTo(undefined, undefined, params);
     }
 
     showAssignNodesModal() {

--- a/frontend/src/app/components/resources/cloud-resources-table/cloud-resources-table.js
+++ b/frontend/src/app/components/resources/cloud-resources-table/cloud-resources-table.js
@@ -2,9 +2,9 @@ import template from './cloud-resources-table.html';
 import Disposable from 'disposable';
 import ko from 'knockout';
 import CloudResourceRowViewModel from './cloud-resource-row';
-import { systemInfo, routeContext } from 'model';
+import { systemInfo, uiState, routeContext } from 'model';
 import { deepFreeze, createCompareFunc } from 'utils';
-import { redirectTo } from 'actions';
+import { navigateTo } from 'actions';
 
 const columns = deepFreeze([
     {
@@ -86,8 +86,8 @@ class CloudResourcesTableViewModel extends Disposable {
 
         this.sorting = ko.pureComputed({
             read: () => {
-                let { params, query } = routeContext();
-                let isOnScreen = params.tab === 'cloud';
+                let { query } = routeContext();
+                let isOnScreen = uiState().tab === 'cloud';
 
                 return {
                     sortBy: (isOnScreen && query.sortBy) || 'name',
@@ -96,7 +96,7 @@ class CloudResourcesTableViewModel extends Disposable {
             },
             write: value => {
                 this.deleteGroup(null);
-                redirectTo(undefined, undefined, value);
+                navigateTo(undefined, undefined, value);
             }
         });
 

--- a/frontend/src/app/components/resources/pools-table/pools-table.js
+++ b/frontend/src/app/components/resources/pools-table/pools-table.js
@@ -3,8 +3,8 @@ import Disposable from 'disposable';
 import ko from 'knockout';
 import PoolRowViewModel from './pool-row';
 import { deepFreeze, createCompareFunc } from 'utils';
-import { redirectTo } from 'actions';
-import { routeContext, systemInfo } from 'model';
+import { navigateTo } from 'actions';
+import { uiState, routeContext, systemInfo } from 'model';
 
 const columns = deepFreeze([
     {
@@ -104,8 +104,8 @@ class PoolsTableViewModel extends Disposable {
 
         this.sorting = ko.pureComputed({
             read: () => {
-                let { params, query } = routeContext();
-                let isOnScreen = params.tab === 'pools';
+                let { query } = routeContext();
+                let isOnScreen = uiState().tab === 'pools';
 
                 return {
                     sortBy: (isOnScreen && query.sortBy) || 'name',
@@ -114,7 +114,7 @@ class PoolsTableViewModel extends Disposable {
             },
             write: value => {
                 this.deleteGroup(null);
-                redirectTo(undefined, undefined, value);
+                navigateTo(undefined, undefined, value);
             }
         });
 


### PR DESCRIPTION
### Purpose

### Checklist
- [x] Components: 
    - Change:
        * bucket-objects-table - change redirectTo to navigateTo to preserve browser history
        * buckets-table - change redirectTo to navigateTo to preserve browser history
        * server-table - change redirectTo to navigateTo to preserve browser history
        * pool-nodes-table - change redirectTo to navigateTo to preserve browser history
        * cloud-resources-table - change redirectTo to navigateTo to preserve browser history
        * pools-table - change redirectTo to navigateTo to preserve browser history
        * server-dns-settings-modal - fix typo
        * server-dns-settings-modal - fix typo

### Fixed Issues References
#792 - fixes some of the bullets in the issue
Fixes #2142
Fixes #2139
