### PR TITLE
Virtual hosting of buckets

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -556,6 +556,12 @@ class Agent {
                 .then(() => {
                     dbg.log0('update_base_address: done -', params.base_address);
                     this.rpc.router = api.new_router(params.base_address);
+                    if (this.endpoint_info && this.endpoint_info.s3rver_process) {
+                        this.endpoint_info.s3rver_process.send({
+                            message: 'update_base_address',
+                            base_address: params.base_address
+                        });
+                    }
                     // on close the agent should call do_heartbeat again when getting the close event
                     this._server_connection.close();
                 });
@@ -678,6 +684,8 @@ class Agent {
         switch (message.code) {
             case 'WAITING_FOR_CERTS':
                 this.endpoint_info.s3rver_process.send({
+                    message: 'run_server',
+                    base_address: this.base_address,
                     certs: this._ssl_certs,
                     host_id: this._host_id,
                     node_id: this._node_id

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -211,7 +211,7 @@ function authenticate_request(req, res) {
 
 function parse_op_name(req) {
     // TODO S3_VIRTUAL_HOST_SUFFIX should get dns_name of the server and use '.'+dns_name
-    const virtual_host_suffix = process.env.S3_VIRTUAL_HOST_SUFFIX;
+    const virtual_host_suffix = req.virtual_host_suffix;
     const method = req.method.toLowerCase();
     const host = req.headers.host.split(':')[0]; // cutting off port
     const url = req.url;

--- a/src/server/node_services/node_server.js
+++ b/src/server/node_services/node_server.js
@@ -102,32 +102,6 @@ function _prepare_nodes_query(req) {
     return query;
 }
 
-
-/*
- * GET_RANDOM_TEST_NODES
- * return X random nodes for self test purposes
- */
-function get_test_nodes(req) {
-    const list_res = monitor.list_nodes({
-        system: String(req.system._id),
-        online: true,
-        decommissioning: false,
-        decommissioned: false,
-        deleting: false,
-        deleted: false,
-        skip_address: req.rpc_params.source,
-        skip_cloud_nodes: true,
-        skip_mongo_nodes: true,
-        skip_internal: true
-    }, {
-        pagination: true,
-        limit: req.rpc_params.count,
-        sort: 'shuffle'
-    });
-    return _.map(list_res.nodes,
-        node => _.pick(node, 'name', 'rpc_address'));
-}
-
 function allocate_nodes(req) {
     const params = req.rpc_params;
     params.system = String(req.system._id);
@@ -152,7 +126,7 @@ exports.recommission_node = req => monitor.recommission_node(req);
 exports.delete_node = req => monitor.delete_node(req.rpc_params);
 exports.list_nodes = list_nodes;
 exports.aggregate_nodes = aggregate_nodes;
-exports.get_test_nodes = get_test_nodes;
+exports.get_test_nodes = req => monitor.get_test_nodes(req);
 exports.allocate_nodes = allocate_nodes;
 exports.get_node_ids = req => monitor.get_node_ids(req);
 exports.aggregate_data_free_by_tier = req => nodes_aggregator.aggregate_data_free_by_tier(req);

--- a/src/tools/s3cat.js
+++ b/src/tools/s3cat.js
@@ -33,7 +33,8 @@ const s3 = new AWS.S3({
     endpoint: argv.endpoint,
     accessKeyId: argv.access_key,
     secretAccessKey: argv.secret_key,
-    s3ForcePathStyle: true,
+    s3ForcePathStyle: !argv.vhost,
+    s3BucketEndpoint: argv.vhost || false,
     signatureVersion: argv.sig, // s3 or v4
     computeChecksums: argv.checksum || false, // disabled by default for performance
     s3DisableBodySigning: !argv.signing || true, // disabled by default for performance
@@ -427,7 +428,7 @@ function get_object() {
 
         const data_size = parseInt(data.ContentLength, 10);
         const start_time = Date.now();
-        const speedometer = new Speedometer('Upload Speed');
+        const speedometer = new Speedometer('Download Speed');
 
         console.log('object size', size_utils.human_size(data_size));
 


### PR DESCRIPTION
### Explain the changes:
- adding support for virtual hosting of buckets - access to bucket using the <bucket_name>.<noobaa_dns_name>
- if it's dns and we will get a hostname that finishes with that dns_name we will strip the bucket name from that hostname and use it for the request
- added support for virtual hosting to s3cat for testing
- fixing part of #4649 - moving audit message from test_node_network to get_test_nodes so it will only print once 

### Issues: Fixed / Gap #xxx
-

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
