### PR TITLE
More Host related fixes

### DIFF
--- a/frontend/src/app/components/bucket/bucket-data-placement-form/placement-row.js
+++ b/frontend/src/app/components/bucket/bucket-data-placement-form/placement-row.js
@@ -40,8 +40,9 @@ export default class PlacementRowViewModel {
                     return '';
                 }
 
+                const { count, by_mode } = pool().hosts;
                 return pool().resource_type === 'HOSTS' ?
-                    `${pool().nodes.online} of ${pool().nodes.count}` :
+                    `${count - by_mode.OFFLINE} of ${count}` :
                     '—';
             }
         );

--- a/frontend/src/app/components/overview/resource-overview/resource-overview.js
+++ b/frontend/src/app/components/overview/resource-overview/resource-overview.js
@@ -109,7 +109,7 @@ class ResourceOverviewViewModel extends BaseViewModel {
 
         this.chartValues = [
             {
-                label: 'Online',
+                label: 'Healthy',
                 value: healthyNodesCount,
                 color: hexToRgb(style['color12'], pieColorsOpacityFactor)
             },

--- a/frontend/src/app/components/shared/pool-selection-table/pool-row.js
+++ b/frontend/src/app/components/shared/pool-selection-table/pool-row.js
@@ -33,8 +33,9 @@ export default class PoolRowViewModel extends BaseViewModel {
                     return '';
                 }
 
+                const { count, by_mode } = pool().hosts;
                 return pool().resource_type === 'HOSTS' ?
-                    `${pool().nodes.online} of ${pool().nodes.count}` :
+                    `${count - by_mode.OFFLINE} of ${count}` :
                     '—';
             }
         );

--- a/frontend/src/app/epics/notify.js
+++ b/frontend/src/app/epics/notify.js
@@ -1,4 +1,5 @@
 import { deepFreeze } from 'utils/core-utils';
+import { getHostDisplayName } from 'utils/host-utils';
 import { showNotification } from 'action-creators';
 import {
     FAIL_CREATE_ACCOUNT,
@@ -91,22 +92,22 @@ const actionToNotification = deepFreeze({
     }),
 
     [COLLECT_HOST_DIAGNOSTICS]: ({ host }) => ({
-        message: `Collecting diagnostic for ${host}, it may take a few seconds`,
+        message: `Collecting diagnostic for ${getHostDisplayName(host)}, it may take a few seconds`,
         severity: 'success'
     }),
 
     [FAIL_COLLECT_HOST_DIAGNOSTICS]: ({ host }) => ({
-        message: `Collecting diagnostic file for ${host} failed`,
+        message: `Collecting diagnostic file for ${getHostDisplayName(host)} failed`,
         severity: 'error'
     }),
 
     [COMPLETE_SET_HOST_DEBUG_MODE]: ({ host, on }) => ({
-        message: `Debug mode was turned ${on ? 'on' : 'off'} for node ${host}`,
+        message: `Debug mode was turned ${on ? 'on' : 'off'} for node ${getHostDisplayName(host)}`,
         severity: 'success'
     }),
 
     [FAIL_SET_HOST_DEBUG_MODE]: ({ host, on }) => ({
-        message: `Could not turn ${on ? 'on' : 'off'} debug mode for node ${host}`,
+        message: `Could not turn ${on ? 'on' : 'off'} debug mode for node ${getHostDisplayName(host)}`,
         severity: 'error'
     }),
 

--- a/frontend/src/app/epics/set-host-debug-mode.js
+++ b/frontend/src/app/epics/set-host-debug-mode.js
@@ -12,7 +12,7 @@ export default function(action$, { api }) {
             try {
                 await api.host.set_debug_host({
                     name: host,
-                    level: on ? 5 : 1
+                    level: on ? 5 : 0
                 });
 
                 return completeSetHostDebugMode(host, on);

--- a/frontend/src/app/utils/host-utils.js
+++ b/frontend/src/app/utils/host-utils.js
@@ -12,7 +12,7 @@ const modeToStateIcon = deepFreeze({
     OFFLINE: {
         name: 'problem',
         css: 'error',
-        tooltip: 'All Services Offline'
+        tooltip: 'Offline'
     },
     S3_OFFLINE: {
         name: 'problem',
@@ -232,6 +232,8 @@ const stateToModes = deepFreeze({
         'OPTIMAL'
     ],
     HAS_ISSUES: [
+        'STORAGE_OFFLINE',
+        'S3_OFFLINE',
         'DECOMMISSIONED',
         'UNTRUSTED',
         'STORAGE_NOT_EXIST',
@@ -469,16 +471,16 @@ export function getHostDisplayName(hostName) {
     return `${namePart}`;
 }
 
-export function getHostStateIcon({ mode }) {
-    return modeToStateIcon[mode];
+export function getHostStateIcon(host) {
+    return modeToStateIcon[host.mode];
 }
 
-export function getHostTrustIcon({ trusted }) {
-    return trustToIcon[trusted];
+export function getHostTrustIcon(host) {
+    return trustToIcon[host.trusted];
 }
 
-export function getHostAccessibilityIcon({ mode }) {
-    return modeToAccessibilityIcon[mode];
+export function getHostAccessibilityIcon(host) {
+    return modeToAccessibilityIcon[host.services.storage.mode];
 }
 
 export function getNodeOrHostCapacityBarValues({ storage }) {


### PR DESCRIPTION
- Fix debug mode clock.
- Fix data placement tables to get node count form hosts counters instead of nodes counters.
- Changed online counter to healthy counters on overview resource pie chart
- Fix host names on host notifications
- Add memory limit for hosts and queries in host cache.
- Support host S3_OFFLINE and STORAGE_OFFLINE modes
- Fix host calculation in case only one service is not decommissioned.

