### PR TITLE
account_test.js: add enable/disable bucket creation

### DIFF
--- a/src/test/qa/account_test.js
+++ b/src/test/qa/account_test.js
@@ -7,7 +7,6 @@ const P = require('../../util/promise');
 const { S3OPS } = require('../utils/s3ops');
 const Report = require('../framework/report');
 const argv = require('minimist')(process.argv);
-const promise_utils = require('../../util/promise_utils');
 const dbg = require('../../util/debug_module')(__filename);
 
 const s3ops = new S3OPS();
@@ -17,18 +16,17 @@ dbg.set_process_name(test_name);
 let rpc;
 let client;
 let errors = [];
-let s3AccessKeys = {};
 let failures_in_test = false;
-const bucketName = 'first.bucket';
 
 const TEST_CFG_DEFAULTS = {
     server_ip: '127.0.0.1',
     name: 'account',
+    bucket: 'first.bucket',
     emailSuffix: '@email.email',
     password: 'Password',
     s3_access: true,
-    cycles: 30,
-    accounts_number: 1,
+    cycles: 15,
+    accounts_number: 2,
     to_delete: true,
     skip_create: false
 };
@@ -37,6 +35,11 @@ if (argv.help) {
     usage();
     process.exit(3);
 }
+
+//define colors
+const YELLOW = "\x1b[33;1m";
+// const RED = "\x1b[31m";
+const NC = "\x1b[0m";
 
 let TEST_CFG = _.defaults(_.pick(argv, _.keys(TEST_CFG_DEFAULTS)), TEST_CFG_DEFAULTS);
 Object.freeze(TEST_CFG);
@@ -47,6 +50,7 @@ function usage() {
     console.log(`
     --server_ip         -   azure location (default: ${TEST_CFG_DEFAULTS.server_ip})
     --name              -   account preffix (default: ${TEST_CFG_DEFAULTS.name})
+    --bucket            -   bucket name (default: ${TEST_CFG_DEFAULTS.bucket})
     --emailSuffix       -   The email suffix (default: ${TEST_CFG_DEFAULTS.emailSuffix})
     --password          -   Account's Password (default: ${TEST_CFG_DEFAULTS.password}) 
     --s3_access         -   should we have s3 access (default: ${TEST_CFG_DEFAULTS.s3_access})
@@ -65,60 +69,62 @@ function saveErrorAndResume(message) {
     errors.push(message);
 }
 
-function get_accounts_emails() {
-    return client.system.read_system()
-        .then(res => res.accounts)
-        .then(accounts => {
-            let emails = [];
-            accounts.forEach(function(acc) {
-                emails.push(acc.email);
-            });
-            console.log("Accounts list: " + emails);
-            return emails;
-        })
-        .catch(err => {
-            console.error('Get account list failed!', err);
-            throw err;
-        });
+async function get_accounts_emails() {
+    try {
+        const system_info = await client.system.read_system();
+        const emails = system_info.accounts.map(account => account.email);
+        console.log("Accounts list: " + emails);
+        return emails;
+    } catch (err) {
+        console.error('Get account list failed!', err);
+        throw err;
+    }
 }
 
-function get_s3_account_access(email) {
-    return client.system.read_system()
-        .then(res => res.accounts)
-        .then(accounts => {
-            for (let i = 0; i < accounts.length; i++) {
-                if (accounts[i].email === email) {
-                    s3AccessKeys = {
-                        accessKeyId: accounts[i].access_keys[0].access_key,
-                        secretAccessKey: accounts[i].access_keys[0].secret_key,
-                        access: accounts[i].has_s3_access
-                    };
-                    break;
-                }
-            }
-            console.log("S3 access keys: " + s3AccessKeys.accessKeyId, s3AccessKeys.secretAccessKey);
-            return s3AccessKeys;
-        })
-        .catch(err => {
-            console.error('Getting s3 access keys return error: ', err);
-            throw err;
-        });
+async function get_s3_account_access(email) {
+    try {
+        const system_info = await client.system.read_system();
+        const accounts = system_info.accounts;
+        const account = _.find(accounts, accountObj => accountObj.email === email);
+        const s3AccessKeys = {
+            accessKeyId: account.access_keys[0].access_key,
+            secretAccessKey: account.access_keys[0].secret_key,
+            access: account.has_s3_access
+        };
+        console.log("S3 access keys: " + s3AccessKeys.accessKeyId, s3AccessKeys.secretAccessKey);
+        return s3AccessKeys;
+    } catch (err) {
+        console.error('Getting s3 access keys return error: ', err);
+        throw err;
+    }
 }
 
-function create_account(has_login, account_name) {
-    //building an account parameters object.
-    console.log('Creating account: ' + account_name + " with access login: " + has_login + " s3 access: " + TEST_CFG.s3_access);
-    let email = account_name + TEST_CFG.emailSuffix;
-    let allowed_buckets;
-    if (TEST_CFG.s3_access === true) {
-        allowed_buckets = {
+async function get_account_create_bucket_status(email) {
+    try {
+        const system_info = await client.system.read_system();
+        const accounts = system_info.accounts;
+        const account = _.find(accounts, accountObj => accountObj.email === email);
+        return account.can_create_buckets;
+    } catch (err) {
+        console.error('Getting create bucket status return error: ', err);
+        throw err;
+    }
+}
+
+function get_allowed_buckets(s3_access) {
+    if (s3_access === true) {
+        return {
             full_permission: true,
             permission_list: undefined
         };
     } else {
-        allowed_buckets = undefined;
+        return undefined;
     }
-    let accountData = {
+}
+
+function set_account_details(has_login, account_name, email, s3_access) {
+    const allowed_buckets = get_allowed_buckets(s3_access);
+    return {
         name: account_name,
         email,
         password: TEST_CFG.password,
@@ -127,258 +133,306 @@ function create_account(has_login, account_name) {
         allowed_buckets,
         default_pool: 'first.pool'
     };
-    return client.account.create_account(accountData)
-        .then(() => report.success('create_account'))
-        .then(() => accountData.email)
-        .catch(err => {
-            report.fail('create_account');
-            console.error('Deleting account with error: ', err);
-            throw err;
-        })
-        .delay(10000);
 }
 
-function delete_account(email) {
+async function create_account(has_login, account_name) {
+    //building an account parameters object.
+    console.log(`Creating account: ${account_name} with access login: ${has_login} s3 access: ${TEST_CFG.s3_access}`);
+    let email = account_name + TEST_CFG.emailSuffix;
+    let accountData = set_account_details(has_login, account_name, email, TEST_CFG.s3_access);
+    try {
+        await client.account.create_account(accountData);
+        await report.success('create_account');
+        return accountData.email;
+    } catch (err) {
+        report.fail('create_account');
+        console.error('Deleting account with error: ', err);
+        throw err;
+    }
+}
+
+async function delete_account(email) {
     console.log('Deleting account: ' + email);
-    return client.account.delete_account({
+    try {
+        await client.account.delete_account({
             email: email
-        })
-        .then(() => report.success('delete_account'))
-        .delay(10000)
-        .catch(err => {
-            report.fail('delete_account');
-            console.error('Deleting account with error: ', err);
-            throw err;
         });
+        await report.success('delete_account');
+    } catch (err) {
+        report.fail('delete_account');
+        console.error('Deleting account with error: ', err);
+        throw err;
+    }
 }
 
-function regenerate_s3Access(email) {
+async function regenerate_s3Access(email) {
     console.log('Regenerating account keys: ' + email);
-    return client.account.generate_account_keys({
+    try {
+        await client.account.generate_account_keys({
             email,
             verification_password: 'DeMo1'
-        })
-        .then(() => report.success('regenerate_s3Access'))
-        .catch(err => {
-            report.fail('regenerate_s3Access');
-            console.error('Regenerating account keys with error: ', err);
-            throw err;
         });
+        await report.success('regenerate_s3Access');
+    } catch (err) {
+        report.fail('regenerate_s3Access');
+        console.error('Regenerating account keys with error: ', err);
+        throw err;
+    }
 }
 
-function edit_s3Access(email, s3Access) {
-    console.log('Editing account s3 access: ' + email + 'with access to bucket ' + s3Access);
-    return client.account.update_account_s3_access({
+async function edit_s3Access(email, s3_access) {
+    console.log(`Editing account s3 access: ${email} with access to bucket ${s3_access}`);
+    const allowed_buckets = get_allowed_buckets(s3_access);
+    try {
+        await client.account.update_account_s3_access({
             email,
-            s3_access: s3Access
-        })
-        .then(() => report.success('edit_s3Access'))
-        .catch(err => {
-            report.fail('edit_s3Access');
-            console.error('Editing access with error: ', err);
-            throw err;
+            s3_access,
+            allowed_buckets,
+            default_pool: 'first.pool'
         });
+        await report.success('edit_s3Access');
+    } catch (err) {
+        report.fail('edit_s3Access');
+        console.error('Editing access with error: ', err);
+        throw err;
+    }
 }
 
-function restrict_ip_access(email, ips) {
+async function edit_bucket_creation(email, allow_bucket_creation) {
+    if (allow_bucket_creation) {
+        console.log(`Enabling bucket creation for ${email}`);
+    } else {
+        console.log(`Disabling bucket creation for ${email}`);
+    }
+    const s3_access = true;
+    const allowed_buckets = get_allowed_buckets(s3_access);
+    try {
+        await client.account.update_account_s3_access({
+            email,
+            s3_access,
+            allowed_buckets,
+            default_pool: 'first.pool',
+            allow_bucket_creation
+        });
+        await report.success('edit_bucket_creation');
+    } catch (err) {
+        report.fail('edit_bucket_creation');
+        console.error('Editing access with error: ', err);
+        throw err;
+    }
+}
+
+async function check_bucket_creation_premissions(email) {
+    let create_bucket_status = await get_account_create_bucket_status(email);
+    if (!create_bucket_status) {
+        throw new Error(`Account ${email} default bucket creation premissions should be enabled`);
+    }
+    await edit_bucket_creation(email, false);
+    create_bucket_status = await get_account_create_bucket_status(email);
+    if (create_bucket_status) {
+        throw new Error(`Account ${email} did not changed to disabled`);
+    } else {
+        try {
+            await s3ops.create_bucket(TEST_CFG.server_ip, 'shouldfail');
+            throw new Error(`Create bucket should have failed`);
+        } catch (e) {
+            console.log(`creating bucket failed, as should`);
+        }
+    }
+    await edit_bucket_creation(email, true);
+}
+
+async function restrict_ip_access(email, ips) {
     console.log('Restrictions ip for account s3 access: ' + email);
-    return client.account.update_account({
+    try {
+        await client.account.update_account({
             email,
             ips
-        })
-        .then(() => report.success('restrict_ip_access'))
-        .catch(err => {
-            report.fail('restrict_ip_access');
-            console.error('Editing restriction ip access with error: ', err);
-            throw err;
         });
+        await report.success('restrict_ip_access');
+    } catch (err) {
+        report.fail('restrict_ip_access');
+        console.error('Editing restriction ip access with error: ', err);
+        throw err;
+    }
 }
 
-function verify_s3_access(email) {
-    return get_s3_account_access(email)
-        .then(keys => s3ops.get_list_buckets(TEST_CFG.server_ip, keys.accessKeyId, keys.secretAccessKey))
-        .then(buckets => {
-            if (buckets.includes(bucketName)) {
-                console.log(`Created account has access to s3 bucket ${bucketName}`);
-            } else {
-                saveErrorAndResume(`Created account doesn't have access to s3 bucket ${bucketName}`);
-                failures_in_test = true;
-            }
-        });
+async function verify_s3_access(email, bucket) {
+    const keys = await get_s3_account_access(email);
+    const buckets = await s3ops.get_list_buckets(TEST_CFG.server_ip, keys.accessKeyId, keys.secretAccessKey);
+    if (buckets.includes(bucket)) {
+        console.log(`Created account has access to s3 bucket ${bucket}`);
+    } else {
+        saveErrorAndResume(`Created account doesn't have access to s3 bucket ${bucket}`);
+        failures_in_test = true;
+    }
 }
 
-function login_user(email) {
+async function verify_s3_no_access(email) {
+    try {
+        const keys = await get_s3_account_access(email);
+        await s3ops.get_list_buckets(TEST_CFG.server_ip, keys.accessKeyId, keys.secretAccessKey);
+    } catch (err) {
+        if (err.code === 'AccessDenied') {
+            console.log(`Account doesn't have access to buckets after switch off access, err ${err.code} - as should`);
+        } else {
+            saveErrorAndResume('After switch off access to buckets account has access to s3');
+            failures_in_test = true;
+        }
+    }
+}
+
+async function login_user(email) {
     rpc = api.new_rpc('wss://' + TEST_CFG.server_ip + ':8443');
     client = rpc.new_client({});
-    return P.fcall(() => {
-            let auth_params = {
-                email,
-                password: 'DeMo1',
-                system: 'demo'
-            };
-            return client.create_auth_token(auth_params);
-        })
-        .then(res => {
-            if (res.token !== null && res.token !== '') {
-                console.log('Account ', email, 'has access to server');
-            } else {
-                saveErrorAndResume('Account can\'t auth');
-                failures_in_test = true;
-            }
-        });
+    let auth_params = {
+        email,
+        password: 'DeMo1',
+        system: 'demo'
+    };
+    const auth_token = await client.create_auth_token(auth_params);
+    if (auth_token.token !== null && auth_token.token !== '') {
+        console.log('Account ', email, 'has access to server');
+    } else {
+        saveErrorAndResume('Account can\'t auth');
+        failures_in_test = true;
+    }
 }
 
-function reset_password(email) {
+async function reset_password(email) {
     console.log('Resetting password for account ' + email);
-    return login_user('demo@noobaa.com')
-        .then(() => client.account.reset_password({
+    try {
+        await login_user('demo@noobaa.com');
+        await client.account.reset_password({
             email,
             must_change_password: false,
             password: "DeMo1",
             verification_password: "DeMo1"
-        }))
-        .then(() => report.success('reset_password'))
-        .catch(err => {
-            report.fail('reset_password');
-            console.error('Resetting password with error: ', err);
-            throw err;
-        })
-        .then(() => rpc.disconnect_all());
-}
-
-function verify_account_in_system(email, isPresent) {
-    return get_accounts_emails()
-        .then(emails => {
-            if (emails.includes(email) === isPresent) {
-                console.log('System contains ', isPresent, 'account');
-            } else {
-                saveErrorAndResume('Created account doesn\'t contain on system');
-                failures_in_test = true;
-            }
         });
+        await report.success('reset_password');
+    } catch (err) {
+        report.fail('reset_password');
+        console.error('Resetting password with error: ', err);
+        throw err;
+    }
+    await rpc.disconnect_all();
 }
 
-function checkAccountFeatures() {
-    let newAccount;
+async function verify_account_in_system(email, isPresent) {
+    const emails = await get_accounts_emails();
+    if (emails.includes(email) === isPresent) {
+        console.log('System contains ', isPresent, 'account');
+    } else {
+        saveErrorAndResume('Created account doesn\'t contain on system');
+        failures_in_test = true;
+    }
+}
+
+async function disable_s3_Access_and_check(email) {
+    await edit_s3Access(email, false);
+    await P.delay(10 * 1000);
+    const keys = await get_s3_account_access(email);
+    if (keys.access === false) {
+        console.log('S3 access was changed successfully');
+    } else {
+        saveErrorAndResume(`S3 access wasn't changed to false after edit`);
+        failures_in_test = true;
+    }
+    const buckets = await s3ops.get_list_buckets(TEST_CFG.server_ip, keys.accessKeyId, keys.secretAccessKey);
+    if (buckets.length === 0) {
+        console.log(`Account doesn't have access to buckets after changing access - as should`);
+    } else {
+        saveErrorAndResume('After switch off s3 access account still has access to ' + buckets);
+        failures_in_test = true;
+    }
+    await edit_s3Access(email, true);
+}
+
+async function checkAccountFeatures() {
     const fullName = `${TEST_CFG.name}` + (Math.floor(Date.now() / 1000));
-    return create_account(true, fullName)
-        .then(res => {
-            newAccount = res;
-            console.log('Created account is ', newAccount, ' with access s3 ', TEST_CFG.s3_access);
-            return verify_account_in_system(newAccount, true);
-        })
-        .then(() => {
-            if (TEST_CFG.s3_access === true) {
-                return verify_s3_access(newAccount)
-                    .then(() => regenerate_s3Access(newAccount))
-                    .then(() => verify_s3_access(newAccount))
-                    .then(() => restrict_ip_access(newAccount, []))
-                    .then(() => get_s3_account_access(newAccount))
-                    .then(keys => s3ops.get_list_buckets(TEST_CFG.server_ip, keys.accessKeyId, keys.secretAccessKey)
-                        .catch(err => {
-                            if (err.code === 'AccessDenied') {
-                                console.log(`Account doesn't have access to buckets after switch off access, err ${err.code} - as should`);
-                            } else {
-                                saveErrorAndResume('After switch off access to buckets account has access to s3');
-                            }
-                        })
-                    )
-                    .then(() => restrict_ip_access(newAccount, null))
-                    .then(() => verify_s3_access(newAccount))
-                    .then(() => edit_s3Access(newAccount, false))
-                    .delay(10000)
-                    .then(() => get_s3_account_access(newAccount))
-                    .then(keys => {
-                        let hasAccess = keys.access;
-                        if (hasAccess === false) {
-                            console.log('S3 access was changed successfully');
-                        } else {
-                            saveErrorAndResume('S3 access wasn\'t changed to false after edit');
-                            failures_in_test = true;
-                        }
-                        return s3ops.get_list_buckets(TEST_CFG.server_ip, keys.accessKeyId, keys.secretAccessKey)
-                            .then(buckets => {
-                                if (buckets.length === 0) {
-                                    console.log('Account doesn\'t have access to buckets after changing access - as should');
-                                } else {
-                                    saveErrorAndResume('After switch off s3 access account still has access to ' + buckets);
-                                    failures_in_test = true;
-                                }
-                            });
-                    })
-                    .then(() => rpc.disconnect_all());
-            } else {
-                return get_s3_account_access(newAccount)
-                    .then(keys => {
-                        let hasAccess = keys.access;
-                        if (hasAccess === false) {
-                            console.log('S3 access was changed successfully');
-                        } else {
-                            saveErrorAndResume('S3 access wasn\'t changed to false after edit');
-                            failures_in_test = true;
-                        }
-                    });
-            }
-        })
-        .then(() => reset_password(newAccount))
-        .then(() => login_user(newAccount))
-        .delay(10000)
-        .then(() => {
-            if (TEST_CFG.to_delete === true) {
-                return login_user('demo@noobaa.com')
-                    .then(() => delete_account(newAccount))
-                    .then(() => verify_account_in_system(newAccount, false));
-            } else {
-                console.log('Deleting skipped');
-            }
-        });
+    const newAccount = await create_account(true, fullName);
+    console.log(`Created account is ${newAccount} with access s3 ${TEST_CFG.s3_access}`);
+    await verify_account_in_system(newAccount, true);
+    if (TEST_CFG.s3_access === true) {
+        await verify_s3_access(newAccount, TEST_CFG.bucket);
+        await regenerate_s3Access(newAccount);
+        await verify_s3_access(newAccount, TEST_CFG.bucket);
+        await restrict_ip_access(newAccount, []);
+        await verify_s3_no_access(newAccount);
+        await restrict_ip_access(newAccount, null);
+        await verify_s3_access(newAccount, TEST_CFG.bucket);
+        await check_bucket_creation_premissions(newAccount);
+        await disable_s3_Access_and_check(newAccount);
+        await rpc.disconnect_all();
+    } else {
+        const keys = await get_s3_account_access(newAccount);
+        if (keys.access === false) {
+            console.log('S3 access was changed successfully');
+        } else {
+            saveErrorAndResume(`S3 access wasn't changed to false after edit`);
+            failures_in_test = true;
+        }
+    }
+    await reset_password(newAccount);
+    await login_user(newAccount);
+    await P.delay(10 * 1000);
+    if (TEST_CFG.to_delete === true) {
+        await login_user('demo@noobaa.com');
+        await delete_account(newAccount);
+        await P.delay(10 * 1000);
+        await verify_account_in_system(newAccount, false);
+    } else {
+        console.log('Deleting skipped');
+    }
 }
 
-function doCycle(cycle_num, count) {
-    return P.all(
-        _.times(count, account_num => {
-            const fullName = `${TEST_CFG.name}${account_num}_cycle${cycle_num}_` + (Math.floor(Date.now() / 1000));
-            let newAccount;
-            return TEST_CFG.skip_create ? fullName : create_account(true, fullName)
-                .then(res => {
-                    newAccount = res;
-                    console.log('Created account is ', newAccount, ' with access s3 ', TEST_CFG.s3_access);
-                    return verify_account_in_system(newAccount, true);
-                })
-                .delay(10000)
-                .then(() => {
-                    if (TEST_CFG.to_delete === true) {
-                        return delete_account(newAccount)
-                            .then(() => verify_account_in_system(newAccount, false));
-                    } else {
-                        console.log('Deleting skipped');
-                    }
-                });
-        }));
+async function create_delete_accounts(cycle_num, count) {
+    for (let account_num = 1; account_num <= count; account_num++) {
+        console.log(`${YELLOW}Creating account number: ${account_num} in cycle ${cycle_num}${NC}`);
+        const fullName = `${TEST_CFG.name}${account_num}_cycle${cycle_num}_` + (Math.floor(Date.now() / 1000));
+        let newAccount;
+        if (TEST_CFG.skip_create) {
+            newAccount = fullName;
+        } else {
+            newAccount = await create_account(true, fullName);
+        }
+        console.log(`Created account is ${newAccount} with access s3 ${TEST_CFG.s3_access}`);
+        await verify_account_in_system(newAccount, true);
+        await P.delay(10 * 1000);
+        if (TEST_CFG.to_delete === true) {
+            await delete_account(newAccount);
+            await P.delay(10 * 1000);
+            await verify_account_in_system(newAccount, false);
+        } else {
+            console.log('Deleting skipped');
+        }
+    }
 }
 
-return promise_utils.loop(TEST_CFG.cycles, cycle => login_user('demo@noobaa.com')
-        .then(() => checkAccountFeatures())
-        .then(() => rpc.disconnect_all())
-        .then(() => login_user('demo@noobaa.com'))
-        .then(() => doCycle(cycle, TEST_CFG.accounts_number))
-        .delay(10000)
-        .then(() => checkAccountFeatures())
-        .then(() => rpc.disconnect_all())
-    )
-    .catch(err => report.print_report()
-        .then(() => {
+async function main() {
+    for (let cycle = 1; cycle <= TEST_CFG.cycles; cycle++) {
+        console.log(`${YELLOW}Starting cycle ${cycle}${NC}`);
+        try {
+            await login_user('demo@noobaa.com');
+            await checkAccountFeatures();
+            await rpc.disconnect_all();
+            await login_user('demo@noobaa.com');
+            await create_delete_accounts(cycle, TEST_CFG.accounts_number);
+            await P.delay(10 * 1000);
+            await rpc.disconnect_all();
+        } catch (err) {
             console.error('something went wrong ' + err + errors);
             failures_in_test = true;
-            process.exit(1);
-        }))
-    .then(() => report.print_report())
-    .then(() => {
-        if (failures_in_test) {
-            console.error('Errors during account test ' + errors);
-            process.exit(1);
-        } else {
-            console.log('account test were successful');
-            process.exit(0);
         }
-    });
+    }
+    await report.print_report();
+    if (failures_in_test) {
+        console.error('Errors during account test ' + errors);
+        process.exit(1);
+    } else {
+        console.log('account test were successful');
+        process.exit(0);
+    }
+}
+
+main();


### PR DESCRIPTION
### Explain the changes
account_test.js:
- Testing enable/disable bucket creation
- changed the default cycle number to 15 and accounts_number to 2
- Add some colors
- Converted to async await

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
