### PR TITLE
A fix for knockout validation not disposing subscriptions

### DIFF
--- a/frontend/src/app/base-view-model.js
+++ b/frontend/src/app/base-view-model.js
@@ -5,7 +5,7 @@ function dispose(handle) {
     handle.dispose();
 }
 
-function isValidaitonGroup(group) {
+function isValidationGroup(group) {
     return group &&
         isFunction(group.showAllMessages) &&
         isFunction (group.isAnyMessageShown);
@@ -33,7 +33,7 @@ export default class BaseViewModel {
         // the view model. This mean that any validatable observale not used in this
         // manner will not be missed in the scan.
         for (const value of Object.values(this)) {
-            if (isValidaitonGroup(value)) {
+            if (isValidationGroup(value)) {
                 value.forEach(
                     obs =>  obs.extend({ validatable: false })
                 );

--- a/frontend/src/app/base-view-model.js
+++ b/frontend/src/app/base-view-model.js
@@ -1,8 +1,14 @@
-// import ko from 'knockout';
+import { isFunction } from 'utils/core-utils';
 
 // Used to dispose an handle that contain a dispose method.
 function dispose(handle) {
     handle.dispose();
+}
+
+function isValidaitonGroup(group) {
+    return group &&
+        isFunction(group.showAllMessages) &&
+        isFunction (group.isAnyMessageShown);
 }
 
 export default class BaseViewModel {
@@ -18,17 +24,21 @@ export default class BaseViewModel {
     }
 
     dispose() {
-        // THIS CODE CREATE A SECONDARY BUG WHERE THING GOT DISPOSED WITH NO REASON
-        // COMMENTING THIS COUNT OUT AND ALLOWING VALIDATORS CODE LEAK AGAIN
-
-        // Used to clean up subscriptions created by knockout validation extenders.
-        // for (const value of Object.values(this)) {
-        //     if (ko.isObservable(value) && value.isValid) {
-        //         value.extend({
-        //             validatable: false
-        //         });
-        //     }
-        // }
+        // This code cleans up subscriptions created by knockout validation extenders.
+        // This is done because knockout validation does not dispose of subscriptions
+        // extended with validations even when there are no subscriptions to the
+        // underlying observable.
+        // The code relay on the fact that every validatable observable in a view model
+        // is used as part of a validation group that sits as an enumerable property of
+        // the view model. This mean that any validatable observale not used in this
+        // manner will not be missed in the scan.
+        for (const value of Object.values(this)) {
+            if (isValidaitonGroup(value)) {
+                value.forEach(
+                    obs =>  obs.extend({ validatable: false })
+                );
+            }
+        }
 
         this.disposeList.forEach(
             disposer => disposer()


### PR DESCRIPTION
### Purpose
- Dispose of knockout validation subscriptions on view model dispose
- Partially fixes bug 2270 (The case when the ViewModel leaking after it's disposal)

