### PR TITLE
fixing clustering issue with gridFS

### DIFF
--- a/config.js
+++ b/config.js
@@ -167,9 +167,10 @@ config.CHUNK_CODER_EC_DATA_FRAGS = 4;
 config.CHUNK_CODER_EC_PARITY_FRAGS = 2;
 config.CHUNK_CODER_EC_PARITY_TYPE = 'isa-c1';
 
-//////////////////////
+
+//////////////////////////
 // DEDUP INDEXER CONFIG //
-//////////////////////
+//////////////////////////
 config.DEDUP_INDEXER_ENABLED = true;
 config.DEDUP_INDEXER_BATCH_SIZE = 200;
 config.DEDUP_INDEXER_BATCH_DELAY = 50;

--- a/src/server/func_services/func_store.js
+++ b/src/server/func_services/func_store.js
@@ -31,6 +31,9 @@ class FuncStore {
                 }
             }]
         });
+        this._func_code = mongo_client.instance().define_gridfs({
+            name: 'func_code_gridfs'
+        });
     }
 
     static instance() {
@@ -40,15 +43,6 @@ class FuncStore {
 
     make_func_id(id_str) {
         return new mongodb.ObjectId(id_str);
-    }
-
-    _code_gridfs() {
-        if (!this._func_code_gridfs) {
-            this._func_code_gridfs = new mongodb.GridFSBucket(mongo_client.instance().db, {
-                bucketName: 'func_code_gridfs'
-            });
-        }
-        return this._func_code_gridfs;
     }
 
     create_func(func) {
@@ -120,7 +114,7 @@ class FuncStore {
         const sha256 = crypto.createHash('sha256');
         var size = 0;
         return new P((resolve, reject) => {
-            const upload_stream = this._code_gridfs().openUploadStream(
+            const upload_stream = this._func_code.gridfs().openUploadStream(
                 this.code_filename(system, name, version));
             code_stream
                 .once('error', reject)
@@ -143,11 +137,11 @@ class FuncStore {
     }
 
     delete_code_gridfs(id) {
-        return this._code_gridfs().delete(id);
+        return this._func_code.gridfs().delete(id);
     }
 
     stream_code_gridfs(id) {
-        return this._code_gridfs().openDownloadStream(id);
+        return this._func_code.gridfs().openDownloadStream(id);
     }
 
     read_code_gridfs(id) {


### PR DESCRIPTION
### Explain the changes:
- moving init of GridFS bucket responsibility to mongo_client instead of block_store_mongo
- now will be inited every time the mongo_client will be reconnected - like in clustering
- cosmetic cleanups and moving some configuration params to config.js

### Issues: Fixed / Gap #xxx
- Fixed #4066

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
