### PR TITLE
added statistics prints in agents logs

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -238,6 +238,12 @@ class Agent {
         // });
     }
 
+    sample_stats() {
+        if (this.block_store) {
+            return this.block_store.sample_stats();
+        }
+    }
+
     _update_servers_list(new_list) {
         // check if base_address appears in new_list. if not add it.
         if (_.isUndefined(new_list.find(srv => srv.address.toLowerCase() === this.base_address.toLowerCase()))) {


### PR DESCRIPTION
### Explain the changes:
- every minute, print the statistics since the last sample
- prints inflight rd\wr, rd\wr count, latency
- also, prints memory and CPU usage

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- related to #3369

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

