### PR TITLE
Edit Server DNS Settings: Search domains placeholder updated

### DIFF
--- a/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.html
+++ b/frontend/src/app/components/modals/edit-server-dns-settings-modal/edit-server-dns-settings-modal.html
@@ -30,7 +30,7 @@
         <div class="row greedy">
             <token-field params="
                 disabled: hasNoPrimaryDNS,
-                placeholder: 'E.g. noobaa, dev.lab',
+                placeholder: 'E.g., noobaa.com and click enter ⏎',
                 tokens: searchDomains
             "></token-field>
             <svg-icon class="icon-small push-prev-half align-start"


### PR DESCRIPTION
### Explain the changes:
- Edit Server DNS Settings: Search domains placeholder updated to 'E.g., noobaa.com and click enter ⏎'

### Issues: Fixed / Gap #xxx
- already closed issue 3882

Tests:
1. Go to management
2. Expand Environment DNS Settings
3. Click 'Edit'
4. Type Primary Dns
5. Search Domains placeholder displayed correctly