### PR TITLE
#2212 - DNS name and hostname in addresses should be treated case ins…

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -54,7 +54,7 @@ class Agent {
             address: params.address
         }];
 
-        this.base_address = params.address || this.rpc.router.default;
+        this.base_address = params.address ? params.address.toLowerCase() : this.rpc.router.default;
         dbg.log0(`this.base_address=${this.base_address}`);
         this.host_id = params.host_id;
 
@@ -217,7 +217,7 @@ class Agent {
 
     _update_servers_list(new_list) {
         // check if base_address appears in new_list. if not add it.
-        if (_.isUndefined(new_list.find(srv => srv.address === this.base_address))) {
+        if (_.isUndefined(new_list.find(srv => srv.address.toLowerCase() === this.base_address.toLowerCase()))) {
             new_list.push({
                 address: this.base_address
             });
@@ -499,7 +499,7 @@ class Agent {
             this._start_stop_server();
         }
 
-        if (params.base_address && params.base_address !== params.old_base_address) {
+        if (params.base_address && params.base_address.toLowerCase() !== params.old_base_address.toLowerCase()) {
             dbg.log0('new base_address', params.base_address,
                 'old', params.old_base_address);
             // test this new address first by pinging it
@@ -509,7 +509,7 @@ class Agent {
                 .then(() => {
                     if (params.store_base_address) {
                         // store base_address to send in get_agent_info_and_update_masters
-                        this.base_address = params.base_address;
+                        this.base_address = params.base_address.toLowerCase();
                         this.agent_conf.update({
                             address: params.base_address
                         });

--- a/src/s3/s3_controller.js
+++ b/src/s3/s3_controller.js
@@ -74,7 +74,7 @@ class S3Controller {
                             .then(addr => {
                                 let base_port = parseInt(process.env.PORT, 10) || 5001;
                                 let new_address = 'ws://' + addr + ':' + base_port;
-                                if (new_address.toLowerCase() !== this._master_address.toLowerCase()) {
+                                if (!this._master_address || new_address.toLowerCase() !== this._master_address.toLowerCase()) {
                                     dbg.log0(`changing _master_address from ${this._master_address}, to ${addr}`);
                                     this._master_address = new_address;
                                     throw err;

--- a/src/s3/s3_controller.js
+++ b/src/s3/s3_controller.js
@@ -74,7 +74,7 @@ class S3Controller {
                             .then(addr => {
                                 let base_port = parseInt(process.env.PORT, 10) || 5001;
                                 let new_address = 'ws://' + addr + ':' + base_port;
-                                if (new_address !== this._master_address) {
+                                if (new_address.toLowerCase() !== this._master_address.toLowerCase()) {
                                     dbg.log0(`changing _master_address from ${this._master_address}, to ${addr}`);
                                     this._master_address = new_address;
                                     throw err;

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -257,7 +257,7 @@ class NodesClient {
         return server_rpc.client.cluster_internal.redirect_to_cluster_master()
             .then(addr => {
                 let new_address = 'ws://' + addr + ':' + server_rpc.get_base_port();
-                if (new_address.toLowerCase() !== this._master_address.toLowerCase()) {
+                if (!this._master_address || new_address.toLowerCase() !== this._master_address.toLowerCase()) {
                     dbg.log0(`nodes_client: changing _master_address from ${this._master_address}, to ${new_address}`);
                     this._master_address = new_address;
                     throw err;

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -257,7 +257,7 @@ class NodesClient {
         return server_rpc.client.cluster_internal.redirect_to_cluster_master()
             .then(addr => {
                 let new_address = 'ws://' + addr + ':' + server_rpc.get_base_port();
-                if (new_address !== this._master_address) {
+                if (new_address.toLowerCase() !== this._master_address.toLowerCase()) {
                     dbg.log0(`nodes_client: changing _master_address from ${this._master_address}, to ${new_address}`);
                     this._master_address = new_address;
                     throw err;

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -692,7 +692,7 @@ class NodesMonitor extends EventEmitter {
         // otherwise the agent is using the ip directly, so no update is needed
         // don't update local agents which are using local host
         if (system.base_address &&
-            system.base_address !== item.agent_info.base_address &&
+            system.base_address.toLowerCase() !== item.agent_info.base_address.toLowerCase() &&
             !item.node.is_internal_node &&
             !is_localhost(item.agent_info.base_address)) {
             rpc_config.base_address = system.base_address;
@@ -2025,7 +2025,7 @@ function progress_by_time(time, now) {
 
 function is_localhost(address) {
     let addr_url = url.parse(address);
-    return addr_url.hostname === '127.0.0.1' || addr_url.hostname === 'localhost';
+    return addr_url.hostname === '127.0.0.1' || addr_url.hostname.toLowerCase() === 'localhost';
 }
 
 // EXPORTS

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -741,7 +741,7 @@ function update_base_address(req) {
             update: {
                 systems: [{
                     _id: req.system._id,
-                    base_address: req.rpc_params.base_address
+                    base_address: req.rpc_params.base_address.toLowerCase()
                 }]
             }
         })


### PR DESCRIPTION
### Purpose
- Fixes #2212 - storing and comparing base_address in lower case

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:


- Fixes #2212
