### PR TITLE
Fix failing unit test for restore session epic

### DIFF
--- a/frontend/src/app/epics/restore-session.js
+++ b/frontend/src/app/epics/restore-session.js
@@ -10,8 +10,8 @@ const UNAUTHORIZED = 'UNAUTHORIZED';
 const RPC_CONNECT_TIMEOUT = 'RPC_CONNECT_TIMEOUT';
 
 function _loadStoredToken(key, localStorage, sessionStorage) {
-    const localToken = localStorage.getItem(key);
     const sessionToken = sessionStorage.getItem(key);
+    const localToken = localStorage.getItem(key);
 
     return {
         token: sessionToken || localToken,

--- a/frontend/src/tests/test-restore-session.js
+++ b/frontend/src/tests/test-restore-session.js
@@ -75,18 +75,20 @@ describe('Restore session', () => {
         });
 
         it('should try to retrieve the token from sessionStorage before trying localStorage', () => {
-            let visitedLocalSotrage = false;
+            const shouldBeTheToken = 'shouldBeTheToken';
+            const shouldNotBeTheToken = 'shouldNotBeTheToken';
 
             const services = mockServices(
                 () => Promise.resolve({}),
-                () => { visitedLocalSotrage = true; },
-                () => assert(
-                    visitedLocalSotrage,
-                    'localStorage.getItem was called before sessionStorage.getItem'
-                )
+                () => shouldBeTheToken,
+                () => shouldNotBeTheToken
             );
 
-            return test(services);
+            return test(services)
+                .then(({ payload }) => assert(
+                    payload.token === shouldBeTheToken,
+                    'Token was taken from localStorage instead of sessionStorage'
+                ));
         });
     });
 
@@ -215,7 +217,7 @@ describe('Restore session', () => {
             return test(services).then(
                 action => assert.deepEqual(
                     action,
-                    completeRestoreSession(token, sessionInfo),
+                    completeRestoreSession(token, sessionInfo, true),
                     'Returned action does not match expected action'
                 )
             );
@@ -255,7 +257,7 @@ describe('Restore session', () => {
             return test(services).then(
                 action => assert.deepEqual(
                     action,
-                    completeRestoreSession(token, sessionInfo),
+                    completeRestoreSession(token, sessionInfo, true),
                     'Returned action does not match expected action'
                 )
             );


### PR DESCRIPTION
### Explain the changes:
- The test catched 1 bug (1 case) and was broken on 2 other cases (the code was updated without the cases being updated)

