### PR TITLE
Fixing bug regarding deletion of pool that still has bucket data stored

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1066,8 +1066,13 @@ function get_bucket_info(bucket, nodes_aggregate_pool, aggregate_data_free_by_ti
         last_update: _.get(bucket, 'storage_stats.last_update')
     };
 
-    info.usage_by_pool.pools = _.mapKeys(_.get(bucket, 'storage_stats.pools', {}), function(storage, pool_id) {
-        return system_store.data.get_by_id(pool_id).name;
+    info.usage_by_pool.pools = _.omitBy(_.mapKeys(_.get(bucket, 'storage_stats.pools', {}), function(storage, pool_id) {
+        const pool = system_store.data.get_by_id(pool_id);
+        if (pool) {
+            return system_store.data.get_by_id(pool_id).name;
+        }
+    }), function(value, key) {
+        return !_.isUndefined(key);
     });
 
     const stats = bucket.stats;


### PR DESCRIPTION
### Explain the changes:
- When we aggregate the usage and delete the pool, the read_system throws an exception because he cannot resolve the id of the deleted pool when reading bucket info in order to get usage

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixed #3101 
- opened #3106

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

