### PR TITLE
S3: ACL missing xml schema attributes

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_acl.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_acl.js
@@ -13,8 +13,14 @@ function get_bucket_acl(req) {
                 Owner: s3_utils.DEFAULT_S3_USER,
                 AccessControlList: [{
                     Grant: {
-                        Grantee: s3_utils.DEFAULT_S3_USER,
-                        Permission: 'FULL_CONTROL'
+                        Grantee: {
+                            _attr: {
+                                'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                                'xsi:type': 'CanonicalUser',
+                            },
+                            _content: s3_utils.DEFAULT_S3_USER,
+                        },
+                        Permission: 'FULL_CONTROL',
                     }
                 }]
             }

--- a/src/endpoint/s3/ops/s3_get_object_acl.js
+++ b/src/endpoint/s3/ops/s3_get_object_acl.js
@@ -16,7 +16,13 @@ function get_object_acl(req) {
                 Owner: s3_utils.DEFAULT_S3_USER,
                 AccessControlList: [{
                     Grant: {
-                        Grantee: s3_utils.DEFAULT_S3_USER,
+                        Grantee: {
+                            _attr: {
+                                'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                                'xsi:type': 'CanonicalUser',
+                            },
+                            _content: s3_utils.DEFAULT_S3_USER,
+                        },
                         Permission: 'FULL_CONTROL'
                     }
                 }]

--- a/src/util/xml_utils.js
+++ b/src/util/xml_utils.js
@@ -14,7 +14,8 @@ exports.encode_xml_str = encode_xml_str;
  *  - string/number/boolean/date will be converted to strings.
  *  - {key: null} will encode an empty tag - <key></key>
  *  - {key: undefined} will not encode the tag at all.
- *  - {key: {_attr:{k1=v1,k2=v2,...}} will encode xml attributes on the tag (_attr can be set on array values too)
+ *  - {key: { _attr:{k1:v1,k2:v2,...}, _content:value } will encode xml attributes on the tag
+ *      (_attr can be set on array values too)
  *
  * for example:
  *   { root: [{a:1,b:2}, {a:3}, {b:4}, [[[[{z:42}]]]], {c:{_attr:{d:5}}} ] }


### PR DESCRIPTION
### Explain the changes:
- Caused NullPointerException in Apache JClouds java client used by IBM Spectrum Scale 

### Issues: Fixed / Gap #xxx
- NA

### Testing Instructions:
- Run apache jclouds as S3 Java SDK

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
