### PR TITLE
use heap dump package on agents

### DIFF
--- a/src/deploy/Linux/build_agent_linux.sh
+++ b/src/deploy/Linux/build_agent_linux.sh
@@ -85,7 +85,6 @@ if [ "$CLEAN" = true ] ; then
     sed -i '/newrelic/d' package.json
     sed -i '/istanbul/d' package.json
     sed -i '/npm-run-all/d' package.json
-    sed -i '/heapdump/d' package.json
     sed -i '/selectize/d' package.json
     sed -i '/jsonwebtoken/d' package.json
     sed -i '/googleapis/d' package.json

--- a/src/deploy/Linux/build_s3rest_linux.sh
+++ b/src/deploy/Linux/build_s3rest_linux.sh
@@ -86,7 +86,6 @@ else
         sed -i '/newrelic/d' package.json
         sed -i '/istanbul/d' package.json
         sed -i '/npm-run-all/d' package.json
-        sed -i '/heapdump/d' package.json
         sed -i '/selectize/d' package.json
         sed -i '/jsonwebtoken/d' package.json
         sed -i '/googleapis/d' package.json

--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -55,7 +55,7 @@ sed -i 's/%current_version_line%/\"version\": \"%current_package_version%-%GIT_C
 
 REM
 REM remove irrelevant packages
-type package.json  | findstr /v npm-run-all | findstr /v forever-service | findstr /v istanbul | findstr /v mongoose | findstr /v heapdump | findstr /v selectize | findstr /v jsonwebtoken | findstr /v forever | findstr /v eslint | findstr /v googleapis | findstr /v gulp | findstr /v bower | findstr /v bootstrap | findstr /v browserify | findstr /v rebuild | findstr /v eslint| findstr /v nodetime| findstr /v newrelic| findstr /v vsphere > package.json_s
+type package.json  | findstr /v npm-run-all | findstr /v forever-service | findstr /v istanbul | findstr /v mongoose | findstr /v selectize | findstr /v jsonwebtoken | findstr /v forever | findstr /v eslint | findstr /v googleapis | findstr /v gulp | findstr /v bower | findstr /v bootstrap | findstr /v browserify | findstr /v rebuild | findstr /v eslint| findstr /v nodetime| findstr /v newrelic| findstr /v vsphere > package.json_s
 
 del /Q package.json
 rename package.json_s package.json

--- a/src/deploy/build_windows_s3rest.bat
+++ b/src/deploy/build_windows_s3rest.bat
@@ -50,7 +50,7 @@ del version.txt
 sed -i 's/%current_version_line%/\"version\": \"%current_package_version%-%GIT_COMMIT%\",/' package.json
 
 REM remove irrelevant packages
-type package.json  | findstr /v npm-run-all | findstr /v forever-service | findstr /v istanbul | findstr /v eslint | findstr /v mongoose | findstr /v heapdump | findstr /v selectize | findstr /v jsonwebtoken | findstr /v forever | findstr /v googleapis | findstr /v gulp | findstr /v bower | findstr /v bootstrap | findstr /v browserify | findstr /v rebuild | findstr /v nodetime| findstr /v newrelic| findstr /v vsphere > package.json_s
+type package.json  | findstr /v npm-run-all | findstr /v forever-service | findstr /v istanbul | findstr /v eslint | findstr /v mongoose | findstr /v selectize | findstr /v jsonwebtoken | findstr /v forever | findstr /v googleapis | findstr /v gulp | findstr /v bower | findstr /v bootstrap | findstr /v browserify | findstr /v rebuild | findstr /v nodetime| findstr /v newrelic| findstr /v vsphere > package.json_s
 del /Q package.json
 rename package.json_s package.json
 copy ..\..\binding.gyp .


### PR DESCRIPTION
### Explain the changes:
- heapdump package should be used in agents

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
