### PR TITLE
fixes #2852 - fix _get_tiering_pools_status to return pool status by id instead of name

### DIFF
--- a/src/server/node_services/node_allocator.js
+++ b/src/server/node_services/node_allocator.js
@@ -85,7 +85,7 @@ function get_tiering_pools_status(tiering) {
 
 
 function _get_tiering_pools_status(pools) {
-    let pools_status_by_name = {};
+    let pools_status_by_id = {};
     _.each(pools, pool => {
         let valid_for_allocation = true;
         let alloc_group = alloc_group_by_pool[String(pool._id)];
@@ -97,12 +97,12 @@ function _get_tiering_pools_status(pools) {
         } else if (num_nodes < config.NODES_MIN_COUNT) {
             valid_for_allocation = false;
         }
-        pools_status_by_name[pool.name] = {
+        pools_status_by_id[pool._id] = {
             valid_for_allocation,
             num_nodes
         };
     });
-    return pools_status_by_name;
+    return pools_status_by_id;
 }
 
 

--- a/src/server/object_services/map_utils.js
+++ b/src/server/object_services/map_utils.js
@@ -43,7 +43,7 @@ function select_prefered_mirrors(tier, tiering_pools_status) {
         let pool_weight = 0;
         _.forEach(mirror.spread_pools, spread_pool => {
             // Checking if the pool is writable
-            if (!_.get(tiering_pools_status, `${spread_pool.name}.valid_for_allocation`, false)) {
+            if (!_.get(tiering_pools_status, `${spread_pool._id}.valid_for_allocation`, false)) {
                 pool_weight += WEIGHTS.non_writable_pool;
             }
 
@@ -90,10 +90,10 @@ function select_pool_type(spread_pools, tiering_pools_status) {
 
     // Checking if there are any valid on premise pools
     mirror_status.regular_pools_valid = _.some(mirror_status.regular_pools,
-        pool => _.get(tiering_pools_status, `${pool.name}.valid_for_allocation`, false));
+        pool => _.get(tiering_pools_status, `${pool._id}.valid_for_allocation`, false));
     // Checking if there are any valid cloud pools
     mirror_status.cloud_pools_valid = _.some(mirror_status.cloud_pools,
-        pool => _.get(tiering_pools_status, `${pool.name}.valid_for_allocation`, false));
+        pool => _.get(tiering_pools_status, `${pool._id}.valid_for_allocation`, false));
 
     // Checking what type of a pool we've selected above
     if (_.get(selected_pool_type, 'cloud_pool_info', false)) {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -848,7 +848,7 @@ function get_bucket_info(bucket, nodes_aggregate_pool, aggregate_data_free_by_ti
         let num_valid_nodes = 0;
         let has_valid_pool = false;
         _.compact((mirror_object.spread_pools || []).map(pool =>
-                tiering_pools_status[pool.name]))
+                tiering_pools_status[pool._id]))
             .forEach(pool_status => {
                 num_valid_nodes += pool_status.num_nodes || 0;
                 has_valid_pool = has_valid_pool || pool_status.valid_for_allocation;

--- a/src/test/unit_tests/test_map_utils.js
+++ b/src/test/unit_tests/test_map_utils.js
@@ -34,7 +34,7 @@ mocha.describe('map_utils', function() {
             pools = _.concat(pools);
             let tiering_pools_status = {};
             _.forEach(pools, pool => {
-                tiering_pools_status[pool.name] = {
+                tiering_pools_status[pool._id] = {
                     valid_for_allocation: true,
                     num_nodes: config.NODES_MIN_COUNT
                 };


### PR DESCRIPTION
### Explain the changes:
- pool names that contains ‘.’ (e.g. first.pool) caused _.get in
- map_utils to not find a valid pool


### Issues (fixed #xxxx / opened technical debt #yyyy)
-  Fixes #2852 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
