### PR TITLE
add S3 server capability to agents - initial delivery, not active yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "db": "mongod -f mongod.conf",
     "web": "node src/server/web_server",
     "bg": "node src/server/bg_workers",
-    "s3": "node src/s3/s3rver",
+    "s3": "node src/s3/s3rver_starter",
     "hosted_agents": "node src/hosted_agents/hosted_agents_starter",
     "tunnel": "sudo node src/tools/tcp_tunnel --ssl",
     "agent": "node src/agent/agent_cli",

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -80,6 +80,22 @@ module.exports = {
                     },
                     create_node_token: {
                         type: 'string'
+                    },
+
+                    // the agent's "recommendation" of it's roles. nodes_monitor will only use it
+                    // when initializing the node and the role is not yet known.
+                    roles: {
+                        type: 'array',
+                        items: {
+                            $ref: 'common_api#/definitions/agent_roles_enum'
+                        }
+                    },
+
+                    s3_info: {
+                        type: 'object',
+                        properties: {
+                            enabled: 'boolean'
+                        }
                     }
                 }
             },
@@ -124,6 +140,20 @@ module.exports = {
                     },
                     n2n_config: {
                         $ref: 'common_api#/definitions/n2n_config'
+                    }
+                }
+            }
+        },
+
+        // only supported by s3 agents
+        update_s3rver: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['enabled'],
+                properties: {
+                    enabled: {
+                        type: 'boolean'
                     }
                 }
             }

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -349,5 +349,10 @@ module.exports = {
                 }
             }
         },
+
+        agent_roles_enum: {
+            type: 'string',
+            enum: ['STORAGE', 'S3']
+        }
     }
 };

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -263,7 +263,15 @@ module.exports = {
                     os_type: {
                         type: 'string',
                         enum: ['LINUX', 'WINDOWS']
+                    },
+                    roles: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                            enum: ['STORAGE', 'S3']
+                        }
                     }
+
                 }
             },
             reply: {

--- a/src/deploy/Linux/build_agent_linux.sh
+++ b/src/deploy/Linux/build_agent_linux.sh
@@ -60,6 +60,8 @@ if [ "$CLEAN" = true ] ; then
     cp ../../config.js ./package/
     cp $(nvm which current) ./package/
     mkdir ./package/src/
+    cp -R ../../src/s3 ./package/src/
+    cp -R ../../src/lambda ./package/src/
     cp -R ../../src/agent ./package/src/
     cp -R ../../src/util ./package/src/
     cp -R ../../src/rpc ./package/src/

--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -29,6 +29,8 @@ copy ..\..\package.json .
 copy ..\..\config.js .
 mkdir .\src\
 xcopy /Y/I/E ..\..\src\agent .\src\agent
+xcopy /Y/I/E ..\..\src\s3 .\src\s3
+xcopy /Y/I/E ..\..\src\lambda .\src\lambda
 xcopy /Y/I/E ..\..\src\util .\src\util
 xcopy /Y/I/E ..\..\src\rpc .\src\rpc
 xcopy /Y/I/E ..\..\src\api .\src\api

--- a/src/s3/s3rver_starter.js
+++ b/src/s3/s3rver_starter.js
@@ -1,4 +1,4 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-module.exports = require('./s3rver');
+require('./s3rver').start_all();

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -18,7 +18,7 @@ const SERVICES = [{
     fork: './src/server/web_server.js'
 }, {
     name: 's3',
-    fork: './src/s3/s3rver.js'
+    fork: './src/s3/s3rver_starter.js'
 }, {
     name: 'hosted_agents',
     fork: './src/hosted_agents/hosted_agents_starter.js'

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -54,6 +54,7 @@ const AGENT_INFO_FIELDS = [
     'os_info',
     'debug_level',
     'is_internal_agent',
+    's3_info'
 ];
 const MONITOR_INFO_FIELDS = [
     'has_issues',
@@ -1239,6 +1240,7 @@ class NodesMonitor extends EventEmitter {
     }
 
     _get_item_storage_full(item) {
+        if (!item.node.storage) return true;
         return item.node.storage.limit ?
             (item.node.storage.used >= item.node.storage.limit) :
             (item.node.storage.free <= config.NODES_FREE_SPACE_RESERVE);
@@ -1293,7 +1295,8 @@ class NodesMonitor extends EventEmitter {
             !item.node.decommissioning &&
             !item.node.decommissioned &&
             !item.node.deleting &&
-            !item.node.deleted);
+            !item.node.deleted &&
+            !item.node.s3_info);
     }
 
     _get_item_accessibility(item) {
@@ -1350,6 +1353,7 @@ class NodesMonitor extends EventEmitter {
     _get_data_activity_reason(item) {
         if (!item.node_from_store) return '';
         if (item.node.deleted) return '';
+        if (item.node.s3_info) return '';
         if (item.node.deleting) return ACT_DELETING;
         if (item.node.decommissioned) return '';
         if (item.node.decommissioning) return ACT_DECOMMISSIONING;

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -717,7 +717,8 @@ function get_node_installation_string(req) {
                 secret_key: secret_key,
                 tier: 'nodes',
                 root_path: './agent_storage/',
-                exclude_drives: req.rpc_params.exclude_drives ? req.rpc_params.exclude_drives : []
+                exclude_drives: req.rpc_params.exclude_drives ? req.rpc_params.exclude_drives : [],
+                roles: req.rpc_params.roles || ['STORAGE']
             };
             const base64_configuration = new Buffer(JSON.stringify(agent_conf)).toString('base64');
             switch (req.rpc_params.os_type) {


### PR DESCRIPTION
### Purpose
- add S3 server capability to agents
- initial delivery, not active yet - code in agent_cli that starts an s3 agent is commented out.
- adds s3 sources to agent package.
- nodes_monitor initial changes - treat s3 agents as not writeable 

### Checklist 
- Code:
 - [ ] User Experience: **Taken a moment to think the effects on our user**
 - [ ] Failure handling and Comments on non trivial sections: 
 - [ ] Cross Platform: **Supporting Win 7/8/10 Server 12, Linux, Mac**
- Testing:
 - [ ] Unit/System Tests: **Added tests ... / Already covered by existing tests ...**
 - [ ] Tested with: `npm test`
- Supportability:
 - [ ] Diagnostics info, Phone Home info, ActivityLog events, External Syslog: 
- Upgrade:
 - [ ] Mongo Schema Upgrade:
 - [ ] Agents changes, Server Platform changes and New packages added to package.json:

### Technical Debt Created
- Opened #xxxx

### Fixed Issues References
- Fixes #yyyy