### PR TITLE
lambda: invoke function on server if allocating nodes does not allow

### DIFF
--- a/src/agent/func_services/func_node.js
+++ b/src/agent/func_services/func_node.js
@@ -88,7 +88,7 @@ class FuncNode {
                         name: name,
                         version: version,
                         read_code: true
-                    }))
+                    }, req.params.rpc_options))
                     .then(res => {
                         func = res;
                         if (code_sha256 !== func.config.code_sha256 ||


### PR DESCRIPTION
### Explain the changes:
- support running lambda functions even without nodes

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- None

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

