### PR TITLE
Internal Storage Backend Preperations

### DIFF
--- a/config.js
+++ b/config.js
@@ -19,8 +19,6 @@ config.LONG_GONE_THRESHOLD = 3600000;
 config.SHORT_GONE_THRESHOLD = 300000;
 config.LONG_BUILD_THRESHOLD = 300000;
 config.MAX_OBJECT_PART_SIZE = 64 * 1024 * 1024;
-config.DEMO_NODES_STORAGE_LIMIT = 500 * 1024 * 1024;
-config.NUM_DEMO_NODES = 3;
 config.NODE_IO_DETENTION_THRESHOLD = 60000;
 config.NODE_IO_DETENTION_RECENT_ISSUES = 5;
 // Picked two because minimum of nodes per pool is three
@@ -83,6 +81,10 @@ config.REBUILD_NODE_CONCURRENCY = 3;
 config.REBUILD_NODE_OFFLINE_GRACE = 5 * 60000;
 config.REBUILD_NODE_BATCH_SIZE = 10;
 config.REBUILD_NODE_BATCH_DELAY = 50;
+
+// TODO: JEN Temporary using the same number but later on they will be different cellings
+config.MIN_TIER_FREE_THRESHOLD = 100 * 1024 * 1024;
+config.MAX_TIER_FREE_THRESHOLD = 100 * 1024 * 1024;
 
 config.SCRUBBER_ENABLED = true;
 config.SCRUBBER_BATCH_SIZE = 10;
@@ -175,11 +177,6 @@ config.SUPERVISOR_DEFAULTS = {
     DIRECTORY: '/root/node_modules/noobaa-core'
 };
 
