### PR TITLE
added experimental flag to use s3 credentials in delegator instead of signed urls

### DIFF
--- a/config.js
+++ b/config.js
@@ -215,6 +215,16 @@ config.DB_CLEANER = {
     BACK_TIME: 3 * 30 * 24 * 60 * 60 * 1000 // 3 months
 };
 
+/////////////////////
+// CLOUD RESOURCES //
+/////////////////////
+// EXPERIMENTAL!! switch to turn off the use of signed urls to delegate cloud read\writes to object_io (s3 compatible only)
+// when this is set to true, block_store_s3 will return s3 credentials to the block_store_client so it can 
+// connect directly to the cloud target (and not via a signed url)
+config.EXPERIMENTAL_DISABLE_S3_COMPATIBLE_SIGNED_URL = false;
+
+
+
 //////////////////////
 // LIFECYCLE CONFIG //
 //////////////////////


### PR DESCRIPTION
### Explain the changes
- when setting `config.EXPERIMENTAL_DISABLE_S3_COMPATIBLE_SIGNED_URL = true`, s3 compatible cloud resource will send actual credentials as delegation info, instead of signed url
- block_store_client will read\write to cloud target directly using s3 sdk

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages