### PR TITLE
fixed upgrade to use new node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",


### PR DESCRIPTION
### Explain the changes:
- fixed upgrade.js to spawn new node version instead of fork from previous version

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages