### PR TITLE
fixes to test_env_builder

### DIFF
--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -6,9 +6,6 @@
 const argv = require('minimist')(process.argv);
 
 const dbg = require('../../util/debug_module')(__filename);
-// disable all dbg.log output
-dbg.set_console_output(false);
-dbg.original_console();
 
 const AzureFunctions = require('../../deploy/azureFunctions');
 const agent_functions = require('../../test/qa/functions/agent_functions');
@@ -74,7 +71,7 @@ function main() {
             exit_code = 1;
         })
         .finally(() => {
-            if (cleanup) clean_test_env();
+            if (cleanup) return clean_test_env();
         })
         .then(() => process.exit(exit_code));
 }
@@ -151,6 +148,9 @@ function upgrade_test_env() {
 }
 
 function run_tests() {
+    // disable all dbg.log output before running tests
+    dbg.set_console_output(false);
+    dbg.original_console();
     if (js_script) {
         console.log(`running js script ${js_script} on ${server.name}`);
         return promise_utils.fork(js_script, ['--server_name', server.name, '--server_ip', server.ip, '--server_secret', server.secret])


### PR DESCRIPTION
### Explain the changes:
- stop console output only before running tests
- wait for cleanup before exiting the script

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
