### PR TITLE
upgrade: fix wait_for_mongo that failed because bash local keyword overrides rc

### DIFF
--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -24,7 +24,9 @@ function check_mongo_status {
     fi
 
     # even if the supervisor reports the service is running try to connect to it
-    local mongo_status=$(mongo nbcore --quiet --eval 'quit(!db.serverStatus().ok)')
+    local mongo_status
+    # beware not to run "local" in the same line changes the exit code
+    mongo_status=$(mongo nbcore --quiet --eval 'quit(!db.serverStatus().ok)')
     if [ $? -ne 0 ]
     then
         deploy_log "check_mongo_status: Failed to connect to mongod: $mongo_status"


### PR DESCRIPTION
### Purpose
- Fix upgrade issue

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Technical Debt Created
- N/A

### Fixed Issues References
- N/A