### PR TITLE
fix diagnostics collection in a cluster

### DIFF
--- a/src/server/utils/server_diagnostics.js
+++ b/src/server/utils/server_diagnostics.js
@@ -16,8 +16,7 @@ const SHORT_EXEC_TIMEOUT = 5 * 1000;
 
 //TODO: Add temp collection dir as param
 function collect_server_diagnostics(req) {
-    let local_cluster = system_store.get_local_cluster_info();
-    return base_diagnostics.prepare_diag_dir(local_cluster && local_cluster.is_clusterized)
+    return base_diagnostics.prepare_diag_dir()
         .then(() => base_diagnostics.collect_basic_diagnostics())
         .then(() => {
 

--- a/src/util/base_diagnostics.js
+++ b/src/util/base_diagnostics.js
@@ -17,22 +17,16 @@ const fs_utils = require('../util/fs_utils');
 const TMP_WORK_DIR = get_tmp_workdir();
 
 
-function prepare_diag_dir(is_clusterized) {
+function prepare_diag_dir() {
     return P.fcall(function() {
-            if (!is_clusterized) {
-                return fs_utils.folder_delete(TMP_WORK_DIR);
-            }
-            return;
+            return fs_utils.folder_delete(TMP_WORK_DIR);
         })
         .then(function() {
             return fs_utils.file_delete(process.cwd() + '/build/public/diagnose.tgz');
         })
         .then(function() {
-            if (!is_clusterized) {
-                console.log('creating ', TMP_WORK_DIR);
-                return fs_utils.create_path(TMP_WORK_DIR);
-            }
-            return;
+            console.log('creating ', TMP_WORK_DIR);
+            return fs_utils.create_path(TMP_WORK_DIR);
         });
 }
 
@@ -57,7 +51,6 @@ function collect_basic_diagnostics(limit_logs_size) {
         .then(() => 'ok')
         .catch(err => {
             console.error('Error in collecting basic diagnostics', err);
-            throw new Error('Error in collecting basic diagnostics ' + err);
         });
 }
 


### PR DESCRIPTION
### Explain the changes:
- in base_diagnostics.prepare_diag_dir - is_clusterized is not important
- in cluster_server.diagnose_system - change TMP_WORK_DIR to
/tmp/cluster_diag to avoid mixing individual server diagnostics and
cluster diagnostics

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #2574

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

