### PR TITLE
use access_keys with account_id for hosted_agents_api

### DIFF
--- a/src/api/hosted_agents_api.js
+++ b/src/api/hosted_agents_api.js
@@ -52,7 +52,19 @@ module.exports = {
                                 type: 'string',
                             },
                             access_keys: {
-                                $ref: 'common_api#/definitions/access_keys',
+                                type: 'object',
+                                required: ['access_key', 'secret_key', 'account_id'],
+                                properties: {
+                                    access_key: {
+                                        type: 'string'
+                                    },
+                                    secret_key: {
+                                        type: 'string'
+                                    },
+                                    account_id: {
+                                        format: 'objectid'
+                                    }
+                                }
                             },
                             endpoint_type: {
                                 type: 'string',

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -97,7 +97,7 @@ function create_cloud_pool(req) {
             let sys_access_keys = req.system.owner.access_keys[0];
             return server_rpc.client.hosted_agents.create_agent({
                 name: req.rpc_params.name,
-                access_keys: _.pick(sys_access_keys, 'access_key', 'secret_key'),
+                access_keys: sys_access_keys,
                 cloud_info: cloud_info,
             });
         })


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)

### Purpose
- Besides making the world a better place it also ...

### Checklist 
- Code:
 - [ ] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [ ] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

### Technical Debt Created
  - Opened #xxxx

### Fixed Issues References
- Fixes #xxxx
- Fixes #yyyy

