### PR TITLE
fixed collect_agent_diagnostics

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -994,7 +994,7 @@ class Agent {
         const inner_path = is_windows ? process.env.ProgramData + '/agent_diag.tgz' : '/tmp/agent_diag.tgz';
 
         return P.resolve()
-            .then(() => diag.collect_agent_diagnostics())
+            .then(() => diag.collect_agent_diagnostics(this.storage_path))
             .then(() => diag.pack_diagnostics(inner_path))
             .catch(err => {
                 dbg.error('DIAGNOSTICS COLLECTION FAILED', err.stack || err);

--- a/src/agent/agent_diagnostics.js
+++ b/src/agent/agent_diagnostics.js
@@ -7,37 +7,47 @@ module.exports = {
 };
 
 const fs = require('fs');
+const path = require('path');
+
 const fs_utils = require('../util/fs_utils');
 const base_diagnostics = require('../util/base_diagnostics');
 
 const TMP_WORK_DIR = base_diagnostics.get_tmp_workdir();
 
-function collect_agent_diagnostics() {
+function collect_agent_diagnostics(storage_path) {
+    const diag_log = fs.createWriteStream(path.join(TMP_WORK_DIR, 'agent_diagnostics.log'));
+
     //mkdir c:\tmp ?
     return base_diagnostics.prepare_diag_dir()
         .then(function() {
-            return base_diagnostics.collect_basic_diagnostics();
+            return base_diagnostics.collect_basic_diagnostics()
+                .catch(err => {
+                    diag_log.write(`failed collecting basic diagnostics. ${err.message}`);
+                });
         })
         .then(function() {
             if (fs.existsSync(process.cwd() + '/logs')) {
                 //will take only noobaa.log and the first 9 zipped logs
                 return fs_utils.full_dir_copy(process.cwd() + '/logs', TMP_WORK_DIR,
-                    'noobaa?[1-9][0-9].log.gz');
-            } else {
-                return;
+                        'noobaa?[1-9][0-9].log.gz')
+                    .catch(err => {
+                        diag_log.write(`failed collecting log files. ${err.message}`);
+                    });
             }
         })
         .then(function() {
             if (fs.existsSync('/var/log/noobaalocalservice.log')) {
-                return fs_utils.file_copy('/var/log/noobaalocalservice.log', TMP_WORK_DIR);
-            } else {
-                return;
+                return fs_utils.file_copy('/var/log/noobaalocalservice.log', TMP_WORK_DIR)
+                    .catch(err => {
+                        diag_log.write(`failed collecting noobaalocalservice.log. ${err.message}`);
+                    });
+
             }
         })
         .then(function() {
             const file = fs.createWriteStream(TMP_WORK_DIR + '/ls_noobaa_storage.out');
             return fs_utils.read_dir_recursive({
-                    root: 'noobaa_storage',
+                    root: storage_path,
                     depth: 5,
                     on_entry: entry => {
                         file.write(JSON.stringify(entry) + '\n');
@@ -50,8 +60,12 @@ function collect_agent_diagnostics() {
                         }
                     },
                 })
-                .finally(() => file.end());
+                .finally(() => file.end())
+                .catch(err => {
+                    diag_log.write(`failed reading ${storage_path} dir. ${err.message}`);
+                });
         })
+        .finally(() => diag_log.end())
         .return()
         .catch(err => {
             console.error('Error in collecting server diagnostics', err);


### PR DESCRIPTION
### Explain the changes:
- failed when reading noobaa_storage dir, due to a wrong path.
- the failure caused the entire collect_agent_diagnostics to fail
- passing the correct nooba_storagae path as a parameter.
- catching specific errors in the collect_diag flow so that a single error will not fail the entire collection.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3781 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

