### PR TITLE
mark cluster as preview

### DIFF
--- a/frontend/src/app/components/layout/main-nav/main-nav.js
+++ b/frontend/src/app/components/layout/main-nav/main-nav.js
@@ -6,6 +6,14 @@ import ko from 'knockout';
 import style from 'style';
 
 const navItems = deepFreeze([
+    /*{
+        name: 'name',
+        route: 'route', (see routes.js)
+        icon: 'icon',
+        label: 'label', (display name, optional)
+        beta: true/false, (show beta label)
+        preview: true/false (hide when browser not in preview mode)
+    },*/
     {
         name: 'overview',
         route: 'system',
@@ -36,7 +44,8 @@ const navItems = deepFreeze([
         route: 'cluster',
         icon: 'cluster',
         label: 'Cluster',
-        beta: true
+        beta: true,
+        preview: true
     },
     {
         name: 'management',


### PR DESCRIPTION
### Purpose
- Set cluster to preview in 0.6

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:
