### PR TITLE
Add previewMode  to unlock preview UI/UX

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -37,6 +37,10 @@ export function start() {
         sessionStorage.getItem('sessionToken') ||
         localStorage.getItem('sessionToken');
 
+    model.previewMode(
+        localStorage.getItem('previewMode')
+    );
+
     return api.auth.read_auth()
         // Try to restore the last session
         .then(({ account, system }) => {

--- a/frontend/src/app/components/layout/main-nav/main-nav.html
+++ b/frontend/src/app/components/layout/main-nav/main-nav.html
@@ -2,7 +2,10 @@
     <!-- ko foreach: items -->
     <a class="nav-link link row alt-colors no-outline pad content-middle" data-bind="
         href: { route: route, params: { tab: null } },
-        css: { selected: $component.isSelected(name) }
+        css: {
+            selected: $component.isSelected(name),
+            'preview-only': $data.preview
+        }
     ">
         <svg-icon params="name: icon"></svg-icon>
         <span class="pad" data-bind="text: label"></span>

--- a/frontend/src/app/components/layout/main-nav/main-nav.js
+++ b/frontend/src/app/components/layout/main-nav/main-nav.js
@@ -29,14 +29,14 @@ const navItems = deepFreeze([
         route: 'management',
         icon: 'manage',
         label: 'Management'
-    }//,
-    // TODO: uncomment when we decide to publish the H/A feature to customers
-    // {
-    //     name: 'cluster',
-    //     route: 'cluster',
-    //     icon: 'cluster',
-    //     label: 'Cluster'
-    // }
+    },
+    {
+        name: 'cluster',
+        route: 'cluster',
+        icon: 'cluster',
+        label: 'Cluster',
+        preview: true
+    }
 ]);
 
 class NavMenuViewModel extends Disposable{

--- a/frontend/src/app/main.js
+++ b/frontend/src/app/main.js
@@ -8,7 +8,7 @@ import registerBindings from 'bindings/register';
 import registerComponents from 'components/register';
 import page from 'page';
 import configureRouter from 'routing';
-import { uiState } from 'model';
+import { previewMode, uiState } from 'model';
 import { start } from 'actions';
 
 // Enable knockout 3.4 deferred updates.
@@ -35,6 +35,7 @@ configureRouter(page);
 
 // Bind the ui to the
 ko.applyBindings({
+    previewMode: previewMode,
     layout: ko.pureComputed( () => uiState().layout ),
     modal: ko.pureComputed( () => uiState().modal )
 });

--- a/frontend/src/app/model.js
+++ b/frontend/src/app/model.js
@@ -1,5 +1,7 @@
 import ko from 'knockout';
 
+export const previewMode = ko.observable(false);
+
 // Hold the current ui state.
 export const uiState = ko.observable({
     layout: 'empty'

--- a/frontend/src/app/styles/site.less
+++ b/frontend/src/app/styles/site.less
@@ -86,6 +86,10 @@ output {
     border-color: transparent;
 }
 
+body:not(.preview) .preview-only {
+    display: none !important;
+}
+
 .text-center {
     text-align: center;
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="/fe/styles.css"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-<body>
+<body data-bind="css: { preview: previewMode }">
     <!-- ko component: layout --><!-- /ko -->
 
     <script src="/fe/lib.js"></script>


### PR DESCRIPTION
### Purpose
Allow developing preview UI/UX thats unlocks only under previewMode (a previewMode prop under  local storage)

### Checklist
- [x] Actions: 
    - Change:
        * start: reads preview mode flag from localStorage

- [x] Model: 
    - Add:
        * previewMode: holds the value of the previewMode flag

- [x] Components: 
    - Change:
        * main-nav: Add cluster item under preview mode

- [x] Infrastructure: 
    - Add: 
        * css - preview-mode class: allow developer to hide ui/ux when not in preview mode.
