### PR TITLE
fix windows agents to build 64-bit only

### DIFF
--- a/src/deploy/atom_agent_win.nsi
+++ b/src/deploy/atom_agent_win.nsi
@@ -69,24 +69,13 @@ Function .onInit
 	Var /global UPGRADE
 	Var /global AUTO_UPGRADE
 
-	;check first if there is an old installation on program files (x86)
-	;if so, just upgrade with x64 binaries
-
-	StrCpy $InstDir "$PROGRAMFILES\${NB}"
-	IfFileExists $INSTDIR\agent_conf.json IgnoreError SetRunningFolder
-		SetRunningFolder:
-			${If} ${RunningX64}
-				# 64 bit code
-				StrCpy $InstDir "$PROGRAMFILES64\${NB}"
-			${Else}
-				# 32 bit code
-				StrCpy $InstDir "$PROGRAMFILES\${NB}"
-			${EndIf}
-		IgnoreError:
-			ClearErrors
-
-
-
+	${If} ${RunningX64}
+		# 64 bit code
+		StrCpy $InstDir "$PROGRAMFILES64\${NB}"
+	${Else}
+		MessageBox MB_OK "Windows 32-bit architecture is not supported, please use Windows 64-bit."
+		Abort
+	${EndIf}
 
 	;Install or upgrade?
 	StrCpy $UPGRADE "false"
@@ -223,54 +212,34 @@ Section "Noobaa Local Service"
 	${EndIf}
 
 	WriteUninstaller "$INSTDIR\uninstall-noobaa.exe"
+
+	RMDir /r "$INSTDIR\build"
+	Delete "$INSTDIR\ver.txt"
+
 	File "${ICON}"
-	File "NooBaa_Agent_wd.exe"
 	File "7za.exe"
+	File "wget.exe"
+	File "node.exe"
+	File "NooBaa_Agent_wd.exe"
 
-	${If} ${RunningX64}
-    # 64 bit code
-		File ".\64\openssl.exe"
-		File ".\64\libeay32.dll"
-		File ".\64\ssleay32.dll"
-		File ".\64\node.exe"
-		RMDir /r "$INSTDIR\build"
-		File /r  "build"
-		RMDir /r "$INSTDIR\build\Release-32"
-		Rename $INSTDIR\build\Release-64 $INSTDIR\build\Release
-		WriteRegStr HKLM "Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
-			 "DisplayName" "NooBaa Local Service"
-		WriteRegStr HKLM "Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
-            "QuietUninstallString" "$\"$INSTDIR\uninstall-noobaa.exe$\" /S"
-		WriteRegStr HKLM "Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
-	        "UninstallString" "$\"$INSTDIR\uninstall-noobaa.exe$\""
-
-	${Else}
-    # 32 bit code
-		File ".\32\openssl.exe"
-		File ".\32\libeay32.dll"
-		File ".\32\ssleay32.dll"
-		File ".\32\node.exe"
-		RMDir /r "$INSTDIR\build"
-		File /r  "build"
-		RMDir /r "$INSTDIR\build\Release-64"
-		Rename $INSTDIR\build\Release-32 $INSTDIR\build\Release
-		WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
-			 "DisplayName" "NooBaa Local Service"
-		WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
-            "QuietUninstallString" "$\"$INSTDIR\uninstall-noobaa.exe$\" /S"
-		WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
-			"UninstallString" "$\"$INSTDIR\uninstall-noobaa.exe$\""
-
-	${EndIf}
+	File "openssl.exe"
+	File "libeay32.dll"
+	File "ssleay32.dll"
 
 	File "package.json"
-	File "wget.exe"
 	File "config.js"
-	File /r "ssl"
-	File /r "src"
-	File /r "node_modules"
 
