### PR TITLE
Addition of temporary upgrade timestamp so UI won't fail on schema validation

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -1427,6 +1427,9 @@ function upgrade_cluster(req) {
                     const system_updates = [{
                         _id: req.system._id,
                         $set: {
+                            // The timestamp is a patch so the UI won't fail on schema validation
+                            // It will be updated once again in mongo_upgrade_mark_completed by design
+                            "last_upgrade.timestamp": Date.now(),
                             "last_upgrade.initiator": (req.account && req.account.email) || ''
                         }
                     }];


### PR DESCRIPTION
### Explain the changes:
- Added temporary timestamp that will be replaced in mongo mark complete.
- This was added because the UI failed on schema validation.

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
