### PR TITLE
set default debug level in cluster server

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -80,7 +80,8 @@ function new_cluster_info(params) {
                 config_servers: [],
                 upgrade: {
                     status: 'COMPLETED',
-                }
+                },
+                debug_level: 0
             };
             return cluster;
         })


### PR DESCRIPTION
### Explain the changes:
- set default debug level in cluster server

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages