### PR TITLE
added named (bind) as a dns cache

### DIFF
--- a/config.js
+++ b/config.js
@@ -222,6 +222,10 @@ config.CLUSTERING_PATHS = {
     SUPER_FILE: '/etc/noobaa_supervisor.conf',
 };
 
+config.NAMED_DEFAULTS = {
+    FORWARDERS_OPTION_FILE: '/etc/noobaa_configured_dns.conf'
+};
+
 config.CLUSTER_HB_INTERVAL = 1 * 60000;
 config.CLUSTER_MASTER_INTERVAL = 10000;
 config.CLUSTER_NODE_MISSING_TIME = 3 * 60000;

--- a/src/deploy/NVA_build/named.conf
+++ b/src/deploy/NVA_build/named.conf
@@ -1,0 +1,59 @@
+//
+// named.conf
+//
+// Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
+// server as a caching only nameserver (as a localhost DNS resolver only).
+//
+// See /usr/share/doc/bind*/sample/ for example named configuration files.
+//
+// See the BIND Administrators Reference Manual (ARM) for details about the
+// configuration located in /usr/share/doc/bind-{version}/Bv9ARM.html
+
+options {
+        listen-on port 53 { 127.0.0.1; };
+        listen-on-v6 port 53 { ::1; };
+        directory       "/var/named";
+        dump-file       "/var/named/data/cache_dump.db";
+        statistics-file "/var/named/data/named_stats.txt";
+        memstatistics-file "/var/named/data/named_mem_stats.txt";
+        allow-query     { localhost; };
+        allow-query-cache     { localhost; };
+        /*
+         - If you are building an AUTHORITATIVE DNS server, do NOT enable recursion.
+         - If you are building a RECURSIVE (caching) DNS server, you need to enable
+           recursion.
+         - If your recursive DNS server has a public IP address, you MUST enable access
+           control to limit queries to your legitimate users. Failing to do so will
+           cause your server to become part of large scale DNS amplification
+           attacks. Implementing BCP38 within your network would greatly
+           reduce such attack surface
+        */
+        recursion yes;
+        include "/etc/noobaa_configured_dns.conf";
+        dnssec-enable yes;
+        // Danny - I removed dnssec-validation since it produced dns errors when there is a clock skew
+        dnssec-validation no;
+
+        /* Path to ISC DLV key */
+        bindkeys-file "/etc/named.iscdlv.key";
+
+        managed-keys-directory "/var/named/dynamic";
+
+        pid-file "/run/named/named.pid";
+        session-keyfile "/run/named/session.key";
+};
+
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+
+zone "." IN {
+        type hint;
+        file "named.ca";
+};
+
+include "/etc/named.rfc1912.zones";
+include "/etc/named.root.key";

--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -120,26 +120,7 @@ function _verify_dns_cluster_config() {
         search_domains: _.compact(server_conf.search_domains)
     };
 
