### PR TITLE
build_windows_agent.bat: Fixed path of openssl

### DIFF
--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -85,7 +85,7 @@ del /q .\build\*.*
 
 curl -L https://nodejs.org/dist/v%NODEJS_VERSION%/win-x64/node.exe > node.exe || exit 1
 
-curl -L https://indy.fulgan.com/SSL/openssl-1.0.2l-x64_86-win64.zip > openssl.zip || exit 1
+curl -L https://storage.googleapis.com/noobaa-temp/openssl/openssl.zip > openssl.zip || exit 1
 7za.exe e openssl.zip -y -x!*.txt || exit 1
 del /Q openssl.zip
 del /s *.pdb


### PR DESCRIPTION
### Explain the changes:
- Fixed path of openssl to be located at our google drive

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
