### PR TITLE
fix for #1902- Show used buckets tab in pool page

### DIFF
--- a/frontend/src/app/components/pool/pool-associated-buckets-list/pool-associated-buckets-list.html
+++ b/frontend/src/app/components/pool/pool-associated-buckets-list/pool-associated-buckets-list.html
@@ -1,0 +1,14 @@
+<div class="pad alt-bg">
+    <h2 class="heading3">
+        Buckets using this pool in their placement policy: {{bucketCount}}
+    </h2>
+    <p>
+        The following buckets are using this pool as part of their placement policy
+    </p>
+</div>
+
+<ul class="list-no-style column greedy pad" ko.foreach="buckets">
+    <li class="push-next">
+        <a class="link" ko.text="name" ko.attr.href="href"></a>
+    </li>
+</ul>

--- a/frontend/src/app/components/pool/pool-associated-buckets-list/pool-associated-buckets-list.js
+++ b/frontend/src/app/components/pool/pool-associated-buckets-list/pool-associated-buckets-list.js
@@ -1,0 +1,40 @@
+import template from './pool-associated-buckets-list.html';
+import Observer from 'observer';
+import state$ from 'state';
+import * as routes from 'routes';
+import ko from 'knockout';
+import { realizeUri } from 'utils/browser-utils';
+
+// TODO: Replace with data from the state$ when available.
+import { routeContext } from 'model';
+
+class PoolAssociatedBucketsListViewModel extends Observer {
+    constructor({ poolName }) {
+        super();
+
+        this.buckets = ko.observable();        
+        this.bucketCount = ko.observable();
+
+        this.observe(
+            state$.get('nodePools', ko.unwrap(poolName), 'associatedBuckets'),
+            this.onBuckets
+        );
+    }
+
+    onBuckets(buckets) {
+        const system = routeContext().params.system;
+
+        this.buckets(
+            buckets.map(bucket => ({
+                name: bucket,
+                href: realizeUri(routes.bucket, { system, bucket })
+            }))
+        );
+        this.bucketCount(buckets.length);
+    }
+}
+
+export default {
+    viewModel: PoolAssociatedBucketsListViewModel,
+    template: template
+};

--- a/frontend/src/app/components/pool/pool-associated-buckets-list/pool-associated-buckets-list.less
+++ b/frontend/src/app/components/pool/pool-associated-buckets-list/pool-associated-buckets-list.less
@@ -1,0 +1,3 @@
+pool-associated-buckets-list {
+    display: block;
+}

--- a/frontend/src/app/components/pool/pool-panel/pool-panel.html
+++ b/frontend/src/app/components/pool/pool-panel/pool-panel.html
@@ -9,6 +9,10 @@
             ko.css="tabCss('associated-accounts')">
             Associated Accounts
         </a>
+        <a ko.href="tabHref('associated-buckets')"
+            ko.css="tabCss('associated-buckets')">
+            Associated Buckets
+        </a>
     </nav>
 
     <div class="tabs-row">
@@ -23,6 +27,12 @@
             ko.css="tabCss('associated-accounts')"
             params="poolName: pool().name"
         ></pool-associated-accounts-list>
+ 
+        <pool-associated-buckets-list
+            class="tab greedy"
+            ko.css="tabCss('associated-buckets')"
+            params="poolName: pool().name"
+        ></pool-associated-buckets-list>
         <!-- /ko -->
     </div>
 </div>

--- a/frontend/src/app/components/register.js
+++ b/frontend/src/app/components/register.js
@@ -127,6 +127,7 @@ export default function register(ko) {
     ko.components.register('pool-summary',          require('./pool/pool-summary/pool-summary').default);
     ko.components.register('pool-nodes-table',      require('./pool/pool-nodes-table/pool-nodes-table').default);
     ko.components.register('pool-associated-accounts-list', require('./pool/pool-associated-accounts-list/pool-associated-accounts-list').default);
+    ko.components.register('pool-associated-buckets-list', require('./pool/pool-associated-buckets-list/pool-associated-buckets-list').default);
     /** INJECT:pool **/
 
     // -------------------------------

--- a/frontend/src/app/reducers/node-pools-reducer.js
+++ b/frontend/src/app/reducers/node-pools-reducer.js
@@ -1,4 +1,4 @@
-import { keyByProperty } from    'utils/core-utils';
+import { keyBy, keyByProperty, flatMap, groupBy } from 'utils/core-utils';
 import { createReducer } from 'utils/reducer-utils';
 
 // ------------------------------
@@ -15,23 +15,46 @@ function onApplicationInit() {
 
 function onSystemInfoFetched(state, { info }) {
     const nodePools = info.pools.filter(pool => Boolean(pool.nodes));
+    const bucketMapping = _mapPoolsToBuckets(info.buckets, info.tiers);    
     return keyByProperty(nodePools, 'name', pool => {
         const {
             name,
             mode,
             storage,
-            associated_accounts: associatedAccounts
-        } = pool;
+            associated_accounts: associatedAccounts,            
+        } = pool;        
+        const associatedBuckets = bucketMapping[pool.name];
 
-
-        return { name, mode, storage, associatedAccounts };
+        return { name, mode, storage, associatedAccounts, associatedBuckets };
     });
 }
 
 // ------------------------------
 // Local util functions
 // ------------------------------
+function _mapPoolsToBuckets(buckets, tiers) {
+    const bucketsByTierName = keyBy(
+        buckets,
+        bucket => bucket.tiering.tiers[0].tier,
+        bucket => bucket.name
+    );
 
+    const pairs = flatMap(
+        tiers,
+        tier => tier.attached_pools.map(
+            poolName => ({
+                bucket: bucketsByTierName[tier.name],
+                pool: poolName
+            })
+        )
+    );
+
+    return groupBy(
+        pairs,
+        pair => pair.pool,
+        pair => pair.bucket
+    );
+}
 // ------------------------------
 // Exported reducer function
 // ------------------------------


### PR DESCRIPTION
### Explain the changes:
- fix for #1902- Show used buckets tab in pool page

### Issues (fixed #xxxx / opened technical debt #yyyy)
- Fixes #1902

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

