### PR TITLE
Fixed: Wrong view of files (or worst) after unsuccessful upload

### DIFF
--- a/frontend/src/app/reducers/objects-reducer.js
+++ b/frontend/src/app/reducers/objects-reducer.js
@@ -43,7 +43,7 @@ function onCompleteFetchObjects(state, { payload }) {
     const { response } = payload;
     const items = keyBy(
         response.objects,
-        obj => getObjectId(obj.bucket, obj.key, obj.uploadId),
+        obj => getObjectId(obj.bucket, obj.key, _getUploadId(obj)),
         _mapObject
     );
 
@@ -93,7 +93,7 @@ function onDropObjectsView(state, { payload }) {
 
 function _mapObject(obj) {
     const mode = obj.upload_started ? 'UPLOADING' : 'OPTIMAL';
-    const uploadId = mode === 'UPLOADING' ? obj.obj_id : undefined;
+    const uploadId = _getUploadId(obj);
     const { reads = 0, last_read } = obj.stats || {};
 
     return {
@@ -112,6 +112,10 @@ function _mapObject(obj) {
         partCount: obj.num_parts,
         s3SignedUrl: obj.s3_signed_url
     };
+}
+
+function _getUploadId(obj) {
+    return obj.upload_started ? obj.obj_id : undefined;
 }
 
 // ------------------------------


### PR DESCRIPTION
### Explain the changes:
- Wrong view of files (or worst) after unsuccessful upload

### Issues: Fixed / Gap #xxx
- fixed: #4445 

### Testing Instructions:
1. go to bucket 
2. select files tab
3. upload file 
4. uploaded file displayed with status healthy
5. try upload same file again and refresh page during the uploading process
6. now you can see 2 files one Healthy and second Uploading status

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
