### PR TITLE
disable NetworkManager in clean_ova and deploy_base.sh

### DIFF
--- a/src/deploy/NVA_build/clean_ova.sh
+++ b/src/deploy/NVA_build/clean_ova.sh
@@ -128,8 +128,7 @@ date -s "21 Aug 2017 00:00:00"
 #Configure 127.0.0.1 as the dns server - we will use named as a dns cache server
 echo "prepend domain-name-servers 127.0.0.1 ;" > /etc/dhclient.conf
 echo "#NooBaa Configured Search" >> /etc/dhclient.conf
-# restore resolve.conf, although NetworkManager will probably reqwrite it
-echo "nameserver 127.0.0.1" > /etc/resolve.conf
+echo "nameserver 127.0.0.1" > /etc/resolv.conf
 # reset /etc/sysconfig/network
 echo "HOSTNAME=noobaa" > /etc/sysconfig/network
 echo "DNS1=127.0.0.1" >> /etc/sysconfig/network
@@ -142,8 +141,8 @@ echo "forward only;" >> /etc/noobaa_configured_dns.conf
 
 cp -f /root/node_modules/noobaa-core/src/deploy/NVA_build/named.conf /etc/named.conf
 
-#make sure NetworkManager and named start on boot
-sudo systemctl enable NetworkManager
+#make sure NetworkManager is disabled and named start on boot
+sudo systemctl disable NetworkManager
 sudo systemctl enable named
 
 sed -i "s:.*#NooBaa Configured NTP Server.*:#NooBaa Configured NTP Server:" /etc/ntp.conf

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -67,8 +67,8 @@ function install_platform {
     systemctl disable firewalld
     systemctl enable iptables
 
-    # make network and NetworkManager run on boot
-    systemctl enable NetworkManager
+    # make network service run on boot
+    systemctl disable NetworkManager
     systemctl enable network
 
 	# make crontab start on boot
@@ -398,7 +398,7 @@ function setup_named {
     #Configure 127.0.0.1 as the dns server - we will use named as a dns cache server
     echo "prepend domain-name-servers 127.0.0.1 ;" > /etc/dhclient.conf
     echo "#NooBaa Configured Search" >> /etc/dhclient.conf
-    echo "nameserver 127.0.0.1" > /etc/resolve.conf
+    echo "nameserver 127.0.0.1" > /etc/resolv.conf
 
     #restore /etc/noobaa_configured_dns.conf
     echo "forwarders { 8.8.8.8; 8.8.4.4; };" > /etc/noobaa_configured_dns.conf


### PR DESCRIPTION
### Explain the changes:
- NetworkManager is automatically using DHCP to assign an IP, even if the `ifcfg-eth0` file is missing
- this can cause problems when trying to set up networking in the first install dialog
- disabling NetworkManager does not seem to cause any problems in the platform (mainly checked DNS and search domains configurations)

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade - DB schema, server platform, agents install, npm packages
