### PR TITLE
Fixing race condition in create system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",


### PR DESCRIPTION
### Explain the changes:
- We had a race condition between the init and the creation of tier method.
- That caused the init to push an existing tier which meant that we were pushing a circular object to make_changed that got resolved from system_store.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3291 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

