### PR TITLE
fix #2082 - verify signature on create_access_key_auth

### DIFF
--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -4,6 +4,7 @@
 const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
+const S3Auth = require('aws-sdk/lib/signers/s3');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -174,6 +175,12 @@ function create_access_key_auth(req) {
     var string_to_sign = req.rpc_params.string_to_sign;
     var signature = req.rpc_params.signature;
 
+    if (_.isUndefined(string_to_sign) || _.isUndefined(signature)) {
+        throw new RpcError('UNAUTHORIZED', 'signature error');
+    }
+
+
+
     var account = _.find(system_store.data.accounts, function(acc) {
         if (acc.access_keys) {
             return acc.access_keys[0].access_key.toString() === access_key.toString();
@@ -185,6 +192,15 @@ function create_access_key_auth(req) {
     if (!account || account.deleted) {
         throw new RpcError('UNAUTHORIZED', 'account not found');
     }
+
+    let s3 = new S3Auth();
+    let secret = account.access_keys[0].secret_key.toString();
+    let signature_test = s3.sign(secret, string_to_sign);
+    if (signature_test !== signature) {
+        throw new RpcError('UNAUTHORIZED', 'signature error');
+    }
+
+
     dbg.log0('create_access_key_auth:',
         'account.name', account.email,
         'access_key', access_key,

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -112,7 +112,14 @@ mocha.describe('system_servers', function() {
                         access_key: res.owner.access_keys[0].access_key,
                         string_to_sign: '',
                         signature: s3_auth.sign(res.owner.access_keys[0].secret_key, '')
-                    }));
+                    }).then(() => res))
+                    .then(res => client.auth.create_access_key_auth({
+                        access_key: res.owner.access_keys[0].access_key,
+                        string_to_sign: 'blabla',
+                        signature: 'blibli'
+                    }))
+                    .catch(err => assert.deepEqual(err.rpc_code, 'UNAUTHORIZED'));
+
             })
             //////////////
             //  SYSTEM  //


### PR DESCRIPTION
### Purpose
- check signature in auth_server
- added test that wrong signature fails

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2082
