### PR TITLE
mapper: protect from too many deletions (see #4418)

### DIFF
--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -181,6 +181,7 @@ class MapBuilder {
             // only delete blocks if the chunk is in good shape,
             // that is no allocations needed, and is accessible.
             if (mapping.accessible && !mapping.allocations && mapping.deletions) {
+                dbg.log0('MapBuilder.build_chunks: print mapping on deletions', mapping);
                 this.delete_blocks = this.delete_blocks || [];
                 js_utils.array_push_all(this.delete_blocks, mapping.deletions);
             }
@@ -321,10 +322,12 @@ class MapBuilder {
             pools, avoid_nodes, allocated_hosts, { special_replica }
         );
 
-        dbg.log0('MapBuilder.allocate_block: block', block_id,
-            'node', node._id, node.name, 'chunk', chunk._id, 'frag', frag);
+        if (!node) {
+            dbg.log0('MapBuilder.allocate_block: no nodes for allocation', block_id, 'chunk', chunk._id, 'frag', frag);
+            throw new Error('MapBuilder.allocate_block: no nodes for allocation');
+        }
 
-        if (!node) throw new Error('MapBuilder.allocate_block: no nodes for allocation');
+        dbg.log0('MapBuilder.allocate_block: block', block_id, 'node', node._id, node.name, 'chunk', chunk._id, 'frag', frag);
 
         const block = {
             _id: block_id,

--- a/src/server/object_services/mapper.js
+++ b/src/server/object_services/mapper.js
@@ -379,8 +379,31 @@ class TierMapper {
 
         if (accessible && !tier_mapping.allocations) {
             const { blocks } = chunk_mapper.chunk;
-            const unused_blocks = _.difference(blocks, tier_mapping.blocks_in_use);
-            if (unused_blocks.length) tier_mapping.deletions = unused_blocks;
+            const used_blocks = _.uniq(tier_mapping.blocks_in_use);
+            const unused_blocks = _.uniq(_.difference(blocks, used_blocks));
+            if (unused_blocks.length) {
+                // Protect from too many deletions by checking:
+                // - the number of unused blocks to delete does not include all blocks
+                // - the number of unused blocks to delete does not exceed number blocks that should exist
+                // - the number of used blocks against the the expected number of blocks
+                const min_num_blocks = this.tier.chunk_config.chunk_coder_config.data_frags || 1;
+                if (unused_blocks.length >= blocks.length ||
+                    unused_blocks.length > blocks.length - min_num_blocks ||
+                    used_blocks.length < min_num_blocks) {
+                    dbg.error('TierMapper.map_tier: ASSERT protect from too many deletions!',
+                        'min_num_blocks', min_num_blocks,
+                        'blocks.length', blocks.length,
+                        'used_blocks.length', used_blocks.length,
+                        'unused_blocks.length', unused_blocks.length,
+                        'tier', this.tier,
+                        'tier_mapping', tier_mapping,
+                        'chunk', chunk_mapper.chunk,
+                        'used_blocks', used_blocks,
+                        'unused_blocks', unused_blocks);
+                } else {
+                    tier_mapping.deletions = unused_blocks;
+                }
+            }
         }
 
         return tier_mapping;


### PR DESCRIPTION
### Explain the changes:
- Add safety check to avoid returning too many deletions from the mapper
- Fix exception of no nodes for allocations instead of dereferencing undefined node._id

### Issues: Fixed / Gap #xxx
- See #4418

### Testing Instructions:
- NA

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
