### PR TITLE
Moved nodes counting to ignore has issues and online nodes when filtering

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1660,12 +1660,6 @@ class NodesMonitor extends EventEmitter {
             this._update_status(item);
             if (!filter_item_func(item)) continue;
 
-            // after counting, we can finally filter by
-            if (!_.isUndefined(query.has_issues) &&
-                query.has_issues !== Boolean(item.has_issues)) continue;
-            if (!_.isUndefined(query.online) &&
-                query.online !== Boolean(item.online)) continue;
-
             // the filter_counts count nodes that passed all filters besides
             // the filters of online and has_issues filters
             // this is used for the frontend to show the total count even
@@ -1678,6 +1672,12 @@ class NodesMonitor extends EventEmitter {
                 }
             }
             filter_counts.count += 1;
+
+            // after counting, we can finally filter by
+            if (!_.isUndefined(query.has_issues) &&
+                query.has_issues !== Boolean(item.has_issues)) continue;
+            if (!_.isUndefined(query.online) &&
+                query.online !== Boolean(item.online)) continue;
 
             console.log('list_nodes: adding node', item.node.name);
             list.push(item);


### PR DESCRIPTION
### Purpose
Will now ignore 'online' and 'has_issues' as filter parameters when counting online and has_issue nodes. 
Also fixed bug where net_util didn't ping ips correctly when input was in the form http:\\(ip):(port)

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
- Testing:
 - [x] Manual testing
 - [x] Tested with: `npm test`

### Fixed Issues References
- Fixes #2553