### PR TITLE
Fixing mongodb_defaults allowed buckets for owner account

### DIFF
--- a/src/test/system_tests/mongodb_defaults.js
+++ b/src/test/system_tests/mongodb_defaults.js
@@ -62,12 +62,24 @@ db.getSiblingDB("nbcore").nodes.update({}, {
 }, {
     multi: true
 });
-// Removing all account except Support and Owner
+// Removing all accounts except Support and Owner
 db.getSiblingDB("nbcore").accounts.remove({
     email: {
         $nin: ['demo@noobaa.com', 'support@noobaa.com']
     }
 });
+
+// Update owner allowed_buckets to files bucket only
+db.getSiblingDB("nbcore").accounts.update({
+    email: 'demo@noobaa.com'
+}, {
+    $set: {
+        allowed_buckets: [db.getSiblingDB("nbcore").buckets.find({
+            name: 'files'
+        })[0]._id]
+    }
+});
+
 // Removing roles of the deleted accounts, except demo and support (which doesn't have a role)
 db.getSiblingDB("nbcore").roles.remove({
     account: {


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)

### Purpose
Removing all old allowed buckets from owner, and leaving him with only files bucket

### Checklist 
- Code:
 - [ ] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [ ] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

### Technical Debt Created
  - Opened #xxxx

### Fixed Issues References
- Fixes #2262 