### PR TITLE
Fix upload and abort flow in dataset + add support for versioning 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/test/utils/s3ops.js
+++ b/src/test/utils/s3ops.js
@@ -69,7 +69,7 @@ function server_side_copy_file_with_md5(ip, bucket, source, destination, version
 
     let params = {
         Bucket: bucket,
-        CopySource: bucket + '/' + source + versionid ? `?versionId=${versionid}` : '',
+        CopySource: bucket + '/' + source + (versionid ? `?versionId=${versionid}` : ''),
         Key: destination,
         MetadataDirective: 'COPY'
     };
@@ -849,6 +849,32 @@ function abort_multipart_upload(ip, bucket, file_name, uploadId) {
         });
 }
 
+function create_multipart_upload(ip, bucket, file_name) {
+    const rest_endpoint = 'http://' + ip + ':' + port;
+    const s3bucket = new AWS.S3({
+        endpoint: rest_endpoint,
+        accessKeyId: accessKeyDefault,
+        secretAccessKey: secretKeyDefault,
+        s3ForcePathStyle: true,
+        sslEnabled: false,
+    });
+
+    const params = {
+        Bucket: bucket,
+        Key: file_name,
+    };
+
+    return P.ninvoke(s3bucket, 'createMultipartUpload', params)
+        .then(res => {
+            console.log(`Initiated multipart upload filename: ${file_name} uploadId ${res.UploadId}`);
+            return res.UploadId;
+        })
+        .catch(err => {
+            console.error(`Initiating multipart upload failed ${file_name}`, err);
+            throw err;
+        });
+}
+
 /*
  * Internal Utils
  */
@@ -924,3 +950,4 @@ exports.set_file_attribute = set_file_attribute;
 exports.set_file_attribute_with_copy = set_file_attribute_with_copy;
 exports.get_object = get_object;
 exports.abort_multipart_upload = abort_multipart_upload;
+exports.create_multipart_upload = create_multipart_upload;


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
-  Add support for dataset to run on a versioning enabled bucket

#### 2. Existing Behavior Changes (Sync with Liran):
- Fix upload and abort flow - instead of uploading and trying to abort in the middle, initiate only and then abort
.

### Testing Instructions:
- Run dataset

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
