### PR TITLE
Cloud agent refactoring and bug fixes

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -89,6 +89,7 @@ class Agent {
             if (params.cloud_info) {
                 this.cloud_info = params.cloud_info;
                 block_store_options.cloud_info = params.cloud_info;
+                block_store_options.cloud_path = params.cloud_path;
                 if (params.cloud_info.endpoint_type === 'AWS' || params.cloud_info.endpoint_type === 'S3_COMPATIBLE') {
                     this.block_store = new BlockStoreS3(block_store_options);
                 } else if (params.cloud_info.endpoint_type === 'AZURE') {
@@ -213,6 +214,7 @@ class Agent {
         this.rpc.set_disconnected_state(true);
         this.rpc_address = '';
         clearTimeout(this._test_connection_timeout);
+        if (this._server_connection) this._server_connection.close();
         this._start_stop_server();
         // TODO: for now commented out the update_n2n_config. revisit if needed (issue #2379)
         // // reset the n2n config to close any open ports

--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -3,7 +3,6 @@
 
 const _ = require('lodash');
 const AWS = require('aws-sdk');
-const path = require('path');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -15,8 +14,9 @@ class BlockStoreS3 extends BlockStoreBase {
     constructor(options) {
         super(options);
         this.cloud_info = options.cloud_info;
-        this.blocks_path = this.cloud_info.blocks_path || 'noobaa_blocks/' + options.node_name + '/blocks_tree';
-        this.usage_path = 'noobaa_blocks/' + options.node_name + '/usage';
+        this.base_path = options.cloud_path;
+        this.blocks_path = this.base_path + '/blocks_tree';
+        this.usage_path = this.base_path + '/usage';
         this.usage_md_key = 'noobaa_usage';
         this._usage = {
             size: 0,
@@ -56,7 +56,12 @@ class BlockStoreS3 extends BlockStoreBase {
                     dbg.log0('found usage data in', this.usage_path, 'usage_data = ', this._usage);
                 }
             }, err => {
-                console.warn('init::recieved', err);
+                if (err.code === 'NotFound') {
+                    // first time init, continue without usage info
+                    dbg.log0('BlockStoreS3 init: no usage path');
+                } else {
+                    dbg.error('got error on init:', err);
+                }
             });
     }
 
@@ -223,7 +228,7 @@ class BlockStoreS3 extends BlockStoreBase {
 
     _block_key(block_id) {
         let block_dir = this._get_block_internal_dir(block_id);
-        return path.join(this.blocks_path, block_dir, block_id);
+        return `${this.blocks_path}/${block_dir}/${block_id}`;
     }
 
     _encode_block_md(block_md) {

--- a/src/api/hosted_agents_api.js
+++ b/src/api/hosted_agents_api.js
@@ -12,6 +12,7 @@ module.exports = {
     id: 'hosted_agents_api',
 
     methods: {
+
         create_agent: {
             method: 'POST',
             params: {
@@ -81,6 +82,22 @@ module.exports = {
 
         },
 
+        create_cloud_agent: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['pool_name'],
+                properties: {
+                    pool_name: {
+                        type: 'string',
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
         remove_agent: {
             method: 'POST',
             params: {
@@ -89,6 +106,25 @@ module.exports = {
                 properties: {
                     name: {
                         type: 'string',
+                    }
+                }
+            },
+            auth: {
+                system: false
+            }
+        },
+
+
+        remove_cloud_agent: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                properties: {
+                    node_name: {
+                        type: 'string',
+                    },
+                    cloud_pool_name: {
+                        type: 'string'
                     }
                 }
             },

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -683,7 +683,13 @@ module.exports = {
                 deleted: {
                     type: 'boolean',
                 },
+                strictly_internal: {
+                    type: 'boolean'
+                },
                 skip_internal: {
+                    type: 'boolean'
+                },
+                strictly_cloud_nodes: {
                     type: 'boolean'
                 },
                 skip_cloud_nodes: {

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -67,10 +67,16 @@ module.exports = {
                         },
                         node_token: {
                             type: 'string'
+                        },
+                        cloud_pool: {
+                            type: 'string'
                         }
                     }
-                }
+                },
 
+                pending_delete: {
+                    type: 'boolean'
+                },
             }
         }
 

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -449,8 +449,8 @@ function read_system(req) {
                     aggregate_data_free_by_tier,
                     obj_count_per_bucket[bucket._id] || 0,
                     cloud_sync_by_bucket[bucket.name])),
-            pools: _.map(system.pools_by_name,
-                pool => pool_server.get_pool_info(pool, nodes_aggregate_pool_with_cloud)),
+            pools: _.filter(system.pools_by_name, pool => !_.get(pool, 'cloud_pool_info.pending_delete'))
+                .map(pool => pool_server.get_pool_info(pool, nodes_aggregate_pool_with_cloud)),
             tiers: _.map(system.tiers_by_name,
                 tier => tier_server.get_tier_info(tier,
                     nodes_aggregate_pool_with_cloud,

--- a/src/test/system_tests/test_node_failure.js
+++ b/src/test/system_tests/test_node_failure.js
@@ -23,6 +23,7 @@ let TEST_CTX = {
     file_size_mb: 2
 };
 
+
 let rpc = api.new_rpc(); //'ws://' + argv.ip + ':8080');
 let client = rpc.new_client({});
 

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -72,7 +72,7 @@ function get_used_cloud_targets(endpoint_type, bucket_list, pool_list) {
             usage_type: 'CLOUD_SYNC'
         })) : [];
     const cloud_resource_targets = pool_list ? pool_list.filter(pool =>
-            (pool.cloud_pool_info && pool.cloud_pool_info.endpoint_type === endpoint_type))
+            (pool.cloud_pool_info && !pool.cloud_pool_info.pending_delete && pool.cloud_pool_info.endpoint_type === endpoint_type))
         .map(pool_with_cloud_resource => ({
             endpoint: pool_with_cloud_resource.cloud_pool_info.endpoint,
             endpoint_type: pool_with_cloud_resource.cloud_pool_info.endpoint_type,


### PR DESCRIPTION
### Purpose
- Changed cloud pool mapping to use pool id instead of pool name. This was done to avoid collisions when creating new cloud pool with same name.
 - Fixed bug where hosted agents could be re-inited (say by cluster_master) while removing a cloud pool which would result in it not stopping internal agent.
 - Fixed same bug from happening when hosted_agents process crashes while removing a cloud pool. 
 - hosted_agents will now fetch state from node_server instead of pool_server when initialized.
 - hosted_agents will no longer use hosted_agents.start as a refresh but instead only to init.
 - removed usage of path module from block_store for cloud. This happened to work because we have cloud agents only on a linux system but is just a coincidental side effect.

### Checklist 
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - Code:
- [x] Failure handling and Comments on non trivial sections: 
- Testing:
 - [x] Manual tests: tested relevant flows
 - [x] Tested with: `npm test`
- Upgrade:
 - [x] cloud_pool_info will hold the cloud_path for old paths to still point by pool name, to support older cloud pools

### Fixed Issues References
- Fixes #2709
