### PR TITLE
Fixed: Missing parity fragments indication in object page

### DIFF
--- a/frontend/src/app/utils/object-utils.js
+++ b/frontend/src/app/utils/object-utils.js
@@ -143,20 +143,11 @@ function _findStoragePolicy(resources, resiliency, blocks) {
             };
         }
     } else {
-        if (storageType === 'HOSTS') {
-            return {
-                replicas: 0,
-                dataFrags: resiliency.dataFrags,
-                parityFrags: resiliency.parityFrags
-            };
-
-        } else {
-            return {
-                replicas: 0,
-                dataFrags: resiliency.dataFrags,
-                parityFrags: 0
-            };
-        }
+        return {
+            replicas: 0,
+            dataFrags: resiliency.dataFrags,
+            parityFrags: resiliency.parityFrags
+        };
     }
 }
 


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
Missing parity fragments indication in object page

### Issues: Fixed #xxx / Gap #xxx
fixed #4601

### Testing Instructions:
1. go to bucket
2. edit data placement, placement should contain cloud resources
3. edit resilency policy like on image:
![image](https://user-images.githubusercontent.com/27498391/41340896-1410de8e-6f01-11e8-91e7-b754ed7c7773.png)
4. upload file 
5. check file parts, now cloud resources contains parity fragments 


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
