### PR TITLE
adding os version to log

### DIFF
--- a/src/agent/agent_wrap.js
+++ b/src/agent/agent_wrap.js
@@ -15,6 +15,7 @@ const WIN_AGENT = os.type() === 'Windows_NT';
 
 const P = require('../util/promise');
 const fs_utils = require('../util/fs_utils');
+const os_utils = require('../util/os_utils');
 const promise_utils = require('../util/promise_utils');
 const dbg = require('../util/debug_module')(__filename);
 dbg.set_process_name('agent_wrapper');
@@ -50,6 +51,8 @@ let new_backup_dir = CONFIGURATION.BACKUP_DIR;
 dbg.log0('deleting file', CONFIGURATION.SETUP_FILE);
 fs_utils.file_delete(CONFIGURATION.SETUP_FILE)
     // clean previous backup folder
+    .then(() => os_utils.get_distro())
+    .then(res => dbg.log0('OS INFO:', res))
     .then(() => fs.readdirAsync(process.cwd()))
     .then(files => files.find(file => file.startsWith('backup_')))
     .then(backup_dir => {

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -155,6 +155,9 @@ function get_distro() {
     if (os.type() === 'Darwin') {
         return P.resolve('OSX - Darwin');
     }
+    if (os.type() === 'Windows_NT') {
+        return `${os.type()} (${os.release()})`;
+    }
     return P.fromCallback(callback => os_detailed_info(callback))
         .then(distro => {
             let res = '';


### PR DESCRIPTION
### Explain the changes:
- changing get_distro to work with windows 
- printing the os_distro in the start of agent

### Issues: Fixed / Gap #xxx
- fixed #3828

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
