### PR TITLE
catch and print errors when failing to delete a vm in test_env_builder

### DIFF
--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -202,7 +202,10 @@ function run_tests() {
 function clean_test_env() {
     const vms_to_delete = agents.map(agent => agent.name).concat([server.name]);
     console.log(`deleting virtual machines`, vms_to_delete);
-    return P.map(vms_to_delete, vm => azf.deleteVirtualMachine(vm));
+    return P.map(vms_to_delete, vm =>
+        azf.deleteVirtualMachine(vm)
+        .catch(err => console.error(`failed deleting ${vm} with error: `, err.message))
+    );
 }
 
 


### PR DESCRIPTION
### Explain the changes:
- catch and print errors when failing to delete a vm in test_env_builder

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages