### PR TITLE
Fixing  #3291 - handle timing between supervisord run (rc.3) and rc.local

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -355,6 +355,8 @@ function setup_mongodb {
 	# setting up mongodb users for admin and nbcore databases
     /usr/bin/mongo admin ${CORE_DIR}/src/deploy/NVA_build/mongo_setup_users.js
 
+    chkconfig mongod off
+
 	deploy_log "----> setup_mongodb done"
 }
 

--- a/src/deploy/NVA_build/supervisord.orig
+++ b/src/deploy/NVA_build/supervisord.orig
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# chkconfig: - 15 15
+# chkconfig: 345 15 15
 
 . /etc/rc.d/init.d/functions
 

--- a/src/deploy/NVA_build/upgrade_wrapper.sh
+++ b/src/deploy/NVA_build/upgrade_wrapper.sh
@@ -380,6 +380,8 @@ function post_upgrade {
   sed -i 's:logfile_backups=.*:logfile_backups=5:' /etc/supervisord.conf
   cp -f ${CORE_DIR}/src/deploy/NVA_build/supervisord.orig /etc/rc.d/init.d/supervisord
   chmod 777 /etc/rc.d/init.d/supervisord
+  chkconfig --level 2 supervisord off
+  chkconfig mongod off
   deploy_log "first install wizard"
   #First Install Wizard
   cp -f ${CORE_DIR}/src/deploy/NVA_build/first_install_diaglog.sh /etc/profile.d/

--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -280,7 +280,8 @@ function _check_network_configuration() {
                     }
                 });
         })
-        .then(() => fs_utils.replace_file('/etc/noobaa_network', data));
+        .then(() => fs_utils.replace_file('/etc/noobaa_network', data))
+        .catch(err => dbg.error(`_check_network_configuration caught ${err}`));
 }
 
 function _check_proxy_configuration() {


### PR DESCRIPTION
### Explain the changes:
- rc.local runs and creates JWT secret if doesn't exist (pristine OVA), supervisord run on rc.2 and starts the services. On Azure we saw that the timing was for supervisord to run before rc.local finished => services started with not JWT_SEC in the .env => fun for the whole family
Push supervisord to rc.2

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixes  #3291

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

