### PR TITLE
propagate s3 server errors to node monitor and UI

### DIFF
--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -126,6 +126,17 @@ module.exports = {
                                     },
                                 }
                             },
+                            srv_error: {
+                                type: 'object',
+                                properties: {
+                                    code: {
+                                        type: 'string',
+                                    },
+                                    message: {
+                                        type: 'string',
+                                    }
+                                }
+                            }
                         }
                     },
                 }

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -673,6 +673,9 @@ module.exports = {
                 HAS_ISSUES: {
                     type: 'integer'
                 },
+                HTTP_SRV_ERRORS: {
+                    type: 'integer'
+                },
                 MEMORY_PRESSURE: {
                     type: 'integer'
                 },

--- a/src/server/node_services/node_schema.js
+++ b/src/server/node_services/node_schema.js
@@ -252,7 +252,17 @@ module.exports = {
                 }
             }
         },
-
+        srv_error: {
+            type: 'object',
+            properties: {
+                code: {
+                    type: 'string',
+                },
+                message: {
+                    type: 'string',
+                }
+            }
+        },
         endpoint_stats: {
             type: 'array',
             items: {

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1061,6 +1061,7 @@ class NodesMonitor extends EventEmitter {
                 updates.heartbeat = Date.now();
                 if (info.endpoint_info) {
                     updates.endpoint_stats = this._accumulate_endpoint_stats(item, info.endpoint_info.stats);
+                    updates.srv_error = info.endpoint_info.srv_error;
                 }
                 return P.resolve()
                     .then(() => {
@@ -1933,6 +1934,7 @@ class NodesMonitor extends EventEmitter {
             (item.node.deleting && 'DELETING') ||
             (item.node.deleted && 'DELETED') ||
             (item.storage_not_exist && 'STORAGE_NOT_EXIST') ||
+            ((item.node.node_type === 'ENDPOINT_S3' && item.node.srv_error) && 'HTTP_SRV_ERRORS') ||
             (item.auth_failed && 'AUTH_FAILED') ||
             (item.node.migrating_to_pool && 'MIGRATING') ||
             (item.n2n_errors && 'N2N_ERRORS') ||


### PR DESCRIPTION
### Explain the changes:
- when S3 server (that is forked from the agent) fails to start its http\https servers, it sends and error message to the agent process
- agent will send the error in get_agent_info
- s3 node mode will be HTTP_SRV_ERROR
- for now we don't distinguish by different errors, but the error code and message are store in DB, so we can change it later (return different modes for different errors)

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3524 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

