### PR TITLE
alert when exceeding 90% of quota and 100% of quota

### DIFF
--- a/src/server/notifications/alerts_log_store.js
+++ b/src/server/notifications/alerts_log_store.js
@@ -66,13 +66,14 @@ class AlertsLogStore {
             .toArray();
     }
 
-    find_alert(sev, sysid, alert) {
-        return this._alertslogs.col().find({
-            system: sysid,
-            severity: sev,
-            alert: alert
-        })
-        .toArray();
+    find_alert(sev, sysid, alert, time) {
+        return this._alertslogs.col().find(_.omitBy({
+                system: sysid,
+                severity: sev,
+                alert: alert,
+                time
+            }, _.isUndefined))
+            .toArray();
     }
 
 

--- a/src/server/notifications/alerts_rules.js
+++ b/src/server/notifications/alerts_rules.js
@@ -11,5 +11,22 @@ function only_once(sev, sysid, alert) {
         });
 }
 
+function once_every(interval) {
+    return function(sev, sysid, alert) {
+        const interval_date = new Date(Date.now() - interval);
+        return P.resolve(AlertsLogStore.instance().find_alert(sev, sysid, alert, { $gt: interval_date }))
+            .then(res => (res.length === 0));
+    };
+}
+
+function once_daily(sev, sysid, alert) {
+    const one_day = 1000 * 60 * 60 * 24;
+    const one_day_ago = new Date(Date.now() - one_day);
+    return P.resolve(AlertsLogStore.instance().find_alert(sev, sysid, alert, { $gt: one_day_ago }))
+        .then(res => (res.length === 0));
+}
+
 
 exports.only_once = only_once;
+exports.once_daily = once_daily;
+exports.once_every = once_every;


### PR DESCRIPTION
### Explain the changes:
- added alerts: 
    - INFO alert when exceeding 90% of quota
    - MAJOR alert when exceeding quota 


### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

