### PR TITLE
fix cloud_sync issues

### DIFF
--- a/src/server/bg_services/cloud_sync.js
+++ b/src/server/bg_services/cloud_sync.js
@@ -587,6 +587,7 @@ function update_c2n_worklist(policy) {
                 if (_.findIndex(joint_worklist, function(it) {
                         return it.key === cloud_obj.key;
                     }) === -1) {
+                    cloud_obj.bucket = policy.bucket._id;
                     work_list.c2n_added.push(cloud_obj);
                 }
             });

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -367,11 +367,11 @@ class MDStore {
         // TODO cloud sync scalability
         return this._objects.col().updateMany({
             bucket: bucket_id,
-            cloud_synced: false,
+            cloud_synced: true,
             deleted: null,
         }, {
             $set: {
-                cloud_synced: true
+                cloud_synced: false
             }
         });
     }
@@ -380,13 +380,13 @@ class MDStore {
         // TODO cloud sync scalability
         return this._objects.col().updateMany({
             bucket: bucket_id,
-            cloud_synced: true,
+            cloud_synced: false,
             deleted: {
                 $exists: true
             },
         }, {
             $set: {
-                cloud_synced: false
+                cloud_synced: true
             }
         });
     }

--- a/src/test/system_tests/test_cloud_sync.js
+++ b/src/test/system_tests/test_cloud_sync.js
@@ -60,10 +60,10 @@ function set_cloud_sync(params) {
         .then(
             () => client.account.add_external_connection({
                 name: TEST_CTX.connection_name,
-                endpoint: TEST_CTX.target_ip,
+                endpoint: 'http://' + TEST_CTX.target_ip,
                 identity: '123',
                 secret: 'abc',
-                endpoint_type: 'AWS'
+                endpoint_type: 'S3_COMPATIBLE'
             })
         )
         .then(


### PR DESCRIPTION
### Purpose
 - on set_cloud_sync, old files were set as synced
 - when marking sync on objects synced from cloud, pass the correct
bucket id

### Checklist 
- Code:
 - [ ] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [ ] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

### Fixed Issues References
- Fixes #2715 
