### PR TITLE
adding support for multiple data disks to azure.js

### DIFF
--- a/src/deploy/azure.js
+++ b/src/deploy/azure.js
@@ -96,6 +96,8 @@ Usage:
     --allimages                 Creates 1 agent per each supported OSs. If the number of agents requested exceeds the number of OSs
                                 duplicates would be created.
     --usemarket                 Use OS Images from the market and not prepared VHDs
+    --ddisknumber <disk-number> Number of data disks to add to the agent (default: 0)
+    --ddisksize <disk-size>     Size of data disks to add to the agent (default: 100GB)
     \n
     Examples:
     \tnode src/deploy/azure.js agent --resource nimrodb-group --storage nimrodbstorage --vnet nimrodb-group-vnet --ip 20.190.61.158 --add 1 --os redhat6 --usemarket
@@ -355,6 +357,17 @@ function _runAgent() {
                                     server_ip: serverIP,
                                     shouldInstall: true
                                 });
+                            }
+                        })
+                        .then(() => {
+                            if (argv.ddisknumber) {
+                                return azf.addDataDiskToVM({
+                                        vm: machine.name,
+                                        size: argv.ddisksize,
+                                        storage: argv.storage,
+                                        number_of_disks: argv.ddisknumber,
+                                    })
+                                    .then(() => azf.rescanDataDisksExtension(machine.name));
                             }
                         })
                         .then(() => console.log(`Successfully created ${util.inspect(machine)}`))


### PR DESCRIPTION
### Explain the changes:
- adding support for attaching data disks for agents
- making addDataDisk in azureFunctions to support adding more than one data disk
- adding rescanDataDisksExtension to azureFunctions to perform rescanning for both windows and linux
- updating add_disks to use the new functionality if anyone use it - maybe we can delete if no one does

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
