### PR TITLE
Fix #3332 - setting debug mode for server/cluster/node

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -2690,8 +2690,8 @@ class NodesMonitor extends EventEmitter {
 
     set_debug_node(req) {
         this._throw_if_not_started_and_loaded();
-        const { level, node_identity } = req.rpc_params;
-        const item = this._get_node(node_identity);
+        const { level, node } = req.rpc_params;
+        const item = this._get_node(node);
         return this._set_agent_debug_level(item, level)
             .then(() => {
                 Dispatcher.instance().activity({

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -362,12 +362,13 @@ class MongoClient extends EventEmitter {
     set_debug_level(level) {
         var self = this;
         var command = {
-            setLogLevel: level
+            setParameter: 1,
+            logLevel: level
         };
 
         return P.fcall(function() {
-            return P.resolve(self.db.command(command))
-                .then(res => dbg.log0(`Recieved ${res} from setLogLevel command (${level})`));
+            return P.resolve(self.db.admin().command(command))
+                .then(res => dbg.log0(`Recieved ${res} from setParameter/logLevel command (${level})`));
         });
     }
 


### PR DESCRIPTION
### Explain the changes:
- Fix #3332 - setting debug mode for server/cluster/node

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixes #3332 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

