### PR TITLE
test_env_builder.js: add clean_by_id flag

### DIFF
--- a/src/deploy/azureFunctions.js
+++ b/src/deploy/azureFunctions.js
@@ -816,6 +816,19 @@ class AzureFunctions {
             }));
     }
 
+    listVirtualMachinesBySuffix(suffix) {
+        return P.fromCallback(callback => this.computeClient.virtualMachines.list(this.resourceGroupName, callback))
+            .then(machines_in_rg => {
+                var machines_with_string = [];
+                return P.map(machines_in_rg, machine => {
+                        if (machine.name.endsWith(suffix)) {
+                            machines_with_string.push(machine.name);
+                        }
+                    })
+                    .then(() => machines_with_string);
+            });
+    }
+
     listVirtualMachines(prefix, status) {
         return P.fromCallback(callback => this.computeClient.virtualMachines.list(this.resourceGroupName, callback))
             .then(machines_in_rg => {

--- a/src/test/qa/rebuild_replicas_test.js
+++ b/src/test/qa/rebuild_replicas_test.js
@@ -122,7 +122,7 @@ const azf = new AzureFunctions(clientId, domain, secret, subscriptionId, resourc
 function uploadAndVerifyFiles(num_agents) {
     let { data_multiplier } = unit_mapping.MB;
     // 1/2 GB per agent. 1 GB seems like too much memory for the lg to handle
-    let dataset_size = num_agents * 512;
+    let dataset_size = num_agents * 128;
     let parts = 20;
     let partSize = dataset_size / parts;
     let file_size = Math.floor(partSize);
@@ -292,7 +292,7 @@ return azf.authenticate()
     .then(() => af.createRandomAgents(azf, server_ip, storage, vnet, agents_number, suffix, osesSet))
     .then(res => {
         oses = Array.from(res.keys());
-        //Create a dataset on it (1/2 GB per agent)
+        //Create a dataset on it (1/4 GB per agent)
         return uploadAndVerifyFiles(agents_number);
     })
     .then(() => promise_utils.loop(iterations_number, cycle => {


### PR DESCRIPTION
### Explain the changes:
test_env_builder.js
- Add clean_by_id flag
- Adding server_external_ip flag
- Add printing to the help

azureFunctions.js:
- Add listVirtualMachinesBySuffix function

rebuild_replicas_test.js:
- Reduced the size of the dataset to 1/4 GB per agent

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
