### PR TITLE
retrust modal

### DIFF
--- a/frontend/src/app/action-creators/modals-actions.js
+++ b/frontend/src/app/action-creators/modals-actions.js
@@ -571,3 +571,19 @@ export function openEditSpilloverTargetsModal() {
         }
     };
 }
+
+export function openSetNodeAsTrustedModal(host, untrustedReasons) {
+    return {
+        type: OPEN_MODAL,
+        payload: {
+            component: {
+                name: 'set-node-as-trusted-modal',
+                params: { host, untrustedReasons }
+            },
+            options: {
+                title: 'Set Node as Trusted',
+                size: 'small'
+            }
+        }
+    };
+}

--- a/frontend/src/app/components/modals/set-node-as-trusted-modal/set-node-as-trusted-modal.html
+++ b/frontend/src/app/components/modals/set-node-as-trusted-modal/set-node-as-trusted-modal.html
@@ -1,0 +1,28 @@
+<!-- Copyright (C) 2016 NooBaa -->
+
+<div class="column greedy">
+    <section class="column c7">
+        <h3 class="heading3 push-next-half">Reliability test result</h3>
+        <data-table class="greedy untrusted-reason-table" params="
+            columns: columns,
+            data: rows
+        "></data-table>
+    </section>
+    <hr class="push-both" />
+    <section class="column c5">
+        <p class="push-next">
+            This node was marked as untrusted after an internal reliability test.
+        </p>
+        <p>
+            Setting this node as trusted may risk its stored data.
+        </p>
+        <p class="push-next">
+            Would you like to trust this node anyway?
+        </p>
+    </section>
+</div>
+<div class="row content-middle align-end">
+    <button class="link alt-colors push-next" data-bind="click: onCancel">Cancel</button>
+    <button class="btn" data-bind="click: onRetrust">Yes, trust this node</button>
+</div>
+

--- a/frontend/src/app/components/modals/set-node-as-trusted-modal/set-node-as-trusted-modal.js
+++ b/frontend/src/app/components/modals/set-node-as-trusted-modal/set-node-as-trusted-modal.js
@@ -1,0 +1,68 @@
+/* Copyright (C) 2016 NooBaa */
+
+import template from './set-node-as-trusted-modal.html';
+import Observer from 'observer';
+import { deepFreeze, flatMap } from 'utils/core-utils';
+import { retrustHost } from 'action-creators';
+import { action$ } from 'state';
+import { timeShortFormat } from 'config';
+import moment from 'moment';
+
+const columns = deepFreeze([
+    {
+        name: 'testDate'
+    },
+    {
+        name: 'drive'
+    },
+    {
+        name: 'testType'
+    },
+    {
+        name: 'results'
+    }
+]);
+
+const eventMapping = deepFreeze({
+    CORRUPTION: {
+        type: 'Disk corruption',
+        results: 'Data was changed'
+    },
+    TEMPERING: {
+        type: 'Node tempering',
+        results: 'missing data'
+    }
+});
+
+class SetNodeAsTrustedModalViewModel extends Observer {
+    constructor({ onClose, host, untrustedReasons }) {
+        super();
+
+        this.columns = columns;
+        this.close = onClose;
+        this.host = host;
+
+        this.rows = flatMap(untrustedReasons,
+            ({ drive, events }) => events.map(event => {
+                const { time, reason } = event;
+                const testDate = moment(time).format(timeShortFormat);
+                const { type: testType, results } = eventMapping[reason];
+                return { testDate, drive, testType, results };
+            })
+        );
+    }
+
+    onRetrust() {
+        action$.onNext(retrustHost(this.host));
+        this.close();
+    }
+
+    onCancel() {
+        this.close();
+    }
+}
+
+export default {
+    viewModel: SetNodeAsTrustedModalViewModel,
+    template: template
+};

--- a/frontend/src/app/components/modals/set-node-as-trusted-modal/set-node-as-trusted-modal.less
+++ b/frontend/src/app/components/modals/set-node-as-trusted-modal/set-node-as-trusted-modal.less
@@ -1,0 +1,26 @@
+/* Copyright (C) 2016 NooBaa */
+
+.set-node-as-trusted-modal {
+    display: block;
+
+    .untrusted-reason-table {
+        text-align: left;
+
+        .test-date-col {
+            min-width: 140px;
+        }
+
+        .drive-col {
+            min-width: 100px;
+            width: 100%;
+        }
+
+        .test-type-col {
+            min-width: 110px;
+        }
+
+        .results-col {
+            min-width: 110px;
+        }
+    }
+}

--- a/frontend/src/app/components/register.js
+++ b/frontend/src/app/components/register.js
@@ -90,6 +90,7 @@ export default function register(ko) {
     ko.components.register('edit-bucket-placement-modal',               require('./modals/edit-bucket-placement-modal/edit-bucket-placement-modal').default);
     ko.components.register('empty-bucket-placement-warning-modal',      require('./modals/empty-bucket-placement-warning-modal/empty-bucket-placement-warning-modal').default);
     ko.components.register('edit-spillover-targets-modal',              require('./modals/edit-spillover-targets-modal/edit-spillover-targets-modal').default);
+    ko.components.register('set-node-as-trusted-modal',                 require('./modals/set-node-as-trusted-modal/set-node-as-trusted-modal').default);
     /** INJECT:modals **/
 
     // -------------------------------


### PR DESCRIPTION
### Explain the changes:
- retrust modal

Tests:

1. When user goes to trusted node details page button 'Set As Trusted' should be hidden
2. When user goes to untrusted node details page button 'Set As Trusted' should be visible
3. When user click on 'Set As Trusted' button modal 'Set Node as Trusted' should appear
4. When user click on 'Yes, trust this node' on modal, node become trusted again
5. Modal correctly display untrusted reason in table
6. Modal correctly display many untrusted reasons in table
7. Clicking cancel in modal closes the modal without retrust.
8. After clicking retrust the “set  as trusted” button is invisible
9. After clicking returst the node reload it’s state