### PR TITLE
DNS name configuration shows an error message before the user even entered any value

### DIFF
--- a/frontend/src/app/components/management/system-address-form/system-address-form.html
+++ b/frontend/src/app/components/management/system-address-form/system-address-form.html
@@ -52,6 +52,9 @@
                         />
                         <validation-indicator params="field: $form.dnsName"></validation-indicator>
                     </div>
+                    <p class="remark" ko.visible="isDnsNameRemarkVisible">
+                        Set server IP as static and not DHCP
+                    </p>
                     <validation-message params="field: $form.dnsName"></validation-message>
 
                     <p class="highlight push-both">

--- a/frontend/src/app/components/management/system-address-form/system-address-form.js
+++ b/frontend/src/app/components/management/system-address-form/system-address-form.js
@@ -6,7 +6,7 @@ import ko from 'knockout';
 import { isDNSName } from 'utils/net-utils';
 import { deepFreeze } from 'utils/core-utils';
 import { realizeUri } from 'utils/browser-utils';
-import { getFieldValue, isFormDirty } from 'utils/form-utils';
+import { getFieldValue, isFormDirty, isFieldTouchedAndInvalid } from 'utils/form-utils';
 import { getMany } from 'rx-extensions';
 import * as routes from 'routes';
 import { action$, state$ } from 'state';
