### PR TITLE
Supporting any resource as spillover

### DIFF
--- a/config.js
+++ b/config.js
@@ -68,7 +68,7 @@ config.DEDUP_ENABLED = true;
 config.NOOBAA_EPOCH = 1430006400000;
 config.NEW_SYSTEM_POOL_NAME = 'first.pool';
 config.INTERNAL_STORAGE_POOL_NAME = 'system-internal-storage-pool';
-config.SPILLOVER_TIER_NAME = 'system-internal-spillover-tier';
+config.SPILLOVER_TIER_NAME = 'bucket-spillover-tier';
 
 config.MD_AGGREGATOR_INTERVAL = 30000;
 // the max cycles limits how many intervals the aggregator will split the gap

--- a/frontend/src/app/schema/buckets.js
+++ b/frontend/src/app/schema/buckets.js
@@ -196,7 +196,7 @@ export default {
                     type: {
                         type: 'string',
                         enum: [
-                            'INTERNAL'
+                            'INTERNAL', 'CLOUD', 'HOSTS'
                         ]
                     },
                     name: {

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -601,8 +601,8 @@ module.exports = {
                 tiering: {
                     $ref: 'tiering_policy_api#/definitions/tiering_policy'
                 },
-                spillover_enabled: {
-                    type: 'boolean'
+                spillover: {
+                    type: 'string'
                 },
                 storage: {
                     type: 'object',
@@ -886,8 +886,12 @@ module.exports = {
                         }
                     }]
                 },
-                use_internal_spillover: {
-                    type: 'boolean',
+                spillover: {
+                    oneOf: [{
+                        type: 'string'
+                    }, {
+                        type: 'null'
+                    }]
                 },
                 namespace: {
                     type: 'object',

--- a/src/deploy/mongo_upgrade/mongo_upgrade_2_3_0.js
+++ b/src/deploy/mongo_upgrade/mongo_upgrade_2_3_0.js
@@ -1,0 +1,46 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-env mongo */
+'use strict';
+
+update_spillover_tiers();
+
+function update_spillover_tiers() {
+    var old_tier = db.tiers.findOne({ name: /^system-internal-spillover-tier/ });
+    if (old_tier) {
+        db.buckets.find().forEach(bucket => {
+            var tier_id = new ObjectId();
+            var insert = {
+                _id: tier_id,
+                name: 'bucket-spillover-tier-' + bucket._id.str,
+                system: bucket.system,
+                chunk_config: old_tier.chunk_config,
+                data_placement: old_tier.data_placement,
+                mirrors: old_tier.mirrors,
+            };
+            if (bucket.deleted) {
+                insert.deleted = bucket.deleted;
+            }
+            print('update_spillover_tiers: creating new tier for bucket', bucket.name);
+            printjson(insert);
+            db.tiers.insertOne(insert);
+            print('update_spillover_tiers: updating tiering policy for bucket', bucket.name, bucket.tiering);
+            var query = {
+                _id: bucket.tiering,
+                'tiers.tier': old_tier._id
+            };
+            var update = {
+                $set: {
+                    'tiers.$.tier': tier_id
+                }
+            };
+            print('update_spillover_tiers: updating tiering policy for bucket', bucket.name, bucket.tiering);
+            printjson(query);
+            printjson(update);
+            db.tieringpolicies.updateOne(query, update);
+        });
+        print('update_spillover_tiers: removing system spillover tier', old_tier._id);
+        db.tiers.remove({
+            _id: old_tier._id
+        });
+    }
+}

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -24,7 +24,6 @@ const cloud_utils = require('../../util/cloud_utils');
 const nodes_client = require('../node_services/nodes_client');
 const pool_server = require('../system_services/pool_server');
 const auth_server = require('../common_services/auth_server');
-const system_server = require('../system_services/system_server');
 const system_store = require('../system_services/system_store').get_instance();
 const func_store = require('../func_services/func_store');
 const node_allocator = require('../node_services/node_allocator');
@@ -88,22 +87,9 @@ function create_bucket(req) {
 
     const mongo_pool = pool_server.get_internal_mongo_pool(req.system);
     if (!mongo_pool) throw new RpcError('MONGO_POOL_NOT_FOUND');
-    const internal_storage_tier = tier_server.get_internal_storage_tier(req.system);
-    if (!internal_storage_tier) throw new RpcError('INTERNAL_TIER_NOT_FOUND');
 
     if (req.rpc_params.tiering) {
         tiering_policy = resolve_tiering_policy(req, req.rpc_params.tiering);
-        changes.update.tieringpolicies = [{
-            _id: tiering_policy._id,
-            $push: {
-                tiers: {
-                    tier: internal_storage_tier._id,
-                    order: 1,
-                    spillover: true,
-                    disabled: true
-                }
-            }
-        }];
     } else {
         // we create dedicated tier and tiering policy for the new bucket
         // that uses the default_pool of that account
@@ -133,15 +119,8 @@ function create_bucket(req) {
                 order: 0,
                 spillover: false,
                 disabled: false
-            }, {
-                tier: internal_storage_tier._id,
-                order: 1,
-                spillover: true,
-                disabled: true
             }]
         );
-
-        changes.insert.tieringpolicies = [tiering_policy];
         changes.insert.tiers = [tier];
     }
 
@@ -150,6 +129,31 @@ function create_bucket(req) {
         req.system._id,
         tiering_policy._id,
         req.rpc_params.tag);
+
+    const bucket_spillover_tier = create_bucket_spillover_tier(req.system, bucket._id, mongo_pool._id);
+    if (req.rpc_params.tiering) {
+        changes.update.tieringpolicies = [{
+            _id: tiering_policy._id,
+            $push: {
+                tiers: {
+                    tier: bucket_spillover_tier._id,
+                    order: 1,
+                    spillover: true,
+                    disabled: true
+                }
+            }
+        }];
+        changes.insert.tiers = [bucket_spillover_tier];
+    } else {
+        tiering_policy.tiers.push({
+            tier: bucket_spillover_tier._id,
+            order: 1,
+            spillover: true,
+            disabled: true
+        });
+        changes.insert.tieringpolicies = [tiering_policy];
+        changes.insert.tiers.push(bucket_spillover_tier);
+    }
 
     if (req.rpc_params.namespace) {
         const read_resources = _.compact(req.rpc_params.namespace.read_resources
@@ -278,7 +282,7 @@ function get_bucket_changes(req, update_request, bucket, tiering_policy) {
         alerts: []
     };
     let quota = update_request.quota;
-    const spillover_sent = !_.isUndefined(update_request.use_internal_spillover);
+    const spillover_sent = !_.isUndefined(update_request.spillover);
 
     let single_bucket_update = {
         _id: bucket._id
@@ -373,14 +377,14 @@ function get_bucket_changes(req, update_request, bucket, tiering_policy) {
 
     }
     if (spillover_sent) {
+        const spillover_pool = req.system.pools_by_name[update_request.spillover];
         const tiering = tiering_policy || bucket.tiering;
         let spillover_tier = tiering.tiers.find(tier_and_order => tier_and_order.spillover);
         if (!spillover_tier) {
-            const internal_mongo_pool = pool_server.get_internal_mongo_pool(req.system);
-            if (!internal_mongo_pool) throw new RpcError('INTERNAL POOL NOT FOUND');
-            spillover_tier = tier_server.get_internal_storage_tier(req.system);
+            if (!spillover_pool) throw new RpcError('POOL NOT FOUND');
+            spillover_tier = req.system.tiers_by_name[`${config.SPILLOVER_TIER_NAME}-${bucket._id}`];
             if (!spillover_tier) {
-                spillover_tier = system_server.create_internal_tier(req.system, internal_mongo_pool);
+                spillover_tier = create_bucket_spillover_tier(req.system, bucket._id, spillover_pool._id);
                 changes.inserts.tiers = changes.inserts.tiers || [];
                 changes.inserts.tiers.push(spillover_tier);
             }
@@ -388,10 +392,18 @@ function get_bucket_changes(req, update_request, bucket, tiering_policy) {
                 tier: spillover_tier,
                 order: 1,
                 spillover: true,
-                disabled: !update_request.use_internal_spillover
+                disabled: !update_request.spillover
             });
         }
-        spillover_tier.disabled = !update_request.use_internal_spillover;
+        if (spillover_pool) {
+            changes.updates.tiers = [{
+                _id: spillover_tier.tier._id,
+                mirrors: [{
+                    spread_pools: [spillover_pool._id]
+                }]
+            }];
+        }
+        spillover_tier.disabled = !update_request.spillover;
         changes.updates.tieringpolicies = changes.updates.tieringpolicies || [];
         changes.updates.tieringpolicies.push({
             _id: tiering._id,
@@ -404,10 +416,10 @@ function get_bucket_changes(req, update_request, bucket, tiering_policy) {
         });
 
         let desc;
-        if (update_request.use_internal_spillover) {
-            desc = `Bucket ${bucket.name} spillover was turned off by ${req.account && req.account.email}`;
+        if (update_request.spillover) {
+            desc = `Bucket ${bucket.name} spillover on resource ${update_request.spillover} was set by ${req.account && req.account.email}`;
         } else {
-            desc = `Bucket ${bucket.name} spillover was turned on by ${req.account && req.account.email}`;
+            desc = `Bucket ${bucket.name} spillover was turned off by ${req.account && req.account.email}`;
         }
         changes.events.push({
             event: 'bucket.spillover',
@@ -421,7 +433,17 @@ function get_bucket_changes(req, update_request, bucket, tiering_policy) {
     return changes;
 }
 
-
+function create_bucket_spillover_tier(system, bucket_id, pool_id) {
+    if (system.tiers_by_name[`${config.SPILLOVER_TIER_NAME}-${bucket_id}`]) return;
+    return tier_server.new_tier_defaults(
+        `${config.SPILLOVER_TIER_NAME}-${bucket_id}`,
+        system._id,
+        system.default_chunk_config._id, [{
+            _id: system_store.generate_id(),
+            spread_pools: [pool_id]
+        }]
+    );
+}
 
 /**
  *
@@ -1022,7 +1044,7 @@ function get_bucket_info({
         tag: bucket.tag ? bucket.tag : '',
         num_objects: num_of_objects || 0,
         writable: false,
-        spillover_enabled: false,
+        spillover: undefined,
         storage: undefined,
         data: undefined,
         usage_by_pool: undefined,
@@ -1095,7 +1117,7 @@ function get_bucket_info({
         count: (bucket.storage_stats && bucket.storage_stats.objects_count) || 0
     };
 
-    info.spillover_enabled = spillover_allowed_in_policy;
+    info.spillover = spillover_tier_in_policy && spillover_tier_in_policy.mirrors[0].spread_pools[0].name;
 
     const used_of_pools_in_policy = size_utils.json_to_bigint(size_utils.reduce_sum('blocks_size', tiering_pools_used_agg));
     const bucket_chunks_capacity = size_utils.json_to_bigint(_.get(bucket, 'storage_stats.chunks_capacity') || 0);
@@ -1325,6 +1347,7 @@ exports.read_bucket = read_bucket;
 exports.update_bucket = update_bucket;
 exports.delete_bucket = delete_bucket;
 exports.delete_bucket_lifecycle = delete_bucket_lifecycle;
+exports.create_bucket_spillover_tier = create_bucket_spillover_tier;
 exports.set_bucket_lifecycle_configuration_rules = set_bucket_lifecycle_configuration_rules;
 exports.get_bucket_lifecycle_configuration_rules = get_bucket_lifecycle_configuration_rules;
 exports.get_bucket_namespaces = get_bucket_namespaces;

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -231,6 +231,7 @@ function create_system(req) {
     const changes = new_system_changes(account.name, account);
     const system_id = changes.insert.systems[0]._id;
     const default_pool = changes.insert.pools[0]._id;
+    const default_bucket = changes.insert.buckets[0]._id;
     const owner_secret = system_store.get_server_secret();
     let reply_token;
     let ntp_configured = false;
@@ -349,7 +350,7 @@ function create_system(req) {
                 auth_token: reply_token
             });
         })
-        .then(() => _ensure_spillover_structure(system_id))
+        .then(() => _ensure_spillover_structure(system_id, default_bucket))
         .then(() => _init_system(system_id))
         .then(() => system_utils.mongo_wrapper_system_created())
         .then(() => ({
@@ -1242,19 +1243,7 @@ function _init_system(sysid) {
         ));
 }
 
-function create_internal_tier(system, mongo_pool) {
-    if (tier_server.get_internal_storage_tier(system)) return;
-    return tier_server.new_tier_defaults(
-        `${config.SPILLOVER_TIER_NAME}-${system._id}`,
-        system._id,
-        system.default_chunk_config._id, [{
-            _id: system_store.generate_id(),
-            spread_pools: [mongo_pool._id]
-        }]
-    );
-}
-
-function _ensure_spillover_structure(system_id) {
+function _ensure_spillover_structure(system_id, bucket_id) {
     return P.resolve()
         .then(() => {
             const system = system_store.data.get_by_id(system_id);
@@ -1276,10 +1265,9 @@ function _ensure_spillover_structure(system_id) {
         .then(() => {
             const system = system_store.data.get_by_id(system_id);
             if (!system) throw new Error('SYSTEM DOES NOT EXIST');
-            if (tier_server.get_internal_storage_tier(system)) return;
             const mongo_pool = pool_server.get_internal_mongo_pool(system);
             if (!mongo_pool) throw new Error('MONGO POOL CREATION FAILURE');
-            const internal_tier = create_internal_tier(system, mongo_pool);
+            const internal_tier = bucket_server.create_bucket_spillover_tier(system, bucket_id, mongo_pool._id);
 
             return system_store.make_changes({
                 insert: {
@@ -1380,7 +1368,6 @@ function _communicate_license_server(params, proxy_address) {
 // EXPORTS
 exports._init = _init;
 exports.new_system_defaults = new_system_defaults;
-exports.create_internal_tier = create_internal_tier;
 exports.new_system_changes = new_system_changes;
 
 exports.create_system = create_system;

--- a/src/server/system_services/tier_server.js
+++ b/src/server/system_services/tier_server.js
@@ -475,10 +475,6 @@ function get_tiering_policy_info(tiering_policy, nodes_aggregate_pool, aggregate
     return info;
 }
 
-function get_internal_storage_tier(system) {
-    return system.tiers_by_name[`${config.SPILLOVER_TIER_NAME}-${system._id}`];
-}
-
 function get_associated_tiering_policies(tier) {
     const associated_tiering_policies = _.filter(tier.system.tiering_policies_by_name,
         policy => _.find(policy.tiers, t => String(t.tier._id) === String(tier._id))
@@ -490,7 +486,6 @@ function get_associated_tiering_policies(tier) {
 
 // EXPORTS
 exports.get_associated_tiering_policies = get_associated_tiering_policies;
-exports.get_internal_storage_tier = get_internal_storage_tier;
 exports.new_tier_defaults = new_tier_defaults;
 exports.new_policy_defaults = new_policy_defaults;
 exports.get_tier_info = get_tier_info;

--- a/src/test/system_tests/mongodb_defaults.js
+++ b/src/test/system_tests/mongodb_defaults.js
@@ -39,7 +39,9 @@ db.pools.remove({
 });
 db.tiers.remove({
     name: {
-        $nin: [/first\.bucket#/, /system-internal-spillover-tier.*/]
+        $nin: [/first\.bucket#/, "bucket-spillover-tier-" + (db.buckets.find({
+            name: 'first.bucket'
+        })[0]._id).valueOf()]
     }
 });
 db.tieringpolicies.remove({

--- a/src/upgrade/upgrade.js
+++ b/src/upgrade/upgrade.js
@@ -407,6 +407,7 @@ function mongo_upgrade_database_metadata(params) {
             if (should_mongo_upgrade === "true") {
                 UPGRADE_SCRIPTS = [
                     'mongo_upgrade_2_1_3.js',
+                    'mongo_upgrade_2_3_0.js',
                     'mongo_upgrade_mark_completed.js'
                 ];
             } else {


### PR DESCRIPTION
### Explain the changes:
- now spillover tier for bucket can support any resource (hosts/cloud/internal) and not only internal
- creating a per bucket spillover-tier - as different bucket can use different spillover reosource
- adding upgrade script which deletes system_spillover_tier and create one for each bucket
- updating spillover tests in test_bucket_placement to verify spillback and checking pool of hosts as spillover

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
