### PR TITLE
A bunch of FE fixes - Resiliency Content

### DIFF
--- a/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.js
+++ b/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.js
@@ -154,6 +154,8 @@ class BucketObjectsTableViewModel extends Observer {
 
     onLocation(location) {
         const { bucket, system } = location.params;
+        if (!bucket) return;
+
         const {
             stateFilter = 'ALL',
             filter = '',

--- a/frontend/src/app/components/bucket/bucket-summary/bucket-summary.html
+++ b/frontend/src/app/components/bucket/bucket-summary/bucket-summary.html
@@ -48,17 +48,19 @@
     <section class="c3 column">
         <div class="greedy borders pad column">
             <div class="row content-middle greedy">
-                <canvas class="usage-chart push-next"
-                    ko.tooltip="dataUsageChartTooltip"
-                    ko.css.disabled="barChart.disabled"
-                    ko.canvas="barChart"
+                <!-- ko with: dataUsageChart -->
+                <canvas class="bucket-chart push-next"
+                    ko.tooltip="tooltip"
+                    ko.css.disabled="disabled"
+                    ko.canvas="$data"
                 ></canvas>
+                <!-- /ko -->
                 <div class="column">
                     <p class="heading3" ko.text="dataOptimization"></p>
                     <p>
                         Data Optimization
                         <svg-icon class="icon-small push-prev-half"
-                            params="name: 'notif-info'"
+                            params="name: 'question'"
                             ko.tooltip="dataUsageTooltip"
                         ></svg-icon>
                     </p>
@@ -66,23 +68,27 @@
             </div>
             <hr />
             <div class="row content-middle greedy">
-                <pie-chart class="push-next"
-                    ko.tooltip="rawUsageChartTooltip"
+                <!-- ko with: rawUsageChart -->
+                <pie-chart class="bucket-chart push-next"
+                    ko.tooltip="tooltip"
+                    ko.css.disabled="disabled"
                     params="
-                        values: rawUsage,
+                        values: values,
                         showSum: false,
                         showValues: false,
                         enableHover: false,
                         radius: 30,
-                        lineWidth: 8
+                        lineWidth: 8,
+                        silhouetteColor: silhouetteColor
                     "
                 ></pie-chart>
+                <!-- /ko -->
                 <div class="column">
-                    <p class="heading3" ko.text="rawUsageTotal"></p>
+                    <p class="heading3" ko.text="rawUsageLabel"></p>
                     <p>
-                        Raw Usage by This Bucket
+                        Raw Usage
                         <svg-icon class="icon-small push-prev-half"
-                            params="name: 'notif-info'"
+                            params="name: 'question'"
                             ko.tooltip="rawUsageTooltip"
                         ></svg-icon>
                     </p>

--- a/frontend/src/app/components/bucket/bucket-summary/bucket-summary.js
+++ b/frontend/src/app/components/bucket/bucket-summary/bucket-summary.js
@@ -16,7 +16,7 @@ import { deepFreeze, flatMap, mapValues } from 'utils/core-utils';
 import { getBucketStateIcon, getPlacementTypeDisplayName } from 'utils/bucket-utils';
 
 const rawUsageTooltip = deepFreeze({
-    text: 'Row usage refers to the actual size this bucket is utilizing from it\'s resources including data resiliency replicas or fragments',
+    text: 'Raw usage refers to the actual size this bucket is utilizing from it\'s resources including data resiliency replicas or fragments',
     align: 'end'
 });
 
@@ -56,34 +56,40 @@ class BucketSummrayViewModel extends Observer {
         {
             label: 'Used Data',
             color: style['color8'],
-            value: ko.observable()
+            value: ko.observable(),
+            tooltip: 'The total amount of data uploaded to this bucket. does not include data optimisation or data resiliency'
         },
         {
             label: 'Overused',
             color: style['color10'],
             value: ko.observable(),
-            visible: ko.observable()
+            visible: ko.observable(),
+            tooltip: 'Data that was written and exceeded the bucket configured quota'
         },
         {
             label: 'Available',
             color: style['color15'],
-            value: ko.observable()
+            value: ko.observable(),
+            tooltip: 'The actual free space on this bucket for data writes taking into account the current configured resiliency policy'
         },
         {
             label: 'Available on spillover',
             color: style['color18'],
             value: ko.observable(),
-            visible: ko.observable()
+            visible: ko.observable(),
+            tooltip: 'The current available storage from the system internal storage resource, will be used only in the case of no available data storage on this bucket. Once possible, data will be spilled-back'
         },
         {
             label: 'Overallocated',
             color: style['color11'],
             value: ko.observable(),
-            visible: ko.observable()
+            visible: ko.observable(),
+            tooltip: 'Overallocation happens when configuring a higher quota than this bucket assigned resources can store'
         }
     ];
 
     dataOptimization = ko.observable();
+    dataUsageTooltip = dataUsageTooltip;
     dataUsage = [
         {
             label: 'Original Data Size',
@@ -96,17 +102,25 @@ class BucketSummrayViewModel extends Observer {
             value: ko.observable()
         }
     ];
-    dataUsageTooltip = dataUsageTooltip;
-    dataUsageChartTooltip = {
-        maxWidth: 280,
-        template: chartTooltipTemplate,
-        text: {
-            updateTime: ko.observable(),
-            values: this.dataUsage
+    dataUsageChart = {
+        width: 60,
+        height: 60,
+        draw: this.onDrawBars.bind(this),
+        disabled: ko.observable(),
+        bars: this.dataUsage.map(item => new BarViewModel(item.color)),
+        tooltip: {
+            maxWidth: 280,
+            template: chartTooltipTemplate,
+            text: {
+                updateTime: ko.observable(),
+                values: this.dataUsage
+            }
         }
     };
 
-    rawUsageTotal = ko.observable();
+
+    rawUsageLabel = ko.observable();
+    rawUsageTooltip = rawUsageTooltip;
     rawUsage = [
         {
             label: 'Available from Resources',
@@ -119,34 +133,29 @@ class BucketSummrayViewModel extends Observer {
             value: ko.observable()
         },
         {
-            label: 'Bucket Usage with Resiliency',
+            label: 'Raw Usage',
             color: style['color13'],
             value: ko.observable()
         },
         {
-            label: 'Shared Usage',
+            label: 'Shared Resource Usage',
             color: style['color14'],
             value: ko.observable()
         }
     ];
-    rawUsageTooltip = rawUsageTooltip;
-    rawUsageChartTooltip = {
-        maxWidth: 280,
-        template: chartTooltipTemplate,
-        text: {
-            caption: ko.observable(),
-            updateTime: ko.observable(),
-            values: this.rawUsage
-        }
-    };
-
-    barChart = {
-        width: 60,
-        height: 60,
-        draw: this.onDrawBars.bind(this),
+    rawUsageChart = {
+        values: this.rawUsage,
+        silhouetteColor: ko.observable(),
         disabled: ko.observable(),
-        bars: this.dataUsage
-            .map(item => new BarViewModel(item.color))
+        tooltip: {
+            maxWidth: 280,
+            template: chartTooltipTemplate,
+            text: {
+                caption: ko.observable(),
+                updateTime: ko.observable(),
+                values: this.rawUsage
+            }
+        }
     };
 
     constructor({ bucketName }) {
@@ -169,7 +178,8 @@ class BucketSummrayViewModel extends Observer {
         const storage = mapValues(bucket.storage, toBytes);
         const data = mapValues(bucket.data, toBytes);
         const availablity = mapValues(getDataBreakdown(data, quota), toBytes);
-        const rawUsageTotal = formatSize(storage.total);
+        const rawUsageLabel = storage.used ? formatSize(storage.used) : 'No Usage';
+        const rawUsageTooltipCaption = `Total Raw Storage: ${formatSize(storage.total)}`;
         const dataLastUpdateTime = moment(storage.lastUpdate).fromNow();
         const storageLastUpdateTime = moment(data.lastUpdate).fromNow();
         const hasSize = data.size > 0;
@@ -193,19 +203,20 @@ class BucketSummrayViewModel extends Observer {
         this.dataOptimization(dataOptimization);
         this.dataUsage[0].value(data.size);
         this.dataUsage[1].value(data.sizeReduced);
-        this.dataUsageChartTooltip.text.updateTime(dataLastUpdateTime);
+        this.dataUsageChart.disabled(!hasSize);
+        this.dataUsageChart.bars[0].onState(1, hasSize);
+        this.dataUsageChart.bars[1].onState(hasSize ? reducedRatio : 1, hasSize);
+        this.dataUsageChart.tooltip.text.updateTime(dataLastUpdateTime);
 
         this.rawUsage[0].value(storage.free);
         this.rawUsage[1].value(storage.spilloverFree);
         this.rawUsage[2].value(storage.used);
         this.rawUsage[3].value(storage.usedOther);
-        this.rawUsageChartTooltip.text.caption(`Total Raw Storage: ${rawUsageTotal}`);
-        this.rawUsageChartTooltip.text.updateTime(storageLastUpdateTime);
-        this.rawUsageTotal(rawUsageTotal);
-
-        this.barChart.disabled(!hasSize);
-        this.barChart.bars[0].onState(1, hasSize);
-        this.barChart.bars[1].onState(hasSize ? reducedRatio : 1, hasSize);
+        this.rawUsageLabel(rawUsageLabel);
+        this.rawUsageChart.disabled(storage.total === 0);
+        this.rawUsageChart.silhouetteColor(storage.total === 0 ? style['color7'] : undefined);
+        this.rawUsageChart.tooltip.text.caption(rawUsageTooltipCaption);
+        this.rawUsageChart.tooltip.text.updateTime(storageLastUpdateTime);
 
         this.bucketLoaded(true);
     }
@@ -215,7 +226,7 @@ class BucketSummrayViewModel extends Observer {
 
         const barWidth = 16;
         const { width, height: scale } = size;
-        const { bars } = this.barChart;
+        const { bars } = this.dataUsageChart;
         const spacing = (width - bars.length * barWidth) / (bars.length + 1);
 
         bars.reduce(

--- a/frontend/src/app/components/bucket/bucket-summary/bucket-summary.less
+++ b/frontend/src/app/components/bucket/bucket-summary/bucket-summary.less
@@ -14,7 +14,7 @@ bucket-summary {
         }
     }
 
-    .usage-chart.disabled {
+    .bucket-chart.disabled {
         opacity: .1;
     }
 }

--- a/frontend/src/app/components/modals/edit-bucket-data-resiliency-modal/edit-bucket-data-resiliency-modal.html
+++ b/frontend/src/app/components/modals/edit-bucket-data-resiliency-modal/edit-bucket-data-resiliency-modal.html
@@ -32,6 +32,7 @@
                 <div class="column">
                     <input type="number"
                         min="1"
+                        max="32"
                         ko.value="form.replicas"
                         ko.disable="isReplicationDisabled"
                         ko.validationCss="form.replicas"
@@ -105,6 +106,7 @@
                     <div class="column">
                         <input type="number"
                             min="1"
+                            max="32"
                             ko.value="form.dataFrags"
                             ko.disable="isErasureCodingDisabled"
                             ko.validationCss="form.dataFrags"
@@ -122,6 +124,7 @@
                     <div class="column">
                         <input type="number"
                             min="1"
+                            max="32"
                             ko.value="form.parityFrags"
                             ko.disable="isErasureCodingDisabled"
                             ko.validationCss="form.parityFrags"

--- a/frontend/src/app/components/modals/edit-bucket-data-resiliency-modal/edit-bucket-data-resiliency-modal.js
+++ b/frontend/src/app/components/modals/edit-bucket-data-resiliency-modal/edit-bucket-data-resiliency-modal.js
@@ -193,20 +193,25 @@ class EditBucketDataResiliencyModalViewModel extends Observer {
         if (resiliencyType === 'REPLICATION') {
             if (Number.isNaN(replicas) || replicas < 1) {
                 errors.replicas = 'Please enter a number bigger then 0';
+
+            } else if (replicas > 32) {
+                errors.replicas = 'Replicas must be below 32';
             }
         }
 
         if (values.resiliencyType === 'ERASURE_CODING') {
             if (Number.isNaN(dataFrags) || dataFrags < 1) {
                 errors.dataFrags = 'Please enter a number bigger then 0';
+
+            } else if (dataFrags > 32) {
+                errors.dataFrags = 'Data must be below 32';
             }
 
             if (Number.isNaN(parityFrags) || parityFrags < 1) {
                 errors.parityFrags = 'Please enter a number bigger then 0';
-            }
 
-            if (dataFrags + parityFrags > 256) {
-                errors.dataFrags = 'Data + parity must be below 256';
+            } else if (parityFrags > 32) {
+                errors.parityFrags = 'Parity must be below 32';
             }
         }
 

--- a/frontend/src/app/components/object/object-parts-list/block-row.js
+++ b/frontend/src/app/components/object/object-parts-list/block-row.js
@@ -29,6 +29,31 @@ const blockModeToState = deepFreeze({
 });
 
 function _getBlockMarking(block) {
+    switch (block.kind) {
+        case 'REPLICA': {
+            return {
+                text: 'R',
+                tooltip: 'Replica'
+            };
+        }
+
+        case 'DATA': {
+            const digit = block.seq + 1;
+            return {
+                text: `R${digit}`,
+                tooltip: `Data Fragment ${digit}`
+            };
+
+        }
+        case 'PARITY': {
+            const digit = block.seq + 1;
+            return {
+                text: `P${digit}`,
+                tooltip: `Parity Fragment ${digit}`
+            };
+        }
+    }
+
     const letter = block.kind[0];
     const digit = block.seq == null ? '' : (block.seq + 1);
     return `${letter}${digit}`;

--- a/frontend/src/app/components/object/object-parts-list/object-parts-list.html
+++ b/frontend/src/app/components/object/object-parts-list/object-parts-list.html
@@ -63,7 +63,7 @@
     <section class="column details-pane">
         <div class="column greedy hpad no-wrap" ko.with="partDetails">
             <div class="row content-middle">
-                <h2 class="heading3 greedy push-next">Part Destribution Details</h2>
+                <h2 class="heading3 greedy push-next">Part {{partSeq}} Distribution Details</h2>
                 <button class="icon-btn no-outline" ko.click="onX">
                     <svg-icon class="icon-small" params="name: 'x'"></svg-icon>
                 </button>
@@ -94,7 +94,9 @@
                         data: rows,
                     ">
                         <template name="marking">
-                            <span ko.text="$data"></span>
+                            <span ko.text="$data().text"
+                                ko.tooltip="$data().tooltip"
+                            ></span>
                         </template>
                     </data-table>
                 </section>

--- a/frontend/src/app/components/object/object-parts-list/part-details.js
+++ b/frontend/src/app/components/object/object-parts-list/part-details.js
@@ -4,17 +4,15 @@ import BlocksTableViewModel from './blocks-table';
 import ko from 'knockout';
 
 export default class PartDetailsViewModel {
+    partSeq = ko.observable();
     blockTables = ko.observableArray();
 
     constructor(close) {
+
         this.close = close;
     }
 
-    onState(partDistribution, system) {
-        if (!partDistribution) {
-            return;
-        }
-
+    onState(partSeq, partDistribution, system) {
         const tables = partDistribution
             .map((group, i) => {
                 const table = this.blockTables.get(i) || new BlocksTableViewModel();
@@ -22,6 +20,7 @@ export default class PartDetailsViewModel {
                 return table;
             });
 
+        this.partSeq(partSeq + 1);
         this.blockTables(tables, system);
     }
 

--- a/frontend/src/app/components/shared/bar/bar.js
+++ b/frontend/src/app/components/shared/bar/bar.js
@@ -97,7 +97,7 @@ class BarViewModel {
         }
     }
 
-    _drawBar(ctx, width ) {
+    _drawBar(ctx, width) {
         const teeth = ko.unwrap(this.teeth);
         const items = ko.deepUnwrap(this.values);
         const values = normalizeValues(
@@ -113,7 +113,7 @@ class BarViewModel {
 
         let offset = 0;
         values.forEach((value, i) => {
-            if (value === 0) return;
+            if (Number.isNaN(value) || value === 0) return;
 
             ctx.fillStyle = items[i].color;
             ctx.fillRect(
@@ -123,7 +123,7 @@ class BarViewModel {
                 barHeight
             );
 
-            if (teeth) {
+            if (teeth && i > 0) {
                 ctx.fillStyle = teethColor;
                 ctx.fillRect(Math.round(offset), barOffset, 1, barHeight + 2 * teeth);
             }
@@ -131,9 +131,11 @@ class BarViewModel {
             offset += value * width;
         });
 
-        if (items.length && teeth) {
+        // Draw external teeth.
+        if (teeth) {
             ctx.fillStyle = teethColor;
-            ctx.fillRect(Math.round(offset) - 1 , barOffset, 1, barHeight + 2 * teeth);
+            ctx.fillRect(0, barOffset, 1, barHeight + 2 * teeth);
+            ctx.fillRect(width - 1 , barOffset, 1, barHeight + 2 * teeth);
         }
     }
 

--- a/frontend/src/app/components/shared/pie-chart/pie-chart.js
+++ b/frontend/src/app/components/shared/pie-chart/pie-chart.js
@@ -15,7 +15,7 @@ const defaultLineWidth = 20;
 const baseAngle = PI / 1.3;
 const separator = (2 * PI) / 1000;
 const threshold = 2 * separator;
-const silhouetteColor = style['color1'];
+const defaultSilhouetteColor = style['color1'];
 const changeResilience = 3;
 
 const sumTextStyle = deepFreeze({
@@ -119,12 +119,14 @@ class PieChartViewModel {
         format,
         radius = defaultRadius,
         lineWidth = defaultLineWidth,
+        silhouetteColor = defaultSilhouetteColor,
         enableHover = true,
         showSum = true,
         showValues = true
     }) {
         this.radius = radius;
         this.lineWidth = lineWidth;
+        this.silhouetteColor = silhouetteColor;
         this.enableHover = enableHover;
 
         const diameter = ko.pureComputed(
@@ -238,7 +240,7 @@ class PieChartViewModel {
         ctx.save();
 
         ctx.rotate(baseAngle);
-        this.drawArc(ctx, 0, 1, silhouetteColor);
+        this.drawArc(ctx, 0, 1, ko.unwrap(this.silhouetteColor));
 
         const colors = this.colors();
         const hasSeparator = this.values.filter(value => value() > 0).length > 1;

--- a/frontend/src/app/utils/object-utils.js
+++ b/frontend/src/app/utils/object-utils.js
@@ -30,7 +30,7 @@ export function summerizePartDistribution(bucket, part) {
         block => _getBlockGroupID(
             block,
             placementMirroSets,
-            spillover.mirrorSet,
+            spillover && spillover.mirrorSet,
             resiliency.kind
         ),
     );


### PR DESCRIPTION
Fix #4325
Fix #4319
Fix #4326
Fix #4327
Fix #4328
Fix “Destribution” typo
Fix Missing tooltips form block/fragment in tables
Fix throw on object page  when no spillover configured
Fix missing bucket availability tooltips
Fix wrong icon for summary tooltips
Fix lnog response time for switching between object parts
Fix some bugs in items cache (effect both objects and hosts)
Fix “Row” typo

