### PR TITLE
Refactor S3ops to create AWS.S3 once

### DIFF
--- a/src/test/qa/agents_matrix.js
+++ b/src/test/qa/agents_matrix.js
@@ -17,7 +17,6 @@ var subscriptionId = process.env.AZURE_SUBSCRIPTION_ID;
 var shasum = crypto.createHash('sha1');
 shasum.update(Date.now().toString());
 
-const s3ops = new S3OPS();
 const dbg = require('../../util/debug_module')(__filename);
 const testName = 'agents_matrix';
 const suffixName = 'am';
@@ -89,6 +88,7 @@ let errors = [];
 let initial_node_number;
 
 var azf = new AzureFunctions(clientId, domain, secret, subscriptionId, resource, location);
+const s3ops = new S3OPS(server_ip);
 
 function saveErrorAndResume(message) {
     console.error(message);
@@ -206,8 +206,8 @@ function runAgentDebug() {
 
 function verifyAgent() {
     console.log(`Starting the verify agents stage`);
-    return s3ops.put_file_with_md5(server_ip, bucket, '100MB_File', 100, 1048576)
-        .then(() => s3ops.get_file_check_md5(server_ip, bucket, '100MB_File'))
+    return s3ops.put_file_with_md5(bucket, '100MB_File', 100, 1048576)
+        .then(() => s3ops.get_file_check_md5(bucket, '100MB_File'))
         .then(runAgentDiagnostics)
         .then(runAgentDebug);
 }

--- a/src/test/qa/cluster_test.js
+++ b/src/test/qa/cluster_test.js
@@ -15,7 +15,7 @@ const dbg = require('../../util/debug_module')(__filename);
 const testName = 'cluster_test';
 let suffix = testName.replace(/_test/g, '');
 dbg.set_process_name(testName);
-const s3ops = new S3OPS();
+let s3ops;
 
 //define colors
 const YELLOW = "\x1b[33;1m";
@@ -231,6 +231,7 @@ function checkClusterStatus(servers, oldMasterNumber) {
                     .then(() => {
                         master_ip = servers[masterIndex].ip.trim();
                         console.log('Master ip', master_ip);
+                        s3ops = new S3OPS(master_ip);
                         rpc = api.new_rpc('wss://' + master_ip + ':8443');
                         client = rpc.new_client({});
                         return P.fcall(() => {
@@ -400,8 +401,8 @@ function createCluster(requestedServes, masterIndex, clusterIndex) {
 function verifyS3Server() {
     console.log(`starting the verify s3 server on `, master_ip);
     let bucket = 'new.bucket' + (Math.floor(Date.now() / 1000));
-    return s3ops.create_bucket(master_ip, bucket)
-        .then(() => s3ops.get_list_buckets(master_ip))
+    return s3ops.create_bucket(bucket)
+        .then(() => s3ops.get_list_buckets())
         .then(res => {
             if (res.includes(bucket)) {
                 console.log('Bucket is successfully added');
@@ -409,8 +410,8 @@ function verifyS3Server() {
                 saveErrorAndResume(`Created bucket ${master_ip} bucket is not returns on list`, res);
             }
         })
-        .then(() => s3ops.put_file_with_md5(master_ip, bucket, '100MB_File', 100, 1048576)
-            .then(() => s3ops.get_file_check_md5(master_ip, bucket, '100MB_File')))
+        .then(() => s3ops.put_file_with_md5(bucket, '100MB_File', 100, 1048576)
+            .then(() => s3ops.get_file_check_md5(bucket, '100MB_File')))
         .catch(err => {
             saveErrorAndResume(`${master_ip} FAILED verification s3 server`, err);
             failures_in_test = true;
@@ -466,7 +467,7 @@ function runSecondFlow() {
         .then(() => stopVirtualMachineWithStatus(2, 180))
         .then(() => {
             let bucket = 'new.bucket' + (Math.floor(Date.now() / 1000));
-            return s3ops.create_bucket(master_ip, bucket)
+            return s3ops.create_bucket(bucket)
                 .catch(err => console.log(`Couldn't create bucket with 2 disconnected clusters - as should ${err.message}`));
         })
         .then(() => startVirtualMachineWithStatus(1, 180))
@@ -487,7 +488,7 @@ function runThirdFlow() {
         })
         .then(() => {
             let bucket = 'new.bucket' + (Math.floor(Date.now() / 1000));
-            return s3ops.create_bucket(master_ip, bucket)
+            return s3ops.create_bucket(bucket)
                 .catch(err => console.log(`Couldn't create bucket with 2 disconnected clusters - as should ${err.message}`));
         })
         .then(() => {

--- a/src/test/qa/data_availability_test.js
+++ b/src/test/qa/data_availability_test.js
@@ -20,7 +20,6 @@ let errors = [];
 let current_size = 0;
 let stopped_oses = [];
 const suffixName = 'da';
-const s3ops = new S3OPS();
 let failures_in_test = false;
 const domain = process.env.DOMAIN;
 const clientId = process.env.CLIENT_ID;
@@ -77,6 +76,7 @@ function usage() {
 }
 
 const suffix = suffixName + '-' + id;
+const s3ops = new S3OPS(server_ip);
 
 if (help) {
     usage();
@@ -152,8 +152,8 @@ async function uploadAndVerifyFiles() {
             files.push(file_name);
             current_size += file_size;
             console.log('Uploading file with size ' + file_size + ' MB');
-            await s3ops.put_file_with_md5(server_ip, bucket, file_name, file_size, data_multiplier);
-            await s3ops.get_file_check_md5(server_ip, bucket, file_name);
+            await s3ops.put_file_with_md5(bucket, file_name, file_size, data_multiplier);
+            await s3ops.get_file_check_md5(bucket, file_name);
         } catch (err) {
             saveErrorAndResume(`${server_ip} FAILED verification uploading and reading `, err);
             failures_in_test = true;
@@ -166,7 +166,7 @@ async function readFiles() {
     for (let index = 0; index < files.length; index++) {
         const file = files[index];
         try {
-            await s3ops.get_file_check_md5(server_ip, bucket, file);
+            await s3ops.get_file_check_md5(bucket, file);
         } catch (err) {
             saveErrorAndResume(`${server_ip} FAILED read file`, err);
             failures_in_test = true;
@@ -178,7 +178,7 @@ async function readFiles() {
 async function clean_up_dataset() {
     console.log('runing clean up files from bucket ' + bucket);
     try {
-        await s3ops.delete_all_objects_in_bucket(server_ip, bucket, true);
+        await s3ops.delete_all_objects_in_bucket(bucket, true);
     } catch (err) {
         console.error(`Errors during deleting `, err);
     }

--- a/src/test/qa/data_resiliency_test.js
+++ b/src/test/qa/data_resiliency_test.js
@@ -13,7 +13,6 @@ dbg.set_process_name('data_avilability');
 const YELLOW = "\x1b[33;1m";
 const NC = "\x1b[0m";
 
-const s3ops = new S3OPS();
 const clientId = process.env.CLIENT_ID;
 const domain = process.env.DOMAIN;
 const secret = process.env.APPLICATION_SECRET;
@@ -75,6 +74,7 @@ function usage() {
 }
 
 const suffix = suffixName + '-' + id;
+const s3ops = new S3OPS(server_ip);
 
 if (help) {
     usage();
@@ -143,8 +143,8 @@ async function uploadAndVerifyFiles() {
             files.push(file_name);
             current_size += file_size;
             console.log('Uploading file with size ' + file_size + ' MB');
-            await s3ops.put_file_with_md5(server_ip, bucket, file_name, file_size, data_multiplier);
-            await s3ops.get_file_check_md5(server_ip, bucket, file_name);
+            await s3ops.put_file_with_md5(bucket, file_name, file_size, data_multiplier);
+            await s3ops.get_file_check_md5(bucket, file_name);
         } catch (err) {
             saveErrorAndResume(`${server_ip} FAILED verification uploading and reading `, err);
             failures_in_test = true;
@@ -157,7 +157,7 @@ async function readFiles() {
     for (let index = 0; index < files.length; index++) {
         const file = files[index];
         try {
-            await s3ops.get_file_check_md5(server_ip, bucket, file);
+            await s3ops.get_file_check_md5(bucket, file);
         } catch (err) {
             saveErrorAndResume(`${server_ip} FAILED read file`, err);
             failures_in_test = true;
@@ -169,7 +169,7 @@ async function readFiles() {
 function clean_up_dataset() {
     console.log('runing clean up files from bucket ' + bucket);
 
-    return s3ops.delete_all_objects_in_bucket(server_ip, bucket, true)
+    return s3ops.delete_all_objects_in_bucket(bucket, true)
         .catch(err => console.error(`Errors during deleting `, err));
 }
 

--- a/src/test/qa/namespace_test.js
+++ b/src/test/qa/namespace_test.js
@@ -64,8 +64,8 @@ report.init_reporter({ suite: test_name, conf: {aws: true, azure: true}, mongo_r
 
 const AWSDefaultConnection = cf.getAWSConnection();
 
-const s3ops = new S3OPS();
-const s3opsAWS = new S3OPS(AWSDefaultConnection.identity, AWSDefaultConnection.secret);
+const s3ops = new S3OPS(server_ip);
+const s3opsAWS = new S3OPS('s3.amazonaws.com', AWSDefaultConnection.identity, AWSDefaultConnection.secret);
 
 const connections_mapping = Object.assign({ AZURE: blobops.AzureDefaultConnection }, { AWS: AWSDefaultConnection });
 
@@ -116,9 +116,9 @@ function saveErrorAndResume(message, err) {
     failures_in_test = true;
 }
 
-async function getMD5fromS3Bucket(ops, ip, bucket, file_name) {
+async function getMD5fromS3Bucket(ops, bucket, file_name) {
     try {
-        const object_list = await ops.get_object(ip, bucket, file_name);
+        const object_list = await ops.get_object(bucket, file_name);
         console.log('Getting md5 data from file ' + file_name);
         return crypto.createHash('md5').update(object_list.Body).digest('base64');
     } catch (err) {
@@ -131,11 +131,11 @@ async function comperMD5betweencloudAndNooBaa(type, bucket, noobaa_bucket, file_
     console.log(`Compering NooBaa bucket to ${type}`);
     let cloudMD5;
     if (type === 'AWS') {
-        cloudMD5 = await getMD5fromS3Bucket(s3opsAWS, 's3.amazonaws.com', bucket, file_name);
+        cloudMD5 = await getMD5fromS3Bucket(s3opsAWS, bucket, file_name);
     } else if (type === 'AZURE') {
         cloudMD5 = await blobops.getMD5Blob(bucket, file_name, saveErrorAndResume);
     }
-    const noobaaMD5 = await getMD5fromS3Bucket(s3ops, server_ip, noobaa_bucket, file_name);
+    const noobaaMD5 = await getMD5fromS3Bucket(s3ops, noobaa_bucket, file_name);
     if (cloudMD5 === noobaaMD5) {
         console.log(`Noobaa bucket contains the md5 ${noobaaMD5} and the cloud md5 is: ${cloudMD5} for file ${file_name}`);
     } else {
@@ -211,7 +211,7 @@ function uploadFileDirectlyToAWS(bucket, file_name, size, multiplier) {
 
 async function isFilesAvailableInNooBaaBucket(gateway, files) {
     console.log('Checking uploaded files ' + files + ' in noobaa s3 server bucket ' + gateway);
-    const list_files = await s3ops.get_list_files(server_ip, gateway);
+    const list_files = await s3ops.get_list_files(gateway);
     const keys = list_files.map(key => key.Key);
     for (const file of files) {
         if (keys.includes(file)) {
@@ -225,7 +225,7 @@ async function isFilesAvailableInNooBaaBucket(gateway, files) {
 async function uploadFileToNoobaaS3(bucket, file_name) {
     let { data_multiplier } = unit_mapping.KB;
     try {
-        await s3ops.put_file_with_md5(server_ip, bucket, file_name, 15, data_multiplier);
+        await s3ops.put_file_with_md5(bucket, file_name, 15, data_multiplier);
     } catch (err) {
         saveErrorAndResume(`Failed upload file ${file_name}`, err);
         throw err;
@@ -304,7 +304,7 @@ async function upload_via_noobaa({ type, file_name, bucket }) {
 async function list_files_in_cloud(type) {
     let list_files = [];
     if (type === 'AWS') {
-        const list_files_obj = await s3opsAWS.get_list_files('s3.amazonaws.com', namespace_mapping[type].bucket2);
+        const list_files_obj = await s3opsAWS.get_list_files(namespace_mapping[type].bucket2);
         list_files = list_files_obj.map(file => file.Key);
     } else if (type === 'AZURE') {
         list_files = await blobops.getListFilesAzure(namespace_mapping[type].bucket2, saveErrorAndResume);
@@ -388,12 +388,12 @@ async function add_and_remove_resources(clouds) {
 }
 
 async function clean_namespace_bucket(bucket) {
-    const list_files = await s3ops.get_list_files(server_ip, bucket);
+    const list_files = await s3ops.get_list_files(bucket);
     const keys = list_files.map(key => key.Key);
     if (keys) {
         for (const file of keys) {
             try {
-                await s3ops.delete_file(server_ip, bucket, file);
+                await s3ops.delete_file(bucket, file);
             } catch (e) {
                 console.error(`${RED}TODO: REMOVE THIS TRY CATCH, IT IS TEMP OVERRIDE FOR BUG #4832${NC}`);
             }

--- a/src/test/qa/reclaim_test.js
+++ b/src/test/qa/reclaim_test.js
@@ -12,8 +12,6 @@ const AzureFunctions = require('../../deploy/azureFunctions');
 const { BucketFunctions } = require('../utils/bucket_functions');
 //const vm = require('../utils/vmware');
 
-const s3ops = new S3OPS();
-
 const test_name = 'reclaim';
 dbg.set_process_name(test_name);
 
@@ -71,6 +69,7 @@ if (argv.help) {
 
 const rpc = api.new_rpc('wss://' + server_ip + ':8443');
 const client = rpc.new_client({});
+const s3ops = new S3OPS(server_ip);
 
 let report = new Report();
 let bf = new BucketFunctions(client, report);
@@ -112,8 +111,8 @@ async function uploadAndVerifyFiles(bucket) {
             files.push(file_name);
             current_size += file_size;
             console.log('Uploading file with size ' + file_size + ' MB');
-            await s3ops.put_file_with_md5(server_ip, bucket, file_name, file_size, data_multiplier);
-            await s3ops.get_file_check_md5(server_ip, bucket, file_name);
+            await s3ops.put_file_with_md5(bucket, file_name, file_size, data_multiplier);
+            await s3ops.get_file_check_md5(bucket, file_name);
         } catch (err) {
             saveErrorAndResume(`${server_ip} FAILED verification uploading and reading `, err);
             throw err;
@@ -156,7 +155,7 @@ async function createReclaimPool(reclaim_pool, agentSuffix) {
 async function cleanupBucket(bucket) {
     try {
         console.log('runing clean up files from bucket ' + bucket);
-        await s3ops.delete_all_objects_in_bucket(server_ip, bucket, true);
+        await s3ops.delete_all_objects_in_bucket(bucket, true);
     } catch (err) {
         console.error(`Errors during deleting `, err);
     }
@@ -179,7 +178,7 @@ async function reclaimCycle(oses, prefix) {
         const stoppedAgent = await af.stopRandomAgents(azf, server_ip, 1, agentSuffix, agentList);
         await cleanupBucket(bucket);
         await af.startOfflineAgents(azf, server_ip, agentSuffix, stoppedAgent);
-        await s3ops.get_list_files(server_ip, bucket, '');
+        await s3ops.get_list_files(bucket, '');
     } catch (err) {
         throw new Error(`reclaimCycle failed: ${err}`);
     }

--- a/src/test/qa/spillover_test.js
+++ b/src/test/qa/spillover_test.js
@@ -14,7 +14,6 @@ const { CloudFunction } = require('../utils/cloud_functions');
 dbg.set_process_name('spillover');
 
 let errors = [];
-const s3ops = new S3OPS();
 let failures_in_test = false;
 const time_stemp = (Math.floor(Date.now() / 1000));
 const bucket = 'spillover.bucket' + time_stemp;
@@ -70,6 +69,7 @@ console.log(`resource: ${resource}, storage: ${storage}, vnet: ${vnet}`);
 
 const rpc = api.new_rpc('wss://' + server_ip + ':8443');
 const client = rpc.new_client({});
+const s3ops = new S3OPS(server_ip);
 
 let report = new Report();
 let bf = new BucketFunctions(client, report);
@@ -104,7 +104,7 @@ function saveErrorAndResume(message) {
 
 
 async function get_files_in_array() {
-    const list_files = await s3ops.get_list_files(server_ip, bucket);
+    const list_files = await s3ops.get_list_files(bucket);
     const keys = list_files.map(key => key.Key);
     return keys;
 }
@@ -112,8 +112,8 @@ async function get_files_in_array() {
 async function createBucketWithEnabledSpillover() {
     console.log('Creating bucket ' + bucket + ' with default pool first.pool');
     try {
-        await s3ops.create_bucket(server_ip, bucket);
-        const list_buckets = await s3ops.get_list_buckets(server_ip);
+        await s3ops.create_bucket(bucket);
+        const list_buckets = await s3ops.get_list_buckets();
         if (list_buckets.includes(bucket)) {
             console.log('Bucket is successfully added');
         } else {
@@ -139,7 +139,7 @@ async function uploadFiles(dataset_size, files) {
         files.push(file_name);
         console.log(`Uploading ${file_name} with size ${file_size} MB`);
         try {
-            await s3ops.upload_file_with_md5(server_ip, bucket, file_name, file_size, parts_num, data_multiplier);
+            await s3ops.upload_file_with_md5(bucket, file_name, file_size, parts_num, data_multiplier);
             await P.delay(1 * 1000);
         } catch (err) {
             saveErrorAndResume(`${server_ip} FAILED uploading files `, err);
@@ -155,7 +155,7 @@ async function test_failed_upload(dataset_size) {
     console.log(`Tring to upload ${dataset_size} MB after we have reached the quota`);
     const file_name = `file_over_${file_size}_${timeStemp}`;
     try {
-        await s3ops.put_file_with_md5(server_ip, bucket, file_name, file_size, data_multiplier);
+        await s3ops.put_file_with_md5(bucket, file_name, file_size, data_multiplier);
     } catch (error) { //When we get to the quota the writes should start failing
         console.log('Tring to upload pass the quota failed - as should');
         return;
@@ -248,9 +248,9 @@ async function assignNodesToPool(pool) {
 
 async function clean_env() {
     console.log('Running cleaning data from ' + bucket);
-    await s3ops.delete_all_objects_in_bucket(server_ip, bucket, true);
+    await s3ops.delete_all_objects_in_bucket(bucket, true);
     await P.delay(10 * 1000);
-    await s3ops.delete_bucket(server_ip, bucket);
+    await s3ops.delete_bucket(bucket);
     await P.delay(10 * 1000);
     await assignNodesToPool('first.pool');
     await cf.deletePool(healthy_pool);
@@ -273,7 +273,7 @@ async function check_internal_spillover_without_agents() {
     try {
         await createBucketWithEnabledSpillover();
         await bf.checkIsSpilloverHasStatus(bucket, true);
-        await s3ops.put_file_with_md5(server_ip, bucket, 'spillover_file', 10, data_multiplier);
+        await s3ops.put_file_with_md5(bucket, 'spillover_file', 10, data_multiplier);
         await checkFileInPool('spillover_file', 'system-internal-storage-pool');
     } catch (e) {
         throw new Error(`Failed to write on internal spillover: ${e}`);
@@ -333,11 +333,11 @@ async function clean_all_files_from_bucket(skip_form_spillover = false, pool) {
         if (skip_form_spillover) {
             const files = await list_files_in_a_pool(keys, pool);
             for (const file of files) {
-                await s3ops.delete_file(server_ip, bucket, file);
+                await s3ops.delete_file(bucket, file);
             }
         } else {
             for (const file of keys) {
-                await s3ops.delete_file(server_ip, bucket, file);
+                await s3ops.delete_file(bucket, file);
             }
         }
     }
@@ -348,7 +348,7 @@ async function aggregated_file_size(files_list, size, return_size = false) {
     let aggregated_size = 0;
     for (const file of files_list) {
         if (aggregated_size < size) {
-            aggregated_size = await s3ops.get_file_size(server_ip, bucket, file);
+            aggregated_size = await s3ops.get_file_size(bucket, file);
             files_to_delete.push(file);
         } else {
             break;
@@ -370,12 +370,12 @@ async function clean_files_from_bucket(skip_form_spillover, pool, size) {
             const files = await list_files_in_a_pool(keys, pool);
             files_to_delete = await aggregated_file_size(files, size);
             for (const file of files_to_delete) {
-                await s3ops.delete_file(server_ip, bucket, file);
+                await s3ops.delete_file(bucket, file);
             }
         } else {
             files_to_delete = await aggregated_file_size(keys, size);
             for (const file of files_to_delete) {
-                await s3ops.delete_file(server_ip, bucket, file);
+                await s3ops.delete_file(bucket, file);
             }
         }
     }


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 3. Other Changes:
- Refactor S3ops to create AWS.S3 once

### Testing Instructions:
- Run this branch under the pipeline to verify the changes (@liranmauda )

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
