### PR TITLE
throw error when setting quota to a non positive size

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -197,6 +197,9 @@ function update_bucket(req) {
                 quota: 1
             };
         } else {
+            if (quota.size <= 0) {
+                throw new RpcError('BAD_REQUEST', 'quota size must be positive');
+            }
             updates.quota = quota;
             quota.value = size_utils.size_unit_to_bigint(quota.size, quota.unit).toJSON();
         }

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -275,6 +275,36 @@ mocha.describe('system_servers', function() {
                 name: BUCKET + 1,
                 new_name: BUCKET,
             }))
+            .then(() => client.bucket.update_bucket({
+                name: BUCKET,
+                quota: {
+                    size: 10,
+                    unit: 'TERABYTE'
+                }
+            }))
+            .then(() => client.bucket.read_bucket({
+                name: BUCKET,
+            }))
+            .then(info => assert(info.quota && info.quota.size === 10 && info.quota.unit === 'TERABYTE'))
+            .then(() => client.bucket.update_bucket({
+                name: BUCKET,
+                quota: null
+            }))
+            .then(() => client.bucket.read_bucket({
+                name: BUCKET,
+            }))
+            .then(info => assert(_.isUndefined(info.quota)))
+            .then(() => client.bucket.update_bucket({
+                name: BUCKET,
+                quota: {
+                    size: 0,
+                    unit: 'GIGABYTE'
+                }
+            }))
+            .then(() => {
+                    throw new Error('update bucket with 0 quota should fail');
+                },
+                () => _.noop) // update bucket with 0 quota should fail
             .then(() => {
                 if (!process.env.AWS_ACCESS_KEY_ID ||
                     !process.env.AWS_SECRET_ACCESS_KEY) {


### PR DESCRIPTION
### Explain the changes:
- throw error when setting quota to a non positive size

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Partial fix to #3011 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

