### PR TITLE
fixed #4384 - bad data was written to S3 cloud resource

### DIFF
--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -63,7 +63,15 @@ class BlockStoreBase {
     delegate_read_block(req) {
         const { block_md } = req.rpc_params;
         const cached_data = this.block_cache.peek_cache(block_md);
-        if (cached_data) return { cached_data };
+        if (cached_data) {
+            const ret = {
+                cached_data: {
+                    block_md,
+                },
+                [RPC_BUFFERS]: { data: cached_data.data }
+            };
+            return ret;
+        }
         return this._delegate_read_block(block_md);
     }
 

--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -114,8 +114,8 @@ class BlockStoreClient {
                 const req_options = {
                     url: signed_url,
                     method: 'PUT',
-                    body: params.data,
-                    followAllRedirects: true
+                    followAllRedirects: true,
+                    body: data
                 };
                 if (delegation_info.proxy) {
                     req_options.proxy = delegation_info.proxy;
@@ -143,7 +143,12 @@ class BlockStoreClient {
         const { timeout = config.IO_READ_BLOCK_TIMEOUT } = options;
         return rpc_client.block_store.delegate_read_block({ block_md: params.block_md }, options)
             .then(delegation_info => {
-                if (delegation_info.cached_data) return delegation_info.cached_data;
+                if (delegation_info.cached_data) {
+                    return {
+                        block_md: delegation_info.cached_data.block_md,
+                        [RPC_BUFFERS]: delegation_info[RPC_BUFFERS]
+                    };
+                }
                 const req_options = {
                     url: delegation_info.signed_url,
                     method: 'GET',


### PR DESCRIPTION
### Explain the changes:
- in `_delegate_write_block_s3`  after getting the signed URL from the cloud agent, the data buffer was taken from `params.data` instead of `params[RPC_BUFFERS].data`
- fixed return of cached data from cloud agent.

### Issues: Fixed / Gap #xxx
- Fixes #4384 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages