### PR TITLE
Bump openssl version to 1.0.2l and fix path for lambda/s3 ops

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",

--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -30,7 +30,7 @@ copy ..\..\config.js .
 mkdir .\src\
 xcopy /Y/I/E ..\..\src\agent .\src\agent
 xcopy /Y/I/E ..\..\src\s3 .\src\s3
-xcopy /Y/I/E ..\..\src\lambda .\src\lambda
+xcopy /Y/I/E ..\..\src\endpoint\ .\src\endpoint
 xcopy /Y/I/E ..\..\src\util .\src\util
 xcopy /Y/I/E ..\..\src\rpc .\src\rpc
 xcopy /Y/I/E ..\..\src\api .\src\api
@@ -90,8 +90,8 @@ xcopy /Y/I/E .\build\Release .\build\Release-64
 
 call curl -L https://nodejs.org/dist/v6.9.5/win-x86/node.exe > node-32.exe
 call curl -L https://nodejs.org/dist/v6.9.5/win-x64/node.exe > node-64.exe
-call curl -L https://indy.fulgan.com/SSL/openssl-1.0.2k-i386-win32.zip > openssl_32.zip
-call curl -L https://indy.fulgan.com/SSL/openssl-1.0.2k-x64_86-win64.zip > openssl_64.zip
+call curl -L https://indy.fulgan.com/SSL/openssl-1.0.2l-i386-win32.zip > openssl_32.zip
+call curl -L https://indy.fulgan.com/SSL/openssl-1.0.2l-x64_86-win64.zip > openssl_64.zip
 
 mkdir .\32
 mkdir .\64

--- a/src/deploy/build_windows_s3rest.bat
+++ b/src/deploy/build_windows_s3rest.bat
@@ -85,8 +85,8 @@ xcopy /Y/I/E .\build\Release .\build\Release-64
 
 call curl -L https://nodejs.org/dist/v6.9.5/win-x86/node.exe > node-32.exe
 call curl -L https://nodejs.org/dist/v6.9.5/win-x64/node.exe > node-64.exe
-call curl -L https://indy.fulgan.com/SSL/openssl-1.0.2k-i386-win32.zip  > openssl_32.zip
-call curl -L https://indy.fulgan.com/SSL/openssl-1.0.2k-x64_86-win64.zip> openssl_64.zip
+call curl -L https://indy.fulgan.com/SSL/openssl-1.0.2l-i386-win32.zip  > openssl_32.zip
+call curl -L https://indy.fulgan.com/SSL/openssl-1.0.2l-x64_86-win64.zip> openssl_64.zip
 
 mkdir .\32
 mkdir .\64


### PR DESCRIPTION
### Explain the changes:
- Bump openssl version to 1.0.2l and fix path for lambda/s3 ops

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

