### PR TITLE
refactored nodes_monitor _update_status to fix eslint complexity error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -249,6 +249,8 @@ module.exports = {
         // the rule object-property-newline is better than object-curly-newline
         'object-curly-newline': 'off',
 
+        'object-curly-spacing': 'off',
+
         // prefer using x={a,b} over x={a:a, b:b} but too much to fix
         'object-shorthand': 'off',
 

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1213,7 +1213,7 @@ class NodesMonitor extends EventEmitter {
             item.io_reported_errors = now;
         }
 
-        item.io_detention = this._get_item_io_detention_time(item);
+        item.io_detention = this._get_item_io_detention(item);
         item.connectivity = 'TCP';
         item.avg_ping = _.mean(item.node.latency_to_server);
         item.avg_disk_read = _.mean(item.node.latency_of_disk_read);
@@ -1234,7 +1234,7 @@ class NodesMonitor extends EventEmitter {
             (item.node.storage.free <= config.NODES_FREE_SPACE_RESERVE);
     }
 
-    _get_item_io_detention_time(item) {
+    _get_item_io_detention(item) {
         const io_detention_time = Math.min(
             item.n2n_errors || Number.POSITIVE_INFINITY,
             item.gateway_errors || Number.POSITIVE_INFINITY,

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -886,33 +886,33 @@ class NodesMonitor extends EventEmitter {
 
         const items_without_issues = this._get_detention_test_nodes(item, config.NODE_IO_DETENTION_TEST_NODES);
         return P.each(items_without_issues, item_without_issues => {
-                dbg.log0('_test_network_perf::', item.node.name, item.io_detention,
-                    item.node.rpc_address, item_without_issues.node.rpc_address);
-                return this.client.agent.test_network_perf_to_peer({
-                        source: item_without_issues.node.rpc_address,
-                        target: item.node.rpc_address,
-                        request_length: 1,
-                        response_length: 1,
-                        count: 1,
-                        concur: 1
-                    }, {
-                        connection: item_without_issues.connection
-                    })
-                    .timeout(AGENT_TEST_CONNECTION_TIMEOUT);
-            })
-            .then(() => {
-                dbg.log0('_test_network_perf:: success in test', item.node.name);
-                if (item.n2n_errors &&
-                    Date.now() - item.n2n_errors > config.NODE_IO_DETENTION_THRESHOLD) {
-                    item.n2n_errors = 0;
-                }
-            })
-            .catch(() => {
-                if (!item.n2n_errors) {
-                    dbg.log0('_test_network_perf:: node has n2n_errors', item.node.name);
-                    item.n2n_errors = Date.now();
-                }
-            });
+            dbg.log0('_test_network_perf::', item.node.name, item.io_detention,
+                item.node.rpc_address, item_without_issues.node.rpc_address);
+            return this.client.agent.test_network_perf_to_peer({
+                    source: item_without_issues.node.rpc_address,
+                    target: item.node.rpc_address,
+                    request_length: 1,
+                    response_length: 1,
+                    count: 1,
+                    concur: 1
+                }, {
+                    connection: item_without_issues.connection
+                })
+                .timeout(AGENT_TEST_CONNECTION_TIMEOUT);
+        })
+        .then(() => {
+            dbg.log0('_test_network_perf:: success in test', item.node.name);
+            if (item.n2n_errors &&
+                Date.now() - item.n2n_errors > config.NODE_IO_DETENTION_THRESHOLD) {
+                item.n2n_errors = 0;
+            }
+        })
+        .catch(() => {
+            if (!item.n2n_errors) {
+                dbg.log0('_test_network_perf:: node has n2n_errors', item.node.name);
+                item.n2n_errors = Date.now();
+            }
+        });
     }
 
     _test_nodes_validity(item) {

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -318,17 +318,15 @@ function get_pool_info(pool, nodes_aggregate_pool) {
 }
 
 function calc_pool_mode(pool_info) {
-    const {nodes, storage, data_activities} = pool_info;
-    const {count, online, has_issues} = nodes;
+    const { nodes, storage, data_activities = [] } = pool_info;
+    const { count, online, has_issues } = nodes;
     const offline = count - (online + has_issues);
     const offline_ratio = (offline / count) * 100;
-    const {free, total, reserved, used_other} = _.assignWith(
-        {}, storage, (__, size) => size_utils.json_to_bigint(size)
-    );
+    const { free, total, reserved, used_other } = _.assignWith({}, storage, (__, size) => size_utils.json_to_bigint(size));
     const potential_for_noobaa = total.subtract(reserved).subtract(used_other);
-    const free_ratio = free.multiply(100).divide(potential_for_noobaa);
+    const free_ratio = potential_for_noobaa.greater(0) ? free.multiply(100).divide(potential_for_noobaa) : size_utils.BigInteger.zero;
     const activity_count = data_activities
-        .reduce((sum, {count}) => sum + count, 0);
+        .reduce((sum, { count }) => sum + count, 0);
     const activity_ratio = (activity_count / count) * 100;
 
     return (count === 0 && 'HAS_NO_NODES') ||

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -8,6 +8,7 @@ const S3Auth = require('aws-sdk/lib/signers/s3');
 
 const P = require('../../util/promise');
 const coretest = require('./coretest');
+const account_server = require('../../server/system_services/account_server');
 
 dotenv.load();
 const s3_auth = new S3Auth();
@@ -40,6 +41,7 @@ mocha.describe('system_servers', function() {
             ///////////////
             .then(() => client.account.accounts_status())
             .then(res => assert(!res.has_accounts, '!has_accounts'))
+            .then(() => account_server.ensure_support_account())
             .then(() => client.system.create_system({
                 activation_code: '1111',
                 name: SYS,


### PR DESCRIPTION
### Purpose
- eslint gave error for "function complexity of 31"
- refactored update_status to reduce complexity (extracted status calculations to outer functions)

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:
