### PR TITLE
introducing db_cleaner

### DIFF
--- a/config.js
+++ b/config.js
@@ -180,6 +180,15 @@ config.DEDUP_INDEXER_IGNORE_BACK_TIME = 7 * 24 * 60 * 60 * 1000; // dedup indexe
 config.DEDUP_INDEXER_LOW_KEYS_NUMBER = 8 * 1000000; // 8M keys max in index ~ 1.5GB
 config.DEDUP_INDEXER_CHECK_INDEX_CYCLE = 60000;
 
+///////////////////////
+// DB CLEANER CONFIG //
+///////////////////////
+config.DB_CLEANER = {
+    ENABLED: true,
+    CYCLE: 120000,
+    BACK_TIME: 3 * 30 * 24 * 60 * 60 * 1000 // 3 months
+};
+
 //////////////////////
 // LIFECYCLE CONFIG //
 //////////////////////

--- a/src/api/cluster_server_api.js
+++ b/src/api/cluster_server_api.js
@@ -50,16 +50,10 @@ module.exports = {
             method: 'POST',
             params: {
                 type: 'object',
-                required: ['old_address', 'new_address', 'shard', 'target_secret'],
+                required: ['new_address', 'target_secret'],
                 properties: {
-                    old_address: {
-                        type: 'string',
-                    },
                     new_address: {
                         type: 'string',
-                    },
-                    shard: {
-                        type: 'string'
                     },
                     target_secret: {
                         type: 'string'

--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -1,0 +1,149 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// const _ = require('lodash');
+const P = require('../../util/promise');
+const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config');
+const MDStore = require('../object_services/md_store').MDStore;
+const system_store = require('../system_services/system_store').get_instance();
+const nodes_store = require('../node_services/nodes_store').NodesStore.instance();
+const system_utils = require('../utils/system_utils');
+const mongo_utils = require('../../util/mongo_utils');
+const md_aggregator = require('./md_aggregator');
+
+dbg.set_level(5);
+
+/**************
+ *
+ * DB_CLEANER
+ *
+ * background worker that cleans documents that were deleted for a long time from the DB
+ *
+ * @this worker instance
+ *
+ *************************/
+function background_worker() {
+    if (!system_store.is_finished_initial_load) {
+        dbg.log0('DB_CLEANER: system_store did not finish initial load');
+        return;
+    }
+    const system = system_store.data.systems[0];
+    if (!system || system_utils.system_in_maintenance(system._id)) return;
+
+    let last_date_to_remove = Date.now() - config.DB_CLEANER.BACK_TIME;
+
+    if (this.last_check && Date.now() - this.last_check < config.DB_CLEANER.CYCLE) return P.resolve();
+    const skip = new Error('skip');
+    const LIMIT = 100;
+
+    return P.resolve()
+        .then(() => md_aggregator.find_minimal_range({
+                target_now: Date.now(),
+                system_store: system_store
+            }) // checks what md_aggreagator should work on next
+        )
+        .then(range => {
+            this.last_check = Date.now();
+            if (range.from_time < last_date_to_remove) {
+                dbg.log0('DB_CLEANER: waiting for md_aggreagator to advance to later than', new Date(last_date_to_remove));
+                throw skip; // if md_aggreagator is still working on more than 3 month old objects - exit
+            } else {
+                dbg.log0('DB_CLEANER: checking the number of objects deleted before', new Date(last_date_to_remove));
+                return MDStore.instance().find_deleted_objects(last_date_to_remove, LIMIT);
+            }
+        })
+        .then(objects => {
+            dbg.log2('DB_CLEANER: list objects:', objects);
+            return objects &&
+                P.map(objects, obj => db_delete_object_parts(obj), { concurrency: 10 })
+                .then(() => MDStore.instance().db_delete_objects(objects));
+        })
+        .then(() => {
+            dbg.log0('DB_CLEANER: checking the number of blocks deleted before', new Date(last_date_to_remove));
+            return MDStore.instance().find_deleted_blocks(last_date_to_remove, LIMIT);
+        })
+        .then(blocks => {
+            dbg.log2('DB_CLEANER: list blocks:', blocks);
+            return blocks && MDStore.instance().db_delete_blocks(blocks);
+        })
+        .then(() => {
+            dbg.log0('DB_CLEANER: checking the number of chunks deleted before', new Date(last_date_to_remove));
+            return MDStore.instance().find_deleted_chunks(last_date_to_remove, LIMIT);
+        }) // remove the objects
+        .then(chunks => {
+            dbg.log2('DB_CLEANER: list chunks:', chunks);
+            const filtered_chunks = chunks.filter(chunk =>
+                MDStore.instance().has_any_blocks_for_chunk(chunk) &&
+                MDStore.instance().has_any_parts_for_chunk(chunk)
+            );
+            dbg.log2('DB_CLEANER: list chunks with no blocks and no parts to be removed from DB', filtered_chunks);
+            return filtered_chunks && MDStore.instance().db_delete_chunks(filtered_chunks);
+        })
+        .then(() => {
+            dbg.log0('DB_CLEANER: checking the number of nodes deleted before', new Date(last_date_to_remove));
+            const query = {
+                deleted: {
+                    $lt: last_date_to_remove
+                },
+            };
+            const options = {
+                limit: LIMIT,
+                fields: {
+                    _id: 1,
+                    deleted: 1
+                }
+            };
+            return nodes_store.find_nodes(query, options)
+                .then(objects => mongo_utils.uniq_ids(objects, '_id'));
+        })
+        .then(nodes => {
+            dbg.log2('DB_CLEANER: list nodes:', nodes);
+            const filtered_nodes = nodes.filter(node => true); // place holder - should verify the agents are really deleted
+            dbg.log2('DB_CLEANER: list nodes with no agents to be removed from DB', filtered_nodes);
+            return filtered_nodes && nodes_store.db_delete_nodes(filtered_nodes);
+        })
+        .then(() => {
+            dbg.log0('DB_CLEANER: checking the number of system_store objects deleted before', new Date(last_date_to_remove));
+            return P.join(
+                system_store.find_deleted_docs('accounts', last_date_to_remove, LIMIT),
+                system_store.find_deleted_docs('buckets', last_date_to_remove, LIMIT),
+                system_store.find_deleted_docs('pools', last_date_to_remove, LIMIT)
+            );
+        })
+        .spread((accounts, buckets, pools) => {
+            dbg.log2('DB_CLEANER: list accounts:', accounts);
+            dbg.log2('DB_CLEANER: list buckets:', buckets);
+            dbg.log2('DB_CLEANER: list pools:', pools);
+            const filtered_buckets = buckets.filter(bucket =>
+                MDStore.instance().has_any_objects_for_bucket(bucket)
+            );
+            const filtered_pools = pools.filter(pool =>
+                nodes_store.has_any_nodes_for_pool(pool)
+            );
+            return system_store.make_changes({
+                db_delete: {
+                    accounts: accounts,
+                    buckets: filtered_buckets,
+                    pools: filtered_pools
+                }
+            });
+        })
+        .catch(err => {
+            if (err === skip) return;
+            dbg.error('DB_CLEANER:', 'ERROR', err, err.stack);
+            return config.DB_CLEANER.CYCLE;
+        });
+}
+
+function db_delete_object_parts(obj) {
+    if (!obj) return P.resolve();
+    dbg.log0('DB_CLEANER: will remove all object mappings of this object:', obj);
+    return P.join(
+        MDStore.instance().db_delete_parts_of_object(obj),
+        MDStore.instance().db_delete_multiparts_of_object(obj)
+    );
+}
+
+// EXPORTS
+exports.background_worker = background_worker;

--- a/src/server/bg_services/md_aggregator.js
+++ b/src/server/bg_services/md_aggregator.js
@@ -48,8 +48,7 @@ function run_md_aggregator(md_store, system_store, target_now, delay) {
     );
 }
 
-// find next from_time/till_time of the first group we want to aggregate
-function find_next_range({
+function find_minimal_range({
     target_now,
     system_store,
 }) {
@@ -89,31 +88,42 @@ function find_next_range({
             till_time = last_update;
         }
     });
+    return { from_time, till_time, should_reset_all };
+}
 
+// find next from_time/till_time of the first group we want to aggregate
+function find_next_range({
+    target_now,
+    system_store,
+}) {
+    const range = find_minimal_range({
+        target_now,
+        system_store,
+    });
     // printing the range and the buckets/pools relative info
     dbg.log1('find_next_range:',
-        'from_time', from_time,
-        'till_time*', till_time - from_time,
-        'target_now*', target_now - from_time
+        'from_time', range.from_time,
+        'till_time*', range.till_time - range.from_time,
+        'target_now*', target_now - range.from_time
     );
     _.forEach(system_store.data.buckets, bucket => {
         const last_update = _.get(bucket, 'storage_stats.last_update') || config.NOOBAA_EPOCH;
         dbg.log1('find_next_range: bucket', bucket.name,
-            'last_update*', last_update - from_time
+            'last_update*', last_update - range.from_time
         );
     });
     _.forEach(system_store.data.pools, pool => {
         const last_update = _.get(pool, 'storage_stats.last_update') || config.NOOBAA_EPOCH;
         dbg.log1('find_next_range: pool', pool.name,
-            'last_update*', last_update - from_time
+            'last_update*', last_update - range.from_time
         );
     });
 
-    if (should_reset_all) {
+    if (range.should_reset_all) {
         dbg.error('find_next_range: reset all storage_stats due to time skews ',
-            'from_time', from_time,
-            'till_time*', till_time - from_time,
-            'target_now*', target_now - from_time
+            'from_time', range.from_time,
+            'till_time*', range.till_time - range.from_time,
+            'target_now*', target_now - range.from_time
         );
         // Assigning NOOBAA_EPOCH so we will gather all data again till the new time
         // This means that we will be eventually consistent
@@ -147,25 +157,26 @@ function find_next_range({
     // but on upgrades or shutdowns the gap can get higher, and then we limit the number of cycles we
     // allow to run to MD_AGGREGATOR_MAX_CYCLES, and therefore increase the interval from MD_AGGREGATOR_INTERVAL
     // to higher interval in order to close the gap in a reasonable number of cycles.
-    const time_diff = till_time - from_time;
+    const time_diff = range.till_time - range.from_time;
     const current_interval = Math.max(
         Math.floor(time_diff / config.MD_AGGREGATOR_MAX_CYCLES),
         config.MD_AGGREGATOR_INTERVAL);
-    till_time = Math.min(from_time + current_interval, till_time);
+    const from_time = range.from_time;
+    const till_time = Math.min(range.from_time + current_interval, range.till_time);
 
-    if (from_time >= target_now || from_time >= till_time) {
+    if (range.from_time >= target_now || range.from_time >= till_time) {
         dbg.log0('find_next_range:: no more work',
-            'from_time', from_time,
-            'till_time*', till_time - from_time,
-            'target_now*', target_now - from_time
+            'from_time', range.from_time,
+            'till_time*', till_time - range.from_time,
+            'target_now*', target_now - range.from_time
         );
         return;
     }
 
     dbg.log0('find_next_range:: next work',
-        'from_time', from_time,
-        'till_time*', till_time - from_time,
-        'target_now*', target_now - from_time
+        'from_time', range.from_time,
+        'till_time*', till_time - range.from_time,
+        'target_now*', target_now - range.from_time
     );
     return { from_time, till_time };
 }
@@ -422,3 +433,4 @@ exports.background_worker = background_worker;
 exports.run_md_aggregator = run_md_aggregator;
 exports.calculate_new_bucket = calculate_new_bucket;
 exports.calculate_new_pool = calculate_new_pool;
+exports.find_minimal_range = find_minimal_range;

--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -29,6 +29,7 @@ var md_aggregator = require('./bg_services/md_aggregator');
 var background_scheduler = require('../util/background_scheduler').get_instance();
 var stats_collector = require('./bg_services/stats_collector');
 var dedup_indexer = require('./bg_services/dedup_indexer');
+var db_cleaner = require('./bg_services/db_cleaner');
 
 const MASTER_BG_WORKERS = [
     'scrubber',
@@ -37,6 +38,7 @@ const MASTER_BG_WORKERS = [
     'md_aggregator',
     'usage_aggregator',
     'dedup_indexer',
+    'db_cleaner',
     'aws_usage_metering'
 ];
 
@@ -115,6 +117,14 @@ function run_master_workers() {
         }, dedup_indexer.background_worker);
     } else {
         dbg.warn('DEDUP INDEXER NOT ENABLED');
+    }
+
+    if (config.DB_CLEANER.ENABLED) {
+        register_bg_worker({
+            name: 'db_cleaner',
+        }, db_cleaner.background_worker);
+    } else {
+        dbg.warn('DB CLEANER NOT ENABLED');
     }
 
     if (config.LIFECYCLE_DISABLED !== 'true') {

--- a/src/server/node_services/nodes_store.js
+++ b/src/server/node_services/nodes_store.js
@@ -55,6 +55,16 @@ class NodesStore {
             .return(node);
     }
 
+    db_delete_nodes(node_ids) {
+        if (!node_ids || !node_ids.length) return;
+        return this._nodes.col().deleteMany({
+            _id: {
+                $in: node_ids
+            },
+            deleted: { $exists: true }
+        });
+    }
+
     update_node_by_id(node_id, updates, options) {
         return P.resolve(this._nodes.col().updateOne({
                 _id: this.make_node_id(node_id)
@@ -165,6 +175,13 @@ class NodesStore {
                 { 'force_hide': { $ne: null } },
             ]
         });
+    }
+
+    has_any_nodes_for_pool(pool_id) {
+        return this._nodes.col().findOne({
+                pool: pool_id,
+            })
+            .then(obj => Boolean(obj));
     }
 
 }

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -379,6 +379,34 @@ class MDStore {
             });
     }
 
+    find_deleted_objects(max_delete_time, limit) {
+        const query = {
+            deleted: {
+                $lt: new Date(max_delete_time)
+            },
+        };
+        return this._objects.col().find(query, {
+                limit: Math.min(limit, 1000),
+                fields: {
+                    _id: 1,
+                    deleted: 1
+                }
+            }).toArray()
+            .then(objects => mongo_utils.uniq_ids(objects, '_id'));
+    }
+
+    db_delete_objects(object_ids) {
+        if (!object_ids || !object_ids.length) return;
+        return this._objects.col().deleteMany({
+            _id: {
+                $in: object_ids
+            },
+            deleted: { $exists: true }
+        });
+    }
+
+
+
 
     ////////////////
     // CLOUD SYNC //
@@ -504,6 +532,20 @@ class MDStore {
                 num: 'num_del',
             }
         });
+    }
+
+    db_delete_multiparts_of_object(obj) {
+        return this._multiparts.col().deleteMany({
+            obj: obj._id,
+            deleted: { $exists: true }
+        });
+    }
+
+    has_any_objects_for_bucket(bucket_id) {
+        return this._objects.col().findOne({
+                bucket: bucket_id,
+            })
+            .then(obj => Boolean(obj));
     }
 
 
@@ -666,6 +708,13 @@ class MDStore {
                 start: 'start_del',
                 // chunk: 'chunk_del',
             }
+        });
+    }
+
+    db_delete_parts_of_object(obj) {
+        return this._parts.col().deleteMany({
+            obj: obj._id,
+            deleted: { $exists: true }
         });
     }
 
@@ -864,6 +913,46 @@ class MDStore {
             }));
     }
 
