### PR TITLE
Fixing printing of buffers on S3 errors

### DIFF
--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -252,7 +252,7 @@ RPC.prototype._request = function(api, method_api, params, options) {
             dbg.error(`RPC._request: response ERROR srv ${
                 req.srv
             } params ${
-                JSON.stringify(params)
+                util.inspect(params, true, null, true)
             } reqid ${
                 req.reqid
             } took [${


### PR DESCRIPTION
### Explain the changes:
- On S3 errors we were printing all of the block buffers and the s3 was crashing due to memory heap

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- #2888 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

