### PR TITLE
fixes #4759 - avoid reading from cloud by verifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",

--- a/src/agent/block_store_services/block_store_azure.js
+++ b/src/agent/block_store_services/block_store_azure.js
@@ -1,7 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-// const _ = require('lodash');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -94,6 +93,25 @@ class BlockStoreAzure extends BlockStoreBase {
                 }
                 throw err;
             });
+    }
+
+
+    async _read_block_for_verification(block_md) {
+        try {
+            const block_info = await P.fromCallback(callback => this.blob.getBlobProperties(
+                this.container_name,
+                this._block_key(block_md.id),
+                callback
+            ));
+            const store_block_md = this._decode_block_md(block_info.metadata.noobaablockmd || block_info.metadata.noobaa_block_md);
+            const store_md5 = block_info.contentSettings.contentMD5;
+            return {
+                block_md: store_block_md,
+                store_md5
+            };
+        } catch (err) {
+            dbg.warn('failed to get object md. block_md =', block_md, err);
+        }
     }
 
     _delegate_write_block(block_md, data_length) {

--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -58,7 +58,6 @@ class BlockStoreClient {
             })
             .then(delegation_info => {
                 const { host, container, block_key, blob_sas, metadata, usage, proxy } = delegation_info;
-
                 // create a shared blob service using the blob_sas (shared access signature)
                 const shared_blob_svc = azure_storage.createBlobServiceWithSas(host, blob_sas);
                 shared_blob_svc.setProxy(proxy ? url.parse(proxy) : null);

--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -89,6 +89,25 @@ class BlockStoreGoogle extends BlockStoreBase {
         }
     }
 
+    async _read_block_for_verification(block_md) {
+        try {
+            const block_key = this._block_key(block_md.id);
+            const file = this.bucket.file(block_key);
+            const block_info = await file.getMetadata();
+            const store_md5 = block_info[0].md5Hash;
+            const block_md_b64 =
+                _.get(block_info[0], 'metadata.noobaablockmd') ||
+                _.get(block_info[0], 'metadata.noobaa_block_md');
+            const store_block_md = this._decode_block_md(block_md_b64);
+            return {
+                block_md: store_block_md,
+                store_md5
+            };
+        } catch (err) {
+            dbg.warn('failed to get object md. block_md =', block_md, err);
+        }
+    }
+
     async _try_read_block(block_md) {
         try {
             const block_key = this._block_key(block_md.id);


### PR DESCRIPTION
### Explain the changes:
- avoid reading from the cloud by the verifier
- for cloud resources verify by getting metadata and comparing md5

### Issues: Fixed / Gap #xxx
- Fixes #4759 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages