### PR TITLE
Fixing untrusted reasons list to survive reboot 

### DIFF
--- a/frontend/src/app/components/modals/set-node-as-trusted-modal/set-node-as-trusted-modal.js
+++ b/frontend/src/app/components/modals/set-node-as-trusted-modal/set-node-as-trusted-modal.js
@@ -29,8 +29,8 @@ const eventMapping = deepFreeze({
         results: 'Data was changed'
     },
     TEMPERING: {
-        type: 'Node tempering',
-        results: 'missing data'
+        type: 'Permission tampering',
+        results: 'Directory permissions were changed'
     }
 });
 

--- a/frontend/src/app/reducers/hosts-reducer.js
+++ b/frontend/src/app/reducers/hosts-reducer.js
@@ -21,8 +21,8 @@ const inMemoryQueryLimit = 10;
 const inMemoryHostLimit = paginationPageSize * inMemoryQueryLimit;
 const endpointUsageStatsTimeSpan = 7 * 24 * 60 * 60 * 1000; /* 7 days in miliseconds */
 const eventToReasonCode = deepFreeze({
-    permission_event: 'TEMPERING',
-    data_event: 'CORRUPTION'
+    PERMISSION_EVENT: 'TEMPERING',
+    DATA_EVENT: 'CORRUPTION'
 });
 
 // ------------------------------
@@ -209,12 +209,11 @@ function _mapDataToHost(host = {}, data, fetchTime) {
     const reasonByMount = groupBy(
         data.untrusted_reasons || [],
         reason => reason.drive.drive_id,
-        reason => Object.entries(reason.events)
-            .map(pair => {
-                const [event, time] = pair;
-                const reason = eventToReasonCode[event];
-                return { reason, time };
-            })
+        reason => reason.events.map(item => {
+            const { event, time } = item;
+            const reason = eventToReasonCode[event];
+            return { reason, time };
+        })
     );
 
     const activities = (storage_nodes_info.data_activities || [])

--- a/src/api/host_api.js
+++ b/src/api/host_api.js
@@ -462,14 +462,21 @@ module.exports = {
                                 $ref: 'common_api#/definitions/drive_info'
                             },
                             events: {
-                                type: 'object',
-                                properties: {
-                                    permission_event: {
-                                        idate: true,
-                                    },
-                                    data_event: {
-                                        idate: true,
-                                    },
+                                type: 'array',
+                                items: {
+                                    type: 'object',
+                                    properties: {
+                                        event: {
+                                            type: 'string',
+                                            enum: [
+                                                'DATA_EVENT',
+                                                'PERMISSION_EVENT'
+                                            ]
+                                        },
+                                        time: {
+                                            idate: true
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -572,14 +572,21 @@ module.exports = {
                     $ref: '#/definitions/node_mode'
                 },
                 untrusted_reasons: {
-                    type: 'object',
-                    properties: {
-                        permission_event: {
-                            idate: true,
-                        },
-                        data_event: {
-                            idate: true,
-                        },
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            event: {
+                                type: 'string',
+                                enum: [
+                                    'DATA_EVENT',
+                                    'PERMISSION_EVENT'
+                                ]
+                            },
+                            time: {
+                                idate: true
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Explain the changes:
- changing the reasons to use fields we save in the DB that will survive reboot
- changing the reasons node_api and host_api to return an array of reasons and not only one reason per drive (they can have more)
- making the reasons in the api to be more accurate 
- fixing the UI to use the first event in the UI so UI won't break - should be temporal

### Issues (fixed #xxxx / opened technical debt #yyyy / partial fix to #zzzz)
- fixed #3891

### Reminders
- User Experience is top priority
- Design for failure
- Keep it simple
- Write for cross-platform
- Run `npm test`
- Create a unit-test - the first is the hardest
- Imagine the support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade from previous version - DB schema, server platform, agents install, new packages added to deploymet

