### PR TITLE
Fixing counting of disabled storage nodes as unavailable

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -3450,7 +3450,7 @@ class NodesMonitor extends EventEmitter {
         reply.free = reply.free.minus(reply.reserved);
 
         if (item.has_issues) {
-            reply.unavailable_free = reply.free;
+            if (item.node.enabled) reply.unavailable_free = reply.free;
             reply.free = BigInteger.zero;
         }
 


### PR DESCRIPTION
### Explain the changes:
- Not count the disabled storage drives as unavailable free

### Issues: Fixed / Gap #xxx
- Fixed #4064 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
