### PR TITLE
diagnostics fixes

### DIFF
--- a/src/server/utils/server_diagnostics.js
+++ b/src/server/utils/server_diagnostics.js
@@ -26,7 +26,7 @@ function collect_server_diagnostics(req) {
                 .then(() => diag_log('collected supervisor logs successfully'))
                 .catch(err => diag_log('collect_supervisor_logs failed with error: ' + err)),
 
-                () => promise_utils.exec('cp -f /var/log/noobaa_deploy* ' + TMP_WORK_DIR, {
+                () => promise_utils.exec('cp -fp /var/log/noobaa_deploy* ' + TMP_WORK_DIR, {
                     ignore_rc: false,
                     return_stdout: false,
                     timeout: LONG_EXEC_TIMEOUT
@@ -34,7 +34,7 @@ function collect_server_diagnostics(req) {
                 .then(() => diag_log('collected noobaa_deploy logs successfully'))
                 .catch(err => diag_log('collecting noobaa_deploy.log failed with error: ' + err)),
 
-                () => promise_utils.exec('cp -f /var/log/noobaa.log* ' + TMP_WORK_DIR, {
+                () => promise_utils.exec('cp -fp /var/log/noobaa.log* ' + TMP_WORK_DIR, {
                     ignore_rc: false,
                     return_stdout: false,
                     timeout: LONG_EXEC_TIMEOUT
@@ -42,7 +42,7 @@ function collect_server_diagnostics(req) {
                 .then(() => diag_log('collected noobaa.log files successfully'))
                 .catch(err => diag_log('collecting noobaa.log failed with error: ' + err)),
 
-                () => promise_utils.exec('cp -f /var/log/client_noobaa.log* ' + TMP_WORK_DIR, {
+                () => promise_utils.exec('cp -fp /var/log/client_noobaa.log* ' + TMP_WORK_DIR, {
                     ignore_rc: false,
                     return_stdout: false,
                     timeout: LONG_EXEC_TIMEOUT
@@ -50,7 +50,7 @@ function collect_server_diagnostics(req) {
                 .then(() => diag_log('collected client_noobaa.log files successfully'))
                 .catch(err => diag_log('collecting client_noobaa.log failed with error: ' + err)),
 
-                () => promise_utils.exec('cp -f ' + process.cwd() + '/.env ' + TMP_WORK_DIR + '/env', {
+                () => promise_utils.exec('cp -fp ' + process.cwd() + '/.env ' + TMP_WORK_DIR + '/env', {
                     ignore_rc: false,
                     return_stdout: false,
                     timeout: LONG_EXEC_TIMEOUT
@@ -62,8 +62,11 @@ function collect_server_diagnostics(req) {
                 .then(() => diag_log('collected top.out successfully'))
                 .catch(err => diag_log('collecting top.out failed with error: ' + err)),
 
+                () => os_utils.slabtop(TMP_WORK_DIR + '/slabtop.out')
+                .then(() => diag_log('collected slabtop.out successfully'))
+                .catch(err => diag_log('collecting slabtop.out failed with error: ' + err)),
 
-                () => promise_utils.exec('cp -f /etc/noobaa* ' + TMP_WORK_DIR, {
+                () => promise_utils.exec('cp -fp /etc/noobaa* ' + TMP_WORK_DIR, {
                     ignore_rc: false,
                     return_stdout: false,
                     timeout: LONG_EXEC_TIMEOUT
@@ -89,7 +92,7 @@ function collect_server_diagnostics(req) {
                 .then(() => diag_log('collected chkconfig.out successfully'))
                 .catch(err => diag_log('collecting chkconfig.out failed with error: ' + err)),
 
-                () => promise_utils.exec('cp -f /var/log/messages* ' + TMP_WORK_DIR, {
+                () => promise_utils.exec('cp -fp /var/log/messages* ' + TMP_WORK_DIR, {
                     ignore_rc: false,
                     return_stdout: false,
                     timeout: LONG_EXEC_TIMEOUT
@@ -117,7 +120,7 @@ function collect_server_diagnostics(req) {
                 .then(() => diag_log('collected df.out successfully'))
                 .catch(err => diag_log('collecting df.out failed with error: ' + err)),
 
-                () => promise_utils.exec('cp -f /tmp/noobaa_wizard.log ' + TMP_WORK_DIR + '/noobaa_wizard.log', {
+                () => promise_utils.exec('cp -fp /tmp/noobaa_wizard.log ' + TMP_WORK_DIR + '/noobaa_wizard.log', {
                     ignore_rc: false,
                     return_stdout: false,
                     timeout: LONG_EXEC_TIMEOUT

--- a/src/test/qa/cluster_test.js
+++ b/src/test/qa/cluster_test.js
@@ -213,19 +213,6 @@ function setNTPConfig(serverIndex) {
     rpc.disable_validation();
     console.log('Secret is ', servers[serverIndex].secret, 'for server ip ', servers[serverIndex].ip);
     return P.fcall(() => {
-<<<<<<< HEAD
-        let auth_params = {
-            email: 'demo@noobaa.com',
-            password: 'DeMo1',
-            system: 'demo'
-        };
-        return client.create_auth_token(auth_params);
-    })
-        .then(() => {
-            console.log('Setting ntp config');
-            return client.cluster_server.update_time_config({
-                target_secret: servers[serverIndex].secret,
-=======
             let auth_params = {
                 email: 'demo@noobaa.com',
                 password: 'DeMo1',
@@ -233,22 +220,10 @@ function setNTPConfig(serverIndex) {
             };
             return client.create_auth_token(auth_params);
         })
-        .then(() => client.system.read_system({}))
-        .then(result => {
-            secretVm = result.cluster.master_secret;
-            console.log('Secret is ', secretVm, 'for server ip ', serverIp);
-        })
-        .then(() => { // time configuration - ntp
-            console.log('Checking connection before setup ntp', configured_ntp);
-            return client.system.attempt_server_resolve({
-                server_name: configured_ntp
-            });
-        })
         .then(() => {
             console.log('Setting ntp config');
             return client.cluster_server.update_time_config({
-                target_secret: secretVm,
->>>>>>> a8d0d92fb...  This is a combination of 2 commits.
+                target_secret: servers[serverIndex].secret,
                 timezone: configured_timezone,
                 ntp_server: configured_ntp
             });

--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -191,7 +191,7 @@ function file_copy(src, dst) {
             src.replace(/\//g, '\\') + '" "' +
             dst.replace(/\//g, '\\') + '"';
     } else {
-        cmd = 'cp -f ' + src + ' ' + dst;
+        cmd = 'cp -fp ' + src + ' ' + dst;
     }
     console.log('file_copy:', cmd);
     return promise_utils.exec(cmd);

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -403,11 +403,18 @@ function top_single(dst) {
     if (os.type() === 'Darwin') {
         return promise_utils.exec('top -c -l 1' + file_redirect);
     } else if (os.type() === 'Linux') {
-        return promise_utils.exec('top -c -b -n 1' + file_redirect);
+        return promise_utils.exec('COLUMNS=512 top -c -b -n 1' + file_redirect);
     } else if (os.type() === 'Windows_NT') {
         return P.resolve();
     } else {
         throw new Error('top_single ' + os.type + ' not supported');
+    }
+}
+
+function slabtop(dst) {
+    const file_redirect = dst ? ' &> ' + dst : '';
+    if (os.type() === 'Linux') {
+        return promise_utils.exec('slabtop -o' + file_redirect);
     }
 }
 
@@ -1108,6 +1115,7 @@ exports.get_main_drive_name = get_main_drive_name;
 exports.get_mount_of_path = get_mount_of_path;
 exports.get_drive_of_path = get_drive_of_path;
 exports.top_single = top_single;
+exports.slabtop = slabtop;
 exports.netstat_single = netstat_single;
 exports.ss_single = ss_single;
 exports.set_manual_time = set_manual_time;


### PR DESCRIPTION
### Explain the changes:
- when copying log files for diagnostics it is more helpful to have the original time stamps of the log files.
- added `-p` flag to copy commands when taking diagnostics.
- fixed `top_single` in diagnostics to save full command to output file
- added `slabtop` in diagnostics

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

