### PR TITLE
blob block api

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -646,7 +646,6 @@ class AgentCLI {
 
 
 function agent_cli_repl() {
-    console.log(`DZDZ: starting repl`);
     // start a Read-Eval-Print-Loop
     var repl_srv = repl.start({
         prompt: 'agent-cli > ',

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -244,6 +244,9 @@ module.exports = {
                     num_parts: {
                         type: 'integer'
                     },
+                    etag: {
+                        type: 'string',
+                    },
                 }
             },
             reply: {

--- a/src/endpoint/blob/blob_rest.js
+++ b/src/endpoint/blob/blob_rest.js
@@ -12,7 +12,8 @@ const BLOB_MAX_BODY_LEN = 4 * 1024 * 1024;
 const RPC_ERRORS_TO_BLOB = Object.freeze({
     NO_SUCH_BUCKET: BlobError.ContainerNotFound,
     BUCKET_ALREADY_EXISTS: BlobError.ContainerAlreadyExists,
-    NO_SUCH_OBJECT: BlobError.BlobNotFound
+    NO_SUCH_OBJECT: BlobError.BlobNotFound,
+    INVALID_REQUEST: BlobError.InvalidBlobOrBlock,
 });
 
 const BLOB_OPS = load_ops();
@@ -168,6 +169,8 @@ function load_ops() {
         get_blob_metadata: r('./ops/blob_get_blob_metadata'),
         get_blob_blocklist: r('./ops/blob_get_blob_blocklist'),
         put_blob: r('./ops/blob_put_blob'),
+        put_blob_block: r('./ops/blob_put_blob_block'),
+        put_blob_blocklist: r('./ops/blob_put_blob_blocklist'),
         put_blob_lease: r('./ops/blob_put_blob_lease'),
         delete_blob: r('./ops/blob_delete_blob'),
     });

--- a/src/endpoint/blob/blob_utils.js
+++ b/src/endpoint/blob/blob_utils.js
@@ -1,8 +1,11 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const url = require('url');
+
 const _ = require('lodash');
 const time_utils = require('../../util/time_utils');
+const endpoint_utils = require('../endpoint_utils');
 
 function set_response_object_md(res, object_md) {
     res.setHeader('ETag', '"' + object_md.etag + '"');
@@ -42,7 +45,18 @@ function parse_etag(etag) {
     return etag;
 }
 
+function parse_copy_source(req) {
+    const copy_source = req.headers['x-ms-copy-source'];
+    if (!copy_source) return;
+
+    const source_url = url.parse(copy_source).path;
+
+    return _.pick(endpoint_utils.parse_source_url(source_url), 'bucket', 'key');
+}
+
+
 exports.set_response_object_md = set_response_object_md;
 exports.get_request_xattr = get_request_xattr;
 exports.set_response_xattr = set_response_xattr;
 exports.parse_etag = parse_etag;
+exports.parse_copy_source = parse_copy_source;

--- a/src/endpoint/blob/ops/blob_delete_blob.js
+++ b/src/endpoint/blob/ops/blob_delete_blob.js
@@ -22,5 +22,6 @@ module.exports = {
     },
     reply: {
         type: 'empty',
+        keep_status_code: true
     },
 };

--- a/src/endpoint/blob/ops/blob_get_blob.js
+++ b/src/endpoint/blob/ops/blob_get_blob.js
@@ -37,7 +37,7 @@ function get_blob(req, res) {
             //      416 (unsatisfiable)
             //      array (ranges)
             const ranges = http_utils.normalize_http_ranges(
-                http_utils.parse_http_range(req.headers.range),
+                http_utils.parse_http_range(req.headers['x-ms-range'] || req.headers.range),
                 obj_size);
 
             if (!ranges) {

--- a/src/endpoint/blob/ops/blob_put_blob.js
+++ b/src/endpoint/blob/ops/blob_put_blob.js
@@ -1,31 +1,45 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const BlobError = require('../blob_errors').BlobError;
 const blob_utils = require('../blob_utils');
 const http_utils = require('../../../util/http_utils');
+const time_utils = require('../../../util/time_utils');
+
 
 /**
  * https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
  */
-function put_blob(req, res) {
-    if (req.headers['x-ms-copy-source']) throw new BlobError(BlobError.NotImplemented);
+async function put_blob(req, res) {
+    let copy_source = blob_utils.parse_copy_source(req);
 
-    return req.object_sdk.upload_object({
-            bucket: req.params.bucket,
-            key: req.params.key,
-            content_type: req.headers['x-ms-blob-content-type'],
-            size: req.content_length >= 0 ? req.content_length : undefined,
-            md5_b64: req.content_md5 ? req.content_md5.toString('base64') : undefined,
-            sha256_b64: req.content_sha256_buf ? req.content_sha256_buf.toString('base64') : undefined,
-            md_conditions: http_utils.get_md_conditions(req),
-            xattr: blob_utils.get_request_xattr(req),
-            source_stream: req,
-        })
-        .then(reply => {
-            res.setHeader('ETag', `"${reply.etag}"`);
-            res.statusCode = 201;
-        });
+    const { etag } = await req.object_sdk.upload_object({
+        bucket: req.params.bucket,
+        key: req.params.key,
+        content_type: req.headers['x-ms-blob-content-type'],
+        size: req.content_length >= 0 ? req.content_length : undefined,
+        md5_b64: req.content_md5 ? req.content_md5.toString('base64') : undefined,
+        sha256_b64: req.content_sha256_buf ? req.content_sha256_buf.toString('base64') : undefined,
+        md_conditions: http_utils.get_md_conditions(req),
+        xattr: blob_utils.get_request_xattr(req),
+        source_stream: req,
+        copy_source
+    });
+
+    if (req.headers['x-ms-copy-source']) {
+        res.setHeader('Last-Modified', time_utils.format_http_header_date(new Date()));
+        // TODO: this should not be hard coded 'success'. the copy operation could be
+        // passed to azure if the target bucket is namespace on azure, and the operations
+        // could be pending there
+        res.setHeader('x-ms-copy-status', 'success');
+        // TODO: for now we return the etag as the copy id. should be replaced with a key that 
+        // we can search the object object by
+        res.setHeader('x-ms-copy-id', etag);
+        // for copy blob return 202
+        res.statusCode = 202;
+    } else {
+        res.setHeader('ETag', `"${etag}"`);
+        res.statusCode = 201;
+    }
 }
 
 module.exports = {

--- a/src/endpoint/blob/ops/blob_put_blob_block.js
+++ b/src/endpoint/blob/ops/blob_put_blob_block.js
@@ -1,0 +1,31 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+/**
+ * https://docs.microsoft.com/en-us/rest/api/storageservices/put-block
+ */
+async function put_blob_block(req, res) {
+
+    const size = Number(req.headers['content-length']);
+    // TODO: check content md5? what to do with x-ms-blob-content-md5?
+    const reply = await req.object_sdk.upload_blob_block({
+        bucket: req.params.bucket,
+        key: req.params.key,
+        size,
+        block_id: req.query.blockid,
+        source_stream: req,
+    });
+
+    res.setHeader('ETag', `"${reply.etag}"`);
+    res.statusCode = 201;
+}
+
+module.exports = {
+    handler: put_blob_block,
+    body: {
+        type: 'raw',
+    },
+    reply: {
+        type: 'empty',
+    },
+};

--- a/src/endpoint/blob/ops/blob_put_blob_blocklist.js
+++ b/src/endpoint/blob/ops/blob_put_blob_blocklist.js
@@ -1,0 +1,46 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+
+const blob_utils = require('../blob_utils');
+const http_utils = require('../../../util/http_utils');
+
+
+/**
+ * https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-list
+ */
+async function put_blob_blocklist(req, res) {
+
+    const req_list = _.get(req.body, 'BlockList.$$') || [];
+    const block_list = req_list.map((block, i) => ({ block_id: block._, type: block['#name'].toLowerCase(), num: i + 1 }));
+
+    // TODO: handle x-ms-blob-content-md5 header
+    const reply = await req.object_sdk.commit_blob_block_list({
+        bucket: req.params.bucket,
+        key: req.params.key,
+        content_type: req.headers['x-ms-blob-content-type'],
+        md_conditions: http_utils.get_md_conditions(req),
+        xattr: blob_utils.get_request_xattr(req),
+        block_list
+    });
+
+    res.setHeader('ETag', `"${reply.etag}"`);
+    res.statusCode = 201;
+}
+
+module.exports = {
+    handler: put_blob_blocklist,
+    body: {
+        type: 'xml',
+        // The Put Block List operation enforces the order in which blocks are to be combined to create a blob
+        // preserv the order when parsing the xml
+        xml_options: {
+            preserveChildrenOrder: true,
+            explicitChildren: true
+        }
+    },
+    reply: {
+        type: 'empty',
+    },
+};

--- a/src/endpoint/endpoint_utils.js
+++ b/src/endpoint/endpoint_utils.js
@@ -1,0 +1,27 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const querystring = require('querystring');
+
+
+function parse_source_url(source_url) {
+    let slash_index = source_url.indexOf('/');
+    let start_index = 0;
+    if (slash_index === 0) {
+        start_index = 1;
+        slash_index = source_url.indexOf('/', 1);
+    }
+    let query_index = source_url.indexOf('?', slash_index);
+    let query;
+    if (query_index < 0) {
+        query_index = source_url.length;
+    } else {
+        query = querystring.parse(source_url.slice(query_index + 1));
+    }
+    const bucket = decodeURIComponent(source_url.slice(start_index, slash_index));
+    const key = decodeURIComponent(source_url.slice(slash_index + 1, query_index));
+    return { query, bucket, key };
+}
+
+
+exports.parse_source_url = parse_source_url;

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -2,12 +2,12 @@
 'use strict';
 
 const _ = require('lodash');
-const querystring = require('querystring');
 
 const dbg = require('../../util/debug_module')(__filename);
 const S3Error = require('./s3_errors').S3Error;
 const http_utils = require('../../util/http_utils');
 const time_utils = require('../../util/time_utils');
+const endpoint_utils = require('../endpoint_utils');
 
 const STORAGE_CLASS_STANDARD = 'STANDARD';
 
@@ -72,22 +72,7 @@ function parse_copy_source(req) {
 
     // I wonder: do we want to support copy source url with host:port too?
 
-    let slash_index = source_url.indexOf('/');
-    let start_index = 0;
-    if (slash_index === 0) {
-        start_index = 1;
-        slash_index = source_url.indexOf('/', 1);
-    }
-    let query_index = source_url.indexOf('?', slash_index);
-    let query;
-    if (query_index < 0) {
-        query_index = source_url.length;
-    } else {
-        query = querystring.parse(source_url.slice(query_index + 1));
-    }
-
-    const bucket = decodeURIComponent(source_url.slice(start_index, slash_index));
-    const key = decodeURIComponent(source_url.slice(slash_index + 1, query_index));
+    const { query, bucket, key } = endpoint_utils.parse_source_url(source_url);
     const version = query && query.versionId;
     const range = http_utils.parse_http_range(req.headers['x-amz-copy-source-range']);
     return {

--- a/src/sdk/blob_translator.js
+++ b/src/sdk/blob_translator.js
@@ -1,0 +1,255 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+
+const dbg = require('../util/debug_module')(__filename);
+const P = require('../util/promise');
+const buffer_utils = require('../util/buffer_utils');
+const BlobError = require('../endpoint/blob/blob_errors').BlobError;
+
+
+
+const BLOCKS_INFO_PATH = '.noobaa_blob';
+
+
+function get_uncommitted_blocks_path(bucket, key) {
+    return `${BLOCKS_INFO_PATH}/${bucket}/${key}/uncommitted_blocks/`;
+}
+
+function get_committed_blocks_path(bucket, key) {
+    return `${BLOCKS_INFO_PATH}/${bucket}/${key}/committed_blocks.json`;
+}
+
+async function upload_blob_block(params, object_sdk) {
+    // use the path .noobaa_blob_blocks/KEY/uncommitted to store data of uncommited blocks
+    const block_key = `${get_uncommitted_blocks_path(params.bucket, params.key)}/${params.block_id}`;
+    return object_sdk.upload_object({
+        bucket: params.bucket,
+        key: block_key,
+        source_stream: params.source_stream,
+        size: params.size,
+    });
+}
+
+
+
+
+async function get_committed_list(params, object_sdk) {
+    try {
+        const key = get_committed_blocks_path(params.bucket, params.key);
+        const object_md = await object_sdk.read_object_md({
+            bucket: params.bucket,
+            key
+        });
+        const read_stream = await object_sdk.read_object_stream({
+            object_md,
+            obj_id: object_md.obj_id,
+            bucket: params.bucket,
+            key,
+        });
+        const data_buffer = await buffer_utils.read_stream_join(read_stream);
+        return JSON.parse(data_buffer);
+    } catch (err) {
+        dbg.warn(`got error on reading committed list for params`, params, err);
+        return [];
+    }
+}
+
+async function get_uncommitted_list(params, object_sdk) {
+    try {
+        const uncommitted_path = get_uncommitted_blocks_path(params.bucket, params.key);
+        const obj_list = [];
+        let next_marker;
+        let is_truncated = true;
+
+        while (is_truncated) {
+            const list_res = await object_sdk.list_objects({
+                bucket: params.bucket,
+                prefix: uncommitted_path,
+                key_marker: next_marker,
+            });
+            obj_list.push(...list_res.objects);
+            next_marker = list_res.next_marker;
+            is_truncated = list_res.is_truncated;
+        }
+        return obj_list.map(obj => ({
+            block_id: obj.key.replace(uncommitted_path + '/', ''),
+            size: obj.size
+        }));
+    } catch (err) {
+        dbg.warn(`got error on reading committed list for params`, params, err);
+        return [];
+    }
+}
+
+
+async function write_committed_list(block_list, bucket, key, object_sdk) {
+    const committed_path = get_committed_blocks_path(bucket, key);
+    const committed_blocks = block_list.map(block => _.omit(block, 'copy_source'));
+    const buf = Buffer.from(JSON.stringify(committed_blocks));
+    const upload_params = {
+        bucket: bucket,
+        key: committed_path,
+        source_stream: buffer_utils.buffer_to_read_stream(buf),
+        size: buf.length,
+    };
+    return object_sdk.upload_object(upload_params);
+}
+
+
+function process_block_list({ block_list, bucket, key, committed_list, uncommitted_list }) {
+    const blocks_by_id = {};
+    let start_offset = 0;
+    committed_list.forEach(item => {
+        blocks_by_id[item.block_id] = Object.assign(item, { block_type: 'committed' });
+    });
+    uncommitted_list.forEach(item => {
+        blocks_by_id[item.block_id] = Object.assign(item, { block_type: 'uncommitted' });
+    });
+
+    return block_list.map(block => {
+        const resolved_block = blocks_by_id[block.block_id];
+        if (block.type !== resolved_block.block_type && block.type !== 'latest') throw new BlobError(BlobError.InvalidBlobOrBlock);
+        const end_offset = start_offset + resolved_block.size;
+        const range = { start: start_offset, end: end_offset };
+        start_offset = end_offset;
+        let copy_source = { bucket };
+        if (resolved_block.block_type === 'uncommitted') {
+            copy_source.key = `${get_uncommitted_blocks_path(bucket, key)}/${block.block_id}`;
+        } else {
+            copy_source.key = key;
+            copy_source.range = resolved_block.range;
+        }
+        return {
+            block_id: block.block_id,
+            copy_source,
+            num: block.num,
+            size: resolved_block.size,
+            range
+        };
+    });
+}
+
+async function remove_block_lists({ bucket, key, uncommitted_list, remove_uncommitted, remove_committed, } = {}, object_sdk) {
+    const uncommitted_path = get_uncommitted_blocks_path(bucket, key);
+    const keys = remove_uncommitted ? uncommitted_list.map(block => `${uncommitted_path}/${block.block_id}`) : [];
+    if (remove_committed) {
+        const committed_path = get_committed_blocks_path(bucket, key);
+        keys.push(committed_path);
+    }
+    if (!keys.length) {
+        return;
+    }
+    return object_sdk.delete_multiple_objects({ bucket, keys });
+}
+
+
+async function commit_blob_block_list(params, object_sdk) {
+    // initiate multipart upload
+    const { bucket, key } = params;
+    dbg.log1(`creating multipart upload for bucket:${bucket}, key:${key}`);
+    const [committed_list, uncommitted_list, init_multipart_res] = await P.all([
+        get_committed_list({ bucket, key }, object_sdk),
+        get_uncommitted_list({ bucket, key }, object_sdk),
+        object_sdk.create_object_upload({
+            bucket,
+            key,
+            content_type: params.content_type,
+            xattr: params.xattr
+            // TODO: check more params to send
+        })
+    ]);
+
+    const { obj_id } = init_multipart_res;
+    const final_block_list = process_block_list({
+        bucket,
+        key,
+        block_list: params.block_list,
+        committed_list,
+        uncommitted_list
+    });
+
+    // upload parts 
+    await P.map(final_block_list, async block => {
+        const multipart_params = {
+            obj_id: obj_id,
+            bucket,
+            key,
+            num: block.num,
+            copy_source: block.copy_source
+        };
+        const { etag } = await object_sdk.upload_multipart(multipart_params);
+        block.etag = etag;
+    });
+
+    const multiparts = final_block_list.map(block => ({ num: block.num, etag: block.etag }));
+    const [, res] = await P.all([
+        write_committed_list(final_block_list, bucket, key, object_sdk),
+        object_sdk.complete_object_upload({
+            obj_id,
+            bucket,
+            key,
+            multiparts
+        })
+    ]);
+
+    await remove_block_lists({
+        bucket,
+        key,
+        uncommitted_list,
+        remove_uncommitted: true,
+    }, object_sdk);
+
+    return res;
+}
+
+
+async function get_blob_block_lists(params, object_sdk) {
+    const [committed_list, uncommitted_list] = await P.all([
+        params.requested_lists.committed ?
+        get_committed_list({ bucket: params.bucket, key: params.key }, object_sdk) : P.resolve(),
+        params.requested_lists.uncommitted ?
+        get_uncommitted_list({ bucket: params.bucket, key: params.key }, object_sdk) : P.resolve()
+    ]);
+
+
+    const res = _.omitBy({
+        committed: committed_list ? committed_list.map(block => _.pick(block, 'block_id', 'size')) : undefined,
+        uncommitted: uncommitted_list ? uncommitted_list.map(block => _.pick(block, 'block_id', 'size')) : undefined,
+    }, _.isUndefined);
+
+    return res;
+}
+
+
+async function delete_blocks({ bucket, keys } = {}, object_sdk) {
+    // get all uncommitted\committed lists for all keys
+    const block_lists = await P.map(keys, async key => {
+        const lists = await get_blob_block_lists({
+            bucket,
+            key,
+            requested_lists: {
+                uncommitted: true
+            }
+        }, object_sdk);
+        const uncommitted_path = get_uncommitted_blocks_path(bucket, key);
+        const committed_path = get_committed_blocks_path(bucket, key);
+        const delete_keys = lists.uncommitted.map(block => `${uncommitted_path}/${block.block_id}`);
+        delete_keys.push(committed_path);
+        return delete_keys;
+    });
+    const all_keys = _.flatten(block_lists);
+    // pass skip_blocks_delete to avoid recursion 
+    if (!all_keys.length) {
+        return;
+    }
+    await object_sdk.delete_multiple_objects({ bucket, keys: all_keys, skip_blocks_delete: true });
+}
+
+
+exports.upload_blob_block = upload_blob_block;
+exports.commit_blob_block_list = commit_blob_block_list;
+exports.get_blob_block_lists = get_blob_block_lists;
+exports.delete_blocks = delete_blocks;
+exports.remove_block_lists = remove_block_lists;

--- a/src/sdk/namespace_merge.js
+++ b/src/sdk/namespace_merge.js
@@ -109,6 +109,20 @@ class NamespaceMerge {
         return this._ns_put(ns => ns.upload_object(params, object_sdk));
     }
 
+    upload_blob_block(params, object_sdk) {
+        return this._ns_put(ns => ns.upload_blob_block(params, object_sdk));
+    }
+
+    commit_blob_block_list(params, object_sdk) {
+        return this._ns_put(ns => ns.commit_blob_block_list(params, object_sdk));
+    }
+
+    get_blob_block_lists(params, object_sdk) {
+        // TODO: should we get blob block lists from read resources as well?
+        return this._ns_put(ns => ns.get_blob_block_lists(params, object_sdk));
+    }
+
+
     /////////////////////////////
     // OBJECT MULTIPART UPLOAD //
     /////////////////////////////

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -2,7 +2,10 @@
 'use strict';
 
 const _ = require('lodash');
+
 // const P = require('../util/promise');
+const blob_translator = require('./blob_translator');
+
 
 class NamespaceNB {
 
@@ -59,6 +62,22 @@ class NamespaceNB {
             bucket: this.target_bucket,
         }, params);
         return object_sdk.object_io.upload_object(params);
+    }
+
+    ////////////////////////
+    // BLOCK BLOB UPLOADS //
+    ////////////////////////
+
+    upload_blob_block(params, object_sdk) {
+        return blob_translator.upload_blob_block(params, object_sdk);
+    }
+
+    commit_blob_block_list(params, object_sdk) {
+        return blob_translator.commit_blob_block_list(params, object_sdk);
+    }
+
+    get_blob_block_lists(params, object_sdk) {
+        return blob_translator.get_blob_block_lists(params, object_sdk);
     }
 
     /////////////////////////////

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -294,6 +294,9 @@ class MDStore {
     has_any_completed_objects_in_bucket(bucket_id) {
         return this._objects.col().findOne({
                 bucket: bucket_id,
+                key: {
+                    $not: /^\.noobaa_blob_blocks/ // prefix for stored blob blocks information. TODO: move somwhere like config.js
+                },
                 deleted: null,
                 upload_started: null,
             })

--- a/src/test/framework/flow.js
+++ b/src/test/framework/flow.js
@@ -119,6 +119,17 @@ var steps = [
         name: 'Restore DB Defaults',
         common: 'restore_db_defaults',
     }, {
+        //Bucket Lambda Triggers Test
+        name: 'Blob API Test',
+        action: 'node',
+        params: [{
+            arg: './src/test/system_tests/test_blob_api'
+        }],
+    }, {
+        //Restore DB to defaults
+        name: 'Restore DB Defaults',
+        common: 'restore_db_defaults',
+    }, {
         //Test MD Aggregator
         name: 'MD Aggregator Test',
         action: 'node',

--- a/src/test/framework/prepare_and_run_tests.sh
+++ b/src/test/framework/prepare_and_run_tests.sh
@@ -3,6 +3,7 @@ source /root/.bashrc
 cd /root/node_modules/noobaa-core
 echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> .env
 echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> .env
+echo 'ENDPOINT_BLOB_ENABLED=true' >> .env
 echo 'DEV_MODE=true' >> .env
 npm install \
     gulp \

--- a/src/test/system_tests/test_blob_api.js
+++ b/src/test/system_tests/test_blob_api.js
@@ -1,0 +1,175 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const P = require('bluebird');
+const crypto = require('crypto');
+
+const buffer_utils = require('../../util/buffer_utils');
+const dotenv = require('../../util/dotenv');
+dotenv.load();
+
+const azure_storage = require('azure-storage');
+
+const blob_service = azure_storage.createBlobService('account', '1234', 'http://127.0.0.1:80');
+// const blob_service = azure_storage.createBlobService();
+
+
+const TEST_CTX = {
+    container: `test-blob-api-${Date.now()}`,
+    block_size: 1024 * 1024, // 1MB block size
+    block_count: 10,
+};
+
+
+async function upload_blocks({ blocks, container, blob }) {
+    await P.all(blocks.map(block => P.fromCallback(callback => blob_service.createBlockFromText(
+        block.block_id,
+        container,
+        blob,
+        block.buffer,
+        callback))));
+}
+
+async function commit_block_list({ block_list, list_type = 'UncommittedBlocks', container, blob } = {}) {
+    const blocks_to_commit = {};
+    blocks_to_commit[list_type] = block_list;
+    await P.fromCallback(callback => blob_service.commitBlocks(container, blob, blocks_to_commit, callback));
+}
+
+function generate_random_blocks({ block_count, block_size }) {
+    // const = params;
+    const block_id_prefix = blob_service.generateBlockIdPrefix();
+    const blocks = [];
+    for (let i = 0; i < block_count; ++i) {
+        const buf = crypto.randomBytes(block_size);
+        const block_id = blob_service.getBlockId(block_id_prefix, i);
+        blocks.push({ block_id, buffer: buf });
+    }
+    return blocks;
+}
+
+function calc_block_list_md5(blocks) {
+    const md5_hash = crypto.createHash('md5');
+    blocks.forEach(block => {
+        md5_hash.update(block.buffer);
+    });
+    return md5_hash.digest('hex');
+}
+
+
+async function test_upload_blocks_and_commit_by_order() {
+    try {
+        const { container, block_count, block_size } = TEST_CTX;
+        const blob = `test_upload_blocks_and_commit_by_order-${Date.now()}`;
+        const blocks = generate_random_blocks({ block_count, block_size });
+        await upload_blocks({ blocks, container, blob });
+        await commit_block_list({
+            block_list: blocks.map(block => block.block_id),
+            blob,
+            container
+        });
+        await compare_md5(blocks, container, blob);
+        console.log('PASSED - test_upload_blocks_and_commit_by_order');
+    } catch (err) {
+        console.error('FAILED - test_upload_blocks_and_commit_by_order');
+        throw err;
+    }
+}
+
+
+async function test_upload_blocks_and_recommit_reverse_order() {
+    try {
+        const { container, block_count, block_size } = TEST_CTX;
+        const blob = `test_upload_blocks_and_recommit_reverse_order-${Date.now()}`;
+        const blocks = generate_random_blocks({ block_count, block_size });
+        await upload_blocks({ blocks, container, blob });
+        await commit_block_list({
+            block_list: blocks.map(block => block.block_id),
+            blob,
+            container
+        });
+        // now recommit from commited blocks but in reverse order
+        blocks.reverse();
+        await commit_block_list({
+            block_list: blocks.map(block => block.block_id),
+            blob,
+            container,
+            list_type: 'CommittedBlocks'
+        });
+        await compare_md5(blocks, container, blob);
+        console.log('PASSED - test_upload_blocks_and_recommit_reverse_order');
+    } catch (err) {
+        console.log('FAILED - test_upload_blocks_and_recommit_reverse_order');
+        throw err;
+    }
+}
+
+// reupload a single block with the same blockid and different data.
+// commit with "Latest" list type
+async function test_upload_blocks_and_modify_single_block() {
+    try {
+        const { container, block_count, block_size } = TEST_CTX;
+        const blob = `test_upload_blocks_and_modify_single_block-${Date.now()}`;
+        const blocks = generate_random_blocks({ block_count, block_size });
+        await upload_blocks({ blocks, container, blob });
+        await commit_block_list({
+            block_list: blocks.map(block => block.block_id),
+            blob,
+            container
+        });
+        // modify single block and recommit as latest
+        blocks[4].buffer = crypto.randomBytes(block_size);
+        await upload_blocks({ blocks: [blocks[4]], container, blob });
+        await commit_block_list({
+            block_list: blocks.map(block => block.block_id),
+            blob,
+            container,
+            list_type: 'LatestBlocks'
+        });
+        await compare_md5(blocks, container, blob);
+        console.log('PASSED - test_upload_blocks_and_modify_single_block');
+    } catch (err) {
+        console.log('FAILED - test_upload_blocks_and_modify_single_block');
+        throw err;
+    }
+}
+
+
+async function compare_md5(blocks, container, blob) {
+    const md5 = calc_block_list_md5(blocks);
+    // download blob and compare md5
+    const dl_buf = await buffer_utils.read_stream_join(blob_service.createReadStream(container, blob));
+    const dl_md5 = crypto.createHash('md5').update(dl_buf).digest('hex');
+    if (dl_md5 !== md5) {
+        throw new Error(`md5 does not match. blocks md5 (${md5}) downloaded md5 (${dl_md5})`);
+    }
+}
+
+async function setup() {
+    console.log('creating test container', TEST_CTX.container);
+    await P.fromCallback(callback => blob_service.createContainer(TEST_CTX.container, callback));
+}
+
+
+async function run_test() {
+    await setup();
+    await test_upload_blocks_and_commit_by_order();
+    await test_upload_blocks_and_recommit_reverse_order();
+    await test_upload_blocks_and_modify_single_block();
+}
+
+
+async function main() {
+    try {
+        await run_test();
+        console.log('test_blob_api PASSED');
+        process.exit(0);
+    } catch (err) {
+        console.error('test_blob_api FAILED', err);
+        process.exit(1);
+    }
+}
+
+if (require.main === module) {
+    main();
+}

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -31,6 +31,7 @@ const DOTENV_VARS_FROM_OLD_VER = Object.freeze([
     'DEV_MODE',
     'MONGO_RS_URL',
     'MONGO_SSL_USER',
+    'ENDPOINT_BLOB_ENABLED'
 ]);
 
 const EXEC_DEFAULTS = Object.freeze({

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -80,6 +80,15 @@ function read_stream_join(readable) {
         .then(res => join(res.buffers, res.total_length));
 }
 
+function buffer_to_read_stream(buf) {
+    return new stream.Readable({
+        read(size) {
+            this.push(buf);
+            this.push(null);
+        }
+    });
+}
+
 function write_stream() {
     const writable = new stream.Writable({
         write(data, encoding, callback) {
@@ -110,3 +119,4 @@ exports.read_stream = read_stream;
 exports.read_stream_join = read_stream_join;
 exports.write_stream = write_stream;
 exports.count_length = count_length;
+exports.buffer_to_read_stream = buffer_to_read_stream;

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -211,12 +211,12 @@ function send_reply(req, res, reply, options) {
         return;
     }
     if (!reply || options.reply.type === 'empty') {
-        dbg.log0('HTTP REPLY EMPTY', req.method, req.originalUrl,
-            JSON.stringify(req.headers), res.statusCode);
-        if (req.method === 'DELETE' &&
+        if (!options.reply.keep_status_code && req.method === 'DELETE' &&
             (!res.statusCode || res.statusCode < 300)) {
             res.statusCode = 204;
         }
+        dbg.log0('HTTP REPLY EMPTY', req.method, req.originalUrl,
+            JSON.stringify(req.headers), res.statusCode);
         res.end();
         return;
     }

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -181,7 +181,7 @@ function parse_request_body(req, options) {
         throw new options.ErrorClass(options.error_missing_body);
     }
     if (options.body.type === 'xml') {
-        return P.fromCallback(callback => xml2js.parseString(req.body, callback))
+        return P.fromCallback(callback => xml2js.parseString(req.body, options.body.xml_options, callback))
             .then(data => {
                 req.body = data;
             })


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- @liranmauda added new verbs to blob api:
   - Put block - https://docs.microsoft.com/en-us/rest/api/storageservices/put-block
   - Put block list - https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-list
   - Get block list - https://docs.microsoft.com/en-us/rest/api/storageservices/get-block-list

#### 2. Existing Behavior Changes (Sync with Liran):
- @liranmauda changed behavior:
    - `put block` and `put block list` stores block data and info under `.noobaa_blob_blocks` path
    - on delete object - all relevant blocks info should be deleted as well
    - on delete bucket - we should ignore any leftovers of `.noobaa_blob_blocks` and allow deletion if there are no other completed upload in the bucket

#### 3. other fixes
- added copy_source support to put_blob
- return statusCode 202 in delete_blob

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages