### PR TITLE
for new buckets don't set last_read\last_write

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -55,8 +55,6 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, tag) {
         stats: {
             reads: 0,
             writes: 0,
-            last_read: now,
-            last_write: now,
         }
     };
 }


### PR DESCRIPTION
### Explain the changes:
- for new buckets don't set last_read\last_write
- in api returning undefined if no last_read\last_write

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

