### PR TITLE
Danny bucket stats

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -304,6 +304,9 @@ function delete_bucket(req) {
             system_id: req.system._id.toString()
         }, {
             auth_token: req.auth_token
+        }).catch(err => {
+            // don't fail delete_bucket if refresh_policy fails
+            dbg.error('got error on refresh_policy when deleting bucket. bucket=', bucket.name, 'error:', err);
         }))
         .then(res => {
             //TODO NEED TO INSERT CODE THAT DELETES BUCKET ID FROM ALL ACCOUNT PERMISSIONS;

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -19,10 +19,10 @@ const object_server = require('../object_services/object_server');
 const bucket_server = require('../system_services/bucket_server');
 const auth_server = require('../common_services/auth_server');
 const server_rpc = require('../server_rpc');
+const MDStore = require('../object_services/md_store').MDStore;
 
 const ops_aggregation = {};
 const SCALE_BYTES_TO_GB = 1024 * 1024 * 1024;
-const SCALE_BYTES_TO_MB = 1024 * 1024;
 const SCALE_SEC_TO_DAYS = 60 * 60 * 24;
 
 var successfuly_sent_period = 0;
@@ -212,25 +212,11 @@ function get_ops_stats(req) {
 }
 
 function get_bucket_sizes_stats(req) {
-    return P.all(_.map(system_store.data.buckets,
-            bucket => {
-                // TODO disabled the object listing here which crashes the process out of memory
-                return [];
-                // let new_req = req;
-                // new_req.rpc_params.bucket = bucket.name;
-                // return object_server.list_objects(new_req);
-            }
-        ))
-        .then(bucket_arr => {
-            let histo_arr = [];
-            _.each(bucket_arr, bucket_res => {
-                let objects_histo = get_empty_objects_histo();
-                _.forEach(bucket_res.objects, obj =>
-                    objects_histo.histo_size.add_value(obj.info.size / SCALE_BYTES_TO_MB));
-                histo_arr.push(_.mapValues(objects_histo, histo => histo.get_object_data(false)));
-            });
-            return histo_arr;
-        });
+    return MDStore.instance().aggregate_object_size_by_ranges()
+        .then(res => res.map(bucket_stats => {
+            let objects_histo = get_empty_objects_histo();
+            return objects_histo.add_values_batch(bucket_stats);
+        }));
 }
 
 function get_pool_stats(req) {

--- a/src/util/histogram.js
+++ b/src/util/histogram.js
@@ -48,6 +48,13 @@ Histogram.prototype.add_value = function(value) {
     }
 };
 
+Histogram.prototype.add_values_batch = function(val_arr) {
+    for (var i = this._bins.length - 1; i >= 0; --i) {
+        this._bins[i].count += val_arr[i].count;
+        this._bins[i].aggregated_sum += val_arr[i].aggregated_sum;
+    }
+};
+
 Histogram.prototype.get_object_data = function(skip_master_label) {
     var ret = {
         master_label: skip_master_label ? this._master_label : '',


### PR DESCRIPTION
### Purpose
- use mongo map reduce instead to create bucket size histograms instead of loading all objects to memory - (issue #2628)
- fix a bug where delete_bucket showed "failed" notification when cloud_sync bg_worker is not running. 

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2628