### PR TITLE
Adding the ability to work with agents on the same RG with different tests

### DIFF
--- a/src/deploy/azure.js
+++ b/src/deploy/azure.js
@@ -123,8 +123,14 @@ function vmOperations(operationCallback) {
                     if (os2.osType === 'Windows') {
                         machine_name = machine_name.substring(0, 15);
                     }
-                    return azf.createAgent(machine_name, storageAccountName, vnetName,
-                            os2, serverName, agentConf)
+                    return azf.createAgent({
+                        vmName: machine_name,
+                        storage: storageAccountName,
+                        vnet: vnetName,
+                        os: os2,
+                        serverName,
+                        agentConf
+                    })
                         .catch(err => console.log('got error with agent', err));
                 });
             }
@@ -138,15 +144,15 @@ function vmOperations(operationCallback) {
                     });
                 }
                 return P.map(servers, server => azf.createServer(server.name, vnetName, storageAccountName)
-                        .then(new_secret => {
-                            server.secret = new_secret;
-                            return azf.getIpAddress(server.name + '_pip');
-                        })
-                        .then(ip => {
-                            server.ip = ip;
-                            return ip;
-                        })
-                    )
+                    .then(new_secret => {
+                        server.secret = new_secret;
+                        return azf.getIpAddress(server.name + '_pip');
+                    })
+                    .then(ip => {
+                        server.ip = ip;
+                        return ip;
+                    })
+                )
                     .then(() => {
                         if (argv.servers > 1) {
                             var slaves = Array.from(servers);
@@ -163,7 +169,14 @@ function vmOperations(operationCallback) {
                 var os = azf.getImagesfromOSname(argv.os);
                 machines = args_builder(machineCount - old_machines.length, os);
                 console.log('adding ', (machineCount - old_machines.length), 'machines');
-                return P.map(machines, machine => azf.createAgent(machine, storageAccountName, vnetName, os, serverName, agentConf)
+                return P.map(machines, machine => azf.createAgent({
+                    vmName: machine,
+                    storage: storageAccountName,
+                    vnet: vnetName,
+                    os,
+                    serverName,
+                    agentConf
+                })
                     .catch(err => console.log('got error with agent', err)));
             }
             console.log('removing ', (old_machines.length - machineCount), 'machines');

--- a/src/deploy/azureFunctions.js
+++ b/src/deploy/azureFunctions.js
@@ -146,7 +146,8 @@ class AzureFunctions {
             .then(res => res.ipAddress);
     }
 
-    createAgent(vmName, storage, vnet, os, server_name, agent_conf) {
+    createAgent(params) {
+        const { vmName, storage, vnet, os, serverName, agentConf } = params;
         return this.getSubnetInfo(vnet)
             .then(subnetInfo => this.createPublicIp(vmName + '_pip')
                 .then(ipInfo => [subnetInfo, ipInfo])
@@ -177,7 +178,7 @@ class AzureFunctions {
                     autoUpgradeMinorVersion: true,
                     settings: {
                         fileUris: ['https://pluginsstorage.blob.core.windows.net/agentscripts/init_agent.sh'],
-                        commandToExecute: 'bash init_agent.sh ' + server_name + ' ' + agent_conf
+                        commandToExecute: 'bash init_agent.sh ' + serverName + ' ' + agentConf
                     },
                     protectedSettings: {
                         storageAccountName: 'pluginsstorage',
@@ -191,8 +192,8 @@ class AzureFunctions {
                     extension.typeHandlerVersion = '1.7';
                     extension.settings = {
                         fileUris: ['https://pluginsstorage.blob.core.windows.net/agentscripts/init_agent.ps1'],
-                        commandToExecute: 'powershell -ExecutionPolicy Unrestricted -File init_agent.ps1 ' + server_name +
-                        ' ' + agent_conf
+                        commandToExecute: 'powershell -ExecutionPolicy Unrestricted -File init_agent.ps1 ' + serverName +
+                            ' ' + agentConf
                     };
                 }
                 return this.createVirtualMachineExtension(vmName, extension);


### PR DESCRIPTION
Adding the ability to work with agents on the same RG with different tests
### Explain the changes:
azureFunctions.js
- createAgent is now getting object as params

azure.js
- fix the calls for the createAgent according to the azureFunctions.js
changes

agent_functions.js
- getTestNodes, list_optimal_agents, createAgents, isIncluded,
deleteAgents and clean_agents are now also getting suffix as param
- removed the create_agents function
- added createAgentsWithList function that will replace the
runCreateAgents on the tests

cluster_test.js:
- removed the runCreateAgents and  deleteAgents functions
- Fixed a bug in the cleanEnv when it didn’t clean the agents when
—clean was called
- fixed the test according to the agent_functions.js and
azureFunctions.js  changes

agents_matrix.js
- fixed the test according to the agent_functions.js and
azureFunctions.js  changes

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

