### PR TITLE
avoid error on frag without blocks, and generate mirror ids for mirror groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "2.1.0",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",

--- a/src/deploy/mongo_upgrade/mongo_upgrade_2_1_3.js
+++ b/src/deploy/mongo_upgrade/mongo_upgrade_2_1_3.js
@@ -1,0 +1,22 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-env mongo */
+'use strict';
+
+update_tier_mirror_ids();
+
+function update_tier_mirror_ids() {
+    db.tiers.find().forEach(tier => {
+        var set_updates;
+        tier.mirrors.forEach((mirror, i) => {
+            if (!mirror._id) {
+                set_updates = set_updates || {};
+                set_updates[`mirrors.${i}._id`] = new ObjectId();
+            }
+        });
+        if (set_updates) {
+            print('update_tier_mirror_ids: updating tier', tier.name, tier._id);
+            printjson(set_updates);
+            db.tiers.updateOne({ _id: tier._id }, { $set: set_updates });
+        }
+    });
+}

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -968,7 +968,7 @@ class ObjectIO {
             );
         } else {
             const read_next_block = i => {
-                if (i >= frag.blocks.length) return; // no more blocks
+                if (i >= frag.blocks.length) return P.resolve(); // no more blocks
                 const block = frag.blocks[i];
                 return this._read_block(params, block.block_md)
                     .then(buffer => {

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -15,7 +15,6 @@ const dbg = require('../../util/debug_module')(__filename);
 const MDStore = require('./md_store').MDStore;
 const LRUCache = require('../../util/lru_cache');
 const size_utils = require('../../util/size_utils');
-const server_utils = require('../utils/system_utils');
 const { RpcError } = require('../../rpc');
 const Dispatcher = require('../notifications/dispatcher');
 const http_utils = require('../../util/http_utils');
@@ -413,19 +412,13 @@ function read_object_mappings(req) {
 
             // when called from admin console, we do not update the stats
             // so that viewing the mapping in the ui will not increase read count
-            if (adminfo) {
-                // Notice that this changes the value of reply.parts
-                _mark_mirror_groups_for_blocks(
-                    reply.parts,
-                    _get_bucket_mirror_groups(obj.bucket)
+            if (!adminfo) {
+                const date = new Date();
+                MDStore.instance().update_object_by_id(
+                    obj._id, { 'stats.last_read': date },
+                    undefined, { 'stats.reads': 1 }
                 );
             }
-
-            const date = new Date();
-            MDStore.instance().update_object_by_id(
-                obj._id, { 'stats.last_read': date },
-                undefined, { 'stats.reads': 1 }
-            );
         })
         .return(reply);
 }
@@ -1044,47 +1037,6 @@ function check_quota(bucket) {
             `Bucket ${bucket.name} exceeded 90% of its configured quota of ${size_utils.human_size(bucket.quota.value)}`,
             Dispatcher.rules.once_daily);
     }
-}
-
-function _get_bucket_mirror_groups(bucket_id) {
-    const bucket = system_store.data.get_by_id(bucket_id);
-
-    if (!bucket) {
-        throw new RpcError('BUCKET_NOT_EXIST',
-            `Could not find bucket:${bucket_id}`);
-    }
-
-    const working_tiers = bucket.tiering.tiers
-        .filter(tiers_obj => !tiers_obj.disabled)
-        .map(filtered_tiers_obj => filtered_tiers_obj.tier);
-
-    if (!working_tiers) {
-        throw new RpcError('NO_VALID_TIER',
-            `Could not find valid tier in bucket bucket:${bucket_id}`);
-    }
-
-    return _.flatten(working_tiers.map(server_utils.get_tier_mirror_groups));
-}
-
-function _mark_mirror_groups_for_blocks(parts, mirror_groups) {
-    const pool_to_mirror_group = mirror_groups.reduce(
-        (mapping, mirror_group) => {
-            mirror_group.pools.forEach(pool_name => {
-                mapping[pool_name] = mirror_group.name;
-            });
-            return mapping;
-        }, {}
-    );
-
-    parts.forEach(part =>
-        part.chunk.frags.forEach(frag =>
-            frag.blocks.forEach(block => {
-                // In case of block not being stored on pool that is not relevant to the main tier of bucket
-                // We will not assign it to any mirror group, this is relevant to spillover blocks and blocks not in policy
-                block.adminfo.mirror_group = pool_to_mirror_group[block.adminfo.pool_name];
-            })
-        )
-    );
 }
 
 // EXPORTS

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -112,7 +112,10 @@ function create_bucket(req) {
             changes.insert.chunk_configs = [chunk_config];
         }
         const bucket_with_suffix = req.rpc_params.name + '#' + Date.now().toString(36);
-        const mirrors = [{ spread_pools: [default_pool._id] }];
+        const mirrors = [{
+            _id: system_store.generate_id(),
+            spread_pools: [default_pool._id]
+        }];
         const tier = tier_server.new_tier_defaults(
             bucket_with_suffix,
             req.system._id,

--- a/src/server/system_services/schemas/tier_schema.js
+++ b/src/server/system_services/schemas/tier_schema.js
@@ -44,8 +44,9 @@ module.exports = {
             type: 'array',
             items: {
                 type: 'object',
-                // required: ['spread_pools'],
+                required: ['_id', 'spread_pools'],
                 properties: {
+                    _id: { objectid: true },
                     spread_pools: {
                         type: 'array',
                         items: { objectid: true } // pool id

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -176,7 +176,10 @@ function new_system_changes(name, owner_account) {
         }),
     };
     system.default_chunk_config = default_chunk_config._id;
-    const tier_mirrors = [{ spread_pools: [pool._id] }];
+    const tier_mirrors = [{
+        _id: system_store.generate_id(),
+        spread_pools: [pool._id]
+    }];
     const tier = tier_server.new_tier_defaults(
         bucket_with_suffix,
         system._id,
@@ -1234,6 +1237,7 @@ function create_internal_tier(system, mongo_pool) {
         `${config.SPILLOVER_TIER_NAME}-${system._id}`,
         system._id,
         system.default_chunk_config._id, [{
+            _id: system_store.generate_id(),
             spread_pools: [mongo_pool._id]
         }]
     );

--- a/src/server/utils/system_utils.js
+++ b/src/server/utils/system_utils.js
@@ -5,7 +5,6 @@ const size_utils = require('../../util/size_utils');
 const os_utils = require('../../util/os_utils');
 const system_store = require('../system_services/system_store').get_instance();
 const MongoCtrl = require('./mongo_ctrl');
-const crypto = require('crypto');
 
 function system_in_maintenance(system_id) {
     const system = system_store.data.get_by_id(system_id);
@@ -45,24 +44,6 @@ function mongo_wrapper_system_created() {
     }
 }
 
-// For each mirror set in the tier create a mirror group object
-// with a uniqe name and a list of pools.
-function get_tier_mirror_groups(tier) {
-    return tier.mirrors
-        .map(mirror_object => {
-            const pools = mirror_object.spread_pools
-                .map(pool => pool.name)
-                .sort();
-
-            const name = crypto.createHash('md5')
-                .update(JSON.stringify(pools))
-                .digest('hex');
-
-            return { name, pools };
-        });
-}
-
 exports.system_in_maintenance = system_in_maintenance;
 exports.get_bucket_quota_usage_percent = get_bucket_quota_usage_percent;
 exports.mongo_wrapper_system_created = mongo_wrapper_system_created;
-exports.get_tier_mirror_groups = get_tier_mirror_groups;

--- a/src/test/system_tests/mongodb_defaults.js
+++ b/src/test/system_tests/mongodb_defaults.js
@@ -20,6 +20,7 @@ db.tiers.update({
     $set: {
         data_placement: 'SPREAD',
         mirrors: [{
+            _id: new ObjectId(),
             spread_pools: [
                 db.pools.find({
                     name: 'first.pool'

--- a/src/test/unit_tests/test_mapper.js
+++ b/src/test/unit_tests/test_mapper.js
@@ -38,9 +38,21 @@ coretest.describe_mapper_test_case({
     const external_pools = _.times(num_pools, i => ({ _id: new mongodb.ObjectId(), name: 'external_pool' + i, }));
     const pool_by_id = _.keyBy(_.concat(regular_pools, spill_pools, external_pools), '_id');
     const regular_mirrors = data_placement === 'MIRROR' ?
-        regular_pools.map(pool => ({ spread_pools: [pool] })) : [{ spread_pools: regular_pools }];
+        regular_pools.map(pool => ({
+            _id: new mongodb.ObjectId(),
+            spread_pools: [pool]
+        })) : [{
+            _id: new mongodb.ObjectId(),
+            spread_pools: regular_pools
+        }];
     const spill_mirrors = data_placement === 'MIRROR' ?
-        spill_pools.map(pool => ({ spread_pools: [pool] })) : [{ spread_pools: spill_pools }];
+        spill_pools.map(pool => ({
+            _id: new mongodb.ObjectId(),
+            spread_pools: [pool]
+        })) : [{
+            _id: new mongodb.ObjectId(),
+            spread_pools: spill_pools
+        }];
     const regular_tier = {
         _id: new mongodb.ObjectId(),
         name: 'regular_tier',

--- a/src/upgrade/upgrade.js
+++ b/src/upgrade/upgrade.js
@@ -406,6 +406,7 @@ function mongo_upgrade_database_metadata(params) {
             dbg.log0(`mongo_upgrade_database_metadata: secret is ${params.secret} - should_mongo_upgrade = ${should_mongo_upgrade}`);
             if (should_mongo_upgrade === "true") {
                 UPGRADE_SCRIPTS = [
+                    'mongo_upgrade_2_1_3.js',
                     'mongo_upgrade_mark_completed.js'
                 ];
             } else {


### PR DESCRIPTION
### Explain the changes:
- save _id per tier mirror in the DB and use it as mirror_group

### Issues: Fixed / Gap #xxx
- Fixes #4417

### Testing Instructions:
- NA

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