-    let static_dns_config;
-    let dynamic_dns_config;
-    return os_utils.get_dns_servers()
-        .then(platform_dns_config => {
-            dynamic_dns_config = platform_dns_config;
-            return os_utils.get_dns_servers_for_static();
-        })
-        .then(platform_dns_config => {
-            static_dns_config = platform_dns_config;
-            if (!_are_platform_and_cluster_conf_equal(dynamic_dns_config, static_dns_config)) {
-                dbg.error(`platform dynamic(/etc/dhclient) and static(/etc/sysconfig/network) dns settings are not synced. 
-                    Dynamic conf: `, dynamic_dns_config, 'Static conf:', static_dns_config);
-                return os_utils.set_dns_server(cluster_conf.dns_servers, cluster_conf.search_domains)
-                    .then(() => os_utils.restart_services());
-            } else if (!_are_platform_and_cluster_conf_equal(platform_dns_config, cluster_conf)) {
-                dbg.warn(`platform dns settings not synced to cluster. Platform conf: `, platform_dns_config, 'cluster_conf:', cluster_conf);
-                return os_utils.set_dns_server(cluster_conf.dns_servers, cluster_conf.search_domains)
-                    .then(() => os_utils.restart_services());
-            }
-        })
+    return os_utils.ensure_dns_and_search_domains(cluster_conf)
         .catch(err => dbg.error('failed to reconfigure dns cluster config on the server. reason:', err));
 }
 

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -856,10 +856,7 @@ function update_dns_servers(req) {
 
 
 function apply_updated_dns_servers(req) {
-    return P.fcall(function() {
-            return os_utils.set_dns_server(req.rpc_params.dns_servers, req.rpc_params.search_domains);
-        })
-        .then(() => os_utils.restart_services())
+    return os_utils.set_dns_and_search_domains(req.rpc_params.dns_servers, req.rpc_params.search_domains)
         .return();
 }
 
@@ -1670,7 +1667,7 @@ function _add_new_server_to_replica_set(params) {
         .then(() => P.join(
             os_utils.get_ntp(),
             os_utils.get_time_config(),
-            os_utils.get_dns_servers(),
+            os_utils.get_dns_and_search_domains(),
             (ntp_server, time_config, dns_config) => {
                 // insert an entry for this server in clusters collection.
                 new_topology._id = system_store.generate_id();
@@ -1779,7 +1776,7 @@ function _attach_server_configuration(cluster_server) {
         return cluster_server;
     }
     return P.join(fs_utils.find_line_in_file('/etc/ntp.conf', '#NooBaa Configured NTP Server'),
-            os_utils.get_time_config(), os_utils.get_dns_servers())
+            os_utils.get_time_config(), os_utils.get_dns_and_search_domains())
         .spread(function(ntp_line, time_config, dns_config) {
             cluster_server.ntp = {
                 timezone: time_config.timezone

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -258,7 +258,7 @@ function create_system(req) {
             cluster_server.new_cluster_info({ address: "127.0.0.1" }),
             os_utils.get_ntp(),
             os_utils.get_time_config(),
-            os_utils.get_dns_servers()
+            os_utils.get_dns_and_search_domains()
         ))
         .spread((cluster_info, ntp_server, time_config, dns_config) => {
             if (cluster_info) {

--- a/src/server/utils/server_diagnostics.js
+++ b/src/server/utils/server_diagnostics.js
@@ -139,6 +139,12 @@ function collect_server_diagnostics(req) {
                 .then(() => diag_log('finished get_system_collections_dump successfully'))
                 .catch(err => diag_log('get_system_collections_dump failed with error: ' + err)),
 
+                () => promise_utils.exec('rndc dumpdb -cache')
+                .then(() => promise_utils.exec(`cp -fp /var/named/data/* ${TMP_WORK_DIR}`))
+                .then(() => promise_utils.exec(`cp -fp /etc/noobaa_configured_dns.conf ${TMP_WORK_DIR}`))
+                .then(() => promise_utils.exec(`cp -fp /etc/named.conf ${TMP_WORK_DIR}`))
+                .catch(err => diag_log('getting named (dns cache) diagnostics failed with error: ' + err)),
+
             ];
 
 

--- a/src/upgrade/upgrade.js
+++ b/src/upgrade/upgrade.js
@@ -168,6 +168,7 @@ function packages_upgrade() {
                 'iperf3',
                 'python-setuptools',
                 'bind-utils',
+                'bind',
                 'screen',
                 'strace',
                 'vim'

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -51,7 +51,7 @@ function _ping_ip(session, ip) {
 
 function dns_resolve(target, options) {
     const modified_target = url.parse(target).hostname || target;
-    return os_utils.get_dns_servers()
+    return os_utils.get_dns_and_search_domains()
         .then(dns_config => {
             if (dns_config.search_domains.length) {
                 let resolved_successfully = false;


### PR DESCRIPTION
### Explain the changes:
- install `bind` on upgrade
- on clean_ova reset `named.conf` which includes `/etc/noobaa_configured_dns.conf` that holds the forwarders list (target DNS servers)
- no restart services after DNS\search domains changes
   - changed set_dns_servers to update the correct configuration files and restart named only
   - changed set_search_domains to 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade from the previous version - DB schema, server platform, agents install, new packages added to deployment

