### PR TITLE
fixing problem with uninstall in linux

### DIFF
--- a/src/deploy/Linux/uninstall_noobaa_agent.sh
+++ b/src/deploy/Linux/uninstall_noobaa_agent.sh
@@ -5,9 +5,9 @@ PATH=/usr/local/noobaa:$PATH;
 
 #attempting to remove service installations
 chmod 777 /usr/local/noobaa/remove_service.sh
-systemctl stop noobaalocalservice >> /dev/null
 /usr/local/noobaa/remove_service.sh
 
 /usr/local/noobaa/node /usr/local/noobaa/src/agent/agent_uninstall.js --remove_noobaa_storage
 rm -rf /usr/local/noobaa
+systemctl stop noobaalocalservice >> /dev/null
 echo "NooBaa agent removed"


### PR DESCRIPTION
### Explain the changes:
- we were stopping the service before the uninstall finishes - which killed the uninstall in the middle - now we will wait for the uninstall to finish and then stop the current service  

### Issues: Fixed / Gap #xxx
- Fixed #4233

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
