### PR TITLE
CEPH Tests - Move to work with a blacklist + enable ~100 new cases

### DIFF
--- a/src/test/system_tests/ceph_s3_tests_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests_deploy.sh
@@ -26,57 +26,67 @@ logger -p local0.info "ceph_s3_tests_deploy.sh executed."
 DIRECTORY="s3-tests"
 CEPH_LINK="https://github.com/ceph/s3-tests.git"
 TURN_DL="http://turnserver.open-sys.org/downloads/v4.3.1.3/turnserver-4.3.1.3-CentOS6.6-x86_64.tar.gz"
-echo "Remove centos-release-scl..."
-logger -p local0.info "Remove centos-release-scl..."
-yum -y remove centos-release-SCL
-echo "Install centos-release-scl..."
-logger -p local0.info "Install centos-release-scl..."
-yum -y install centos-release-scl
-echo "Finished Re-Installing centos-release-scl..."
-logger -p local0.info "Finished Re-Installing centos-release-scl..."
-echo "Erase new version of libevent-2..."
-logger -p local0.info "Erase new version of libevent-2..."
-yum -y erase libevent-2.0.21-2.el6.x86_64
-echo "Finished Erasing new version of libevent-2..."
-logger -p local0.info "Finished Erasing new version of libevent-2..."
 if [ ! -d $DIRECTORY ]; then
+    echo "Remove centos-release-scl..."
+    logger -p local0.info "Remove centos-release-scl..."
+    yum -y remove centos-release-SCL
+
+    echo "Install centos-release-scl..."
+    logger -p local0.info "Install centos-release-scl..."
+    yum -y install centos-release-scl
+    echo "Finished Re-Installing centos-release-scl..."
+    logger -p local0.info "Finished Re-Installing centos-release-scl..."
+
+    echo "Erase new version of libevent-2..."
+    logger -p local0.info "Erase new version of libevent-2..."
+    yum -y erase libevent-2.0.21-2.el6.x86_64
+    echo "Finished Erasing new version of libevent-2..."
+    logger -p local0.info "Finished Erasing new version of libevent-2..."
+
     echo "Downloading Ceph S3 Tests..."
     logger -p local0.info "Downloading Ceph S3 Tests..."
     git clone $CEPH_LINK
     echo "Finished Downloading Ceph S3 Tests"
     logger -p local0.info "Finished Downloading Ceph S3 Tests"
+
+    echo "Installing virtualenv using Yum..."
+    logger -p local0.info "Installing virtualenv using Yum..."
+    yum install -y python-virtualenv
+    echo "Finished Installing virtualenv"
+    logger -p local0.info "Finished Installing virtualenv"
+
+    echo "Installing libxml2, libxslt..."
+    logger -p local0.info "Installing libxml2, libxslt..."
+    yum install -y libxml2
+    yum install -y libxslt
+    echo "Finished Installing libxml2, libxslt..."
+    logger -p local0.info "Finished Installing libxml2, libxslt..."
+
+    echo "Running Bootstrap..."
+    logger -p local0.info "Running Bootstrap..."
+    cd $DIRECTORY
+    ./bootstrap
+    touch ./s3tests/tests/__init__.py
+    echo "Finished Running Bootstrap..."
+    logger -p local0.info "Finished Running Bootstrap..."
+
+    echo "Downloading turnserver package and unpacking..."
+    logger -p local0.info "Downloading turnserver package and unpacking..."
+    cd /tmp
+    curl -sL ${TURN_DL} | tar -xzv
+    echo "Finished Downloading turnserver package and unpacking..."
+    logger -p local0.info "Finished Downloading turnserver package and unpacking..."
+
+    cd /tmp/turnserver-4.3.1.3
+    echo "Installing turnserver..."
+    logger -p local0.info "Installing turnserver..."
+    ./install.sh
+    echo "Finished Installing turnserver..."
+    logger -p local0.info "Finished Installing turnserver..."
+    
+    echo "Starting turnserver..."
+    logger -p local0.info "Starting turnserver..."
+    supervisorctl start STUN
+    echo "Finished Starting turnserver..."
+    logger -p local0.info "Finished Starting turnserver..."
 fi
-echo "Installing virtualenv using Yum..."
-logger -p local0.info "Installing virtualenv using Yum..."
-yum install -y python-virtualenv
-echo "Finished Installing virtualenv"
-logger -p local0.info "Finished Installing virtualenv"
-echo "Installing libxml2, libxslt..."
-logger -p local0.info "Installing libxml2, libxslt..."
-yum install -y libxml2
-yum install -y libxslt
-echo "Finished Installing libxml2, libxslt..."
-logger -p local0.info "Finished Installing libxml2, libxslt..."
-echo "Running Bootstrap..."
-logger -p local0.info "Running Bootstrap..."
-cd $DIRECTORY
-./bootstrap
-echo "Finished Running Bootstrap..."
-logger -p local0.info "Finished Running Bootstrap..."
-echo "Downloading turnserver package and unpacking..."
-logger -p local0.info "Downloading turnserver package and unpacking..."
-cd /tmp
-curl -sL ${TURN_DL} | tar -xzv
-echo "Finished Downloading turnserver package and unpacking..."
-logger -p local0.info "Finished Downloading turnserver package and unpacking..."
-cd /tmp/turnserver-4.3.1.3
-echo "Installing turnserver..."
-logger -p local0.info "Installing turnserver..."
-./install.sh
-echo "Finished Installing turnserver..."
-logger -p local0.info "Finished Installing turnserver..."
-echo "Starting turnserver..."
-logger -p local0.info "Starting turnserver..."
-supervisorctl start STUN
-echo "Finished Starting turnserver..."
-logger -p local0.info "Finished Starting turnserver..."

--- a/src/test/system_tests/test_ceph_s3.js
+++ b/src/test/system_tests/test_ceph_s3.js
@@ -1,13 +1,16 @@
 /* Copyright (C) 2016 NooBaa */
 "use strict";
 
-var config = require('../../../config.js');
-var promise_utils = require('../../util/promise_utils');
-var _ = require('lodash');
+let _ = require('lodash');
+let P = require('../../util/promise');
+let config = require('../../../config.js');
+let promise_utils = require('../../util/promise_utils');
 
-var api = require('../../api');
-var rpc = api.new_rpc();
-var client = rpc.new_client({
+
+let api = require('../../api');
+let rpc = api.new_rpc();
+
+let client = rpc.new_client({
     address: 'ws://127.0.0.1:' + process.env.PORT
 });
 let auth_params = {
@@ -16,12 +19,11 @@ let auth_params = {
     system: 'demo'
 };
 
-var CEPH_TEST = {
+let CEPH_TEST = {
     test_dir: 'src/test/system_tests/',
     s3_test_dir: 's3-tests/',
     ceph_config: 'ceph_s3_config.conf',
     ceph_deploy: 'ceph_s3_tests_deploy.sh',
-    rpc_shell_file: 'src/tools/rpc_shell.js',
     new_account: {
         name: 'cephalt',
         email: 'ceph.alt@noobaa.com',
@@ -36,312 +38,347 @@ var CEPH_TEST = {
     },
 };
 
-const S3_CEPH_TEST_WHITELIST = [
-    's3tests.functional.test_headers:test_object_create_bad_md5_invalid_short',
-    's3tests.functional.test_headers:test_object_create_bad_md5_bad',
-    's3tests.functional.test_headers:test_object_create_bad_md5_empty',
-    's3tests.functional.test_headers:test_object_create_bad_md5_none',
-    's3tests.functional.test_headers:test_object_create_bad_expect_mismatch',
-    's3tests.functional.test_headers:test_object_create_bad_expect_empty',
-    's3tests.functional.test_headers:test_object_create_bad_expect_none',
-    's3tests.functional.test_headers:test_object_create_bad_contenttype_invalid',
-    's3tests.functional.test_headers:test_object_create_bad_contenttype_empty',
-    's3tests.functional.test_headers:test_object_create_bad_contenttype_none',
-    's3tests.functional.test_headers:test_bucket_create_bad_expect_mismatch',
-    's3tests.functional.test_headers:test_bucket_create_bad_expect_empty',
-    's3tests.functional.test_headers:test_object_create_bad_md5_invalid_garbage_aws2',
-    's3tests.functional.test_headers:test_object_create_bad_authorization_incorrect_aws2',
-    's3tests.functional.test_headers:test_object_create_bad_ua_empty_aws2',
-    's3tests.functional.test_headers:test_object_create_bad_ua_none_aws2',
-    's3tests.functional.test_headers:test_object_create_bad_date_none_aws2',
-    's3tests.functional.test_headers:test_object_create_bad_date_before_today_aws2',
-    's3tests.functional.test_headers:test_object_create_bad_date_after_today_aws2',
-    's3tests.functional.test_headers:test_object_create_bad_date_after_end_aws2',
-    's3tests.functional.test_headers:test_bucket_create_bad_ua_empty_aws2',
-    's3tests.functional.test_headers:test_bucket_create_bad_ua_none_aws2',
-    's3tests.functional.test_headers:test_bucket_create_bad_date_none_aws2',
-    's3tests.functional.test_headers:test_bucket_create_bad_date_before_today_aws2',
-    's3tests.functional.test_headers:test_bucket_create_bad_date_after_today_aws2',
-    's3tests.functional.test_s3:test_bucket_list_empty',
-    's3tests.functional.test_s3:test_bucket_list_distinct',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_basic',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_prefix_ends_with_delimiter',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_alt',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_percentage',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_whitespace',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_dot',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_empty',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_none',
-    's3tests.functional.test_s3:test_bucket_list_delimiter_not_exist',
-    's3tests.functional.test_s3:test_bucket_list_prefix_basic',
-    's3tests.functional.test_s3:test_bucket_list_prefix_alt',
-    's3tests.functional.test_s3:test_bucket_list_prefix_empty',
-    's3tests.functional.test_s3:test_bucket_list_prefix_none',
-    's3tests.functional.test_s3:test_bucket_list_prefix_not_exist',
-    's3tests.functional.test_s3:test_bucket_list_prefix_delimiter_basic',
-    's3tests.functional.test_s3:test_bucket_list_prefix_delimiter_alt',
-    's3tests.functional.test_s3:test_bucket_list_prefix_delimiter_prefix_not_exist',
-    's3tests.functional.test_s3:test_bucket_list_prefix_delimiter_delimiter_not_exist',
-    's3tests.functional.test_s3:test_bucket_list_prefix_delimiter_prefix_delimiter_not_exist',
-    's3tests.functional.test_s3:test_bucket_list_marker_before_list',
-    's3tests.functional.test_s3:test_bucket_list_objects_anonymous_fail',
-    's3tests.functional.test_s3:test_bucket_notexist',
-    's3tests.functional.test_s3:test_bucket_delete_notexist',
-    's3tests.functional.test_s3:test_bucket_delete_nonempty',
-    's3tests.functional.test_s3:test_object_write_to_nonexist_bucket',
-    's3tests.functional.test_s3:test_bucket_create_delete',
-    's3tests.functional.test_s3:test_object_read_notexist',
-    's3tests.functional.test_s3:test_object_requestid_on_error',
-    's3tests.functional.test_s3:test_object_requestid_matchs_header_on_error',
-    's3tests.functional.test_s3:test_object_head_zero_bytes',
-    's3tests.functional.test_s3:test_object_write_check_etag',
-    's3tests.functional.test_s3:test_object_write_read_update_read_delete',
-    's3tests.functional.test_s3:test_object_set_get_metadata_none_to_good',
-    's3tests.functional.test_s3:test_object_set_get_metadata_none_to_empty',
-    's3tests.functional.test_s3:test_object_set_get_metadata_overwrite_to_good',
-    's3tests.functional.test_s3:test_object_set_get_metadata_overwrite_to_empty',
-    's3tests.functional.test_s3:test_object_set_get_unicode_metadata',
-    's3tests.functional.test_s3:test_object_metadata_replaced_on_put',
-    's3tests.functional.test_s3:test_object_write_file',
-    //// POST Object is not implemented
-    // 's3tests.functional.test_s3:test_post_object_authenticated_request_bad_access_key',
-    // 's3tests.functional.test_s3:test_post_object_invalid_signature',
-    // 's3tests.functional.test_s3:test_post_object_invalid_access_key',
-    // 's3tests.functional.test_s3:test_post_object_missing_policy_condition',
-    // 's3tests.functional.test_s3:test_post_object_request_missing_policy_specified_field',
-    // 's3tests.functional.test_s3:test_post_object_expired_policy',
-    // 's3tests.functional.test_s3:test_post_object_invalid_request_field_value',
-    's3tests.functional.test_s3:test_get_object_ifmatch_failed',
-    's3tests.functional.test_s3:test_get_object_ifnonematch_failed',
-    's3tests.functional.test_s3:test_get_object_ifmodifiedsince_good',
-    's3tests.functional.test_s3:test_get_object_ifunmodifiedsince_good',
-    's3tests.functional.test_s3:test_get_object_ifmodifiedsince_failed',
-    's3tests.functional.test_s3:test_get_object_ifunmodifiedsince_failed',
-    's3tests.functional.test_s3:test_put_object_ifmatch_good',
-    's3tests.functional.test_s3:test_put_object_ifmatch_overwrite_existed_good',
-    's3tests.functional.test_s3:test_put_object_ifnonmatch_good',
-    's3tests.functional.test_s3:test_put_object_ifnonmatch_nonexisted_good',
-    's3tests.functional.test_s3:test_object_delete_key_bucket_gone',
-    's3tests.functional.test_s3:test_bucket_head',
-    's3tests.functional.test_s3:test_bucket_head_extended',
-    's3tests.functional.test_s3:test_object_raw_get_object_acl',
-    's3tests.functional.test_s3:test_object_raw_authenticated',
-    's3tests.functional.test_s3:test_object_raw_authenticated_bucket_acl',
-    's3tests.functional.test_s3:test_object_raw_authenticated_object_acl',
-    's3tests.functional.test_s3:test_object_raw_authenticated_bucket_gone',
-    's3tests.functional.test_s3:test_object_raw_authenticated_object_gone',
-    's3tests.functional.test_s3:test_object_raw_put',
-    's3tests.functional.test_s3:test_object_raw_put_authenticated',
-    's3tests.functional.test_s3:test_object_raw_put_authenticated_expired',
-    's3tests.functional.test_s3:test_bucket_create_naming_bad_starts_nonalpha',
-    's3tests.functional.test_s3:test_bucket_create_naming_bad_short_one',
-    's3tests.functional.test_s3:test_bucket_create_naming_bad_short_two',
-    's3tests.functional.test_s3:test_bucket_create_naming_bad_long',
-    's3tests.functional.test_s3:test_bucket_create_naming_bad_ip',
-    's3tests.functional.test_s3:test_bucket_create_naming_bad_punctuation',
-    's3tests.functional.test_s3:test_bucket_get_location',
-    's3tests.functional.test_s3:test_bucket_create_exists_nonowner',
-    's3tests.functional.test_s3:test_bucket_delete_nonowner',
-    's3tests.functional.test_s3:test_bucket_acl_canned_private_to_private',
-    's3tests.functional.test_s3:test_access_bucket_private_object_private',
-    's3tests.functional.test_s3:test_object_set_valid_acl',
-    's3tests.functional.test_s3:test_buckets_create_then_list',
-    's3tests.functional.test_s3:test_bucket_create_naming_good_starts_alpha',
-    's3tests.functional.test_s3:test_bucket_create_naming_good_starts_digit',
-    's3tests.functional.test_s3:test_bucket_create_naming_good_contains_period',
-    's3tests.functional.test_s3:test_bucket_create_naming_good_contains_hyphen',
-    's3tests.functional.test_s3:test_bucket_create_special_key_names',
-    's3tests.functional.test_s3:test_bucket_list_special_prefix',
-    's3tests.functional.test_s3:test_object_copy_zero_size',
-    's3tests.functional.test_s3:test_object_copy_same_bucket',
-    's3tests.functional.test_s3:test_object_copy_verify_contenttype',
-    's3tests.functional.test_s3:test_object_copy_to_itself_with_metadata',
-    's3tests.functional.test_s3:test_object_copy_diff_bucket',
-    's3tests.functional.test_s3:test_object_copy_not_owned_bucket',
-    's3tests.functional.test_s3:test_object_copy_retaining_metadata',
-    's3tests.functional.test_s3:test_object_copy_replacing_metadata',
-    's3tests.functional.test_s3:test_object_copy_bucket_not_found',
-    's3tests.functional.test_s3:test_object_copy_key_not_found',
-    's3tests.functional.test_s3:test_multipart_upload_small',
-    's3tests.functional.test_s3:test_multipart_upload',
-    's3tests.functional.test_s3:test_multipart_upload_multiple_sizes',
-    's3tests.functional.test_s3:test_multipart_upload_contents',
-    's3tests.functional.test_s3:test_multipart_upload_overwrite_existing_object',
-    's3tests.functional.test_s3:test_multipart_upload_incorrect_etag',
-    's3tests.functional.test_s3:test_multipart_upload_missing_part',
-    's3tests.functional.test_s3:test_abort_multipart_upload',
-    's3tests.functional.test_s3:test_multipart_resend_first_finishes_last',
-    's3tests.functional.test_s3:test_ranged_request_response_code',
-    's3tests.functional.test_s3:test_ranged_request_skip_leading_bytes_response_code',
-    's3tests.functional.test_s3:test_ranged_request_return_trailing_bytes_response_code',
-    's3tests.functional.test_s3:test_ranged_request_invalid_range',
-    's3tests.functional.test_utils:test_generate'
-];
+let stats = {
+    pass: [],
+    fail: [],
+    skip: [],
+    total: 0
+};
 
-const SYSTEM_CEPH_TEST_WHITELIST = [
-    's3tests.fuzz.test.test_fuzzer:test_load_graph',
-    's3tests.fuzz.test.test_fuzzer:test_descend_leaf_node',
-    's3tests.fuzz.test.test_fuzzer:test_descend_node',
-    's3tests.fuzz.test.test_fuzzer:test_descend_bad_node',
-    's3tests.fuzz.test.test_fuzzer:test_descend_nonexistant_child',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_printable',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_binary',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_printable_no_whitespace',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_binary_no_whitespace',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_no_args',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_no_charset',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_exact_length',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_bad_charset',
-    's3tests.fuzz.test.test_fuzzer:test_expand_random_missing_length',
-    's3tests.fuzz.test.test_fuzzer:test_assemble_decision',
-    's3tests.fuzz.test.test_fuzzer:test_expand_escape',
-    's3tests.fuzz.test.test_fuzzer:test_expand_indirect',
-    's3tests.fuzz.test.test_fuzzer:test_expand_indirect_double',
-    's3tests.fuzz.test.test_fuzzer:test_expand_recursive',
-    's3tests.fuzz.test.test_fuzzer:test_expand_recursive_mutual',
-    's3tests.fuzz.test.test_fuzzer:test_expand_recursive_not_too_eager',
-    's3tests.fuzz.test.test_fuzzer:test_make_choice_unweighted_with_space',
-    's3tests.fuzz.test.test_fuzzer:test_weighted_choices',
-    's3tests.fuzz.test.test_fuzzer:test_null_choices',
-    's3tests.fuzz.test.test_fuzzer:test_weighted_null_choices',
-    's3tests.fuzz.test.test_fuzzer:test_null_child',
-    's3tests.fuzz.test.test_fuzzer:test_weighted_set',
-    's3tests.fuzz.test.test_fuzzer:test_header_presence',
-    's3tests.fuzz.test.test_fuzzer:test_duplicate_header',
-    's3tests.fuzz.test.test_fuzzer:test_expand_headers'
-    // 's3tests.tests.test_realistic:TestFileValidator:test_new_file_is_valid',
-    // 's3tests.tests.test_realistic:TestFileValidator:test_new_file_is_valid_on_several_calls',
-    // 's3tests.tests.test_realistic:TestFileValidator:test_new_file_is_valid_when_size_is_1',
-    // 's3tests.tests.test_realistic:TestFiles:test_random_file_valid'
-];
+let tests_list;
 
-const IGNORE_S3_CEPH_TEST_LIST = [];
+//Regexp match will be tested per each entry
+const S3_CEPH_TEST_BLACKLIST = [
+    's3tests.functional.test_headers.test_object_create_date_and_amz_date',
+    's3tests.functional.test_headers.test_bucket_put_bad_canned_acl',
+    's3tests.functional.test_headers.test_object_create_bad_contentlength_mismatch_below_aws2',
+    's3tests.functional.test_headers.test_object_create_bad_authorization_invalid_aws2',
+    's3tests.functional.test_headers.test_object_create_bad_ua_unreadable_aws2',
+    's3tests.functional.test_headers.test_object_create_bad_date_invalid_aws2',
+    's3tests.functional.test_headers.test_object_create_bad_date_empty_aws2',
+    's3tests.functional.test_headers.test_object_create_bad_date_before_epoch_aws2',
+    's3tests.functional.test_headers.test_bucket_create_bad_authorization_invalid_aws2',
+    's3tests.functional.test_headers.test_bucket_create_bad_ua_unreadable_aws2',
+    's3tests.functional.test_headers.test_bucket_create_bad_date_invalid_aws2',
+    's3tests.functional.test_headers.test_bucket_create_bad_date_empty_aws2',
+    's3tests.functional.test_headers.test_bucket_create_bad_date_before_epoch_aws2',
+    's3tests.functional.test_headers.test_object_create_bad_contentlength_mismatch_below_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_authorization_invalid_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_ua_empty_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_ua_unreadable_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_ua_none_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_date_unreadable_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_date_none_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_amz_date_none_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_date_before_today_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_date_after_today_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_date_before_epoch_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_amz_date_before_epoch_aws4',
+    's3tests.functional.test_headers.test_object_create_bad_date_after_end_aws4',
+    's3tests.functional.test_headers.test_object_create_missing_signed_custom_header_aws4',
+    's3tests.functional.test_headers.test_object_create_missing_signed_header_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_authorization_invalid_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_ua_empty_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_ua_unreadable_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_ua_none_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_date_unreadable_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_date_none_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_amz_date_none_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_date_before_today_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_date_after_today_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_date_before_epoch_aws4',
+    's3tests.functional.test_headers.test_bucket_create_bad_amz_date_before_epoch_aws4',
+    's3tests.functional.test_s3.test_bucket_list_delimiter_prefix',
+    's3tests.functional.test_s3.test_bucket_list_delimiter_prefix_underscore',
+    's3tests.functional.test_s3.test_bucket_list_delimiter_unreadable',
+    's3tests.functional.test_s3.test_bucket_list_prefix_unreadable',
+    's3tests.functional.test_s3.test_bucket_list_objects_anonymous',
+    's3tests.functional.test_s3.test_object_write_cache_control',
+    's3tests.functional.test_s3.test_object_write_expires',
+    's3tests.functional.test_s3.test_object_set_get_non_utf8_metadata',
+    's3tests.functional.test_s3.test_object_set_get_metadata_empty_to_unreadable_prefix',
+    's3tests.functional.test_s3.test_object_set_get_metadata_empty_to_unreadable_suffix',
+    's3tests.functional.test_s3.test_object_set_get_metadata_empty_to_unreadable_infix',
+    's3tests.functional.test_s3.test_object_set_get_metadata_overwrite_to_unreadable_prefix',
+    's3tests.functional.test_s3.test_object_set_get_metadata_overwrite_to_unreadable_suffix',
+    's3tests.functional.test_s3.test_object_set_get_metadata_overwrite_to_unreadable_infix',
+    's3tests.functional.test_s3.test_post_object',
+    's3tests.functional.test_s3.test_put_object_ifmatch_nonexisted_failed',
+    's3tests.functional.test_s3.test_object_raw_get',
+    's3tests.functional.test_s3.test_object_raw_get_bucket_gone',
+    's3tests.functional.test_s3.test_object_raw_get_object_gone',
+    's3tests.functional.test_s3.test_object_raw_get_bucket_acl',
+    's3tests.functional.test_s3.test_object_raw_response_headers',
+    's3tests.functional.test_s3.test_object_raw_get_x_amz_expires_not_expired',
+    's3tests.functional.test_s3.test_object_raw_get_x_amz_expires_out_range_zero',
+    's3tests.functional.test_s3.test_object_raw_get_x_amz_expires_out_max_range',
+    's3tests.functional.test_s3.test_object_raw_get_x_amz_expires_out_positive_range',
+    's3tests.functional.test_s3.test_object_raw_put_write_access',
+    's3tests.functional.test_s3.test_bucket_create_naming_bad_short_empty',
+    's3tests.functional.test_s3.test_bucket_create_naming_good_long_250',
+    's3tests.functional.test_s3.test_bucket_create_naming_good_long_251',
+    's3tests.functional.test_s3.test_bucket_create_naming_good_long_252',
+    's3tests.functional.test_s3.test_bucket_create_naming_good_long_253',
+    's3tests.functional.test_s3.test_bucket_create_naming_good_long_254',
+    's3tests.functional.test_s3.test_bucket_create_naming_good_long_255',
+    's3tests.functional.test_s3.test_bucket_list_long_name',
+    's3tests.functional.test_s3.test_bucket_create_naming_dns_underscore',
+    's3tests.functional.test_s3.test_bucket_create_naming_dns_long',
+    's3tests.functional.test_s3.test_bucket_create_naming_dns_dash_at_end',
+    's3tests.functional.test_s3.test_bucket_create_naming_dns_dot_dot',
+    's3tests.functional.test_s3.test_bucket_create_naming_dns_dot_dash',
+    's3tests.functional.test_s3.test_bucket_create_naming_dns_dash_dot',
+    's3tests.functional.test_s3.test_bucket_create_exists',
+    's3tests.functional.test_s3.test_bucket_configure_recreate',
+    's3tests.functional.test_s3.test_bucket_delete_nonowner',
+    's3tests.functional.test_s3.test_bucket_acl_default',
+    's3tests.functional.test_s3.test_bucket_acl_canned_during_create',
+    's3tests.functional.test_s3.test_bucket_acl_canned',
+    's3tests.functional.test_s3.test_bucket_acl_canned_publicreadwrite',
+    's3tests.functional.test_s3.test_bucket_acl_canned_authenticatedread',
+    's3tests.functional.test_s3.test_object_acl_canned_during_create',
+    's3tests.functional.test_s3.test_object_acl_canned',
+    's3tests.functional.test_s3.test_object_acl_canned_publicreadwrite',
+    's3tests.functional.test_s3.test_object_acl_canned_authenticatedread',
+    's3tests.functional.test_s3.test_object_acl_canned_bucketownerread',
+    's3tests.functional.test_s3.test_object_acl_canned_bucketownerfullcontrol',
+    's3tests.functional.test_s3.test_object_acl_full_control_verify_owner',
+    's3tests.functional.test_s3.test_bucket_acl_xml_write',
+    's3tests.functional.test_s3.test_bucket_acl_xml_writeacp',
+    's3tests.functional.test_s3.test_bucket_acl_xml_read',
+    's3tests.functional.test_s3.test_bucket_acl_xml_readacp',
+    's3tests.functional.test_s3.test_object_acl_xml_write',
+    's3tests.functional.test_s3.test_object_acl_xml_writeacp',
+    's3tests.functional.test_s3.test_object_acl_xml_read',
+    's3tests.functional.test_s3.test_object_acl_xml_readacp',
+    's3tests.functional.test_s3.test_bucket_acl_grant_userid_fullcontrol',
+    's3tests.functional.test_s3.test_bucket_acl_grant_userid_read',
+    's3tests.functional.test_s3.test_bucket_acl_grant_userid_readacp',
+    's3tests.functional.test_s3.test_bucket_acl_grant_userid_write',
+    's3tests.functional.test_s3.test_bucket_acl_grant_userid_writeacp',
+    's3tests.functional.test_s3.test_bucket_acl_grant_nonexist_user',
+    's3tests.functional.test_s3.test_bucket_acl_no_grants',
+    's3tests.functional.test_s3.test_object_header_acl_grants',
+    's3tests.functional.test_s3.test_bucket_header_acl_grants',
+    's3tests.functional.test_s3.test_bucket_acl_grant_email',
+    's3tests.functional.test_s3.test_bucket_acl_grant_email_notexist',
+    's3tests.functional.test_s3.test_bucket_acl_revoke_all',
+    's3tests.functional.test_s3.test_logging_toggle',
+    's3tests.functional.test_s3.test_access_bucket',
+    's3tests.functional.test_s3.test_object_giveaway',
+    's3tests.functional.test_s3.test_list_buckets_anonymous',
+    's3tests.functional.test_s3.test_list_buckets_invalid_auth',
+    's3tests.functional.test_s3.test_list_buckets_bad_auth',
+    's3tests.functional.test_s3.test_bucket_recreate_not_overriding',
+    's3tests.functional.test_s3.test_object_copy_to_itself',
+    's3tests.functional.test_s3.test_object_copy_canned_acl',
+    's3tests.functional.test_s3.test_object_copy_versioned_bucket',
+    's3tests.functional.test_s3.test_object_copy_versioning_multipart_upload',
+    's3tests.functional.test_s3.test_multipart_copy_small',
+    's3tests.functional.test_s3.test_multipart_copy_invalid_range',
+    's3tests.functional.test_s3.test_multipart_copy_special_names',
+    's3tests.functional.test_s3.test_multipart_copy_versioned',
+    's3tests.functional.test_s3.test_multipart_copy_multiple_sizes',
+    's3tests.functional.test_s3.test_multipart_upload_size_too_small',
+    's3tests.functional.test_s3.test_abort_multipart_upload',
+    's3tests.functional.test_s3.test_abort_multipart_upload_not_found',
+    's3tests.functional.test_s3.test_list_multipart_upload',
+    's3tests.functional.test_s3.test_100_continue',
+    's3tests.functional.test_s3.test_bucket_acls_changes_persistent',
+    's3tests.functional.test_s3.test_stress_bucket_acls_changes',
+    's3tests.functional.test_s3.test_set_cors',
+    's3tests.functional.test_s3.test_cors_origin_response',
+    's3tests.functional.test_s3.test_cors_origin_wildcard',
+    's3tests.functional.test_s3.test_cors_header_option',
+    's3tests.functional.test_s3.check_can_test_multiregion',
+    's3tests.functional.test_s3.test_region_bucket_create_secondary_access_remove_master',
+    's3tests.functional.test_s3.test_region_bucket_create_master_access_remove_secondary',
+    's3tests.functional.test_s3.test_region_copy_object',
+    's3tests.functional.test_s3.test_versioning',
+    's3tests.functional.test_s3.test_versioned',
+    's3tests.functional.test_s3.test_lifecycle_expiration',
+    's3tests.functional.test_s3.test_lifecycle_id_too_long',
+    's3tests.functional.test_s3.test_lifecycle_same_id',
+    's3tests.functional.test_s3.test_lifecycle_invalid_status',
+    's3tests.functional.test_s3.test_lifecycle_rules_conflicted',
+    's3tests.functional.test_s3.test_lifecycle_set_date',
+    's3tests.functional.test_s3.test_lifecycle_set_invalid_date',
+    's3tests.functional.test_s3.test_lifecycle_expiration_date',
+    's3tests.functional.test_s3.test_lifecycle_set_noncurrent',
+    's3tests.functional.test_s3.test_lifecycle_noncur_expiration',
+    's3tests.functional.test_s3.test_lifecycle_set_deletemarker',
+    's3tests.functional.test_s3.test_lifecycle_set_filter',
+    's3tests.functional.test_s3.test_lifecycle_set_empty_filter',
+    's3tests.functional.test_s3.test_lifecycle_deletemarker_expiration',
+    's3tests.functional.test_s3.test_lifecycle_set_multipart',
+    's3tests.functional.test_s3.test_lifecycle_multipart_expiration',
+    's3tests.functional.test_s3.test_encrypted',
+    's3tests.functional.test_s3.test_encryption',
+    's3tests.functional.test_s3.test_sse_kms',
+    's3tests.functional.test_s3.test_bucket_policy',
+    's3tests.functional.test_s3.test_get_obj_tagging',
+    's3tests.functional.test_s3.test_get_obj_head_tagging',
+    's3tests.functional.test_s3.test_put_max_tags',
+    's3tests.functional.test_s3.test_put_excess_tags',
+    's3tests.functional.test_s3.test_put_max_kvsize_tags',
+    's3tests.functional.test_s3.test_put_excess_key_tags',
+    's3tests.functional.test_s3.test_put_excess_val_tags',
+    's3tests.functional.test_s3.test_put_modify_tags',
+    's3tests.functional.test_s3.test_put_delete_tags',
+    's3tests.functional.test_s3.test_put_obj_with_tags',
+    's3tests.functional.test_s3.test_get_tags_acl_public',
+    's3tests.functional.test_s3.test_put_tags_acl_public',
+    's3tests.functional.test_s3.test_delete_tags_obj_public',
+    's3tests.functional.test_s3_website.check_can_test_website',
+    's3tests.functional.test_headers.test_object_create_bad_contentlength_none',
+    's3tests.functional.test_headers.test_object_create_bad_contentlength_mismatch_above',
+    's3tests.functional.test_s3.test_bucket_list_return_data_versioning',
+    's3tests.functional.test_s3.test_bucket_list_marker_versioning',
+    's3tests.functional.test_s3.test_object_copy_not_owned_bucke',
+    's3tests.functional.test_s3.test_object_copy_not_owned_object_bucket',
+    's3tests.fuzz.test.test_fuzzer.test_load_graph',
+    's3tests.functional.test_s3_website',
+];
+const S3_CEPH_TEST_BLACKLIST_REGEXP = new RegExp(`(${S3_CEPH_TEST_BLACKLIST.join(')|(')})`);
+const S3_CEPH_TEST_STEMS = [
+    's3tests.functional.test_headers.',
+    's3tests.functional.test_s3.',
+    's3tests.fuzz.test.test_fuzzer.',
+    's3tests.functional.test_s3_website.',
+    's3tests.tests.test_realistic.',
+];
+const S3_CEPH_TEST_STEMS_REGEXP = new RegExp(`(${S3_CEPH_TEST_STEMS.join(')|(')})`);
+
+/*// s3tests.tests.test_realistic:TestFileValidator.test_new_file_is_valid
+//Some tests have to be different and have a different path
+const S3_CEPH_TEST_STEMS_2 = [
+    's3tests.tests.test_realistic.',
+];
+const S3_CEPH_TEST_STEMS_2_REGEXP = new RegExp(`(${S3_CEPH_TEST_STEMS_2.join(')|(')})`);*/
 
 
 module.exports = {
     run_test: run_test
 };
 
-function deploy_ceph() {
-    console.log('Starting Deployment Of Ceph Tests...');
+async function deploy_ceph() {
+    console.info('Starting Deployment Of Ceph Tests...');
     let command = `cd ${CEPH_TEST.test_dir};./${CEPH_TEST.ceph_deploy} > /tmp/ceph_deploy.log`;
-    return promise_utils.exec(command, {
+    try {
+        let res = await promise_utils.exec(command, {
             ignore_rc: false,
             return_stdout: true
-        })
-        .then(function(res) {
-            return console.log(res);
-        })
-        .catch(function(err) {
-            console.error('Failed Deployment Of Ceph Tests', err, err.stack);
-            throw new Error('Failed Deployment Of Ceph Tests');
         });
+        console.info(res);
+    } catch (err) {
+        console.error('Failed Deployment Of Ceph Tests', err, err.stack);
+        throw new Error('Failed Deployment Of Ceph Tests');
+    }
 }
 
-function s3_ceph_test() {
-    console.log('Running Ceph S3 Tests... (' + S3_CEPH_TEST_WHITELIST.length + ' tests)');
-    var i = -1;
-    var fail_count = 0;
-    var had_errors = false;
-    return promise_utils.pwhile(
-            function() {
-                i += 1;
-                return i < S3_CEPH_TEST_WHITELIST.length;
-            },
-            function() {
-                var command = `S3TEST_CONF=${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config} ./${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir}virtualenv/bin/nosetests ${S3_CEPH_TEST_WHITELIST[i]}`;
-                return promise_utils.exec(command, {
-                        ignore_rc: false,
-                        return_stdout: true
-                    })
-                    .then(() => {
-                        console.log('Test Passed:', S3_CEPH_TEST_WHITELIST[i]);
-                    })
-                    .catch(err => {
-                        if (!_.includes(IGNORE_S3_CEPH_TEST_LIST, S3_CEPH_TEST_WHITELIST[i])) {
-                            fail_count += 1;
-                            had_errors = true;
-                        }
-                        console.warn('Test Failed:', S3_CEPH_TEST_WHITELIST[i], '\n' + err);
-                    });
-            })
-        .then(() => {
-            if (had_errors) {
-                throw new Error('Failed Running Ceph S3 Tests (' + fail_count + ' failed )');
+async function run_single_test(test) {
+    const base_cmd = `S3TEST_CONF=${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config} ./${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir}virtualenv/bin/nosetests`;
+    let res;
+    let test_name;
+    //Check if test should run
+    if (!S3_CEPH_TEST_BLACKLIST_REGEXP.test(test)) {
+        try {
+            test_name = test.replace(S3_CEPH_TEST_STEMS_REGEXP, pref => `${pref.slice(0, -1)}:`); //Match against the common test path
+            //test_name = test_name.replace(S3_CEPH_TEST_STEMS_2_REGEXP, pref => `${pref.slice(0, -1)}:`); //Match against test_realistic path
+            res = await promise_utils.exec(`${base_cmd} ${test_name}`, { ignore_rc: false, return_stdout: true });
+            if (res.indexOf('SKIP') >= 0) {
+                console.warn('Test skipped:', test);
+                stats.skip.push(test);
             } else {
-                console.log('Finished Running Ceph S3 Tests');
+                console.info('Test Passed:', test);
+                stats.pass.push(test);
             }
-        });
+        } catch (err) {
+            console.error('Test Failed:', test);
+            stats.fail.push(test);
+        }
+    }
 }
 
-function system_ceph_test() {
-    console.log('Running System Ceph S3 Tests... (' + SYSTEM_CEPH_TEST_WHITELIST.length + ' tests)');
-    var i = -1;
-    var fail_count = 0;
-    var had_errors = false;
-    return promise_utils.pwhile(
-            function() {
-                i += 1;
-                return i < SYSTEM_CEPH_TEST_WHITELIST.length;
-            },
-            function() {
-                var command = `S3TEST_CONF=${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config} ./${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir}virtualenv/bin/nosetests -w ${process.cwd()}/${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir} ${SYSTEM_CEPH_TEST_WHITELIST[i]}`;
-                return promise_utils.exec(command, {
-                        ignore_rc: false,
-                        return_stdout: true
-                    })
-                    .then(() => {
-                        console.log('Test Passed:', SYSTEM_CEPH_TEST_WHITELIST[i]);
-                    })
-                    .catch(err => {
-                        had_errors = true;
-                        fail_count += 1;
-                        console.warn('Test Failed:', SYSTEM_CEPH_TEST_WHITELIST[i], '\n' + err);
-                    });
-            })
-        .then(() => {
-            if (had_errors) {
-                throw new Error('Failed Running System Ceph S3 Tests (' + fail_count + ' failed )');
-            } else {
-                console.log('Finished Running System Ceph S3 Tests');
-            }
-        });
+async function test_worker() {
+    for (;;) {
+        const t = tests_list.shift();
+        if (!t) return;
+        await run_single_test(t);
+    }
 }
 
+async function run_all_tests() {
+    console.info('Running Ceph S3 Tests...');
+    const tests_list_command =
+        `S3TEST_CONF=${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}  ./${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir}virtualenv/bin/nosetests -v --collect-only  2>&1 | awk '{print $1}' | grep test`;
+    try {
+        tests_list = await promise_utils.exec(tests_list_command, { ignore_rc: false, return_stdout: true });
+    } catch (err) {
+        console.error('Failed getting tests list');
+        throw new Error('Failed getting tests list', err);
+    }
 
-function main() {
-    return run_test()
-        .then(function() {
-            process.exit(0);
-        })
-        .catch(function(err) {
-            console.error(`Ceph Test Failed: ${err}`);
-            process.exit(1);
-        });
+    tests_list = tests_list.split('\n');
+    stats.total = tests_list.length;
+
+    await P.map(_.times(5), test_worker);
+
+    console.log('Finished Running Ceph S3 Tests');
 }
 
-function run_test() {
-    return client.create_auth_token(auth_params)
-        .then(() => deploy_ceph())
-        .then(() => client.account.create_account(CEPH_TEST.new_account))
-        .then(() => client.system.read_system())
-        .then(system_info => {
-            const access_keys = system_info.accounts.find(
-                account => account.email === CEPH_TEST.new_account.email
-            ).access_keys;
-            CEPH_TEST.new_account.access_keys = access_keys;
-            console.log('CEPH TEST CONFIGURATION:', JSON.stringify(CEPH_TEST));
-        })
-        .then(() => promise_utils.exec(`echo access_key = ${CEPH_TEST.new_account.access_keys[0].access_key} >> ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`, false, true))
-        .then(() => promise_utils.exec(`echo secret_key = ${CEPH_TEST.new_account.access_keys[0].secret_key} >> ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`, false, true))
-        .then(() => system_ceph_test())
-        .catch(function(err) {
-            throw new Error('System Ceph Tests Failed:', err);
-        })
-        .then(() => s3_ceph_test())
-        .catch(function(err) {
-            throw new Error('Ceph Tests Failed:', err);
-        });
+async function main() {
+    try {
+        await run_test();
+    } catch (err) {
+        console.error(`Ceph Test Failed: ${err}`);
+        process.exit(1);
+    }
+    process.exit(0);
+}
+
+async function run_test() {
+    await client.create_auth_token(auth_params);
+
+    try {
+        await deploy_ceph();
+    } catch (err) {
+        console.error('Failed deplying ceph tests', err);
+        throw new Error('Failed deplying ceph tests');
+    }
+
+    let system_info = await client.system.read_system();
+    let ceph_account = system_info.accounts.find(
+        account => account.email === CEPH_TEST.new_account.email
+    );
+    if (ceph_account) {
+        CEPH_TEST.new_account.access_keys = ceph_account.access_keys;
+    } else {
+        await client.account.create_account(CEPH_TEST.new_account);
+        system_info = await client.system.read_system();
+        CEPH_TEST.new_account.access_keys = system_info.accounts.find(
+            account => account.email === CEPH_TEST.new_account.email
+        ).access_keys;
+    }
+
+    console.info('CEPH TEST CONFIGURATION:', JSON.stringify(CEPH_TEST));
+    await promise_utils.exec(`echo access_key = ${CEPH_TEST.new_account.access_keys[0].access_key} >> ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+    await promise_utils.exec(`echo secret_key = ${CEPH_TEST.new_account.access_keys[0].secret_key} >> ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+    try {
+        await run_all_tests();
+    } catch (err) {
+        console.error('Failed running ceph tests', err);
+        throw new Error('Running Ceph Tests Failed');
+    }
+
+    console.info(`CEPH TEST SUMMARY: Suite contains ${stats.total}, ran ${stats.pass.length + stats.fail.length + stats.skip.length} tests, Passed: ${stats.pass.length}, Skipped: ${stats.skip.length}, Failed: ${stats.fail.length}`);
+    if (stats.skip.length) {
+        console.warn(`CEPH TEST SUMMARY:  ${stats.skip.length} skipped tests ${stats.skip.join('\n')}`);
+    }
+    if (stats.fail.length) {
+        console.error(`CEPH TEST SUMMARY: ${stats.fail.length} failed tests ${stats.fail.join('\n')}`);
+        throw new Error('Ceph Tests Returned with Failures');
+    }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- Changed ceph tests (which is run in vitaly) to work with a blacklist instead of a white list
- Turn on additional 101 cases to run

### Testing Instructions:
- Run ceph tests (node src/test/system_tests/test_ceph_s3.js)

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
