### PR TITLE
Additions to the FE versioning API

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -521,6 +521,9 @@ module.exports = {
                                 key: {
                                     type: 'string'
                                 },
+                                version_id: {
+                                    type: 'string'
+                                },
                                 bucket: {
                                     type: 'string'
                                 },
@@ -581,6 +584,9 @@ module.exports = {
                                     idate: true
                                 },
                                 key: {
+                                    type: 'string'
+                                },
+                                version_id: {
                                     type: 'string'
                                 },
                                 bucket: {
@@ -961,6 +967,9 @@ module.exports = {
                         type: 'boolean'
                     },
                     latest_versions: {
+                        type: 'boolean'
+                    },
+                    filter_delete_markers: {
                         type: 'boolean'
                     },
                     adminfo: {

--- a/src/endpoint/s3/ops/s3_get_bucket_versions.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_versions.js
@@ -43,7 +43,7 @@ async function get_bucket_versions(req) {
             _.map(reply.objects, obj => (obj.delete_marker ? ({
                 DeleteMarker: {
                     Key: obj.key,
-                    VersionId: obj.version_id,
+                    VersionId: obj.version_id || 'null',
                     IsLatest: obj.is_latest,
                     LastModified: s3_utils.format_s3_xml_date(obj.create_time),
                     Owner: s3_utils.DEFAULT_S3_USER,
@@ -51,7 +51,7 @@ async function get_bucket_versions(req) {
             }) : ({
                 Version: {
                     Key: obj.key,
-                    VersionId: obj.version_id,
+                    VersionId: obj.version_id || 'null',
                     IsLatest: obj.is_latest,
                     LastModified: s3_utils.format_s3_xml_date(obj.create_time),
                     ETag: `"${obj.etag}"`,

--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -35,7 +35,7 @@ async function put_object(req, res) {
         res.setHeader('x-amz-version-id', reply.version_id);
     }
     if (copy_source) {
-        res.setHeader('x-amz-copy-source-version-id', reply.copy_source.version_id);
+        if (reply.copy_source.version_id) res.setHeader('x-amz-copy-source-version-id', reply.copy_source.version_id);
         return {
             CopyObjectResult: {
                 // TODO S3 last modified and etag should be for the new part

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -95,7 +95,7 @@ function set_response_object_md(res, object_md) {
     res.setHeader('Content-Type', object_md.content_type);
     res.setHeader('Content-Length', object_md.size);
     res.setHeader('Accept-Ranges', 'bytes');
-    res.setHeader('x-amz-version-id', object_md.version_id);
+    if (object_md.version_id) res.setHeader('x-amz-version-id', object_md.version_id);
     set_response_xattr(res, object_md.xattr);
     return object_md;
 }

--- a/src/lambda_funcs/delete_entire_bucket.js
+++ b/src/lambda_funcs/delete_entire_bucket.js
@@ -17,24 +17,27 @@ module.exports.handler = async function(event, context, callback) {
 
         let truncated = true;
         let marker;
+        let version_id_marker;
         let count = 0;
 
         while (truncated) {
 
-            const res = await s3.listObjects({
+            const res = await s3.listObjectVersions({
                 Bucket: event.bucket,
                 Marker: marker,
+                VersionIdMarker: version_id_marker
             }).promise();
 
             const objs = res.Contents;
             truncated = res.IsTruncated;
             marker = res.NextMarker;
+            version_id_marker = res.NextVersionIdMarker;
             count += objs.length;
 
             if (sure && objs.length) {
                 await s3.deleteObjects({
                     Bucket: event.bucket,
-                    Delete: { Objects: objs.map(o => ({ Key: o.Key })) }
+                    Delete: { Objects: objs.map(o => ({ Key: o.Key, VersionId: o.VersionId })) }
                 }).promise();
             }
         }

--- a/src/sdk/namespace_merge.js
+++ b/src/sdk/namespace_merge.js
@@ -189,6 +189,9 @@ class NamespaceMerge {
         }
     }
 
+    // TODO: Currently it only takes the most recent objects without duplicates
+    // This means that in list_object_versions we will only see the is_latest objects
+    // Which is not what we wanted since we want to see all of the versions
     _handle_list(res, params) {
         res = this._throw_if_all_failed_or_get_succeeded(res);
         if (res.length === 1) return res[0];
@@ -230,11 +233,22 @@ class NamespaceMerge {
         // because the marker is opaque to the client and therefore it is not safe to assume that using this as next marker
         // will really provide a stable iteration.
         const next_marker = is_truncated ? names[names.length - 1] : undefined;
+        // In case of prefix there will be no object (which means undefined)
+        const last_obj_or_prefix = map[names[names.length - 1]];
+        const next_version_id_marker =
+            is_truncated && (typeof last_obj_or_prefix === 'object') ?
+            last_obj_or_prefix.version_id : undefined;
+        const next_upload_id_marker =
+            is_truncated && (typeof last_obj_or_prefix === 'object') ?
+            last_obj_or_prefix.obj_id : undefined;
+
         return {
             objects,
             common_prefixes,
             is_truncated,
             next_marker,
+            next_version_id_marker,
+            next_upload_id_marker
         };
     }
 }

--- a/src/sdk/namespace_multipart.js
+++ b/src/sdk/namespace_multipart.js
@@ -178,6 +178,9 @@ class NamespaceMultipart {
         }
     }
 
+    // TODO: Currently it only takes the most recent objects without duplicates
+    // This means that in list_object_versions we will only see the is_latest objects
+    // Which is not what we wanted since we want to see all of the versions
     _handle_list(res, params) {
         res = this._throw_if_all_failed_or_get_succeeded(res);
         if (res.length === 1) return res[0];
@@ -219,11 +222,18 @@ class NamespaceMultipart {
         // because the marker is opaque to the client and therefore it is not safe to assume that using this as next marker
         // will really provide a stable iteration.
         const next_marker = is_truncated ? names[names.length - 1] : undefined;
+        // In case of prefix there will be no object (which means undefined)
+        const last_obj_or_prefix = map[names[names.length - 1]];
+        const next_version_id_marker = is_truncated && (typeof last_obj_or_prefix === 'object') ? last_obj_or_prefix.version_id : undefined;
+        const next_upload_id_marker = is_truncated && (typeof last_obj_or_prefix === 'object') ? last_obj_or_prefix.obj_id : undefined;
+
         return {
             objects,
             common_prefixes,
             is_truncated,
             next_marker,
+            next_upload_id_marker,
+            next_version_id_marker
         };
     }
 

--- a/src/sdk/namespace_net_storage.js
+++ b/src/sdk/namespace_net_storage.js
@@ -17,6 +17,7 @@ const CONFIG_FIELDS = [
     'ssl'
 ];
 
+// TODO: This does not work after the versioning changes
 class NamespaceNetStorage {
 
     constructor(options) {

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -79,7 +79,7 @@ class ObjectSDK {
     async _validate_bucket_namespace(data, params) {
         const time = Date.now();
         if (time <= data.valid_until) return true;
-        const bucket = this.rpc_client.bucket.get_bucket_namespaces({ name: params.name });
+        const bucket = await this.rpc_client.bucket.get_bucket_namespaces({ name: params.name });
         if (_.isEqual(bucket.namespace, data.bucket.namespace)) {
             // namespace unchanged - extend validity for another period
             data.valid_until = time + NAMESPACE_CACHE_EXPIRY;

--- a/src/server/object_services/map_reader.js
+++ b/src/server/object_services/map_reader.js
@@ -74,13 +74,13 @@ function read_node_mappings(node_ids, skip, limit) {
                 obj_id,
                 upload_started: obj.upload_started ? obj.upload_started.getTimestamp().getTime() : undefined,
                 key: obj.key,
+                version_id: MDStore.instance().get_object_version_id(obj),
                 bucket: system_store.data.get_by_id(obj.bucket).name,
                 parts: parts_per_obj_id[obj_id],
             }));
             return objects_reply;
         });
 }
-
 
 
 /**

--- a/src/server/object_services/schemas/object_md_indexes.js
+++ b/src/server/object_services/schemas/object_md_indexes.js
@@ -8,7 +8,6 @@ module.exports = [
     {
         // find_object_latest()
         // list_objects()
-        // has_any_completed_objects_in_bucket()
         fields: {
             bucket: 1,
             key: 1,
@@ -55,7 +54,8 @@ module.exports = [
     {
         // find_object_by_version()
         // find_object_prev_version()
-        // list_object_versions()
+        // list_object_versions()       
+        // has_any_completed_objects_in_bucket()
         fields: {
             bucket: 1,
             key: 1,

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -334,6 +334,10 @@ function get_bucket_changes(req, update_request, bucket, tiering_policy) {
         if (update_request.versioning === 'DISABLED') {
             throw new RpcError('BAD_REQUEST', 'Cannot set versioning to DISABLED');
         }
+        if (bucket.namespace) {
+            throw new RpcError('BAD_REQUEST', 'Cannot set versioning on namespace buckets');
+        }
+
         single_bucket_update.versioning = update_request.versioning;
     }
 
@@ -648,10 +652,10 @@ function delete_bucket(req) {
                 }));
 
             return system_store.make_changes({
-                    update: {
-                        accounts: accounts_update
-                    }
-                });
+                update: {
+                    accounts: accounts_update
+                }
+            });
         })
         .return();
 }


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- Added version_id and delete_marker indication on read_node_mappings for objects
- Added option to filter out delete_markers from list_objects_admin (FE method)

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- Fixed #4935 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
