### PR TITLE
Fixed system-address link issue

### DIFF
--- a/frontend/src/app/components/server/server-details-form/server-details-form.js
+++ b/frontend/src/app/components/server/server-details-form/server-details-form.js
@@ -37,7 +37,7 @@ const icons = deepFreeze({
 const tab = 'settings';
 
 const sections = deepFreeze({
-    serverDns: 'server-dns',
+    serverDns: 'system-address',
     remoteSyslog: 'remote-syslog',
     phoneHome: 'phone-home'
 });


### PR DESCRIPTION
### Issues: Fixed #xxx / Gap #xxx
- "server details - > Services Monitoring -> DNS Name: -> Go to configuration" link issue
 
### Testing Instructions:

1. go to server details page
2. click on "DNS Name" -> "Go to configuration"
3. uri '...management/settings/system-address' opened correctly