### PR TITLE
Adding edit option for cluster servers

### DIFF
--- a/src/api/cluster_server_api.js
+++ b/src/api/cluster_server_api.js
@@ -45,6 +45,32 @@ module.exports = {
             },
         },
 
+        update_member_of_cluster: {
+            doc: 'Update member of the cluster',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['old_address', 'new_address', 'shard', 'hostname'],
+                properties: {
+                    old_address: {
+                        type: 'string',
+                    },
+                    new_address: {
+                        type: 'string',
+                    },
+                    shard: {
+                        type: 'string'
+                    },
+                    hostname: {
+                        type: 'string'
+                    }
+                },
+            },
+            auth: {
+                system: 'admin'
+            },
+        },
+
         update_time_config: {
             method: 'POST',
             params: {


### PR DESCRIPTION
### Explain the changes:
- Edit cluster server's IP address
- This came to solve the bug when the servers went down and changed their IP's, realizing they are not a part of cluster anymore since we recognize by IP

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- #2204 
- #2617 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

