### PR TITLE
	Prevent upgrade from 1.12 -> 2.X and fix upgrade failure message

### DIFF
--- a/frontend/src/app/components/modals/system-upgrade-modal/system-upgrade-modal.html
+++ b/frontend/src/app/components/modals/system-upgrade-modal/system-upgrade-modal.html
@@ -22,7 +22,9 @@
     </h1>
 
     <p class="text-center push-both">
-        Sorry for the hold up. You can download the upgrade package again and restart the upgrading process or contact support for more information
+        Sorry for the hold up. You can download the upgrade package again and restart the upgrading process or contact 
+        <a class="link" ko.attr.href="supportEmailHref">{{supportEmail}}</a>
+        for more information
     </p>
 
     <button class="btn align-middle push-prev" ko.click="close">

--- a/frontend/src/app/components/modals/system-upgrade-modal/system-upgrade-modal.js
+++ b/frontend/src/app/components/modals/system-upgrade-modal/system-upgrade-modal.js
@@ -5,6 +5,7 @@ import BaseViewModel from 'components/base-view-model';
 import ko from 'knockout';
 import numeral from 'numeral';
 import { upgradeStatus } from 'model';
+import { support } from 'config';
 
 class UpgradeModalViewModel extends BaseViewModel {
     constructor({ onClose }) {
@@ -34,6 +35,9 @@ class UpgradeModalViewModel extends BaseViewModel {
                 `Uploading Package ${numeral(this.progress()).format('0%')}` :
                 'Installing Package...'
         );
+        
+        this.supportEmail = support.email;
+        this.supportEmailHref = `mailto:${support.email}`;
     }
 
     close() {

--- a/src/server/notifications/alerts_log_store.js
+++ b/src/server/notifications/alerts_log_store.js
@@ -66,7 +66,6 @@ class AlertsLogStore {
 
     read_alerts(sysid, query, skip, limit) {
         const selector = this._create_selector(sysid, query);
-        console.warn('NBNB:: read_alerts', selector, 'skip', skip, 'limit', limit);
         return this._alertslogs.col().find(selector)
             .skip(skip)
             .limit(limit)


### PR DESCRIPTION
### Explain the changes:
- Prevent upgrade from 1.12 -> 2.X and fix upgrade failure message

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

