### PR TITLE
Temporary fix to prevent build failures

### DIFF
--- a/frontend/src/app/base-view-model.js
+++ b/frontend/src/app/base-view-model.js
@@ -1,4 +1,4 @@
-import ko from 'knockout';
+// import ko from 'knockout';
 
 // Used to dispose an handle that contain a dispose method.
 function dispose(handle) {


### PR DESCRIPTION
knockout is unused due to commenting it out. This created a lint error that prevented build
