### PR TITLE
fixed ceph tests - mime.lookup was renamed to mime.getType

### DIFF
--- a/src/sdk/namespace_net_storage.js
+++ b/src/sdk/namespace_net_storage.js
@@ -145,7 +145,7 @@ class NamespaceNetStorage {
             size: res.size,
             etag,
             create_time: new Date(Number(res.mtime || 0) * 1000),
-            content_type: mime.lookup(res.name) || 'application/octet-stream',
+            content_type: mime.getType(res.name) || 'application/octet-stream',
             xattr,
         };
     }

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -47,7 +47,7 @@ function create_object_upload(req) {
         bucket: req.bucket._id,
         key: req.rpc_params.key,
         content_type: req.rpc_params.content_type ||
-            mime.lookup(req.rpc_params.key) ||
+            mime.getType(req.rpc_params.key) ||
             'application/octet-stream',
         cloud_synced: false,
         upload_started: obj_id,

--- a/src/tools/s3cat.js
+++ b/src/tools/s3cat.js
@@ -293,7 +293,7 @@ function upload_object() {
         const params = {
             Key: upload_key,
             CopySource: argv.bucket + '/' + argv.copy,
-            ContentType: mime.lookup(upload_key) || '',
+            ContentType: mime.getType(upload_key) || '',
         };
         if (argv.presign) {
             console.log(s3.getSignedUrl('copyObject', params));
@@ -307,7 +307,7 @@ function upload_object() {
         const params = {
             Key: upload_key,
             Body: data_source,
-            ContentType: mime.lookup(file_path) || '',
+            ContentType: mime.getType(file_path) || '',
             ContentLength: data_size
         };
         if (argv.presign) {
@@ -323,7 +323,7 @@ function upload_object() {
         s3.upload({
                 Key: upload_key,
                 Body: data_source,
-                ContentType: mime.lookup(file_path),
+                ContentType: mime.getType(file_path),
                 ContentLength: data_size
             }, {
                 partSize: part_size,
@@ -339,7 +339,7 @@ function upload_object() {
         };
         s3.createMultipartUpload({
             Key: upload_key,
-            ContentType: mime.lookup(file_path),
+            ContentType: mime.getType(file_path),
         }, (err, create_res) => {
             if (err) {
                 console.error('s3.createMultipartUpload ERROR', err);


### PR DESCRIPTION
### Explain the changes:
- fixed ceph tests 
- `mime.lookup()` was renamed to `mime.getType()`

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages