### PR TITLE
fixed num_of_nodes always returning 0

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -559,7 +559,7 @@ class MDStore {
     // We've measured the performance on 25 objects of 25GB each with 4MB chunks and it seemed to work fine
     // In case of heavier loads we should remove this code or think of a better way to gather the data needed
     read_objects_part_count_and_blocks_capacity(object_ids) {
-        if (!object_ids || !object_ids.length) return {};
+        if (!object_ids || !object_ids.length) return P.resolve({});
         return this._parts.col().find({
                 obj: {
                     $in: object_ids

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -896,7 +896,7 @@ function get_bucket_info(bucket, nodes_aggregate_pool, aggregate_data_free_by_ti
             if (has_valid_pool || ((num_valid_nodes || 0) >= config.NODES_MIN_COUNT)) mirror_with_valid_pool += 1;
             // return valid;
             const exitsting_minimum = _.isUndefined(info.num_of_nodes) ? Number.MAX_SAFE_INTEGER : info.num_of_nodes;
-            const num_valid_nodes_for_minimum = _.isUndefined(num_valid_nodes) ? Number.MAX_SAFE_INTEGER : 0;
+            const num_valid_nodes_for_minimum = _.isUndefined(num_valid_nodes) ? Number.MAX_SAFE_INTEGER : num_valid_nodes;
             const potential_new_minimum = has_internal_or_cloud_pool ? Number.MAX_SAFE_INTEGER : num_valid_nodes_for_minimum;
             info.num_of_nodes = Math.min(exitsting_minimum, potential_new_minimum);
         });

--- a/src/server/system_services/tier_server.js
+++ b/src/server/system_services/tier_server.js
@@ -178,9 +178,9 @@ function update_tier(req) {
 
     return system_store.make_changes(changes)
         .then(res => {
-            const bucket = find_bucket_by_tier(req);
-            const desc_string = [];
             if (req.rpc_params.data_placement) { //Placement policy changes
+                const bucket = find_bucket_by_tier(req);
+                const desc_string = [];
                 let policy_type_change = String(tier.data_placement) === String(req.rpc_params.data_placement) ? 'No changes' :
                     `Changed to ${req.rpc_params.data_placement} from ${tier.data_placement}`;
                 let removed_pools = _.difference(old_pool_names, req.rpc_params.attached_pools || []);
@@ -193,18 +193,18 @@ function update_tier(req) {
                 if (added_pools.length) {
                     desc_string.push(`Added resources: ${added_pools.join(', ')}`);
                 }
+                if (bucket) {
+                    Dispatcher.instance().activity({
+                        event: 'bucket.edit_policy',
+                        level: 'info',
+                        system: req.system._id,
+                        actor: req.account && req.account._id,
+                        bucket: bucket._id,
+                        desc: desc_string.join('\n'),
+                    });
+                }
             }
 
-            if (bucket) {
-                Dispatcher.instance().activity({
-                    event: 'bucket.edit_policy',
-                    level: 'info',
-                    system: req.system._id,
-                    actor: req.account && req.account._id,
-                    bucket: bucket._id,
-                    desc: desc_string.join('\n'),
-                });
-            }
             return res;
         })
         .return();


### PR DESCRIPTION
### Explain the changes:
- fixed num_of_nodes always returning 0
- this caused data resiliency screen to always give a warning that the data policy does not have enough nodes for the chosen data resiliency 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade - DB schema, server platform, agents install, npm packages