### PR TITLE
missing legends tooltips & Raw usage graph double drawing

### DIFF
--- a/frontend/src/app/components/bucket/bucket-summary/bucket-summary.js
+++ b/frontend/src/app/components/bucket/bucket-summary/bucket-summary.js
@@ -3,7 +3,7 @@
 import template from './bucket-summary.html';
 import Observer from 'observer';
 import { state$, action$ } from 'state';
-import { deepFreeze, sumBy } from 'utils/core-utils';
+import { deepFreeze } from 'utils/core-utils';
 import { stringifyAmount } from 'utils/string-utils';
 import { realizeUri } from 'utils/browser-utils';
 import { isSizeZero, formatSize, toBytes } from 'utils/size-utils';
@@ -64,7 +64,8 @@ class BucketSummrayViewModel extends Observer {
             {
                 label: 'Used Data',
                 color: style['color8'],
-                value: ko.observable()
+                value: ko.observable(),
+                tooltip: 'The total amount of data uploaded to this bucket. Does not include data optimisation or data resiliency'
             },
             {
                 label: 'Overused',
@@ -75,75 +76,71 @@ class BucketSummrayViewModel extends Observer {
             {
                 label: 'Available',
                 color: style['color5'],
-                value: ko.observable()
+                value: ko.observable(),
+                tooltip: 'The actual free space on this bucket for data writes taking into account the current configured resiliency policy'
             },
             {
                 label: 'Available on spillover',
                 color: style['color18'],
                 value: ko.observable(),
-                visible: ko.observable()
+                visible: ko.observable(),
+                tooltip: 'The current available storage from the system internal storage resource, will be used only in the case of no available data storage on this bucket. Once possible, data will be spilled-back'
             },
             {
                 label: 'Overallocated',
                 color: style['color11'],
                 value: ko.observable(),
-                visible: ko.observable()
+                visible: ko.observable(),
+                tooltip: 'Overallocation happens when configuring a higher quota than this bucket assigned resources can store'
             }
         ];
 
-        this.barChartData  = [
+        this.dataUsage = [
             {
                 label: 'Total Original Size',
                 color: style['color7'],
-                parts: [
-                    {
-                        value: ko.observable(),
-                        color: style['color7']
-
-                    }
-                ]
-
+                tooltip: 'The total aggregated size of all data written on this bucket',
+                value: ko.observable()
             },
             {
                 label: 'Compressed & Deduped',
                 color: style['color13'],
-                parts: [
-                    {
-                        value: ko.observable(),
-                        color: style['color13']
-
-                    }
-                ]
-
+                tooltip: 'The size of all data written on this bucket after optimization',
+                value: ko.observable()
             }
         ];
 
-        this.dataUsage = this.barChartData.map(({ label, color, parts }) => ({
+        this.barChartData = this.dataUsage.map(({ label, color, tooltip, value }) => ({
             label,
-            color: color,
-            value: ko.pureComputed(() => sumBy(parts, ({ value }) => value()))
+            tooltip,
+            color,
+            parts: [{ value, color }]
         }));
 
         this.rawUsage = [
             {
                 label: 'Available from Resources',
                 color: style['color5'],
-                value: ko.observable()
+                value: ko.observable(),
+                tooltip: 'An aggregation of the available storage from the resources selected for this bucket data placement policy'
             },
             {
                 label: 'Available Spillover',
                 color: style['color18'],
-                value: ko.observable()
+                value: ko.observable(),
+                tooltip: 'The current available storage from the system internal storage resource'
             },
             {
                 label: 'Bucket Usage (Replicated)',
                 color: style['color13'],
-                value: ko.observable()
+                value: ko.observable(),
+                tooltip: 'The actual raw usage of this bucket includes the data resiliency replications or fragments'
             },
             {
                 label: 'Shared Usage',
                 color: style['color14'],
-                value: ko.observable()
+                value: ko.observable(),
+                tooltip: 'Resources in the system are not exclusively allocated per bucket, other buckets may be using the same resources and utilizing this bucket free storage'
             }
         ];
 

--- a/frontend/src/app/components/host/host-summary/host-summary.js
+++ b/frontend/src/app/components/host/host-summary/host-summary.js
@@ -48,27 +48,32 @@ class HostSummaryViewModel extends Observer {
             {
                 label: 'Available',
                 color: style['color5'],
-                value: this.availableCapacity
+                value: this.availableCapacity,
+                tooltip: 'The total storage of this machine, does not include any offline or deactivated drives'
             },
             {
                 label: 'Unavailable Capacity',
                 color: style['color17'],
-                value: this.unavailableCapacity
+                value: this.unavailableCapacity,
+                tooltip: 'The total storage from drives which are either offline or in process'
             },
             {
                 label: 'NooBaa Usage',
                 color: style['color13'],
-                value: this.usedByNoobaaCapacity
+                value: this.usedByNoobaaCapacity,
+                tooltip: 'The actual storage utilization of this node by the buckets connected to its assigned pool'
             },
             {
                 label: 'Other Usage',
                 color: style['color14'],
-                value: this.usedByOthersCapacity
+                value: this.usedByOthersCapacity,
+                tooltip: 'The machine utilization by OS, local files etc'
             },
             {
                 label: 'Reserved',
                 color: style['color7'],
-                value: this.reservedCapacity
+                value: this.reservedCapacity,
+                tooltip: 'NooBaa reserves 10GB from each storage node to avoid a complete utilization of the local storage on the machine'
             }
         ];
 

--- a/frontend/src/app/components/object/object-summary/object-summary.js
+++ b/frontend/src/app/components/object/object-summary/object-summary.js
@@ -43,30 +43,31 @@ class ObjectSummaryViewModel extends BaseViewModel {
             {
                 label: 'Original size',
                 color: style['color7'],
+                tooltip: 'The original size of the file as written prior to optimization or data resiliency',
                 parts: [
                     {
                         value: ko.pureComputed(() => toBytes(obj().size)),
                         color: style['color7']
                     }
                 ]
-
             },
             {
-                label: 'Size on Disk (with replicas)',
+                label: 'Actual Used Storage',
                 color: style['color13'],
+                tooltip: 'The actual raw usage of this file includes the data resiliency replications or fragments after compression',
                 parts: [
                     {
                         value: ko.pureComputed(() => toBytes(obj().capacity_size)),
                         color: style['color13']
                     }
                 ]
-
             }
         ];
 
-        this.barsValues = this.barChartData.map(({ label, color, parts }) => ({
+        this.barsValues = this.barChartData.map(({ label, color, tooltip, parts }) => ({
             label,
-            color: color,
+            color,
+            tooltip,
             value: sumBy(parts, ({ value }) => value())
         }));
     }

--- a/frontend/src/app/components/pool/pool-summary/pool-summary.js
+++ b/frontend/src/app/components/pool/pool-summary/pool-summary.js
@@ -29,17 +29,20 @@ class PoolSummaryViewModel extends Observer {
             {
                 label: 'Healthy',
                 color: style['color12'],
-                value: this.healthyCount
+                value: this.healthyCount,
+                tooltip: 'The number of fully operative storage nodes that can be used as a storage target for NooBaa'
             },
             {
                 label: 'Issues',
                 color: style['color11'],
-                value: this.issuesCount
+                value: this.issuesCount,
+                tooltip: 'The number of storage nodes that are partially operative due to a current process or low spec'
             },
             {
                 label: 'Offline',
                 color: style['color10'],
-                value: this.offlineCount
+                value: this.offlineCount,
+                tooltip: 'The number of storage nodes that are currently not operative and are not considered as part of NooBaa’s available storage'
             }
         ];
 
@@ -54,27 +57,32 @@ class PoolSummaryViewModel extends Observer {
             {
                 label: 'Available',
                 color: style['color5'],
-                value: this.availableCapacity
+                value: this.availableCapacity,
+                tooltip: 'The total aggregated storage from installed nodes in this pool, does not include any offline or deactivated node'
             },
             {
                 label: 'Unavailable Capacity',
                 color: style['color17'],
-                value: this.unavailableCapacity
+                value: this.unavailableCapacity,
+                tooltip: 'The total aggregated storage from offline nodes in this pool'
             },
             {
                 label: 'NooBaa Usage',
                 color: style['color13'],
-                value: this.usedByNoobaaCapacity
+                value: this.usedByNoobaaCapacity,
+                tooltip: 'The actual storage utilization of this pool by the buckets connected to it'
             },
             {
                 label: 'Other Usage',
                 color: style['color14'],
-                value: this.usedByOthersCapacity
+                value: this.usedByOthersCapacity,
+                tooltip: 'The machines utilization by OS, local files etc'
             },
             {
                 label: 'Reserved',
                 color: style['color7'],
-                value: this.reservedCapacity
+                value: this.reservedCapacity,
+                tooltip: 'NooBaa reserves 10GB from each storage node to avoid a complete utilization of the local storage on the machine'
             }
         ];
 


### PR DESCRIPTION
### Explain the changes:
- Missing legends tooltips
- Raw usage graph double drawing

### Issues: Fixed / Gap #xxx
- fixed #3992 

### Testing Instructions:
Tests: **Missing legends tooltips (check tooltips)**
1. Overview -> Storage bar
Used: ok
Unavailable: ok
Available:  ok
Pool -> nodes status
Healthy: ok
Issues: ok
Offline: ok 

2. Pool page
Available: ok.
Unavailable: ok 
NooBaa usage: ok
Other usage: ok
Reserved: ok

3. Node Page
Available: ok
Unavailable: ok
NooBaa usage: ok
Other usage: ok
Reserved: ok

4. Bucket page
Availability 
Used data: ok
Available to upload: ok
Available spillover: ok
Overallocated: ok
Data usage:
Total original size: ok
After compression and dedup: ok
Raw Usage
Available from resources: ok
Available spillover: ok
Bucket usage (Replicated): ok
Shared usage: ok

5. Go to bucket -> Files -> File (object page) -> Check tooltips
Original Size: ok
Actual Used Storage: ok


Tests: **Raw usage graph double drawing**

1. Change switchMap to flatMap to reproduce issue
2. Go to Overview page
3. Try to update with refresh button on command-bar, chart redraws only every 5s
4. Try to change datasets, chart redraws correctly
5. Try to change duration, chart redraws correctly

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages

  
  