### PR TITLE
A lot of fixes

### DIFF
--- a/frontend/src/app/components/bucket/bucket-objects-table/object-row.js
+++ b/frontend/src/app/components/bucket/bucket-objects-table/object-row.js
@@ -10,11 +10,13 @@ import ko from 'knockout';
 const statusMapping = deepFreeze({
     OPTIMAL: {
         css: 'success',
-        name: 'healthy'
+        name: 'healthy',
+        tooltip: 'Healthy'
     },
     UPLOADING: {
         css: 'warning',
-        name: 'working'
+        name: 'working',
+        tooltip: 'Uploading'
     }
 });
 

--- a/frontend/src/app/components/buckets/buckets-table/bucket-row.js
+++ b/frontend/src/app/components/buckets/buckets-table/bucket-row.js
@@ -85,8 +85,6 @@ export default class BucketRowViewModel {
 
         const spillover = formatSize(bucket.spillover ? bucket.spillover.usage : 0);
 
-        console.warn(getBucketStateIcon(bucket, 'start'));
-
         this.state(getBucketStateIcon(bucket, 'start'));
         this.name(name);
         this.objectCount(numeral(bucket.objectCount).format('0,0'));

--- a/frontend/src/app/components/management/version-form/version-form.js
+++ b/frontend/src/app/components/management/version-form/version-form.js
@@ -60,6 +60,7 @@ const uploadBtnTooltips = {
 };
 
 const upgradeBtnTooltips = {
+    PACKAGE_NOT_READY: 'Upgrade can be initiated only after uploading a validated package',
     NOT_ALL_MEMBERS_UP: 'All cluster members must be connected in order to start an upgrade. Please make sure all servers are up.'
 };
 
@@ -149,7 +150,7 @@ class VersionFormViewModel extends Observer {
                 value: this.pkgVersion
             },
             {
-                label: 'Uploaded and Validated at',
+                label: 'Validated at',
                 value: this.pkgTestTime,
                 visible: this.pkgTestTime
             },
@@ -199,7 +200,9 @@ class VersionFormViewModel extends Observer {
         };
         const upgradeBtn = {
             disabled: Boolean(upgrade.preconditionFailure) || pkgTestResult !== 'SUCCESS',
-            tooltip: upgradeBtnTooltips[upgrade.preconditionFailure]
+            tooltip: upgradeBtnTooltips[
+                pkgTestResult !== 'SUCCESS' ? 'PACKAGE_NOT_READY' : upgrade.preconditionFailure
+            ]
         };
         const uploadArea = {
             expanded: isPkgUploadingOrTesting,

--- a/frontend/src/app/components/modals/after-upgrade-modal/after-upgrade-modal.js
+++ b/frontend/src/app/components/modals/after-upgrade-modal/after-upgrade-modal.js
@@ -28,7 +28,7 @@ class AfterUpgradeModalViewModel extends Observer {
 
     onDone() {
         action$.onNext(closeModal());
-        action$.onNext(requestLocation(this.pathname));
+        action$.onNext(requestLocation(this.pathname, true));
     }
 }
 

--- a/frontend/src/app/components/modals/create-account-modal/create-account-modal.js
+++ b/frontend/src/app/components/modals/create-account-modal/create-account-modal.js
@@ -209,7 +209,7 @@ class CreateAccountWizardViewModel extends Observer {
     }
 
     onCancel() {
-        action$.onNext(closeModal);
+        action$.onNext(closeModal());
     }
 
     dispose() {

--- a/frontend/src/app/components/modals/upgrading-system-modal/upgrading-system-modal.html
+++ b/frontend/src/app/components/modals/upgrading-system-modal/upgrading-system-modal.html
@@ -21,7 +21,11 @@
     </span>
     <ul class="list-no-style column alt-bg greedy pad" ko.foreach="serverRows">
         <li class="row content-middle push-both-half">
-            <svg-icon class="push-next" ko.css="icon().css" params="name: icon().name"></svg-icon>
+            <svg-icon class="push-next"
+                ko.css="icon().css"
+                ko.tooltip="icon().tooltip"
+                params="name: icon().name"
+            ></svg-icon>
             {{name}}
             <span class="master-marking push-prev-half"
                 ko.visible="markAsMaster"

--- a/frontend/src/app/components/object/object-parts-list/block-row.js
+++ b/frontend/src/app/components/object/object-parts-list/block-row.js
@@ -8,7 +8,7 @@ export default class BlockRowViewModel extends BaseViewModel {
     constructor({ adminfo }, index, count, poolIconMapping) {
         super();
 
-        let { online, in_cloud_pool, node_name, pool_name } = adminfo;
+        let { online, in_cloud_pool, in_mongo_pool, node_name, pool_name } = adminfo;
 
         this.state = {
             name: online ? 'healthy' : 'problem',
@@ -20,11 +20,11 @@ export default class BlockRowViewModel extends BaseViewModel {
         this.resourceType = poolIconMapping()[pool_name] || {};
         this.poolName = pool_name;
 
-        if (in_cloud_pool) {
+        if (in_cloud_pool || in_mongo_pool) {
             this.nodeName = null;
             this.node = '---';
             this.replicaLocation = {
-                text: pool_name,
+                text: in_mongo_pool ? 'Internal Storage' : pool_name,
                 tooltip: pool_name
             };
 

--- a/frontend/src/app/epics/fetch-version-release-notes.js
+++ b/frontend/src/app/epics/fetch-version-release-notes.js
@@ -17,7 +17,10 @@ export default function(action$, { fetch }) {
             const url = `${baseUrl}/${versionWithNoBuildNumber}.${suffix}`;
 
             try {
-                const notes = await(await fetch(url)).text();
+                const res = await fetch(url);
+                if (!res.ok) throw new Error(`Got HTTP: ${res.status}`);
+
+                const notes = await(res).text();
                 return completeFetchVersionReleaseNotes(version, notes);
 
             } catch (error) {

--- a/frontend/src/app/reducers/buckets-reducer.js
+++ b/frontend/src/app/reducers/buckets-reducer.js
@@ -61,7 +61,6 @@ function _mapBucket(bucket, tiersByName, resTypeByName) {
             state: cloud_sync.status
         },
         undeletable: bucket.undeletable,
-        writable: bucket.writable,
         placement: _mapPlacement(placementTiers[0], resTypeByName, resUsageByName),
         spillover: _mapSpillover(spilloverTiers[0], resTypeByName, resUsageByName),
         io: _mapIO(stats)

--- a/frontend/src/app/schema/buckets.js
+++ b/frontend/src/app/schema/buckets.js
@@ -190,9 +190,6 @@ export default {
                     'LAST_BUCKET',
                     'NOT_EMPTY'
                 ]
-            },
-            writable: {
-                type: 'boolean'
             }
         }
     }

--- a/frontend/src/app/utils/bucket-utils.js
+++ b/frontend/src/app/utils/bucket-utils.js
@@ -97,6 +97,9 @@ const namespaceBucketToStateIcon = deepFreeze({
 const writableStates = deepFreeze([
     'LOW_CAPACITY',
     'APPROUCHING_QOUTA',
+    'SPILLOVER_NO_RESOURCES',
+    'SPILLOVER_NOT_ENOUGH_HEALTHY_RESOURCES',
+    'SPILLOVER_NO_CAPACITY',
     'OPTIMAL'
 ]);
 


### PR DESCRIPTION
- Remove permanent history for after upgrade modal dismissal
- Add missing tooltip in upgrading modal
- Handle Non 2## HTTP responses for release notes.
- Fixes: #4002, Cannot upload while using spillover
- fixes: #4036, Files status icons has no tooltips
- Fixes #4046, Missing tooltip for disabled upgrade button
- Fix broken close button in create account modal
- Fixes #4037,  Replica location link leads to internal storage page even due it doesn't exist
- Fixes #4038, Replica Node column contains a link that leads to delete node screen
- Fixes #3064, Show confirmation on tab close when in the middle of an async operation (upload file, upload upgrade package etc.)

