### PR TITLE
Add filters to Pool/Cloud Resource page + more fixes 

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -117,7 +117,7 @@ export function reloadTo(route = model.routeContext().pathname, params = {},  qu
 export function refresh() {
     logAction('refresh');
 
-    let { pathname, search } = window.location;
+    const { pathname, search } = window.location;
 
     // Refresh the current path
     page.redirect(pathname + search);
@@ -130,7 +130,7 @@ export function refresh() {
 export function showLogin() {
     logAction('showLogin');
 
-    let ctx = model.routeContext();
+    const ctx = model.routeContext();
 
     model.uiState({
         layout: 'login-layout',
@@ -172,9 +172,9 @@ export function showBuckets() {
 export function showBucket() {
     logAction('showBucket');
 
-    let ctx = model.routeContext();
-    let { bucket, tab = 'data-placement' } = ctx.params;
-    let { filter, sortBy = 'name', order = 1, page = 0 } = ctx.query;
+    const ctx = model.routeContext();
+    const { bucket, tab = 'data-placement' } = ctx.params;
+    const { filter, sortBy = 'name', order = 1, page = 0 } = ctx.query;
 
     model.uiState({
         layout: 'main-layout',
@@ -194,9 +194,9 @@ export function showBucket() {
 export function showObject() {
     logAction('showObject');
 
-    let ctx = model.routeContext();
-    let { object, bucket, tab = 'parts' } = ctx.params;
-    let { page = 0 } = ctx.query;
+    const ctx = model.routeContext();
+    const { object, bucket, tab = 'parts' } = ctx.params;
+    const { page = 0 } = ctx.query;
 
     model.uiState({
         layout: 'main-layout',
@@ -218,8 +218,8 @@ export function showObject() {
 export function showResources() {
     logAction('showResources');
 
-    let ctx = model.routeContext();
-    let { tab = 'pools' } = ctx.params;
+    const ctx = model.routeContext();
+    const { tab = 'pools' } = ctx.params;
 
     model.uiState({
         layout: 'main-layout',
@@ -236,8 +236,8 @@ export function showResources() {
 export function showPool() {
     logAction('showPool');
 
-    let ctx = model.routeContext();
-    let { pool, tab = 'nodes' } = ctx.params;
+    const ctx = model.routeContext();
+    const { pool, tab = 'nodes' } = ctx.params;
 
     model.uiState({
         layout: 'main-layout',
@@ -251,16 +251,16 @@ export function showPool() {
         tab: tab
     });
 
-    let { filter, hasIssues, sortBy = 'name', order = 1, page = 0 } = ctx.query;
+    const { filter, hasIssues, sortBy = 'name', order = 1, page = 0 } = ctx.query;
     loadPoolNodeList(pool, filter, hasIssues, sortBy, parseInt(order), parseInt(page));
 }
 
 export function showNode() {
     logAction('showNode');
 
-    let ctx = model.routeContext();
-    let { pool, node, tab = 'details' } = ctx.params;
-    let { page = 0 } = ctx.query;
+    const ctx = model.routeContext();
+    const { pool, node, tab = 'details' } = ctx.params;
+    const { page = 0 } = ctx.query;
 
     model.uiState({
         layout: 'main-layout',
@@ -282,7 +282,7 @@ export function showNode() {
 export function showManagement() {
     logAction('showManagement');
 
-    let { tab = 'accounts', section } = model.routeContext().params;
+    const { tab = 'accounts', section } = model.routeContext().params;
 
     model.uiState({
         layout: 'main-layout',
@@ -301,8 +301,8 @@ export function showManagement() {
 export function showAccount() {
     logAction('showAccount');
 
-    let ctx = model.routeContext();
-    let { account, tab = 's3-access' } = ctx.params;
+    const ctx = model.routeContext();
+    const { account, tab = 's3-access' } = ctx.params;
 
     model.uiState({
         layout: 'main-layout',
@@ -320,8 +320,8 @@ export function showAccount() {
 export function showCluster() {
     logAction('showCluster');
 
-    let ctx = model.routeContext();
-    let { tab = 'servers' } = ctx.params;
+    const ctx = model.routeContext();
+    const { tab = 'servers' } = ctx.params;
 
     model.uiState({
         layout: 'main-layout',
@@ -374,8 +374,8 @@ export function showFuncs() {
 export function showFunc() {
     logAction('showFunc');
 
-    let ctx = model.routeContext();
-    let { func, tab = 'monitoring' } = ctx.params;
+    const ctx = model.routeContext();
+    const { func, tab = 'monitoring' } = ctx.params;
 
     model.uiState({
         layout: 'main-layout',
@@ -510,8 +510,8 @@ export function deleteFunc(name, version) {
 export function handleUnknownRoute() {
     logAction('handleUnknownRoute');
 
-    let system = model.sessionInfo().system;
-    let uri = realizeUri(routes.system, { system });
+    const system = model.sessionInfo().system;
+    const uri = realizeUri(routes.system, { system });
     redirectTo(uri);
 }
 
@@ -549,7 +549,7 @@ export function signIn(email, password, keepSessionAlive = false) {
         .then(() => api.system.list_systems())
         .then(
             ({ systems }) => {
-                let system = systems[0].name;
+                const system = systems[0].name;
 
                 return api.create_auth_token({ system, email, password })
                     .then(({ token, info }) => {
@@ -779,8 +779,8 @@ export function loadNodeStoredPartsList(nodeName, page) {
 export function loadAuditEntries(categories, count) {
     logAction('loadAuditEntries', { categories, count });
 
-    let auditLog = model.auditLog;
-    let filter = categories
+    const auditLog = model.auditLog;
+    const filter = categories
         .map(
             category => `(^${category}.)`
         )
@@ -808,9 +808,9 @@ export function loadAuditEntries(categories, count) {
 export function loadMoreAuditEntries(count) {
     logAction('loadMoreAuditEntries', { count });
 
-    let auditLog = model.auditLog;
-    let lastEntryTime = last(auditLog()).time;
-    let filter = model.auditLog.loadedCategories()
+    const auditLog = model.auditLog;
+    const lastEntryTime = last(auditLog()).time;
+    const filter = model.auditLog.loadedCategories()
         .map(
             category => `(^${category}.)`
         )
@@ -832,7 +832,7 @@ export function loadMoreAuditEntries(count) {
 export function exportAuditEnteries(categories) {
     logAction('exportAuditEnteries', { categories });
 
-    let filter = categories
+    const filter = categories
         .map(
             category => `(^${category}.)`
         )
@@ -941,7 +941,7 @@ export function deleteAccount(email) {
     api.account.delete_account({ email })
         .then(
             () => {
-                let user = model.sessionInfo() && model.sessionInfo().user;
+                const user = model.sessionInfo() && model.sessionInfo().user;
                 if (email === user) {
                     signOut();
                 } else {
@@ -993,7 +993,7 @@ export function createBucket(name, dataPlacement, pools) {
 
     // TODO: remove the random string after patching the server
     // with a delete bucket that deletes also the policy
-    let bucket_with_suffix = `${name}#${Date.now().toString(36)}`;
+    const bucket_with_suffix = `${name}#${Date.now().toString(36)}`;
 
     api.tier.create_tier({
         name: bucket_with_suffix,
@@ -1002,7 +1002,7 @@ export function createBucket(name, dataPlacement, pools) {
     })
         .then(
             tier => {
-                let policy = {
+                const policy = {
                     name: bucket_with_suffix,
                     tiers: [ { order: 0, tier: tier.name } ]
                 };
@@ -1042,7 +1042,7 @@ export function deleteBucket(name) {
 export function updateBucketPlacementPolicy(tierName, placementType, attachedPools) {
     logAction('updateBucketPlacementPolicy', { tierName, placementType, attachedPools });
 
-    let bucket = model.systemInfo().buckets.find(
+    const bucket = model.systemInfo().buckets.find(
         bucket => bucket.tiering.tiers.find(
             entry => entry.tier === tierName
         )
@@ -1138,10 +1138,10 @@ export function uploadFiles(bucketName, files) {
         queueSize: 4
     });
 
-    let uploads = model.uploads;
+    const uploads = model.uploads;
 
-    let { access_key , secret_key } = model.systemInfo().owner.access_keys[0];
-    let s3 = new AWS.S3({
+    const { access_key , secret_key } = model.systemInfo().owner.access_keys[0];
+    const s3 = new AWS.S3({
         endpoint: endpoint,
         credentials: {
             accessKeyId: access_key,
@@ -1153,7 +1153,7 @@ export function uploadFiles(bucketName, files) {
 
     for (const file of files) {
         // Create an entry in the recent uploaded list.
-        let upload = {
+        const upload = {
             name: file.name,
             targetBucket: bucketName,
             completed: false,
@@ -1183,11 +1183,11 @@ export function uploadFiles(bucketName, files) {
                     upload.progress = upload.size;
                 }
 
-                let currentBatch = uploads().filter(
+                const currentBatch = uploads().filter(
                     upload => !upload.archived
                 );
 
-                let noMoreUploads = currentBatch.every(
+                const noMoreUploads = currentBatch.every(
                     upload => upload.completed
                 );
 
@@ -1231,7 +1231,7 @@ export function testNode(source, testSet) {
     logAction('testNode', { source, testSet });
 
     const regexp = /=>(\w{3}):\/\/([0-9.]+):(\d+)/;
-    let { nodeTestInfo } = model;
+    const { nodeTestInfo } = model;
 
     nodeTestInfo({
         source: source,
@@ -1241,7 +1241,7 @@ export function testNode(source, testSet) {
         state:'IN_PROGRESS'
     });
 
-    let { targetCount, testSettings } = config.nodeTest;
+    const { targetCount, testSettings } = config.nodeTest;
     api.node.get_test_nodes({
         count: targetCount,
         source: source
@@ -1252,7 +1252,7 @@ export function testNode(source, testSet) {
                 ...testSet.map(
                     testType => targets.map(
                         ({ name, rpc_address }) => {
-                            let result = {
+                            const result = {
                                 testType: testType,
                                 targetName: name,
                                 targetAddress: rpc_address,
@@ -1289,12 +1289,12 @@ export function testNode(source, testSet) {
                         return;
                     }
 
-                    let { stepCount, requestLength, responseLength, count, concur } = testSettings[testType];
-                    let stepSize = count * (requestLength + responseLength);
-                    let totalTestSize = stepSize * stepCount;
+                    const { stepCount, requestLength, responseLength, count, concur } = testSettings[testType];
+                    const stepSize = count * (requestLength + responseLength);
+                    const totalTestSize = stepSize * stepCount;
 
                     // Create a step list for the test.
-                    let steps = makeArray(
+                    const steps = makeArray(
                         stepCount,
                         {
                             source: source,
@@ -1307,7 +1307,7 @@ export function testNode(source, testSet) {
                     );
 
                     // Set start time.
-                    let start = Date.now();
+                    const start = Date.now();
                     result.state = 'RUNNING';
 
                     // Execute the steps in order.
@@ -1321,7 +1321,7 @@ export function testNode(source, testSet) {
                             return api.node.test_node_network(stepRequest)
                                 .then(
                                     ({ session }) => {
-                                        let [,protocol, ip, port] = session.match(regexp);
+                                        const [,protocol, ip, port] = session.match(regexp);
                                         result.protocol = protocol;
                                         result.targetIp = ip;
                                         result.targetPort = port;
@@ -1369,7 +1369,7 @@ export function testNode(source, testSet) {
 export function abortNodeTest() {
     logAction('abortNodeTest');
 
-    let nodeTestInfo = model.nodeTestInfo;
+    const nodeTestInfo = model.nodeTestInfo;
     if (nodeTestInfo().state === 'IN_PROGRESS') {
         nodeTestInfo.assign({
             state: 'ABORTING'
@@ -1406,8 +1406,8 @@ export function updateHostname(hostname) {
         // The system changed it's name, reload the page using the new IP/Name
         .then(
             () => {
-                let { protocol, port } = window.location;
-                let baseAddress = `${protocol}//${hostname}:${port}`;
+                const { protocol, port } = window.location;
+                const baseAddress = `${protocol}//${hostname}:${port}`;
 
                 reloadTo(
                     `${baseAddress}${routes.management}`,
@@ -1470,7 +1470,7 @@ export function upgradeSystem(upgradePackage) {
 export function uploadSSLCertificate(SSLCertificate) {
     logAction('uploadSSLCertificate', { SSLCertificate });
 
-    let uploadStatus = model.sslCertificateUploadStatus;
+    const uploadStatus = model.sslCertificateUploadStatus;
     uploadStatus({
         state: 'IN_PROGRESS',
         progress: 0,
@@ -1513,7 +1513,7 @@ export function uploadSSLCertificate(SSLCertificate) {
 export function downloadNodeDiagnosticPack(nodeName) {
     logAction('downloadDiagnosticFile', { nodeName });
 
-    let currentNodeKey = `node:${nodeName}`;
+    const currentNodeKey = `node:${nodeName}`;
     if(model.collectDiagnosticsState[currentNodeKey] === true) {
         return;
     }
@@ -1742,7 +1742,7 @@ export function checkCloudConnection(endpointType, endpoint, identity, secret) {
 export function addCloudConnection(name, endpointType, endpoint, identity, secret) {
     logAction('addCloudConnection', { name, endpointType, endpoint, identity, secret });
 
-    let connection = {
+    const connection = {
         name: name,
         endpoint_type: endpointType,
         endpoint: endpoint,

--- a/frontend/src/app/bindings/href.js
+++ b/frontend/src/app/bindings/href.js
@@ -7,10 +7,11 @@ export default {
     update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
         let value = ko.deepUnwrap(valueAccessor());
         if (value) {
-            let { route, params } = value;
+            let { route, params, query } = value;
             let href = realizeUri(
                 routes[route] || '',
-                Object.assign({}, routeContext().params, params)
+                Object.assign({}, routeContext().params, params),
+                query
             );
 
             return ko.bindingHandlers.attr.update(

--- a/frontend/src/app/components/buckets/buckets-table/bucket-row.js
+++ b/frontend/src/app/components/buckets/buckets-table/bucket-row.js
@@ -187,10 +187,10 @@ export default class BucketRowViewModel extends BaseViewModel {
 
         this.capacity = {
             total: ko.pureComputed(
-                () => storage().total
+                () => storage().total || 0
             ),
             used: ko.pureComputed(
-                () => storage().used
+                () => storage().used || 0
             )
         };
 

--- a/frontend/src/app/components/buckets/create-bucket-wizard/choose-name-step.html
+++ b/frontend/src/app/components/buckets/create-bucket-wizard/choose-name-step.html
@@ -1,18 +1,19 @@
-<h2 class="heading3 push-next">
-    Choose a name for the bucket
-</h2>
-
-<ul class="bullet-list">
-    <li>Bucket names must be between 3-63 chars</li>
-    <li>The name can only contain lowercase letters, numbers, periods and hyphens</li>
-    <li>The name must start and end with a lowercase letter or number</li>
-    <li>The name cannot be changed later</li>
-</ul>
-
-<editor params="label: 'Bucket Name'">
-    <input type="text" placeholder="Type here" data-bind="
-        value: bucketName,
-        hasFocus: $inActiveStep
-    "/>
-</editor>
-
+<div class="push-next greedy">
+    <editor params="label: 'Bucket Name'">
+        <div class="push-next">
+            <input type="text" placeholder="Type here" data-bind="
+                value: bucketName,
+                hasFocus: $inActiveStep
+            "/>
+        </div>
+        <ul class="bullet-list remark push-prev">
+            <li>3-63 characters</li>
+            <li>Only lowercase letters, numbers, periods and hyphens</li>
+            <li>Starts and ends with a lowercase letter or number</li>
+        </ul>
+    </editor>
+</div>
+<p class="remark">
+    <svg-icon params="name: 'notif-info'" class="icon-small"></svg-icon>
+    <span>The name cannot be changed later</span>
+</p>

--- a/frontend/src/app/components/buckets/create-bucket-wizard/create-bucket-wizard.less
+++ b/frontend/src/app/components/buckets/create-bucket-wizard/create-bucket-wizard.less
@@ -7,4 +7,12 @@ create-bucket-wizard {
         display: inline-block;
         line-height: inherit;
     }
+
+    .remark {
+        line-height: 16px;
+
+        > span {
+            vertical-align: middle;
+        }
+    }
 }

--- a/frontend/src/app/components/overview/buckets-overview/buckets-overview.html
+++ b/frontend/src/app/components/overview/buckets-overview/buckets-overview.html
@@ -16,7 +16,7 @@
         "></toggle-filter>
     </div>
 
-    <checkbox class="push-next" params="
+    <checkbox class="cloud-filter" params="
         checked: includeCloudStorage,
         label: 'Include cloud storage'
     "></checkbox>

--- a/frontend/src/app/components/overview/buckets-overview/buckets-overview.js
+++ b/frontend/src/app/components/overview/buckets-overview/buckets-overview.js
@@ -245,7 +245,7 @@ class BucketsOverviewViewModel extends BaseViewModel {
                 bodyFontSize: parseInt(style['font-size1']),
                 bodySpacing: gutter / 2,
                 callbacks: {
-                    title: items => moment(items[0].xLabel).format('D MMM HH:mm:ss'),
+                    title: items => moment.tz(items[0].xLabel, timezone).format('D MMM HH:mm:ss'),
                     label: item => {
                         const { label } = chartDatasets[item.datasetIndex];
                         const value = formatSize(item.yLabel);

--- a/frontend/src/app/components/overview/buckets-overview/buckets-overview.less
+++ b/frontend/src/app/components/overview/buckets-overview/buckets-overview.less
@@ -5,4 +5,8 @@ buckets-overview {
     .duration-chooser .toggle-btn {
         min-width: 90px;
     }
+
+    .cloud-filter {
+        margin: @gutter/2 0;
+    }
 }

--- a/frontend/src/app/components/overview/resource-overview/resource-overview.html
+++ b/frontend/src/app/components/overview/resource-overview/resource-overview.html
@@ -19,7 +19,11 @@
         </a>
 
         <a class="column content-middle greedy" data-bind="
-                href: { route: 'pools', params: { tab: 'cloud' } }
+                href: {
+                    route: 'pools',
+                    params: { tab: 'cloud' },
+                    query: { resourceType: 'AWS' }
+                }
             ">
             <svg-icon class="resource-icon"
                 params="name: awsResourceIcon"
@@ -29,7 +33,11 @@
         </a>
 
         <a class="column content-middle greedy" data-bind="
-                href: { route: 'pools', params: { tab: 'cloud' } }
+                href: {
+                    route: 'pools',
+                    params: { tab: 'cloud' },
+                    query: { resourceType: 'AZURE' }
+                }
             ">
             <svg-icon class="resource-icon"
                 params="name: azureResourceIcon"
@@ -39,7 +47,11 @@
         </a>
 
         <a class="column content-middle greedy" data-bind="
-                href: { route: 'pools', params: { tab: 'cloud' } }
+                href: {
+                    route: 'pools',
+                    params: { tab: 'cloud' },
+                    query: { resourceType: 'S3_COMPATIBLE' }
+                }
             ">
             <svg-icon class="resource-icon"
                 params="name: genericResourceIcon"

--- a/frontend/src/app/components/overview/system-health/system-health.js
+++ b/frontend/src/app/components/overview/system-health/system-health.js
@@ -93,7 +93,7 @@ class SystemHealthViewModel extends BaseViewModel {
                     false;
 
                 return serverCount() >= 3 ?
-                    (isHighlyAvailable() ? 'ENABLED' : 'DISABLED') :
+                    (isHighlyAvailable ? 'ENABLED' : 'DISABLED') :
                     'NO_ENOUGH_SERVERS';
             }
         );

--- a/frontend/src/app/components/pool/pool-panel/pool-panel.html
+++ b/frontend/src/app/components/pool/pool-panel/pool-panel.html
@@ -2,7 +2,7 @@
 
 <div class="tabs greedy">
     <nav>
-        <a class="selected" data-bind="
+        <a data-bind="
             href: tabHref('nodes'),
             css: tabCss('nodes')
         ">
@@ -11,8 +11,9 @@
     </nav>
 
     <div class="tabs-row">
-        <pool-nodes-table class="selected greedy" data-bind="css: tabCss('nodes')"
-            params="pool: pool, nodeList: nodes">
-        </pool-nodes-table>
+        <pool-nodes-table class="tab greedy" data-bind="css: tabCss('nodes')" params="
+            pool: pool,
+            nodeList: nodes
+        "></pool-nodes-table>
     </div>
 </div>

--- a/frontend/src/app/components/resources/cloud-resources-table/cloud-resources-table.html
+++ b/frontend/src/app/components/resources/cloud-resources-table/cloud-resources-table.html
@@ -1,8 +1,20 @@
-<div class="column pad alt-bg">
+<div class="row alt-bg pad content-middle">
+    <div class="push-next">
+        <input type="search" placeholder="Filter by resource name" data-bind="
+            textInput: filter
+        "/>
+    </div>
+
+    <p class="push-next">By type:</p>
+    <dropdown class="greedy" params="
+        options: resourceTypeOptions,
+        selected: selectedResourceType
+    "></dropdown>
+
     <button class="btn align-end" data-bind="
-        click: () => showAddCloudResourceModal()
+        click: () => showAddCloudResourceModal(),
     ">
-        Add Cloud Resource
+         Add Cloud Resource
     </button>
 </div>
 
@@ -11,7 +23,7 @@
     rowFactory: resource => newResourceRow(resource),
     sorting: sorting,
     data: resources,
-    emptyMessage: 'System does not contain any cloud resources'
+    emptyMessage: emptyMessage
 "></data-table>
 
 <!-- ko if: isAddCloudResourceModalVisible -->

--- a/frontend/src/app/components/resources/create-pool-wizard/assign-nodes-step.html
+++ b/frontend/src/app/components/resources/create-pool-wizard/assign-nodes-step.html
@@ -1,7 +1,7 @@
 <div class="row push-next content-middle">
     <input type="search" placeholder="filter by node name or ip" class="push-next" data-bind="textInput: nameOrIpFilter, hasFocus: $inActiveStep"/>
 
-    <span class="push-both">in</span>
+    <span class="push-next">in</span>
 
     <dropdown class="push-next" params="
         placeholder: 'All Pools',

--- a/frontend/src/app/components/resources/create-pool-wizard/choose-name-step.html
+++ b/frontend/src/app/components/resources/create-pool-wizard/choose-name-step.html
@@ -1,16 +1,14 @@
-<h2 class="heading3 push-next">
-    Choose a name for the pool
-</h2>
-
-<ul class="bullet-list">
-    <li>Pool names must be between 3-63 chars</li>
-    <li>The name can only contain lowercase letters, numbers, periods and hyphens</li>
-    <li>The name must start and end with a lowercase letter or number</li>
-</ul>
-
 <editor params="label: 'Pool Name'">
-    <input type="text" placeholder="Type here" data-bind="
-        value: poolName,
-        hasFocus: $inActiveStep
-    "/>
+    <div class="push-next">
+        <input type="text" placeholder="Type here" data-bind="
+            value: poolName,
+            hasFocus: $inActiveStep
+        "/>
+    </div>
+
+    <ul class="bullet-list remark push-prev">
+        <li>3-63 characters</li>
+        <li>Only lowercase letters, numbers, periods and hyphens</li>
+        <li>Starts and ends with a lowercase letter or number</li>
+    </ul>
 </editor>

--- a/frontend/src/app/components/resources/create-pool-wizard/create-pool-wizard.html
+++ b/frontend/src/app/components/resources/create-pool-wizard/create-pool-wizard.html
@@ -1,5 +1,5 @@
 <wizard params="
-    heading: 'Create Pool',
+    heading: 'Create Nodes Pool',
     steps: steps,
     doneLabel: 'Create',
     validateStep: step => validateStep(step),

--- a/frontend/src/app/components/resources/pools-table/pool-row.js
+++ b/frontend/src/app/components/resources/pools-table/pool-row.js
@@ -19,7 +19,7 @@ export default class PoolRowViewModel extends BaseViewModel {
 
                 return {
                     text: pool().name,
-                    href: { route: 'pool', params: { pool: pool().name } }
+                    href: { route: 'pool', params: { pool: pool().name, tab: null } }
                 };
             }
         );

--- a/frontend/src/app/components/resources/pools-table/pools-table.html
+++ b/frontend/src/app/components/resources/pools-table/pools-table.html
@@ -1,19 +1,24 @@
-<div class="column alt-bg pad">
-    <div class="align-end" data-bind="tooltip: createPoolTooltip">
-        <button class="btn" data-bind="
-            click: () => showCreatePoolWizard(),
-            disable: isCreatePoolDisabled,
-        ">
-            Create Pool
-        </button>
+<div class="row alt-bg pad">
+    <div class="greedy push-next">
+        <input type="search" placeholder="Filter by pool name" data-bind="
+            textInput: filter
+        "/>
     </div>
+
+    <button class="btn align-end" data-bind="
+        click: () => showCreatePoolWizard(),
+        disable: isCreatePoolDisabled,
+    ">
+        Create Pool
+    </button>
 </div>
 
 <data-table class="greedy" params="
     columns: columns,
     data: pools,
     rowFactory: pool => newPoolRow(pool),
-    sorting: sorting
+    sorting: sorting,
+    emptyMessage: 'The current filter does not match any nodes pool'
 "></data-table>
 
 <!-- ko if: isCreatePoolWizardVisible -->

--- a/frontend/src/app/components/resources/pools-table/pools-table.js
+++ b/frontend/src/app/components/resources/pools-table/pools-table.js
@@ -2,9 +2,10 @@ import template from './pools-table.html';
 import BaseViewModel from 'base-view-model';
 import ko from 'knockout';
 import PoolRowViewModel from './pool-row';
-import { deepFreeze, createCompareFunc } from 'utils/core-utils';
+import { deepFreeze, throttle, createCompareFunc } from 'utils/core-utils';
 import { navigateTo } from 'actions';
-import { uiState, routeContext, systemInfo } from 'model';
+import { routeContext, systemInfo } from 'model';
+import { inputThrottle } from 'config';
 
 const columns = deepFreeze([
     {
@@ -102,32 +103,43 @@ class PoolsTableViewModel extends BaseViewModel {
 
         this.columns = columns;
 
+        const query = ko.pureComputed(
+            () => routeContext().query || {}
+        );
+
+        this.filter = ko.pureComputed({
+            read: () => query().filter,
+            write: throttle(phrase => this.filterPools(phrase), inputThrottle)
+        });
+
         this.sorting = ko.pureComputed({
             read: () => {
-                let { query } = routeContext();
-                let isOnScreen = uiState().tab === 'pools';
-
+                const { sortBy, order } = query();
+                const canSort = Object.keys(compareAccessors).includes(sortBy);
                 return {
-                    sortBy: (isOnScreen && query.sortBy) || 'name',
-                    order: (isOnScreen && Number(routeContext().query.order)) || 1
+                    sortBy: (canSort && sortBy) || 'name',
+                    order: (canSort && Number(order)) || 1
                 };
             },
-            write: value => {
-                this.deleteGroup(null);
-                navigateTo(undefined, undefined, value);
-            }
+            write: value => this.orderBy(value)
         });
+
+        const allNodePools = ko.pureComputed(
+            () => (systemInfo() ? systemInfo().pools : []).filter(
+                ({ nodes }) => Boolean(nodes)
+            )
+        );
 
         this.pools = ko.pureComputed(
             () => {
-                let { sortBy, order } = this.sorting();
-                let compareOp = createCompareFunc(compareAccessors[sortBy], order);
+                const { sortBy, order } = this.sorting();
+                const compareOp = createCompareFunc(compareAccessors[sortBy], order);
+                const filter = (this.filter() || '').toLowerCase();
 
-                return systemInfo() && systemInfo().pools
+                return allNodePools()
                     .filter(
-                        pool => pool.nodes
+                        ({ name }) => name.toLowerCase().includes(filter)
                     )
-                    .slice(0)
                     .sort(compareOp);
             }
         );
@@ -138,6 +150,21 @@ class PoolsTableViewModel extends BaseViewModel {
 
     newPoolRow(pool) {
         return new PoolRowViewModel(pool, this.deleteGroup, poolsToBuckets);
+    }
+
+    orderBy({ sortBy, order }) {
+        this.deleteGroup(null);
+
+        const filter = this.filter() || undefined;
+        navigateTo(undefined, undefined, { filter, sortBy, order });
+    }
+
+    filterPools(phrase) {
+        this.deleteGroup(null);
+
+        const filter = phrase || undefined;
+        const { sortBy, order } = this.sorting() || {};
+        navigateTo(undefined, undefined, { filter, sortBy, order });
     }
 
     showCreatePoolWizard() {

--- a/frontend/src/app/components/resources/pools-table/pools-table.js
+++ b/frontend/src/app/components/resources/pools-table/pools-table.js
@@ -20,7 +20,7 @@ const columns = deepFreeze([
     },
     {
         name: 'buckets',
-        label: 'bucket using pool',
+        label: 'buckets using pool',
         sortable: true
     },
     {

--- a/frontend/src/app/components/server/server-details-form/server-details-form.html
+++ b/frontend/src/app/components/server/server-details-form/server-details-form.html
@@ -36,9 +36,11 @@
             "></svg-icon>
             <span class="label push-next highlight">Server Date and Time:</span>
             <span class="row" data-bind="visible: $component.isConnected">
-                <span class="highlight push-next">Server Clock:</span>
-                <span data-bind="text: clock" class="push-next"></span>
-                <span class="highlight push-both">NTP:</span>
+                <span class="push-next">Server Clock:</span>
+                <span data-bind="text: clock"></span>
+                <span class="push-both">|</span>
+
+                <span class="push-next">NTP:</span>
                 <span data-bind="text: ntp"></span>
             </span>
             <span data-bind="visible: !$component.isConnected()">Not Available</span>
@@ -50,12 +52,13 @@
                 tooltip: tooltip
             "></svg-icon>
             <span class="label push-next highlight">DNS Servers:</span>
-            <span class="row push-next" data-bind="visible: $component.isConnected">
-                <span class="highlight push-next">Primary:</span>
+            <span class="row" data-bind="visible: $component.isConnected">
+                <span class="push-next">Primary:</span>
                 <span data-bind="text: primary"></span>
             </span>
-            <span class="row push-prev" data-bind="visible: $component.isConnected">
-                <span class="highlight push-next">Secondary:</span>
+            <span class="push-both">|</span>
+            <span class="row" data-bind="visible: $component.isConnected">
+                <span class="push-next">Secondary:</span>
                 <span data-bind="text: secondary"></span>
             </span>
             <span data-bind="visible: !$component.isConnected()">Not Available</span>
@@ -88,7 +91,7 @@
             "></svg-icon>
             <span class="label push-next highlight">Phone Home:</span>
             <span class="row" data-bind="visible: $component.isConnected">
-                <span class="highlight push-next">Proxy:</span>
+                <span class="push-next">Proxy:</span>
                 <span data-bind="text: proxy"></span>
             </span>
             <span data-bind="visible: !$component.isConnected()">Not Available</span>

--- a/frontend/src/app/components/shared/node-selection-table/node-selection-table.html
+++ b/frontend/src/app/components/shared/node-selection-table/node-selection-table.html
@@ -2,7 +2,7 @@
     <h2 class="heading3 greedy" data-bind="text: caption"></h2>
     <div>
         <button class="link alt-colors" data-bind="click: selectListedNodes">
-            Select nodes
+            Select all nodes
         </button>
         |
         <button class="link alt-colors" data-bind="click: clearListedNodes">


### PR DESCRIPTION
### Purpose
- Allow the user to filter pool list by pool name
- Allow the user to filter cloud resources list by resource name and/or resource type
- Redesign of bucket/pool name field restrictions
- General FE fixes

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2581
- Fixes #2575
