### PR TITLE
Add an option (using an env variable) to skip the build process after npm install

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,9 +58,10 @@
     "yargs": "^3.27.0"
   },
   "scripts": {
-    "nbbuild": "./node_modules/.bin/gulp build",
+    "prepare": "[ \"$NB_NO_BUILD\" ] || npm run build",
+    "build": "./node_modules/.bin/gulp build",
     "lint": "./node_modules/.bin/gulp lint-app",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/gulp test"
   },
   "author": "Ohad Mitrani"
 }


### PR DESCRIPTION
This will allow Jenkins to run: 

```NB_NO_BUILD=true npm install —only=dev;```

In order to install only dev dependencies and skip build, so it can 

```npm run lint``` 

as soon as possible

