### PR TITLE
fix create_system to ignore empty dns_servers array

### DIFF
--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -305,7 +305,7 @@ function create_system(req) {
                 })
                 .then(() => {
                     //DNS servers, if supplied
-                    if (!req.rpc_params.dns_servers) {
+                    if (_.isEmpty(req.rpc_params.dns_servers)) {
                         return;
                     }
 


### PR DESCRIPTION
fix create_system to ignore empty dns_servers array. before it was clearing dns serves and restarting services

