### PR TITLE
Added checks for when cluster configurations are empty but not undefined

### DIFF
--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -59,7 +59,7 @@ function _verify_ntp_cluster_config() {
                 server: platform_ntp,
                 timezone: platform_time_config.timezone
             };
-            if (!_are_platform_and_cluster_conf_equal(platform_ntp, cluster_conf)) {
+            if (!_are_platform_and_cluster_conf_equal(platform_conf, cluster_conf)) {
                 dbg.warn(`platform ntp not synced to cluster. Platform conf: `, platform_conf, 'cluster_conf:', cluster_conf);
                 return os_utils.set_ntp(cluster_conf.server, cluster_conf.timezone);
             }
@@ -95,8 +95,8 @@ function _verify_remote_syslog_cluster_config() {
 }
 
 function _are_platform_and_cluster_conf_equal(platform_conf, cluster_conf) {
-    return (_.isEmpty(platform_conf) && _.isEmpty(cluster_conf)) ||
-        _.isEqual(platform_conf, cluster_conf);
+    return (_.isEmpty(platform_conf) && _.isEmpty(cluster_conf)) || // are they both either empty or undefined
+        _.isEqual(platform_conf, cluster_conf); // if not, are they equal
 }
 
 function _check_ntp() {

--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -99,7 +99,7 @@ function _verify_remote_syslog_cluster_config() {
 
 function _check_ntp() {
     dbg.log2('_check_ntp');
-    if (!server_conf.ntp || !server_conf.ntp.server) return;
+    if (_.isEmpty(server_conf.ntp) || _.isEmpty(server_conf.ntp.server)) return;
     monitoring_status.ntp_status = "UNKNOWN";
     return net_utils.ping(server_conf.ntp.server)
         .catch(err => {
@@ -161,7 +161,7 @@ function _check_dns_and_phonehome() {
 function _check_proxy_configuration() {
     dbg.log2('_check_proxy_configuration');
     let system = system_store.data.systems[0];
-    if (!system.phone_home_proxy_address) return;
+    if (_.isEmpty(system.phone_home_proxy_address)) return;
     return net_utils.ping(system.phone_home_proxy_address)
         .then(() => {
             monitoring_status.proxy_status = "OPERATIONAL";
@@ -175,9 +175,9 @@ function _check_proxy_configuration() {
 function _check_remote_syslog() {
     dbg.log2('_check_remote_syslog');
     let system = system_store.data.systems[0];
-    if (!system.remote_syslog_config) return;
+    if (_.isEmpty(system.remote_syslog_config)) return;
     monitoring_status.remote_syslog_status = "UNKNOWN";
-    if (!system.remote_syslog_config.address) return;
+    if (_.isEmpty(system.remote_syslog_config.address)) return;
     return net_utils.ping(system.remote_syslog_config.address)
         .then(() => {
             monitoring_status.remote_syslog_status = "OPERATIONAL";
@@ -192,7 +192,7 @@ function _check_is_self_in_dns_table() {
     dbg.log2('_check_is_self_in_dns_table');
     let system_dns = system_store.data.systems[0].base_address;
     let address = server_conf.owner_address;
-    if (!system_dns || net.isIPv4(system_dns) || net.isIPv6(system_dns)) return; // dns name is not configured
+    if (_.isEmpty(system_dns) || net.isIPv4(system_dns) || net.isIPv6(system_dns)) return; // dns name is not configured
     return net_utils.dns_resolve(system_dns)
         .then(ip_address_table => {
             if (_.includes(ip_address_table, address)) {


### PR DESCRIPTION
### Purpose
Fix for situations where the cluster configuration (the configuration in the cache / db) was *empty* but not *undefined*. After being set and unset, the configurations could be empty objects or arrays.

### Checklist 
- Code:
 - [x] Failure handling and Comments on non trivial sections
- Testing:
 - [x] Tested with: `npm test`
 - [x] Manual testing

### Fixed Issues References
- Fixes #2267 

Prior assumption was that when not set, system configurations are
undefined. Actually might be empty objects/arrays