### PR TITLE
Service install bug fix

### DIFF
--- a/src/deploy/Linux/noobaa_service_installer.sh
+++ b/src/deploy/Linux/noobaa_service_installer.sh
@@ -21,10 +21,10 @@ chmod 777 /usr/local/noobaa/remove_service.sh
 /usr/local/noobaa/remove_service.sh ignore_rc >> /var/log/noobaa_service_${instdate} 2>&1
 if [ -f /usr/bin/systemctl ] || [ -f /bin/systemctl ]; then
   echo "Systemd detected. Installing service"
-  cp /usr/local/noobaa/src/agent/system_d.conf /etc/systemd/system/multi-user.target.wants/noobaalocalservice.service
+  cp /usr/local/noobaa/src/agent/system_d.conf /lib/systemd/system/noobaalocalservice.service
   echo "Updating systemctl"
   verify_command_run systemctl daemon-reload
-  systemctl enable noobaalocalservice >> /var/log/noobaa_service_${instdate} 2>&1
+  verify_command_run systemctl enable noobaalocalservice
   echo "Starting Service"
   verify_command_run systemctl start noobaalocalservice
   verify_command_run systemctl daemon-reload

--- a/src/deploy/Linux/noobaa_service_installer.sh
+++ b/src/deploy/Linux/noobaa_service_installer.sh
@@ -24,7 +24,7 @@ if [ -f /usr/bin/systemctl ] || [ -f /bin/systemctl ]; then
   cp /usr/local/noobaa/src/agent/system_d.conf /etc/systemd/system/multi-user.target.wants/noobaalocalservice.service
   echo "Updating systemctl"
   verify_command_run systemctl daemon-reload
-  verify_command_run systemctl enable noobaalocalservice
+  systemctl enable noobaalocalservice >> /var/log/noobaa_service_${instdate} 2>&1
   echo "Starting Service"
   verify_command_run systemctl start noobaalocalservice
   verify_command_run systemctl daemon-reload
@@ -41,7 +41,7 @@ elif [[ -d /etc/init.d ]]; then
   if [ $? -eq 0 ]; then
     verify_command_run chkconfig noobaalocalservice on
   else
-    verify_command_run update-rc.d noobaalocalservice enable 
+    verify_command_run update-rc.d noobaalocalservice enable
   fi
   echo "Starting Service"
   verify_command_run service noobaalocalservice start

--- a/src/deploy/Linux/remove_service.sh
+++ b/src/deploy/Linux/remove_service.sh
@@ -33,7 +33,7 @@ if [ -f /usr/bin/systemctl ] || [ -f /bin/systemctl ]; then
   systemctl stop noobaalocalservice >> /var/log/noobaa_service_rem_${instdate} 2>&1
   verify_command_run systemctl disable noobaalocalservice
   #attempting to uninstall bruteforce service installations
-  rm /etc/systemd/system/multi-user.target.wants/noobaalocalservice.service
+  rm /etc/systemd/system/multi-user.target.wants/noobaalocalservice.service >> /var/log/noobaa_service_rem_${instdate} 2>&1
   rm /lib/systemd/system/noobaalocalservice.service
   verify_command_run systemctl daemon-reload
 elif [[ -d /etc/init ]]; then
@@ -56,3 +56,4 @@ else
   echo "ERROR: Cannot detect init mechanism, NooBaa uninstallation failed"
   exit 1
 fi
+echo "Uninstalled NooBaa local agent"

--- a/src/deploy/Linux/remove_service.sh
+++ b/src/deploy/Linux/remove_service.sh
@@ -32,7 +32,9 @@ if [ -f /usr/bin/systemctl ] || [ -f /bin/systemctl ]; then
   echo "Systemd detected. Uninstalling service"
   systemctl stop noobaalocalservice >> /var/log/noobaa_service_rem_${instdate} 2>&1
   verify_command_run systemctl disable noobaalocalservice
+  #attempting to uninstall bruteforce service installations
   rm /etc/systemd/system/multi-user.target.wants/noobaalocalservice.service
+  rm /lib/systemd/system/noobaalocalservice.service
   verify_command_run systemctl daemon-reload
 elif [[ -d /etc/init ]]; then
   echo "Upstart detected. Removing init script"


### PR DESCRIPTION
### Purpose
- Fix bug where service install failed on linux system-d distros when attempting to run command 'systemctl enable'.
This command creates a symlink for systemd to find a startup script on load. What our installation was doing up until now is place our startup script directly in the directory from which it loads. When attempted to create symlink, 'systemctl enable' failed because it already had a value for 'noobaalocalservice'.