### PR TITLE
added ports check on iptables on linux agents

### DIFF
--- a/frontend/src/app/reducers/hosts-reducer.js
+++ b/frontend/src/app/reducers/hosts-reducer.js
@@ -180,7 +180,7 @@ function _generateQueryKey(query) {
 }
 
 function _mapDataToHost(host = {}, data, fetchTime) {
-    const { storage_nodes_info, s3_nodes_info, os_info, port_range, debug } = data;
+    const { storage_nodes_info, s3_nodes_info, os_info, ports, debug } = data;
     const { diagnostics = initialHostDiagnosticsState } = host;
 
     const activities = (storage_nodes_info.data_activities || [])
@@ -199,9 +199,9 @@ function _mapDataToHost(host = {}, data, fetchTime) {
         mode: data.mode,
         version: data.version,
         ip: data.ip,
-        ports: port_range && {
-            min: port_range.min || port_range.port,
-            max: port_range.max || port_range.port,
+        ports: ports && {
+            min: ports.range.min || ports.range.port,
+            max: ports.range.max || ports.range.port,
         },
         protocol: data.connectivity,
         endpoint: data.base_address,

--- a/frontend/src/app/utils/host-utils.js
+++ b/frontend/src/app/utils/host-utils.js
@@ -114,6 +114,11 @@ const modeToStateIcon = deepFreeze({
         css: 'warning',
         tooltip: 'Services has Issues'
     },
+    N2N_PORTS_BLOCKED: {
+        name: 'healthy',
+        css: 'success',
+        tooltip: 'Healthy'
+    },
     OPTIMAL: {
         name: 'healthy',
         css: 'success',

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -790,6 +790,14 @@ class Agent {
                 //     }
                 // });
             })
+            .then(() => {
+                const start_port = reply.n2n_config.tcp_permanent_passive.min || reply.n2n_config.tcp_permanent_passive.port;
+                const end_port = reply.n2n_config.tcp_permanent_passive.max || reply.n2n_config.tcp_permanent_passive.port;
+                return os_utils.is_port_range_open_in_firewall([ip], start_port, end_port)
+                    .then(ports_allowed => {
+                        reply.ports_allowed = ports_allowed;
+                    });
+            })
             .return(reply);
     }
 

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -63,6 +63,9 @@ module.exports = {
                     n2n_config: {
                         $ref: 'common_api#/definitions/n2n_config'
                     },
+                    ports_allowed: {
+                        type: 'boolean'
+                    },
                     enabled: {
                         type: 'boolean'
                     },

--- a/src/api/host_api.js
+++ b/src/api/host_api.js
@@ -343,8 +343,16 @@ module.exports = {
                 rpc_address: {
                     type: 'string'
                 },
-                port_range: {
-                    $ref: 'common_api#/definitions/port_range_config'
+                ports: {
+                    type: 'object',
+                    properties: {
+                        range: {
+                            $ref: 'common_api#/definitions/port_range_config'
+                        },
+                        allowed: {
+                            type: 'boolean'
+                        }
+                    }
                 },
                 suggested_pool: {
                     type: 'string'
@@ -439,6 +447,7 @@ module.exports = {
                 'IN_PROCESS',
                 'NO_CAPACITY',
                 'LOW_CAPACITY',
+                'N2N_PORTS_BLOCKED',
                 'INITIALIZING',
                 'OPTIMAL',
                 'SOME_STORAGE_OFFLINE',
@@ -477,6 +486,7 @@ module.exports = {
                 'IN_PROCESS',
                 'NO_CAPACITY',
                 'LOW_CAPACITY',
+                'N2N_PORTS_BLOCKED',
                 'INITIALIZING',
                 'OPTIMAL',
                 'SOME_STORAGE_OFFLINE',
@@ -581,6 +591,9 @@ module.exports = {
                     type: 'integer'
                 },
                 LOW_CAPACITY: {
+                    type: 'integer'
+                },
+                N2N_PORTS_BLOCKED: {
                     type: 'integer'
                 },
                 INITIALIZING: {

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -591,6 +591,7 @@ module.exports = {
                 'DECOMMISSIONING',
                 'MIGRATING',
                 'N2N_ERRORS',
+                'N2N_PORTS_BLOCKED',
                 'GATEWAY_ERRORS',
                 'IO_ERRORS',
                 'LOW_CAPACITY',
@@ -640,6 +641,9 @@ module.exports = {
                     type: 'integer'
                 },
                 N2N_ERRORS: {
+                    type: 'integer'
+                },
+                N2N_PORTS_BLOCKED: {
                     type: 'integer'
                 },
                 GATEWAY_ERRORS: {

--- a/src/server/node_services/node_schema.js
+++ b/src/server/node_services/node_schema.js
@@ -66,6 +66,10 @@ module.exports = {
             type: 'integer'
         },
 
+        ports_allowed: {
+            type: 'boolean',
+        },
+
         ip: {
             // the public ip of the node
             type: 'string',

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -454,6 +454,7 @@ function calc_hosts_pool_mode(pool_info, storage_by_mode) {
     const { count } = hosts;
     const offline = storage_by_mode.OFFLINE || 0;
     const optimal = storage_by_mode.OPTIMAL || 0;
+    const ports_blocked = storage_by_mode.N2N_PORTS_BLOCKED || 0;
     const offline_ratio = (offline / count) * 100;
     const { free, total, reserved, used_other } = _.assignWith({}, storage, (__, size) => size_utils.json_to_bigint(size));
     const potential_for_noobaa = total.subtract(reserved).subtract(used_other);
@@ -465,7 +466,7 @@ function calc_hosts_pool_mode(pool_info, storage_by_mode) {
     return (count === 0 && 'HAS_NO_NODES') ||
         (offline === count && 'ALL_NODES_OFFLINE') ||
         (count < 3 && 'NOT_ENOUGH_NODES') ||
-        (optimal < 3 && 'NOT_ENOUGH_HEALTHY_NODES') ||
+        (optimal + ports_blocked < 3 && 'NOT_ENOUGH_HEALTHY_NODES') ||
         (offline_ratio >= 30 && 'MANY_NODES_OFFLINE') ||
         (activity_ratio > 50 && 'HIGH_DATA_ACTIVITY') ||
         (free < NO_CAPAITY_LIMIT && 'NO_CAPACITY') ||


### PR DESCRIPTION
### Explain the changes:
- parse iptables output, and determine if n2n ports are blocked
- return ports blocked to nodes_monitor, and determine the storage and host modes by it
- treat the mode as optimal when calculating the pool's mode  

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Partial fix to #2583 - still need to implement for windows

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

