### PR TITLE
Adding option to pass on  version check in tests

### DIFF
--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -274,7 +274,7 @@ function upgrade_test_env() {
         return;
     }
     console.log(`upgrading server with package ${upgrade}`);
-    return sanity_build_test.upgrade_and_test(server.ip, upgrade)
+    return sanity_build_test.upgrade_and_test(server.ip, upgrade, false)
         .catch(err => {
             console.error('upgrade_test_env failed', err);
             throw err;
@@ -282,7 +282,7 @@ function upgrade_test_env() {
         .then(() => {
             if (rerun_upgrade) {
                 console.log(`Got rerun_upgrade flag. running upgrade again from the new version to the same version (${upgrade})`);
-                return sanity_build_test.upgrade_and_test(server.ip, upgrade)
+                return sanity_build_test.upgrade_and_test(server.ip, upgrade, true)
                     .catch(err => {
                         console.error(`Failed upgrading from the new version ${upgrade}`, err);
                         throw err;

--- a/src/test/system_tests/sanity_build_test.js
+++ b/src/test/system_tests/sanity_build_test.js
@@ -31,14 +31,14 @@ function main() {
         return;
     }
 
-    return upgrade_and_test(argv.target_ip, argv.upgrade_pack)
+    return upgrade_and_test(argv.target_ip, argv.upgrade_pack, false)
         .then(() => process.exit(0));
 }
 
-function upgrade_and_test(target_ip, upgrade_pack) {
+function upgrade_and_test(target_ip, upgrade_pack, dont_verify_version) {
     ops.disable_rpc_validation();
     console.log('Basic sanity test started, Upgrading MD server at', target_ip);
-    return P.resolve(ops.upload_and_upgrade(target_ip, upgrade_pack))
+    return P.resolve(ops.upload_and_upgrade(target_ip, upgrade_pack, dont_verify_version))
         .catch(function(error) {
             console.warn('Upgrading failed with', error, error.stack);
             stop();

--- a/src/test/utils/basic_server_ops.js
+++ b/src/test/utils/basic_server_ops.js
@@ -32,7 +32,7 @@ function disable_rpc_validation() {
     rpc_validation_disabled = true;
 }
 
-function upload_and_upgrade(ip, upgrade_pack) {
+function upload_and_upgrade(ip, upgrade_pack, dont_verify_version) {
     console.log('Upgrading the machine');
     rpc_validation_disabled = true; //Running from a new code onto an older code server
     let client = get_rpc_client(ip);
@@ -119,6 +119,10 @@ function upload_and_upgrade(ip, upgrade_pack) {
         .then(() => client.system.read_system())
         .then(res => {
             //Server is up, check returned version to verify the server was upgraded
+            if (dont_verify_version) {
+                console.warn('Skipping version check - probably upgrading to the same version intensionly');
+                return;
+            }
             if (res.version === previous_srv_version) {
                 //Upgrade actually failed
                 console.error('Upgrade failed, version did not change');


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- 

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
- Adding option to pass on  version check in tests
- using this option in test_env_builder for passing on version check after upgrading to the same version

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
