### PR TITLE
Add filters to the dropdowns

### DIFF
--- a/frontend/src/app/components/modals/add-bucket-trigger-modal/add-bucket-trigger-modal.html
+++ b/frontend/src/app/components/modals/add-bucket-trigger-modal/add-bucket-trigger-modal.html
@@ -6,6 +6,7 @@
 
     <editor params="label: 'Function'">
         <dropdown params="
+                filter: true,
                 options: funcOptions,
                 selected: form.func,
                 placeholder: 'Choose Function',

--- a/frontend/src/app/components/modals/assign-hosts-modal/assign-hosts-modal.html
+++ b/frontend/src/app/components/modals/assign-hosts-modal/assign-hosts-modal.html
@@ -11,6 +11,7 @@
         <span class="push-both-half">in</span>
 
         <dropdown class="push-next" params="
+            filter: true,
             placeholder: 'All Pools',
             options: poolOptions,
             selected: form.selectedPools

--- a/frontend/src/app/components/modals/connect-app-modal/connect-app-modal.html
+++ b/frontend/src/app/components/modals/connect-app-modal/connect-app-modal.html
@@ -6,6 +6,7 @@
     </h2>
 
     <dropdown class="push-next" params="
+        filter: true,
         options: accountOptions,
         selected: form.selectedAccount,
         placeholder: 'Select account',

--- a/frontend/src/app/components/modals/create-account-modal/create-account-modal.html
+++ b/frontend/src/app/components/modals/create-account-modal/create-account-modal.html
@@ -55,6 +55,7 @@
         <editor params="label: 'S3 default placement', disabled: isS3AccessDisabled">
             <div class="row">
                 <dropdown params="
+                        filter: true,
                         options: resourceOptions,
                         selected: form.defaultResource,
                         disabled: isS3AccessDisabled,

--- a/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.html
+++ b/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.html
@@ -17,6 +17,7 @@
     <editor params="label: 'S3 default placement', disabled: !form.hasS3Access()">
         <div class="row">
             <dropdown params="
+                    filter: true,
                     options: resourceOptions,
                     selected: form.defaultResource,
                     disabled: !form.hasS3Access(),

--- a/frontend/src/app/components/modals/install-nodes-modal/install-nodes-modal.html
+++ b/frontend/src/app/components/modals/install-nodes-modal/install-nodes-modal.html
@@ -15,6 +15,7 @@
         </p>
         <editor params="label: 'Target Pool'">
             <dropdown params="
+                    filter: true,
                     options: poolOptions,
                     selected: form.targetPool,
                     placeholder: 'Choose pool...',

--- a/frontend/src/app/components/shared/dropdown/dropdown.js
+++ b/frontend/src/app/components/shared/dropdown/dropdown.js
@@ -8,6 +8,7 @@ import ActionRowViewModel from './action-row';
 import ko from 'knockout';
 import { isObject } from 'utils/core-utils';
 import { stringifyAmount } from 'utils/string-utils';
+import { isString } from 'utils/core-utils';
 import { inputThrottle } from 'config';
 
 // Cannot use ensure array util (core utils) because
@@ -71,7 +72,8 @@ function _getEmptyMessage(
 }
 
 function _matchOption(option, filter) {
-    const { value = option, text = value } = option;
+    const { value = option, label = value } = option;
+    const text = isString(value) ? value : label;
     return !filter || text.toLowerCase().includes(filter);
 }
 

--- a/frontend/src/app/components/shared/dropdown/dropdown.less
+++ b/frontend/src/app/components/shared/dropdown/dropdown.less
@@ -181,6 +181,7 @@ dropdown {
         position: relative;
         font-size: @font-size1;
         color: @color7;
+        line-height: 42px;
 
         &.error {
             .error();


### PR DESCRIPTION
### Explain the changes:

- Add bucket trigger modal -  function dropdown
- Assign hosts modal -  pools dropdown
- Connect application modal - account dropdown
- Create account modal  - default pool dropdown
- Edit account s3 modal - default resource  dropdown
- Install nodes modal - pools dropdown

dropdown component changes was needed, for:
Add bucket trigger modal - function dropdown ( .../dropdown/dropdown.js options.value is object but expected string  )
Assign hosts modal -  pools dropdown ( .../dropdown/dropdown.less css issues fixed)


### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
- Check all the app modals with dropdowns to correct behavior

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
