### PR TITLE
creating agents from VHD (phase 1)

### DIFF
--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -81,13 +81,15 @@ function main() {
 //this function is getting servers array creating and upgrading them.
 function prepare_server() {
     console.log(`prepare_server: creating server ${server.name}`);
+    const vmSize = 'Standard_A2_v2';
+    console.log(`NooBaa server vmSize is: ${vmSize}`);
     return azf.createServer({
-            serverName: server.name,
-            vnet,
-            storage,
-            vmSize: 'Standard_A2_v2',
-            latestRelease: true
-        })
+        serverName: server.name,
+        vnet,
+        storage,
+        vmSize,
+        latestRelease: true
+    })
         .then(new_secret => {
             server.secret = new_secret;
             return azf.getIpAddress(server.name + '_pip');
@@ -105,21 +107,21 @@ function prepare_server() {
 function prepare_agents() {
     console.log(`starting the create agents stage`);
     return P.map(agents, agent => azf.createAgent({
-                vmName: agent.name,
-                storage,
-                vnet,
-                os: azf.getImagesfromOSname(agent.os),
-            })
-            .then(ip => {
-                console.log(`assign ip ${ip} to ${agent.name}`);
-                agent.prepared = true;
-                agent.ip = ip;
-                created_agents.push(agent);
-            })
-            .catch(err => {
-                console.error(`Creating agent ${agent.name} VM failed`, err);
-            })
-        )
+        vmName: agent.name,
+        storage,
+        vnet,
+        os: azf.getImagesfromOSname(agent.os),
+    })
+        .then(ip => {
+            console.log(`assign ip ${ip} to ${agent.name}`);
+            agent.prepared = true;
+            agent.ip = ip;
+            created_agents.push(agent);
+        })
+        .catch(err => {
+            console.error(`Creating agent ${agent.name} VM failed`, err);
+        })
+    )
         .then(() => {
             if (created_agents.length < min_required_agents) {
                 console.error(`could not create the minimum number of required agents (${min_required_agents})`);
@@ -136,23 +138,23 @@ function install_agents() {
         .then(agent_conf => {
             console.log(`got agent conf: ${agent_conf}`);
             return P.map(created_agents, agent => {
-                    console.log(`installing agent on ${agent.name}`);
-                    return azf.createAgentExtension({
-                            vmName: agent.name,
-                            storage,
-                            vnet,
-                            os: azf.getImagesfromOSname(agent.os),
-                            serverName: server.ip,
-                            agentConf: agent_conf,
-                        })
-                        .then(
-                            () => { // successfully installed
-                                num_installed += 1;
-                            },
-                            err => { // failed installation
-                                console.error(`failed installing agent on ${agent.name}`, err);
-                            });
+                console.log(`installing agent on ${agent.name}`);
+                return azf.createAgentExtension({
+                    vmName: agent.name,
+                    storage,
+                    vnet,
+                    os: azf.getImagesfromOSname(agent.os),
+                    serverName: server.ip,
+                    agentConf: agent_conf,
                 })
+                    .then(
+                    () => { // successfully installed
+                        num_installed += 1;
+                    },
+                    err => { // failed installation
+                        console.error(`failed installing agent on ${agent.name}`, err);
+                    });
+            })
                 .then(() => {
                     if (num_installed < min_required_agents) {
                         console.error(`could not install the minimum number of required agents (${min_required_agents})`);
@@ -204,7 +206,7 @@ function clean_test_env() {
     console.log(`deleting virtual machines`, vms_to_delete);
     return P.map(vms_to_delete, vm =>
         azf.deleteVirtualMachine(vm)
-        .catch(err => console.error(`failed deleting ${vm} with error: `, err.message))
+            .catch(err => console.error(`failed deleting ${vm} with error: `, err.message))
     );
 }
 


### PR DESCRIPTION
### Explain the changes:
test_env_builder.js:
- vmSize is now a viable and printing it

azureFunctions.js:
- Add createAgentFromImage function that create agent from image
- Add to createVirtualMachineFromImage function the ability to change
the disk size
- Changed the default password
- Cleaned some printing

agent_functions.js:
- Add getAgentConfCommand function that gets the intire agent command
- Add runAgentCommandViaSsh function

azure.js:
- Add secret printing
- Calling createAgentFromImage instead of createAgent for linux
- Fixed some printing.
- When we are installing windows we will use the market
- Failing if the storage account is not configured correctly in the
.env file
- Win machines and redhat7 is still installed from the market
- Will delete agents only if using —delete_agents flag

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
