### PR TITLE
Handle empty updates in system_store

### DIFF
--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -530,6 +530,7 @@ class SystemStore extends EventEmitter {
                     _.each(list, item => {
                         data.check_indexes(col, item);
                         let updates = _.omit(item, '_id');
+                        if (_.isEmpty(updates)) return;
                         let keys = _.keys(updates);
 
                         if (_.first(keys)[0] === '$') {


### PR DESCRIPTION
### Explain the changes:
- When we send an update query with only _id without any updates to the collection we get an exception of trying to [0] of undefined.
This is because we omit the _id and are left with an empty object without any keys.
Then we attempt to take the first key and use [0] on it.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

