### PR TITLE
BE Fix for #1211 - Allow deletion of buckets with uncompleted objects

### DIFF
--- a/src/server/object_services/map_deleter.js
+++ b/src/server/object_services/map_deleter.js
@@ -76,7 +76,30 @@ function delete_blocks_from_node(blocks) {
         });
 }
 
+/*
+ * delete_object
+ * delete objects mappings and MD
+ */
+function delete_object(obj) {
+    if (!obj) return;
+    return MDStore.instance().update_object_by_id(obj._id, {
+            deleted: new Date(),
+            cloud_synced: false
+        })
+        .then(() => delete_object_mappings(obj))
+        .return();
+}
+
+/*
+ * delete_multiple_objects
+ * delete multiple bjects mappings and MD
+ */
+function delete_multiple_objects(objects) {
+    return P.map(objects, obj => P.resolve(delete_object(obj)).reflect(), { concurrency: 10 });
+}
 
 // EXPORTS
+exports.delete_object = delete_object;
+exports.delete_multiple_objects = delete_multiple_objects;
 exports.delete_object_mappings = delete_object_mappings;
 exports.delete_blocks_from_nodes = delete_blocks_from_nodes;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -241,9 +241,10 @@ class MDStore {
             .then(obj => Boolean(obj));
     }
 
-    has_any_objects_in_bucket(bucket_id) {
+    has_any_completed_objects_in_bucket(bucket_id) {
         return this._objects.col().findOne({
                 bucket: bucket_id,
+                upload_started: null,
                 deleted: null,
             })
             .then(obj => Boolean(obj));

--- a/src/server/object_services/schemas/object_md_indexes.js
+++ b/src/server/object_services/schemas/object_md_indexes.js
@@ -8,7 +8,7 @@ module.exports = [{
         // find_object_by_key_allow_missing()
         // find_objects()
         // find_objects_by_prefix_and_delimiter()
-        // TODO index ??? has_any_objects_in_bucket()
+        // TODO index ??? has_any_completed_objects_in_bucket()
         // TODO index ??? count_objects_of_bucket()
         // TODO index ??? list_all_objects_of_bucket_ordered_by_key()
         fields: {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -333,7 +333,7 @@ function delete_bucket(req) {
         throw new RpcError('BAD_REQUEST', 'Cannot delete last bucket');
     }
 
-    return MDStore.instance().has_any_objects_in_bucket(bucket._id)
+    return MDStore.instance().has_any_completed_objects_in_bucket(bucket._id)
         .then(has_objects => {
             if (has_objects) {
                 throw new RpcError('BUCKET_NOT_EMPTY', 'Bucket not empty: ' + bucket.name);

--- a/src/test/unit_tests/test_md_store.js
+++ b/src/test/unit_tests/test_md_store.js
@@ -98,8 +98,8 @@ mocha.describe('md_store', function() {
             return md_store.has_any_objects_in_system(system_id);
         });
 
-        mocha.it('has_any_objects_in_bucket()', function() {
-            return md_store.has_any_objects_in_bucket(bucket_id);
+        mocha.it('has_any_completed_objects_in_bucket()', function() {
+            return md_store.has_any_completed_objects_in_bucket(bucket_id);
         });
 
         mocha.it('count_objects_of_bucket()', function() {


### PR DESCRIPTION
### Explain the changes:
- BE Fix for #1211 - Allow deletion of buckets with uncompleted objects, scrubber will reclaim them (entire object hierarchy) later. This will also work for completed objects which bucket was deleted.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Relates to #1211 (BE part only)

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

