### PR TITLE
Adding back test_wait_queue, Fix for #3172

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -377,6 +377,19 @@ function update_account(req) {
         allowed_ips: params.ips === null ? true : undefined
     };
 
+    //Create the event description according to the changes performed    
+    let event_desc = '';
+    if (params.new_email && params.new_email !== params.email) {
+        event_desc += `Email address changed from ${params.email} to ${params.new_email}. `;
+    }
+    if (account.allowed_ips !== params.ips) {
+        if (params.ips === null) {
+            event_desc += `Restriction for IPs were removed`
+        } else {
+            event_desc += `Allowed IPs were changed to ` + params.ips.toString().replace(/,/g, ', ');
+        }
+    }
+
     return system_store.make_changes({
             update: {
                 accounts: [{
@@ -392,7 +405,8 @@ function update_account(req) {
             system: req.system && req.system._id,
             actor: req.account && req.account._id,
             account: account._id,
-            desc: `${account.email} was updated by ${req.account && req.account.email}`,
+            desc: `${account.email} was updated by ${req.account && req.account.email}` +
+                (event_desc ? '. ' + event_desc : ''),
         }))
         .return();
 }

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -34,5 +34,5 @@ require('./test_http_utils');
 require('./test_v8_optimizations');
 require('./test_native_core_crypto');
 require('./test_zip_utils');
-// require('./test_wait_queue');
+require('./test_wait_queue');
 // require('./test_debug_module');


### PR DESCRIPTION
### Explain the changes:
- Adding back test_wait_queue
- Fix for #3172

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixed #3172 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

