### PR TITLE
Fixes #3000 - fixed drive exclusion in nodes monitor

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -814,10 +814,10 @@ class NodesMonitor extends EventEmitter {
                             this._add_node_to_hosts_map(updates.host_id, item);
 
                             let agent_config = system_store.data.get_by_id(item.node.agent_config) || {};
-                            let { use_s3 = false, use_storage = true, exclude_drive = [] } = agent_config;
+                            let { use_s3 = false, use_storage = true, exclude_drives = [] } = agent_config;
                             // on first call to get_agent_info enable\disable the node according to the configuration
                             let should_start_service = (info.s3_agent && use_s3) ||
-                                (!info.s3_agent && use_storage && this._should_include_drives(info.drives[0].mount, info.os_info, exclude_drive));
+                                (!info.s3_agent && use_storage && this._should_include_drives(info.drives[0].mount, info.os_info, exclude_drives));
                             dbg.log0(`first call to get_agent_info. ${info.s3_agent ? "s3 agent" : "storage agent"} ${item.node.name}. should_start_service=${should_start_service}. `);
                             if (!should_start_service) {
                                 item.node.decommissioning = item.node.decommissioned = Date.now();


### PR DESCRIPTION
### Explain the changes:
- wrong name was used to get the excluded drives from DB (exclude_drive instead of exclude_drives)

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3000

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

