### PR TITLE
bucket files list pagination loads issue

### DIFF
--- a/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.js
+++ b/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.js
@@ -174,6 +174,7 @@ class BucketObjectsTableViewModel extends Observer {
         if (!bucket || !bucketObjects || !user || !accounts || !bucketObjectsQuery || !bucketObjectsQuery.result) {
             this.uploadButton({});
             this.objectsLoaded(false);
+            this.rows([]);
         } else {
             const account = accounts[user];
             const { system } = location.params;


### PR DESCRIPTION
### Explain the changes:
- Files list pagination loads new data without cleaning the previous page data before

### Issues: Fixed / Gap #xxx
fixed: #4088

### Testing Instructions:
- Tests
1. go to the bucket 
2. go to bucket files tab
3. refresh page
4. page refreshed with no errors
5. upload 15 files
6. set config.json paginationPageSize = 7 to test purpose
7. reload page
8. pagination show 1-7 of 15
9. click next page
10. table rows cleaned
11. loading gif showed 
12. data loaded
13. pagination show 8-14 0f 15
14. all works as expected

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
