### PR TITLE
Danny fixes

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -14,7 +14,6 @@ const express_compress = require('compression');
 const express_body_parser = require('body-parser');
 const express_morgan_logger = require('morgan');
 const express_method_override = require('method-override');
-const util = require('util');
 
 const P = require('../util/promise');
 const pem = require('../util/pem');


### PR DESCRIPTION
### Purpose
- fixes #2211 
 - throw error on heartbeat when the connection is already assigned on
an item.
 - skip update_rpc_config, test_nodes_validity on the first run before
node is stored.
 - on update_rpc_config - agent will disconnect current connection after
changes.

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2211 
