### PR TITLE
in test_node_failure - retry list_nodes if number of nodes is less than expected

### DIFF
--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -32,6 +32,7 @@ class HostedAgents {
     start() {
         const system = system_store.data.systems[0];
         if (!system) return;
+        this._started = true;
         const cloud_pools = _.filter(system.pools_by_name, pool => Boolean(pool.cloud_pool_info));
         // start agent for all cloud pools that doesn't already have a running agent
         const pools_to_start = _.filter(cloud_pools, pool => _.isUndefined(this._started_agents[pool.name]));
@@ -43,7 +44,6 @@ class HostedAgents {
         dbg.log0(`stopping the following agents: ${util.inspect(agents_to_stop)}`);
         _.each(agents_to_stop, (agent, name) => this.stop_agent(name));
 
-        this._started = true;
         dbg.log0(`starting agents for the following pools: ${pools_to_start.map(pool => pool.name)}`);
         return P.map(pools_to_start, pool => this.start_cloud_agent(pool))
             .catch(err => {
@@ -227,6 +227,7 @@ function create_agent(req) {
         const cloud_pool = system_store.data.systems[0].pools_by_name[req.params.name];
         return HostedAgents.instance().start_cloud_agent(cloud_pool);
     }
+    dbg.log0(`not a cloud agnet. call start_local_agent`);
     return HostedAgents.instance().start_local_agent(req.params);
 }
 

--- a/src/test/system_tests/test_cloud_sync.js
+++ b/src/test/system_tests/test_cloud_sync.js
@@ -249,7 +249,8 @@ function run_basic_test() {
     });
 
     return authenticate()
-        .then(() => _create_bucket(source_params).then(() => _create_bucket(target_params)))
+        .then(() => _create_bucket(source_params))
+        .then(() => _create_bucket(target_params))
         .then(() => P.all(_.map(file_sizes, size => ops.generate_random_file(size))))
         .then(function(res_file_names) {
             let i = 0;


### PR DESCRIPTION
[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)

### Purpose
- fixed node_failure_test. retry list_nodes if number of nodes is less than expected

### Checklist 
- Code:
 - [ ] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [ ] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

