### PR TITLE
fixing diagnostics issue

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1014,7 +1014,7 @@ function diagnose_system(req) {
                 });
         }))
         .then(() => promise_utils.exec(`find ${TMP_WORK_DIR} -maxdepth 1 -type f -delete`))
-        .then(() => diag.pack_diagnostics(WORKING_PATH))
+        .then(() => diag.pack_diagnostics(WORKING_PATH, TMP_WORK_DIR))
         .then(() => (OUT_PATH));
 }
 

--- a/src/server/utils/server_diagnostics.js
+++ b/src/server/utils/server_diagnostics.js
@@ -145,8 +145,8 @@ function collect_server_diagnostics(req) {
         });
 }
 
-function pack_diagnostics(dst) {
-    return base_diagnostics.pack_diagnostics(dst);
+function pack_diagnostics(dst, work_dir) {
+    return base_diagnostics.pack_diagnostics(dst, work_dir);
 }
 
 function write_agent_diag_file(data) {

--- a/src/util/base_diagnostics.js
+++ b/src/util/base_diagnostics.js
@@ -53,11 +53,12 @@ function write_agent_diag_file(data) {
     return fs.writeFileAsync(TMP_WORK_DIR + '/from_agent_diag.tgz', data);
 }
 
-function pack_diagnostics(dst) {
+function pack_diagnostics(dst, working_dir) {
+    const work_dir = working_dir || TMP_WORK_DIR;
     return P.resolve()
         .then(() => fs_utils.file_delete(dst))
         .then(() => fs_utils.create_path(path.dirname(dst)))
-        .then(() => fs_utils.tar_pack(dst, TMP_WORK_DIR))
+        .then(() => fs_utils.tar_pack(dst, work_dir))
         .then(() => archive_diagnostics_pack(dst))
         .catch(err => {
             //The reason is that every distribution has its own issues.
@@ -66,7 +67,7 @@ function pack_diagnostics(dst) {
             //This is not valid for windows where we have our own executable
             console.error("failed to tar, an attempt to ignore file changes", err);
             return P.resolve()
-                .then(() => fs_utils.tar_pack(dst, TMP_WORK_DIR, 'ignore_file_changes'))
+                .then(() => fs_utils.tar_pack(dst, work_dir, 'ignore_file_changes'))
                 .then(() => archive_diagnostics_pack(dst))
                 .catch(err2 => {
                     console.error('Error in packing diagnostics', err2);


### PR DESCRIPTION
### Explain the changes:
- fixed using the wrong path for cluster diagnostics packing: /tmp/diag (default) instead of /tmp/cluster_diag(when using cluster)

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixed #3745

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

