### PR TITLE
Nimrod eslint fixes and turn cleared ones into errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -169,7 +169,7 @@ module.exports = {
         'no-else-return': 'warn',
 
         // for empty functions we expect at least a comment why it's there
-        'no-empty-function': 'warn',
+        'no-empty-function': 'error',
 
         'no-extra-parens': ['off', 'all', {
             nestedBinaryExpressions: false

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
         ]],
 
         // arrow function styling is not a real error but should be consistent
-        'arrow-parens': ['warn', 'as-needed'],
+        'arrow-parens': ['error', 'as-needed'],
         'arrow-body-style': ['warn', 'as-needed'],
 
         // camelcase is a religion. we were born differently.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,7 +80,7 @@ module.exports = {
         }],
 
         // prefer that requires are on module scope and not in a function
-        'global-require': 'warn',
+        'global-require': 'error',
 
         // better handle every err in callbacks
         // TODO eslint handle-callback-err should be error
@@ -138,7 +138,7 @@ module.exports = {
         // newlines to separate vars and return are not productive
         'newline-after-var': 'off',
         'newline-before-return': 'off',
-        'newline-per-chained-call': 'warn',
+        'newline-per-chained-call': 'error',
 
         // use only x|0 for int casting, but avoid other bitwise operators
         'no-bitwise': ['warn', {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,7 +84,7 @@ module.exports = {
 
         // better handle every err in callbacks
         // TODO eslint handle-callback-err should be error
-        'handle-callback-err': 'warn',
+        'handle-callback-err': 'error',
 
         // allow short variable names like '_' or 'P' etc. use with care.
         'id-length': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,7 +97,7 @@ module.exports = {
         'init-declarations': 'off',
 
         // expect empty line before comment to create visual relation to the relevant code
-        'lines-around-comment': 'warn',
+        'lines-around-comment': 'error',
 
         // directive means 'use strict', we don't enforce lines around
         'lines-around-directive': 'off',
@@ -158,7 +158,7 @@ module.exports = {
         // constant conditions make loop breaking unclear
         // prefer to use a loop variable
         // TODO eslint no-constant-condition should be error
-        'no-constant-condition': 'warn',
+        'no-constant-condition': 'error',
 
         // continue in loops is better off avoided for readability
         // prefer to use a function with returns and call from the loop

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,7 @@ module.exports = {
         'no-div-regex': 'off',
 
         // prefer to always return when calling callbacks to avoid double calls
-        'callback-return': 'warn',
+        'callback-return': 'error',
 
         // not enforcing all class methods to use 'this'
         'class-methods-use-this': 'off',
@@ -194,8 +194,7 @@ module.exports = {
         'no-negated-condition': 'warn',
 
         // avoid nesting ternary operators. really.
-        // TODO eslint no-nested-ternary should be error
-        'no-nested-ternary': 'warn',
+        'no-nested-ternary': 'error',
 
         // prefer to avoid reassigning to function params and use a new variable
         'no-param-reassign': 'off',
@@ -259,7 +258,7 @@ module.exports = {
         'object-shorthand': 'off',
 
         // prefer x+=4 over x=x+4
-        'operator-assignment': 'warn',
+        'operator-assignment': 'error',
 
         // break lines after operators, not before
         'operator-linebreak': ['error', 'after'],

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -572,7 +572,7 @@ class Agent {
                     this._test_connection_timeout = null;
                 })
                 .catch(P.TimeoutError, err => {
-                    dbg.error('node_server did not respond to ping. closing connection');
+                    dbg.error('node_server did not respond to ping. closing connection', err);
                     this._server_connection.close();
                     this._test_connection_timeout = null;
                 });

--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -116,7 +116,9 @@ AgentCLI.prototype.init = function() {
             if (self.params.cleanup) {
                 return P.all(_.map(self.params.all_storage_paths, storage_path_info => {
                     var storage_path = storage_path_info.mount;
-                    var path_modification = storage_path.replace('/agent_storage/', '').replace('/', '').replace('.', '');
+                    var path_modification = storage_path.replace('/agent_storage/', '')
+                        .replace('/', '')
+                        .replace('.', '');
                     return fs_utils.folder_delete(path_modification);
                 }));
             } else if (self.params.duplicate) {
@@ -138,7 +140,7 @@ AgentCLI.prototype.init = function() {
                         process.exit(0);
                     })
                     .catch(err => {
-                        dbg.error('got error while handling duplication!!');
+                        dbg.error('got error while handling duplication!!', err);
                         process.exit(1);
                     });
             } else {
@@ -147,7 +149,8 @@ AgentCLI.prototype.init = function() {
                         dbg.log0('COMPLETED: load');
                     });
             }
-        }).then(null, function(err) {
+        })
+        .then(null, function(err) {
             dbg.error('ERROR: load', self.params, err.stack);
             throw new Error(err);
         });
@@ -301,10 +304,12 @@ AgentCLI.prototype.create_node_helper = function(current_node_path_info, use_hos
         dbg.log0('create_node_helper called with self.params', self.params);
         var current_node_path = current_node_path_info.mount;
         var node_name = internal_node_name || os.hostname();
-        var path_modification = current_node_path.replace('/agent_storage/', '').replace(/\//g, '').replace('.', '');
+        var path_modification = current_node_path.replace('/agent_storage/', '').replace(/\//g, '')
+            .replace('.', '');
         //windows
         path_modification = path_modification.replace('\\agent_storage\\', '');
-        dbg.log0('create_node_helper with path_modification', path_modification, 'node:', node_name, 'current_node_path', current_node_path, 'exists');
+        dbg.log0('create_node_helper with path_modification', path_modification, 'node:',
+            node_name, 'current_node_path', current_node_path, 'exists');
         if (os.type().indexOf('Windows') >= 0) {
             node_name = node_name + '-' + current_node_path_info.drive_id.replace(':', '');
         } else if (!_.isEmpty(path_modification)) {
@@ -556,7 +561,7 @@ AgentCLI.prototype.list = function() {
     _.each(self.agents, function(agent, node_name) {
         dbg.log0('#' + i, agent.is_started ? '<ok>' : '<STOPPED>',
             'node', node_name, 'address', agent.rpc_address);
-        i++;
+        i += 1;
     });
 };
 

--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -381,6 +381,7 @@ AgentCLI.prototype.create_node_helper = function(current_node_path_info, use_hos
             });
     });
 };
+
 /**
  *
  * CREATE

--- a/src/agent/block_store_services/block_store_azure.js
+++ b/src/agent/block_store_services/block_store_azure.js
@@ -86,7 +86,7 @@ class BlockStoreAzure extends BlockStoreBase {
                 overwrite_size += md_size;
                 console.warn('block already found in cloud, will overwrite. id =', block_md.id);
                 overwrite_count = 1;
-            }, err => {
+            }, () => {
                 // noop when missing
             })
             .then(() => dbg.log3('writing block id to cloud: ', block_key))

--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -59,7 +59,9 @@ class BlockStoreS3 extends BlockStoreBase {
                     this._usage = this._decode_block_md(usage_data);
                     dbg.log0('found usage data in', this.usage_path, 'usage_data = ', this._usage);
                 }
-            }, err => {});
+            }, err => {
+                console.warn('init::recieved', err);
+            });
     }
 
     get_storage_info() {
@@ -121,7 +123,9 @@ class BlockStoreS3 extends BlockStoreBase {
                 overwrite_size += md_size;
                 console.warn('block already found in cloud, will overwrite. id =', block_md.id);
                 overwrite_count = 1;
-            }, err => {})
+            }, err => {
+                console.warn('_write_block reiceved', err);
+            })
             .then(() => {
                 dbg.log3('writing block id to cloud: ', params.Key);
                 //  write block + md to cloud
@@ -211,7 +215,9 @@ class BlockStoreS3 extends BlockStoreBase {
                         deleted_size += md_size;
                         usage.size += deleted_size;
                         usage.count += 1;
-                    }, err => {});
+                    }, err => {
+                        console.warn('_get_blocks_usage recieved', err);
+                    });
             }, {
                 // limit concurrency to 10
                 concurrency: 10

--- a/src/api/object_io.js
+++ b/src/api/object_io.js
@@ -939,7 +939,7 @@ class ObjectIO {
                 })
                 .catch(err => this._report_error_on_object_read(
                     params, part, block.block_md, err))
-                .catch(err => read_next_block(index + 1));
+                .catch(() => read_next_block(index + 1));
         };
         return read_next_block(0);
     }

--- a/src/deploy/ec2_wrapper.js
+++ b/src/deploy/ec2_wrapper.js
@@ -131,7 +131,8 @@ function describe_instances(params, filter, verbose) {
                         }
                         return true;
                     });
-                }).then(null, function(err) {
+                })
+                .then(null, function(err) {
                     if (verbose) {
                         console.log('Error:', err);
                     }
@@ -436,7 +437,8 @@ function get_object(ip, path) {
     console.log('about to download object');
     return P.fcall(function() {
             if (path) {
-                return s3bucket.getObject(params).createReadStream().pipe(file);
+                return s3bucket.getObject(params).createReadStream()
+                    .pipe(file);
             } else {
                 return s3bucket.getObject(params).createWriteStream();
             }
@@ -520,7 +522,8 @@ function scale_agent_instances(count, allow_terminate, is_docker_host, number_of
                 }
                 new_count += region_count;
             }
-            return scale_region(region_name, region_count, instances, allow_terminate, is_docker_host, number_of_dockers, is_win, agent_conf);
+            return scale_region(region_name, region_count, instances, allow_terminate,
+                    is_docker_host, number_of_dockers, is_win, agent_conf);
         }));
     });
 }
@@ -708,7 +711,8 @@ function scale_region(region_name, count, instances, allow_terminate, is_docker_
             if (count > instances.length) {
                 console.log('ScaleRegion:', region_name, 'has', instances.length,
                     ' +++ adding', count - instances.length);
-                return add_agent_region_instances(region_name, count - instances.length, is_docker_host, number_of_dockers, is_win, agent_conf);
+                return add_agent_region_instances(region_name, count - instances.length, is_docker_host,
+                        number_of_dockers, is_win, agent_conf);
             }
 
             // need to terminate

--- a/src/deploy/gcloud.js
+++ b/src/deploy/gcloud.js
@@ -84,7 +84,7 @@ function promiseWhile(condition, body) {
  *
  */
 function import_key_pair_to_region() {
-
+    //Empty function
 }
 
 // eslint-disable-next-line max-params
@@ -154,7 +154,8 @@ function scale_instances(count, allow_terminate, is_docker_host, number_of_docke
 
             return scale_region(zone_name, zone_count, instances, allow_terminate, is_docker_host, number_of_dockers, is_win, agent_conf);
         }));
-    }).catch(function(err) {
+    })
+    .catch(function(err) {
         console.log('####');
         console.log('#### Cannot scale. Reason:', err.message, err.stack);
         console.log('####');
@@ -232,7 +233,9 @@ function scale_region(region_name, count, instances, allow_terminate, is_docker_
     if (count > instances.length) {
         console.log('ScaleRegion:', region_name, 'has', instances.length,
             ' +++ adding', count - instances.length);
-        return add_region_instances(region_name, count - instances.length, is_docker_host, number_of_dockers, is_win, agent_conf, instanceCreationProgressHandler)
+        return add_region_instances(
+                region_name, count - instances.length, is_docker_host, number_of_dockers,
+                is_win, agent_conf, instanceCreationProgressHandler)
             //once the instances are up, we can add disk dependency
             .then(instance_post_creation_handler,
                 instance_creation_error_handler);
@@ -410,10 +413,12 @@ function describe_instances(params, filter) {
             return true;
         });
 
-    }).then(function(instances) {
+    })
+    .then(function(instances) {
         instances.zones = zones;
         return instances;
-    }).catch(
+    })
+    .catch(
         function(error) {
             if (error && error.errors && error.errors[0].reason === 'notFound') {
                 console.log('Setup issue. Make sure you have the right credentials (https://console.developers.google.com/project/<project_name>/apiui/credential)', error);

--- a/src/deploy/gcloud.js
+++ b/src/deploy/gcloud.js
@@ -385,6 +385,9 @@ function describe_instances(params, filter) {
             });
     }).then(function(err, data) {
         var instances = _.flatten(created_instance_data);
+        if (err) {
+            console.warn('got err', err);
+        }
         // also put the regions list as a "secret" property of the array
         return _.filter(instances, function(instance) {
             instance.tags_map = _.mapValues(_.keyBy(instance.metadata.items, 'key'), 'value');
@@ -702,6 +705,9 @@ function init(callback) {
     setTimeout(function() {
         authClient.authorize(function(err, token) {
             console.log('Authenticated!', token);
+            if (err) {
+                console.warn('err', err);
+            }
             callback(token);
         });
     }, 2000);

--- a/src/deploy/gcloud.js
+++ b/src/deploy/gcloud.js
@@ -173,7 +173,7 @@ function get_network_counter() {
         if (cloud_context) {
             return cloud_context.sem.surround(function() {
                 console.log('Current network counter is', cloud_context.counter);
-                cloud_context.counter = cloud_context.counter + 1;
+                cloud_context.counter += 1;
                 return cloud_context.counter;
             });
 

--- a/src/deploy/gcloud.js
+++ b/src/deploy/gcloud.js
@@ -546,7 +546,7 @@ function add_region_instances(region_name, count, is_docker_host, number_of_dock
                                     key: 'startup-script-url',
                                     //production
                                     value: startup_script
-                                        //value: 'https://s3.amazonaws.com/elasticbeanstalk-us-east-1-628038730422/setupgc.sh'
+                                    //value: 'https://s3.amazonaws.com/elasticbeanstalk-us-east-1-628038730422/setupgc.sh'
                                 }, {
                                     key: 'windows-startup-script-url',
                                     value: startup_script
@@ -592,59 +592,58 @@ function add_region_instances(region_name, count, is_docker_host, number_of_dock
                             var instanceName = pieces_array[pieces_array.length - 1];
                             console.log('New instance name:' + JSON.stringify(instanceName));
 
-                            if (true) {
-                                //waiting until the instance is running.
-                                //Disk dependecy can be added only after the instance is up and running.
-                                var interval = setInterval(function() {
-                                    var operationsParams = {
-                                        project: NooBaaProject,
-                                        zone: instanceResource.zone,
-                                        operation: instanceInformation.name,
-                                        auth: authClient,
-                                        instanceName: instanceName
-                                    };
+                            //waiting until the instance is running.
+                            //Disk dependecy can be added only after the instance is up and running.
+                            var interval = setInterval(function() {
+                                var operationsParams = {
+                                    project: NooBaaProject,
+                                    zone: instanceResource.zone,
+                                    operation: instanceInformation.name,
+                                    auth: authClient,
+                                    instanceName: instanceName
+                                };
 
-                                    return P.nfcall(compute.zoneOperations.get, operationsParams)
-                                        .then(function(operationResource) {
-                                            progress_func(operationResource);
+                                return P.nfcall(compute.zoneOperations.get, operationsParams)
+                                    .then(function(operationResource) {
+                                        progress_func(operationResource);
 
-                                            if (operationResource.status === 'DONE') {
-                                                console.log('Instance ' + instanceName + '::: is up and started installation ' + JSON.stringify(operationResource.status));
-                                                var instanceDetailedInformationParams = {
-                                                    instance: operationsParams.instanceName,
-                                                    zone: operationsParams.zone,
-                                                    project: NooBaaProject,
-                                                    auth: authClient,
+                                        if (operationResource.status === 'DONE') {
+                                            console.log('Instance ' + instanceName +
+                                                '::: is up and started installation ' + JSON.stringify(operationResource.status));
+                                            var instanceDetailedInformationParams = {
+                                                instance: operationsParams.instanceName,
+                                                zone: operationsParams.zone,
+                                                project: NooBaaProject,
+                                                auth: authClient,
 
-                                                };
-                                                return P.nfcall(compute.instances.get, instanceDetailedInformationParams)
-                                                    .then(function(instanceDetails) {
-                                                        console.log('instanceDetails up:' + instanceDetails.name);
-                                                        instancesDetails.push(instanceDetails);
-                                                        if (instancesDetails.length === count) {
-                                                            deferred.resolve(instancesDetails);
-                                                        }
-                                                        clearInterval(interval);
-                                                    }).then(null, function(err) {
-                                                        console.log('Instance get details err (2):', err);
-                                                    });
-                                            }
+                                            };
+                                            return P.nfcall(compute.instances.get, instanceDetailedInformationParams)
+                                                .then(function(instanceDetails) {
+                                                    console.log('instanceDetails up:' + instanceDetails.name);
+                                                    instancesDetails.push(instanceDetails);
+                                                    if (instancesDetails.length === count) {
+                                                        deferred.resolve(instancesDetails);
+                                                    }
+                                                    clearInterval(interval);
+                                                })
+                                                .then(null, function(err) {
+                                                    console.log('Instance get details err (2):', err);
+                                                });
+                                        }
 
 
-                                        })
-                                        .catch(function(err) {
-                                            console.log('Zone Operation err(1):', err);
-                                            console.log('Zone Operation err:' + JSON.stringify(err) + JSON.stringify(operationsParams));
-                                            deferred.resolve(null);
-                                            clearInterval(interval);
-                                        });
+                                    })
+                                    .catch(function(err) {
+                                        console.log('Zone Operation err(1):', err);
+                                        console.log('Zone Operation err:' + JSON.stringify(err) + JSON.stringify(operationsParams));
+                                        deferred.resolve(null);
+                                        clearInterval(interval);
+                                    });
 
-                                }, 8000);
-                            }
-                            index++;
+                            }, 8000);
+                            index += 1;
                             return P.delay(1000); // arbitrary async
                         });
-
 
                 });
 

--- a/src/deploy/gcloudFunctions.js
+++ b/src/deploy/gcloudFunctions.js
@@ -54,7 +54,8 @@ class GcloudFunctions {
                     filter: '(name eq ^' + prefix + '.*)(status eq RUNNING)',
                 };
                 return P.nfcall(compute.instances.list, instancesListParams);
-            }).then(instances_list => {
+            })
+            .then(instances_list => {
                 return instances_list.items.length;
             });
     }
@@ -64,7 +65,8 @@ class GcloudFunctions {
             .then(function(list) {
                 let rand = Math.floor(Math.random() * list.length);
                 return list[rand];
-            }).catch(err => {
+            })
+            .catch(err => {
                 console.error('Get random machine failed!', err);
                 throw err;
             });
@@ -125,7 +127,8 @@ class GcloudFunctions {
                 .then(machine_info => {
                     c_state = machine_info.status;
                     console.log('Current state is: ' + c_state + ' waiting for: ' + state + ' - will wait for extra 5 seconds');
-                }).delay(5000);
+                })
+                .delay(5000);
         });
     }
 }

