### PR TITLE
Data availability test update: added tier config and ability to use existing env 

### DIFF
--- a/src/test/qa/data_availability_test.js
+++ b/src/test/qa/data_availability_test.js
@@ -191,6 +191,7 @@ return azf.authenticate()
         if ((use_existing_env) && (res)) {
             let agents = new Map();
             let createdAgents = af.getRandomOsesFromList(agents_number, osesSet);
+            //Reemoving existing agents from the map
             for (let i = 0; i < createdAgents.length; i++) {
                 agents.set(suffix + i, createdAgents[i]);
             }


### PR DESCRIPTION
### Explain the changes:

- Added bucket tier configuration
- Added ability to use existing nodes
- Added ability to deal with more agents then oses
- On cleanup agents removed not only from Azure but from from server also 

### Issues: Fixed / Gap #xxx

### Testing Instructions:
- Run script several times with  --use_existing_env  true to check that agents are not created each time if they are already created by previous run
- Run script with  --use_existing_env  false to check agents cleanup 
- Run with different tier configurations (--data_frags, --parity_frags,  --replicas  parameters) 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages