### PR TITLE
md aggregator fixes and unit-test

### DIFF
--- a/src/server/bg_services/md_aggregator.js
+++ b/src/server/bg_services/md_aggregator.js
@@ -4,254 +4,343 @@
 const _ = require('lodash');
 const util = require('util');
 const P = require('../../util/promise');
-const promise_utils = require('../../util/promise_utils');
-const config = require('../../../config');
 const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config');
 const MDStore = require('../object_services/md_store').MDStore;
 const size_utils = require('../../util/size_utils');
-const system_store = require('../system_services/system_store').get_instance();
+const SystemStore = require('../system_services/system_store');
+const promise_utils = require('../../util/promise_utils');
 
 // TODO: This method is based on a single system
 function background_worker() {
+    const target_now = Date.now() - config.MD_GRACE_IN_MILLISECONDS;
+
+    return run_md_aggregator(
+        MDStore.instance(),
+        SystemStore.get_instance(),
+        target_now,
+        1000
+    );
+}
+
+function run_md_aggregator(md_store, system_store, target_now, delay) {
+
     if (!system_store.is_finished_initial_load) {
         dbg.log0('System did not finish initial load');
         return;
     }
 
-    const target_now = Date.now() - config.MD_GRACE_IN_MILLISECONDS;
+    let has_more = true;
 
-    let bucket_groups_by_update_time =
-        _.groupBy(system_store.data.buckets, g_bucket =>
-            _.get(g_bucket, 'storage_stats.last_update') || config.NOOBAA_EPOCH);
-
-    const sorted_group_update_times = _.keysIn(bucket_groups_by_update_time)
-        .sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
-
-    if (_.isEmpty(bucket_groups_by_update_time)) {
-        dbg.log0('md_aggregator: There are no groups to work on');
-        return P.resolve();
-    }
-
-    return P.each(sorted_group_update_times, (group_update_date, group_index, length) => {
-            const is_last_group = Boolean(group_index === (length - 1));
-            const current_group = bucket_groups_by_update_time[group_update_date];
-            let group_finished = false;
-            let from_date = parseInt(group_update_date, 10);
-            const next_group_from_date = is_last_group ? target_now :
-                parseInt(sorted_group_update_times[group_index + 1], 10);
-            const time_diff = next_group_from_date - from_date;
-
-            // on normal operation the time_diff to close can be closed within a single MD_AGGREGATOR_INTERVAL
-            // but on upgrades or shutdowns the gap can get higher, and then we limit the number of cycles we
-            // allow to run to MD_AGGREGATOR_MAX_CYCLES, and therefore increase the interval from MD_AGGREGATOR_INTERVAL
-            // to higher interval in order to close the gap in a reasonable number of cycles.
-            const current_interval = Math.max(
-                Math.floor(time_diff / config.MD_AGGREGATOR_MAX_CYCLES),
-                config.MD_AGGREGATOR_INTERVAL);
-
-            return promise_utils.pwhile(
-                    () => !group_finished,
-                    () => {
-                        const till_date = Math.min(from_date + current_interval, next_group_from_date);
-                        return group_md_aggregator(
-                                from_date,
-                                till_date,
-                                current_group,
-                                target_now
-                            )
-                            .then(bucket_updates => {
-                                from_date = till_date;
-                                current_group.forEach(bucket => {
-                                    bucket.storage_stats = _.find(
-                                        bucket_updates,
-                                        obj => String(obj._id) === String(bucket._id)
-                                    ).storage_stats;
-                                });
-
-                                if (from_date === next_group_from_date) {
-                                    group_finished = true;
-                                }
-                            });
-                    })
-                .then(() => {
-                    // On the last group the aggregation not needed since there is no more work
-                    if (!is_last_group) {
-                        // The buckets inside the groups are unique so I'm not worried that I will have an overwrite
-                        bucket_groups_by_update_time[sorted_group_update_times[group_index + 1]] =
-                            _.concat(bucket_groups_by_update_time[sorted_group_update_times[group_index + 1]], current_group);
-                    }
-                })
-                .catch(err => {
-                    console.error(`MD AGGREGATOR: Group aggregation ${util.inspect(_.map(current_group,
-                            bucket => ({
-                                bucket_id: bucket._id,
-                                storage: bucket.storage_stats
-                            })), false, null, true)} had an error`, err);
-                });
+    return promise_utils.pwhile(
+        () => has_more,
+        () => P.resolve()
+        .then(() => find_next_range({ target_now, system_store }))
+        .then(range => range && range_md_aggregator({ md_store, system_store, range }))
+        .then(update => {
+            if (update) {
+                return P.resolve(system_store.make_changes({ update }))
+                    .delay(delay);
+            } else {
+                has_more = false;
+            }
         })
-        .return();
+    );
 }
 
+// find next from_time/till_time of the first group we want to aggregate
+function find_next_range({
+    target_now,
+    system_store,
+}) {
+    let from_time = target_now;
+    let till_time = target_now;
+    let should_reset_all = false;
 
-function group_md_aggregator(from_time, till_time, group_to_aggregate, current_time) {
-    return check_time_conditions(from_time, till_time, group_to_aggregate, current_time)
-        .then(function() {
-            const from_date = new Date(from_time);
-            const till_date = new Date(till_time);
-            return P.join(
-                MDStore.instance().aggregate_chunks_by_create_dates(from_date, till_date),
-                MDStore.instance().aggregate_chunks_by_delete_dates(from_date, till_date),
-                MDStore.instance().aggregate_objects_by_create_dates(from_date, till_date),
-                MDStore.instance().aggregate_objects_by_delete_dates(from_date, till_date),
-                MDStore.instance().aggregate_blocks_by_create_dates(from_date, till_date),
-                MDStore.instance().aggregate_blocks_by_delete_dates(from_date, till_date)
-            ).spread(function(
-                existing_chunks_aggregate,
-                deleted_chunks_aggregate,
-                existing_objects_aggregate,
-                deleted_objects_aggregate,
-                existing_blocks_aggregate,
-                deleted_blocks_aggregate) {
-                const pool_updates = _.map(system_store.data.pools, pool => {
-                    const new_storage_stats = {
-                        blocks_size: (pool.storage_stats && pool.storage_stats.blocks_size) || 0,
-                        last_update: till_time,
-                    };
-                    dbg.log3('Pool storage stats before deltas:', new_storage_stats);
-                    const bigint_ex_blocks_agg = size_utils.json_to_bigint((existing_blocks_aggregate.pools[pool._id] &&
-                        existing_blocks_aggregate.pools[pool._id].size) || 0);
-                    const bigint_de_blocks_agg = size_utils.json_to_bigint((deleted_blocks_aggregate.pools[pool._id] &&
-                        deleted_blocks_aggregate.pools[pool._id].size) || 0);
+    _.forEach(system_store.data.buckets, bucket => {
+        const last_update = _.get(bucket, 'storage_stats.last_update') || config.NOOBAA_EPOCH;
+        if (last_update > target_now) {
+            dbg.error('find_next_range: time skew detected for bucket', bucket.name,
+                'last_update', last_update,
+                'target_now', target_now
+            );
+            should_reset_all = true;
+        }
+        if (last_update < from_time) {
+            till_time = from_time;
+            from_time = last_update;
+        } else if (from_time < last_update && last_update < till_time) {
+            till_time = last_update;
+        }
+    });
+    _.forEach(system_store.data.pools, pool => {
+        const last_update = _.get(pool, 'storage_stats.last_update') || config.NOOBAA_EPOCH;
+        if (last_update > target_now) {
+            dbg.error('find_next_range: time skew detected for pool', pool.name,
+                'last_update', last_update,
+                'target_now', target_now
+            );
+            should_reset_all = true;
+        }
+        if (last_update < from_time) {
+            till_time = from_time;
+            from_time = last_update;
+        } else if (from_time < last_update && last_update < till_time) {
+            till_time = last_update;
+        }
+    });
 
-                    const delta_block_size = bigint_ex_blocks_agg.minus(bigint_de_blocks_agg);
+    // printing the range and the buckets/pools relative info
+    dbg.log1('find_next_range:',
+        'from_time', from_time,
+        'till_time*', till_time - from_time,
+        'target_now*', target_now - from_time
+    );
+    _.forEach(system_store.data.buckets, bucket => {
+        const last_update = _.get(bucket, 'storage_stats.last_update') || config.NOOBAA_EPOCH;
+        dbg.log1('find_next_range: bucket', bucket.name,
+            'last_update*', last_update - from_time
+        );
+    });
+    _.forEach(system_store.data.pools, pool => {
+        const last_update = _.get(pool, 'storage_stats.last_update') || config.NOOBAA_EPOCH;
+        dbg.log1('find_next_range: pool', pool.name,
+            'last_update*', last_update - from_time
+        );
+    });
 
-                    // If we won't always update the checkpoint, on no changes
-                    // We will reduce all of the chunks from last checkpoint (which can be a lot)
-                    new_storage_stats.blocks_size = (size_utils.json_to_bigint(new_storage_stats.blocks_size)
-                            .plus(delta_block_size))
-                        .toJSON();
-
-                    dbg.log3('Bucket storage stats after deltas:', new_storage_stats);
-                    return {
-                        _id: pool._id,
-                        storage_stats: new_storage_stats,
-                    };
-                });
-
-                const bucket_updates = _.map(group_to_aggregate, bucket => {
-                    const new_storage_stats = {
-                        chunks_capacity: (bucket.storage_stats && bucket.storage_stats.chunks_capacity) || 0,
-                        objects_size: (bucket.storage_stats && bucket.storage_stats.objects_size) || 0,
-                        objects_count: (bucket.storage_stats && bucket.storage_stats.objects_count) || 0,
-                        blocks_size: (bucket.storage_stats && bucket.storage_stats.blocks_size) || 0,
-                        pools: (bucket.storage_stats && bucket.storage_stats.pools) || {},
-                        last_update: till_time,
-                    };
-                    dbg.log3('Bucket storage stats before deltas:', new_storage_stats);
-                    const bigint_ex_chunks_agg = size_utils.json_to_bigint((existing_chunks_aggregate[bucket._id] &&
-                        existing_chunks_aggregate[bucket._id].compress_size) || 0);
-                    const bigint_de_chunks_agg = size_utils.json_to_bigint((deleted_chunks_aggregate[bucket._id] &&
-                        deleted_chunks_aggregate[bucket._id].compress_size) || 0);
-                    const bigint_ex_blocks_agg = size_utils.json_to_bigint((existing_blocks_aggregate.buckets[bucket._id] &&
-                        existing_blocks_aggregate.buckets[bucket._id].size) || 0);
-                    const bigint_de_blocks_agg = size_utils.json_to_bigint((deleted_blocks_aggregate.buckets[bucket._id] &&
-                        deleted_blocks_aggregate.buckets[bucket._id].size) || 0);
-                    const ex_pools = (existing_blocks_aggregate.buckets[bucket._id] &&
-                        existing_blocks_aggregate.buckets[bucket._id].pools) || {};
-                    const de_pools = (deleted_blocks_aggregate.buckets[bucket._id] &&
-                        deleted_blocks_aggregate.buckets[bucket._id].pools) || {};
-                    const bigint_ex_obj_agg = size_utils.json_to_bigint((existing_objects_aggregate[bucket._id] &&
-                        existing_objects_aggregate[bucket._id].size) || 0);
-                    const bigint_de_obj_agg = size_utils.json_to_bigint((deleted_objects_aggregate[bucket._id] &&
-                        deleted_objects_aggregate[bucket._id].size) || 0);
-
-                    const delta_chunk_compress_size = bigint_ex_chunks_agg.minus(bigint_de_chunks_agg);
-                    const delta_block_size = bigint_ex_blocks_agg.minus(bigint_de_blocks_agg);
-
-                    const delta_buckets_pool_size = _.mergeWith(ex_pools, de_pools, (ex_value, de_value) => ({
-                        size: size_utils.json_to_bigint((ex_value && ex_value.size) || 0)
-                            .minus(size_utils.json_to_bigint((de_value && de_value.size) || 0))
-                    }));
-
-                    const delta_object_size = bigint_ex_obj_agg.minus(bigint_de_obj_agg);
-                    const delta_object_count = ((existing_objects_aggregate[bucket._id] &&
-                            existing_objects_aggregate[bucket._id].count) || 0) -
-                        ((deleted_objects_aggregate[bucket._id] &&
-                            deleted_objects_aggregate[bucket._id].count) || 0);
-                    // If we won't always update the checkpoint, on no changes
-                    // We will reduce all of the chunks from last checkpoint (which can be a lot)
-                    new_storage_stats.chunks_capacity = size_utils.json_to_bigint(new_storage_stats.chunks_capacity)
-                        .plus(delta_chunk_compress_size)
-                        .toJSON();
-                    new_storage_stats.blocks_size = size_utils.json_to_bigint(new_storage_stats.blocks_size)
-                        .plus(delta_block_size)
-                        .toJSON();
-                    new_storage_stats.pools = _.mergeWith(new_storage_stats.pools, delta_buckets_pool_size, (ex_value, de_value) => ({
-                        blocks_size: size_utils.json_to_bigint((ex_value && ex_value.blocks_size) || 0)
-                            .plus((de_value && de_value.size) || 0)
-                            .toJSON()
-                    }));
-                    new_storage_stats.pools = _.pickBy(new_storage_stats.pools, pool => ((pool && pool.blocks_size) || 0));
-                    new_storage_stats.objects_size = size_utils.json_to_bigint(new_storage_stats.objects_size)
-                        .plus(delta_object_size)
-                        .toJSON();
-                    new_storage_stats.objects_count += delta_object_count;
-                    new_storage_stats.objects_hist = build_objects_hist(bucket, existing_objects_aggregate, deleted_objects_aggregate);
-
-                    dbg.log3('Bucket storage stats after deltas:', new_storage_stats);
-                    return {
-                        _id: bucket._id,
-                        storage_stats: new_storage_stats,
-                    };
-                });
-
-                return system_store.make_changes({
-                        update: {
-                            buckets: bucket_updates,
-                            pools: pool_updates
-                        }
-                    })
-                    .delay(1000)
-                    .return(bucket_updates);
-            });
-        });
-}
-
-
-function check_time_conditions(from_date, till_date, group_to_aggregate, current_time) {
-    if (from_date > till_date) {
-        return P.reject(new Error(`Skipping current group: ${_.map(group_to_aggregate,
-                        bucket => bucket.name)}`));
-    }
-
-    if (from_date > current_time || till_date > current_time) {
-        console.error(`Timeskew detected: reverting buckets ${_.map(group_to_aggregate,
-                        bucket => bucket.name)} to initialized values`);
+    if (should_reset_all) {
+        dbg.error('find_next_range: reset all storage_stats due to time skews ',
+            'from_time', from_time,
+            'till_time*', till_time - from_time,
+            'target_now*', target_now - from_time
+        );
+        // Assigning NOOBAA_EPOCH so we will gather all data again till the new time
+        // This means that we will be eventually consistent
         return system_store.make_changes({
                 update: {
-                    buckets: _.map(group_to_aggregate, bucket => ({
+                    buckets: _.map(system_store.data.buckets, bucket => ({
                         _id: bucket._id,
                         storage_stats: {
+                            last_update: config.NOOBAA_EPOCH,
                             chunks_capacity: 0,
                             blocks_size: 0,
                             objects_size: 0,
                             objects_count: 0,
                             objects_hist: [],
-                            // Assigning NOOBAA_EPOCH so we will gather all data again till the new time
-                            // This means that we will be eventually consistent
-                            last_update: config.NOOBAA_EPOCH
+                            pools: {},
+                        },
+                    })),
+                    pools: _.map(system_store.data.pools, pool => ({
+                        _id: pool._id,
+                        storage_stats: {
+                            last_update: config.NOOBAA_EPOCH,
+                            blocks_size: 0,
                         },
                     }))
                 }
             })
-            .then(() => {
-                throw new Error('check_time_conditions: Reverted successfully');
-            });
+            .return();
     }
 
-    return P.resolve();
+    // on normal operation the time_diff to close can be closed within a single MD_AGGREGATOR_INTERVAL
+    // but on upgrades or shutdowns the gap can get higher, and then we limit the number of cycles we
+    // allow to run to MD_AGGREGATOR_MAX_CYCLES, and therefore increase the interval from MD_AGGREGATOR_INTERVAL
+    // to higher interval in order to close the gap in a reasonable number of cycles.
+    const time_diff = till_time - from_time;
+    const current_interval = Math.max(
+        Math.floor(time_diff / config.MD_AGGREGATOR_MAX_CYCLES),
+        config.MD_AGGREGATOR_INTERVAL);
+    till_time = Math.min(from_time + current_interval, till_time);
+
+    if (from_time >= target_now || from_time >= till_time) {
+        dbg.log0('find_next_range:: no more work',
+            'from_time', from_time,
+            'till_time*', till_time - from_time,
+            'target_now*', target_now - from_time
+        );
+        return;
+    }
+
+    dbg.log0('find_next_range:: next work',
+        'from_time', from_time,
+        'till_time*', till_time - from_time,
+        'target_now*', target_now - from_time
+    );
+    return { from_time, till_time };
 }
 
+function range_md_aggregator({
+    md_store,
+    system_store,
+    range,
+}) {
+    const from_time = range.from_time;
+    const till_time = range.till_time;
+
+    const buckets = _.filter(system_store.data.buckets, bucket => bucket.storage_stats.last_update === from_time);
+    const pools = _.filter(system_store.data.pools, pool => pool.storage_stats.last_update === from_time);
+
+    return P.join(
+            md_store.aggregate_chunks_by_create_dates(from_time, till_time),
+            md_store.aggregate_chunks_by_delete_dates(from_time, till_time),
+            md_store.aggregate_objects_by_create_dates(from_time, till_time),
+            md_store.aggregate_objects_by_delete_dates(from_time, till_time),
+            md_store.aggregate_blocks_by_create_dates(from_time, till_time),
+            md_store.aggregate_blocks_by_delete_dates(from_time, till_time)
+        )
+        .spread((
+            existing_chunks_aggregate,
+            deleted_chunks_aggregate,
+            existing_objects_aggregate,
+            deleted_objects_aggregate,
+            existing_blocks_aggregate,
+            deleted_blocks_aggregate) => {
+
+            dbg.log3('range_md_aggregator:',
+                'from_time', from_time,
+                'till_time', till_time,
+                'existing_objects_aggregate', util.inspect(existing_objects_aggregate, true, null, true),
+                'deleted_objects_aggregate', util.inspect(deleted_objects_aggregate, true, null, true),
+                'existing_blocks_aggregate', util.inspect(existing_blocks_aggregate, true, null, true),
+                'deleted_blocks_aggregate', util.inspect(deleted_blocks_aggregate, true, null, true)
+            );
+
+            const buckets_updates = _.map(buckets, bucket => {
+                const new_storage_stats = calculate_new_bucket({
+                    bucket,
+                    existing_chunks_aggregate,
+                    deleted_chunks_aggregate,
+                    existing_objects_aggregate,
+                    deleted_objects_aggregate,
+                    existing_blocks_aggregate,
+                    deleted_blocks_aggregate
+                });
+                new_storage_stats.last_update = till_time;
+                return {
+                    _id: bucket._id,
+                    storage_stats: new_storage_stats,
+                };
+            });
+
+            const pools_updates = _.map(pools, pool => {
+                const new_storage_stats = calculate_new_pool({
+                    pool,
+                    existing_blocks_aggregate,
+                    deleted_blocks_aggregate
+                });
+                new_storage_stats.last_update = till_time;
+                return {
+                    _id: pool._id,
+                    storage_stats: new_storage_stats,
+                };
+            });
+
+            return {
+                buckets: buckets_updates,
+                pools: pools_updates,
+            };
+        });
+}
+
+function calculate_new_pool({
+    pool,
+    existing_blocks_aggregate,
+    deleted_blocks_aggregate
+}) {
+    const new_storage_stats = {
+        blocks_size: (pool.storage_stats && pool.storage_stats.blocks_size) || 0,
+    };
+    dbg.log3('Pool storage stats before deltas:', new_storage_stats);
+    const bigint_ex_blocks_agg = size_utils.json_to_bigint((existing_blocks_aggregate.pools[pool._id] &&
+        existing_blocks_aggregate.pools[pool._id].size) || 0);
+    const bigint_de_blocks_agg = size_utils.json_to_bigint((deleted_blocks_aggregate.pools[pool._id] &&
+        deleted_blocks_aggregate.pools[pool._id].size) || 0);
+    dbg.log3('Pool storage stats', bigint_ex_blocks_agg, bigint_de_blocks_agg);
+
+    const delta_block_size = bigint_ex_blocks_agg.minus(bigint_de_blocks_agg);
+
+    // If we won't always update the checkpoint, on no changes
+    // We will reduce all of the chunks from last checkpoint (which can be a lot)
+    new_storage_stats.blocks_size = (size_utils.json_to_bigint(new_storage_stats.blocks_size)
+            .plus(delta_block_size))
+        .toJSON();
+
+    dbg.log3('Pool storage stats after deltas:', new_storage_stats);
+    return new_storage_stats;
+}
+
+function calculate_new_bucket({
+    bucket,
+    existing_chunks_aggregate,
+    deleted_chunks_aggregate,
+    existing_objects_aggregate,
+    deleted_objects_aggregate,
+    existing_blocks_aggregate,
+    deleted_blocks_aggregate,
+}) {
+    const new_storage_stats = {
+        chunks_capacity: (bucket.storage_stats && bucket.storage_stats.chunks_capacity) || 0,
+        objects_size: (bucket.storage_stats && bucket.storage_stats.objects_size) || 0,
+        objects_count: (bucket.storage_stats && bucket.storage_stats.objects_count) || 0,
+        blocks_size: (bucket.storage_stats && bucket.storage_stats.blocks_size) || 0,
+        pools: (bucket.storage_stats && bucket.storage_stats.pools) || {},
+    };
+    dbg.log3('Bucket storage stats before deltas:', new_storage_stats);
+    const bigint_ex_chunks_agg = size_utils.json_to_bigint((existing_chunks_aggregate[bucket._id] &&
+        existing_chunks_aggregate[bucket._id].compress_size) || 0);
+    const bigint_de_chunks_agg = size_utils.json_to_bigint((deleted_chunks_aggregate[bucket._id] &&
+        deleted_chunks_aggregate[bucket._id].compress_size) || 0);
+    const bigint_ex_blocks_agg = size_utils.json_to_bigint((existing_blocks_aggregate.buckets[bucket._id] &&
+        existing_blocks_aggregate.buckets[bucket._id].size) || 0);
+    const bigint_de_blocks_agg = size_utils.json_to_bigint((deleted_blocks_aggregate.buckets[bucket._id] &&
+        deleted_blocks_aggregate.buckets[bucket._id].size) || 0);
+    const ex_pools = (existing_blocks_aggregate.buckets[bucket._id] &&
+        existing_blocks_aggregate.buckets[bucket._id].pools) || {};
+    const de_pools = (deleted_blocks_aggregate.buckets[bucket._id] &&
+        deleted_blocks_aggregate.buckets[bucket._id].pools) || {};
+    const bigint_ex_obj_agg = size_utils.json_to_bigint((existing_objects_aggregate[bucket._id] &&
+        existing_objects_aggregate[bucket._id].size) || 0);
+    const bigint_de_obj_agg = size_utils.json_to_bigint((deleted_objects_aggregate[bucket._id] &&
+        deleted_objects_aggregate[bucket._id].size) || 0);
+
+    const delta_chunk_compress_size = bigint_ex_chunks_agg.minus(bigint_de_chunks_agg);
+    const delta_block_size = bigint_ex_blocks_agg.minus(bigint_de_blocks_agg);
+
+    const delta_buckets_pool_size = _.mergeWith(ex_pools, de_pools, (ex_value, de_value) => ({
+        size: size_utils.json_to_bigint((ex_value && ex_value.size) || 0)
+            .minus(size_utils.json_to_bigint((de_value && de_value.size) || 0))
+    }));
+
+    const delta_object_size = bigint_ex_obj_agg.minus(bigint_de_obj_agg);
+    const delta_object_count = ((existing_objects_aggregate[bucket._id] &&
+            existing_objects_aggregate[bucket._id].count) || 0) -
+        ((deleted_objects_aggregate[bucket._id] &&
+            deleted_objects_aggregate[bucket._id].count) || 0);
+
+    // If we won't always update the checkpoint, on no changes
+    // We will reduce all of the chunks from last checkpoint (which can be a lot)
+    new_storage_stats.chunks_capacity = size_utils.json_to_bigint(new_storage_stats.chunks_capacity)
+        .plus(delta_chunk_compress_size)
+        .toJSON();
+    new_storage_stats.blocks_size = size_utils.json_to_bigint(new_storage_stats.blocks_size)
+        .plus(delta_block_size)
+        .toJSON();
+    new_storage_stats.pools = _.mergeWith(new_storage_stats.pools, delta_buckets_pool_size, (ex_value, de_value) => ({
+        blocks_size: size_utils.json_to_bigint((ex_value && ex_value.blocks_size) || 0)
+            .plus(size_utils.json_to_bigint((de_value && de_value.size) || 0))
+            .toJSON()
+    }));
+    new_storage_stats.pools = _.pickBy(new_storage_stats.pools, pool => ((pool && pool.blocks_size) || 0));
+    new_storage_stats.objects_size = size_utils.json_to_bigint(new_storage_stats.objects_size)
+        .plus(delta_object_size)
+        .toJSON();
+    new_storage_stats.objects_count += delta_object_count;
+    new_storage_stats.objects_hist = build_objects_hist(bucket, existing_objects_aggregate, deleted_objects_aggregate);
+
+    dbg.log3('Bucket storage stats after deltas:', new_storage_stats);
+    return new_storage_stats;
+}
 
 function get_hist_array_from_aggregate(agg, key) {
     const key_prefix = key + '_pow2_';
@@ -330,3 +419,6 @@ function get_new_bin(existing, deleted, current) {
 
 // EXPORTS
 exports.background_worker = background_worker;
+exports.run_md_aggregator = run_md_aggregator;
+exports.calculate_new_bucket = calculate_new_bucket;
+exports.calculate_new_pool = calculate_new_pool;

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -959,6 +959,7 @@ class NodesMonitor extends EventEmitter {
         if (item.node.issues_report) {
             _.remove(item.node.issues_report, issue => issue.reason === 'TAMPERING');
         }
+        if (_.isEmpty(item.node.issues_report)) delete item.node.issues_report;
         this._set_need_update.add(item);
         this._update_status(item);
     }

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -126,7 +126,6 @@ function complete_object_upload(req) {
             }
             set_updates.size = res.size;
             set_updates.num_parts = res.num_parts;
-            set_updates.create_time = new Date();
             if (req.rpc_params.etag) {
                 set_updates.etag = req.rpc_params.etag;
             } else if (res.size === 0) {
@@ -144,7 +143,11 @@ function complete_object_upload(req) {
             // we passed the checks, so we can delete the existing object if exists
             return map_deleter.delete_object(existing_obj);
         })
-        .then(() => MDStore.instance().update_object_by_id(obj._id, set_updates, unset_updates))
+        .then(() => {
+            // setting create_time close to the mdstore update
+            set_updates.create_time = new Date();
+            return MDStore.instance().update_object_by_id(obj._id, set_updates, unset_updates);
+        })
         .then(() => {
             const bucket = system_store.data.get_by_id(obj.bucket);
             Dispatcher.instance().activity({

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -50,7 +50,7 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, tag) {
             objects_size: 0,
             objects_count: 0,
             objects_hist: [],
-            last_update: now - config.MD_GRACE_IN_MILLISECONDS
+            last_update: now - (2 * config.MD_GRACE_IN_MILLISECONDS)
         },
         stats: {
             reads: 0,

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -43,12 +43,17 @@ const NO_CAPAITY_LIMIT = Math.pow(1024, 2); // 1MB
 const LOW_CAPACITY_HARD_LIMIT = 30 * Math.pow(1024, 3); // 30GB
 
 function new_pool_defaults(name, system_id, resource_type, pool_node_type) {
+    let now = Date.now();
     return {
         _id: system_store.generate_id(),
         system: system_id,
         name: name,
         resource_type: resource_type,
-        pool_node_type: pool_node_type
+        pool_node_type: pool_node_type,
+        storage_stats: {
+            blocks_size: 0,
+            last_update: now - (2 * config.MD_GRACE_IN_MILLISECONDS)
+        },
     };
 }
 

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -238,6 +238,9 @@ class SystemStoreData {
         this.rebuild_indexes();
         this.rebuild_allowed_buckets_links();
         this.rebuild_accounts_by_email_lowercase();
+
+        // TODO: deep freeze the data once tested enough
+        // js_utils.deep_freeze(this);
     }
 
     rebuild_idmap() {
@@ -311,9 +314,9 @@ class SystemStoreData {
             let key = _.get(item, index.key || '_id');
             let context = index.context ? _.get(item, index.context) : this;
             if (!context) return;
-            let map = context[index.name] = context[index.name] || {};
+            let map = context[index.name];
             if (!index.val_array) {
-                let existing = map[key];
+                let existing = map && map[key];
                 if (existing && String(existing._id) !== String(item._id)) {
                     let err = new Error(index.name + ' collision on key ' + key);
                     err.rpc_code = 'CONFLICT';

--- a/src/test/system_tests/mongodb_defaults.js
+++ b/src/test/system_tests/mongodb_defaults.js
@@ -14,7 +14,7 @@ db.objectparts.remove({});
 db.objectmds.remove({});
 db.tiers.update({
     name: {
-        $regex: 'first\.bucket.*'
+        $regex: 'first\\.bucket.*'
     }
 }, {
     $set: {
@@ -74,7 +74,16 @@ db.buckets.updateMany({}, {
             pools: {},
             objects_count: 0,
             objects_hist: [],
-            last_update: Date.now()
+            last_update: Date.now() - 600000
+        }
+    }
+});
+
+db.pools.updateMany({}, {
+    $set: {
+        storage_stats: {
+            blocks_size: 0,
+            last_update: Date.now() - 600000
         }
     }
 });

--- a/src/test/system_tests/test_md_aggregator.js
+++ b/src/test/system_tests/test_md_aggregator.js
@@ -262,9 +262,9 @@ function main() {
             process.exit(0);
         })
         .catch(function(err) {
+            console.error('TEST FAILED: ', err.stack || err);
             return init_system_to_ntp()
                 .finally(() => {
-                    console.error('TEST FAILED: ', err.stack || err);
                     rpc.disconnect_all();
                     process.exit(1);
                 });

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -19,6 +19,7 @@ require('./test_s3_list_objects');
 require('./test_md_store');
 require('./test_nodes_store');
 require('./test_system_store');
+require('./test_md_aggregator_unit');
 
 // UTILS
 require('./test_job_queue');

--- a/src/test/unit_tests/test_md_aggregator_unit.js
+++ b/src/test/unit_tests/test_md_aggregator_unit.js
@@ -1,0 +1,593 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('./coretest');
+coretest.setup();
+
+const _ = require('lodash');
+const util = require('util');
+const mocha = require('mocha');
+const assert = require('assert');
+// const mongodb = require('mongodb');
+
+const P = require('../../util/promise');
+const config = require('../../../config.js');
+const MDStore = require('../../server/object_services/md_store').MDStore;
+const md_aggregator = require('../../server/bg_services/md_aggregator.js');
+
+mocha.describe('md_aggregator', function() {
+
+    const md_store = new MDStore(`_test_md_store_${Date.now().toString(36)}`);
+    const system_id = md_store.make_md_id();
+
+    mocha.describe('calculations', function() {
+
+        mocha.it('should update each pool right', function() {
+            const pools = [
+                { _id: 123 },
+                { _id: 234 },
+            ];
+            const existing_blocks_aggregate = {
+                pools: {
+                    123: { _id: '123', size: 50000 },
+                    234: { _id: '234', size: 41000 }
+                }
+            };
+            const deleted_blocks_aggregate = {
+                pools: {
+                    123: { _id: '123', size: 45000 },
+                    234: { _id: '234', size: 18000 }
+                }
+            };
+            _.each(pools, pool => {
+                const pool_update = md_aggregator.calculate_new_pool({
+                    pool,
+                    existing_blocks_aggregate,
+                    deleted_blocks_aggregate,
+                });
+                assert(pool_update.blocks_size === (existing_blocks_aggregate.pools[pool._id].size - deleted_blocks_aggregate.pools[pool._id].size));
+            });
+        });
+
+        mocha.it('should calculate pool delta', function() {
+            const existing_blocks_aggregate = {
+                buckets: {
+                    123: {
+                        pools: {
+                            890: { size: 150000 },
+                            789: { size: 18112 }
+                        }
+                    },
+                    234: {
+                        pools: {
+                            678: { size: 151007 },
+                            567: { size: 12321 }
+                        }
+                    }
+                }
+            };
+            const deleted_blocks_aggregate = {
+                buckets: {
+                    123: {
+                        pools: {
+                            890: { size: 500 },
+                            789: { size: 8112 },
+                            150: { size: 112 }
+                        }
+                    },
+                    234: {
+                        pools: {
+                            678: { size: 7 },
+                            567: { size: 0 }
+                        }
+                    }
+                }
+            };
+            // console.log(pool_deltas);
+            const bucket_update = md_aggregator.calculate_new_bucket({
+                bucket: { _id: 123 },
+                existing_chunks_aggregate: { 123: null, 234: null },
+                deleted_chunks_aggregate: { 123: null, 234: null },
+                existing_objects_aggregate: { 123: null, 234: null },
+                deleted_objects_aggregate: { 123: null, 234: null },
+                existing_blocks_aggregate: _.cloneDeep(existing_blocks_aggregate),
+                deleted_blocks_aggregate: _.cloneDeep(deleted_blocks_aggregate),
+            });
+            _.each(bucket_update.pools, function(pool, id) {
+                const added_block_size = (existing_blocks_aggregate.buckets[123].pools[id] && existing_blocks_aggregate.buckets[123].pools[id].size) || 0;
+                const deleted_block_size = (deleted_blocks_aggregate.buckets[123].pools[id] && deleted_blocks_aggregate.buckets[123].pools[id].size) || 0;
+                assert(pool.blocks_size === (added_block_size - deleted_block_size));
+            });
+        });
+
+        mocha.it('should update storage stats', function() {
+            const storage_stats = {
+                chunks_capacity: 10000,
+                blocks_size: 30000,
+                objects_size: 8000,
+                objects_count: 400,
+                pools: {
+                    '890': { blocks_size: 10000 },
+                    '789': { blocks_size: 10000 },
+                    '900': { blocks_size: 10000 },
+                    '901': undefined
+                }
+            };
+            const added_chunk = {
+                '123': { compress_size: 2000 }
+            };
+            const deleted_chunk = {
+                '123': { compress_size: 3000 }
+            };
+            const added_block = {
+                buckets: {
+                    '123': {
+                        size: 1800,
+                        pools: {
+                            '890': { size: 500 },
+                            '789': { size: 600 },
+                            '902': { size: 700 }
+                        }
+                    }
+                }
+            };
+            const deleted_block = {
+                buckets: {
+                    '123': {
+                        size: 2400,
+                        pools: {
+                            '890': { size: 500 },
+                            '789': { size: 1200 },
+                            '902': { size: 700 }
+                        }
+                    }
+                }
+            };
+            const added_object = {
+                '123': {
+                    count: 20,
+                    size: 400
+                }
+            };
+            const deleted_object = {
+                '123': {
+                    count: 50,
+                    size: 500
+                }
+            };
+
+            const expected_storage_stats = {
+                chunks_capacity: storage_stats.chunks_capacity + added_chunk['123'].compress_size - deleted_chunk['123'].compress_size,
+                blocks_size: storage_stats.blocks_size + added_block.buckets['123'].size - deleted_block.buckets['123'].size,
+                objects_size: storage_stats.objects_size + added_object['123'].size - deleted_object['123'].size,
+                objects_count: storage_stats.objects_count + added_object['123'].count - deleted_object['123'].count,
+                pools: {
+                    '890': {
+                        blocks_size: storage_stats.pools['890'].blocks_size +
+                            added_block.buckets['123'].pools['890'].size - deleted_block.buckets['123'].pools['890'].size
+                    },
+                    '789': {
+                        blocks_size: storage_stats.pools['789'].blocks_size +
+                            added_block.buckets['123'].pools['789'].size - deleted_block.buckets['123'].pools['789'].size
+                    },
+                    '900': {
+                        blocks_size: storage_stats.pools['900'].blocks_size
+                    },
+                },
+                objects_hist: []
+            };
+
+            const new_storage_stats = md_aggregator.calculate_new_bucket({
+                bucket: { _id: 123, storage_stats: storage_stats },
+                existing_chunks_aggregate: added_chunk,
+                deleted_chunks_aggregate: deleted_chunk,
+                existing_objects_aggregate: added_object,
+                deleted_objects_aggregate: deleted_object,
+                existing_blocks_aggregate: added_block,
+                deleted_blocks_aggregate: deleted_block,
+            });
+            // console.log(new_storage_stats);
+            assert.deepStrictEqual(new_storage_stats, expected_storage_stats);
+        });
+
+    });
+
+    mocha.describe('aggregation', function() {
+
+        const CYCLE = config.MD_AGGREGATOR_INTERVAL;
+        const ID_RESOLUTION = 3000;
+
+        function sub_cycle() {
+            const x = Math.random() * CYCLE;
+            return (CYCLE - x < ID_RESOLUTION) ? CYCLE - ID_RESOLUTION : x;
+        }
+
+        mocha.it('should aggregate basic', function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(30000);
+            const last_update = Date.now();
+            const target_now = last_update + CYCLE;
+            const system_store = make_test_system_store(last_update);
+            const block_id1 = md_store.make_md_id_from_time(last_update + sub_cycle());
+            console.log('block 1 addtion date', block_id1.getTimestamp().getTime());
+
+            return P.resolve()
+                .then(() => md_store.insert_blocks([{
+                    _id: block_id1,
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    pool: system_store.data.pools[0]._id,
+                    node: md_store.make_md_id(),
+                    chunk: md_store.make_md_id(),
+                    size: 12,
+                    frag: 0,
+                    layer_n: 0,
+                    layer: 'D',
+                    digest_type: '',
+                    digest_b64: '',
+                }]))
+                .then(() => md_store.insert_chunks([{
+                    _id: md_store.make_md_id_from_time(last_update + sub_cycle()),
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    size: 12,
+                    digest_type: '',
+                    digest_b64: '',
+                    cipher_type: '',
+                    cipher_key_b64: '',
+                    data_frags: 1,
+                    lrc_frags: 0,
+                }]))
+                .then(() => md_store.insert_object({
+                    _id: md_store.make_md_id_from_time(last_update + sub_cycle()),
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    key: '',
+                    content_type: '',
+                }))
+                .then(() => md_aggregator.run_md_aggregator(md_store, system_store, target_now, 0))
+                .then(() => {
+                    assert.strictEqual(system_store.changes_list.length, 1);
+                    const changes = system_store.changes_list[0];
+                    assert.strictEqual(changes.update.buckets.length, system_store.data.buckets.length);
+                    assert.strictEqual(changes.update.pools.length, system_store.data.pools.length);
+                    assert.strictEqual(changes.update.buckets[0].storage_stats.blocks_size, 12);
+                    assert.strictEqual(changes.update.pools[0].storage_stats.blocks_size, 12);
+                    changes.update.buckets.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + CYCLE);
+                    });
+                    changes.update.pools.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + CYCLE);
+                    });
+                });
+        });
+
+        mocha.it('should aggregate deletions', function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(30000);
+            const last_update = Date.now();
+            const target_now = last_update + (2 * CYCLE);
+            const system_store = make_test_system_store(last_update);
+            const block_id1 = md_store.make_md_id_from_time(last_update + sub_cycle());
+            const block_id2 = md_store.make_md_id_from_time(last_update + sub_cycle());
+            const bucket = system_store.data.buckets[0];
+            const pool = system_store.data.pools[0];
+            console.log('block 1 addtion date', block_id1.getTimestamp().getTime());
+            console.log('block 2 addtion date', block_id2.getTimestamp().getTime());
+
+            return P.resolve()
+                .then(() => md_store.insert_blocks([
+                    make_block(block_id1, 120, bucket, pool),
+                    make_block(block_id2, 350, bucket, pool),
+                ]))
+                .then(() => md_store.insert_chunks([{
+                    _id: md_store.make_md_id_from_time(last_update + sub_cycle()),
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    size: 230,
+                    digest_type: '',
+                    digest_b64: '',
+                    cipher_type: '',
+                    cipher_key_b64: '',
+                    data_frags: 1,
+                    lrc_frags: 0,
+                }]))
+                .then(() => md_store.insert_object({
+                    _id: md_store.make_md_id_from_time(last_update + sub_cycle()),
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    key: '',
+                    content_type: '',
+                }))
+                .then(() => md_store.update_blocks_by_ids([block_id2], {
+                    deleted: new Date(last_update + CYCLE + sub_cycle())
+                }))
+                .then(() => md_aggregator.run_md_aggregator(md_store, system_store, target_now, 0))
+                .then(() => {
+                    assert.strictEqual(system_store.changes_list.length, 2);
+                    const changes0 = system_store.changes_list[0];
+                    assert.strictEqual(changes0.update.buckets.length, system_store.data.buckets.length);
+                    assert.strictEqual(changes0.update.pools.length, system_store.data.pools.length);
+                    assert.strictEqual(changes0.update.buckets[0].storage_stats.blocks_size, 470);
+                    assert.strictEqual(changes0.update.pools[0].storage_stats.blocks_size, 470);
+                    changes0.update.buckets.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + CYCLE);
+                    });
+                    changes0.update.pools.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + CYCLE);
+                    });
+                    const changes1 = system_store.changes_list[1];
+                    assert.strictEqual(changes1.update.buckets[0].storage_stats.blocks_size, 120);
+                    assert.strictEqual(changes1.update.pools[0].storage_stats.blocks_size, 120);
+                    changes1.update.buckets.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + (2 * CYCLE));
+                    });
+                    changes1.update.pools.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + (2 * CYCLE));
+                    });
+                });
+        });
+
+        mocha.it('should aggregate petabytes', function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(30000);
+            const last_update = Date.now();
+            const target_now = last_update + (2 * CYCLE);
+            const system_store = make_test_system_store(last_update);
+            const bucket = system_store.data.buckets[0];
+            const pool = system_store.data.pools[0];
+            const blocks_to_delete = [];
+
+            return P.resolve()
+                .then(() => {
+                    const blocks = [];
+                    for (let i = 0; i < 1024; ++i) { // 1 PB
+                        const block_id = md_store.make_md_id_from_time(last_update + sub_cycle());
+                        blocks.push(make_block(block_id, 1024 * 1024 * 1024 * 1024, bucket, pool));
+                        if (i % 2) blocks_to_delete.push(block_id);
+                    }
+                    return md_store.insert_blocks(blocks);
+                })
+                .then(() => md_store.insert_chunks([{
+                    _id: md_store.make_md_id_from_time(last_update + sub_cycle()),
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    size: 300000,
+                    digest_type: '',
+                    digest_b64: '',
+                    cipher_type: '',
+                    cipher_key_b64: '',
+                    data_frags: 1,
+                    lrc_frags: 0,
+                }]))
+                .then(() => md_store.insert_object({
+                    _id: md_store.make_md_id_from_time(last_update + sub_cycle()),
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    key: '',
+                    content_type: '',
+                }))
+                .then(() => md_store.update_blocks_by_ids(blocks_to_delete, {
+                    deleted: new Date(last_update + CYCLE + sub_cycle())
+                }))
+                .then(() => md_aggregator.run_md_aggregator(md_store, system_store, target_now, 0))
+                .then(() => {
+                    assert.strictEqual(system_store.changes_list.length, 2);
+                    const changes0 = system_store.changes_list[0];
+                    assert.strictEqual(changes0.update.buckets.length, system_store.data.buckets.length);
+                    assert.strictEqual(changes0.update.pools.length, system_store.data.pools.length);
+                    assert.deepEqual(changes0.update.buckets[0].storage_stats.blocks_size, { n: 0, peta: 1 });
+                    assert.deepEqual(changes0.update.pools[0].storage_stats.blocks_size, { n: 0, peta: 1 });
+                    changes0.update.buckets.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + CYCLE);
+                    });
+                    changes0.update.pools.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + CYCLE);
+                    });
+                    const changes1 = system_store.changes_list[1];
+                    assert.deepEqual(changes1.update.buckets[0].storage_stats.blocks_size, Math.pow(2, 49));
+                    assert.deepEqual(changes1.update.pools[0].storage_stats.blocks_size, Math.pow(2, 49));
+                    changes1.update.buckets.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + (2 * CYCLE));
+                    });
+                    changes1.update.pools.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, last_update + (2 * CYCLE));
+                    });
+                });
+        });
+
+
+        mocha.it('should aggregate multiple ranges', function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(30000);
+            const last_update = Date.now();
+            const system_store = make_test_system_store(last_update);
+            const num_ranges = system_store.data.buckets.length;
+            const range = CYCLE / 2;
+            const target_now = last_update + (num_ranges * range);
+
+            return P.resolve()
+                .then(() => {
+                    return md_store.insert_blocks(_.times(num_ranges, i => {
+                        const current_cycle = last_update + (i * range);
+                        const bucket = system_store.data.buckets[i];
+                        const pool = system_store.data.pools[i];
+                        bucket.storage_stats.last_update = current_cycle;
+                        pool.storage_stats.last_update = current_cycle;
+                        const block_id = md_store.make_md_id_from_time(current_cycle + (sub_cycle() / 2));
+                        return make_block(block_id, 666, bucket, pool);
+                    }));
+                })
+                .then(() => md_store.insert_chunks([{
+                    _id: md_store.make_md_id_from_time(last_update + sub_cycle()),
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    size: 300000,
+                    digest_type: '',
+                    digest_b64: '',
+                    cipher_type: '',
+                    cipher_key_b64: '',
+                    data_frags: 1,
+                    lrc_frags: 0,
+                }]))
+                .then(() => md_store.insert_object({
+                    _id: md_store.make_md_id_from_time(last_update + sub_cycle()),
+                    system: system_id,
+                    bucket: system_store.data.buckets[0]._id,
+                    key: '',
+                    content_type: '',
+                }))
+                .then(() => md_aggregator.run_md_aggregator(md_store, system_store, target_now, 0))
+                .then(() => {
+                    assert.strictEqual(system_store.changes_list.length, num_ranges);
+                    system_store.changes_list.forEach((changes, i) => {
+                        assert.strictEqual(changes.update.buckets.length, i + 1);
+                        assert.strictEqual(changes.update.pools.length, i + 1);
+                        assert.strictEqual(changes.update.buckets[0].storage_stats.blocks_size, 666);
+                        assert.strictEqual(changes.update.pools[0].storage_stats.blocks_size, 666);
+                        changes.update.buckets.forEach(item => {
+                            assert.strictEqual(item.storage_stats.last_update, last_update + ((i + 1) * range));
+                        });
+                        changes.update.pools.forEach(item => {
+                            assert.strictEqual(item.storage_stats.last_update, last_update + ((i + 1) * range));
+                        });
+                    });
+                });
+        });
+
+        mocha.it('should reset to epoch', function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(30000);
+            const last_update = Date.now();
+            const target_now = last_update - 1;
+            const system_store = make_test_system_store(last_update);
+
+            return P.resolve()
+                .then(() => md_aggregator.run_md_aggregator(md_store, system_store, target_now, 0))
+                .then(() => {
+                    assert.strictEqual(system_store.changes_list.length, 1);
+                    const changes0 = system_store.changes_list[0];
+                    assert.strictEqual(changes0.update.buckets.length, system_store.data.buckets.length);
+                    assert.strictEqual(changes0.update.pools.length, system_store.data.pools.length);
+                    changes0.update.buckets.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, config.NOOBAA_EPOCH);
+                        assert.strictEqual(item.storage_stats.blocks_size, 0);
+                        assert.strictEqual(item.storage_stats.chunks_capacity, 0);
+                        assert.strictEqual(item.storage_stats.objects_size, 0);
+                        assert.strictEqual(item.storage_stats.objects_count, 0);
+                    });
+                    changes0.update.pools.forEach(item => {
+                        assert.strictEqual(item.storage_stats.last_update, config.NOOBAA_EPOCH);
+                        assert.strictEqual(item.storage_stats.blocks_size, 0);
+                    });
+                });
+        });
+
+        mocha.it('should split cycles from epoch', function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(300000);
+            const num_splits = 13;
+            const last_update = Date.now();
+            const target_now = last_update + (num_splits * CYCLE);
+            const system_store = make_test_system_store(last_update);
+            system_store.debug = false;
+
+            return P.resolve()
+                .then(() => md_aggregator.run_md_aggregator(md_store, system_store, target_now, 0))
+                .then(() => {
+                    assert.strictEqual(system_store.changes_list.length, num_splits);
+                    system_store.changes_list.forEach((changes, i) => {
+                        assert.strictEqual(changes.update.buckets.length, system_store.data.buckets.length);
+                        assert.strictEqual(changes.update.pools.length, system_store.data.pools.length);
+                    });
+                });
+        });
+
+    });
+
+
+    function make_test_system_store(last_update) {
+
+        const buckets = _.times(10, i => ({
+            _id: md_store.make_md_id(),
+            name: `bucket${i}`,
+            storage_stats: {
+                last_update,
+                chunks_capacity: 0,
+                blocks_size: 0,
+                pools: {},
+                objects_size: 0,
+                objects_count: 0,
+                objects_hist: [],
+            },
+        }));
+
+        const pools = _.times(10, i => ({
+            _id: md_store.make_md_id(),
+            name: `pool${i}`,
+            storage_stats: {
+                last_update,
+                blocks_size: 0,
+            }
+        }));
+
+        const system_store = {
+            is_finished_initial_load: true,
+            data: {
+                buckets,
+                pools,
+            },
+            changes_list: [],
+            debug: true,
+            find_bucket_by_id(id) {
+                return _.find(this.data.buckets, bucket => String(bucket._id) === String(id));
+            },
+            find_pool_by_id(id) {
+                return _.find(this.data.pools, pool => String(pool._id) === String(id));
+            },
+            make_changes(changes) {
+                this.changes_list.push(changes);
+                if (this.debug) {
+                    console.log('system store changes #',
+                        this.changes_list.length,
+                        util.inspect(changes, true, null, true)
+                    );
+                }
+                changes.update.buckets.forEach(updates => {
+                    const bucket = this.find_bucket_by_id(updates._id);
+                    _.forEach(updates, (val, key) => {
+                        if (key !== '_id') _.set(bucket, key, val);
+                    });
+                });
+                changes.update.pools.forEach(updates => {
+                    const pool = this.find_pool_by_id(updates._id);
+                    _.forEach(updates, (val, key) => {
+                        if (key !== '_id') _.set(pool, key, val);
+                    });
+                });
+                return P.resolve();
+            },
+        };
+
+        return system_store;
+    }
+
+
+    function make_block(block_id, size, bucket, pool) {
+        return {
+            _id: block_id,
+            system: system_id,
+            bucket: bucket._id,
+            pool: pool._id,
+            node: md_store.make_md_id(),
+            chunk: md_store.make_md_id(),
+            size,
+            frag: 0,
+            layer_n: 0,
+            layer: 'D',
+            digest_type: '',
+            digest_b64: '',
+        };
+    }
+});

--- a/src/test/unit_tests/test_md_store.js
+++ b/src/test/unit_tests/test_md_store.js
@@ -111,15 +111,15 @@ mocha.describe('md_store', function() {
         });
 
         mocha.it('aggregate_objects_by_create_dates()', function() {
-            const till_date = new Date();
-            const from_date = new Date(till_date.getTime() - (24 * 3600 * 1000));
-            return md_store.aggregate_objects_by_create_dates(from_date, till_date);
+            const till_time = Date.now();
+            const from_time = till_time.getTime() - (24 * 3600 * 1000);
+            return md_store.aggregate_objects_by_create_dates(from_time, till_time);
         });
 
         mocha.it('aggregate_objects_by_delete_dates()', function() {
-            const till_date = new Date();
-            const from_date = new Date(till_date.getTime() - (24 * 3600 * 1000));
-            return md_store.aggregate_objects_by_delete_dates(from_date, till_date);
+            const till_time = Date.now();
+            const from_time = till_time.getTime() - (24 * 3600 * 1000);
+            return md_store.aggregate_objects_by_delete_dates(from_time, till_time);
         });
 
     });

--- a/src/util/js_utils.js
+++ b/src/util/js_utils.js
@@ -93,12 +93,25 @@ function append_buffer_or_array(buffer_or_array, item) {
 
 
 function deep_freeze(obj) {
+
+    // Checking isFrozen is the break condition for the recursion
+    // Since isFrozen(non_object)===false it will break if it is number,string,etc,..
+    // But note that any shallow frozen object will not get recursive freeze by this
+    if (Object.isFrozen(obj)) return obj;
+
+    // Cannot freeze buffers - TypeError: Cannot freeze array buffer views with elements
+    if (Buffer.isBuffer(obj)) return obj;
+
     Object.freeze(obj);
-    _.each(obj, val => {
-        if (typeof(val) === 'object' && val !== null && !Object.isFrozen(val)) {
-            deep_freeze(val);
-        }
-    });
+
+    // Freeze all properties
+    const keys = Object.keys(obj);
+    for (var i = 0; i < keys.length; ++i) {
+        const k = keys[i];
+        const v = obj[k];
+        deep_freeze(v);
+    }
+
     return obj;
 }
 


### PR DESCRIPTION
### Explain the changes:
- md_aggregator: fix loop - timing based instead of groups - both pools and buckets
- md_aggregator: reset all buckets and pools on time skew
- md_aggregator: added test - test of large range splits
- pool_server: fixing storage_stats of new pool
- nodes_monitor: fixing a small issue discovered in retrust

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet
