### PR TITLE
Addition of mongo wrapper

### DIFF
--- a/src/deploy/NVA_build/common_funcs.sh
+++ b/src/deploy/NVA_build/common_funcs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MONGO_PROGRAM="mongodb"
+MONGO_PROGRAM="mongo_wrapper"
 MONGO_SHELL="/usr/bin/mongo nbcore"
 LOG_FILE="/var/log/noobaa_deploy_wrapper.log"
 
@@ -13,21 +13,11 @@ function deploy_log {
 }
 
 function set_mongo_cluster_mode {
-    MONGO_PROGRAM="mongors-shard1"
 	RS_SERVERS=`grep MONGO_RS_URL /root/node_modules/noobaa-core/.env | cut -d'@' -f 2 | cut -d'/' -f 1`
-    MONGO_SHELL="/usr/bin/mongors --host shard1/${RS_SERVERS} nbcore"
+    MONGO_SHELL="/usr/bin/mongors --host shard1/${RS_SERVERS}"
 }
 
 function check_mongo_status {
-    # check the supervisor status first
-    local super_status=$(supervisorctl status ${MONGO_PROGRAM})
-    local super_state=$(awk '{ print $2 }' <<< $super_status)
-    if [ "$super_state" != "RUNNING" ]
-    then
-        deploy_log "check_mongo_status: Supervisor status not running: $super_status"
-        return 1
-    fi
-
     # even if the supervisor reports the service is running try to connect to it
     local mongo_status
     # beware not to run "local" in the same line changes the exit code

--- a/src/deploy/NVA_build/fix_mongo_ssl.sh
+++ b/src/deploy/NVA_build/fix_mongo_ssl.sh
@@ -10,7 +10,7 @@ if [ ! -d /etc/mongo_ssl/ ]; then
   chmod +x /usr/bin/mongors
 fi
 
-if grep -q MONGO_SSL_USER /root/node_modules/noobaa-core/.env; then
+if ! grep -q MONGO_SSL_USER /root/node_modules/noobaa-core/.env; then
   client_subject=`openssl x509 -in /etc/mongo_ssl/client.pem -inform PEM -subject -nameopt RFC2253 | grep subject | awk '{sub("subject= ",""); print}'`
   echo "MONGO_SSL_USER=${client_subject}" >> /root/node_modules/noobaa-core/.env
 fi

--- a/src/deploy/NVA_build/mongo_wrapper.sh
+++ b/src/deploy/NVA_build/mongo_wrapper.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+COMMON_FUNCS_PATH="/root/node_modules"
+. ${COMMON_FUNCS_PATH}/noobaa-core/src/deploy/NVA_build/common_funcs.sh
+MONGO_SHELL="/usr/bin/mongo nbcore"
+MONGO_EXEC="$@"
+deploy_log "MONGO_EXEC is: ${MONGO_EXEC}"
+MONGO_PORT=$(echo $@ | sed -n -e 's/^.*port //p' | awk '{print $1}')
+deploy_log "MONGO_PORT is: ${MONGO_PORT}"
+#Mongo uses two ports
+#27000 is currently the port for cluster
+#27015 is the port for a single server
+if [ ${MONGO_PORT} -eq '27000' ]; then
+  set_mongo_cluster_mode
+fi
+
+#Killing all of the procs that hold the desired port
+#Since mongo has a dedicated port nobody should hold it
+#Probably the only procs that will actually hold the ports
+#Are non supervised mongos, so we kill them in order to supervise
+function kill_services_on_mongo_ports {
+  local proc
+  proc=$(lsof -i :27017,27000 | awk '{if(NR>1)print $1,"",$2}')
+  #kill pids
+  for p in ${proc}; do
+    local pid=$(echo $proc | awk '{print $2}')
+    deploy_log "Killing ${p}"
+    kill -9 ${pid}
+  done
+
+  proc=$(ps -elf | grep mongo_wrapper | grep -v $$ | awk '{print $4}')
+  for p in ${proc}; do
+    deploy_log "Killing mongo_wrapper ${p}"
+    kill -9 ${p}
+  done
+}
+
+#Testing mongo for sanity every 10 seconds
+#TODO: Maybe change the time?!
+function mongo_sanity_check {
+  while check_mongo_status
+  do
+    sleep 10
+  done
+  deploy_log "mongo_sanity_check: Failed"
+  return 1
+}
+
+#MONGO_EXEC varies and can be either for cluster or single mongo
+function run_mongo {
+  local proc
+  deploy_log "run_mongo: Starting mongo process"
+  proc=$($MONGO_EXEC &)
+  deploy_log "run_mongo: Mongo process pid: ${proc}"
+  wait_for_mongo
+  deploy_log "run_mongo: Mongo started"
+}
+
+#First of all we kill proc that hold the desired port
+kill_services_on_mongo_ports
+#Limit run time so it won't get stuck in infinite loop on waiting for mongo
+timeout --signal=SIGINT 60 cat <( run_mongo )
+#Test sanity of mongo in order to catch problems and reload
+mongo_sanity_check
+if [ $? -eq 1 ]; then
+  deploy_log "mongo_sanity_check failure: Killing services"
+  kill_services_on_mongo_ports
+  exit 1
+fi

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -42,8 +42,11 @@ directory=/root/node_modules/noobaa-core
 command=/usr/local/bin/node src/s3/s3rver_starter.js --address 'wss://127.0.0.1:8443'
 #endprogram
 
-[program:mongodb]
-command=/usr/bin/mongod --bind_ip 127.0.0.1 --dbpath /var/lib/mongo/cluster/shard1
+[program:mongo_wrapper]
+stopsignal=KILL
+killasgroup=true
+stopasgroup=true
+command=/root/node_modules/noobaa-core/src/deploy/NVA_build/mongo_wrapper.sh /usr/bin/mongod --port 27017 --bind_ip 127.0.0.1 --dbpath /var/lib/mongo/cluster/shard1
 directory=/usr/bin
 user=root
 autostart=true

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -126,7 +126,7 @@ function upgrade_mongo_version {
 	sed -i 's:exclude=mongodb-org.*::' /etc/yum.conf
 
   deploy_log "stopping mongo"
-	${SUPERCTL} stop mongodb
+	${SUPERCTL} stop mongo_wrapper
 
 	#Upgrade to 3.4
 	deploy_log "Upgrade MongoDB to 3.4"
@@ -312,8 +312,10 @@ function post_upgrade {
   echo "${AGENT_VERSION_VAR}" >> ${CORE_DIR}/.env
 
   #if noobaa supervisor.conf is pre hosted_agents
-  local FOUND=$(grep "bg_workers_starter" /etc/noobaa_supervisor.conf | wc -l)
-  if [ ${FOUND} -eq 1 ]; then
+  local BG=$(grep "bg_workers_starter" /etc/noobaa_supervisor.conf | wc -l)
+  #if noobaa supervisor.conf is pre mongo_wrapper
+  local MONGO_DB=$(grep "mongodb" /etc/noobaa_supervisor.conf | wc -l)
+  if [ ${BG} -eq 1 ] || [ ${MONGO_DB} -eq 1 ]; then
     cp -f ${CORE_DIR}/src/deploy/NVA_build/noobaa_supervisor.conf /etc/noobaa_supervisor.conf
   fi
 

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -7,6 +7,7 @@ const DEV_MODE = (process.env.DEV_MODE === 'true');
 const _ = require('lodash');
 const dns = require('dns');
 const fs = require('fs');
+const os = require('os');
 const moment = require('moment');
 const url = require('url');
 const net = require('net');
@@ -1204,7 +1205,7 @@ function read_server_config(req) {
 
     return P.resolve()
         .then(function() {
-            if (DEV_MODE) {
+            if (DEV_MODE || os.type() === 'Darwin') {
                 // Notice that we only return from the current promise and continue the chain
                 // Later in method _verify_connection_to_phonehome, we attach the connection status
                 return;

--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -177,9 +177,10 @@ MongoCtrl.prototype._add_replica_set_member_program = function(name, first_serve
 
     let program_obj = {};
     let dbpath = config.MONGO_DEFAULTS.COMMON_PATH + '/' + name + (first_server ? '' : 'rs');
-    program_obj.name = 'mongors-' + name;
-    program_obj.command = 'mongod ' +
-        '--replSet ' + name +
+    program_obj.name = 'mongo_wrapper';
+    program_obj.command = '/root/node_modules/noobaa-core/src/deploy/NVA_build/mongo_wrapper.sh' +
+        ' mongod' +
+        ' --replSet ' + name +
         ' --port ' + config.MONGO_DEFAULTS.SHARD_SRV_PORT +
         ' --dbpath ' + dbpath +
         ' --sslMode requireSSL --clusterAuthMode x509 --sslAllowInvalidHostnames' +
@@ -188,6 +189,9 @@ MongoCtrl.prototype._add_replica_set_member_program = function(name, first_serve
         ' --sslClusterFile ' + config.MONGO_DEFAULTS.SERVER_CERT_PATH;
     program_obj.directory = '/usr/bin';
     program_obj.user = 'root';
+    program_obj.stopsignal = 'KILL';
+    program_obj.killasgroup = 'true';
+    program_obj.stopasgroup = 'true';
     program_obj.autostart = 'true';
     program_obj.priority = '1';
 
@@ -298,7 +302,7 @@ MongoCtrl.prototype._add_new_config_program = function() {
 };
 
 MongoCtrl.prototype._remove_single_mongo_program = function() {
-    return P.resolve(SupervisorCtl.remove_program('mongodb'));
+    return P.resolve(SupervisorCtl.remove_program('mongo_wrapper'));
 };
 
 MongoCtrl.prototype._refresh_services_list = function() {

--- a/src/server/utils/supervisor_ctrl.js
+++ b/src/server/utils/supervisor_ctrl.js
@@ -123,9 +123,10 @@ SupervisorCtrl.prototype.get_mongo_services = function() {
                     mongo_progs.push({
                         type: 'config',
                     });
-                } else if (prog.name.indexOf('mongodb') > 0) {
+                    // This should be for both cluster and single mongo
+                } else if (prog.name.indexOf('mongo_wrapper') > 0) {
                     mongo_progs.push({
-                        type: 'mongo_single',
+                        type: 'mongodb',
                     });
                 }
             });

--- a/src/test/system_tests/test_md_aggregator.js
+++ b/src/test/system_tests/test_md_aggregator.js
@@ -303,7 +303,7 @@ function wait_for_mongodb_to_start(max_seconds_to_wait) {
                 return isNotListening;
             },
             function() {
-                return promise_utils.exec('supervisorctl status mongodb', false, true)
+                return promise_utils.exec('supervisorctl status mongo_wrapper', false, true)
                     .then(function(res) {
                         if (String(res).indexOf('RUNNING') > -1) {
                             console.log('mongodb started after ' + wait_counter + ' seconds');


### PR DESCRIPTION
Fixing errors

Fixing bugs

Adding mongo wrapper

### Explain the changes:
- Addition of mongo wrapper that will check status every 10 seconds and attempt to run mongo in case of a failure, with the help of killing processes that hold desired ports

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixed #2106 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

