### PR TITLE
Nimrod Treat EMAIL As case insensitive when logging

### DIFF
--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -45,7 +45,7 @@ function create_auth(req) {
         if (!email) return;
 
         // consider email not found the same as bad password to avoid phishing attacks.
-        target_account = system_store.data.accounts_by_email[email];
+        target_account = system_store.get_accounts_by_email(email);
         dbg.log0('credentials account not found', email, system_name);
         if (!target_account) throw new RpcError('UNAUTHORIZED', 'credentials not found');
 

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -613,6 +613,10 @@ function validate_create_account_params(req) {
     if (req.rpc_params.name !== req.rpc_params.name.trim()) {
         throw new RpcError('BAD_REQUEST', 'system name must not contain leading or trailing spaces');
     }
+
+    if (system_store.get_accounts_by_email(req.rpc_params.email)) {
+        throw new RpcError('BAD_REQUEST', 'email address already registered');
+    }
 }
 
 // EXPORTS

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -112,7 +112,7 @@ function create_account(req) {
 function read_account(req) {
     let email = req.rpc_params.email;
 
-    let account = system_store.data.accounts_by_email[email];
+    let account = system_store.get_accounts_by_email(email);
     if (!account) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + email);
     }
@@ -127,7 +127,7 @@ function read_account(req) {
  *
  */
 function generate_account_keys(req) {
-    let account = system_store.data.accounts_by_email[req.rpc_params.email];
+    let account = system_store.get_accounts_by_email(req.rpc_params.email);
     if (!account) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + req.rpc_params.email);
     }
@@ -165,7 +165,7 @@ function generate_account_keys(req) {
  */
 function update_account_s3_acl(req) {
     var system = req.system;
-    let account = _.cloneDeep(system_store.data.accounts_by_email[req.rpc_params.email]);
+    let account = _.cloneDeep(system_store.data.get_accounts_by_email(req.rpc_params.email));
     if (!account) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + req.rpc_params.email);
     }
@@ -248,7 +248,7 @@ function update_account_s3_acl(req) {
  *
  */
 function update_account(req) {
-    let account = system_store.data.accounts_by_email[req.rpc_params.email];
+    let account = system_store.get_accounts_by_email(req.rpc_params.email);
     if (!account) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + req.rpc_params.email);
     }
@@ -304,7 +304,7 @@ function update_account(req) {
  *
  */
 function delete_account(req) {
-    let account_to_delete = system_store.data.accounts_by_email[req.rpc_params.email];
+    let account_to_delete = system_store.get_accounts_by_email(req.rpc_params.email);
     if (!account_to_delete) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + req.rpc_params.email);
     }
@@ -493,7 +493,7 @@ function check_account_sync_credentials(req) {
  *
  */
 function list_account_s3_acl(req) {
-    let account = system_store.data.accounts_by_email[req.rpc_params.email];
+    let account = system_store.get_accounts_by_email(req.rpc_params.email);
     if (!account) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + req.rpc_params.email);
     }

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -240,7 +240,7 @@ function update_bucket_s3_acl(req) {
     let updates = req.rpc_params.access_control
         .map(
             record => {
-                let account = system_store.data.accounts_by_email[record.account];
+                let account = system_store.get_accounts_by_email(record.account);
                 let allowed_buckets = record.is_allowed ?
                     _.unionWith(account.allowed_buckets, [bucket], system_store.has_same_id) :
                     _.differenceWith(account.allowed_buckets, [bucket], system_store.has_same_id);

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -912,7 +912,7 @@ function get_system_info(system, get_id) {
 }
 
 function find_account_by_email(req) {
-    var account = system_store.data.accounts_by_email[req.rpc_params.email];
+    var account = system_store.get_accounts_by_email(req.rpc_params.email);
     if (!account) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + req.rpc_params.email);
     }

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -161,6 +161,8 @@ const COLLECTIONS = js_utils.deep_freeze([{
 
 const COLLECTIONS_BY_NAME = _.keyBy(COLLECTIONS, 'name');
 
+let accounts_by_email_lowercase = [];
+
 
 /**
  *
@@ -221,6 +223,7 @@ class SystemStoreData {
         this.rebuild_object_links();
         this.rebuild_indexes();
         this.rebuild_allowed_buckets_links();
+        this.rebuild_accounts_by_email_lowercase();
     }
 
     rebuild_idmap() {
@@ -282,6 +285,12 @@ class SystemStoreData {
                     bucket => Boolean(bucket._id)
                 );
             }
+        });
+    }
+
+    rebuild_accounts_by_email_lowercase() {
+        _.each(this.accounts, account => {
+            accounts_by_email_lowercase[account.email.toLowerCase()] = account.email;
         });
     }
 
@@ -594,6 +603,12 @@ class SystemStore extends EventEmitter {
 
     get_server_secret() {
         return this._server_secret;
+    }
+
+    get_accounts_by_email(email) {
+        if (this.data && this.data.accounts) {
+            return this.data.accounts_by_email[accounts_by_email_lowercase[email.toLowerCase()]];
+        }
     }
 
 }


### PR DESCRIPTION
### Purpose
- Preserve email case when creating account
- Treat email as case insensitive when logging in
- Treat email as case insensitive when creating new account (verification of existing account)

### Checklist 
- Code:
 - [x] User Experience: Allow user to log in even if he wrote the email in a different case
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2156 
