### PR TITLE
when a drive is unmounted, return error STORAGE_NOT_EXIST

### DIFF
--- a/frontend/src/app/components/node/node-summary/node-summary.js
+++ b/frontend/src/app/components/node/node-summary/node-summary.js
@@ -65,6 +65,11 @@ const stateMapping = deepFreeze({
         css: 'success',
         text: 'Online'
     },
+    STORAGE_NOT_EXIST: {
+        icon: 'problem',
+        css: 'error',
+        text: 'Unmounted'
+    },
     LOW_CAPACITY: {
         icon: 'problem',
         css: 'warning',
@@ -161,6 +166,12 @@ const accessibilityMapping = deepFreeze({
         css: 'error',
         access: 'No Access:',
         reason: 'Read/Write problems'
+    },
+    STORAGE_NOT_EXIST: {
+        icon: 'problem',
+        css: 'error',
+        access: 'No Access:',
+        reason: 'Unmounted'
     },
     LOW_CAPACITY: {
         icon: 'healthy',

--- a/frontend/src/app/utils/ui-utils.js
+++ b/frontend/src/app/utils/ui-utils.js
@@ -60,6 +60,11 @@ const nodeStateIconMapping = deepFreeze({
         css: 'warning',
         tooltip: 'Read/Write problems'
     },
+    STORAGE_NOT_EXIST: {
+        name: 'problem',
+        css: 'warning',
+        tooltip: 'Unmounted'
+    },
     LOW_CAPACITY: {
         name: 'problem',
         css: 'warning',

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -915,6 +915,10 @@ class NodesMonitor extends EventEmitter {
                     });
             })
             .catch(err => {
+                if (err.rpc_code === 'STORAGE_NOT_EXIST' && !item.storage_not_exist) {
+                    dbg.error('got STORAGE_NOT_EXIST error from node', item.node.name, err.message);
+                    item.storage_not_exist = Date.now();
+                }
                 if (item.node.deleting) {
                     dbg.warn('got error in _get_agent_info on a deleting node, ignoring error. node name', item.node.name, err.message);
                     return;


### PR DESCRIPTION
### Explain the changes:
- When read\write fails in BLOCK_STORE_FS, the agent test for storage dir existence.
- If storage dir is missing, throw's STORAGE_NOT_EXIST which is translated to  **Unmounted** in the UI

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- related to bug #3065 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

