### PR TITLE
fixed make_changes in cluster_server + vitaly fixes

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1289,9 +1289,7 @@ function upgrade_cluster(req) {
         })
         .then(() => {
             const updates = system_store.data.clusters.map(cluster => ({
-                _id: {
-                    $in: cluster._id
-                },
+                _id: cluster._id,
                 $set: {
                     "upgrade.initiator_email": req.account.email
                 }

--- a/src/test/framework/flow.js
+++ b/src/test/framework/flow.js
@@ -108,7 +108,6 @@ var steps = [
         common: 'restore_db_defaults',
     }, {
         //Test Cloud Pools
-        ignore_failure: true,
         action: 'node',
         name: 'Cloud Pools Test',
         params: [{

--- a/src/test/framework/runner.js
+++ b/src/test/framework/runner.js
@@ -315,7 +315,7 @@ class TestRunner {
                         '\n------------------------------   ' +
                         '( took ' + ((new Date() - ts) / 1000) + 's )';
                 }
-                console.error('Failed action with', err.message);
+                console.error(step_res, 'Failed action with', err.message);
                 return step_res;
             });
     }


### PR DESCRIPTION
### Explain the changes:
- fixed make_changes in cluster_server to remove $in

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
