### PR TITLE
use proxy for namespace buckets

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -795,7 +795,10 @@ module.exports = {
                         write_resource: {
                             $ref: 'pool_api#/definitions/namespace_resource_extended_info'
                         }
-                    }
+                    },
+                },
+                proxy: {
+                    type: 'string'
                 }
             }
         },

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -152,7 +152,7 @@ function run_server(options) {
                 });
 
                 P.resolve(ftp_srv.listen())
-                    .catch(err => console.log(`DZDZ: got error from ftp_srv.listen`, err));
+                    .catch(err => console.log(`got error from ftp_srv.listen`, err));
             }
         })
         .then(() => dbg.log0('Starting HTTP', params.port))

--- a/src/endpoint/ftp/ftp_filesystem.js
+++ b/src/endpoint/ftp/ftp_filesystem.js
@@ -75,12 +75,12 @@ class FtpFileSystemNB {
     }
 
     currentDirectory() {
-        console.log(`DZDZ: returning current directory: ${this.working_dir}`);
+        console.log(`returning current directory: ${this.working_dir}`);
         return this.working_dir;
     }
 
     get(file_name) {
-        console.log(`DZDZ: get called with file_name=${file_name}`);
+        console.log(`get called with file_name=${file_name}`);
         const key = this._get_absolute_path(file_name).substring(1);
         if (!key) return this._get_new_file_stats_object('/', true, 0, new Date());
         // return this.authenticate.then(() => this.object_sdk.read_object_md({ bucket: this.bucket, key }))
@@ -93,7 +93,7 @@ class FtpFileSystemNB {
             }))
             .tap(console.log)
             .then(res => {
-                console.log(`DZDZ: in get - got res = `, res);
+                console.log(`in get - got res = `, res);
                 if (res.objects.length) {
                     const object_md = res.objects[0];
                     return this._get_new_file_stats_object(object_md.key, false, object_md.size, object_md.create_time);
@@ -112,7 +112,7 @@ class FtpFileSystemNB {
 
 
     list(dir_path = '.') {
-        console.log(`DZDZ: list called with dir_path ${dir_path}`);
+        console.log(`list called with dir_path ${dir_path}`);
         const key = this._get_absolute_path(dir_path).substring(1);
         const params = {
             bucket: this.bucket,
@@ -122,7 +122,7 @@ class FtpFileSystemNB {
             limit: 1000
         };
 
-        console.log(`DZDZ: calling list_objects with params =`, params);
+        console.log(`calling list_objects with params =`, params);
 
         return this.authenticate.then(() => this.object_sdk.list_objects(params))
             .tap(console.log)
@@ -130,18 +130,18 @@ class FtpFileSystemNB {
                 .concat(res.objects.filter(obj => !obj.key.endsWith('/')) // filter out dirs
                     .map(obj => this._get_new_file_stats_object(path.parse(obj.key).base, false, obj.size, obj.create_time)))
                 .concat(res.common_prefixes.map(prefix => this._get_new_file_stats_object(path.parse(prefix).base, true, 0, new Date()))))
-            .tap(list => console.log(`DZDZ: retruning list`, list));
+            .tap(list => console.log(`retruning list`, list));
     }
 
     chdir(dir_path = '.') {
         // no error checking, just change
         this.working_dir = this._get_absolute_path(dir_path);
-        console.log(`DZDZ: changed dir to ${this.working_dir}`);
+        console.log(`changed dir to ${this.working_dir}`);
     }
 
     read(file_name, { start = undefined } = {}) {
         const key = this._get_absolute_path(file_name).substring(1);
-        console.log(`DZDZ: got read for file`, key, ' with start offset = ', start);
+        console.log(`got read for file`, key, ' with start offset = ', start);
 
         return this.object_sdk.read_object_md({
                 bucket: this.bucket,

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const util = require('util');
 const stream = require('stream');
 const crypto = require('crypto');
+const url = require('url');
 
 const P = require('../util/promise');
 const dbg = require('../util/debug_module')(__filename);
@@ -13,10 +14,11 @@ const azure_storage = require('../util/azure_storage_wrap');
 
 class NamespaceBlob {
 
-    constructor({ connection_string, container }) {
+    constructor({ connection_string, container, proxy }) {
         this.connection_string = connection_string;
         this.container = container;
         this.blob = azure_storage.createBlobService(connection_string);
+        this.blob.setProxy(this.proxy ? url.parse(this.proxy) : null);
     }
 
     /////////////////

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -12,6 +12,7 @@ const s3_utils = require('../endpoint/s3/s3_utils');
 class NamespaceS3 {
 
     constructor(options) {
+        this.proxy = options.proxy;
         this.s3 = new AWS.S3(options);
         this.bucket = this.s3.config.params.Bucket;
     }

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -242,7 +242,8 @@ function get_bucket_namespaces(req) {
                             system.namespace_resources_by_name[bucket.namespace.write_resource.name]
                         ),
                         read_resources: _.map(bucket.namespace.read_resources, rs => pool_server.get_namespace_resource_extended_info(rs))
-                    }
+                    },
+                    proxy: system.phone_home_proxy_address
                 };
             } else {
                 return read_bucket(req);


### PR DESCRIPTION
### Explain the changes:
- return proxy in bucket_server `get_bucket_namespaces`
- in object_sdk pass proxy if exists to namespace

### Issues: Fixed / Gap #xxx
- Fixed #3816 

### Testing Instructions:
- test namespace without a direct connection to the internet and through a proxy 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade - DB schema, server platform, agents install, npm packages