### PR TITLE
Clustering and Certificate timing fixes 

### DIFF
--- a/frontend/src/app/components/cluster/attach-server-modal/attach-server-modal.js
+++ b/frontend/src/app/components/cluster/attach-server-modal/attach-server-modal.js
@@ -75,6 +75,13 @@ class AttachServerModalViewModel extends BaseViewModel {
                             return newAddress !== address || result !== 'HAS_OBJECTS';
                         },
                         message: 'Server hold uploaded files'
+                    },
+                    {
+                        validator: newAddress => {
+                            const { address, result } = serverVerificationState() || {};
+                            return newAddress !== address || result !== 'NO_NTP_SET';
+                        },
+                        message: 'Server should be configured with NTP before attaching'
                     }
                 ]
             });

--- a/src/api/cluster_server_api.js
+++ b/src/api/cluster_server_api.js
@@ -322,7 +322,7 @@ module.exports = {
         },
 
         verify_new_member_result: {
-            enum: ['OKAY', 'SECRET_MISMATCH', 'VERSION_MISMATCH', 'ALREADY_A_MEMBER', 'HAS_OBJECTS', 'UNREACHABLE', 'ADDING_SELF'],
+            enum: ['OKAY', 'SECRET_MISMATCH', 'VERSION_MISMATCH', 'ALREADY_A_MEMBER', 'HAS_OBJECTS', 'UNREACHABLE', 'ADDING_SELF', 'NO_NTP_SET'],
             type: 'string'
         }
     },

