### PR TITLE
fixed bucket mode when there is only cloud resource in policy

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -902,7 +902,7 @@ function get_bucket_info(bucket, nodes_aggregate_pool, hosts_aggregate_pool, agg
                 });
             // let valid = ;
             if (has_valid_pool || ((num_valid_nodes || 0) >= required_valid_nodes)) mirrors_with_valid_pool += 1;
-            if (num_nodes_in_mirror_group >= required_valid_nodes) mirrors_with_enough_nodes += 1;
+            if (num_nodes_in_mirror_group >= required_valid_nodes || has_internal_or_cloud_pool) mirrors_with_enough_nodes += 1;
             // return valid;
             const exitsting_minimum = _.isUndefined(info.num_of_nodes) ? Number.MAX_SAFE_INTEGER : info.num_of_nodes;
             const num_valid_nodes_for_minimum = _.isUndefined(num_valid_nodes) ? Number.MAX_SAFE_INTEGER : num_valid_nodes;


### PR DESCRIPTION
### Explain the changes:
- when there is a cloud resource in a mirror group the mirror is considered having enough nodes.

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
