### PR TITLE
alert when setting bucket quota below the bucket usage

### DIFF
--- a/src/server/bg_services/scrubber.js
+++ b/src/server/bg_services/scrubber.js
@@ -7,7 +7,7 @@ const config = require('../../../config');
 const MDStore = require('../object_services/md_store').MDStore;
 const map_builder = require('../object_services/map_builder');
 const system_store = require('../system_services/system_store').get_instance();
-const system_server_utils = require('../utils/system_server_utils');
+const system_utils = require('../utils/system_utils');
 
 
 /**
@@ -25,7 +25,7 @@ function background_worker() {
         return;
     }
     const system = system_store.data.systems[0];
-    if (!system || system_server_utils.system_in_maintenance(system._id)) return;
+    if (!system || system_utils.system_in_maintenance(system._id)) return;
 
     if (!this.marker) {
         dbg.log0('SCRUBBER:', 'BEGIN');

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -31,7 +31,7 @@ const system_store = require('../system_services/system_store').get_instance();
 const promise_utils = require('../../util/promise_utils');
 const cluster_server = require('../system_services/cluster_server');
 const clustering_utils = require('../utils/clustering_utils');
-const system_server_utils = require('../utils/system_server_utils');
+const system_utils = require('../utils/system_utils');
 
 const RUN_DELAY_MS = 60000;
 const RUN_NODE_CONCUR = 5;
@@ -1716,7 +1716,7 @@ class NodesMonitor extends EventEmitter {
             return;
         }
 
-        if (system_server_utils.system_in_maintenance(item.node.system)) {
+        if (system_utils.system_in_maintenance(item.node.system)) {
             dbg.warn('_update_status: delay node data_activity',
                 'while system in maintenance', item.node.name);
             act.stage.wait_reason = WAIT_SYSTEM_MAINTENANCE;

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -41,7 +41,7 @@ const cluster_server = require('./cluster_server');
 const node_allocator = require('../node_services/node_allocator');
 const stats_collector = require('../bg_services/stats_collector');
 const config_file_store = require('./config_file_store').instance();
-const system_server_utils = require('../utils/system_server_utils');
+const system_utils = require('../utils/system_utils');
 const api = require('../../api/api');
 
 const SYS_STORAGE_DEFAULTS = Object.freeze({
@@ -390,7 +390,7 @@ function read_system(req) {
             message: system.upgrade ? system.upgrade.error : undefined
         };
         const maintenance_mode = {
-            state: system_server_utils.system_in_maintenance(system._id)
+            state: system_utils.system_in_maintenance(system._id)
         };
         if (maintenance_mode.state) {
             maintenance_mode.till = system.maintenance_mode;

--- a/src/server/utils/system_utils.js
+++ b/src/server/utils/system_utils.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const system_store = require('../system_services/system_store').get_instance();
+const size_utils = require('../../util/size_utils');
 
 function system_in_maintenance(system_id) {
     const system = system_store.data.get_by_id(system_id);
@@ -20,4 +21,18 @@ function system_in_maintenance(system_id) {
     return false;
 }
 
+
+
+// returns the percent of quota used by the bucket
+function get_bucket_quota_usage_percent(bucket, bucket_quota) {
+    if (!bucket_quota) return 0;
+
+    const bucket_used = bucket.storage_stats && size_utils.json_to_bigint(bucket.storage_stats.objects_size);
+    const quota = size_utils.json_to_bigint(bucket_quota.value);
+    let used_percent = bucket_used.multiply(100).divide(quota);
+    return used_percent.valueOf();
+}
+
+
 exports.system_in_maintenance = system_in_maintenance;
+exports.get_bucket_quota_usage_percent = get_bucket_quota_usage_percent;


### PR DESCRIPTION
### Explain the changes:
- generate alert on update_bucket if needed
- renamed system_server_utils.js to system_utils.js and moved quota checks function there so it will be shared by object_server and bucket_server

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3023  

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

