### PR TITLE
fix #2812 - removed setting EXTRACTION_PATH as /root/node_modules/

### DIFF
--- a/src/deploy/NVA_build/fix_mongo_ssl.sh
+++ b/src/deploy/NVA_build/fix_mongo_ssl.sh
@@ -5,8 +5,13 @@ if [ ! -d /etc/mongo_ssl/ ]; then
   . ${CORE_DIR}/src/deploy/NVA_build/setup_mongo_ssl.sh
   chmod 400 -R /etc/mongo_ssl
   client_subject=`openssl x509 -in /etc/mongo_ssl/client.pem -inform PEM -subject -nameopt RFC2253 | grep subject | awk '{sub("subject= ",""); print}'`
-  echo "MONGO_SSL_USER=${client_subject}" >> ${CORE_DIR}/.env
   # add bash script to run mongo shell with authentications
   echo "mongo --ssl --sslPEMKeyFile /etc/mongo_ssl/client.pem --sslCAFile /etc/mongo_ssl/root-ca.pem --sslAllowInvalidHostnames -u \"${client_subject}\" --authenticationMechanism MONGODB-X509 --authenticationDatabase \"\\\$external\" \"\$@\"" > /usr/bin/mongors
   chmod +x /usr/bin/mongors
 fi
+
+if grep -q MONGO_SSL_USER /root/node_modules/noobaa-core/.env; then
+  client_subject=`openssl x509 -in /etc/mongo_ssl/client.pem -inform PEM -subject -nameopt RFC2253 | grep subject | awk '{sub("subject= ",""); print}'`
+  echo "MONGO_SSL_USER=${client_subject}" >> /root/node_modules/noobaa-core/.env
+fi
+

--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -3,14 +3,18 @@
 # redirect the output log file to syslog (http://urbanautomaton.com/blog/2014/09/09/redirecting-bash-script-output-to-syslog)
 exec 1> >(logger -t UPGRADE -p local0.warn) 2>&1
 
+EXTRACTION_PATH="/tmp/test/"
+
+#TODO do we want to load base on /tmp/test? maybe load common_funcs differenetly
 if [ -d /tmp/test/ ]; then
-  EXTRACTION_PATH="/tmp/test/"
+  COMMON_FUNCS_PATH="/tmp/test/"
 else
-  EXTRACTION_PATH="/root/node_modules"
+  COMMON_FUNCS_PATH="/root/node_modules"
 fi
 
-. ${EXTRACTION_PATH}/noobaa-core/src/deploy/NVA_build/deploy_base.sh
-. ${EXTRACTION_PATH}noobaa-core/src/deploy/NVA_build/common_funcs.sh
+
+. ${COMMON_FUNCS_PATH}/noobaa-core/src/deploy/NVA_build/deploy_base.sh
+. ${COMMON_FUNCS_PATH}noobaa-core/src/deploy/NVA_build/common_funcs.sh
 
 PACKAGE_FILE_NAME="new_version.tar.gz"
 WRAPPER_FILE_NAME="upgrade_wrapper.sh"
@@ -140,7 +144,6 @@ function check_latest_version {
 }
 
 function extract_package {
-  EXTRACTION_PATH="/root/node_modules"
   #Clean previous extracted package
   rm -rf ${EXTRACTION_PATH}*
   #Create path and extract package
@@ -173,6 +176,7 @@ function extract_package {
   #   exit 1
   # fi
 }
+
 
 function do_upgrade {
   #Update packages before we stop services, minimize downtime, limit run time for yum update so it won't get stuck

--- a/src/util/dotenv.js
+++ b/src/util/dotenv.js
@@ -82,7 +82,10 @@ module.exports = {
      * @param {String|Buffer} src - source to be parsed
      * @returns {Object}
      */
-    parse: function(src) {
+    parse: function(src_param) {
+        let src = src_param || fs.readFileSync('.env', {
+            encoding: 'utf8'
+        });
         var obj = {};
         var idx = 0;
 


### PR DESCRIPTION
rebase from 1.2
on web_server start check if JWT_SECRET and MONGO_SSL_USER are missing from .env
and present in process.env. if so then rewrite it to .env

fix #2812 - regenerate missing JWT_SECRET and MONGO_SSL_USER

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
