### PR TITLE
fix disabled download diagnostics in all servers

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1402,7 +1402,7 @@ export function downloadNodeDiagnosticPack(nodeName) {
 export function downloadServerDiagnosticPack(targetSecret, targetHostname) {
     logAction('downloadServerDiagnosticPack', { targetSecret, targetHostname });
 
-    let currentServerKey = `server:${targetHostname}`;
+    let currentServerKey = `server:${targetSecret}`;
     if(model.collectDiagnosticsState[currentServerKey] === true) {
         return;
     }


### PR DESCRIPTION
### Purpose
fix disabled download  diagnostics in all servers with the same name

### Checklist
- [x] Actions: 
    - Change: 
        * downloadServerDiagnosticPack - Use server secret as a key into diagnostics state instead of hostname.

### Fixed Issues References
Fixes #2198