### PR TITLE
Fixed #4419 - prevent creating more than one S3 agent per host

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -293,11 +293,13 @@ AgentCLI.prototype.load = function(added_storage_paths) {
             // no need to load s3 when adding new drives
             if (added_storage_paths) return storage_path_nodes;
             // if no s3 agent exist for root storage path, run one
-            let s3_started = _.find(storage_path_nodes[0], name => this._is_s3_agent(name));
+            let s3_started = _.find(_.flatten(storage_path_nodes), name => this._is_s3_agent(name));
             if (!s3_started) {
+                const root_storage_path = self.params.all_storage_paths.find(storage_path => storage_path.mount === '/noobaa_storage') ||
+                    self.params.all_storage_paths[0];
                 // create path for s3 agent. it will be used if agent_conf contains s3 role
-                dbg.log0(`creating s3 storage_path in ${self.params.all_storage_paths[0]}`);
-                return self.create_node_helper(self.params.all_storage_paths[0], {
+                dbg.log0(`creating s3 storage_path in ${root_storage_path}`);
+                return self.create_node_helper(root_storage_path, {
                         is_s3_agent: true
                     })
                     // return storage nodes that will be created according to scale


### PR DESCRIPTION
### Explain the changes:
- in some cases where the root path of the host was not positioned at `storage_path_nodes[0]`, we could create another S3 agent for the same host. 
- if this agent was on a mount that was later removed than the host was reporting that it's S3 service is offline.
- fixed by checking that there is only one S3 agent across all drives (`_.flatten(storage_path_nodes)`)

### Issues: Fixed / Gap #xxx
- Fixed #4419 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages