### PR TITLE
Object parts list columns sizes

### DIFF
--- a/frontend/src/app/components/object/object-parts-list/object-parts-list.less
+++ b/frontend/src/app/components/object/object-parts-list/object-parts-list.less
@@ -37,16 +37,16 @@ object-parts-list {
         }
 
         .node-name-col {
-            min-width: 14em;
+            min-width: 230px;
         }
 
         .node-ip-col {
-            min-width: 8em;
+            min-width: 116px;
         }
 
         .pool-col {
-            min-width: 10em;
-            max-width: 10em;
+            min-width: 140px;
+            max-width: 140px;
         }
     }
 }


### PR DESCRIPTION
### Purpose
Changing the size of object part list columns from 'em' to 'px' & increasing the size of the node-name column

### Checklist
- [x] Components:
    - Change: object-part-list.less -> change sizes from em to px and increasing the size of the node-name to fit wide texts