### PR TITLE
in test_env_builder - moved rerun_upgrade before tests run

### DIFF
--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -76,11 +76,6 @@ function main() {
         .spread((dummy, agents_ips) => install_agents())
         .then(upgrade_test_env)
         .then(run_tests)
-        .then(() => {
-            if (rerun_upgrade) {
-                return upgrade_test_env();
-            }
-        })
         .catch(err => {
             console.error('got error:', err);
             exit_code = 1;
@@ -248,6 +243,16 @@ function upgrade_test_env() {
         .catch(err => {
             console.error('upgrade_test_env failed', err);
             throw err;
+        })
+        .then(() => {
+            if (rerun_upgrade) {
+                console.log(`Got rerun_upgrade flag. running upgrade again from the new version to the same version (${upgrade})`);
+                return sanity_build_test.upgrade_and_test(server.ip, upgrade)
+                    .catch(err => {
+                        console.error(`Failed upgrading from the new version ${upgrade}`, err);
+                        throw err;
+                    });
+            }
         });
 }
 


### PR DESCRIPTION
### Explain the changes:
- rerun upgrade (if a flag is set) before the test suit run instead after.
- This will prevent the upgrade failures due to garbage left by tests
- It will also leave the tests report as the last output in Jenkins log, which makes it clearer to read.

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
