### PR TITLE
use empty array as default when DNS is not configured in a server

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -781,12 +781,12 @@ function update_dns_servers(req) {
                 throw new RpcError('OFFLINE_SERVER', 'Server is disconnected');
             }
             const config_to_compare = [
-                dns_servers_config.dns_servers ? dns_servers_config.dns_servers.sort() : undefined,
-                dns_servers_config.search_domains ? dns_servers_config.search_domains.sort() : undefined
+                dns_servers_config.dns_servers ? dns_servers_config.dns_servers.sort() : [],
+                dns_servers_config.search_domains ? dns_servers_config.search_domains.sort() : []
             ];
             // don't update servers that already have the dame configuration
             target_servers = target_servers.filter(srv => {
-                const { dns_servers, search_domains } = srv;
+                const { dns_servers = [], search_domains = [] } = srv;
                 return !_.isEqual(config_to_compare, [dns_servers.sort(), search_domains.sort()]);
             });
             if (!target_servers.length) {


### PR DESCRIPTION
### Explain the changes:
- use empty array as default when DNS is not configured in a server

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

