### PR TITLE
Fixed _node_rebuild bugs

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1886,10 +1886,11 @@ class NodesMonitor extends EventEmitter {
                 // increase the completed size only if succeeded
                 act.stage.size.completed += blocks_size;
                 if (!act.stage.marker) {
-                    if (act.stage.error_marker) {
+                    if (act.stage.rebuild_error) {
                         dbg.log0('_rebuild_node: HAD ERRORS. RESTART', item.node.name, act);
                         act.stage.marker = act.stage.error_marker;
                         act.stage.size.completed = act.stage.error_marker_completed || 0;
+                        act.stage.rebuild_error = 0;
                         act.stage.error_marker = null;
                         act.stage.error_marker_completed = 0;
                     } else {
@@ -1902,7 +1903,8 @@ class NodesMonitor extends EventEmitter {
             .catch(err => {
                 act.running = false;
                 dbg.warn('_rebuild_node: ERROR', item.node.name, err.stack || err);
-                if (!act.stage.error_marker) {
+                if (!act.stage.rebuild_error) {
+                    act.stage.rebuild_error = Date.now();
                     act.stage.error_marker = start_marker;
                     act.stage.error_marker_completed = act.stage.size.completed || 0;
                 }

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -629,8 +629,7 @@ class MDStore {
         return this._chunks.col().find({
                 _id: {
                     $in: chunk_ids
-                },
-                deleted: null,
+                }
             })
             .toArray();
     }


### PR DESCRIPTION

### Explain the changes:
- in nodes_monitor - if map_builder throws error in the first
iteration, than error_marker will receive null, and rebuild will not be
retried
- in map_builder - fix undeleted blocks of deleted chunks, by marking
these blocks for deletion

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

