### PR TITLE
Changes to clustering ip change flow

### DIFF
--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -44,8 +44,22 @@ module.exports = {
                         type: 'object',
                         additionalProperties: true,
                         properties: {}
-                    },
-                    first_server_internal_ip: {
+                    }
+                }
+            },
+            auth: {
+                system: false
+            }
+        },
+
+        verify_join_conditions: {
+            doc: 'check join conditions to the cluster and return caller ip (stun)',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['secret'],
+                properties: {
+                    secret: {
                         type: 'string'
                     }
                 }


### PR DESCRIPTION
### Purpose
- Will now use the first server being added to the cluster as a stun server *before* being added to the cluster. This prevents some potential bugs and simplifies the flow.

### Checklist 
- Testing:
 - [x] Manual testing: created a cluster with 2 and 3 servers.
