### PR TITLE
Adding MD5 verifications to the agent upgrade procedure 

### DIFF
--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -475,6 +475,8 @@ var setup_filename = 'noobaa-setup-' + pkg.version;
 var s3_rest_setup_filename = 'noobaa-s3rest-' + pkg.version;
 app.use('/public/noobaa-setup.exe', express.static(path.join(rootdir, 'build', 'public', setup_filename + '.exe')));
 app.use('/public/noobaa-setup', express.static(path.join(rootdir, 'build', 'public', setup_filename)));
+app.use('/public/noobaa-setup.exe.md5', express.static(path.join(rootdir, 'build', 'public', setup_filename + '.exe.md5')));
+app.use('/public/noobaa-setup.md5', express.static(path.join(rootdir, 'build', 'public', setup_filename + '.md5')));
 app.use('/public/noobaa-s3rest.exe', express.static(path.join(rootdir, 'build', 'public', s3_rest_setup_filename + 'exe')));
 
 app.use('/public/', cache_control(dev_mode ? 0 : 10 * 60)); // 10 minutes

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -303,6 +303,7 @@ async function copy_new_code() {
 // make sure that all the file which are requiered by the new version (.env, etc.) are in the new dir
 async function prepare_new_dir() {
     await _build_dotenv();
+    await _create_packages_md5();
 }
 
 // build .env file in new version by taking all required env vars from old version
@@ -317,6 +318,14 @@ async function _build_dotenv() {
     dbg.log0('UPGRADE: genertaing .env file for new version:', new_env);
 
     await fs.writeFileAsync(`${NEW_VERSION_DIR}/.env`, dotenv.stringify(new_env));
+}
+
+async function _create_packages_md5() {
+    const linux_md5_string = await fs_utils.get_md5_of_file(path.join(NEW_VERSION_DIR, 'build/public/noobaa-setup-' + pkg.version));
+    await fs.writeFileAsync(path.join(NEW_VERSION_DIR, 'build/public/noobaa-setup-' + pkg.version + '.md5'), linux_md5_string);
+    const win_md5_string = await fs_utils.get_md5_of_file(path.join(NEW_VERSION_DIR, 'build/public/noobaa-setup-' + pkg.version + '.exe'));
+    await fs.writeFileAsync(path.join(NEW_VERSION_DIR, 'build/public/noobaa-setup-' + pkg.version + '.exe.md5'), win_md5_string);
+    dbg.log0(`UPGRADE: creating a hash file for both linux/windows upgrade packs: ${linux_md5_string}/${win_md5_string}`);
 }
 
 async function update_services() {

--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -269,6 +269,18 @@ function write_file_from_stream(file_path, read_stream) {
     );
 }
 
+function get_md5_of_file(file_path) {
+    // the file you want to get the hash    
+    var fd = fs.createReadStream(file_path);
+    var hash = crypto.createHash('md5');
+    return new P((resolve, reject) =>
+        fd.on('data', function(data) {
+            hash.update(data);
+        })
+        .on('end', () => resolve(hash.digest('hex')))
+    );
+}
+
 // lock per full file path, to avoid parallel replace to same path, at least from the same process
 const process_file_locks = new Map();
 
@@ -327,6 +339,7 @@ exports.file_delete = file_delete;
 exports.folder_delete = folder_delete;
 exports.tar_pack = tar_pack;
 exports.write_file_from_stream = write_file_from_stream;
+exports.get_md5_of_file = get_md5_of_file;
 exports.replace_file = replace_file;
 exports.ignore_eexist = ignore_eexist;
 exports.ignore_enoent = ignore_enoent;


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- 

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
- now in upgrade agent will download both the upgarde package and md5 file and verify the download is legit
- we will create the md5 files as part of the server upgrade process 

### Issues: Fixed #xxx / Gap #xxx
- Fixed #4864

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
