### PR TITLE
Nimrodg 0.6 fixes

### DIFF
--- a/src/deploy/Linux/noobaa_service_installer.sh
+++ b/src/deploy/Linux/noobaa_service_installer.sh
@@ -19,15 +19,19 @@ PATH=/usr/local/noobaa:$PATH;
 mkdir /usr/local/noobaa/logs
 chmod 777 /usr/local/noobaa/remove_service.sh
 /usr/local/noobaa/remove_service.sh ignore_rc >> /var/log/noobaa_service_${instdate} 2>&1
+echo "Old services were removed if exited."
 if [ -f /usr/bin/systemctl ] || [ -f /bin/systemctl ]; then
   echo "Systemd detected. Installing service"
   cp /usr/local/noobaa/src/agent/system_d.conf /lib/systemd/system/noobaalocalservice.service
   echo "Updating systemctl"
   verify_command_run systemctl daemon-reload
+  echo "systemctl daemons reloaded"
   verify_command_run systemctl enable noobaalocalservice
   echo "Starting Service"
   verify_command_run systemctl start noobaalocalservice
+  echo "Service started"
   verify_command_run systemctl daemon-reload
+  echo "systemctl daemons reloaded"
 elif [[ -d /etc/init ]]; then
   echo "Upstart detected. Creating startup script"
   cp /usr/local/noobaa/src/agent/upstart.conf /etc/init/noobaalocalservice.conf
@@ -51,3 +55,4 @@ else
 fi
 
 echo "NooBaa installation completed successfully"
+exit 0

--- a/src/deploy/Linux/noobaa_service_installer.sh
+++ b/src/deploy/Linux/noobaa_service_installer.sh
@@ -18,7 +18,7 @@ function verify_command_run {
 PATH=/usr/local/noobaa:$PATH;
 mkdir /usr/local/noobaa/logs
 chmod 777 /usr/local/noobaa/remove_service.sh
-/usr/local/noobaa/remove_service.sh ignore_rc >> /var/log/noobaa_service_${instdate} 2>&1
+/usr/local/noobaa/remove_service.sh ignore_rc > /dev/null 2>&
 echo "Old services were removed if exited."
 if [ -f /usr/bin/systemctl ] || [ -f /bin/systemctl ]; then
   echo "Systemd detected. Installing service"

--- a/src/deploy/Linux/remove_service.sh
+++ b/src/deploy/Linux/remove_service.sh
@@ -36,9 +36,7 @@ if [ -f /usr/bin/systemctl ] || [ -f /bin/systemctl ]; then
   echo "Service disabled. removing config files"
   #attempting to uninstall bruteforce service installations
   rm /etc/systemd/system/multi-user.target.wants/noobaalocalservice.service >> /var/log/noobaa_service_rem_${instdate} 2>&1
-  echo "Bruteforce config removed"
   rm /lib/systemd/system/noobaalocalservice.service
-  echo "service config removed"
   verify_command_run systemctl daemon-reload
 elif [[ -d /etc/init ]]; then
   echo "Upstart detected. Removing init script"

--- a/src/deploy/Linux/remove_service.sh
+++ b/src/deploy/Linux/remove_service.sh
@@ -31,10 +31,14 @@ echo "Uninstalling NooBaa local service"
 if [ -f /usr/bin/systemctl ] || [ -f /bin/systemctl ]; then
   echo "Systemd detected. Uninstalling service"
   systemctl stop noobaalocalservice >> /var/log/noobaa_service_rem_${instdate} 2>&1
+  echo "Service stopped. Disabling service"
   verify_command_run systemctl disable noobaalocalservice
+  echo "Service disabled. removing config files"
   #attempting to uninstall bruteforce service installations
   rm /etc/systemd/system/multi-user.target.wants/noobaalocalservice.service >> /var/log/noobaa_service_rem_${instdate} 2>&1
+  echo "Bruteforce config removed"
   rm /lib/systemd/system/noobaalocalservice.service
+  echo "service config removed"
   verify_command_run systemctl daemon-reload
 elif [[ -d /etc/init ]]; then
   echo "Upstart detected. Removing init script"
@@ -57,3 +61,4 @@ else
   exit 1
 fi
 echo "Uninstalled NooBaa local agent"
+exit 0


### PR DESCRIPTION
### Purpose
- Removed output redirect of service remove from install, to prevent it from killing calling process and stopping upgrade.

### Checklist 
- Testing:
 - [x] Manual testing - upgrade flow