### PR TITLE
s3ops.js: Change error to warning for dataset tests

### DIFF
--- a/src/test/qa/s3ops.js
+++ b/src/test/qa/s3ops.js
@@ -247,7 +247,7 @@ function get_list_files(ip, bucket, prefix) {
         .then(res => {
             list = res.Contents;
             if (list.length === 0) {
-                throw new Error('No files with prefix in bucket');
+                console.warn('No files with prefix in bucket');
             } else {
                 list.forEach(function(file) {
                     listFiles.push({Key: file.Key});
@@ -280,7 +280,7 @@ function get_list_prefixes(ip, bucket) {
         .then(res => {
             list = res.CommonPrefixes;
             if (list.length === 0) {
-                throw new Error('No folders in bucket');
+                console.warn('No folders in bucket');
             } else {
                 list.forEach(function(prefix) {
                     listPrefixes.push(prefix.Prefix);


### PR DESCRIPTION
### Explain the changes:
- Change error to warning for dataset tests

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

