### PR TITLE
On mongo restart, call fsync

### DIFF
--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -207,6 +207,10 @@ MongoCtrl.prototype.set_debug_level = function(level) {
     return mongo_client.instance().set_debug_level(level);
 };
 
+MongoCtrl.prototype.force_mongo_sync_journal = function() {
+    return mongo_client.instance().force_mongo_sync_journal();
+};
+
 //
 //Internals
 //

--- a/src/server/utils/supervisor_ctrl.js
+++ b/src/server/utils/supervisor_ctrl.js
@@ -96,7 +96,6 @@ SupervisorCtrl.prototype.remove_program = function(prog_name) {
             if (ind !== -1) {
                 self._programs.splice(ind, 1);
             }
-            return;
         });
 };
 

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -377,14 +377,14 @@ class MongoClient extends EventEmitter {
         };
 
         return P.fcall(function() {
-                if (!is_config_set) { //connect the mongod server
+                if (is_config_set) { //connect the server running the config replica set
+                    return P.resolve(self._send_command_config_rs(command));
+                } else { //connect the mongod server
                     return P.resolve(self.db.admin().command(command))
                         .catch(err => {
                             dbg.error('Failed get_rs_version with', err.message);
                             throw err;
                         });
-                } else { //connect the server running the config replica set
-                    return P.resolve(self._send_command_config_rs(command));
                 }
             })
             .then(res => {
@@ -404,6 +404,20 @@ class MongoClient extends EventEmitter {
         return P.fcall(function() {
             return P.resolve(self.db.admin().command(command))
                 .then(res => dbg.log0(`Recieved ${res} from setParameter/logLevel command (${level})`));
+        });
+    }
+
+    force_mongo_sync_journal() {
+        var self = this;
+        var command = {
+            fsync: 1,
+            async: false,
+
+        };
+
+        return P.fcall(function() {
+            return P.resolve(self.db.admin().command(command))
+                .then(res => dbg.log0(`Recieved ${res} from sforce_mongo_sync_journal command`));
         });
     }
 


### PR DESCRIPTION
### Explain the changes:
- On mongo restart, call fsync

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
