### PR TITLE
machine_killer test: change counting of vm, conditions of killing

### DIFF
--- a/src/deploy/Jenkinsfile
+++ b/src/deploy/Jenkinsfile
@@ -11,8 +11,8 @@ def service = 'azure'
 def resource = 'pipeline-dataset'
 def zone = 'westus2'
 def prefix = 'ubuntu-node-'
-def min_machines = '5' // minimum 3 machine
-def max_machines = '15' // maximum 10 machines
+def min_machines = '0' // minimum 3 machine
+def max_machines = '3' // maximum 10 machines
 //cluster
 def clusterResource = 'pipelie-cluster'
 def clusterVnet = 'pipelie-cluster-vnet'


### PR DESCRIPTION
edit condition of killing and running

### Explain the changes:
- run on http://52.183.117.149:8080 with 4 nodes, 2 nodes with ubuntu-node prefix, so kill or start one of 2 machine

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

