### PR TITLE
added get_ntp_time in net_utils and removed ntp-client package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8221,11 +8221,6 @@
         "lazy": "1.0.11"
       }
     },
-    "ntp-client": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ntp-client/-/ntp-client-0.5.3.tgz",
-      "integrity": "sha1-A8DI2mfj9Jl9oIPUaC3M4NkgijU="
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "node-addon-api": "1.1.0",
     "node-df": "0.1.1",
     "node-gyp": "3.6.2",
-    "ntp-client": "0.5.3",
     "performance-now": "2.1.0",
     "proxy-agent": "2.1.0",
     "request": "2.83.0",

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -14,7 +14,7 @@ const promise_utils = require('../util/promise_utils');
 const phone_home_utils = require('../util/phone_home');
 const argv = require('minimist')(process.argv);
 const mongo_client = require('../util/mongo_client');
-const ntp_client = require('ntp-client');
+const net_utils = require('../util/net_utils');
 
 const TMP_PATH = '/tmp';
 const EXTRACTION_PATH = `${TMP_PATH}/test`;
@@ -149,13 +149,7 @@ function do_upgrade(upgrade_file, is_clusterized, err_handler) {
 }
 
 function test_ntp_timeskew(ntp_server) {
-    const defaultNtpPort = 123;
-    const defaultNtpServer = "pool.ntp.org";
-    return P.fromCallback(callback => ntp_client.getNetworkTime(
-            ntp_server || defaultNtpServer,
-            defaultNtpPort,
-            callback
-        ))
+    return net_utils.get_ntp_time({ server: ntp_server })
         .catch(err => {
             dbg.error('test_ntp_timeskew failed', err);
             throw new Error('NTP_COMMUNICATION_ERROR');

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -7,6 +7,7 @@ const net = require('net');
 const dns = require('dns');
 const net_ping = require('net-ping');
 const ip_module = require('ip');
+const dgram = require('dgram');
 
 const P = require('./promise');
 const dbg = require('./debug_module')(__filename);
@@ -110,9 +111,68 @@ function ip_to_long(ip) {
     return ip_module.toLong(unwrap_ipv6(ip));
 }
 
+function get_ntp_time({ server = 'pool.ntp.org', port = 123, timeout = 60000 } = {}) {
+    return new P((resolve, reject) => {
+            server = server || "pool.ntp.org";
+            port = port || 123;
+
+            let udp_client = dgram.createSocket("udp4");
+            let data = Buffer.alloc(48, 0);
+            // RFC 2030
+            data[0] = 0x1B;
+
+
+            let had_error = false;
+
+            function handle_error(err) {
+                if (!had_error) {
+                    had_error = true;
+                    udp_client.close();
+                    return reject(err);
+                }
+            }
+
+            udp_client.on('error', handle_error);
+
+            udp_client.once('message', function(msg) {
+                udp_client.close();
+
+                // Offset to get to the "Transmit Timestamp" field (time at which the reply
+                // departed the server for the client, in 64-bit timestamp format."
+                let offset_transmit_time = 40;
+                let intpart = 0;
+                let fractpart = 0;
+
+                // get seconds
+                for (let i = 0; i <= 3; i++) {
+                    intpart = (256 * intpart) + msg[offset_transmit_time + i];
+                }
+
+                // get seconds fraction
+                for (let i = 4; i <= 7; i++) {
+                    fractpart = (256 * fractpart) + msg[offset_transmit_time + i];
+                }
+
+                let milliseconds = (intpart * 1000) + (fractpart * 1000 / 0x100000000);
+
+                // **UTC** time
+                let date = new Date("Jan 01 1900 GMT");
+                date.setUTCMilliseconds(date.getUTCMilliseconds() + milliseconds);
+
+                resolve(date);
+            });
+
+            udp_client.send(data, 0, data.length, port, server, function(err) {
+                if (err) return handle_error(err);
+            });
+        })
+        .timeout(timeout);
+}
+
 exports.ping = ping;
 exports.dns_resolve = dns_resolve;
 exports.is_hostname = is_hostname;
 exports.is_fqdn = is_fqdn;
 exports.unwrap_ipv6 = unwrap_ipv6;
 exports.ip_to_long = ip_to_long;
+exports.get_ntp_time = get_ntp_time;


### PR DESCRIPTION
### Explain the changes:
- added get_ntp_time function in net_utils 
- removed dependency in ntp-client package

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages