### PR TITLE
Nimrodg no cloud cycles

### DIFF
--- a/frontend/src/app/components/bucket/set-cloud-sync-modal/set-cloud-sync-modal.js
+++ b/frontend/src/app/components/bucket/set-cloud-sync-modal/set-cloud-sync-modal.js
@@ -116,7 +116,7 @@ class SetCloudSyncModalViewModel extends BaseViewModel {
                 }
 
                 return cloudBucketList().map(
-                    bucketName => ({ value: bucketName })
+                    ({ name }) => ({ value: name })
                 );
             }
         );
@@ -191,3 +191,4 @@ export default {
     viewModel: SetCloudSyncModalViewModel,
     template: template
 };
+

--- a/frontend/src/app/components/resources/add-cloud-resource-modal/add-cloud-resource-modal.js
+++ b/frontend/src/app/components/resources/add-cloud-resource-modal/add-cloud-resource-modal.js
@@ -87,7 +87,7 @@ class AddCloudResourceModalViewModel extends BaseViewModel {
 
         this.targetBucketsOptions = ko.pureComputed(
             () => this.connection() && cloudBucketList() && cloudBucketList().map(
-                bucketName => ({ value: bucketName })
+                ({ name }) => ({ value: name })
             )
 
         );
@@ -171,3 +171,4 @@ export default {
     viewModel: AddCloudResourceModalViewModel,
     template: template
 };
+

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -315,7 +315,26 @@ module.exports = {
             reply: {
                 type: 'array',
                 items: {
-                    type: 'string'
+                    type: 'object',
+                    required: ['name'],
+                    properties: {
+                        name: {
+                            type: 'string'
+                        },
+                        used_by: {
+                            type: 'object',
+                            required: ['name', 'usage_type'],
+                            properties: {
+                                name: {
+                                    type: 'string'
+                                },
+                                usage_type: {
+                                    type: 'string',
+                                    enum: ['CLOUD_SYNC', 'CLOUD_RESOURCE']
+                                },
+                            }
+                        }
+                    }
                 }
             },
             auth: {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -508,7 +508,6 @@ function set_cloud_sync(req) {
 
     const already_used_by = cloud_utils.get_used_cloud_targets(cloud_sync.endpoint_type, system_store.data.buckets, system_store.data.pools)
         .find(candidate_target => (candidate_target.endpoint === cloud_sync.endpoint));
-    dbg.warn('WOOP already_used_by', already_used_by);
     if (already_used_by) {
         dbg.error(`This endpoint is already being used by a ${already_used_by.usage_type}: ${already_used_by.source_name}`);
         throw new Error('Target already in use');

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -480,7 +480,6 @@ function delete_cloud_sync(req) {
  */
 function set_cloud_sync(req) {
     dbg.log0('set_cloud_sync:', req.rpc_params);
-
     var connection = cloud_utils.find_cloud_connection(req.account, req.rpc_params.connection);
     var bucket = find_bucket(req);
     //Verify parameters, bi-directional sync can't be set with additions_only
@@ -506,6 +505,15 @@ function set_cloud_sync(req) {
         n2c_enabled: js_utils.default_value(req.rpc_params.policy.n2c_enabled, true),
         additions_only: js_utils.default_value(req.rpc_params.policy.additions_only, false)
     };
+
+    const already_used_by = cloud_utils.get_used_cloud_targets(cloud_sync.endpoint_type, system_store.data.buckets, system_store.data.pools)
+        .find(candidate_target => (candidate_target.endpoint === cloud_sync.endpoint));
+    dbg.warn('WOOP already_used_by', already_used_by);
+    if (already_used_by) {
+        dbg.error(`This endpoint is already being used by a ${already_used_by.usage_type}: ${already_used_by.source_name}`);
+        throw new Error('Target already in use');
+    }
+
     return system_store.make_changes({
 
             update: {
@@ -749,9 +757,7 @@ function get_bucket_lifecycle_configuration_rules(req) {
  *
  */
 function get_cloud_buckets(req) {
-    var buckets = [];
     dbg.log0('get cloud buckets', req.rpc_params);
-
     return P.fcall(function() {
         var connection = cloud_utils.find_cloud_connection(
             req.account,
@@ -759,34 +765,46 @@ function get_cloud_buckets(req) {
         );
         if (connection.endpoint_type === 'AZURE') {
             let blob_svc = azure.createBlobService(cloud_utils.get_azure_connection_string(connection));
+            let used_cloud_buckets = cloud_utils.get_used_cloud_targets('AZURE', system_store.data.buckets, system_store.data.pools);
             return P.ninvoke(blob_svc, 'listContainersSegmented', null, {})
-                .then(function(data) {
-                    return data.entries.map(entry => entry.name);
-                });
-        } else {
-            var s3 = new AWS.S3({
-                endpoint: connection.endpoint,
-                accessKeyId: connection.access_key,
-                secretAccessKey: connection.secret_key,
-                httpOptions: {
-                    agent: new https.Agent({
-                        rejectUnauthorized: false,
-                    })
-                }
-            });
-            return P.ninvoke(s3, "listBuckets")
-                .then(function(data) {
-                    _.each(data.Buckets, function(bucket) {
-                        buckets.push(bucket.Name);
-                    });
-                    return buckets;
-                });
-        }
+                .then(data => data.entries.map(entry =>
+                    _inject_usage_to_cloud_bucket(entry.name, connection.endpoint, used_cloud_buckets)));
+        } //else if AWS
+        let used_cloud_buckets = cloud_utils.get_used_cloud_targets('AWS', system_store.data.buckets, system_store.data.pools);
+        var s3 = new AWS.S3({
+            endpoint: connection.endpoint,
+            accessKeyId: connection.access_key,
+            secretAccessKey: connection.secret_key,
+            httpOptions: {
+                agent: new https.Agent({
+                    rejectUnauthorized: false,
+                })
+            }
+        });
+        return P.ninvoke(s3, "listBuckets")
+            .then(data => data.Buckets.map(bucket =>
+                _inject_usage_to_cloud_bucket(bucket.Name, connection.endpoint, used_cloud_buckets)));
     }).catch(function(err) {
         dbg.error("get_cloud_buckets ERROR", err.stack || err);
         throw err;
     });
 
+}
+
+function _inject_usage_to_cloud_bucket(target_name, endpoint, usage_list) {
+    let res = {
+        name: target_name
+    };
+    let using_target = usage_list.find(candidate_target =>
+        (target_name === candidate_target.target_name &&
+            endpoint === candidate_target.endpoint));
+    if (using_target) {
+        res.used_by = {
+            name: using_target.source_name,
+            usage_type: using_target.usage_type
+        };
+    }
+    return res;
 }
 
 

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -85,6 +85,16 @@ function create_cloud_pool(req) {
         endpoint_type: connection.endpoint_type || 'AWS'
     };
 
+
+    const already_used_by = cloud_utils.get_used_cloud_targets(cloud_info.endpoint_type,
+            system_store.data.buckets, system_store.data.pools)
+        .find(candidate_target => (candidate_target.endpoint === cloud_info.endpoint &&
+            candidate_target.target_name === cloud_info.target_bucket));
+    if (already_used_by) {
+        dbg.error(`This endpoint is already being used by a ${already_used_by.usage_type}: ${already_used_by.source_name}`);
+        throw new Error('Target already in use');
+    }
+
     var pool = new_pool_defaults(name, req.system._id);
     dbg.log0('Creating new cloud_pool', pool);
     pool.cloud_pool_info = cloud_info;

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -55,6 +55,29 @@ function get_azure_connection_string(params) {
 }
 
 
+function get_used_cloud_targets(endpoint_type, bucket_list, pool_list) {
+    const cloud_sync_targets = bucket_list ? bucket_list.filter(bucket =>
+            (bucket.cloud_sync && bucket.cloud_sync.endpoint_type === endpoint_type))
+        .map(bucket_with_cloud_sync => ({
+            endpoint: bucket_with_cloud_sync.cloud_sync.endpoint,
+            endpoint_type: bucket_with_cloud_sync.cloud_sync.endpoint_type,
+            source_name: bucket_with_cloud_sync.name,
+            target_name: bucket_with_cloud_sync.cloud_sync.target_bucket,
+            usage_type: 'CLOUD_SYNC'
+        })) : [];
+    const cloud_resource_targets = pool_list ? pool_list.filter(pool =>
+            (pool.cloud_pool_info && pool.cloud_pool_info.endpoint_type === endpoint_type))
+        .map(pool_with_cloud_resource => ({
+            endpoint: pool_with_cloud_resource.cloud_pool_info.endpoint,
+            endpoint_type: pool_with_cloud_resource.cloud_pool_info.endpoint_type,
+            source_name: pool_with_cloud_resource.name,
+            target_name: pool_with_cloud_resource.cloud_pool_info.target_bucket,
+            usage_type: 'CLOUD_RESOURCE'
+        })) : [];
+    return cloud_sync_targets.concat(cloud_resource_targets);
+}
+
 exports.find_cloud_connection = find_cloud_connection;
 exports.get_azure_connection_string = get_azure_connection_string;
 exports.get_signed_url = get_signed_url;
+exports.get_used_cloud_targets = get_used_cloud_targets;


### PR DESCRIPTION
### Purpose
- Disallowing usage of the same cloud target for two usages. Both cloud sync and cloud pools count. Can still use the same cloud pool for multiple buckets.
- This is currently enforced by comparing endpoint and target bucket name pairs.
- Also added the information to the API so all the relevant information will be in FE

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`

### Technical Debt Created
- Opened #2488

### Fixed Issues References
- Fixes #2373 
