### PR TITLE
[1.12.4] endpoint: disable blob service by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -34,6 +34,8 @@ const s3_rest = require('./s3/s3_rest');
 const blob_rest = require('./blob/blob_rest');
 const lambda_rest = require('./lambda/lambda_rest');
 
+const ENDPOINT_BLOB_ENABLED = process.env.ENDPOINT_BLOB_ENABLED === 'true';
+
 function start_all() {
     dbg.set_process_name('Endpoint');
     if (cluster.isMaster && config.ENDPOINT_FORKS_ENABLED && argv.address) {
@@ -62,8 +64,8 @@ function start_all() {
                 dbg.log0(`got ssl certificates. running server`);
                 run_server({
                     s3: true,
-                    blob: false,
                     lambda: true,
+                    blob: ENDPOINT_BLOB_ENABLED,
                     certs: params.certs,
                     node_id: params.node_id,
                     host_id: params.host_id
@@ -82,8 +84,8 @@ function start_all() {
     } else {
         run_server({
             s3: true,
-            blob: true,
-            lambda: true
+            lambda: true,
+            blob: ENDPOINT_BLOB_ENABLED,
         });
     }
 }


### PR DESCRIPTION
### Explain the changes:
- avoid data access by blob unless manuall enabled in .env with 
```
ENDPOINT_BLOB_ENABLED=true
```

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- Related to #3850, not closing it.

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

