### PR TITLE
Time left for maintenance mode refactoring

### DIFF
--- a/frontend/src/app/components/management/maintenance-form/maintenance-form.js
+++ b/frontend/src/app/components/management/maintenance-form/maintenance-form.js
@@ -5,7 +5,6 @@ import Observer from 'observer';
 import ko from 'knockout';
 import { formatTimeLeftForMaintenanceMode } from 'utils/maintenance-utils';
 import { realizeUri } from 'utils/browser-utils';
-import { isUndefined } from 'utils/core-utils';
 import { action$, state$ } from 'state';
 import { getMany } from 'rx-extensions';
 import * as routes from 'routes';
@@ -33,7 +32,7 @@ class MaintenanceFormViewModel extends Observer {
         this.observe(
             state$.pipe(
                 getMany(
-                    ['system', 'timeLeftForMaintenanceMode'],
+                    ['system', 'maintenanceMode'],
                     'location'
                 )
             ),
@@ -41,9 +40,10 @@ class MaintenanceFormViewModel extends Observer {
         );
     }
 
-    onState([timeLeft, location]) {
-        if (isUndefined(timeLeft)) return;
+    onState([maintenanceMode, location]) {
+        if (!maintenanceMode) return;
 
+        const timeLeft = Math.max(maintenanceMode.till - Date.now(), 0);
         const { system, tab, section } = location.params;
         const toggleSection = section === sectionName ? undefined : sectionName;
         const toggleUri = realizeUri(

--- a/frontend/src/app/components/stickies/maintenance-sticky/maintenance-sticky.js
+++ b/frontend/src/app/components/stickies/maintenance-sticky/maintenance-sticky.js
@@ -4,7 +4,6 @@ import template from './maintenance-sticky.html';
 import Observer from 'observer';
 import ko from 'knockout';
 import { formatTimeLeftForMaintenanceMode } from 'utils/maintenance-utils';
-import { isUndefined } from 'utils/core-utils';
 import { get } from 'rx-extensions';
 import { action$, state$ } from 'state';
 import { timeTickInterval } from 'config';
@@ -21,13 +20,15 @@ class MaintenanceModeStickyViewModel extends Observer {
         this.ticker = setInterval(this.onTick.bind(this), timeTickInterval);
 
         this.observe(
-            state$.pipe(get('system', 'timeLeftForMaintenanceMode')),
+            state$.pipe(get('system', 'maintenanceMode')),
             this.onState
         );
     }
 
-    onState(timeLeft) {
-        if (isUndefined(timeLeft)) return;
+    onState(maintenanceMode) {
+        if (!maintenanceMode) return;
+
+        const timeLeft = Math.max(maintenanceMode.till - Date.now(), 0);
 
         this.isActive(Boolean(timeLeft));
         this.timeLeft(timeLeft);

--- a/frontend/src/app/reducers/system-reducer.js
+++ b/frontend/src/app/reducers/system-reducer.js
@@ -36,7 +36,9 @@ function onCompleteFetchSystemInfo(state, { payload }) {
         upgrade: _mapUpgrade(upgrade),
         remoteSyslog: _mapRemoteSyslog(remote_syslog_config),
         releaseNotes,
-        timeLeftForMaintenanceMode: maintenance_mode.state ? maintenance_mode.time_left : 0
+        maintenanceMode: {
+            till:  maintenance_mode.state ? Date.now() + maintenance_mode.time_left : 0
+        }
     };
 }
 

--- a/frontend/src/app/schema/system.js
+++ b/frontend/src/app/schema/system.js
@@ -3,7 +3,7 @@ export default {
     required: [
         'ipAddress',
         'version',
-        'timeLeftForMaintenanceMode'
+        'maintenanceMode'
     ],
     properties: {
         dnsName: {
@@ -85,8 +85,16 @@ export default {
                 }
             }
         },
-        timeLeftForMaintenanceMode: {
-            type: 'integer'
+        maintenanceMode: {
+            type: 'object',
+            required: [
+                'till'
+            ],
+            properties: {
+                till: {
+                    type: 'integer'
+                }
+            }
         }
     }
 };


### PR DESCRIPTION
#### 3. Other Changes:
- Time left for maintenance mode refactoring

### Testing Instructions:
1. go to management tab
2. select advanced-options tab
3. expand Maintenance block
4. click 'Turn Maintenance On' button
9. click start Maintenance
10. Maintenance mode enabled
11. click Turn maintenance off
12. Maintenance mode disabled

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
