### PR TITLE
Fix wrong name for model collection

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -827,7 +827,7 @@ export function loadCloudBucketList(connection) {
         connection: connection
     })
         .then(
-            model.CloudBucketList,
+            model.cloudBucketList,
             () => model.CloudBucketList(null)
         )
         .done();


### PR DESCRIPTION
### Purpose
- Fix: cloud buckets are not showing in "set cloud sync" and "create cloud resource" modals



