### PR TITLE
fix zip utils to decode file names by default and leave data as buffers + add test_zip_utils

### DIFF
--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -966,16 +966,16 @@ function set_certificate(zip_file) {
     let cert;
     return P.resolve()
         .then(() => zip_utils.unzip_from_file(zip_file.path))
-        .then(zipfile => zip_utils.unzip_to_mem(zipfile, 'utf8'))
+        .then(zipfile => zip_utils.unzip_to_mem(zipfile))
         .then(files => {
             let key_count = 0;
             let cert_count = 0;
             _.forEach(files, file => {
                 if (file.path.endsWith('.key')) {
-                    key = file.data;
+                    key = file.data.toString();
                     key_count += 1;
                 } else if (file.path.endsWith('.cert')) {
-                    cert = file.data;
+                    cert = file.data.toString();
                     cert_count += 1;
                 }
             });

--- a/src/test/lambda/dildos.js
+++ b/src/test/lambda/dildos.js
@@ -34,11 +34,10 @@ const word_count_func = {
     VpcConfig: {
         SubnetIds: POOLS
     },
-    Files: {
-        'word_count_func.js': {
-            path: path.join(__dirname, 'word_count_func.js')
-        },
-    }
+    Files: [{
+        path: 'word_count_func.js',
+        fs_path: path.join(__dirname, 'word_count_func.js'),
+    }]
 };
 
 const dos_func = {
@@ -51,11 +50,10 @@ const dos_func = {
     VpcConfig: {
         SubnetIds: POOLS
     },
-    Files: {
-        'denial_of_service_func.js': {
-            path: path.join(__dirname, 'denial_of_service_func.js')
-        },
-    }
+    Files: [{
+        path: 'denial_of_service_func.js',
+        fs_path: path.join(__dirname, 'denial_of_service_func.js'),
+    }]
 };
 
 const sync_func = {
@@ -68,11 +66,10 @@ const sync_func = {
     VpcConfig: {
         SubnetIds: POOLS
     },
-    Files: {
-        'sync_s3_to_azure.js': {
-            path: path.join(__dirname, 'sync_s3_to_azure.js')
-        },
-    }
+    Files: [{
+        path: 'sync_s3_to_azure.js',
+        fs_path: path.join(__dirname, 'sync_s3_to_azure.js'),
+    }]
 };
 
 const create_account_func = {
@@ -85,11 +82,10 @@ const create_account_func = {
     VpcConfig: {
         SubnetIds: POOLS
     },
-    Files: {
-        'create_account_func.js': {
-            path: path.join(__dirname, 'create_account_func.js')
-        },
-    }
+    Files: [{
+        path: 'create_account_func.js',
+        fs_path: path.join(__dirname, 'create_account_func.js'),
+    }]
 };
 
 const WC_EVENT = {

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -20,7 +20,6 @@ require('./test_nodes_store');
 require('./test_system_store');
 
 // UTILS
-// require('./test_debug_module');
 require('./test_job_queue');
 require('./test_linked_list');
 require('./test_keys_lock');
@@ -34,4 +33,6 @@ require('./test_signature_utils');
 require('./test_http_utils');
 require('./test_v8_optimizations');
 require('./test_native_core_crypto');
-//require('./test_wait_queue');
+require('./test_zip_utils');
+// require('./test_wait_queue');
+// require('./test_debug_module');

--- a/src/test/unit_tests/test_native_core_crypto.js
+++ b/src/test/unit_tests/test_native_core_crypto.js
@@ -29,26 +29,29 @@ mocha.describe('native_core_crypto', function() {
         mocha.it('should detect invalid key', function() {
             const x = nc.x509();
             x.key = x.key.slice(0, 500) + '!' + x.key.slice(501);
-            assert.throws(() => nc.x509_verify(x));
+            assert.throws(() => nc.x509_verify(x),
+                /^Error: Private key PEM decode failed: bad base64 decode$/);
             assert.throws(() => tls.createSecureContext(x),
-                'error:0906D064:PEM routines:PEM_read_bio:bad base64 decode');
+                /^Error: error:0906D064:PEM routines:PEM_read_bio:bad base64 decode$/);
         });
 
         mocha.it('should detect invalid cert', function() {
             const x = nc.x509();
             x.cert = x.cert.slice(0, 500) + '!' + x.cert.slice(501);
-            assert.throws(() => nc.x509_verify(x));
+            assert.throws(() => nc.x509_verify(x),
+                /^Error: X509 PEM decode failed: bad base64 decode$/);
             assert.throws(() => tls.createSecureContext(x),
-                'error:0906D064:PEM routines:PEM_read_bio:bad base64 decode');
+                /^Error: error:0906D064:PEM routines:PEM_read_bio:bad base64 decode$/);
         });
 
         mocha.it('should detect micmatch key cert', function() {
             const x = nc.x509();
             const y = nc.x509();
             x.key = y.key;
-            assert.throws(() => nc.x509_verify(x));
+            assert.throws(() => nc.x509_verify(x),
+                /^Error: X509 verify failed: PEM lib$/);
             assert.throws(() => tls.createSecureContext(x),
-                'error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch');
+                /^Error: error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch$/);
         });
 
     });

--- a/src/test/unit_tests/test_zip_utils.js
+++ b/src/test/unit_tests/test_zip_utils.js
@@ -1,0 +1,143 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const mocha = require('mocha');
+const assert = require('assert');
+const crypto = require('crypto');
+const chance = require('chance')();
+
+const P = require('../../util/promise');
+const zip_utils = require('../../util/zip_utils');
+const fs_utils = require('../../util/fs_utils');
+
+mocha.describe('zip_utils', function() {
+
+    var temp_dir;
+
+    mocha.before(function() {
+        return fs.mkdtempAsync('/tmp/test_zip_utils_')
+            .then(dir => {
+                temp_dir = dir;
+            });
+    });
+
+    mocha.after(function() {
+        return temp_dir && fs_utils.folder_delete(temp_dir);
+    });
+
+    mocha.it('should zip to buffer', function() {
+        const files = generate_files();
+        return P.resolve()
+            .then(() => zip_utils.zip_from_files(files))
+            .then(zipfile => zip_utils.zip_to_buffer(zipfile))
+            .then(buffer => assert(Buffer.isBuffer(buffer)) || buffer)
+            .then(buffer => zip_utils.unzip_from_buffer(buffer))
+            .then(zipfile => zip_utils.unzip_to_mem(zipfile))
+            .then(files2 => check_files(files, files2));
+    });
+    mocha.it('should zip to file', function() {
+        const files = generate_files();
+        const fname = path.join(temp_dir, 'zip-to-file');
+        return P.resolve()
+            .then(() => zip_utils.zip_from_files(files))
+            .then(zipfile => zip_utils.zip_to_file(zipfile, fname))
+            .then(() => zip_utils.unzip_from_file(fname))
+            .then(zipfile => zip_utils.unzip_to_mem(zipfile))
+            .then(files2 => check_files(files, files2));
+    });
+
+    mocha.it('should zip from dir', function() {
+        const files = generate_files();
+        const dname = path.join(temp_dir, 'zip-from-dir');
+        return P.resolve()
+            .then(() => fs_utils.create_path(dname))
+            .then(() => P.map(files, file =>
+                fs_utils.create_path(path.dirname(path.join(dname, file.path)))
+                .then(() => fs.writeFileAsync(path.join(dname, file.path), file.data))
+            ))
+            .then(() => zip_utils.zip_from_dir(dname))
+            .then(zipfile => zip_utils.zip_to_buffer(zipfile))
+            .then(buffer => assert(Buffer.isBuffer(buffer)) || buffer)
+            .then(buffer => zip_utils.unzip_from_buffer(buffer))
+            .then(zipfile => zip_utils.unzip_to_mem(zipfile))
+            .then(files2 => check_files(files, files2));
+    });
+
+    mocha.it('should unzip to dir', function() {
+        const files = generate_files();
+        const files2 = [];
+        const dname = path.join(temp_dir, 'unzip-to-dir');
+        return P.resolve()
+            .then(() => zip_utils.zip_from_files(files))
+            .then(zipfile => zip_utils.zip_to_buffer(zipfile))
+            .then(buffer => assert(Buffer.isBuffer(buffer)) || buffer)
+            .then(buffer => zip_utils.unzip_from_buffer(buffer))
+            .then(zipfile => zip_utils.unzip_to_dir(zipfile, dname))
+            .then(() => fs_utils.read_dir_recursive({
+                root: dname,
+                on_entry: entry => {
+                    const relative_path = path.relative(dname, entry.path);
+                    if (!entry.stat.isFile()) return;
+                    return fs.readFileAsync(entry.path)
+                        .then(data => {
+                            files2.push({
+                                path: relative_path,
+                                data,
+                            });
+                        });
+                }
+            }))
+            .then(() => check_files(files, files2));
+    });
+
+});
+
+
+function generate_files() {
+    return [
+        { path: 'dir/a', data: 'a file in dir' },
+        { path: 'dir/b', data: 'b file in the same dir' },
+        { path: 'random file data', data: crypto.randomBytes(100) },
+        { path: random_file_name(30), data: 'random file name' },
+    ];
+}
+
+function check_files(files, files2) {
+    const files_sorted = _.sortBy(files, 'path');
+    const files2_sorted = _.sortBy(files2.filter(f => !f.path.endsWith('/')), 'path');
+    const l = Math.max(files_sorted.length, files2_sorted.length);
+    for (var i = 0; i < l; ++i) {
+        const file = files_sorted[i];
+        const file2 = files2_sorted[i];
+        assert.strictEqual(typeof file.path, 'string');
+        assert.strictEqual(typeof file2.path, 'string');
+        assert.strictEqual(file2.path, file.path);
+        assert.deepStrictEqual(file2.data, Buffer.from(file.data));
+    }
+}
+
+// See http://jrgraphix.net/research/unicode_blocks.php
+const file_name_charset =
+    charset_range('a-z') +
+    charset_range('A-Z') +
+    charset_range('0-9') +
+    charset_range('א—ת') +
+    ' ';
+
+function random_file_name(len) {
+    return chance.string({ pool: file_name_charset });
+}
+
+function charset_range(range) {
+    var charset = '';
+    const start = range.charCodeAt(0);
+    const end = range.charCodeAt(2);
+    assert(start <= end);
+    for (var i = start; i <= end; ++i) {
+        charset += String.fromCharCode(i);
+    }
+    return charset;
+}

--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -203,9 +203,7 @@ function folder_delete(dir) {
 
 function file_delete(file_name) {
     return fs.unlinkAsync(file_name)
-        .catch(err => {
-            if (err.code !== 'ENOENT') throw err;
-        })
+        .catch(ignore_enoent)
         .return();
 }
 
@@ -294,6 +292,14 @@ function replace_file(file_path, data) {
         });
 }
 
+function ignore_eexist(err) {
+    if (err.code !== 'EEXIST') throw err;
+}
+
+function ignore_enoent(err) {
+    if (err.code !== 'ENOENT') throw err;
+}
+
 // EXPORTS
 exports.file_must_not_exist = file_must_not_exist;
 exports.file_must_exist = file_must_exist;
@@ -311,4 +317,6 @@ exports.folder_delete = folder_delete;
 exports.tar_pack = tar_pack;
 exports.write_file_from_stream = write_file_from_stream;
 exports.replace_file = replace_file;
+exports.ignore_eexist = ignore_eexist;
+exports.ignore_enoent = ignore_enoent;
 exports.PRIVATE_DIR_PERMISSIONS = PRIVATE_DIR_PERMISSIONS;


### PR DESCRIPTION
### Explain the changes:
- the fix is for the set certificate admin action

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- NA

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

