### PR TITLE
fixes #4602 - BLOCK_STORE_GOOGLE was not considered as cloud node

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -3575,7 +3575,8 @@ class NodesMonitor extends EventEmitter {
     _is_cloud_node(item) {
         const cloud_node_types = [
             'BLOCK_STORE_S3',
-            'BLOCK_STORE_AZURE'
+            'BLOCK_STORE_AZURE',
+            'BLOCK_STORE_GOOGLE'
         ];
         return cloud_node_types.includes(item.node.node_type);
     }


### PR DESCRIPTION
### Explain the changes:
- BLOCK_STORE_GOOGLE was not considered as a cloud node

### Issues: Fixed / Gap #xxx
- fixes #4602 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
