### PR TITLE
fix to #2497 - redirect ui after cluster upgrade

### DIFF
--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -370,8 +370,10 @@ app.get('/get_log_level', function(req, res) {
 
 // Get the current version
 app.get('/version', function(req, res) {
+    const WEBSERVER_START_TIME = 20 * 1000;
     const registered = server_rpc.is_service_registered('system_api.read_system');
-    if (webserver_started && registered && !shutting_down) {
+    let started = webserver_started && (Date.now() - webserver_started) > WEBSERVER_START_TIME;
+    if (started && registered && !shutting_down) {
         dbg.log0(`/version returning ${pkg.version}, service registered and not shutting down`);
         res.send(pkg.version);
         res.end();

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -84,6 +84,7 @@ var https_server;
 // this is not cleared if upgrade fails, and will block UI until browser refresh.
 // maybe we need to change it to use upgrade status in DB.
 let shutting_down = false;
+let webserver_started = 0;
 
 P.fcall(function() {
         // we register the rpc before listening on the port
@@ -119,6 +120,7 @@ P.fcall(function() {
     })
     .then(function() {
         dbg.log('Web Server Started, ports: http', http_port, 'https', https_port);
+        webserver_started = Date.now();
     })
     .catch(function(err) {
         dbg.error('Web Server FAILED TO START', err.stack || err);
@@ -159,7 +161,7 @@ app.use(function(req, res, next) {
 app.use(function(req, res, next) {
     let current_clustering = system_store.get_local_cluster_info();
     if ((current_clustering && current_clustering.is_clusterized) &&
-        !system_store.is_cluster_master && req.originalUrl !== '/upload_package') {
+        !system_store.is_cluster_master && req.originalUrl !== '/upload_package' && req.originalUrl !== '/version') {
         P.fcall(() => server_rpc.client.cluster_internal.redirect_to_cluster_master())
             .then(host => {
                 res.status(307);
@@ -369,7 +371,7 @@ app.get('/get_log_level', function(req, res) {
 // Get the current version
 app.get('/version', function(req, res) {
     const registered = server_rpc.is_service_registered('system_api.read_system');
-    if (registered && !shutting_down) {
+    if (webserver_started && registered && !shutting_down) {
         dbg.log0(`/version returning ${pkg.version}, service registered and not shutting down`);
         res.send(pkg.version);
         res.end();


### PR DESCRIPTION
### Purpose
- exclude /version path from redirect to master
- after starting web server, continue to respond with 404 on /version for 20 more seconds. This is a temp fix to let the new master load completely before redirecting to it.

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2497 