### PR TITLE
fixing issue on node upgrade with windows agent

### DIFF
--- a/src/agent/agent_wrap.js
+++ b/src/agent/agent_wrap.js
@@ -41,6 +41,7 @@ CONFIGURATION.INSTALLATION_COMMAND = WIN_AGENT ? `"${CONFIGURATION.SETUP_FILE}" 
     `setsid ${CONFIGURATION.SETUP_FILE} >> /dev/null`;
 CONFIGURATION.UNINSTALL_COMMAND = WIN_AGENT ? `"${CONFIGURATION.UNINSTALL_FILE}" /S` :
     `setsid ${CONFIGURATION.UNINSTALL_FILE} >> /dev/null`;
+CONFIGURATION.WIN_OLD_NODE_FILE = path.join(CONFIGURATION.PROCESS_DIR, 'node_old.exe');
 
 process.chdir(path.join(__dirname, '..', '..'));
 CONFIGURATION.BACKUP_DIR = path.join(process.cwd(), `backup`);
@@ -52,7 +53,12 @@ dbg.log0('deleting file', CONFIGURATION.SETUP_FILE);
 fs_utils.file_delete(CONFIGURATION.SETUP_FILE)
     // clean previous backup folder
     .then(() => os_utils.get_distro())
-    .then(res => dbg.log0('OS INFO:', res))
+    .then(res => {
+        dbg.log0('OS INFO:', res);
+        if (WIN_AGENT) {
+            return fs_utils.file_delete(CONFIGURATION.WIN_OLD_NODE_FILE);
+        }
+    })
     .then(() => fs.readdirAsync(process.cwd()))
     .then(files => files.find(file => file.startsWith('backup_')))
     .then(backup_dir => {

--- a/src/deploy/atom_agent_win.nsi
+++ b/src/deploy/atom_agent_win.nsi
@@ -197,10 +197,10 @@ Section "Noobaa Local Service"
 		RMDir /r "$INSTDIR\node_modules"
 		RMDir /r "$INSTDIR\src"
 		RMDir /r "$INSTDIR\ssl"
+		Rename "$INSTDIR\node.exe" "$INSTDIR\node_old.exe"
 		${If} $AUTO_UPGRADE == "false" ;delete all files that we want to update
 			Delete "$INSTDIR\service_uninstaller.bat"
 			Delete "$INSTDIR\service_installer.bat"
-			Delete "$INSTDIR\node.exe"
 			Delete "$INSTDIR\service.bat"
 			RMDir /r "$INSTDIR\build"
 		${EndIf}
@@ -208,7 +208,6 @@ Section "Noobaa Local Service"
 		File "7za.exe"
 		File "NooBaa_Agent_wd.exe"
 		File "wget.exe"
-
 	${EndIf}
 
 	WriteUninstaller "$INSTDIR\uninstall-noobaa.exe"


### PR DESCRIPTION
### Explain the changes:
- changing the nsis to use rename instead of delete - so both node versions will stay at the agent
- changing agent_wrapper to run with the new node version and to delete the old version on startup

### Issues: Fixed / Gap #xxx
- fixed #4287

### Testing Instructions:
- run: node src/test/framework/test_env_builder.js - with latest master upgrade pack

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
