### PR TITLE
Adding bucket lambda triggers

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -543,8 +543,43 @@ module.exports = {
             auth: {
                 system: 'admin'
             }
+        },
+        add_bucket_lambda_trigger: {
+            method: 'PUT',
+            params: {
+                $ref: '#/definitions/new_lambda_trigger'
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+        delete_bucket_lambda_trigger: {
+            method: 'DELETE',
+            required: ['id', 'bucket_name'],
+            params: {
+                type: 'object',
+                properties: {
+                    id: {
+                        objectid: true
+                    },
+                    bucket_name: {
+                        type: 'string'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+        update_bucket_lambda_trigger: {
+            method: 'PUT',
+            params: {
+                $ref: '#/definitions/update_lambda_trigger'
+            },
+            auth: {
+                system: 'admin'
+            }
         }
-
     },
 
     definitions: {
@@ -690,6 +725,12 @@ module.exports = {
                 undeletable: {
                     $ref: '#/definitions/undeletable_bucket_reason'
                 },
+                triggers: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/definitions/lambda_trigger_info'
+                    }
+                }
             }
         },
 
@@ -886,5 +927,103 @@ module.exports = {
             enum: ['LAST_BUCKET', 'NOT_EMPTY'],
             type: 'string',
         },
-    },
+
+        event_name: { // Based on AWS: https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#supported-notification-event-types
+            enum: ['ObjectCreated', 'ObjectRemoved', /* 'ObjectCreated:Put', 'ObjectCreated:CompleteMultipartUpload', ... */ ],
+            type: 'string',
+        },
+
+        new_lambda_trigger: {
+            type: 'object',
+            required: ['bucket_name', 'event_name', 'func_name'],
+            properties: {
+                bucket_name: {
+                    type: 'string'
+                },
+                event_name: {
+                    $ref: '#/definitions/event_name'
+                },
+                func_name: {
+                    type: 'string'
+                },
+                func_version: {
+                    type: 'string'
+                },
+                enabled: {
+                    type: 'boolean',
+                },
+                object_prefix: {
+                    type: 'string'
+                },
+                object_suffix: {
+                    type: 'string'
+                },
+            }
+        },
+
+        update_lambda_trigger: {
+            type: 'object',
+            required: ['id'],
+            properties: {
+                id: {
+                    objectid: true
+                },
+                bucket_name: {
+                    type: 'string'
+                },
+                event_name: {
+                    $ref: '#/definitions/event_name'
+                },
+                func_name: {
+                    type: 'string'
+                },
+                func_version: {
+                    type: 'string'
+                },
+                enabled: {
+                    type: 'boolean',
+                },
+                object_prefix: {
+                    type: 'string'
+                },
+                object_suffix: {
+                    type: 'string'
+                },
+            }
+        },
+
+        lambda_trigger_info: {
+            type: 'object',
+            required: ['id', 'event_name', 'func_name'],
+            properties: {
+                id: {
+                    objectid: true
+                },
+                event_name: {
+                    $ref: '#/definitions/event_name'
+                },
+                func_name: {
+                    type: 'string'
+                },
+                func_version: {
+                    type: 'string'
+                },
+                enabled: {
+                    type: 'boolean',
+                },
+                permission_problem: {
+                    type: 'boolean',
+                },
+                last_run: {
+                    idate: true
+                },
+                object_prefix: {
+                    type: 'string'
+                },
+                object_suffix: {
+                    type: 'string'
+                },
+            }
+        },
+    }
 };

--- a/src/api/func_api.js
+++ b/src/api/func_api.js
@@ -233,6 +233,9 @@ module.exports = {
                 version: {
                     type: 'string'
                 },
+                exec_account: {
+                    type: 'string'
+                },
                 description: {
                     type: 'string'
                 },

--- a/src/server/func_services/func_schema.js
+++ b/src/server/func_services/func_schema.js
@@ -9,6 +9,7 @@ module.exports = {
         'system',
         'pools',
         'name',
+        'exec_account',
         'version',
         'runtime',
         'handler',
@@ -35,6 +36,9 @@ module.exports = {
         },
         name: {
             type: 'string'
+        },
+        exec_account: {
+            objectid: true
         },
         version: {
             type: 'string'

--- a/src/server/object_services/events_dispatcher.js
+++ b/src/server/object_services/events_dispatcher.js
@@ -1,0 +1,96 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const server_rpc = require('../server_rpc');
+const P = require('../../util/promise');
+const _ = require('lodash');
+const promise_utils = require('../../util/promise_utils');
+const system_store = require('../system_services/system_store').get_instance();
+
+const TRIGGER_ATTEMPTS = 2;
+const DELAY_BETWEEEN_TRIGGER_ATTEMPTS = 5000; // ?
+
+function get_triggers_for_event(bucket, obj, event_name) {
+    return _.filter(bucket.lambda_triggers, trigger =>
+        trigger.enabled && (trigger.event_name === event_name || trigger.event_name === event_name.split(':')[0]) &&
+        (!trigger.object_prefix || obj.key.startsWith(trigger.object_prefix)) &&
+        (!trigger.object_suffix || obj.key.endsWith(trigger.object_suffix))
+    );
+}
+
+function run_bucket_triggers(triggers_to_run, bucket, obj, actor, token) {
+    if (!triggers_to_run || !triggers_to_run.length) return;
+    const now = Date.now();
+    const updates = [];
+    for (const { _id: trigger_id } of triggers_to_run) {
+        updates.push({
+            $find: { _id: bucket._id, 'lambda_triggers._id': trigger_id },
+            $set: { 'lambda_triggers.$.last_run': now },
+        });
+    }
+    return P.resolve()
+        .then(() => system_store.make_changes_in_background({
+            update: {
+                buckets: updates
+            }
+        }))
+        .then(() => P.map(triggers_to_run, trigger => {
+            const event = create_object_event({
+                bucket: bucket.name,
+                time: obj.create_time,
+                object: obj,
+                actor: actor,
+                event_name: trigger.event_name,
+                id: trigger._id
+            });
+            return promise_utils.retry(
+                TRIGGER_ATTEMPTS,
+                DELAY_BETWEEEN_TRIGGER_ATTEMPTS,
+                () => run_trigger(trigger, event, bucket.system, token)
+            );
+        }));
+}
+
+function run_trigger(trigger, event, system, token) {
+    return server_rpc.client.func.invoke_func({
+        name: trigger.func_name,
+        version: trigger.func_version,
+        event: event,
+    }, {
+        auth_token: token
+    });
+}
+
+function create_object_event({ bucket, object, time, actor, event_name, id }) {
+    const event = {
+        Records: [{
+            eventVersion: 2.0,
+            eventSource: 'aws:s3',
+            eventTime: time,
+            eventName: event_name,
+            userIdentity: {
+                principalId: String(actor.id)
+            },
+            requestParameters: {
+                sourceIPAddress: '127.0.0.1'
+            },
+            s3: {
+                s3SchemaVersion: 1.0,
+                configurationId: id,
+                bucket: {
+                    name: bucket,
+                },
+                object: {
+                    key: object.key,
+                    size: object.size,
+                    eTag: object.etag,
+                    // sequencer: TBD
+                }
+            }
+        }]
+    };
+    return event;
+}
+
+exports.run_bucket_triggers = run_bucket_triggers;
+exports.get_triggers_for_event = get_triggers_for_event;

--- a/src/server/system_services/cloud_sync_server.js
+++ b/src/server/system_services/cloud_sync_server.js
@@ -359,7 +359,7 @@ function find_bucket(req, bucket_name = req.rpc_params.name) {
         dbg.error('BUCKET NOT FOUND', bucket_name);
         throw new RpcError('NO_SUCH_BUCKET', 'No such bucket: ' + bucket_name);
     }
-    req.check_bucket_permission(bucket);
+    req.check_s3_bucket_permission(bucket);
     return bucket;
 }
 

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -251,6 +251,40 @@ module.exports = {
                 }
             }
         },
