### PR TITLE
Nimrodb Fixing #2601, Upgrade to mongo 3.4.2

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -165,16 +165,16 @@ function install_mongo {
     deploy_log "----> install_mongo start"
 
     mkdir -p /var/lib/mongo/cluster/shard1
-    # create a Mongo 3.2 Repo file
-    cp -f ${CORE_DIR}/src/deploy/NVA_build/mongo.repo /etc/yum.repos.d/mongodb-org-3.2.repo
+    # create a Mongo 3.4 Repo file
+    cp -f ${CORE_DIR}/src/deploy/NVA_build/mongo.repo /etc/yum.repos.d/mongodb-org-3.4.repo
 
     # install the needed RPM
     yum install -y \
-		mongodb-org-3.2.1 \
-		mongodb-org-server-3.2.1 \
-		mongodb-org-shell-3.2.1 \
-		mongodb-org-mongos-3.2.1 \
-		mongodb-org-tools-3.2.1
+		mongodb-org-3.4.2 \
+		mongodb-org-server-3.4.2 \
+		mongodb-org-shell-3.4.2 \
+		mongodb-org-mongos-3.4.2 \
+		mongodb-org-tools-3.4.2
 
     # pin mongo version in yum, so it won't auto update
     echo "exclude=mongodb-org,mongodb-org-server,mongodb-org-shell,mongodb-org-mongos,mongodb-org-tools" >> /etc/yum.conf

--- a/src/deploy/NVA_build/mongo.repo
+++ b/src/deploy/NVA_build/mongo.repo
@@ -1,5 +1,5 @@
-[mongodb-org-3.2]
+[mongodb-org-3.4]
 name=MongoDB Repository
-baseurl=http://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.2/x86_64/
+baseurl=http://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.4/x86_64/
 gpgcheck=0
 enabled=1

--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -140,6 +140,7 @@ function check_latest_version {
 }
 
 function extract_package {
+  EXTRACTION_PATH="/root/node_modules"
   #Clean previous extracted package
   rm -rf ${EXTRACTION_PATH}*
   #Create path and extract package

--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -3,7 +3,11 @@
 # redirect the output log file to syslog (http://urbanautomaton.com/blog/2014/09/09/redirecting-bash-script-output-to-syslog)
 exec 1> >(logger -t UPGRADE -p local0.warn) 2>&1
 
-EXTRACTION_PATH="/tmp/test/"
+if [ -d /tmp/test/ ]; then
+  EXTRACTION_PATH="/tmp/test/"
+else
+  EXTRACTION_PATH="/root/node_modules"
+fi
 
 . ${EXTRACTION_PATH}/noobaa-core/src/deploy/NVA_build/deploy_base.sh
 . ${EXTRACTION_PATH}noobaa-core/src/deploy/NVA_build/common_funcs.sh

--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -104,8 +104,6 @@ function mongo_upgrade {
       deploy_log "finished mongo data upgrade"
   fi
 
-
-
   enable_autostart
 
   ${SUPERCTL} update

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -457,7 +457,7 @@ function read_system(req) {
                     aggregate_data_free_by_tier[tier.name])),
             storage: size_utils.to_bigint_storage(_.defaults({
                 used: objects_sys.size,
-            }, nodes_aggregate_pool_no_cloud.storage, SYS_STORAGE_DEFAULTS)),
+            }, nodes_aggregate_pool_with_cloud.storage, SYS_STORAGE_DEFAULTS)),
             nodes: _.defaults({}, nodes_aggregate_pool_no_cloud.nodes, SYS_NODES_INFO_DEFAULTS),
             owner: account_server.get_account_info(system_store.data.get_by_id(system._id).owner),
             last_stats_report: system.last_stats_report || 0,


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)

### Purpose
- Fixing #2601 - Return Cloud (if exists) as part of the storage under read_system (res.storage)
- Upgrade to mongo 3.4
- Fix calls to common funcs and funcs from deploy_base in upgrade.sh prior to package extraction

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade: Mongo Upgrade to 3.4
 - [x] Agents changes, Server Platform changes and New packages added to package.json: Mongo Upgrade to 3.4 (repo file changed, deploy_base & upgrade_wrapper changed accordingly) 

### Fixed Issues References
- Fixes #2601 
