### PR TITLE
Nimrodg server monitor fix

### DIFF
--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -360,9 +360,13 @@ function get_dns_servers() {
     if (os.type() === 'Linux') {
         return promise_utils.exec("cat /etc/resolv.conf | grep NooBaa", true, true)
             .then(cmd_res => {
-                let regex_res = (/nameserver (.*) #NooBaa/).exec(cmd_res);
-                for (var i = 1; i < regex_res.length; i++) {
-                    res.push(regex_res[i]);
+                if (cmd_res) {
+                    let regex_res = (/nameserver (.*) #NooBaa/).exec(cmd_res);
+                    if (regex_res) {
+                        for (var i = 1; i < regex_res.length; i++) {
+                            res.push(regex_res[i]);
+                        }
+                    }
                 }
                 return res;
             });

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -356,12 +356,15 @@ function set_ntp(server, timez) {
 }
 
 function get_dns_servers() {
-    let res = {};
+    let res = [];
     if (os.type() === 'Linux') {
         return promise_utils.exec("cat /etc/resolv.conf | grep NooBaa", true, true)
             .then(cmd_res => {
                 let regex_res = (/nameserver (.*) #NooBaa/).exec(cmd_res);
-                if (regex_res) return regex_res.shift();
+                for (var i = 1; i < regex_res.length; i++) {
+                    res.push(regex_res[i]);
+                }
+                return res;
             });
     } else if (os.type() === 'Darwin') { //Bypass for dev environment
         return P.resolve(res);

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -356,22 +356,18 @@ function set_ntp(server, timez) {
 }
 
 function get_dns_servers() {
-    let res = [];
     if (os.type() === 'Linux') {
         return promise_utils.exec("cat /etc/resolv.conf | grep NooBaa", true, true)
             .then(cmd_res => {
-                if (cmd_res) {
-                    let regex_res = (/nameserver (.*) #NooBaa/).exec(cmd_res);
-                    if (regex_res) {
-                        for (var i = 1; i < regex_res.length; i++) {
-                            res.push(regex_res[i]);
-                        }
-                    }
-                }
-                return res;
+                let conf_lines = cmd_res.split(/\n/);
+                return conf_lines.map(line => {
+                        let regex_res = (/nameserver (.*) #NooBaa/).exec(line);
+                        return regex_res && regex_res[1];
+                    })
+                    .filter(regex_group => !_.isEmpty(regex_group));
             });
     } else if (os.type() === 'Darwin') { //Bypass for dev environment
-        return P.resolve(res);
+        return P.resolve([]);
     }
     throw new Error('DNS not supported on non-Linux platforms');
 }


### PR DESCRIPTION
### Purpose
os_utils.get_dns_servers() was returning a string containing dns_servers information instead of extracting them directly from the regex result into an array.

The mismatch between the expected result format and the actual result made it so that **every server in which DNS servers were configured would infinitely restart**. 