### PR TITLE
Danny 1.13

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -962,9 +962,40 @@ module.exports = {
                 system: 'admin'
             }
         },
+
+        update_bucket_read_counters: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['bucket'],
+                properties: {
+                    bucket: {
+                        type: 'string'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
+        update_bucket_write_counters: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['bucket'],
+                properties: {
+                    bucket: {
+                        type: 'string'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        }
+
     },
-
-
 
     definitions: {
 

--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -153,8 +153,8 @@ function configure_ips_dialog {
 }
 
 function configure_dns_dialog {
-    local cur_dns1=$(grep "#NooBaa Configured Primary DNS Server" /etc/resolv.conf | sed 's:nameserver.*\(.*\)#.*:\1:')
-    local cur_dns2=$(grep "#NooBaa Configured Secondary DNS Server" /etc/resolv.conf | sed 's:nameserver.*\(.*\)#.*:\1:')
+    local cur_dns1=$(grep "nameserver.*#NooBaa Configured Primary DNS Server" /etc/resolv.conf | sed 's:nameserver.*\(.*\)#.*:\1:')
+    local cur_dns2=$(grep "nameserver.*#NooBaa Configured Secondary DNS Server" /etc/resolv.conf | sed 's:nameserver.*\(.*\)#.*:\1:')
     dialog --colors --backtitle "NooBaa First Install" --title "DNS Configuration" --form "\nPlease supply a primary and secondary DNS servers (Use \Z4\ZbUp/Down\Zn to navigate)." 12 80 4 "Primary DNS:" 1 1 "${cur_dns1}" 1 25 25 30 "Secondary DNS:" 2 1 "${cur_dns2}" 2 25 25 30 2> answer_dns
 
     if test $? -eq 1 ; then #cancel pressed
@@ -205,7 +205,7 @@ function configure_networking_dialog {
     done
 }
 function configure_ntp_dialog {
-  local ntp_server=$(grep "NooBaa Configured" /etc/ntp.conf | sed 's:.*server \(.*\) iburst.*:\1:')
+  local ntp_server=$(grep "server.*NooBaa Configured" /etc/ntp.conf | sed 's:.*server \(.*\) iburst.*:\1:')
   local tz=$(ls -la /etc/localtime  | sed 's:.*/usr/share/zoneinfo/\(.*\):\1:')
   local tz_file=""
   local err_tz_msg=""

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -122,8 +122,9 @@ class NamespaceS3 {
             .promise()
             .then(res => {
                 dbg.log0('NamespaceS3.upload_object:', this.bucket, inspect(params), 'res', inspect(res));
+                const etag = s3_utils.parse_etag(res.ETag);
                 return {
-                    etag: res.ETag,
+                    etag,
                 };
             });
     }
@@ -163,8 +164,9 @@ class NamespaceS3 {
             .promise()
             .then(res => {
                 dbg.log0('NamespaceS3.upload_multipart:', this.bucket, inspect(params), 'res', inspect(res));
+                const etag = s3_utils.parse_etag(res.ETag);
                 return {
-                    etag: res.ETag,
+                    etag,
                 };
             });
     }
@@ -186,7 +188,7 @@ class NamespaceS3 {
                     multiparts: _.map(res.Parts, p => ({
                         num: p.PartNumber,
                         size: p.Size,
-                        etag: p.ETag,
+                        etag: s3_utils.parse_etag(p.ETag),
                         last_modified: p.LastModified,
                     }))
                 };
@@ -208,8 +210,9 @@ class NamespaceS3 {
             .promise()
             .then(res => {
                 dbg.log0('NamespaceS3.complete_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
+                const etag = s3_utils.parse_etag(res.ETag);
                 return {
-                    etag: res.ETag,
+                    etag,
                 };
             });
     }

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -201,7 +201,8 @@ class ObjectSDK {
 
     read_object_stream(params) {
         return this._get_bucket_namespace(params.bucket)
-            .then(ns => ns.read_object_stream(params, this));
+            .then(ns => ns.read_object_stream(params, this))
+            .then(this.rpc_client.object.update_bucket_read_counters({ bucket: params.bucket }));
     }
 
     ///////////////////
@@ -210,7 +211,8 @@ class ObjectSDK {
 
     upload_object(params) {
         return this._get_bucket_namespace(params.bucket)
-            .then(ns => ns.upload_object(params, this));
+            .then(ns => ns.upload_object(params, this))
+            .then(this.rpc_client.object.update_bucket_write_counters({ bucket: params.bucket }));
     }
 
     /////////////////////////////
@@ -234,7 +236,9 @@ class ObjectSDK {
 
     complete_object_upload(params) {
         return this._get_bucket_namespace(params.bucket)
-            .then(ns => ns.complete_object_upload(params, this));
+            .then(ns => ns.complete_object_upload(params, this))
+            .then(this.rpc_client.object.update_bucket_write_counters({ bucket: params.bucket }));
+
     }
 
     abort_object_upload(params) {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -150,8 +150,11 @@ function create_bucket(req) {
             throw new RpcError('INVALID_WRITE_RESOURCES');
         }
 
+        // reorder read resources so that the write resource is the first in the list
+        const ordered_read_resources = [write_resource].concat(read_resources.filter(resource => resource !== write_resource));
+
         bucket.namespace = {
-            read_resources,
+            ordered_read_resources,
             write_resource
         };
     }


### PR DESCRIPTION
### Explain the changes:
-  avoid sending double quotes in the response ETag when using S3 target in namespace
- fix #3678 - fixing default values for ntp and dns in first install dialog
- reorder read resources so that the write resource is the first in the list so it will be read first
- moved update of read\write counts to object_sdk instead of object server, so it will be counted also for namespace bucket


### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