--- a/src/deploy/NVA_build/common_funcs.sh
+++ b/src/deploy/NVA_build/common_funcs.sh
@@ -46,7 +46,7 @@ function check_mongo_status {
 
     #if test system is checked, verify system exists in our db
     local sysnumber
-    if [ $1 -eq "--testsystem" ]; then
+    if [ "$1" == "--testsystem" ]; then
         sysnumber=$(${MONGO_SHELL} --quiet --eval 'db.systems.count()')
         if [ $sysnumber -ne 1 ]
         then

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -54,7 +54,7 @@ function install_platform {
     cd ~
 
     # By Default, NTP is disabled, set local TZ to US Pacific
-    echo "#NooBaa Configured NTP Server"     >> /etc/ntp.conf
+    echo "# NooBaa Configured NTP Server"     >> /etc/ntp.conf
     echo "#NooBaa Configured Primary DNS Server" >> /etc/resolv.conf
     echo "#NooBaa Configured Secondary DNS Server" >> /etc/resolv.conf
     echo "#NooBaa Configured Search" >> /etc/resolv.conf

--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -169,7 +169,7 @@ function configure_dns_dialog {
     if [ "${dns2}" != "" ]; then
       sudo bash -c "echo 'nameserver ${dns2} #NooBaa Configured Secondary DNS Server' >> /etc/resolv.conf"
     fi
-    sudo supervisorctl restart all
+    sudo supervisorctl restart all > /dev/null 2>&1
 }
 
 function configure_hostname_dialog {
@@ -236,12 +236,13 @@ function configure_ntp_dialog {
   done
     echo "${ntp_server}" > /tmp/ntp
 
-    sudo sed -i "s/.*NooBaa Configured NTP Server.*/server ${ntp_server} iburst #NooBaa Configured NTP Server/" /etc/ntp.conf
+    sudo sed -i "s/.*NooBaa Configured NTP Server//" /etc/ntp.conf
+    sudo bash -c "echo 'server ${ntp_server} iburst # NooBaa Configured NTP Server' >> /etc/ntp.conf"
     sudo /sbin/chkconfig ntpd on 2345
-    sudo /etc/init.d/ntpd restart
-    sudo /etc/init.d/rsyslog restart
-    sudo /etc/init.d/supervisord restart
-}
+    sudo /etc/init.d/ntpd restart > /dev/null 2>&1
+    sudo /etc/init.d/rsyslog restart > /dev/null 2>&1
+    sudo /etc/init.d/supervisord restart > /dev/null 2>&1
+} 
 
 
 function reset_password {

--- a/src/deploy/NVA_build/setup_mongo_ssl.sh
+++ b/src/deploy/NVA_build/setup_mongo_ssl.sh
@@ -15,7 +15,7 @@ openssl genrsa -out ${MONGO_SSL_PATH}/root-ca.key 2048
 # !!! In production you will want to use -aes256 to password protect the keys
 # openssl genrsa -aes256 -out root-ca.key 2048
 
-openssl req -new -x509 -days 3650 -key ${MONGO_SSL_PATH}/root-ca.key -out ${MONGO_SSL_PATH}/root-ca.crt -subj "$dn_prefix/CN=ROOTCA"
+openssl req -new -x509 -days 7300 -key ${MONGO_SSL_PATH}/root-ca.key -out ${MONGO_SSL_PATH}/root-ca.crt -subj "$dn_prefix/CN=ROOTCA"
 
 mkdir -p ${MONGO_SSL_PATH}/RootCA/ca.db.certs
 echo "01" >> ${MONGO_SSL_PATH}/RootCA/ca.db.serial
@@ -83,8 +83,8 @@ openssl genrsa -out ${MONGO_SSL_PATH}/signing-ca.key 2048
 # !!! In production you will want to use -aes256 to password protect the keys
 # openssl genrsa -aes256 -out signing-ca.key 2048
 
-openssl req -new -days 3650 -key ${MONGO_SSL_PATH}/signing-ca.key -out ${MONGO_SSL_PATH}/signing-ca.csr -subj "$dn_prefix/CN=CA-SIGNER"
-openssl ca -batch -name RootCA -config ${MONGO_SSL_PATH}/root-ca.cfg -extensions v3_ca -out ${MONGO_SSL_PATH}/signing-ca.crt -infiles ${MONGO_SSL_PATH}/signing-ca.csr 
+openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/signing-ca.key -out ${MONGO_SSL_PATH}/signing-ca.csr -subj "$dn_prefix/CN=CA-SIGNER"
+openssl ca -batch -name RootCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -extensions v3_ca -out ${MONGO_SSL_PATH}/signing-ca.crt -infiles ${MONGO_SSL_PATH}/signing-ca.csr 
 
 mkdir -p ${MONGO_SSL_PATH}/SigningCA/ca.db.certs
 echo "01" >> ${MONGO_SSL_PATH}/SigningCA/ca.db.serial
@@ -105,8 +105,8 @@ echo "##### STEP 4: Create server certificates"
 for host in "${mongodb_server_hosts[@]}"; do
 	echo "Generating key for $host"
   	openssl genrsa  -out ${MONGO_SSL_PATH}/${host}.key 2048
-	openssl req -new -days 3650 -key ${MONGO_SSL_PATH}/${host}.key -out ${MONGO_SSL_PATH}/${host}.csr -subj "$dn_prefix/OU=$ou_member/CN=${host}"
-	openssl ca -batch -name SigningCA -config ${MONGO_SSL_PATH}/root-ca.cfg -out ${MONGO_SSL_PATH}/${host}.crt -infiles ${MONGO_SSL_PATH}/${host}.csr
+	openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/${host}.key -out ${MONGO_SSL_PATH}/${host}.csr -subj "$dn_prefix/OU=$ou_member/CN=${host}"
+	openssl ca -batch -name SigningCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -out ${MONGO_SSL_PATH}/${host}.crt -infiles ${MONGO_SSL_PATH}/${host}.csr
 	cat ${MONGO_SSL_PATH}/${host}.crt ${MONGO_SSL_PATH}/${host}.key > ${MONGO_SSL_PATH}/${host}.pem	
 done 
 
@@ -116,8 +116,8 @@ echo "##### STEP 5: Create client certificates"
 for host in "${mongodb_client_hosts[@]}"; do
 	echo "Generating key for $host"
   	openssl genrsa  -out ${MONGO_SSL_PATH}/${host}.key 2048
-	openssl req -new -days 3650 -key ${MONGO_SSL_PATH}/${host}.key -out ${MONGO_SSL_PATH}/${host}.csr -subj "$dn_prefix/OU=$ou_client/CN=${host}"
-	openssl ca -batch -name SigningCA -config ${MONGO_SSL_PATH}/root-ca.cfg -out ${MONGO_SSL_PATH}/${host}.crt -infiles ${MONGO_SSL_PATH}/${host}.csr
+	openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/${host}.key -out ${MONGO_SSL_PATH}/${host}.csr -subj "$dn_prefix/OU=$ou_client/CN=${host}"
+	openssl ca -batch -name SigningCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -out ${MONGO_SSL_PATH}/${host}.crt -infiles ${MONGO_SSL_PATH}/${host}.csr
 	cat ${MONGO_SSL_PATH}/${host}.crt ${MONGO_SSL_PATH}/${host}.key > ${MONGO_SSL_PATH}/${host}.pem
 done 
 

--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -37,7 +37,12 @@ function run() {
         dbg.log0('waiting for system store to load');
         return;
     }
+    if (!system_store.data.systems[0]) {
+        dbg.log0('system does not exist, skipping');
+        return;
+    }
     server_conf = system_store.get_local_cluster_info(true);
+
     return system_store.refresh()
         .then(() => _verify_cluster_configuration())
         .then(() => _check_ntp())

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1478,11 +1478,16 @@ function _verify_join_preconditons(req) {
                                 }
                             });
                     }
-                    // If we do not need system in order to add a server to a cluster
-                    dbg.log0('_verify_join_preconditons okay. server has no system');
-                    return 'OKAY';
                 })
-                .catch(err => err.message);
+                .then(() => {
+                     // If we do not need system in order to add a server to a cluster
+                     dbg.log0('_verify_join_preconditons okay. server has no system');
+                     return 'OKAY';
+                })
+                .catch(err => {
+                    dbg.warn('failed _verify_join_preconditons on', err.message);
+                    return err.message;
+                });
         });
 }
 
