### PR TITLE
Node Detention fixing bug when passed single pool and not array of single pool

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -827,7 +827,7 @@ class NodesMonitor extends EventEmitter {
         const filter_res = this._filter_nodes({
             skip_address: item.node.rpc_address,
             skip_no_address: true,
-            pool: item.node.pool,
+            pools: [item.node.pool],
             has_issues: false
         });
         const list = filter_res.list;


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)

### Purpose
- Besides making the world a better place it also ...

### Checklist 
- Code:
 - [ ] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [ ] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

### Technical Debt Created
  - Opened #xxxx

### Fixed Issues References
- Fixes #xxxx
- Fixes #yyyy

Expected to pass array and not single pool