### PR TITLE
Refactor namespace_test into blobops and test logic

### DIFF
--- a/src/test/utils/blobops.js
+++ b/src/test/utils/blobops.js
@@ -1,0 +1,74 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const P = require('../../util/promise');
+const azure_storage = require('../../util/azure_storage_wrap');
+const RandStream = require('../../util/rand_stream');
+
+const AzureDefaultConnection = {
+    name: 'AZUREConnection',
+    endpoint: "https://azureconnection.blob.core.windows.net",
+    endpoint_type: "AZURE",
+    identity: "azureconnection",
+    secret: "UsMgM/8uX2FMAwW765fSBATLjROZn+JbxxHLYXDUfBmV0vtpiYkGnRrB8hkSvVcV92pbSxG4J1j/q0IFy3nb6g=="
+};
+
+const blobService = azure_storage.createBlobService(
+    AzureDefaultConnection.identity,
+    AzureDefaultConnection.secret,
+    AzureDefaultConnection.endpoint);
+
+function uploadRandomFileToAzure(container, file_name, size, err_handler) {
+    const message = `Uploading random file ${file_name} to azure container ${container}`;
+    console.log(message);
+    let streamFile = new RandStream(size, {
+        highWaterMark: 1024 * 1024,
+    });
+    let options = {
+        storeBlobContentMD5: true,
+        useTransactionalMD5: true,
+        transactionalContentMD5: true
+    };
+    return P.fromCallback(callback => blobService.createBlockBlobFromStream(container, file_name, streamFile, size, options, callback))
+        .catch(err => _handle_error(err, message, err_handler));
+}
+
+function getMD5Blob(container, file_name, err_handler) {
+    const message = `Getting md5 for ${file_name} azure container ${container}`;
+    console.log(message);
+    return P.fromCallback(callback => blobService.getBlobProperties(container, file_name, callback))
+        .then(res => {
+            console.log(JSON.stringify(res));
+            return res.contentSettings.contentMD5;
+        })
+        .catch(err => _handle_error(err, message, err_handler));
+}
+
+function getListFilesAzure(bucket, err_handler) {
+    const message = `Getting list of files from azure container for ${bucket}`;
+    console.log(message);
+    let blobs = [];
+    return P.fromCallback(callback => blobService.listBlobsSegmented(bucket, null, callback))
+        .then(res => {
+            res.entries.forEach(function(blob) {
+                blobs.push(blob.name);
+            });
+        })
+        .then(() => blobs)
+        .catch(err => _handle_error(err, message, err_handler));
+}
+
+function _handle_error(err, mesage, err_handler) {
+    console.error(`Failed ${mesage}`);
+    if (err_handler) {
+        err_handler(mesage, err);
+    } else {
+        throw err;
+    }
+}
+
+
+exports.AzureDefaultConnection = AzureDefaultConnection;
+exports.uploadRandomFileToAzure = uploadRandomFileToAzure;
+exports.getMD5Blob = getMD5Blob;
+exports.getListFilesAzure = getListFilesAzure;


### PR DESCRIPTION
### Explain the changes:
-  Break current namespace test into 2
    - blobops (similar to our s3ops) - contain operation on azure blob
    - namespace_test - contain test login and use blobops
    - refactor error handling in the test a bit (pass err_handler to the functions instead of inline handling each case)

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages

  