### PR TITLE
fix toggling eye icon when pressing 'enter' in forms with password field

### DIFF
--- a/frontend/src/app/components/shared/password-field/password-field.html
+++ b/frontend/src/app/components/shared/password-field/password-field.html
@@ -6,7 +6,7 @@
         attr: { type: type, placeholder: placeholder }
     "/>
 
-    <button class="eye-button icon-btn btn-flat no-outline" tabindex="-1" data-bind="
+    <button class="eye-button icon-btn btn-flat no-outline" type="button" tabindex="-1" data-bind="
         click: toogleType,
         tooltip: tooltip,
         visible: value


### PR DESCRIPTION
### Purpose
fix toggling eye icon when pressing 'enter' in forms with password field

### Checklist
- [x] Components: 
    - Change: add `type="button"` to <button> tag to prevent default submit behaviour
        (as suggested in: http://stackoverflow.com/questions/932653/how-to-prevent-buttons-from-submitting-forms)

### Fixed Issues References
Fixes #1968 
