### PR TITLE
fixes #3449 - adding agents for new disks failed

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -197,6 +197,7 @@ AgentCLI.prototype.detect_new_drives = function() {
             let added_paths = _.differenceWith(added_mount_points, self.params.all_storage_paths,
                 (a, b) => String(a.drive_id) === String(b.drive_id));
             if (_.isEmpty(added_paths)) return P.resolve();
+            dbg.log0('identified new drives:', added_paths);
             return self.load(added_paths)
                 .then(function() {
                     dbg.log0('Drives added:', added_paths);
@@ -304,6 +305,8 @@ AgentCLI.prototype.load = function(added_storage_paths) {
                 });
         }))
         .then(storage_path_nodes => {
+            // no need to load s3 when adding new drives
+            if (added_storage_paths) return storage_path_nodes;
             // if no s3 agent exist for root storage path, run one
             let s3_started = _.find(storage_path_nodes[0], name => this._is_s3_agent(name));
             if (!s3_started) {


### PR DESCRIPTION
### Explain the changes:
- when adding new drives, agent_cli tried to add also another s3 agent, which failed the operation. ignoring s3 agents when coming from add_new_drives flow

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixes #3449 - adding agents for new disks failed

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

