### PR TITLE
Fixed: Wrongly written "No data uploaded yet" when we are garying out…

### DIFF
--- a/frontend/src/app/components/overview/buckets-overview/buckets-overview.html
+++ b/frontend/src/app/components/overview/buckets-overview/buckets-overview.html
@@ -31,9 +31,9 @@
             options: chartParams().options,
             data: chartParams().data
         "></chartjs>
-        <div class="fill column content-middle" ko.visible="noChartData">
+        <div class="fill column content-middle" ko.visible="emptyChartMessage">
             <p class="row greedy content-middle">
-                No data uploaded yet
+                {{emptyChartMessage}}
             </p>
         </div>
     </div>


### PR DESCRIPTION
### Explain the changes:
- Wrongly written "No data uploaded yet" when we are garying out all of the fields in Data Buckets graph

### Issues: Fixed / Gap #xxx
- fixed #4295

### Testing Instructions:
1. go to the overview page
2. data bucket chart show 3 lines
3. when unselecting all legends will empty chart with no messages displayed
4. recreate system from scratch
5. go to overview page
6. data bucket chart have no data and show message "No data uploaded yet"
7. go to bucket and upload few files
8. go back to overview page, wait a few moments while total is updated with fresh info
9. now chart still empty and show message "No usage history"

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
