### PR TITLE
when storage node is decommissioned set the usage to 0

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -639,7 +639,8 @@ class Agent {
             this.endpoint_info.s3rver_process.kill('SIGTERM');
             this.endpoint_info.s3rver_process = null;
         } else {
-            dbg.warn('got _disable_service on storage agent');
+            // for storage nodes reset the usage count in block_store
+            this.block_store.reset_usage();
         }
     }
 

--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -171,6 +171,13 @@ class BlockStoreBase {
         );
     }
 
+    reset_usage() {
+        if (this._usage && (this._usage.size || this._usage.count)) {
+            dbg.warn('storage usage for this agent is expected to be zero but got', this._usage, '. resetting...');
+            this._update_usage({ size: -(this._usage.size || 0), count: -(this._usage.count || 0) });
+        }
+    }
+
     sample_stats() {
         const old_stats = this.stats;
         // zero all but the inflight

--- a/src/agent/block_store_services/block_store_fs.js
+++ b/src/agent/block_store_services/block_store_fs.js
@@ -146,6 +146,7 @@ class BlockStoreFs extends BlockStoreBase {
                     overwrite_size = overwrite_stat.size + (md_overwrite_stat ?
                         md_overwrite_stat.size : 0);
                     overwrite_count = 1;
+                    dbg.warn('overwriting block', block_md, 'overwrite_size =', overwrite_size);
                 }
                 let usage = {
                     size: data.length + block_md_data.length - overwrite_size,


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
- when a node is decommissioned, set its usage to 0 to clear any leak in usage calculations.

### Issues: Fixed #xxx / Gap #xxx
-  Related to #3473

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages