### PR TITLE
Windows agent agent_storage folder permissions fix

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -66,6 +66,7 @@ class Agent {
 
         this.connect_attempts = 0;
         this._test_connection_timeout = null;
+        this.permission_tempering = params.permission_tempering;
 
         assert(params.node_name, 'missing param: node_name');
         this.node_name = params.node_name;
@@ -669,6 +670,7 @@ class Agent {
             host_name: this.host_name,
             rpc_address: this.rpc_address || '',
             base_address: this.base_address,
+            permission_tempering: this.permission_tempering,
             n2n_config: this.n2n_agent.get_plain_n2n_config(),
             enabled: this.enabled,
             geolocation: this.geolocation,

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -57,6 +57,9 @@ module.exports = {
                     rpc_address: {
                         type: 'string'
                     },
+                    permission_tempering: {
+                        format: 'idate'
+                    },
                     n2n_config: {
                         $ref: 'common_api#/definitions/n2n_config'
                     },

--- a/src/server/bg_services/md_aggregator.js
+++ b/src/server/bg_services/md_aggregator.js
@@ -22,7 +22,7 @@ function background_worker() {
 
     let bucket_groups_by_update_time =
         _.groupBy(system_store.data.buckets, g_bucket =>
-            _.get(g_bucket, 'storage_stats.last_update', config.NOOBAA_EPOCH));
+            _.get(g_bucket, 'storage_stats.last_update') || config.NOOBAA_EPOCH);
 
     const sorted_group_update_times = _.keysIn(bucket_groups_by_update_time)
         .sort((a, b) => parseInt(a, 10) - parseInt(b, 10));

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -420,7 +420,7 @@ function _prepare_auth_request(req) {
         if (req.auth_token && typeof req.auth_token === 'object') {
             return _.get(account, 'allowed_buckets.full_permission', false) ||
                 _.find(
-                    _.get(account, 'allowed_buckets.permission_list', []),
+                    _.get(account, 'allowed_buckets.permission_list') || [],
                     allowed_bucket => String(allowed_bucket._id) === String(bucket._id)
                 );
         } else {

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -57,6 +57,7 @@ const AGENT_INFO_FIELDS = [
     's3_agent',
     'node_type',
     'host_name',
+    'permission_tempering'
 ];
 const MONITOR_INFO_FIELDS = [
     'has_issues',
@@ -1433,6 +1434,8 @@ class NodesMonitor extends EventEmitter {
         // to decide the node trusted status we check the reported issues
         item.trusted = true;
         let io_detention_recent_issues = 0;
+
+        if (item.node.permission_tempering) item.trusted = false;
 
         if (item.node.issues_report) {
             // only print to log if the node had issues in the last hour

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -598,7 +598,7 @@ function list_objects_s3(req) {
     // This is used in order to continue from a certain key when the response is truncated
     var marker = req.rpc_params.key_marker ? (prefix + req.rpc_params.key_marker) : '';
 
-    const received_limit = _.get(req, 'rpc_params.limit', 1000);
+    const received_limit = _.get(req, 'rpc_params.limit') || 1000;
 
     if (received_limit < 0) {
         const new_err = new Error();

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1001,7 +1001,7 @@ function get_bucket_info(bucket, nodes_aggregate_pool, aggregate_data_free_by_ti
             let has_valid_pool = false;
             _.compact((mirror_object.spread_pools || []).map(pool => {
                     const spread_pool = system_store.data.pools.find(pool_rec => String(pool_rec._id) === String(pool._id));
-                    tiering_pools_used_agg.push(_.get(spread_pool, 'storage_stats.blocks_size', 0));
+                    tiering_pools_used_agg.push(_.get(spread_pool, 'storage_stats.blocks_size') || 0);
                     return tiering_pools_status[tier_and_order.tier._id].pools[pool._id];
                 }))
                 .forEach(pool_status => {
@@ -1023,10 +1023,10 @@ function get_bucket_info(bucket, nodes_aggregate_pool, aggregate_data_free_by_ti
     info.num_objects = num_of_objects || 0;
 
     const used_of_pools_in_policy = size_utils.json_to_bigint(size_utils.reduce_sum('blocks_size', tiering_pools_used_agg));
-    const bucket_chunks_capacity = size_utils.json_to_bigint(_.get(bucket, 'storage_stats.chunks_capacity', 0));
-    const bucket_used = size_utils.json_to_bigint(_.get(bucket, 'storage_stats.blocks_size', 0));
+    const bucket_chunks_capacity = size_utils.json_to_bigint(_.get(bucket, 'storage_stats.chunks_capacity') || 0);
+    const bucket_used = size_utils.json_to_bigint(_.get(bucket, 'storage_stats.blocks_size') || 0);
     const bucket_used_other = BigInteger.max(used_of_pools_in_policy.minus(bucket_used), BigInteger.zero);
-    const bucket_free = size_utils.json_to_bigint(_.get(info, 'tiering.storage.free', 0));
+    const bucket_free = size_utils.json_to_bigint(_.get(info, 'tiering.storage.free') || 0);
     const spillover_tier_storage = spillover_tier_in_policy && _.mapValues(_.get(tier_server.get_tier_info(
             spillover_tier_in_policy,
             nodes_aggregate_pool,
@@ -1053,7 +1053,7 @@ function get_bucket_info(bucket, nodes_aggregate_pool, aggregate_data_free_by_ti
         last_update: _.get(bucket, 'storage_stats.last_update')
     };
 
-    const actual_free = size_utils.json_to_bigint(_.get(info, 'tiering.data.free', 0));
+    const actual_free = size_utils.json_to_bigint(_.get(info, 'tiering.data.free') || 0);
     let available_for_upload = actual_free.plus(spillover_storage.free);
     if (bucket.quota) {
         info.quota = _.omit(bucket.quota, 'value');
@@ -1080,7 +1080,7 @@ function get_bucket_info(bucket, nodes_aggregate_pool, aggregate_data_free_by_ti
     };
 
     info.usage_by_pool.pools = [];
-    _.mapKeys(_.get(bucket, 'storage_stats.pools', {}), function(storage, pool_id) {
+    _.mapKeys(_.get(bucket, 'storage_stats.pools') || {}, function(storage, pool_id) {
         const pool = system_store.data.get_by_id(pool_id);
         if (pool) {
             info.usage_by_pool.pools.push({

--- a/src/util/phone_home.js
+++ b/src/util/phone_home.js
@@ -64,7 +64,7 @@ function _handle_ph_get(ph_get_result, google_get_result, ph_dns_result) {
         let ph_reply = ph_get_result.value();
         dbg.log0(`Received Response From ${config.PHONE_HOME_BASE_URL}`,
             ph_reply && ph_reply.response.statusCode, ph_reply.body);
-        if (_.get(ph_reply, 'response.statusCode', 0) === 200) {
+        if ((_.get(ph_reply, 'response.statusCode') || 0) === 200) {
             if (String(ph_reply.body) === 'Phone Home Connectivity Test Passed!') {
                 return 'CONNECTED';
             }


### PR DESCRIPTION
On big agents the permission took a lot of time which meant that the agent is offline.
We were configuring the permission on every start of agent without regard to the configuration.
Which meant that every restart of noobaa_service made us do the configuration which took a lot of time.

This is a fix which scans the scenario and applies one of the following actions:
1) On new agent_storage directory (initialization) it will configure the permissions
2) On tampering it will not configure anything and report the agent as untrusted
3) If everything okay, it will not do anything

### Explain the changes:
- 

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- partial fix to #3195 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

