### PR TITLE
workaround to mongodb bug with "mongo --host"

### DIFF
--- a/src/deploy/NVA_build/common_funcs.sh
+++ b/src/deploy/NVA_build/common_funcs.sh
@@ -14,7 +14,7 @@ function deploy_log {
 
 function set_mongo_cluster_mode {
 	RS_SERVERS=`grep MONGO_RS_URL /root/node_modules/noobaa-core/.env | cut -d'@' -f 2 | cut -d'/' -f 1`
-    MONGO_SHELL="/usr/bin/mongors --host shard1/${RS_SERVERS}"
+    MONGO_SHELL="/usr/bin/mongors --host mongodb://${RS_SERVERS}/nbcore?replicaSet=shard1"
 }
 
 function check_mongo_status {

--- a/src/deploy/NVA_build/upgrade.sh
+++ b/src/deploy/NVA_build/upgrade.sh
@@ -110,7 +110,7 @@ function mongo_upgrade {
   local ip=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | cut -f 1 -d' ')
   local client_subject=$(openssl x509 -in /etc/mongo_ssl/client.pem -inform PEM -subject -nameopt RFC2253 | grep subject | awk '{sub("subject= ",""); print}')
   deploy_log "starting mongo data upgrade ${bcrypt_sec} ${id} ${ip}"
-  ${CORE_DIR}/src/deploy/mongo_upgrade/mongo_upgrade.sh --param_secret ${sec} --param_bcrypt_secret ${bcrypt_sec} --param_ip ${ip} --param_client_subject ${client_subject}  
+  ${CORE_DIR}/src/deploy/mongo_upgrade/mongo_upgrade.sh ${CLUSTER} --param_secret ${sec} --param_bcrypt_secret ${bcrypt_sec} --param_ip ${ip} --param_client_subject ${client_subject}  
   local rc=$?
   if [ $rc -ne 0 ]; then
       deploy_log "FAILED mongo data upgrade!"
@@ -297,6 +297,8 @@ else
     if [ "$CLUSTER" == 'cluster' ]; then
       # TODO: handle differenet shard
       set_mongo_cluster_mode
+    else
+      CLUSTER=""
     fi
 
 

--- a/src/deploy/mongo_upgrade/mongo_upgrade.sh
+++ b/src/deploy/mongo_upgrade/mongo_upgrade.sh
@@ -9,6 +9,14 @@ fi
 . ${COMMON_FUNCS_PATH}/noobaa-core/src/deploy/NVA_build/deploy_base.sh
 . ${COMMON_FUNCS_PATH}noobaa-core/src/deploy/NVA_build/common_funcs.sh
 
+CLUSTER="$1"
+if [ "$CLUSTER" == 'cluster' ]; then
+    shift
+    # TODO: handle differenet shard
+    set_mongo_cluster_mode
+fi
+
+
 while [[ $# -gt 1 ]]; do
     key="$1"
     case $key in


### PR DESCRIPTION


fixed MONGO_SHELL in mongo_upgrade.sh

### Explain the changes:
- when executing mongo shell use mongo connection string URI format after --host flag (mongodb://servers...)
- call set_mongo_cluster_mode from mongo_upgrade.sh to set the mongo shell to the correct one

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #2933

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

