### PR TITLE
fix deleted cloud pool name in events

### DIFF
--- a/src/server/notifications/dispatcher.js
+++ b/src/server/notifications/dispatcher.js
@@ -210,6 +210,7 @@ class Dispatcher {
             .then(pool => {
                 if (pool) {
                     l.pool = _.pick(pool.record, 'name');
+                    l.pool.name = l.pool.name.split('#')[0];
                     l.pool.linkable = pool.linkable;
                 }
                 return P.resolve(log_item.account && system_store.data.get_by_id_include_deleted(log_item.account, 'accounts'));

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -364,7 +364,7 @@ function _delete_resource_pool(req, pool, account) {
                     // with a new resource pool name
                     let db_update = {
                         _id: pool._id,
-                        name: pool.name + '-' + pool._id
+                        name: pool.name + '#' + pool._id
                     };
                     const pending_del_property = pool.resource_type === 'INTERNAL' ?
                         'mongo_pool_info.pending_delete' : 'cloud_pool_info.pending_delete';


### PR DESCRIPTION
### Explain the changes:
- when cloud pool is deleted we add the object id to its name to make it unique in case another cloud pool is created with the same name.
- changed the suffix to start with `#` instead of `-`. when resolving the pool's name in event server, splitting using `#` as a delimiter.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #2834 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from the previous version - DB schema, server platform, agents install, new packages added to deployment

