### PR TITLE
Changing the default size of disk when creating machine to 100GB

### DIFF
--- a/src/deploy/azureFunctions.js
+++ b/src/deploy/azureFunctions.js
@@ -154,7 +154,11 @@ class AzureFunctions {
                     sku: os.sku,
                     version: 'latest'
                 };
-                return this.createVirtualMachine(vmName, nic.id, image, storage);
+                let diskSizeGB = 40;
+                if (os.osType === 'Windows') {
+                    diskSizeGB = 140;
+                }
+                return this.createVirtualMachine(vmName, nic.id, image, storage, diskSizeGB);
             })
             .then(() => {
                 console.log('Started the Virtual Machine!');
@@ -242,6 +246,9 @@ class AzureFunctions {
     }
 
     createVirtualMachine(vmName, nicId, imageReference, storageAccountName, diskSizeGB) {
+        if (!diskSizeGB) {
+            throw new Error('must Enter disk size in GB');
+        }
         var vmParameters = {
             location: this.location,
             // tags: {


### PR DESCRIPTION
### Explain the changes:
Changing the default size of disk when creating machine to 100GB

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

