### PR TITLE
Fixing 3687 - restart services after JWT is generated for the first time

### DIFF
--- a/src/deploy/NVA_build/fix_server_plat.sh
+++ b/src/deploy/NVA_build/fix_server_plat.sh
@@ -14,5 +14,8 @@ if [ ! -f ${NOOBAASEC} ]; then
       jwt=$(cat /etc/noobaa_sec | openssl sha512 -hmac | cut -c10-44)
       echo "JWT_SECRET=${jwt}"  >> /root/node_modules/noobaa-core/.env
   fi
+
+  #Reload services so they would read the newly created JWT
+  supervisorctl restart bg_workers hosted_agents s3rver webserver || true
 fi
 


### PR DESCRIPTION
### Explain the changes:
- restart services after JWT is generated for the first time

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3687 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

