### PR TITLE
bump to 1.12.7 to cause yum update (intel sec issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "private": true,
   "license": "UNLICENSED",
   "description": "noobaa-core ===========",


### PR DESCRIPTION
### Explain the changes:
- bump to 1.12.7 to cause yum update (intel sec issue) on system upgrade

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
