### PR TITLE
Danny 2.8

### DIFF
--- a/frontend/src/app/components/modals/attach-server-modal/attach-server-modal.js
+++ b/frontend/src/app/components/modals/attach-server-modal/attach-server-modal.js
@@ -69,9 +69,9 @@ class AttachServerModalViewModel extends Observer {
             }
 
             if (!secret) {
-                errors.secret = 'Please enter the server unique id';
+                errors.secret = 'Please enter the server secret key';
             } else if (secret.length !== secretLength) {
-                errors.secret = `Unique id is exactly ${secretLength} characters long`;
+                errors.secret = `Server secret key should be ${secretLength} characters long`;
             }
         }
 
@@ -88,7 +88,7 @@ class AttachServerModalViewModel extends Observer {
 
         switch (result) {
             case 'SECRET_MISMATCH': {
-                errors.secret = `This unique id does not match the server at ${address}`;
+                errors.secret = `Secret key does not match the server secret key at ${address}`;
                 break;
             }
             case 'ADDING_SELF': {
@@ -116,8 +116,13 @@ class AttachServerModalViewModel extends Observer {
                 break;
             }
 
-            case 'CONNECTION_TIMEOUT': {
-                errors.address = 'Could not reach server, might be due to firewall blocking';
+            case 'CONNECTION_TIMEOUT_ORIGIN': {
+                errors.address = 'Firewall might be blocking master connectivity to new server';
+                break;
+            }
+
+            case 'CONNECTION_TIMEOUT_NEW': {
+                errors.address = 'Firewall might be blocking new server connectivity to master';
                 break;
             }
         }

--- a/src/api/cluster_server_api.js
+++ b/src/api/cluster_server_api.js
@@ -357,7 +357,17 @@ module.exports = {
         },
 
         verify_new_member_result: {
-            enum: ['OKAY', 'SECRET_MISMATCH', 'VERSION_MISMATCH', 'ALREADY_A_MEMBER', 'HAS_OBJECTS', 'UNREACHABLE', 'ADDING_SELF', 'NO_NTP_SET', 'CONNECTION_TIMEOUT'],
+            enum: ['OKAY',
+                'SECRET_MISMATCH',
+                'VERSION_MISMATCH',
+                'ALREADY_A_MEMBER',
+                'HAS_OBJECTS',
+                'UNREACHABLE',
+                'ADDING_SELF',
+                'NO_NTP_SET',
+                'CONNECTION_TIMEOUT_ORIGIN',
+                'CONNECTION_TIMEOUT_NEW'
+            ],
             type: 'string'
         },
 

--- a/src/deploy/mongo_upgrade/mongo_upgrade_2_8_0.js
+++ b/src/deploy/mongo_upgrade/mongo_upgrade_2_8_0.js
@@ -36,7 +36,16 @@ function add_create_time_to_multiparts() {
     }
 }
 
+function fix_upgrade_stage_changed_date() {
+    db.clusters.updateMany({}, {
+        $unset: {
+            "stage_changed_date": 1
+        }
+    });
+}
+
 update_buckets_set_versioning();
 update_buckets_unset_cloud_sync();
 drop_old_md_indexes();
 add_create_time_to_multiparts();
+fix_upgrade_stage_changed_date();

--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -148,7 +148,7 @@ function _verify_server_certificate() {
                         certificate && certificate.data && fs.writeFileAsync(ssl_utils.SERVER_SSL_CERT_PATH, certificate.data),
                         key && key.data && fs.writeFileAsync(ssl_utils.SERVER_SSL_KEY_PATH, key.data)
                     ))
-                    .then(() => os_utils.restart_services());
+                    .then(() => os_utils.restart_noobaa_services());
             }
         });
 }

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -42,7 +42,8 @@ const VERIFY_RESPONSE = [
     'UNREACHABLE',
     'ADDING_SELF',
     'NO_NTP_SET',
-    'CONNECTION_TIMEOUT'
+    'CONNECTION_TIMEOUT_ORIGIN',
+    'CONNECTION_TIMEOUT_NEW'
 ];
 
 function _init() {
@@ -294,6 +295,7 @@ function verify_join_conditions(req) {
                 .catch(err => {
                     dbg.error('verify_join_conditions: HAD ERROR', err, err.message);
                     if (_.includes(VERIFY_RESPONSE, err.message)) return err.message;
+                    if (err.message === 'CONNECTION_TIMEOUT') return 'CONNECTION_TIMEOUT_NEW';
                     throw err;
                 })
                 .then(result => ({
@@ -351,7 +353,7 @@ function verify_candidate_join_conditions(req) {
                     if (response.includes('Connection timed out')) {
                         dbg.warn(`Could not reach ${req.rpc_params.address}:${config.MONGO_DEFAULTS.SHARD_SRV_PORT}, might be due to a FW blocking`);
                         return {
-                            result: 'CONNECTION_TIMEOUT'
+                            result: 'CONNECTION_TIMEOUT_ORIGIN'
                         };
                     } else {
                         return P.resolve()

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -86,7 +86,7 @@ function new_cluster_info(params) {
 }
 
 function init_cluster() {
-    return cluster_hb.do_heartbeat();
+    return cluster_hb.do_heartbeat({ skip_server_monitor: true });
 }
 
 //Initiate process of adding a server to the cluster
@@ -253,7 +253,7 @@ function add_member_to_cluster_invoke(req, my_address) {
             return system_store.load();
         })
         // ugly but works. perform first heartbeat after server is joined, so UI will present updated data
-        .then(() => cluster_hb.do_heartbeat())
+        .then(() => cluster_hb.do_heartbeat({ skip_server_monitor: true }))
         .then(() => {
             if (first_server) {
                 return MongoCtrl.add_mongo_monitor_program();
@@ -479,7 +479,7 @@ function join_to_cluster(req) {
             });
         })
         // ugly but works. perform first heartbeat after server is joined, so UI will present updated data
-        .then(() => cluster_hb.do_heartbeat())
+        .then(() => cluster_hb.do_heartbeat({ skip_server_monitor: true }))
         // send update to all services with the master address
         .then(() => cutil.send_master_update(false, req.rpc_params.master_ip))
         // restart bg_workers and s3rver to fix stale data\connections issues. maybe we can do it in a more elgant way
@@ -611,7 +611,7 @@ function update_member_of_cluster(req) {
             return system_store.load();
         })
         // ugly but works. perform first heartbeat after server was edited, so UI will present updated data
-        .then(() => cluster_hb.do_heartbeat())
+        .then(() => cluster_hb.do_heartbeat({ skip_server_monitor: true }))
         .catch(function(err) {
             console.error('Failed edit of member to cluster', req.rpc_params, 'with', err);
             throw new Error('Failed edit of member to cluster');
@@ -1251,7 +1251,7 @@ function update_server_conf(req) {
                         address: server_rpc.get_base_address(cluster_server.owner_address),
                         timeout: 60000 //60s
                     })
-                    .then(() => cluster_hb.do_heartbeat()) //We call for HB since the hostname changed
+                    .then(() => cluster_hb.do_heartbeat({ skip_server_monitor: true })) //We call for HB since the hostname changed
                     .then(() => cluster_server);
             }
             return cluster_server;

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -216,6 +216,14 @@ function get_cluster_info(rs_status) {
                     results: status.cluster_status === 'UNKNOWN' ? undefined : status.cluster_status
                 }
             }, _.isUndefined);
+        } else {
+            server_info.services_status = {
+                phonehome_server: {
+                    status: 'UNKNOWN',
+                    test_time: Date.now()
+                },
+                cluster_communication: {}
+            };
         }
         shard.servers.push(server_info);
     });

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -190,7 +190,7 @@ function get_cluster_info(rs_status) {
             storage: storage,
             cpus: cpus,
             location: location,
-            upgrade: cinfo.upgrade,
+            upgrade: _.omit(cinfo.upgrade, 'stage_changed_date'),
             debug: _.omitBy({
                 level: cinfo.debug_level,
                 time_left: debug_time

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -135,6 +135,14 @@ async function run_platform_upgrade_steps() {
     await platform_upgrade_common();
     await platform_upgrade_2_4_0();
     await platform_upgrade_2_7_0();
+    await platform_upgrade_2_8_0();
+}
+
+async function platform_upgrade_2_8_0() {
+    // exclude cleaning of supervisor and upgrade files
+    await fs.appendFileAsync('/usr/lib/tmpfiles.d/tmp.conf', 'x /tmp/supervisor*\n');
+    await fs.appendFileAsync('/usr/lib/tmpfiles.d/tmp.conf', 'x /tmp/test\n');
+    await exec('systemctl restart systemd-tmpfiles-clean.service');
 }
 
 async function platform_upgrade_2_7_0() {

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -119,7 +119,7 @@ class UpgradeManager {
     async update_db(updates) {
 
         let server = system_store.get_local_cluster_info(); //Update path in DB
-        updates.stage_changed_date = Date.now();
+        updates['upgrade.stage_changed_date'] = Date.now();
         const update = {
             clusters: [{
                 _id: server._id,

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -945,7 +945,7 @@ function get_syslog_server_configuration() {
         });
 }
 
-function noobaa_() {
+function restart_noobaa_services() {
     if (os.type() !== 'Linux') {
         return;
     }

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -945,7 +945,7 @@ function get_syslog_server_configuration() {
         });
 }
 
-function restart_services() {
+function noobaa_() {
     if (os.type() !== 'Linux') {
         return;
     }
@@ -958,7 +958,7 @@ function restart_services() {
     spawn('nohup', [
         '/usr/bin/supervisorctl',
         'restart',
-        'all'
+        'webserver bg_workers hosted_agents s3rver'
     ], {
         detached: true,
         stdio: ['ignore', stdout, stderr],
@@ -1263,7 +1263,7 @@ exports.reload_syslog_configuration = reload_syslog_configuration;
 exports.get_syslog_server_configuration = get_syslog_server_configuration;
 exports.set_dns_and_search_domains = set_dns_and_search_domains;
 exports.get_dns_and_search_domains = get_dns_and_search_domains;
-exports.restart_services = restart_services;
+exports.restart_noobaa_services = restart_noobaa_services;
 exports.set_hostname = set_hostname;
 exports.is_valid_hostname = is_valid_hostname;
 exports.get_disk_mount_points = get_disk_mount_points;


### PR DESCRIPTION
### Explain the changes
- prevent server_monitor from restarting services on add_member
- refined connectivity errors on join to cluster validation
- remove stage_changed_date from cluster documents during upgrade
- exclude supervisor and upgrade files on tmp cleaning

### Issues: Fixed #xxx / Gap #xxx
- Fixes #4849
- Fixes #4923

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages