### PR TITLE
monitor the upgrade script status and reply /version accordingly

### DIFF
--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -312,6 +312,23 @@ module.exports = {
             }
         },
 
+        get_upgrade_status: {
+            doc: 'get the status of cluster upgrade',
+            method: 'GET',
+            reply: {
+                type: 'object',
+                required: ['in_process'],
+                properties: {
+                    in_process: {
+                        type: 'boolean'
+                    },
+                }
+            },
+            auth: {
+                system: false
+            }
+        },
+
         set_hostname_internal: {
             method: 'POST',
             params: {


### PR DESCRIPTION
### Explain the changes:
- removed `shutting_down` flag from webserver
- in cluster_server, maintain an `upgrade_in_process` flag that can be queried through rpc call
- in case the upgrade.sh script exit, set `upgrade_in_process` to false 

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixed #3024 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