-
-config.DEMO_DEFAULTS = {
-    POOL_NAME: 'demo-pool',
-    BUCKET_NAME: 'demo-bucket'
-};
 
 config.SERVER_MIN_REQUIREMENTS = {
     RAM_GB: 16,

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -358,9 +358,9 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
-                required: ['tier_names'],
+                required: ['tier_ids'],
                 properties: {
-                    tier_names: {
+                    tier_ids: {
                         type: 'array',
                         items: {
                             type: 'string'
@@ -372,9 +372,9 @@ module.exports = {
                 type: 'array',
                 items: {
                     type: 'object',
-                    required: ['tier_name', 'mirrors_storage'],
+                    required: ['tier_id', 'mirrors_storage'],
                     properties: {
-                        tier_name: {
+                        tier_id: {
                             type: 'string'
                         },
                         mirrors_storage: {

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -237,9 +237,6 @@ module.exports = {
                 data_activities: {
                     $ref: 'node_api#/definitions/data_activities'
                 },
-                demo_pool: {
-                    type: 'boolean'
-                },
                 cloud_info: {
                     type: 'object',
                     properties: {

--- a/src/api/tiering_policy_api.js
+++ b/src/api/tiering_policy_api.js
@@ -125,6 +125,9 @@ module.exports = {
                             tier: {
                                 type: 'string',
                             },
+                            is_spillover: {
+                                type: 'boolean'
+                            }
                         }
                     }
                 }

--- a/src/server/node_services/nodes_aggregator.js
+++ b/src/server/node_services/nodes_aggregator.js
@@ -8,34 +8,35 @@ const P = require('../../util/promise');
 const server_rpc = require('../server_rpc');
 const auth_server = require('../common_services/auth_server');
 const size_utils = require('../../util/size_utils');
+const system_store = require('../system_services/system_store').get_instance();
 const BigInteger = size_utils.BigInteger;
 
 
 function aggregate_data_free_by_tier(req) {
     let available_by_tiers = [];
 
-    return P.each(req.rpc_params.tier_names, tier_name => {
-            return _aggregate_data_free_for_tier(tier_name, req.system)
+    return P.each(req.rpc_params.tier_ids, tier_id => {
+            return _aggregate_data_free_for_tier(tier_id, req.system)
                 .then(available_storage => {
                     available_by_tiers.push({
-                        tier_name: tier_name,
+                        tier_id: tier_id,
                         mirrors_storage: available_storage
                     });
                 })
                 .catch(err => {
-                    console.error(`Error getting available to upload of tier: ${tier_name}`, err);
+                    console.error(`Error getting available to upload of tier: ${tier_id}`, err);
                 });
         })
         .return(available_by_tiers);
 }
 
 
-function _aggregate_data_free_for_tier(tier_name, system) {
+function _aggregate_data_free_for_tier(tier_id, system) {
     let mirror_available_storage = [];
-    let tier = system.tiers_by_name[tier_name];
+    let tier = system_store.data.get_by_id(tier_id);
 
     if (!tier) {
-        let err = new Error(`Tier ${tier_name} was not found`);
+        let err = new Error(`Tier ${tier_id} was not found`);
         console.error(err);
         return P.reject(err);
     }

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -72,16 +72,16 @@ class NodesClient {
     }
 
 
-    aggregate_data_free_by_tier(tier_names, system_id) {
+    aggregate_data_free_by_tier(tier_ids, system_id) {
         return server_rpc.client.node.aggregate_data_free_by_tier({
-            tier_names: tier_names,
-        }, {
-            auth_token: auth_server.make_auth_token({
-                system_id: system_id,
-                role: 'admin'
+                tier_ids: tier_ids,
+            }, {
+                auth_token: auth_server.make_auth_token({
+                    system_id: system_id,
+                    role: 'admin'
+                })
             })
-        })
-        .then(res => _.mapValues(_.keyBy(res, 'tier_name'), 'mirrors_storage'));
+            .then(res => _.mapValues(_.keyBy(res, 'tier_id'), 'mirrors_storage'));
     }
 
 

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -493,11 +493,11 @@ class NodesMonitor extends EventEmitter {
                 name: NO_NAME_PREFIX + Date.now().toString(36),
             },
         };
+
         if (pool.cloud_pool_info) {
             item.node.is_cloud_node = true;
-        } else if (pool.demo_pool) {
-            item.node.is_internal_node = true;
         }
+
         dbg.log0('_add_new_node', item.node);
         this._set_need_update.add(item);
         this._add_node_to_maps(item);

--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -130,15 +130,19 @@ class MapBuilder {
         _.each(this.chunks, chunk => {
             if (chunk.had_errors) return;
             map_utils.set_chunk_frags_from_blocks(chunk, chunk.blocks);
-            const tiering_pools_status = node_allocator.get_tiering_pools_status(chunk.bucket.tiering);
-            chunk.status = map_utils.get_chunk_status(chunk, chunk.bucket.tiering, {
-                tiering_pools_status: tiering_pools_status
-            });
+
+            chunk.status = map_utils.get_chunk_status(
+                chunk,
+                chunk.bucket.tiering, {
+                    tiering_status: node_allocator.get_tiering_status(chunk.bucket.tiering)
+                });
+
             // first allocate the basic allocations of the chunk.
             // if there are no allocations, then try to allocate extra_allocations for special replicas
             chunk.current_cycle_allocations = chunk.status.allocations.length ?
                 chunk.status.allocations :
                 chunk.status.extra_allocations;
+
             // only delete blocks if the chunk is in good shape,
             // that is no allocations needed, and is accessible.
             if (chunk.status.accessible &&

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -521,8 +521,7 @@ function read_object_md(req) {
             });
 
             return map_reader.read_object_mappings({
-                    obj: obj,
-                    adminfo: true
+                    obj: obj
                 })
                 .then(parts => {
                     info.total_parts_count = parts.length;

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -327,7 +327,6 @@ function get_pool_info(pool, nodes_aggregate_pool) {
     } else {
         info.nodes = _.defaults({}, p.nodes, POOL_NODES_INFO_DEFAULTS);
         info.undeletable = check_pool_deletion(pool, nodes_aggregate_pool);
-        info.demo_pool = Boolean(pool.demo_pool);
         info.mode = calc_pool_mode(info);
     }
 
@@ -362,11 +361,6 @@ function calc_pool_mode(pool_info) {
 }
 
 function check_pool_deletion(pool, nodes_aggregate_pool) {
-    // Check if the demo pool
-    if (pool.name === config.DEMO_DEFAULTS.POOL_NAME) {
-        return 'SYSTEM_ENTITY';
-    }
-
     // Check if there are nodes till associated to this pool
     const nodes_count = _.get(nodes_aggregate_pool, [
         'groups', String(pool._id), 'nodes', 'count'

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -22,11 +22,6 @@ module.exports = {
         name: {
             type: 'string'
         },
-
-        demo_pool: {
-            type: 'boolean'
-        },
-
         // cloud pool information - exist only for cloud pools
         cloud_pool_info: {
             type: 'object',

--- a/src/server/system_services/schemas/tiering_policy_schema.js
+++ b/src/server/system_services/schemas/tiering_policy_schema.js
@@ -35,6 +35,9 @@ module.exports = {
                     tier: {
                         format: 'objectid'
                     },
+                    is_spillover: {
+                        type: 'boolean'
+                    }
                 }
             }
         },

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -340,6 +340,8 @@ class SystemStore extends EventEmitter {
 
     constructor() {
         super();
+        // // TODO: This is currently used as a cache, maybe will be moved in the future
+        // this.valid_for_alloc_by_tier = {};
         this.is_cluster_master = false;
         this.is_finished_initial_load = false;
         this.START_REFRESH_THRESHOLD = 10 * 60 * 1000;

--- a/src/test/system_tests/test_build_chunks.js
+++ b/src/test/system_tests/test_build_chunks.js
@@ -518,6 +518,7 @@ function test_setup(bucket_name, pool_names, mirrored, cloud_pool, num_of_nodes_
         .then(() => client.tiering_policy.create_policy({
             name: TEST_CTX.default_tier_policy_name,
             tiers: [{
+                is_spillover: false,
                 order: 0,
                 tier: TEST_CTX.default_tier_name
             }]

--- a/src/test/system_tests/test_cloud_sync.js
+++ b/src/test/system_tests/test_cloud_sync.js
@@ -595,6 +595,7 @@ function _create_bucket(params) {
             client.tiering_policy.create_policy({
                 name: params.tiering_policy,
                 tiers: [{
+                    is_spillover: false,
                     order: 0,
                     tier: params.tier
                 }]

--- a/src/test/system_tests/test_files_spread.js
+++ b/src/test/system_tests/test_files_spread.js
@@ -72,6 +72,7 @@ function run_test() {
             client.tiering_policy.create_policy({
                 name: 'tiering1',
                 tiers: [{
+                    is_spillover: false,
                     order: 0,
                     tier: 'tier1'
                 }]

--- a/src/test/system_tests/test_md_aggregator.js
+++ b/src/test/system_tests/test_md_aggregator.js
@@ -65,6 +65,7 @@ function create_bucket(bucket_name) {
         .then(() => client.tiering_policy.create_policy({
             name: `${bucket_name}tiering`,
             tiers: [{
+                is_spillover: false,
                 order: 0,
                 tier: `${bucket_name}tier`
             }]

--- a/src/test/system_tests/test_node_failure.js
+++ b/src/test/system_tests/test_node_failure.js
@@ -128,6 +128,7 @@ function create_test_bucket() {
             client.tiering_policy.create_policy({
                 name: 'tiering-' + TEST_CTX.bucket,
                 tiers: [{
+                    is_spillover: false,
                     order: 0,
                     tier: 'tier-' + TEST_CTX.bucket
                 }]

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -226,6 +226,7 @@ mocha.describe('system_servers', function() {
             .then(() => client.tiering_policy.create_policy({
                 name: TIERING_POLICY,
                 tiers: [{
+                    is_spillover: false,
                     order: 0,
                     tier: TIER
                 }]
@@ -236,9 +237,11 @@ mocha.describe('system_servers', function() {
             .then(() => client.tiering_policy.update_policy({
                     name: TIERING_POLICY,
                     tiers: [{
+                        is_spillover: false,
                         order: 0,
                         tier: TIER
                     }, {
+                        is_spillover: false,
                         order: 1,
                         tier: TIER
                     }]

--- a/src/util/size_utils.js
+++ b/src/util/size_utils.js
@@ -116,9 +116,6 @@ function reduce_storage(reducer, storage_items, mult_factor, div_factor) {
 }
 
 
-// a map-reduce part for finding the minimum value
-// this function must be self contained to be able to send to mongo mapReduce()
-// so not using any functions or constants from above.
 function reduce_minimum(key, values) {
     var n_min = PETABYTE;
     var peta_min = 100000;
@@ -145,6 +142,35 @@ function reduce_minimum(key, values) {
         n: n_min,
         peta: peta_min,
     } : n_min;
+}
+
+
+function reduce_maximum(key, values) {
+    var n_max = 0;
+    var peta_max = 0;
+    values.forEach(function(v) {
+        var n = 0;
+        var peta = 0;
+        if (typeof(v) === 'number') {
+            n = v;
+        } else if (v) {
+            n = v.n;
+            peta = v.peta;
+        }
+        while (n >= PETABYTE) {
+            n -= PETABYTE;
+            peta += 1;
+        }
+
+        if (peta > peta_max || (peta === peta_max && n > n_max)) {
+            n_max = n;
+            peta_max = peta;
+        }
+    });
+    return peta_max ? {
+        n: n_max,
+        peta: peta_max,
+    } : n_max;
 }
 
 
@@ -247,6 +273,7 @@ exports.json_to_bigint = json_to_bigint;
 exports.to_bigint_storage = to_bigint_storage;
 exports.reduce_storage = reduce_storage;
 exports.reduce_minimum = reduce_minimum;
+exports.reduce_maximum = reduce_maximum;
 exports.reduce_sum = mongo_functions.reduce_sum;
 exports.human_size = human_size;
 exports.human_offset = human_offset;


### PR DESCRIPTION
### Explain the changes:
- Adding Internal Storage to the system as a second tier
- Currently only the map functionalities without any RPC
- Fixed previous tests and added couple of new tests for spillover

### Issues (fixed #xxxx / opened technical debt #yyyy)

### GAPS
- Should implement the threshold with the usage of the tier states.
- Should call aggregate_data_free_by_tier in the nodes_monitor like BG worker of some sort
And it should update the free for tiers inside the system_store ( update in DB).
All of the places that currently call and wait for the response will just read from the system_store.
- Should update the tier algorithm to work with more than two tiers (maybe it works right now as well but it was not tested)

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

[For FE PRs use the template](https://github.com/noobaa/noobaa-core/blob/master/FE_PULL_REQUEST.md)
