### PR TITLE
Addition of tests to system_store

### DIFF
--- a/src/test/unit_tests/test_system_store.js
+++ b/src/test/unit_tests/test_system_store.js
@@ -3,6 +3,10 @@
 
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
+const promise_utils = require('../../util/promise_utils');
+const P = require('../../util/promise');
+const _ = require('lodash');
+const mongo_client = require('../../util/mongo_client');
 coretest.setup();
 
 // const _ = require('lodash');
@@ -11,10 +15,75 @@ const mocha = require('mocha');
 
 const system_store = require('../../server/system_services/system_store').get_instance();
 
+function _get_wiredtiger_log() {
+    return mongo_client.instance().connect()
+        .then(() => mongo_client.instance().db.command({ serverStatus: 1 }))
+        .then(res => res.wiredTiger.log);
+}
+
+function _get_wiredtiger_log_diff(a, b) {
+    return _.omitBy(_.mergeWith(a, b, (a_prop, b_prop) => b_prop - a_prop), value => !value);
+}
+
+
 mocha.describe('system_store', function() {
 
     mocha.it('load()', function() {
         return system_store.load();
+    });
+
+    mocha.it('Loop make_changes', function() {
+        const LOOP_CYCLES = 26;
+        let first_log;
+        let second_log;
+        return _get_wiredtiger_log()
+            .then(first_log_res => {
+                first_log = first_log_res;
+                console.log('Loop make_changes: First WiredTiger Log', first_log_res);
+                return promise_utils.loop(LOOP_CYCLES, cycle => system_store.make_changes({
+                    insert: {
+                        systems: [{
+                            _id: system_store.generate_id(),
+                            name: `JenTheMajesticSlothSystemStoreLoop-${cycle}`,
+                            owner: system_store.generate_id()
+                        }]
+                    }
+                }));
+            })
+            .then(() => _get_wiredtiger_log())
+            .then(second_log_res => {
+                second_log = second_log_res;
+                console.log('Loop make_changes: Second WiredTiger Log', second_log_res);
+                const log_diff = _get_wiredtiger_log_diff(first_log, second_log);
+                console.log('Loop make_changes: WiredTiger Log Diff', log_diff);
+            });
+    });
+
+    mocha.it('Parallel make_changes', function() {
+        const PARALLEL_CHANGES = 26;
+        let first_log;
+        let second_log;
+        return _get_wiredtiger_log()
+            .then(first_log_res => {
+                first_log = first_log_res;
+                console.log('Parallel make_changes: First WiredTiger Log', first_log_res);
+                return P.map(new Array(PARALLEL_CHANGES), (x, i) => system_store.make_changes({
+                    insert: {
+                        systems: [{
+                            _id: system_store.generate_id(),
+                            name: `JenTheMajesticSlothSystemStoreParallel-${i}`,
+                            owner: system_store.generate_id()
+                        }]
+                    }
+                }));
+            })
+            .then(() => _get_wiredtiger_log())
+            .then(second_log_res => {
+                second_log = second_log_res;
+                console.log('Parallel make_changes: Second WiredTiger Log', second_log_res);
+                const log_diff = _get_wiredtiger_log_diff(first_log, second_log);
+                console.log('Parallel make_changes: WiredTiger Log Diff', log_diff);
+            });
     });
 
     // TODO continue test_system_store ...


### PR DESCRIPTION
### Explain the changes:
- Addition of tests for parallel make changes
- Addition of tests for serial make changes
- Pulling wiredTiger logs and comparing them with verbosity of delta for prior and after running make changes in every case
- This is done after the change of journaling in make changes bulk operations in order to spot the efficiency loss on multiple make changes and under pressure

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
- mocha src/test/unit_tests/test_system_store.js

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages

  
  