### PR TITLE
test_env_builder.js: Machines will be created with the size ‘Standard_B2s’ by default

### DIFF
--- a/src/deploy/azureFunctions.js
+++ b/src/deploy/azureFunctions.js
@@ -64,9 +64,6 @@ class AzureFunctions {
         this.subscriptionId = subscriptionId;
         this.resourceGroupName = resourceGroupName;
         this.location = location;
-        if (location !== 'northeurope') {
-            DEFAULT_SIZE = 'Standard_A2_v2';
-        }
     }
 
     authenticate() {

--- a/src/deploy/azure_clean_env.js
+++ b/src/deploy/azure_clean_env.js
@@ -1,0 +1,73 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const argv = require('minimist')(process.argv);
+const dbg = require('../util/debug_module')(__filename);
+const AzureFunctions = require('../deploy/azureFunctions');
+const P = require('../util/promise');
+dbg.set_process_name('clean_azure_env');
+let azf;
+
+const {
+    resource,
+    storage,
+    vnet,
+    location = 'westus2',
+} = argv;
+
+let {
+    id
+} = argv;
+
+function _validateEnvironmentVariablesAndBaseParams() {
+    const clientId = process.env.CLIENT_ID;
+    const domain = process.env.DOMAIN;
+    const secret = process.env.APPLICATION_SECRET;
+    const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID;
+
+    let missing_args = '';
+    //Verify ENV
+    if (!process.env.CLIENT_ID) missing_args.push('\tmissing env parameter CLIENT_ID\n');
+    if (!process.env.DOMAIN) missing_args.push('\tmissing env parameter DOMAIN\n');
+    if (!process.env.APPLICATION_SECRET) missing_args.push('\tmissing env parameter APPLICATION_SECRET\n');
+
+    //Verify base params supplied
+
+    if (!resource) {
+        missing_args += '\t--resource <resource-group>\n';
+    }
+    if (!storage) {
+        missing_args += '\t--storage <storage-account>\n';
+    }
+    if (!vnet) {
+        missing_args += '\t--vnet <vnet>\n';
+    }
+
+    if (argv.id) {
+        id = '-' + id;
+    } else {
+        id = '-';
+    }
+
+    azf = new AzureFunctions(clientId, domain, secret, subscriptionId, resource, location);
+}
+
+function main() {
+    let exit_code = 0;
+    return azf.authenticate()
+        .then(() => azf.listVirtualMachines('', 'VM running'))
+        .then(current_vms => P.map(current_vms, vmName => {
+            if (vmName.includes(id) && !vmName.toLowerCase().includes('lg')) {
+                console.log('Cleaning machine:' + vmName);
+                return azf.deleteVirtualMachine(vmName)
+                    .catch(err => {
+                        console.error(`failed deleting ${vmName} with error: `, err.message);
+                        exit_code = 1;
+                    });
+            }
+        }))
+        .then(() => process.exit(exit_code));
+}
+
+_validateEnvironmentVariablesAndBaseParams();
+main();

--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -41,7 +41,7 @@ const {
     num_agents = oses.length,
     help,
     min_required_agents = 7,
-    vm_size = 'A'
+    vm_size = 'B'
 } = argv;
 
 dbg.set_process_name('test_env_builder');
@@ -138,9 +138,9 @@ function prepare_agents() {
                     if (hasImage) {
                         console.log('Creating new agent from an image');
                         return azf.createAgentFromImage({
-        vmName: agent.name,
-        storage,
-        vnet,
+                            vmName: agent.name,
+                            storage,
+                            vnet,
                             os: agent.os,
                             vmSize,
                             server_ip: server_ip,
@@ -157,17 +157,17 @@ function prepare_agents() {
                             serverIP: server_ip
                         });
                     }
-    })
-        .then(ip => {
+                })
+                .then(ip => {
                     console.log(`agent created: ip ${ip} name ${agent.name} of type ${agent.os}`);
-            agent.prepared = true;
-            agent.ip = ip;
-            created_agents.push(agent);
-        })
-        .catch(err => {
-            console.error(`Creating agent ${agent.name} VM failed`, err);
+                    agent.prepared = true;
+                    agent.ip = ip;
+                    created_agents.push(agent);
+                })
+                .catch(err => {
+                    console.error(`Creating agent ${agent.name} VM failed`, err);
                 });
-            })
+        })
         .then(() => {
             if (created_agents.length < min_required_agents) {
                 console.error(`could not create the minimum number of required agents (${min_required_agents})`);
@@ -268,7 +268,10 @@ function run_tests() {
 }
 
 function clean_test_env() {
-    const vms_to_delete = agents.map(agent => agent.name).concat([server.name]);
+    const vms_to_delete = [
+        ...agents.map(agent => agent.name),
+        server.name.replace(/_/g, '-')
+    ];
     console.log(`deleting virtual machines`, vms_to_delete);
     return P.map(vms_to_delete, vm =>
         azf.deleteVirtualMachine(vm)


### PR DESCRIPTION
### Explain the changes:
test_env_builder.js:
- Machines will be created with the size  ‘Standard_B2s’ by default
- Fixed the leak where the server name contain “_”

azure_clean_env.js:
- Moved the azure_clean into a separate file

azureFunctions.js:
- Changed the default of azure machine to B

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
