### PR TITLE
Fix #4023: translate xattr keys to avoid dots

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -53,10 +53,15 @@ function create_object_upload(req) {
         upload_started: obj_id,
         upload_size: 0,
     };
-    if (req.rpc_params.xattr) info.xattr = req.rpc_params.xattr;
     if (req.rpc_params.size >= 0) info.size = req.rpc_params.size;
     if (req.rpc_params.md5_b64) info.md5_b64 = req.rpc_params.md5_b64;
     if (req.rpc_params.sha256_b64) info.sha256_b64 = req.rpc_params.sha256_b64;
+
+    if (req.rpc_params.xattr) {
+        // translating xattr names to valid mongo property names which do not allow dots
+        // we use `@` since it is not a valid char in HTTP header names
+        info.xattr = _.mapKeys(req.rpc_params.xattr, (v, k) => k.replace(/\./g, '@'));
+    }
 
     let tier;
     return P.resolve()
@@ -501,7 +506,10 @@ function read_object_md(req) {
 function update_object_md(req) {
     dbg.log0('update object md', req.rpc_params);
     throw_if_maintenance(req);
-    const set_updates = _.pick(req.rpc_params, 'content_type', 'xattr');
+    const set_updates = _.pick(req.rpc_params, 'content_type');
+    if (req.rpc_params.xattr) {
+        set_updates.xattr = _.mapKeys(req.rpc_params.xattr, (v, k) => k.replace(/\./g, '@'));
+    }
     return find_object_md(req)
         .then(obj => MDStore.instance().update_object_by_id(obj._id, set_updates))
         .return();
@@ -822,7 +830,7 @@ function get_object_info(md) {
         create_time: md.create_time ? md.create_time.getTime() : md._id.getTimestamp().getTime(),
         upload_started: md.upload_started ? md.upload_started.getTimestamp().getTime() : undefined,
         upload_size: _.isNumber(md.upload_size) ? md.upload_size : undefined,
-        xattr: md.xattr,
+        xattr: md.xattr && _.mapKeys(md.xattr, (v, k) => k.replace(/@/g, '.')),
         cloud_synced: md.cloud_synced,
         stats: md.stats ? {
             reads: md.stats.reads || 0,


### PR DESCRIPTION
### Explain the changes:
- Replace xattr dots to `@` and back
- See more info on the issue comments

### Issues: Fixed / Gap #xxx
- Fix #4023 

### Testing Instructions:
- Use Cyberduck to set custom metadata on objects

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
