### PR TITLE
fixing issue on untrusting node due to acl's duplicates 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",


### PR DESCRIPTION
### Explain the changes:
- checked that all user with Full Control is one of two: SYSTEM user or Administrators group
- moved the verifying function to os_utils
- moved the list of admin users to an outside constant

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixed #3400

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

