### PR TITLE
fixes  #2628 - collect object sizes for histogram in bucket_storage_f…

### DIFF
--- a/src/server/bg_services/bucket_storage_fetch.js
+++ b/src/server/bg_services/bucket_storage_fetch.js
@@ -10,8 +10,6 @@ const size_utils = require('../../util/size_utils');
 const system_store = require('../system_services/system_store').get_instance();
 
 
-const MAX_NUM_BINS = 31;
-
 // TODO: This method is based on a single system
 function background_worker() {
     if (!system_store.is_finished_initial_load) {
@@ -91,8 +89,7 @@ function background_worker() {
                 new_storage_stats.chunks_capacity = (new size_utils.BigInteger(new_storage_stats.chunks_capacity).plus(delta_chunk_compress_size)).toJSON();
                 new_storage_stats.objects_size = (new size_utils.BigInteger(new_storage_stats.objects_size).plus(delta_object_size)).toJSON();
                 new_storage_stats.objects_count += delta_object_count;
-                new_storage_stats.objects_size_hist = get_objects_size_hist(bucket, existing_objects_aggregate, deleted_objects_aggregate);
-                new_storage_stats.objects_count_hist = get_objects_count_hist(bucket, existing_objects_aggregate, deleted_objects_aggregate);
+                new_storage_stats.objects_hist = build_objects_hist(bucket, existing_objects_aggregate, deleted_objects_aggregate);
 
                 dbg.log0('Bucket storage stats after deltas:', new_storage_stats);
                 return {
@@ -115,41 +112,74 @@ function background_worker() {
 function get_hist_array_from_aggregate(agg, key) {
     const key_prefix = key + '_pow2_';
     let bins_arr = [];
-    for (var i = 0; i < MAX_NUM_BINS; i++) {
-        let bin_key = key_prefix + i.toString();
-        bins_arr.push((agg && agg[bin_key]) || 0);
+    for (var prop in agg) {
+        if (prop.startsWith(key_prefix)) {
+            let index = parseInt(prop.replace(key_prefix, ''), 10);
+            bins_arr[index] = agg[prop];
+        }
     }
     return bins_arr;
 }
 
+function build_objects_hist(bucket, existing_agg, deleted_agg) {
+    // get the current histogram from DB
+    let current_objects_hist = (bucket.storage_stats && bucket.storage_stats.objects_hist) || [];
 
-function get_objects_size_hist(bucket, existing_agg, deleted_agg) {
-    let current_objects_size_hist = (bucket.storage_stats && bucket.storage_stats.objects_size_hist) || [];
+    // get the latest additions\deletions in an array form
     let existing_size_hist = get_hist_array_from_aggregate(existing_agg[bucket._id], 'size');
     let deleted_size_hist = get_hist_array_from_aggregate(deleted_agg[bucket._id], 'size');
-    let new_size_hist = [];
-    // calculate new size for each bin
-    for (var i = 0; i < MAX_NUM_BINS; i++) {
-        let bigint_existing_size_bin = new size_utils.BigInteger(existing_size_hist[i]);
-        let bigint_deleted_size_bin = new size_utils.BigInteger(deleted_size_hist[i]);
-        let delta_size_bin = bigint_existing_size_bin.minus(bigint_deleted_size_bin);
-        new_size_hist.push((new size_utils.BigInteger(current_objects_size_hist[i] || 0).plus(delta_size_bin)).toJSON());
+    let existing_count_hist = get_hist_array_from_aggregate(existing_agg[bucket._id], 'count');
+    let deleted_count_hist = get_hist_array_from_aggregate(deleted_agg[bucket._id], 'count');
+
+    // size and count should have the same length, since they are emitted together in mongo mapreduce
+    if (deleted_size_hist.length !== deleted_count_hist.length ||
+        existing_size_hist.length !== existing_count_hist.length) {
+        dbg.error('size histogram and count histogram have different lengths',
+            'deleted_size_hist.length =', deleted_size_hist.length,
+            'deleted_count_hist.length =', deleted_count_hist.length,
+            'existing_size_hist.length =', existing_size_hist.length,
+            'existing_count_hist.length =', existing_count_hist.length);
     }
+
+    let num_bins = Math.max(deleted_size_hist.length, existing_size_hist.length, current_objects_hist.length);
+    if (num_bins === 0) return current_objects_hist;
+    let new_size_hist = [];
+    for (var i = 0; i < num_bins; i++) {
+        let bin = {
+            label: (current_objects_hist[i] && current_objects_hist[i].label) || get_hist_label(i),
+            aggregated_sum: get_new_bin(
+                existing_size_hist[i] || 0,
+                deleted_size_hist[i] || 0,
+                (current_objects_hist[i] && current_objects_hist[i].aggregated_sum) || 0),
+            count: get_new_bin(
+                existing_count_hist[i] || 0,
+                deleted_count_hist[i] || 0,
+                (current_objects_hist[i] && current_objects_hist[i].count) || 0)
+        };
+        new_size_hist.push(bin);
+    }
+
     return new_size_hist;
 }
 
-
-function get_objects_count_hist(bucket, existing_agg, deleted_agg) {
-    let current_objects_count_hist = (bucket.storage_stats && bucket.storage_stats.objects_count_hist) || [];
-    let existing_count_hist = get_hist_array_from_aggregate(existing_agg[bucket._id], 'count');
-    let deleted_count_hist = get_hist_array_from_aggregate(deleted_agg[bucket._id], 'count');
-    let new_count_hist = [];
-    // calculate new size for each bin
-    for (var i = 0; i < MAX_NUM_BINS; i++) {
-        let delta_count_bin = existing_count_hist[i] - deleted_count_hist[i];
-        new_count_hist.push((current_objects_count_hist[i] || 0) + delta_count_bin);
+function get_hist_label(pow) {
+    if (pow === 0) {
+        return "0 - " + size_utils.human_size(1);
     }
-    return new_count_hist;
+    return `${size_utils.human_size(Math.pow(2, pow - 1))} - ${size_utils.human_size(Math.pow(2, pow))}`;
+}
+
+function get_new_bin(existing, deleted, current) {
+    if (!existing && !deleted) {
+        return current;
+    }
+    let bigint_existing_size_bin = new size_utils.BigInteger(existing);
+    let bigint_deleted_size_bin = new size_utils.BigInteger(deleted);
+    let delta_size_bin = bigint_existing_size_bin
+        .minus(bigint_deleted_size_bin);
+    let new_bin = (new size_utils.BigInteger(current).plus(delta_size_bin))
+        .toJSON();
+    return new_bin;
 }
 
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -37,8 +37,8 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, tag) {
             chunks_capacity: 0,
             objects_size: 0,
             objects_count: 0,
-            objects_size_hist: [0, 0, 0, 0, 0, 0, 0],
-            objects_count_hist: [0, 0, 0, 0, 0, 0, 0],
+            objects_size_hist: [],
+            objects_count_hist: [],
             last_update: now
         },
         stats: {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -37,8 +37,6 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, tag) {
             chunks_capacity: 0,
             objects_size: 0,
             objects_count: 0,
-            objects_size_hist: [],
-            objects_count_hist: [],
             last_update: now
         },
         stats: {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -37,6 +37,8 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, tag) {
             chunks_capacity: 0,
             objects_size: 0,
             objects_count: 0,
+            objects_size_hist: [0, 0, 0, 0, 0, 0, 0],
+            objects_count_hist: [0, 0, 0, 0, 0, 0, 0],
             last_update: now
         },
         stats: {

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -84,28 +84,51 @@ module.exports = {
         },
         storage_stats: {
             type: 'object',
-            required: ['chunks_capacity', 'objects_size', 'objects_count', 'last_update'],
+            required: ['chunks_capacity', 'objects_size', 'objects_count', 'last_update', 'objects_count_hist', 'objects_size_hist'],
             properties: {
                 chunks_capacity: {
                     oneOf: [{
-                            type: 'integer'
-                        }, {
-                            type: 'object',
-                            properties: {
-                                n: {
-                                    type: 'integer',
-                                },
-                                // to support bigger integers we can specify a peta field
-                                // which is considered to be based from 2^50
-                                peta: {
-                                    type: 'integer',
-                                }
+                        type: 'integer'
+                    }, {
+                        type: 'object',
+                        properties: {
+                            n: {
+                                type: 'integer',
+                            },
+                            // to support bigger integers we can specify a peta field
+                            // which is considered to be based from 2^50
+                            peta: {
+                                type: 'integer',
                             }
-                        }]
-                        // $ref: 'common_api#/definitions/bigint'
+                        }
+                    }]
+                    // $ref: 'common_api#/definitions/bigint'
                 },
                 objects_size: {
                     oneOf: [{
+                        type: 'integer'
+                    }, {
+                        type: 'object',
+                        properties: {
+                            n: {
+                                type: 'integer',
+                            },
+                            // to support bigger integers we can specify a peta field
+                            // which is considered to be based from 2^50
+                            peta: {
+                                type: 'integer',
+                            }
+                        }
+                    }]
+                    // $ref: 'common_api#/definitions/bigint'
+                },
+                objects_count: {
+                    type: 'integer'
+                },
+                objects_size_hist: {
+                    type: 'array',
+                    items: {
+                        oneOf: [{
                             type: 'integer'
                         }, {
                             type: 'object',
@@ -121,9 +144,13 @@ module.exports = {
                             }
                         }]
                         // $ref: 'common_api#/definitions/bigint'
+                    },
                 },
-                objects_count: {
-                    type: 'integer'
+                objects_count_hist: {
+                    type: 'array',
+                    items: {
+                        type: 'integer'
+                    },
                 },
                 last_update: {
                     format: 'idate'

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -1,5 +1,24 @@
 'use strict';
 
+
+const bigint = {
+    oneOf: [{
+        type: 'integer'
+    }, {
+        type: 'object',
+        properties: {
+            n: {
+                type: 'integer',
+            },
+            // to support bigger integers we can specify a peta field
+            // which is considered to be based from 2^50
+            peta: {
+                type: 'integer',
+            }
+        }
+    }]
+};
+
 module.exports = {
     id: 'bucket_schema',
     type: 'object',
@@ -84,7 +103,7 @@ module.exports = {
         },
         storage_stats: {
             type: 'object',
-            required: ['chunks_capacity', 'objects_size', 'objects_count', 'last_update', 'objects_count_hist', 'objects_size_hist'],
+            required: ['chunks_capacity', 'objects_size', 'objects_count', 'last_update'],
             properties: {
                 chunks_capacity: {
                     oneOf: [{
@@ -102,59 +121,24 @@ module.exports = {
                             }
                         }
                     }]
-                    // $ref: 'common_api#/definitions/bigint'
                 },
-                objects_size: {
-                    oneOf: [{
-                        type: 'integer'
-                    }, {
-                        type: 'object',
-                        properties: {
-                            n: {
-                                type: 'integer',
-                            },
-                            // to support bigger integers we can specify a peta field
-                            // which is considered to be based from 2^50
-                            peta: {
-                                type: 'integer',
-                            }
-                        }
-                    }]
-                    // $ref: 'common_api#/definitions/bigint'
-                },
+                objects_size: bigint,
                 objects_count: {
                     type: 'integer'
                 },
-                objects_size_hist: {
+                objects_hist: {
                     type: 'array',
                     items: {
-                        oneOf: [{
-                            type: 'integer'
-                        }, {
-                            type: 'object',
-                            properties: {
-                                n: {
-                                    type: 'integer',
-                                },
-                                // to support bigger integers we can specify a peta field
-                                // which is considered to be based from 2^50
-                                peta: {
-                                    type: 'integer',
-                                }
+                        type: 'object',
+                        properties: {
+                            aggregated_sum: bigint,
+                            count: bigint,
+                            label: {
+                                type: 'string'
                             }
-                        }]
-                        // $ref: 'common_api#/definitions/bigint'
-                    },
+                        }
+                    }
                 },
-                objects_count_hist: {
-                    type: 'array',
-                    items: {
-                        type: 'integer'
-                    },
-                },
-                last_update: {
-                    format: 'idate'
-                }
             }
         },
         //lifecycle rules if exist

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -22,7 +22,6 @@ const server_rpc = require('../server_rpc');
 
 const ops_aggregation = {};
 const SCALE_BYTES_TO_GB = 1024 * 1024 * 1024;
-const SCALE_BYTES_TO_MB = 1024 * 1024;
 const SCALE_SEC_TO_DAYS = 60 * 60 * 24;
 
 var successfuly_sent_period = 0;
@@ -212,25 +211,14 @@ function get_ops_stats(req) {
 }
 
 function get_bucket_sizes_stats(req) {
-    return P.all(_.map(system_store.data.buckets,
-            bucket => {
-                // TODO disabled the object listing here which crashes the process out of memory
-                return [];
-                // let new_req = req;
-                // new_req.rpc_params.bucket = bucket.name;
-                // return object_server.list_objects(new_req);
-            }
-        ))
-        .then(bucket_arr => {
-            let histo_arr = [];
-            _.each(bucket_arr, bucket_res => {
-                let objects_histo = get_empty_objects_histo();
-                _.forEach(bucket_res.objects, obj =>
-                    objects_histo.histo_size.add_value(obj.info.size / SCALE_BYTES_TO_MB));
-                histo_arr.push(_.mapValues(objects_histo, histo => histo.get_object_data(false)));
-            });
-            return histo_arr;
+    return system_store.data.buckets.map(bucket => {
+        let objects_histo = get_empty_objects_histo();
+        objects_histo.histo_size.add_aggregated_values({
+            count: bucket.storage_stats.objects_count_hist,
+            aggregated_sum: bucket.storage_stats.objects_size_hist
         });
+        return _.mapValues(objects_histo, histo => histo.get_object_data(false));
+    });
 }
 
 function get_pool_stats(req) {

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -19,6 +19,7 @@ const object_server = require('../object_services/object_server');
 const bucket_server = require('../system_services/bucket_server');
 const auth_server = require('../common_services/auth_server');
 const server_rpc = require('../server_rpc');
+const size_utils = require('../../util/size_utils');
 
 const ops_aggregation = {};
 const SCALE_BYTES_TO_GB = 1024 * 1024 * 1024;
@@ -212,7 +213,7 @@ function get_ops_stats(req) {
 
 function get_bucket_sizes_stats(req) {
     return system_store.data.buckets.map(bucket => {
-        let objects_histo = get_empty_objects_histo();
+        let objects_histo = get_empty_objects_histo(bucket.storage_stats.objects_count_hist.length);
         objects_histo.histo_size.add_aggregated_values({
             count: bucket.storage_stats.objects_count_hist,
             aggregated_sum: bucket.storage_stats.objects_size_hist
@@ -553,32 +554,28 @@ function get_empty_sync_histo() {
     return empty_sync_histo;
 }
 
-function get_empty_objects_histo() {
+function get_empty_objects_histo(len) {
     //TODO: Add histogram for limit, once implemented
-    var empty_objects_histo = {};
-    empty_objects_histo.histo_size = new Histogram('Size(MegaBytes)', [{
-        label: '0 MegaBytes - 5 MegaBytes',
-        start_val: 0
-    }, {
-        label: '5 MegaBytes - 100 MegaBytes',
-        start_val: 5
-    }, {
-        label: '100 MegaBytes - 1 GigaBytes',
-        start_val: 100
-    }, {
-        label: '1 GigaBytes - 100 GigaBytes',
-        start_val: 1000
-    }, {
-        label: '100 GigaBytes - 1 TeraBytes',
-        start_val: 100000
-    }, {
-        label: '1 TeraBytes - 10 TeraBytes',
-        start_val: 1000000
-    }, {
-        label: '10 TeraBytes - What?!',
-        start_val: 10000000
-    }]);
-
+    let empty_objects_histo = {};
+    let labels_arr = [];
+    let prev_size_label = '0';
+    let prev_size = 0;
+    let sizebytes = 1024;
+    for (var i = 0; i <= len - 1; i++) {
+        let size_label = prev_size_label + ' - ' + size_utils.human_size(sizebytes);
+        labels_arr.push({
+            label: size_label,
+            start_val: prev_size
+        });
+        prev_size_label = size_utils.human_size(sizebytes);
+        prev_size = sizebytes;
+        sizebytes *= 2;
+    }
+    labels_arr.push({
+        label: 'Over ' + prev_size_label,
+        start_val: prev_size
+    });
+    empty_objects_histo.histo_size = new Histogram('Size', labels_arr);
     return empty_objects_histo;
 }
 

--- a/src/util/histogram.js
+++ b/src/util/histogram.js
@@ -48,6 +48,15 @@ Histogram.prototype.add_value = function(value) {
     }
 };
 
+
+Histogram.prototype.add_aggregated_values = function(values) {
+    for (var i = this._bins.length - 1; i >= 0; --i) {
+        this._bins[i].count += values.count[i];
+        this._bins[i].aggregated_sum += values.aggregated_sum[i];
+    }
+};
+
+
 Histogram.prototype.get_object_data = function(skip_master_label) {
     var ret = {
         master_label: skip_master_label ? this._master_label : '',

--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -76,10 +76,9 @@ function map_aggregate_objects() {
     emit([this.bucket, 'count'], 1);
 
     // map for histogram calcs - emit the size and count with a key that is the log2 of the size
-    const sizeKB = this.size / 1024;
     var pow = 0;
-    if (sizeKB > 1) {
-        pow = Math.ceil(Math.log2(sizeKB));
+    if (this.size > 1) {
+        pow = Math.ceil(Math.log2(this.size));
     }
     emit([this.bucket, 'count_pow2_' + pow], 1);
     emit([this.bucket, 'size_pow2_' + pow], this.size);

--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -74,6 +74,17 @@ function map_aggregate_objects() {
     emit(['', 'count'], 1);
     emit([this.bucket, 'size'], this.size);
     emit([this.bucket, 'count'], 1);
+    const bins = [0, 5, 100, 1000, 100000, 1000000, 10000000];
+    const keys_suff = ['0mega', '5mega', '100mega', '1gig', '100gig', '1tb', '10tb'];
+    const sizeMB = this.size / (1024 * 1024);
+    for (var i = bins.length - 1; i >= 0; --i) {
+        if (sizeMB >= bins[i]) {
+            var suff = keys_suff[i];
+            emit([this.bucket, 'count_' + suff], 1);
+            emit([this.bucket, 'size_' + suff], this.size);
+            break;
+        }
+    }
 }
 
 /**

--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -74,17 +74,15 @@ function map_aggregate_objects() {
     emit(['', 'count'], 1);
     emit([this.bucket, 'size'], this.size);
     emit([this.bucket, 'count'], 1);
-    const bins = [0, 5, 100, 1000, 100000, 1000000, 10000000];
-    const keys_suff = ['0mega', '5mega', '100mega', '1gig', '100gig', '1tb', '10tb'];
-    const sizeMB = this.size / (1024 * 1024);
-    for (var i = bins.length - 1; i >= 0; --i) {
-        if (sizeMB >= bins[i]) {
-            var suff = keys_suff[i];
-            emit([this.bucket, 'count_' + suff], 1);
-            emit([this.bucket, 'size_' + suff], this.size);
-            break;
-        }
+
+    // map for histogram calcs - emit the size and count with a key that is the log2 of the size
+    const sizeKB = this.size / 1024;
+    var pow = 0;
+    if (sizeKB > 1) {
+        pow = Math.ceil(Math.log2(sizeKB));
     }
+    emit([this.bucket, 'count_pow2_' + pow], 1);
+    emit([this.bucket, 'size_pow2_' + pow], this.size);
 }
 
 /**


### PR DESCRIPTION
### Purpose
- #2628  - perform object size stats collection using mongo map reduce

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2628 