### PR TITLE
cast block_md.id to string before acquiring keyed lock

### DIFF
--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -116,7 +116,7 @@ class BlockStoreBase {
         this.stats.inflight_writes += 1;
         this.stats.max_inflight_writes = Math.max(this.stats.inflight_writes, this.stats.max_inflight_writes);
         const start = time_utils.millistamp();
-        return this.block_modify_lock.surround_keys([block_md.id], () => P.resolve(this._write_block(block_md, data))
+        return this.block_modify_lock.surround_keys([String(block_md.id)], () => P.resolve(this._write_block(block_md, data))
             .then(() => {
                 this.block_cache.put_in_cache(block_md, { block_md, data });
             })
@@ -156,7 +156,8 @@ class BlockStoreBase {
         const block_ids = req.rpc_params.block_ids;
         dbg.log0('delete_blocks', block_ids, 'node', this.node_name);
         this.block_cache.multi_invalidate_keys(block_ids);
-        return this.block_modify_lock.surround_keys(block_ids, () => P.resolve(this._delete_blocks(block_ids)).return());
+        return this.block_modify_lock.surround_keys(block_ids.map(block_id => String(block_id)),
+            () => P.resolve(this._delete_blocks(block_ids)).return());
     }
 
     _verify_block(block_md, data, block_md_from_store) {


### PR DESCRIPTION
### Explain the changes:
- cast block_md.id to string before acquiring keyed lock

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
