### PR TITLE
Calculate raw size for under 20GB objects

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -491,6 +491,17 @@ function read_object_md(req) {
                 bucket: req.rpc_params.bucket,
                 key: req.rpc_params.key,
             });
+
+            const MAX_SIZE_CAP_FOR_OBJECT_RAW_QUERY = 20 * 1024 * 1024 * 1024;
+            if (info.size < MAX_SIZE_CAP_FOR_OBJECT_RAW_QUERY) {
+                return map_reader.read_object_mappings(obj)
+                    .then(parts => {
+                        info.capacity_size = 0;
+                        _.forEach(parts, part => _.forEach(part.chunk.frags, frag => _.forEach(frag.blocks, block => {
+                            info.capacity_size += block.block_md.size;
+                        })));
+                    });
+            }
         })
         .then(() => info);
 }

--- a/src/test/unit_tests/test_object_io.js
+++ b/src/test/unit_tests/test_object_io.js
@@ -79,7 +79,12 @@ coretest.describe_mapper_test_case({
                 bucket,
                 key,
             }))
-            .then(() => rpc_client.object.read_object_md({ bucket, key }))
+            .then(() => rpc_client.object.read_object_md({ bucket, key, adminfo: {} })
+                .then(object_md => {
+                    assert.strictEqual(object_md.num_parts, 0);
+                    assert.strictEqual(object_md.capacity_size, 0);
+                })
+            )
             .then(() => rpc_client.object.update_object_md({ bucket, key, content_type: content_type2 }))
             .then(() => rpc_client.object.list_objects({ bucket, prefix: key }))
             .then(() => rpc_client.object.delete_object({ bucket, key }));


### PR DESCRIPTION
### Explain the changes:
- For objects with uploaded size below 20GB we will perform the queries that calculate their raw size of blocks.
- This was done in order to support larger objects (we just crash on large objects when attempt to read and sum the blocks)
- Note that even with such limitation there could be a crash since this limitation doesn't pay attention to blocks. 
- We can have a 1MB object that is configurated to be replicated lots of times and we could crash because of the number of blocks.
- The better limitation would be block size wise and not the uploaded size.

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
