### PR TITLE
Fixing read node mappings crashes because of get_chunk_status

### DIFF
--- a/src/server/object_services/map_allocator.js
+++ b/src/server/object_services/map_allocator.js
@@ -87,7 +87,12 @@ class MapAllocator {
         _.each(this.parts, part => {
             if (part.chunk_dedup) return; // already found dup
             let tiering_pools_status = node_allocator.get_tiering_pools_status(this.bucket.tiering);
-            let status = map_utils.get_chunk_status(part.chunk, this.bucket.tiering, /*async_mirror=*/ true, tiering_pools_status);
+            let status = map_utils.get_chunk_status(
+                part.chunk,
+                this.bucket.tiering, {
+                    async_mirror: true,
+                    tiering_pools_status: tiering_pools_status
+                });
             var avoid_nodes = [];
             let allocated_hosts = [];
 

--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -84,7 +84,9 @@ class MapBuilder {
             let bucket = system_store.data.get_by_id(chunk.bucket);
             map_utils.set_chunk_frags_from_blocks(chunk, chunk.blocks);
             let tiering_pools_status = node_allocator.get_tiering_pools_status(bucket.tiering);
-            chunk.status = map_utils.get_chunk_status(chunk, bucket.tiering, /*async_mirror=*/ false, tiering_pools_status);
+            chunk.status = map_utils.get_chunk_status(chunk, bucket.tiering, {
+                tiering_pools_status: tiering_pools_status
+            });
             // only delete blocks if the chunk is in good shape,
             // that is no allocations needed, and is accessible.
             if (chunk.status.accessible &&

--- a/src/test/unit_tests/test_map_utils.js
+++ b/src/test/unit_tests/test_map_utils.js
@@ -41,7 +41,9 @@ mocha.describe('map_utils', function() {
                     let chunk = {};
                     chunk.frags = map_utils.get_missing_frags_in_chunk(
                         chunk, tiering.tiers[0].tier);
-                    let status = map_utils.get_chunk_status(chunk, tiering, false, tiering_pools_status);
+                    let status = map_utils.get_chunk_status(chunk, tiering, {
+                        tiering_pools_status: tiering_pools_status
+                    });
                     assert.strictEqual(status.allocations.length, total_num_blocks);
                     assert.strictEqual(status.deletions.length, 0);
                     assert(!status.accessible, '!accessible');
@@ -61,7 +63,9 @@ mocha.describe('map_utils', function() {
                             frag: 0,
                             node: mock_node(pools[i % num_pools]._id)
                         })));
-                    let status = map_utils.get_chunk_status(chunk, tiering, false, tiering_pools_status);
+                    let status = map_utils.get_chunk_status(chunk, tiering, {
+                        tiering_pools_status: tiering_pools_status
+                    });
                     assert.strictEqual(status.allocations.length, 0);
                     assert.strictEqual(status.deletions.length, 0);
                     assert(status.accessible, 'accessible');
@@ -84,7 +88,9 @@ mocha.describe('map_utils', function() {
                         });
                     });
                     map_utils.set_chunk_frags_from_blocks(chunk, blocks);
-                    let status = map_utils.get_chunk_status(chunk, tiering, false, tiering_pools_status);
+                    let status = map_utils.get_chunk_status(chunk, tiering, {
+                        tiering_pools_status: tiering_pools_status
+                    });
                     assert.strictEqual(status.allocations.length, 0);
                     assert.strictEqual(status.deletions.length, num_extra);
                     assert(status.accessible, 'accessible');
@@ -98,7 +104,9 @@ mocha.describe('map_utils', function() {
                         frag: 0,
                         node: mock_node(pools[0]._id)
                     }]);
-                    let status = map_utils.get_chunk_status(chunk, tiering, false, tiering_pools_status);
+                    let status = map_utils.get_chunk_status(chunk, tiering, {
+                        tiering_pools_status: tiering_pools_status
+                    });
                     assert.strictEqual(status.allocations.length, total_num_blocks - 1);
                     assert.strictEqual(status.deletions.length, 0);
                     assert(status.accessible, 'accessible');
@@ -125,7 +133,9 @@ mocha.describe('map_utils', function() {
                         node: mock_node(pools[0]._id)
                     }];
                     map_utils.set_chunk_frags_from_blocks(chunk, blocks);
-                    let status = map_utils.get_chunk_status(chunk, tiering, false, tiering_pools_status);
+                    let status = map_utils.get_chunk_status(chunk, tiering, {
+                        tiering_pools_status: tiering_pools_status
+                    });
                     assert.strictEqual(status.allocations.length, total_num_blocks - 1);
                     assert.strictEqual(status.deletions.length, 1);
                     assert(status.accessible, 'accessible');
@@ -137,7 +147,9 @@ mocha.describe('map_utils', function() {
                         });
                     });
                     map_utils.set_chunk_frags_from_blocks(chunk, blocks);
-                    status = map_utils.get_chunk_status(chunk, tiering, false, tiering_pools_status);
+                    status = map_utils.get_chunk_status(chunk, tiering, {
+                        tiering_pools_status: tiering_pools_status
+                    });
                     assert.strictEqual(status.allocations.length, 0);
                     assert.strictEqual(status.deletions.length, 1);
                     assert(status.accessible, 'accessible');


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)

### Purpose
- Besides making the world a better place it also ...

### Checklist 
- Code:
 - [ ] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [ ] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

### Technical Debt Created
- Opened #xxxx

### Fixed Issues References
- Fixes #2401 
