### PR TITLE
System store make_changes journaling and fixes to package extraction

### DIFF
--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -628,7 +628,7 @@ class SystemStore extends EventEmitter {
                 });
 
                 return P.all(_.map(bulk_per_collection,
-                    bulk => bulk.length && P.resolve(bulk.execute())));
+                    bulk => bulk.length && P.resolve(bulk.execute({ j: 1 }))));
             })
             .then(() =>
                 // notify all the cluster (including myself) to reload

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -425,7 +425,7 @@ function extract_package() {
             trim_stdout: true
         }))
         .then(function() {
-            return promise_utils.exec(`cd ${EXTRACTION_PATH}/;tar -xzvf ${EXTRACTION_PATH}/${PACKAGE_FILE_NAME} >& /dev/null`, {
+            return promise_utils.exec(`cd ${EXTRACTION_PATH}/;tar --same-owner -xzvf ${EXTRACTION_PATH}/${PACKAGE_FILE_NAME} >& /dev/null`, {
                     ignore_rc: false,
                     return_stdout: true,
                     trim_stdout: true


### PR DESCRIPTION
### Explain the changes:
- Added write concern journaling on every make_changes inside the bulk operations
This was done after realizing that we had changes that weren't written on mongo shutdowns. 

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
