### PR TITLE
fix browserify to avoid nb_native module correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,13 +53,12 @@
   },
   "homepage": "https://github.com/noobaa/noobaa-core",
   "browser": {
-    "nb_native": false,
-    "nb_native_nan": false,
     "express": false,
     "morgan": false,
     "compression": false,
     "bindings": false,
     "ws": false,
+    "./src/util/nb_native": false,
     "./config-local": false
   },
   "dependencies": {


### PR DESCRIPTION
### Explain the changes:
- Frontend failed with `Uncaught TypeError: util.promisify is not a function`
- The reason is that the path to nb_native should be relative in order to exclude it from browserify.

### Issues: Fixed / Gap #xxx
- Fix broken frontend after PR #4555 

### Testing Instructions:
- Open frontend, if it works then it's fixed.

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
