### PR TITLE
deploy_base.sh: set the timeout of grub menu to 0

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -83,6 +83,8 @@ function install_platform {
     echo "GRUB_HIDDEN_TIMEOUT=0" >> /etc/default/grub
     echo "GRUB_FORCE_HIDDEN_MENU=true" >> /etc/default/grub
     grub2-mkconfig --output=/boot/grub2/grub.cfg
+    sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0' /etc/default/grub
+    grub2-mkconfig –o /boot/grub2/grub.cfg
 
 	# easy_install is for Supervisord and comes from python-setuptools
 	easy_install supervisor


### PR DESCRIPTION
### Explain the changes:
deploy_base.sh:
- Set the timeout of grub menu to 0

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
