### PR TITLE
Adding option to install vmtools

### DIFF
--- a/frontend/src/app/components/admin/audit-pane/categories.js
+++ b/frontend/src/app/components/admin/audit-pane/categories.js
@@ -348,6 +348,11 @@ export default {
                 entityId: () => ''
             },
 
+            vmtools_install: {
+                message: 'VMware tools installed',
+                entityId: () => ''
+            },
+
             upload_package: {
                 message: 'Upgrade package upload started',
                 entityId: () => ''

--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -244,6 +244,21 @@ module.exports = {
             }
         },
 
+        apply_install_vmtools: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                properties: {
+                    target_secret: {
+                        type: 'string'
+                    }
+                },
+            },
+            auth: {
+                system: false,
+            }
+        },
+
         collect_server_diagnostics: {
             method: 'POST',
             reply: {

--- a/src/api/cluster_server_api.js
+++ b/src/api/cluster_server_api.js
@@ -85,6 +85,21 @@ module.exports = {
             }
         },
 
+        install_vmtools: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                properties: {
+                    target_secret: {
+                        type: 'string'
+                    }
+                },
+            },
+            auth: {
+                system: 'admin',
+            }
+        },
+
         set_debug_level: {
             method: 'POST',
             params: {

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -855,6 +855,9 @@ module.exports = {
                         },
                     },
                 },
+                vmtools_installed: {
+                    type: 'boolean'
+                },
                 services_status: {
                     $ref: '#/definitions/services_status'
                 },

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -816,6 +816,72 @@ function apply_updated_time_config(req) {
         .return();
 }
 
+function install_vmtools(req) {
+    dbg.log0('install_vmtools called with', req.rpc_params);
+    const local_info = system_store.get_local_cluster_info(true);
+    var params = req.rpc_params;
+    var target_servers = [];
+    let audit_hostname;
+    return P.resolve()
+        .then(() => {
+            if (params.target_secret) {
+                let cluster_server = system_store.data.cluster_by_server[params.target_secret];
+                if (!cluster_server) {
+                    throw new RpcError('CLUSTER_SERVER_NOT_FOUND', 'Server with secret key:', params.target_secret, ' was not found');
+                }
+                target_servers.push(cluster_server);
+                audit_hostname = _.get(cluster_server, 'heartbeat.health.os_info.hostname');
+            } else {
+                _.each(system_store.data.clusters, cluster => target_servers.push(cluster));
+            }
+
+            if (local_info.is_clusterized && !target_servers.every(server => {
+                    let server_status = _.find(local_info.heartbeat.health.mongo_rs_status.members, { name: server.owner_address + ':27000' });
+                    return server_status && (server_status.stateStr === 'PRIMARY' || server_status.stateStr === 'SECONDARY');
+                })) {
+                throw new RpcError('OFFLINE_SERVER', 'Server is disconnected');
+            }
+
+            let updates = _.map(target_servers, server => ({
+                _id: server._id,
+                vmtools_installed: true,
+            }));
+
+            return system_store.make_changes({
+                update: {
+                    clusters: updates,
+                }
+            });
+        })
+        .then(() => {
+            dbg.log0('calling install_vmtools for', _.map(target_servers, srv => srv.owner_address));
+            return P.each(target_servers, function(server) {
+                return server_rpc.client.cluster_internal.apply_install_vmtools(params, {
+                    address: server_rpc.get_base_address(server.owner_address)
+                });
+            });
+        })
+        .then(() => {
+            Dispatcher.instance().activity({
+                event: 'conf.vmtools_install',
+                level: 'info',
+                system: req.system._id,
+                actor: req.account && req.account._id,
+                server: {
+                    hostname: audit_hostname,
+                    secret: params.target_secret
+                },
+                desc: `VMware tools was succesfully installed`,
+            });
+        })
+        .return();
+}
+
+
+function apply_install_vmtools(req) {
+    dbg.log0('Recieved apply_install_vmtools req', req.rpc_params);
+    return os_utils.install_vmtools();
+}
 
 function update_dns_servers(req) {
     var dns_servers_config = req.rpc_params;
@@ -1222,7 +1288,7 @@ function read_server_config(req) {
                     timezone,
                     ntp_server: server,
                     used_proxy,
-                    owner
+                    owner,
                 }));
         });
 }
@@ -1755,6 +1821,8 @@ exports.news_updated_topology = news_updated_topology;
 exports.news_replicaset_servers = news_replicaset_servers;
 exports.update_time_config = update_time_config;
 exports.apply_updated_time_config = apply_updated_time_config;
+exports.install_vmtools = install_vmtools;
+exports.apply_install_vmtools = apply_install_vmtools;
 exports.update_dns_servers = update_dns_servers;
 exports.apply_updated_dns_servers = apply_updated_dns_servers;
 exports.set_debug_level = set_debug_level;

--- a/src/server/system_services/schemas/cluster_schema.js
+++ b/src/server/system_services/schemas/cluster_schema.js
@@ -106,6 +106,10 @@ module.exports = {
             idate: true
         },
 
+        vmtools_installed: {
+            type: 'boolean'
+        },
+
         //Upgrade proccess
         upgrade: {
             type: 'object',

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -199,7 +199,8 @@ function get_cluster_info(rs_status) {
             timezone: cinfo.ntp && cinfo.ntp.timezone,
             dns_servers: cinfo.dns_servers || [],
             search_domains: cinfo.search_domains || [],
-            time_epoch: time_epoch
+            time_epoch: time_epoch,
+            vmtools_installed: Boolean(cinfo.vmtools_installed)
         };
 
         const status = cinfo.services_status;

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -1233,6 +1233,23 @@ function get_iptables_rules() {
         });
 }
 
+async function install_vmtools() {
+    if (os.type() !== 'Linux') return;
+    if (process.env.PLATFORM !== 'esx') return;
+    await promise_utils.exec('yum install -y open-vm-tools');
+    await promise_utils.exec('systemctl start vmtoolsd.service');
+}
+
+async function is_vmtools_installed() {
+    try {
+        await promise_utils.exec('yum -q list installed open-vm-tools', { ignore_rc: false });
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+
 
 // EXPORTS
 exports.os_info = os_info;
@@ -1275,3 +1292,5 @@ exports.is_port_range_open_in_firewall = is_port_range_open_in_firewall;
 exports.get_iptables_rules = get_iptables_rules;
 exports.ensure_dns_and_search_domains = ensure_dns_and_search_domains;
 exports.get_services_ps_info = get_services_ps_info;
+exports.install_vmtools = install_vmtools;
+exports.is_vmtools_installed = is_vmtools_installed;


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- User will know be able to install vmtools on NooBaa if running it under Linux OS in ESX platform
- adding api command install_vmtools and apply_install_vmtools for cluster_server.api and cluster_internal.api accordingly 
- adding a test in server monitor to examin if vmtools is installed and if not to install it
- fixing schema

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
