### PR TITLE
Nimrod Bug fixes - NTP Dialog box, Login Errors

### DIFF
--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -134,7 +134,7 @@ function configure_ntp_dialog {
   local err_tz=1
   local err_ntp=1
   while [ ${err_tz} -eq 1 ] || [ ${err_ntp} -eq 1 ]; do
-    dialog --colors --backtitle "NooBaa First Install" --title "NTP Configuration" --form "\nPlease supply an NTP server address and Time Zone (TZ format https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)\nYou can configure NTP later in the management console\n${err_ntp_msg}\n${err_tz_msg}\n(Use \Z4\ZbUp/Down\Zn to navigate)" 12 80 2 "NTP Server:" 1 1 "${ntp_server}" 1 25 25 30  "Time Zone:" 2 1 "${tz}" 2 25 25 30 2> answer_ntp
+    dialog --colors --backtitle "NooBaa First Install" --title "NTP Configuration" --form "\nPlease supply an NTP server address and Time Zone (TZ format https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)\nYou can configure NTP later in the management console\n${err_ntp_msg}\n${err_tz_msg}\n(Use \Z4\ZbUp/Down\Zn to navigate)" 15 80 2 "NTP Server:" 1 1 "${ntp_server}" 1 25 25 30  "Time Zone:" 2 1 "${tz}" 2 25 25 30 2> answer_ntp
     ntp_server="$(head -1 answer_ntp)"
     tz=$(tail -1 answer_ntp)
     #check cancel

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -46,7 +46,8 @@ function create_auth(req) {
 
         // consider email not found the same as bad password to avoid phishing attacks.
         target_account = system_store.data.accounts_by_email[email];
-        if (!target_account) throw new RpcError('UNAUTHORIZED', 'credentials account not found');
+        dbg.log0('credentials account not found', email, system_name);
+        if (!target_account) throw new RpcError('UNAUTHORIZED', 'credentials not found');
 
         // when password is not provided it means we want to give authorization
         // by the currently authorized to another specific account instead of
@@ -57,7 +58,8 @@ function create_auth(req) {
         return P.fromCallback(callback =>
                 bcrypt.compare(password, target_account.password, callback))
             .then(function(match) {
-                if (!match) throw new RpcError('UNAUTHORIZED', 'password mismatch');
+                dbg.log0('password mismatch', email, system_name);
+                if (!match) throw new RpcError('UNAUTHORIZED', 'credentials not found');
                 // authentication passed!
                 // so this account is the authenticated_account
                 authenticated_account = target_account;
@@ -70,7 +72,8 @@ function create_auth(req) {
         if (!authenticated_account || !target_account) {
             // find the current authorized account and assign
             if (!req.auth || !req.auth.account_id) {
-                throw new RpcError('UNAUTHORIZED', 'no account_id in auth and no credetials');
+                dbg.log0('no account_id in auth and no credetials', email, system_name);
+                throw new RpcError('UNAUTHORIZED', 'credentials not found');
             }
 
             var account_arg = system_store.data.get_by_id(req.auth.account_id);
@@ -81,10 +84,12 @@ function create_auth(req) {
 
         // check the accounts are valid
         if (!authenticated_account || authenticated_account.deleted) {
-            throw new RpcError('UNAUTHORIZED', 'authenticated account not found');
+            dbg.log0('authenticated account not found', email, system_name);
+            throw new RpcError('UNAUTHORIZED', 'credentials not found');
         }
         if (!target_account || target_account.deleted) {
-            throw new RpcError('UNAUTHORIZED', 'target account not found');
+            dbg.log0('target account not found', email, system_name);
+            throw new RpcError('UNAUTHORIZED', 'credentials not found');
         }
 
         // system is optional, and will not be included in the token if not provided


### PR DESCRIPTION
### Purpose
- #2231- Make the NTP dialog box larger
- #2237 - Don't send different errors on login when user does not exist and when pass does not match 

### Checklist 
- Code:
 - [x] User Experience: Enhance user experience 
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2231
- Fixes #2237
