### PR TITLE
Move server-details-form into new arch

### DIFF
--- a/frontend/src/app/components/server/server-details-form/server-details-form.html
+++ b/frontend/src/app/components/server/server-details-form/server-details-form.html
@@ -17,26 +17,39 @@
             Edit Server Details
         </button>
     </div>
-    <property-sheet class="pad server-details" params="properties: infoSheet">
-        <template name="internal-storage">
+    <property-sheet class="pad server-details" params="
+        properties: infoSheet,
+        loading: !isServerLoaded()
+    ">
+        <template name="hardwareInfo">
+            <p class="row content-middle">
+                {{text}}
+                <!-- ko if: message -->
+                <span class="remark warning push-prev-half"> * Minimum requirements: {{message}}</span>
+                <!-- /ko -->
+            <p class="row content-middle">
+        </template>
+        <template name="internalStorage">
             <p class="row content-middle">
                 Using {{used}} of {{total}} (by bucket spillover)
-                <a class="link push-prev-half" ko.href="href">See internal resource</a>
+                <a class="link push-prev-half" ko.attr.href="href">See internal resource</a>
             </p>
         </template>
     </property-sheet>
 </section>
 
-<section class="column server-monitor" ko.css.disabled="!isConnected()">
+
+<section class="column server-monitor">
     <h2 class="heading3 pad alt-bg">
         Services Monitoring
     </h2>
-
+    <loading-indicator class="align-start pad" ko.visible="!isServerLoaded()"></loading-indicator>
+    <!-- ko if: isServerLoaded -->
     <ul class="pad column list-no-style status-list" >
-        <li class="row push-next" ko.with="version">
+        <li class="row push-next" ko.with="version()">
             <svg-icon class="push-next"
-                params="name: icon().name"
-                ko.css="icon().css"
+                params="name: icon.name"
+                ko.css="icon.css"
                 ko.tooltip="tooltip"
             ></svg-icon>
             <span class="label push-next highlight">Version:</span>
@@ -44,16 +57,16 @@
             <span ko.visible="!$component.isConnected()">Not Available</span>
         </li>
 
-        <li class="row push-next" ko.with="serverTime">
+        <li class="row push-next" ko.with="serverTime()">
             <svg-icon class="push-next"
-                params="name: icon().name"
-                ko.css="icon().css"
+                params="name: icon.name"
+                ko.css="icon.css"
                 ko.tooltip="tooltip"
             ></svg-icon>
             <span class="label push-next highlight">Server Date and Time:</span>
             <span class="row" ko.visible="$component.isConnected">
                 <span class="push-next-half">Server Clock:</span>
-                <span ko.text="clock"></span>
+                <span ko.text="$component.formattedTime"></span>
                 <span class="push-both">|</span>
 
                 <span class="push-next-half">NTP:</span>
@@ -69,10 +82,10 @@
             </button>
         </li>
 
-        <li class="row push-next" ko.with="dnsServers">
+        <li class="row push-next" ko.with="dnsServers()">
             <svg-icon class="push-next"
-                params="name: icon().name"
-                ko.css="icon().css"
+                params="name: icon.name"
+                ko.css="icon.css"
                 ko.tooltip="tooltip"
             ></svg-icon>
             <span class="label push-next highlight">DNS Servers:</span>
@@ -95,10 +108,10 @@
             </button>
         </li>
 
-        <li class="row push-next" ko.with="dnsName">
+        <li class="row push-next" ko.with="dnsName()">
             <svg-icon class="push-next"
-                params="name: icon().name"
-                ko.css="icon().css"
+                params="name: icon.name"
+                ko.css="icon.css"
                 ko.tooltip="tooltip"
             ></svg-icon>
             <span class="label push-next highlight">DNS Name:</span>
@@ -113,10 +126,10 @@
             </a>
         </li>
 
-        <li class="row push-next" ko.with="remoteSyslog">
+        <li class="row push-next" ko.with="remoteSyslog()">
             <svg-icon class="push-next"
-                params="name: icon().name"
-                ko.css="icon().css"
+                params="name: icon.name"
+                ko.css="icon.css"
                 ko.tooltip="tooltip"
             ></svg-icon>
             <span class="label push-next highlight">Remote Syslog:</span>
@@ -144,10 +157,10 @@
             </a>
         </li>
 
-        <li class="row push-next" ko.with="phoneHome">
+        <li class="row push-next" ko.with="phoneHome()">
             <svg-icon class="push-next"
-                params="name: icon().name"
-                ko.css="icon().css"
+                params="name: icon.name"
+                ko.css="icon.css"
                 ko.tooltip="tooltip"
             ></svg-icon>
             <span class="label push-next highlight">Phone Home:</span>
@@ -170,4 +183,5 @@
             </a>
         </li>
     </ul>
+    <!-- /ko -->
 </section>

--- a/frontend/src/app/reducers/system-reducer.js
+++ b/frontend/src/app/reducers/system-reducer.js
@@ -23,9 +23,12 @@ function onCompleteFetchSystemInfo(state, { payload, timestamp }) {
         upgrade,
         has_ssl_cert,
         remote_syslog_config,
-        dns_name, ip_address,
-        maintenance_mode
+        maintenance_mode,
+        dns_name,
+        ip_address,
+        phone_home_config
     } = payload;
+
     const { releaseNotes } = state || {};
 
     return {
@@ -38,7 +41,8 @@ function onCompleteFetchSystemInfo(state, { payload, timestamp }) {
         releaseNotes,
         maintenanceMode: {
             till:  maintenance_mode.state ? timestamp + maintenance_mode.time_left : 0
-        }
+        },
+        phonehome: phone_home_config && phone_home_config.proxy_address
     };
 }
 

--- a/frontend/src/app/schema/system.js
+++ b/frontend/src/app/schema/system.js
@@ -95,6 +95,9 @@ export default {
                     type: 'integer'
                 }
             }
+        },
+        phonehome: {
+            type: 'string'
         }
     }
 };


### PR DESCRIPTION
[skip ci]
### Explain the changes:
- Move server-details-form into new arch

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
1. go to cluster, select server in the table and go to the server page
2. page loaded without errors
3. try to reload the page, reloaded with no errors
4. check 'Cluster Connectivity IP' modal, works correctly
5. check 'Edit Server Details' modal, works correctly
6. try Server Date and Time edit, works correctly, updated data displayed correctly
7. try DNS Servers edit, works correctly, updated data displayed correctly
8. check DNS Name 'Go to configuration' link, works correctly,  updated data displayed correctly
9. check Remote Syslog  'Go to configuration' link, works correctly,  updated data displayed correctly
10. Phone Home  'Go to configuration' link, works correctly,  updated data displayed correctly
11. check Internal Storage Resource See internal resource link, works correctly

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
