### PR TITLE
Change osmap into a single location & allow dataset to run from another test

### DIFF
--- a/src/test/qa/agents_matrix.js
+++ b/src/test/qa/agents_matrix.js
@@ -81,12 +81,7 @@ const NC = "\x1b[0m";
 var api = require('../../api');
 var rpc = api.new_rpc('wss://' + server_ip + ':8443');
 var client = rpc.new_client({});
-const oses = [
-    'ubuntu12', 'ubuntu14', 'ubuntu16',
-    'centos6', 'centos7',
-    'redhat6', 'redhat7',
-    'win2008', 'win2012', 'win2016'
-];
+const oses = af.supported_oses();
 
 const size = 16; //size in GB
 let nodes = [];

--- a/src/test/qa/cluster_test.js
+++ b/src/test/qa/cluster_test.js
@@ -83,12 +83,7 @@ if (argv.help) {
     process.exit(1);
 }
 
-let osesSet = [
-    'ubuntu12', 'ubuntu14', 'ubuntu16',
-    'centos6', 'centos7',
-    'redhat6', 'redhat7',
-    'win2008', 'win2012', 'win2016'
-];
+const osesSet = af.supported_oses();
 
 
 function saveErrorAndResume(message) {

--- a/src/test/qa/data_resiliency_test.js
+++ b/src/test/qa/data_resiliency_test.js
@@ -1,13 +1,12 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const { S3OPS } = require('../utils/s3ops');
-const Report = require('../framework/report');
 const argv = require('minimist')(process.argv);
-const af = require('../utils/agent_functions');
-const dbg = require('../../util/debug_module')(__filename);
 const AzureFunctions = require('../../deploy/azureFunctions');
-const { BucketFunctions } = require('../utils/bucket_functions');
+const { S3OPS } = require('../utils/s3ops');
+const af = require('../utils/agent_functions');
+const bf = require('../utils/bucket_functions');
+const dbg = require('../../util/debug_module')(__filename);
 dbg.set_process_name('data_avilability');
 
 //define colors
@@ -82,11 +81,7 @@ if (help) {
     process.exit(1);
 }
 
-let report = new Report();
-let bf = new BucketFunctions(server_ip, report);
-
 const osesSet = af.supported_oses();
-
 
 const baseUnit = 1024;
 const unit_mapping = {

--- a/src/test/qa/rebuild_replicas_test.js
+++ b/src/test/qa/rebuild_replicas_test.js
@@ -94,12 +94,7 @@ let auth_params = {
     system: 'demo'
 };
 
-let osesSet = [
-    'ubuntu12', 'ubuntu14', 'ubuntu16',
-    'centos6', 'centos7',
-    'redhat6', 'redhat7',
-    'win2008', 'win2012', 'win2016'
-];
+const osesSet = af.supported_oses();
 
 const baseUnit = 1024;
 const unit_mapping = {

--- a/src/test/qa/reclaim_test.js
+++ b/src/test/qa/reclaim_test.js
@@ -75,7 +75,7 @@ let report = new Report();
 let bf = new BucketFunctions(server_ip, report);
 
 const osesLinuxSet = af.supported_oses('LINUX');
-const osesWinSet = af.supported_oses('WIN';)
+const osesWinSet = af.supported_oses('WIN');
 
 
 const baseUnit = 1024;

--- a/src/test/qa/reclaim_test.js
+++ b/src/test/qa/reclaim_test.js
@@ -74,15 +74,9 @@ if (argv.help) {
 let report = new Report();
 let bf = new BucketFunctions(server_ip, report);
 
-const osesLinuxSet = [
-    'ubuntu12', 'ubuntu14', 'ubuntu16',
-    'centos6', 'centos7',
-    'redhat6', 'redhat7'
-];
+const osesLinuxSet = af.supported_oses('LINUX');
+const osesWinSet = af.supported_oses('WIN';)
 
-const osesWinSet = [
-    'win2008', 'win2012', 'win2016'
-];
 
 const baseUnit = 1024;
 const unit_mapping = {

--- a/src/test/qa/spillover_test.js
+++ b/src/test/qa/spillover_test.js
@@ -67,12 +67,7 @@ let report = new Report();
 let bf = new BucketFunctions(server_ip, report);
 const azf = new AzureFunctions(clientId, domain, secret, subscriptionId, resource, location);
 
-let osesSet = [
-    'ubuntu12', 'ubuntu14', 'ubuntu16',
-    'centos6', 'centos7',
-    'redhat6', 'redhat7',
-    'win2008', 'win2012', 'win2016'
-];
+let osesSet = af.supported_oses();
 
 const baseUnit = 1024;
 const unit_mapping = {

--- a/src/test/utils/agent_functions.js
+++ b/src/test/utils/agent_functions.js
@@ -22,6 +22,25 @@ const auth_params = {
 const Yellow = "\x1b[33;1m";
 const NC = "\x1b[0m";
 
+function supported_oses(flavor) {
+    const LINUX_FLAVORS = [
+        'ubuntu12', 'ubuntu14', 'ubuntu16',
+        'centos6', 'centos7',
+        'redhat6', 'redhat7'
+    ];
+    const WIN_FLAVORS = [
+        'win2008', 'win2012', 'win2016'
+    ];
+
+    if (flavor === 'WIN') {
+        return WIN_FLAVORS;
+    } else if (flavor === 'LINUX') {
+        return LINUX_FLAVORS;
+    } else {
+        return LINUX_FLAVORS.concat(WIN_FLAVORS);
+    }
+}
+
 function list_nodes(server_ip) {
     let online_agents;
     const rpc = api.new_rpc('wss://' + server_ip + ':8443');
@@ -508,6 +527,7 @@ function manipulateLocalDisk(params) {
         });
 }
 
+exports.supported_oses = supported_oses;
 exports.list_nodes = list_nodes;
 exports.getTestNodes = getTestNodes;
 exports.getAgentConf = getAgentConf;

--- a/src/test/utils/s3ops.js
+++ b/src/test/utils/s3ops.js
@@ -311,7 +311,7 @@ class S3OPS {
             });
     }
 
-    get_list_files(ip, bucket, prefix) {
+    get_list_files(ip, bucket, prefix, supress_logs) {
         const rest_endpoint = 'http://' + ip + ':' + port;
         const s3bucket = new AWS.S3({
             endpoint: rest_endpoint,
@@ -330,11 +330,15 @@ class S3OPS {
             .then(res => {
                 list = res.Contents;
                 if (list.length === 0) {
-                    console.warn('No files with prefix in bucket');
+                    if (!supress_logs) {
+                        console.warn('No files with prefix in bucket');
+                    }
                 } else {
                     list.forEach(function(file) {
                         listFiles.push({ Key: file.Key });
-                        console.log('files key is: ' + file.Key);
+                        if (!supress_logs) {
+                            console.log('files key is: ' + file.Key);
+                        }
                     });
                 }
                 return listFiles;


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 2. Existing Behavior Changes (Sync with Liran):
- Change osmap into a single location
- Allow dataset to run from another test

Disregard data_resiliency_test.js , its a placeholder (currently a copy of data_availability_test)

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
