### PR TITLE
fix for #2696 / #2729 - correct pool status on < 3 optimal nodes & return min server requirements

### DIFF
--- a/frontend/src/app/utils/ui-utils.js
+++ b/frontend/src/app/utils/ui-utils.js
@@ -85,6 +85,11 @@ const poolStateIconMapping = deepFreeze({
         css: 'error',
         name: 'problem'
     },
+    NOT_ENOUGH_NODES: {
+        tooltip: 'Not enough nodes in pool',
+        css: 'error',
+        name: 'problem'
+    },
     ALL_NODES_OFFLINE: {
         tooltip: 'All nodes are offline',
         css: 'error',

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -700,6 +700,20 @@ module.exports = {
                             }
                         }
                     }
+                },
+                min_requirements: {
+                    type: 'object',
+                    properties: {
+                        ram_gb: {
+                            type: 'integer',
+                        },
+                        disk_gb: {
+                            type: 'integer',
+                        },
+                        cpu_count: {
+                            type: 'integer'
+                        }
+                    }
                 }
             }
         },

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -320,8 +320,8 @@ function get_pool_info(pool, nodes_aggregate_pool) {
 
 function calc_pool_mode(pool_info) {
     const { nodes, storage, data_activities = [] } = pool_info;
-    const { count, online, has_issues } = nodes;
-    const offline = count - (online + has_issues);
+    const { count } = nodes;
+    const offline = nodes.by_mode.OFFLINE;
     const offline_ratio = (offline / count) * 100;
     const { free, total, reserved, used_other } = _.assignWith({}, storage, (__, size) => size_utils.json_to_bigint(size));
     const potential_for_noobaa = total.subtract(reserved).subtract(used_other);
@@ -332,7 +332,8 @@ function calc_pool_mode(pool_info) {
 
     return (count === 0 && 'HAS_NO_NODES') ||
         (offline === count && 'ALL_NODES_OFFLINE') ||
-        (online < 3 && 'NOT_ENOUGH_HEALTHY_NODES') ||
+        (count < 3 && 'NOT_ENOUGH_NODES') ||
+        (nodes.by_mode.OPTIMAL < 3 && 'NOT_ENOUGH_HEALTHY_NODES') ||
         (offline_ratio >= 30 && 'MANY_NODES_OFFLINE') ||
         (free < NO_CAPAITY_LIMIT && 'NO_CAPACITY') ||
         (free < LOW_CAPACITY_HARD_LIMIT && 'LOW_CAPACITY') ||

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -212,7 +212,8 @@ function get_cluster_info() {
     });
     let cluster_info = {
         master_secret: system_store.get_server_secret(),
-        shards: shards
+        shards: shards,
+        min_requirements: _get_min_requirements()
     };
     return cluster_info;
 }
@@ -279,6 +280,14 @@ function send_master_update(is_master, master_address) {
             update_master_promise.catch(err => dbg.error('got error on update_master_promise.', err))
         )
         .return();
+}
+
+function _get_min_requirements() {
+        return {
+            ram_gb: 16,
+            disk_gb: 120,
+            cpu_count: 4,
+        };
 }
 
 


### PR DESCRIPTION
### Purpose
- fix for #2696 / #2729 - correct pool status on < 3 optimal nodes

### Checklist 
- Code:
 - [x] User Experience: **Taken a moment to think the effects on our user**
 - [x] Failure handling and Comments on non trivial sections: 
 - [x] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [x] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [x] Tested with: `npm test`
- Supportability:
 - [x] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [x] Mongo Schema Upgrade:
 - [x] Agents changes, Server Platform changes and New packages added to package.json:


### Fixed Issues References
- Fixes #2696
- Fixes #2729 
- Related to #2629 (add BE)
