### PR TITLE
Fixed rpc base conn to throw rpc_error instead of error

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -234,14 +234,13 @@ function verify_candidate_join_conditions(req) {
             result: res.result,
             version: res.version
         }))
-        .catch(err => {
-            if (err.message && err.message.startsWith('RPC CONN CLOSED')) {
-                dbg.warn('received RPC CONN CLOSED on verify_candidate_join_conditions');
+        .catch(RpcError, err => {
+            if (err.rpc_code === 'RPC_CONNECT_TIMEOUT') {
+                dbg.warn('received', err, ' on verify_candidate_join_conditions');
                 return {
                     result: 'UNREACHABLE'
                 };
             }
-            dbg.error('received error on verify_candidate_join_conditions', err);
             throw err;
         });
 }


### PR DESCRIPTION
RpcError can be caught to handle specific cases in which we could not RPC connect to a remote server
