### PR TITLE
Fix for #4183

### DIFF
--- a/frontend/src/app/components/management/version-form/version-form.js
+++ b/frontend/src/app/components/management/version-form/version-form.js
@@ -104,7 +104,7 @@ function _getPackageVersionText(version) {
     }
 
     if (version === 'UNKNOWN') {
-        return 'Not a NooBaa upgrade package';
+        return 'Package might be corrupted or not a NooBaa upgrade package';
     }
 
     return version;

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -96,7 +96,7 @@ function pre_upgrade(params) {
             if (error instanceof ExtractionError) { //Failed in extracting, no staged package
                 staged_package = 'UNKNOWN';
             }
-            if (error instanceof NewTestsError || error instanceof VersionMismatchError) {
+            if (error instanceof NewTestsError) {
                 err_message = error.message;
             }
             return _.omitBy({

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -47,6 +47,7 @@ const ERROR_MAPPING = {
 let staged_package = 'UNKNOWN';
 
 class ExtractionError extends Error {}
+class VersionMismatchError extends Error {}
 class NewTestsError extends Error {}
 
 function pre_upgrade(params) {
@@ -95,7 +96,7 @@ function pre_upgrade(params) {
             if (error instanceof ExtractionError) { //Failed in extracting, no staged package
                 staged_package = 'UNKNOWN';
             }
-            if (error instanceof NewTestsError) {
+            if (error instanceof NewTestsError || error instanceof VersionMismatchError) {
                 err_message = error.message;
             }
             return _.omitBy({
@@ -229,11 +230,11 @@ function test_major_version_change() {
             const major_part = Number(staged_package.split('.')[0]);
             if (major_part < 2) {
                 dbg.error('Unsupported upgrade, 2.X to 1.X');
-                throw new Error('MAJOR_VERSION_CHANGE');
+                throw new VersionMismatchError('MAJOR_VERSION_CHANGE');
             }
             if (staged_package.split('-')[0] > pkg.version.split('-')[0]) {
                 dbg.error('Unsupported upgrade, cannot downgrade');
-                throw new Error('CANNOT_DOWNGRADE');
+                throw new VersionMismatchError('CANNOT_DOWNGRADE');
             }
         });
 }
@@ -284,12 +285,12 @@ function new_pre_upgrade() {
 
 function pre_upgrade_checkups() {
     return P.join(
-            test_major_version_change(),
-            test_package_extraction()
-        )
+        test_major_version_change(),
+        test_package_extraction()
         .catch(err => {
             throw new ExtractionError(err.message);
-        });
+        })
+    );
 }
 
 function extract_new_pre_upgrade_params() {
@@ -330,7 +331,6 @@ function _get_ntp_address() {
 
 function new_pre_upgrade_checkups(params) {
     return P.join(
-        // test_major_version_change(),
         test_internet_connectivity(params.phone_home_proxy_address),
         // TODO: Check the NTP with consideration to the proxy
         test_ntp_timeskew(params.ntp_server),


### PR DESCRIPTION
### Explain the changes:
- If validation tests fail on version mismatch, still show the version as the staged package

### Issues: Fixed / Gap #xxx
- Fixes #4183 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