-	Delete "$INSTDIR\ver.txt"
+	File /r "ssl\"
+	File /r "src\"
+	File /r "build\"
+	File /r "node_modules\"
+
+	WriteRegStr HKLM "Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
+		"DisplayName" "NooBaa Local Service"
+	WriteRegStr HKLM "Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
+		"QuietUninstallString" "$\"$INSTDIR\uninstall-noobaa.exe$\" /S"
+	WriteRegStr HKLM "Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\NooBaa" \
+		"UninstallString" "$\"$INSTDIR\uninstall-noobaa.exe$\""
 
 	${If} $AUTO_UPGRADE == "false" ;delete all files that we want to update
 

--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -68,25 +68,7 @@ echo "Cleaning previous build"
 rd /q/s .\build\Release
 rd /q/s %USERPROFILE%\.node-gyp
 
-echo "Build 32 bit"
-nvm install "%NODEJS_VERSION%" 32 || exit 1
-nvm use "%NODEJS_VERSION%" 32 || exit 1
-sleep 5
-nvm list
-nvm arch
-node -p process.arch
-cmd /c npm config set msvs_version=2015 --global
-cmd /c npm install --production || exit 1
-
-echo "Copy 32 bit build results"
-if not exist ".\build\Release" exit 1
-xcopy /Y/I/E .\build\Release .\build\Release-32
-
-echo "Cleaning previous build"
-rd /q/s .\build\Release
-rd /q/s %USERPROFILE%\.node-gyp
-
-echo "Build 64 bit"
+echo "Build"
 nvm install "%NODEJS_VERSION%" 64 || exit 1
 nvm use "%NODEJS_VERSION%" 64 || exit 1
 sleep 5
@@ -95,46 +77,16 @@ nvm arch
 node -p process.arch
 cmd /c npm config set msvs_version=2015 --global
 cmd /c npm install --production || exit 1
-
-echo "Copy 64 bit build results"
 if not exist ".\build\Release" exit 1
-xcopy /Y/I/E .\build\Release .\build\Release-64
-
-curl -L https://nodejs.org/dist/v%NODEJS_VERSION%/win-x86/node.exe > node-32.exe || exit 1
-curl -L https://nodejs.org/dist/v%NODEJS_VERSION%/win-x64/node.exe > node-64.exe || exit 1
-curl -L https://indy.fulgan.com/SSL/openssl-1.0.2l-i386-win32.zip > openssl_32.zip || exit 1
-curl -L https://indy.fulgan.com/SSL/openssl-1.0.2l-x64_86-win64.zip > openssl_64.zip || exit 1
-
-mkdir .\32
-mkdir .\64
-
-rd /q/s .\build\Release
 rd /q/s .\build\src
 rd /q/s .\build\Windows
 del /q .\build\*.*
 
-7za.exe e openssl_32.zip -y -x!*.txt || exit 1
-del /Q openssl_32.zip
+curl -L https://nodejs.org/dist/v%NODEJS_VERSION%/win-x64/node.exe > node.exe || exit 1
 
-copy /y *.dll .\32\
-copy /y node-32.exe .\32\node.exe
-copy /y openssl.exe .\32\openssl.exe
-
-del /Q *.dll
-del /Q node-32.exe
-del /Q openssl.exe
-
-7za.exe e openssl_64.zip -y -x!*.txt || exit 1
-del /Q openssl_64.zip
-
-copy /y *.dll .\64\
-copy /y node-64.exe .\64\node.exe
-copy /y openssl.exe .\64\openssl.exe
-
-del /Q *.dll
-del /Q node-64.exe
-del /Q openssl.exe
-
+curl -L https://indy.fulgan.com/SSL/openssl-1.0.2l-x64_86-win64.zip > openssl.zip || exit 1
+7za.exe e openssl.zip -y -x!*.txt || exit 1
+del /Q openssl.zip
 del /s *.pdb
 
 cd ..\..


### PR DESCRIPTION
### Explain the changes:
- Decided to drop support for 32-bit OS

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- NA

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

