### PR TITLE
unlink current local time only if TZ was provided and is valid (#3722)

### DIFF
--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -221,11 +221,11 @@ function configure_ntp_dialog {
       err_ntp_msg="\Z1NTP Server must be set.\Zn"
     fi
 
-    sudo unlink /etc/localtime
     if [ -z ${tz} ]; then #TZ was not supplied
       err_tz=0
       err_tz_msg=""
     elif [ -f "/usr/share/zoneinfo/${tz}" ]; then
+      sudo unlink /etc/localtime
       err_tz=0
       err_tz_msg=""
       sudo ln -sf "/usr/share/zoneinfo/${tz}" /etc/localtime


### PR DESCRIPTION
### Explain the changes:
- unlink current local time only if TZ was provided and is valid

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixes #3722 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

