### PR TITLE
upgrade to mongodb 3.6 in upgrade process

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -220,16 +220,16 @@ function install_mongo {
     deploy_log "install_mongo start"
 
     mkdir -p /var/lib/mongo/cluster/shard1
-    # create a Mongo 3.4 Repo file
-    cp -f ${CORE_DIR}/src/deploy/NVA_build/mongo.repo /etc/yum.repos.d/mongodb-org-3.4.repo
+    # create a Mongo 3.6 Repo file
+    cp -f ${CORE_DIR}/src/deploy/NVA_build/mongo.repo /etc/yum.repos.d/mongodb-org-3.6.repo
 
     # install the needed RPM
     yum install -y \
-		mongodb-org-3.4.10 \
-		mongodb-org-server-3.4.10 \
-		mongodb-org-shell-3.4.10 \
-		mongodb-org-mongos-3.4.10 \
-		mongodb-org-tools-3.4.10
+		mongodb-org-3.6.5 \
+		mongodb-org-server-3.6.5 \
+		mongodb-org-shell-3.6.5 \
+		mongodb-org-mongos-3.6.5 \
+		mongodb-org-tools-3.6.5
 
     # pin mongo version in yum, so it won't auto update
     echo "exclude=mongodb-org,mongodb-org-server,mongodb-org-shell,mongodb-org-mongos,mongodb-org-tools" >> /etc/yum.conf

--- a/src/deploy/NVA_build/mongo.repo
+++ b/src/deploy/NVA_build/mongo.repo
@@ -1,5 +1,6 @@
-[mongodb-org-3.4]
+[mongodb-org-3.6]
 name=MongoDB Repository
-baseurl=http://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.4/x86_64/
-gpgcheck=0
+baseurl=https://repo.mongodb.org/yum/redhat/7Server/mongodb-org/3.6/x86_64/
+gpgcheck=1
 enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc

--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -244,7 +244,8 @@ MongoCtrl.prototype._add_replica_set_member_program = function(name, first_serve
         ' --sslPEMKeyFile ' + config.MONGO_DEFAULTS.SERVER_CERT_PATH +
         ' --sslClusterFile ' + config.MONGO_DEFAULTS.SERVER_CERT_PATH +
         ' --syslog' +
-        ' --syslogFacility local0';
+        ' --syslogFacility local0' +
+        ' --bind_ip_all'; // in mongodb 3.6 bind_ip is by default 127.0.0.1 - bind to all interfaces
     program_obj.directory = '/usr/bin';
     program_obj.user = 'root';
     program_obj.stopsignal = 'KILL';

--- a/src/server/utils/supervisor_ctrl.js
+++ b/src/server/utils/supervisor_ctrl.js
@@ -114,6 +114,22 @@ class SupervisorCtrl {
             });
     }
 
+    async get_program(prog_name) {
+        await this.init();
+        const program = this._programs.find(prog => prog.name === prog_name);
+        if (program) {
+            return _.clone(program);
+        }
+    }
+
+    async update_program(program) {
+        await this.init();
+        const prog_index = this._programs.findIndex(prog => prog.name === program.name);
+        if (prog_index >= 0) {
+            this._programs[prog_index] = program;
+        }
+    }
+
     get_mongo_services() {
         let mongo_progs = [];
         return P.resolve()
@@ -161,13 +177,13 @@ class SupervisorCtrl {
 
     restart_supervisord() {
         return promise_utils.spawn('/etc/init.d/supervisord', ['restart'], {
-            detached: true
-        }, false)
-        .delay(5000) //TODO:: Better solution
-        .catch(function(err) {
-            console.error('failed to restart superisor daemon');
-            throw new Error('failed to restart superisor daemon ' + err);
-        });
+                detached: true
+            }, false)
+            .delay(5000) //TODO:: Better solution
+            .catch(function(err) {
+                console.error('failed to restart superisor daemon');
+                throw new Error('failed to restart superisor daemon ' + err);
+            });
     }
 
     // Internals


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- in upgrade (single server and cluster) upgrading mongodb from 3.4 to 3.6.5
- upgrading npm to version 6.1.0
- upgrading nvm to version 0.33.11

### Testing Instructions:
- before upgrade check that  mongodb version is 3.4 (`mongo --version`)
- after upgrade check versions:
   - `mongo --version`
   - `npm --version`
   - `nvm --version`

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
