### PR TITLE
fixed rebuild issues - same as PR #2867

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",

--- a/src/server/object_services/map_utils.js
+++ b/src/server/object_services/map_utils.js
@@ -205,6 +205,7 @@ function get_chunk_status(chunk, tiering, additional_params) {
 
     let chunk_status = {
         allocations: [],
+        extra_allocations: [],
         deletions: [],
         accessible: false,
     };
@@ -226,6 +227,7 @@ function get_chunk_status(chunk, tiering, additional_params) {
         let status_result = _get_mirror_chunk_status(chunk, tier, mirror_status,
             mirror.spread_pools, additional_params);
         chunk_status.allocations = _.concat(chunk_status.allocations, status_result.allocations);
+        chunk_status.extra_allocations = _.concat(chunk_status.extra_allocations, status_result.extra_allocations);
         chunk_status.deletions = _.concat(chunk_status.deletions, status_result.deletions);
         // These two are used in order to delete all unused blocks by the policy
         // Which actually means blocks that are not relevant to the tier policy anymore
@@ -249,6 +251,7 @@ function _get_mirror_chunk_status(chunk, tier, mirror_status, mirror_pools, addi
     const tier_pools_by_name = _.keyBy(mirror_pools, 'name');
 
     let allocations = [];
+    let extra_allocations = []; // used for special replicas
     let deletions = [];
     let chunk_accessible = true;
 
@@ -355,7 +358,7 @@ function _get_mirror_chunk_status(chunk, tier, mirror_status, mirror_pools, addi
 
             // There is no point in special replicas when save in cloud
             if (!is_cloud_allocation) {
-                _.times(num_missing - min_replicas, () => allocations.push(_.defaults(_.clone(alloc), {
+                _.times(num_missing - min_replicas, () => extra_allocations.push(_.defaults(_.clone(alloc), {
                     special_replica: true
                 })));
             }
@@ -388,6 +391,7 @@ function _get_mirror_chunk_status(chunk, tier, mirror_status, mirror_pools, addi
 
     return {
         allocations: allocations,
+        extra_allocations: extra_allocations,
         deletions: deletions,
         accessible: chunk_accessible,
         unused_blocks: unused_blocks,

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -544,8 +544,7 @@ class MDStore {
         return this._parts.col().find({
                 chunk: {
                     $in: mongo_utils.uniq_ids(chunks, '_id')
-                },
-                deleted: null,
+                }
             })
             .toArray()
             .then(res_parts => {
@@ -553,8 +552,7 @@ class MDStore {
                 return this._objects.col().find({
                         _id: {
                             $in: mongo_utils.uniq_ids(res_parts, 'obj')
-                        },
-                        deleted: null,
+                        }
                     })
                     .toArray();
             })


### PR DESCRIPTION
Same as PR #2867 
### Explain the changes:
- fixed load_parts_objects_for_chunks which is called by map_builder,
to also find deleted objects and parts, so they will not cause node
migration to get stuck
- in map_utils.get_chunk_status, separated allocations of special
replicas to a different allocations array which is handled as an
optional allocation that doesn’t block rebuilds\migrations. chunk is
considered good even if it doesn’t have all of the extra allocations
stored.


### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
