### PR TITLE
Danny fixes

### DIFF
--- a/src/upgrade/upgrade_wrapper.js
+++ b/src/upgrade/upgrade_wrapper.js
@@ -177,6 +177,12 @@ function post_upgrade() {
                 ignore_rc: false,
                 return_stdout: true,
                 trim_stdout: true
+            }),
+            // eslint-disable-next-line no-useless-escape
+            promise_utils.exec(`sed -i "s:^.*ActionFileDefaultTemplate.*::" /etc/rsyslog.conf`, {
+                ignore_rc: true,
+                return_stdout: true,
+                trim_stdout: true
             })
         )
         .spread((res_curmd, res_prevmd) => {


### PR DESCRIPTION
### Explain the changes:
- refactored InternalDebugLogger to ES6 class
- added throttling mechanism to debug module
   - if a message is printed more than once in 30 seconds it will be silenced.
   - it will be printed again during the 30 seconds every 200 repetitions.
- on upgrade remove $ActionFileDefaultTemplate from rsyslog.conf to print milisec precision in log messages

### Fixes
- Fixes #4196 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade - DB schema, server platform, agents install, npm packages