### PR TITLE
Fix #2912 - show 0 for pools with no associated buckets

### DIFF
--- a/frontend/src/app/reducers/node-pools-reducer.js
+++ b/frontend/src/app/reducers/node-pools-reducer.js
@@ -23,7 +23,7 @@ function onSystemInfoFetched(state, { info }) {
             storage,
             associated_accounts: associatedAccounts,            
         } = pool;        
-        const associatedBuckets = bucketMapping[pool.name];
+        const associatedBuckets = bucketMapping[pool.name] || [];
 
         return { name, mode, storage, associatedAccounts, associatedBuckets };
     });


### PR DESCRIPTION
### Explain the changes:
- Fix #2912 - show 0 for pools with no associated buckets

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixed #2912

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

