### PR TITLE
nimrodb default_pool feature

### DIFF
--- a/config.js
+++ b/config.js
@@ -49,6 +49,7 @@ config.TIME_SKEW_MAX_SECONDS = 15 * 60;
 config.DEDUP_ENABLED = false;
 // Date was chosen as default NooBaa epoch date 2015
 config.NOOBAA_EPOCH = 1430006400000;
+config.NEW_SYSTEM_POOL_NAME = 'first.pool';
 
 ///////////////
 // IO CONFIG //

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -830,7 +830,9 @@ export function createAccount(email, password, S3AccessList) {
         email: email,
         password: password,
         must_change_password: true,
-        allowed_buckets: S3AccessList
+        s3_access: Boolean(S3AccessList),
+        allowed_buckets: S3AccessList,
+        default_pool: S3AccessList && config.defaultPoolName  // TODO: should be user selected
     })
         .then(
             () => {
@@ -1697,7 +1699,9 @@ export function updateAccountS3Access(email, allowedBuckets) {
 
     api.account.update_account_s3_access({
         email: email,
-        allowed_buckets: allowedBuckets
+        s3_access: Boolean(allowedBuckets),
+        allowed_buckets: allowedBuckets,
+        default_pool: allowedBuckets && config.defaultPoolName  // TODO: should be user selected
     })
         .then(
             () => notify(`${email} S3 permissions updated successfully`, 'success'),

--- a/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.js
+++ b/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.js
@@ -49,7 +49,7 @@ class EditAccountS3AccessModalViewModel extends BaseViewModel {
     save() {
         updateAccountS3Access(
             ko.unwrap(this.accountEmail),
-            this.hasS3Access() ? this.selectedBuckets() : null
+            this.hasS3Access() ? this.selectedBuckets() : undefined
         );
         this.onClose();
     }

--- a/frontend/src/app/config.json
+++ b/frontend/src/app/config.json
@@ -4,7 +4,7 @@
     "infinitScrollPageSize": 25,
     "timeShortFormat": "DD MMM YYYY hh:mm:ss",
     "timeLongFormat": "DD MMM YYYY HH:mm:ss ([GMT]Z)",
-    "defaultPoolName": "default_pool",
+    "defaultPoolName": "first.pool", //TODO need to think / move to server side
     "sslCertificateSuffix": ".zip",
     "upgradePackageSuffix": ".gz",
     "defaultIconFile": "icons.svg",

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -19,7 +19,7 @@ module.exports = {
             method: 'POST',
             params: {
                 type: 'object',
-                required: ['name', 'email', 'password'],
+                required: ['name', 'email', 'password', 's3_access'],
                 properties: {
                     name: {
                         type: 'string',
@@ -33,11 +33,17 @@ module.exports = {
                     must_change_password: {
                         type: 'boolean',
                     },
+                    s3_access: {
+                        type: 'boolean'
+                    },
                     allowed_buckets: {
                         type: 'array',
                         items: {
                             type: 'string',
                         }
+                    },
+                    default_pool: {
+                        type: 'string',
                     },
                     //Special handling for the first account created with create_system
                     new_system_parameters: {
@@ -54,6 +60,9 @@ module.exports = {
                                 items: {
                                     type: 'string',
                                 }
+                            },
+                            default_pool: {
+                                type: 'string',
                             },
                         },
                     },
@@ -172,20 +181,22 @@ module.exports = {
             method: 'PUT',
             params: {
                 type: 'object',
-                required: ['email', 'allowed_buckets'],
+                required: ['email', 's3_access'],
                 properties: {
                     email: {
                         type: 'string',
                     },
+                    s3_access: {
+                        type: 'boolean'
+                    },
                     allowed_buckets: {
-                        anyOf: [{
-                            type: 'null'
-                        }, {
-                            type: 'array',
-                            items: {
-                                type: 'string'
-                            }
-                        }]
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        }
+                    },
+                    default_pool: {
+                        type: 'string'
                     }
                 },
             },
@@ -360,6 +371,9 @@ module.exports = {
                     items: {
                         type: 'string'
                     }
+                },
+                default_pool: {
+                    type: 'string',
                 },
                 external_connections: {
                     type: 'object',

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -46,26 +46,6 @@ module.exports = {
             }
         },
 
-        update_pool: {
-            doc: 'Update Pool',
-            method: 'POST',
-            params: {
-                type: 'object',
-                required: ['name'],
-                properties: {
-                    name: {
-                        type: 'string',
-                    },
-                    new_name: {
-                        type: 'string',
-                    },
-                }
-            },
-            auth: {
-                system: 'admin'
-            }
-        },
-
         list_pool_nodes: {
             doc: 'List Pool Nodes',
             method: 'GET',
@@ -240,7 +220,7 @@ module.exports = {
 
         pool_extended_info: {
             type: 'object',
-            required: ['name', 'storage'],
+            required: ['name', 'storage', 'associated_accounts'],
             properties: {
                 name: {
                     type: 'string'
@@ -277,6 +257,18 @@ module.exports = {
                 },
                 mode: {
                     $ref: '#/definitions/pool_mode'
+                },
+                associated_accounts: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        required: ['name'],
+                        properties: {
+                            name: {
+                                type: 'string',
+                            },
+                        }
+                    }
                 }
             },
         },

--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -31,6 +31,7 @@ function upgrade() {
     upgrade_cloud_agents();
     upgrade_tier_pools();
     upgrade_accounts();
+    update_default_pool();
     upgrade_pools();
     upgrade_buckets();
     upgrade_usage_stats();
@@ -598,6 +599,7 @@ function upgrade_accounts() {
 }
 
 function add_defaults_to_sync_credentials_cache() {
+    print('\n*** add_defaults_to_sync_credentials_cache ...');
     db.accounts.find().forEach(function(account) {
         var credentials = account.sync_credentials_cache;
         if (credentials) {
@@ -617,6 +619,24 @@ function add_defaults_to_sync_credentials_cache() {
             });
         }
     });
+}
+
+function update_default_pool() {
+    print('\n*** update_default_pool ...');
+    var default_pool = db.pools.find({ name: "default_pool" });
+    if (default_pool) {
+        db.accounts.find().forEach(function(account) {
+            if (!account.default_pool) {
+                db.accounts.update({
+                    _id: account._id
+                }, {
+                    $set: {
+                        default_pool: default_pool
+                    }
+                });
+            }
+        });
+    }
 }
 
 function upgrade_pools() {
@@ -652,6 +672,7 @@ function upgrade_usage_stats() {
 }
 
 function add_account_id_to_cloud_pools() {
+    print('\n*** add_account_id_to_cloud_pools ...');
     db.pools.find({
         cloud_pool_info: {
             $exists: true
@@ -671,6 +692,7 @@ function add_account_id_to_cloud_pools() {
 }
 
 function add_account_id_to_cloud_sync() {
+    print('\n*** add_account_id_to_cloud_sync ...');
     db.buckets.find({
         cloud_sync: {
             $exists: true
@@ -690,6 +712,7 @@ function add_account_id_to_cloud_sync() {
 }
 
 function add_credentials_to_missing_account_id(credentials) {
+    print('\n*** add_credentials_to_missing_account_id ...');
     if (credentials &&
         credentials.access_keys &&
         credentials.access_keys.access_key &&
@@ -720,6 +743,7 @@ function find_account_id_by_credentials(access_key) {
 }
 
 function fix_nodes_pool_to_object_id() {
+    print('\n*** fix_nodes_pool_to_object_id ...');
     // Type 2 is String ref: https://docs.mongodb.com/v3.0/reference/operator/query/type/
     db.nodes.find({
         pool: {

--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -631,7 +631,7 @@ function update_default_pool() {
                     _id: account._id
                 }, {
                     $set: {
-                        default_pool: default_pool
+                        default_pool: default_pool._id
                     }
                 });
             }

--- a/src/server/func_services/func_server.js
+++ b/src/server/func_services/func_server.js
@@ -54,7 +54,7 @@ function create_func(req) {
         func.pools = _.map(req.params.config.pools, pool_name =>
             req.system.pools_by_name[pool_name]._id);
     } else {
-        func.pools = [req.system.pools_by_name.default_pool._id];
+        func.pools = [req.account.default_pool._id];
     }
     if (!func.pools.length) {
         throw new Error('No pools');

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -77,8 +77,8 @@ function create_bucket(req) {
         tiering_policy = resolve_tiering_policy(req, req.rpc_params.tiering);
     } else {
         // we create dedicated tier and tiering policy for the new bucket
-        // that uses the default_pool
-        let default_pool = req.system.pools_by_name.default_pool;
+        // that uses the default_pool of that account
+        let default_pool = req.system.pools_by_name[req.account.default_pool];
         let bucket_with_suffix = req.rpc_params.name + '#' + Date.now().toString(36);
         let tier = tier_server.new_tier_defaults(
             bucket_with_suffix, req.system._id, [{

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -278,13 +278,11 @@ function get_associated_buckets_int(pool) {
 }
 
 function get_associated_accounts(pool) {
-    var associated_accounts = _.filter(pool.system.accounts_by_email, function(account) {
-        return String(account.default_pool._id) === String(pool._id);
-    });
-
-    return _.map(associated_accounts, function(account) {
-        return account.name;
-    });
+    return system_store.data.accounts
+        .filter(account => (account.default_pool && account.default_pool._id === pool._id))
+        .map(associated_account => ({
+            name: associated_account.email
+        }));
 }
 
 function find_pool_by_name(req) {
@@ -323,11 +321,7 @@ function get_pool_info(pool, nodes_aggregate_pool) {
     }
 
     //Get associated accounts
-    info.associated_accounts = system_store.data.accounts
-        .filter(account => (account.default_pool && account.default_pool._id === pool._id))
-        .map(associated_account => ({
-            name: associated_account.email
-        }));
+    info.associated_accounts = get_associated_accounts(pool);
 
     return info;
 }

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -53,6 +53,9 @@ module.exports = {
                 format: 'objectid'
             }
         },
+        default_pool: {
+            format: 'objectid'
+        },
         sync_credentials_cache: {
             type: 'array',
             items: {

--- a/src/test/lambda/dildos.js
+++ b/src/test/lambda/dildos.js
@@ -8,6 +8,7 @@ const path = require('path');
 const argv = require('minimist')(process.argv);
 
 const P = require('../../util/promise');
+const config = require('../../../config.js');
 const zip_utils = require('../../util/zip_utils');
 
 const LAMBDA_CONF = {
@@ -21,7 +22,7 @@ const LAMBDA_CONF = {
 const lambda = new AWS.Lambda(LAMBDA_CONF);
 
 const ROLE_ARN = 'arn:aws:iam::638243541865:role/lambda-test';
-const POOLS = argv.pools ? argv.pools.split(',') : ['default_pool'];
+const POOLS = argv.pools ? argv.pools.split(',') : [config.NEW_SYSTEM_POOL_NAME];
 
 const word_count_func = {
     FunctionName: 'word_count_func',

--- a/src/test/system_tests/mongodb_defaults.js
+++ b/src/test/system_tests/mongodb_defaults.js
@@ -19,13 +19,13 @@ db.getSiblingDB("nbcore").tiers.update({
 }, {
     $set: {
         pool: db.getSiblingDB("nbcore").pools.find({
-            name: 'default_pool'
+            name: 'first.pool'
         })[0]._id
     }
 });
 db.getSiblingDB("nbcore").pools.remove({
     name: {
-        $ne: 'default_pool'
+        $ne: 'first.pool'
     }
 });
 db.getSiblingDB("nbcore").tiers.remove({
@@ -60,11 +60,11 @@ db.getSiblingDB("nbcore").buckets.updateMany({}, {
     }
 });
 
-// We assign all of the nodes to the default_pool, because we've removed all of the pools
+// We assign all of the nodes to the first.pool, because we've removed all of the pools
 db.getSiblingDB("nbcore").nodes.update({}, {
     $set: {
         pool: db.getSiblingDB("nbcore").pools.find({
-            name: 'default_pool'
+            name: 'first.pool'
         })[0]._id
     },
     $unset: {

--- a/src/test/system_tests/test_bucket_access.js
+++ b/src/test/system_tests/test_bucket_access.js
@@ -2,12 +2,14 @@
 'use strict';
 
 var api = require('../../api');
-var rpc = api.new_rpc();
-var argv = require('minimist')(process.argv);
 var P = require('../../util/promise');
-var ops = require('./basic_server_ops');
-var assert = require('assert');
 var dotenv = require('../../util/dotenv');
+var ops = require('./basic_server_ops');
+var config = require('../../../config.js');
+var rpc = api.new_rpc();
+
+var argv = require('minimist')(process.argv);
+var assert = require('assert');
 var AWS = require('aws-sdk');
 var https = require('https');
 var fs = require('fs');
@@ -26,20 +28,23 @@ let full_access_user = {
     name: 'full_access',
     email: 'full_access@noobaa.com',
     password: 'master',
-    allowed_buckets: ['bucket1', 'bucket2']
+    allowed_buckets: ['bucket1', 'bucket2'],
+    default_pool: config.NEW_SYSTEM_POOL_NAME,
 };
 
 let bucket1_user = {
     name: 'bucket1_access',
     email: 'bucket1_access@noobaa.com',
     password: 'onlyb1',
-    allowed_buckets: ['bucket1']
+    allowed_buckets: ['bucket1'],
+    default_pool: config.NEW_SYSTEM_POOL_NAME,
 };
 
 let no_access_user = {
     name: 'no_access',
     email: 'no_access@noobaa.com',
     password: 'goaway',
+    default_pool: config.NEW_SYSTEM_POOL_NAME,
 };
 
 module.exports = {

--- a/src/test/system_tests/test_build_chunks.js
+++ b/src/test/system_tests/test_build_chunks.js
@@ -1,18 +1,21 @@
 /* Copyright (C) 2016 NooBaa */
 "use strict";
 
-const _ = require('lodash');
+
 const P = require('../../util/promise');
 const api = require('../../api');
 const ops = require('./basic_server_ops');
-const promise_utils = require('../../util/promise_utils');
+const config = require('../../../config.js');
 const dotenv = require('../../util/dotenv');
-const fs = require('fs');
-const crypto = require('crypto');
-const util = require('util');
-const AWS = require('aws-sdk');
 const ObjectIO = require('../../api/object_io');
 const test_utils = require('./test_utils');
+const promise_utils = require('../../util/promise_utils');
+
+const _ = require('lodash');
+const fs = require('fs');
+const AWS = require('aws-sdk');
+const util = require('util');
+const crypto = require('crypto');
 
 dotenv.load();
 
@@ -22,7 +25,7 @@ let TEST_CTX = {
     default_bucket: 'files',
     object_key: '',
     timeout: 120,
-    discard_pool_name: 'default_pool',
+    discard_pool_name: config.NEW_SYSTEM_POOL_NAME,
     default_tier_name: 'test_tier',
     default_tier_policy_name: 'tiering1',
     cloud_pool_name: 'cloud-pool-aws'
@@ -566,13 +569,13 @@ function test_tear_down() {
         .then(system => {
             let pools_to_delete = [];
             _.each(system.pools, pool => {
-                if (pool.name !== 'default_pool') {
+                if (pool.name !== config.NEW_SYSTEM_POOL_NAME) {
                     pools_to_delete.push(client.node.list_nodes({
                             query: {
                                 pools: [pool.name]
                             }
                         })
-                        .then(node_list => pool.cloud_info || // making sure not to assign cloud pool nodes to default_pool
+                        .then(node_list => pool.cloud_info || // making sure not to assign cloud pool nodes to first.pool
                             client.pool.assign_nodes_to_pool({
                                 name: TEST_CTX.discard_pool_name,
                                 nodes: node_list.nodes.map(node_object => ({

--- a/src/test/system_tests/test_ceph_s3.js
+++ b/src/test/system_tests/test_ceph_s3.js
@@ -2,6 +2,7 @@
 "use strict";
 
 var P = require('../../util/promise');
+var config = require('../../../config.js');
 var promise_utils = require('../../util/promise_utils');
 
 var CEPH_TEST = {
@@ -14,7 +15,8 @@ var CEPH_TEST = {
         name: 'cephalt',
         email: 'ceph.alt@noobaa.com',
         password: 'ceph',
-        allowed_buckets: []
+        allowed_buckets: [],
+        default_pool: config.NEW_SYSTEM_POOL_NAME
     },
 };
 

--- a/src/test/system_tests/test_cloud_sync.js
+++ b/src/test/system_tests/test_cloud_sync.js
@@ -1,16 +1,19 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-var api = require('../../api');
-var rpc = api.new_rpc();
-var target_rpc = api.new_rpc();
-var argv = require('minimist')(process.argv);
 var P = require('../../util/promise');
+var api = require('../../api');
 var ops = require('./basic_server_ops');
-var _ = require('lodash');
-var assert = require('assert');
-var promise_utils = require('../../util/promise_utils');
+var config = require('../../../config.js');
 var dotenv = require('../../util/dotenv');
+var target_rpc = api.new_rpc();
+var promise_utils = require('../../util/promise_utils');
+
+var _ = require('lodash');
+var argv = require('minimist')(process.argv);
+var assert = require('assert');
+
+var rpc = api.new_rpc();
 dotenv.load();
 
 // var dbg = require('../util/debug_module')(__filename);
@@ -576,7 +579,7 @@ function _params_by_name(input) {
     return {
         tier: 'tier-' + input.suffix,
         tiering_policy: 'tiering-' + input.suffix,
-        pools: input.pools || ['default_pool'],
+        pools: input.pools || [config.NEW_SYSTEM_POOL_NAME],
         data_placement: input.data_placement || 'SPREAD',
         bucket: 'bucket-' + input.suffix,
     };

--- a/src/test/system_tests/test_upgrade_ec2.js
+++ b/src/test/system_tests/test_upgrade_ec2.js
@@ -10,8 +10,7 @@ var ec2_deploy_agents = require('../../deploy/ec2_deploy_agents');
 var promise_utils = require('../../util/promise_utils');
 var ops = require('./basic_server_ops');
 
-var default_instance_type = 'm3.large';
-//var default_instance_type = 't2.micro'; //TODO:: NBNB change back
+var default_instance_type = 't2.micro';
 
 
 //TODO: on upload file, wait for systemOk ? (see next todo, maybe sleep too)

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -12,6 +12,7 @@ const S3Auth = require('aws-sdk/lib/signers/s3');
 
 const P = require('../../util/promise');
 const account_server = require('../../server/system_services/account_server');
+const config = require('../../../config.js');
 
 const s3_auth = new S3Auth();
 
@@ -73,13 +74,12 @@ mocha.describe('system_servers', function() {
             .then(() => client.system.update_system({
                 name: SYS,
             }))
-            .then(() => {
-                return client.account.create_account({
-                    name: EMAIL1,
-                    email: EMAIL1,
-                    password: PASSWORD,
-                });
-            })
+            .then(() => client.account.create_account({
+                name: EMAIL1,
+                email: EMAIL1,
+                password: PASSWORD,
+                default_pool: config.NEW_SYSTEM_POOL_NAME
+            }))
             .then(() => client.system.read_system())
             .then(() => client.system.add_role({
                 email: EMAIL1,
@@ -182,21 +182,13 @@ mocha.describe('system_servers', function() {
             .then(() => client.pool.read_pool({
                 name: POOL,
             }))
-            .then(() => client.pool.update_pool({
-                name: POOL,
-                new_name: POOL + 1,
-            }))
             .then(() => client.pool.assign_nodes_to_pool({
-                name: POOL + 1,
+                name: POOL,
                 nodes: _.map(nodes_list.slice(3, 6),
                     node => _.pick(node, 'name')),
             }))
-            .then(() => client.pool.update_pool({
-                name: POOL + 1,
-                new_name: POOL,
-            }))
             .then(() => client.pool.assign_nodes_to_pool({
-                name: 'default_pool',
+                name: config.NEW_SYSTEM_POOL_NAME,
                 nodes: _.map([nodes_list[1], nodes_list[3], nodes_list[5]],
                     node => _.pick(node, 'name')),
             }))
@@ -366,7 +358,7 @@ mocha.describe('system_servers', function() {
                 })
             )
             .then(() => client.pool.assign_nodes_to_pool({
-                name: 'default_pool',
+                name: config.NEW_SYSTEM_POOL_NAME,
                 nodes: _.map(nodes_list, node => _.pick(node, 'name')),
             }))
             .then(() => coretest.clear_test_nodes())

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -20,13 +20,13 @@ Tools contains various tools which are not part of the working flows but can be 
       The equivalent for a js call for
       ___node.list_nodes({
         query: {
-          pools: 'default_pool',
+          pools: 'first.pool',
         }
       })___
 
       Is done in the following way:
 
-      ___.call node list_nodes query={pools='default_pool'}___
+      ___.call node list_nodes query={pools='first.pool'}___
 
   Currently rpc_shell does not support argument execution mode (i.e. node rpc_shell.js .call system read_system),
   but can be added should the need arise (in testing scenarios for example).


### PR DESCRIPTION
default pool per account, change current defaltt_pool to first.pool

### Explain the changes:
- Default pool will no longer be used for node placement (on install node, admin will choose a pool to associate node with)
- Create a default pool property per account which has s3 access. This pool will be used when creating new buckets via S3 and will be selected as the default placement policy.
- Cloud can also be selected as default pool
- Change the name default_pool (the pool which comes with a newly created system) to first.pool

### Issues (fixed #xxxx / opened technical debt #yyyy)
- Fixes #1712 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

