### PR TITLE
fix #3176 - support copy from file to same name (used for set metadata attributes)

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -35,9 +35,6 @@ module.exports = {
                     xattr: {
                         $ref: '#/definitions/xattr',
                     },
-                    md_conditions: {
-                        $ref: '#/definitions/md_conditions',
-                    },
                     size: {
                         type: 'integer',
                     },
@@ -96,6 +93,9 @@ module.exports = {
                     },
                     etag: {
                         type: 'string',
+                    },
+                    md_conditions: {
+                        $ref: '#/definitions/md_conditions',
                     },
                     multiparts: {
                         type: 'array',

--- a/src/api/object_io.js
+++ b/src/api/object_io.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const _ = require('lodash');
+const util = require('util');
 const stream = require('stream');
 const crypto = require('crypto');
 
@@ -141,15 +142,17 @@ class ObjectIO {
             'size',
             'md5_b64',
             'sha256_b64',
-            'md_conditions',
             'xattr'
         );
         const complete_params = _.pick(params,
             'bucket',
-            'key'
+            'key',
+            'md_conditions'
         );
 
-        dbg.log0('upload_object: start upload', complete_params);
+        dbg.log0('upload_object: start upload',
+            util.inspect(create_params, { colors: true, depth: null, breakLength: Infinity }));
+
         return P.resolve()
             .then(() => this._load_copy_source_md(params, create_params))
             .then(() => params.client.object.create_object_upload(create_params))

--- a/src/deploy/mongo_upgrade/mongo_upgrade.sh
+++ b/src/deploy/mongo_upgrade/mongo_upgrade.sh
@@ -47,6 +47,8 @@ done
 UPGRADE_SCRIPTS=(
     'mongo_upgrade_15.js' 
     'mongo_upgrade_17.js'
+    'mongo_upgrade_18.js'
+    'mongo_upgrade_mark_completed.js'
 )
 
 upgrade_failed=0

--- a/src/deploy/mongo_upgrade/mongo_upgrade_15.js
+++ b/src/deploy/mongo_upgrade/mongo_upgrade_15.js
@@ -1,9 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 /* eslint-env mongo */
-/* global setVerboseShell */
-/* global sleep */
-
+/* global setVerboseShell, sleep */
 'use strict';
+
 // the following params are set from outside the script
 // using mongo --eval 'var param_ip="..."' and we only declare them here for completeness
 var param_secret;
@@ -13,11 +12,12 @@ var param_client_subject;
 // This NooBaa epoch is used as initialization date value for md_aggregator
 const NOOBAA_EPOCH = 1430006400000;
 
-setVerboseShell(true);
-upgrade();
+mongo_upgrade_15();
 
 /* Upade mongo structures and values with new things since the latest version*/
-function upgrade() {
+function mongo_upgrade_15() {
+    print('\nMONGO UPGRADE 15 - START ...');
+    setVerboseShell(true);
     add_ssl_user();
     sync_cluster_upgrade();
     upgrade_systems();
@@ -33,7 +33,7 @@ function upgrade() {
     blocks_to_buckets_upgrade();
     upgrade_object_mds_total_parts();
     upgrade_server_hb();
-    print('\nUPGRADE DONE 15.');
+    print('\nMONGO UPGRADE 15 - DONE.');
 }
 
 function add_ssl_user() {

--- a/src/deploy/mongo_upgrade/mongo_upgrade_17.js
+++ b/src/deploy/mongo_upgrade/mongo_upgrade_17.js
@@ -1,43 +1,24 @@
 /* Copyright (C) 2016 NooBaa */
 /* eslint-env mongo */
 /* global setVerboseShell */
-// /* global sleep */
-
 'use strict';
-// the following params are set from outside the script
-// using mongo --eval 'var param_ip="..."' and we only declare them here for completeness
-var param_secret;
-// var param_bcrypt_secret;
-// var param_client_subject;
 
 // This NooBaa epoch is used as initialization date value for md_aggregator
 const NOOBAA_EPOCH = 1430006400000;
 
-setVerboseShell(true);
-upgrade();
+mongo_upgrade_17();
 
 /* Upade mongo structures and values with new things since the latest version*/
-function upgrade() {
+function mongo_upgrade_17() {
+    print('\nMONGO UPGRADE 17 - START ...');
+    setVerboseShell(true);
     upgrade_buckets();
     upgrade_accounts();
     upgrade_pools();
     upgrade_nodes();
     upgrade_blocks();
     upgrade_tiering_policies();
-    // cluster upgrade: mark that upgrade is completed for this server
-    mark_completed(); // do not remove
-    print('\nUPGRADE DONE 17.');
-}
-
-function mark_completed() {
-    // mark upgrade status of this server as completed
-    db.clusters.update({
-        owner_secret: param_secret
-    }, {
-        $set: {
-            "upgrade.status": "COMPLETED"
-        }
-    });
+    print('\nMONGO UPGRADE 17 - DONE.');
 }
 
 function upgrade_buckets() {

--- a/src/deploy/mongo_upgrade/mongo_upgrade_18.js
+++ b/src/deploy/mongo_upgrade/mongo_upgrade_18.js
@@ -1,0 +1,19 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-env mongo */
+/* global setVerboseShell */
+'use strict';
+
+mongo_upgrade_18();
+
+function mongo_upgrade_18() {
+    print('\nMONGO UPGRADE 18 - START ...');
+    setVerboseShell(true);
+    drop_objects_unique_index();
+    print('\nMONGO UPGRADE 18 - DONE.');
+}
+
+function drop_objects_unique_index() {
+    // new unique index includes additional field - upload_started
+    // the index will be created when the server starts
+    db.objectmds.dropIndex('bucket_1_key_1_deleted_1');
+}

--- a/src/deploy/mongo_upgrade/mongo_upgrade_mark_completed.js
+++ b/src/deploy/mongo_upgrade/mongo_upgrade_mark_completed.js
@@ -1,0 +1,26 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-env mongo */
+/* global setVerboseShell */
+'use strict';
+
+// the following params are set from outside the script
+// using mongo --eval 'var param_ip="..."' and we only declare them here for completeness
+var param_secret;
+// var param_bcrypt_secret;
+// var param_client_subject;
+
+mongo_upgrade_mark_completed();
+
+function mongo_upgrade_mark_completed() {
+    print('\nMONGO UPGRADE MARK COMPLETED - START ...');
+    setVerboseShell(true);
+    // mark upgrade status of this server as completed
+    db.clusters.update({
+        owner_secret: param_secret
+    }, {
+        $set: {
+            "upgrade.status": "COMPLETED"
+        }
+    });
+    print('\nMONGO UPGRADE MARK COMPLETED - DONE.');
+}

--- a/src/endpoint/s3/ops/s3_get_bucket_uploads.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_uploads.js
@@ -10,7 +10,7 @@ const s3_utils = require('../s3_utils');
  * http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html
  */
 function get_bucket_uploads(req) {
-    // TODO S3 MUST implement Marker & MaxKeys & IsTruncated
+    // TODO S3 MUST implement KeyMarker & UploadIdMarker & MaxKeys & IsTruncated
     let params = {
         bucket: req.params.bucket,
         upload_mode: true,

--- a/src/endpoint/s3/ops/s3_post_object_uploadId.js
+++ b/src/endpoint/s3/ops/s3_post_object_uploadId.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const dbg = require('../../../util/debug_module')(__filename);
 const S3Error = require('../s3_errors').S3Error;
 const s3_utils = require('../s3_utils');
+const http_utils = require('../../../util/http_utils');
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
@@ -27,6 +28,7 @@ function post_object_uploadId(req) {
             obj_id: req.query.uploadId,
             bucket: req.params.bucket,
             key: req.params.key,
+            md_conditions: http_utils.get_md_conditions(req),
             multiparts
         })
         .then(reply => ({

--- a/src/endpoint/s3/ops/s3_post_object_uploads.js
+++ b/src/endpoint/s3/ops/s3_post_object_uploads.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const s3_utils = require('../s3_utils');
-const http_utils = require('../../../util/http_utils');
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html
@@ -13,7 +12,6 @@ function post_object_uploads(req) {
             bucket: req.params.bucket,
             key: req.params.key,
             content_type: req.headers['content-type'],
-            md_conditions: http_utils.get_md_conditions(req),
             xattr: s3_utils.get_request_xattr(req),
         })
         .then(reply => ({

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -91,6 +91,7 @@ class MDStore {
                 bucket: bucket_id,
                 key: key,
                 deleted: null,
+                upload_started: null,
             }, compact_updates(set_updates))
             .then(res => mongo_utils.check_update_one(res, 'object'));
     }
@@ -117,6 +118,7 @@ class MDStore {
             bucket: bucket_id,
             key: key,
             deleted: null,
+            upload_started: null,
         }));
     }
 
@@ -129,13 +131,12 @@ class MDStore {
             bucket: bucket_id,
             key: key,
             deleted: null,
+            // allow filtering of uploading/non-uploading objects
+            upload_started: typeof upload_mode === 'boolean' ? {
+                $exists: upload_mode
+            } : undefined,
             create_time: max_create_time ? {
                 $lt: new Date(moment.unix(max_create_time).toISOString())
-            } : undefined,
-            // TODO: Should look at the upload_size or upload_completed?
-            // allow filtering of uploading/non-uploading objects
-            upload_mode: typeof upload_mode === 'boolean' ? {
-                $exists: upload_mode
             } : undefined,
         });
 
@@ -177,7 +178,7 @@ class MDStore {
                 $gt: marker
             },
             deleted: null,
-            upload_size: {
+            upload_started: {
                 $exists: Boolean(upload_mode)
             }
         };
@@ -234,8 +235,8 @@ class MDStore {
     has_any_completed_objects_in_bucket(bucket_id) {
         return this._objects.col().findOne({
                 bucket: bucket_id,
-                upload_started: null,
                 deleted: null,
+                upload_started: null,
             })
             .then(obj => Boolean(obj));
     }
@@ -331,6 +332,7 @@ class MDStore {
         return this._objects.col().find({
                 bucket: bucket_id,
                 deleted: null,
+                upload_started: null,
                 create_time: {
                     $exists: true
                 }
@@ -347,6 +349,7 @@ class MDStore {
         return this._objects.col().find({
                 bucket: bucket_id,
                 cloud_synced: false,
+                upload_started: null,
                 create_time: {
                     $exists: true
                 }

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -55,14 +55,7 @@ function create_object_upload(req) {
     if (req.rpc_params.size >= 0) info.size = req.rpc_params.size;
     if (req.rpc_params.md5_b64) info.md5_b64 = req.rpc_params.md5_b64;
     if (req.rpc_params.sha256_b64) info.sha256_b64 = req.rpc_params.sha256_b64;
-    return MDStore.instance().find_object_by_key(req.bucket._id, req.rpc_params.key)
-        .then(existing_obj => {
-            // check if the conditions for overwrite are met, throws if not
-            check_md_conditions(req, req.rpc_params.md_conditions, existing_obj);
-            // we passed the checks, so we can delete the existing object if exists
-            return map_deleter.delete_object(existing_obj);
-        })
-        .then(() => MDStore.instance().insert_object(info))
+    return MDStore.instance().insert_object(info)
         .return({
             obj_id: String(info._id)
         });
@@ -142,6 +135,13 @@ function complete_object_upload(req) {
             } else {
                 set_updates.etag = Buffer.from(req.rpc_params.md5_b64, 'base64').toString('hex');
             }
+        })
+        .then(() => MDStore.instance().find_object_by_key(req.bucket._id, req.rpc_params.key))
+        .then(existing_obj => {
+            // check if the conditions for overwrite are met, throws if not
+            check_md_conditions(req, req.rpc_params.md_conditions, existing_obj);
+            // we passed the checks, so we can delete the existing object if exists
+            return map_deleter.delete_object(existing_obj);
         })
         .then(() => MDStore.instance().update_object_by_id(obj._id, set_updates, unset_updates))
         .then(() => {
@@ -733,7 +733,7 @@ function get_object_info(md) {
         create_time: md.create_time ? md.create_time.getTime() : md._id.getTimestamp().getTime(),
         upload_started: md.upload_started ? md.upload_started.getTime() : undefined,
         upload_size: _.isNumber(md.upload_size) ? md.upload_size : undefined,
-        xattr: md.attr,
+        xattr: md.xattr,
         cloud_synced: md.cloud_synced,
         stats: md.stats ? {
             reads: md.stats.reads || 0,
@@ -827,9 +827,9 @@ function check_object_mode(req, obj, rpc_code) {
             `No such object id for key: ${obj.key} obj_id ${req.rpc_params.obj_id}`);
     }
     if (rpc_code === 'NO_SUCH_UPLOAD') {
-        if (!_.isNumber(obj.upload_size)) {
+        if (!obj.upload_started) {
             throw new RpcError(rpc_code,
-                `Object not in upload mode: ${obj.key} upload_size ${obj.upload_size}`);
+                `Object not in upload mode: ${obj.key} create_time ${obj.create_time}`);
         }
     }
     return obj;

--- a/src/server/object_services/schemas/object_md_indexes.js
+++ b/src/server/object_services/schemas/object_md_indexes.js
@@ -14,6 +14,7 @@ module.exports = [{
             bucket: 1,
             key: 1,
             deleted: 1,
+            upload_started: 1,
         },
         options: {
             unique: true,


### PR DESCRIPTION
### Explain the changes:
- the fix is to move the target file deletion to complete_multipart_upload.
- this was actually a historic misunderstanding that we implemented it in create_multipart_upload,
and also AWS only deletes the target file on complete.
- so we added the upload_started field to the unique index to allow multiple objects with same key to exist.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- #3176

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

