### PR TITLE
Fixed #4371 - use signatureVersion v4 in cloud resources\sync

### DIFF
--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -114,7 +114,8 @@ class BlockStoreClient {
                 const req_options = {
                     url: signed_url,
                     method: 'PUT',
-                    body: params.data
+                    body: params.data,
+                    followAllRedirects: true
                 };
                 if (delegation_info.proxy) {
                     req_options.proxy = delegation_info.proxy;
@@ -146,7 +147,8 @@ class BlockStoreClient {
                 const req_options = {
                     url: delegation_info.signed_url,
                     method: 'GET',
-                    encoding: null // get a Buffer
+                    encoding: null, // get a Buffer
+                    followAllRedirects: true
                 };
                 if (delegation_info.proxy) {
                     req_options.proxy = delegation_info.proxy;
@@ -187,6 +189,7 @@ class BlockStoreClient {
                     err = new Error(xml_obj.Error.Message[0]);
                     err.code = xml_obj.Error.Code[0];
                 }
+                err.statusCode = res.statusCode;
                 err.raw_error = res.body.toString();
                 throw err;
             });


### PR DESCRIPTION
### Explain the changes:
- use signatureVersion v4 in cloud resources\sync
- get bucket region and set in s3 client

### Issues: Fixed / Gap #xxx
- Fixes #4371 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages