### PR TITLE
Add domain search option for DNS settings, reregister alerts on FE reconnect

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1774,7 +1774,7 @@ export function updateServerDNSSettings(serverSecret, primaryDNS, secondaryDNS, 
     api.cluster_server.update_dns_servers({
         target_secret: serverSecret,
         dns_servers: [primaryDNS, secondaryDNS].filter(isDefined),
-        search_domain: searchDomains
+        search_domains: searchDomains
     })
         .then(
             () => sleep(config.serverRestartWaitInterval)

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -1768,12 +1768,13 @@ export function updateServerDetails(serverSecret, hostname, location) {
         .done();
 }
 
-export function updateServerDNSSettings(serverSecret, primaryDNS, secondaryDNS) {
-    logAction('updateServerDNSSettings', { serverSecret, primaryDNS, secondaryDNS });
+export function updateServerDNSSettings(serverSecret, primaryDNS, secondaryDNS, searchDomains) {
+    logAction('updateServerDNSSettings', { serverSecret, primaryDNS, secondaryDNS , searchDomains});
 
     api.cluster_server.update_dns_servers({
         target_secret: serverSecret,
-        dns_servers: [primaryDNS, secondaryDNS].filter(isDefined)
+        dns_servers: [primaryDNS, secondaryDNS].filter(isDefined),
+        search_domain: searchDomains
     })
         .then(
             () => sleep(config.serverRestartWaitInterval)

--- a/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.html
+++ b/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.html
@@ -17,6 +17,12 @@
     <editor params="label: 'Secondary DNS'" class="push-next">
         <input type="text" data-bind="value: secondaryDNS" />
     </editor>
+    <editor params="label: 'Search Domains'" class="push-next">
+        <input type="text" placeholder="e.g. noobaa, dev.lab" data-bind="value: searchDomains" />
+        <p class="remark push-prev-half">
+            Type Domain names seperated by a comma
+        </p>
+    </editor>
 </section>
 
 <div class="row content-middle align-end push-prev">

--- a/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.js
+++ b/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.js
@@ -36,7 +36,7 @@ class EditServerDNSSettingsModalViewModel extends BaseViewModel {
             () => server() ? server().dns_servers : []
         );
 
-        this.serachDomains = ko.observableWithDefault(
+        this.searchDomains = ko.observableWithDefault(
             () => (server() ? server().search_domains : []).join(',')
         );
 
@@ -77,10 +77,8 @@ class EditServerDNSSettingsModalViewModel extends BaseViewModel {
             this.errors.showAllMessages();
 
         } else {
-            updateServerDNSSettings(
-                this.serverSecret, this.primaryDNS(), this.secondaryDNS(),
-                this.searchDomains() ? this.searchDomains().split(',') : []
-            );
+            const sdomains = (this.searchDomains() ? this.searchDomains().split(',') : []).map(d => d.trim());
+            updateServerDNSSettings(this.serverSecret, this.primaryDNS(), this.secondaryDNS(), sdomains);
 
             lockActiveModal();
             this.updating(true);

--- a/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.js
+++ b/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.js
@@ -36,7 +36,12 @@ class EditServerDNSSettingsModalViewModel extends BaseViewModel {
             () => server() ? server().dns_servers : []
         );
 
+        this.serachDomains = ko.observableWithDefault(
+            () => (server() ? server().search_domains : []).join(',')
+        );
+
         this.warning = ko.pureComputed(
+
             () => {
                 if (!server()) {
                     return '';
@@ -48,8 +53,8 @@ class EditServerDNSSettingsModalViewModel extends BaseViewModel {
         );
 
         this.primaryDNS = ko.observableWithDefault(
-            () => dnsServers()[0]
-        )
+                () => dnsServers()[0]
+            )
             .extend({
                 required: {
                     onlyIf: () => this.secondaryDNS(),
@@ -59,8 +64,8 @@ class EditServerDNSSettingsModalViewModel extends BaseViewModel {
             });
 
         this.secondaryDNS = ko.observableWithDefault(
-            () => dnsServers()[1]
-        )
+                () => dnsServers()[1]
+            )
             .extend({ isIP: true });
 
         this.updating = ko.observable(false);
@@ -73,7 +78,8 @@ class EditServerDNSSettingsModalViewModel extends BaseViewModel {
 
         } else {
             updateServerDNSSettings(
-                this.serverSecret, this.primaryDNS(), this.secondaryDNS()
+                this.serverSecret, this.primaryDNS(), this.secondaryDNS(),
+                this.searchDomains() ? this.searchDomains().split(',') : []
             );
 
             lockActiveModal();

--- a/frontend/src/app/dispatchers/modals-dispatchers.js
+++ b/frontend/src/app/dispatchers/modals-dispatchers.js
@@ -186,7 +186,8 @@ export function openEditServerDNSSettingsModal(serverSecret) {
             params: { serverSecret }
         },
         options: {
-            title: 'Edit Server DNS Settings'
+            title: 'Edit Server DNS Settings',
+            size: 'medium'
         }
     });
 }

--- a/frontend/src/app/services/api.js
+++ b/frontend/src/app/services/api.js
@@ -19,5 +19,8 @@ rpc.register_service(
     {}
 );
 
-export default window.api = rpc.new_client();
+const api = rpc.new_client();
+rpc.on('reconnect', () => api.redirector.register_for_alerts());
+
+export default window.api = api;
 

--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -362,7 +362,7 @@ module.exports = {
                         type: 'string'
                     },
                 },
-                search_domain: {
+                search_domains: {
                     type: 'array',
                     items: {
                         type: 'string'

--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -362,6 +362,12 @@ module.exports = {
                         type: 'string'
                     },
                 },
+                search_domain: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    },
+                }
             },
         }
     },

--- a/src/api/cluster_server_api.js
+++ b/src/api/cluster_server_api.js
@@ -187,6 +187,12 @@ module.exports = {
                     using_dhcp: {
                         type: 'boolean'
                     },
+                    search_domains: {
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        },
+                    },
                     used_proxy: {
                         type: 'object',
                         properties: {

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -808,7 +808,7 @@ module.exports = {
                         type: 'string'
                     },
                 },
-                search_domain: {
+                search_domains: {
                     type: 'array',
                     items: {
                         type: 'string'

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -808,6 +808,12 @@ module.exports = {
                         type: 'string'
                     },
                 },
+                search_domain: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    },
+                },
                 debug_level: {
                     type: 'integer'
                 },

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -57,6 +57,7 @@ function install_platform {
     echo "#NooBaa Configured NTP Server"     >> /etc/ntp.conf
     echo "#NooBaa Configured Primary DNS Server" >> /etc/resolv.conf
     echo "#NooBaa Configured Secondary DNS Server" >> /etc/resolv.conf
+    echo "#NooBaa Configured Search" >> /etc/resolv.conf
     sed -i 's:\(^server.*\):#\1:g' /etc/ntp.conf
     ln -sf /usr/share/zoneinfo/US/Pacific /etc/localtime
 

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -393,6 +393,11 @@ function post_upgrade {
 			echo "#NooBaa Configured Secondary DNS Server" >> /etc/resolv.conf
 	fi
 
+  local noobaa_dns=$(grep 'NooBaa Configured Search' /etc/resolv.conf | wc -l)
+	if [ ${noobaa_dns} -eq 0 ]; then #was not configured yet
+			echo "#NooBaa Configured Search" >> /etc/resolv.conf			
+	fi
+
 	#Upgrade mongo to 3.2 if needed
 	upgrade_mongo_version
 

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -393,8 +393,8 @@ function post_upgrade {
 			echo "#NooBaa Configured Secondary DNS Server" >> /etc/resolv.conf
 	fi
 
-  local noobaa_dns=$(grep 'NooBaa Configured Search' /etc/resolv.conf | wc -l)
-	if [ ${noobaa_dns} -eq 0 ]; then #was not configured yet
+  local noobaa_search=$(grep 'NooBaa Configured Search' /etc/resolv.conf | wc -l)
+	if [ ${noobaa_search} -eq 0 ]; then #was not configured yet
 			echo "#NooBaa Configured Search" >> /etc/resolv.conf			
 	fi
 

--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -79,11 +79,14 @@ function _verify_ntp_cluster_config() {
 
 function _verify_dns_cluster_config() {
     dbg.log2('Verifying dns configuration in relation to cluster config');
-    let cluster_conf = server_conf.dns_servers;
+    let cluster_conf = {
+        dns_servers: server_conf.dns_servers,
+        search_domains: server_conf.search_domains
+    };
     return os_utils.get_dns_servers()
-        .then(platform_dns_servers => {
-            if (!_are_platform_and_cluster_conf_equal(platform_dns_servers, cluster_conf)) {
-                dbg.warn(`platform dns settings not synced to cluster. Platform conf: `, platform_dns_servers, 'cluster_conf:', cluster_conf);
+        .then(platform_dns_config => {
+            if (!_are_platform_and_cluster_conf_equal(platform_dns_config, cluster_conf)) {
+                dbg.warn(`platform dns settings not synced to cluster. Platform conf: `, platform_dns_config, 'cluster_conf:', cluster_conf);
                 return os_utils.set_dns_server(cluster_conf)
                     .then(() => os_utils.restart_services());
             }

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -726,7 +726,7 @@ function update_dns_servers(req) {
             let updates = _.map(target_servers, server => ({
                 _id: server._id,
                 dns_servers: dns_servers_config.dns_servers,
-                search_domains: dns_servers_config.search_domain
+                search_domains: dns_servers_config.search_domains
             }));
             return system_store.make_changes({
                 update: {
@@ -757,7 +757,7 @@ function update_dns_servers(req) {
 
 function apply_updated_dns_servers(req) {
     return P.fcall(function() {
-            return os_utils.set_dns_server(req.rpc_params.dns_servers, req.rpc_params.search_domain);
+            return os_utils.set_dns_server(req.rpc_params.dns_servers, req.rpc_params.search_domains);
         })
         .then(() => {
             return os_utils.restart_services();
@@ -1633,7 +1633,7 @@ function _attach_server_configuration(cluster_server, dhcp_dns_servers) {
             os_utils.get_time_config(),
             fs_utils.find_line_in_file('/etc/resolv.conf', '#NooBaa Configured Primary DNS Server'),
             fs_utils.find_line_in_file('/etc/resolv.conf', '#NooBaa Configured Secondary DNS Server'),
-            fs_utils.find_all_lines_in_file('/etc/resolv.conf', SEARCH_DOMAIN_CONFIG),
+            fs_utils.find_line_in_file('/etc/resolv.conf', SEARCH_DOMAIN_CONFIG),
             dhcp_dns_servers && dns.getServers()
         )
         .spread(function(ntp_line, time_config, primary_dns_line, secondary_dns_line, search_domains, dhcp_dns) {
@@ -1667,12 +1667,12 @@ function _attach_server_configuration(cluster_server, dhcp_dns_servers) {
             }
 
             let domains = [];
-            if (search_domains) {
+            if (search_domains && search_domains.split(' ')[0] === 'search') {
                 domains = search_domains.slice('search'.length, -SEARCH_DOMAIN_CONFIG.length).split(' ');
                 dbg.log0('found configured search domain in resolv.conf:', domains);
             }
 
-            if (domains) {
+            if (domains.length) {
                 cluster_server.search_domains = domains;
             }
 

--- a/src/server/system_services/schemas/cluster_schema.js
+++ b/src/server/system_services/schemas/cluster_schema.js
@@ -88,9 +88,17 @@ module.exports = {
             },
         },
 
+        search_domains: {
+            type: 'array',
+            items: {
+                type: 'string'
+            },
+        },
+
         debug_level: {
             type: 'integer'
         },
+
         //Upgrade proccess
         upgrade: {
             type: 'object',

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -190,7 +190,7 @@ function get_cluster_info() {
             ntp_server: cinfo.ntp && cinfo.ntp.server,
             timezone: cinfo.ntp && cinfo.ntp.timezone,
             dns_servers: cinfo.dns_servers || [],
-            search_domain: cinfo.search_domains || [],
+            search_domains: cinfo.search_domains || [],
             time_epoch: time_epoch
         };
 

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -190,6 +190,7 @@ function get_cluster_info() {
             ntp_server: cinfo.ntp && cinfo.ntp.server,
             timezone: cinfo.ntp && cinfo.ntp.timezone,
             dns_servers: cinfo.dns_servers || [],
+            search_domain: cinfo.search_domains || [],
             time_epoch: time_epoch
         };
 

--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -153,6 +153,17 @@ function find_line_in_file(file_name, line_sub_string) {
         });
 }
 
+// returns all lines in the file that contains the substring
+function find_all_lines_in_file(file_name, line_sub_string) {
+    return fs.readFileAsync(file_name, 'utf8')
+        .then(data => {
+            return data.split('\n')
+                .filter(function(line) {
+                    return line.indexOf(line_sub_string) > -1;
+                });
+        });
+}
+
 function get_last_line_in_file(file_name) {
     return fs.readFileAsync(file_name, 'utf8')
         .then(data => {
@@ -295,6 +306,7 @@ exports.file_must_exist = file_must_exist;
 exports.disk_usage = disk_usage;
 exports.read_dir_recursive = read_dir_recursive;
 exports.find_line_in_file = find_line_in_file;
+exports.find_all_lines_in_file = find_all_lines_in_file;
 exports.get_last_line_in_file = get_last_line_in_file;
 exports.create_path = create_path;
 exports.create_fresh_path = create_fresh_path;

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -8,7 +8,7 @@ const url = require('url');
 const dns = require('dns');
 const P = require('./promise');
 const os_utils = require('./os_utils');
-const promise_utils = require('promise_utils');
+const promise_utils = require('./promise_utils');
 
 const DEFAULT_PING_OPTIONS = {
     timeout: 5000,
@@ -47,31 +47,35 @@ function _ping_ip(session, ip) {
 }
 
 function dns_resolve(target, options) {
-    let resolved_successfully = false;
-    let current = -1;
     const modified_target = url.parse(target).hostname || target;
     return os_utils.get_dns_servers()
-        .then(dns_config =>
-            promise_utils.pwhile(
-                () => !resolved_successfully && current < dns_config.search_domains.length,
-                () => {
-                    current += 1;
-                    return P.fromCallback(callback => dns.resolve(modified_target + '.' + dns_config.search_domains[current],
-                            (options && options.rrtype) || 'A', callback))
-                        .then(() => {
-                            dbg.log3('Resolved DNS name successfuly with', modified_target + '.' + dns_config.search_domains[current]);
-                            resolved_successfully = true;
+        .then(dns_config => {
+            if (dns_config.search_domains.length) {
+                let resolved_successfully = false;
+                let current = -1;
+                return promise_utils.pwhile(
+                        () => !resolved_successfully && current < dns_config.search_domains.length,
+                        () => {
+                            current += 1;
+                            return P.fromCallback(callback => dns.resolve(modified_target + '.' + dns_config.search_domains[current],
+                                    (options && options.rrtype) || 'A', callback))
+                                .then(() => {
+                                    dbg.log3('Resolved DNS name successfuly with', modified_target + '.' + dns_config.search_domains[current]);
+                                    resolved_successfully = true;
+                                })
+                                .catch(_.noop);
                         })
-                        .catch(_.noop);
-                })
-            .then(() => {
-                if (resolved_successfully) {
-                    return P.resolve();
-                }
-                return P.fromCallback(callback => dns.resolve(modified_target,
-                    (options && options.rrtype) || 'A', callback));
-            })
-        );
+                    .then(() => {
+                        if (resolved_successfully) {
+                            return P.resolve();
+                        }
+                        return P.fromCallback(callback => dns.resolve(modified_target,
+                            (options && options.rrtype) || 'A', callback));
+                    });
+            }
+            return P.fromCallback(callback => dns.resolve(modified_target,
+                (options && options.rrtype) || 'A', callback));
+        });
 }
 
 function is_hostname(target) {

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -7,6 +7,8 @@ const dbg = require('./debug_module')(__filename);
 const url = require('url');
 const dns = require('dns');
 const P = require('./promise');
+const os_utils = require('./os_utils');
+const promise_utils = require('promise_utils');
 
 const DEFAULT_PING_OPTIONS = {
     timeout: 5000,
@@ -45,9 +47,31 @@ function _ping_ip(session, ip) {
 }
 
 function dns_resolve(target, options) {
-    dbg.log0('resolving dns address', target);
-    return P.fromCallback(callback => dns.resolve(url.parse(target).hostname || target,
-        (options && options.rrtype) || 'A', callback));
+    let resolved_successfully = false;
+    let current = -1;
+    const modified_target = url.parse(target).hostname || target;
+    return os_utils.get_dns_servers()
+        .then(dns_config =>
+            promise_utils.pwhile(
+                () => !resolved_successfully && current < dns_config.search_domains.length,
+                () => {
+                    current += 1;
+                    return P.fromCallback(callback => dns.resolve(modified_target + '.' + dns_config.search_domains[current],
+                            (options && options.rrtype) || 'A', callback))
+                        .then(() => {
+                            dbg.log3('Resolved DNS name successfuly with', modified_target + '.' + dns_config.search_domains[current]);
+                            resolved_successfully = true;
+                        })
+                        .catch(_.noop);
+                })
+            .then(() => {
+                if (resolved_successfully) {
+                    return P.resolve();
+                }
+                return P.fromCallback(callback => dns.resolve(modified_target,
+                    (options && options.rrtype) || 'A', callback));
+            })
+        );
 }
 
 function is_hostname(target) {

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -458,9 +458,11 @@ function set_dns_server(servers, search_domains) {
             commands_to_exec.push("sed -i 's/.*NooBaa Configured Secondary DNS Server.*/#NooBaa Configured Secondary DNS Server/' /etc/resolv.conf");
         }
 
-        if (search_domains) {
+        if (search_domains.length) {
             commands_to_exec.push("sed -i 's/.*NooBaa Configured Search.*/search " +
                 search_domains + " #NooBaa Configured Search/' /etc/resolv.conf");
+        } else {
+            commands_to_exec.push("sed -i 's/.*NooBaa Configured Search.*/#NooBaa Configured Search/' /etc/resolv.conf");
         }
 
         return P.each(commands_to_exec, function(command) {


### PR DESCRIPTION
### Explain the changes:
- Add domain search option for DNS settings
- On rpc reconnect in FE, re-register for alerts

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #2337  
- Fixes #2952 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

