### PR TITLE
Fixing reads and semaphore configuration

### DIFF
--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -844,9 +844,8 @@ class ObjectIO {
                         dbg.error('prefetch end of file error', err);
                     });
             }
-
-            return reader;
         };
+        return reader;
     }
 
 
@@ -1226,8 +1225,8 @@ function get_frag_key(f) {
 }
 
 function _get_io_semaphore_size(size) {
-    return _.isNumber(size) ? config.IO_STREAM_SEMAPHORE_SIZE_CAP :
-        Math.min(config.IO_STREAM_SEMAPHORE_SIZE_CAP, size);
+    return _.isNumber(size) ? Math.min(config.IO_STREAM_SEMAPHORE_SIZE_CAP, size) :
+        config.IO_STREAM_SEMAPHORE_SIZE_CAP;
 }
 
 module.exports = ObjectIO;


### PR DESCRIPTION
### Explain the changes:
- Semaphore was always taking 256mb for each item regardless of it's size.
- Did not return the reader thus all reads failed in the system

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

