### PR TITLE
1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",


### PR DESCRIPTION
### Explain the changes:
- bump version for fixing build_windows_agent 
- no need for code change, instead I forced the jenkins windows slave to always build 64 bit by overriding the PATH for nvm.exe with a dummy nvm.exe that just returns - you will see these prints in the build log:
```
= DummyNVM ===================================================
=                                                            =
= This is dummy nvm to bypass building 32-bit on this server =
= We are simply ignoring your request - hope you understand  =
= Called with: [ install 6.11.2 32 ]
=                                                            =
==============================================================
```

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixed #3635

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

