### PR TITLE
Prevent upgrade 2.x -> 1.x

### DIFF
--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -63,9 +63,9 @@ function test_major_version_change(upgrade_file) {
             return_stdout: true
         })
         .then(ver => {
-            if (ver.charAt(1) === '2') {
-                dbg.error('Unsupported upgrade, 1.X to 2.X');
-                throw new Error('Unsupported upgrade path 1.X -> 2.X');
+            if (ver.charAt(1) === '1') {
+                dbg.error('Unsupported upgrade, 2.X to 1.X');
+                throw new Error('Unsupported upgrade path 2.X -> 1.X');
             }
         });
 }


### PR DESCRIPTION
### Explain the changes:
- Prevent upgrade 2.x -> 1.x



### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

