### PR TITLE
Fixes #3829 - globally replace dots with dash in NIC name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -31,7 +31,7 @@ function os_info(count_mongo_reserved_as_free) {
 
     _.each(orig_ifaces, function(iface, name) {
         if (name.indexOf('.') !== -1) {
-            var new_name = name.replace('.', '-');
+            var new_name = name.replace(/\./g, '-');
             interfaces[new_name] = iface;
             delete interfaces[name];
         }


### PR DESCRIPTION
### Explain the changes:
- mongo DB does not allow keys with dot character. dots were meant to be replaced by `-` but it was not replaced globally.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Fixes #3829

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade from the previous version - DB schema, server platform, agents install, new packages added to deployment

