### PR TITLE
fix #3349: copy content type from source object, unless provided by copy request

### DIFF
--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -228,6 +228,9 @@ class ObjectIO {
                 params.copy_source.obj_id = object_md.obj_id;
                 create_params.md5_b64 = object_md.md5_b64;
                 create_params.sha256_b64 = object_md.sha256_b64;
+                if (!create_params.content_type && object_md.content_type) {
+                    create_params.content_type = object_md.content_type;
+                }
                 if (params.xattr_copy) {
                     create_params.xattr = object_md.xattr;
                 }


### PR DESCRIPTION
### Explain the changes:
- Copy request did not copy the content type attribute from the source
- Now it does

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fix #3349 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

