### PR TITLE
build agent fix user inside docker to avoid writing files as root

### DIFF
--- a/src/deploy/Linux/build_agent_manylinux.Dockerfile
+++ b/src/deploy/Linux/build_agent_manylinux.Dockerfile
@@ -3,8 +3,8 @@ FROM centos:6
 #################
 # INSTALLATIONS #
 #################
-# best keep installations first for best docker images caching
 
+# best keep installations first for best docker images caching
 RUN yum -y update
 RUN yum -y install centos-release-scl
 RUN yum -y install devtoolset-7
@@ -18,30 +18,39 @@ RUN touch /etc/profile.d/nvm.sh && \
 ADD http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz .
 RUN tar xf yasm-1.3.0.tar.gz && pushd yasm-1.3.0 && ./configure && make && make install && popd && rm -rf yasm-1.3.0 yasm-1.3.0.tar.gz
 
+
 ##############
 # BASH SETUP #
 ##############
 
-#   1. non-interactive shell        => setting BASH_ENV to make bash load /etc/profile too
-#   2. interactive login shell      => bash loads /etc/profile + ~/.bash_profile|~/.bash_login|~/.profile
-#   3. interactive non-login shell  => ~/.bashrc
-#   4. remote shell daemon (ssh)    => ~/.bashrc
-#   (refere to https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html)
+# 1. non-interactive shell        => setting BASH_ENV to make bash load /etc/profile too
+# 2. interactive login shell      => bash loads /etc/profile + ~/.bash_profile|~/.bash_login|~/.profile
+# 3. interactive non-login shell  => ~/.bashrc
+# 4. remote shell daemon (ssh)    => ~/.bashrc
+# (refere to https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html)
+
 SHELL [ "/bin/bash", "-c" ]
 ENV BASH_ENV '/etc/profile'
 RUN echo '. /etc/profile' >> ~/.bashrc
+
 
 #################
 # NODE.JS SETUP #
 #################
 
 # install current node.js version
-ADD .nvmrc .
+COPY .nvmrc .
 RUN nvm install
 
 # configure npm
 # unsafe-perm is needed in order to run by root
 RUN npm config set unsafe-perm true
 
-RUN mkdir /work
+
+################
+# DOCKER SETUP #
+################
+
+COPY src/deploy/Linux/build_agent_manylinux_entrypoint.sh /tmp/build_agent_manylinux_entrypoint.sh
+ENTRYPOINT [ "/tmp/build_agent_manylinux_entrypoint.sh" ]
 WORKDIR /work

--- a/src/deploy/Linux/build_agent_manylinux.sh
+++ b/src/deploy/Linux/build_agent_manylinux.sh
@@ -6,16 +6,15 @@
 # (https://github.com/dockcross/dockcross) however since node.js v8 doesn't support glibc 2.5
 # and dropped the support for centos-5 we moved to use centos 6 directly.
 
-IMAGE="noobaa/manylinux-x64"
-DOCKERFILE="src/deploy/Linux/Dockerfile.noobaa-manylinux-x64"
+IMAGE="noobaa/build_agent_manylinux"
+DOCKERFILE="src/deploy/Linux/build_agent_manylinux.Dockerfile"
 # use the same user ids as the current user
 USER_IDS="-e BUILDER_UID=$(id -u) -e BUILDER_GID=$(id -g) -e BUILDER_USER=$(id -un) -e BUILDER_GROUP=$(id -gn)"
 # map the current directory as /work dir in the container
 HOST_VOLUMES="-v $PWD:/work"
 # when running inside a tty we can also run docker interactively
 tty -s && TTY_ARGS="-it" || TTY_ARGS=""
-SCL_COMMAND="scl enable devtoolset-7"
-BUILD_COMMAND="bash -c \"src/deploy/Linux/build_agent_linux.sh $@\""
+BUILD_COMMAND="src/deploy/Linux/build_agent_linux.sh $@"
 
 # deleting files is significantly slower within docker, so prefer to clean here before
 mkdir -p build
@@ -35,6 +34,5 @@ docker run --rm \
     $USER_IDS \
     $HOST_VOLUMES \
     $IMAGE \
-    $SCL_COMMAND \
-    "$BUILD_COMMAND" \
+    $BUILD_COMMAND \
     || exit 1

--- a/src/deploy/Linux/build_agent_manylinux_entrypoint.sh
+++ b/src/deploy/Linux/build_agent_manylinux_entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# If we are running docker natively, we want to create a user in the container
+# with the same UID and GID as the user on the host machine, so that any files
+# created are owned by that user. Without this they are all owned by root.
+
+SCRIPT="/tmp/build_agent_manylinux_args.sh"
+echo "Entrypoint Args ($SCRIPT): $@"
+echo "$@" > $SCRIPT
+chmod +x $SCRIPT
+
+if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]
+then
+    echo "Creating user $BUILDER_USER($BUILDER_UID):$BUILDER_GROUP($BUILDER_GID)"
+    groupadd -o -g $BUILDER_GID $BUILDER_GROUP
+    useradd -o -m -g $BUILDER_GID -u $BUILDER_UID $BUILDER_USER
+    export HOME=/home/${BUILDER_USER}
+    shopt -s dotglob
+    cp -r /root/* $HOME/
+    chown -R $BUILDER_UID:$BUILDER_GID $HOME
+    su $BUILDER_USER -c "scl enable devtoolset-7 $SCRIPT"
+else
+    scl enable devtoolset-7 $SCRIPT
+fi


### PR DESCRIPTION
### Explain the changes:
- Had to use the same method as dockcross is using to create a user/group with the same uid/gid as the calling user so that all files created inside the container will be using that user.

### Issues: Fixed / Gap #xxx
- None

### Testing Instructions:
- Run a build on master

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
