### PR TITLE
fix #1941 - change default base_address to wss:

### DIFF
--- a/frontend/src/app/services/api.js
+++ b/frontend/src/app/services/api.js
@@ -1,13 +1,12 @@
-import { new_rpc } from 'nb-api';
+import { new_rpc_default_only } from 'nb-api';
 import * as notifs from './notifications';
 
 const rpc_proto = window.WebSocket ?
     (window.location.protocol === 'https:' ? 'wss:' : 'ws:') :
     window.location.protocol;
+const base_address = `${rpc_proto}//${window.location.host}`;
+const rpc = new_rpc_default_only(base_address);
 
-const base_address = `${rpc_proto}//${window.location.hostname}:${window.location.port}`;
-
-const rpc = new_rpc(base_address);
 rpc.set_request_logger(
     (...args) => console.info(...args)
 );

--- a/src/hosted_agents/hosted_agents_starter.js
+++ b/src/hosted_agents/hosted_agents_starter.js
@@ -16,11 +16,10 @@ register_rpc();
 function register_rpc() {
     server_rpc.register_hosted_agents_services();
     server_rpc.register_common_services();
-    let http_port = url.parse(server_rpc.rpc.router.hosted_agents).port;
+    const u = url.parse(server_rpc.rpc.router.hosted_agents);
     return server_rpc.rpc.start_http_server({
-        port: http_port,
-        ws: true,
+        port: u.port,
+        protocol: u.protocol,
         logging: true,
-        secure: false,
     });
 }

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -813,7 +813,8 @@ RPC.prototype.start_http_server = function(options) {
     rpc_http_server.on('connection', conn => this._accept_new_connection(conn));
     return rpc_http_server.start(options)
         .then(http_server => {
-            if (options.ws) {
+            if (options.protocol === 'ws:' ||
+                options.protocol === 'wss:') {
                 this.register_ws_transport(http_server);
             }
             return http_server;

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -195,17 +195,11 @@ function start() {
                     });
             }
 
-            var secure = argv.addr.protocol in {
-                'https:': 1,
-                'wss:': 1,
-            };
-
             // open http listening port for http based protocols
             return rpc.start_http_server({
                 port: argv.addr.port,
-                secure: secure,
+                protocol: argv.addr.protocol,
                 logging: false,
-                ws: true
             });
         })
         .then(function() {

--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -52,12 +52,11 @@ register_rpc();
 function register_rpc() {
     server_rpc.register_bg_services();
     server_rpc.register_common_services();
-    let http_port = url.parse(server_rpc.rpc.router.bg).port;
+    const u = url.parse(server_rpc.rpc.router.bg);
     return server_rpc.rpc.start_http_server({
-        port: http_port,
-        ws: true,
+        port: u.port,
+        protocol: u.protocol,
         logging: true,
-        secure: false,
     });
 }
 

--- a/src/server/md_server.js
+++ b/src/server/md_server.js
@@ -15,13 +15,12 @@ server_rpc.register_func_services();
 server_rpc.register_common_services();
 
 function register_rpc() {
-    let http_port = url.parse(server_rpc.rpc.router.md).port;
     // TODO missing? server_rpc.rpc.router.md = 'fcall://fcall';
+    const u = url.parse(server_rpc.rpc.router.md);
     return server_rpc.rpc.start_http_server({
-        port: http_port,
-        ws: true,
+        port: u.port,
+        protocol: u.protocol,
         logging: true,
-        secure: false,
     }).return(server_rpc.rpc);
 }
 

--- a/src/server/server_rpc.js
+++ b/src/server/server_rpc.js
@@ -16,8 +16,8 @@ class ServerRpc {
         this.rpc.register_n2n_proxy(this.client.node.n2n_proxy);
     }
 
-    get_base_port() {
-        return api.get_base_port();
+    get_base_address(base_hostname) {
+        return api.get_base_address(base_hostname);
     }
 
     get_server_options() {
@@ -36,19 +36,19 @@ class ServerRpc {
     set_new_router(params) {
         // check if some domains are changed to fcall://fcall
         let is_default_fcall = this.rpc.router.default === 'fcall://fcall';
-        let base_address = params.base_address;
-        let master_address = params.master_address;
-        if (base_address) {
-            base_address = 'ws://' + base_address + ':' + this.get_base_port();
+        let base_address;
+        let master_address;
+
+        if (params.base_address) {
+            base_address = this.get_base_address(params.base_address);
         } else if (is_default_fcall) {
-            base_address = 'ws://127.0.0.1:' + this.get_base_port();
+            base_address = this.get_base_address();
         } else {
             base_address = this.rpc.router.default;
         }
 
-
-        if (master_address) {
-            master_address = 'ws://' + master_address + ':' + this.get_base_port();
+        if (params.master_address) {
+            master_address = this.get_base_address(params.master_address);
         }
 
         this.rpc.router = api.new_router(base_address, master_address);

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -76,9 +76,8 @@ mocha.before('coretest-before', function() {
         .then(() => console.log('running server_rpc.rpc.start_http_server'))
         .then(() => server_rpc.rpc.start_http_server({
             port: http_port,
-            secure: false,
+            protocol: 'ws:',
             logging: true,
-            ws: true
         }))
         .then(http_server_arg => {
             // the http/ws port is used by the agents

--- a/src/test/unit_tests/test_rpc.js
+++ b/src/test/unit_tests/test_rpc.js
@@ -278,9 +278,8 @@ mocha.describe('RPC', function() {
         let ws_client;
         return rpc.start_http_server({
                 port: 0,
-                ws: true,
-                secure: false,
-                logging: true
+                protocol: 'ws:',
+                logging: true,
             })
             .then(http_server_arg => {
                 http_server = http_server_arg;
@@ -307,9 +306,8 @@ mocha.describe('RPC', function() {
         let wss_client;
         return rpc.start_http_server({
                 port: 0,
-                ws: true,
-                secure: true,
-                logging: true
+                protocol: 'wss:',
+                logging: true,
             })
             .then(https_server_arg => {
                 https_server = https_server_arg;


### PR DESCRIPTION
### Purpose
- Change RPC to use wss: by default
- Besides for the frontend which uses only the default base address which remains open for both wss: (8443) and ws: (8080).
- Should allow to invoke Lambda on non-dev deployment.

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #1941
