### PR TITLE
Danny ha

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -210,10 +210,11 @@ class Agent {
         this.rpc.set_disconnected_state(true);
         this.rpc_address = '';
         this._start_stop_server();
-        // reset the n2n config to close any open ports
-        this.n2n_agent.update_n2n_config({
-            tcp_permanent_passive: false
-        });
+        // TODO: for now commented out the update_n2n_config. revisit if needed (issue #2379)
+        // // reset the n2n config to close any open ports
+        // this.n2n_agent.update_n2n_config({
+        //     tcp_permanent_passive: false
+        // });
     }
 
     _update_servers_list(new_list) {
@@ -538,6 +539,7 @@ class Agent {
 
 
     get_agent_info_and_update_masters(req) {
+        if (!this.is_started) return;
         const extended_hb = true;
         const ip = ip_module.address();
         dbg.log0(this.node_name, 'Recieved potential servers list', req.rpc_params.addresses);

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -36,11 +36,11 @@ class HostedAgents {
         // start agent for all cloud pools that doesn't already have a running agent
         const pools_to_start = _.filter(cloud_pools, pool => _.isUndefined(this._started_agents[pool.name]));
         // stop all running agents that doesn't have a cloud pool in the DB
-        const agents_to_stop = _.filter(this._started_agents, (agent, name) => _.isUndefined(system.pools_by_name[name]));
+        const agents_to_stop = _.pickBy(this._started_agents, (agent, name) => _.isUndefined(system.pools_by_name[name]));
 
         if (!pools_to_start.length && !agents_to_stop.length) return;
 
-        dbg.log0(`stopping the following agents: ${agents_to_stop}`);
+        dbg.log0(`stopping the following agents: ${util.inspect(agents_to_stop)}`);
         _.each(agents_to_stop, (agent, name) => this.stop_agent(name));
 
         this._started = true;


### PR DESCRIPTION
### Purpose
- related to #2379 - don't stop global_tcp_permanent_passive on agent stop
- fixed errors on delete_node (INVALID_SCHEMA, and run_node on node in  deleted\deleting state)

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Technical Debt Created
- Opened #xxxx

### Fixed Issues References
- Fixes #yyyy