### PR TITLE
move ssl rand seed to be async

### DIFF
--- a/src/deploy/NVA_build/clean_ova.sh
+++ b/src/deploy/NVA_build/clean_ova.sh
@@ -38,21 +38,6 @@ function aws_specific(){
     shred -u ~/.*history
 }
 
-function generate_entropy(){
-    local path
-    local pid=()
-    echo "Generate entropy for /dev/random (openssl and such) for 5m"
-    for path in $(find /dev/disk/by-uuid/ -type l )
-    do
-        md5sum ${path} &
-        pid+=($!)
-    done
-    ps -ef | grep md5 | grep -v grep
-    sleep 300
-    echo "killing md5sum (pid: ${pid[@]})"
-    kill -9 ${pid[@]} 2> /dev/null
-}
-
 OPTIONS=$( getopt -o 'h,e,a,l,w,d' --long "help,esx,azure,alyun,aws,dev" -- "$@" )
 eval set -- "${OPTIONS}"
 
@@ -176,12 +161,6 @@ mongo nbcore --eval 'db.dropDatabase()'
 sudo sed -i "s:Configured IP on this NooBaa Server.*:Configured IP on this NooBaa Server \x1b[0;32;40mNONE\x1b[0m.:" /etc/issue
 sudo sed -i "s:This server's secret is.*:No Server Secret:" /etc/issue
 sudo sysctl kernel.hostname=noobaa
-
-if ! ${dev}
-then
-    #Generate entropy for /dev/random (openssl and such)
-    generate_entropy
-fi
 
 #reduce VM size
 set +e

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -61,7 +61,9 @@ function install_platform {
         strace \
         vim \
         net-tools \
-        iptables-services
+        iptables-services \
+        rng-tools \
+        pv
 
     # make iptables run on boot instead of firewalld
     systemctl disable firewalld
@@ -70,6 +72,11 @@ function install_platform {
     # make network service run on boot
     systemctl disable NetworkManager
     systemctl enable network
+
+    # enable random number generator daemon
+    # see https://www.certdepot.net/rhel7-get-started-random-number-generator/
+    systemctl enable rngd
+    systemctl start rngd
 
 	# make crontab start on boot
 	chkconfig crond on

--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -233,19 +233,6 @@ function configure_networking_dialog {
     done
 }
 
-
-function generate_entropy(){
-    local path
-    echo "Generate entropy for /dev/random (openssl and such) for 5m"
-    for path in $(find /dev/disk/by-uuid/ -type l)
-    do
-        sudo md5sum ${path}
-    done &
-    pid=$!
-    sleep 300
-    sudo kill -9 ${pid} 2> /dev/null
-}
-
 function configure_ntp_dialog {
   local ntp_server=$(grep "server.*NooBaa Configured" /etc/ntp.conf | sed 's:.*server \(.*\) iburst.*:\1:')
   local tz=$(ls -la /etc/localtime  | sed 's:.*/usr/share/zoneinfo/\(.*\):\1:')
@@ -419,7 +406,6 @@ is a short first install wizard to help configure \n\Z5\ZbNooBaa\Zn to best suit
 }
 
 function end_wizard {
-  nohup bash -c generate_entropy &
   local current_ip=$(ifconfig | grep -w 'inet' | grep -v 127.0.0.1 | awk '{print $2}' | head -n 1)
   dialog --colors --nocancel --backtitle "NooBaa First Install" --title '\Z5\ZbNooBaa\Zn is Ready' --msgbox "\n\Z5\ZbNooBaa\Zn was configured and is ready to use.\nYou can access \Z5\Zbhttp://${current_ip}:8080\Zn to start using your system." 7 72
   date | sudo tee -a ${FIRST_INSTALL_MARK} &> /dev/null
@@ -455,7 +441,6 @@ function rotateLogs {
 }
 
 who=$(whoami)
-export -f generate_entropy
 if [ "$who" = "noobaa" ]; then
   echo ======$(date)====== >> ${LOG_FILE}
   exec 2>> ${LOG_FILE}

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -414,9 +414,14 @@ function packages_upgrade() {
                 'iperf3',
                 'python-setuptools',
                 'bind-utils',
+                'bind',
                 'screen',
                 'strace',
-                'vim'
+                'vim',
+                'net-tools',
+                'iptables-services',
+                'rng-tools', // random number generator tools
+                'pv', // pipe viewer
             ];
             dbg.log0(`install additional packages`);
             return promise_utils.exec(`yum install -y ${packages_to_install.join(' ')}`, {
@@ -428,6 +433,11 @@ function packages_upgrade() {
                     dbg.log0(res);
                 });
         })
+        .then(() => promise_utils.exec(`systemctl enable rngd && systemctl start rngd`, {
+            ignore_rc: false,
+            return_stdout: true,
+            trim_stdout: true
+        }))
         .then(do_yum_update)
         .catch(err => {
             dbg.error('packages_upgrade: Failure', err);

--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -1,9 +1,19 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const _ = require('lodash');
+const fs = require('fs');
+const util = require('util');
+const events = require('events');
+const chance = require('chance')();
+const child_process = require('child_process');
 
-var _ = require('lodash');
-var events = require('events');
+const async_exec = util.promisify(child_process.exec);
+const async_delay = util.promisify(setTimeout);
+const async_open_fd = util.promisify(fs.open);
+const async_close_fd = util.promisify(fs.close);
+const async_read_fd = util.promisify(fs.read);
+const async_read_file = util.promisify(fs.readFile);
 
 var nb_native_napi;
 
@@ -20,6 +30,8 @@ function nb_native() {
     inherits(nb_native_nan.Ntcp, events.EventEmitter);
     _.defaults(nb_native_napi, nb_native_nan);
 
+    init_rand_seed();
+
     return nb_native_napi;
 }
 
@@ -28,6 +40,83 @@ function inherits(target, source) {
     _.forIn(source.prototype, function(v, k) {
         target.prototype[k] = source.prototype[k];
     });
+}
+
+// https://wiki.openssl.org/index.php/Random_Numbers#Entropy
+// doing as suggested and seeding with /dev/random
+async function init_rand_seed() {
+
+    console.log('init_rand_seed: starting ...');
+    let still_reading = true;
+    const promise = generate_entropy(() => still_reading);
+
+    const seed = await read_rand_seed(32);
+    if (seed) {
+        console.log(`init_rand_seed: seeding with ${seed.length} bytes`);
+        nb_native_napi.rand_seed(seed);
+    }
+
+    still_reading = false;
+    await promise;
+    console.log('init_rand_seed: done');
+}
+
+async function read_rand_seed(seed_bytes) {
+    if (process.platform === 'win32') return;
+    let fd = 0;
+    let offset = 0;
+    const buf = Buffer.allocUnsafe(seed_bytes);
+    while (offset < buf.length) {
+        try {
+            const count = buf.length - offset;
+            if (!fd) {
+                console.log(`read_rand_seed: opening /dev/random ...`);
+                fd = await async_open_fd('/dev/random', 'r');
+            }
+            console.log(`read_rand_seed: reading ${count} bytes from /dev/random ...`);
+            const { bytesRead } = await async_read_fd(fd, buf, offset, count, null);
+            offset += bytesRead;
+            console.log(`read_rand_seed: got ${bytesRead} bytes from /dev/random, total ${offset} ...`);
+        } catch (err) {
+            console.log('read_rand_seed: error', err);
+            if (fd) {
+                console.log('read_rand_seed: closing fd ...');
+                try {
+                    await async_close_fd(fd);
+                } catch (close_err) {
+                    console.log('read_rand_seed: closing fd error', close_err);
+                }
+                fd = 0;
+            }
+            console.log('read_rand_seed: delay before retry');
+            await async_delay(1000);
+        }
+    }
+    return buf;
+}
+
+async function generate_entropy(loop_cond) {
+    if (process.platform !== 'linux') return;
+    while (loop_cond()) {
+        try {
+            await async_delay(1000);
+            const ENTROPY_AVAIL_PATH = '/proc/sys/kernel/random/entropy_avail';
+            const entropy_avail = parseInt(await async_read_file(ENTROPY_AVAIL_PATH, 'utf8'), 10);
+            console.log(`generate_entropy: entropy_avail ${entropy_avail}`);
+            if (entropy_avail < 512) {
+                const disk = '/dev/sda';
+                const bs = 1024 * 1024;
+                const count = 32;
+                const { stdout: disk_size } = await async_exec(`blockdev --getsize64 ${disk}`);
+                const disk_size_in_blocks = parseInt(disk_size, 10) / bs;
+                const skip = chance.integer({ min: 0, max: disk_size_in_blocks });
+                console.log(`generate_entropy: adding entropy: dd if=${disk} bs=${bs} count=${count} skip=${skip} | md5sum`);
+                await async_exec(`dd if=${disk} bs=${bs} count=${count} skip=${skip} | md5sum`);
+            }
+        } catch (err) {
+            console.log('generate_entropy: error', err);
+        }
+    }
 }
 
 module.exports = nb_native;


### PR DESCRIPTION
### Explain the changes:
- random seed of openssl from /dev/random as recommended to ensure proper entropy.
- enable rngd service to ensure /dev/random has enough bits.
- processes we start will read seed from random bits and will also try to increase entropy by md5 of disk data.
- remove attempts to generate entropy from installation scripts because it caused too much load.

### Issues: Fixed / Gap #xxx
- see #2721

### Testing Instructions:
- check cpu load is not excessive by rngd or md5sum during supervisor restarts
- check both on esx and cloud as virtualization will effect the performance of entropy vreation.

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
