### PR TITLE
Fixing bucket statuses regarding drives calculations

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -235,7 +235,7 @@ AgentCLI.prototype.rename_agent_storage = function(mount_points) {
 };
 
 AgentCLI.prototype.update_ignored_drives = function(mount_points) {
-    if (os.type() === 'Darwin') return; // skip rename in mac os
+    if (os.type() === 'Darwin') return mount_points; // skip rename in mac os
     this.params.ignore_drives = this.params.ignore_drives || [];
     return P.map(mount_points, mount_point => {
         if (mount_point.temporary_drive) {

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -2866,6 +2866,7 @@ class NodesMonitor extends EventEmitter {
 
     _aggregate_nodes_list(list) {
         let count = 0;
+        let storage_count = 0;
         let online = 0;
         const by_mode = {};
         let storage = {
@@ -2879,6 +2880,7 @@ class NodesMonitor extends EventEmitter {
         const data_activities = {};
         _.each(list, item => {
             count += 1;
+            if (item.node.node_type !== 'ENDPOINT_S3') storage_count += 1;
             by_mode[item.mode] = (by_mode[item.mode] || 0) + 1;
             if (item.online) online += 1;
 
@@ -2909,6 +2911,7 @@ class NodesMonitor extends EventEmitter {
         return {
             nodes: {
                 count,
+                storage_count,
                 online,
                 by_mode,
             },

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -895,7 +895,7 @@ function get_bucket_info(bucket, nodes_aggregate_pool, hosts_aggregate_pool, agg
                     return _.extend({ pool_id: pool._id }, tiering_pools_status[tier_and_order.tier._id].pools[pool._id]);
                 }))
                 .forEach(pool_status => {
-                    const pool_num_nodes = _.get(hosts_aggregate_pool, `groups.${pool_status.pool_id}.nodes.by_service.STORAGE`) || 0;
+                    const pool_num_nodes = _.get(nodes_aggregate_pool, `groups.${pool_status.pool_id}.nodes.storage_count`) || 0;
                     num_nodes_in_mirror_group += pool_num_nodes;
                     num_valid_nodes += (pool_status.num_nodes || 0);
                     has_valid_pool = has_valid_pool || pool_status.valid_for_allocation;

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -29,6 +29,7 @@ const POOL_STORAGE_DEFAULTS = Object.freeze({
 });
 const POOL_NODES_INFO_DEFAULTS = Object.freeze({
     count: 0,
+    storage_count: 0,
     online: 0,
     by_mode: {},
 });

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -61,6 +61,7 @@ const SYS_STORAGE_DEFAULTS = Object.freeze({
 });
 const SYS_NODES_INFO_DEFAULTS = Object.freeze({
     count: 0,
+    storage_count: 0,
     online: 0,
     by_mode: {},
 });
@@ -519,7 +520,7 @@ function read_system(req) {
                 used: objects_sys.size,
             }, nodes_aggregate_pool_no_cloud_and_mongo.storage, SYS_STORAGE_DEFAULTS)),
             nodes: _.defaults({}, nodes_aggregate_pool_no_cloud_and_mongo.nodes, SYS_NODES_INFO_DEFAULTS),
-            hosts: _.defaults({}, hosts_aggregate_pool.nodes, SYS_NODES_INFO_DEFAULTS),
+            hosts: _.omit(_.defaults({}, hosts_aggregate_pool.nodes, SYS_NODES_INFO_DEFAULTS), 'storage_count'),
             owner: account_server.get_account_info(system_store.data.get_by_id(system._id).owner),
             last_stats_report: system.last_stats_report || 0,
             maintenance_mode: maintenance_mode,


### PR DESCRIPTION
### Explain the changes:
- Calculate storage drives instead of nodes for bucket statuses

### Issues: Fixed / Gap #xxx
- Fixed #4421 
- Fixed #4357 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
