### PR TITLE
Bar chart upgrades

### DIFF
--- a/frontend/src/app/components/bucket/bucket-summary/bucket-summary.html
+++ b/frontend/src/app/components/bucket/bucket-summary/bucket-summary.html
@@ -60,7 +60,7 @@
             <!-- ko if: selectedView.eq('DATA_USAGE') -->
             <bar-chart class="align-end push-prev"
                 ko.visibility="selectedView.eq('DATA_USAGE')"
-                params="values: dataUsage"
+                params="values: barChartData"
             ></bar-chart>
             <!-- /ko -->
 

--- a/frontend/src/app/components/bucket/bucket-summary/bucket-summary.js
+++ b/frontend/src/app/components/bucket/bucket-summary/bucket-summary.js
@@ -3,7 +3,7 @@
 import template from './bucket-summary.html';
 import Observer from 'observer';
 import { state$, action$ } from 'state';
-import { deepFreeze } from 'utils/core-utils';
+import { deepFreeze, sumBy } from 'utils/core-utils';
 import { stringifyAmount } from 'utils/string-utils';
 import { realizeUri } from 'utils/browser-utils';
 import { isSizeZero, formatSize, toBytes } from 'utils/size-utils';
@@ -91,18 +91,38 @@ class BucketSummrayViewModel extends Observer {
             }
         ];
 
