### PR TITLE
Dataset test: support different unit size

### DIFF
--- a/src/test/qa/agents_matrix.js
+++ b/src/test/qa/agents_matrix.js
@@ -124,7 +124,7 @@ function runCreateAgents(isInclude) {
 
 function verifyAgent() {
     console.log(`starting the verify agents stage`);
-    return s3ops.put_file_with_md5(server_ip, 'files', '100MB_File', 100)
+    return s3ops.put_file_with_md5(server_ip, 'files', '100MB_File', 100, 1048576)
         .then(() => s3ops.get_file_check_md5(server_ip, 'files', '100MB_File'))
         // .then(() => {
         //     console.warn(`Will take diagnostics from all the agents`);

--- a/src/test/qa/s3ops.js
+++ b/src/test/qa/s3ops.js
@@ -9,9 +9,14 @@ let P = require('../../util/promise');
 const accessKeyDefault = '123';
 const secretKeyDefault = 'abc';
 
+function validate_multiplier(multiplier) {
+    if (!multiplier % 1024) throw new Error(`multiplier must be in multiples of 1024`);
+}
+
 // copy_file_with_md5('127.0.0.1', 'first.bucket', 'DataSet1470756819/file1', 'DataSet1470756819/file45');
 
-function put_file_with_md5(ip, bucket, file_name, data_size) {
+function put_file_with_md5(ip, bucket, file_name, data_size, multiplier) {
+    validate_multiplier(multiplier);
     var rest_endpoint = 'http://' + ip + ':80';
     var s3bucket = new AWS.S3({
         endpoint: rest_endpoint,
@@ -23,7 +28,7 @@ function put_file_with_md5(ip, bucket, file_name, data_size) {
     bucket = bucket || 'first.bucket';
     data_size = data_size || 50;
 
-    var actual_size = data_size * 1024 * 1024;
+    var actual_size = data_size * multiplier;
 
     var data = crypto.randomBytes(actual_size);
     let md5 = crypto.createHash('md5').update(data)
@@ -79,7 +84,8 @@ function copy_file_with_md5(ip, bucket, source, destination) {
         });
 }
 
-function upload_file_with_md5(ip, bucket, file_name, data_size, parts_num) {
+function upload_file_with_md5(ip, bucket, file_name, data_size, parts_num, multiplier) {
+    validate_multiplier(multiplier);
     var rest_endpoint = 'http://' + ip + ':80';
     var s3bucket = new AWS.S3({
         endpoint: rest_endpoint,
@@ -91,7 +97,7 @@ function upload_file_with_md5(ip, bucket, file_name, data_size, parts_num) {
     bucket = bucket || 'first.bucket';
     data_size = data_size || 50;
 
-    var actual_size = data_size * 1024 * 1024;
+    var actual_size = data_size * multiplier;
 
     var data = crypto.randomBytes(actual_size);
     let md5 = crypto.createHash('md5').update(data)

--- a/src/test/qa/upgrade_test.js
+++ b/src/test/qa/upgrade_test.js
@@ -207,7 +207,7 @@ return P.each(procedure, upgrade_procedure => {
                 .delay(120000)
                 .then(() => P.each(upgrade_procedure.versions_list, version => {
                     console.log('Upgrading to', version);
-                    return s3ops.put_file_with_md5(machine_ip, 'first.bucket', '20MBFile-' + version, 5)
+                    return s3ops.put_file_with_md5(machine_ip, 'first.bucket', '20MBFile-' + version, 5, 1048576)
                         .then(filepath => {
                             file_path = filepath;
                             var file = fs.createWriteStream(version_map_tar[version]);

--- a/src/util/string_utils.js
+++ b/src/util/string_utils.js
@@ -126,9 +126,13 @@ function rolling_hash(str, roll_context) {
     return c.hash;
 }
 
+function equal_case_insensitive(str1, str2) {
+    return str1.toLowerCase() === str2.toLowerCase();
+}
 
 exports.ALPHA_NUMERIC_CHARSET = ALPHA_NUMERIC_CHARSET;
 exports.crypto_random_string = crypto_random_string;
 exports.left_pad_zeros = left_pad_zeros;
 exports.levenshtein_distance = levenshtein_distance;
 exports.rolling_hash = rolling_hash;
+exports.equal_case_insensitive = equal_case_insensitive;


### PR DESCRIPTION
### Explain the changes:

dataset.js
- changed the % of aging operation
- add some printing
- fixed a bug with size of the files
- add the ability to change the unit size

s3ops.js
- add validate multiplier function that throw error if the multiplier
is not divided by 1024
- add multiplier to put_file_with_md5 and upload_file_with_md5 functions

agent_metrix.js
- fixed put_file_with_md5 according to the s3ops.js changes

upgrade_test.js
- fixed put_file_with_md5 according to the s3ops.js changes

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

