### PR TITLE
Patch to work without body sign on http s3 compatible connections

### DIFF
--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -51,6 +51,7 @@ class BlockStoreS3 extends BlockStoreBase {
                 accessKeyId: this.cloud_info.access_keys.access_key,
                 secretAccessKey: this.cloud_info.access_keys.secret_key,
                 signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint),
+                s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(endpoint),
                 httpOptions: {
                     agent: http_utils.get_unsecured_http_agent(endpoint, this.proxy)
                 }

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -166,7 +166,7 @@ class ObjectSDK {
                 signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(ns_info.endpoint),
                 s3ForcePathStyle: true,
                 // computeChecksums: false, // disabled by default for performance
-                // s3DisableBodySigning: true, // disabled by default for performance
+                s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(ns_info.endpoint),
                 httpOptions
             });
         }

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -154,9 +154,9 @@ class ObjectSDK {
         }
         if (ns_info.endpoint_type === 'AWS' ||
             ns_info.endpoint_type === 'S3_COMPATIBLE') {
-            const httpOptions = ns_info.proxy ? {
+            const httpOptions = (ns_info.endpoint_type === 'AWS' && !ns_info.proxy) ? undefined : {
                 agent: http_utils.get_unsecured_http_agent(ns_info.endpoint, ns_info.proxy)
-            } : undefined;
+            };
             return new NamespaceS3({
                 params: { Bucket: ns_info.target_bucket },
                 endpoint: ns_info.endpoint,

--- a/src/server/bg_services/cloud_sync.js
+++ b/src/server/bg_services/cloud_sync.js
@@ -423,6 +423,7 @@ function load_single_policy(bucket_id, system_id) {
             accessKeyId: policy.access_keys.access_key,
             secretAccessKey: policy.access_keys.secret_key,
             signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(policy.endpoint),
+            s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(policy.endpoint),
             httpOptions: {
                 agent: get_shared_http_agent(policy.endpoint)
             }

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -744,6 +744,7 @@ function check_aws_connection(params) {
         accessKeyId: params.identity,
         secretAccessKey: params.secret,
         signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(params.endpoint),
+        s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(params.endpoint),
         httpOptions: {
             agent: http_utils.get_unsecured_http_agent(params.endpoint, params.proxy)
         }

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -793,6 +793,7 @@ function get_cloud_buckets(req) {
                 accessKeyId: connection.access_key,
                 secretAccessKey: connection.secret_key,
                 signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(connection.endpoint),
+                s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(connection.endpoint),
                 httpOptions: {
                     agent: http_utils.get_unsecured_http_agent(connection.endpoint, proxy)
                 }

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -32,6 +32,7 @@ function get_signed_url(params) {
         s3ForcePathStyle: true,
         sslEnabled: false,
         signatureVersion: get_s3_endpoint_signature_ver(params.endpoint),
+        s3DisableBodySigning: disable_s3_compatible_bodysigning(params.endpoint),
         region: 'eu-central-1',
         httpOptions: {
             agent: agent
@@ -66,6 +67,12 @@ function is_aws_endpoint(endpoint) {
     const endpoint_url = url.parse(endpoint);
     const is_aws = endpoint_url.host && endpoint_url.host.endsWith('amazonaws.com');
     return is_aws;
+}
+
+function disable_s3_compatible_bodysigning(endpoint) {
+    const endpoint_url = url.parse(endpoint);
+    const disable_sign = Boolean(!is_aws_endpoint(endpoint) && endpoint_url.protocol === 'http:');
+    return disable_sign;
 }
 
 function get_s3_endpoint_signature_ver(endpoint) {
@@ -113,3 +120,4 @@ exports.get_signed_url = get_signed_url;
 exports.get_used_cloud_targets = get_used_cloud_targets;
 exports.get_s3_endpoint_signature_ver = get_s3_endpoint_signature_ver;
 exports.is_aws_endpoint = is_aws_endpoint;
+exports.disable_s3_compatible_bodysigning = disable_s3_compatible_bodysigning;


### PR DESCRIPTION
### Explain the changes:
- Not perform body sign on s3 connections that their endpoint is s3 compatible and http

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
