### PR TITLE
Member add version check fix

### DIFF
--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -69,15 +69,12 @@ module.exports = {
 
         verify_join_conditions: {
             doc: 'check join conditions to the cluster and return caller ip (stun)',
-            method: 'POST',
+            method: 'GET',
             params: {
                 type: 'object',
-                required: ['secret', 'version'],
+                required: ['secret'],
                 properties: {
                     secret: {
-                        type: 'string'
-                    },
-                    version: {
                         type: 'string'
                     }
                 }
@@ -92,12 +89,24 @@ module.exports = {
                     hostname: {
                         type: 'string'
                     },
-                    version: {
-                        type: 'string'
-                    },
                     result: {
                         $ref: 'cluster_server_api#/definitions/verify_new_member_result'
                     }
+                }
+            },
+            auth: {
+                system: false
+            }
+        },
+
+        get_version: {
+            doc: 'get server version',
+            method: 'GET',
+            reply: {
+                type: 'object',
+                required: ['version'],
+                properties: {
+                    type: 'string'
                 }
             },
             auth: {

--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -106,7 +106,9 @@ module.exports = {
                 type: 'object',
                 required: ['version'],
                 properties: {
-                    type: 'string'
+                    version: {
+                        type: 'string'
+                    },
                 }
             },
             auth: {

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -87,9 +87,12 @@ function add_member_to_cluster(req) {
         .catch(err => {
             throw err;
         })
+        .then(() => check_candidate_version(req))
+        .then(version_check_res => {
+            if (version_check_res.result !== 'OKAY') throw new Error('Verify join version check returned', version_check_res);
+        })
         .then(() => server_rpc.client.cluster_internal.verify_join_conditions({
             secret: req.rpc_params.secret,
-            version: pkg.version
         }, {
             address: server_rpc.get_base_address(req.rpc_params.address),
             timeout: 60000 //60s
@@ -213,10 +216,37 @@ function verify_join_conditions(req) {
         .then(() => _verify_join_preconditons(req))
         .then(result => ({
             result,
-            version: pkg.version,
             caller_address,
             hostname,
         }));
+}
+
+function check_candidate_version(req) {
+    return server_rpc.client.cluster_internal.get_version(undefined, {
+            address: server_rpc.get_base_address(req.rpc_params.address),
+            timeout: 60000 //60s
+        })
+        .then(({ version }) => {
+            if (version !== pkg.version) {
+                return {
+                    result: 'VERSION_MISMATCH',
+                    version
+                };
+            }
+            return {
+                result: 'OKAY'
+            };
+        })
+        .catch(RpcError, rpc_err => {
+            dbg.warn('WOOP errcode', rpc_err.rpc_code);
+            if (rpc_err.rpc_code === 'NO_SUCH_RPC_SERVICE') {
+                // Called server is too old to have this code
+                return {
+                    result: 'VERSION_MISMATCH'
+                };
+            }
+            throw rpc_err;
+        });
 }
 
 function verify_candidate_join_conditions(req) {
@@ -228,29 +258,37 @@ function verify_candidate_join_conditions(req) {
             result: 'ADDING_SELF'
         };
     }
-    return server_rpc.client.cluster_internal.verify_join_conditions({
-            secret: req.rpc_params.secret,
-            version: pkg.version
-        }, {
-            address: server_rpc.get_base_address(req.rpc_params.address),
-            timeout: 60000 //60s
-        })
-        .then(res => ({
-            hostname: res.hostname,
-            result: res.result,
-            version: res.version
-        }))
-        .catch(RpcError, err => {
-            if (err.rpc_code === 'RPC_CONNECT_TIMEOUT') {
-                dbg.warn('received', err, ' on verify_candidate_join_conditions');
-                return {
-                    result: 'UNREACHABLE'
-                };
-            }
-            throw err;
+    return check_candidate_version(req)
+        .then(version_check_res => {
+            if (version_check_res.result !== 'OKAY') return version_check_res;
+            return server_rpc.client.cluster_internal.verify_join_conditions({
+                    secret: req.rpc_params.secret
+                }, {
+                    address: server_rpc.get_base_address(req.rpc_params.address),
+                    timeout: 60000 //60s
+                })
+                .then(res => ({
+                    hostname: res.hostname,
+                    result: res.result,
+                    version: version_check_res.version
+                }))
+                .catch(RpcError, err => {
+                    if (err.rpc_code === 'RPC_CONNECT_TIMEOUT') {
+                        dbg.warn('received', err, ' on verify_candidate_join_conditions');
+                        return {
+                            result: 'UNREACHABLE'
+                        };
+                    }
+                    throw err;
+                });
         });
 }
 
+function get_version(req) {
+    return P.resolve(() => ({
+        version: pkg.version
+    }));
+}
 
 function join_to_cluster(req) {
     dbg.log0('Got join_to_cluster request with topology', cutil.pretty_topology(req.rpc_params.topology),
@@ -259,8 +297,8 @@ function join_to_cluster(req) {
     return P.resolve()
         .then(() => _verify_join_preconditons(req))
         .then(verify_res => {
-            if (verify_res.result !== 'OKAY') {
-                throw new Error('Verify joing preconditions failed with result', verify_res);
+            if (verify_res !== 'OKAY') {
+                throw new Error('Verify join preconditions failed with result', verify_res);
             }
             req.rpc_params.topology.owner_shardname = req.rpc_params.shard;
             req.rpc_params.topology.owner_address = req.rpc_params.ip;
@@ -1160,12 +1198,6 @@ function _verify_join_preconditons(req) {
         return 'SECRET_MISMATCH';
     }
 
-    if (req.rpc_params.version && req.rpc_params.version !== pkg.version) {
-        dbg.error(`versions does not match - master version = ${req.rpc_params.version}  joined version = ${pkg.version}`);
-        return 'VERSION_MISMATCH';
-    }
-
-
     let system = system_store.data.systems[0];
     if (system) {
         //Verify we are not already joined to a cluster
@@ -1550,3 +1582,4 @@ exports.verify_candidate_join_conditions = verify_candidate_join_conditions;
 exports.verify_join_conditions = verify_join_conditions;
 exports.update_server_conf = update_server_conf;
 exports.set_hostname_internal = set_hostname_internal;
+exports.get_version = get_version;

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -222,11 +222,13 @@ function verify_join_conditions(req) {
 }
 
 function check_candidate_version(req) {
+    dbg.log0('check_candidate_version for address', req.rpc_params.address);
     return server_rpc.client.cluster_internal.get_version(undefined, {
             address: server_rpc.get_base_address(req.rpc_params.address),
             timeout: 60000 //60s
         })
         .then(({ version }) => {
+            dbg.log0('check_candidate_version got version', version);
             if (version !== pkg.version) {
                 return {
                     result: 'VERSION_MISMATCH',
@@ -238,8 +240,8 @@ function check_candidate_version(req) {
             };
         })
         .catch(RpcError, rpc_err => {
-            dbg.warn('WOOP errcode', rpc_err.rpc_code);
             if (rpc_err.rpc_code === 'NO_SUCH_RPC_SERVICE') {
+                dbg.warn('check_candidate_version got NO_SUCH_RPC_SERVICE from a server with an old version');
                 // Called server is too old to have this code
                 return {
                     result: 'VERSION_MISMATCH'
@@ -285,9 +287,11 @@ function verify_candidate_join_conditions(req) {
 }
 
 function get_version(req) {
-    return P.resolve(() => ({
-        version: pkg.version
-    }));
+    dbg.log0('get_version sending version', pkg.version);
+    return P.resolve()
+        .then(() => ({
+            version: pkg.version
+        }));
 }
 
 function join_to_cluster(req) {
@@ -1192,6 +1196,7 @@ function _validate_add_member_request(req) {
 }
 
 function _verify_join_preconditons(req) {
+    dbg.log0('_verify_join_preconditons');
     //Verify secrets match
     if (req.rpc_params.secret !== system_store.get_server_secret()) {
         dbg.error('Secrets do not match!');
@@ -1216,6 +1221,7 @@ function _verify_join_preconditons(req) {
             .then(obj_count => (obj_count[''] > 0 ? 'HAS_OBJECTS' : 'OKAY'));
     }
     // If we do not need system in order to add a server to a cluster
+    dbg.log0('_verify_join_preconditons okay. server has no system');
     return 'OKAY';
 }
 

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -87,7 +87,7 @@ function add_member_to_cluster(req) {
         .catch(err => {
             throw err;
         })
-        .then(() => check_candidate_version(req))
+        .then(() => _check_candidate_version(req))
         .then(version_check_res => {
             if (version_check_res.result !== 'OKAY') throw new Error('Verify join version check returned', version_check_res);
         })
@@ -221,14 +221,14 @@ function verify_join_conditions(req) {
         }));
 }
 
-function check_candidate_version(req) {
-    dbg.log0('check_candidate_version for address', req.rpc_params.address);
+function _check_candidate_version(req) {
+    dbg.log0('_check_candidate_version for address', req.rpc_params.address);
     return server_rpc.client.cluster_internal.get_version(undefined, {
             address: server_rpc.get_base_address(req.rpc_params.address),
             timeout: 60000 //60s
         })
         .then(({ version }) => {
-            dbg.log0('check_candidate_version got version', version);
+            dbg.log0('_check_candidate_version got version', version);
             if (version !== pkg.version) {
                 return {
                     result: 'VERSION_MISMATCH',
@@ -241,7 +241,7 @@ function check_candidate_version(req) {
         })
         .catch(RpcError, rpc_err => {
             if (rpc_err.rpc_code === 'NO_SUCH_RPC_SERVICE') {
-                dbg.warn('check_candidate_version got NO_SUCH_RPC_SERVICE from a server with an old version');
+                dbg.warn('_check_candidate_version got NO_SUCH_RPC_SERVICE from a server with an old version');
                 // Called server is too old to have this code
                 return {
                     result: 'VERSION_MISMATCH'
@@ -260,7 +260,7 @@ function verify_candidate_join_conditions(req) {
             result: 'ADDING_SELF'
         };
     }
-    return check_candidate_version(req)
+    return _check_candidate_version(req)
         .then(version_check_res => {
             if (version_check_res.result !== 'OKAY') return version_check_res;
             return server_rpc.client.cluster_internal.verify_join_conditions({


### PR DESCRIPTION
### Purpose
- Funny enough, I altered code that verifies if a server can be added to a cluster. One of the tests checks that the added server has the same version as the adding server. The added server might be to old to have the new API for the test!
I added a get_version RPC to the API. It will return an NO_SUCH_RPC_SERVICE on servers too old to have the new code, and it will be converted to a VERSION_MISMATCH return code.

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**. On old servers we won't be able to tell what version they have to the user. Just that it's older than 0.9
 - [x] Failure handling and Comments on non trivial sections: 
- Testing:
 - [x] Manual test
 - [x] Tested with: `npm test`

### Fixed Issues References
- Fixes #2597