### PR TITLE
Fixing getting null in error object from S3

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -795,13 +795,13 @@ function check_aws_connection(params) {
         .then(
             ret => ({ status: 'SUCCESS' }),
             err => {
-                dbg.warn(`got error on listBuckets with params`, _.omit(params, 'secret'), ` error: ${err}`, err.message);
+                dbg.warn(`got error on listBuckets with params`, _.omit(params, 'secret'), ` error: ${err}, code: ${err.code}, message: ${err.message}`);
                 const status = aws_error_mapping[err.code] || 'UNKNOWN_FAILURE';
                 return {
                     status,
                     error: {
                         code: err.code,
-                        message: err.message
+                        message: err.message || 'Unkown Error'
                     }
                 };
             }


### PR DESCRIPTION
### Explain the changes:
- When we receive null as a message in the S3 error we fail on schema since it is not a string

### Issues: Fixed / Gap #xxx
- Fixed #4608 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
