### PR TITLE
fixed set_dns_servers when given an empty list

### DIFF
--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -641,7 +641,7 @@ function set_dns_and_search_domains(dns_servers, search_domains) {
 
 function _set_dns_server(servers) {
     if (!servers) return;
-    const forwarders_str = `forwarders { ${servers.join('; ')}; };\nforward only;\n`;
+    const forwarders_str = (servers.length ? `forwarders { ${servers.join('; ')}; };` : `forwarders { };`) + '\nforward only;\n';
     dbg.log0('setting dns servers in named forwarders configuration');
     dbg.log0('writing', forwarders_str, 'to', config.NAMED_DEFAULTS.FORWARDERS_OPTION_FILE);
     return fs_utils.replace_file(config.NAMED_DEFAULTS.FORWARDERS_OPTION_FILE, forwarders_str)


### PR DESCRIPTION
### Explain the changes:
- when an empty list of dns server was passed to set_dns_servers a wrong format was written to named configuration file 

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

