### PR TITLE
#fix for 1211 - Allow deletion of buckets with uncompleted objects only

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -651,9 +651,6 @@ module.exports = {
                 writable: {
                     type: 'boolean'
                 },
-                demo_bucket: {
-                    type: 'boolean'
-                },
                 stats: {
                     type: 'object',
                     properties: {
@@ -674,6 +671,9 @@ module.exports = {
                 mode: {
                     $ref: '#/definitions/bucket_mode'
                 },
+                undeletable: {
+                   $ref: '#/definitions/undeletable_bucket_reason'
+                }
             }
         },
 
@@ -793,6 +793,10 @@ module.exports = {
                 'EXCEEDING_QOUTA',
                 'OPTIMAL'
             ]
-        }
+        },
+        undeletable_bucket_reason: {
+            enum: ['LAST_BUCKET', 'NOT_EMPTY'],
+            type: 'string',
+        },
     },
 };

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -280,9 +280,6 @@ module.exports = {
                 }
             }
         },
-        demo_bucket: {
-            type: 'boolean'
-        }
 
     }
 };

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -330,7 +330,7 @@ function create_system(req) {
                 auth_token: reply_token
             });
         })
-        .then(() => _init_system())
+        .then(() => _init_system(system_changes.insert.systems[0]._id))
         .then(() => system_utils.mongo_wrapper_system_created())
         .then(() => ({
             token: reply_token
@@ -1136,9 +1136,13 @@ function log_client_console(req) {
     });
 }
 
-function _init_system() {
+function _init_system(sysid) {
     return cluster_server.init_cluster()
-        .then(() => stats_collector.collect_system_stats());
+        .then(() => stats_collector.collect_system_stats())
+        .then(() => Dispatcher.instance().alert('INFO',
+            sysid,
+            'Welcome to NooBaa! It\'s time to get started. Connect your first resources, either 3 nodes or 1 cloud resource',
+            Dispatcher.rules.only_once));
 }
 
 function create_internal_tier(system_id, mongo_pool_id) {


### PR DESCRIPTION
### Explain the changes:
- Allow deletion of buckets with uncompleted objects only

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
-  fixes #1211 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

