### PR TITLE
Fix #4170: exclude /boot mount points from host drives

### DIFF
--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -213,7 +213,7 @@ function get_disk_mount_points() {
                 const exclude_drive =
                     mount.includes('/Volumes/') ||
                     mount.startsWith('/etc/') ||
-                    mount.startsWith('/boot/') ||
+                    mount.startsWith('/boot') ||
                     mount.startsWith('/private/') || // mac
                     drive_id.includes('by-uuid');
                 if ((is_win_drive || is_linux_drive) && !exclude_drive) {


### PR DESCRIPTION
### Explain the changes:
- Fix the check to exclude `/boot` and not just `/boot/`

### Issues: Fixed / Gap #xxx
- Fix #4170 

### Testing Instructions:
- Add linux agent and verify it has just one drive (`/`)

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
