### PR TITLE
restore console logs in test_env_builder after running tests

### DIFF
--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -255,21 +255,28 @@ function run_tests() {
     // disable all dbg.log output before running tests
     dbg.set_console_output(false);
     dbg.original_console();
-    if (js_script) {
-        console.log(`running js script ${js_script} on ${server.name}`);
-        return promise_utils.fork(js_script, ['--server_name', server.name, '--server_ip', server.ip, '--server_secret', server.secret].concat(process.argv))
-            .catch(err => {
-                console.log('Failed running script', err);
-                throw err;
-            });
-    } else if (shell_script) {
-        console.log(`running bash script ${shell_script} on ${server.name}`);
-        return promise_utils.spawn(shell_script, [server.name, server.ip, server.secret])
-            .catch(err => {
-                console.log('Failed running script', err);
-                throw err;
-            });
-    }
+    return P.resolve()
+        .then(() => {
+            if (js_script) {
+                console.log(`running js script ${js_script} on ${server.name}`);
+                return promise_utils.fork(js_script, ['--server_name', server.name, '--server_ip', server.ip, '--server_secret', server.secret].concat(process.argv))
+                    .catch(err => {
+                        console.log('Failed running script', err);
+                        throw err;
+                    });
+            } else if (shell_script) {
+                console.log(`running bash script ${shell_script} on ${server.name}`);
+                return promise_utils.spawn(shell_script, [server.name, server.ip, server.secret])
+                    .catch(err => {
+                        console.log('Failed running script', err);
+                        throw err;
+                    });
+            }
+        })
+        .finally(() => {
+            dbg.wrapper_console();
+            dbg.set_console_output(true);
+        });
 }
 
 function clean_test_env() {

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -664,6 +664,10 @@ DebugLogger.prototype.original_console = function() {
     console_wrapper.original_console();
 };
 
+DebugLogger.prototype.wrapper_console = function() {
+    console_wrapper.wrapper_console();
+};
+
 if (console_wrapper) {
     //Register a "console" module DebugLogger for the console wrapper
     var conlogger = new DebugLogger("CONSOLE.js");


### PR DESCRIPTION
### Explain the changes:
- restore console logs in test_env_builder after running tests
- Added list hosts to server diagnostics

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages