### PR TITLE
When clicking enter key when the first checkbox has focus in table, all checkboxes are selected

### DIFF
--- a/frontend/src/app/components/admin/audit-pane/audit-pane.html
+++ b/frontend/src/app/components/admin/audit-pane/audit-pane.html
@@ -13,11 +13,11 @@
         <h2 class="heading3 greedy">Choose Categories</h2>
 
         <div>
-            <button class="link alt-colors" data-bind="click: selectAllCategories">
+            <button type="button" class="link alt-colors" data-bind="click: selectAllCategories">
                 Select all
             </button>
             |
-            <button class="link alt-colors" data-bind="click: clearAllCategories">
+            <button type="button" class="link alt-colors" data-bind="click: clearAllCategories">
                 Clear
             </button>
         </div>

--- a/frontend/src/app/components/modals/assign-hosts-modal/assign-hosts-modal.html
+++ b/frontend/src/app/components/modals/assign-hosts-modal/assign-hosts-modal.html
@@ -44,11 +44,11 @@
         </h2>
 
         <div>
-            <button class="link alt-colors" ko.click="onSelectAll">
+            <button type="button" class="link alt-colors" ko.click="onSelectAll">
                 Select all
             </button>
             |
-            <button class="link alt-colors" ko.click="onClearAll">
+            <button type="button" class="link alt-colors" ko.click="onClearAll">
                 Clear all
             </button>
         </div>
@@ -65,7 +65,7 @@
     <div class="row content-middle alt-bg push-next">
         <span class="selection-text push-prev" ko.text="selectedMessage"></span>
         <span class="push-both-half">|</span>
-        <button class="link alt-colors" ko.click="onClearSelection">
+        <button type="button" class="link alt-colors" ko.click="onClearSelection">
             Clear
         </button>
         <paginator class="greedy push-prev" params="

--- a/frontend/src/app/components/modals/create-bucket-modal/create-bucket-modal.html
+++ b/frontend/src/app/components/modals/create-bucket-modal/create-bucket-modal.html
@@ -67,11 +67,11 @@
                         Resources in Policy
                     </h2>
                     <div>
-                        <button class="link alt-colors" ko.click="onSelectAll">
+                        <button type="button" class="link alt-colors" ko.click="onSelectAll">
                             Select all
                         </button>
                         |
-                        <button class="link alt-colors" ko.click="onClearAll">
+                        <button type="button" class="link alt-colors" ko.click="onClearAll">
                             Clear all
                         </button>
                     </div>

--- a/frontend/src/app/components/modals/create-pool-modal/create-pool-modal.html
+++ b/frontend/src/app/components/modals/create-pool-modal/create-pool-modal.html
@@ -70,11 +70,11 @@
                 </h2>
 
                 <div>
-                    <button class="link alt-colors" ko.click="onSelectAll">
+                    <button type="button" class="link alt-colors" ko.click="onSelectAll">
                         Select all
                     </button>
                     |
-                    <button class="link alt-colors" ko.click="onClearAll">
+                    <button type="button" class="link alt-colors" ko.click="onClearAll">
                         Clear all
                     </button>
                 </div>

--- a/frontend/src/app/components/modals/edit-bucket-placement-modal/edit-bucket-placement-modal.html
+++ b/frontend/src/app/components/modals/edit-bucket-placement-modal/edit-bucket-placement-modal.html
@@ -39,11 +39,11 @@
                 Resources in Policy
             </h2>
             <div>
-                <button class="link alt-colors" ko.click="onSelectAll">
+                <button type="button" class="link alt-colors" ko.click="onSelectAll">
                     Select all
                 </button>
                 |
-                <button class="link alt-colors" ko.click="onClearAll">
+                <button type="button" class="link alt-colors" ko.click="onClearAll">
                     Clear all
                 </button>
             </div>

--- a/frontend/src/app/components/modals/edit-bucket-s3-access-modal/edit-bucket-s3-access-modal.html
+++ b/frontend/src/app/components/modals/edit-bucket-s3-access-modal/edit-bucket-s3-access-modal.html
@@ -8,11 +8,11 @@
     <div class="row content-middle">
         <h2 class="heading3 greedy">Edit accounts S3 access permissions</h2>
         <div>
-            <button class="link alt-colors" ko.click="selectAllAccounts">
+            <button type="button" class="link alt-colors" ko.click="selectAllAccounts">
                 Select all
             </button>
             |
-            <button class="link alt-colors" ko.click="clearAllAccounts">
+            <button type="button" class="link alt-colors" ko.click="clearAllAccounts">
                 Clear
             </button>
         </div>

--- a/frontend/src/app/components/modals/edit-host-storage-drives-modal/edit-host-storage-drives-modal.html
+++ b/frontend/src/app/components/modals/edit-host-storage-drives-modal/edit-host-storage-drives-modal.html
@@ -26,13 +26,13 @@
             Choose the drives you wish to use as storage resources
         </h2>
         <div ko.css.disabled="!$form.serviceState()">
-            <button class="link alt-colors"
+            <button type="button" class="link alt-colors"
                 ko.enable="$form.serviceState"
                 ko.click="onSelectAll">
                 Select all
             </button>
             |
-            <button class="link alt-colors"
+            <button type="button" class="link alt-colors"
                 ko.enable="$form.serviceState"
                 ko.click="onClearAll"
             >


### PR DESCRIPTION
### Explain the changes
When clicking enter key when the first checkbox has focus in table, all checkboxes are selected

list of modals which have same issue:
src/app/components/admin/audit-pane
src/app/components/modals/assign-hosts-modal
src/app/components/modals/create-bucket-modal
src/app/components/modals/create-pool-modal
src/app/components/modals/edit-bucket-placement-modal
src/app/components/modals/edit-bucket-s3-access-modal
src/app/components/modals/edit-host-storage-drives-modal

### Issues: Fixed #xxx / Gap #xxx
fixed 4576

### Testing Instructions:
src/app/components/modals/edit-bucket-placement-modal
1. the system should have few resources to reproduce
2. go to the bucket
3. click on 'edit bucket placement' 
4. use tab to navigate on checkboxes
5. use space to check/uncheck checkboxes
6. click enter
7. form submitted and closed

the general test for all modal, when focus on a checkbox and press enter should lead to form submit

