### PR TITLE
basic azure rest api implementation

### DIFF
--- a/src/s3/azure_rest.js
+++ b/src/s3/azure_rest.js
@@ -1,0 +1,189 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+// const xml2js = require('xml2js');
+const express = require('express');
+const uuid = require('node-uuid');
+
+const P = require('../util/promise');
+const dbg = require('../util/debug_module')(__filename);
+// const config = require('../../config');
+const S3Error = require('./s3_errors').S3Error;
+const xml_utils = require('../util/xml_utils');
+const auth_server = require('../server/common_services/auth_server');
+const system_store = require('../server/system_services/system_store').get_instance();
+// const time_utils = require('../util/time_utils');
+// const signature_utils = require('../util/signature_utils');
+
+
+const AZURE_XML_ATTRS = Object.freeze({
+    ServiceEndpoint: 'http://azure.noobaa/'
+});
+
+
+
+
+function azure_rest(controller) {
+
+    let app = new express.Router();
+    app.use((req, res, next) => {
+        if (!req.headers['x-ms-version']) {
+            return next(new Error('S3_REQUEST'));
+        }
+        return next();
+    });
+    app.use(handle_options);
+    // app.use(check_headers);
+    // app.use(handle_testme);
+    app.use(authenticate_azure_request);
+    app.get('/', azure_handler('list_containers'));
+    app.head('/:container', azure_handler('get_container_properties'));
+    app.get('/:container', azure_handler('get_container'));
+    app.put('/:container', azure_handler('put_container'));
+    // app.post('/:bucket', prepare_post_bucket_req, s3_handler('post_bucket', ['delete']));
+    // app.delete('/:bucket', s3_handler('delete_bucket', BUCKET_QUERIES));
+    app.head('/:bucket/:key(*)', azure_handler('get_blob_properties'));
+    app.get('/:bucket/:key(*)', azure_handler('get_object'));
+    app.put('/:bucket/:key(*)', azure_handler('put_blob'));
+    // app.post('/:bucket/:key(*)', prepare_post_object_req, s3_handler('post_object', ['uploadId', 'uploads']));
+    // app.delete('/:bucket/:key(*)', s3_handler('delete_object', ['uploadId']));
+    app.use(handle_common_azure_errors);
+    return app;
+
+
+    /**
+     * returns a route handler for the given function
+     * the queries are optional list of sub queries that
+     * will be checked in the req.query and change the
+     * called function accordingly.
+     */
+    function azure_handler(func_name, queries) {
+        return function(req, res, next) {
+            let found_query = queries && _.find(queries, q => {
+                if (q in req.query) {
+                    azure_call(func_name + '_' + q, req, res, next);
+                    return true; // break from _.find
+                }
+            });
+            if (!found_query) {
+                azure_call(func_name, req, res, next);
+            }
+        };
+    }
+
+    /**
+     * call a function in the controller, and prepare the result
+     * to send as xml.
+     */
+    function azure_call(func_name, req, res, next) {
+        dbg.log0('AZURE REQUEST', func_name, req.method, req.originalUrl, req.headers);
+        let func = controller[func_name];
+        if (!func) {
+            dbg.error('AZURE TODO (NotImplemented)', func_name, req.method, req.originalUrl);
+            next(new S3Error(S3Error.NotImplemented));
+            return;
+        }
+        P.fcall(() => func.call(controller, req, res))
+            .then(reply => {
+                if (reply === false) {
+                    // in this case the controller already replied
+                    return;
+                }
+                dbg.log1('AZURE REPLY', func_name, req.method, req.originalUrl, reply);
+                if (reply) {
+                    let _attr = {
+                        ServiceEndpoint: AZURE_XML_ATTRS.ServiceEndpoint
+                    };
+                    if (reply.container) {
+                        _attr.ContainerName = reply.container;
+                        delete reply.container;
+                    }
+                    let xml_root = _.mapValues(reply, val => ({
+                        _attr,
+                        _content: val
+                    }));
+                    let xml_reply = xml_utils.encode_xml(xml_root);
+                    dbg.log0('AZURE XML REPLY', func_name, req.method, req.originalUrl,
+                        JSON.stringify(res._headers), xml_reply);
+                    res.status(200).send(xml_reply);
+                } else {
+                    dbg.log0('AZURE EMPTY REPLY', func_name, req.method, req.originalUrl,
+                        JSON.stringify(res._headers));
+                    if (res.created) {
+                        res.status(201).end();
+                    } else {
+                        res.status(200).end();
+                    }
+                }
+            })
+            .catch(err => next(err));
+    }
+
+    /**
+     * TODO: fix authentication. currently autherizes everything.
+     */
+    function authenticate_azure_request(req, res, next) {
+        P.fcall(function() {
+                let system = system_store.data.systems[0];
+                req.auth_token = auth_server.make_auth_token({
+                    system_id: system._id,
+                    account_id: system.owner._id,
+                    role: 'admin'
+                });
+                return controller.prepare_request(req);
+            })
+            .then(() => next())
+            .catch(err => {
+                dbg.error('authenticate_azure_request: ERROR', err.stack || err);
+                next(new S3Error(S3Error.SignatureDoesNotMatch));
+            });
+    }
+
+    /**
+     * handle s3 errors and send the response xml
+     */
+    function handle_common_azure_errors(err, req, res, next) {
+        if (!err) {
+            dbg.log0('S3 InvalidURI.', req.method, req.originalUrl);
+            err = new S3Error(S3Error.InvalidURI);
+        }
+        if (err.message === 'S3_REQUEST') {
+            return next();
+        }
+        if (err.rpc_code === 'NO_SUCH_BUCKET') {
+            res.status(404).send('The specified container does not exist.');
+        }
+    }
+
+
+
+
+}
+
+
+function handle_options(req, res, next) {
+    // note that browsers will not allow origin=* with credentials
+    // but anyway we allow it by the agent server.
+
+    // these are the default and might get overriden by api's that
+    // return actual data in the reply instead of xml
+    res.setHeader('ETag', '"1"');
+    res.setHeader('Content-Type', 'application/xml');
+    res.setHeader('x-ms-version', req.headers['x-ms-version']);
+
+    req.request_id = Date.now().toString(36);
+    res.setHeader('x-ms-request-id', uuid());
+    res.setHeader('Date', (new Date()).toUTCString());
+
+    // replace hadoop _$folder$
+    if (req.params.key) {
+        req.params.key = req.params.key.replace(/_\$folder\$/, '/');
+    }
+
+    next();
+}
+
+
+// EXPORTS
+module.exports = azure_rest;


### PR DESCRIPTION
### Explain the changes:
- very basic support for azure storage blob service API
- to start s3rver with azure support the flag `--azure` should be used. without this flag there is no effect on s3rver.
- Implemented verbs (not all options are supported for each verb):
    - list containers (https://docs.microsoft.com/en-us/rest/api/storageservices/list-containers2)
        - not supporting maxresults\marker\prefix and include=metadata
    - list blobs (https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs)
    - get container properties (https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties)
        - used by Azure Storage Explorer - returns fake properties for lease state
    - get blob (https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob)
    * put blob (https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob)
        * analog to put object, not multipart
    * create container (https://docs.microsoft.com/en-us/rest/api/storageservices/create-container)
- **cyberduck** only works with HTTPS, and fails on get_blob. looks like it is related to the fact that we use self signed certificates (saw it in cyberduck logs).
- **Microsoft Azure Storage Explorer** (http://storageexplorer.com/) works with HTTP, but also doesn't work with HTTPS and self signed.
    - it uses the URI format of account.blob.endpoint, so to make it work I had o edit /etc/hosts to route the requests to the correct IP


### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

