### PR TITLE
fixed mongo_upgrade not running from when upgrading from older versions (<0.5.2)

### DIFF
--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -50,7 +50,7 @@ function sync_cluster_upgrade() {
         owner_secret: param_secret
     }).toArray()[0].upgrade ? db.clusters.find({
         owner_secret: param_secret
-    }).toArray()[0].upgrade.mongo_upgrade : false;
+    }).toArray()[0].upgrade.mongo_upgrade : true;
 
     // if this server shouldn't run mongo_upgrade, set status to DB_READY,
     // to indicate that this server is upgraded and with mongo running.


### PR DESCRIPTION
### Purpose
- Besides making the world a better place it also ...

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:


when upgrade field is missing from clusters document the default of
upgrade.mongo_upgrade should be true