### PR TITLE
delete will delete uncompleted uploads as well

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -131,12 +131,12 @@ class MDStore {
         });
     }
 
-    find_object_by_key(bucket_id, key) {
+    find_object_by_key(bucket_id, key, include_uncompleted) {
         return this._objects.col().findOne(compact({
             bucket: bucket_id,
             key: key,
             deleted: null,
-            upload_started: null,
+            upload_started: include_uncompleted ? undefined : null,
         }));
     }
 


### PR DESCRIPTION
### Explain the changes:
- change delete to also abort_object_upload if object is uncompleted
- support md_store to find uncompleted objects

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixed #3793 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