@@ -1531,8 +1536,6 @@ function _add_new_shard_on_server(shardname, ip, params) {
                         clusters: [current_topology]
                     }
                 });
-            } else {
-
             }
         })
         .then(function() {
@@ -1542,8 +1545,6 @@ function _add_new_shard_on_server(shardname, ip, params) {
                     IPs: config_updates.config_servers,
                     cluster_id: current_topology.cluster_id
                 });
-            } else {
-
             }
         });
 }
@@ -1687,8 +1688,6 @@ function _add_new_config_on_server(cfg_array, params) {
                 return MongoCtrl.add_member_to_replica_set(
                     config.MONGO_DEFAULTS.CFG_RSET_NAME, cfg_array, true
                 ); //3rd param /*=config set*/
-            } else {
-
             }
         });
 }

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1438,7 +1438,9 @@ function _validate_member_request(req) {
         })
         .then(() => os_utils.get_ntp())
         .then(platform_ntp => {
-            throw new Error('Could not add members when NTP is not set');
+            if (!platform_ntp) {
+                throw new Error('Could not add members when NTP is not set');
+            }
         });
 }
 
@@ -1740,7 +1742,7 @@ function _attach_server_configuration(cluster_server, dhcp_dns_servers) {
         };
         return cluster_server;
     }
-    return P.join(fs_utils.find_line_in_file('/etc/ntp.conf', '#NooBaa Configured NTP Server'),
+    return P.join(fs_utils.find_line_in_file('/etc/ntp.conf', '# NooBaa Configured NTP Server'),
             os_utils.get_time_config(),
             fs_utils.find_line_in_file('/etc/resolv.conf', '#NooBaa Configured Primary DNS Server'),
             fs_utils.find_line_in_file('/etc/resolv.conf', '#NooBaa Configured Secondary DNS Server'),

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1435,6 +1435,10 @@ function _validate_member_request(req) {
         .catch(() => {
             throw new Error(`Could not reach ${req.rpc_params.address}:${config.MONGO_DEFAULTS.SHARD_SRV_PORT},
             might be due to a FW blocking`);
+        })
+        .then(() => os_utils.get_ntp())
+        .then(platform_ntp => {
+            throw new Error('Could not add members when NTP is not set');
         });
 }
 

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -257,7 +257,7 @@ function read_mac_linux_drives(include_all) {
                     .then(() => linux_volume_to_drive(vol))
                     .catch(() => {
                         dbg.log0('Skipping drive', vol, 'Azure tmp disk indicated');
-                        return;
+                        
                     });
             }))
             .then(res => _.compact(res)));
@@ -428,7 +428,7 @@ function get_ntp() {
     if (os.type() === 'Linux') {
         return promise_utils.exec("cat /etc/ntp.conf | grep NooBaa", false, true)
             .then(res => {
-                let regex_res = (/server (.*) iburst #NooBaa Configured NTP Server/).exec(res);
+                let regex_res = (/server (.*) iburst # NooBaa Configured NTP Server/).exec(res);
                 return regex_res ? regex_res[1] : "";
             });
     } else if (os.type() === 'Darwin') { //Bypass for dev environment
@@ -440,7 +440,7 @@ function get_ntp() {
 function set_ntp(server, timez) {
     if (os.type() === 'Linux') {
         var command = "sed -i 's/.*NooBaa Configured NTP Server.*/server " + server +
-            " iburst #NooBaa Configured NTP Server/' /etc/ntp.conf";
+            " iburst # NooBaa Configured NTP Server/' /etc/ntp.conf";
         return _set_time_zone(timez)
             .then(() => promise_utils.exec(command))
             .then(() => promise_utils.exec('/sbin/chkconfig ntpd on 2345'))
@@ -761,7 +761,7 @@ function handle_unreleased_fds() {
             if (res) {
                 dbg.log0('Deleted FDs which were not released', res);
             }
-            return;
+            
         });
 }
 

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -257,7 +257,6 @@ function read_mac_linux_drives(include_all) {
                     .then(() => linux_volume_to_drive(vol))
                     .catch(() => {
                         dbg.log0('Skipping drive', vol, 'Azure tmp disk indicated');
-                        
                     });
             }))
             .then(res => _.compact(res)));
@@ -761,7 +760,7 @@ function handle_unreleased_fds() {
             if (res) {
                 dbg.log0('Deleted FDs which were not released', res);
             }
-            
+
         });
 }
 


### PR DESCRIPTION
### Explain the changes:
- Don't allow adding new members to a cluster if NTP is not set on the existing system
- Don't allow adding new members to a cluster if NTP is not set on the new members
- Set mongo self signed certificates start time to 1/8/2017
- On upgrade, if single server, regenerate mongo certificates according to previous point 
- Don't run server_monitor if no system created

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)


### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

