### PR TITLE
fix #4171 - quick fix by allowing cloud/mongo to repeat in the chunk

### DIFF
--- a/src/deploy/Linux/build_agent_linux.sh
+++ b/src/deploy/Linux/build_agent_linux.sh
@@ -86,7 +86,7 @@ then
     verbose npm install --production
     verbose npm install node-linux@0.1.8
 
-    verbose rm -f agent_conf.json
+    verbose rm -rf agent_conf.json src/native
     verbose popd
 fi
 

--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -79,6 +79,8 @@ node -p process.arch
 cmd /c npm config set msvs_version=2015 --global
 cmd /c npm install --production || exit 1
 if not exist ".\build\Release" exit 1
+
+rd /q/s .\src\native
 rd /q/s .\build\src
 rd /q/s .\build\Windows
 del /q .\build\*.*

--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -191,8 +191,9 @@ class MapBuilder {
                     chunk, _.map(chunk.objects, 'key'));
             }
 
-            chunk.avoid_nodes = chunk.blocks.map(block => String(block.node._id));
-            chunk.allocated_hosts = chunk.blocks.map(block => block.node.host_id);
+            const avoid_blocks = chunk.blocks.filter(block => block.node.node_type === 'BLOCK_STORE_FS');
+            chunk.avoid_nodes = avoid_blocks.map(block => String(block.node._id));
+            chunk.allocated_hosts = avoid_blocks.map(block => block.node.host_id);
             chunk.rpc_client = server_rpc.rpc.new_client({
                 auth_token: auth_server.make_auth_token({
                     system_id: chunk.system,
@@ -328,8 +329,10 @@ class MapBuilder {
             bucket: chunk.bucket._id,
         };
         mapper.assign_node_to_block(block, node, chunk.system);
-        avoid_nodes.push(String(node._id));
-        allocated_hosts.push(node.host_id);
+        if (node.node_type === 'BLOCK_STORE_FS') {
+            avoid_nodes.push(String(node._id));
+            allocated_hosts.push(node.host_id);
+        }
         return block;
     }
 

--- a/src/server/object_services/map_writer.js
+++ b/src/server/object_services/map_writer.js
@@ -132,8 +132,10 @@ class MapAllocator {
                 mapper.assign_node_to_block(block, node, this.bucket.system._id);
                 frag.blocks = frag.blocks || [];
                 frag.blocks.push(mapper.get_block_info(chunk, frag, block));
-                avoid_nodes.push(String(node._id));
-                allocated_hosts.push(node.host_id);
+                if (node.node_type === 'BLOCK_STORE_FS') {
+                    avoid_nodes.push(String(node._id));
+                    allocated_hosts.push(node.host_id);
+                }
             });
         }
     }


### PR DESCRIPTION
### Explain the changes:
- See the issue for more details on the problem.
- This quick fix is just to add only BLOCK_STORE_FS nodes to avoid_nodes/hosts

### Issues: Fixed / Gap #xxx
- Fix #4171 

### Testing Instructions:
- EC with spillover
- EC with cloud

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
