### PR TITLE
add create_node_token to installation string

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -270,6 +270,9 @@ module.exports = {
                             type: 'string',
                             enum: ['STORAGE', 'S3']
                         }
+                    },
+                    pool: {
+                        type: 'string'
                     }
 
                 }

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -264,7 +264,8 @@ class NodesMonitor extends EventEmitter {
         // new node heartbeat
         // create the node and then update the heartbeat
         if (!node_id && (req.role === 'create_node' || req.role === 'admin')) {
-            this._add_new_node(req.connection, req.system._id, extra.pool_id, req.rpc_params.pool_name);
+            let agent_config = extra.agent_config_id && system_store.data.get_by_id(extra.agent_config_id);
+            this._add_new_node(req.connection, req.system._id, agent_config, req.rpc_params.pool_name);
             return reply;
         }
 
@@ -478,10 +479,10 @@ class NodesMonitor extends EventEmitter {
         this._set_node_defaults(item);
     }
 
-    _add_new_node(conn, system_id, pool_id, pool_name) {
+    _add_new_node(conn, system_id, agent_config, pool_name) {
         const system = system_store.data.get_by_id(system_id);
         const pool =
-            system_store.data.get_by_id(pool_id) ||
+            agent_config.pool ||
             system.pools_by_name[pool_name] ||
             system.pools_by_name.default_pool;
         if (pool.system !== system) {

--- a/src/server/system_services/schemas/agent_config_schema.js
+++ b/src/server/system_services/schemas/agent_config_schema.js
@@ -1,0 +1,38 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+module.exports = {
+    id: 'agent_config_schema',
+    type: 'object',
+    required: [
+        '_id',
+        'system',
+        'name'
+    ],
+    properties: {
+        _id: {
+            format: 'objectid'
+        },
+        system: {
+            format: 'objectid'
+        },
+        name: {
+            type: 'string'
+        },
+        pool: {
+            format: 'objectid'
+        },
+        exclude_drive: {
+            type: 'array',
+            items: {
+                type: 'string'
+            }
+        },
+        use_storage: {
+            type: 'boolean'
+        },
+        use_s3: {
+            type: 'boolean'
+        }
+    }
+};

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -13,6 +13,7 @@ const bucket_schema = require('./schemas/bucket_schema');
 const tieringpolicy_schema = require('./schemas/tiering_policy_schema');
 const tier_schema = require('./schemas/tier_schema');
 const pools_schema = require('./schemas/pool_schema');
+const agent_config_schema = require('./schemas/agent_config_schema');
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const js_utils = require('../../util/js_utils');
@@ -154,6 +155,18 @@ const COLLECTIONS = [{
             system: 1,
             name: 1,
             deleted: 1
+        },
+        options: {
+            unique: true,
+        }
+    }],
+}, {
+    name: 'agent_configs',
+    schema: agent_config_schema,
+    db_indexes: [{
+        fields: {
+            system: 1,
+            name: 1
         },
         options: {
             unique: true,


### PR DESCRIPTION
### Explain the changes:
- first authentication is done using this token, so no need to pass
access\secret keys to agents.
- pool_id, excluded_drives and roles are stored in system_store and db
(agent_configurations collection).
- configuration id is passed in the create node token to the server, so
agents can be handled correctly in nodes monitor when making the
initial connection

### Issues (fixed #xxxx / opened technical debt #yyyy)
- updated issue #2096 - update create_node_token with configuration id

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)