+        lambda_triggers: {
+            type: 'array',
+            items: {
+                type: 'object',
+                required: ['_id', 'event_name', 'func_name', 'func_version', 'enabled'],
+                properties: {
+                    _id: {
+                        objectid: true
+                    },
+                    event_name: {
+                        type: 'string',
+                        enum: ['ObjectCreated', 'ObjectRemoved', /* 'ObjectCreated:Put', 'ObjectCreated:CompleteMultipartUpload', ... */ ]
+                    },
+                    func_name: {
+                        type: 'string'
+                    },
+                    func_version: {
+                        type: 'string'
+                    },
+                    enabled: {
+                        type: 'boolean',
+                    },
+                    last_run: {
+                        idate: true
+                    },
+                    object_prefix: {
+                        type: 'string'
+                    },
+                    object_suffix: {
+                        type: 'string'
+                    },
+                }
+            }
+        },
         stats: {
             type: 'object',
             // required: [],

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -535,6 +535,7 @@ class SystemStore extends EventEmitter {
      *   update: {
      *      systems: [{_id:123, ...}],
      *      buckets: [{_id:456, ...}],
+     *      buckets: [{ $find: { _id: 543, 'lambda_triggers._id': 567}, $set: {...}}]
      *   },
      *   remove: {
      *      systems: [123, 789],
@@ -578,7 +579,8 @@ class SystemStore extends EventEmitter {
                     const col = get_collection(name);
                     _.each(list, item => {
                         data.check_indexes(col, item);
-                        let updates = _.omit(item, '_id');
+                        let updates = _.omit(item, '_id', '$find');
+                        let finds = item.$find || _.pick(item, '_id');
                         if (_.isEmpty(updates)) return;
                         let keys = _.keys(updates);
 
@@ -606,9 +608,7 @@ class SystemStore extends EventEmitter {
                         //     this._check_schema(col, updates.$set, 'warn');
                         // }
                         get_bulk(name)
-                            .find({
-                                _id: item._id
-                            })
+                            .find(finds)
                             .updateOne(updates);
                     });
                 });

--- a/src/test/framework/flow.js
+++ b/src/test/framework/flow.js
@@ -130,6 +130,17 @@ var steps = [
         //Restore DB to defaults
         name: 'Restore DB Defaults',
         common: 'restore_db_defaults',
+    }, {
+        //Bucket Lambda Triggers Test
+        name: 'Bucket Lambda Triggers Test',
+        action: 'node',
+        params: [{
+            arg: './src/test/system_tests/test_bucket_lambda_triggers'
+        }],
+    }, {
+        //Restore DB to defaults
+        name: 'Restore DB Defaults',
+        common: 'restore_db_defaults',
     }
 ];
 

--- a/src/test/lambda/create_backup_file_func.js
+++ b/src/test/lambda/create_backup_file_func.js
@@ -1,0 +1,26 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+var AWS = require('aws-sdk');
+
+exports.handler = function(event, context, callback) {
+    var srcBucket = event.Records[0].s3.bucket.name;
+    var key = event.Records[0].s3.object.key;
+    var s3 = new AWS.S3();
+
+    s3.headObject({
+            Bucket: srcBucket,
+            Key: key
+        })
+        .promise()
+        .then(head => s3.putObject({
+                Bucket: srcBucket,
+                Key: key + '.json',
+                ContentType: 'text/json',
+                Body: JSON.stringify({ event, head }, null, 4),
+            })
+            .promise()
+        )
+        .then(() => callback(null))
+        .catch(err => callback(err));
+};

--- a/src/test/lambda/delete_backup_file_func.js
+++ b/src/test/lambda/delete_backup_file_func.js
@@ -1,0 +1,18 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+var AWS = require('aws-sdk');
+
+exports.handler = function(event, context, callback) {
+    var srcBucket = event.Records[0].s3.bucket.name;
+    var key = event.Records[0].s3.object.key;
+    var s3 = new AWS.S3();
+
+    s3.deleteObject({
+            Bucket: srcBucket,
+            Key: key + '.json',
+        })
+        .promise()
+        .then(() => callback(null))
+        .catch(err => callback(err));
+};

--- a/src/test/system_tests/mongodb_defaults.js
+++ b/src/test/system_tests/mongodb_defaults.js
@@ -12,6 +12,9 @@ db.datablocks.remove({});
 db.datachunks.remove({});
 db.objectparts.remove({});
 db.objectmds.remove({});
+db.func_code_gridfs.chunks.remove({});
+db.func_code_gridfs.files.remove({});
+db.funcs.remove({});
 db.tiers.update({
     name: {
         $regex: 'first\\.bucket.*'

--- a/src/test/system_tests/test_bucket_lambda_triggers.js
+++ b/src/test/system_tests/test_bucket_lambda_triggers.js
@@ -1,0 +1,402 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+var api = require('../../api');
+var P = require('../../util/promise');
+var dotenv = require('../../util/dotenv');
+var ops = require('../utils/basic_server_ops');
+var config = require('../../../config.js');
+const path = require('path');
+var rpc = api.new_rpc();
+
+var argv = require('minimist')(process.argv);
+const zip_utils = require('../../util/zip_utils');
+var assert = require('assert');
+var AWS = require('aws-sdk');
+var https = require('https');
+var fs = require('fs');
+
+dotenv.load();
+const TIME_FOR_FUNC_TO_RUN = 15000;
+
+var client = rpc.new_client({
+    address: 'ws://127.0.0.1:' + process.env.PORT
+});
+
+let full_access_user = {
+    name: 'full_access',
+    email: 'full_access@noobaa.com',
+    password: 'master',
+    has_login: true,
+    s3_access: true,
+    allowed_buckets: {
+        full_permission: false,
+        permission_list: ['bucket1', 'bucket2']
+    },
+    default_pool: config.NEW_SYSTEM_POOL_NAME,
+};
+
+let bucket1_user = {
+    name: 'bucket1_access',
+    email: 'bucket1_access@noobaa.com',
+    password: 'onlyb1',
+    has_login: true,
+    s3_access: true,
+    allowed_buckets: {
+        full_permission: false,
+        permission_list: ['bucket1']
+    },
+    default_pool: config.NEW_SYSTEM_POOL_NAME,
+};
+
+const ROLE_ARN = 'arn:aws:iam::112233445566:role/lambda-test';
+const POOLS = [config.NEW_SYSTEM_POOL_NAME];
+
+const trigger_based_func = {
+    FunctionName: 'create_backup_file',
+    Description: 'will create second copy of the same file',
+    Runtime: 'nodejs6',
+    Handler: 'create_backup_file_func.handler',
+    Role: ROLE_ARN,
+    MemorySize: 128,
+    VpcConfig: {
+        SubnetIds: POOLS
+    },
+    Files: [{
+        path: 'create_backup_file_func.js',
+        fs_path: path.join(__dirname, '../lambda/create_backup_file_func.js'),
+    }]
+};
+
+const trigger_based_func2 = {
+    FunctionName: 'delete_backup_file',
+    Description: 'will create second copy of the same file',
+    Runtime: 'nodejs6',
+    Handler: 'delete_backup_file_func.handler',
+    Role: ROLE_ARN,
+    MemorySize: 128,
+    VpcConfig: {
+        SubnetIds: POOLS
+    },
+    Files: [{
+        path: 'delete_backup_file_func.js',
+        fs_path: path.join(__dirname, '../lambda/delete_backup_file_func.js'),
+    }]
+};
+
+module.exports = {
+    run_test: run_test
+};
+
+function authenticate() {
+    let auth_params = {
+        email: 'demo@noobaa.com',
+        password: 'DeMo1',
+        system: 'demo'
+    };
+    return client.create_auth_token(auth_params);
+}
+
+function prepare_func(fn) {
+    return P.resolve()
+        .then(() => zip_utils.zip_from_files(fn.Files))
+        .then(zipfile => zip_utils.zip_to_buffer(zipfile))
+        .then(zip_buffer => {
+            delete fn.Files;
+            fn.Code = {
+                ZipFile: zip_buffer
+            };
+        });
+}
+
+function main() {
+    return run_test()
+        .then(function() {
+            process.exit(0);
+        })
+        .catch(function(err) {
+            console.error('run_test failed with error:', err, err.stack);
+            process.exit(1);
+        });
+}
+
+function setup() {
+    if (argv.no_setup) {
+        return;
+    }
+
+    let account;
+    return P.resolve()
+        // Create test buckets.
+        .then(() => client.bucket.create_bucket({ name: 'bucket1' }))
+        .then(() => client.bucket.create_bucket({ name: 'bucket2' }))
+        // add new accounts:
+        .then(() => client.account.create_account(full_access_user))
+        .then(() => client.account.create_account(bucket1_user))
+        // .then(() => client.account.create_account(no_access_user))
+        .then(() => client.system.read_system())
+        .then(system_info => {
+            account = account_by_name(system_info.accounts, full_access_user.email);
+            full_access_user.access_keys = account.access_keys[0];
+
+            account = account_by_name(system_info.accounts, bucket1_user.email);
+            bucket1_user.access_keys = account.access_keys[0];
+
+            // account = account_by_name(system_info.accounts, no_access_user.email);
+            // no_access_user.access_keys = account.access_keys[0];
+        });
+}
+
+function get_new_server(user) {
+    let access_key = user.access_keys.access_key;
+    let secret_key = user.access_keys.secret_key;
+    return new AWS.S3({
+        endpoint: 'https://127.0.0.1',
+        s3ForcePathStyle: true,
+        accessKeyId: access_key,
+        secretAccessKey: secret_key,
+        maxRedirects: 10,
+        httpOptions: {
+            agent: new https.Agent({
+                rejectUnauthorized: false,
+            })
+        }
+    });
+}
+
+function get_new_lambda(user) {
+    let access_key = user.access_keys.access_key;
+    let secret_key = user.access_keys.secret_key;
+    return new AWS.Lambda({
+        region: 'us-east-1',
+        endpoint: 'http://127.0.0.1:' + String(process.env.ENDPOINT_PORT || 80),
+        accessKeyId: access_key,
+        secretAccessKey: secret_key,
+        sslEnabled: false,
+    });
+}
+
+function run_test() {
+    let trigger_id;
+    let last_run;
+    return authenticate()
+        .then(() => setup())
+        // .then(() => test_list_buckets_returns_allowed_buckets())
+        .then(() => test_add_function(bucket1_user, trigger_based_func))
+        .then(() => test_add_bucket_trigger('ObjectCreated', trigger_based_func))
+        .then(() => client.system.read_system())
+        .then(system_info => {
+            const bucket = bucket_by_name(system_info.buckets, 'bucket1');
+            trigger_id = bucket.triggers[0].id;
+        })
+        .then(() => test_trigger_run_when_should(bucket1_user, 'file0.dat'))
+        .then(() => client.system.read_system())
+        .then(system_info => {
+            const bucket = bucket_by_name(system_info.buckets, 'bucket1');
+            last_run = bucket.triggers[0].last_run;
+        })
+        .then(() => test_trigger_dont_run_when_shouldnt(bucket1_user, 'file1.notdat'))
+        .then(() => {
+            console.log('disabling bucket lambda trigger.');
+            return client.bucket.update_bucket_lambda_trigger({
+                bucket_name: 'bucket1',
+                id: trigger_id,
+                enabled: false
+            });
+        })
+        .then(() => test_trigger_dont_run_when_shouldnt(bucket1_user, 'file2.dat'))
+        .then(() => {
+            console.log('enabling bucket lambda trigger.');
+            return client.bucket.update_bucket_lambda_trigger({
+                bucket_name: 'bucket1',
+                id: trigger_id,
+                enabled: true
+            });
+        })
+        .then(() => test_trigger_run_when_should(bucket1_user, 'file3.dat'))
+        .then(() => {
+            console.log('changing bucket lambda trigger prefix to /bla.');
+            return client.bucket.update_bucket_lambda_trigger({
+                bucket_name: 'bucket1',
+                id: trigger_id,
+                object_prefix: '/bla'
+            });
+        })
+        .then(() => test_trigger_dont_run_when_shouldnt(bucket1_user, '/tmp/file4.dat'))
+        .then(() => {
+            console.log('changing bucket lambda trigger prefix to /tmp.');
+            return client.bucket.update_bucket_lambda_trigger({
+                bucket_name: 'bucket1',
+                id: trigger_id,
+                object_prefix: '/tmp'
+            });
+        })
+        .then(() => test_trigger_run_when_should(bucket1_user, '/tmp/file5.dat'))
+        .then(() => client.system.read_system())
+        .then(system_info => {
+            console.log('Checking that last_run of bucket_trigger has advanced');
+            const bucket = bucket_by_name(system_info.buckets, 'bucket1');
+            const last_run_new = bucket.triggers[0].last_run;
+            assert(last_run_new > last_run, `expecting last run to advance but didn't. previous last_run: ${new Date(last_run)} new last_run: ${new Date(last_run_new)}`);
+            console.log(`last run has advanced as should. previous last_run: ${new Date(last_run)} new last_run: ${new Date(last_run_new)}`);
+        })
+        .then(() => test_trigger_run_when_should_multi(bucket1_user, '/tmp/multi-file', '.dat', 10))
+        .then(() => client.bucket.update_bucket_s3_access({
+            name: 'bucket1',
+            allowed_accounts: ['full_access@noobaa.com']
+        }))
+        .then(() => test_trigger_dont_run_when_shouldnt(full_access_user, '/tmp/file6.dat')) // should fail as bucket1_user is the runner of the function
+        .then(() => test_add_function(full_access_user, trigger_based_func2))
+        .then(() => test_add_bucket_trigger('ObjectRemoved', trigger_based_func2))
+        .then(() => test_delete_trigger_run(full_access_user, 'file3.dat'))
+        .then(() => {
+            console.log('test_bucket_lambda_triggers PASSED');
+        });
+}
+
+
+/********************Tests:****************************/
+
+function test_add_function(user, func) {
+    let lambda = get_new_lambda(user);
+    return prepare_func(func)
+        .then(() => P.fromCallback(callback => lambda.deleteFunction({
+                FunctionName: func.FunctionName,
+            }, callback))
+            .catch(err => {
+                console.log('Delete function if exist:', func.FunctionName, err.message);
+            }))
+        .then(() => P.fromCallback(callback => lambda.createFunction(func, callback)))
+        .then(() => console.log('function created.'));
+}
+
+function test_add_bucket_trigger(type, func) {
+    return P.resolve()
+        .then(() => client.bucket.add_bucket_lambda_trigger({
+            bucket_name: 'bucket1',
+            object_suffix: '.dat',
+            func_name: func.FunctionName,
+            event_name: type
+        }))
+        .then(() => console.log('bucket lambda trigger created.'));
+}
+
+function test_trigger_run_when_should(user, file_param) {
+    let s3 = get_new_server(user);
+    return ops.generate_random_file(1)
+        .then(fname => {
+            let params1 = {
+                Bucket: 'bucket1',
+                Key: file_param,
+                Body: fs.createReadStream(fname)
+            };
+            return P.fromCallback(callback => s3.upload(params1, callback));
+        })
+        .delay(TIME_FOR_FUNC_TO_RUN) // wait for the function to run...
+        .then(() => {
+            let params2 = {
+                Bucket: 'bucket1',
+                Key: file_param + '.json'
+            };
+            return P.fromCallback(callback => s3.headObject(params2, callback));
+        })
+        .then(data => {
+            console.log('bucket lambda trigger worked. file created:', file_param + '.json');
+        });
+}
+
+function test_trigger_dont_run_when_shouldnt(user, file_param) {
+    let s3 = get_new_server(user);
+    return ops.generate_random_file(1)
+        .then(fname => {
+            let params1 = {
+                Bucket: 'bucket1',
+                Key: file_param,
+                Body: fs.createReadStream(fname)
+            };
+            return P.fromCallback(callback => s3.upload(params1, callback));
+        })
+        .delay(TIME_FOR_FUNC_TO_RUN) // wait for the function to run...
+        .then(() => {
+            let params2 = {
+                Bucket: 'bucket1',
+                Key: file_param + '.json'
+            };
+            return P.fromCallback(callback => s3.headObject(params2, callback));
+        })
+        .then(resp => {
+            throw new Error('expecting head to fail with statusCode 404 - File not found');
+        })
+        .catch(err => {
+            assert(err.statusCode === 404, 'expecting upload to fail with statusCode 404 - File not found' + err.statusCode);
+            console.log('bucket lambda trigger worked. file not created for:', file_param);
+        });
+}
+
+function test_delete_trigger_run(user, file_param) {
+    let s3 = get_new_server(user);
+    let params = {
+        Bucket: 'bucket1',
+        Key: file_param
+    };
+    let params2 = {
+        Bucket: 'bucket1',
+        Key: file_param + '.json'
+    };
+    return P.fromCallback(callback => s3.headObject(params2, callback))
+        .catch(err => {
+            console.log('json file not exist - test can\'t succeed:', file_param + '.json', err);
+            throw new Error('expecting head to fail with statusCode 404 - File not found');
+        })
+        .then(() => P.fromCallback(callback => s3.deleteObject(params, callback)))
+        .delay(TIME_FOR_FUNC_TO_RUN) // wait for the function to run...
+        .then(() => P.fromCallback(callback => s3.headObject(params2, callback)))
+        .then(resp => {
+            throw new Error('expecting head to fail with statusCode 404 - File not found');
+        })
+        .catch(err => {
+            assert(err.statusCode === 404, 'expecting upload to fail with statusCode 404 - File not found' + err.statusCode);
+            console.log('bucket lambda trigger worked. file deleted for:', file_param);
+        });
+}
+
+function test_trigger_run_when_should_multi(user, files_prefix, suffix, num_of_files) {
+    let s3 = get_new_server(user);
+    const names = [];
+    for (let i = 0; i < num_of_files; ++i) {
+        names.push(files_prefix + '_no_' + i + suffix);
+    }
+    return ops.generate_random_file(1)
+        .then(fname => P.map(names, name => {
+            let params1 = {
+                Bucket: 'bucket1',
+                Key: name,
+                Body: fs.createReadStream(fname)
+            };
+            return P.fromCallback(callback => s3.upload(params1, callback));
+        }))
+        .delay(TIME_FOR_FUNC_TO_RUN * 2) // wait for the functions to run...
+        .then(() => {
+            let params2 = {
+                Bucket: 'bucket1',
+                Prefix: files_prefix
+            };
+            return P.fromCallback(callback => s3.listObjects(params2, callback));
+        })
+        .then(data => {
+            assert(data.Contents.length === (num_of_files * 2), `bucket lambda trigger failed. files created: ${data.Contents}`);
+            console.log(`bucket lambda trigger worked. files ${data.Contents.length} created`);
+        });
+}
+
+function account_by_name(accounts, email) {
+    return accounts.find(account => account.email === email);
+}
+
+function bucket_by_name(buckets, name) {
+    return buckets.find(bucket => bucket.name === name);
+}
+
+if (require.main === module) {
+    main();
+}


### PR DESCRIPTION
### Explain the changes:
- adding lambda triggers support 
  - add/update/delete lambda triggers to bucket
  - object_server to run function on put/complete and delete
  - new module for running the funcs for each trigger named event_dispatcher.js
- adding func_executer to lambda functions
  - adding to the DB and to func_server
  - running the func in executer instead of the req.account
  - validating bucket access when event is triggered 
  - sending alert when executor doesn't have bucket permission
- testing
  - testing of prefixes/suffixes/enabled/disabled
    - lambda function running when should and not running when shouldn't
  - testing user stop having permission - function doesn't run
    - removing bucket permission for function owner - function doesn't run
  - added 2 new lambda test function for creating json files of uploaded files and deleting it for removed
    - making sure the right trigger runs when the right event happens
    - when file created - creates second JSON file with his meta-data
    - when file deleted - delete this second JSON file 
  - test creates 10 new file together checking function run 10 times
  - adding to system tests

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
- run as part of system test or as standalone 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
