### PR TITLE
on nodes_monitor.stop - close all connections

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -198,6 +198,7 @@ class NodesMonitor extends EventEmitter {
     stop() {
         dbg.log0('stoping nodes_monitor');
         this._started = false;
+        this._close_all_nodes_connections();
         this._clear();
     }
 
@@ -565,6 +566,13 @@ class NodesMonitor extends EventEmitter {
         if (!item) throw new RpcError('NODE_NOT_FOUND', node_id);
         this._set_connection(item, conn);
     }
+
+    _close_all_nodes_connections() {
+        for (const item of this._map_node_id.values()) {
+            this._close_node_connection(item);
+        }
+    }
+
 
     _close_node_connection(item) {
         if (!item.connection) return;


### PR DESCRIPTION
### Explain the changes:
- close all agents connections when nodes_monitor is closed

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #2638 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

