### PR TITLE
Moving MD Aggregator to be last test and removing DB defaults at the end

### DIFF
--- a/src/test/framework/flow.js
+++ b/src/test/framework/flow.js
@@ -107,18 +107,6 @@ var steps = [
         //Restore DB to defaults
         name: 'Restore DB Defaults',
         common: 'restore_db_defaults',
-    },
-    {
-        //Test MD Aggregator
-        name: 'MD Aggregator Test',
-        action: 'node',
-        params: [{
-            arg: './src/test/system_tests/test_md_aggregator'
-        }],
-    }, {
-        //Restore DB to defaults
-        name: 'Restore DB Defaults',
-        common: 'restore_db_defaults',
     }, {
         //Bucket Lambda Triggers Test
         name: 'Bucket Lambda Triggers Test',
@@ -130,6 +118,13 @@ var steps = [
         //Restore DB to defaults
         name: 'Restore DB Defaults',
         common: 'restore_db_defaults',
+    }, {
+        //Test MD Aggregator
+        name: 'MD Aggregator Test',
+        action: 'node',
+        params: [{
+            arg: './src/test/system_tests/test_md_aggregator'
+        }],
     }
 ];
 


### PR DESCRIPTION
### Explain the changes:
- Since Vitaly failed on MD Aggregator test I've attempted to reproduce without any success.
- I'm moving the test to be at the end of the flow and removing the last mongodb_default call in order to be able to investigate when the next Vitaly failure occurs

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
