### PR TITLE
saving list of ignored drives to agent.conf

### DIFF
--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -297,6 +297,7 @@ function read_mac_linux_drives(include_all) {
                     .then(() => linux_volume_to_drive(vol))
                     .catch(() => {
                         dbg.log0('Skipping drive', vol, 'Azure tmp disk indicated');
+                        return linux_volume_to_drive(vol, true);
                     });
             }))
             .then(res => _.compact(res)));
@@ -348,15 +349,16 @@ function read_windows_drives() {
         });
 }
 
-function linux_volume_to_drive(vol) {
-    return {
+function linux_volume_to_drive(vol, skip) {
+    return _.omitBy({
         mount: vol.mount,
         drive_id: vol.filesystem,
         storage: {
             total: vol.size * 1024,
             free: vol.available * 1024,
-        }
-    };
+        },
+        temporary_drive: skip
+    }, _.isUndefined);
 }
 
 function windows_volume_to_drive(vol) {


### PR DESCRIPTION
### Explain the changes:
- adding a flag for drives diagnosed as temporary azure
- adding list of mount to be ignored to agent.conf
- removing the ignored mounts from wherever needed

### Issues: Fixed / Gap #xxx
- Fixed #4358 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
