### PR TITLE
Allow empty TZ in first_install_dialog

### DIFF
--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -151,7 +151,10 @@ function configure_ntp_dialog {
       err_ntp_msg="\Z1NTP Server must be set.\Zn"
     fi
 
-    if [ -f "/usr/share/zoneinfo/${tz}" ]; then
+    if [ -z ${tz} ]; then #TZ was not supplied
+      err_tz=0
+      err_tz_msg=""
+    elif [ -f "/usr/share/zoneinfo/${tz}" ]; then
       err_tz=0
       err_tz_msg=""
     else


### PR DESCRIPTION

### Purpose
- Allow empty TZ in first_install_dialog

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

Related to #2231 , allow empty TZ

