### PR TITLE
API fix non working format validation to keywords (date, idate, objectid)

### DIFF
--- a/src/agent/block_store_services/block_store_mongo.js
+++ b/src/agent/block_store_services/block_store_mongo.js
@@ -11,7 +11,7 @@ const size_utils = require('../../util/size_utils');
 const mongo_client = require('../../util/mongo_client');
 const buffer_utils = require('../../util/buffer_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
-const { SERVER_MIN_REQUIREMENTS } = require('../../config');
+const { SERVER_MIN_REQUIREMENTS } = require('../../../config');
 
 const GRID_FS_BUCKET_NAME = 'mongo_internal_agent';
 const GRID_FS_BUCKET_NAME_FILES = `${GRID_FS_BUCKET_NAME}.files`;

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -389,7 +389,7 @@ module.exports = {
                     type: 'boolean',
                 },
                 next_password_change: {
-                    format: 'idate',
+                    idate: true,
                 },
                 access_keys: {
                     type: 'array',

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -58,7 +58,7 @@ module.exports = {
                         type: 'string'
                     },
                     permission_tempering: {
-                        format: 'idate'
+                        idate: true
                     },
                     n2n_config: {
                         $ref: 'common_api#/definitions/n2n_config'

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -208,10 +208,10 @@ module.exports = {
                         type: 'string',
                     },
                     since: {
-                        format: 'idate'
+                        idate: true
                     },
                     till: {
-                        format: 'idate'
+                        idate: true
                     },
                 }
             },
@@ -404,7 +404,7 @@ module.exports = {
                                             type: 'integer'
                                         },
                                         date: {
-                                            format: 'idate'
+                                            idate: true
                                         },
                                         expired_object_delete_marker: {
                                             type: 'boolean'
@@ -424,7 +424,7 @@ module.exports = {
                                     type: 'object',
                                     properties: {
                                         date: {
-                                            format: 'idate'
+                                            idate: true
                                         },
                                         storage_class: {
                                             $ref: '#/definitions/storage_class_enum'
@@ -485,7 +485,7 @@ module.exports = {
                             type: 'string'
                         },
                         last_sync: {
-                            format: 'idate'
+                            idate: true
                         },
                         expiration: {
                             type: 'object',
@@ -494,7 +494,7 @@ module.exports = {
                                     type: 'integer'
                                 },
                                 date: {
-                                    format: 'idate'
+                                    idate: true
                                 },
                                 expired_object_delete_marker: {
                                     type: 'boolean'
@@ -514,7 +514,7 @@ module.exports = {
                             type: 'object',
                             properties: {
                                 date: {
-                                    format: 'idate'
+                                    idate: true
                                 },
                                 storage_class: {
                                     $ref: '#/definitions/storage_class_enum'
@@ -579,7 +579,7 @@ module.exports = {
                             $ref: 'common_api#/definitions/storage_info'
                         },
                         last_update: {
-                            format: 'idate'
+                            idate: true
                         }
                     }
                 },
@@ -621,7 +621,7 @@ module.exports = {
                             $ref: 'common_api#/definitions/bigint'
                         },
                         last_update: {
-                            format: 'idate'
+                            idate: true
                         }
                     }
                 },
@@ -630,7 +630,7 @@ module.exports = {
                     required: ['last_update', 'pools'],
                     properties: {
                         last_update: {
-                            format: 'idate'
+                            idate: true
                         },
                         pools: {
                             type: 'array',
@@ -677,10 +677,10 @@ module.exports = {
                             type: 'integer'
                         },
                         last_read: {
-                            format: 'idate'
+                            idate: true
                         },
                         last_write: {
-                            format: 'idate'
+                            idate: true
                         },
                     },
                 },
@@ -722,7 +722,7 @@ module.exports = {
                     $ref: '#/definitions/api_cloud_sync_status'
                 },
                 last_sync: {
-                    format: 'idate'
+                    idate: true
                 },
             }
         },

--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -252,7 +252,7 @@ module.exports = {
                 },
             },
             reply: {
-                format: 'idate',
+                idate: true,
             },
             auth: {
                 system: false,

--- a/src/api/cluster_server_api.js
+++ b/src/api/cluster_server_api.js
@@ -140,7 +140,7 @@ module.exports = {
                 },
             },
             reply: {
-                format: 'idate',
+                idate: true,
             },
             auth: {
                 system: 'admin',

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -83,7 +83,7 @@ module.exports = {
             // required: [],
             properties: {
                 last_update: {
-                    format: 'idate'
+                    idate: true
                 },
                 hostname: {
                     type: 'string'
@@ -101,7 +101,7 @@ module.exports = {
                     type: 'string'
                 },
                 uptime: {
-                    format: 'idate'
+                    idate: true
                 },
                 loadavg: {
                     type: 'array',
@@ -244,27 +244,13 @@ module.exports = {
             type: 'object',
             required: ['id'],
             properties: {
-                id: {
-                    type: 'string'
-                },
-                address: {
-                    type: 'string'
-                },
-                node: {
-                    type: 'string'
-                },
-                pool: {
-                    type: 'string'
-                },
-                size: {
-                    type: 'integer'
-                },
-                digest_type: {
-                    type: 'string'
-                },
-                digest_b64: {
-                    type: 'string'
-                },
+                id: { objectid: true },
+                address: { type: 'string' },
+                node: { objectid: true },
+                pool: { objectid: true },
+                size: { type: 'integer' },
+                digest_type: { $ref: '#/definitions/digest_type' },
+                digest_b64: { type: 'string' },
             }
         },
 
@@ -365,9 +351,57 @@ module.exports = {
                 }
             }
         },
+
         agent_roles_enum: {
             type: 'string',
             enum: ['STORAGE', 'S3']
-        }
+        },
+
+        digest_type: {
+            type: 'string',
+            enum: ['sha1', 'sha256', 'sha384', 'sha512']
+        },
+
+        compress_type: {
+            type: 'string',
+            enum: ['snappy', 'zlib']
+        },
+
+        cipher_type: {
+            type: 'string',
+            enum: ['aes-256-gcm']
+        },
+
+        parity_type: {
+            type: 'string',
+            enum: ['isa-c1', 'isa-rs', 'cm256']
+        },
+
+        chunk_split_config: {
+            type: 'object',
+            properties: {
+                avg_chunk: { type: 'integer' },
+                delta_chunk: { type: 'integer' },
+            }
+        },
+
+        chunk_coder_config: {
+            type: 'object',
+            properties: {
+                digest_type: { $ref: '#/definitions/digest_type' },
+                frag_digest_type: { $ref: '#/definitions/digest_type' },
+                compress_type: { $ref: '#/definitions/compress_type' },
+                cipher_type: { $ref: '#/definitions/cipher_type' },
+                data_frags: { type: 'integer' },
+                // Erasure Coding:
+                parity_type: { $ref: '#/definitions/parity_type' },
+                parity_frags: { type: 'integer' },
+                // LRC:
+                lrc_type: { $ref: '#/definitions/parity_type' },
+                lrc_group: { type: 'integer' },
+                lrc_frags: { type: 'integer' },
+            }
+        },
+
     }
 };

--- a/src/api/events_api.js
+++ b/src/api/events_api.js
@@ -21,10 +21,10 @@ module.exports = {
                         type: 'string',
                     },
                     till: {
-                        format: 'idate'
+                        idate: true
                     },
                     since: {
-                        format: 'idate'
+                        idate: true
                     },
                     skip: {
                         type: 'integer',
@@ -48,7 +48,7 @@ module.exports = {
                                     type: 'string',
                                 },
                                 time: {
-                                    format: 'idate'
+                                    idate: true
                                 },
                                 level: {
                                     type: 'string',
@@ -174,10 +174,10 @@ module.exports = {
                         }
                     },
                     till: {
-                        format: 'idate'
+                        idate: true
                     },
                     since: {
-                        format: 'idate'
+                        idate: true
                     }
                 }
             },
@@ -255,7 +255,7 @@ module.exports = {
                             type: 'string',
                         },
                         time: {
-                            format: 'idate'
+                            idate: true
                         },
                         severity: {
                             $ref: '#/definitions/alert_severity_enum'

--- a/src/api/func_api.js
+++ b/src/api/func_api.js
@@ -273,7 +273,7 @@ module.exports = {
                     type: 'string'
                 },
                 last_modified: {
-                    format: 'idate'
+                    idate: true
                 },
                 resource_name: {
                     type: 'string'
@@ -381,7 +381,7 @@ module.exports = {
                         type: 'object',
                         properties: {
                             time: {
-                                format: 'idate'
+                                idate: true
                             },
                             requests: {
                                 type: 'integer'

--- a/src/api/host_api.js
+++ b/src/api/host_api.js
@@ -321,10 +321,10 @@ module.exports = {
                     type: 'string'
                 },
                 version_install_time: {
-                    format: 'idate'
+                    idate: true
                 },
                 last_communication: {
-                    format: 'idate'
+                    idate: true
                 },
                 trusted: {
                     type: 'boolean',
@@ -421,10 +421,10 @@ module.exports = {
                             type: 'object',
                             properties: {
                                 last_read: {
-                                    format: 'idate'
+                                    idate: true
                                 },
                                 last_write: {
-                                    format: 'idate'
+                                    idate: true
                                 },
                                 daily_stats: {
                                     type: 'array',
@@ -432,7 +432,7 @@ module.exports = {
                                         type: 'object',
                                         properties: {
                                             time: {
-                                                format: 'idate'
+                                                idate: true
                                             },
                                             read_count: {
                                                 type: 'integer'

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -494,10 +494,10 @@ module.exports = {
                     type: 'string'
                 },
                 version_install_time: {
-                    format: 'idate'
+                    idate: true
                 },
                 heartbeat: {
-                    format: 'idate'
+                    idate: true
                 },
                 has_issues: {
                     type: 'boolean',
@@ -518,19 +518,19 @@ module.exports = {
                     type: 'boolean',
                 },
                 migrating_to_pool: {
-                    format: 'idate'
+                    idate: true
                 },
                 decommissioning: {
-                    format: 'idate'
+                    idate: true
                 },
                 decommissioned: {
-                    format: 'idate'
+                    idate: true
                 },
                 deleting: {
-                    format: 'idate'
+                    idate: true
                 },
                 deleted: {
-                    format: 'idate'
+                    idate: true
                 },
                 accessibility: {
                     $ref: '#/definitions/accessibility_type'
@@ -894,10 +894,10 @@ module.exports = {
             type: 'object',
             properties: {
                 start: {
-                    format: 'idate',
+                    idate: true,
                 },
                 end: {
-                    format: 'idate',
+                    idate: true,
                 },
             }
         },

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -50,9 +50,7 @@ module.exports = {
                 type: 'object',
                 required: ['obj_id'],
                 properties: {
-                    obj_id: {
-                        type: 'string'
-                    }
+                    obj_id: { objectid: true },
                 }
             },
             auth: {
@@ -71,7 +69,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true,
                     },
                     bucket: {
                         type: 'string',
@@ -139,7 +137,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true,
                     },
                     bucket: {
                         type: 'string',
@@ -166,7 +164,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true,
                     },
                     bucket: {
                         type: 'string',
@@ -192,9 +190,7 @@ module.exports = {
                 type: 'object',
                 required: ['multipart_id'],
                 properties: {
-                    multipart_id: {
-                        type: 'string'
-                    }
+                    multipart_id: { objectid: true },
                 }
             },
             auth: {
@@ -218,7 +214,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true
                     },
                     bucket: {
                         type: 'string',
@@ -230,7 +226,7 @@ module.exports = {
                         type: 'integer',
                     },
                     multipart_id: {
-                        type: 'string',
+                        objectid: true
                     },
                     size: {
                         type: 'integer',
@@ -254,7 +250,7 @@ module.exports = {
                         type: 'string'
                     },
                     create_time: {
-                        format: 'idate'
+                        idate: true
                     },
                 }
             },
@@ -274,7 +270,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true
                     },
                     bucket: {
                         type: 'string',
@@ -324,7 +320,7 @@ module.exports = {
                                     type: 'string'
                                 },
                                 last_modified: {
-                                    format: 'idate'
+                                    idate: true
                                 },
                             }
                         }
@@ -348,7 +344,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true
                     },
                     bucket: {
                         type: 'string',
@@ -393,7 +389,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true
                     },
                     bucket: {
                         type: 'string',
@@ -425,7 +421,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string'
+                        objectid: true
                     },
                     bucket: {
                         type: 'string',
@@ -595,7 +591,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true
                     },
                     bucket: {
                         type: 'string',
@@ -634,7 +630,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true
                     },
                     bucket: {
                         type: 'string',
@@ -665,7 +661,7 @@ module.exports = {
                 ],
                 properties: {
                     obj_id: {
-                        type: 'string',
+                        objectid: true
                     },
                     bucket: {
                         type: 'string',
@@ -862,7 +858,7 @@ module.exports = {
                         enum: ['read', 'upload']
                     },
                     obj_id: {
-                        type: 'string'
+                        objectid: true
                     },
                     bucket: {
                         type: 'string'
@@ -899,7 +895,7 @@ module.exports = {
                         type: 'string'
                     },
                     node_id: {
-                        type: 'string'
+                        objectid: true
                     },
                     host_id: {
                         type: 'string'
@@ -917,10 +913,10 @@ module.exports = {
                 type: 'object',
                 properties: {
                     start_time: {
-                        format: 'idate',
+                        idate: true,
                     },
                     end_time: {
-                        format: 'idate',
+                        idate: true,
                     },
                     s3_usage_info: {
                         $ref: '#/definitions/s3_usage_info',
@@ -976,7 +972,7 @@ module.exports = {
                         type: 'string',
                     },
                     create_time: {
-                        format: 'idate',
+                        idate: true,
                     }
                 }
             },
@@ -1021,32 +1017,6 @@ module.exports = {
 
     definitions: {
 
-        // metadata if's - conditions to use metadata
-        md_conditions: {
-            type: 'object',
-            properties: {
-                if_modified_since: {
-                    format: 'idate'
-                },
-                if_unmodified_since: {
-                    format: 'idate'
-                },
-                if_match_etag: {
-                    type: 'string'
-                },
-                if_none_match_etag: {
-                    type: 'string'
-                },
-            }
-        },
-
-        // free form object
-        xattr: {
-            type: 'object',
-            additionalProperties: true,
-            properties: {}
-        },
-
         object_info: {
             type: 'object',
             required: [
@@ -1058,7 +1028,7 @@ module.exports = {
             ],
             properties: {
                 obj_id: {
-                    type: 'string'
+                    objectid: true
                 },
                 bucket: {
                     type: 'string'
@@ -1073,10 +1043,10 @@ module.exports = {
                     type: 'string',
                 },
                 create_time: {
-                    format: 'idate'
+                    idate: true
                 },
                 upload_started: {
-                    format: 'idate'
+                    idate: true
                 },
                 upload_size: {
                     type: 'integer',
@@ -1103,7 +1073,7 @@ module.exports = {
                             type: 'integer',
                         },
                         last_read: {
-                            format: 'idate',
+                            idate: true,
                         }
                     }
                 },
@@ -1138,7 +1108,7 @@ module.exports = {
                     type: 'integer',
                 },
                 multipart_id: {
-                    type: 'string',
+                    objectid: true
                 },
                 chunk_offset: {
                     type: 'integer',
@@ -1147,7 +1117,7 @@ module.exports = {
                     $ref: '#/definitions/chunk_info',
                 },
                 chunk_id: {
-                    type: 'string',
+                    objectid: true
                 },
             }
         },
@@ -1291,6 +1261,32 @@ module.exports = {
             }
         },
 
+        // metadata if's - conditions to use metadata
+        md_conditions: {
+            type: 'object',
+            properties: {
+                if_modified_since: {
+                    idate: true
+                },
+                if_unmodified_since: {
+                    idate: true
+                },
+                if_match_etag: {
+                    type: 'string'
+                },
+                if_none_match_etag: {
+                    type: 'string'
+                },
+            }
+        },
+
+        // free form object
+        xattr: {
+            type: 'object',
+            additionalProperties: true,
+            properties: {}
+        },
+
         s3_usage_info: {
             type: 'object',
             patternProperties: {
@@ -1308,6 +1304,7 @@ module.exports = {
                 }
             }
         },
+
         bandwidth_usage_info: {
             type: 'array',
             items: {

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -293,7 +293,7 @@ module.exports = {
                     required: ['timestamp', 'pool_list'],
                     properties: {
                         timestamp: {
-                            format: 'idate'
+                            idate: true
                         },
                         pool_list: {
                             type: 'array',

--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -391,7 +391,7 @@ module.exports = {
                         type: 'string',
                     },
                     time: {
-                        format: 'idate',
+                        idate: true,
                     },
                     s3_usage_info: {
                         $ref: 'object_api#/definitions/s3_usage_info',

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -226,7 +226,7 @@ module.exports = {
                 required: ['last_stats_report'],
                 properties: {
                     last_stats_report: {
-                        format: 'idate',
+                        idate: true,
                     },
                 }
             },
@@ -505,7 +505,7 @@ module.exports = {
                     $ref: 'account_api#/definitions/account_info'
                 },
                 last_stats_report: {
-                    format: 'idate',
+                    idate: true,
                 },
                 tiers: {
                     type: 'array',
@@ -582,7 +582,7 @@ module.exports = {
                             type: 'boolean',
                         },
                         till: {
-                            format: 'idate',
+                            idate: true,
                         },
                     }
                 },
@@ -654,7 +654,7 @@ module.exports = {
                             type: 'string',
                         },
                         last_upgrade: {
-                            format: 'idate'
+                            idate: true
                         },
                         unavailable: {
                             type: 'string',
@@ -803,7 +803,7 @@ module.exports = {
                     type: 'string'
                 },
                 time_epoch: {
-                    format: 'idate'
+                    idate: true
                 },
                 timezone: {
                     type: 'string'
@@ -889,7 +889,7 @@ module.exports = {
                     $ref: '#/definitions/service_status_enum'
                 },
                 test_time: {
-                    format: 'idate'
+                    idate: true
                 },
             }
         }

--- a/src/api/tiering_policy_api.js
+++ b/src/api/tiering_policy_api.js
@@ -12,6 +12,7 @@ module.exports = {
     id: 'tiering_policy_api',
 
     methods: {
+
         create_policy: {
             doc: 'Create Tiering Policy',
             method: 'POST',

--- a/src/rpc/rpc_schema.js
+++ b/src/rpc/rpc_schema.js
@@ -24,11 +24,9 @@ const VALID_HTTP_METHODS = {
 class RpcSchema {
 
     constructor() {
-        this._ajv = new Ajv({
-            formats: {
-                idate: schema_utils.idate_format,
-            },
-        });
+        this._ajv = new Ajv({ verbose: true });
+        this._ajv.addKeyword('idate', schema_utils.KEYWORDS.idate);
+        this._ajv.addKeyword('objectid', schema_utils.KEYWORDS.objectid);
     }
 
     /**

--- a/src/server/analytic_services/activity_log_schema.js
+++ b/src/server/analytic_services/activity_log_schema.js
@@ -13,13 +13,13 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         time: {
-            format: 'date',
+            date: true,
         },
         level: {
             type: 'string',
@@ -32,22 +32,22 @@ module.exports = {
             type: 'string',
         },
         tier: {
-            format: 'objectid'
+            objectid: true
         },
         node: {
-            format: 'objectid'
+            objectid: true
         },
         bucket: {
-            format: 'objectid'
+            objectid: true
         },
         obj: {
-            format: 'objectid'
+            objectid: true
         },
         account: {
-            format: 'objectid'
+            objectid: true
         },
         pool: {
-            format: 'objectid'
+            objectid: true
         },
         server: {
             type: 'object',
@@ -62,7 +62,7 @@ module.exports = {
         },
         // The User that performed the action
         actor: {
-            format: 'objectid'
+            objectid: true
         }
     }
 };

--- a/src/server/analytic_services/s3_usage_schema.js
+++ b/src/server/analytic_services/s3_usage_schema.js
@@ -7,7 +7,7 @@ module.exports = {
     required: ['system', 's3_usage_info', 's3_errors_info'],
     properties: {
         system: {
-            format: 'objectid'
+            objectid: true
         },
         s3_usage_info: {
             type: 'object',

--- a/src/server/analytic_services/system_history_schema.js
+++ b/src/server/analytic_services/system_history_schema.js
@@ -7,10 +7,10 @@ module.exports = {
     required: ['_id', 'time_stamp', 'system_snapshot'],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         time_stamp: {
-            format: 'date'
+            date: true
         },
         system_snapshot: { // Future proofing system snapshots. Old snapshots not conforming to upgrades is expected and fine so the data here is not validated
             type: 'object',

--- a/src/server/analytic_services/usage_report_schema.js
+++ b/src/server/analytic_services/usage_report_schema.js
@@ -7,21 +7,21 @@ module.exports = {
     required: ['_id', 'system', 'start_time', 'end_time'],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         // start time of the aggregated report rounded to the aggregated_time_range
         start_time: {
-            format: 'idate'
+            idate: true
         },
         end_time: {
-            format: 'idate'
+            idate: true
         },
         // the time of the first sample in the range (the "real" start time)
         first_sample_time: {
-            format: 'idate'
+            idate: true
         },
         // the time range in ms that this document is aggregated to
         // e.g. aggregated_time_range for 1 hour is 3600000
@@ -29,13 +29,13 @@ module.exports = {
             type: 'integer',
         },
         aggregated_time: {
-            format: 'idate'
+            idate: true
         },
         bucket: {
-            format: 'objectid'
+            objectid: true
         },
         account: {
-            format: 'objectid'
+            objectid: true
         },
         read_bytes: {
             type: 'integer',

--- a/src/server/func_services/func_schema.js
+++ b/src/server/func_services/func_schema.js
@@ -19,18 +19,18 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         deleted: {
-            format: 'date'
+            date: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         pools: {
             type: 'array',
             items: {
-                format: 'objectid'
+                objectid: true
             }
         },
         name: {
@@ -65,7 +65,7 @@ module.exports = {
             type: 'integer'
         },
         last_modified: {
-            format: 'date'
+            date: true
         },
         code_size: {
             type: 'integer'
@@ -74,7 +74,7 @@ module.exports = {
             type: 'string'
         },
         code_gridfs_id: {
-            format: 'objectid'
+            objectid: true
         },
     }
 };

--- a/src/server/func_services/func_stats_schema.js
+++ b/src/server/func_services/func_stats_schema.js
@@ -13,16 +13,16 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         func: {
-            format: 'objectid'
+            objectid: true
         },
         time: {
-            format: 'date'
+            date: true
         },
         took: {
             type: 'number'

--- a/src/server/node_services/node_schema.js
+++ b/src/server/node_services/node_schema.js
@@ -37,23 +37,23 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         name: {
             type: 'string'
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         pool: {
-            format: 'objectid'
+            objectid: true
         },
         agent_config: {
-            format: 'objectid'
+            objectid: true
         },
         peer_id: {
             // the identifier used for p2p signaling
-            format: 'objectid'
+            objectid: true
         },
 
         // a uuid to identify the host machine of the node (one host can hold several nodes, one for each drive)
@@ -84,7 +84,7 @@ module.exports = {
         },
         heartbeat: {
             // the last time the agent sent heartbeat
-            format: 'idate',
+            idate: true,
         },
         version: {
             // the last agent version acknoledged
@@ -92,22 +92,22 @@ module.exports = {
         },
 
         migrating_to_pool: {
-            format: 'idate'
+            idate: true
         },
         decommissioning: {
-            format: 'idate'
+            idate: true
         },
         decommissioned: {
-            format: 'idate'
+            idate: true
         },
         deleting: {
-            format: 'idate'
+            idate: true
         },
         deleted: {
-            format: 'idate'
+            idate: true
         },
         force_hide: {
-            format: 'idate'
+            idate: true
         },
 
         // node storage stats - sum of drives
@@ -153,7 +153,7 @@ module.exports = {
                     type: 'string'
                 },
                 uptime: {
-                    format: 'idate'
+                    idate: true
                 },
                 loadavg: {
                     type: 'array',
@@ -235,7 +235,7 @@ module.exports = {
                 type: 'object',
                 properties: {
                     time: {
-                        format: 'idate'
+                        idate: true
                     },
                     action: {
                         type: 'string'
@@ -244,7 +244,7 @@ module.exports = {
                         type: 'string'
                     },
                     count_since: {
-                        format: 'idate'
+                        idate: true
                     },
                     count: {
                         type: 'integer'
@@ -269,7 +269,7 @@ module.exports = {
                 type: 'object',
                 properties: {
                     time: {
-                        format: 'idate'
+                        idate: true
                     },
                     read_count: {
                         type: 'integer'
@@ -284,10 +284,10 @@ module.exports = {
                         type: 'integer'
                     },
                     last_read: {
-                        format: 'idate'
+                        idate: true
                     },
                     last_write: {
-                        format: 'idate'
+                        idate: true
                     },
                 }
             }

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -2812,7 +2812,7 @@ class NodesMonitor extends EventEmitter {
             },
             storage: storage,
             data_activities: _.map(data_activities, a => {
-                if (!_.isFinite(a.time.end)) delete a.time.end;
+                if (!Number.isFinite(a.time.end)) delete a.time.end;
                 a.progress = progress_by_time(a.time, now);
                 return a;
             })
@@ -2886,7 +2886,7 @@ class NodesMonitor extends EventEmitter {
             },
             storage: storage,
             data_activities: _.map(data_activities, a => {
-                if (!_.isFinite(a.time.end)) delete a.time.end;
+                if (!Number.isFinite(a.time.end)) delete a.time.end;
                 a.progress = progress_by_time(a.time, now);
                 return a;
             })
@@ -3042,6 +3042,12 @@ class NodesMonitor extends EventEmitter {
                 'time',
                 'size',
                 'wait_reason');
+            if (info.data_activity.time && !Number.isFinite(info.data_activity.time.end)) {
+                delete info.data_activity.time.end;
+            }
+            if (info.data_activity.stage.time && !Number.isFinite(info.data_activity.stage.time.end)) {
+                delete info.data_activity.stage.time.end;
+            }
         }
         info.storage = this._node_storage_info(item);
         info.drive = {

--- a/src/server/notifications/alerts_log_schema.js
+++ b/src/server/notifications/alerts_log_schema.js
@@ -14,13 +14,13 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         time: {
-            format: 'date',
+            date: true,
         },
         severity: {
             type: 'string',

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -829,7 +829,7 @@ function report_endpoint_problems(req) {
 function get_object_info(md) {
     var bucket = system_store.data.get_by_id(md.bucket);
     return {
-        obj_id: String(md._id),
+        obj_id: md._id,
         bucket: bucket.name,
         key: md.key,
         size: md.size || 0,

--- a/src/server/object_services/schemas/data_block_schema.js
+++ b/src/server/object_services/schemas/data_block_schema.js
@@ -18,39 +18,20 @@ module.exports = {
     ],
     properties: {
 
-        _id: {
-            format: 'objectid'
-        },
-
-        deleted: {
-            format: 'date'
-        },
-
-        system: {
-            format: 'objectid'
-        },
+        _id: { objectid: true },
+        system: { objectid: true },
+        deleted: { date: true },
 
         // bucket is copied from the chunk
         // every chunk belongs exclusively to a single bucket in order to specify its data placement
         // TODO consider changing chunks to refer to tier/tieringpolicy instead so multiple buckets could share dedup
-        bucket: {
-            format: 'objectid'
-        },
+        bucket: { objectid: true },
 
-        pool: {
-            format: 'objectid'
-        },
-
-        // the storage node of this block
-        node: {
-            format: 'objectid'
-        },
+        // the storage node of this block, and the associated pool
+        node: { objectid: true },
+        pool: { objectid: true },
 
         // (chunk,frag) define the block content
-        chunk: {
-            format: 'objectid'
-        },
-
         // the chunk redundancy layer and fragment index - see DataChunk
         // when layer==='D' this is the data layer,
         // when layer==='RS' for Reed-Solomon parity,
@@ -65,6 +46,7 @@ module.exports = {
         frag: {
             type: 'integer'
         },
+        chunk: { objectid: true },
 
         // block size is the size of the fragment
         // this is the same as the chunk size when not using erasure coding since the chunk has a single fragment

--- a/src/server/object_services/schemas/data_chunk_schema.js
+++ b/src/server/object_services/schemas/data_chunk_schema.js
@@ -17,23 +17,15 @@ module.exports = {
     ],
     properties: {
 
-        _id: {
-            format: 'objectid'
-        },
+        // identification
+        _id: { objectid: true },
+        system: { objectid: true },
+        deleted: { date: true },
 
-        deleted: {
-            format: 'date'
-        },
-
-        system: {
-            format: 'objectid'
-        },
 
         // every chunk belongs exclusively to a single bucket in order to specify its data placement
         // TODO consider changing chunks to refer to tier/tieringpolicy instead so multiple buckets could share dedup
-        bucket: {
-            format: 'objectid'
-        },
+        bucket: { objectid: true },
 
         // size in bytes
         size: {

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -14,22 +14,22 @@ module.exports = {
     properties: {
 
         _id: {
-            format: 'objectid'
+            objectid: true
         },
 
         // on delete set deletion time
         // see relation to cloud_synced, if deleted will ever be actually
         // remove from the DB, need to wait until its cloud_synced === true
         deleted: {
-            format: 'date'
+            date: true
         },
 
         system: {
-            format: 'objectid'
+            objectid: true
         },
 
         bucket: {
-            format: 'objectid'
+            objectid: true
         },
 
         // the object key is sort of a path in the bucket namespace
@@ -61,11 +61,11 @@ module.exports = {
         },
 
         upload_started: {
-            format: 'objectid'
+            objectid: true
         },
 
         create_time: {
-            format: 'date'
+            date: true
         },
 
         // etag is the object md5 hex for objects uploaded in single action.
@@ -103,7 +103,7 @@ module.exports = {
                     type: 'integer'
                 },
                 last_read: {
-                    format: 'date'
+                    date: true
                 },
             }
         },

--- a/src/server/object_services/schemas/object_multipart_schema.js
+++ b/src/server/object_services/schemas/object_multipart_schema.js
@@ -14,23 +14,23 @@ module.exports = {
     properties: {
 
         _id: {
-            format: 'objectid'
+            objectid: true
         },
 
         deleted: {
-            format: 'date'
+            date: true
         },
 
         system: {
-            format: 'objectid'
+            objectid: true
         },
 
         bucket: {
-            format: 'objectid'
+            objectid: true
         },
 
         obj: {
-            format: 'objectid'
+            objectid: true
         },
 
         // the multipart number in range 1 - 10000

--- a/src/server/object_services/schemas/object_part_schema.js
+++ b/src/server/object_services/schemas/object_part_schema.js
@@ -16,32 +16,32 @@ module.exports = {
     properties: {
 
         _id: {
-            format: 'objectid'
+            objectid: true
         },
 
         deleted: {
-            format: 'date'
+            date: true
         },
 
         system: {
-            format: 'objectid'
+            objectid: true
         },
 
         bucket: {
-            format: 'objectid'
+            objectid: true
         },
 
         // link to the data chunk
         // chunk can be shared by several parts even by different objects for dedup.
         // NOTE: on deletion rename the chunk field to chunk_del to remove from sparse index
         chunk: {
-            format: 'objectid'
+            objectid: true
         },
 
         // the object that this part belong to.
         // NOTE: on deletion rename the obj field to obj_del to remove from sparse index
         obj: {
-            format: 'objectid'
+            objectid: true
         },
 
         // the range [start,end) in the object
@@ -65,7 +65,7 @@ module.exports = {
         // for multipart upload we reference a multipart item
         // NOTE: on deletion rename the multipart field to multipart_del to remove from sparse index
         multipart: {
-            format: 'objectid'
+            objectid: true
         },
 
         // sequential number for the parts in the object

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -12,10 +12,10 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         deleted: {
-            format: 'date'
+            date: true
         },
         name: {
             type: 'string'
@@ -27,7 +27,7 @@ module.exports = {
             type: 'string' // bcrypted password
         },
         next_password_change: {
-            format: 'date'
+            date: true
         },
         is_support: {
             type: 'boolean'
@@ -60,7 +60,7 @@ module.exports = {
                 permission_list: {
                     type: 'array',
                     items: {
-                        format: 'objectid'
+                        objectid: true
                     }
                 }
             }
@@ -81,7 +81,7 @@ module.exports = {
             }
         },
         default_pool: {
-            format: 'objectid'
+            objectid: true
         },
         sync_credentials_cache: {
             type: 'array',

--- a/src/server/system_services/schemas/agent_config_schema.js
+++ b/src/server/system_services/schemas/agent_config_schema.js
@@ -11,16 +11,16 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         name: {
             type: 'string'
         },
         pool: {
-            format: 'objectid'
+            objectid: true
         },
         exclude_drive: {
             type: 'array',

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -31,13 +31,13 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         deleted: {
-            format: 'date'
+            date: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         name: {
             type: 'string'
@@ -52,16 +52,16 @@ module.exports = {
                 read_resources: {
                     type: 'array',
                     items: {
-                        format: 'objectid' // namespace resource id
+                        objectid: true // namespace resource id
                     }
                 },
                 write_resource: {
-                    format: 'objectid' // namespace resource id
+                    objectid: true // namespace resource id
                 }
             }
         },
         tiering: {
-            format: 'objectid' // tiering policy id
+            objectid: true // tiering policy id
         },
         quota: {
             type: 'object',
@@ -104,7 +104,7 @@ module.exports = {
                             type: 'string'
                         },
                         account_id: {
-                            format: 'objectid'
+                            objectid: true
                         }
                     }
                 },
@@ -118,7 +118,7 @@ module.exports = {
                 },
                 // Last finished sync
                 last_sync: {
-                    format: 'idate'
+                    idate: true
                 },
                 // Enable cloud to NooBaa bucket sync
                 c2n_enabled: {
@@ -170,7 +170,7 @@ module.exports = {
                     }
                 },
                 last_update: {
-                    format: 'idate'
+                    idate: true
                 }
             }
         },
@@ -197,7 +197,7 @@ module.exports = {
                                 type: 'integer'
                             },
                             date: {
-                                format: 'idate'
+                                idate: true
                             },
                             expired_object_delete_marker: {
                                 type: 'boolean'
@@ -217,7 +217,7 @@ module.exports = {
                         type: 'object',
                         properties: {
                             date: {
-                                format: 'idate'
+                                idate: true
                             },
                             storage_class: {
                                 type: 'string',
@@ -246,7 +246,7 @@ module.exports = {
                         }
                     },
                     last_sync: {
-                        format: 'idate'
+                        idate: true
                     }
                 }
             }
@@ -262,10 +262,10 @@ module.exports = {
                     type: 'integer',
                 },
                 last_read: {
-                    format: 'idate'
+                    idate: true
                 },
                 last_write: {
-                    format: 'idate'
+                    idate: true
                 }
             }
         },

--- a/src/server/system_services/schemas/cluster_schema.js
+++ b/src/server/system_services/schemas/cluster_schema.js
@@ -10,7 +10,7 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         is_clusterized: {
             type: 'boolean'
@@ -127,7 +127,7 @@ module.exports = {
                     type: 'string'
                 },
                 time: {
-                    format: 'idate'
+                    idate: true
                 },
                 health: {
                     type: 'object',
@@ -154,7 +154,7 @@ module.exports = {
                                     type: 'string'
                                 },
                                 uptime: {
-                                    format: 'idate'
+                                    idate: true
                                 },
                                 loadavg: {
                                     type: 'array',

--- a/src/server/system_services/schemas/config_file_schema.js
+++ b/src/server/system_services/schemas/config_file_schema.js
@@ -11,7 +11,7 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         encoding: {
             type: 'string',

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -13,16 +13,16 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         deleted: {
-            format: 'date'
+            date: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         account: {
-            format: 'objectid'
+            objectid: true
         },
         name: {
             type: 'string'

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -30,13 +30,13 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         deleted: {
-            format: 'date'
+            date: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         name: {
             type: 'string'
@@ -74,7 +74,7 @@ module.exports = {
             properties: {
                 blocks_size: bigint,
                 last_update: {
-                    format: 'idate'
+                    idate: true
                 }
             }
         },
@@ -101,7 +101,7 @@ module.exports = {
                             type: 'string'
                         },
                         account_id: {
-                            format: 'objectid'
+                            objectid: true
                         }
                     }
                 },

--- a/src/server/system_services/schemas/role_schema.js
+++ b/src/server/system_services/schemas/role_schema.js
@@ -12,16 +12,16 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         deleted: {
-            format: 'date'
+            date: true
         },
         system: {
-            format: 'objectid'
+            objectid: true
         },
         account: {
-            format: 'objectid'
+            objectid: true
         },
         role: {
             type: 'string',

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -11,16 +11,16 @@ module.exports = {
     ],
     properties: {
         _id: {
-            format: 'objectid'
+            objectid: true
         },
         deleted: {
-            format: 'date'
+            date: true
         },
         name: {
             type: 'string'
         },
         owner: {
-            format: 'objectid' // account id
+            objectid: true // account id
         },
         // links to system resources used for storing install packages
         resources: {
@@ -49,10 +49,10 @@ module.exports = {
             properties: {}
         },
         last_stats_report: {
-            format: 'idate'
+            idate: true
         },
         maintenance_mode: {
-            format: 'idate'
+            idate: true
         },
         // the DNS name or IP address used for the server
         base_address: {
@@ -126,7 +126,7 @@ module.exports = {
 
         //Last upgrade date
         upgrade_date: {
-            format: 'idate'
+            idate: true
         }
 
     }

--- a/src/server/system_services/schemas/tier_schema.js
+++ b/src/server/system_services/schemas/tier_schema.js
@@ -15,18 +15,6 @@ module.exports = {
         'mirrors',
     ],
     properties: {
-        _id: {
-            format: 'objectid'
-        },
-        deleted: {
-            format: 'date'
-        },
-        system: {
-            format: 'objectid'
-        },
-        name: {
-            type: 'string'
-        },
         replicas: {
             type: 'integer'
         },
@@ -37,6 +25,13 @@ module.exports = {
         parity_fragments: {
             type: 'integer'
         },
+
+        // identifiers
+        _id: { objectid: true },
+        name: { type: 'string' },
+        system: { objectid: true },
+        deleted: { date: true },
+
         data_placement: {
             type: 'string',
             enum: ['MIRROR', 'SPREAD']
@@ -52,9 +47,7 @@ module.exports = {
                 properties: {
                     spread_pools: {
                         type: 'array',
-                        items: {
-                            format: 'objectid' // pool id
-                        }
+                        items: { objectid: true } // pool id
                     }
                 }
             }

--- a/src/server/system_services/schemas/tiering_policy_schema.js
+++ b/src/server/system_services/schemas/tiering_policy_schema.js
@@ -11,36 +11,23 @@ module.exports = {
         'tiers',
     ],
     properties: {
-        _id: {
-            format: 'objectid'
-        },
-        deleted: {
-            format: 'date'
-        },
-        system: {
-            format: 'objectid'
-        },
-        name: {
-            type: 'string',
-        },
+
+        // identifiers
+        _id: { objectid: true },
+        name: { type: 'string' },
+        system: { objectid: true },
+        deleted: { date: true },
+
         tiers: {
             type: 'array',
             items: {
                 type: 'object',
                 required: ['order', 'tier'],
                 properties: {
-                    order: {
-                        type: 'integer',
-                    },
-                    tier: {
-                        format: 'objectid'
-                    },
-                    spillover: {
-                        type: 'boolean',
-                    },
-                    disabled: {
-                        type: 'boolean',
-                    }
+                    order: { type: 'integer' },
+                    tier: { objectid: true },
+                    spillover: { type: 'boolean' },
+                    disabled: { type: 'boolean' }
                 }
             }
         },

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -6,11 +6,37 @@ const stream = require('stream');
 
 const EMPTY_BUFFER = Buffer.allocUnsafeSlow(0);
 
+function eq(buf1, buf2) {
+    return buf1 ? buf1.equals(buf2) : !buf2;
+}
+
+function neq(buf1, buf2) {
+    return !eq(buf1, buf2);
+}
+
+/**
+ * join() improves Buffer.concat() for a common pathological case
+ * where the list has just 1 buffer.
+ * In that case we simply return that buffer and avoid a memory copy
+ * that concat will always make.
+ * 
+ * @param {[Buffer]} buffers list of buffers to join
+ * @param {Number} total_length number of bytes to pass to concat
+ * @returns {Buffer} concatenated buffer
+ */
 function join(buffers, total_length) {
     if (buffers.length > 1) return Buffer.concat(buffers, total_length);
     return buffers[0] || EMPTY_BUFFER;
 }
 
+/**
+ * extract() is like Buffer.slice() but for array of buffers
+ * Removes len bytes from the beginning of the array, or less if not available
+ * 
+ * @param {[Buffer]} buffers array of buffers to update
+ * @param {Number} len number of bytes to extract
+ * @returns {[Buffer]} array of buffers with total length of len or less
+ */
 function extract(buffers, len) {
     const res = [];
     var pos = 0;
@@ -75,6 +101,8 @@ function count_length(buffers) {
     return l;
 }
 
+exports.eq = eq;
+exports.neq = neq;
 exports.join = join;
 exports.extract = extract;
 exports.extract_join = extract_join;

--- a/src/util/mongo_utils.js
+++ b/src/util/mongo_utils.js
@@ -6,8 +6,7 @@ const util = require('util');
 const mongodb = require('mongodb');
 
 const P = require('./promise');
-const RpcError = require('../rpc/rpc_error');
-const schema_utils = require('./schema_utils');
+const { RpcError } = require('../rpc');
 
 /* exported constants */
 const mongo_operators = new Set([
@@ -197,13 +196,6 @@ function make_object_diff(current, prev) {
     return diff;
 }
 
-const mongo_ajv_formats = Object.freeze({
-    date: schema_utils.date_format,
-    idate: schema_utils.idate_format,
-    objectid: val => is_object_id(val)
-});
-
-
 // EXPORTS
 exports.mongo_operators = mongo_operators;
 exports.obj_ids_difference = obj_ids_difference;
@@ -221,4 +213,3 @@ exports.check_entity_not_found = check_entity_not_found;
 exports.check_entity_not_deleted = check_entity_not_deleted;
 exports.check_update_one = check_update_one;
 exports.make_object_diff = make_object_diff;
-exports.mongo_ajv_formats = mongo_ajv_formats;


### PR DESCRIPTION
### Explain the changes:
- Apparently, the JSON validation we had for date, idate using `format: 'date'` was not really working - had to use an AJV keyword to make it work.
- This change found few issues in the code, and might find some more.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- None

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