--- a/src/rpc/ice.js
+++ b/src/rpc/ice.js
@@ -608,12 +608,13 @@ Ice.prototype._connect_tcp_active_passive_pair = function(session) {
         }
         session.tcp = net.connect(session.remote.port, session.remote.address);
         session.tcp.on('error', function(err) {
+            dbg.log0('Got error', err);
             session.tcp.destroy();
             setTimeout(try_ap, delay);
             attempts += 1;
         });
         session.tcp.on('connect', function(err) {
-            dbg.log0('ICE TCP AP CONNECTED', session.key, 'took', attempts, 'attempts');
+            dbg.log0('ICE TCP AP CONNECTED', session.key, 'took', attempts, 'attempts', err);
             attempts = MAX_ATTEMPTS;
             if (self.active_session || self.closed || session.is_closed()) {
                 session.tcp.destroy();
@@ -654,6 +655,7 @@ Ice.prototype._connect_tcp_simultaneous_open_pair = function(session) {
         }
         session.tcp = net.connect(so_connect_conf);
         session.tcp.on('error', function(err) {
+            dbg.log0('Got error', err);
             session.tcp.destroy();
             setTimeout(try_so, delay);
             attempts += 1;
@@ -662,7 +664,7 @@ Ice.prototype._connect_tcp_simultaneous_open_pair = function(session) {
             }
         });
         session.tcp.on('connect', function(err) {
-            dbg.log0('ICE TCP SO CONNECTED', session.key, 'took', attempts, 'attempts');
+            dbg.log0('ICE TCP SO CONNECTED', session.key, 'took', attempts, 'attempts', err);
             attempts = MAX_ATTEMPTS;
             if (self.active_session || self.closed || session.is_closed()) {
                 session.tcp.destroy();

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -2,6 +2,8 @@
 'use strict';
 
 var _ = require('lodash');
+var path = require('path');
+var look = require('look');
 var P = require('../util/promise');
 var url = require('url');
 var util = require('util');
@@ -20,7 +22,7 @@ argv.client = argv.client || false;
 argv.server = argv.server || false;
 
 if (!argv.server && !argv.client) {
-    let script_name = require('path').relative(process.cwd(), process.argv[1]);
+    let script_name = path.relative(process.cwd(), process.argv[1]);
     process.stdout.write('Usage: \n');
     process.stdout.write('node ' + script_name + ' --server --addr tcp://server:5656 [--n2n] \n');
     process.stdout.write('node ' + script_name + ' --client --addr tcp://server:5656 [--n2n] \n');
@@ -58,7 +60,7 @@ argv.debug = argv.debug || 0;
 
 // profiling tools
 if (argv.look) {
-    require('look').start();
+    look.start();
 }
 if (argv.leak) {
     memwatch.on('leak', function(info) {

--- a/src/rpc/rpc_n2n.js
+++ b/src/rpc/rpc_n2n.js
@@ -84,6 +84,7 @@ class RpcN2NConnection extends RpcBaseConnection {
     }
 
     _close(err) {
+        dbg.log0('_close', err);
         this.n2n_agent.removeListener('reset_n2n', this.reset_n2n_listener);
         this.ice.close();
     }

--- a/src/rpc/rpc_ntcp_server.js
+++ b/src/rpc/rpc_ntcp_server.js
@@ -22,12 +22,14 @@ class RpcNtcpServer extends EventEmitter {
         let Ntcp = native_core().Ntcp;
         this.server = new Ntcp();
         this.server.on('connection', ntcp => this._on_connection(ntcp));
-        this.server.on('close', err =>
-            this.emit('error', new Error('NTCP SERVER CLOSED')));
+        this.server.on('close', err => {
+                dbg.log0('on close::', err);
+                this.emit('error', new Error('NTCP SERVER CLOSED'));
+            });
         this.server.on('error', err => this.emit('error', err));
     }
 
-    close(err) {
+    close() {
         if (this.closed) return;
         this.closed = true;
         this.emit('close');

--- a/src/rpc/rpc_tcp_server.js
+++ b/src/rpc/rpc_tcp_server.js
@@ -24,12 +24,14 @@ class RpcTcpServer extends EventEmitter {
         this.server = tls_options ?
             tls.createServer(tls_options, tcp_conn => this._on_tcp_conn(tcp_conn)) :
             net.createServer(tcp_conn => this._on_tcp_conn(tcp_conn));
-        this.server.on('close', err =>
-            this.emit('error', new Error('TCP SERVER CLOSED')));
+        this.server.on('close', err => {
+                dbg.log0('on close:', err);
+                this.emit('error', new Error('TCP SERVER CLOSED'));
+        });
         this.server.on('error', err => this.emit('error', err));
     }
 
-    close(err) {
+    close() {
         if (this.closed) return;
         this.closed = true;
         this.emit('close');

--- a/src/rpc/rpc_ws.js
+++ b/src/rpc/rpc_ws.js
@@ -6,7 +6,7 @@ let _ = require('lodash');
 let RpcBaseConnection = require('./rpc_base_conn');
 let buffer_utils = require('../util/buffer_utils');
 let dbg = require('../util/debug_module')(__filename);
-let WS = global.WebSocket || require('ws');
+let WS = global.WebSocket || require('ws'); // eslint-disable-line global-require
 
 let WS_CONNECT_OPTIONS = {
     // accept self signed ssl certificates

--- a/src/rpc/rpc_ws_server.js
+++ b/src/rpc/rpc_ws_server.js
@@ -7,7 +7,7 @@ let url = require('url');
 let EventEmitter = require('events').EventEmitter;
 let RpcWsConnection = require('./rpc_ws');
 let dbg = require('../util/debug_module')(__filename);
-let WS = global.WebSocket || require('ws');
+let WS = global.WebSocket || require('ws'); // eslint-disable-line global-require
 
 
 /**

--- a/src/rpc/stun.js
+++ b/src/rpc/stun.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var _ = require('lodash');
+var util = require('util');
 var P = require('../util/promise');
 var url = require('url');
 // var util = require('util');
@@ -554,7 +555,7 @@ function align_offset(offset) {
  *
  */
 function test() {
-    var argv = require('minimist')(process.argv);
+    var argv = require('minimist')(process.argv); // eslint-disable-line global-require
     var socket = dgram.createSocket('udp4');
     var stun_url = stun.PUBLIC_SERVERS[0];
     if (argv.stun_host) {
@@ -578,7 +579,7 @@ function test() {
                 attr.attr,
                 '0x' + attr.type.toString(16),
                 '[len ' + attr.length + ']',
-                require('util').inspect(attr.value, {
+                util.inspect(attr.value, {
                     depth: null
                 }));
         });

--- a/src/s3/s3rver.js
+++ b/src/s3/s3rver.js
@@ -91,7 +91,7 @@ function run_server() {
                 addr_url.hostname === 'localhost';
             if (is_local_address) {
                 dbg.log0('Initialize S3 RPC with MDServer');
-                const md_server = require('../server/md_server');
+                const md_server = require('../server/md_server'); // eslint-disable-line global-require
                 return md_server.register_rpc();
             } else {
                 dbg.log0('Initialize S3 RPC to address', params.address);

--- a/src/server/bg_services/bucket_storage_fetch.js
+++ b/src/server/bg_services/bucket_storage_fetch.js
@@ -85,8 +85,12 @@ function background_worker() {
                     ((deleted_objects_aggregate[bucket._id] && deleted_objects_aggregate[bucket._id].count) || 0);
                 // If we won't always update the checkpoint, on no changes
                 // We will reduce all of the chunks from last checkpoint (which can be a lot)
-                new_storage_stats.chunks_capacity = (new size_utils.BigInteger(new_storage_stats.chunks_capacity).plus(delta_chunk_compress_size)).toJSON();
-                new_storage_stats.objects_size = (new size_utils.BigInteger(new_storage_stats.objects_size).plus(delta_object_size)).toJSON();
+                new_storage_stats.chunks_capacity = (new size_utils.BigInteger(new_storage_stats.chunks_capacity)
+                    .plus(delta_chunk_compress_size))
+                    .toJSON();
+                new_storage_stats.objects_size = (new size_utils.BigInteger(new_storage_stats.objects_size)
+                    .plus(delta_object_size))
+                    .toJSON();
                 new_storage_stats.objects_count += delta_object_count;
                 dbg.log0('Bucket storage stats after deltas:', new_storage_stats);
                 return {

--- a/src/server/bg_services/cloud_sync.js
+++ b/src/server/bg_services/cloud_sync.js
@@ -270,7 +270,7 @@ function diff_worklists(wl1, wl2, sync_time) {
 
     while (comp(wl1[pos1], wl2[pos2]) === -1 && pos1 < wl1.length) {
         uniq_1.push(wl1[pos1]);
-        pos1++;
+        pos1 += 1;
     }
 
     var res;
@@ -278,33 +278,33 @@ function diff_worklists(wl1, wl2, sync_time) {
         res = comp(wl1[pos1], wl2[pos2]);
         if (res === -1) { //appear in bucket
             uniq_1.push(wl1[pos1]);
-            pos1++;
+            pos1 += 1;
         } else if (res === 1) { //appear in cloud
             uniq_2.push(wl2[pos2]);
-            pos2++;
+            pos2 += 1;
         } else if (res === 2) { //same key, mod time newer in bucket
             uniq_1.push(wl1[pos1]);
-            pos1++;
-            pos2++;
+            pos1 += 1;
+            pos2 += 1;
         } else if (res === -2) { //same key, mod time newer in cloud
             uniq_2.push(wl2[pos2]);
-            pos1++;
-            pos2++;
+            pos1 += 1;
+            pos2 += 1;
         } else { //same key, same mod time
-            pos1++;
-            pos2++;
+            pos1 += 1;
+            pos2 += 1;
         }
     }
 
     //Handle tails
     for (; pos1 < wl1.length; ++pos1) {
         uniq_1.push(wl1[pos1]);
-        pos1++;
+        pos1 += 1;
     }
 
     for (; pos2 < wl2.length; ++pos2) {
         uniq_2.push(wl2[pos2]);
-        pos2++;
+        pos2 += 1;
     }
 
     dbg.log4('diff_arrays recieved wl1 #', wl1.length, 'wl2 #', wl2.length,
@@ -499,7 +499,7 @@ function update_c2n_worklist(policy) {
                                 signatureVersion: 'v4',
                             });
                             return P.ninvoke(policy.s3cloud, 'listObjects', params)
-                                .catch(function(err) {
+                                .catch(function() {
                                     dbg.error('update_c2n_worklist failed to list files from cloud: sys',
                                         policy.system._id, 'bucket', policy.bucket.id, error, error.stack);
                                     throw new Error('update_c2n_worklist failed to list files from cloud');

--- a/src/server/bg_services/cluster_master.js
+++ b/src/server/bg_services/cluster_master.js
@@ -34,7 +34,7 @@ function background_worker() {
         // TODO: Currently checks the replica set master since we don't have shards
         // We always need to send so the webserver will be updated if the
         return MongoCtrl.is_master()
-            .then((is_master) => {
+            .then(is_master => {
                 if (!is_master.ismaster && is_cluster_master) {
                     dbg.log0(`this server was master before, but now is not. remove master workers`);
                     bg_workers.remove_master_workers();
@@ -57,7 +57,7 @@ function background_worker() {
                 cluster_master_retries = 0;
                 return cutil.send_master_update(is_cluster_master, is_master.master_address);
             })
-            .catch((err) => {
+            .catch(err => {
                 if (cluster_master_retries > MAX_RETRIES && is_cluster_master) {
                     dbg.error(`number of retries exceeded ${MAX_RETRIES}. step down as master if was master before`);
                     // step down after MAX_RETRIES

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -33,10 +33,13 @@ function background_worker() {
                             var now = Date.now();
                             //If refresh time
                             if (!lifecycle_rule.last_sync) {
-                                dbg.log0('LIFECYCLE HANDLING bucket:', bucket.name, 'rule id', lifecycle_rule.id, 'status:', lifecycle_rule.status, ' setting yesterday time');
+                                dbg.log0('LIFECYCLE HANDLING bucket:', bucket.name, 'rule id', lifecycle_rule.id,
+                                    'status:', lifecycle_rule.status, ' setting yesterday time');
                                 lifecycle_rule.last_sync = now - 1000 * 60 * 60 * 24; //set yesterday as last sync
                             }
-                            dbg.log0('LIFECYCLE HANDLING bucket:', bucket.name, 'rule id(', i, ')', lifecycle_rule.id, 'status:', lifecycle_rule.status, 'last_sync', Math.floor((now - lifecycle_rule.last_sync) / 1000 / 60), 'min ago.');
+                            dbg.log0('LIFECYCLE HANDLING bucket:', bucket.name, 'rule id(', i, ')', lifecycle_rule.id,
+                                'status:', lifecycle_rule.status, 'last_sync',
+                                    Math.floor((now - lifecycle_rule.last_sync) / 1000 / 60), 'min ago.');
 
                             if ((lifecycle_rule.status === 'Enabled') &&
                                 ((now - lifecycle_rule.last_sync) / 1000 / 60 > LIFECYCLE.schedule_min)) {
@@ -50,19 +53,24 @@ function background_worker() {
                                     };
                                     // Delete objects with create time older than exipration days
                                     if (lifecycle_rule.expiration.days) {
-                                        deletion_params.create_time = moment().subtract(lifecycle_rule.expiration.days, 'minutes').unix();
-                                        dbg.log0('LIFECYCLE DELETING bucket:', bucket.name, 'rule id(', i, ')', lifecycle_rule.id, ' Days:', lifecycle_rule.expiration.days, '==', deletion_params.create_time, '(', moment().subtract(lifecycle_rule.expiration.days, 'min'), ')');
+                                        deletion_params.create_time = moment().subtract(lifecycle_rule.expiration.days, 'minutes')
+                                            .unix();
+                                        dbg.log0('LIFECYCLE DELETING bucket:', bucket.name, 'rule id(', i, ')',
+                                            lifecycle_rule.id, ' Days:', lifecycle_rule.expiration.days, '==', deletion_params.create_time,
+                                                '(', moment().subtract(lifecycle_rule.expiration.days, 'min'), ')');
                                     }
                                     return server_rpc.client.object.delete_multiple_objects_by_prefix(deletion_params).then(function() {
                                         bucket.lifecycle_configuration_rules[i].last_sync = Date.now();
-                                        dbg.log0('LIFECYCLE Done bucket:', bucket.name, ' done deletion of objects per prefix ', lifecycle_rule.prefix, ' time:', bucket.lifecycle_configuration_rules[i].last_sync);
+                                        dbg.log0('LIFECYCLE Done bucket:', bucket.name, ' done deletion of objects per prefix ',
+                                            lifecycle_rule.prefix, ' time:', bucket.lifecycle_configuration_rules[i].last_sync);
                                     });
                                 }
                             } else {
                                 dbg.log0('LIFECYCLE NOTHING bucket:', bucket.name, 'rule id', lifecycle_rule.id, ' nothing to do');
                             }
                         })).then(() => {
-                            dbg.log('LIFECYCLE SYNC TIME bucket ', bucket.name, ' SAVE last sync', bucket.lifecycle_configuration_rules[0].last_sync);
+                            dbg.log('LIFECYCLE SYNC TIME bucket ', bucket.name, ' SAVE last sync',
+                                bucket.lifecycle_configuration_rules[0].last_sync);
                             update_lifecycle_rules_last_sync(bucket, bucket.lifecycle_configuration_rules);
                         });
                     });

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -410,6 +410,7 @@ function _prepare_auth_request(req) {
 
     req.has_bucket_permission = function(bucket, optional_account) {
         let account = optional_account || req.account;
+
         /*if (req.role === 'admin' || account.is_support) {
             return true;
         }*/

--- a/src/server/node_services/node_allocator.js
+++ b/src/server/node_services/node_allocator.js
@@ -117,7 +117,9 @@ function _get_tiering_pools_status(pools) {
  *
  */
 function allocate_node(pools, avoid_nodes, allocated_hosts, content_tiering_params) {
-    let pool_set = _.map(pools, pool => String(pool._id)).sort().join(',');
+    let pool_set = _.map(pools, pool => String(pool._id))
+        .sort()
+        .join(',');
     let alloc_group =
         alloc_group_by_pool_set[pool_set] =
         alloc_group_by_pool_set[pool_set] || {

--- a/src/server/node_services/node_server.js
+++ b/src/server/node_services/node_server.js
@@ -144,4 +144,4 @@ exports.set_debug_node = req => monitor.set_debug_node(req);
 exports.collect_agent_diagnostics = req => monitor.collect_agent_diagnostics(req.rpc_params);
 exports.report_error_on_node_blocks = req => monitor.report_error_on_node_blocks(req.rpc_params);
 exports.sync_monitor_to_store = req => monitor.sync_to_store();
-exports.ping = req => {};
+exports.ping = req => { /*Empty Func*/ };

--- a/src/server/notifications/event_server.js
+++ b/src/server/notifications/event_server.js
@@ -41,9 +41,10 @@ function export_activity_log(req) {
                     let account = entry.actor ? entry.actor.email : '';
                     let entity = entry[entity_type];
                     let description = entry.desc.join(' ');
-                    let entity_name = entity ?
-                        (entity_type === 'obj' ? entity.key : entity.name) :
-                        '';
+                    let entity_name = '';
+                    if (entity) {
+                        entity_name = entity_type === 'obj' ? entity.key : entity.name;
+                    }
 
                     lines.push(`"${time}",${entry.level},${account},${entry.event},${entity_name},"${description}"`);
                     return lines;

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -808,7 +808,8 @@ function read_s3_usage_report(req) {
     if (req.rpc_params.from_time) {
         // query backwards from given time
         req.rpc_params.from_time = new Date(req.rpc_params.from_time);
-        q.where('time').gt(req.rpc_params.from_time).sort('-time');
+        q.where('time').gt(req.rpc_params.from_time)
+            .sort('-time');
     } else {
         // query backward from last time
         q.sort('-time');

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -730,7 +730,8 @@ function validate_create_account_params(req) {
 function generate_access_keys() {
     return {
         access_key: random_string(20),
-        secret_key: crypto.randomBytes(40).toString('base64').slice(0, 40)
+        secret_key: crypto.randomBytes(40).toString('base64')
+            .slice(0, 40)
     };
 }
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -750,6 +750,7 @@ function get_bucket_lifecycle_configuration_rules(req) {
     var bucket = find_bucket(req);
     return bucket.lifecycle_configuration_rules || [];
 }
+
 /**
  *
  * GET_CLOUD_BUCKETS

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -885,7 +885,12 @@ function get_bucket_info(bucket, nodes_aggregate_pool, num_of_objects, cloud_syn
         last_write: last_write
     };
 
-    info.cloud_sync = cloud_sync_policy ? (cloud_sync_policy.status ? cloud_sync_policy : undefined) : undefined;
+    if (cloud_sync_policy) {
+        info.cloud_sync = cloud_sync_policy.status ? cloud_sync_policy : undefined;
+    } else {
+        info.cloud_sync = undefined;
+    }
+
     info.demo_bucket = Boolean(bucket.demo_bucket);
     return info;
 }

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1353,7 +1353,7 @@ function _update_cluster_info(params) {
                     dbg.log0('local cluster info updates successfully');
                     return;
                 })
-                .catch((err) => {
+                .catch(err => {
                     console.error('failed on local cluster info update with', err.message);
                     throw err;
                 });

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1191,9 +1191,9 @@ function _validate_add_member_request(req) {
     //TODO on sharding will also need to add verification to the cfg port
     return promise_utils.exec(`nc -z ${req.rpc_params.address} ${config.MONGO_DEFAULTS.SHARD_SRV_PORT}`)
         .then(() => P.resolve())
-        .catch(err => P.resolve()) //Error in this case still means no FW dropped us on the way
+        .catch(() => P.resolve()) //Error in this case still means no FW dropped us on the way
         .timeout(30 * 1000)
-        .catch(err => {
+        .catch(() => {
             throw new Error(`Could not reach ${req.rpc_params.address}:${config.MONGO_DEFAULTS.SHARD_SRV_PORT},
             might be due to a FW blocking`);
         });

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -82,7 +82,7 @@ function _init() {
                     }
                 }
             })
-            .catch((err) => {
+            .catch(err => {
                 dbg.log('system_server _init', 'UNCAUGHT ERROR', err, err.stack);
                 return promise_utils.delay_unblocking(DEFUALT_DELAY).then(wait_for_system_store);
             })

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -101,6 +101,7 @@ function new_system_defaults(name, owner_account_id) {
         _id: system_store.generate_id(),
         name: name,
         owner: owner_account_id,
+
         /*access_keys: (name === 'demo') ? [{
             access_key: '123',
             secret_key: 'abc',

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -59,7 +59,7 @@ var client_syslog;
 function _init() {
     const DEFUALT_DELAY = 5000;
 
-    var native_core = require('../../util/native_core')();
+    var native_core = require('../../util/native_core')(); // eslint-disable-line global-require
     client_syslog = new native_core.Syslog();
 
     function wait_for_system_store() {

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const util = require('util');
 const mongodb = require('mongodb');
 const EventEmitter = require('events').EventEmitter;
+const system_schema = require('./schemas/system_schema');
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const js_utils = require('../../util/js_utils');
@@ -17,7 +18,7 @@ const mongo_client = require('../../util/mongo_client');
 
 const COLLECTIONS = [{
     name: 'clusters',
-    schema: require('./schemas/cluster_schema'),
+    schema: system_schema,
     mem_indexes: [{
         name: 'cluster_by_server',
         key: 'owner_secret'
@@ -32,7 +33,7 @@ const COLLECTIONS = [{
     }],
 }, {
     name: 'systems',
-    schema: require('./schemas/system_schema'),
+    schema: system_schema,
     mem_indexes: [{
         name: 'systems_by_name',
         key: 'name'
@@ -48,7 +49,7 @@ const COLLECTIONS = [{
     }],
 }, {
     name: 'roles',
-    schema: require('./schemas/role_schema'),
+    schema: system_schema,
     mem_indexes: [{
         name: 'roles_by_account',
         context: 'system',
@@ -65,7 +66,7 @@ const COLLECTIONS = [{
     db_indexes: [],
 }, {
     name: 'accounts',
-    schema: require('./schemas/account_schema'),
+    schema: system_schema,
     mem_indexes: [{
         name: 'accounts_by_email',
         key: 'email'
@@ -81,7 +82,7 @@ const COLLECTIONS = [{
     }],
 }, {
     name: 'buckets',
-    schema: require('./schemas/bucket_schema'),
+    schema: system_schema,
     mem_indexes: [{
         name: 'buckets_by_name',
         context: 'system',
@@ -99,7 +100,7 @@ const COLLECTIONS = [{
     }],
 }, {
     name: 'tieringpolicies',
-    schema: require('./schemas/tiering_policy_schema'),
+    schema: system_schema,
     mem_indexes: [{
         name: 'tiering_policies_by_name',
         context: 'system',
@@ -117,7 +118,7 @@ const COLLECTIONS = [{
     }],
 }, {
     name: 'tiers',
-    schema: require('./schemas/tier_schema'),
+    schema: system_schema,
     mem_indexes: [{
         name: 'tiers_by_name',
         context: 'system',
@@ -135,7 +136,7 @@ const COLLECTIONS = [{
     }],
 }, {
     name: 'pools',
-    schema: require('./schemas/pool_schema'),
+    schema: system_schema,
     mem_indexes: [{
         name: 'pools_by_name',
         context: 'system',

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -45,7 +45,7 @@ function update_host_address(address) {
                 clusters: [current_clustering]
             }
         })
-        .catch((err) => {
+        .catch(err => {
             dbg.log0('Failed updating host address in clustering info');
             throw new Error('Failed updating host address in clustering info', err, err.stack);
         });

--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -19,7 +19,7 @@ module.exports = new MongoCtrl(); // Singleton
 //API
 //
 function MongoCtrl() {
-
+    //Empty Constructor
 }
 
 MongoCtrl.prototype.init = function() {

--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -86,7 +86,7 @@ MongoCtrl.prototype.is_master = function(is_config_set) {
     return mongo_client.instance().get_mongo_rs_status({
             is_config_set: is_config_set,
         })
-        .then((res) => {
+        .then(res => {
             mongo_res = res;
             let topo = cutil.get_topology();
             let res_master = false;
@@ -109,7 +109,7 @@ MongoCtrl.prototype.is_master = function(is_config_set) {
 
 MongoCtrl.prototype.redirect_to_cluster_master = function() {
     return mongo_client.instance().get_mongo_rs_status()
-        .then((mongo_res) => {
+        .then(mongo_res => {
             let res_address;
             _.forEach(mongo_res.members, member => {
                 if (member.stateStr === 'PRIMARY') {

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -165,7 +165,7 @@ app.use(function(req, res, next) {
                 res.status(307);
                 return res.redirect(`http://${host}:8080` + req.originalUrl);
             })
-            .catch(err => {
+            .catch(() => {
                 res.status(500);
             });
     } else {

--- a/src/test/framework/runner.js
+++ b/src/test/framework/runner.js
@@ -25,9 +25,9 @@ function TestRunner(args) {
     this._argv = args;
     this._error = false;
     if (args.FLOW_FILE) {
-        this._steps = require(args.FLOW_FILE);
+        this._steps = require(args.FLOW_FILE); // eslint-disable-line global-require
     } else {
-        this._steps = require(process.cwd() + '/src/test/framework/flow.js');
+        this._steps = require(process.cwd() + '/src/test/framework/flow.js'); // eslint-disable-line global-require
     }
 }
 
@@ -49,14 +49,16 @@ TestRunner.prototype.wait_for_server_to_start = function(max_seconds_to_wait, po
                 return P.ninvoke(request, 'get', {
                     url: 'http://127.0.0.1:' + port,
                     rejectUnauthorized: false,
-                }).then(function() {
+                })
+                .then(function() {
                     console.log('server started after ' + wait_counter + ' seconds');
                     isNotListening = false;
-                }).catch(function(err) {
+                })
+                .catch(function(err) {
                     console.log('waiting for server to start(2)');
                     wait_counter += 1;
                     if (wait_counter >= MAX_RETRIES) {
-                        console.Error('Too many retries after restart server');
+                        console.Error('Too many retries after restart server', err);
                         throw new Error('Too many retries');
                     }
                     return P.delay(1000);
@@ -160,7 +162,7 @@ TestRunner.prototype.complete_run = function() {
             return ops.upload_file('127.0.0.1', dst, 'files', 'report_' + self._version + '.tgz');
         })
         .catch(function(err) {
-            console.log('Failed restarting webserver');
+            console.log('Failed restarting webserver', err);
             throw new Error('Failed restarting webserver');
         });
 };
@@ -176,7 +178,8 @@ TestRunner.prototype.run_tests = function() {
                 .then(function(step_res) {
                     fs.appendFileSync(REPORT_PATH, step_res + '\n');
                     return;
-                }).catch(function(error) {
+                })
+                .catch(function(error) {
                     fs.appendFileSync(REPORT_PATH, 'Stopping tests with error ' + error + ' ' + error.stace + ' ' + error.message);
                     throw new Error(error);
                 });
@@ -235,7 +238,8 @@ TestRunner.prototype._run_current_step = function(current_step, step_res) {
                 return step_res + ' - Successeful common step ( took ' +
                     ((new Date() - ts) / 1000) + 's )';
                 //return step_res;
-            }).catch(function(err) {
+            })
+            .catch(function(err) {
                 console.warn('Failure while running ' + step_res + ' with error ' + err);
                 throw new Error(err);
             });
@@ -296,7 +300,7 @@ TestRunner.prototype._run_lib_test = function(current_step, step_res) {
     var ts = new Date();
     // Used in order to log inside a file instead of console prints
     dbg.set_log_to_file(process.cwd() + COVERAGE_DIR.substring(1) + '/' + path.parse(current_step.lib_test).name);
-    var test = require(process.cwd() + current_step.lib_test);
+    var test = require(process.cwd() + current_step.lib_test); // eslint-disable-line global-require
     return P.resolve(test.run_test())
         .then(function(res) {
             dbg.set_log_to_file();

--- a/src/test/licenses/license_analyzer.js
+++ b/src/test/licenses/license_analyzer.js
@@ -2,6 +2,7 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
+var minimist = require('minimist');
 
 var DETECTABLE_LICENSES;
 var PERMISSIVE_LICENSES_MAP_UPPERCASE;
@@ -18,7 +19,7 @@ module.exports = {
 };
 
 if (require.main === module) {
-    var argv = require('minimist')(process.argv);
+    var argv = minimist(process.argv);
     // run with --debug for debug printouts
     config.debug = argv.debug;
     // run with --comments to add comments on parse errors to the output

--- a/src/test/licenses/license_analyzer.js
+++ b/src/test/licenses/license_analyzer.js
@@ -110,7 +110,7 @@ function read_all_files(dir, names, callback) {
             res[i] = data;
             remain -= 1;
             if (remain === 0) {
-                callback(null, res);
+                return callback(null, res);
             }
         });
     });

--- a/src/test/qa/dataset.js
+++ b/src/test/qa/dataset.js
@@ -66,7 +66,8 @@ promise_utils.pwhile(() => current_size < size_of_ds, () => {
                             .then(function(res) {
                                 console.log("file copying from: " + res.Key);
                                 return s3ops.copy_file_with_md5(server, bucket, res.Key, dataset_name + 'file' + (i++));
-                            }).then(function(res) {
+                            })
+                            .then(function(res) {
                                 console.log("file copied to: " + dataset_name + 'file' + (i));
                                 current_size += rand_size;
                             });

--- a/src/test/qa/gcops.js
+++ b/src/test/qa/gcops.js
@@ -18,7 +18,8 @@ function list_machines(project, authClient, zone, prefix) {
                 filter: 'name eq ^' + prefix + '.*',
             };
             return P.nfcall(compute.instances.list, instancesListParams);
-        }).then(instances_list => {
+        })
+        .then(instances_list => {
             var names_list = [];
             _.each(instances_list.items, function(current_instance) {
                 names_list.push(current_instance.name);
@@ -37,7 +38,8 @@ function count_on_machines(project, authClient, zone, prefix) {
                 filter: '(name eq ^' + prefix + '.*)(status eq RUNNING)',
             };
             return P.nfcall(compute.instances.list, instancesListParams);
-        }).then(instances_list => {
+        })
+        .then(instances_list => {
             console.log(instances_list.items.length);
             return instances_list.items.length;
         });
@@ -48,7 +50,8 @@ function get_random_machine(project, authClient, zone, prefix) {
         .then(function(list) {
             let rand = Math.floor(Math.random() * list.length);
             return list[rand];
-        }).catch(err => {
+        })
+        .catch(err => {
             console.error('Get random machine failed!', err);
             throw err;
         });
@@ -123,7 +126,8 @@ function wait_machine_state(project, authClient, zone, machine, state) {
                     .then(machine_info => {
                         c_state = machine_info.status;
                         console.log('Current state is: ' + c_state + ' waiting for: ' + state + ' - will wait for extra 5 seconds');
-                    }).delay(5000);
+                    })
+                    .delay(5000);
             });
         });
 }

--- a/src/test/qa/s3ops.js
+++ b/src/test/qa/s3ops.js
@@ -95,7 +95,7 @@ function upload_file_with_md5(ip, bucket, file_name, data_size, parts_num) {
 
     var data = crypto.randomBytes(actual_size);
     let md5 = crypto.createHash('md5').update(data)
-    	.digest('hex');
+        .digest('hex');
 
     var start_ts = Date.now();
     var size = Math.ceil(actual_size / parts_num);

--- a/src/test/qa/s3ops.js
+++ b/src/test/qa/s3ops.js
@@ -26,7 +26,8 @@ function put_file_with_md5(ip, bucket, file_name, data_size) {
     var actual_size = data_size * 1024 * 1024;
 
     var data = crypto.randomBytes(actual_size);
-    let md5 = crypto.createHash('md5').update(data).digest('hex');
+    let md5 = crypto.createHash('md5').update(data)
+        .digest('hex');
 
     var params = {
         Bucket: bucket,
@@ -42,7 +43,8 @@ function put_file_with_md5(ip, bucket, file_name, data_size) {
         .then(res => {
             console.log('Upload object took', (Date.now() - start_ts) / 1000, 'seconds');
             return md5;
-        }).catch(err => {
+        })
+        .catch(err => {
             console.error('Put failed!', err);
             throw err;
         });
@@ -70,7 +72,8 @@ function copy_file_with_md5(ip, bucket, source, destination) {
     return P.ninvoke(s3bucket, 'copyObject', params)
         .then(res => {
             console.log('Copy object took', (Date.now() - start_ts) / 1000, 'seconds');
-        }).catch(err => {
+        })
+        .catch(err => {
             console.error('Copy failed!', err);
             throw err;
         });
@@ -91,7 +94,8 @@ function upload_file_with_md5(ip, bucket, file_name, data_size, parts_num) {
     var actual_size = data_size * 1024 * 1024;
 
     var data = crypto.randomBytes(actual_size);
-    let md5 = crypto.createHash('md5').update(data).digest('hex');
+    let md5 = crypto.createHash('md5').update(data)
+        .digest('hex');
 
     console.log('>>> MultiPart UPLOAD - About to multipart upload object...' + file_name);
     var start_ts = Date.now();
@@ -120,7 +124,8 @@ function upload_file_with_md5(ip, bucket, file_name, data_size, parts_num) {
                 });
             }
             return P.all(promises);
-        }).then(() => {
+        })
+        .then(() => {
             console.log('Upload object took', (Date.now() - start_ts) / 1000, 'seconds');
             P.ninvoke(s3bucket, 'completeMultipartUpload', {
                 Key: file_name,
@@ -128,7 +133,8 @@ function upload_file_with_md5(ip, bucket, file_name, data_size, parts_num) {
                 UploadId: uploadID,
             });
             return md5;
-        }).catch(err => {
+        })
+        .catch(err => {
             console.error('Multipart upload failed!', err);
             throw err;
         });
@@ -154,7 +160,8 @@ function get_file_check_md5(ip, bucket, file_name) {
     return P.ninvoke(s3bucket, 'getObject', params)
         .then(res => {
             console.log('Download object took', (Date.now() - start_ts) / 1000, 'seconds');
-            var md5 = crypto.createHash('md5').update(res.Body).digest('hex');
+            var md5 = crypto.createHash('md5').update(res.Body)
+                .digest('hex');
             var file_md5 = res.Metadata.md5;
             if (md5 === file_md5) {
                 console.log("uploaded MD5: " + file_md5 + " and downloaded MD5: " + md5 + " - they are same :)");
@@ -162,7 +169,8 @@ function get_file_check_md5(ip, bucket, file_name) {
                 console.error("uploaded MD5: " + file_md5 + " and downloaded MD5: " + md5 + " - they are different :(");
                 throw new Error('Bad MD5 from download');
             }
-        }).catch(err => {
+        })
+        .catch(err => {
             console.error('Download failed!', err);
             throw err;
         });
@@ -226,7 +234,8 @@ function get_a_random_file(ip, bucket, prefix) {
             }
             let rand = Math.floor(Math.random() * list.length);
             return list[rand];
-        }).catch(err => {
+        })
+        .catch(err => {
             console.error('Get random file failed!', err);
             throw err;
         });
@@ -251,7 +260,8 @@ function get_file_number(ip, bucket, prefix) {
         .then(function(res) {
             let list = res.Contents;
             return list.length;
-        }).catch(err => {
+        })
+        .catch(err => {
             console.error('Get number of files failed!', err);
             throw err;
         });
@@ -278,7 +288,8 @@ function delete_file(ip, bucket, file_name) {
         .then(function() {
             console.log('Delete object took', (Date.now() - start_ts) / 1000, 'seconds');
             console.log('file ' + file_name + ' successfully deleted');
-        }).catch(err => {
+        })
+        .catch(err => {
             console.error('Delete file failed!', err);
             throw err;
         });

--- a/src/test/qa/system_config.js
+++ b/src/test/qa/system_config.js
@@ -103,7 +103,7 @@ P.fcall(function() {
                         retries = 0;
                         final_result = res;
                     })
-                    .catch(err => {
+                    .catch(() => {
                         console.log('waiting for read server config, will retry extra', retries, 'times');
                         return P.delay(10000);
                     });

--- a/src/test/system_tests/basic_server_ops.js
+++ b/src/test/system_tests/basic_server_ops.js
@@ -70,7 +70,7 @@ function upload_and_upgrade(ip, upgrade_pack) {
                         console.log('S3 server started after upgrade');
                         isNotListening = false;
                     }, err => {
-                        console.log('waiting for S3 server to start');
+                        console.log('waiting for S3 server to start', err);
                         return P.delay(10000);
                     });
                 });

--- a/src/test/system_tests/test_ceph_s3.js
+++ b/src/test/system_tests/test_ceph_s3.js
@@ -230,7 +230,7 @@ function s3_ceph_test() {
     var had_errors = false;
     return promise_utils.pwhile(
             function() {
-                i++;
+                i += 1;
                 return i < S3_CEPH_TEST_WHITELIST.length;
             },
             function() {
@@ -241,7 +241,7 @@ function s3_ceph_test() {
                     })
                     .catch((err) => {
                         if (!IGNORE_S3_CEPH_TEST_LIST.contains(S3_CEPH_TEST_WHITELIST[i])) {
-                            fail_count++;
+                            fail_count += 1;
                             had_errors = true;
                         }
                         console.warn('Test Failed:', S3_CEPH_TEST_WHITELIST[i], '\n' + err);
@@ -264,7 +264,7 @@ function system_ceph_test() {
     var had_errors = false;
     return promise_utils.pwhile(
             function() {
-                i++;
+                i += 1;
                 return i < SYSTEM_CEPH_TEST_WHITELIST.length;
             },
             function() {
@@ -295,7 +295,7 @@ function main() {
         .then(function() {
             process.exit(0);
         })
-        .catch(function(err) {
+        .catch(function() {
             process.exit(1);
         });
 }

--- a/src/test/system_tests/test_ceph_s3.js
+++ b/src/test/system_tests/test_ceph_s3.js
@@ -209,12 +209,12 @@ module.exports = {
 function deploy_ceph() {
     var command = `chmod a+x ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_deploy}`;
     return promise_utils.exec(command, false, true)
-        .then((res) => {
+        .then(res => {
             console.log('Starting Deployment Of Ceph Tests...');
             command = `cd ${CEPH_TEST.test_dir};./${CEPH_TEST.ceph_deploy} > /tmp/ceph_deploy.log`;
             return promise_utils.exec(command, false, true);
         })
-        .then((res) => {
+        .then(res => {
             return console.log(res);
         })
         .catch(function(err) {
@@ -239,7 +239,7 @@ function s3_ceph_test() {
                     .then(() => {
                         console.log('Test Passed:', S3_CEPH_TEST_WHITELIST[i]);
                     })
-                    .catch((err) => {
+                    .catch(err => {
                         if (!IGNORE_S3_CEPH_TEST_LIST.contains(S3_CEPH_TEST_WHITELIST[i])) {
                             fail_count += 1;
                             had_errors = true;
@@ -273,9 +273,9 @@ function system_ceph_test() {
                     .then(() => {
                         console.log('Test Passed:', SYSTEM_CEPH_TEST_WHITELIST[i]);
                     })
-                    .catch((err) => {
+                    .catch(err => {
                         had_errors = true;
-                        fail_count++;
+                        fail_count += 1;
                         console.warn('Test Failed:', SYSTEM_CEPH_TEST_WHITELIST[i], '\n' + err);
                     });
             })

--- a/src/test/system_tests/test_cloud_pools.js
+++ b/src/test/system_tests/test_cloud_pools.js
@@ -313,7 +313,7 @@ function main() {
         })
         .then(() => verify_object_parts_on_cloud_nodes(replicas_in_tier, TEST_CTX.source_bucket,
             file_names[1], ['noobaa-internal-agent-' + TEST_CTX.cloud_pool_name]))
-        .then((block_ids) => {
+        .then(block_ids => {
             return verify_object_parts_on_cloud_nodes(replicas_in_tier, TEST_CTX.source_bucket,
                     file_names[2], ['noobaa-internal-agent-' + TEST_CTX.cloud_pool_name])
                 .then(function(second_block_ids) {

--- a/src/test/system_tests/test_cloud_sync.js
+++ b/src/test/system_tests/test_cloud_sync.js
@@ -232,7 +232,7 @@ function main() {
         .then(function() {
             process.exit(0);
         })
-        .catch(function(err) {
+        .catch(function() {
             process.exit(1);
         });
 }

--- a/src/test/system_tests/test_files_spread.js
+++ b/src/test/system_tests/test_files_spread.js
@@ -81,7 +81,7 @@ function run_test() {
             tiering: 'tiering1',
         }))
         .then(() => basic_server_ops.generate_random_file(20))
-        .then((fl) => {
+        .then(fl => {
             fkey = fl;
             return basic_server_ops.upload_file(argv.ip, fkey, 'bucket1', fkey);
         })
@@ -97,7 +97,7 @@ function run_test() {
                 adminfo: true
             });
         })
-        .then((res) => {
+        .then(res => {
             _.each(res.parts, part => {
                 _.each(part.chunk.frags, frag => {
                     if (frag.blocks.length !== 3) {
@@ -112,7 +112,7 @@ function run_test() {
             data_placement: 'MIRROR'
         }))
         .then(() => basic_server_ops.generate_random_file(20))
-        .then((fl) => {
+        .then(fl => {
             fkey = fl;
             return basic_server_ops.upload_file(argv.ip, fkey, 'bucket1', fkey);
         })
@@ -128,7 +128,7 @@ function run_test() {
                 adminfo: true
             });
         })
-        .then((res) => {
+        .then(res => {
             _.each(res.parts, part => {
                 var pool1_count = 0;
                 var pool2_count = 0;

--- a/src/test/system_tests/test_files_spread.js
+++ b/src/test/system_tests/test_files_spread.js
@@ -135,9 +135,9 @@ function run_test() {
                 _.each(part.chunk.frags, frag => {
                     _.each(frag.blocks, block => {
                         if (block.adminfo.pool_name === 'pool1') {
-                            pool1_count++;
+                            pool1_count += 1;
                         } else {
-                            pool2_count++;
+                            pool2_count += 1;
                         }
                     });
                 });
@@ -161,7 +161,7 @@ function main() {
         .then(function() {
             process.exit(0);
         })
-        .catch(function(err) {
+        .catch(function() {
             process.exit(1);
         });
 }

--- a/src/test/system_tests/test_files_ul.js
+++ b/src/test/system_tests/test_files_ul.js
@@ -57,7 +57,7 @@ function pre_generation() {
                     return i < dirs;
                 },
                 function() {
-                    ++i;
+                    i += 1;
                     return promise_utils.exec('mkdir -p ' + UL_TEST.base_dir + '/dir' + i);
                 });
         })
@@ -73,7 +73,7 @@ function pre_generation() {
                     return d < dirs;
                 },
                 function() {
-                    ++d;
+                    d += 1;
                     var files = (d === dirs) ? UL_TEST.num_files % UL_TEST.files_per_dir : UL_TEST.files_per_dir;
                     console.log(' generating batch', d, 'of', files, 'files');
                     for (var i = 1; i <= files; ++i) {
@@ -124,7 +124,7 @@ function upload_file(test_file) {
                 .then(function(res) {
                     console.log('Done uploading', test_file);
                     //TODO:: Add histogram as well
-                    UL_TEST.measurement.points++;
+                    UL_TEST.measurement.points += 1;
                     UL_TEST.measurement.time += (Date.now() - start_ts) / 1000;
 
                     if (UL_TEST.measurement.points === 1000) { //Save mid results per each 1K files
@@ -140,7 +140,7 @@ function upload_file(test_file) {
         })
         .then(null, function(err) {
             console.error('Error in upload_file', err);
-            ++UL_TEST.total_ul_errors;
+            UL_TEST.total_ul_errors += 1;
             if (UL_TEST.total_ul_errors > UL_TEST.num_files * 0.1) {
                 throw new Error('Failed uploading ' + UL_TEST.total_ul_errors + ' files');
             }
@@ -162,7 +162,7 @@ function print_summary() {
     var i = 0;
     _.each(UL_TEST.measurement.mid, function(m) {
         console.log('  for files', (i * 1000) + 1, 'to', (i + 1) * 1000, 'avg ul time', m);
-        ++i;
+        i += 1;
     });
     console.log('  for files', (i * 1000) + 1, 'to', (i + 1) * 1000 + UL_TEST.measurement.points, 'avg ul time',
         UL_TEST.measurement.time / UL_TEST.measurement.points);
@@ -238,7 +238,7 @@ function main() {
             console.log('Finished running upload test');
             return;
         })
-        .catch(function(err) {
+        .catch(function() {
             if (!UL_TEST.skip_cleanup) {
                 return promise_utils.exec('rm -rf /tmp/' + UL_TEST.base_dir);
             }

--- a/src/test/system_tests/test_node_failure.js
+++ b/src/test/system_tests/test_node_failure.js
@@ -163,7 +163,9 @@ function validate_mappings() {
         }
         let num_online = 0;
         _.each(part.blocks, block => {
-            if (block.online) num_online++;
+            if (block.online) {
+                num_online += 1;
+            }
         });
         if (num_online < 3) {
             console.log('not enough online replicas, wait and retry');
@@ -210,7 +212,7 @@ function main() {
         .then(function() {
             process.exit(0);
         })
-        .catch(function(err) {
+        .catch(function() {
             process.exit(1);
         });
 }

--- a/src/test/system_tests/test_s3_authentication.js
+++ b/src/test/system_tests/test_s3_authentication.js
@@ -55,7 +55,7 @@ function test_s3_connection() {
             return P.ninvoke(s3, "listBuckets");
         })
         .then(() => true,
-            (error) => {
+            error => {
                 console.warn('Failed with', error, error.stack);
                 throw new Error(error);
             }
@@ -104,8 +104,8 @@ function getSignedUrl(bucket, obj, expiry) {
             });
         })
         .delay(1000)
-        .then((url) => url,
-            (error) => {
+        .then(url => url,
+            error => {
                 console.warn('Failed with', error, error.stack);
                 throw new Error(error);
             }
@@ -115,7 +115,7 @@ function getSignedUrl(bucket, obj, expiry) {
 function httpGetAsPromise(url) {
     console.log('TEST SIGNED_URL: ', url);
     return new P(function(resolve, reject) {
-        return http.get(url, (res) => {
+        return http.get(url, res => {
             if (res.statusCode >= 400) {
                 reject(({
                     url: url,
@@ -326,7 +326,7 @@ function run_test() {
     let signed_url;
     return authenticate().then(() => test_s3_connection())
         .then(() => basic_server_ops.generate_random_file(file_sizes[0]))
-        .then((fl) => {
+        .then(fl => {
             fkey = fl;
             return basic_server_ops.upload_file(TEST_PARAMS.ip, fkey, 'files', file_names[0]);
         })
@@ -336,14 +336,14 @@ function run_test() {
         .then(() => get_object('files', file_names[0]))
         .delay(1000)
         .then(() => getSignedUrl('files', file_names[0]))
-        .then((url) => {
+        .then(url => {
             signed_url = url;
             return httpGetAsPromise(url);
         })
         .delay(1000)
         .then(() => create_bucket('s3testbucket'))
         .then(() => basic_server_ops.generate_random_file(file_sizes[1]))
-        .then((fl) => {
+        .then(fl => {
             fkey = fl;
             return basic_server_ops.upload_file(TEST_PARAMS.ip, fkey, 's3testbucket', file_names[1]);
         })
@@ -353,14 +353,14 @@ function run_test() {
         .then(() => get_object('s3testbucket', file_names[1]))
         .delay(1000)
         .then(() => getSignedUrl('s3testbucket', file_names[1]))
-        .then((url) => {
+        .then(url => {
             signed_url = url;
             return httpGetAsPromise(url);
         })
         .delay(1000)
         .then(() => create_folder('s3testbucket', 's3folder'))
         .then(() => basic_server_ops.generate_random_file(file_sizes[2]))
-        .then((fl) => {
+        .then(fl => {
             fkey = fl;
             return basic_server_ops.upload_file(TEST_PARAMS.ip, fkey, 's3testbucket', 's3folder/' + file_names[2]);
         })
@@ -370,13 +370,13 @@ function run_test() {
         .then(() => get_object('s3testbucket', 's3folder/' + file_names[2]))
         .delay(1000)
         .then(() => getSignedUrl('s3testbucket', 's3folder/' + file_names[2]))
-        .then((url) => {
+        .then(url => {
             signed_url = url;
             return httpGetAsPromise(url);
         })
         .delay(1000)
         .then(() => getSignedUrl('s3testbucket', 's3folder/' + file_names[2], 1))
-        .then((url) => {
+        .then(url => {
             signed_url = url;
             return httpGetAsPromise(url);
         })

--- a/src/test/system_tests/test_s3_authentication.js
+++ b/src/test/system_tests/test_s3_authentication.js
@@ -314,7 +314,7 @@ function main() {
         .then(function() {
             process.exit(0);
         })
-        .catch(function(err) {
+        .catch(function() {
             process.exit(1);
         });
 }

--- a/src/test/system_tests/test_upgrade_ec2.js
+++ b/src/test/system_tests/test_upgrade_ec2.js
@@ -142,7 +142,7 @@ function main() {
                                 }).spread(function(res, body) {
                                     console.log('server started');
                                     isNotListening = false;
-                                }, function(err) {
+                                }, function() {
                                     console.log('waiting for server to start');
                                     return P.delay(10000);
                                 });

--- a/src/test/unit_tests/test_agent.js
+++ b/src/test/unit_tests/test_agent.js
@@ -35,7 +35,7 @@ mocha.describe('agent', function() {
             .then(() => coretest.init_test_nodes(client, SYS, 5))
             .delay(2000)
             .then(() => coretest.clear_test_nodes())
-            .catch((err) => {
+            .catch(err => {
                 console.log('Failure during testing agent:' + err, err.stack);
             });
     });

--- a/src/test/unit_tests/test_job_queue.js
+++ b/src/test/unit_tests/test_job_queue.js
@@ -143,7 +143,7 @@ function assert_callback(condition, callback, message) {
     /* istanbul ignore if */
     if (!condition) {
         message = message || 'assertion failed (no message)';
-        callback(message);
+        callback(message); // eslint-disable-line callback-return
         throw new Error(message);
     }
 }

--- a/src/test/unit_tests/test_job_queue.js
+++ b/src/test/unit_tests/test_job_queue.js
@@ -140,6 +140,7 @@ mocha.describe('job_queue', function() {
 });
 
 function assert_callback(condition, callback, message) {
+
     /* istanbul ignore if */
     if (!condition) {
         message = message || 'assertion failed (no message)';

--- a/src/test/unit_tests/test_keys_lock.js
+++ b/src/test/unit_tests/test_keys_lock.js
@@ -81,7 +81,7 @@ mocha.describe('keys_lock', function() {
                 kl = new KeysLock();
                 assert.strictEqual(kl.length, 0);
 
-                P.resolve(kl.surround_keys(['key1'], () => {}));
+                P.resolve(kl.surround_keys(['key1'], () => { /* Empty Func */ }));
                 assert.strictEqual(kl.length, 0);
 
                 P.resolve(kl.surround_keys(['key2'], do_wake_first));

--- a/src/test/unit_tests/test_rpc.js
+++ b/src/test/unit_tests/test_rpc.js
@@ -201,11 +201,11 @@ mocha.describe('RPC', function() {
 
         mocha.it('should work on mock server', function() {
             var server = {
-                get: function() {},
-                put: function() {},
-                post: function() {},
-                delete: function() {},
-                use: function() {},
+                get: function() { /* Empty Func */ },
+                put: function() { /* Empty Func */ },
+                post: function() { /* Empty Func */ },
+                delete: function() { /* Empty Func */ },
+                use: function() { /* Empty Func */ },
             };
             rpc.register_service(test_api, server);
         });

--- a/src/test/unrelated/measure_bind_perf.js
+++ b/src/test/unrelated/measure_bind_perf.js
@@ -15,7 +15,8 @@ Clazz.prototype.measure = function() {
     var start = Date.now();
     var now = Date.now();
     var count = 0;
-    while (true) {
+    var run = true;
+    while (run) {
         for (var i = 0; i < 100000; ++i) {
             if (self.func() !== self) {
                 throw new Error('HUH');
@@ -26,7 +27,7 @@ Clazz.prototype.measure = function() {
         now = Date.now();
         if (now - start > 2000) {
             process.stdout.write('\n');
-            break;
+            run = false;
         }
     }
     console.log('Calls per second', (count * 1000 / (now - start)).toFixed(1));

--- a/src/test/unrelated/measure_bind_perf.js
+++ b/src/test/unrelated/measure_bind_perf.js
@@ -4,7 +4,7 @@
 var _ = require('lodash');
 var js_utils = require('../util/js_utils');
 
-function Clazz() {}
+function Clazz() { /* Clazz? */ }
 
 Clazz.prototype.func = function() {
     return this;

--- a/src/test/unrelated/spawn_lsof_issue_with_cluster.js
+++ b/src/test/unrelated/spawn_lsof_issue_with_cluster.js
@@ -23,7 +23,7 @@ if (cluster.isMaster) {
 
 } else {
     show_spawn_fds('WORKER');
-    setInterval(function() {}, 10000);
+    setInterval(function() { /* Empty Func */ }, 10000);
 }
 
 function show_spawn_fds(who) {

--- a/src/test/unrelated/tcp_simultaneous_open.js
+++ b/src/test/unrelated/tcp_simultaneous_open.js
@@ -32,7 +32,7 @@ function tcp_simultaneous_open(local_port, remote_port, attempts) {
         if (attempts < 1000) {
             setTimeout(tcp_simultaneous_open, delay, local_port, remote_port, attempts);
         } else {
-            console.log('PEW EXHAUSTED');
+            console.log('PEW EXHAUSTED', err);
         }
     });
     conn.on('data', function(data) {
@@ -73,7 +73,8 @@ function get_seq_buffer(buffer) {
 }
 
 function on_readable(conn, is_server) {
-    while (true) {
+    var run = true;
+    while (run) {
         var buffer = conn.read(4);
         if (!buffer) return;
         var seq = get_seq_buffer(buffer);
@@ -84,7 +85,10 @@ function on_readable(conn, is_server) {
         if (seq <= 100) {
             conn.write(new_seq_buffer(seq + 1));
         }
-        if (seq >= 100) return;
+        if (seq >= 100) {
+            run = false;
+            return;
+        }
     }
 
     function do_upgrade() {

--- a/src/tools/http_speed.js
+++ b/src/tools/http_speed.js
@@ -103,7 +103,7 @@ function run_sender(port, host, ssl) {
                 process.exit();
             }
             send_speedometer.update(buf.length);
-            res.on('data', () => {});
+            res.on('data', () => { /* Empty Func */ });
             res.on('end', send);
         });
         req.on('error', err => {

--- a/src/tools/nbcat.js
+++ b/src/tools/nbcat.js
@@ -20,7 +20,8 @@ var object_io = new ObjectIO();
 if (!bkt) {
     init_api().then(function() {
         return client.bucket.list_buckets();
-    }).then(function(res) {
+    })
+    .then(function(res) {
         output.write('\nLIST BUCKETS:\n\n');
         res.buckets.forEach(function(bucket) {
             output.write('    ' +
@@ -35,7 +36,8 @@ if (!bkt) {
         return client.object.list_objects({
             bucket: bkt
         });
-    }).then(function(res) {
+    })
+    .then(function(res) {
         output.write('\nLIST OBJECTS:\n\n');
         res.objects.forEach(function(obj) {
             output.write('    ' +

--- a/src/tools/tcp_speed.js
+++ b/src/tools/tcp_speed.js
@@ -146,24 +146,32 @@ function run_sender(conn, send_speedometer) {
 function run_receiver(conn, recv_speedometer) {
     if (!argv.noframe) {
         let hdr;
+        let run = true;
         conn.on('readable', () => {
-            while (true) {
+            while (run) {
                 if (!hdr) {
                     hdr = conn.read(4);
                     if (!hdr) break;
                 }
                 let len = hdr.readUInt32BE(0);
                 let data = conn.read(len);
-                if (!data) break;
+                if (!data) {
+                    run = false;
+                    break;
+                }
                 hdr = null;
                 recv_speedometer.update(data.length);
             }
         });
     } else {
         conn.on('readable', () => {
-            while (true) {
+            let run = true;
+            while (run) {
                 let data = conn.read();
-                if (!data) break;
+                if (!data) {
+                    run = false;
+                    break;
+                }
                 recv_speedometer.update(data.length);
             }
         });

--- a/src/util/chunk_stream.js
+++ b/src/util/chunk_stream.js
@@ -49,7 +49,7 @@ class ChunkStream extends stream.Transform {
             this.pending_bytes = 0;
         }
         if (callback) {
-            callback();
+            return callback();
         }
     }
 }

--- a/src/util/coalesce_stream.js
+++ b/src/util/coalesce_stream.js
@@ -74,6 +74,6 @@ CoalesceStream.prototype._flush = function(callback) {
 
     // done
     if (callback) {
-        callback();
+        return callback();
     }
 };

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -205,11 +205,13 @@ function InternalDebugLogger() {
                 formatter: function(options) {
                     //prefix - time, level, module & pid
                     var proc = '[' + self._proc_name + '/' + self._pid + ']';
+                    var formatted_level = ' \x1B[31m[';
+                    if (self._levels[options.level]) {
+                        formatted_level = self._levels[options.level] === 1 ? ' \x1B[33m[' : ' \x1B[36m[';
+                    }
                     var prefix = '\x1B[32m' + formatted_time() +
                         '\x1B[35m ' + proc +
-                        ((self._levels[options.level] === 0) ?
-                            ' \x1B[31m[' :
-                            ((self._levels[options.level] === 1) ? ' \x1B[33m[' : ' \x1B[36m[')) +
+                        formatted_level +
                         options.level + ']\x1B[39m ';
                     //message - one liner for file transport
                     var message = (options.message !== undefined ? (options.message.replace(/(\r\n|\n|\r)/gm, "")) : '');
@@ -225,11 +227,13 @@ function InternalDebugLogger() {
                 showLevel: false,
                 formatter: function(options) {
                     var proc = '[' + self._proc_name + '/' + self._pid + ']';
+                    var formatted_level = ' \x1B[31m[';
+                    if (self._levels[options.level]) {
+                        formatted_level = self._levels[options.level] === 1 ? ' \x1B[33m[' : ' \x1B[36m[';
+                    }
                     return '\x1B[32m' + formatted_time() +
                         '\x1B[35m ' + proc +
-                        ((self._levels[options.level] === 0) ?
-                            ' \x1B[31m[' :
-                            ((self._levels[options.level] === 1) ? ' \x1B[33m[' : ' \x1B[36m[')) +
+                        formatted_level +
                         options.level + ']\x1B[39m ' +
                         (undefined !== options.message ? options.message : '') +
                         (options.meta && Object.keys(options.meta).length ?
@@ -343,12 +347,13 @@ InternalDebugLogger.prototype.syslog_formatter = function(level, args) {
     if (args.length > 2) {
         msg = util.format.apply(msg, Array.prototype.slice.call(args, 1));
     }
-    let level_str = ((self._levels[level] === 0) ?
-            ' \x1B[31m[' :
-            ((self._levels[level] === 1) ? ' \x1B[33m[' : ' \x1B[36m[')) +
-        level + ']\x1B[39m ';
+    let formmated_level = ' \x1B[31m[';
+    if (self._levels[level]) {
+        formmated_level = self._levels[level] === 1 ? ' \x1B[33m[' : ' \x1B[36m[';
+    }
+    let level_str = formmated_level + level + ']\x1B[39m ';
 
-    var proc = '[' + self._proc_name + '/' + self._pid + ']';
+    let proc = '[' + self._proc_name + '/' + self._pid + ']';
     let prefix = '\x1B[32m' + formatted_time() +
         '\x1B[35m ' + proc;
 
@@ -384,11 +389,13 @@ InternalDebugLogger.prototype.log_internal = function(level) {
                         formatter: function(options) {
                             //prefix - time, level, module & pid
                             var proc = '[' + self._proc_name + '/' + self._pid + ']';
+                            var formatted_level = ' \x1B[31m[';
+                            if (self._levels[options.level]) {
+                                formatted_level = self._levels[options.level] === 1 ? ' \x1B[33m[' : ' \x1B[36m[';
+                            }
                             var prefix = '\x1B[32m' + formatted_time() +
                                 '\x1B[35m ' + proc +
-                                ((self._levels[options.level] === 0) ?
-                                    ' \x1B[31m[' :
-                                    ((self._levels[options.level] === 1) ? ' \x1B[33m[' : ' \x1B[36m[')) +
+                                formatted_level +
                                 options.level + ']\x1B[39m ';
                             //message - one liner for file transport
                             var message = (options.message !== undefined ? (options.message.replace(/(\r\n|\n|\r)/gm, "")) : '');

--- a/src/util/dotenv.js
+++ b/src/util/dotenv.js
@@ -87,33 +87,34 @@ module.exports = {
         var idx = 0;
 
         // convert Buffers before splitting into lines and processing
-        src.toString().split('\n').forEach(function(line) {
-            // matching "KEY' and 'VAL' in 'KEY=VAL'
-            var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
-            // matched?
-            if (keyValueArr !== null) {
-                var key = keyValueArr[1];
+        src.toString().split('\n')
+            .forEach(function(line) {
+                // matching "KEY' and 'VAL' in 'KEY=VAL'
+                var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
+                // matched?
+                if (keyValueArr !== null) {
+                    var key = keyValueArr[1];
 
-                // default undefined or missing values to empty string
-                var value = keyValueArr[2] ? keyValueArr[2] : '';
+                    // default undefined or missing values to empty string
+                    var value = keyValueArr[2] ? keyValueArr[2] : '';
 
-                // expand newlines in quoted values
-                var len = value ? value.length : 0;
-                if (len > 0 && value.charAt(0) === '"' && value.charAt(len - 1) === '"') {
-                    value = value.replace(/\\n/gm, '\n');
+                    // expand newlines in quoted values
+                    var len = value ? value.length : 0;
+                    if (len > 0 && value.charAt(0) === '"' && value.charAt(len - 1) === '"') {
+                        value = value.replace(/\\n/gm, '\n');
+                    }
+
+                    // remove any surrounding quotes and extra spaces
+                    value = value.replace(/(^['"]|['"]$)/g, '').trim();
+
+                    obj[key] = value;
+                } else {
+                    DROPPED_LINES.INDICES.push(idx);
+                    DROPPED_LINES.LINES.push(line);
+                    // console.warn('line', line);
                 }
-
-                // remove any surrounding quotes and extra spaces
-                value = value.replace(/(^['"]|['"]$)/g, '').trim();
-
-                obj[key] = value;
-            } else {
-                DROPPED_LINES.INDICES.push(idx);
-                DROPPED_LINES.LINES.push(line);
-                // console.warn('line', line);
-            }
-            ++idx;
-        });
+                idx += 1;
+            });
 
         return obj;
     },
@@ -160,24 +161,25 @@ module.exports = {
         var found = false;
 
         // convert Buffers before splitting into lines and processing
-        src.toString().split('\n').forEach(function(line) {
-            // matching "KEY' and 'VAL' in 'KEY=VAL'
-            var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
-            // matched?
-            if (keyValueArr !== null) {
-                var key = keyValueArr[1];
-                var value;
-                if (key === newVal.key) {
-                    value = newVal.value;
-                    found = true;
-                } else {
-                    // default undefined or missing values to empty string
-                    value = keyValueArr[2] ? keyValueArr[2] : '';
-                }
+        src.toString().split('\n')
+            .forEach(function(line) {
+                // matching "KEY' and 'VAL' in 'KEY=VAL'
+                var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
+                // matched?
+                if (keyValueArr !== null) {
+                    var key = keyValueArr[1];
+                    var value;
+                    if (key === newVal.key) {
+                        value = newVal.value;
+                        found = true;
+                    } else {
+                        // default undefined or missing values to empty string
+                        value = keyValueArr[2] ? keyValueArr[2] : '';
+                    }
 
-                obj[key] = value;
-            }
-        });
+                    obj[key] = value;
+                }
+            });
 
         if (!found) {
             obj[newVal.key] = newVal.value;

--- a/src/util/dotenv.js
+++ b/src/util/dotenv.js
@@ -35,6 +35,7 @@ var DROPPED_LINES = {
 };
 
 module.exports = {
+
     /*
      * Main entry point into dotenv. Allows configuration before loading .env
      * @param {Object} options - valid options: path ('.env'), encoding ('utf8')

--- a/src/util/frame_stream.js
+++ b/src/util/frame_stream.js
@@ -76,8 +76,8 @@ FrameStream.prototype.send_message = function(buffer_or_buffers, message_type_co
 };
 
 FrameStream.prototype._on_readable = function() {
-    while (true) {
-
+    var run = true;
+    while (run) {
         // read the message header if not already read
         if (!this._msg_header) {
 
@@ -86,13 +86,17 @@ FrameStream.prototype._on_readable = function() {
             // and not extract any bytes, so will be kept in the buffer for next
             // 'readable' event.
             this._msg_header = this.stream.read(this._header_len);
-            if (!this._msg_header) return;
+            if (!this._msg_header) {
+                run = false;
+                return;
+            }
 
             // verify the magic
             var magic = this._msg_header.slice(0, this._magic_len).toString();
             if (magic !== this._magic) {
                 this.stream.emit('error', new Error('received magic mismatch ' +
                     magic + ' expected ' + this._magic));
+                run = false;
                 return;
             }
 
@@ -110,6 +114,7 @@ FrameStream.prototype._on_readable = function() {
                 } else {
                     this.stream.emit('error', new Error('received seq mismatch ' +
                         seq + ' expected ' + (this._recv_seq + 1)));
+                    run = false;
                     return;
                 }
             }
@@ -122,13 +127,17 @@ FrameStream.prototype._on_readable = function() {
         if (msg_len > this._max_len) {
             this.stream.emit('error', new Error('received message too big ' +
                 msg_len + ' expected up to ' + this._max_len));
+            run = false;
             return;
         }
 
         // try to get the entire message from the stream buffer
         // if not available, will wait for next 'readable' event
         var msg = this.stream.read(msg_len);
-        if (!msg) return;
+        if (!msg) {
+            run = false;
+            return;
+        }
 
         // got a complete message, remove the previous header and emit
         var msg_type = this._msg_header.readUInt16BE(this._magic_len + 2);

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -253,13 +253,13 @@ class MongoClient extends EventEmitter {
             replSetReconfig: rep_config
         };
         return P.resolve(this.get_rs_version(is_config_set))
-            .then((ver) => {
+            .then(ver => {
                 ver += 1;
                 rep_config.version = ver;
                 dbg.log0('Calling replica_update_members', util.inspect(command, false, null));
                 if (!is_config_set) { //connect the mongod server
                     return P.resolve(this.db.admin().command(command))
-                        .catch((err) => {
+                        .catch(err => {
                             dbg.error('Failed replica_update_members', set, members, 'with', err.message);
                             throw err;
                         });
@@ -337,7 +337,7 @@ class MongoClient extends EventEmitter {
         return P.fcall(function() {
                 if (!is_config_set) { //connect the mongod server
                     return P.resolve(self.db.admin().command(command))
-                        .catch((err) => {
+                        .catch(err => {
                             dbg.error('Failed get_rs_version with', err.message);
                             throw err;
                         });
@@ -345,7 +345,7 @@ class MongoClient extends EventEmitter {
                     return P.resolve(self._send_command_config_rs(command));
                 }
             })
-            .then((res) => {
+            .then(res => {
                 dbg.log0('Recieved replSetConfig', res, 'Returning RS version', res.config.version);
                 return res.config.version;
             });

--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -123,4 +123,4 @@ function reduce_sum(key, values) {
     } : n;
 }
 
-function reduce_noop() {}
+function reduce_noop() { /* Empty Func */ }

--- a/src/util/native_core.js
+++ b/src/util/native_core.js
@@ -10,7 +10,7 @@ var native_core;
 function lazy_init_native_core(dont_fail) {
     if (!native_core) {
         try {
-            native_core = require('bindings')('native_core.node');
+            native_core = require('bindings')('native_core.node'); // eslint-disable-line global-require
 
             // see https://github.com/bnoordhuis/node-event-emitter
             inherits(native_core.Nudp, events.EventEmitter);

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -139,7 +139,8 @@ function get_disk_mount_points() {
 
             if (os.type() === 'Windows_NT') {
                 _.each(hds, function(hd_info) {
-                    if (process.cwd().toLowerCase().indexOf(hd_info.drive_id.toLowerCase()) === 0) {
+                    if (process.cwd().toLowerCase()
+                        .indexOf(hd_info.drive_id.toLowerCase()) === 0) {
                         hd_info.mount = '.\\agent_storage\\';
                         mount_points.push(hd_info);
                     } else {
@@ -258,7 +259,8 @@ function read_windows_drives() {
                 if (vol.Label.indexOf('Temporary Storage') === 0) return;
                 return windows_volume_to_drive(vol);
             }));
-        }).then(function(local_volumes) {
+        })
+        .then(function(local_volumes) {
             windows_drives = local_volumes;
             return wmic('netuse')
                 .then(function(network_volumes) {
@@ -397,7 +399,8 @@ function get_ntp() {
 
 function set_ntp(server, timez) {
     if (os.type() === 'Linux') {
-        var command = "sed -i 's/.*NooBaa Configured NTP Server.*/server " + server + " iburst #NooBaa Configured NTP Server/' /etc/ntp.conf";
+        var command = "sed -i 's/.*NooBaa Configured NTP Server.*/server " + server +
+            " iburst #NooBaa Configured NTP Server/' /etc/ntp.conf";
         return _set_time_zone(timez)
             .then(() => promise_utils.exec(command))
             .then(() => promise_utils.exec('/sbin/chkconfig ntpd on 2345'))
@@ -479,7 +482,8 @@ function get_time_config() {
                     reply.timezone = '';
                 } else {
                     var symlink = tzone.split('>')[1].split('/usr/share/zoneinfo/')[1].trim();
-                    reply.srv_time = moment().tz(symlink).format();
+                    reply.srv_time = moment().tz(symlink)
+                        .format();
                     reply.timezone = symlink;
                 }
                 return reply;
@@ -489,7 +493,8 @@ function get_time_config() {
         return promise_utils.exec('ls -l /etc/localtime', false, true)
             .then(tzone => {
                 var symlink = tzone.split('>')[1].split('/usr/share/zoneinfo/')[1].trim();
-                reply.srv_time = moment().tz(symlink).format();
+                reply.srv_time = moment().tz(symlink)
+                    .format();
                 reply.timezone = symlink;
                 return reply;
             });

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -231,7 +231,7 @@ function read_mac_linux_drives(include_all) {
         .then(volumes => P.all(_.map(volumes, function(vol) {
                 return fs_utils.file_must_not_exist(vol.mount + '/' + AZURE_TMP_DISK_README)
                     .then(() => linux_volume_to_drive(vol))
-                    .catch(err => {
+                    .catch(() => {
                         dbg.log0('Skipping drive', vol, 'Azure tmp disk indicated');
                         return;
                     });

--- a/src/util/prefetch.js
+++ b/src/util/prefetch.js
@@ -38,7 +38,7 @@ function Prefetch(options) {
         get: function() {
             return self._length;
         },
-        set: function(value) {}
+        set: function(value) { /* Empty Func */ }
     });
 }
 

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -81,7 +81,7 @@ P.hijackQ = function hijackQ() {
         // the reason we define the module name as a variable
         // is to avoid browserify loading it to the bundle
         const q_module_name = 'q';
-        const Q = require(q_module_name);
+        const Q = require(q_module_name); // eslint-disable-line global-require
         _.forIn(P, function(key, val) {
             Q[key] = val;
         });

--- a/src/util/time_utils.js
+++ b/src/util/time_utils.js
@@ -35,7 +35,8 @@ function sectook(since) {
 
 function time_suffix() {
     var d = new Date();
-    return d.toISOString().replace(/T/, '-').substr(5, 11);
+    return d.toISOString().replace(/T/, '-')
+        .substr(5, 11);
 }
 
 //UTC is RFC822 + full year presentation (4 digits).
@@ -44,5 +45,6 @@ function time_suffix() {
 function toRFC822(in_date) {
     return in_date.toUTCString().replace(
         ' ' + in_date.getFullYear() + ' ',
-        ' ' + (in_date.getFullYear().toString()).substr(2) + ' ');
+        ' ' + (in_date.getFullYear().toString())
+            .substr(2) + ' ');
 }


### PR DESCRIPTION
### Purpose
- Clear the code of certain eslint warning and turn them to errors:

callback-return, no-nested-ternary, operator-assignment, lines-around-comment, no-constant-condition, no-empty-function, newline-per-chained-call, global-require, handle-callback-err, arrow-parens

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:


