### PR TITLE
Fixing lsblck sort order in  map_new_disk.sh

### DIFF
--- a/src/tools/platform/map_new_disk.sh
+++ b/src/tools/platform/map_new_disk.sh
@@ -55,7 +55,7 @@ then
             ${sudo} mount -t ${ext} /dev/${name} /${mountDir}
         fi
         unset mountpoint
-    done < <(lsblk | grep disk | tail -1) 
+    done < <(lsblk | sort -d | grep disk | tail -1) 
 fi
 
 if ! ${remount}
@@ -76,5 +76,5 @@ then
             ${sudo} mkfs -F -t ${ext} /dev/${name}
             ${sudo} mount -t ${ext} /dev/${name} /${mountDir}
         fi
-    done < <(lsblk | grep disk | awk '{print $1}')
+    done < <(lsblk | sort -d | grep disk | awk '{print $1}')
 fi


### PR DESCRIPTION
### Explain the changes:
- Ubuntu 16 has different default sort order for lsblck command
added sort -d to lsblck calls to unify script behavior for all Linux OSes 

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
- Run agent_matrix.js

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
