### PR TITLE
prevent s3 nodes from going to MIGRATING state

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1179,7 +1179,9 @@ class NodesMonitor extends EventEmitter {
         // now we update all nodes to the new pool
         _.each(items, item => {
             if (String(item.node.pool) !== String(pool._id)) {
-                item.node.migrating_to_pool = Date.now();
+                if (item.node.node_type === 'BLOCK_STORE_FS') {
+                    item.node.migrating_to_pool = Date.now();
+                }
                 item.node.pool = pool._id;
                 item.suggested_pool = ''; // reset previous suggestion
             }


### PR DESCRIPTION
### Explain the changes:
- for non FS nodes: only change pool id and do not set migrating_to_pool


### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

