### PR TITLE
Danny jenkins

### DIFF
--- a/src/server/server_rpc.js
+++ b/src/server/server_rpc.js
@@ -34,23 +34,29 @@ class ServerRpc {
     }
 
     set_new_router(params) {
+        // check if some domains are changed to fcall://fcall
+        let is_default_fcall = this.rpc.router.default === 'fcall://fcall';
         let base_address = params.base_address;
         let master_address = params.master_address;
         if (base_address) {
             base_address = 'ws://' + base_address + ':' + this.get_base_port();
+        } else if (is_default_fcall) {
+            base_address = 'ws://127.0.0.1:' + this.get_base_port();
         } else {
             base_address = this.rpc.router.default;
         }
+
 
         if (master_address) {
             master_address = 'ws://' + master_address + ':' + this.get_base_port();
         }
 
         this.rpc.router = api.new_router(base_address, master_address);
-    }
 
-    is_service_registered(service) {
-        return this.rpc.is_service_registered(service);
+        // restore default to fcall if needed
+        if (is_default_fcall) {
+            this.rpc.router.default = 'fcall://fcall';
+        }
     }
 
     register_system_services() {

--- a/src/server/server_rpc.js
+++ b/src/server/server_rpc.js
@@ -59,6 +59,10 @@ class ServerRpc {
         }
     }
 
+    is_service_registered(service) {
+        return this.rpc.is_service_registered(service);
+    }
+
     register_system_services() {
         let rpc = this.rpc;
         let schema = rpc.schema;


### PR DESCRIPTION
### Purpose
- handle the case that default address in router is fcall://fcall
 - if the default domain is fcall (like in the web server), we need to use
127.0.0.1 instead

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

