### PR TITLE
fixed internal resource status when there is no capacity

### DIFF
--- a/frontend/src/app/schema/internal-resources.js
+++ b/frontend/src/app/schema/internal-resources.js
@@ -17,7 +17,8 @@ export default {
                     'OPTIMAL',
                     'INITIALIZING',
                     'IO_ERRORS',
-                    'ALL_NODES_OFFLINE'
+                    'ALL_NODES_OFFLINE',
+                    'NO_CAPACITY'
                 ]
             },
             storage: {

--- a/frontend/src/app/utils/resource-utils.js
+++ b/frontend/src/app/utils/resource-utils.js
@@ -112,6 +112,11 @@ const internalResourceModeToStateIcon = deepFreeze({
         css: 'error',
         name: 'problem'
     },
+    NO_CAPACITY: {
+        tooltip: 'No available resource capacity',
+        css: 'error',
+        name: 'problem'
+    },
     IO_ERRORS: {
         tooltip: 'Resource has Read/Write problems',
         css: 'error',

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -573,10 +573,13 @@ function calc_cloud_pool_mode(p) {
 
 function calc_mongo_pool_mode(p) {
     const { by_mode } = _.defaults({}, p.nodes, POOL_NODES_INFO_DEFAULTS);
+    const { free } = _.defaults({}, p.storage, { free: NO_CAPAITY_LIMIT + 1 });
     return (!p.nodes && 'INITIALIZING') ||
         (by_mode.OPTIMAL && 'OPTIMAL') ||
         (by_mode.IO_ERRORS && 'IO_ERRORS') ||
         (by_mode.INITIALIZING && 'INITIALIZING') ||
+        (by_mode.OFFLINE && 'ALL_NODES_OFFLINE') ||
+        (free < NO_CAPAITY_LIMIT && 'NO_CAPACITY') ||
         'ALL_NODES_OFFLINE';
 }
 


### PR DESCRIPTION
### Explain the changes:
- return NO_CAPACITY for mongo pool
- handle NO_CAPCITY in UI


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
