### PR TITLE
Fixed wrong condition check in ignoring RC for service removal

### DIFF
--- a/src/deploy/Linux/noobaa_service_installer.sh
+++ b/src/deploy/Linux/noobaa_service_installer.sh
@@ -10,7 +10,7 @@ function verify_command_run {
         $@ >> /var/log/noobaa_service_${instdate} 2>&1
         local rc=$?
         if [ $rc -ne 0 ]; then
-                echo "NooBaa installation failed"
+                echo "NooBaa installation failed (on $@)"
                 exit 1
         fi
 }

--- a/src/deploy/Linux/remove_service.sh
+++ b/src/deploy/Linux/remove_service.sh
@@ -16,9 +16,9 @@ fi
 function verify_command_run {
         $@ >> /var/log/noobaa_service_rem_${instdate} 2>&1
         local rc=$?
-        if [ $ignore_rc -eq 1 ]; then
+        if [ $ignore_rc -ne 1 ]; then
             if [ $rc -ne 0 ]; then
-                echo "NooBaa uninstall failed"
+                echo "NooBaa uninstall failed (on $@)"
                 exit 1
             fi
         fi


### PR DESCRIPTION
### Purpose
- Fixed bad check in service removal. Did not properly ignore the return code, resulting in service  not being installed.