### PR TITLE
Patching to return object_id from read_node_mappings

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -503,6 +503,12 @@ module.exports = {
                             type: 'object',
                             // required: [],
                             properties: {
+                                obj_id: {
+                                    objectid: true
+                                },
+                                upload_started: {
+                                    idate: true
+                                },
                                 key: {
                                     type: 'string'
                                 },
@@ -559,6 +565,12 @@ module.exports = {
                             type: 'object',
                             // required: [],
                             properties: {
+                                obj_id: {
+                                    objectid: true
+                                },
+                                upload_started: {
+                                    idate: true
+                                },
                                 key: {
                                     type: 'string'
                                 },

--- a/src/server/object_services/map_reader.js
+++ b/src/server/object_services/map_reader.js
@@ -79,6 +79,8 @@ function read_node_mappings(params) {
                 return obj._id;
             });
             const objects_reply = _.map(objects_by_id, (obj, obj_id) => ({
+                obj_id,
+                upload_started: obj.upload_started ? obj.upload_started.getTimestamp().getTime() : undefined,
                 key: obj.key,
                 bucket: system_store.data.get_by_id(obj.bucket).name,
                 parts: parts_per_obj_id[obj_id],

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -217,6 +217,16 @@ function init_mock_nodes(client, system, count) {
                 nodes: _.map(this._nodes, node => this._get_node_info(node))
             };
         },
+        get_node_ids(req) {
+            let ids = [];
+            if (req.params.by_host) {
+                ids = _.filter(_.map(this._nodes, n => this._get_node_info(n)), node =>
+                    String(node.os_info.hostname) === String(req.params.identity));
+            } else {
+                ids = [_.find(this._nodes, node => String(node.name) === String(req.params.identity))];
+            }
+            return _.map(ids, id => String(id._id));
+        },
         allocate_nodes(params) {
             return {
                 nodes: _.map(this._nodes, node => this._get_node_info(node))


### PR DESCRIPTION
### Explain the changes:
- We agreed on regarding the listing of objected and uncompleted uploads:
1) The FE will work with object.key in case the object was completed and object.key-uploadId if not.
2) BE would support all actions needed with both object.key only and objectID.

This is the change that will allow the FE to receive the ObjectId and Uploading state in read_nodes_mappings/read_hosts_mappings.

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

