### PR TITLE
added auth_method to AWS connection to indicate auth version (v2\v4)

### DIFF
--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -41,7 +41,7 @@ class BlockStoreS3 extends BlockStoreBase {
                 secretAccessKey: this.cloud_info.access_keys.secret_key,
                 s3ForcePathStyle: true,
                 httpOptions,
-                signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint),
+                signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint, this.cloud_info.auth_method),
                 region: DEFAULT_REGION
             });
         } else {
@@ -50,7 +50,7 @@ class BlockStoreS3 extends BlockStoreBase {
                 s3ForcePathStyle: true,
                 accessKeyId: this.cloud_info.access_keys.access_key,
                 secretAccessKey: this.cloud_info.access_keys.secret_key,
-                signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint),
+                signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint, this.cloud_info.auth_method),
                 s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(endpoint),
                 httpOptions: {
                     agent: http_utils.get_unsecured_http_agent(endpoint, this.proxy)

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -302,6 +302,9 @@ module.exports = {
                     secret: {
                         type: 'string'
                     },
+                    auth_method: {
+                        $ref: 'common_api#/definitions/cloud_auth_method'
+                    },
                     cp_code: {
                         type: 'string'
                     },
@@ -333,7 +336,9 @@ module.exports = {
                     secret: {
                         type: 'string'
                     },
-
+                    auth_method: {
+                        $ref: 'common_api#/definitions/cloud_auth_method'
+                    },
                     cp_code: {
                         type: 'string'
                     },
@@ -472,6 +477,9 @@ module.exports = {
                                     },
                                     cp_code: {
                                         type: 'string'
+                                    },
+                                    auth_method: {
+                                        $ref: 'common_api#/definitions/cloud_auth_method'
                                     },
                                     endpoint_type: {
                                         type: 'string',

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -306,6 +306,11 @@ module.exports = {
             }
         },
 
+        cloud_auth_method: {
+            type: 'string',
+            enum: ['AWS_V2', 'AWS_V4']
+        },
+
         proxy_params: {
             type: 'object',
             required: ['target', 'method_api', 'method_name'],

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -354,6 +354,9 @@ module.exports = {
                     type: 'string',
                     enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'NOOBAA', 'NET_STORAGE']
                 },
+                auth_method: {
+                    $ref: 'common_api#/definitions/cloud_auth_method'
+                },
                 target_bucket: {
                     type: 'string'
                 },
@@ -387,6 +390,9 @@ module.exports = {
                 endpoint_type: {
                     type: 'string',
                     enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'NOOBAA', 'NET_STORAGE']
+                },
+                auth_method: {
+                    $ref: 'common_api#/definitions/cloud_auth_method'
                 },
                 target_bucket: {
                     type: 'string'

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -162,6 +162,7 @@ class HostedAgents {
                     endpoint: pool.cloud_pool_info.endpoint,
                     endpoint_type: pool.cloud_pool_info.endpoint_type,
                     target_bucket: pool.cloud_pool_info.target_bucket,
+                    auth_method: pool.cloud_pool_info.auth_method,
                     access_keys: {
                         access_key: pool.cloud_pool_info.access_keys.access_key,
                         secret_key: pool.cloud_pool_info.access_keys.secret_key

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -163,7 +163,7 @@ class ObjectSDK {
                 accessKeyId: ns_info.access_key,
                 secretAccessKey: ns_info.secret_key,
                 // region: 'us-east-1', // TODO needed?
-                signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(ns_info.endpoint),
+                signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(ns_info.endpoint, ns_info.auth_method),
                 s3ForcePathStyle: true,
                 // computeChecksums: false, // disabled by default for performance
                 s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(ns_info.endpoint),

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -602,6 +602,7 @@ async function add_external_connection(req) {
     info.access_key = req.rpc_params.identity;
     info.secret_key = req.rpc_params.secret;
     info.cp_code = req.rpc_params.cp_code || undefined;
+    info.auth_method = req.rpc_params.auth_method || undefined;
     info = _.omitBy(info, _.isUndefined);
 
     // TODO: Maybe we should check differently regarding NET_STORAGE connections
@@ -781,7 +782,7 @@ function check_aws_connection(params) {
         endpoint: params.endpoint,
         accessKeyId: params.identity,
         secretAccessKey: params.secret,
-        signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(params.endpoint),
+        signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(params.endpoint, params.auth_method),
         s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(params.endpoint),
         httpOptions: {
             agent: http_utils.get_unsecured_http_agent(params.endpoint, params.proxy)
@@ -951,6 +952,7 @@ function get_account_info(account, include_connection_cache) {
             name: credentials.name,
             endpoint: credentials.endpoint,
             identity: credentials.access_key,
+            auth_method: credentials.auth_method,
             cp_code: credentials.cp_code || undefined,
             endpoint_type: credentials.endpoint_type,
             usage: _list_connection_usage(account, credentials)

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -848,7 +848,7 @@ function get_cloud_buckets(req) {
                     endpoint: connection.endpoint,
                     accessKeyId: connection.access_key,
                     secretAccessKey: connection.secret_key,
-                    signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(connection.endpoint),
+                    signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(connection.endpoint, connection.auth_method),
                     s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(connection.endpoint),
                     httpOptions: {
                         agent: http_utils.get_unsecured_http_agent(connection.endpoint, proxy)

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -127,6 +127,7 @@ function create_namespace_resource(req) {
         endpoint: connection.endpoint,
         target_bucket: req.rpc_params.target_bucket,
         access_key: connection.access_key,
+        auth_method: connection.auth_method,
         cp_code: connection.cp_code || undefined,
         secret_key: connection.secret_key,
         endpoint_type: connection.endpoint_type || 'AWS'
@@ -166,6 +167,7 @@ function create_cloud_pool(req) {
     var cloud_info = {
         endpoint: connection.endpoint,
         target_bucket: req.rpc_params.target_bucket,
+        auth_method: connection.auth_method,
         access_keys: {
             access_key: connection.access_key,
             secret_key: connection.secret_key,
@@ -557,6 +559,7 @@ function get_namespace_resource_extended_info(namespace_resource) {
         name: namespace_resource.name,
         endpoint_type: namespace_resource.connection.endpoint_type,
         endpoint: namespace_resource.connection.endpoint,
+        auth_method: namespace_resource.connection.auth_method,
         cp_code: namespace_resource.connection.cp_code || undefined,
         target_bucket: namespace_resource.connection.target_bucket,
         access_key: namespace_resource.connection.access_key,

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -73,6 +73,10 @@ module.exports = {
                     name: { type: 'string' },
                     access_key: { type: 'string' },
                     secret_key: { type: 'string' },
+                    auth_method: {
+                        type: 'string',
+                        enum: ['AWS_V2', 'AWS_V4']
+                    },
                     endpoint: { type: 'string' },
                     cp_code: { type: 'string' },
                     endpoint_type: {

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -35,6 +35,10 @@ module.exports = {
                     type: 'string',
                     enum: ['NOOBAA', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'NET_STORAGE']
                 },
+                auth_method: {
+                    type: 'string',
+                    enum: ['AWS_V2', 'AWS_V4']
+                },
                 endpoint: {
                     type: 'string'
                 },

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -90,6 +90,10 @@ module.exports = {
                 target_bucket: {
                     type: 'string'
                 },
+                auth_method: {
+                    type: 'string',
+                    enum: ['AWS_V2', 'AWS_V4']
+                },
                 access_keys: {
                     type: 'object',
                     required: ['access_key', 'secret_key', 'account_id'],

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -75,7 +75,9 @@ function disable_s3_compatible_bodysigning(endpoint) {
     return disable_sign;
 }
 
-function get_s3_endpoint_signature_ver(endpoint) {
+function get_s3_endpoint_signature_ver(endpoint, auth_method) {
+    if (auth_method === 'AWS_V4') return 'v4';
+    if (auth_method === 'AWS_V2') return 'v2';
     if (is_aws_endpoint(endpoint)) {
         return 'v4';
     } else {


### PR DESCRIPTION
### Explain the changes:
- added `auth_method` property to connection. can be `AWS_V2` or `AWS_V4`
- auth method is passed to cloud_resource\namespace_resource and is used to determine the signature version when connecting to AWS

### Issues: Fixed / Gap #xxx
- Related to #4622 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages