### PR TITLE
Change our signing server to a more robust one

### DIFF
--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -108,7 +108,7 @@ rename noobaa-setup.exe %FINAL_SETUP_FILE_NAME%
 
 if exist "%SIGNTOOL_PATH%" (
     echo "Signing installer with %SIGNTOOL_PATH%"
-    "%SIGNTOOL_PATH%" sign /v /s my /t http://timestamp.digicert.com /a %FINAL_SETUP_FILE_NAME% || exit 1
+    "%SIGNTOOL_PATH%" sign /v /s my /t http://timestamp.comodoca.com /a %FINAL_SETUP_FILE_NAME% || exit 1
 )
 
 echo "%FINAL_SETUP_FILE_NAME% installer available under build\windows"

--- a/src/deploy/build_windows_s3rest.bat
+++ b/src/deploy/build_windows_s3rest.bat
@@ -152,7 +152,7 @@ rename noobaa-s3rest.exe %FINAL_SETUP_FILE_NAME%
 
 if exist "%SIGNTOOL_PATH%" (
     echo "Signing installer with %SIGNTOOL_PATH%"
-    "%SIGNTOOL_PATH%" sign /v /sm /t http://timestamp.digicert.com /a %FINAL_SETUP_FILE_NAME% || exit 1
+    "%SIGNTOOL_PATH%" sign /v /sm /t http://timestamp.comodoca.com /a %FINAL_SETUP_FILE_NAME% || exit 1
 )
 
 echo "%FINAL_SETUP_FILE_NAME% installer available under build\windows"


### PR DESCRIPTION
### Explain the changes:
- Change our signing server to a more robust one, after talking to digicert support, this server was recommended as more stable and robust.
This change should help us avoid the occasional failure we see in windows agent build on signing the executable. 

### Testing Instructions:
- Verify the agent .exe is still signed 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
