### PR TITLE
fix #4519 - avoid leak of blocks (on node but not in DB)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -312,6 +312,10 @@ module.exports = {
         'vars-on-top': 'off',
 
         // Allow await in the body of loops.
-        'no-await-in-loop': 'off'
+        'no-await-in-loop': 'off',
+
+        // Allow async function without await, for `return P.map(...)`
+        'require-await': 'off',
+
     }
 };

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1031,7 +1031,7 @@ class MDStore {
                 if (orphan_blocks.length) console.log('ORPHAN BLOCKS (ignoring)', orphan_blocks);
                 const blocks_by_chunk = _.groupBy(blocks, 'chunk');
                 for (let i = 0; i < chunks.length; ++i) {
-                    chunks[i].blocks = blocks_by_chunk[chunks[i]._id];
+                    chunks[i].blocks = blocks_by_chunk[chunks[i]._id] || [];
                 }
                 return chunks;
             });


### PR DESCRIPTION

### Explain the changes:
- The case is when another chunk fails in same rebuild batch (i.e.
due to all fragments being unreadable, or no nodes for allocation etc.)
- The fix is to catch single chunk errors, and anyway continue to update_db().

### Issues: Fixed / Gap #xxx
- Fixes #4519 

### Testing Instructions:
- Create 2 small files (<1MB) on three different pools, for example, London, Paris.
- Make all the nodes of Paris offline so that the chunk stored there is unreadable.
- Change placement from London to Berlin
- Let the scrubber work on these 2 chunks in the same batch
- It should allocate on Berlin while catching the error from Paris not being readable
- The file from London should complete its reallocation to Berlin and no blocks should be leaked on Berlin nodes.


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
