### PR TITLE
Fixes to the mapper

### DIFF
--- a/src/server/bg_services/agent_blocks_verifier.js
+++ b/src/server/bg_services/agent_blocks_verifier.js
@@ -71,6 +71,7 @@ class AgentBlocksVerifier {
 
         return this.populate_nodes_for_blocks(blocks)
             .then(blocks_with_nodes => {
+                this.populate_pools_for_blocks(blocks_with_nodes);
                 const blocks_with_alive_nodes = blocks_with_nodes.filter(block =>
                     block.node && block.node.rpc_address && block.node.online);
                 if (!blocks_with_alive_nodes || !blocks_with_alive_nodes.length) return;
@@ -150,6 +151,13 @@ class AgentBlocksVerifier {
      */
     verify_blocks(...args) {
         return server_rpc.client.block_store.verify_blocks(...args);
+    }
+
+    /**
+     * @override in unit tests for decoupling dependencies
+     */
+    populate_pools_for_blocks(...args) {
+        return system_utils.populate_pools_for_blocks(...args);
     }
 
 }

--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -19,6 +19,7 @@ const mongo_utils = require('../../util/mongo_utils');
 const auth_server = require('../common_services/auth_server');
 const system_store = require('../system_services/system_store').get_instance();
 const node_allocator = require('../node_services/node_allocator');
+const system_utils = require('../utils/system_utils');
 
 const builder_lock = new KeysLock();
 const object_io = new ObjectIO();
@@ -102,6 +103,7 @@ class MapBuilder {
             chunk.chunk_coder_config = system_store.data.get_by_id(chunk.chunk_config).chunk_coder_config;
             chunk.parts = parts_by_chunk[chunk._id];
             chunk.objects = _.uniq(_.compact(_.map(chunk.parts, part => objects_by_id[part.obj])));
+            system_utils.populate_pools_for_blocks(chunk.blocks);
             return P.resolve()
                 .then(() => {
                     if (!chunk.parts || !chunk.parts.length) throw new Error('No valid parts are pointing to chunk', chunk._id);

--- a/src/server/object_services/map_reader.js
+++ b/src/server/object_services/map_reader.js
@@ -10,6 +10,7 @@ const mapper = require('./mapper');
 const MDStore = require('./md_store').MDStore;
 const node_allocator = require('../node_services/node_allocator');
 const system_store = require('../system_services/system_store').get_instance();
+const system_utils = require('../utils/system_utils');
 
 
 /**
@@ -111,6 +112,7 @@ function read_parts_mappings(parts, adminfo, set_obj) {
             })
         )
         .then(() => _.map(parts, part => {
+            system_utils.populate_pools_for_blocks(part.chunk.blocks);
             part.chunk.chunk_coder_config = system_store.data.get_by_id(part.chunk.chunk_config).chunk_coder_config;
             const part_info = mapper.get_part_info(
                 part, adminfo, tiering_status_by_bucket_id[part.chunk.bucket]

--- a/src/server/object_services/map_writer.js
+++ b/src/server/object_services/map_writer.js
@@ -15,6 +15,7 @@ const range_utils = require('../../util/range_utils');
 const mongo_utils = require('../../util/mongo_utils');
 const system_store = require('../system_services/system_store').get_instance();
 const node_allocator = require('../node_services/node_allocator');
+const system_utils = require('../utils/system_utils');
 
 // dbg.set_level(5);
 
@@ -89,6 +90,7 @@ class MapAllocator {
             .then(dup_chunks => {
                 for (let i = 0; i < dup_chunks.length; ++i) {
                     const dup_chunk = dup_chunks[i];
+                    system_utils.populate_pools_for_blocks(dup_chunk.blocks);
                     dup_chunk.chunk_coder_config = system_store.data.get_by_id(dup_chunk.chunk_config).chunk_coder_config;
                     const is_good_for_dedup = mapper.is_chunk_good_for_dedup(
                         dup_chunk, this.bucket.tiering, this.tiering_status

--- a/src/server/utils/system_utils.js
+++ b/src/server/utils/system_utils.js
@@ -44,6 +44,17 @@ function mongo_wrapper_system_created() {
     }
 }
 
+function populate_pools_for_blocks(blocks) {
+    if (!blocks || !blocks.length) return;
+    blocks.forEach(block => {
+        const system = system_store.data.get_by_id(block.system);
+        const node_pool = system.pools_by_name[block.node.pool];
+        block.node_pool_id = node_pool._id;
+    });
+}
+
+
 exports.system_in_maintenance = system_in_maintenance;
 exports.get_bucket_quota_usage_percent = get_bucket_quota_usage_percent;
 exports.mongo_wrapper_system_created = mongo_wrapper_system_created;
+exports.populate_pools_for_blocks = populate_pools_for_blocks;

--- a/src/test/unit_tests/test_agent_blocks_verifier.js
+++ b/src/test/unit_tests/test_agent_blocks_verifier.js
@@ -77,6 +77,10 @@ class VerifierMock extends AgentBlocksVerifier {
             });
     }
 
+    populate_pools_for_blocks(blocks) {
+        // We already create the pools in block's nodes as mock objects
+    }
+
     populate_nodes_for_blocks(blocks) {
         const docs = blocks;
         const doc_path = 'node';
@@ -139,6 +143,9 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             _id: new mongodb.ObjectId(),
             rpc_address: 'n2n://SlothTown',
             online: true,
+            pool: {
+                _id: new mongodb.ObjectId()
+            }
         }];
         const chunk_coder_configs = [{
             _id: new mongodb.ObjectId(),
@@ -158,7 +165,8 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             _id: new mongodb.ObjectId(),
             node: nodes[0]._id,
             frag: chunks[0].frags[0]._id,
-            chunk: chunks[0]._id
+            chunk: chunks[0]._id,
+            node_pool_id: new mongodb.ObjectId()
         }];
         const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
         return P.resolve()
@@ -178,6 +186,9 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             _id: new mongodb.ObjectId(),
             rpc_address: 'n2n://SlothTown',
             online: false,
+            pool: {
+                _id: new mongodb.ObjectId()
+            },
             deleted: new Date()
         }];
         const chunk_coder_configs = [{
@@ -218,6 +229,9 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             _id: new mongodb.ObjectId(),
             rpc_address: 'n2n://SlothTown',
             online: false,
+            pool: {
+                _id: new mongodb.ObjectId()
+            }
         }];
         const chunk_coder_configs = [{
             _id: new mongodb.ObjectId(),
@@ -237,7 +251,8 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             _id: new mongodb.ObjectId(),
             node: nodes[0]._id,
             frag: chunks[0].frags[0]._id,
-            chunk: chunks[0]._id
+            chunk: chunks[0]._id,
+            node_pool_id: new mongodb.ObjectId()
         }];
         const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
         return P.resolve()
@@ -257,6 +272,9 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             _id: new mongodb.ObjectId(),
             rpc_address: 'n2n://SlothTown',
             online: true,
+            pool: {
+                _id: new mongodb.ObjectId()
+            }
         }];
         const chunk_coder_configs = [{
             _id: new mongodb.ObjectId(),
@@ -276,7 +294,8 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             _id: new mongodb.ObjectId(),
             node: new mongodb.ObjectId(),
             frag: chunks[0].frags[0]._id,
-            chunk: chunks[0]._id
+            chunk: chunks[0]._id,
+            node_pool_id: new mongodb.ObjectId()
         }];
         const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
         return P.resolve()

--- a/src/test/unit_tests/test_map_builder.js
+++ b/src/test/unit_tests/test_map_builder.js
@@ -20,6 +20,7 @@ const map_builder = require('../../server/object_services/map_builder');
 const map_deleter = require('../../server/object_services/map_deleter');
 const SliceReader = require('../../util/slice_reader');
 const system_store = require('../../server/system_services/system_store').get_instance();
+const system_utils = require('../../server/utils/system_utils');
 
 const { rpc_client } = coretest;
 const object_io = new ObjectIO();
@@ -151,6 +152,7 @@ coretest.describe_mapper_test_case({
     async function load_chunks(obj) {
         const chunks = await MDStore.instance().find_chunks_by_ids(obj.chunk_ids);
         await MDStore.instance().load_blocks_for_chunks(chunks);
+        _.forEach(chunks, chunk => system_utils.populate_pools_for_blocks(chunk.blocks));
         obj.chunks = chunks;
     }
 

--- a/src/test/unit_tests/test_mapper.js
+++ b/src/test/unit_tests/test_mapper.js
@@ -472,6 +472,7 @@ coretest.describe_mapper_test_case({
             _id,
             frag: frag._id,
             pool: pool._id,
+            node_pool_id: pool._id,
             node: {
                 pool: pool._id,
                 readable: readable !== false,


### PR DESCRIPTION
### Explain the changes:
- Taking pool id from nodes and not from block_mds. This is done because when we assign nodes to the different pool we do not update the block_mds.

### Issues: Fixed / Gap #xxx
- #4560 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
