### PR TITLE
fix possible long run time of mongo_upgrade:upgrade_object_mds

### DIFF
--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -450,6 +450,9 @@ function upgrade_object_mds() {
     db.objectmds.find({
         upload_size: {
             $exists: true
+        },
+        upload_started: {
+            $exists: false
         }
     }).forEach(function(obj) {
         db.objectmds.update({


### PR DESCRIPTION
### Purpose
- in mongo_upgrade:upgrade_object_mds - find only object_mds without
upload_started

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json: