### PR TITLE
Removing redundant support accounts on mongo upgrade

### DIFF
--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -257,7 +257,7 @@ function upgrade_system(system) {
         });
     });
 
-    let support_account_found = false;
+    var support_account_found = false;
     db.accounts.find().forEach(function(account) {
 
         if (account.sync_credentials_cache &&


### PR DESCRIPTION
### Purpose
- We had multiple support accounts on a 0.5.0 for some reason. 
Mongo upgrade will now remove all but one (specifically, the first).

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
- Testing:
 - [x] Tested with: `npm test`
- Upgrade:
 - [x] Mongo Upgrade
