### PR TITLE
Fixed issue: clicking "My Connections" link from modal, doesn't close modal

### DIFF
--- a/frontend/src/app/epics/close-modals-on-location-change.js
+++ b/frontend/src/app/epics/close-modals-on-location-change.js
@@ -1,0 +1,10 @@
+/* Copyright (C) 2018 NooBaa */
+
+import { CHANGE_LOCATION } from 'action-types';
+import { closeModal } from 'action-creators';
+
+export default function(action$) {
+    return action$
+        .ofType(CHANGE_LOCATION)
+        .map(() => closeModal(Number.POSITIVE_INFINITY));
+}

--- a/frontend/src/app/epics/index.js
+++ b/frontend/src/app/epics/index.js
@@ -62,13 +62,15 @@ import updateServerAddress from './update-server-address';
 import updateBucketS3Access from './update-bucket-s3-access';
 import deleteCloudSyncPolicy from './delete-cloud-sync-policy';
 import toggleCloudSyncPolicy from './toggle-cloud-sync-policy';
+import closeModalsOnLocationChange from './close-modals-on-location-change';
 
 const generalEpics = [
     handleLocationRequests,
     notify,
     downloadFile,
     fetchCloudTargets,
-    reloadAfterSystemUpgrade
+    reloadAfterSystemUpgrade,
+    closeModalsOnLocationChange
 ];
 
 const sessionRelatedEpics = [


### PR DESCRIPTION
### Explain the changes:
- clicking "My Connections" link from "Create Namespace Resource" modal does not close the modal


### Issues: Fixed / Gap #xxx
- fixed #4304

### Testing Instructions:
1. Go to overview page
2. open Connect an Application modal
3. click bottom link Accounts
4. modal closed and page redirected to accounts 

1.go to resources
2. select Namespace resources tab
3. open Create Namespace Resource modal
4. click the bottom link My connections
5. modal closed and page redirected to My connections  

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
