### PR TITLE
Fix #4382 - Show current configured hostname in first_install

### DIFF
--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -192,7 +192,8 @@ function configure_dns_dialog {
 }
 
 function configure_hostname_dialog {
-    dialog --colors --nocancel --backtitle "NooBaa First Install" --title "Hostname Configuration" --form "\nPlease supply a hostname for this \Z5\ZbNooBaa\Zn installation." 12 65 4 "Hostname:" 1 1 "" 1 25 25 30 2> answer_host
+    local current_name=$(hostname)
+    dialog --colors --nocancel --backtitle "NooBaa First Install" --title "Hostname Configuration" --form "\nPlease supply a hostname for this \Z5\ZbNooBaa\Zn installation." 12 65 4 "Hostname:" 1 1 "${current_name}" 1 25 25 30 2> answer_host
 
     local host=$(tail -1 answer_host)
     rc=$(sudo sysctl kernel.hostname=${host})


### PR DESCRIPTION
### Explain the changes:
- Fix #4382 - Show current configured hostname in first_install

### Issues: Fixed / Gap #xxx
- fixes #4382 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
