### PR TITLE
Fixed calls to update_bucket_counters in promise chains

### DIFF
--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -202,7 +202,9 @@ class ObjectSDK {
     read_object_stream(params) {
         return this._get_bucket_namespace(params.bucket)
             .then(ns => ns.read_object_stream(params, this))
-            .then(this.rpc_client.object.update_bucket_read_counters({ bucket: params.bucket }));
+            .then(() => {
+                this.rpc_client.object.update_bucket_read_counters({ bucket: params.bucket });
+            });
     }
 
     ///////////////////
@@ -212,7 +214,9 @@ class ObjectSDK {
     upload_object(params) {
         return this._get_bucket_namespace(params.bucket)
             .then(ns => ns.upload_object(params, this))
-            .then(this.rpc_client.object.update_bucket_write_counters({ bucket: params.bucket }));
+            .then(() => {
+                this.rpc_client.object.update_bucket_write_counters({ bucket: params.bucket });
+            });
     }
 
     /////////////////////////////
@@ -237,8 +241,9 @@ class ObjectSDK {
     complete_object_upload(params) {
         return this._get_bucket_namespace(params.bucket)
             .then(ns => ns.complete_object_upload(params, this))
-            .then(this.rpc_client.object.update_bucket_write_counters({ bucket: params.bucket }));
-
+            .then(() => {
+                this.rpc_client.object.update_bucket_write_counters({ bucket: params.bucket });
+            });
     }
 
     abort_object_upload(params) {


### PR DESCRIPTION
### Explain the changes:
- the functions update_bucket_read_counters and update_bucket_write_counters were called in the `then` statement directly and not in a function 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

