### PR TITLE
Fix Audit/Alert panes limited to 25 Entries

### DIFF
--- a/src/server/analytic_services/activity_log_store.js
+++ b/src/server/analytic_services/activity_log_store.js
@@ -63,9 +63,9 @@ class ActivityLogStore {
 
         let time;
         if (till) {
-            time = { $lt: till };
+            time = { $lt: new Date(till) };
         } else if (since) {
-            time = { $gt: since };
+            time = { $gt: new Date(since) };
         }
 
         let event_regex;

--- a/src/server/notifications/alerts_log_store.js
+++ b/src/server/notifications/alerts_log_store.js
@@ -66,6 +66,7 @@ class AlertsLogStore {
 
     read_alerts(sysid, query, skip, limit) {
         const selector = this._create_selector(sysid, query);
+        console.warn('NBNB:: read_alerts', selector, 'skip', skip, 'limit', limit);
         return this._alertslogs.col().find(selector)
             .skip(skip)
             .limit(limit)
@@ -93,9 +94,9 @@ class AlertsLogStore {
             let obj_ids = ids.map(id => new mongodb.ObjectID(id));
             _id = { $in: obj_ids };
         } else if (till) {
-            _id = { $lt: till };
+            _id = { $lt: new mongodb.ObjectID(till) };
         } else if (since) {
-            _id = { $gt: since };
+            _id = { $gt: new mongodb.ObjectID(since) };
         }
 
         return _.omitBy({


### PR DESCRIPTION
### Explain the changes:
- In alerts, pass ObjectID to mongo instead of string
- In events, pass lt and gt as dates instead of strings

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3109 
- Fixes #2998 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