-        this.dataUsage = [
+        this.barChartData  = [
             {
                 label: 'Total Original Size',
                 color: style['color7'],
-                value: ko.observable()
+                parts: [
+                    {
+                        value: ko.observable(),
+                        color: style['color7']
+
+                    }
+                ]
+
             },
             {
                 label: 'Compressed & Deduped',
                 color: style['color13'],
-                value: ko.observable()
+                parts: [
+                    {
+                        value: ko.observable(),
+                        color: style['color13']
+
+                    }
+                ]
+
             }
         ];
+
+        this.dataUsage = this.barChartData.map(({ label, color, parts }) => ({
+            label,
+            color: color,
+            value: ko.pureComputed(() => sumBy(parts, ({ value }) => value()))
+        }));
 
         this.rawUsage = [
             {
@@ -201,8 +221,8 @@ class BucketSummrayViewModel extends Observer {
         this.availablity[4].value(toBytes(availablity.overallocated));
         this.availablity[4].visible(!isSizeZero(availablity.overallocated));
         this.availablityMarkers(availablityMarkers);
-        this.dataUsage[0].value(toBytes(data.size));
-        this.dataUsage[1].value(toBytes(data.sizeReduced));
+        this.barChartData[0].parts[0].value(toBytes(data.size));
+        this.barChartData[1].parts[0].value(toBytes(data.sizeReduced));
         this.lastRawUsageTime(lastRawUsageTime);
         this.rawUsage[0].value(toBytes(storage.free));
         this.rawUsage[1].value(toBytes(storage.spilloverFree));

--- a/frontend/src/app/components/object/object-summary/object-summary.html
+++ b/frontend/src/app/components/object/object-summary/object-summary.html
@@ -23,7 +23,7 @@
                 caption: 'File Size',
                 format: 'size'
             "></chart-legend>
-            <bar-chart class="greedy" params="values: barsValues"></bar-chart>
+            <bar-chart class="greedy" params="values: barChartData"></bar-chart>
         </div>
     </section>
 

--- a/frontend/src/app/components/object/object-summary/object-summary.js
+++ b/frontend/src/app/components/object/object-summary/object-summary.js
@@ -5,6 +5,7 @@ import BaseViewModel from 'components/base-view-model';
 import ko from 'knockout';
 import style from 'style';
 import { toBytes } from 'utils/size-utils';
+import { sumBy } from 'utils/core-utils';
 
 class ObjectSummaryViewModel extends BaseViewModel {
     constructor({ obj }) {
@@ -38,22 +39,36 @@ class ObjectSummaryViewModel extends BaseViewModel {
             () => obj() ? obj().stats.reads : 0
         );
 
-        this.barsValues = [
+        this.barChartData  = [
             {
                 label: 'Original size',
-                value: ko.pureComputed(
-                    () => toBytes(obj().size)
-                ),
-                color: style['color7']
+                color: style['color7'],
+                parts: [
+                    {
+                        value: ko.pureComputed(() => toBytes(obj().size)),
+                        color: style['color7']
+                    }
+                ]
+
             },
             {
                 label: 'Size on Disk (with replicas)',
-                value: ko.pureComputed(
-                    () => toBytes(obj().capacity_size)
-                ),
-                color: style['color13']
+                color: style['color13'],
+                parts: [
+                    {
+                        value: ko.pureComputed(() => toBytes(obj().capacity_size)),
+                        color: style['color13']
+                    }
+                ]
+
             }
         ];
+
+        this.barsValues = this.barChartData.map(({ label, color, parts }) => ({
+            label,
+            color: color,
+            value: sumBy(parts, ({ value }) => value())
+        }));
     }
 }
 

--- a/frontend/src/app/components/server/server-summary/server-summary.js
+++ b/frontend/src/app/components/server/server-summary/server-summary.js
@@ -186,10 +186,14 @@ class ServerSummaryViewModel extends BaseViewModel {
                         this.isConnected() ? numeral(cpus().usage).format('%') : '-'
                     }`
                 ),
-                value: ko.pureComputed(
-                    () => cpus().count ? cpus().usage / cpus().count : 0
-                ),
-                color: style['color13']
+                parts: [
+                    {
+                        value: ko.pureComputed(
+                            () => cpus().count ? cpus().usage / cpus().count : 0
+                        ),
+                        color: style['color13']
+                    }
+                ]
             },
             {
                 label: ko.pureComputed(
@@ -197,8 +201,12 @@ class ServerSummaryViewModel extends BaseViewModel {
                         this.isConnected() ? numeral(diskUsage()).format('%') : '-'
                     }`
                 ),
-                value: diskUsage,
-                color: style['color13']
+                parts: [
+                    {
+                        value: diskUsage,
+                        color: style['color13']
+                    }
+                ]
             },
             {
                 label: ko.pureComputed(
@@ -206,8 +214,12 @@ class ServerSummaryViewModel extends BaseViewModel {
                         this.isConnected() ? numeral(memoryUsage()).format('%') : '-'
                     }`
                 ),
-                value: memoryUsage,
-                color: style['color13']
+                parts: [
+                    {
+                        value: memoryUsage,
+                        color: style['color13']
+                    }
+                ]
             }
         ];
     }


### PR DESCRIPTION
### Explain the changes:
-Multi color bars -  include internal resource usage percentage on disk bar (Server Page ) - defer update if data is not changed enough 

Tests: 
1. Go to Buckets
2. Go to bucket page
3. In bucket summary click on Data Usage tab
4. Bar chart loaded without errors, draws and displays correctly
5. Go to object page
6. Bar chart loaded without errors, draws and displays correctly
7. Go to cluster
8. Go to server page
9. Bar chart loaded without errors, draws and displays correctly
10. Switch tabs, bar chart not redrawing every time (as was before)
11. Change settings in server-summary.js barOptions.values=true to show percentage
12. Bar top values labels displaed correctly
13. Created func to change value of part by 0.0001 every 1s
14. Bar chart updates every 10 s 
15. Redraws only bar which value was changed
16. Added dummy data to create multipart bar chart (0.4, 0.3) - scale = 1
17. Bar chart draws correctly 
18. Values displays correctly (70% - combined value of 2 parts)
19. Added dummy data to create multipart bar chart (0.4, 0.8) - scale = 1
20. Bar chart draws correctly 
21. Value scaled, displays 100%   
22. Added dummy data to create multipart bar chart (0.4, 0.8) - no scale
23. Bar chart draws correctly
24. Value displays 100%   
25. Other values scaled in relation to biggest vale


