### PR TITLE
Issues and gaps session

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -981,7 +981,10 @@ export function updateServerDNSSettings(serverSecret, primaryDNS, secondaryDNS, 
         dns_servers: [primaryDNS, secondaryDNS].filter(Boolean),
         search_domains: searchDomains
     })
-        .then(() => action$.onNext(refreshLocation()))
+        .then(() => {
+            notify('DNS server settings updated successfully', 'success');
+            action$.onNext(refreshLocation());
+        })
         .catch(() => {
             notify('Updating server DNS setting failed, Please try again later', 'error');
         })

--- a/frontend/src/app/components/management/server-time-form/server-row.js
+++ b/frontend/src/app/components/management/server-time-form/server-row.js
@@ -68,8 +68,12 @@ export default class ServerRowViewModel extends BaseViewModel {
             () => server() && server().timezone
         );
 
-        const time = ko.observableWithDefault(
+        const _time = ko.pureComputed(
             () => server() && server().time_epoch * 1000
+        );
+
+        const time = ko.observableWithDefault(
+            () => _time()
         );
 
         this.time = time.extend({
@@ -79,9 +83,18 @@ export default class ServerRowViewModel extends BaseViewModel {
             }
         });
 
+        let timestamp = _time();
+
         this.addToDisposeList(
             setInterval(
-                () => time() && time(time() + 1000),
+                () => {
+                    if(_time() === timestamp) {
+                        time() && time(time() + 1000);
+                    } else {
+                        timestamp = _time();
+                        time() && time(_time());
+                    }
+                },
                 1000
             ),
             clearInterval

--- a/frontend/src/app/services/notifications.js
+++ b/frontend/src/app/services/notifications.js
@@ -1,7 +1,13 @@
 /* Copyright (C) 2016 NooBaa */
 
 import { action$ } from 'state';
-import { fetchUnreadAlertsCount, showNotification, removeHost, fetchSystemInfo } from 'action-creators';
+import {
+    fetchUnreadAlertsCount,
+    showNotification,
+    removeHost,
+    fetchSystemInfo,
+    refreshLocation
+} from 'action-creators';
 
 export function alert() {
     action$.onNext(fetchUnreadAlertsCount());
@@ -21,6 +27,7 @@ export function add_memeber_to_cluster(req) {
 export function remove_host(req) {
     const { name: host } = req.rpc_params;
     action$.onNext(removeHost(host));
+    action$.onNext(refreshLocation());
 }
 
 export function change_upgrade_status() {


### PR DESCRIPTION
1. After configuration of NTP I need to refresh all browser to get new time (not only read_system)
2. Missing popup notification after editing server DNS settings
3. Pool page doesn't refresh on delete nodes

### Explain the changes:
- fixed #4123
- fixed #4117
- fixed #4102

### Testing Instructions:
Test: Missing popup notification after editing server DNS settings
1. Go to Management, 
2. Open Environment DNS Settings modal
3. Add primary and secondary DNS
4. Notifications appears with message ‘DNS server settings updated successfully’
5. Brake updateServerDNSSettings function in actions to send invalid ip (‘1111’)
6. Get error with message ‘Updating server DNS setting failed, Please try again later’

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
