### PR TITLE
Increase T/O for waiting on server HB (Upgrade Test)

### DIFF
--- a/src/test/qa/two_step_upgrade_test.js
+++ b/src/test/qa/two_step_upgrade_test.js
@@ -352,7 +352,7 @@ function test_second_step() {
                 timezone: "Asia/Jerusalem",
                 ntp_server: "pool.ntp.org"
             }))
-            .delay(25000)) //time update restarts the services
+            .delay(65000)) //time update restarts the services
         .then(() => server_function.upload_upgrade_package(TEST_CFG.ip, TEST_CFG.upgrade_package))
         .then(() => _verify_upgrade_status('CAN_UPGRADE', 'FAILED', 'Staging package, final time'))
         .then(() => _call_upgrade());


### PR DESCRIPTION
### Explain the changes:
- Increase T/O for waiting on server HB (Upgrade Test)

### Issues: Fixed / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
