### PR TITLE
If there are two connections with the same name (different types) - d…

### DIFF
--- a/frontend/src/app/components/account/account-connections-table/account-connections-table.js
+++ b/frontend/src/app/components/account/account-connections-table/account-connections-table.js
@@ -193,7 +193,8 @@ class AccountConnectionsTableViewModel extends Observer {
         action$.next(openAddCloudConnectionModal());
     }
 
-    onDeleteConnection(name) {
+    onDeleteConnection(id) {
+        const [name] = id.split(':');
         action$.next(deleteExternalConnection(name));
     }
 }

--- a/frontend/src/app/components/account/account-connections-table/connection-row.js
+++ b/frontend/src/app/components/account/account-connections-table/connection-row.js
@@ -112,6 +112,7 @@ export default class ConnectionRowViewModel {
     onConnection(connection, buckets, namespaceBuckets, system, isExpanded) {
         const { name, service, endpoint, identity, usage } = connection;
         const bucketsList = Object.values(buckets);
+        const id = `${name}:${service}`;
         const namespaceBucketsList = Object.values(namespaceBuckets);
         const hasExternalConnections = Boolean(usage.length);
         const { icon, displayName, subject } = getCloudServiceMeta(service);
@@ -156,7 +157,7 @@ export default class ConnectionRowViewModel {
         this.endpoint(endpointInfo);
         this.identity(identity);
         this.externalTargets(externalTargetsInfo);
-        this.deleteButton.id(name);
+        this.deleteButton.id(id);
         this.deleteButton.disabled(hasExternalConnections);
         this.deleteButton.tooltip(deleteToolTip);
         this._isExpanded(isExpanded);


### PR DESCRIPTION
### Explain the changes
- If there are two connections with the same name (different types) - delete affects both

### Issues: Fixed #xxx / Gap #xxx
fixed #4940

### Testing Instructions:
1. create 2 connections with same name (update mongo account document):
"sync_credentials_cache" : [ { "name" : "compatible_V2", "endpoint" : "http://172.20.80.30", "endpoint_type" : "S3_COMPATIBLE", "access_key" : "123", "secret_key" : "abc", "auth_method" : "AWS_V2" }, { "name" : "compatible_V2", "endpoint" : "http://127.0.0.1", "endpoint_type" : "S3_COMPATIBLE", "access_key" : "123", "secret_key" : "abc", "auth_method" : "AWS_V4" } ]

2. when user click Delete record button, it should affect only current record

![2018-07-02_14-15-47](https://user-images.githubusercontent.com/27498391/42161786-fe3ec946-7e04-11e8-8ad9-39e2c5090c6c.gif)


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
