### PR TITLE
Propagate and enforce certificate across the cluster

### DIFF
--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -1,14 +1,18 @@
 'use strict';
+const fs = require('fs');
+const net = require('net');
 const phone_home_utils = require('../../util/phone_home');
 const dbg = require('../../util/debug_module')(__filename);
 const P = require('../../util/promise');
 const _ = require('lodash');
+const path = require('path');
 const promise_utils = require('../../util/promise_utils');
 const os_utils = require('../../util/os_utils');
 const server_rpc = require('../server_rpc');
 const net_utils = require('../../util/net');
-const net = require('net');
 const system_store = require('../system_services/system_store').get_instance();
+const config_file_store = require('../system_services/config_file_store').instance();
+const fs_utils = require('../../util/fs_utils');
 
 let server_conf = {};
 let monitoring_status = {};
@@ -47,7 +51,8 @@ function _verify_cluster_configuration() {
     dbg.log1('Verifying configuration in cluster');
     return _verify_ntp_cluster_config()
         .then(() => _verify_dns_cluster_config())
-        .then(() => _verify_remote_syslog_cluster_config());
+        .then(() => _verify_remote_syslog_cluster_config())
+        .then(() => _verify_server_certificate());
 }
 
 function _verify_ntp_cluster_config() {
@@ -81,6 +86,34 @@ function _verify_dns_cluster_config() {
         .catch(err => dbg.error('failed to reconfigure dns cluster config on the server. reason:', err));
 }
 
+
+function _verify_server_certificate() {
+    dbg.log2('Verifying certificate in relation to cluster config');
+    let dir = path.join('/etc', 'private_ssl_path');
+    let cert_file = path.join(dir, 'server.crt');
+    let key_file = path.join(dir, 'server.key');
+    return P.join(
+            config_file_store.get(cert_file),
+            config_file_store.get(key_file),
+            fs.readFileAsync(cert_file, 'utf8')
+            .catch(err => dbg.warn('could not read crt file', err)),
+            fs.readFileAsync(key_file, 'utf8')
+            .catch(err => dbg.warn('could not read key file', err))
+        )
+        .spread((certificate, key, platform_cert, platform_key) => {
+            if (!_are_platform_and_cluster_conf_equal(platform_cert, certificate && certificate.data) ||
+                !_are_platform_and_cluster_conf_equal(platform_key, key && key.data)) {
+                dbg.warn('platform certificate not synced to cluster. Resetting now');
+                return fs_utils.clear_dir(dir)
+                    .then(() => P.join(
+                        certificate && certificate.data && fs.writeFileAsync(cert_file, certificate.data),
+                        key && key.data && fs.writeFileAsync(key_file, key.data)))
+                    .then(() => os_utils.restart_services());
+            }
+        });
+}
+
+
 function _verify_remote_syslog_cluster_config() {
     dbg.log2('Verifying remote syslog server configuration in relation to cluster config');
     let cluster_conf = system_store.data.systems[0].remote_syslog_config;
@@ -95,6 +128,8 @@ function _verify_remote_syslog_cluster_config() {
 }
 
 function _are_platform_and_cluster_conf_equal(platform_conf, cluster_conf) {
+    platform_conf = _.omitBy(platform_conf, _.isEmpty);
+    cluster_conf = _.omitBy(cluster_conf, _.isEmpty);
     return (_.isEmpty(platform_conf) && _.isEmpty(cluster_conf)) || // are they both either empty or undefined
         _.isEqual(platform_conf, cluster_conf); // if not, are they equal
 }

--- a/src/server/system_services/config_file_store.js
+++ b/src/server/system_services/config_file_store.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const _ = require('lodash');
+const Ajv = require('ajv');
+const P = require('../../util/promise');
+const dbg = require('../../util/debug_module')(__filename);
+const js_utils = require('../../util/js_utils');
+const mongo_utils = require('../../util/mongo_utils');
+const mongo_client = require('../../util/mongo_client').instance();
+const schema_utils = require('../../util/schema_utils');
+const mongodb = require('mongodb');
+const config_file_schema = require('./schemas/config_file_schema');
+
+
+const CONFIG_FILE_COLLECTION = js_utils.deep_freeze({
+    name: 'config_files',
+    schema: schema_utils.strictify(config_file_schema),
+    db_indexes: [{
+        fields: {
+            filename: 1,
+        }
+    }]
+});
+
+class ConfigFileStore {
+
+    static instance() {
+        ConfigFileStore._instance = ConfigFileStore._instance || new ConfigFileStore();
+        return ConfigFileStore._instance;
+    }
+
+    constructor() {
+        this._json_validator = new Ajv({
+            formats: {
+                objectid: val => mongo_utils.is_object_id(val)
+            }
+        });
+
+        try {
+            mongo_client.define_collection(CONFIG_FILE_COLLECTION);
+        } catch (err) {
+            // this might be a legit exception if system_collection was already defined
+            dbg.warn('Exception while trying to init', CONFIG_FILE_COLLECTION.name, err);
+        }
+        this._json_validator.addSchema(CONFIG_FILE_COLLECTION.schema, CONFIG_FILE_COLLECTION.name);
+    }
+
+    connect() {
+        return mongo_client.connect();
+    }
+
+    insert(item) {
+        dbg.log0(`Inserting `, item);
+        let validator = this._json_validator.getSchema(CONFIG_FILE_COLLECTION.name);
+        _.defaults(item, {
+            _id: new mongodb.ObjectId()
+        });
+        if (validator(item)) {
+            return mongo_client.db.collection(CONFIG_FILE_COLLECTION.name).insert(item);
+        }
+        dbg.error(`item not valid in config file store`, validator.errors, item);
+        return P.reject(new Error('history_data_store: item not valid in config file store'));
+    }
+
+    get(filename) {
+        return mongo_client.db.collection(CONFIG_FILE_COLLECTION.name).findOne({
+            filename: filename
+        });
+    }
+}
+
+exports.instance = ConfigFileStore.instance;

--- a/src/server/system_services/schemas/config_file_schema.js
+++ b/src/server/system_services/schemas/config_file_schema.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+    id: 'certificate_schema',
+    type: 'object',
+    required: [
+        '_id',
+        'filename',
+        'data'
+    ],
+    properties: {
+        _id: {
+            format: 'objectid'
+        },
+        encoding: {
+            type: 'string',
+            enum: ['ascii', 'utf8', 'base64', 'hex']
+        },
+        filename: {
+            type: 'string'
+        },
+        data: {
+            type: 'string'
+        }
+    }
+};

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -50,6 +50,8 @@ const system_store = require('./system_services/system_store').get_instance();
 const promise_utils = require('../util/promise_utils');
 const SupervisorCtl = require('./utils/supervisor_ctrl');
 const account_server = require('./system_services/account_server');
+const config_file_store = require('./system_services/config_file_store').instance();
+const fs_utils = require('../util/fs_utils');
 
 const rootdir = path.join(__dirname, '..', '..');
 const dev_mode = (process.env.DEV_MODE === 'true');
@@ -267,40 +269,58 @@ app.post('/upload_certificate',
             }
         })
     })
-    .single('upload_file'),
-    function(req, res) {
-        var ssl_certificate = req.file;
-        dbg.log0('upload ssl certificate file', ssl_certificate);
-        promise_utils.spawn(process.cwd() + '/src/deploy/NVA_build/ssl_verifier.sh', [
-                'from_file', ssl_certificate.path
-            ], {}, false)
-            .then(function() {
+    .single('upload_file'), (req, res) => {
+        const zip_file = req.file;
+        const tmp_dir = '/tmp/ssl';
+        const dest_dir = '/etc/private_ssl_path';
+        dbg.log0('upload_certificate');
+        fs_utils.clear_dir(tmp_dir)
+            .then(() => promise_utils.exec(`/usr/bin/unzip ${zip_file.path} -d ${tmp_dir}`))
+            .then(() => fs.readdirAsync(tmp_dir))
+            .then(files => {
+                const cert_file = _throw_if_not_single_item(files, '.cert');
+                const key_file = _throw_if_not_single_item(files, '.key');
+                return promise_utils.exec(`(/usr/bin/openssl x509 -noout -modulus -in ${cert_file} | /usr/bin/openssl md5 ; /usr/bin/openssl rsa -noout -modulus -in ${key_file} | /usr/bin/openssl md5) | uniq | wc -l`,
+                        false, true).then(openssl_res => {
+                        if (openssl_res.trim() !== '1') {
+                            throw new Error('No match between key and certificate');
+                        }
+                    })
+                    .then(() => fs_utils.clear_dir(dest_dir))
+                    .then(() => P.join(
+                        _move_and_insert_config_file_to_store(`${tmp_dir}/${cert_file}`, `${dest_dir}/server.crt`),
+                        _move_and_insert_config_file_to_store(`${tmp_dir}/${key_file}`, `${dest_dir}/server.key`)
+                    ));
+            })
+            .then(() => {
                 res.status(200).send('SUCCESS');
                 if (os.type() === 'Linux') {
+                    dbg.log0('Restarting server on certificate set');
                     return SupervisorCtl.restart(['s3rver', 'webserver']);
                 }
-            }).catch(function(err) {
-                let error_message = '';
-                //TODO: replace this ugly code.
-                dbg.log0('failed to upload certificate. ' + err.message, err);
-                if (err.message.indexOf(' error code 1') > 0) {
-                    error_message = 'No match between key and certificate.';
-                } else if (err.message.indexOf(' error code 2') > 0) {
-                    error_message = 'Only one key is required.';
-                } else if (err.message.indexOf(' error code 3') > 0) {
-                    error_message = 'Only one certificate is required.';
-                } else if (err.message.indexOf(' error code 5') > 0) {
-                    error_message = 'Not a zip file. Please upload zip with certificate and key in pem format';
-                } else {
-                    error_message = err.message;
-                }
-                dbg.error(error_message);
-
-                res.status(500).send(error_message);
-
+            })
+            .catch(err => {
+                dbg.error('Was unable to set certificate', err);
+                res.status(500).send('Was unable to set certificate');
             });
-
     });
+
+function _move_and_insert_config_file_to_store(src, dest) {
+    return fs.readFileAsync(src, 'utf8')
+        .then(file_data => config_file_store.insert({
+            filename: dest,
+            data: file_data
+        }))
+        .then(() => fs.renameAsync(src, dest));
+}
+
+function _throw_if_not_single_item(arr, extension) {
+    const list = _.filter(arr, item => item.endsWith(extension));
+    if (list.length !== 1) {
+        throw new Error(`There should be exactly one ${extension} file in zip. Instead got ${list.length}`);
+    }
+    return list[0];
+}
 
 app.post('/upload_package',
     multer({

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -275,7 +275,7 @@ app.post('/upload_certificate',
         const dest_dir = '/etc/private_ssl_path';
         dbg.log0('upload_certificate');
         fs_utils.clear_dir(tmp_dir)
-            .then(() => promise_utils.exec(`/usr/bin/unzip ${zip_file.path} -d ${tmp_dir}`))
+            .then(() => promise_utils.exec(`/usr/bin/unzip '${zip_file.path}' -d ${tmp_dir}`))
             .then(() => fs.readdirAsync(tmp_dir))
             .then(files => {
                 const cert_file = _throw_if_not_single_item(files, '.cert');

--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -40,6 +40,11 @@ function file_must_exist(file_path) {
     return fs.statAsync(file_path).return();
 }
 
+function clear_dir(dir) {
+    return folder_delete(dir)
+        .catch(err => console.log(`dir ${dir} deletion failed: `, err))
+        .then(() => fs.mkdirAsync(dir));
+}
 
 /**
  * options.on_entry - function({path, stat})
@@ -253,6 +258,7 @@ function write_file_from_stream(file_path, read_stream) {
 // EXPORTS
 exports.file_must_not_exist = file_must_not_exist;
 exports.file_must_exist = file_must_exist;
+exports.clear_dir = clear_dir;
 exports.disk_usage = disk_usage;
 exports.read_dir_recursive = read_dir_recursive;
 exports.find_line_in_file = find_line_in_file;


### PR DESCRIPTION
### Purpose
- This PR does a few things with the certificate set flow.
 - Fixed a bug where setting the certificate could not be set under any circumstances.
 - Moved set certificate flow from bash script to node.
 - Created a new store for config files. Setting the certificate also inserts it to the config files store.
 - Will compare certificate to value in db in server monitor and propagate across the cluster.

### Checklist 
- Code:
 - [x] Failure handling and Comments on non trivial sections: 
- Testing:
 - [x] Tested with: `npm test`
 - [x] Manually tested
