### PR TITLE
added 10 seconds delay before node_allocator test

### DIFF
--- a/src/test/unit_tests/test_node_allocator.js
+++ b/src/test/unit_tests/test_node_allocator.js
@@ -35,9 +35,10 @@ mocha.describe('node_allocator', function() {
     const { rpc_client } = coretest;
 
     mocha.it('kmeans divided to groups', function() {
-        this.timeout(40000); // eslint-disable-line no-invalid-this
+        this.timeout(50000); // eslint-disable-line no-invalid-this
 
         return P.resolve()
+            .delay(10000)
             .then(() => system_store.data.pools.find(pool => pool.name === 'first.pool'))
             .then(pool => P.join(
                 rpc_client.node.allocate_nodes({ pool_id: String(pool._id), fields: NODE_FIELDS_FOR_MAP }),


### PR DESCRIPTION
### Explain the changes:
- test_nodes_allocator fails **sometimes**, probably because test nodes are not in a stable state.
- added delay to try and give the nodes more time before the test

### Testing Instructions:
- BE unit tests in vitaly

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
