### PR TITLE
#3551 - changed check_external_connection api

### DIFF
--- a/frontend/src/app/components/modals/add-cloud-connection-modal/add-cloud-connection-modal.js
+++ b/frontend/src/app/components/modals/add-cloud-connection-modal/add-cloud-connection-modal.js
@@ -128,7 +128,7 @@ class addCloudConnectionModalViewModel extends Observer {
     }
 
     async onValidateAsync({ service, endpoint, identity, secret }) {
-        const result = await api.account.check_external_connection({
+        const { status } = await api.account.check_external_connection({
             endpoint_type: service,
             endpoint: endpoint,
             identity: identity,
@@ -137,19 +137,21 @@ class addCloudConnectionModalViewModel extends Observer {
 
         const errors = {};
 
-        if (result === 'TIMEOUT') {
+        if (status === 'TIMEOUT') {
             errors.endpoint = 'Endpoint communication timed out';
 
-        } else if (result === 'INVALID_ENDPOINT') {
+        } else if (status === 'INVALID_ENDPOINT') {
             errors.endpoint = 'Please enter a valid endpoint';
 
-        } else if (result === 'INVALID_CREDENTIALS') {
+        } else if (status === 'INVALID_CREDENTIALS') {
             errors.secret = errors.identity = 'Credentials does not match';
 
-        } else if (result === 'NOT_SUPPORTED') {
+        } else if (status === 'NOT_SUPPORTED') {
             errors.identity = 'Account type is not supported';
+        } else if (status === 'TIME_SKEW') {
+            errors.endpoint = 'Time difference with the server is too large';
         }
-        else if (result === 'UNKNOWN_FAILURE') {
+        else if (status === 'UNKNOWN_FAILURE') {
             errors.endpoint = 'Something went wrong';
         }
 

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -318,15 +318,34 @@ module.exports = {
                 }
             },
             reply: {
-                type: 'string',
-                enum: [
-                    'SUCCESS',
-                    'TIMEOUT',
-                    'INVALID_ENDPOINT',
-                    'INVALID_CREDENTIALS',
-                    'NOT_SUPPORTED',
-                    'UNKNOWN_FAILURE'
-                ]
+                type: 'object',
+                required: ['status'],
+                properties: {
+                    status: {
+                        type: 'string',
+                        enum: [
+                            'SUCCESS',
+                            'TIMEOUT',
+                            'INVALID_ENDPOINT',
+                            'INVALID_CREDENTIALS',
+                            'NOT_SUPPORTED',
+                            'TIME_SKEW',
+                            'UNKNOWN_FAILURE'
+                        ]
+                    },
+                    error: {
+                        type: 'object',
+                        required: ['code', 'message'],
+                        properties: {
+                            code: {
+                                type: 'string'
+                            },
+                            message: {
+                                type: 'string'
+                            },
+                        }
+                    }
+                }
             },
             auth: {
                 system: 'admin'


### PR DESCRIPTION
### Explain the changes:
- changed check_external_connection to return object with status and error, in case there is one.
- Added TIME_SKEW status
- changed onValidateAsync on cloud connection modal to look at `status` instead of result

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- partial fix to #3551 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

