### PR TITLE
Fixing upgrade, addition of NTP pre upgrade checks and stub for newer version notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "index.js",
   "config": {
-    "covdir" : "coverage"
+    "covdir": "coverage"
   },
   "scripts": {
     "preinstall": "npm install node-addon-api nan",
@@ -110,6 +110,7 @@
     "node-addon-api": "0.6.3",
     "node-df": "0.1.1",
     "node-gyp": "3.6.2",
+    "ntp-client": "0.5.3",
     "performance-now": "2.1.0",
     "proxy-agent": "2.1.0",
     "request": "2.81.0",

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1373,12 +1373,12 @@ function upgrade_cluster(req) {
                 }
             }));
             //set last upgrade initiator under system
-            const system_updates = {
+            const system_updates = [{
                 _id: req.system._id,
                 $set: {
                     "last_upgrade.initiator": (req.account && req.account.email) || ''
                 }
-            };
+            }];
             return system_store.make_changes({
                 update: {
                     clusters: cluster_updates,


### PR DESCRIPTION
### Explain the changes:
- Fixed bug regarding upgrades initiator email.
- Added test of time skew with configured NTP or default ntp pool
- Added stub in stats aggregator that will check if a newer version exists and pushes notification every week.

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
