### PR TITLE
Fix copyright stripping bug 

### DIFF
--- a/frontend/src/app/knockout-extensions.js
+++ b/frontend/src/app/knockout-extensions.js
@@ -268,6 +268,7 @@ function preprocessComment(comment) {
     const text = comment.nodeValue.toLowerCase();
     if (copyrightsIdentifiers.every(identifier => text.includes(identifier))) {
         comment.parentNode.removeChild(comment);
+        return [];
     }
 }
 


### PR DESCRIPTION
### Explain the changes:
- Return an empty array from the preprocess function that tell knockout to rebind the template.

