### PR TITLE
s3: fix last-modified header to proper 4 digits year

### DIFF
--- a/src/util/time_utils.js
+++ b/src/util/time_utils.js
@@ -25,14 +25,13 @@ function sectook(since) {
 
 /**
  * Date.toUTCString returns RFC-822 with full year (4 digits).
- * This function convert it to 2 digits year,
- * required by S3 (and specifically enforced by hadoop)
+ * Previously this function used to convert the year to 2 digits for hadoop,
+ * but apparently this is not done by S3, and failed aws-sdk-go.
+ * We don't know if hadoop will still fail on it or not but for now we just don't care.
  * @param {Date} date
  */
 function format_http_header_date(date) {
-    const full_year = date.getFullYear().toString();
-    const short_year = full_year.slice(-2); // keep last two digits
-    return date.toUTCString().replace(' ' + full_year + ' ', ' ' + short_year + ' ');
+    return date.toUTCString();
 }
 
 /**


### PR DESCRIPTION
### Explain the changes:
- Customer Reported by GrayMeta
- Previously format_http_header_date used to convert the year to 2 digits for hadoop, but apparently this is not done by S3, and failed aws-sdk-go. We don't know if hadoop will still fail on it or not but for now we just don't care.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

