### PR TITLE
Adding dedup_indexer bg_worker - monitor dedup index size

### DIFF
--- a/config.js
+++ b/config.js
@@ -152,6 +152,18 @@ config.CHUNK_CODER_EC_PARITY_FRAGS = 2;
 config.CHUNK_CODER_EC_PARITY_TYPE = 'isa-c1';
 
 //////////////////////
+// DEDUP INDEXER CONFIG //
+//////////////////////
+config.DEDUP_INDEXER_ENABLED = true;
+config.DEDUP_INDEXER_BATCH_SIZE = 200;
+config.DEDUP_INDEXER_BATCH_DELAY = 50;
+config.DEDUP_INDEXER_ERROR_DELAY = 3000;
+config.DEDUP_INDEXER_RESTART_DELAY = 30000;
+config.DEDUP_INDEXER_IGNORE_BACK_TIME = 7 * 24 * 60 * 60 * 1000; // dedup indexer will ignore dedup keys from the last week
+config.DEDUP_INDEXER_LOW_KEYS_NUMBER = 8 * 1000000; // 8M keys max in index ~ 1.5GB
+config.DEDUP_INDEXER_CHECK_INDEX_CYCLE = 60000;
+
+//////////////////////
 // LIFECYCLE CONFIG //
 //////////////////////
 

--- a/src/agent/agent_diagnostics.js
+++ b/src/agent/agent_diagnostics.js
@@ -15,11 +15,13 @@ const base_diagnostics = require('../util/base_diagnostics');
 const TMP_WORK_DIR = base_diagnostics.get_tmp_workdir();
 
 function collect_agent_diagnostics(storage_path) {
-    const diag_log = fs.createWriteStream(path.join(TMP_WORK_DIR, 'agent_diagnostics.log'));
+    let diag_log;
 
     //mkdir c:\tmp ?
     return base_diagnostics.prepare_diag_dir()
         .then(function() {
+            diag_log = fs.createWriteStream(path.join(TMP_WORK_DIR, 'agent_diagnostics.log'))
+                .on('error', err => console.error('ERROR in agent_diagnostics.log', err));
             return base_diagnostics.collect_basic_diagnostics()
                 .catch(err => {
                     diag_log.write(`failed collecting basic diagnostics. ${err.message}`);

--- a/src/server/bg_services/dedup_indexer.js
+++ b/src/server/bg_services/dedup_indexer.js
@@ -1,0 +1,104 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// const _ = require('lodash');
+const P = require('../../util/promise');
+const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config');
+const MDStore = require('../object_services/md_store').MDStore;
+const system_store = require('../system_services/system_store').get_instance();
+const system_utils = require('../utils/system_utils');
+
+// dbg.set_level(5);
+
+/**
+ *
+ * DEDUP_INDEXER
+ *
+ * background worker that validates the chunk collection's dedup_key index size in not too big to fit in RAM
+ *
+ * @this worker instance
+ *
+ */
+function background_worker() {
+    if (!system_store.is_finished_initial_load) {
+        dbg.log0('DEDUP_INDEXER: system_store did not finish initial load');
+        return;
+    }
+    const system = system_store.data.systems[0];
+    if (!system || system_utils.system_in_maintenance(system._id)) return;
+
+    let chunk_ids = [];
+
+    return P.resolve()
+        .then(() => {
+            if (this.last_check && Date.now() - this.last_check < config.DEDUP_INDEXER_CHECK_INDEX_CYCLE) return;
+            dbg.log0('DEDUP_INDEXER: checking index size ...');
+            return P.join(
+                    MDStore.instance().get_dedup_index_size(),
+                    MDStore.instance().get_aprox_dedup_keys_number()
+                )
+                .then(([dedup_index_size, dedup_aprox_keys]) => {
+                    dbg.log0('DEDUP_INDEXER: dedup_index_size', dedup_index_size, 'dedup_aprox_keys', dedup_aprox_keys);
+                    this.last_check = Date.now();
+                    this.dedup_index_size = dedup_index_size;
+                    this.dedup_keys_count = dedup_aprox_keys;
+                });
+        })
+        .then(() => {
+            dbg.log1('DEDUP_INDEXER: the index size is', this.dedup_index_size);
+
+            if (this.dedup_keys_count < config.DEDUP_INDEXER_LOW_KEYS_NUMBER) {
+                dbg.log0('DEDUP_INDEXER: the index keys number is smaller than', config.DEDUP_INDEXER_LOW_KEYS_NUMBER, ' - nothing to do');
+                // return the delay before next batch
+                this.marker = undefined;
+                return;
+            }
+
+            const batch_size = config.DEDUP_INDEXER_BATCH_SIZE;
+            return MDStore.instance().iterate_indexed_chunks(batch_size, this.marker);
+        })
+        .then(res => {
+            if (!res || !res.chunk_ids || !res.chunk_ids.length) {
+                this.marker = undefined;
+                return;
+            }
+            this.marker = res.marker;
+            dbg.log1('DEDUP_INDEXER:', 'WORKING ON', res.chunk_ids.length, 'CHUNKS');
+            const ignore_back_time = Date.now() - config.DEDUP_INDEXER_IGNORE_BACK_TIME;
+            chunk_ids = res.chunk_ids.filter(id => (id.getTimestamp().getTime() < ignore_back_time));
+            if (!chunk_ids.length) return;
+
+            dbg.log1('DEDUP_INDEXER:', 'not_last_week_res', chunk_ids.length);
+            return MDStore.instance().find_parts_chunks_references(chunk_ids);
+        })
+        .then(parts_by_chunk_id => {
+            if (parts_by_chunk_id) {
+                chunk_ids = chunk_ids.filter(
+                    chunk_id => !parts_by_chunk_id[chunk_id] || parts_by_chunk_id[chunk_id].length <= 1
+                );
+            }
+            if (!chunk_ids.length) return;
+
+            dbg.log1('DEDUP_INDEXER:', 'chunk_ids_to_deindex', chunk_ids.length);
+            dbg.log1('DEDUP_INDEXER:', 'marker', this.marker);
+            return MDStore.instance().update_chunks_by_ids(
+                chunk_ids, undefined, { dedup_key: true }
+            );
+        })
+        .then(() => {
+            if (this.marker) {
+                return config.DEDUP_INDEXER_BATCH_DELAY;
+            } else {
+                dbg.log0('DEDUP_INDEXER:', 'RESTART');
+                return config.DEDUP_INDEXER_RESTART_DELAY;
+            }
+        })
+        .catch(err => {
+            dbg.error('DEDUP_INDEXER:', 'ERROR', err, err.stack);
+            return config.DEDUP_INDEXER_ERROR_DELAY;
+        });
+}
+
+// EXPORTS
+exports.background_worker = background_worker;

--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -38,13 +38,15 @@ var usage_aggregator = require('./bg_services/usage_aggregator');
 var md_aggregator = require('./bg_services/md_aggregator');
 var background_scheduler = require('../util/background_scheduler').get_instance();
 var stats_collector = require('./bg_services/stats_collector');
+var dedup_indexer = require('./bg_services/dedup_indexer');
 
 const MASTER_BG_WORKERS = [
     'scrubber',
     'cloud_sync_refresher',
     'system_server_stats_aggregator',
     'md_aggregator',
-    'usage_aggregator'
+    'usage_aggregator',
+    'dedup_indexer'
 ];
 
 dbg.set_process_name('BGWorkers');
@@ -114,6 +116,14 @@ function run_master_workers() {
         }, scrubber.background_worker);
     } else {
         dbg.warn('SCRUBBER NOT ENABLED');
+    }
+
+    if (config.DEDUP_INDEXER_ENABLED) {
+        register_bg_worker({
+            name: 'dedup_indexer',
+        }, dedup_indexer.background_worker);
+    } else {
+        dbg.warn('DEDUP INDEXER NOT ENABLED');
     }
 
     if (config.LIFECYCLE_DISABLED !== 'true') {

--- a/src/server/object_services/map_writer.js
+++ b/src/server/object_services/map_writer.js
@@ -69,6 +69,7 @@ function finalize_object_parts(bucket, obj, parts) {
                 _id: chunk_id,
                 system: obj.system,
                 bucket: bucket._id,
+                dedup_key: part.chunk.digest_b64,
             }, _.pick(part.chunk,
                 'size',
                 'digest_type',

--- a/src/server/object_services/schemas/data_block_indexes.js
+++ b/src/server/object_services/schemas/data_block_indexes.js
@@ -10,7 +10,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                chunk: { $exists: true }
+            }
         }
     },
     {
@@ -22,7 +24,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                node: { $exists: true }
+            }
         }
     },
     {
@@ -31,7 +35,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                deleted: { $exists: true }
+            }
         }
     }
 ];

--- a/src/server/object_services/schemas/data_chunk_indexes.js
+++ b/src/server/object_services/schemas/data_chunk_indexes.js
@@ -7,7 +7,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                dedup_key: { $exists: true }
+            }
         }
     },
     {
@@ -17,7 +19,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                deleted: { $exists: true }
+            }
         }
     }
 ];

--- a/src/server/object_services/schemas/object_md_indexes.js
+++ b/src/server/object_services/schemas/object_md_indexes.js
@@ -51,7 +51,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                create_time: { $exists: true }
+            }
         }
     },
     {
@@ -61,7 +63,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                deleted: { $exists: true }
+            }
         }
     }
 ];

