### PR TITLE
cloud_test.js: changed the upgrade_pack flag to upgrade

### DIFF
--- a/src/test/qa/cloud_test.js
+++ b/src/test/qa/cloud_test.js
@@ -29,7 +29,7 @@ const {
     storage,
     vnet,
     id = 0,
-    upgrade_pack,
+    upgrade,
     name = 'compatible',
     compatible_ip,
     compatible_password,
@@ -57,7 +57,7 @@ function usage() {
     --vnet                  -   azure vnet on the resource group
     --id                    -   an id that is attached to the agents name
     --name                  -   compatible s3 server name (default: ${name})
-    --upgrade_pack          -   location of the file for upgrade
+    --upgrade               -   location of the file for upgrade
     --compatible_ip         -   use an allready installed compatible s3 (by ip)
     --compatible_password   -   the compatible s3 password
     --help                  -   show this help.
@@ -154,8 +154,8 @@ async function create_noobaa_for_compatible() {
             console.log(`${YELLOW}${server.name} and ip is: ${ip}${NC}`);
             server.ip = ip;
         }
-        if (!_.isUndefined(upgrade_pack)) {
-            await ops.upload_and_upgrade(server.ip, upgrade_pack);
+        if (!_.isUndefined(upgrade)) {
+            await ops.upload_and_upgrade(server.ip, upgrade);
         }
         server.internal_ip = await azf.getPrivateIpAddress(`${server.name}_nic`, `${server.name}_ip`);
         connections_mapping.COMPATIBLE.endpoint = 'https://' + server.internal_ip;


### PR DESCRIPTION
cloud_test.js:
- changed the upgrade_pack flag to upgrade

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
