### PR TITLE
report used storage 0 when usage in agent is under 200KB

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -782,6 +782,15 @@ class Agent {
                 if (storage_info) {
                     dbg.log0('storage_info:', storage_info);
                     reply.storage = storage_info;
+
+                    // treat small amount of used storage as 0 (under 200 KB) to avoid noisy 
+                    // reporting in a new system
+                    const MIN_USED_STORAGE = 200 * 1024;
+                    if (storage_info.used < MIN_USED_STORAGE) {
+                        dbg.log0(`used storage is under 200 KB (${storage_info.used}), treat as 0`);
+                        storage_info.used = 0;
+                    }
+
                     if (this.storage_limit) {
                         this._fix_storage_limit(reply.storage);
                         // reply.storage.limit = this.storage_limit;


### PR DESCRIPTION
### Explain the changes:
- if the used storage is under 200 KB the agent reports used=0
- this is done to prevent reporting of small amounts of usage (like test blocks mostly from cloud\internal) on new systems

### Issues: Fixed / Gap #xxx
- Fixed #3920 
- Fixed #3914 

### Testing Instructions:
- check usage of internal\cloud resources on new systems

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
