### PR TITLE
Danny cluster

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -160,6 +160,8 @@ function add_member_to_cluster(req) {
             // reload system_store to update after new member HB
             return system_store.load();
         })
+        // ugly but works. perform first heartbeat after server is joined, so UI will present updated data
+        .then(() => cluster_hb.do_heartbeat())
         .return();
 }
 

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -199,7 +199,8 @@ function _get_online_members(rs_status) {
     let online_members = [];
     if (rs_status && rs_status.members) {
         _.each(rs_status.members, member => {
-            if (member.stateStr === 'PRIMARY' || member.stateStr === 'SECONDARY') {
+            // STARTUP state is used when a server was just added, and we want to show it as online.
+            if (member.stateStr === 'PRIMARY' || member.stateStr === 'SECONDARY' || member.stateStr.indexOf('STARTUP') > -1) {
                 let res_address = member.name.substring(0, member.name.indexOf(':'));
                 online_members.push(res_address);
             }


### PR DESCRIPTION
### Purpose
- fixes #2171 - show servers as online after adding to cluster

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

