### PR TITLE
send phone-home stats after create system

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -109,6 +109,13 @@ module.exports = {
                 system: 'admin'
             }
         },
+
+        send_stats: {
+            method: 'PUT',
+            auth: {
+                system: 'admin'
+            }
+        }
     },
 
     definitions: {

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -436,15 +436,12 @@ function add_sample_point(opname, duration) {
     ops_aggregation[opname].add_value(duration);
 }
 
-function object_usage_scrubber(req) {
+async function object_usage_scrubber(req) {
     let new_req = req;
     new_req.rpc_params.till_time = req.system.last_stats_report;
-    return object_server.remove_endpoint_usage_reports(new_req)
-        .then(() => {
-            new_req.rpc_params.last_stats_report = Date.now();
-            return system_server.set_last_stats_report_time(new_req);
-        })
-        .return();
+    await object_server.remove_endpoint_usage_reports(new_req);
+    new_req.rpc_params.last_stats_report = Date.now();
+    await system_server.set_last_stats_report_time(new_req);
 }
 
 //_.noop(send_stats_payload); // lint unused bypass
@@ -720,4 +717,5 @@ exports.get_object_usage_stats = get_object_usage_stats;
 exports.register_histogram = register_histogram;
 exports.add_sample_point = add_sample_point;
 exports.object_usage_scrubber = object_usage_scrubber;
+exports.send_stats = background_worker;
 exports.background_worker = background_worker;

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -253,11 +253,11 @@ function create_system(req) {
                 return;
             }
             return attempt_server_resolve(_.defaults({
-                rpc_params: {
-                    server_name: req.rpc_params.dns_name,
-                    version_check: true
-                }
-            }, req))
+                    rpc_params: {
+                        server_name: req.rpc_params.dns_name,
+                        version_check: true
+                    }
+                }, req))
                 .then(result => {
                     if (!result.valid) {
                         throw new Error('Could not resolve ' + req.rpc_params.dns_name +
@@ -371,6 +371,12 @@ function create_system(req) {
         })
         .then(() => _init_system(system_id))
         .then(() => system_utils.mongo_wrapper_system_created())
+        .then(() => {
+            dbg.log0(`sending first stats to phone home`);
+            return server_rpc.client.stats.send_stats(null, {
+                auth_token: reply_token
+            });
+        })
         .then(() => ({
             token: reply_token
         }))


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
- after a system is created, send the first phone home stats immediately 

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
