### PR TITLE
Fix for 3359 - save hostname after ova clean, also save after linux install

### DIFF
--- a/src/deploy/NVA_build/clean_ova.sh
+++ b/src/deploy/NVA_build/clean_ova.sh
@@ -10,7 +10,7 @@ function clean_ifcfg() {
     for int in ${interfaces//:/}; do
         sudo rm /etc/sysconfig/network-scripts/ifcfg-${int}
     done
-    sudo echo -n > /etc/sysconfig/network
+    sudo echo "HOSTNAME=noobaa" > /etc/sysconfig/network
 }
 
 OPTIONS=$( getopt -o 'h,e,a,l,w' --long "help,esx,azure,alyun,aws" -- "$@" )

--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -174,6 +174,15 @@ function configure_hostname_dialog {
 
     local host=$(tail -1 answer_host)
     rc=$(sudo sysctl kernel.hostname=${host})
+    if [ -f /etc/sysconfig/network ]; then
+      if ! grep -q HOSTNAME /etc/sysconfig/network; then
+        sudo echo "HOSTNAME=${host}" >> /etc/sysconfig/network
+      else
+        sudo sed -i "s:HOSTNAME=.*:HOSTNAME=${host}:" /etc/sysconfig/network
+      fi
+    else
+        sudo echo "HOSTNAME=${host}" >> /etc/sysconfig/network
+    fi
 }
 
 function configure_networking_dialog {


### PR DESCRIPTION
### Explain the changes:
- Save default hostname after clean ova
- Fix hostname change on first_install to survive reboot

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3359 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

