### PR TITLE
using signature_utils for signature check in create_access_key_auth

### DIFF
--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -4,7 +4,6 @@
 const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
-const S3Auth = require('aws-sdk/lib/signers/s3');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -193,9 +192,8 @@ function create_access_key_auth(req) {
         throw new RpcError('UNAUTHORIZED', 'account not found');
     }
 
-    let s3 = new S3Auth();
     let secret = account.access_keys[0].secret_key.toString();
-    let signature_test = s3.sign(secret, string_to_sign);
+    let signature_test = signature_utils.signature({ string_to_sign: string_to_sign }, secret);
     if (signature_test !== signature) {
         throw new RpcError('UNAUTHORIZED', 'signature error');
     }

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -118,7 +118,10 @@ mocha.describe('system_servers', function() {
                         string_to_sign: 'blabla',
                         signature: 'blibli'
                     }))
-                    .catch(err => assert.deepEqual(err.rpc_code, 'UNAUTHORIZED'));
+                    .then(
+                        () => assert.ifError('should fail with UNAUTHORIZED'),
+                        err => assert.deepEqual(err.rpc_code, 'UNAUTHORIZED')
+                    );
 
             })
             //////////////


### PR DESCRIPTION
### Purpose
- changes to pr #2082
- using signature_utils for signature check in create_access_key_auth instead of using s3.sign directly

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:


