### PR TITLE
Fixed: system raw usage shows a flat line combined with the text "no …

### DIFF
--- a/frontend/src/app/components/overview/buckets-overview/buckets-overview.js
+++ b/frontend/src/app/components/overview/buckets-overview/buckets-overview.js
@@ -246,25 +246,28 @@ function _getChartParams(selectedDatasets, used, storageHistory, selectedDuratio
     const filteredSamples = _filterSamples(allSamples, start, end);
     const emptyChartMessage = _getChartEmptyMessage(showSamples, filteredSamples, selectedDatasets);
     const options = _getChartOptions(selectedDatasets, filteredSamples, durationSettings, start, end, timezone);
-    const datasets = selectedDatasets
-        .map(({ key, color }) => ({
-            lineTension: 0,
-            borderWidth: 2,
-            borderColor: color,
-            backgroundColor: 'transparent',
-            pointRadius: points ? 2 : 0,
-            pointBorderWidth: 4,
-            pointHitRadius: 10,
-            pointBackgroundColor: style['color6'],
-            pointBorderColor: hexToRgb(style['color6'], 0.2),
-            pointHoverBorderColor: 'transparent',
-            data: filteredSamples
-                .map(sample => ({
-                    x: sample.timestamp,
-                    y: toBytes(sample[key])
-                }))
-        })
-    );
+    let datasets = [];
+    if (!emptyChartMessage) {
+        datasets = selectedDatasets
+            .map(({ key, color }) => ({
+                lineTension: 0,
+                borderWidth: 2,
+                borderColor: color,
+                backgroundColor: 'transparent',
+                pointRadius: points ? 2 : 0,
+                pointBorderWidth: 4,
+                pointHitRadius: 10,
+                pointBackgroundColor: style['color6'],
+                pointBorderColor: hexToRgb(style['color6'], 0.2),
+                pointHoverBorderColor: 'transparent',
+                data: filteredSamples
+                    .map(sample => ({
+                        x: sample.timestamp,
+                        y: toBytes(sample[key])
+                    }))
+            })
+        );
+    }
 
     return {
         options,


### PR DESCRIPTION
### Explain the changes:
- system raw usage shows a flat line combined with the text "no data uploaded yet"

### Issues: Fixed / Gap #xxx
- fixed #4574 

### Testing Instructions:
1. open overview page
2. if you system was created more than 1 hour ago and no data uploaded yet
3. you will see the message 'No data uploaded yet' and no lines on the chart


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
