### PR TITLE
build linux agent on centos6 docker instead of centos5

### DIFF
--- a/src/deploy/Linux/Dockerfile.noobaa-manylinux-x64
+++ b/src/deploy/Linux/Dockerfile.noobaa-manylinux-x64
@@ -1,13 +1,13 @@
-FROM dockcross/manylinux-x64
+FROM centos:6
 
 #################
 # INSTALLATIONS #
 #################
 # best keep installations first for best docker images caching
 
-# python2.6 - required for node-gyp
 RUN yum -y update
-RUN yum -y install python26
+RUN yum -y install centos-release-scl
+RUN yum -y install devtoolset-7
 
 # nvm - for all users
 # adding nvm.sh to /etc/profile.d/nvm.sh to be loaded by any non-interactive shells
@@ -41,8 +41,7 @@ RUN nvm install
 
 # configure npm
 # unsafe-perm is needed in order to run by root
-RUN npm config set python /usr/bin/python26 && \
-    npm config set unsafe-perm true
+RUN npm config set unsafe-perm true
 
-# set DEFAULT_DOCKCROSS_IMAGE so that the generated control script will default to using our image
-ENV DEFAULT_DOCKCROSS_IMAGE noobaa-manylinux-x64
+RUN mkdir /work
+WORKDIR /work

--- a/src/deploy/Linux/build_agent_manylinux.sh
+++ b/src/deploy/Linux/build_agent_manylinux.sh
@@ -2,19 +2,39 @@
 
 # This script runs build_agent_linux.sh inside a docker container
 # so that the build will run against old linux glibc shared libraries
-# this is based on dockcross/manylinux-x64 which bundles centos-5 with gcc-4.8
-# see https://github.com/dockcross/dockcross
+# this was origianlly based on dockcross/manylinux-x64 which bundles centos-5 with gcc-4.8
+# (https://github.com/dockcross/dockcross) however since node.js v8 doesn't support glibc 2.5
+# and dropped the support for centos-5 we moved to use centos 6 directly.
+
+IMAGE="noobaa/manylinux-x64"
+DOCKERFILE="src/deploy/Linux/Dockerfile.noobaa-manylinux-x64"
+# use the same user ids as the current user
+USER_IDS="-e BUILDER_UID=$(id -u) -e BUILDER_GID=$(id -g) -e BUILDER_USER=$(id -un) -e BUILDER_GROUP=$(id -gn)"
+# map the current directory as /work dir in the container
+HOST_VOLUMES="-v $PWD:/work"
+# when running inside a tty we can also run docker interactively
+tty -s && TTY_ARGS="-it" || TTY_ARGS=""
+SCL_COMMAND="scl enable devtoolset-7"
+BUILD_COMMAND="bash -c \"src/deploy/Linux/build_agent_linux.sh $@\""
+
+# deleting files is significantly slower within docker, so prefer to clean here before
 mkdir -p build
-
-# build noobaa-manylinux-x64 image which adds node.js on top of dockcross/manylinux-x64
-# docker will use cached build if available
-docker build -f src/deploy/Linux/Dockerfile.noobaa-manylinux-x64 -t noobaa-manylinux-x64 . || exit 1
-
-# generate the wrapper script
-docker run --rm noobaa-manylinux-x64 > build/noobaa-manylinux-x64 || exit 1
-
-# cleaning is significantly slower within docker, so prefer to clean here before
 rm -rf build/linux
 
-# run build_agent_linux.sh inside the container
-bash build/noobaa-manylinux-x64 src/deploy/Linux/build_agent_linux.sh "$@" || exit 1
+# build image which includes all the tools needed for building
+# this stage will be cached by docker after the first run
+docker build \
+    -f $DOCKERFILE \
+    -t $IMAGE \
+    . \
+    || exit 1
+
+# run the build command inside the container
+docker run --rm \
+    $TTY_ARGS \
+    $USER_IDS \
+    $HOST_VOLUMES \
+    $IMAGE \
+    $SCL_COMMAND \
+    "$BUILD_COMMAND" \
+    || exit 1

--- a/src/tools/npm_install.js
+++ b/src/tools/npm_install.js
@@ -9,10 +9,9 @@ const child_process = require('child_process');
 // but skip it if the frontend folder is missing such as when building agent package.
 const folder = process.argv[2];
 
-fs.exists(folder, function(exists) {
-    if (!exists) return;
+if (fs.existsSync(folder)) {
     child_process.spawn('npm', ['install'], {
         cwd: folder,
         stdio: 'inherit',
     });
-});
+}


### PR DESCRIPTION
### Explain the changes:
- centos5 has reached end-of-life and not supported by nodejs v8
- this means we now require kernel >= 2.6.32, glibc >= 2.12 (previously was kernel >= 2.6.18, glibc >= 2.5)
- nodejs v8 requirements https://github.com/nodejs/node/blob/v8.x/BUILDING.md
- for previous nodejs v6 refer to https://github.com/nodejs/node/blob/v6.x/BUILDING.md

### Issues: Fixed / Gap #xxx
- Gap #4157

### Testing Instructions:
- QA test agent matrix

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
