### PR TITLE
Addition of KMEANS and smart drive selection on allocations

### DIFF
--- a/config.js
+++ b/config.js
@@ -31,6 +31,8 @@ config.NODE_IO_DETENTION_TEST_NODES = 2;
 
 config.HOSTED_AGENTS_HOST_ID = 'hosted_agents';
 
+config.SSD_LATENCY_MS = 1;
+
 ////////////////
 // RPC CONFIG //
 ////////////////

--- a/config.js
+++ b/config.js
@@ -31,7 +31,7 @@ config.NODE_IO_DETENTION_TEST_NODES = 2;
 
 config.HOSTED_AGENTS_HOST_ID = 'hosted_agents';
 
-config.SSD_LATENCY_MS = 1;
+config.NODE_ALLOCATOR_NUM_CLUSTERS = 2;
 
 ////////////////
 // RPC CONFIG //

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -342,12 +342,21 @@ module.exports = {
             },
             reply: {
                 type: 'object',
-                required: ['nodes'],
+                required: ['latency_groups'],
                 properties: {
-                    nodes: {
+                    latency_groups: {
                         type: 'array',
                         items: {
-                            $ref: '#/definitions/node_info'
+                            type: 'object',
+                            required: ['nodes'],
+                            properties: {
+                                nodes: {
+                                    type: 'array',
+                                    items: {
+                                        $ref: '#/definitions/node_info'
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -24,7 +24,6 @@ const NODE_FIELDS_FOR_MAP = [
     'writable',
     'storage_full',
     'latency_of_disk_read',
-    'latency_of_disk_write',
     // ... more?
 ];
 
@@ -210,7 +209,7 @@ class NodesClient {
                     role: 'admin'
                 })
             }))
-            .tap(res => mongo_utils.fix_id_type(res.nodes));
+            .tap(res => res.latency_groups.forEach(group => mongo_utils.fix_id_type(group.nodes)));
     }
 
     // TODO: Fields doesn't seem to filter and work

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -24,6 +24,7 @@ const NODE_FIELDS_FOR_MAP = [
     'writable',
     'storage_full',
     'latency_of_disk_read',
+    'latency_of_disk_write',
     // ... more?
 ];
 

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -23,6 +23,7 @@ require('./test_v8_optimizations');
 require('./test_ssl_utils');
 require('./test_zip_utils');
 require('./test_wait_queue');
+require('./test_kmeans');
 // require('./test_debug_module');
 
 // STORES
@@ -46,6 +47,7 @@ require('./test_agent_blocks_reclaimer');
 require('./test_s3_ops');
 require('./test_s3_list_objects');
 require('./test_nb_native_b64');
+require('./test_node_allocator');
 
 // SERVERS
 require('./test_agent');

--- a/src/test/unit_tests/test_kmeans.js
+++ b/src/test/unit_tests/test_kmeans.js
@@ -1,0 +1,128 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+const mocha = require('mocha');
+const assert = require('assert');
+const kmeans = require('../../util/kmeans');
+
+mocha.describe('kmeans errors', function() {
+
+    mocha.it('should throw an error if there aren\'t 2 arguments', () => {
+        let was_thrown = false;
+        try {
+            kmeans.run();
+        } catch (err) {
+            was_thrown = true;
+        }
+        assert(was_thrown, 'should throw an error if there aren\'t 2 arguments');
+    });
+
+    mocha.it('should throw an error if there isn\'t options', () => {
+        let was_thrown = false;
+        try {
+            kmeans.run([]);
+        } catch (err) {
+            was_thrown = true;
+        }
+        assert(was_thrown, 'should throw an error if there isn\'t options');
+    });
+
+    mocha.it('should throw an error if K isn\'t in options', () => {
+        let was_thrown = false;
+        try {
+            kmeans.run([], { sloth: 1 });
+        } catch (err) {
+            was_thrown = true;
+        }
+        assert(was_thrown, 'should throw an error if K isn\'t in options');
+    });
+
+    mocha.it('should throw an error if K isn\'t in good range', () => {
+        let was_thrown = false;
+        try {
+            kmeans.run([], { k: 0 });
+        } catch (err) {
+            was_thrown = true;
+        }
+        assert(was_thrown, 'should throw an error if K isn\'t in good range');
+    });
+
+    mocha.it('should throw an error if K larger than number of vectors', () => {
+        let was_thrown = false;
+        try {
+            kmeans.run([], { k: 1 });
+        } catch (err) {
+            was_thrown = true;
+        }
+        assert(was_thrown, 'should throw an error if K larger than number of vectors');
+    });
+
+    mocha.it('should throw an error if distance isn\'t a function', () => {
+        let was_thrown = false;
+        try {
+            kmeans.run([1], { k: 1, distance: {} });
+        } catch (err) {
+            was_thrown = true;
+        }
+        assert(was_thrown, 'should throw an error if distance isn\'t a function');
+    });
+
+    mocha.it('should throw an error if distance isn\'t a function with 2 parameters', () => {
+        let was_thrown = false;
+        try {
+            kmeans.run([1], { k: 1, distance: (a, b, c) => (a + b + c) });
+        } catch (err) {
+            was_thrown = true;
+        }
+        assert(was_thrown, 'should throw an error if distance isn\'t a function with 2 parameters');
+    });
+
+});
+
+mocha.describe('kmeans working', function() {
+
+    mocha.it('handle noise in vector', () => {
+        const result = kmeans.run([
+            [26],
+            [4],
+            [1992],
+            [9999]
+        ], { k: 2 });
+
+        const expected_response = [{
+                centroid: [674],
+                cluster: [
+                    [26],
+                    [4],
+                    [1992],
+                ],
+                clusterInd: [0, 1, 2]
+            },
+            {
+                centroid: [9999],
+                cluster: [
+                    [9999]
+                ],
+                clusterInd: [3]
+            }
+        ];
+
+        const noise_cluster = _.find(result, cluster => _.isEmpty(_.difference(cluster.centroid, expected_response[1].centroid)));
+        const regular_cluster = _.find(result, cluster => _.isEmpty(_.difference(cluster.centroid, expected_response[0].centroid)));
+
+        assert(result.length === 2, 'KMEANS did not divide to two clusters');
+        assert(noise_cluster, 'KMEANS did not create a noise cluster with expected centroid');
+        assert(regular_cluster, 'KMEANS did not create a regular cluster with expected centroid');
+        assert(_.isEmpty(_.difference(noise_cluster.clusterInd, expected_response[1].clusterInd)),
+            'KMEANS did not create a noise cluster with expected vectors');
+        assert(_.isEmpty(_.difference(regular_cluster.clusterInd, expected_response[0].clusterInd)),
+            'KMEANS did not create a regular cluster with expected vectors');
+        assert(_.isEmpty(_.difference(_.flatten(noise_cluster.cluster), _.flatten(expected_response[1].cluster))),
+            'KMEANS did not create a noise cluster with expected vectors');
+        assert(_.isEmpty(_.difference(_.flatten(regular_cluster.cluster), _.flatten(expected_response[0].cluster))),
+            'KMEANS did not create a regular cluster with expected vectors');
+
+    });
+
+});

--- a/src/test/unit_tests/test_node_allocator.js
+++ b/src/test/unit_tests/test_node_allocator.js
@@ -1,0 +1,58 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('./coretest');
+coretest.setup();
+
+const _ = require('lodash');
+const mocha = require('mocha');
+const system_store = require('../../server/system_services/system_store').get_instance();
+const assert = require('assert');
+const config = require('../../../config');
+const P = require('../../util/promise');
+
+const NODE_FIELDS_FOR_MAP = [
+    'name',
+    'pool',
+    'ip',
+    'host_id',
+    'heartbeat',
+    'rpc_address',
+    'is_cloud_node',
+    'node_type',
+    'is_mongo_node',
+    'online',
+    'readable',
+    'writable',
+    'storage_full',
+    'latency_of_disk_read',
+    // ... more?
+];
+
+mocha.describe('node_allocator', function() {
+
+    const { rpc_client } = coretest;
+
+    mocha.it('kmeans divided to groups', function() {
+        this.timeout(40000); // eslint-disable-line no-invalid-this
+
+        return P.resolve()
+            .then(() => system_store.data.pools.find(pool => pool.name === 'first.pool'))
+            .then(pool => P.join(
+                rpc_client.node.allocate_nodes({ pool_id: String(pool._id), fields: NODE_FIELDS_FOR_MAP }),
+                rpc_client.node.list_nodes({
+                    query: {
+                        pools: [pool.name]
+                    }
+                })
+            ))
+            .spread((allocation, pool_nodes) => {
+                assert(allocation.latency_groups.length === config.NODE_ALLOCATOR_NUM_CLUSTERS, 'KMEANS did not divide to correct K number of groups');
+                assert(_.every(allocation.latency_groups, group => group.nodes.length), 'KMEANS groups should have nodes');
+                assert(_.reduce(allocation.latency_groups, (sum, group) => sum + group.nodes.length, 0) === pool_nodes.total_count, 'KMEANS groups should have all nodes');
+            });
+
+    });
+
+});

--- a/src/util/kmeans.js
+++ b/src/util/kmeans.js
@@ -1,0 +1,224 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+/*
+Synchronous implementation of the k-means clustering algorithm.
+
+The kmeans function takes as input the number k of clusters and a list of N
+input vectors and it outputs an object with two attributes:
+  - centroids: an Array of k vectors containing the centroid of each cluster
+  - assignments: An Array of size N representing for each input vector the
+    index of the cluster
+
+The kmeans will return an error if:
+  - N < k
+  - The number of different input vectors is smaller than k
+*/
+
+const _ = require('lodash');
+
+/**
+ * Compute the Euclidean distance
+ *
+ * @param {Array} a
+ * @param {Array} b
+ * @api private
+ */
+
+function euclidianDistance(a, b) {
+    if (a.length !== b.length) {
+        return (new Error('The vectors must have the same length'));
+    }
+    let d = 0.0;
+    for (let i = 0, max = a.length; i < max; ++i) {
+        d += Math.pow((a[i] - b[i]), 2);
+    }
+    return Math.sqrt(d);
+}
+
+class Group {
+    constructor() {
+        this.centroidMoved = true;
+    }
+
+    initCluster() {
+        this.cluster = []; // dimensions
+        this.clusterInd = []; // index
+    }
+
+    /**
+     * Define Centroid
+     *  - if they exist, calculate the new position
+     *  - otherwise, randomly choose one existing item
+     */
+    defineCentroid(indexes, v) {
+        this.centroidOld = (this.centroid) ? this.centroid : [];
+        if (this.centroid && this.cluster.length > 0) {
+            this.calculateCentroid();
+        } else { // random selection
+            const i = Math.floor(Math.random() * indexes.length);
+            this.centroidIndex = indexes[i];
+            indexes.splice(i, 1);
+            this.centroid = [];
+            if (_.isArray(v[this.centroidIndex])) {
+                for (let j = 0, max = v[this.centroidIndex].length; j < max; ++j) {
+                    this.centroid[j] = v[this.centroidIndex][j];
+                }
+            } else { // only one dimension
+                this.centroid[0] = v[this.centroidIndex];
+            }
+        }
+        // Centroid has moved if old value != new value
+        this.centroidMoved = !_.isEqual(this.centroid, this.centroidOld);
+    }
+
+    calculateCentroid() {
+        this.centroid = [];
+        for (let i = 0; i < this.cluster.length; ++i) { // loop through the cluster elements
+            for (let j = 0, max = this.cluster[i].length; j < max; ++j) { // loop through the dimensions
+                this.centroid[j] = this.centroid[j] ?
+                    this.centroid[j] + this.cluster[i][j] :
+                    this.cluster[i][j];
+            }
+        }
+        for (let i = 0, max = this.centroid.length; i < max; ++i) {
+            this.centroid[i] = this.centroid[i] / this.cluster.length; // average
+        }
+        return this;
+    }
+
+    distanceObjects(v, distanceFunction) {
+        if (!this.distances) {
+            this.distances = [];
+        }
+        for (let i = 0, max = v.length; i < max; ++i) {
+            this.distances[i] = distanceFunction(this.centroid, v[i]);
+        }
+    }
+}
+
+class Clusterize {
+    constructor(vector, options) {
+        if (!options || !vector) {
+            throw new Error('Provide 2 arguments: vector, options');
+        }
+        if (!options || !options.k || options.k < 1) {
+            throw new Error('Provide a correct number k of clusters');
+        }
+        if (options.distance &&
+            (typeof options.distance !== 'function' || options.distance.length !== 2)) {
+            throw new Error('options.distance must be a function with two arguments');
+        }
+        if (!_.isArray(vector)) {
+            throw new Error('Provide an array of data');
+        }
+
+        this.options = options;
+        this.v = this.checkV(vector);
+        this.k = this.options.k;
+        this.distanceFunction = this.options.distance || euclidianDistance;
+        if (this.v.length < this.k) {
+            const errMessage = `The number of points must be greater than
+      the number k of clusters`;
+            throw new Error(errMessage);
+        }
+
+        this.initialize(); // initialize the group arrays
+
+    }
+
+    iterate(first_step) {
+        if (first_step) this.moved = -1;
+        if (this.moved === 0) {
+            return this.output(); // converged if 0 centroid has moved
+        }
+        this.moved = 0;
+        for (let i = 0, max = this.groups.length; i < max; ++i) {
+            this.groups[i].defineCentroid(this.indexes, this.v); // define the new centroids
+            this.groups[i].distanceObjects(this.v, this.distanceFunction); // distances from centroids to items
+        }
+        this.clustering(); // clustering by choosing the centroid the closest of each item
+        for (let i = 0, max = this.groups.length; i < max; ++i) {
+            // check how many centroids have moved in this iteration
+            if (this.groups[i].centroidMoved) {
+                this.moved += 1;
+            }
+        }
+        return this.iterate();
+    }
+
+    checkV(v) {
+        let dim = 1;
+        if (_.isArray(v[0])) {
+            dim = v[0].length;
+        }
+        for (let i = 0, max = v.length; i < max; ++i) {
+            if (_.isArray(v[i])) {
+                if (v[i].length !== dim) {
+                    throw new Error('All the elements must have the same dimension');
+                }
+                for (let j = 0, max2 = v[i].length; j < max2; ++j) {
+                    v[i][j] = Number(v[i][j]);
+                    if (isNaN(v[i][j])) {
+                        throw new Error('All the elements must be float type');
+                    }
+                }
+            } else {
+                if (dim !== 1) {
+                    throw new Error('All the elements must have the same dimension');
+                }
+                v[i] = Number(v[i]);
+                if (isNaN(v[i])) {
+                    throw new Error('All the elements must be float type');
+                }
+            }
+        }
+        return v;
+    }
+
+    initialize() {
+        this.groups = [];
+        for (let i = 0, max = this.k; i < max; ++i) {
+            this.groups[i] = new Group(this);
+        }
+        this.indexes = []; // used to choose randomly the initial centroids
+        for (let i = 0, max = this.v.length; i < max; ++i) {
+            this.indexes[i] = i;
+        }
+        return this;
+    }
+
+    clustering() {
+        for (let j = 0, max = this.groups.length; j < max; ++j) {
+            this.groups[j].initCluster();
+        }
+        for (let i = 0, max = this.v.length; i < max; ++i) {
+            let min = this.groups[0].distances[i];
+            let indexGroup = 0;
+            for (let j = 1, max2 = this.groups.length; j < max2; ++j) {
+                if (this.groups[j].distances[i] < min) {
+                    min = this.groups[j].distances[i];
+                    indexGroup = j;
+                }
+            }
+            this.groups[indexGroup].cluster.push(this.v[i]);
+            this.groups[indexGroup].clusterInd.push(i);
+        }
+        return this;
+    }
+
+    output() {
+        const out = [];
+        for (let j = 0, max = this.groups.length; j < max; ++j) {
+            out[j] = _.pick(this.groups[j], 'centroid', 'cluster', 'clusterInd');
+        }
+        return out;
+    }
+}
+
+function run(vector, options) {
+    const clusters = new Clusterize(vector, options);
+    return clusters.iterate(true); /* first_step = true */
+}
+
+exports.run = run;


### PR DESCRIPTION
### Explain the changes:
- Addition of KMEANS algorithm
- Working support for K drive clusters for allocation priority

### Issues: Fixed / Gap #xxx
- We merge the KMEANS of each pool in pool_sets and break the clusterization (see comment in the code for example).
This is because we allocate from pool_sets and not fro single pools.
- There is no handling for noise in our KMEANS vectors (nodes with noisy average of write)

### Testing Instructions:
- mocha src/test/unit_tests/test_kmeans.js
- mocha src/test/unit_tests/test_node_allocator.js

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
