### PR TITLE
Bug Fixes

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -188,6 +188,34 @@ module.exports = {
                                         type: 'integer'
                                     }
                                 }
+                            },
+                            cluster: {
+                                type: 'object',
+                                properties: {
+                                    members: {
+                                        type: 'integer'
+                                    }
+                                }
+                            },
+                            configuration: {
+                                type: 'object',
+                                properties: {
+                                    dns_servers: {
+                                        type: 'integer'
+                                    },
+                                    dns_search: {
+                                        type: 'integer'
+                                    },
+                                    ntp_server: {
+                                        type: 'boolean'
+                                    },
+                                    proxy: {
+                                        type: 'boolean'
+                                    },
+                                    remote_syslog: {
+                                        type: 'boolean'
+                                    },
+                                }
                             }
                         }
                     }

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -180,6 +180,10 @@ RPC.prototype._request = function(api, method_api, params, options) {
                 'srv', req.srv,
                 'reqid', req.reqid);
 
+            if (this._request_logger) {
+                this._request_logger('RPC REQUEST SEND', req.srv, params); //NBNB
+            }
+
             // send request over the connection
             return req.connection.send(req._encode_request(), 'req', req);
 
@@ -200,7 +204,7 @@ RPC.prototype._request = function(api, method_api, params, options) {
             }
 
             if (this._request_logger) {
-                this._request_logger('RPC REQUEST', req.srv, params, '==>', reply);
+                this._request_logger('RPC REQUEST REPLY', req.srv, '==>', reply);
             }
 
             // if failed without getting a response (connect/send) we fill times for printing
@@ -227,6 +231,10 @@ RPC.prototype._request = function(api, method_api, params, options) {
             // if failed without getting a response (connect/send) we fill times for printing
             if (!req.took_srv) req._set_times(0);
 
+             if (this._request_logger) {
+                this._request_logger('RPC REQUEST CATCH', req.srv, '==>', err);
+            }
+
             dbg.error(`RPC._request: response ERROR srv ${
                 req.srv
             } params ${
@@ -244,10 +252,9 @@ RPC.prototype._request = function(api, method_api, params, options) {
             throw err;
 
         })
-        .finally(() => {
+        .finally(() =>
             // dbg.log0('RPC', req.srv, 'took', time_utils.millitook(millistamp));
-            return this._release_connection(req);
-        });
+             this._release_connection(req));
 
     if (options.timeout) {
         request_promise.timeout(options.timeout, 'RPC REQUEST TIMEOUT');

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -183,7 +183,7 @@ RPC.prototype._request = function(api, method_api, params, options) {
                 'reqid', req.reqid);
 
             if (this._request_logger) {
-                this._request_logger('RPC REQUEST SEND', req.srv, params); //NBNB
+                this._request_logger('RPC REQUEST SEND', req.srv, params);
             }
 
             // send request over the connection
@@ -227,6 +227,9 @@ RPC.prototype._request = function(api, method_api, params, options) {
             // return_rpc_req mode allows callers to get back the request
             // instead of a bare reply, and the reply is in req.reply
             this._update_flight_avg(req.took_flight);
+            if (this._stats_handler) {
+                this._stats_handler(this._aggregated_flight_time / this._served_requests);
+            }
             return options.return_rpc_req ? req : reply;
         })
         .catch(err => {
@@ -234,7 +237,7 @@ RPC.prototype._request = function(api, method_api, params, options) {
             // if failed without getting a response (connect/send) we fill times for printing
             if (!req.took_srv) req._set_times(0);
 
-             if (this._request_logger) {
+            if (this._request_logger) {
                 this._request_logger('RPC REQUEST CATCH', req.srv, '==>', err);
             }
 
@@ -257,7 +260,7 @@ RPC.prototype._request = function(api, method_api, params, options) {
         })
         .finally(() =>
             // dbg.log0('RPC', req.srv, 'took', time_utils.millitook(millistamp));
-             this._release_connection(req));
+            this._release_connection(req));
 
     if (options.timeout) {
         request_promise.timeout(options.timeout, 'RPC REQUEST TIMEOUT');
@@ -913,13 +916,8 @@ RPC.prototype.set_request_logger = function(request_logger) {
 /**
  * Statistics & Performance metrics
  */
-RPC.prototype.rpc_perf_stats = function() {
-    console.log('NBNB:: ', this._aggregated_flight_time, this._served_requests);
-    if (this._served_requests) {
-        return this._aggregated_flight_time / this._served_requests;
-    } else {
-        return 1;
-    }
+RPC.prototype.set_stats_handler = function(stats_handler) {
+    this._stats_handler = stats_handler;
 };
 
 

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -61,7 +61,7 @@ const SINGLE_SYS_DEFAULTS = {
     },
     configuration: {
         dns_servers: 0,
-        dns_search: false,
+        dns_search: 0,
         ntp_server: false,
         proxy: false,
         remote_syslog: false
@@ -702,10 +702,14 @@ function _handle_payload(payload) {
 
 function background_worker() {
     let statistics;
+
+    if (!system_store.is_finished_initial_load) return P.resolve();
+    let system = system_store.data.systems[0];
+    if (!system) return P.resolve();
+
     dbg.log('Central Statistics gathering started');
     //Run the system statistics gatheting
     return P.fcall(() => {
-            let system = system_store.data.systems[0];
             let support_account = _.find(system_store.data.accounts, account => account.is_support);
             return server_rpc.client.stats.get_all_stats({}, {
                 auth_token: auth_server.make_auth_token({

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -59,6 +59,16 @@ const SINGLE_SYS_DEFAULTS = {
         on: 0,
         off: 0,
     },
+    configuration: {
+        dns_servers: 0,
+        dns_search: false,
+        ntp_server: false,
+        proxy: false,
+        remote_syslog: false
+    },
+    cluster: {
+        members: 0
+    }
 };
 
 //Collect systems related stats and usage
@@ -93,6 +103,16 @@ function get_systems_stats(req) {
                             off: res.nodes.count - res.nodes.online,
                         },
                         owner: res.owner.email,
+                        configuration: {
+                            dns_servers: res.cluster.shards[0].servers[0].dns_servers.length,
+                            dns_search: res.cluster.shards[0].servers[0].search_domains.length,
+                            ntp_server: !_.isEmpty(res.cluster.shards[0].servers[0].ntp_server),
+                            proxy: !_.isEmpty(res.phone_home_config.proxy_address),
+                            remote_syslog: !_.isEmpty(res.remote_syslog_config),
+                        },
+                        cluster: {
+                            members: res.cluster.shards[0].servers.length
+                        }
                     }, SINGLE_SYS_DEFAULTS);
                 });
             // TODO: Need to handle it differently


### PR DESCRIPTION
### Explain the changes:
- Fix RPC prints if logger supplied (split between send, receive and err) 
- Add stats CB handler for RPC, if supplied rolling average will be reported back
- Add platform stats for phonehome payload (NTP, DNS config etc.)
- Fix for 3589 - Add cancel btn to DNS settings
- Fix for 3574 - Show current config of DNS/NTP in the linux config

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixes #3589 
- fixes #3574 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

