### PR TITLE
fix missing MONGO_SSL_USER after upgrade from old versions(<1.6)

### DIFF
--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -345,6 +345,8 @@ function post_upgrade {
   if grep -q MONGO_SSL_USER /backup/.env; then
       local mongo_user=$(grep MONGO_SSL_USER /backup/.env)
       echo "${mongo_user}" >> ${CORE_DIR}/.env
+  else 
+      /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_mongo_ssl.sh
   fi
 
   local AGENT_VERSION_VAR=$(grep AGENT_VERSION /backup/.env)


### PR DESCRIPTION
### Explain the changes:
- on upgrade, add MONGO_SSL_USER to .env if it's not already exist

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

