### PR TITLE
Check port 27000 is opened on the new server which is being added

### DIFF
--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
+EXTRACTION_PATH="/tmp/test/"
+
 . /root/node_modules/noobaa-core/src/deploy/NVA_build/deploy_base.sh
-. /root/node_modules/noobaa-core/src/deploy/NVA_build/common_funcs.sh
+. ${EXTRACTION_PATH}noobaa-core/src/deploy/NVA_build/common_funcs.sh
 
 PACKAGE_FILE_NAME="new_version.tar.gz"
 WRAPPER_FILE_NAME="upgrade_wrapper.sh"
 WRAPPER_FILE_PATH="/tmp/test/noobaa-core/src/deploy/NVA_build/"
 TMP_PATH="/tmp/"
-EXTRACTION_PATH="/tmp/test/"
 VER_CHECK="/root/node_modules/noobaa-core/src/deploy/NVA_build/version_check.js"
 NEW_UPGRADE_SCRIPT="${EXTRACTION_PATH}noobaa-core/src/deploy/NVA_build/upgrade.sh"
 MONGO_SHELL="/usr/bin/mongo nbcore"


### PR DESCRIPTION
### Purpose
- Check port 27000 is opened on the new server which is being added, throw an error if not opened.

### Checklist 
- Code:
 - [x] User Experience: Help user understand why the join succeeded but system looks bad (in case of FW)
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2332
