### PR TITLE
Fixing list_objects in azure namespace

### DIFF
--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -231,7 +231,9 @@ function send_reply(req, res, reply, options) {
             reply;
         const xml_reply = xml_utils.encode_xml(xml_root);
         dbg.log0('HTTP REPLY XML', req.method, req.originalUrl,
-            JSON.stringify(req.headers), xml_reply);
+            JSON.stringify(req.headers),
+            xml_reply.length <= 2000 ?
+            xml_reply : xml_reply.slice(0, 1000) + ' ... ' + xml_reply(-1000));
         res.setHeader('Content-Type', 'application/xml');
         res.setHeader('Content-Length', Buffer.byteLength(xml_reply));
         res.end(xml_reply);


### PR DESCRIPTION
### Explain the changes:
- Fixing list objects for azure namespace bucket.

3 main issues were fixed in this PR:
1) max-keys when sent to Azure cannot be 0 
2) the SKD forces us to list prefixes and blobs separately and then we combine them together, but we did not take into account the max-keys requested and simply concated the two responses. 
3) The SDK version for Blob was changed, and instead of a next marker, a continuation token is being returned ({storageLocation, nextMarker}) - changes were required in our namespace_blob

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
