### PR TITLE
test_env_builder.js: Add vm size

### DIFF
--- a/src/deploy/azureFunctions.js
+++ b/src/deploy/azureFunctions.js
@@ -176,7 +176,7 @@ class AzureFunctions {
             .then(res => res.ipAddress);
     }
 
-    createAgent({ vmName, storage, vnet, os, agentConf, serverIP }) {
+    createAgent({ vmName, storage, vnet, os, vmSize, agentConf, serverIP }) {
         const osDetails = this.getImagesfromOSname(os);
         return this.getSubnetInfo(vnet)
             .then(subnetInfo => this.createPublicIp(vmName + '_pip')
@@ -200,7 +200,8 @@ class AzureFunctions {
                     nicId: nic.id,
                     imageReference: image,
                     storageAccountName: storage,
-                    diskSizeGB
+                    diskSizeGB,
+                    vmSize
                 });
             })
             .then(() => this.getIpAddress(vmName + '_pip'))


### PR DESCRIPTION
### Explain the changes:
test_env_builder.js:
- Add vm size
- Fixed a bug where the exit code on clan only was always 0
- Passing the arguments (process.argv) to the fork
- Add verify_args function

azureFunctions.js:
- Add vm size to createAgent

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
