### PR TITLE
adding new error for problem in opening http/s ports

### DIFF
--- a/frontend/src/app/schema/hosts.js
+++ b/frontend/src/app/schema/hosts.js
@@ -171,6 +171,7 @@ const host = {
                 'NO_CAPACITY',
                 'LOW_CAPACITY',
                 'HTTP_SRV_ERRORS',
+                'HTTP_PORT_ACCESS_ERROR',
                 'HAS_ERRORS',
                 'HAS_ISSUES',
                 'N2N_PORTS_BLOCKED',
@@ -275,6 +276,7 @@ const host = {
                                 'OFFLINE',
                                 'DECOMMISSIONED',
                                 'HTTP_SRV_ERRORS',
+                                'HTTP_PORT_ACCESS_ERROR',
                                 'INITIALIZING',
                                 'DELETING',
                                 'OPTIMAL'
@@ -563,6 +565,9 @@ export default {
                                                 type: 'integer'
                                             },
                                             HTTP_SRV_ERRORS: {
+                                                type: 'integer'
+                                            },
+                                            HTTP_PORT_ACCESS_ERROR: {
                                                 type: 'integer'
                                             },
                                             HAS_ERRORS: {

--- a/frontend/src/app/utils/host-utils.js
+++ b/frontend/src/app/utils/host-utils.js
@@ -111,6 +111,11 @@ const modeToStateIcon = deepFreeze({
         css: 'error',
         tooltip: 'Cannot Start HTTP Server'
     },
+    HTTP_PORT_ACCESS_ERROR: {
+        name: 'problem',
+        css: 'error',
+        tooltip: 'Endpoint Cannot Use Ports 80/443'
+    },
     HAS_ERRORS: {
         name: 'problem',
         css: 'error',
@@ -274,6 +279,7 @@ const stateToModes = deepFreeze({
         'NO_CAPACITY',
         'LOW_CAPACITY',
         'HTTP_SRV_ERRORS',
+        'HTTP_PORT_ACCESS_ERROR',
         'HAS_ERRORS',
         'HAS_ISSUES',
         'N2N_PORTS_BLOCKED'
@@ -483,8 +489,13 @@ const endpointServiceModeToIcon = deepFreeze({
     HTTP_SRV_ERRORS: {
         name: 'problem',
         css: 'error',
-        tooltip: 'Cannot start HTTP server'
+        tooltip: 'Cannot Start HTTP server'
     },
+    HTTP_PORT_ACCESS_ERROR: {
+        name: 'problem',
+        css: 'error',
+        tooltip: 'Endpoint Cannot Use Ports 80/443'
+    }, 
     INITIALIZING: {
         name: 'working',
         css: 'warning',

--- a/src/api/host_api.js
+++ b/src/api/host_api.js
@@ -520,6 +520,7 @@ module.exports = {
                 'DECOMMISSIONED',
                 'UNTRUSTED',
                 'HTTP_SRV_ERRORS',
+                'HTTP_PORT_ACCESS_ERROR',
                 'INITIALIZING',
                 'OPTIMAL',
             ]
@@ -551,6 +552,7 @@ module.exports = {
                 'SOME_STORAGE_INITIALIZING',
                 'SOME_STORAGE_MIGRATING',
                 'HTTP_SRV_ERRORS',
+                'HTTP_PORT_ACCESS_ERROR',
                 'HAS_ERRORS',
                 'HAS_ISSUES'
             ]
@@ -682,6 +684,9 @@ module.exports = {
                     type: 'integer'
                 },
                 HTTP_SRV_ERRORS: {
+                    type: 'integer'
+                },
+                HTTP_PORT_ACCESS_ERROR: {
                     type: 'integer'
                 },
                 HAS_ERRORS: {

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -634,6 +634,7 @@ module.exports = {
                 'MEMORY_PRESSURE',
                 'OPTIMAL',
                 'HTTP_SRV_ERRORS',
+                'HTTP_PORT_ACCESS_ERROR'
             ]
         },
 
@@ -698,6 +699,9 @@ module.exports = {
                     type: 'integer'
                 },
                 HTTP_SRV_ERRORS: {
+                    type: 'integer'
+                },
+                HTTP_PORT_ACCESS_ERROR: {
                     type: 'integer'
                 },
                 MEMORY_PRESSURE: {

--- a/src/deploy/azure.js
+++ b/src/deploy/azure.js
@@ -127,9 +127,9 @@ const OSNAMES = [
     { type: 'centos7', shortname: 'c7' },
     { type: 'redhat6', shortname: 'r6' },
     { type: 'redhat7', shortname: 'r7' },
-    { type: 'win2008', shortname: 'w08' },
-    { type: 'win2012', shortname: 'w12' },
-    { type: 'win2016', shortname: 'w16' },
+    { type: 'win2008', shortname: 'w8' },
+    { type: 'win2012', shortname: 'w2' },
+    { type: 'win2016', shortname: 'w6' },
 ];
 
 let azf;

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -157,6 +157,7 @@ const MODE_COMPARE_ORDER = [
     'DECOMMISSIONED',
     'STORAGE_NOT_EXIST',
     'DETENTION',
+    'HTTP_PORT_ACCESS_ERROR',
     'HTTP_SRV_ERRORS',
     'IN_PROCESS',
     'SOME_STORAGE_MIGRATING',
@@ -197,6 +198,7 @@ const mode_priority = Object.freeze({
     UNTRUSTED: ERROR_PRI,
     STORAGE_NOT_EXIST: ERROR_PRI,
     DETENTION: ERROR_PRI,
+    HTTP_PORT_ACCESS_ERROR: ERROR_PRI,
     HTTP_SRV_ERRORS: ERROR_PRI,
     INITIALIZING: IN_PROCESS_PRI,
     DECOMMISSIONING: IN_PROCESS_PRI,
@@ -2045,6 +2047,8 @@ class NodesMonitor extends EventEmitter {
             (!item.trusted && 'UNTRUSTED') ||
             (item.node.deleted && 'DELETED') ||
             (item.storage_not_exist && 'STORAGE_NOT_EXIST') ||
+            ((item.node.node_type === 'ENDPOINT_S3' && item.node.srv_error &&
+                (item.node.srv_error.code === 'EACCES' || item.node.srv_error.code === 'EADDRINUSE')) && 'HTTP_PORT_ACCESS_ERROR') ||
             ((item.node.node_type === 'ENDPOINT_S3' && item.node.srv_error) && 'HTTP_SRV_ERRORS') ||
             (item.auth_failed && 'AUTH_FAILED') ||
             (item.node.migrating_to_pool && 'MIGRATING') ||
@@ -2613,6 +2617,7 @@ class NodesMonitor extends EventEmitter {
             'DECOMMISSIONED',
             'GATEWAY_ERRORS',
             'OPTIMAL',
+            'HTTP_PORT_ACCESS_ERROR',
             'HTTP_SRV_ERRORS',
         ];
         s3_nodes.forEach(node => {


### PR DESCRIPTION
### Explain the changes:
- adding special error when the endpoint can't open one of ports 80/443: HTTP_PORT_ACCESS_ERROR
- updating apis and frontend accordingly 

### Issues: Fixed / Gap #xxx
- Fixed #4627

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
