### PR TITLE
Addition of agent blocks reclaimer and verifier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,10 @@ module.exports = {
         es6: true,
     },
 
+    parserOptions: {
+        ecmaVersion: 2017
+    },
+
     plugins: [
         // eslint-plugin-header validates copyright header
         'header'
@@ -262,6 +266,8 @@ module.exports = {
 
         // turn off todo/fixme comments - will grep it to a different report
         'no-warning-comments': 'off',
+
+        'no-await-in-loop': 'off',
 
         // the rule object-property-newline is better than object-curly-newline
         'object-property-newline': 'off',

--- a/config.js
+++ b/config.js
@@ -120,6 +120,28 @@ config.IO_SEMAPHORE_CAP = Math.floor(
 
 config.CLOUD_MAX_ALLOWED_IO_TEST_ERRORS = 3;
 
+///////////////////////////
+// AGENT BLOCKS VERIFIER //
+///////////////////////////
+
+config.AGENT_BLOCKS_VERIFIER_ENABLED = true;
+// TODO: Should check what is the optiomal amount of batch
+config.AGENT_BLOCKS_VERIFIER_BATCH_SIZE = 1000;
+config.AGENT_BLOCKS_VERIFIER_BATCH_DELAY = 50;
+config.AGENT_BLOCKS_VERIFIER_ERROR_DELAY = 3000;
+config.AGENT_BLOCKS_VERIFIER_RESTART_DELAY = 30000;
+config.AGENT_BLOCKS_VERIFIER_TIMEOUT = 120 * 1000;
+
+////////////////////////////
+// AGENT BLOCKS RECLAIMER //
+////////////////////////////
+
+config.AGENT_BLOCKS_RECLAIMER_ENABLED = true;
+// TODO: Should check what is the optiomal amount of batch
+config.AGENT_BLOCKS_RECLAIMER_BATCH_SIZE = 1000;
+config.AGENT_BLOCKS_RECLAIMER_BATCH_DELAY = 50;
+config.AGENT_BLOCKS_RECLAIMER_ERROR_DELAY = 3000;
+config.AGENT_BLOCKS_RECLAIMER_RESTART_DELAY = 30000;
 
 ////////////////////
 // REBUILD CONFIG //

--- a/src/agent/block_store_services/block_store_mem.js
+++ b/src/agent/block_store_services/block_store_mem.js
@@ -68,8 +68,12 @@ class BlockStoreMem extends BlockStoreBase {
                 this._blocks.delete(block_id);
             }
         });
+        // Just a place filler since we always succeed in deletions
+        return {
+            failed_block_ids: [],
+            succeeded_block_ids: _.difference(block_ids, [])
+        };
     }
-
 }
 
 // EXPORTS

--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -230,6 +230,7 @@ class BlockStoreS3 extends BlockStoreBase {
             size: 0,
             count: 0
         };
+        let failed_to_delete_block_ids = [];
         // Todo: Assuming that all requested blocks were deleted, which a bit naive
         return this._get_blocks_usage(block_ids)
             .then(ret_usage => {
@@ -245,10 +246,15 @@ class BlockStoreS3 extends BlockStoreBase {
                     })
                     .catch(err => {
                         dbg.error('_delete_blocks failed:', err, _.omit(this.cloud_info, 'secret_key'));
+                        failed_to_delete_block_ids = block_ids;
                         throw err;
                     });
             })
-            .then(() => this._update_usage(deleted_storage));
+            .then(() => this._update_usage(deleted_storage))
+            .then(() => ({
+                failed_block_ids: failed_to_delete_block_ids,
+                succeeded_block_ids: _.difference(block_ids, failed_to_delete_block_ids)
+            }));
     }
 
 

--- a/src/api/block_store_api.js
+++ b/src/api/block_store_api.js
@@ -28,6 +28,21 @@ module.exports = {
             },
         },
 
+        verify_blocks: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['verify_blocks'],
+                properties: {
+                    verify_blocks: {
+                        type: 'array',
+                        items: {
+                            $ref: 'common_api#/definitions/block_md'
+                        }
+                    }
+                },
+            },
+        },
 
         handle_delegator_error: {
             method: 'POST',
@@ -158,6 +173,25 @@ module.exports = {
                             type: 'string'
                         }
                     }
+                },
+            },
+            reply: {
+                type: 'object',
+                required: ['succeeded_block_ids', 'failed_block_ids'],
+                properties: {
+                    failed_block_ids: {
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        }
+                    },
+                    succeeded_block_ids: {
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        }
+                    }
+
                 },
             },
         },

--- a/src/server/bg_services/agent_blocks_reclaimer.js
+++ b/src/server/bg_services/agent_blocks_reclaimer.js
@@ -1,0 +1,117 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config');
+const MDStore = require('../object_services/md_store').MDStore;
+const system_store = require('../system_services/system_store').get_instance();
+const system_utils = require('../utils/system_utils');
+const mongo_utils = require('../../util/mongo_utils');
+const map_deleter = require('../object_services/map_deleter');
+
+class AgentBlocksReclaimer {
+
+    constructor(name) {
+        this.name = name;
+    }
+
+    run_batch() {
+        if (!system_store.is_finished_initial_load) {
+            dbg.log0('AGENT_BLOCKS_RECLAIMER: system_store did not finish initial load');
+            return;
+        }
+
+        const system = system_store.data.systems[0];
+        if (!system || system_utils.system_in_maintenance(system._id)) return;
+
+        return this.run_agent_blocks_reclaimer();
+    }
+
+    run_agent_blocks_reclaimer() {
+        if (!this.marker) {
+            dbg.log0('AGENT_BLOCKS_RECLAIMER:', 'BEGIN');
+        }
+
+        return this.iterate_all_blocks(
+                this.marker,
+                config.AGENT_BLOCKS_RECLAIMER_BATCH_SIZE,
+                true /* deleted_only */
+            )
+            .then(blocks => {
+                this.marker = blocks.length ? blocks[blocks.length - 1]._id : null;
+                return this.populate_agent_blocks_reclaimer_blocks(blocks);
+            })
+            .then(blocks_to_reclaim => {
+                if (!blocks_to_reclaim || !blocks_to_reclaim.length) return;
+                dbg.log0('AGENT_BLOCKS_RECLAIMER:',
+                    'DELETING:', blocks_to_reclaim);
+                return this.delete_blocks_from_nodes(blocks_to_reclaim);
+            })
+            .then(() => {
+                // return the delay before next batch
+                if (this.marker) {
+                    dbg.log0('AGENT_BLOCKS_RECLAIMER:', 'CONTINUE', this.marker, this.marker.getTimestamp());
+                    return config.AGENT_BLOCKS_RECLAIMER_BATCH_DELAY;
+                }
+                dbg.log0('AGENT_BLOCKS_RECLAIMER:', 'END');
+                return config.AGENT_BLOCKS_RECLAIMER_RESTART_DELAY;
+            })
+            .catch(err => {
+                // return the delay before next batch
+                dbg.error('AGENT_BLOCKS_RECLAIMER:', 'ERROR', err, err.stack);
+                return config.AGENT_BLOCKS_RECLAIMER_ERROR_DELAY;
+            });
+    }
+
+    populate_agent_blocks_reclaimer_blocks(blocks) {
+
+        if (!blocks || !blocks.length) return;
+
+        let blocks_with_nodes;
+        return this.populate_nodes_for_blocks(blocks)
+            .then(res => {
+                blocks_with_nodes = res;
+                const blocks_with_unpopulated_nodes = blocks_with_nodes.filter(block =>
+                    !(block.node && block.node.rpc_address));
+                const block_ids = mongo_utils.uniq_ids(blocks_with_unpopulated_nodes, '_id');
+                return block_ids.length && this.update_blocks_by_ids(block_ids, { reclaimed: new Date() });
+            })
+            .then(() => {
+                const blocks_with_alive_nodes = blocks_with_nodes.filter(block =>
+                    block.node && block.node.rpc_address && block.node.online);
+                return blocks_with_alive_nodes;
+            });
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    iterate_all_blocks(...args) {
+        return MDStore.instance().iterate_all_blocks(...args);
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    delete_blocks_from_nodes(...args) {
+        return map_deleter.delete_blocks_from_nodes(...args);
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    update_blocks_by_ids(...args) {
+        return MDStore.instance().update_blocks_by_ids(...args);
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    populate_nodes_for_blocks(...args) {
+        return MDStore.instance().populate_nodes_for_blocks(...args);
+    }
+
+}
+
+// EXPORTS
+exports.AgentBlocksReclaimer = AgentBlocksReclaimer;

--- a/src/server/bg_services/agent_blocks_verifier.js
+++ b/src/server/bg_services/agent_blocks_verifier.js
@@ -1,0 +1,158 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+
+const P = require('../../util/promise');
+const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config');
+const MDStore = require('../object_services/md_store').MDStore;
+const system_store = require('../system_services/system_store').get_instance();
+const system_utils = require('../utils/system_utils');
+const server_rpc = require('../server_rpc');
+const mapper = require('../object_services/mapper');
+
+class AgentBlocksVerifier {
+
+    constructor(name) {
+        this.name = name;
+    }
+
+    run_batch() {
+        if (!system_store.is_finished_initial_load) {
+            dbg.log0('AGENT_BLOCKS_VERIFIER: system_store did not finish initial load');
+            return;
+        }
+
+        const system = system_store.data.systems[0];
+        if (!system || system_utils.system_in_maintenance(system._id)) return;
+
+        return this.run_agent_blocks_verifier();
+    }
+
+    run_agent_blocks_verifier() {
+        if (!this.marker) {
+            dbg.log0('AGENT_BLOCKS_VERIFIER:', 'BEGIN');
+        }
+
+        return this.iterate_all_blocks(
+                this.marker,
+                config.AGENT_BLOCKS_VERIFIER_BATCH_SIZE,
+                false /* deleted_only */
+            )
+            .then(blocks => {
+                this.marker = blocks.length ? blocks[blocks.length - 1].id : null;
+                return this.populate_agent_blocks_verifier_blocks(blocks);
+            })
+            .then(blocks_to_verify => {
+                if (!blocks_to_verify || !blocks_to_verify.length) return;
+                dbg.log0('AGENT_BLOCKS_VERIFIER:',
+                    'VERIFYING:', blocks_to_verify);
+                return this.verify_blocks_on_agents(blocks_to_verify);
+            })
+            .then(() => {
+                // return the delay before next batch
+                if (this.marker) {
+                    dbg.log0('AGENT_BLOCKS_VERIFIER:', 'CONTINUE', this.marker, this.marker.getTimestamp());
+                    return config.AGENT_BLOCKS_VERIFIER_BATCH_DELAY;
+                }
+                dbg.log0('AGENT_BLOCKS_VERIFIER:', 'END');
+                return config.AGENT_BLOCKS_VERIFIER_RESTART_DELAY;
+            })
+            .catch(err => {
+                // return the delay before next batch
+                dbg.error('AGENT_BLOCKS_VERIFIER:', 'ERROR', err, err.stack);
+                return config.AGENT_BLOCKS_VERIFIER_ERROR_DELAY;
+            });
+    }
+
+    populate_agent_blocks_verifier_blocks(blocks) {
+        if (!blocks || !blocks.length) return;
+
+        return this.populate_nodes_for_blocks(blocks)
+            .then(blocks_with_nodes => {
+                const blocks_with_alive_nodes = blocks_with_nodes.filter(block =>
+                    block.node && block.node.rpc_address && block.node.online);
+                if (!blocks_with_alive_nodes || !blocks_with_alive_nodes.length) return;
+                return this.populate_chunks(blocks_with_alive_nodes, 'chunk', { frags: 1, chunk_config: 1 });
+            })
+            .then(populated_blocks => {
+                if (!populated_blocks || !populated_blocks.length) return;
+                return populated_blocks.map(block => {
+                    const chunk_config = this.get_by_id(block.chunk.chunk_config);
+                    if (!chunk_config) {
+                        dbg.warn('populate_agent_blocks_verifier_blocks: Chunk config not found', block.chunk.chunk_config);
+                    }
+                    block.chunk.chunk_coder_config = chunk_config && chunk_config.chunk_coder_config;
+                    const frag = block.chunk.frags.find(frag_rec => String(frag_rec._id) === String(block.frag));
+                    return mapper.get_block_md(block.chunk, frag, block);
+                });
+            });
+    }
+
+    verify_blocks_on_agents(blocks_to_verify) {
+        return P.resolve()
+            .then(() => {
+                const verify_blocks_group_by_nodes = _.groupBy(blocks_to_verify, 'address');
+                return P.map(Object.keys(verify_blocks_group_by_nodes), address => {
+                    const verify_blocks = verify_blocks_group_by_nodes[address];
+                    return this.verify_blocks({
+                            verify_blocks
+                        }, {
+                            address: address,
+                            timeout: config.AGENT_BLOCKS_RECLAIMER_TIMEOUT,
+                        })
+                        .catch(err => {
+                            dbg.warn('AGENT_BLOCKS_VERIFIER:',
+                                'verify_blocks FAILED',
+                                'ADDR:', address,
+                                'VERIFY_BLOCKS:', verify_blocks,
+                                'ERROR:', err);
+                            // TODO: Should perform further action
+                            // throw err;
+                        });
+                });
+            })
+            .return();
+    }
+
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    iterate_all_blocks(...args) {
+        return MDStore.instance().iterate_all_blocks(...args);
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    populate_nodes_for_blocks(...args) {
+        return MDStore.instance().populate_nodes_for_blocks(...args);
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    populate_chunks(...args) {
+        return MDStore.instance().populate_chunks(...args);
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    get_by_id(...args) {
+        return system_store.data.get_by_id(...args);
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    verify_blocks(...args) {
+        return server_rpc.client.block_store.verify_blocks(...args);
+    }
+
+}
+
+// EXPORTS
+exports.AgentBlocksVerifier = AgentBlocksVerifier;

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -212,6 +212,7 @@ class NodesClient {
             .tap(res => mongo_utils.fix_id_type(res.nodes));
     }
 
+    // TODO: Fields doesn't seem to filter and work
     populate_nodes(system_id, docs, doc_path, fields) {
         const docs_list = docs && !_.isArray(docs) ? [docs] : docs;
         const ids = mongo_utils.uniq_ids(docs_list, doc_path);

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1458,7 +1458,7 @@ class NodesMonitor extends EventEmitter {
                     return;
                 }
                 if (!item.io_test_errors) {
-                    dbg.log0('_test_store_perf:: node has io_test_errors', item.node.name);
+                    dbg.error('_test_store_perf:: node has io_test_errors', item.node.name, err);
                     item.io_test_errors = Date.now();
                 }
             });
@@ -1495,9 +1495,9 @@ class NodesMonitor extends EventEmitter {
                     item.gateway_errors = 0;
                 }
             })
-            .catch(() => {
+            .catch(err => {
                 if (!item.gateway_errors) {
-                    dbg.log0('_test_network_to_server:: node has gateway_errors', item.node.name);
+                    dbg.error('_test_network_to_server:: node has gateway_errors', item.node.name, err);
                     item.gateway_errors = Date.now();
                 }
             });
@@ -1532,9 +1532,9 @@ class NodesMonitor extends EventEmitter {
                     item.n2n_errors = 0;
                 }
             })
-            .catch(() => {
+            .catch(err => {
                 if (!item.n2n_errors) {
-                    dbg.log0('_test_network_perf:: node has n2n_errors', item.node.name);
+                    dbg.error('_test_network_perf:: node has n2n_errors', item.node.name, err);
                     item.n2n_errors = Date.now();
                 }
             });

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -144,6 +144,10 @@ class MDStore {
         return mongo_utils.populate(docs, doc_path, this._objects.col(), fields);
     }
 
+    populate_chunks(docs, doc_path, fields) {
+        return mongo_utils.populate(docs, doc_path, this._chunks.col(), fields);
+    }
+
     find_objects({ bucket_id, key, upload_mode, max_create_time, skip, limit, sort, order, pagination }) {
         const query = compact({
             bucket: bucket_id,
@@ -958,6 +962,29 @@ class MDStore {
     // BLOCKS //
     ////////////
 
+    iterate_all_blocks(marker, limit, deleted_only) {
+        const query = compact({
+            _id: marker ? {
+                $lt: marker
+            } : undefined,
+            deleted: null
+        });
+        if (deleted_only) {
+            query.deleted = {
+                $exists: true
+            };
+            query.reclaimed = {
+                $exists: false
+            };
+        }
+        return this._blocks.col().find(query, {
+                sort: {
+                    _id: -1
+                },
+                limit: limit,
+            })
+            .toArray();
+    }
 
     insert_blocks(blocks) {
         if (!blocks || !blocks.length) return;

--- a/src/server/object_services/schemas/data_block_schema.js
+++ b/src/server/object_services/schemas/data_block_schema.js
@@ -34,6 +34,7 @@ module.exports = {
         // block size is the size of the fragment
         // this is the same as the chunk size when not using erasure coding since the chunk has a single fragment
         size: { type: 'integer' },
+        reclaimed: { date: true },
 
     }
 };

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -41,6 +41,8 @@ require('./test_chunk_splitter');
 require('./test_chunk_config_utils');
 require('./test_object_io');
 require('./test_md_aggregator_unit');
+require('./test_agent_blocks_verifier');
+require('./test_agent_blocks_reclaimer');
 require('./test_s3_ops');
 require('./test_s3_list_objects');
 require('./test_nb_native_b64');

--- a/src/test/unit_tests/test_agent_blocks_reclaimer.js
+++ b/src/test/unit_tests/test_agent_blocks_reclaimer.js
@@ -1,0 +1,366 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('./coretest');
+coretest.setup();
+
+const _ = require('lodash');
+const mocha = require('mocha');
+const assert = require('assert');
+const MDStore = require('../../server/object_services/md_store').MDStore;
+const ObjectIO = require('../../sdk/object_io');
+const P = require('../../util/promise');
+const crypto = require('crypto');
+const SliceReader = require('../../util/slice_reader');
+const AgentBlocksReclaimer = require('../../server/bg_services/agent_blocks_reclaimer').AgentBlocksReclaimer;
+const mongo_utils = require('../../util/mongo_utils');
+const mongodb = require('mongodb');
+const config = require('../../../config');
+const promise_utils = require('../../util/promise_utils');
+
+class ReclaimerMock extends AgentBlocksReclaimer {
+
+    constructor(blocks = [], nodes = [], test_suffix = '') {
+        super(`ReclaimerMock-${test_suffix}`);
+        console.log('ReclaimerMock INIT', test_suffix, blocks, nodes);
+        this.blocks = blocks;
+        this.nodes = nodes;
+        this.reclaimed_blocks = [];
+    }
+
+    iterate_all_blocks(marker, limit, deleted_only) {
+        assert(marker === undefined || marker === null || this.is_valid_md_id(marker),
+            'Marker not null or valid ObjectId');
+        assert(limit === config.AGENT_BLOCKS_RECLAIMER_BATCH_SIZE, 'Wrong reclaimer config limit');
+        assert(deleted_only === true, 'Reclaimer should check only deleted and non reclaimed blocks');
+        // TODO: Pay attention to marker and limit
+        return P.resolve(this.blocks.filter(block => (deleted_only ? block.deleted : !block.deleted)));
+    }
+
+    update_blocks_by_ids(block_ids, set_updates, unset_updates) {
+        assert(!unset_updates, 'Reclaimer should only send set_updates');
+        assert(set_updates &&
+            _.difference(Object.keys(set_updates), ['reclaimed']).length === 0,
+            'Reclaimer should only send set_updates with reclaimed');
+        assert(_.every(block_ids, block_id =>
+            this.is_valid_md_id(block_id)), 'Block_ids not valid ObjectId');
+        return P.resolve()
+            .then(() => {
+                if (!block_ids || !block_ids.length) return;
+                const update_blocks = this.blocks.filter(block =>
+                    _.includes(block_ids.map(block_id => String(block_id)), String(block._id)));
+                update_blocks.forEach(block => {
+                    block.reclaimed = set_updates.reclaimed;
+                });
+            });
+    }
+
+    is_valid_md_id(id_str) {
+        return mongodb.ObjectId.isValid(id_str);
+    }
+
+    populate_nodes_for_blocks(blocks) {
+        const docs = blocks;
+        const doc_path = 'node';
+        // assert(doc_path === 'node',
+        //     'Reclaimer should only send populate to node property of block');
+        const docs_list = docs && !_.isArray(docs) ? [docs] : docs;
+        const ids = mongo_utils.uniq_ids(docs_list, doc_path);
+        if (!ids.length) return P.resolve(docs);
+
+
+        return P.resolve()
+            .then(() => this.nodes.filter(node => !node.deleted &&
+                _.includes(ids.map(node_id => String(node_id)), String(node._id))))
+            .then(nodes => {
+                const idmap = _.keyBy(nodes, '_id');
+                _.each(docs_list, doc => {
+                    const id = _.get(doc, doc_path);
+                    const node = idmap[String(id)];
+                    if (node) {
+                        mongo_utils.fix_id_type(node);
+                        _.set(doc, doc_path, node);
+                    } else {
+                        console.warn('populate_nodes: missing node for id',
+                            id, 'DOC', doc, 'IDMAP', _.keys(idmap));
+                    }
+                });
+                return docs;
+            })
+            .catch(err => {
+                console.error('populate_nodes: ERROR', err.stack);
+                throw err;
+            });
+    }
+
+    delete_blocks_from_nodes(blocks) {
+        this.reclaimed_blocks = _.concat(this.reclaimed_blocks, blocks.map(block => String(block._id)));
+        console.log('delete_blocks', blocks);
+        return P.resolve()
+            .then(() => {
+                blocks.forEach(block_rec => {
+                    let block = this.blocks.find(mock_block => String(mock_block._id) === String(block_rec._id));
+                    // This allows us to mock failure of deletes
+                    if (block && !block.fail_to_delete) {
+                        block.reclaimed = new Date();
+                    }
+                });
+            });
+    }
+
+}
+
+
+mocha.describe('not mocked agent_blocks_reclaimer', function() {
+
+    const object_io = new ObjectIO();
+    object_io.set_verification_mode();
+    const seed = crypto.randomBytes(16);
+    const generator = crypto.createCipheriv('aes-128-gcm', seed, Buffer.alloc(12));
+    const bucket = 'first.bucket';
+    const obj_size = 1;
+    const obj_data = generator.update(Buffer.alloc(obj_size));
+    let nodes_list;
+    const { rpc_client } = coretest;
+
+    mocha.it('should reclaim deleted blocks with alive nodes', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(40000);
+        const obj_key = 'sloth_obj';
+        let blocks_uploaded = [];
+        const agent_blocks_reclaimer =
+            new AgentBlocksReclaimer(self.test.title);
+        return P.resolve()
+            .then(() => rpc_client.node.list_nodes({}))
+            .then(res => {
+                nodes_list = res.nodes;
+            })
+            .then(() => upload_object(obj_key, obj_data, obj_size))
+            .then(obj_id => MDStore.instance().find_parts_chunk_ids({ _id: mongo_utils.make_object_id(obj_id) }))
+            .then(chunk_ids => MDStore.instance().find_blocks_of_chunks(chunk_ids))
+            .then(blocks => {
+                blocks_uploaded = blocks;
+                return MDStore.instance()._blocks.col().updateMany({
+                    _id: { $in: blocks.map(block => block._id) }
+                }, {
+                    $set: { deleted: new Date() }
+                });
+            })
+            .then(() => agent_blocks_reclaimer.run_batch())
+            .then(() => promise_utils.pwhile(
+                () => agent_blocks_reclaimer.marker,
+                () => agent_blocks_reclaimer.run_batch()))
+            .then(() => MDStore.instance()._blocks.col().find({
+                _id: { $in: blocks_uploaded.map(block => block._id) }
+            }).toArray())
+            .then(blocks => {
+                // Object read cache still keeps the data and we want to read from agents
+                object_io._init_read_cache();
+                const all_reclaimed = _.every(blocks, block => block.reclaimed);
+                if (!all_reclaimed) throw new Error('NOT ALL BLOCKS WERE RECLAIMED');
+            })
+            .then(() => verify_read_data(obj_key, obj_data)
+                .then(
+                    () => {
+                        throw new Error('verify_read_data BLOCKS WERE NOT DELETED');
+                    },
+                    err =>
+                    console.error('verify_read_data EXPECTED ERROR of deleted blocks:', err)
+                )
+            )
+            .then(() => verify_read_mappings(obj_key, obj_data)
+                .then(
+                    () => {
+                        throw new Error('verify_read_mappings BLOCKS WERE NOT DELETED');
+                    },
+                    err =>
+                    console.error('verify_read_mappings EXPECTED ERROR of deleted blocks:', err)
+                )
+            )
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+    function upload_object(key, data, size) {
+        let params = {
+            client: rpc_client,
+            bucket,
+            key,
+            size,
+            content_type: 'application/octet-stream',
+            source_stream: new SliceReader(data),
+        };
+        return P.resolve()
+            .then(() => object_io.upload_object(params))
+            .then(() => verify_read_data(key, data))
+            .then(() => verify_read_mappings(key, size))
+            .then(() => verify_nodes_mappings())
+            .then(() => params.obj_id);
+    }
+
+    function verify_read_mappings(key, size) {
+        const total_frags = 1;
+        const replicas = 3;
+        return rpc_client.object.read_object_mappings({ bucket, key, adminfo: true })
+            .then(({ parts }) => {
+                let pos = 0;
+                parts.forEach(part => {
+                    const { start, end, chunk: { frags } } = part;
+                    assert.strictEqual(start, pos);
+                    pos = end;
+                    assert.strictEqual(frags.length, total_frags);
+                    _.forEach(frags, frag => assert.strictEqual(frag.blocks.length, replicas));
+                    // check blocks don't repeat in the same chunk
+                    const part_blocks = _.flatMap(frags, 'blocks');
+                    const blocks_per_node = _.groupBy(part_blocks, block => block.adminfo.node_name);
+                    _.forEach(blocks_per_node, (b, node_name) => assert.strictEqual(b.length, 1));
+                });
+                assert.strictEqual(pos, size);
+            });
+    }
+
+    function verify_read_data(key, data) {
+        return object_io.read_entire_object({ client: rpc_client, bucket, key })
+            .then(read_buf => {
+                // verify the read buffer equals the written buffer
+                assert.strictEqual(data.length, read_buf.length);
+                for (let i = 0; i < data.length; i++) {
+                    assert.strictEqual(data[i], read_buf[i], `mismatch data at pos ${i}`);
+                }
+            });
+    }
+
+    function verify_nodes_mappings() {
+        return P.all(_.map(nodes_list, node => P.join(
+            rpc_client.object.read_node_mappings({
+                name: node.name,
+                adminfo: true
+            }),
+            rpc_client.object.read_host_mappings({
+                name: `${node.os_info.hostname}#${node.host_seq}`,
+                adminfo: true
+            })
+        )));
+    }
+
+});
+
+
+mocha.describe('mocked agent_blocks_reclaimer', function() {
+
+    mocha.it('should mark reclaimed on deleted nodes', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        const nodes = [{
+            _id: new mongodb.ObjectId(),
+            rpc_address: 'n2n://SlothTown',
+            online: false,
+            deleted: new Date()
+        }];
+        const blocks = [{
+            _id: new mongodb.ObjectId(),
+            node: nodes[0]._id,
+            deleted: new Date()
+        }];
+        const reclaimer_mock =
+            new ReclaimerMock(blocks, nodes, self.test.title);
+        return P.resolve()
+            .then(() => reclaimer_mock.run_agent_blocks_reclaimer())
+            .then(() => {
+                assert(reclaimer_mock.blocks[0].reclaimed, 'Block was not reclaimed');
+                assert(reclaimer_mock.reclaimed_blocks.length === 0, 'Reclaimer sent delete to deleted node');
+            })
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+    mocha.it('should not mark reclaimed on offline nodes', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        const nodes = [{
+            _id: new mongodb.ObjectId(),
+            rpc_address: 'n2n://SlothTown',
+            online: false,
+        }];
+        const blocks = [{
+            _id: new mongodb.ObjectId(),
+            node: nodes[0]._id,
+            deleted: new Date()
+        }];
+        const reclaimer_mock =
+            new ReclaimerMock(blocks, nodes, self.test.title);
+        return P.resolve()
+            .then(() => reclaimer_mock.run_agent_blocks_reclaimer())
+            .then(() => {
+                assert(!reclaimer_mock.blocks[0].reclaimed, 'Block was reclaimed');
+                assert(reclaimer_mock.reclaimed_blocks.length === 0, 'Reclaimer sent delete to offline node');
+            })
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+    mocha.it('should mark reclaimed on non existing nodes', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        const nodes = [{
+            _id: new mongodb.ObjectId(),
+            rpc_address: 'n2n://SlothTown',
+            online: true,
+        }];
+        const blocks = [{
+            _id: new mongodb.ObjectId(),
+            // Non existing node on purpose
+            node: new mongodb.ObjectId(),
+            deleted: new Date()
+        }];
+        const reclaimer_mock =
+            new ReclaimerMock(blocks, nodes, self.test.title);
+        return P.resolve()
+            .then(() => reclaimer_mock.run_agent_blocks_reclaimer())
+            .then(() => {
+                assert(reclaimer_mock.blocks[0].reclaimed, 'Block was not reclaimed');
+                assert(reclaimer_mock.reclaimed_blocks.length === 0, 'Reclaimer sent delete to non existing node');
+            })
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+    mocha.it('should not mark reclaimed on failure to delete', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        const nodes = [{
+            _id: new mongodb.ObjectId(),
+            rpc_address: 'n2n://SlothTown',
+            online: true,
+        }];
+        const blocks = [{
+            _id: new mongodb.ObjectId(),
+            node: nodes[0]._id,
+            deleted: new Date()
+        }, {
+            _id: new mongodb.ObjectId(),
+            node: nodes[0]._id,
+            deleted: new Date(),
+            fail_to_delete: true
+        }];
+        const reclaimer_mock =
+            new ReclaimerMock(blocks, nodes, self.test.title);
+        return P.resolve()
+            .then(() => reclaimer_mock.run_agent_blocks_reclaimer())
+            .then(() => {
+                assert(reclaimer_mock.blocks[0].reclaimed && !reclaimer_mock.blocks[0].fail_to_delete, 'Block was not reclaimed');
+                assert(!reclaimer_mock.blocks[1].reclaimed && reclaimer_mock.blocks[1].fail_to_delete, 'Block was reclaimed on failure to delete');
+                assert(reclaimer_mock.reclaimed_blocks.length === 2, 'Reclaimer did not sent delete to nodes');
+            })
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+});

--- a/src/test/unit_tests/test_agent_blocks_verifier.js
+++ b/src/test/unit_tests/test_agent_blocks_verifier.js
@@ -1,0 +1,293 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('./coretest');
+coretest.setup();
+
+const _ = require('lodash');
+const mocha = require('mocha');
+const assert = require('assert');
+const P = require('../../util/promise');
+const AgentBlocksVerifier = require('../../server/bg_services/agent_blocks_verifier').AgentBlocksVerifier;
+const mongo_utils = require('../../util/mongo_utils');
+const mongodb = require('mongodb');
+const config = require('../../../config');
+
+class VerifierMock extends AgentBlocksVerifier {
+
+    constructor(blocks = [], nodes = [], chunks = [], chunk_coder_configs = [], test_suffix = '') {
+        super(`VerifierMock-${test_suffix}`);
+        console.log('VerifierMock INIT', test_suffix, blocks, nodes, chunks, chunk_coder_configs);
+        this.blocks = blocks;
+        this.nodes = nodes;
+        this.chunks = chunks;
+        this.chunk_coder_configs = chunk_coder_configs;
+        this.verified_blocks = [];
+    }
+
+    iterate_all_blocks(marker, limit, deleted_only) {
+        assert(marker === undefined || marker === null || this.is_valid_md_id(marker),
+            'Marker not null or valid ObjectId');
+        assert(limit === config.AGENT_BLOCKS_VERIFIER_BATCH_SIZE, 'Wrong verifier config limit');
+        assert(deleted_only === false, 'Verifier should check only non deleted and non reclaimed blocks');
+        // TODO: Pay attention to marker and limit
+        return P.resolve(this.blocks.filter(block => (deleted_only ? block.deleted : !block.deleted)));
+    }
+
+    is_valid_md_id(id_str) {
+        return mongodb.ObjectId.isValid(id_str);
+    }
+
+    get_by_id(id_str) {
+        return this.chunk_coder_configs.find(coder => String(coder._id) === String(id_str));
+    }
+
+    populate_chunks(docs, doc_path, fields) {
+        assert(doc_path === 'chunk', 'Verifier should only send populate to chunk property of block');
+        assert(fields &&
+            _.difference(Object.keys(fields), ['frags', 'chunk_config']).length === 0,
+            'Verifier should only send fields with frags and chunk_config');
+
+        const docs_list = docs && !_.isArray(docs) ? [docs] : docs;
+        const ids = mongo_utils.uniq_ids(docs_list, doc_path);
+        if (!ids.length) return P.resolve(docs);
+
+        return P.resolve()
+            .then(() => this.chunks.filter(chunk =>
+                _.includes(ids.map(chunk_id => String(chunk_id)), String(chunk._id))))
+            .then(chunks => {
+                const idmap = _.keyBy(chunks, '_id');
+                _.each(docs_list, doc => {
+                    const id = _.get(doc, doc_path);
+                    const chunk = idmap[String(id)];
+                    if (chunk) {
+                        mongo_utils.fix_id_type(chunk);
+                        _.set(doc, doc_path, chunk);
+                    } else {
+                        console.warn('populate_chunks: missing chunk for id',
+                            id, 'DOC', doc, 'IDMAP', _.keys(idmap));
+                    }
+                });
+                return docs;
+            })
+            .catch(err => {
+                console.error('populate_chunks: ERROR', err.stack);
+                throw err;
+            });
+    }
+
+    populate_nodes_for_blocks(blocks) {
+        const docs = blocks;
+        const doc_path = 'node';
+        const docs_list = docs && !_.isArray(docs) ? [docs] : docs;
+        const ids = mongo_utils.uniq_ids(docs_list, doc_path);
+        if (!ids.length) return P.resolve(docs);
+
+        return P.resolve()
+            .then(() => this.nodes.filter(node => !node.deleted &&
+                _.includes(ids.map(node_id => String(node_id)), String(node._id))))
+            .then(nodes => {
+                const idmap = _.keyBy(nodes, '_id');
+                _.each(docs_list, doc => {
+                    const id = _.get(doc, doc_path);
+                    const node = idmap[String(id)];
+                    if (node) {
+                        mongo_utils.fix_id_type(node);
+                        _.set(doc, doc_path, node);
+                    } else {
+                        console.warn('populate_nodes: missing node for id',
+                            id, 'DOC', doc, 'IDMAP', _.keys(idmap));
+                    }
+                });
+                return docs;
+            })
+            .catch(err => {
+                console.error('populate_nodes: ERROR', err.stack);
+                throw err;
+            });
+    }
+
+    verify_blocks(rpc_params, target_params) {
+        assert(target_params &&
+            _.difference(Object.keys(target_params), ['address', 'timeout']).length === 0,
+            'Verifier should only send to address with timeout');
+        assert(rpc_params &&
+            _.difference(Object.keys(rpc_params), ['verify_blocks']).length === 0,
+            'Verifier should only have verify_blocks in parameters');
+
+        const block_ids = rpc_params.verify_blocks.map(block => {
+            assert(this.is_valid_md_id(block.id), 'Block id not valid ObjectId');
+            assert(block.address, 'Block id without node address');
+            assert(block.digest_type, 'Block without digest_type');
+            assert(block.digest_b64, 'Block without digest_b64');
+            return block.id;
+        });
+        this.verified_blocks = _.concat(this.verified_blocks, block_ids);
+        console.log('verify_blocks', block_ids, 'node', target_params.address);
+        return P.resolve();
+    }
+
+}
+
+
+mocha.describe('mocked agent_blocks_verifier', function() {
+
+    mocha.it('should verify blocks on nodes', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        const nodes = [{
+            _id: new mongodb.ObjectId(),
+            rpc_address: 'n2n://SlothTown',
+            online: true,
+        }];
+        const chunk_coder_configs = [{
+            _id: new mongodb.ObjectId(),
+            chunk_coder_config: {
+                frag_digest_type: 'sloth_type'
+            }
+        }];
+        const chunks = [{
+            _id: new mongodb.ObjectId(),
+            frags: [{
+                _id: new mongodb.ObjectId(),
+                digest: 'sloth_digest'
+            }],
+            chunk_config: chunk_coder_configs[0]._id
+        }];
+        const blocks = [{
+            _id: new mongodb.ObjectId(),
+            node: nodes[0]._id,
+            frag: chunks[0].frags[0]._id,
+            chunk: chunks[0]._id
+        }];
+        const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
+        return P.resolve()
+            .then(() => verifier_mock.run_agent_blocks_verifier())
+            .then(() => {
+                assert(verifier_mock.verified_blocks.length === 1, self.test.title);
+            })
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+    mocha.it('should not verify blocks on deleted nodes', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        const nodes = [{
+            _id: new mongodb.ObjectId(),
+            rpc_address: 'n2n://SlothTown',
+            online: false,
+            deleted: new Date()
+        }];
+        const chunk_coder_configs = [{
+            _id: new mongodb.ObjectId(),
+            chunk_coder_config: {
+                frag_digest_type: 'sloth_type'
+            }
+        }];
+        const chunks = [{
+            _id: new mongodb.ObjectId(),
+            frags: [{
+                _id: new mongodb.ObjectId(),
+                digest: 'sloth_digest'
+            }],
+            chunk_config: chunk_coder_configs[0]._id
+        }];
+        const blocks = [{
+            _id: new mongodb.ObjectId(),
+            node: nodes[0]._id,
+            frag: chunks[0].frags[0]._id,
+            chunk: chunks[0]._id
+        }];
+        const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
+        return P.resolve()
+            .then(() => verifier_mock.run_agent_blocks_verifier())
+            .then(() => {
+                assert(verifier_mock.verified_blocks.length === 0, self.test.title);
+            })
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+    mocha.it('should not verify blocks on offline nodes', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        const nodes = [{
+            _id: new mongodb.ObjectId(),
+            rpc_address: 'n2n://SlothTown',
+            online: false,
+        }];
+        const chunk_coder_configs = [{
+            _id: new mongodb.ObjectId(),
+            chunk_coder_config: {
+                frag_digest_type: 'sloth_type'
+            }
+        }];
+        const chunks = [{
+            _id: new mongodb.ObjectId(),
+            frags: [{
+                _id: new mongodb.ObjectId(),
+                digest: 'sloth_digest'
+            }],
+            chunk_config: chunk_coder_configs[0]._id
+        }];
+        const blocks = [{
+            _id: new mongodb.ObjectId(),
+            node: nodes[0]._id,
+            frag: chunks[0].frags[0]._id,
+            chunk: chunks[0]._id
+        }];
+        const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
+        return P.resolve()
+            .then(() => verifier_mock.run_agent_blocks_verifier())
+            .then(() => {
+                assert(verifier_mock.verified_blocks.length === 0, self.test.title);
+            })
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+    mocha.it('should not verify blocks on non existing nodes', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        const nodes = [{
+            _id: new mongodb.ObjectId(),
+            rpc_address: 'n2n://SlothTown',
+            online: true,
+        }];
+        const chunk_coder_configs = [{
+            _id: new mongodb.ObjectId(),
+            chunk_coder_config: {
+                frag_digest_type: 'sloth_type'
+            }
+        }];
+        const chunks = [{
+            _id: new mongodb.ObjectId(),
+            frags: [{
+                _id: new mongodb.ObjectId(),
+                digest: 'sloth_digest'
+            }],
+            chunk_config: chunk_coder_configs[0]._id
+        }];
+        const blocks = [{
+            _id: new mongodb.ObjectId(),
+            node: new mongodb.ObjectId(),
+            frag: chunks[0].frags[0]._id,
+            chunk: chunks[0]._id
+        }];
+        const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
+        return P.resolve()
+            .then(() => verifier_mock.run_agent_blocks_verifier())
+            .then(() => {
+                assert(verifier_mock.verified_blocks.length === 0, self.test.title);
+            })
+            .catch(err => {
+                console.error(err, err.stack);
+                throw err;
+            });
+    });
+
+});

--- a/src/tools/gridfs_stress.js
+++ b/src/tools/gridfs_stress.js
@@ -1,0 +1,67 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const mongodb = require('mongodb');
+
+var global_id = 0;
+const WRITE_SIZE = 4 * 1024 * 1024;
+const COLL = 'gridfs_stress';
+const CHUNKS_COLL = `${COLL}.chunks`;
+const FILES_COLL = `${COLL}.files`;
+const CHUNK_SIZE = undefined; // Default value is: 256 * 1024;
+const GRID_FS_CHUNK_COLLECTION_OPTIONS = {
+    storageEngine: {
+        wiredTiger: {
+            configString: "memory_page_max=512,os_cache_dirty_max=1,os_cache_max=1"
+        }
+    }
+};
+
+// gridfs_stress's whole purpose is to check capabilities and limits of GridFS
+// we simulate a clean enviroment for GridFS with same configurations as on our md servers
+// this is done in order to find benchmarks that we could compare with our server's implementation
+function write_gridfs_file(bucket) {
+    return new Promise((resolve, reject) => {
+
+        const fname = `gridfs_stress_${Date.now()}_${global_id}`;
+        global_id += 1;
+
+        const data = Buffer.alloc(WRITE_SIZE, 'J');
+
+        console.log('writing', fname, 'size', data.length);
+
+        const stream = bucket.openUploadStream(fname);
+        stream.once('error', reject)
+            .once('finish', resolve)
+            .end(data);
+    });
+}
+
+async function write_gridfs_files(bucket) {
+    for (let i = 0; i < 50; ++i) {
+        await write_gridfs_file(bucket);
+    }
+}
+
+async function gridfs_stress(db) {
+    const bucket = new mongodb.GridFSBucket(db, {
+        bucketName: COLL,
+        chunkSizeBytes: CHUNK_SIZE,
+    });
+    await db.dropCollection(CHUNKS_COLL);
+    await db.dropCollection(FILES_COLL);
+    await db.createCollection(CHUNKS_COLL, GRID_FS_CHUNK_COLLECTION_OPTIONS);
+    await db.createCollection(FILES_COLL);
+
+    await Promise.all(
+        new Array(35).fill(1).map(() => write_gridfs_files(bucket))
+    );
+}
+
+async function main() {
+    const db = await mongodb.MongoClient.connect('mongodb://localhost/test');
+    await gridfs_stress(db);
+    await db.close();
+}
+
+main();

--- a/src/tools/mem_grabber.js
+++ b/src/tools/mem_grabber.js
@@ -1,0 +1,21 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const crypto = require('crypto');
+const argv = require('minimist')(process.argv);
+const size = argv.size_mb;
+var cipher = crypto.createCipheriv('aes-128-gcm', crypto.randomBytes(16), crypto.randomBytes(12));
+var zero_buf = Buffer.alloc(1024 * 1024);
+
+let arr = [];
+for (let index = 0; index < size; index++) {
+    var buffer = cipher.update(zero_buf);
+    arr.push(buffer);
+}
+
+// mem_grabber's whole purpose is to lock logical memory (RAM)
+// size_mb - marks how many megabytes of RAM the process should lock
+// Do not forget that there is a limit for node process RAM locking which you cannot exceed 
+setInterval(() => {
+    console.log('RUNNING LOOP');
+}, 60000);

--- a/src/util/pipeline.js
+++ b/src/util/pipeline.js
@@ -20,7 +20,7 @@ class Pipeline {
         });
         this._input = input;
         this._pipes = [];
-        input.once('close', () => this.close());
+        input.once('close', () => this.close(new Error('INPUT STREAM CLOSED UNEXPECTEDLY')));
         input.on('error', err => this.close(err));
     }
 
@@ -46,6 +46,8 @@ class Pipeline {
     }
 
     close(err) {
+        if (this._closed) return;
+        this._closed = true;
         err = err || new Error('pipeline closed');
         this._reject(err);
         this._pipes.forEach(strm => strm.emit('close'));


### PR DESCRIPTION
### Explain the changes:
- Added agent blocks reclaimer:
1) It reclaims blocks on online / deleted / nonexisting agents
2) Blocks on agents that are offline are not going to be reclaimed until the agent comes back online
3) It only cycles deleted and not reclaimed blocks
- Added agent blocks verifier:
1) It will verify both block data and block metadata on online agents
2) It will print in the agent in case of errors but still won't do any action or report

### Issues: Fixed / Gap #xxx
- Fixed #2114 
- Fixed #4114 
- Fixed #4172 
- Fixed #3223 
- Fixed #2104 

### Testing Instructions:
- mocha src/test/unit_tests/test_agent_blocks_reclaimer.js
- mocha src/test/unit_tests/test_agent_blocks_verifier.js

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
