### PR TITLE
Add a working_dir option to runner.js/flow.js

### DIFF
--- a/src/test/framework/flow.js
+++ b/src/test/framework/flow.js
@@ -9,14 +9,10 @@ var steps = [
     },
     {
         //Run FE Unit tests
-        ignore_failure: true,
         name: 'FE Unit Tests',
+        working_dir: 'frontend',
         action: 'gulp',
         params: [{
-            arg: '--cwd'
-        }, {
-            arg: 'frontend'
-        }, {
             arg: 'test'
         }],
     },
@@ -155,6 +151,7 @@ module.exports = steps;
         arg: 'value',
         input_arg: argument name of arg which was sent to the runner
       ]
+  working_dir: if exsits this value will be set as the cwd of the the action process (child process).
   blocking: if true, will stop execution on failure of this step
   ignore_failure: if true the test will only report fail\pass without failing the run
 }

--- a/src/test/framework/runner.js
+++ b/src/test/framework/runner.js
@@ -289,7 +289,10 @@ class TestRunner {
                 }
             }
         }));
-        var options = _.pick(current_step, 'env');
+        const options = _.omitBy({
+            env: current_step.env,
+            cwd: current_step.working_dir
+        }, _.isUndefined);
         return promise_utils.spawn(command, args, options, false, false, current_step.timeout || DEFAULT_TEST_TIMEOUT)
             .then(res => {
                 this.tests_results.push({ name: current_step.name, success: true });


### PR DESCRIPTION
### Explain the changes:
 Add a working_dir option to test runner to allow to set the working directory of the FE test child process to be frontend (fixing the broken frontend test)

