### PR TITLE
fixed logrotate configuration file to send HUP signal to rsyslog process

### DIFF
--- a/src/deploy/NVA_build/logrotate_noobaa.conf
+++ b/src/deploy/NVA_build/logrotate_noobaa.conf
@@ -9,7 +9,7 @@
         create 640 root root
         sharedscripts
         postrotate
-                /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+                /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
         endscript
 }
 
@@ -24,6 +24,6 @@
         create 640 root root
         sharedscripts
         postrotate
-                /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+                /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
         endscript
 }


### PR DESCRIPTION
### Explain the changes:
- after rotating log file, HUP signal should be sent to rsyslog so it can refresh its fd.
- wrong system file was used to get rsyslog pid. in centos 7 it was changed to `/var/run/syslogd.pid`

### Issues: Fixed / Gap #xxx
- Fixes #3981 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
