### PR TITLE
fix #2637 call rs.initiate through mongo shell instead of command in mongo_client

### DIFF
--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -56,15 +56,6 @@ module.exports = {
             auth: {
                 system: false
             },
-            reply: {
-                type: 'object',
-                required: ['new_hostname'],
-                properties: {
-                    new_hostname: {
-                        type: 'string'
-                    }
-                }
-            },
         },
 
         verify_join_conditions: {

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1304,10 +1304,7 @@ function _initiate_replica_set(shardname) {
     return P.resolve(() => _update_cluster_info(new_topology))
         .then(() => MongoCtrl.add_replica_set_member(shardname, /*first_server=*/ true, new_topology.shards[shard_idx].servers))
         .then(() => {
-            dbg.log0('Replica set created, calling initiate');
-            return MongoCtrl.initiate_replica_set(shardname, cutil.extract_servers_ip(
-                cutil.get_topology().shards[shard_idx].servers
-            ));
+            dbg.log0('Replica set created and initiated');
         });
 }
 

--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var _ = require('lodash');
-var server_rpc = require('../server_rpc');
-var P = require('../../util/promise');
-var fs_utils = require('../../util/fs_utils');
-var config = require('../../../config.js');
-var SupervisorCtl = require('./supervisor_ctrl');
-var mongo_client = require('../../util/mongo_client');
-var mongoose_client = require('../../util/mongoose_utils');
-var dotenv = require('../../util/dotenv');
-var dbg = require('../../util/debug_module')(__filename);
-var cutil = require('./clustering_utils');
+const _ = require('lodash');
+const server_rpc = require('../server_rpc');
+const P = require('../../util/promise');
+const fs_utils = require('../../util/fs_utils');
+const config = require('../../../config.js');
+const SupervisorCtl = require('./supervisor_ctrl');
+const mongo_client = require('../../util/mongo_client');
+const mongoose_client = require('../../util/mongoose_utils');
+const dotenv = require('../../util/dotenv');
+const dbg = require('../../util/debug_module')(__filename);
+const cutil = require('./clustering_utils');
+const promise_utils = require('../../util/promise_utils');
 
 module.exports = new MongoCtrl(); // Singleton
 
@@ -35,6 +36,11 @@ MongoCtrl.prototype.add_replica_set_member = function(name, first_server, server
         .then(() => self._add_replica_set_member_program(name, first_server))
         .then(() => SupervisorCtl.apply_changes())
         .delay(5000) // TODO: find better solution
+        .then(() => {
+            if (first_server) {
+                self._init_replica_set_from_shell(cutil.extract_servers_ip(servers)[0]);
+            }
+        })
         .then(() => {
             // build new connection url for mongo and write to .env
             return self.update_dotenv(name, cutil.extract_servers_ip(servers));
@@ -163,6 +169,15 @@ MongoCtrl.prototype.get_hb_rs_status = function() {
 //
 //Internals
 //
+MongoCtrl.prototype._init_replica_set_from_shell = function(ip) {
+    let host = ip + ':' + config.MONGO_DEFAULTS.SHARD_SRV_PORT;
+    let mongo_shell_command = `mongo nbcore --port ${config.MONGO_DEFAULTS.SHARD_SRV_PORT}` +
+        ` --eval "rs.initiate({_id: 'shard1',members: [{_id: 0,host: '${host}'}]})"`;
+    dbg.log0(`init replica set: running command ${mongo_shell_command}`);
+    return promise_utils.exec(mongo_shell_command, false, false);
+};
+
+
 MongoCtrl.prototype._add_replica_set_member_program = function(name, first_server) {
     if (!name) {
         throw new Error('port and name must be supplied to add new shard');


### PR DESCRIPTION
### Purpose
- call rs.initiate from mongo shell before trying to connect to replica set from node

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2637 
