### PR TITLE
fixed mapper to calculate pools validity by storage

### DIFF
--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -405,7 +405,18 @@ module.exports = {
                         mirrors_storage: {
                             type: 'array',
                             items: {
-                                $ref: 'common_api#/definitions/storage_info'
+                                type: 'object',
+                                properties: {
+                                    free: {
+                                        $ref: 'common_api#/definitions/bigint'
+                                    },
+                                    regular_free: {
+                                        $ref: 'common_api#/definitions/bigint'
+                                    },
+                                    redundant_free: {
+                                        $ref: 'common_api#/definitions/bigint'
+                                    },
+                                }
                             }
                         }
                     },

--- a/src/test/unit_tests/test_map_builder.js
+++ b/src/test/unit_tests/test_map_builder.js
@@ -195,7 +195,11 @@ coretest.describe_mapper_test_case({
                     pools: _.fromPairs(_.map(system_store.data.pools,
                         pool => [pool._id, { valid_for_allocation: true, num_nodes: 1000 }]
                     )),
-                    mirrors_storage: tier.mirrors.map(mirror => ({ free: { peta: 1, n: 0 } }))
+                    mirrors_storage: tier.mirrors.map(mirror => ({
+                        free: { peta: 2, n: 0 },
+                        regular_free: { peta: 1, n: 0 },
+                        redundant_free: { peta: 1, n: 0 },
+                    }))
                 }]
             ));
             chunk.chunk_coder_config = chunk_coder_config;

--- a/src/test/unit_tests/test_mapper.js
+++ b/src/test/unit_tests/test_mapper.js
@@ -86,12 +86,20 @@ coretest.describe_mapper_test_case({
     const pools_by_tier_id = _.fromPairs(_.map(tiering.tiers,
         ({ tier }) => [tier._id, _.flatMap(tier.mirrors, 'spread_pools')]
     ));
+
+    const ZERO_STORAGE = { free: 0, regular_free: 0, redundant_free: 0 };
+    const FULL_STORAGE = {
+        free: { peta: 2, n: 0 },
+        regular_free: { peta: 1, n: 0 },
+        redundant_free: { peta: 1, n: 0 }
+    };
+
     const default_tiering_status = _.fromPairs(_.map(tiering.tiers,
         ({ tier, spillover }) => [tier._id, {
             pools: _.fromPairs(_.map(pools_by_tier_id[tier._id],
                 pool => [pool._id, { valid_for_allocation: true, num_nodes: config.NODES_MIN_COUNT }]
             )),
-            mirrors_storage: tier.mirrors.map(mirror => ({ free: { peta: 1, n: 0 } }))
+            mirrors_storage: tier.mirrors.map(mirror => FULL_STORAGE)
         }]
     ));
     const spillover_tiering_status = _.fromPairs(_.map(tiering.tiers,
@@ -99,7 +107,7 @@ coretest.describe_mapper_test_case({
             pools: _.fromPairs(_.map(pools_by_tier_id[tier._id],
                 pool => [pool._id, { valid_for_allocation: true, num_nodes: config.NODES_MIN_COUNT }]
             )),
-            mirrors_storage: tier.mirrors.map(mirror => ({ free: spillover ? { peta: 1, n: 0 } : 0 }))
+            mirrors_storage: tier.mirrors.map(mirror => (spillover ? FULL_STORAGE : ZERO_STORAGE))
         }]
     ));
     const empty_tiering_status = _.fromPairs(_.map(tiering.tiers,
@@ -107,7 +115,7 @@ coretest.describe_mapper_test_case({
             pools: _.fromPairs(_.map(pools_by_tier_id[tier._id],
                 pool => [pool._id, { valid_for_allocation: true, num_nodes: config.NODES_MIN_COUNT }]
             )),
-            mirrors_storage: tier.mirrors.map(mirror => ({ free: 0 }))
+            mirrors_storage: tier.mirrors.map(mirror => ZERO_STORAGE)
         }]
     ));
     const regular_tiering_status = _.fromPairs(_.map(tiering.tiers,
@@ -115,7 +123,7 @@ coretest.describe_mapper_test_case({
             pools: _.fromPairs(_.map(pools_by_tier_id[tier._id],
                 pool => [pool._id, { valid_for_allocation: true, num_nodes: config.NODES_MIN_COUNT }]
             )),
-            mirrors_storage: tier.mirrors.map(mirror => ({ free: spillover ? 0 : { peta: 1, n: 0 } }))
+            mirrors_storage: tier.mirrors.map(mirror => (spillover ? ZERO_STORAGE : FULL_STORAGE))
         }]
     ));
 


### PR DESCRIPTION
### Explain the changes:
- use the amount of storage on regular and redundant pools to calculate if pools are valid
- replaces calculations according to `valid_for_allocation` flag

### Issues: Fixed / Gap #xxx
- Fixes #4355 
- Opened tech debt #4439 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages