### PR TITLE
automatic repair of permission tampering in windows hosts

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -1046,6 +1046,28 @@ class Agent {
             });
     }
 
+    fix_storage_permissions() {
+        if (os.type() !== 'Windows_NT') return P.resolve();
+        const dbg = this.dbg;
+        const root_path = path.win32.parse(this.storage_path).dir;
+        return P.resolve()
+            .then(() => os_utils.is_folder_permissions_set(root_path))
+            .then(permissions_set => {
+                if (!permissions_set && (this.node_type !== 'ENDPOINT_S3')) {
+                    os_utils.set_win_folder_permissions(root_path)
+                        .catch(err => dbg.error('Icacls configuration failed with:', err));
+                }
+            })
+            .then(() => {
+                dbg.log0('fix_storage_permissions configuration success');
+                this.permission_tempering = false;
+            })
+            .catch(function(err) {
+                dbg.error('fix_storage_permissions configuration failed with:', err);
+                throw new Error('fix_storage_permissions configuration failed!');
+            });
+    }
+
 }
 
 

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -323,6 +323,9 @@ module.exports = {
             method: 'DELETE',
         },
 
+        fix_storage_permissions: {
+            method: 'DELETE',
+        },
     },
 
     definitions: {

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1048,8 +1048,15 @@ class NodesMonitor extends EventEmitter {
         if (!item.node.permission_tempering && !item.node.issues_report) {
             return;
         }
-
         return P.resolve()
+            .then(() => {
+                if (item.node.permission_tempering) {
+                    if (!item.connection) return;
+                    return server_rpc.client.agent.fix_storage_permissions(undefined, {
+                        connection: item.connection,
+                    });
+                }
+            })
             .then(() => {
                 this._clear_untrusted(item);
                 return this._update_nodes_store('force');

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -836,6 +836,19 @@ function is_folder_permissions_set(current_path) {
         });
 }
 
+function set_win_folder_permissions(current_path) {
+    if (os.type() !== 'Windows_NT') {
+        return P.resolve(true);
+    }
+    return promise_utils.exec('attrib +H ' + current_path)
+        .then(() => promise_utils.exec('icacls  ' + current_path + ' /reset /t /c /q'))
+        .then(() => promise_utils.exec('icacls  ' + current_path +
+            ' /grant:r administrators:(oi)(ci)F' +
+            ' /grant:r system:F' +
+            ' /remove:g BUILTIN\\Users' +
+            ' /inheritance:r'));
+}
+
 function _set_time_zone(tzone) {
     // TODO _set_time_zone: Ugly Ugly, change to datectrl on centos7
     return promise_utils.exec('ln -sf /usr/share/zoneinfo/' +
@@ -1235,6 +1248,7 @@ exports.get_networking_info = get_networking_info;
 exports.read_server_secret = read_server_secret;
 exports.is_supervised_env = is_supervised_env;
 exports.is_folder_permissions_set = is_folder_permissions_set;
+exports.set_win_folder_permissions = set_win_folder_permissions;
 exports.reload_syslog_configuration = reload_syslog_configuration;
 exports.get_syslog_server_configuration = get_syslog_server_configuration;
 exports.set_dns_and_search_domains = set_dns_and_search_domains;


### PR DESCRIPTION
### Explain the changes:
- when doing retrust on host will send api call to agent to reset permissions to default
- then will set the tempering from the agent to off
- add new api call to fix permission to default
- will set permission only for none-s3 nodes - will fix once for both s3 and storage

### Issues: Fixed / Gap #xxx
- Fixed #4021

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
