### PR TITLE
load system_store before checking upgrade state

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1188,22 +1188,28 @@ function member_pre_upgrade(req) {
 }
 
 function do_upgrade(req) {
-    dbg.log0('UPGRADE:', 'got do_upgrade');
-    let server = system_store.get_local_cluster_info();
-    if (server.upgrade.status !== 'UPGRADING') {
-        throw new Error('Not in upgrade state:', server.upgrade.error ? server.upgrade.error : '', ' State Is: ', server.upgrade.status || 'NO_STATUS');
-    }
-    if (server.upgrade.path === '') {
-        throw new Error('No package path supplied');
-    }
-    let filepath = server.upgrade.path;
-    //Async as the server will soon be restarted anyway
-    const on_err = err => {
-        dbg.error('upgrade scripted failed. Aborting upgrade:', err);
-        upgrade_in_process = false;
-        _handle_cluster_upgrade_failure(err, server.owner_address);
-    };
-    upgrade_utils.do_upgrade(filepath, server.is_clusterized, on_err);
+    system_store.load()
+        .then(() => {
+            dbg.log0('UPGRADE:', 'got do_upgrade');
+            let server = system_store.get_local_cluster_info();
+            if (server.upgrade.status !== 'UPGRADING') {
+                dbg.error('Not in upgrade state:', ' State Is: ', server.upgrade.status || 'NO_STATUS');
+                throw new Error('Not in upgrade state:', server.upgrade.error ? server.upgrade.error : '',
+                    ' State Is: ', server.upgrade.status || 'NO_STATUS');
+            }
+            if (server.upgrade.path === '') {
+                dbg.error('No package path supplied');
+                throw new Error('No package path supplied');
+            }
+            let filepath = server.upgrade.path;
+            //Async as the server will soon be restarted anyway
+            const on_err = err => {
+                dbg.error('upgrade scripted failed. Aborting upgrade:', err);
+                upgrade_in_process = false;
+                _handle_cluster_upgrade_failure(err, server.owner_address);
+            };
+            upgrade_utils.do_upgrade(filepath, server.is_clusterized, on_err);
+        });
 }
 
 


### PR DESCRIPTION
### Explain the changes:
- load system_store before checking upgrade state

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
