### PR TITLE
fixed #101 - added audit log events for node going online\offline

### DIFF
--- a/frontend/src/app/components/admin/audit-pane/categories.js
+++ b/frontend/src/app/components/admin/audit-pane/categories.js
@@ -20,6 +20,16 @@ export default {
             recommission: {
                 message: 'Node Reactivated',
                 entityId: ({ node }) => node && node.name
+            },
+
+            connected: {
+                message: 'Node Connected',
+                entityId: ({ node }) => node && node.name
+            },
+
+            disconnected: {
+                message: 'Node Disconnected',
+                entityId: ({ node }) => node && node.name
             }
         }
     },


### PR DESCRIPTION
### Explain the changes:
- fixed #101 - added audit log events for node going online\offline
- events are triggered when item.online is changed in nodes monitor

### Issues (fixed #xxxx / opened technical debt #yyyy)
- Fixed #101 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deployment

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
