### PR TITLE
Fix for #3015 - Proper reply on read_system if rsyslog is unreachable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",

--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -26,7 +26,14 @@ function run() {
     dbg.log0('SERVER_MONITOR: BEGIN');
     monitoring_status = {
         dns_status: "UNKNOWN",
-        ph_status: "UNKNOWN",
+        ph_status: {
+            status: "UNKNOWN",
+            test_time: moment().unix()
+        },
+        remote_syslog_status: {
+            status: "UNKNOWN",
+            test_time: moment().unix()
+        }
     };
     if (!system_store.is_finished_initial_load) {
         dbg.log0('waiting for system store to load');
@@ -236,7 +243,6 @@ function _check_remote_syslog() {
     dbg.log2('_check_remote_syslog');
     let system = system_store.data.systems[0];
     if (_.isEmpty(system.remote_syslog_config)) return;
-    monitoring_status.remote_syslog_status = "UNKNOWN";
     if (_.isEmpty(system.remote_syslog_config.address)) return;
     monitoring_status.remote_syslog_status = {
         test_time: moment().unix()
@@ -246,7 +252,7 @@ function _check_remote_syslog() {
             monitoring_status.remote_syslog_status.status = "OPERATIONAL";
         })
         .catch(err => {
-            monitoring_status.remote_syslog_status = "UNREACHABLE";
+            monitoring_status.remote_syslog_status.status = "UNREACHABLE";
             dbg.warn('Error when trying to check remote syslog status.', err.stack || err);
         });
 }

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -458,7 +458,7 @@ function set_dns_server(servers, search_domains) {
             commands_to_exec.push("sed -i 's/.*NooBaa Configured Secondary DNS Server.*/#NooBaa Configured Secondary DNS Server/' /etc/resolv.conf");
         }
 
-        if (search_domains.length) {
+        if (search_domains && search_domains.length) {
             commands_to_exec.push("sed -i 's/.*NooBaa Configured Search.*/search " +
                 search_domains + " #NooBaa Configured Search/' /etc/resolv.conf");
         } else {


### PR DESCRIPTION
### Explain the changes:
- Proper reply on read_system if rsyslog is unreachable (timestamp AND status)
- on os_utils.set_dns_server take into account search_domains doesn't have to exist

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3015 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

