### PR TITLE
EC rebuild fix

### DIFF
--- a/frontend/src/app/dev-cli.js
+++ b/frontend/src/app/dev-cli.js
@@ -12,12 +12,19 @@ const actions = mapValues(
     }
 );
 
+function print_json_in_new_tab(data) {
+    data = JSON.stringify(data, undefined, 2);
+    const blob = new Blob([data], { type: 'text/json' });
+    window.open(window.URL.createObjectURL(blob));
+}
+
 const cli = Object.seal({
     model: model,
     schema: schema.def,
     actions: actions,
     state: undefined,
-    api: api
+    api: api,
+    print_json_in_new_tab
 });
 
 state$.subscribe(state => { cli.state = state; });


### PR DESCRIPTION
### Explain the changes:
-  EC rebuild: fix rpc client to use token with system needed in case object_io needs to send report_error_on_object()
- Two additional changes:
  - FE: add nb.print_json_in_new_tab function to share nb.state from QA
  - fix dev agents (--scale) for macOS 10.13 (High Sierra)

### Issues: Fixed / Gap #xxx
- None

### Testing Instructions:
- EC rebuild due to offline nodes

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
