### PR TITLE
Gaps and issues 5

### DIFF
--- a/frontend/src/app/components/buckets/namespace-buckets-table/bucket-row.js
+++ b/frontend/src/app/components/buckets/namespace-buckets-table/bucket-row.js
@@ -13,7 +13,7 @@ export default class BucketRowViewModel {
         this.readPolicy = ko.observable();
         this.writePolicy = ko.observable();
         this.deleteButton = {
-            subject: 'resource',
+            subject: 'bucket',
             id: ko.observable(),
             tooltip: 'Delete Bucket',
             group: deleteGroup,

--- a/frontend/src/app/components/host/host-panel/host-panel.html
+++ b/frontend/src/app/components/host/host-panel/host-panel.html
@@ -41,7 +41,7 @@
             params="name: host"
         ></host-details-form>
 
-        <host-storage-form class="tab"
+        <host-storage-form class="tab column"
             ko.css.selected="selectedTab.eq('storage')"
             params="name: host"
         ></host-storage-form>

--- a/frontend/src/app/components/host/host-storage-form/host-storage-form.html
+++ b/frontend/src/app/components/host/host-storage-form/host-storage-form.html
@@ -23,10 +23,17 @@
     </div>
 </div>
 
-<data-table class="node-table" params="
+<data-table class="greedy node-table" params="
     columns: columns,
     data: rows,
     loading: !hostLoaded(),
     rowCssProp: 'rowCss',
-    emptyMessage: 'Storage service is disabled'
+    emptyMessage: 'Storage service is disabled',
+    sorting: ko.pc(sorting, onSort, $component)
 "></data-table>
+
+<paginator params="
+    pageSize: pageSize,
+    itemCount: itemCount,
+    page: ko.pc(page, onPage, $component)
+"></paginator>

--- a/frontend/src/app/components/host/host-storage-form/host-storage-form.js
+++ b/frontend/src/app/components/host/host-storage-form/host-storage-form.js
@@ -5,9 +5,13 @@ import Observer from 'observer';
 import StorageNodeRowViewModel from './storage-node-row';
 import { state$, action$ } from 'state';
 import { openEditHostStorageDrivesModal } from 'action-creators';
+import { paginationPageSize } from 'config';
 import ko from 'knockout';
-import { deepFreeze, compare } from 'utils/core-utils';
+import { deepFreeze, createCompareFunc } from 'utils/core-utils';
 import { getStorageServiceStateIcon } from 'utils/host-utils';
+import { toBytes } from 'utils/size-utils';
+import { realizeUri } from 'utils/browser-utils';
+import { requestLocation } from 'action-creators';
 
 const operationsDisabledTooltip = deepFreeze({
     align: 'end',
@@ -17,57 +21,70 @@ const operationsDisabledTooltip = deepFreeze({
 const columns = deepFreeze([
     {
         name: 'state',
-        type: 'icon'
+        type: 'icon',
+        sortable: true,
+        compareKey: node => node.mode === 'DECOMMISSIONED' ? String.fromCodePoint(9999) : node.mode
     },
     {
-        name: 'mount'
+        name: 'mount',
+        sortable: true,
+        compareKey: node => node.mount
     },
     {
-        name: 'readLatency'
+        name: 'readLatency',
+        sortable: true,
+        compareKey: node => node.readLatency
     },
     {
-        name: 'writeLatency'
+        name: 'writeLatency',
+        sortable: true,
+        compareKey: node => node.writeLatency
     },
     {
         name: 'capacity',
         label: 'Used Capacity',
-        type: 'capacity'
+        type: 'capacity',
+        sortable: true,
+        compareKey: node => toBytes(node.storage.total || 0)
     },
     {
-        name: 'dataActivity'
+        name: 'dataActivity',
+        sortable: true,
+        compareKey: node => node.activity
     }
 ]);
 
-function _compareNodes(node1, node2) {
-    if (node1.mode === node2.mode) {
-        return 0;
-    } if (node1.mode === 'DECOMMISSIONED') {
-        return 1;
-    } else if (node2.mode === 'DECOMMISSIONED'){
-        return -1;
-    } else {
-        return compare(node1.mode, node2.mode);
-    }
-}
-
 class HostStorageFormViewModel extends Observer {
+    hostName = '';
+    columns = columns;
+    pageSize = paginationPageSize;
+    pathname = '';
+    itemCount = ko.observable();
+    hostLoaded = ko.observable();
+    driveCount = ko.observable();
+    page = ko.observable();
+    sorting = ko.observable();
+    mode = ko.observable();
+    os = ko.observable();
+    isEditDrivesDisabled = ko.observable();
+    editDrivesTooltip = ko.observable();
+    rows = ko.observableArray();
+
     constructor({ name }) {
         super();
 
         this.hostName = ko.unwrap(name);
-        this.columns = columns;
-        this.hostLoaded = ko.observable();
-        this.driveCount = ko.observable('');
-        this.mode = ko.observable('');
-        this.os = ko.observable('');
-        this.isEditDrivesDisabled = ko.observable();
-        this.editDrivesTooltip = ko.observable();
-        this.rows = ko.observableArray();
 
-        this.observe(state$.get('hosts', 'items', this.hostName), this.onHost);
+        this.observe(
+            state$.getMany(
+                ['hosts', 'items', this.hostName],
+                'location'
+            ),
+            this.onHost
+        );
     }
 
-    onHost(host) {
+    onHost([host, location]) {
         if (!host) {
             this.isEditDrivesDisabled(true);
             return;
@@ -77,21 +94,63 @@ class HostStorageFormViewModel extends Observer {
         const enabledNodesCount = nodes.filter(node => node.mode !== 'DECOMMISSIONED').length;
         const isHostBeingDeleted = host.mode === 'DELETING';
         const editDrivesTooltip = isHostBeingDeleted ? operationsDisabledTooltip : '';
-        const rows = Array.from(nodes)
-            .sort(_compareNodes)
+        const page = Number(location.query.page) || 0;
+        const order = Number(location.query.order) || 1;
+        const sortBy = location.query.sortBy || 'state';
+        const pageStart = page * this.pageSize;
+        const { compareKey } = this.columns.find(column => column.name === sortBy);
+
+        const rows =  Array.from(nodes)
+            .sort(createCompareFunc(compareKey, order))
+            .slice(pageStart, pageStart + this.pageSize)
             .map((node, i) => {
                 const row = this.rows.get(i) || new StorageNodeRowViewModel();
                 row.onNode(node);
                 return row;
             });
 
+        this.pathname = location.pathname;
+        this.page(page);
+        this.sorting({ sortBy, order });
         this.mode(getStorageServiceStateIcon(host));
         this.driveCount(`${enabledNodesCount} of ${nodes.length}`);
+        this.itemCount(nodes.length);
         this.os(host.os);
         this.isEditDrivesDisabled(isHostBeingDeleted);
         this.editDrivesTooltip(editDrivesTooltip);
         this.rows(rows);
         this.hostLoaded(true);
+    }
+
+    onSort(sorting) {
+        this._query({
+            sorting,
+            page: 0
+        });
+    }
+
+    onPage(page) {
+        this._query({
+            page
+        });
+    }
+
+    _query(params) {
+        const {
+            sorting = this.sorting(),
+            page = this.page()
+        } = params;
+
+        const { sortBy, order } = sorting;
+        const query = {
+            sortBy: sortBy,
+            order: order,
+            page: page || undefined
+        };
+
+        action$.onNext(requestLocation(
+            realizeUri(this.pathname, {}, query)
+        ));
     }
 
     onEditDrives() {

--- a/frontend/src/app/components/management/server-dns-settings-form/server-dns-settings-form.html
+++ b/frontend/src/app/components/management/server-dns-settings-form/server-dns-settings-form.html
@@ -7,10 +7,11 @@
         <div class="column greedy">
             <h2 class="heading3 greedy">Environment DNS Settings</h2>
             <div class="row" ko.visible="!isExpanded()">
-                <span class="push-next">
+                <span>
                     Master server DNS settings
                 </span>
-                <span class="push-prev">
+                <vr class="push-both"></vr>
+                <span>
                     Primary DNS:
                     <span ko.css="{ 'text-tech': masterPrimaryDNS }"
                         ko.text="masterPrimaryDNS"
@@ -25,7 +26,7 @@
                 </span>
             </div>
         </div>
-        <svg-icon class="icon-small rotate"
+        <svg-icon class="icon-small rotate push-next-half"
                   ko.css="{ 'deg-90': !isExpanded() }"
                   params="name: 'chevron'"
         ></svg-icon>

--- a/frontend/src/app/components/management/server-time-form/server-time-form.html
+++ b/frontend/src/app/components/management/server-time-form/server-time-form.html
@@ -11,7 +11,7 @@
                 <span class="text-tech" ko.text="formattedMasterTime"></span>
             </p>
         </div>
-        <svg-icon class="icon-small rotate"
+        <svg-icon class="icon-small rotate push-next-half"
                   ko.css="{ 'deg-90': !isExpanded() }"
                   params="name: 'chevron'"
         ></svg-icon>

--- a/frontend/src/app/components/resources/pools-table/pool-row.js
+++ b/frontend/src/app/components/resources/pools-table/pool-row.js
@@ -87,8 +87,9 @@ export default class PoolRowViewModel {
         this.usedByOthersCapacity(usedOther);
         this.reservedCapacity(reserved);
 
+        const deleteTooltip = undeletableReasons[undeletable] || null;
         this.deleteButton.id(name);
         this.deleteButton.disabled(Boolean(undeletable));
-        this.deleteButton.tooltip(undeletableReasons[undeletable]);
+        this.deleteButton.tooltip(deleteTooltip);
     }
 }


### PR DESCRIPTION
### Explain the changes:
- Delete icon tooltip doesn't show the full text 
- The head lineof Storage & drives table should be sticky

### Issues: Fixed / Gap #xxx
- fixed #4527
- fixed #4547

### Testing Instructions:
Delete icon tooltip doesn't show the full text 
1. go to resources
2. create new host pool resource
3. remove hosts from the newly created pool
4. now remove button enabled and tooltip is not displayed on hover

The head line of Storage & drives table should be sticky
1. go to resources -> pool -> host
2. select drives tab
3. manually (in code) simulate lot of drive nodes
4. pagination works
5. scroll works as expected


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
