### PR TITLE
Remove restart modal from DNS settings

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -15,7 +15,6 @@ import { action$ } from 'state';
 import {
     fetchSystemInfo,
     showNotification,
-    closeModal,
     requestLocation
 } from 'action-creators';
 
@@ -1029,11 +1028,7 @@ export function updateServerDNSSettings(serverSecret, primaryDNS, secondaryDNS, 
         dns_servers: [primaryDNS, secondaryDNS].filter(Boolean),
         search_domains: searchDomains
     })
-        .then(() => sleep(config.serverRestartWaitInterval))
-        .then(() => httpWaitForResponse('/version', 200))
-        .then(reload)
         .catch(() => {
-            action$.onNext(closeModal());
             notify('Updating server DNS setting failed, Please try again later', 'error');
         })
         .done();

--- a/frontend/src/app/components/login/create-system-form/create-system-form.html
+++ b/frontend/src/app/components/login/create-system-form/create-system-form.html
@@ -69,7 +69,7 @@
                     <input type="text" placeholder="Name your system" ko.value="systemName">
                 </editor>
 
-                <editor class="preview-only" params="label: 'Server DNS name'">
+                <editor params="label: 'Server DNS name'">
                     <div class="row content-middle"
                         data-bind="validationOptions: { insertMessages: false }"
                     >
@@ -79,7 +79,7 @@
                                   params="name: 'in-progress'"></svg-icon>
                     </div>
                     <span class="val-msg" data-bind="validationMessage: serverDNSName"></span>
-                    <p class="hint">optional</p>
+                    <p class="hint" ko.visible="serverDNSName.isValid">optional</p>
                 </editor>
 
                 <p class="remark push-prev">

--- a/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.html
+++ b/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.html
@@ -1,53 +1,45 @@
 <!-- Copyright (C) 2016 NooBaa -->
 
-<div class="warning-msg warning row pad alt-bg content-middle push-next">
-    <svg-icon class="push-next warning" params="name: 'notif-warning'">
-    </svg-icon>
-    <span class="greedy" ko.text="warning"></span>
-</div>
-
-<p class="push-next" ko.css.disabled="isUpdating">
+<p class="push-next">
     Setup the server to use the following DNS servers for name resolution
 </p>
 
 <section class="greedy">
     <editor class="push-prev" params="
-        label: 'Primary DNS',
-        disabled: isUpdating
+        label: 'Primary DNS'
     ">
         <input type="text"
             ko.value="primaryDNS"
-            ko.disable="isUpdating"
         />
     </editor>
     <editor class="push-next" params="
         label: 'Secondary DNS',
-        disabled: isUpdatingOrPrimaryDNS
+        disabled: hasNoPrimaryDNS
     ">
         <input type="text"
             ko.value="secondaryDNS"
-            ko.disable="isUpdatingOrPrimaryDNS"
+            ko.disable="hasNoPrimaryDNS"
         />
     </editor>
     <editor class="push-next" params="
         label: 'Search Domains',
-        disabled: isUpdatingOrPrimaryDNS
+        disabled: hasNoPrimaryDNS
     ">
         <div class="row">
             <input type="text"
                 placeholder="E.g. noobaa, dev.lab"
                 ko.value="searchDomains"
-                ko.disable="isUpdatingOrPrimaryDNS"
+                ko.disable="hasNoPrimaryDNS"
             />
             <svg-icon class="icon-small push-prev-half align-middle"
                       params="name: 'question'"
                       ko.tooltip="searchDomainTooltip"
-                      ko.css.disabled="isUpdatingOrPrimaryDNS"
+                      ko.css.disabled="hasNoPrimaryDNS"
             >
             </svg-icon>
         </div>
-        <p class="remark" ko.css.disabled="isUpdatingOrPrimaryDNS">
-            Type Domain names seperated by a comma
+        <p class="remark" ko.css.disabled="hasNoPrimaryDNS">
+            Type Domain names separated by a comma
         </p>
     </editor>
 </section>
@@ -55,16 +47,11 @@
 <div class="row content-middle align-end push-prev">
     <button class="link push-next alt-colors"
         ko.click="cancel"
-        ko.disable="isUpdating"
     >
         Cancel
     </button>
 
-    <working-button ko.shakeOnClick="errors().length" params="
-        click: update,
-        working: isUpdating,
-        workingLabel: 'Restarting...'
-    ">
-        Update and restart system
-    </working-button>
+    <button class="btn" ko.shakeOnClick="errors().length" ko.click="update">
+        Update
+    </button>
 </div>


### PR DESCRIPTION
### Explain the changes:
- Remove restart modal from DNS settings

tests:

1. Open modal, modal opened without errors
2. Click cancel, modal closed without errors
3. Open Modal and click 'Update', modal closed and request to server was sent cluster_server_api.update_dns_servers
4. Entered invalid Primary DNS, validation error appeared, “Update” button shake on click
5. Entered valid Primary DNS, validation passed
6. Entered  invalid Secondary DNS, validation error appeared, “Update” button shake on click
7. Entered valid Secondary DNS, validation passed
8. Updated Secondary DNS with no value 
9. Updated Primary DNS with no value 
10. Create system with server DNS Name parameter, make sure that it set in Management -> Configuration -> System DNS Name /Address
11. Create system without server DNS Name parameter