### PR TITLE
add missing LOW_CAPACITY UI status for internal storage

### DIFF
--- a/frontend/src/app/schema/internal-resources.js
+++ b/frontend/src/app/schema/internal-resources.js
@@ -18,6 +18,7 @@ export default {
                     'INITIALIZING',
                     'IO_ERRORS',
                     'ALL_NODES_OFFLINE',
+                    'LOW_CAPACITY',
                     'NO_CAPACITY'
                 ]
             },

--- a/frontend/src/app/utils/resource-utils.js
+++ b/frontend/src/app/utils/resource-utils.js
@@ -109,6 +109,16 @@ const internalResourceModeToStateIcon = deepFreeze({
         css: 'warning',
         name: 'working'
     },
+    LOW_CAPACITY: pool => {
+        const free = toBytes(pool.storage.free);
+        const limit = formatSize(Math.max(30 * GB, .2 * free));
+
+        return {
+            tooltip: `Available capacity is below ${limit}`,
+            css: 'warning',
+            name: 'problem'
+        };
+    },
     ALL_NODES_OFFLINE: {
         tooltip: 'Resource is offline',
         css: 'error',
@@ -175,7 +185,8 @@ export function getCloudResourceStateIcon(resource) {
 
 export function getInternalResourceStateIcon(resource) {
     const { mode } = resource;
-    return internalResourceModeToStateIcon[mode];
+    const state = internalResourceModeToStateIcon[mode];
+    return isFunction(state) ? state(resource) : state;
 }
 
 export function getInternalResourceDisplayName(resource) {

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -580,6 +580,7 @@ function calc_mongo_pool_mode(p) {
         (by_mode.IO_ERRORS && 'IO_ERRORS') ||
         (by_mode.INITIALIZING && 'INITIALIZING') ||
         (by_mode.OFFLINE && 'ALL_NODES_OFFLINE') ||
+        (by_mode.LOW_CAPACITY && 'LOW_CAPACITY') ||
         (free < NO_CAPAITY_LIMIT && 'NO_CAPACITY') ||
         'ALL_NODES_OFFLINE';
 }


### PR DESCRIPTION
### Explain the changes:
- Translate the LOW_CAPACITY status from node -> pool -> UI resource correctly instead of the previous translation to ALL_NODES_OFFLINE.

### Issues: Fixed / Gap #xxx
- NA

### Testing Instructions:
- When the free capacity of the internal storage drops below 20% the LOW_CAPACITY status is returned and should be shown in the UI.

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