@@ -26,6 +26,7 @@ class SystemAddressFormViewModel extends Observer {
     formName = this.constructor.name;
     addressOptions = addressOptions;
     isExpanded = ko.observable();
+    isDnsNameRemarkVisible = ko.observable();
     isDirtyMarkerVisible = ko.observable();
     systemAddress = ko.observable();
     ipAddress = ko.observable();
@@ -67,6 +68,7 @@ class SystemAddressFormViewModel extends Observer {
             (form && getFieldValue(form, 'dnsName')) ||
             dnsName;
 
+        const isDnsNameRemarkVisible = !form || !isFieldTouchedAndInvalid(form, 'dnsName');
         const isDirtyMarkerVisible = form ? isFormDirty(form) : false;
         //TODO: remove  ``` = 'settings' ``` default tab should be used in uri if tab undefined
         const { system, tab = 'settings', section } = location.params;
@@ -76,6 +78,7 @@ class SystemAddressFormViewModel extends Observer {
             { system, tab, section: toggleSection }
         );
 
+        this.isDnsNameRemarkVisible(isDnsNameRemarkVisible);
         this.ipAddress(ipAddress);
         this.systemAddress(systemAddress);
         this.isDirtyMarkerVisible(isDirtyMarkerVisible);
@@ -84,7 +87,6 @@ class SystemAddressFormViewModel extends Observer {
 
         if (!this.fields()) {
             this.fields({ addressType, dnsName });
-
         }
     }
 

--- a/frontend/src/app/components/shared/managed-form/managed-form.js
+++ b/frontend/src/app/components/shared/managed-form/managed-form.js
@@ -285,7 +285,8 @@ class ManagedFormViewModel extends Observer {
                 const asyncErrors = await _validateAsyncHandler(values);
                 if (this._asyncValidationHandle !== handle) return;
 
-                const fieldsValidity = Object.keys(asyncErrors).length > 0 ?
+                const hasAsyncErrors = Object.keys(asyncErrors).length > 0;
+                const fieldsValidity = hasAsyncErrors ?
                     mapValues(values, (_, name) => asyncErrors.hasOwnProperty(name) ? 'INVALID' : 'UNKNOWN') :
                     mapValues(values, () => 'VALID');
 
@@ -296,7 +297,7 @@ class ManagedFormViewModel extends Observer {
                         fieldsValidity,
                         asyncErrors,
                         validatingAsync: null,
-                        touch: true
+                        touch: hasAsyncErrors
                     }
                 ));
                 break;

--- a/frontend/src/app/utils/form-utils.js
+++ b/frontend/src/app/utils/form-utils.js
@@ -49,3 +49,7 @@ export function isFormDirty(form) {
     return Object.keys(form.fields)
         .some(field => isFieldDirty(form, field));
 }
+
+export function isFieldTouchedAndInvalid(form, fieldName) {
+    return isFieldTouched(form, fieldName) && !isFieldValid(form, fieldName);
+}


### PR DESCRIPTION
### Explain the changes
- DNS name configuration shows an error message before the user even entered any value 

### Issues: Fixed #xxx / Gap #xxx
fixed #4865

### Testing Instructions:
#### list of managed-form with async validation:
1. src/app/components/management/system-address-form
2. src/app/components/modals/add-cloud-connection-modal
3. src/app/components/modals/attach-server-modal
4. src/app/components/modals/change-cluster-connectivity-ip-modal

#### system-address-form 
1. IP to DNS trigger validation with press 'Update' button
- go to management
- expand 'System DNS Name / Address'
- change System Address radiobutton from IP to DNS
- field don't show validation errors
- click 'Update' button, 
- validation error displayed 'Please enter a valid DNS Name'
- edit 'DNS Name' to 'localhost' and leve field
- validation passed  

2. IP to DNS trigger validation with editing input field 
- go to management
- expand 'System DNS Name / Address'
- change System Address radiobutton from IP to DNS
- field don't show validation errors
- focus 'DNS Name' input and leve field
- validation error displayed 'Please enter a valid DNS Name'
- focus 'DNS Name' and type 'test' and leave field 
- validation error displayed 'Could not resolve dns name'
- edit 'DNS Name' to 'localhost' and leve field
- validation passed
- press 'Update' and press 'Update and Refresh' on modal

3. DNS to IP validation
- go to management
- expand 'System DNS Name / Address'
- DNS selected and 'DNS Name' = 'localhost'
- validation passed and grren success icon displayed
- change System Address radiobutton from DNS to IP 
- validation passed
- press 'Update' and press 'Update and Refresh' on modal

#### add-cloud-connection-modal
1. trigger validation with press enter
- go to account -> connections
- click 'Add connection' modal 'Add Cloud Connection' opned
- form don't show any validation errors
- press enter 
- validaton errors displayed 'Please enter an AWS access key' nad 'Please enter an AWS secret key'

2. Check async validation with wrong key and secret key
- go to account -> connections
- click 'Add connection' modal 'Add Cloud Connection' opned
- type 'Access key' =  'access123' and Secret Key =  'Secret123'
- async validation failed, errors displayed 'Credentials do not match'

3. Create AWS connection with correct key and secret key
- go to account -> connections
- click 'Add connection' modal 'Add Cloud Connection' opned
- type correct  'Access key' and Secret Key
- validation passed

#### attach-server-modal
1. trigger validation with click 'Next' button
- go to cluster page
- click 'Attach Server' button
- modal 'Attach New Server' opned
- form don't show any validation errors
- click   'Next' button 
- validaton errors displayed 'Please enter a valid IP address' nad 'Please enter the server unique id'

2. Check async validation with wrong 'Server IP' and 'Server secret key'
- go to cluster page
- click 'Attach Server' button
- modal 'Attach New Server' opned
- type 'Server IP' =  '1.1.1.1' and Secret Key =  '12345678'
- async validation failed, errors displayed 'Address unreachable'

3. Check async validation with my pc 'Server IP' and 'Server secret key'
- go to cluster page
- click 'Attach Server' button
- modal 'Attach New Server' opned
- type my pc IP 'Server IP' =  '77.120.43.108' and Secret Key =  'f2618c32'
- async validation failed, errors displayed 'Already a member of this cluster'

#### change-cluster-connectivity-ip-modal
1. trigger validation with click 'Update' button
- go to server page
- click 'Change Cluster Connectivity IP' button
- modal 'Change Cluster Connectivity IP' opned
- form don't show any validation errors
- click   'Update' button 
- validaton errors displayed 'Please enter a valid IP'

2. Check async validation with wrong 'Server IP' and 'Server secret key'
- go to server page
- click 'Change Cluster Connectivity IP' button
- modal 'Change Cluster Connectivity IP' opned
- form don't show any validation errors
- type 'New Server IP' =  '1.1.1.1'
- async validation failed, errors displayed 'Server is unreachable'

3. Check async validation with my pc 'New Server IP'
- go to cluster page
- click 'Attach Server' button
- modal 'Attach New Server' opned
- type 'New Server IP' same as current value '192.168.1.10'
- async validation passed