### PR TITLE
Fixing error writing string instead of objectid into DB

### DIFF
--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -20,6 +20,7 @@ function upgrade() {
     upgrade_system_access_keys();
     upgrade_object_mds();
     remove_unnamed_nodes();
+    fix_nodes_pool_to_object_id();
     upgrade_cloud_agents();
     // cluster upgrade: mark that upgrade is completed for this server
     mark_completed(); // do not remove
@@ -488,4 +489,18 @@ function remove_unnamed_nodes() {
             }
         });
     }
+}
+
+
+function fix_nodes_pool_to_object_id() {
+    // Type 2 is String ref: https://docs.mongodb.com/v3.0/reference/operator/query/type/
+    db.nodes.find({ pool: { $type: 2 }}).forEach(function(node) {
+        db.nodes.update({
+            _id: node._id
+        }, {
+            $set: {
+                pool: new ObjectId(node.pool)
+            }
+        });
+    });
 }

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -31,6 +31,7 @@ const cluster_server = require('../system_services/cluster_server');
 const system_server_utils = require('../utils/system_server_utils');
 const clustering_utils = require('../utils/clustering_utils');
 const url = require('url');
+const mongodb = require('mongodb');
 
 const RUN_DELAY_MS = 60000;
 const RUN_NODE_CONCUR = 5;
@@ -288,7 +289,7 @@ class NodesMonitor extends EventEmitter {
                 'pool_id', pool_id, 'from pool', item.node.pool);
             if (String(item.node.pool) !== String(pool_id)) {
                 item.node.migrating_to_pool = Date.now();
-                item.node.pool = pool_id;
+                item.node.pool = new mongodb.ObjectId(pool_id);
                 item.suggested_pool = ''; // reset previous suggestion
             }
             this._set_need_update.add(item);


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)

### Purpose
In the old code before refactoring we were passing ObjectID, later after refactor we were passing the ID as a string.

### Checklist 
- Code:
 - [ ] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [ ] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

### Technical Debt Created
  - Opened #xxxx

### Fixed Issues References
- Fixes #xxxx
- Fixes #yyyy

