### PR TITLE
Proximity I/O - phase II - Rebuilds on Read

### DIFF
--- a/src/server/bg_services/agent_blocks_verifier.js
+++ b/src/server/bg_services/agent_blocks_verifier.js
@@ -75,7 +75,6 @@ class AgentBlocksVerifier {
 
         return this.populate_nodes_for_blocks(blocks)
             .then(blocks_with_nodes => {
-                this.populate_pools_for_blocks(blocks_with_nodes);
                 const blocks_with_alive_nodes = blocks_with_nodes.filter(block =>
                     block.node && block.node.rpc_address && block.node.online);
                 if (!blocks_with_alive_nodes || !blocks_with_alive_nodes.length) return;
@@ -155,13 +154,6 @@ class AgentBlocksVerifier {
      */
     verify_blocks(...args) {
         return server_rpc.client.block_store.verify_blocks(...args);
-    }
-
-    /**
-     * @override in unit tests for decoupling dependencies
-     */
-    populate_pools_for_blocks(...args) {
-        return system_utils.populate_pools_for_blocks(...args);
     }
 
 }

--- a/src/server/func_services/func_schema.js
+++ b/src/server/func_services/func_schema.js
@@ -71,6 +71,9 @@ module.exports = {
         last_modified: {
             date: true
         },
+        resource_name: {
+            type: 'string'
+        },
         code_size: {
             type: 'integer'
         },

--- a/src/server/node_services/node_schema.js
+++ b/src/server/node_services/node_schema.js
@@ -58,12 +58,28 @@ module.exports = {
 
         // a uuid to identify the host machine of the node (one host can hold several nodes, one for each drive)
         host_id: {
-            type: 'string'
+            type: 'string',
         },
 
         // an incremental sequence number
         host_sequence: {
-            type: 'integer'
+            type: 'integer',
+        },
+
+        host_name: {
+            type: 'string',
+        },
+
+        n2n_config: {
+            $ref: 'common_api#/definitions/n2n_config',
+        },
+
+        mem_usage: {
+            type: 'number'
+        },
+
+        cpu_usage: {
+            type: 'number'
         },
 
         ports_allowed: {
@@ -112,6 +128,12 @@ module.exports = {
         },
         force_hide: {
             idate: true
+        },
+        enabled: {
+            type: 'boolean',
+        },
+        geolocation: {
+            type: 'string'
         },
 
         // node storage stats - sum of drives

--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -117,10 +117,9 @@ class MapBuilder {
         const objects_by_id = _.keyBy(objects, '_id');
         await P.map(this.chunks, async chunk => {
             // if other actions should be done to prepare a chunk for build, those actions should be added here
-            chunk.chunk_coder_config = system_store.data.get_by_id(chunk.chunk_config).chunk_coder_config;
             chunk.parts = parts_by_chunk[chunk._id];
             chunk.objects = _.uniq(_.compact(_.map(chunk.parts, part => objects_by_id[part.obj])));
-            system_utils.populate_pools_for_blocks(chunk.blocks);
+            system_utils.prepare_chunk_for_mapping(chunk);
 
             try {
                 if (!chunk.parts || !chunk.parts.length) throw new Error('No valid parts are pointing to chunk', chunk._id);
@@ -207,7 +206,7 @@ class MapBuilder {
 
         const tiering_status = node_allocator.get_tiering_status(chunk.bucket.tiering);
         const mapping = mapper.map_chunk(chunk, chunk.bucket.tiering, tiering_status);
-        dbg.log2('MapBuilder.build_chunks: mapping', mapping);
+        dbg.log2('MapBuilder.build_chunks: mapping', chunk._id, util.inspect(mapping, { depth: null, colors: true }));
 
         // only delete blocks if the chunk is in good shape,
         // that is no allocations needed, and is accessible.

--- a/src/server/object_services/map_writer.js
+++ b/src/server/object_services/map_writer.js
@@ -13,7 +13,6 @@ const MDStore = require('./md_store').MDStore;
 const time_utils = require('../../util/time_utils');
 const range_utils = require('../../util/range_utils');
 const mongo_utils = require('../../util/mongo_utils');
-const system_store = require('../system_services/system_store').get_instance();
 const node_allocator = require('../node_services/node_allocator');
 const system_utils = require('../utils/system_utils');
 const map_deleter = require('./map_deleter');
@@ -93,8 +92,7 @@ class MapAllocator {
             .then(dup_chunks => {
                 for (let i = 0; i < dup_chunks.length; ++i) {
                     const dup_chunk = dup_chunks[i];
-                    system_utils.populate_pools_for_blocks(dup_chunk.blocks);
-                    dup_chunk.chunk_coder_config = system_store.data.get_by_id(dup_chunk.chunk_config).chunk_coder_config;
+                    system_utils.prepare_chunk_for_mapping(dup_chunk);
                     const is_good_for_dedup = mapper.is_chunk_good_for_dedup(
                         dup_chunk, this.bucket.tiering, this.tiering_status
                     );

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -82,6 +82,9 @@ module.exports = {
             type: 'string',
             enum: ['DISABLED', 'SUSPENDED', 'ENABLED']
         },
+        tag: {
+            type: 'string',
+        },
         storage_stats: {
             type: 'object',
             required: ['chunks_capacity', 'pools', 'blocks_size', 'objects_size', 'objects_count', 'last_update'],

--- a/src/server/system_services/schemas/cluster_schema.js
+++ b/src/server/system_services/schemas/cluster_schema.js
@@ -259,63 +259,74 @@ module.exports = {
                                     }
                                 }
                             }
+                        },
+                        storage: {
+                            $ref: 'common_api#/definitions/storage_info'
                         }
                     }
                 },
-                services_status: {
+            }
+        },
+        services_status: {
+            type: 'object',
+            required: ['ph_status'],
+            properties: {
+                dns_status: {
+                    type: 'string',
+                    enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
+                },
+                ph_status: {
                     type: 'object',
-                    required: ['ph_status'],
                     properties: {
-                        dns_status: {
+                        status: {
                             type: 'string',
                             enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
                         },
-                        ph_status: {
-                            type: 'string',
-                            enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
-                        },
-                        dns_name: {
-                            type: 'string',
-                            enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
-                        },
-                        ntp_status: {
-                            type: 'string',
-                            enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
-                        },
-                        internet_connectivity: {
-                            type: 'string',
-                            enum: ['FAULTY']
-                        },
-                        proxy_status: {
-                            type: 'string',
-                            enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
-                        },
-                        remote_syslog_status: {
-                            type: 'string',
-                            enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
-                        },
-                        cluster_status: {
-                            anyOf: [{
-                                type: 'string',
-                                enum: ['UNKNOWN']
-                            }, {
-                                type: 'array',
-                                items: {
-                                    type: 'object',
-                                    required: ['secret', 'status'],
-                                    properties: {
-                                        secret: {
-                                            type: 'string'
-                                        },
-                                        status: {
-                                            type: 'string',
-                                            enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
-                                        }
-                                    }
-                                }
-                            }]
+                        test_time: {
+                            idate: true
                         }
                     }
+                },
+                dns_name: {
+                    type: 'string',
+                    enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
+                },
+                ntp_status: {
+                    type: 'string',
+                    enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
+                },
+                internet_connectivity: {
+                    type: 'string',
+                    enum: ['FAULTY']
+                },
+                proxy_status: {
+                    type: 'string',
+                    enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
+                },
+                remote_syslog_status: {
+                    type: 'string',
+                    enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
+                },
+                cluster_status: {
+                    anyOf: [{
+                        type: 'string',
+                        enum: ['UNKNOWN']
+                    }, {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            required: ['secret', 'status'],
+                            properties: {
+                                secret: {
+                                    type: 'string'
+                                },
+                                status: {
+                                    type: 'string',
+                                    enum: ['UNKNOWN', 'FAULTY', 'UNREACHABLE', 'OPERATIONAL']
+                                }
+                            }
+                        }
+                    }]
                 }
             }
         }

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -58,7 +58,7 @@ module.exports = {
                         node_token: {
                             type: 'string'
                         },
-                        mongo_pool: {
+                        mongo_path: {
                             type: 'string'
                         }
                     }

--- a/src/server/utils/system_utils.js
+++ b/src/server/utils/system_utils.js
@@ -44,17 +44,12 @@ function mongo_wrapper_system_created() {
     }
 }
 
-function populate_pools_for_blocks(blocks) {
-    if (!blocks || !blocks.length) return;
-    blocks.forEach(block => {
-        const system = system_store.data.get_by_id(block.system);
-        const node_pool = system.pools_by_name[block.node.pool];
-        block.node_pool_id = node_pool._id;
-    });
+function prepare_chunk_for_mapping(chunk) {
+    chunk.chunk_coder_config = system_store.data.get_by_id(chunk.chunk_config).chunk_coder_config;
 }
 
 
 exports.system_in_maintenance = system_in_maintenance;
 exports.get_bucket_quota_usage_percent = get_bucket_quota_usage_percent;
 exports.mongo_wrapper_system_created = mongo_wrapper_system_created;
-exports.populate_pools_for_blocks = populate_pools_for_blocks;
+exports.prepare_chunk_for_mapping = prepare_chunk_for_mapping;

--- a/src/test/unit_tests/test_agent_blocks_verifier.js
+++ b/src/test/unit_tests/test_agent_blocks_verifier.js
@@ -77,10 +77,6 @@ class VerifierMock extends AgentBlocksVerifier {
             });
     }
 
-    populate_pools_for_blocks(blocks) {
-        // We already create the pools in block's nodes as mock objects
-    }
-
     populate_nodes_for_blocks(blocks) {
         const docs = blocks;
         const doc_path = 'node';
@@ -166,7 +162,6 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             node: nodes[0]._id,
             frag: chunks[0].frags[0]._id,
             chunk: chunks[0]._id,
-            node_pool_id: new mongodb.ObjectId()
         }];
         const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
         return P.resolve()
@@ -252,7 +247,6 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             node: nodes[0]._id,
             frag: chunks[0].frags[0]._id,
             chunk: chunks[0]._id,
-            node_pool_id: new mongodb.ObjectId()
         }];
         const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
         return P.resolve()
@@ -295,7 +289,6 @@ mocha.describe('mocked agent_blocks_verifier', function() {
             node: new mongodb.ObjectId(),
             frag: chunks[0].frags[0]._id,
             chunk: chunks[0]._id,
-            node_pool_id: new mongodb.ObjectId()
         }];
         const verifier_mock = new VerifierMock(blocks, nodes, chunks, chunk_coder_configs);
         return P.resolve()

--- a/src/test/unit_tests/test_map_builder.js
+++ b/src/test/unit_tests/test_map_builder.js
@@ -20,7 +20,6 @@ const map_builder = require('../../server/object_services/map_builder');
 const map_deleter = require('../../server/object_services/map_deleter');
 const SliceReader = require('../../util/slice_reader');
 const system_store = require('../../server/system_services/system_store').get_instance();
-const system_utils = require('../../server/utils/system_utils');
 
 const { rpc_client } = coretest;
 const object_io = new ObjectIO();
@@ -152,7 +151,6 @@ coretest.describe_mapper_test_case({
     async function load_chunks(obj) {
         const chunks = await MDStore.instance().find_chunks_by_ids(obj.chunk_ids);
         await MDStore.instance().load_blocks_for_chunks(chunks);
-        _.forEach(chunks, chunk => system_utils.populate_pools_for_blocks(chunk.blocks));
         obj.chunks = chunks;
     }
 

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -214,7 +214,9 @@ class MongoClient extends EventEmitter {
             throw new Error('define_collection: collection already defined ' + col.name);
         }
         if (col.schema) {
-            schema_utils.strictify(col.schema);
+            schema_utils.strictify(col.schema, {
+                additionalProperties: false
+            });
             this._ajv.addSchema(col.schema, col.name);
             col.validate = (doc, warn) => this.validate(col.name, doc, warn);
         }


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- Adding rebuild chunks for local pools which doesn't have those chunks and should
- Adding help function to refresh chunks mappings before and after the rebuilding
- Adding help function to decide if a chunk should be rebuilt when local info is set
- Adding test cases from test_mapper to check this function behavior 

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
- Adding db schema limitation (strictify) to disallow additional properties for new objects in mongo 
- Fixing all missing schema properties to avoid getting schema errors due to this change
- changing 'node_pool_id' attribute of a block to a new name: 'pool_migrate_dest'
- changing accordingly all access to this attribute especially removing the ones not needed - as we could just use the 'pool' attribute
- Adding and fixing some log printings

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
