### PR TITLE
Fix missing system in session info

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -530,7 +530,7 @@ export function signIn(email, password, keepSessionAlive = false) {
                         const account = info.account;
                         model.sessionInfo({
                             user: account.email,
-                            system: account.system,
+                            system: info.system.name,
                             mustChangePassword: account.must_change_password
                         });
                         //api.redirector.register_for_alerts(); ////For now comment this out until add it properly


### PR DESCRIPTION
### Purpose
- Take the system name from ```info.system.name``` instead of ```info.account.system```
