### PR TITLE
Mongo upgrade, fixing block pointers to buckets for old systems

### DIFF
--- a/src/deploy/NVA_build/mongo_upgrade.js
+++ b/src/deploy/NVA_build/mongo_upgrade.js
@@ -31,6 +31,7 @@ function upgrade() {
     upgrade_pools();
     upgrade_buckets();
     upgrade_usage_stats();
+    blocks_to_buckets_upgrade();
     // cluster upgrade: mark that upgrade is completed for this server
     mark_completed(); // do not remove
     print('\nUPGRADE DONE.');
@@ -711,4 +712,55 @@ function fix_nodes_pool_to_object_id() {
             }
         });
     });
+}
+
+
+function blocks_to_buckets_upgrade() {
+    var num_blocks = db.datablocks.count({});
+    var block_ids_by_bucket_ids = null;
+    const BLOCKS_PER_CYCLE = 100;
+
+    function find_bucket_id_for_block(block) {
+        var block_bucket = db.datachunks.find({
+                _id: block.chunk
+            }, {
+                bucket: 1
+            })
+            .toArray()[0];
+
+        if (block_ids_by_bucket_ids[block_bucket.bucket.valueOf()]) {
+            block_ids_by_bucket_ids[block_bucket.bucket.valueOf()].push(block._id);
+        } else {
+            block_ids_by_bucket_ids[block_bucket.bucket.valueOf()] = [block._id];
+        }
+    }
+
+    function update_blocks_bucket(bucket_id) {
+        db.datablocks.updateMany({
+            _id: {
+                $in: block_ids_by_bucket_ids[bucket_id]
+            }
+        }, {
+            $set: {
+                bucket: new ObjectId(bucket_id)
+            }
+        });
+    }
+
+    for (var pIndex = 0; pIndex < Math.ceil(num_blocks / BLOCKS_PER_CYCLE); pIndex++) {
+        block_ids_by_bucket_ids = {};
+        db.datablocks.find({
+                bucket: {
+                    $exists: false
+                }
+            }, {
+                _id: 1,
+                chunk: 1
+            })
+            .limit(BLOCKS_PER_CYCLE)
+            .forEach(find_bucket_id_for_block);
+
+        Object.keys(block_ids_by_bucket_ids)
+            .forEach(update_blocks_bucket);
+    }
 }


### PR DESCRIPTION
### Explain the changes:
- Addition to mongo upgrade script
- Updating the old blocks in the system and pointing them to their relevant buckets

### Issues (fixed #xxxx / opened technical debt #yyyy)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
