### PR TITLE
calculate pool status according to storage nodes only

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -2692,6 +2692,7 @@ class NodesMonitor extends EventEmitter {
         let count = 0;
         let online = 0;
         const by_mode = {};
+        const storage_by_mode = aggregate_hosts ? {} : undefined;
         const by_service = aggregate_hosts ? { STORAGE: 0, GATEWAY: 0 } : undefined;
         let storage = {
             total: 0,
@@ -2705,7 +2706,8 @@ class NodesMonitor extends EventEmitter {
         _.each(list, item => {
             count += 1;
             by_mode[item.mode] = (by_mode[item.mode] || 0) + 1;
-            if (by_service) {
+            if (aggregate_hosts) {
+                storage_by_mode[item.storage_nodes_mode] = (storage_by_mode[item.storage_nodes_mode] || 0) + 1;
                 by_service.STORAGE += item.storage_nodes && item.storage_nodes.every(i => i.node.decommissioned) ? 0 : 1;
                 by_service.GATEWAY += item.s3_nodes && item.s3_nodes.every(i => i.node.decommissioned) ? 0 : 1;
             }
@@ -2742,6 +2744,7 @@ class NodesMonitor extends EventEmitter {
                 online,
                 by_mode,
                 by_service,
+                storage_by_mode,
             },
             storage: storage,
             data_activities: _.map(data_activities, a => {

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -413,7 +413,7 @@ function get_pool_info(pool, nodes_aggregate_pool, hosts_aggregate_pool) {
         info.nodes = _.defaults({}, p_nodes.nodes, POOL_NODES_INFO_DEFAULTS);
         info.hosts = _.mapValues(POOL_HOSTS_INFO_DEFAULTS, (val, key) => p_hosts.nodes[key] || val);
         info.undeletable = check_pool_deletion(pool, nodes_aggregate_pool);
-        info.mode = calc_hosts_pool_mode(info);
+        info.mode = calc_hosts_pool_mode(info, p_hosts.nodes.storage_by_mode || {});
     }
 
     //Get associated accounts
@@ -442,10 +442,10 @@ function calc_mongo_pool_mode(p) {
         'ALL_NODES_OFFLINE';
 }
 
-function calc_hosts_pool_mode(pool_info) {
+function calc_hosts_pool_mode(pool_info, storage_by_mode) {
     const { hosts, storage, data_activities = [] } = pool_info;
-    const { count, by_mode } = hosts;
-    const { OFFLINE: offline, OPTIMAL: optimal } = by_mode;
+    const { count } = hosts;
+    const { OFFLINE: offline = 0, OPTIMAL: optimal = 0 } = storage_by_mode;
     const offline_ratio = (offline / count) * 100;
     const { free, total, reserved, used_other } = _.assignWith({}, storage, (__, size) => size_utils.json_to_bigint(size));
     const potential_for_noobaa = total.subtract(reserved).subtract(used_other);


### PR DESCRIPTION
### Explain the changes:
- calculate pool status according to storage nodes only

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

