### PR TITLE
Fixed wrong send_time initial value

### DIFF
--- a/config.js
+++ b/config.js
@@ -126,11 +126,11 @@ if (!is_windows) {
 config.PHONE_HOME_BASE_URL = 'https://phonehome.noobaa.com';
 config.central_stats = {
     send_stats: 'true',
-    send_time_cycle: 30 * 60000, //min
+    send_time_cycle: 30 * 60 * 1000, //30 min
     previous_diag_packs_dir: process.env.ProgramData + '/prev_diags',
     previous_diag_packs_count: 3 //TODO: We might want to split between agent and server
 };
-config.central_stats.send_time = 10 * (24 / (config.central_stats.send_time_cycle / 60000 / 60)); //10 days
+config.central_stats.send_time = 14 * 24 * 60 * 60 * 1000; //14 days
 
 /*
   Clustering Defaults


### PR DESCRIPTION
### Purpose
- Wrong values in config.js for stats aggregator led to wrong comparison.

The problem is that

```
stats_aggregator.636: successfuly_sent_period += config.central_stats.send_time_cycle;
```

```
stats_aggregator.638: if (successfuly_sent_period > config.central_stats.send_time && ...
```

means they should be in the same unit (minute, hour, day, config.central_stats.send_time_cycle quanta, whatever). However, 

```
config.129: send_time_cycle: 30 * 60 * 1000, //30 **min**
```

```
config.133: config.central_stats.send_time = 10 * (24 / (config.central_stats.send_time_cycle / 60000 / 60)); //10 days
```

Refers to them with different units.

config.central_stats.send_time is now measured in seconds, same as send_time_cycle, to allow the two to be compared correctly.

Also changed from 10 days to 2 weeks after discussion with @shirimordechay 

### Fixed Issues References
- Fixes #2432 
