### PR TITLE
Object Info version_id return fix for FE

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -950,7 +950,7 @@ function get_object_info(md) {
         upload_started: md.upload_started ? md.upload_started.getTimestamp().getTime() : undefined,
         upload_size: _.isNumber(md.upload_size) ? md.upload_size : undefined,
         num_parts: md.num_parts,
-        version_id: bucket.versioning === 'DISABLED' ? undefined : MDStore.instance().get_object_version_id(md),
+        version_id: MDStore.instance().get_object_version_id(md),
         is_latest: md.version_past ? undefined : true,
         delete_marker: md.delete_marker,
         xattr: md.xattr && _.mapKeys(md.xattr, (v, k) => k.replace(/@/g, '.')),


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes

The FE crashed since it expected to always see version_id in the response of object_info, even if we are in a versioning disabled bucket.

#### 1. New Features / Capabilities (Sync with Liran):
- 

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