--- a/src/server/object_services/schemas/object_multipart_indexes.js
+++ b/src/server/object_services/schemas/object_multipart_indexes.js
@@ -8,6 +8,8 @@ module.exports = [{
     },
     options: {
         unique: false,
-        sparse: true,
+        partialFilterExpression: {
+            obj: { $exists: true },
+        }
     }
 }];

--- a/src/server/object_services/schemas/object_part_indexes.js
+++ b/src/server/object_services/schemas/object_part_indexes.js
@@ -13,7 +13,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                obj: { $exists: true },
+            }
         }
     },
     {
@@ -22,7 +24,9 @@ module.exports = [{
         },
         options: {
             unique: false,
-            sparse: true,
+            partialFilterExpression: {
+                chunk: { $exists: true },
+            }
         }
     },
 ];

--- a/src/test/unit_tests/test_md_store.js
+++ b/src/test/unit_tests/test_md_store.js
@@ -213,6 +213,11 @@ mocha.describe('md_store', function() {
             return md_store.find_parts_unreferenced_chunk_ids(chunk_ids);
         });
 
+        mocha.it('find_parts_chunks_references()', function() {
+            const chunk_ids = _.map(parts, 'chunk');
+            return md_store.find_parts_chunks_references(chunk_ids);
+        });
+
         mocha.it('load_parts_objects_for_chunks()', function() {
             const chunks = _.map(parts, part => ({
                 _id: part.chunk
@@ -312,6 +317,22 @@ mocha.describe('md_store', function() {
 
 
     });
+
+    mocha.describe('dedup-index', function() {
+        mocha.it('get_dedup_index_size()', function() {
+            return md_store.get_dedup_index_size();
+        });
+
+        mocha.it('get_aprox_dedup_keys_number()', function() {
+            return md_store.get_aprox_dedup_keys_number();
+        });
+
+        mocha.it('iterate_indexed_chunks()', function() {
+            return md_store.iterate_indexed_chunks(5);
+        });
+    });
+
+
 
 
 });

--- a/src/tools/md_blow.js
+++ b/src/tools/md_blow.js
@@ -59,7 +59,8 @@ function blow_object(index) {
             return blow_parts(params);
         })
         .then(() => {
-            let complete_params = _.pick(params, 'bucket', 'key', 'obj_id');
+            let complete_params = _.pick(params, 'bucket', 'key', 'size', 'obj_id');
+            complete_params.etag = 'bla';
             dbg.log0('complete_object_upload', params.key);
             return client.object.complete_object_upload(complete_params);
         });
@@ -80,7 +81,7 @@ function blow_parts(params) {
                     compress_size: argv.chunk_size,
                     data_frags: 1,
                     lrc_frags: 0,
-                    digest_type: '',
+                    digest_type: 'sha384',
                     digest_b64: crypto.randomBytes(16).toString('base64'),
                     cipher_type: '',
                     cipher_key_b64: '',
@@ -88,7 +89,7 @@ function blow_parts(params) {
                         size: argv.chunk_size,
                         layer: 'D',
                         frag: 0,
-                        digest_type: '',
+                        digest_type: 'sha384',
                         digest_b64: crypto.randomBytes(16).toString('base64'),
                     }]
                 }

--- a/src/tools/mongodb_blow.js
+++ b/src/tools/mongodb_blow.js
@@ -1,0 +1,45 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-env mongo */
+/* global HexData */
+'use strict';
+
+/*
+ * mongodb script to add massive ammount of chunks to DB
+ *
+ * usage: mongo nbcore mongodb_blow.js
+ *
+ */
+function random_hex_char() {
+    let hexchars = "0123456789abcdef";
+    return hexchars[Math.floor(_rand() * 16)];
+}
+
+function random_hex_string(n) {
+    let s = "";
+    for (let i = 0; i < n; ++i) {
+        s += random_hex_char();
+    }
+    return s;
+}
+
+let system = db.systems.findOne()._id;
+let bucket = db.buckets.findOne()._id;
+
+for (let j = 0; j < 10000; ++j) {
+    let array_of_chunks = [];
+    for (let i = 0; i < 1000; ++i) {
+        let digest_b64 = new HexData(0, random_hex_string(96)).base64();
+        array_of_chunks.push({
+            _id: new ObjectId(),
+            system,
+            bucket,
+            size: 1048576,
+            digest_type: "test",
+            digest_b64: digest_b64,
+            dedup_key: digest_b64,
+            data_frags: 1,
+            lrc_frags: 0,
+        });
+    }
+    db.datachunks.insert(array_of_chunks);
+}


### PR DESCRIPTION
### Explain the changes:
- dedup_indexer will monitor number of chunk in dedup index size 
  if too big will start removing chunks from index 
- dedup_indexer will now work with dedup index objects number and not dedup mongo's index
size
- changing all sparse indexes to partial - as recommended by mongo
- adding mongodb_blow for adding chunks directly to DB
- fixing md_blow for supporting some schema changes
- fixing some npm test failures

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

