### PR TITLE
call set_mongo_cluster_mode every time check_mongo_status is called

### DIFF
--- a/src/deploy/NVA_build/common_funcs.sh
+++ b/src/deploy/NVA_build/common_funcs.sh
@@ -34,6 +34,9 @@ function update_noobaa_net {
 }
 
 function check_mongo_status {
+    if [ $2 -eq '27000' ]; then
+      set_mongo_cluster_mode
+    fi
     # even if the supervisor reports the service is running try to connect to it
     local mongo_status
     # beware not to run "local" in the same line changes the exit code

--- a/src/deploy/NVA_build/mongo_wrapper.sh
+++ b/src/deploy/NVA_build/mongo_wrapper.sh
@@ -38,7 +38,7 @@ function kill_services_on_mongo_ports {
 #Testing mongo for sanity every 10 seconds
 #TODO: Maybe change the time?!
 function mongo_sanity_check {
-  while check_mongo_status $1
+  while check_mongo_status $1 ${MONGO_PORT}
   do
     echo 1 > ${BACKOFF_FILE}
     sleep 10


### PR DESCRIPTION
### Explain the changes:
- MONGO_SHELL is only set once when mongo_wrapper starts. in case new members are added it is outdated.
-  we want to update the MONGO_SHELL command also when other members were
added


### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

