### PR TITLE
fixing clustering issue with gridFS

### DIFF
--- a/config.js
+++ b/config.js
@@ -167,9 +167,15 @@ config.CHUNK_CODER_EC_DATA_FRAGS = 4;
 config.CHUNK_CODER_EC_PARITY_FRAGS = 2;
 config.CHUNK_CODER_EC_PARITY_TYPE = 'isa-c1';
 
-//////////////////////
+///////////////////
+// GRIDFS CONFIG //
+///////////////////
+config.GRID_FS_BUCKET_NAME = 'mongo_internal_agent';
+config.GRID_FS_CHUNK_SIZE = 8 * 1024 * 1024;
+
+//////////////////////////
 // DEDUP INDEXER CONFIG //
-//////////////////////
+//////////////////////////
 config.DEDUP_INDEXER_ENABLED = true;
 config.DEDUP_INDEXER_BATCH_SIZE = 200;
 config.DEDUP_INDEXER_BATCH_DELAY = 50;

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -151,6 +151,17 @@ class MongoClient extends EventEmitter {
             });
     }
 
+    _gridfs() {
+        if (!this._internal_gridfs) {
+            this._internal_gridfs = new mongodb.GridFSBucket(this.db, {
+                bucketName: config.GRID_FS_BUCKET_NAME,
+                chunkSizeBytes: config.GRID_FS_CHUNK_SIZE
+            });
+        }
+        return this._internal_gridfs;
+    }
+
+
     _init_collections(db) {
         return P.map(this.collections, col => this._init_collection(db, col))
             .then(() => P.map(this.collections, col => db.collection(col.name).indexes()
@@ -184,6 +195,7 @@ class MongoClient extends EventEmitter {
         dbg.log0('disconnect called');
         this._disconnected_state = true;
         this.promise = null;
+        this._internal_gridfs = null;
         if (this.db) {
             this.db.close();
             this.db = null;


### PR DESCRIPTION
### Explain the changes:
- moving init of GridFS bucket responsibility to mongo_client instead of block_store_mongo
- now will be inited every time the mongo_client will be reconnected - like in clustering
- cosmetic cleanups and moving some configuration params to config.js

### Issues: Fixed / Gap #xxx
- Fixed #4066 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
