### PR TITLE
1.8 bug fixes

### DIFF
--- a/frontend/src/app/action-creators/ui-actions.js
+++ b/frontend/src/app/action-creators/ui-actions.js
@@ -8,7 +8,7 @@ import {
 } from 'action-types';
 
 // -------------------------------
-// Drawer action dispatchers
+// Drawer action creators
 // -------------------------------
 export function openAuditDrawer() {
     return {
@@ -29,7 +29,7 @@ export function closeDrawer() {
 }
 
 // -------------------------------
-// Notificaitons action dispatchers
+// Notificaitons action creators
 // -------------------------------
 export function hideNotification(id) {
     return {
@@ -38,10 +38,6 @@ export function hideNotification(id) {
     };
 }
 
-// --------------------------------------------------------------------
-// REFACTOR: this is used for backword compatability where
-// that sender is an old architecture action
-// --------------------------------------------------------------------
 export function showNotification(message, severity = 'info') {
     return {
         type: SHOW_NOTIFICATION,

--- a/frontend/src/app/components/account/account-details-form/account-details-form.html
+++ b/frontend/src/app/components/account/account-details-form/account-details-form.html
@@ -5,12 +5,13 @@
         General Information
     </h2>
 
-    <button class="btn"
-        ko.click="showPasswordModal"
-        ko.text="changePasswordButtonLabel"
-        ko.disable="disableResetPassword"
-    ></button>
-
+    <div ko.tooltip="changePasswordButtonTooltip">
+        <button class="btn"
+            ko.click="showPasswordModal"
+            ko.text="changePasswordButtonLabel"
+            ko.disable="disableChangePasswordButton"
+        ></button>
+    </div>
 </div>
 
 <property-sheet class="pad" params="properties: profileInfo">

--- a/frontend/src/app/components/account/account-details-form/account-details-form.js
+++ b/frontend/src/app/components/account/account-details-form/account-details-form.js
@@ -13,7 +13,8 @@ class AccountDetailsFormViewModel extends Observer {
         this.role = ko.observable();
         this.isCurrentUser = ko.observable();
         this.changePasswordButtonLabel = ko.observable();
-        this.disableResetPassword = ko.observable();
+        this.disableChangePasswordButton = ko.observable();
+        this.changePasswordButtonTooltip = ko.observable();
 
         this.profileInfo = [
             {
@@ -45,12 +46,19 @@ class AccountDetailsFormViewModel extends Observer {
 
         const { isOwner } = account;
         const isCurrentUser = currentUser === accountName;
+        const role  = !isOwner ?
+            (account.hasLoginAccess ? 'Admin' : 'Application') :
+            'Owner';
 
         this.accountName(accountName);
-        this.role(isOwner ? 'Owner' : 'Admin');
+        this.role(role);
         this.isCurrentUser(isCurrentUser);
         this.changePasswordButtonLabel(isCurrentUser ? 'Change Password' : 'Reset Password');
-        this.disableResetPassword(!account.hasLoginAccess);
+        this.disableChangePasswordButton(!account.hasLoginAccess);
+        this.changePasswordButtonTooltip(!account.hasLoginAccess ?
+            'This action is unavailable for accounts without login access' :
+            ''
+        );
     }
 
     showPasswordModal() {

--- a/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.html
+++ b/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.html
@@ -4,12 +4,16 @@
     <h2 class="heading3 greedy push-next">
         Account S3 Access
     </h2>
-    <button class="btn push-next"
-        ko.click="onSetIPRestrictions"
-        ko.disable="isS3AccessDisabled"
-    >
-        Set IP Restrictions
-    </button>
+
+    <div class="push-next" ko.tooltip="setIPRestrictionsButtonTooltip">
+        <button class="btn"
+            ko.click="onSetIPRestrictions"
+            ko.disable="isS3AccessDisabled"
+        >
+            Set IP Restrictions
+        </button>
+    </div>
+
     <button class="btn" ko.click="onEditS3Access">
         Edit S3 Access
     </button>
@@ -22,12 +26,15 @@
     <h2 class="heading3 greedy push-next" ko.css.disabled="isS3AccessDisabled">
         Account Security Credentials
     </h2>
-    <button class="btn"
-        ko.click="showRegenerateAccountCredentialsModal"
-        ko.disable="isS3AccessDisabled"
-    ">
-        Regenerate Credentials
-    </button>
+
+    <div ko.tooltip="regenerateCredentialsButtonTooltip">
+        <button class="btn"
+            ko.click="showRegenerateAccountCredentialsModal"
+            ko.disable="isS3AccessDisabled"
+        ">
+            Regenerate Credentials
+        </button>
+    </div>
 </div>
 
 <div class="pad column">

--- a/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.js
+++ b/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.js
@@ -6,6 +6,8 @@ import Observer from 'observer';
 import ko from 'knockout';
 import { openEditAccountS3AccessModal, opensetAccountIpRestrictions } from 'action-creators';
 
+const disabledActionTooltip = 'This option is unavailable for accounts without S3 access';
+
 function _createIpBox(ip) {
     return `<span class="ip-box">${ip}</span>`;
 }
@@ -24,6 +26,8 @@ class AccountS3AccessFormViewModel extends Observer {
         this.ipRestrictions = ko.observable();
         this.allowedIps = ko.observable();
         this.isAllowedIpVisible = ko.observable();
+        this.setIPRestrictionsButtonTooltip = ko.observable();
+        this.regenerateCredentialsButtonTooltip = ko.observable();
 
         this.s3AccessInfo = [
             {
@@ -103,8 +107,11 @@ class AccountS3AccessFormViewModel extends Observer {
         this.ipRestrictions(allowedIps ? 'Enabled' : 'Not set');
         this.isAllowedIpVisible(Boolean(hasS3Access && allowedIps));
         this.allowedIps(
-            allowedIps && (allowedIps.length ? allowedIps.map(_createIpBox).join('') : 'No IP allowed')
+            allowedIps &&
+            (allowedIps.length ? allowedIps.map(_createIpBox).join('') : 'No IP allowed')
         );
+        this.setIPRestrictionsButtonTooltip(hasS3Access ? '' : disabledActionTooltip);
+        this.regenerateCredentialsButtonTooltip(hasS3Access ? '' : disabledActionTooltip);
     }
 
     onEditS3Access() {

--- a/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.less
+++ b/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.less
@@ -9,9 +9,9 @@ account-s3-access-form {
         }
 
         .ip-box {
-            .alt-bg();
-            .remark();
-
+            font-size: @font-size1;
+            background-color: @color15;
+            color: @color6;
             margin-right: @gutter/2;
             padding: @gutter/4 @gutter/2;
         }

--- a/frontend/src/app/components/management/accounts-table/account-row.js
+++ b/frontend/src/app/components/management/accounts-table/account-row.js
@@ -62,9 +62,9 @@ export default class AccountRowViewModel extends BaseViewModel {
                     return '';
                 }
 
-                return  this.isSystemOwner() ? 'owner' : account().systems.find(
-                    ({ name }) => name === systemName()
-                ).roles[0];
+                return  !this.isSystemOwner() ?
+                 (account().has_login ? 'Admin' : 'Application') :
+                'Owner';
             }
         );
 

--- a/frontend/src/app/components/management/accounts-table/accounts-table.js
+++ b/frontend/src/app/components/management/accounts-table/accounts-table.js
@@ -45,9 +45,9 @@ const columns = deepFreeze([
 ]);
 
 function getAccountRole(account) {
-    return account.email === systemInfo().owner.email ?
-        'owner' :
-        account.systems[0].roles[0];
+    return account.email !== systemInfo().owner.email ?
+        (account.had_login ? 'admin' : 'application') :
+        'owner';
 }
 
 const compareAccessors = deepFreeze({

--- a/frontend/src/app/components/management/server-dns-form/server-dns-form.html
+++ b/frontend/src/app/components/management/server-dns-form/server-dns-form.html
@@ -39,7 +39,7 @@
 
                 <ol class="bullet-list">
                     <li>
-                        Add the new name in your DNS to have both the old and new names avaliable
+                        Add the new name in your DNS to have both the old and new names available
                         <div class="alt-bg pad config">
                             <span>
                                 <span class="highlight">IP:</span>

--- a/frontend/src/app/components/modals/create-account-modal/create-account-modal.html
+++ b/frontend/src/app/components/modals/create-account-modal/create-account-modal.html
@@ -18,7 +18,7 @@
                     offLabel: 'Disabled'
                 "></toggle-switch>
                 <p class="remark push-prev-half">
-                    Enabling this will generate a password that allows login to <br>
+                    Enabling login access will generate a password that allows login to <br>
                     NooBaa management  console as a system admin
                 </p>
             </editor>
@@ -31,7 +31,7 @@
                 />
                 <validation-message params="field: form.accountName"></validation-message>
                 <p class="remark" ko.visible="isAccountNameRemarkVisible">
-                    1 - 32 characters
+                    3 - 32 characters
                 </p>
 
             </editor>
@@ -46,8 +46,8 @@
                     disabled: form.isLocked
                 "></toggle-switch>
                 <p class="remark push-prev-half" ko.css.disabled="form.isLocked">
-                    Granting S3 access will allow this account to connect an <br>
-                    S3 client applicationby generating a security credentials (key set).
+                    Granting S3 access will allow this account to connect S3 client <br>
+                    applications by generating security credentials (key set).
                 </p>
                 <validation-message params="field: form.hasS3Access"></validation-message>
             </editor>
@@ -70,7 +70,7 @@
                 disabled: !form.hasS3Access() || form.isLocked()
             "></radio-group>
 
-            <div class="align-end push-next-half">
+            <div class="align-end push-next-half" ko.css.disabled="isBucketSelectionDisabled">
                 <button class="link alt-colors"
                     ko.click="onSelectAllBuckets"
                     ko.disable="isBucketSelectionDisabled"

--- a/frontend/src/app/components/modals/create-account-modal/create-account-modal.js
+++ b/frontend/src/app/components/modals/create-account-modal/create-account-modal.js
@@ -22,7 +22,7 @@ function mapResourceToOptions({ type, name: value, storage }) {
 
 const steps = deepFreeze([
     'Account Details',
-    'S3Access'
+    'S3 Access'
 ]);
 
 const bucketPermissionModes = deepFreeze([
@@ -126,21 +126,22 @@ class CreateAccountWizardViewModel extends Observer {
             defaultResource
         } = values;
 
-        const subject = hasLoginAccess ? 'Account name' : 'Email address';
+        const subject = hasLoginAccess ? 'Email address' : 'Account name';
         const accounts = this.accountNames;
         const errors = {};
+        const trimmedName = accountName.trim();
 
         if (step == 0) {
-            if (!accountName) {
+            if (!trimmedName) {
                 errors.accountName = `${subject} is required`;
             }
-            else if (hasLoginAccess && !isEmail(accountName)) {
+            else if (hasLoginAccess && !isEmail(trimmedName)) {
                 errors.accountName = 'Please enter a valid email address';
 
-            } else if (!hasLoginAccess && (accountName.length < 3 || accountName.length > 32)) {
-                errors.accountName = 'Please enter a name between 3-63 characters';
+            } else if (!hasLoginAccess && (trimmedName.length < 3 || trimmedName.length > 32)) {
+                errors.accountName = 'Please enter a name between 3 - 32 characters';
 
-            } else if (accounts.includes(accountName)) {
+            } else if (accounts.includes(trimmedName)) {
                 errors.accountName = `${subject} already in use by another account`;
             }
 
@@ -177,7 +178,7 @@ class CreateAccountWizardViewModel extends Observer {
 
     async onSubmit(values) {
         dispatch(createAccount(
-            values.accountName,
+            values.accountName.trim(),
             values.hasLoginAccess,
             this.password,
             values.hasS3Access,

--- a/frontend/src/app/components/modals/set-account-ip-restrictions-modal/set-account-ip-restrictions-modal.html
+++ b/frontend/src/app/components/modals/set-account-ip-restrictions-modal/set-account-ip-restrictions-modal.html
@@ -8,12 +8,14 @@
             value: form.usingIpRestrictions
         "></toggle-switch>
     </editor>
-    <p class="push-next-half" ko.css.disabled="!form.usingIpRestrictions()">
-        Accept S3 access requests from these IP addresses only.
-        Specify a single IP address or IP address range
-    </p>
 
     <div class="column greedy push-next">
+        <h2 class="heading3" ko.css.disabled="!form.usingIpRestrictions()">
+            Allowed IPs
+        </h2>
+        <p class="push-next" ko.css.disabled="!form.usingIpRestrictions()">
+            Accept S3 access requests from these addresses only:
+        </p>
         <token-field class="greedy" params="
             disabled: !form.usingIpRestrictions(),
             placeholder: allowedIpsPlaceholder,

--- a/frontend/src/app/components/modals/set-account-ip-restrictions-modal/set-account-ip-restrictions-modal.js
+++ b/frontend/src/app/components/modals/set-account-ip-restrictions-modal/set-account-ip-restrictions-modal.js
@@ -11,7 +11,7 @@ import { setAccountIpRestrictions } from 'action-creators';
 // import moment from 'moment';
 
 const allowedIpsPlaceholder =
-    `e.g., 10.5.3.2 or 10.2.1.5-24 and click enter ${String.fromCodePoint(0x23ce)}`;
+    `e.g., 10.5.3.2 or 10.2.253.5 and click enter ${String.fromCodePoint(0x23ce)}`;
 
 class setAccountIpRestrictionsModalViewModel extends Observer {
     constructor({ onClose, accountName }) {

--- a/frontend/src/app/components/modals/set-account-ip-restrictions-modal/set-account-ip-restrictions-modal.less
+++ b/frontend/src/app/components/modals/set-account-ip-restrictions-modal/set-account-ip-restrictions-modal.less
@@ -2,4 +2,8 @@
 
 .set-account-ip-restrictions-modal {
     display: block;
+
+    form {
+        margin-top: -@gutter;
+    }
 }

--- a/frontend/src/app/components/pool/pool-summary/pool-summary.js
+++ b/frontend/src/app/components/pool/pool-summary/pool-summary.js
@@ -111,7 +111,7 @@ class PoolSummaryViewModel extends BaseViewModel {
 
         this.pieValues = [
             {
-                label: 'Currently Avaliable',
+                label: 'Currently Available',
                 color: style['color5'],
                 value: ko.pureComputed(
                     () => toBytes(storage().free)

--- a/frontend/src/app/components/shared/property-sheet/property-sheet.html
+++ b/frontend/src/app/components/shared/property-sheet/property-sheet.html
@@ -9,7 +9,7 @@
 
         <div class="prop-value no-wrap greedy"
             ko.html="value"
-            ko.css.disabled="$data.disabled"
+            ko.css="{ disabled: $data.disabled, 'push-next': $data.allowCopy }"
         "></div>
 
         <copy-to-clipboard-button ko.visible="$data.allowCopy" params="

--- a/frontend/src/app/components/shared/token-field/token-field.less
+++ b/frontend/src/app/components/shared/token-field/token-field.less
@@ -40,7 +40,7 @@ token-field {
         &:before {
             .fill();
             content: '';
-            background: @color4;
+            background: @color15;
             border: 1px solid @color2;
             animation: fade-in 250ms ease-out;
         }

--- a/frontend/src/app/epics/close-create-account-on-faliure.js
+++ b/frontend/src/app/epics/close-create-account-on-faliure.js
@@ -1,0 +1,10 @@
+/* Copyright (C) 2016 NooBaa */
+
+import { FAIL_CREATE_ACCOUNT } from 'action-types';
+import { closeModal } from 'action-creators';
+
+export default function(action$) {
+    return action$
+        .ofType(FAIL_CREATE_ACCOUNT)
+        .map(() => closeModal());
+}

--- a/frontend/src/app/epics/index.js
+++ b/frontend/src/app/epics/index.js
@@ -1,6 +1,7 @@
 /* Copyright (C) 2016 NooBaa */
 
 import Rx from 'rx';
+import notifyEpic from './notify';
 import createSystemEpic from './create-system';
 import restoreSessionEpic from './restore-session';
 import signInEpic from './sign-in';
@@ -9,6 +10,7 @@ import createAccountEpic from './create-account';
 import triggerFetchSystemInfoEpic from './trigger-fetch-system-info';
 import lockCreateAccountModalEpic from './lock-create-account-modal';
 import showAccountCreatedMessageEpic from './show-account-created-message';
+import closeCreateAccountOnFaliureEpic from './close-create-account-on-faliure';
 import updateAccountS3AccessEpic from './update-account-s3-access';
 import fetchAlertsEpic from './fetch-alerts';
 import updateAlertsEpic from './update-alerts';
@@ -29,6 +31,7 @@ function combineEpics(epics) {
 }
 
 export default combineEpics([
+    notifyEpic,
     createSystemEpic,
     restoreSessionEpic,
     signInEpic,
@@ -37,6 +40,7 @@ export default combineEpics([
     createAccountEpic,
     lockCreateAccountModalEpic,
     showAccountCreatedMessageEpic,
+    closeCreateAccountOnFaliureEpic,
     updateAccountS3AccessEpic,
     fetchAlertsEpic,
     updateAlertsEpic,

--- a/frontend/src/app/epics/notify.js
+++ b/frontend/src/app/epics/notify.js
@@ -1,0 +1,54 @@
+import { deepFreeze } from 'utils/core-utils';
+import { showNotification } from 'action-creators';
+import {
+    FAIL_CREATE_ACCOUNT,
+    COMPLETE_UPDATE_ACCOUNT_S3_ACCESS,
+    FAIL_UPDATE_ACCOUNT_S3_ACCESS,
+    FAIL_UPDATE_BUCKET_QUOTA,
+    COMPLETE_SET_ACCOUNT_IP_RESTRICTIONS,
+    FAIL_SET_ACCOUNT_IP_RESTRICTIONS
+} from 'action-types';
+
+const actionToNotification = deepFreeze({
+    [FAIL_CREATE_ACCOUNT]: ({ accountName }) => ({
+        message: `Creating account ${accountName} failed`,
+        severity: 'error'
+    }),
+
+    [COMPLETE_UPDATE_ACCOUNT_S3_ACCESS]: ({ accountName }) => ({
+        message: `${accountName} S3 access updated successfully`,
+        severity: 'success'
+    }),
+
+    [FAIL_UPDATE_ACCOUNT_S3_ACCESS]: ({ accountName }) => ({
+        message: `Updating ${accountName} S3 access failed`,
+        severity: 'error'
+    }),
+
+    [FAIL_UPDATE_BUCKET_QUOTA]: ({ bucket }) => ({
+        message: `Updating quota for ${bucket} failed`,
+        severity: 'error'
+    }),
+
+    [COMPLETE_SET_ACCOUNT_IP_RESTRICTIONS]: ({ accountName }) => ({
+        message: `IP restrictions for ${accountName} set successfully`,
+        severity: 'error'
+    }),
+
+    [FAIL_SET_ACCOUNT_IP_RESTRICTIONS]: ({ accountName }) => ({
+        message: `Setting IP restrictions for ${accountName} failed`,
+        severity: 'error'
+    })
+});
+
+export default function(action$) {
+    return action$
+        .map(action => {
+            const notif = actionToNotification[action.type];
+            if (notif) {
+                const { message, severity } = notif(action.payload);
+                return showNotification(message, severity);
+            }
+        })
+        .filter(Boolean);
+}

--- a/frontend/src/app/epics/upload-objects.js
+++ b/frontend/src/app/epics/upload-objects.js
@@ -36,7 +36,7 @@ export default function(action$) {
                         );
 
                         if (--uploading == 0) {
-                            uploadEvent$.onComplete();
+                            uploadEvent$.onCompleted();
                         }
                     }
                 )

--- a/frontend/src/app/reducers/notificaitons-reducer.js
+++ b/frontend/src/app/reducers/notificaitons-reducer.js
@@ -3,13 +3,7 @@
 import { createReducer } from 'utils/reducer-utils';
 import {
     HIDE_NOTIFICATION,
-    FAIL_CREATE_ACCOUNT,
-    COMPLETE_UPDATE_ACCOUNT_S3_ACCESS,
-    FAIL_UPDATE_ACCOUNT_S3_ACCESS,
-    FAIL_UPDATE_BUCKET_QUOTA,
-    SHOW_NOTIFICATION,
-    COMPLETE_SET_ACCOUNT_IP_RESTRICTIONS,
-    FAIL_SET_ACCOUNT_IP_RESTRICTIONS
+    SHOW_NOTIFICATION
 } from 'action-types';
 
 // ------------------------------
@@ -31,85 +25,23 @@ function onHideNotification(notifications, { payload}) {
     return { ...notifications, list: newlist };
 }
 
-function onFailCreateAccount(notifications, { payload }) {
-    return _queueNotification(
-        notifications,
-        `Creating account ${payload.email} failed`,
-        'error'
-    );
-}
-
-function onCompleteUpdateAccountS3Access(notifications, { payload }) {
-    return _queueNotification(
-        notifications,
-        `${payload.accountName} S3 access updated successfully`,
-        'success'
-    );
-}
-
-function onFailUpdateAccountS3Access(notifications, { payload }) {
-    return _queueNotification(
-        notifications,
-        `Updating ${payload.accountName} S3 access failed`,
-        'error'
-    );
-}
-
-function onFailUpdateBucketQuota(notifications, { payload }) {
-    return _queueNotification(
-        notifications,
-        `Updating quota for ${payload.bucket} failed`,
-        'error'
-    );
-}
-
-function onCompleteSetAccountIpRestrictions(notifications, { payload }) {
-    return _queueNotification(
-        notifications,
-        `IP restrictions for ${payload.accountName} set successfully`,
-        'success'
-    );
-}
-
-function onFailSetAccountIpRestrictions(notifications, { payload }) {
-    return _queueNotification(
-        notifications,
-        `Setting IP restrictions for ${payload.accountName} failed`,
-        'error'
-    );
-}
-
-// --------------------------------------------------------------------
-// REFACTOR: this is used for backword compatability where
-// that sender is an old architecture action
-// --------------------------------------------------------------------
 function onShowNotification(notifications, { payload }) {
     const { severity, message } = payload;
-    return _queueNotification(notifications, message, severity);
-}
-
-// ------------------------------
-// Local util functions
-// ------------------------------
-function _queueNotification(notifications, message, severity) {
     const { list, nextId } = notifications;
+
     return {
-        list: [ ...list, { id: nextId, severity, message } ],
+        list: [
+            ...list,
+            { id: nextId, severity, message }
+        ],
         nextId: nextId + 1
     };
 }
-
 
 // ------------------------------
 // Exported reducer function
 // ------------------------------
 export default createReducer(initialState, {
     [HIDE_NOTIFICATION]: onHideNotification,
-    [FAIL_CREATE_ACCOUNT]: onFailCreateAccount,
-    [COMPLETE_UPDATE_ACCOUNT_S3_ACCESS]: onCompleteUpdateAccountS3Access,
-    [FAIL_UPDATE_ACCOUNT_S3_ACCESS]: onFailUpdateAccountS3Access,
-    [FAIL_UPDATE_BUCKET_QUOTA]: onFailUpdateBucketQuota,
-    [COMPLETE_SET_ACCOUNT_IP_RESTRICTIONS]: onCompleteSetAccountIpRestrictions,
-    [FAIL_SET_ACCOUNT_IP_RESTRICTIONS]: onFailSetAccountIpRestrictions,
     [SHOW_NOTIFICATION]: onShowNotification,
 });


### PR DESCRIPTION
### Chagnes
- Change S3Access to S3 Access on create account second
- Change role of users without login to "Application"
-  Match the enforcement and error message on account name field in create account modal (now it's 3-32)
- Fix disabled style on "|"  in create bucket modal
-  Create account modal will not stuck anymore on failure
-  Trim account name before sending it to server on create account modal
- Add disabled tooltip  to Set IP Restrictions, Generate Credentials, Reset password buttons
- Remove range text form set IP restriction modal
- Fix "Applicaitonby" on create account step 2
- Fix "Avliable" Misspell on pool chart legend 
- Fix code bug on file upload 

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixed #3167
- Fixed  #3166
- Fixed #3169
