### PR TITLE
version_map.json: bumped version to 2.6.2

### DIFF
--- a/src/deploy/version_map.json
+++ b/src/deploy/version_map.json
@@ -1,37 +1,7 @@
 {
     "versions": [{
-            "ver": "2.0.0",
-            "vhd": "2.0.0-7c5952a.vhd",
-            "released": true
-        },
-        {
-            "ver": "2.0.1",
-            "vhd": "2.0.1-855c22f.vhd",
-            "released": true
-        },
-        {
-            "ver": "2.1.0",
-            "vhd": "2.1.0-8c1f04c.vhd",
-            "released": true
-        },
-        {
-            "ver": "2.1.2",
-            "vhd": "2.1.2-52e964c.vhd",
-            "released": true
-        },
-        {
             "ver": "2.1.3",
             "vhd": "2.1.3-b3379aa.vhd",
-            "released": true
-        },
-        {
-            "ver": "2.2.0",
-            "vhd": "2.2.0-48d87ce.vhd",
-            "released": true
-        },
-        {
-            "ver": "2.3.0",
-            "vhd": "2.3.0-0d13ab6.vhd",
             "released": true
         },
         {
@@ -50,13 +20,8 @@
             "released": true
         },
         {
-            "ver": "2.6.0",
-            "vhd": "2.6.0-2c95897.vhd",
-            "released": true
-        },
-        {
-            "ver": "2.6.1",
-            "vhd": "2.6.1-9492c8b.vhd",
+            "ver": "2.6.2",
+            "vhd": "2.6.2-a848376.vhd",
             "released": true
         }
     ]


### PR DESCRIPTION
### Explain the changes
version_map.json:
- Bumped version to 2.6.2
- Cleaned up versions according to the phonehome

#### 1. New Features / Capabilities (Sync with Liran):
- 

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
