### PR TITLE
copy object fix etag (v1.8)

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -962,6 +962,12 @@ module.exports = {
                 etag: {
                     type: 'string',
                 },
+                md5_b64: {
+                    type: 'string',
+                },
+                sha256_b64: {
+                    type: 'string',
+                },
                 cloud_synced: {
                     type: 'boolean'
                 },

--- a/src/api/object_io.js
+++ b/src/api/object_io.js
@@ -156,13 +156,10 @@ class ObjectIO {
             .then(create_reply => {
                 params.obj_id = create_reply.obj_id;
                 complete_params.obj_id = create_reply.obj_id;
+                return params.copy_source ?
+                    this._upload_copy(params, complete_params) :
+                    this._upload_stream(params, complete_params);
             })
-            .then(() => (
-                params.copy_source ?
-                this._upload_copy(params) :
-                this._upload_stream(params)
-            ))
-            .then(upload_info => _.assign(complete_params, upload_info))
             .then(() => dbg.log0('upload_object: complete upload', complete_params))
             .then(() => params.client.object.complete_object_upload(complete_params))
             .catch(err => {
@@ -203,13 +200,10 @@ class ObjectIO {
             .then(multipart_reply => {
                 params.multipart_id = multipart_reply.multipart_id;
                 complete_params.multipart_id = multipart_reply.multipart_id;
+                return params.copy_source ?
+                    this._upload_copy(params, complete_params) :
+                    this._upload_stream(params, complete_params);
             })
-            .then(() => (
-                params.copy_source ?
-                this._upload_copy(params) :
-                this._upload_stream(params)
-            ))
-            .then(upload_info => _.assign(complete_params, upload_info))
             .then(() => dbg.log0('upload_multipart: complete upload', complete_params))
             .then(() => params.client.object.complete_multipart(complete_params))
             .catch(err => {
@@ -228,13 +222,15 @@ class ObjectIO {
             })
             .then(object_md => {
                 params.copy_source.obj_id = object_md.obj_id;
+                create_params.md5_b64 = object_md.md5_b64;
+                create_params.sha256_b64 = object_md.sha256_b64;
                 if (params.xattr_copy) {
                     create_params.xattr = object_md.xattr;
                 }
             });
     }
 
-    _upload_copy(params) {
+    _upload_copy(params, complete_params) {
         if (params.copy_source.bucket !== params.bucket) {
             params.source_stream = this.create_read_stream({
                 client: params.client,
@@ -242,35 +238,28 @@ class ObjectIO {
                 bucket: params.copy_source.bucket,
                 key: params.copy_source.key,
             });
-            return this._upload_stream(params);
+            return this._upload_stream(params, complete_params);
         }
 
         // copy mappings
-        var mappings;
         return params.client.object.read_object_mappings({
                 obj_id: params.copy_source.obj_id,
                 bucket: params.copy_source.bucket,
                 key: params.copy_source.key,
             })
-            .then(res => {
-                mappings = res;
-            })
-            .then(() => params.client.object.finalize_object_parts({
-                obj_id: params.obj_id,
-                bucket: params.bucket,
-                key: params.key,
-                // sending part.chunk_id so no need for part.chunk info
-                parts: _.map(mappings.parts, p => _.omit(p, 'chunk')),
-            }))
-            .then(() => {
-                const upload_info = {
-                    size: mappings.object_md.size,
-                    num_parts: mappings.parts.length,
-                    // TODO S3 COPY etag, md5_b64, sha256_b64 require handling for multipart and in general
-                    md5_b64: Buffer.from(mappings.object_md.etag, 'hex').toString('base64'),
-                    sha256_b64: '',
-                };
-                return upload_info;
+            .then(({ object_md, parts }) => {
+                complete_params.size = object_md.size;
+                complete_params.num_parts = parts.length;
+                complete_params.md5_b64 = object_md.md5_b64;
+                complete_params.sha256_b64 = object_md.sha256_b64;
+                complete_params.etag = object_md.etag; // preserve source etag
+                return params.client.object.finalize_object_parts({
+                    obj_id: params.obj_id,
+                    bucket: params.bucket,
+                    key: params.key,
+                    // sending part.chunk_id so no need for part.chunk info
+                    parts: _.map(parts, p => _.omit(p, 'chunk', 'multipart_id')),
+                });
             });
     }
 
@@ -283,7 +272,7 @@ class ObjectIO {
      * by reading large portions from the stream and call _upload_buffers()
      *
      */
-    _upload_stream(params) {
+    _upload_stream(params, complete_params) {
         params.desc = `${params.obj_id}${
             params.num ? '[' + params.num + ']' : ''
         }`;
@@ -303,15 +292,14 @@ class ObjectIO {
         const upload_buffers = buffers => this._upload_buffers(params, buffers);
         const md5 = crypto.createHash('md5');
         const sha256 = params.sha256_b64 ? crypto.createHash('sha256') : null;
-        const upload_info = {
-            size: 0,
-            num_parts: 0,
-        };
+
+        var size = 0;
+        var num_parts = 0;
 
         params.source_stream.on('readable', () =>
             dbg.log0('UPLOAD:', params.desc,
                 'streaming to', params.bucket, params.key,
-                'readable', upload_info.size
+                'readable', size
             )
         );
 
@@ -324,7 +312,7 @@ class ObjectIO {
                 transform(buf, encoding, callback) {
                     md5.update(buf);
                     if (sha256) sha256.update(buf);
-                    upload_info.size += buf.length;
+                    size += buf.length;
                     this.bufs = this.bufs || [];
                     this.bufs.push(buf);
                     this.bytes = (this.bytes || 0) + buf.length;
@@ -336,8 +324,6 @@ class ObjectIO {
                     return callback();
                 },
                 flush(callback) {
-                    upload_info.md5_b64 = md5.digest('base64');
-                    if (sha256) upload_info.sha256_b64 = sha256.digest('base64');
                     if (this.bytes) {
                         this.push(this.bufs);
                         this.bufs = null;
@@ -372,7 +358,7 @@ class ObjectIO {
                 transform(buffers, encoding, callback) {
                     upload_buffers(buffers)
                         .then(parts => {
-                            upload_info.num_parts += parts.length;
+                            num_parts += parts.length;
                             for (const part of parts) {
                                 dbg.log0('UPLOAD:', params.desc,
                                     'streaming at', range_utils.human_range(part),
@@ -386,7 +372,12 @@ class ObjectIO {
                 },
             }))
             .promise()
-            .return(upload_info);
+            .then(() => {
+                complete_params.size = size;
+                complete_params.num_parts = num_parts;
+                complete_params.md5_b64 = md5.digest('base64');
+                if (sha256) complete_params.sha256_b64 = sha256.digest('base64');
+            });
     }
 
 

--- a/src/server/object_services/map_utils.js
+++ b/src/server/object_services/map_utils.js
@@ -493,13 +493,15 @@ function is_chunk_good_for_dedup(chunk, tiering, tiering_status) {
 
 
 function get_part_info(part, adminfo, tiering_status) {
-    let p = _.pick(part,
-        'start',
-        'end',
-        'chunk_offset');
-    p.chunk_id = String(part.chunk._id);
-    p.chunk = get_chunk_info(part.chunk, adminfo, tiering_status);
-    return p;
+    return {
+        start: part.start,
+        end: part.end,
+        seq: part.seq,
+        multipart_id: String(part.multipart_id),
+        chunk_id: String(part.chunk._id),
+        chunk: get_chunk_info(part.chunk, adminfo, tiering_status),
+        chunk_offset: part.chunk_offset, // currently undefined
+    };
 }
 
 function get_chunk_info(chunk, adminfo, tiering_status) {

--- a/src/server/object_services/map_writer.js
+++ b/src/server/object_services/map_writer.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const _ = require('lodash');
+const util = require('util');
 const crypto = require('crypto');
 
 const P = require('../../util/promise');
@@ -120,8 +121,9 @@ function complete_object_parts(obj, multiparts_req) {
         for (const part of parts) {
             const len = part.end - part.start;
             if (part.seq !== seq) {
-                console.log('complete_object_parts: update part at seq', seq,
-                    'pos', pos, 'len', len, part._id);
+                dbg.log0('complete_object_parts: update part at seq', seq,
+                    'pos', pos, 'len', len,
+                    'part', util.inspect(part, { colors: true, depth: null, breakLength: Infinity }));
                 parts_updates.push({
                     _id: part._id,
                     set_updates: {


### PR DESCRIPTION
### Explain the changes:
- Etag was not set correctly in the path of copy object, so fixed in both the copy-mappings and the copy-between-buckets paths.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- NA

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

