### PR TITLE
fix #3333 - object_sdk namespace cache was reusing token from previous request

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -23,7 +23,7 @@ class NamespaceBlob {
     // OBJECT LIST //
     /////////////////
 
-    list_objects(params) {
+    list_objects(params, object_sdk) {
         dbg.log0('NamespaceBlob.list_objects:',
             this.container,
             inspect(params)
@@ -84,7 +84,7 @@ class NamespaceBlob {
     // OBJECT READ //
     /////////////////
 
-    read_object_md(params) {
+    read_object_md(params, object_sdk) {
         dbg.log0('NamespaceBlob.read_object_md:',
             this.container,
             inspect(params)
@@ -110,7 +110,7 @@ class NamespaceBlob {
             });
     }
 
-    read_object_stream(params) {
+    read_object_stream(params, object_sdk) {
         dbg.log0('NamespaceBlob.read_object_stream:',
             this.container,
             inspect(_.omit(params, 'object_md.ns'))
@@ -181,7 +181,7 @@ class NamespaceBlob {
     // OBJECT UPLOAD //
     ///////////////////
 
-    upload_object(params) {
+    upload_object(params, object_sdk) {
         dbg.log0('NamespaceBlob.upload_object:',
             this.container,
             inspect(_.omit(params, 'source_stream'))
@@ -218,7 +218,7 @@ class NamespaceBlob {
     // OBJECT MULTIPART UPLOAD //
     /////////////////////////////
 
-    create_object_upload(params) {
+    create_object_upload(params, object_sdk) {
         // azure blob does not have start upload operation
         // instead starting multipart upload is implicit
         // TODO how to handle xattr that s3 sends in the create command
@@ -233,7 +233,7 @@ class NamespaceBlob {
         });
     }
 
-    upload_multipart(params) {
+    upload_multipart(params, object_sdk) {
         // generating block ids in the form: '95342c3f-000005'
         // this is needed mostly since azure requires all the block_ids to have the same fixed length
         const block_id = this.blob.getBlockId(this.blob.generateBlockIdPrefix(), params.num);
@@ -269,7 +269,7 @@ class NamespaceBlob {
             });
     }
 
-    list_multiparts(params) {
+    list_multiparts(params, object_sdk) {
         dbg.log0('NamespaceBlob.list_multiparts:',
             this.container,
             inspect(params)
@@ -299,7 +299,7 @@ class NamespaceBlob {
             });
     }
 
-    complete_object_upload(params) {
+    complete_object_upload(params, object_sdk) {
         dbg.log0('NamespaceBlob.complete_object_upload:',
             this.container,
             inspect(params)
@@ -331,7 +331,7 @@ class NamespaceBlob {
             });
     }
 
-    abort_object_upload(params) {
+    abort_object_upload(params, object_sdk) {
         // azure blob does not have abort upload operation
         // instead it will garbage collect blocks after 7 days
         // so we simply ignore the abort operation
@@ -347,7 +347,7 @@ class NamespaceBlob {
     // OBJECT DELETE //
     ///////////////////
 
-    delete_object(params) {
+    delete_object(params, object_sdk) {
         dbg.log0('NamespaceBlob.delete_object:',
             this.container,
             inspect(params)
@@ -367,7 +367,7 @@ class NamespaceBlob {
             });
     }
 
-    delete_multiple_objects(params) {
+    delete_multiple_objects(params, object_sdk) {
         dbg.log0('NamespaceBlob.delete_multiple_objects:',
             this.container,
             params

--- a/src/sdk/namespace_merge.js
+++ b/src/sdk/namespace_merge.js
@@ -14,7 +14,7 @@ class NamespaceMerge {
     // OBJECT LIST //
     /////////////////
 
-    list_objects(params) {
+    list_objects(params, object_sdk) {
         return P.map(this.namespaces, ns => ns.list_objects(params))
             .then(res => {
                 if (res.length === 1) return res[0];
@@ -67,7 +67,7 @@ class NamespaceMerge {
     // OBJECT READ //
     /////////////////
 
-    read_object_md(params) {
+    read_object_md(params, object_sdk) {
         return this._ns_get(ns => P.resolve(ns.read_object_md(params))
             .then(res => {
                 // save the ns in the response for optimizing read_object_stream
@@ -76,7 +76,7 @@ class NamespaceMerge {
             }));
     }
 
-    read_object_stream(params) {
+    read_object_stream(params, object_sdk) {
         // use the saved ns from read_object_md
         if (params.object_md && params.object_md.ns) return params.object_md.ns.read_object_stream(params);
         return this._ns_get(ns => ns.read_object_stream(params));
@@ -86,7 +86,7 @@ class NamespaceMerge {
     // OBJECT UPLOAD //
     ///////////////////
 
-    upload_object(params) {
+    upload_object(params, object_sdk) {
         return this._ns_put(ns => ns.upload_object(params));
     }
 
@@ -94,23 +94,23 @@ class NamespaceMerge {
     // OBJECT MULTIPART UPLOAD //
     /////////////////////////////
 
-    create_object_upload(params) {
+    create_object_upload(params, object_sdk) {
         return this._ns_put(ns => ns.create_object_upload(params));
     }
 
-    upload_multipart(params) {
+    upload_multipart(params, object_sdk) {
         return this._ns_put(ns => ns.upload_multipart(params));
     }
 
-    list_multiparts(params) {
+    list_multiparts(params, object_sdk) {
         return this._ns_put(ns => ns.list_multiparts(params));
     }
 
-    complete_object_upload(params) {
+    complete_object_upload(params, object_sdk) {
         return this._ns_put(ns => ns.complete_object_upload(params));
     }
 
-    abort_object_upload(params) {
+    abort_object_upload(params, object_sdk) {
         return this._ns_put(ns => ns.abort_object_upload(params));
     }
 
@@ -120,11 +120,11 @@ class NamespaceMerge {
 
     // TODO should we: (1) delete from all ns ? (2) delete from writable ns ? (3) create a "delete marker" on writable ns
 
-    delete_object(params) {
+    delete_object(params, object_sdk) {
         return this._ns_put(ns => ns.delete_object(params));
     }
 
-    delete_multiple_objects(params) {
+    delete_multiple_objects(params, object_sdk) {
         return this._ns_put(ns => ns.delete_multiple_objects(params));
     }
 

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -6,102 +6,92 @@ const _ = require('lodash');
 
 class NamespaceNB {
 
-    constructor(rpc_client, object_io, target_bucket) {
-        this.rpc_client = rpc_client;
-        this.object_io = object_io;
+    constructor(target_bucket) {
         this.target_bucket = target_bucket;
-    }
-
-    set_auth_token(auth_token) {
-        this.rpc_client.options.auth_token = auth_token;
-    }
-
-    get_auth_token() {
-        return this.rpc_client.options.auth_token;
     }
 
     /////////////////
     // OBJECT LIST //
     /////////////////
 
-    list_objects(params) {
+    list_objects(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return this.rpc_client.object.list_objects_s3(params);
+        return object_sdk.rpc_client.object.list_objects_s3(params);
     }
 
     /////////////////
     // OBJECT READ //
     /////////////////
 
-    read_object_md(params) {
+    read_object_md(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return this.rpc_client.object.read_object_md(params);
+        return object_sdk.rpc_client.object.read_object_md(params);
     }
 
-    read_object_stream(params) {
+    read_object_stream(params, object_sdk) {
         params = _.defaults({
-            client: this.rpc_client,
+            client: object_sdk.rpc_client,
             bucket: this.target_bucket,
         }, params);
-        return this.object_io.read_object_stream(params);
+        return object_sdk.object_io.read_object_stream(params);
     }
 
     ///////////////////
     // OBJECT UPLOAD //
     ///////////////////
 
-    upload_object(params) {
+    upload_object(params, object_sdk) {
         params = _.defaults({
-            client: this.rpc_client,
+            client: object_sdk.rpc_client,
             bucket: this.target_bucket,
         }, params);
-        return this.object_io.upload_object(params);
+        return object_sdk.object_io.upload_object(params);
     }
 
     /////////////////////////////
     // OBJECT MULTIPART UPLOAD //
     /////////////////////////////
 
-    create_object_upload(params) {
+    create_object_upload(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return this.rpc_client.object.create_object_upload(params);
+        return object_sdk.rpc_client.object.create_object_upload(params);
     }
 
-    upload_multipart(params) {
+    upload_multipart(params, object_sdk) {
         params = _.defaults({
-            client: this.rpc_client,
+            client: object_sdk.rpc_client,
             bucket: this.target_bucket,
         }, params);
-        return this.object_io.upload_multipart(params);
+        return object_sdk.object_io.upload_multipart(params);
     }
 
-    list_multiparts(params) {
+    list_multiparts(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return this.rpc_client.object.list_multiparts(params);
+        return object_sdk.rpc_client.object.list_multiparts(params);
     }
 
-    complete_object_upload(params) {
+    complete_object_upload(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return this.rpc_client.object.complete_object_upload(params);
+        return object_sdk.rpc_client.object.complete_object_upload(params);
     }
 
-    abort_object_upload(params) {
+    abort_object_upload(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return this.rpc_client.object.abort_object_upload(params);
+        return object_sdk.rpc_client.object.abort_object_upload(params);
     }
 
     ///////////////////
     // OBJECT DELETE //
     ///////////////////
 
-    delete_object(params) {
+    delete_object(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return this.rpc_client.object.delete_object(params);
+        return object_sdk.rpc_client.object.delete_object(params);
     }
 
-    delete_multiple_objects(params) {
+    delete_multiple_objects(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return this.rpc_client.object.delete_multiple_objects(params);
+        return object_sdk.rpc_client.object.delete_multiple_objects(params);
     }
 
 }

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -20,7 +20,7 @@ class NamespaceS3 {
     // OBJECT LIST //
     /////////////////
 
-    list_objects(params) {
+    list_objects(params, object_sdk) {
         dbg.log0('NamespaceS3.list_objects:', this.bucket, inspect(params));
         // TODO list uploads
         if (params.upload_mode) {
@@ -52,7 +52,7 @@ class NamespaceS3 {
     // OBJECT READ //
     /////////////////
 
-    read_object_md(params) {
+    read_object_md(params, object_sdk) {
         dbg.log0('NamespaceS3.read_object_md:', this.bucket, inspect(params));
         return this.s3.headObject({
                 Key: params.key,
@@ -69,7 +69,7 @@ class NamespaceS3 {
             });
     }
 
-    read_object_stream(params) {
+    read_object_stream(params, object_sdk) {
         dbg.log0('NamespaceS3.read_object_stream:', this.bucket, inspect(_.omit(params, 'object_md.ns')));
         return new P((resolve, reject) => {
             const req = this.s3.getObject({
@@ -102,7 +102,7 @@ class NamespaceS3 {
     // OBJECT UPLOAD //
     ///////////////////
 
-    upload_object(params) {
+    upload_object(params, object_sdk) {
         dbg.log0('NamespaceS3.upload_object:', this.bucket, inspect(params));
         if (params.copy_source) {
             // this.s3.copyObject({
@@ -132,7 +132,7 @@ class NamespaceS3 {
     // OBJECT MULTIPART UPLOAD //
     /////////////////////////////
 
-    create_object_upload(params) {
+    create_object_upload(params, object_sdk) {
         dbg.log0('NamespaceS3.create_object_upload:', this.bucket, inspect(params));
         return this.s3.createMultipartUpload({
                 Key: params.key,
@@ -148,7 +148,7 @@ class NamespaceS3 {
             });
     }
 
-    upload_multipart(params) {
+    upload_multipart(params, object_sdk) {
         dbg.log0('NamespaceS3.upload_multipart:', this.bucket, inspect(params));
         if (params.copy_source) {
             throw new Error('NamespaceS3.upload_multipart: copy part not yet supported');
@@ -169,7 +169,7 @@ class NamespaceS3 {
             });
     }
 
-    list_multiparts(params) {
+    list_multiparts(params, object_sdk) {
         dbg.log0('NamespaceS3.list_multiparts:', this.bucket, inspect(params));
         return this.s3.listParts({
                 Key: params.key,
@@ -193,7 +193,7 @@ class NamespaceS3 {
             });
     }
 
-    complete_object_upload(params) {
+    complete_object_upload(params, object_sdk) {
         dbg.log0('NamespaceS3.complete_object_upload:', this.bucket, inspect(params));
         return this.s3.completeMultipartUpload({
                 Key: params.key,
@@ -214,7 +214,7 @@ class NamespaceS3 {
             });
     }
 
-    abort_object_upload(params) {
+    abort_object_upload(params, object_sdk) {
         dbg.log0('NamespaceS3.abort_object_upload:', this.bucket, inspect(params));
         return this.s3.abortMultipartUpload({
                 Key: params.key,
@@ -230,7 +230,7 @@ class NamespaceS3 {
     // OBJECT DELETE //
     ///////////////////
 
-    delete_object(params) {
+    delete_object(params, object_sdk) {
         dbg.log0('NamespaceS3.delete_object:', this.bucket, inspect(params));
         return this.s3.deleteObject({
                 Key: params.key
@@ -241,7 +241,7 @@ class NamespaceS3 {
             });
     }
 
-    delete_multiple_objects(params) {
+    delete_multiple_objects(params, object_sdk) {
         dbg.log0('NamespaceS3.delete_multiple_objects:', this.bucket, inspect(params));
         return this.s3.deleteObjects({
                 Delete: { Objects: _.map(params.keys, Key => ({ Key })) }


### PR DESCRIPTION
### Explain the changes:
- now the namespace objects in the cache will no longer hold the rpc_client and the token
- and instead will receive a reference to object_sdk per function call

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixes #3333 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

