### PR TITLE
use 'x-ms-blob-content-type' for the uploaded blob content type

### DIFF
--- a/src/s3/s3_controller.js
+++ b/src/s3/s3_controller.js
@@ -1017,7 +1017,7 @@ class S3Controller {
             client: req.rpc_client,
             bucket: req.params.bucket,
             key: req.params.key,
-            content_type: req.headers['content-type'],
+            content_type: req.headers['x-ms-blob-content-type'],
             xattr: get_request_xattr(req),
             source_stream: req,
         };


### PR DESCRIPTION
### Explain the changes:
- blob content type is passed in  'x-ms-blob-content-type' header and not 'content-type' header

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #2935

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

