### PR TITLE
Fix horizontal scroll in scroll in edit data placement resources table

### DIFF
--- a/frontend/src/app/components/modals/edit-bucket-placement-modal/edit-bucket-placement-modal.less
+++ b/frontend/src/app/components/modals/edit-bucket-placement-modal/edit-bucket-placement-modal.less
@@ -9,7 +9,7 @@
 
     .resource-table {
         .selected-col {
-            min-width: 24px;
+            min-width: 25px;
         }
 
         .state-col {
@@ -21,19 +21,17 @@
         }
 
         .name-col {
-            .no-wrap();
-
             text-align: left;
             width: 100%;
-            max-width: 92px;
+            max-width: 156px;
         }
 
         .healthy-hosts-col {
-            min-width: 118px;
+            min-width: 90px;
         }
 
         .healthy-nodes-col {
-            min-width: 132px;
+            min-width: 90px;
         }
 
         .usage-col {

--- a/frontend/src/app/components/shared/data-table/data-table.html
+++ b/frontend/src/app/components/shared/data-table/data-table.html
@@ -1,6 +1,6 @@
 <!-- Copyright (C) 2016 NooBaa -->
 
-<table ko.css="tableCss" ko.scroll="scroll" ko.dataTable="rows">
+<table ko.css="tableCss" ko.scroll="scroll" data-bind="dataTable: rows">
     <thead>
         <tr class="header-row" ko.foreach="columns">
             <th ko.css="css">


### PR DESCRIPTION
### Explain the changes
Fix horizontal scroll in scroll in edit data placement resources table

### Issues: Fixed #xxx / Gap #xxx
- fixed #4808

### Testing Instructions:
1. if you have more than 5 resources pools and some cloud
2. go to the bucket
3. Click 'Edit Data Placement' button
5. select Spread and two types of resources cloud and pool
6. validation message displayed with no horizontal scroll

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
