### PR TITLE
Nimrodg cloud sync fixes

### DIFF
--- a/src/server/bg_services/cloud_sync.js
+++ b/src/server/bg_services/cloud_sync.js
@@ -226,7 +226,6 @@ function list_need_sync(sysid, bucket) {
                     res.added.push(obj);
                 }
             });
-            dbg.warn('WOOP length:', res.deleted.length, 'WOOP res:', res.deleted);
             return res;
         })
         .then(null, function(err) {


### PR DESCRIPTION
### Purpose
- Fix of several bugs in cloud sync that led to some pretty bad side effects.
 - Fixed the query to mark an object as cloud sync to distinguish between deleted and non-deleted objects.
 - Made cloud syncs from cloud to NooBaa mark written objects as cloud synced. 
 - Fixed call to function that diffs between work lists.
 - Split deleteObject calls to avoid sending requests too big for AWS SDK

### Checklist 
- Testing:
 - [x] Manual tests
 - [x] Tested with: `npm test`

### Fixed Issues References
- Fixes #1539  