### PR TITLE
More 2.1 Fixes 

### DIFF
--- a/frontend/src/app/components/bucket/bucket-data-resiliency-policy-form/bucket-data-resiliency-policy-form.js
+++ b/frontend/src/app/components/bucket/bucket-data-resiliency-policy-form/bucket-data-resiliency-policy-form.js
@@ -5,10 +5,14 @@ import Observer from 'observer';
 import { state$, action$ } from 'state';
 import { deepFreeze } from 'utils/core-utils';
 import { realizeUri } from 'utils/browser-utils';
-import { summrizeResiliency, getResiliencyTypeDisplay } from 'utils/bucket-utils';
 import ko from 'knockout';
 import numeral from 'numeral';
 import * as routes from 'routes';
+import {
+    summrizeResiliency,
+    getResiliencyTypeDisplay,
+    getResiliencyRequirementsWarning
+ } from 'utils/bucket-utils';
 import {
     requestLocation,
     openEditBucketDataResiliencyModal
@@ -45,14 +49,14 @@ function _getFailureTolerance(tolerance) {
     };
 }
 
-function _getRequiredDrives(requiredDrives, driveCountMetric) {
+function _getRequiredDrives(resiliency, driveCountMetric) {
+    const { type, requiredDrives } = resiliency;
     const warn = requiredDrives > driveCountMetric;
+    const tooltip = getResiliencyRequirementsWarning(type, driveCountMetric);
     return {
         text: `${requiredDrives} drives per mirror set`,
         css: warn ? 'warning' : '',
-        tooltip: warn ?
-            'Current resources does not support this configured resiliency policy' :
-             ''
+        tooltip: warn ? tooltip : ''
     };
 }
 
@@ -139,7 +143,7 @@ class BucketDataResiliencyPolicyFormViewModel extends Observer {
             `${resiliency.replicas} copies` :
             `${resiliency.dataFrags} data + ${resiliency.parityFrags} parity fragments`;
         const failureTolerance = _getFailureTolerance(resiliency.failureTolerance);
-        const requiredDrives = _getRequiredDrives(resiliency.requiredDrives, driveCountMetric);
+        const requiredDrives = _getRequiredDrives(resiliency, driveCountMetric);
         const rebuildEffort = rebuildEffortToDisplay[resiliency.rebuildEffort];
 
         this.bucketName = bucket;

--- a/frontend/src/app/utils/bucket-utils.js
+++ b/frontend/src/app/utils/bucket-utils.js
@@ -2,6 +2,7 @@
 
 import { deepFreeze, isUndefined } from './core-utils';
 import { toBigInteger, fromBigInteger, bigInteger, unitsInBytes } from 'utils/size-utils';
+import { stringifyAmount, pluralize } from 'utils/string-utils';
 
 const bucketStateToIcon = deepFreeze({
     NO_RESOURCES: {
@@ -120,6 +121,11 @@ const writableStates = deepFreeze([
     'OPTIMAL'
 ]);
 
+const resiliencyTypeToBlockType = deepFreeze({
+    REPLICATION: 'replica',
+    ERASURE_CODING: 'fragment'
+});
+
 export function getBucketStateIcon(bucket, align) {
     if (isUndefined(align)) {
         return bucketStateToIcon[bucket.mode];
@@ -234,4 +240,15 @@ export function summrizeResiliency(resiliency) {
 
 export function getResiliencyTypeDisplay(resiliencyType) {
     return resiliencyTypeToDisplay[resiliencyType];
+}
+
+
+export function getResiliencyRequirementsWarning(resiliencyType, drivesCount) {
+    const subject = resiliencyTypeToBlockType[resiliencyType];
+
+    return `The current placement policy allows for a maximum of ${
+        stringifyAmount(subject, drivesCount)
+    }. The number of possible ${
+        pluralize(subject)
+    } is derived from the minimal number of available drives across all mirror sets.`;
 }

--- a/frontend/src/app/utils/core-utils.js
+++ b/frontend/src/app/utils/core-utils.js
@@ -146,8 +146,8 @@ export function bitsToNumber(...bits) {
 
 export function flatMap(arr, predicate = echo) {
     return arr.reduce(
-        (result, item) => {
-            let mappedValue = predicate(item);
+        (result, item, i) => {
+            let mappedValue = predicate(item, i);
 
             if (Array.isArray(mappedValue)) {
                 result.push(...mappedValue);
@@ -316,10 +316,9 @@ export function ensureArray(val) {
 export function unique(values) {
     return Array.from(new Set(values).values());
 }
-global.unique = unique;
 
 export function union(...arrays) {
-    return unique(flatMap(...arrays));
+    return unique(flatMap(arrays));
 }
 
 export function hashCode(value) {

--- a/frontend/src/app/utils/item-cache-utils.js
+++ b/frontend/src/app/utils/item-cache-utils.js
@@ -141,7 +141,7 @@ export function handleRemoveItem(state, itemKey, handleExtras = echo) {
     if (!item) return state;
 
     const items = omitUndefined({
-        ...items,
+        ...state.items,
         [itemKey]: undefined
     });
 

--- a/frontend/src/app/utils/string-utils.js
+++ b/frontend/src/app/utils/string-utils.js
@@ -87,7 +87,7 @@ export function isDigit(str) {
     return !isNaN(Number(str)) && str.length === 1;
 }
 
-export function pluralize(word, amount) {
+export function pluralize(word, amount = 2) {
     if (amount === 1) {
         return word;
     }

--- a/src/server/object_services/mapper.js
+++ b/src/server/object_services/mapper.js
@@ -615,7 +615,8 @@ function analyze_special_chunks(chunks, parts, objects) {
         var tmp_parts = _.filter(parts, part => String(part.chunk) === String(chunk._id));
         var tmp_objects = _.filter(objects, obj => _.find(tmp_parts, part => String(part.obj) === String(obj._id)));
         _.forEach(tmp_objects, obj => {
-            if (_.includes(config.SPECIAL_CHUNK_CONTENT_TYPES, obj.content_type)) {
+            if (config.SPECIAL_CHUNK_CONTENT_TYPES
+                .some(type => obj.content_type.toLowerCase().startsWith(type.toLowerCase()))) {
                 let obj_parts = _.filter(tmp_parts, part => String(part.obj) === String(obj._id));
                 _.forEach(obj_parts, part => {
                     if (part.start === 0 || part.end === obj.size) {


### PR DESCRIPTION
- Re-fix of wrong block row generation algorithm
- Fix content-type recognition for special chunks (BE)
- Refactor the error message for bucket resiliency requirements into a
parameterized util
- Fix broken selectAll on tables
- Allow pluralize util to automatically add plural suffix if not amount
is passed to the function
- Fix broken item-cache function that prevented removal of time by id
from the cache