### PR TITLE
Fixing #3139 - Limiting logs and backup data, adding option to reside HD

### DIFF
--- a/config.js
+++ b/config.js
@@ -151,7 +151,7 @@ config.central_stats = {
     send_stats: 'true',
     send_time_cycle: 30 * 60 * 1000, //30 min
     previous_diag_packs_dir: process.env.ProgramData + '/prev_diags',
-    previous_diag_packs_count: 3 //TODO: We might want to split between agent and server
+    previous_diag_packs_count: 2 //TODO: We might want to split between agent and server
 };
 config.central_stats.send_time = 14 * 24 * 60 * 60 * 1000; //14 days
 

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -290,9 +290,9 @@ function fix_security_issues {
 		echo '	PasswordAuthentication no'  >> /etc/ssh/sshd_config
 	fi
 
-    # copy fix_server_sec to rc.local
-    if ! grep -q 'fix_server_sec' /etc/rc.local; then
-        echo "bash /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_sec.sh" >> /etc/rc.local
+    # copy fix_server_plat to rc.local
+    if ! grep -q 'fix_server_plat' /etc/rc.local; then
+        echo "bash /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_plat.sh" >> /etc/rc.local
     fi
     # copy fix_mongo_ssl to rc.local
     if ! grep -q 'fix_mongo_ssl' /etc/rc.local; then

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -308,6 +308,7 @@ function setup_supervisors {
     echo_supervisord_conf > /etc/supervisord.conf
     sed -i 's:logfile=.*:logfile=/tmp/supervisor/supervisord.log:' /etc/supervisord.conf
     sed -i 's:;childlogdir=.*:childlogdir=/tmp/supervisor/:' /etc/supervisord.conf
+    sed -i 's:logfile_backups=.*:logfile_backups=5:' /etc/supervisord.conf
 
     # Autostart supervisor
     deploy_log "setup_supervisors autostart"

--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -200,6 +200,46 @@ function reset_password {
     local bcrypt_sec=$(sudo /usr/local/bin/node /root/node_modules/noobaa-core/src/util/crypto_utils.js --bcrypt_password $answer_reset_password)
     /usr/bin/mongo nbcore --eval  "db.accounts.update({email:'${user_name}'},{\$set:{password:'${bcrypt_sec}'}})" --quiet
 
+}
+
+function resize_hd {
+
+  dialog --colors --backtitle "NooBaa First Install" --infobox "Resizing HD, this might take some time" 4 42 
+  logger -p local0.info -s -t resize_fs_on_sda "Starting ..."
+  logger -p local0.info -s -t resize_fs_on_sda "Running fdisk -s /dev/sda: $(fdisk -s /dev/sda)"
+  logger -p local0.info -s -t resize_fs_on_sda "Running fdisk -s /dev/sda2: $(fdisk -s /dev/sda2)"
+  logger -p local0.info -s -t resize_fs_on_sda "Running fdisk -l:"
+  logger -p local0.info -s -t resize_fs_on_sda "$(fdisk -l)"
+  logger -p local0.info -s -t resize_fs_on_sda "Running lvs:"
+  logger -p local0.info -s -t resize_fs_on_sda "$(lvs)"
+  logger -p local0.info -s -t resize_fs_on_sda "Running pvs:"
+  logger -p local0.info -s -t resize_fs_on_sda "$(pvs)"
+  logger -p local0.info -s -t resize_fs_on_sda "Running df:"
+  logger -p local0.info -s -t resize_fs_on_sda "$(df)"
+
+  logger -p local0.info -s -t resize_fs_on_sda "Running fdisk to resize sda2 partition and reboot ..."
+  echo -e "d\n2\nn\np\n2\n\n\nw\n" | fdisk -cu /dev/sda
+  logger -p local0.info -s -t resize_fs_on_sda "Running fdisk -l after repartitioning:"
+  logger -p local0.info -s -t resize_fs_on_sda "$(fdisk -l)"
+  dialog --colors --backtitle "NooBaa First Install" --infobox "Rebooting Machine" 4 22; sleep 2
+  reboot
+
+}
+
+function apply_resize  {
+
+  dialog --colors --backtitle "NooBaa First Install" --infobox "Applying resize changes" 4 28 
+  logger -p local0.info -s -t fix_server_plat "Running lvs (PRE):"
+  logger -p local0.info -s -t fix_server_plat "$(lvs)"
+  logger -p local0.info -s -t fix_server_plat "Running pvs (PRE):"
+  logger -p local0.info -s -t fix_server_plat "$(pvs)"
+  pvresize /dev/sda2
+  lvextend --resizefs -l +100%FREE /dev/VolGroup/lv_root
+  logger -p local0.info -s -t fix_server_plat "Running lvs (POST):"
+  logger -p local0.info -s -t fix_server_plat "$(lvs)"
+  logger -p local0.info -s -t fix_server_plat "Running pvs (POST):"
+  logger -p local0.info -s -t fix_server_plat "$(pvs)"
+  dialog --colors --backtitle "NooBaa First Install" --infobox "Done" 4 8 ; sleep 2 
 
 }
 
@@ -209,7 +249,7 @@ function run_wizard {
 is a short first install wizard to help configure \Z5\ZbNooBaa\Zn to best suit your needs' 8 60
   local menu_entry="0"
   while [ "${menu_entry}" -ne "4" ]; do
-    dialog --colors --nocancel --backtitle "NooBaa First Install" --menu "Choose one of the items below\n(Use \Z4\ZbUp/Down\Zn to navigate):" 12 55 4 1 "Networking Configuration" 2 "NTP Configuration (Optional)" 3 "Password reset" 4 "Exit" 2> choice
+    dialog --colors --nocancel --backtitle "NooBaa First Install" --menu "Choose one of the items below\n(Use \Z4\ZbUp/Down\Zn to navigate):" 14 57 6 1 "Networking Configuration" 2 "NTP Configuration (optional)" 3 "Password reset" 4 "Resize Partition (requires reboot)" 5 "Resize FS (after partition was resized)" 6 "Exit" 2> choice
     menu_entry=$(cat choice)
   if [ "${menu_entry}" -eq "1" ]; then
     configure_networking_dialog
@@ -218,6 +258,10 @@ is a short first install wizard to help configure \Z5\ZbNooBaa\Zn to best suit y
     configure_ntp_dialog
   elif [ "${menu_entry}" -eq "3" ]; then
     reset_password
+  elif [ "${menu_entry}" -eq "4" ]; then
+    resize_hd
+  elif [ "${menu_entry}" -eq "5" ]; then
+    apply_resize
   fi
   done
   dialog --colors --nocancel --backtitle "NooBaa First Install" --infobox "Finalizing \Z5\ZbNooBaa\Zn first install..." 4 40 ; sleep 2

--- a/src/deploy/NVA_build/fix_server_plat.sh
+++ b/src/deploy/NVA_build/fix_server_plat.sh
@@ -14,3 +14,4 @@ if [ ! -f ${NOOBAASEC} ]; then
       echo "JWT_SECRET=${jwt}" | tee -a /root/node_modules/noobaa-core/.env
   fi
 fi
+

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -4,6 +4,8 @@ command=/usr/bin/turnserver
 user=root
 autostart=true
 autorestart=true
+stderr_logfile_backups=3
+stdout_logfile_backups=3
 #endprogram
 
 [program:webserver]
@@ -12,6 +14,8 @@ killasgroup=true
 stopasgroup=true
 autorestart=true
 directory=/root/node_modules/noobaa-core
+stderr_logfile_backups=3
+stdout_logfile_backups=3
 command=/usr/local/bin/node src/server/web_server.js
 #endprogram
 
@@ -21,6 +25,8 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/root/node_modules/noobaa-core
+stderr_logfile_backups=3
+stdout_logfile_backups=3
 command=/usr/local/bin/node src/server/bg_workers.js
 #endprogram
 
@@ -30,6 +36,8 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/root/node_modules/noobaa-core
+stderr_logfile_backups=3
+stdout_logfile_backups=3
 command=/usr/local/bin/node src/hosted_agents/hosted_agents_starter.js
 #endprogram
 
@@ -39,6 +47,8 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/root/node_modules/noobaa-core
+stderr_logfile_backups=3
+stdout_logfile_backups=3
 command=/usr/local/bin/node src/s3/s3rver_starter.js --address 'wss://127.0.0.1:8443'
 #endprogram
 
@@ -51,4 +61,6 @@ directory=/usr/bin
 user=root
 autostart=true
 priority=1
+stderr_logfile_backups=3
+stdout_logfile_backups=3
 #endprogram

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -285,7 +285,9 @@ function post_upgrade {
   local BG=$(grep "bg_workers_starter" /etc/noobaa_supervisor.conf | wc -l)
   #if noobaa supervisor.conf is pre mongo_wrapper
   local MONGO_DB=$(grep "mongodb" /etc/noobaa_supervisor.conf | wc -l)
-  if [ ${BG} -eq 1 ] || [ ${MONGO_DB} -eq 1 ]; then
+  #if noobaa supervisor.conf is pre limit to logs
+  local LOG_LIMIT=$(grep "stderr_logfile_backups" /etc/noobaa_supervisor.conf | wc -l)
+  if [ ${BG} -eq 1 ] || [ ${MONGO_DB} -eq 1 ] || [ ${LOG_LIMIT} -eq 0 ] ; then
     cp -f ${CORE_DIR}/src/deploy/NVA_build/noobaa_supervisor.conf /etc/noobaa_supervisor.conf
   fi
 
@@ -296,6 +298,7 @@ function post_upgrade {
   #NooBaa supervisor services configuration changes
   sed -i 's:logfile=.*:logfile=/tmp/supervisor/supervisord.log:' /etc/supervisord.conf
   sed -i 's:;childlogdir=.*:childlogdir=/tmp/supervisor/:' /etc/supervisord.conf
+  sed -i 's:logfile_backups=.*:logfile_backups=5:' /etc/supervisord.conf
   cp -f ${CORE_DIR}/src/deploy/NVA_build/supervisord.orig /etc/rc.d/init.d/supervisord
   chmod 777 /etc/rc.d/init.d/supervisord
   deploy_log "first install wizard"
@@ -386,9 +389,8 @@ function post_upgrade {
     rm -rf /usr/src/node-v0.10.33/
   fi
 
-  #/usr/lib/node_modules/
-  #/usr/local/lib/node_modules/
-  #/usr/src/node-v0.10.33/
+  rm -rf ${EXTRACTION_PATH}/*
+  rm -rf /backup/build/public/*diagnostics*
 }
 
 #Log file name supplied

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -189,18 +189,20 @@ function pre_upgrade {
   sysctl -e -p
   agent_conf=${CORE_DIR}/agent_conf.json
   if [ -f "$agent_conf" ]
-    then
-        deploy_log "$agent_conf found. Save to /tmp and restore"
-        rm -f /tmp/agent_conf.json
-        cp ${agent_conf} /tmp/agent_conf.json
-    else
-        deploy_log "$agent_conf not found."
-    fi
+  then
+      deploy_log "$agent_conf found. Save to /tmp and restore"
+      rm -f /tmp/agent_conf.json
+      cp ${agent_conf} /tmp/agent_conf.json
+  else
+      deploy_log "$agent_conf not found."
+  fi
 
-	# copy fix_server_sec to
-    if ! grep -q 'fix_server_sec' /etc/rc.local; then
-        echo "bash /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_sec.sh" >> /etc/rc.local
-    fi
+	# copy fix_server_plat
+  if ! grep -q 'fix_server_plat' /etc/rc.local; then
+      echo "bash /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_plat.sh" >> /etc/rc.local
+  fi
+  sed -i 's:.*fix_server_sec.sh::' /etc/rc.local
+
 
 	rm -rf ~/.nvm
 	mkdir ~/.nvm

--- a/src/server/utils/supervisor_ctrl.js
+++ b/src/server/utils/supervisor_ctrl.js
@@ -73,6 +73,8 @@ SupervisorCtrl.prototype.add_program = function(prog) {
             if (!self._supervised) {
                 return;
             }
+            prog.stderr_logfile_backups = '3';
+            prog.stdout_logfile_backups = '3';
             return self._programs.push(prog);
         });
 };


### PR DESCRIPTION
### Explain the changes:
- Limiting Supervisor logs, prev diags
- Cleaning obsolete data after upgrade (tmp extraction, prev debug in /backup)
- Adding an ability to resize the disk to the first_install_wizard

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3139 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

