### PR TITLE
on list_hosts filter out drives that are not yet stored in db

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -3025,16 +3025,20 @@ class NodesMonitor extends EventEmitter {
     _get_host_info(host_item, adminfo) {
         let info = {
             s3_nodes_info: {
-                nodes: host_item.s3_nodes.map(item => {
-                    this._update_status(item);
-                    return this._get_node_info(item);
-                })
+                nodes: host_item.s3_nodes
+                    .filter(item => Boolean(item.node_from_store))
+                    .map(item => {
+                        this._update_status(item);
+                        return this._get_node_info(item);
+                    })
             },
             storage_nodes_info: {
-                nodes: host_item.storage_nodes.map(item => {
-                    this._update_status(item);
-                    return this._get_node_info(item);
-                })
+                nodes: host_item.storage_nodes
+                    .filter(item => Boolean(item.node_from_store))
+                    .map(item => {
+                        this._update_status(item);
+                        return this._get_node_info(item);
+                    })
             }
         };
         info.s3_nodes_info.mode = host_item.s3_nodes_mode;


### PR DESCRIPTION
### Explain the changes:
- if `item.node_from_store` is undefined the drive is not returned in list_hosts

### Issues: Fixed / Gap #xxx
- Fixes #3777 
- Fixes #4219 

### Testing Instructions:
- add a new drive to an existing agent
- soft refresh the UI in drives screen and wait for the drive to be added. make sure no errors appears in the console.

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade - DB schema, server platform, agents install, npm packages