### PR TITLE
0.5.4 nimrod fixes

### DIFF
--- a/frontend/src/app/components/buckets/create-bucket-wizard/create-bucket-wizard.js
+++ b/frontend/src/app/components/buckets/create-bucket-wizard/create-bucket-wizard.js
@@ -37,9 +37,7 @@ class CreateBucketWizardViewModel extends Disposable {
         this.placementType = ko.observable('SPREAD');
 
         this.pools = ko.pureComputed(
-            () => (systemInfo() ? systemInfo().pools : []).filter(
-                pool => Boolean(pool.nodes)
-            )
+            () => systemInfo() ? systemInfo().pools : []
         );
 
         this.selectedPools = ko.observableArray([ defaultPoolName ])

--- a/frontend/src/app/components/cluster/attach-server-modal/attach-server-modal.html
+++ b/frontend/src/app/components/cluster/attach-server-modal/attach-server-modal.html
@@ -3,7 +3,7 @@
     onClose: () => cancel()
 ">
     <section class="push-next greedy">
-        <editor params="label: 'Server IP or DNS name'">
+        <editor params="label: 'Server Address'">
             <input type="text" data-bind="value: address"/>
         </editor>
         <editor params="label: 'Server Secret'">

--- a/src/server/node_services/node_allocator.js
+++ b/src/server/node_services/node_allocator.js
@@ -141,11 +141,8 @@ function allocate_node(pools, avoid_nodes, allocated_hosts, content_tiering_para
     dbg.log1('allocate_node: pool_set', pool_set,
         'num_nodes', num_nodes,
         'alloc_group', alloc_group);
-    if (pools[0].cloud_pool_info) {
-        if (num_nodes !== config.NODES_PER_CLOUD_POOL) {
-            throw new Error('allocate_node: cloud_pool allocations should have only one node (cloud node)');
-        }
-    } else if (num_nodes < config.NODES_MIN_COUNT) {
+    if (!pools[0].cloud_pool_info &&
+        num_nodes < config.NODES_MIN_COUNT) { //Not cloud requires NODES_MIN_COUNT
         dbg.warn('allocate_node: not enough online nodes in pool set',
             pools, avoid_nodes, allocated_hosts, content_tiering_params);
         throw new Error('allocate_node: not enough online nodes in pool set ' +


### PR DESCRIPTION
### Purpose
- Allow a creation of bucker on cloud resources only
- Fix spread of cloud resources allocation issue
- Change attach server label to reflect only IPs are allowed at this point

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

