### PR TITLE
Azure errors fixes

### DIFF
--- a/src/s3/azure_errors.js
+++ b/src/s3/azure_errors.js
@@ -1,0 +1,52 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const xml_utils = require('../util/xml_utils');
+
+class AzureError extends Error {
+
+    constructor(err) {
+        super(err.message);
+        this.code = err.code;
+        this.http_code = err.http_code;
+        if (err.reply) {
+            this.reply = err.reply;
+        }
+    }
+
+    reply() {
+        return xml_utils.encode_xml({
+            Error: {
+                Code: this.code,
+                Message: this.message,
+            }
+        });
+    }
+
+}
+
+// See http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+
+const errors_defs = [{
+    code: 'InternalError',
+    message: 'The server encountered an internal error. Please retry the request.',
+    http_code: 500,
+}, {
+    code: 'ContainerAlreadyExists',
+    message: 'The specified container already exists.',
+    http_code: 409,
+}, {
+    code: 'NotImplemented',
+    message: 'functionality not implemented.',
+    http_code: 501,
+}, {
+    code: 'InvalidBlobOrBlock',
+    message: 'The specified blob or block content is invalid.',
+    http_code: 400,
+}];
+
+for (const err_def of errors_defs) {
+    AzureError[err_def.code] = err_def;
+}
+
+exports.AzureError = AzureError;

--- a/src/s3/s3_controller.js
+++ b/src/s3/s3_controller.js
@@ -7,6 +7,7 @@ const uuid = require('node-uuid');
 const dbg = require('../util/debug_module')(__filename);
 const ObjectIO = require('../api/object_io');
 const S3Error = require('./s3_errors').S3Error;
+const AzureError = require('./azure_errors').AzureError;
 const http_utils = require('../util/http_utils');
 const time_utils = require('../util/time_utils');
 
@@ -1012,6 +1013,10 @@ class S3Controller {
 
 
     put_blob(req, res) {
+        if (req.query.comp === 'block') {
+            // fail the operation for block upload (multipart)
+            throw new AzureError(AzureError.InternalError);
+        }
         this.usage_report.s3_usage_info.put_object += 1;
         let params = {
             client: req.rpc_client,


### PR DESCRIPTION

return ContainerAlreadyExists on create container with name exists

### Explain the changes:
- added azure_errors file
- return ContainerAlreadyExists on create container with name exists
- return error on put_block (multipart upload)

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #2937

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

