### PR TITLE
Add replay capability to the DataSet test & generate entropy in clean_ova

### DIFF
--- a/src/deploy/NVA_build/clean_ova.sh
+++ b/src/deploy/NVA_build/clean_ova.sh
@@ -157,6 +157,9 @@ mongo nbcore --eval 'db.dropDatabase()'
 sudo sed -i "s:Configured IP on this NooBaa Server.*:Configured IP on this NooBaa Server \x1b[0;32;40mNONE\x1b[0m.:" /etc/issue
 sudo sed -i "s:This server's secret is.*:No Server Secret:" /etc/issue
 sudo sysctl kernel.hostname=noobaa
+
+#Generate entropy for /dev/random (openssl and such)
+find /dev/disk/by-uuid/ -type l | xargs md5sum
 #reduce VM size
 set +e
 /sbin/swapoff -a


### PR DESCRIPTION
### Explain the changes:
- Add replay capability to the DataSet test
- Generate entropy in clean_ova

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- 

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

