### PR TITLE
first_install_diaglog.sh: Fix running supervisorctl after IP and DNS changes

### DIFF
--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -215,10 +215,10 @@ function configure_networking_dialog {
       menu_entry=$(cat choice)
       if [ "${menu_entry}" -eq "1" ]; then
         configure_ips_dialog
-        /usr/bin/supervisorctl restart all #Restart services after IP and DNS changes
+        sudo /usr/bin/supervisorctl restart all 1> /dev/null #Restart services after IP and DNS changes
       elif [ "${menu_entry}" -eq "2" ]; then
         configure_dns_dialog
-        /usr/bin/supervisorctl restart all #Restart services after IP and DNS changes
+        sudo /usr/bin/supervisorctl restart all 1> /dev/null #Restart services after IP and DNS changes
       elif [ "${menu_entry}" -eq "3" ]; then
         configure_hostname_dialog
       fi


### PR DESCRIPTION
### Explain the changes:
first_install_diaglog.sh:
- Fix running supervisorctl after IP and DNS changes

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
