### PR TITLE
return nodes only storage on read_system and fix N/A graph

### DIFF
--- a/frontend/src/app/components/overview/resource-overview/resource-overview.js
+++ b/frontend/src/app/components/overview/resource-overview/resource-overview.js
@@ -8,6 +8,7 @@ import ko from 'knockout';
 import { deepFreeze } from 'utils/core-utils';
 import { stringifyAmount} from 'utils/string-utils';
 import { countNodesByState } from 'utils/ui-utils';
+import { toBytes } from 'utils/size-utils';
 import { hexToRgb } from 'utils/color-utils';
 import { openInstallNodesModal } from 'dispatchers';
 
@@ -121,7 +122,7 @@ class ResourceOverviewViewModel extends BaseViewModel {
         ];
 
         this.systemCapacity = ko.pureComputed(
-            () => systemInfo() && systemInfo().storage.total
+            () => toBytes(systemInfo() ? systemInfo().nodes_storage.total : 0)
         )
         .extend({
             tween: { useDiscreteValues: true, resetValue: 0 },

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -533,6 +533,9 @@ module.exports = {
                 storage: {
                     $ref: 'common_api#/definitions/storage_info'
                 },
+                nodes_storage: {
+                    $ref: 'common_api#/definitions/storage_info'
+                },
                 nodes: {
                     $ref: 'node_api#/definitions/nodes_aggregate_info'
                 },

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -443,6 +443,9 @@ function read_system(req) {
             storage: size_utils.to_bigint_storage(_.defaults({
                 used: objects_sys.size,
             }, nodes_aggregate_pool_with_cloud.storage, SYS_STORAGE_DEFAULTS)),
+            nodes_storage: size_utils.to_bigint_storage(_.defaults({
+                used: objects_sys.size,
+            }, nodes_aggregate_pool_no_cloud.storage, SYS_STORAGE_DEFAULTS)),
             nodes: _.defaults({}, nodes_aggregate_pool_no_cloud.nodes, SYS_NODES_INFO_DEFAULTS),
             owner: account_server.get_account_info(system_store.data.get_by_id(system._id).owner),
             last_stats_report: system.last_stats_report || 0,


### PR DESCRIPTION
### Explain the changes:
- In addition to total storage also return nodes only storage (without cloud resources) on read_system. Convert from bigint to bytes and protect against non-existent data on the overview nodes pie graph.


### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #2825

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

