### PR TITLE
fixing db_cleaner review rejects

### DIFF
--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -704,7 +704,7 @@ class SystemStore extends EventEmitter {
                     deleted: 1
                 }
             }).toArray()
-            .then(objects => mongo_utils.uniq_ids(objects, '_id'));
+            .then(docs => mongo_utils.uniq_ids(docs, '_id'));
     }
 }
 


### PR DESCRIPTION
### Explain the changes:
- splitting the main function into 3 - for MD, for nodes, and for system stores
- returning cycle to bg_workers for reject as well as resolve
- getting rid of the range object  and some more cosemetics

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
