### PR TITLE
fixed read_system errors when endpoint process is down

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1028,7 +1028,7 @@
     },
     "babel-preset-es2015": {
       "version": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz",
-      "integrity": "sha1-uMcN+E7JSMQ9zyv3cOmI632ogxI=",
+      "integrity": "sha512-H9GDbUBadt4IpjwHuMvQlcpd5DCTxr+aRHgLpdvcmiNwEvSX4HRisenKFDgmxSgQGPY2Ot4UHyEQE0GW04aaSg==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -1059,7 +1059,7 @@
     },
     "babel-register": {
       "version": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
-      "integrity": "sha1-iS4uA4ZQeN2QrSxxURHsREmzKmg=",
+      "integrity": "sha512-2wxuq90cFwZ9vqoWUgw3KMfI+z9sSdR8PBNAAErYTyHwOtUkQOoAtq0rw7RDFm/sqrCj22dgvAviZoD5l4Z8MQ==",
       "dev": true,
       "requires": {
         "babel-core": "6.18.2",
@@ -5042,7 +5042,7 @@
     },
     "gulp-svgstore": {
       "version": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-6.0.0.tgz",
-      "integrity": "sha1-BQdkWy/TuE9NJ/fIpfdOZQv5kH0=",
+      "integrity": "sha512-Xyx63iO0t54Yp2PavKF95g+3aovBqHZi/q68OhjfYUzn9wtPNWC3qqyKMga1NNvMWgKzOFyg4vGVTgWg6db34g==",
       "dev": true,
       "requires": {
         "cheerio": "0.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12720,7 +12720,7 @@
     },
     "vsphere": {
       "version": "https://download3.vmware.com/software/vmw-tools/vsphere-sdk-for-javascript/vsphere-1.1.0.tgz",
-      "integrity": "sha1-i3FgyG2ynWcbM8/7yM8WKE7zlos=",
+      "integrity": "sha512-LsZ3J1EkmlFIsQxDCOzaKkqkGIJGJYFf8Qg1S1En1wX1XTONKiwf1PxipKfpJXXADDpQNNytO53p2XUIyZZWFg==",
       "requires": {
         "es6-shim": "0.35.1",
         "node-localstorage": "1.3.0",

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -418,7 +418,12 @@ function read_system(req) {
             }) : undefined,
 
         funcs: P.resolve()
-            .then(() => server_rpc.client.func.list_funcs({}, { auth_token: req.auth_token }))
+            // using default domain - will serve the list_funcs from web_server so if 
+            // endpoint is down it will not fail the read_system
+            .then(() => server_rpc.client.func.list_funcs({}, {
+                auth_token: req.auth_token,
+                domain: 'default'
+            }))
             .then(res => res.functions)
 
     }).then(({


### PR DESCRIPTION
### Explain the changes:
- fixed read_system errors when endpoint process is down
- use `'default'` domain when calling func_api so that the call is will be served from the web_server

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages