### PR TITLE
Fixed circular mongo object insertions into db 

### DIFF
--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -603,10 +603,9 @@ function add_account_id_to_cloud_sync() {
 function add_credentials_to_missing_account_id(credentials) {
     if (credentials &&
         credentials.access_keys &&
-        credentials.access_keys.access_key) {
-        credentials.access_keys.account_id = credentials.access_keys.account_id ?
-            credentials.access_keys.account_id.toString() :
-            find_account_id_by_credentials(credentials.access_keys.access_key);
+        credentials.access_keys.access_key &&
+        !credentials.access_keys.account_id) {
+        credentials.access_keys.account_id = find_account_id_by_credentials(credentials.access_keys.access_key);
         return credentials;
     }
 }
@@ -624,7 +623,7 @@ function find_account_id_by_credentials(access_key) {
         var candidate_credentials = account.sync_credentials_cache;
         candidate_credentials.forEach(function(connection) {
             if (connection.access_key === access_key) {
-                ret = account._id.toString();
+                ret = account._id;
             }
         });
     });

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -92,15 +92,13 @@ class HostedAgents {
 
         const write_token = (new_token, token_key) => {
             dbg.log1(`write_token with params: ${new_token}, ${token_key}`);
-            const sys = system_store.data.systems[0];
-            const cloud_info = sys.pools_by_name[cloud_pool.name].cloud_pool_info;
-            cloud_info.agent_info[token_key] = new_token;
+            const db_update = {
+                _id: cloud_pool._id,
+            };
+            db_update['cloud_pool_info.agent_info.' + token_key] = new_token;
             return system_store.make_changes({
                 update: {
-                    pools: [{
-                        _id: cloud_pool._id,
-                        cloud_pool_info: cloud_info
-                    }]
+                    pools: [db_update]
                 }
             });
         };
@@ -123,16 +121,14 @@ class HostedAgents {
                     // after upgrade of systems with old cloud_resources we will have a node_token but not create_node_token
                     // in that case we just want to add a new create_node_token
                     const existing_token = cloud_info.agent_info ? cloud_info.agent_info.node_token : null;
-                    const agent_info = {
-                        create_node_token: token,
-                        node_token: existing_token || token
-                    };
-                    cloud_info.agent_info = agent_info;
                     return system_store.make_changes({
                         update: {
                             pools: [{
                                 _id: cloud_pool._id,
-                                cloud_pool_info: cloud_info
+                                'cloud_pool_info.agent_info': {
+                                    create_node_token: token,
+                                    node_token: existing_token || token
+                                }
                             }]
                         }
                     });

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -559,14 +559,14 @@ function delete_external_connection(req) {
     if (_.find(system_store.data.buckets, bucket => (
             bucket.cloud_sync &&
             bucket.cloud_sync.endpoint === connection_to_delete.endpoint &&
-            bucket.cloud_sync.access_keys.account_id === account._id.toString() &&
+            bucket.cloud_sync.access_keys.account_id === account._id &&
             bucket.cloud_sync.access_keys.access_key === connection_to_delete.access_key))) {
         throw new Error('Cannot delete connection from account as it is being used for a cloud sync');
     }
     if (_.find(system_store.data.pools, pool => (
             pool.cloud_pool_info &&
             pool.cloud_pool_info.endpoint === connection_to_delete.endpoint &&
-            pool.cloud_pool_info.account_id === account._id.toString() &&
+            pool.cloud_pool_info.account_id === account._id &&
             pool.cloud_pool_info.access_key === connection_to_delete.access_key
         ))) {
         throw new Error('Cannot delete account as it is being used for a cloud sync');

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -80,7 +80,7 @@ function create_cloud_pool(req) {
         access_keys: {
             access_key: connection.access_key,
             secret_key: connection.secret_key,
-            account_id: req.account._id.toString()
+            account_id: req.account._id
         },
         endpoint_type: connection.endpoint_type || 'AWS'
     };

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -52,7 +52,7 @@ module.exports = {
                             type: 'string'
                         },
                         account_id: {
-                            type: 'string'
+                            format: 'objectid'
                         }
                     }
                 },

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -49,7 +49,7 @@ module.exports = {
                             type: 'string'
                         },
                         account_id: {
-                            type: 'string'
+                            format: 'objectid'
                         }
                     }
                 },


### PR DESCRIPTION
### Purpose
- Reverted the fix that changed account id to a string in cloud connections. Instead made sure objects are updated correctly so no circular objects are inserted.

### Checklist 
- Testing:
 - [x] Tested with: `npm test`
 - [x] Manually tested: creating and editing cloud pool and cloud sync.
- Upgrade:
 - [x] Mongo Schema Upgrade: reverted
