### PR TITLE
Set timestamp so UI won't fail on schema validation

### DIFF
--- a/src/server/system_services/upgrade_server.js
+++ b/src/server/system_services/upgrade_server.js
@@ -302,6 +302,9 @@ async function _test_and_upgrade_in_background(cinfo, upgrade_path, req) {
         const system_updates = [{
             _id: req.system._id,
             $set: {
+                // The timestamp is a patch so the UI won't fail on schema validation
+                // It will be updated once again in mongo_upgrade_mark_completed by design
+                "last_upgrade.timestamp": Date.now(),
                 "last_upgrade.initiator": (req.account && req.account.email) || ''
             }
         }];


### PR DESCRIPTION
### Explain the changes:
- taken from commit f72c59b0be1910ae5728f282c688ffeaf882e4fc


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade - DB schema, server platform, agents install, npm packages