### PR TITLE
Fixing md aggregator system test

### DIFF
--- a/src/test/framework/flow.js
+++ b/src/test/framework/flow.js
@@ -119,21 +119,18 @@ var steps = [
         name: 'Restore DB Defaults',
         common: 'restore_db_defaults',
     },
-    // TODO:    test_md_aggregator cuases supervisord to shutdown and not start again.
-    //          we should resove it before uncommenting the test
-    // {
-    //     //Test MD Aggregator
-    //     ignore_failure: true,
-    //     name: 'MD Aggregator Test',
-    //     action: 'node',
-    //     params: [{
-    //         arg: './src/test/system_tests/test_md_aggregator'
-    //     }],
-    // }, {
-    //     //Restore DB to defaults
-    //     name: 'Restore DB Defaults',
-    //     common: 'restore_db_defaults',
-    // }
+    {
+        //Test MD Aggregator
+        name: 'MD Aggregator Test',
+        action: 'node',
+        params: [{
+            arg: './src/test/system_tests/test_md_aggregator'
+        }],
+    }, {
+        //Restore DB to defaults
+        name: 'Restore DB Defaults',
+        common: 'restore_db_defaults',
+    }
 ];
 
 module.exports = steps;

--- a/src/test/system_tests/test_md_aggregator.js
+++ b/src/test/system_tests/test_md_aggregator.js
@@ -132,7 +132,7 @@ function init_system_to_ntp() {
         .finally(() => P.resolve()
             .then(() => {
                 console.log('start supervisord');
-                return promise_utils.exec('/etc/init.d/supervisord start', {
+                return promise_utils.exec('supervisord', {
                     ignore_rc: false,
                     return_stdout: false
                 });


### PR DESCRIPTION
### Explain the changes:
- We've called init.d supervisord start instead of just calling supervisord.
- This meant that the services did not start up and we've ended the tests with services down.

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
