### PR TITLE
reset upgrade statuses on new upload, bucket with spillover but no space returns NO_CAPACITY

### DIFF
--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -357,6 +357,14 @@ module.exports = {
             }
         },
 
+        reset_upgrade_package_status: {
+            doc: 'reset upgrade package status on a new upload',
+            method: 'POST',
+            auth: {
+                system: 'admin',
+            }
+        },
+
         set_hostname_internal: {
             method: 'POST',
             params: {

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -2048,6 +2048,21 @@ function check_cluster_status() {
         }));
 }
 
+function reset_upgrade_package_status() {
+    const updates = system_store.data.clusters.map(cluster => ({
+        _id: cluster._id,
+        $set: {
+            'upgrade.status': 'COMPLETED'
+        }
+    }));
+    return system_store.make_changes({
+            update: {
+                clusters: updates
+            }
+        })
+        .then(() => Dispatcher.instance().publish_fe_notifications({ secret: system_store.get_server_secret() }, 'change_upgrade_status'));
+}
+
 function ping() {
     return "PONG";
 }
@@ -2099,3 +2114,4 @@ exports.get_secret = get_secret;
 exports.get_upgrade_status = get_upgrade_status;
 exports.update_member_of_cluster = update_member_of_cluster;
 exports.cluster_pre_upgrade = cluster_pre_upgrade;
+exports.reset_upgrade_package_status = reset_upgrade_package_status;

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -263,6 +263,18 @@ app.post('/upgrade', function(req, res, next) {
         if (!can_upload) {
             res.status(503).end();
         }
+        req.system = system;
+        next();
+    },
+    function(req, res, next) {
+        server_rpc.client.cluster_internal.reset_upgrade_package_status({}, {
+            address: 'http://127.0.0.1:' + http_port,
+            auth_token: auth_server.make_auth_token({
+                system_id: req.system._id,
+                role: 'admin',
+                account_id: req.system.owner._id,
+            })
+        });
         next();
     },
     multer({
@@ -408,13 +420,12 @@ function getVersion(route) {
 }
 
 // Get the current version
-app.get('/version', (req, res) =>
-    getVersion(req.url)
-        .then(({ status, version }) => {
-            if (version) res.send(version);
-            if (status !== 200) res.status(status);
-            res.end();
-        })
+app.get('/version', (req, res) => getVersion(req.url)
+    .then(({ status, version }) => {
+        if (version) res.send(version);
+        if (status !== 200) res.status(status);
+        res.end();
+    })
 );
 
 ////////////


### PR DESCRIPTION
### Explain the changes:
- Reset package status on uploading a new package
- Bucket with spillover configured but no space on tier0 and on spillover should return NO_CAPACITY

### Issues: Fixed / Gap #xxx


### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
