### PR TITLE
clean_ova.sh: dropping db before cleaning supervisors

### DIFF
--- a/src/deploy/NVA_build/clean_ova.sh
+++ b/src/deploy/NVA_build/clean_ova.sh
@@ -163,6 +163,7 @@ rm -rf /tmp/npm-*
 #Clean /backup
 rm -rf /backup
 
+mongo nbcore --eval 'db.dropDatabase()'
 #Clean supervisors
 sudo cp -f /root/node_modules/noobaa-core/src/deploy/NVA_build/noobaa_supervisor.conf /etc/noobaa_supervisor.conf
 sudo cp -f /root/node_modules/noobaa-core/src/deploy/NVA_build/env.orig /root/node_modules/noobaa-core/.env
@@ -178,7 +179,6 @@ if [ -d /root/node_modules/noobaa-core/noobaa_storage/ ]; then
     rm -rf /root/node_modules/noobaa-core/noobaa_storage/
 fi
 sleep 15
-mongo nbcore --eval 'db.dropDatabase()'
 
 sudo sed -i "s:Configured IP on this NooBaa Server.*:Configured IP on this NooBaa Server \x1b[0;32;40mNONE\x1b[0m.:" /etc/issue
 sudo sed -i "s:This server's secret is.*:No Server Secret:" /etc/issue


### PR DESCRIPTION
### Explain the changes
clean_ova.sh:
- Dropping db before cleaning supervisors

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
