### PR TITLE
Initiating stats store

### DIFF
--- a/src/server/bg_services/stats_collector.js
+++ b/src/server/bg_services/stats_collector.js
@@ -28,3 +28,4 @@ function collect_system_stats() {
 }
 
 exports.collect_all_stats = collect_all_stats;
+exports.collect_system_stats = collect_system_stats;

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -40,6 +40,7 @@ const dns = require('dns');
 const node_allocator = require('../node_services/node_allocator');
 const config_file_store = require('./config_file_store').instance();
 const fs_utils = require('../../util/fs_utils');
+const stats_collector = require('../bg_services/stats_collector');
 
 const SYS_STORAGE_DEFAULTS = Object.freeze({
     total: 0,
@@ -1009,7 +1010,8 @@ function log_client_console(req) {
 }
 
 function _init_system() {
-    return cluster_server.init_cluster();
+    return cluster_server.init_cluster()
+        .then(() => stats_collector.collect_system_stats());
 }
 
 


### PR DESCRIPTION
### Purpose
- Will now hold an initial empty system value on system creation for FE capacity graph.

### Checklist 
- Testing:
 - [x] Manual testing
 - [x] Tested with: `npm test`
