### PR TITLE
avoid setting dns on create_system

### DIFF
--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -305,7 +305,7 @@ function create_system(req) {
                 })
                 .then(() => {
                     //DNS servers, if supplied
-                    if (!req.rpc_params.dns_servers) {
+                    if (_.isEmpty(req.rpc_params.dns_servers)) {
                         return;
                     }
 


### PR DESCRIPTION
### Purpose
- avoid setting dns and restarting services on create_system

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:
