### PR TITLE
Clicking on an accordion line to expand should automatically scroll according to the relevant position

### DIFF
--- a/frontend/src/app/bindings/register.js
+++ b/frontend/src/app/bindings/register.js
@@ -24,6 +24,7 @@ export default function register(ko) {
     registerHandler('expand',               require('./expand').default);
     registerHandler('tooltip',              require('./tooltip').default);
     registerHandler('scrollTo',             require('./scroll-to').default);
+    registerHandler('scrollToIf',             require('./scroll-to-if').default);
     registerHandler('hover',                require('./hover').default);
     registerHandler('shakeOnClick',         require('./shake-on-click').default);
     registerHandler('childEvent',           require('./child-event').default);

--- a/frontend/src/app/bindings/scroll-to-if.js
+++ b/frontend/src/app/bindings/scroll-to-if.js
@@ -1,0 +1,20 @@
+/* Copyright (C) 2016 NooBaa */
+
+import ko from 'knockout';
+import { sleep } from 'utils/promise-utils';
+
+function scroll(element, valueAccessor) {
+    const value = ko.utils.unwrapObservable(valueAccessor());
+    if (value) {
+        const scrollParent = element.closest('.scroll');
+        const nodes = [...scrollParent.children];
+        const node = nodes.find((node) => node.contains(element));
+
+        sleep(1000, false).then(() => scrollParent.scrollTop = node.offsetTop);
+    }
+}
+
+export default {
+    init: scroll,
+    update: scroll
+};

--- a/frontend/src/app/components/bucket/bucket-data-placement-policy-form/bucket-data-placement-policy-form.html
+++ b/frontend/src/app/components/bucket/bucket-data-placement-policy-form/bucket-data-placement-policy-form.html
@@ -3,6 +3,7 @@
 <section class="pad">
     <div class="row content-middle bucket-policy-summary"
         ko.click="onToggleSection"
+        ko.scrollToIf="isExpanded"
     >
         <svg-icon class="push-next"
             params="name: stateIcon().name"

--- a/frontend/src/app/components/bucket/bucket-data-policies-form/bucket-data-policies-form.html
+++ b/frontend/src/app/components/bucket/bucket-data-policies-form/bucket-data-policies-form.html
@@ -4,19 +4,13 @@
     Bucket Policies and Configurations
 </h1>
 <loading-indicator class="align-start pad" ko.visible="!bucketLoaded()"></loading-indicator>
-<section class="fade-in" ko.visible="bucketLoaded">
-    <bucket-data-placement-policy-form>
+<section class="fade-in column greedy scroll" ko.visible="bucketLoaded">
+    <bucket-data-placement-policy-form class="border-bottom push-next-half">
     </bucket-data-placement-policy-form>
-    <hr>
-    <bucket-data-resiliency-policy-form>
+    <bucket-data-resiliency-policy-form class="border-bottom push-next-half">
     </bucket-data-resiliency-policy-form>
-    <hr>
-    <bucket-quota-policy-form>
+    <bucket-quota-policy-form class="border-bottom push-next-half">
     </bucket-quota-policy-form>
-    <hr>
-    <bucket-spillover-policy-form>
+    <bucket-spillover-policy-form class="border-bottom push-next-half">
     </bucket-spillover-policy-form>
 </section>
-
-
-

--- a/frontend/src/app/components/bucket/bucket-data-policies-form/bucket-data-policies-form.less
+++ b/frontend/src/app/components/bucket/bucket-data-policies-form/bucket-data-policies-form.less
@@ -1,8 +1,7 @@
 /* Copyright (C) 2016 NooBaa */
 
 bucket-data-policies-form {
-    display: block;
-
+    .column();
 
     .bucket-policy-summary {
         cursor: @cursor-pointer;

--- a/frontend/src/app/components/bucket/bucket-data-resiliency-policy-form/bucket-data-resiliency-policy-form.html
+++ b/frontend/src/app/components/bucket/bucket-data-resiliency-policy-form/bucket-data-resiliency-policy-form.html
@@ -3,6 +3,7 @@
 <section class="pad">
     <div class="row content-middle bucket-policy-summary"
         ko.click="onToggleSection"
+        ko.scrollToIf="isExpanded"
     >
         <svg-icon class="push-next"
             params="name: stateIcon().name"

--- a/frontend/src/app/components/bucket/bucket-quota-policy-form/bucket-quota-policy-form.html
+++ b/frontend/src/app/components/bucket/bucket-quota-policy-form/bucket-quota-policy-form.html
@@ -3,6 +3,7 @@
 <section class="pad">
     <div class="row content-middle bucket-policy-summary"
         ko.click="onToggleSection"
+        ko.scrollToIf="isExpanded"
     >
         <svg-icon class="push-next"
             params="name: stateIcon().name"

--- a/frontend/src/app/components/bucket/bucket-spillover-policy-form/bucket-spillover-policy-form.html
+++ b/frontend/src/app/components/bucket/bucket-spillover-policy-form/bucket-spillover-policy-form.html
@@ -3,6 +3,7 @@
 <section class="pad">
     <div class="row content-middle bucket-policy-summary"
         ko.click="onToggleSection"
+        ko.scrollToIf="isExpanded"
     >
         <svg-icon class="push-next"
             params="name: stateIcon().name"

--- a/frontend/src/app/styles/site.less
+++ b/frontend/src/app/styles/site.less
@@ -474,3 +474,8 @@ dirty-mark {
         content: '*';
     }
 }
+
+.scroll {
+    position: relative;
+    overflow-y: auto;
+}


### PR DESCRIPTION
### Explain the changes
Clicking on an accordion line to expand should automatically scroll according to the relevant position

### Issues: Fixed #xxx / Gap #xxx
fixed #4259

### Testing Instructions:
1. go to any bucket 
2. go to bucket policies
3. try to expand accordion elements

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
