### PR TITLE
set agent_config to empty object by default

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -746,8 +746,8 @@ class NodesMonitor extends EventEmitter {
                             dbg.log0('_get_agent_info: set node name',
                                 item.node.name, 'to', updates.name);
 
-                            let agent_config = system_store.data.get_by_id(item.node.agent_config);
-                            let { use_s3 = false, use_storage = true, exclude_drive = [] } = agent_config || {};
+                            let agent_config = system_store.data.get_by_id(item.node.agent_config) || {};
+                            let { use_s3 = false, use_storage = true, exclude_drive = [] } = agent_config;
                             // on first call to get_agent_info enable\disable the node according to the configuration
                             let should_start_service = (info.s3_agent_info && use_s3) ||
                                 (!info.s3_agent_info && use_storage && exclude_drive.indexOf(info.drives[0].mount) === -1);


### PR DESCRIPTION
### Explain the changes:
- set agent_config to empty object by default

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
