### PR TITLE
Rebase from 2.7.1 (added empty implementation for put_blob_properties)

### DIFF
--- a/src/endpoint/blob/blob_rest.js
+++ b/src/endpoint/blob/blob_rest.js
@@ -171,6 +171,7 @@ function load_ops() {
         put_blob: r('./ops/blob_put_blob'),
         put_blob_block: r('./ops/blob_put_blob_block'),
         put_blob_blocklist: r('./ops/blob_put_blob_blocklist'),
+        put_blob_properties: r('./ops/blob_put_blob_properties'),
         put_blob_lease: r('./ops/blob_put_blob_lease'),
         delete_blob: r('./ops/blob_delete_blob'),
     });

--- a/src/endpoint/blob/ops/blob_put_blob_properties.js
+++ b/src/endpoint/blob/ops/blob_put_blob_properties.js
@@ -1,0 +1,31 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const http_utils = require('../../../util/http_utils');
+
+
+/**
+ * https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-properties
+ */
+async function put_blob_properties(req, res) {
+    // TODO: implement PUT Blob Properties. for now just return success if blob exist 
+    return req.object_sdk.read_object_md({
+            bucket: req.params.bucket,
+            key: req.params.key,
+            md_conditions: http_utils.get_md_conditions(req),
+        })
+        .then(object_md => {
+            res.statusCode = 200;
+        });
+
+}
+
+module.exports = {
+    handler: put_blob_properties,
+    body: {
+        type: 'empty',
+    },
+    reply: {
+        type: 'empty',
+    },
+};


### PR DESCRIPTION

### Explain the changes
Rebase from 2.7.1 (added empty implementation for put_blob_properties)


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
