### PR TITLE
deploy: build_agent_linux fix to avoid node-gyp rebuild failure

### DIFF
--- a/src/deploy/Linux/build_agent_linux.sh
+++ b/src/deploy/Linux/build_agent_linux.sh
@@ -74,31 +74,17 @@ if [ "$CLEAN" = true ] ; then
     #TODO: create new package for that matter
     cd package
     sed -i '/gulp/d' package.json
-    sed -i '/babel/d' package.json
-    sed -i '/eslint/d' package.json
-    sed -i '/mongoose/d' package.json
-    sed -i '/googleapis/d' package.json
-    sed -i '/bower/d' package.json
-    sed -i '/bootstrap/d' package.json
-    sed -i '/browserify"/d' package.json
-    sed -i '/rebuild/d' package.json
-    sed -i '/nodetime/d' package.json
-    sed -i '/newrelic/d' package.json
+    sed -i '/mocha/d' package.json
     sed -i '/istanbul/d' package.json
-    sed -i '/npm-run-all/d' package.json
-    sed -i '/selectize/d' package.json
-    sed -i '/jsonwebtoken/d' package.json
-    sed -i '/googleapis/d' package.json
+    sed -i '/eslint/d' package.json
     sed -i '/vsphere/d' package.json
-    echo "npm install node-gyp"
-    npm install -g node-gyp
-    npm install nan
+
     echo "npm install node-linux@0.1.8"
     npm install node-linux@0.1.8
-    echo "rebuild"
-    node-gyp rebuild
     echo "npm install"
     npm install --production
+
+    echo "make self extracting package"
     cd ..
     wget https://raw.githubusercontent.com/megastep/makeself/master/makeself-header.sh
     wget https://raw.githubusercontent.com/megastep/makeself/master/makeself.sh

--- a/src/deploy/Linux/build_s3rest_linux.sh
+++ b/src/deploy/Linux/build_s3rest_linux.sh
@@ -65,33 +65,20 @@ else
         cp -R ../../src/api ./package/src/
         cp -R ../../src/native ./package/src/
         cp -R ../../binding.gyp ./package/
-        cd ./package
-        npm install -g node-gyp
-        npm install nan
 
-        node-gyp rebuild
         #remove irrelevant packages
         #TODO: create new package for that matter
-        echo "npm install"
+        cd package
         sed -i '/gulp/d' package.json
-        sed -i '/babel/d' package.json
-        sed -i '/eslint/d' package.json
-        sed -i '/mongoose/d' package.json
-        sed -i '/googleapis/d' package.json
-        sed -i '/bower/d' package.json
-        sed -i '/bootstrap/d' package.json
-        sed -i '/browserify"/d' package.json
-        sed -i '/rebuild/d' package.json
-        sed -i '/nodetime/d' package.json
-        sed -i '/newrelic/d' package.json
+        sed -i '/mocha/d' package.json
         sed -i '/istanbul/d' package.json
-        sed -i '/npm-run-all/d' package.json
-        sed -i '/selectize/d' package.json
-        sed -i '/jsonwebtoken/d' package.json
-        sed -i '/googleapis/d' package.json
+        sed -i '/eslint/d' package.json
         sed -i '/vsphere/d' package.json
-        npm install -dd --production
 
+        echo "npm install"
+        npm install --production
+
+        echo "make self extracting package"
         cd ..
         wget https://raw.githubusercontent.com/megastep/makeself/master/makeself-header.sh
         wget https://raw.githubusercontent.com/megastep/makeself/master/makeself.sh


### PR DESCRIPTION
### Explain the changes:
- sed -i /rebuild/ removed the build:native script from the package.json
- so I narrowed down the list of filtered packages like for windows.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- NA

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

