### PR TITLE
Issues and gaps session

### DIFF
--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -981,7 +981,10 @@ export function updateServerDNSSettings(serverSecret, primaryDNS, secondaryDNS, 
         dns_servers: [primaryDNS, secondaryDNS].filter(Boolean),
         search_domains: searchDomains
     })
-        .then(() => action$.onNext(refreshLocation()))
+        .then(() => {
+            notify('DNS server settings updated successfully', 'success');
+            action$.onNext(refreshLocation());
+        })
         .catch(() => {
             notify('Updating server DNS setting failed, Please try again later', 'error');
         })

--- a/frontend/src/app/components/host/host-diagnostics-form/host-diagnostics-form.js
+++ b/frontend/src/app/components/host/host-diagnostics-form/host-diagnostics-form.js
@@ -75,6 +75,7 @@ class HostDiagnosticsFormViewModel extends Observer{
     onHost(host) {
         if (!host) {
             this.areActionsDisabled(true);
+            this.actionsTooltip({});
             this.debugModeToggleText(_getDebugModeToggleText(false));
             return;
         }

--- a/frontend/src/app/components/management/server-time-form/server-row.js
+++ b/frontend/src/app/components/management/server-time-form/server-row.js
@@ -68,9 +68,11 @@ export default class ServerRowViewModel extends BaseViewModel {
             () => server() && server().timezone
         );
 
-        const time = ko.observableWithDefault(
+        const timeFromServer = ko.pureComputed(
             () => server() && server().time_epoch * 1000
         );
+
+        const time = ko.observableWithDefault(timeFromServer);
 
         this.time = time.extend({
             formatTime: {
@@ -79,6 +81,7 @@ export default class ServerRowViewModel extends BaseViewModel {
             }
         });
 
+        this.addToDisposeList(timeFromServer.subscribe(time));
         this.addToDisposeList(
             setInterval(
                 () => time() && time(time() + 1000),

--- a/frontend/src/app/epics/refresh.js
+++ b/frontend/src/app/epics/refresh.js
@@ -34,6 +34,7 @@ export default function(action$) {
             types.UPLOAD_OBJECTS,
             types.COMPLETE_OBJECT_UPLOAD,
             types.COMPLETE_INVOKE_UPGRADE_SYSTEM,
+            types.REMOVE_HOST
         )
         .map(() => refreshLocation());
 }

--- a/frontend/src/app/reducers/host-parts-reducer.js
+++ b/frontend/src/app/reducers/host-parts-reducer.js
@@ -67,7 +67,7 @@ function onFailFetchHostObjects(state, { payload }) {
     return {
         ...state,
         fetching: false,
-        errors: true
+        error: true
     };
 }
 


### PR DESCRIPTION
1. After configuration of NTP I need to refresh all browser to get new
time (not only read_system)
2. Missing popup notification after editing server DNS settings
3. Pool page doesn't refresh on delete nodes

### Explain the changes:
- fixed #4123
- fixed #4117
- fixed #4102

### Testing Instructions:
Test: Missing popup notification after editing server DNS settings
1. Go to Management, 
2. Open Environment DNS Settings modal
3. Add primary and secondary DNS
4. Notifications appears with message ‘DNS server settings updated successfully’
5. Brake updateServerDNSSettings function in actions to send invalid ip (‘1111’)
6. Get error with message ‘Updating server DNS setting failed, Please try again later’

Test: Pool page doesn't refresh on delete nodes
1. Go to pool page
2. Select node, go to node page
3. Click 'Delete node' button
4. waiting for node delete completed
5. after node deleted page redirected to pool page 
6. select another node, go to the node page
7. click  'Delete node' button
8. Go back to pool page
9. when delete node process completed page refreshed 
10. deleted node removed from the table
11. summary nodes count reduced by one
12. try use uri of the deleted node, you will be redirected on the pool page

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
  