### PR TITLE
s3 v2 signature fix for virtual hosted bucket + recorded tests

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -104,10 +104,9 @@ function handle_request(req, res) {
     }
 
     check_headers(req);
+    const op_name = parse_op_name(req);
     authenticate_request(req);
 
-    // resolve the op to call
-    const op_name = parse_op_name(req);
     dbg.log0('S3 REQUEST', req.method, req.originalUrl, 'op', op_name, 'request_id', req.request_id, req.headers);
     usage_report.s3_usage_info.total_calls += 1;
     usage_report.s3_usage_info[op_name] = (usage_report.s3_usage_info[op_name] || 0) + 1;
@@ -222,6 +221,7 @@ function parse_op_name(req) {
     if (host && virtual_host_suffix && host.endsWith(virtual_host_suffix)) {
         bucket = host.slice(0, -virtual_host_suffix.length);
         key = url.slice(1);
+        req.virtual_hosted_bucket = bucket;
     }
 
     if (!bucket) {

--- a/src/test/unit_tests/signature_test_suite/awssdkruby2/awssdkruby2_GET_j5j8rpgr.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkruby2/awssdkruby2_GET_j5j8rpgr.sreq
@@ -1,0 +1,10 @@
+GET /?encoding-type=url HTTP/1.1
+Content-Type: 
+Accept-Encoding: 
+User-Agent: aws-sdk-ruby2/2.10.12 ruby/2.4.1 x86_64-darwin16
+Date: Tue, 25 Jul 2017 07:10:16 GMT
+Authorization: AWS 123:wMxoTMtsIciymeqQA6YGrNjN+n8=
+Content-Length: 0
+Accept: */*
+Host: movies.noobaademo.westus2.cloudapp.azure.com
+

--- a/src/test/unit_tests/signature_test_suite/awssdkruby2/awssdkruby2_GET_j5j9wb4d.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkruby2/awssdkruby2_GET_j5j9wb4d.sreq
@@ -1,0 +1,10 @@
+GET /The%20Young%20And%20Restless%20-%20Season%2083748716287351678235%20Final%20Episode%21.pdf HTTP/1.1
+Content-Type: 
+Accept-Encoding: 
+User-Agent: aws-sdk-ruby2/2.10.12 ruby/2.4.1 x86_64-darwin16
+Date: Tue, 25 Jul 2017 07:41:50 GMT
+Authorization: AWS 123:yFmc8fShciAYdXRQCB9Xa1Y3mH4=
+Content-Length: 0
+Accept: */*
+Host: movies.noobaademo.westus2.cloudapp.azure.com
+

--- a/src/test/unit_tests/signature_test_suite/awssdkruby2/awssdkruby2_GET_j5ja2mvl.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkruby2/awssdkruby2_GET_j5ja2mvl.sreq
@@ -1,0 +1,10 @@
+GET /?acl HTTP/1.1
+Content-Type: 
+Accept-Encoding: 
+User-Agent: aws-sdk-ruby2/2.10.12 ruby/2.4.1 x86_64-darwin16
+Date: Tue, 25 Jul 2017 07:46:45 GMT
+Authorization: AWS 123:oUrC/EWtrZe56xQUssMubkuKwmw=
+Content-Length: 0
+Accept: */*
+Host: movies.noobaademo.westus2.cloudapp.azure.com
+

--- a/src/test/unit_tests/signature_test_suite/awssdkruby2/awssdkruby2_PUT_j5jajnre.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkruby2/awssdkruby2_PUT_j5jajnre.sreq
@@ -1,0 +1,34 @@
+PUT /The%20Young%20And%20Restless%20-%20Season%2083748716287351678235%20Final%20Episode%21.pdf HTTP/1.1
+Content-Type: 
+Accept-Encoding: 
+User-Agent: aws-sdk-ruby2/2.10.12 ruby/2.4.1 x86_64-darwin16
+Expect: 100-continue
+Content-Md5: IEQuSfXOyXdAbPWghqkLWA==
+Date: Tue, 25 Jul 2017 08:00:00 GMT
+Authorization: AWS 123:l57iBXAa8zEHzXK2y9TpEBj8Jks=
+Content-Length: 929
+Accept: */*
+Host: movies.noobaademo.westus2.cloudapp.azure.com
+
+
+
+Episode # 11078 ~ Dylan accepts a dangerous assignment, Victoria's world is turned upside down, & Devon fights for his life.
+
+Provided By Suzanne
+
+[Door closes]
+
+Christine: We have been trying to bust Luthor Fisk for years, and it's not just about he drugs that he's moved, but it's about the bodies he's piled up along the way. I want this guy stopped and in a cell.
+
+Dylan: Yeah, we all do. That's why I signed up for this.
+
+Christine: I just want you to understand what you've signed up for.  Less prep time means a great possibility of slip-ups. I can't have any slip-ups.
+
+Dylan: Okay, I got it.
+
+Christine: Okay, so you're Derek Young, right? You need to know every name, every date, every word of this guy's background. You need to know Derek Young's identity as well as your own, if not better. If you talk in your sleep, these are the words you'd say.
+
+Dylan: Okay, then that's how it's gonna be.
+
+Christine: [Sighs]
+

--- a/src/test/unit_tests/test_signature_utils.js
+++ b/src/test/unit_tests/test_signature_utils.js
@@ -42,6 +42,7 @@ mocha.describe('signature_utils', function() {
     add_tests_from(path.join(SIG_TEST_SUITE, 'awssdkjs'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'awssdknodejs'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'awssdkjava'), '.sreq');
+    add_tests_from(path.join(SIG_TEST_SUITE, 'awssdkruby2'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'cyberduck'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'postman'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'presigned'), '.sreq');
@@ -132,6 +133,10 @@ mocha.describe('signature_utils', function() {
         const parsed_url = url.parse(req.originalUrl, true);
         req.url = parsed_url.pathname;
         req.query = parsed_url.query;
+        const virtual_hosted_bucket = req.headers.host.split('.', 1)[0];
+        if (/[a-zA-Z][a-zA-Z0-9]*/.test(virtual_hosted_bucket)) {
+            req.virtual_hosted_bucket = virtual_hosted_bucket;
+        }
         res.setHeader('Connection', 'close');
         if (req.method === 'OPTIONS') return res.end();
         console.log(

--- a/src/tools/tcp_tunnel.js
+++ b/src/tools/tcp_tunnel.js
@@ -109,7 +109,7 @@ function tunnel_port({
                 record_http,
             }))
         .on('error', err => console.error(name, 'server error', err.stack || err))
-        .on('listening', () => console.log(name, 'listening ...'))
+        .on('listening', () => console.log(name, 'listening ...', record_http ? '(Recording HTTP)' : ''))
         .listen(source_port);
 }
 

--- a/src/util/signature_utils.js
+++ b/src/util/signature_utils.js
@@ -233,6 +233,7 @@ function _aws_request(req, region, service) {
         headers: headers_for_sdk,
         search: () => search_string,
         pathname: () => pathname,
+        virtualHostedBucket: req.virtual_hosted_bucket,
     };
     return aws_request;
 }


### PR DESCRIPTION
### Explain the changes:
- Following up on commit 02b2b08983c3baa4bc6b00c1774d7b411d20ceff in #3200 Eran found that Synology and Ruby SDK still fail with AccessDenied
- This fixes the issue as for S3 V2 signature there is a special flag we need to pass to the signer to build the string-to-sign correctly.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- NA

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

