### PR TITLE
fix upgrade_in_process indication after upgrade was aborted

### DIFF
--- a/src/server/system_services/upgrade_server.js
+++ b/src/server/system_services/upgrade_server.js
@@ -113,6 +113,12 @@ async function do_upgrade(req) {
 }
 
 function get_upgrade_status(req) {
+    const server = system_store.get_local_cluster_info();
+    const upgrade_stage = _.get(server, 'upgrade.stage');
+    if (upgrade_stage === 'UPGRADE_ABORTED') {
+        dbg.warn('UPGRADE: upgrade was aborted by upgrade manager. resetting upgrade_in_process to false');
+        upgrade_in_process = false;
+    }
     return { in_process: upgrade_in_process };
 }
 

--- a/src/upgrade/upgrade.js
+++ b/src/upgrade/upgrade.js
@@ -28,7 +28,10 @@ async function do_upgrade() {
     dbg.log0('UPGRADE: starting do_upgrade in upgrade.js');
     try {
         dbg.log0('UPGRADE: backup up old version before starting..');
+        // TODO: move the backup stage into upgrade_manager
         await platform_upgrade.backup_old_version();
+        // prepare_new_dir must run before running upgrade manager since it fixes .env parameters that
+        // upgrade manager might need (e.g. mongo connection string, etc.)
         await platform_upgrade.prepare_new_dir();
         await start_upgrade_manager();
     } catch (err) {

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -126,8 +126,7 @@ class UpgradeManager {
     async run_upgrade_stages() {
         const UPGRADE_STAGES = Object.freeze([{
             name: 'START_UPGRADE',
-            func: () => this.start_upgrade_stage(),
-            rollback_on_error: true
+            func: () => this.start_upgrade_stage()
         }, {
             name: 'COPY_NEW_CODE',
             func: () => this.copy_new_code_stage(),


### PR DESCRIPTION
### Explain the changes:
- on `upgrade_server.get_upgrade_status` check if upgrade.stage is `UPGRADE_ABORTED` and reset `upgrade_in_process` in that case

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is a top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages