### PR TITLE
host_api + ssl certificates on s3 agents

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -166,7 +166,7 @@ module.exports = {
         'no-continue': 'off',
 
         // avoid redundant 'else' when using return statements in all cases
-        'no-else-return': 'warn',
+        'no-else-return': 'off',
 
         // for empty functions we expect at least a comment why it's there
         'no-empty-function': 'error',

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -48,6 +48,9 @@ module.exports = {
                     host_id: {
                         type: 'string'
                     },
+                    host_name: {
+                        type: 'string'
+                    },
                     base_address: {
                         type: 'string'
                     },
@@ -94,16 +97,8 @@ module.exports = {
                         }
                     },
 
-                    s3_agent_info: {
-                        type: 'object',
-                        properties: {
-                            port: {
-                                type: 'integer'
-                            },
-                            ssl_port: {
-                                type: 'integer'
-                            },
-                        }
+                    s3_agent: {
+                        type: 'boolean'
                     },
                 }
             },
@@ -157,9 +152,22 @@ module.exports = {
             method: 'POST',
             params: {
                 type: 'object',
+                required: ['enabled'],
                 properties: {
                     enabled: {
                         type: 'boolean'
+                    },
+                    ssl_certs: {
+                        type: 'object',
+                        required: ['key', 'cert'],
+                        properties: {
+                            key: {
+                                type: 'string'
+                            },
+                            cert: {
+                                type: 'string'
+                            },
+                        }
                     }
                 }
             }

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -15,6 +15,7 @@ api_schema.register_api(require('./account_api'));
 api_schema.register_api(require('./system_api'));
 api_schema.register_api(require('./tier_api'));
 api_schema.register_api(require('./node_api'));
+api_schema.register_api(require('./host_api'));
 api_schema.register_api(require('./bucket_api'));
 api_schema.register_api(require('./events_api'));
 api_schema.register_api(require('./object_api'));
@@ -103,7 +104,8 @@ function new_rpc(base_address) {
             func_api: 'md',
             cloud_sync_api: 'bg',
             hosted_agents_api: 'hosted_agents',
-            node_api: 'master'
+            node_api: 'master',
+            host_api: 'master'
         }
     });
     return rpc;

--- a/src/api/host_api.js
+++ b/src/api/host_api.js
@@ -1,0 +1,201 @@
+/* Copyright (C) 2016 NooBaa */
+/**
+ *
+ * HOST API
+ *
+ */
+'use strict';
+
+
+module.exports = {
+
+    id: 'host_api',
+
+    methods: {
+
+
+        read_host: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                properties: {
+                    host_id: {
+                        type: 'string'
+                    },
+                },
+            },
+            reply: {
+                $ref: '#/definitions/host_info'
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
+        list_hosts: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                // required: [],
+                properties: {
+                    query: {
+                        $ref: '#/definitions/hosts_query'
+                    },
+                    skip: {
+                        type: 'integer'
+                    },
+                    limit: {
+                        type: 'integer'
+                    },
+                    pagination: {
+                        type: 'boolean'
+                    },
+                    sort: {
+                        type: 'string',
+                        enum: [
+                            'name',
+                            'ip',
+                            'online',
+                            'used',
+                            'trusted',
+                            'accessibility',
+                            'connectivity',
+                            'data_activity',
+                            'mode'
+                        ]
+                    },
+                    order: {
+                        type: 'integer',
+                    }
+                }
+            },
+            reply: {
+                type: 'object',
+                required: ['hosts'],
+                properties: {
+                    total_count: {
+                        type: 'integer'
+                    },
+                    filter_counts: {
+                        $ref: '#/definitions/hosts_aggregate_info'
+                    },
+                    hosts: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/definitions/host_info'
+                        }
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
+        update_host_services: {
+            method: 'DELETE',
+            params: {
+                type: 'object',
+                properties: {
+                    updates: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            required: ['node', 'enabled'],
+                            properties: {
+                                node: {
+                                    $ref: 'node_api#/definitions/node_identity'
+                                },
+                                enabled: {
+                                    type: 'boolean'
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
+
+
+        // get_test_hosts: {
+        //     method: 'GET',
+        //     params: {
+        //         type: 'object',
+        //         required: ['count', 'source'],
+        //         properties: {
+        //             count: {
+        //                 type: 'integer',
+        //             },
+        //             source: {
+        //                 type: 'string',
+        //             },
+        //         }
+        //     },
+        //     reply: {
+        //         type: 'array',
+        //         items: {
+        //             type: 'object',
+        //             required: ['name', 'rpc_address'],
+        //             properties: {
+        //                 name: {
+        //                     type: 'string'
+        //                 },
+        //                 rpc_address: {
+        //                     type: 'string'
+        //                 }
+        //             }
+        //         }
+        //     },
+        //     auth: {
+        //         system: 'admin',
+        //     }
+        // },
+
+
+    },
+
+
+    definitions: {
+
+        host_info: {
+            type: 'object',
+            required: ['host_info', 'storage_nodes_info', 's3_nodes_info'],
+            properties: {
+
+                // TODO: change host_info to hold only the neccessary fields. node_info contains
+                // many unnecessary fields
+                host_info: {
+                    $ref: 'node_api#/definitions/node_info',
+                },
+                storage_nodes_info: {
+                    type: 'array',
+                    items: {
+                        $ref: 'node_api#/definitions/node_info'
+                    }
+                },
+                s3_nodes_info: {
+                    type: 'array',
+                    items: {
+                        $ref: 'node_api#/definitions/node_info'
+                    }
+                },
+            }
+        },
+
+        hosts_aggregate_info: {
+            $ref: 'node_api#/definitions/nodes_aggregate_info'
+        },
+
+        hosts_query: {
+            $ref: 'node_api#/definitions/nodes_query'
+        }
+
+
+
+    }
+
+};

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -561,6 +561,7 @@ module.exports = {
                 'LOW_CAPACITY',
                 'NO_CAPACITY',
                 'OPTIMAL',
+                'HTTP_SRV_ERRORS',
             ]
         },
 

--- a/src/server/node_services/host_server.js
+++ b/src/server/node_services/host_server.js
@@ -1,0 +1,83 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+// const util = require('util');
+
+
+// const pkg = require('../../../package.json');
+// const dbg = require('../../util/debug_module')(__filename);
+// const config = require('../../../config');
+// const system_store = require('../system_services/system_store').get_instance();
+const nodes_server = require('./node_server');
+// const nodes_aggregator = require('./nodes_aggregator');
+// const dbg = require('../../util/debug_module')(__filename);
+
+
+function read_host(req) {
+    return nodes_server.get_local_monitor().read_host(req.rpc_params.host_id);
+}
+
+function list_hosts(req) {
+    const query = _prepare_hosts_query(req);
+    const options = _.pick(req.rpc_params,
+        'pagination',
+        'skip',
+        'limit',
+        'sort',
+        'order');
+    return nodes_server.get_local_monitor().list_hosts(query, options);
+}
+
+function get_test_hosts() {
+    throw new Error('NOT_IMPLEMENTED');
+}
+
+function test_host_network() {
+    throw new Error('NOT_IMPLEMENTED');
+}
+
+function set_debug_host() {
+    throw new Error('NOT_IMPLEMENTED');
+}
+
+function update_host_services(req) {
+    let monitor = nodes_server.get_local_monitor();
+    return monitor.update_nodes_services(req)
+        .return();
+}
+
+
+
+
+/**
+ * internal functions
+ */
+
+
+
+function _prepare_hosts_query(req) {
+    const query = req.rpc_params.query || {};
+    query.system = String(req.system._id);
+    if (query.filter) {
+        query.filter = new RegExp(_.escapeRegExp(query.filter), 'i');
+    }
+    if (query.geolocation) {
+        query.geolocation = new RegExp(_.escapeRegExp(query.geolocation), 'i');
+    }
+    if (query.pools) {
+        query.pools = new Set(_.map(query.pools, pool_name => {
+            const pool = req.system.pools_by_name[pool_name];
+            return String(pool._id);
+        }));
+    }
+    return query;
+}
+
+
+exports.read_host = read_host;
+exports.get_test_hosts = get_test_hosts;
+exports.test_host_network = test_host_network;
+exports.set_debug_host = set_debug_host;
+exports.update_host_services = update_host_services;
+exports.list_hosts = list_hosts;

--- a/src/server/server_rpc.js
+++ b/src/server/server_rpc.js
@@ -104,6 +104,8 @@ class ServerRpc {
         let options = this.get_server_options();
         rpc.register_service(schema.node_api,
             require('./node_services/node_server'), options);
+        rpc.register_service(schema.host_api,
+            require('./node_services/host_server'), options);
     }
 
     register_object_services() {

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -22,7 +22,6 @@ if (process.env.TESTRUN === 'true') {
 require('../util/panic');
 
 const _ = require('lodash');
-const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const util = require('util');
@@ -36,8 +35,8 @@ const express_body_parser = require('body-parser');
 const express_morgan_logger = require('morgan');
 const express_method_override = require('method-override');
 const P = require('../util/promise');
+const http_utils = require('../util/http_utils');
 const dbg = require('../util/debug_module')(__filename);
-const pem = require('../util/pem');
 const pkg = require('../../package.json');
 const config = require('../../config.js');
 const license_info = require('./license_info');
@@ -122,28 +121,9 @@ P.fcall(function() {
         server_rpc.rpc.register_ws_transport(http_server);
         return P.ninvoke(http_server, 'listen', http_port);
     })
-    .then(function() {
-        if (fs.existsSync(path.join('/etc', 'private_ssl_path', 'server.key')) &&
-            fs.existsSync(path.join('/etc', 'private_ssl_path', 'server.crt'))) {
-            dbg.log0('Using local certificate');
-            var local_certificate = {
-                serviceKey: fs.readFileSync(path.join('/etc', 'private_ssl_path', 'server.key')),
-                certificate: fs.readFileSync(path.join('/etc', 'private_ssl_path', 'server.crt'))
-            };
-            return local_certificate;
-        } else {
-            dbg.log0('Using self-signed certificate', path.join('/etc', 'private_ssl_path', 'server.key'));
-            return P.fromCallback(callback => pem.createCertificate({
-                days: 365 * 100,
-                selfSigned: true
-            }, callback));
-        }
-    })
+    .then(() => http_utils.get_ssl_certificate())
     .then(function(cert) {
-        https_server = https.createServer({
-            key: cert.serviceKey,
-            cert: cert.certificate
-        }, app);
+        https_server = https.createServer(cert, app);
         server_rpc.rpc.register_ws_transport(https_server);
         return P.ninvoke(https_server, 'listen', https_port);
     })

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -4,6 +4,11 @@
 const url = require('url');
 const http = require('http');
 const https = require('https');
+const pem = require('pem');
+const fs = require('fs');
+const path = require('path');
+
+const P = require('./promise');
 
 /**
  * see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24
@@ -37,5 +42,31 @@ function get_unsecured_http_agent(endpoint) {
         new http.Agent();
 }
 
+function get_ssl_certificate() {
+    console.log('certificate location:', path.join('/etc', 'private_ssl_path', 'server.key'));
+    if (fs.existsSync(path.join('/etc', 'private_ssl_path', 'server.key')) &&
+        fs.existsSync(path.join('/etc', 'private_ssl_path', 'server.crt'))) {
+        console.log('Using local certificate');
+        var local_certificate = {
+            key: fs.readFileSync(path.join('/etc', 'private_ssl_path', 'server.key')),
+            cert: fs.readFileSync(path.join('/etc', 'private_ssl_path', 'server.crt'))
+        };
+        return local_certificate;
+    } else {
+
+        console.log('Generating self signed certificate');
+        return P.fromCallback(callback => pem.createCertificate({
+                days: 365 * 100,
+                selfSigned: true
+            }, callback))
+            .then(cert => ({
+                key: cert.serviceKey,
+                cert: cert.certificate
+            }));
+    }
+}
+
+
 exports.match_etag = match_etag;
 exports.get_unsecured_http_agent = get_unsecured_http_agent;
+exports.get_ssl_certificate = get_ssl_certificate;


### PR DESCRIPTION
### Explain the changes:

- nodes_monitor: added map **host_id -> [nodes]**
- added host_api with list_hosts\read_host\update_nodes_services (batch decommission\recommission)
- send ssl certificate to s3 agents when starting s3 service.


### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

