### PR TITLE
Nimrod Allow creation of both HTTPS and HTTP external connections

### DIFF
--- a/frontend/src/app/components/shared/add-cloud-connection-modal/add-cloud-connection-modal.html
+++ b/frontend/src/app/components/shared/add-cloud-connection-modal/add-cloud-connection-modal.html
@@ -16,7 +16,7 @@
         </editor>
 
         <editor params="label: 'Endpoint'">
-            <input type="text" placeholder="enter endpoint" data-bind="value: endpoint" />
+            <input type="text" placeholder="Enter endpoint" data-bind="value: endpoint" />
         </editor>
 
         <editor params="label: identityLabel">

--- a/frontend/src/app/components/shared/add-cloud-connection-modal/add-cloud-connection-modal.js
+++ b/frontend/src/app/components/shared/add-cloud-connection-modal/add-cloud-connection-modal.js
@@ -14,13 +14,13 @@ const serviceMapping = deepFreeze({
         },
         identity: {
             label: 'Access Key',
-            placeholder: 'Enter Key',
+            placeholder: 'Enter key',
             requiredMessage: 'Please enter an AWS access key',
             duplicateMessage: 'Access key already used in another AWS connection'
         },
         secret: {
             label: 'Secret Key',
-            placeholder: 'Enter Secret',
+            placeholder: 'Enter secret',
             requiredMessage: 'Please enter an AWS secret key'
         },
         defaultEndpoint: 'https://s3.amazonaws.com'
@@ -33,13 +33,13 @@ const serviceMapping = deepFreeze({
         },
         identity: {
             label: 'Account Name',
-            placeholder: 'Enter Name',
+            placeholder: 'Enter name',
             requiredMessage: 'Please enter an Azure acount name',
             duplicateMessage: 'Account name already used in another azure connection'
         },
         secret: {
             label: 'Account Key',
-            placeholder: 'Enter Key',
+            placeholder: 'Enter key',
             requiredMessage: 'Please enter an Azure account key'
         },
         defaultEndpoint: 'https://blob.core.windows.net'
@@ -52,13 +52,13 @@ const serviceMapping = deepFreeze({
         },
         identity: {
             label: 'Access Key',
-            placeholder: 'Enter Key',
+            placeholder: 'Enter key',
             requiredMessage: 'Please enter an access key',
             duplicateMessage: 'Access key already used in another S3 compatible connection'
         },
         secret: {
             label: 'Secret Key',
-            placeholder: 'Enter Secret',
+            placeholder: 'Enter secret',
             requiredMessage: 'Please enter a secret key'
         }
     }

--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -4,15 +4,11 @@
 const _ = require('lodash');
 const AWS = require('aws-sdk');
 const path = require('path');
-const https = require('https');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
+const http_utils = require('../../util/http_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
-
-const https_agent = new https.Agent({
-    rejectUnauthorized: false,
-});
 
 class BlockStoreS3 extends BlockStoreBase {
 
@@ -41,7 +37,7 @@ class BlockStoreS3 extends BlockStoreBase {
                 accessKeyId: this.cloud_info.access_keys.access_key,
                 secretAccessKey: this.cloud_info.access_keys.secret_key,
                 httpOptions: {
-                    agent: https_agent
+                    agent: http_utils.get_unsecured_http_agent(this.cloud_info.endpoint)
                 }
             });
         }

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -9,7 +9,6 @@ const P = require('../../util/promise');
 
 const _ = require('lodash');
 const AWS = require('aws-sdk');
-const https = require('https');
 const crypto = require('crypto');
 const bcrypt = P.promisifyAll(require('bcrypt'));
 const random_string = require('../../util/string_utils').random_string;
@@ -21,6 +20,7 @@ const Dispatcher = require('../notifications/dispatcher');
 const mongo_utils = require('../../util/mongo_utils');
 const system_store = require('../system_services/system_store').get_instance();
 const cloud_utils = require('../../util/cloud_utils');
+const http_utils = require('../../util/http_utils');
 const azure = require('azure-storage');
 
 const demo_access_keys = Object.freeze({
@@ -538,9 +538,7 @@ function check_external_connection(req) {
                 accessKeyId: params.identity,
                 secretAccessKey: params.secret,
                 httpOptions: {
-                    agent: new https.Agent({
-                        rejectUnauthorized: false,
-                    })
+                    agent: http_utils.get_unsecured_http_agent(params.endpoint)
                 }
             });
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -4,7 +4,6 @@
 const _ = require('lodash');
 const AWS = require('aws-sdk');
 const net = require('net');
-const https = require('https');
 const azure = require('azure-storage');
 
 const P = require('../../util/promise');
@@ -17,6 +16,7 @@ const Dispatcher = require('../notifications/dispatcher');
 const size_utils = require('../../util/size_utils');
 const server_rpc = require('../server_rpc');
 const tier_server = require('./tier_server');
+const http_utils = require('../../util/http_utils');
 const cloud_utils = require('../../util/cloud_utils');
 const nodes_client = require('../node_services/nodes_client');
 const system_store = require('../system_services/system_store').get_instance();
@@ -781,9 +781,7 @@ function get_cloud_buckets(req) {
             accessKeyId: connection.access_key,
             secretAccessKey: connection.secret_key,
             httpOptions: {
-                agent: new https.Agent({
-                    rejectUnauthorized: false,
-                })
+                agent: http_utils.get_unsecured_http_agent(connection.endpoint)
             }
         });
         return P.ninvoke(s3, "listBuckets")

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -670,15 +670,6 @@ function remove_role(req) {
 }
 
 
-
-// var S3_SYSTEM_BUCKET = process.env.S3_SYSTEM_BUCKET || 'noobaa-core';
-// var aws_s3 = process.env.AWS_ACCESS_KEY_ID && new AWS.S3({
-//     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-//     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-//     region: process.env.AWS_REGION || 'eu-central-1'
-// });
-
-
 function get_system_web_links(system) {
     var reply = _.mapValues(system.resources, function(val, key) {
         if (key === 'toObject' || !_.isString(val) || !val) {

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -198,9 +198,6 @@ function get_cluster_info() {
                 }
             }, _.isUndefined);
         }
-        for (var i = 0; i < 50; ++i) {
-            shard.servers.push(server_info);
-        }
         shard.servers.push(server_info);
     });
     _.each(shards, shard => {

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -3,6 +3,7 @@
 
 const dbg = require('./debug_module')(__filename);
 const RpcError = require('../rpc/rpc_error');
+const http_utils = require('./http_utils');
 const AWS = require('aws-sdk');
 const url = require('url');
 
@@ -20,6 +21,7 @@ function find_cloud_connection(account, conn_name) {
 
 
 function get_signed_url(params) {
+    let agent = http_utils.get_unsecured_http_agent(params.endpoint);
     let s3 = new AWS.S3({
         endpoint: params.endpoint,
         credentials: {
@@ -29,7 +31,10 @@ function get_signed_url(params) {
         s3ForcePathStyle: true,
         sslEnabled: false,
         signatureVersion: 'v4',
-        region: 'eu-central-1'
+        region: 'eu-central-1',
+        httpOptions: {
+            agent: agent
+        }
     });
     return s3.getSignedUrl(
         'getObject', {

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -1,6 +1,10 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const url = require('url');
+const http = require('http');
+const https = require('https');
+
 /**
  * see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24
  */
@@ -21,4 +25,17 @@ function match_etag(condition, etag) {
         .some(c => c.trim() === `"${etag}"`);
 }
 
+/**
+ * Get http / https agent according to protocol
+ */
+function get_unsecured_http_agent(endpoint) {
+    const protocol = url.parse(endpoint).protocol;
+    return protocol === "https:" ?
+        new https.Agent({
+            rejectUnauthorized: false,
+        }) :
+        new http.Agent();
+}
+
 exports.match_etag = match_etag;
+exports.get_unsecured_http_agent = get_unsecured_http_agent;


### PR DESCRIPTION

### Purpose
- Fix 2693 - Allow creation of external connection with http
- Remove test code from previous PR
- Fix cases in external connection modal

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2693
