### PR TITLE
Fix #4193: Run MapBuilder only from Scrubber

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -23,6 +23,7 @@ api_schema.register_api(require('./agent_api'));
 api_schema.register_api(require('./block_store_api'));
 api_schema.register_api(require('./stats_api'));
 api_schema.register_api(require('./cloud_sync_api'));
+api_schema.register_api(require('./scrubber_api'));
 api_schema.register_api(require('./debug_api'));
 api_schema.register_api(require('./redirector_api'));
 api_schema.register_api(require('./tiering_policy_api'));
@@ -103,6 +104,7 @@ function new_rpc(base_address) {
             object_api: 'md',
             func_api: 'md',
             cloud_sync_api: 'bg',
+            scrubber_api: 'bg',
             hosted_agents_api: 'hosted_agents',
             node_api: 'master',
             host_api: 'master'

--- a/src/api/scrubber_api.js
+++ b/src/api/scrubber_api.js
@@ -1,0 +1,35 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+/**
+ *
+ * SCRUBBER API
+ *
+ */
+module.exports = {
+
+    id: 'scrubber_api',
+
+    methods: {
+
+        build_chunks: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: ['chunk_ids'],
+                properties: {
+                    chunk_ids: {
+                        type: 'array',
+                        items: { objectid: true }
+                    },
+                }
+            },
+            auth: { system: 'admin' }
+        },
+
+    },
+
+    definitions: {
+
+    }
+};

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -23,7 +23,6 @@ const NodesStore = require('./nodes_store').NodesStore;
 const size_utils = require('../../util/size_utils');
 const BigInteger = size_utils.BigInteger;
 const Dispatcher = require('../notifications/dispatcher');
-const MapBuilder = require('../object_services/map_builder').MapBuilder;
 const server_rpc = require('../server_rpc');
 const auth_server = require('../common_services/auth_server');
 const system_store = require('../system_services/system_store').get_instance();
@@ -2254,8 +2253,14 @@ class NodesMonitor extends EventEmitter {
                 // we update the stage marker even if failed to advance the scan
                 act.stage.marker = res.marker;
                 blocks_size = res.blocks_size;
-                const builder = new MapBuilder(res.chunk_ids);
-                return builder.run();
+                return this.client.scrubber.build_chunks({
+                    chunk_ids: res.chunk_ids
+                }, {
+                    auth_token: auth_server.make_auth_token({
+                        system_id: String(item.node.system),
+                        role: 'admin'
+                    })
+                });
             })
             .then(() => {
                 act.running = false;

--- a/src/server/server_rpc.js
+++ b/src/server/server_rpc.js
@@ -130,6 +130,8 @@ class ServerRpc {
         let options = this.get_server_options();
         rpc.register_service(schema.cloud_sync_api,
             require('./bg_services/cloud_sync'), options);
+        rpc.register_service(schema.scrubber_api,
+            require('./bg_services/scrubber'), options);
     }
 
     register_hosted_agents_services() {

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -628,7 +628,7 @@ class SystemStore extends EventEmitter {
                 });
 
                 return P.all(_.map(bulk_per_collection,
-                    bulk => bulk.length && P.resolve(bulk.execute({ j: 1 }))));
+                    bulk => bulk.length && P.resolve(bulk.execute({ j: true }))));
             })
             .then(() =>
                 // notify all the cluster (including myself) to reload

--- a/src/util/mongo_utils.js
+++ b/src/util/mongo_utils.js
@@ -33,6 +33,10 @@ const mongo_operators = new Set([
     '$isolated'
 ]);
 
+mongodb.Binary.prototype[util.inspect.custom] = function custom_inspect_binary() {
+    return `<mongodb.Binary ${this.buffer.toString('base64')} >`;
+};
+
 /*
  *@param base - the array to subtract from
  *@param values - array of values to subtract from base


### PR DESCRIPTION
### Explain the changes:
- In order for our builder locks in MapBuilder to actually work we knew we had to send the chunk build requests to the scrubber, but that remained a gap so far.
- Now we do send the list of chunk_ids to rebuild from the nodes monitor to the scrubber, so it will synchronize the work on these chunks.
- Also change j:1 to j:true for #4195

### Issues: Fixed / Gap #xxx
- Fix #4193 
- Fix #2499

### Testing Instructions:
- This is a race so hard to positively validate
- The best way is to have very little data in the system, and delete some nodes while the scrubber is working.
- Maybe @YuliaKovalenko can tell better how she did it in #4193

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages

  