### PR TITLE
Send server secret to BE when updating time config to ntp

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1801,6 +1801,7 @@ export function updateServerNTPSettings(serverSecret, timezone, ntpServerAddress
     );
 
     api.cluster_server.update_time_config({
+        target_secret: serverSecret,
         timezone: timezone,
         ntp_server: ntpServerAddress
     })


### PR DESCRIPTION
### Purpose

### Checklist
- [x] Actions: 
    - Change:
        * updateServerNTPSettings - forward serverSecret parameter to update_time_config call

### Fixed Issues References
Fixes #2184
