### PR TITLE
added cpu and memory usage of the process to agent info

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -56,6 +56,9 @@ class Agent {
             address: params.address
         }];
 
+        this.cpu_usage = process.cpuUsage();
+        this.cpu_usage.time_stamp = time_utils.microstamp();
+
         this.base_address = params.address ? params.address.toLowerCase() : this.rpc.router.default;
         this.proxy = params.proxy;
         dbg.log0(`this.base_address=${this.base_address}`);
@@ -708,6 +711,11 @@ class Agent {
         const extended_hb = true;
         const ip = ip_module.address();
         dbg.log0('Recieved potential servers list', req.rpc_params.addresses);
+        const prev_cpu_usage = this.cpu_usage;
+        this.cpu_usage = process.cpuUsage();
+        this.cpu_usage.time_stamp = time_utils.microstamp();
+        const cpu_percent = (this.cpu_usage.user + this.cpu_usage.system - prev_cpu_usage.user - prev_cpu_usage.system) /
+            (this.cpu_usage.time_stamp - prev_cpu_usage.time_stamp);
         const reply = {
             version: pkg.version || '',
             name: this.node_name || '',
@@ -722,6 +730,8 @@ class Agent {
             geolocation: this.geolocation,
             debug_level: dbg.get_module_level('core'),
             node_type: this.node_type,
+            mem_usage: process.memoryUsage().rss,
+            cpu_usage: cpu_percent
         };
         if (this.cloud_info && this.cloud_info.pool_name) {
             reply.pool_name = this.cloud_info.pool_name;

--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -55,7 +55,7 @@ function AgentCLI(params) {
 
 AgentCLI.prototype.monitor_stats = function() {
     promise_utils.pwhile(() => true, () => {
-        const cpu_usage = process.cpuUsage(this.cpu_usage); //usage since last sample
+        const cpu_usage = process.cpuUsage(this.cpu_usage); //usage since init
         const mem_usage = process.memoryUsage();
         dbg.log0(`agent_stats_titles - process: cpu_usage_user, cpu_usage_sys, mem_usage_rss`);
         dbg.log0(`agent_stats_values - process: ${cpu_usage.user}, ${cpu_usage.system}, ${mem_usage.rss}`);

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -87,6 +87,12 @@ module.exports = {
                     node_type: {
                         $ref: 'node_api#/definitions/node_type'
                     },
+                    cpu_usage: {
+                        type: 'number'
+                    },
+                    mem_usage: {
+                        type: 'integer'
+                    },
                     debug_level: {
                         type: 'integer',
                     },

--- a/src/api/host_api.js
+++ b/src/api/host_api.js
@@ -341,6 +341,12 @@ module.exports = {
                 os_info: {
                     $ref: 'common_api#/definitions/os_info'
                 },
+                process_cpu_usage: {
+                    type: 'number'
+                },
+                process_mem_usage: {
+                    type: 'integer'
+                },
                 latency_to_server: {
                     $ref: 'node_api#/definitions/latency_array'
                 },

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -63,7 +63,9 @@ const AGENT_INFO_FIELDS = [
     'node_type',
     'host_name',
     'ports_allowed',
-    'permission_tempering'
+    'permission_tempering',
+    'mem_usage',
+    'cpu_usage',
 ];
 const MONITOR_INFO_FIELDS = [
     'has_issues',
@@ -2969,6 +2971,8 @@ class NodesMonitor extends EventEmitter {
             info.os_info.last_update = new Date(info.os_info.last_update).getTime();
         }
         info.os_info.cpu_usage = host_item.cpu_usage;
+        info.process_cpu_usage = host_item.node.cpu_usage;
+        info.process_mem_usage = host_item.node.mem_usage;
         info.rpc_address = host_item.node.rpc_address;
         info.latency_to_server = host_item.node.latency_to_server;
         const debug_time = host_item.node.debug_mode ?

--- a/src/util/time_utils.js
+++ b/src/util/time_utils.js
@@ -11,6 +11,10 @@ function nanostamp() {
     return perf_now() * 1e6;
 }
 
+function microstamp() {
+    return perf_now() * 1e3;
+}
+
 function secstamp() {
     return perf_now() / 1000;
 }
@@ -62,6 +66,7 @@ function parse_amz_date(str) {
 
 
 exports.millistamp = millistamp;
+exports.microstamp = microstamp;
 exports.nanostamp = nanostamp;
 exports.secstamp = secstamp;
 exports.millitook = millitook;


### PR DESCRIPTION
### Explain the changes:
- get CPU and mem usage using `process.memoryUsage()` and `process.cpuUsage()`
- return rss and cpu usage percentage in get_agent_info

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- partial fix to #3369

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

