### PR TITLE
fix for #4211 - Cut down init time for cloud and internal agents

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -953,6 +953,11 @@ class NodesMonitor extends EventEmitter {
             P.resolve()
             .then(() => dbg.log0('_run_node:', item.node.name))
             .then(() => this._get_agent_info(item))
+            .then(() => { //If internal or cloud resource, cut down initializing time (in update_rpc_config)
+                if (!item.node_from_store && (item.node.is_mongo_node || item.node.is_cloud_node)) {
+                    return this._update_nodes_store('force');
+                }
+            })
             .then(() => this._uninstall_deleting_node(item))
             .then(() => this._remove_hideable_nodes(item))
             .then(() => this._update_node_service(item))


### PR DESCRIPTION
### Explain the changes:
- fix for #4211 - Cut down init time for cloud and internal agents, save node to store after first get_info

### Issues: Fixed / Gap #xxx
- fixes #4211 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