+    find_deleted_chunks(max_delete_time, limit) {
+        const query = {
+            deleted: {
+                $lt: new Date(max_delete_time)
+            },
+        };
+        return this._chunks.col().find(query, {
+                limit: Math.min(limit, 1000),
+                fields: {
+                    _id: 1,
+                    deleted: 1
+                }
+            }).toArray()
+            .then(objects => mongo_utils.uniq_ids(objects, '_id'));
+    }
+
+    has_any_blocks_for_chunk(chunk_id) {
+        return this._blocks.col().findOne({
+                chunk: chunk_id,
+            })
+            .then(obj => Boolean(obj));
+    }
+
+    has_any_parts_for_chunk(chunk_id) {
+        return this._parts.col().findOne({
+                chunk: chunk_id,
+            })
+            .then(obj => Boolean(obj));
+    }
+
+    db_delete_chunks(chunk_ids) {
+        if (!chunk_ids || !chunk_ids.length) return;
+        return this._chunks.col().deleteMany({
+            _id: {
+                $in: chunk_ids
+            },
+            deleted: { $exists: true }
+        });
+    }
+
     ////////////
     // BLOCKS //
     ////////////
@@ -1058,6 +1147,32 @@ class MDStore {
                     pools
                 };
             });
+    }
+
+    find_deleted_blocks(max_delete_time, limit) {
+        const query = {
+            deleted: {
+                $lt: new Date(max_delete_time)
+            },
+        };
+        return this._blocks.col().find(query, {
+                limit: Math.min(limit, 1000),
+                fields: {
+                    _id: 1,
+                    deleted: 1
+                }
+            }).toArray()
+            .then(objects => mongo_utils.uniq_ids(objects, '_id'));
+    }
+
+    db_delete_blocks(block_ids) {
+        if (!block_ids || !block_ids.length) return;
+        return this._blocks.col().deleteMany({
+            _id: {
+                $in: block_ids
+            },
+            deleted: { $exists: true }
+        });
     }
 }
 


### PR DESCRIPTION
### Explain the changes:
- adding bg_worker called db_cleaner which will remove documents older than 3 month from the DB
- dividing find_next_range in md_aggreagator to - one part will be used by db_cleaner to know that the aggregator already counted the md its about to delete  
- currently deleting all of md_store documents
- some of system_store objects (accounts, bucket and pools)
- and nodes from nodes_store
- fixing cluseter_server api

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
