### PR TITLE
Trying to use larger VM for vitaly server

### DIFF
--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -80,7 +80,10 @@ function main() {
 //this function is getting servers array creating and upgrading them.
 function prepare_server() {
     console.log(`prepare_server: creating server ${server.name}`);
-    return azf.createServer(server.name, vnet, storage)
+    // TODO GUY Temporary attempt to use larger VM size
+    const vmSize = 'Standard_A8_v2';
+    const ipType = 'Dynamic';
+    return azf.createServer(server.name, vnet, storage, ipType, vmSize)
         .then(new_secret => {
             server.secret = new_secret;
             return azf.getIpAddress(server.name + '_pip');


### PR DESCRIPTION
### Explain the changes:
- Increase from the default Standard_A2_v2 to Standard_A8_v2

### Issues: Fixed / Gap #xxx
- None

### Testing Instructions:
- Vitaly

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
