### PR TITLE
fixed get_master_secret when clustered

### DIFF
--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -255,7 +255,7 @@ function _get_master_secret(rs_status) {
     }
 
     if (rs_status && rs_status.members) {
-        const master_member = rs_status.find(member => member.stateStr === 'PRIMARY');
+        const master_member = rs_status.members.find(member => member.stateStr === 'PRIMARY');
         const master_address = master_member.name.substring(0, master_member.name.indexOf(':'));
         master_secret = (system_store.data.clusters.find(server => server.owner_address === master_address)).secret;
     }


### PR DESCRIPTION
### Explain the changes:
- was calling `find` on rs_status instead of rs_status.members


### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

