### PR TITLE
collect io statistics per node and aggregate per pool in read_system

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -761,6 +761,7 @@ class Agent {
             mem_usage: process.memoryUsage().rss,
             cpu_usage: cpu_percent,
             location_info: this.location_info,
+            io_stats: this.block_store && this.block_store.get_and_reset_io_stats()
         };
         if (this.cloud_info && this.cloud_info.pool_name) {
             reply.pool_name = this.cloud_info.pool_name;

--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -71,7 +71,7 @@ class BlockStoreClient {
                     .catch(err => {
                         dbg.error('encountered error on _delegate_write_block_azure:', err);
                         const error = _.pick(err, 'message', 'code');
-                        return rpc_client.block_store.handle_delegator_error({ error, usage }, options);
+                        return rpc_client.block_store.handle_delegator_error({ error, usage, op_type: 'WRITE' }, options);
                     });
             })
             .timeout(timeout);
@@ -98,7 +98,14 @@ class BlockStoreClient {
                     .catch(err => {
                         dbg.error('encountered error on _delegate_read_block_azure:', err);
                         const error = _.pick(err, 'message', 'code');
-                        return rpc_client.block_store.handle_delegator_error({ error }, options);
+                        return rpc_client.block_store.handle_delegator_error({
+                            error,
+                            usage: {
+                                count: 1,
+                                size: params.block_md.size,
+                            },
+                            op_type: 'READ'
+                        }, options);
                     })
                     .then(info => {
                         const noobaablockmd = info.metadata.noobaablockmd || info.metadata.noobaa_block_md;
@@ -163,7 +170,7 @@ class BlockStoreClient {
                 } catch (err) {
                     dbg.error('encountered error on _delegate_write_block_s3:', err);
                     const error = _.pick(err, 'message', 'code');
-                    return rpc_client.block_store.handle_delegator_error({ error, usage }, options);
+                    return rpc_client.block_store.handle_delegator_error({ error, usage, op_type: 'WRITE' }, options);
                 }
 
             })
@@ -249,7 +256,14 @@ class BlockStoreClient {
                 } catch (err) {
                     dbg.error('encountered error on _delegate_read_block_s3:', err);
                     const error = _.pick(err, 'message', 'code');
-                    return rpc_client.block_store.handle_delegator_error({ error }, options);
+                    return rpc_client.block_store.handle_delegator_error({
+                        error,
+                        usage: {
+                            count: 1,
+                            size: params.block_md.size,
+                        },
+                        op_type: 'READ'
+                    }, options);
                 }
             })
             .timeout(timeout);

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -106,6 +106,36 @@ module.exports = {
                         type: 'string'
                     },
 
+                    io_stats: {
+                        type: 'object',
+                        properties: {
+                            read_count: {
+                                type: 'integer'
+                            },
+                            write_count: {
+                                type: 'integer'
+                            },
+                            read_bytes: {
+                                type: 'integer'
+                            },
+                            write_bytes: {
+                                type: 'integer'
+                            },
+                            error_read_count: {
+                                type: 'integer'
+                            },
+                            error_write_count: {
+                                type: 'integer'
+                            },
+                            error_read_bytes: {
+                                type: 'integer'
+                            },
+                            error_write_bytes: {
+                                type: 'integer'
+                            },
+                        }
+                    },
+
                     // the agent's "recommendation" of it's roles. nodes_monitor will only use it
                     // when initializing the node and the role is not yet known.
                     roles: {

--- a/src/api/block_store_api.js
+++ b/src/api/block_store_api.js
@@ -57,7 +57,7 @@ module.exports = {
                     },
                     usage: { // the usage that was counted for failed operation - need to undo
                         type: 'object',
-                        required: ['size', 'count'],
+                        required: ['size', 'count', 'op_type'],
                         properties: {
                             size: {
                                 type: 'integer'
@@ -65,6 +65,10 @@ module.exports = {
                             count: {
                                 type: 'integer'
                             },
+                            op_type: {
+                                type: 'string',
+                                enum: ['READ', 'WRITE']
+                            }
                         }
                     }
                 }

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -473,6 +473,23 @@ module.exports = {
                 storage: {
                     $ref: 'common_api#/definitions/storage_info'
                 },
+                io_stats: {
+                    type: 'object',
+                    properties: {
+                        read_count: {
+                            type: 'integer'
+                        },
+                        write_count: {
+                            type: 'integer'
+                        },
+                        read_bytes: {
+                            $ref: 'common_api#/definitions/bigint'
+                        },
+                        write_bytes: {
+                            $ref: 'common_api#/definitions/bigint'
+                        },
+                    }
+                },
                 undeletable: {
                     $ref: 'common_api#/definitions/undeletable_enum'
                 },

--- a/src/endpoint/s3/ops/s3_post_object_uploadId.js
+++ b/src/endpoint/s3/ops/s3_post_object_uploadId.js
@@ -29,7 +29,8 @@ async function post_object_uploadId(req, res) {
         bucket: req.params.bucket,
         key: req.params.key,
         md_conditions: http_utils.get_md_conditions(req),
-        multiparts
+        multiparts,
+        content_type: req.headers['content-type']
     });
 
     if (reply.version_id && reply.version_id !== 'null') {

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -357,7 +357,7 @@ class ObjectSDK {
 
     async complete_object_upload(params) {
         const ns = await this._get_bucket_namespace(params.bucket);
-        const reply = await ns.complete_object_upload(params, this);
+        const reply = await ns.complete_object_upload(_.omit(params, 'content_type'), this);
         // update counters in background
         this.rpc_client.object.update_bucket_write_counters({ bucket: params.bucket, content_type: params.content_type });
         return reply;

--- a/src/server/analytic_services/bucket_stats_schema.js
+++ b/src/server/analytic_services/bucket_stats_schema.js
@@ -4,7 +4,7 @@
 module.exports = {
     id: 'bucket_stats_schema',
     type: 'object',
-    required: ['_id', 'system', 'bucket', 'content_type', 'stats'],
+    required: ['_id', 'system', 'bucket', 'content_type'],
     properties: {
         _id: {
             objectid: true

--- a/src/server/analytic_services/bucket_stats_store.js
+++ b/src/server/analytic_services/bucket_stats_store.js
@@ -38,15 +38,15 @@ class BucketStatsStore {
                 last_write: write_count ? Date.now() : undefined,
                 last_read: read_count ? Date.now() : undefined,
             }, selector), _.isUndefined),
-            $inc: {
+            $inc: _.omitBy({
                 writes: write_count,
                 reads: read_count
-            }
+            }, _.isUndefined)
         };
 
-        const res = await this._bucket_stats.col().updateOne(selector, update, {
+        const res = await this._bucket_stats.col().findOneAndUpdate(selector, update, {
             upsert: true,
-            returnNewDocument: true
+            returnOriginal: false
         });
 
         this._bucket_stats.validate(res.value, 'warn');

--- a/src/server/analytic_services/io_stats_schema.js
+++ b/src/server/analytic_services/io_stats_schema.js
@@ -1,0 +1,60 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+module.exports = {
+    id: 'io_stats_schema',
+    type: 'object',
+    required: [
+        '_id',
+        'system',
+        'start_time',
+        'end_time',
+        'resource_id',
+        'resource_type'
+    ],
+    properties: {
+        _id: {
+            objectid: true
+        },
+        system: {
+            objectid: true
+        },
+        start_time: {
+            idate: true
+        },
+        end_time: {
+            idate: true
+        },
+        resource_type: {
+            type: 'string',
+            enum: ['NODE', 'NAMESPACE_RESOURCE']
+        },
+        resource_id: {
+            objectid: true
+        },
+        read_bytes: {
+            type: 'integer',
+        },
+        write_bytes: {
+            type: 'integer',
+        },
+        read_count: {
+            type: 'integer',
+        },
+        write_count: {
+            type: 'integer',
+        },
+        error_read_bytes: {
+            type: 'integer',
+        },
+        error_write_bytes: {
+            type: 'integer',
+        },
+        error_read_count: {
+            type: 'integer',
+        },
+        error_write_count: {
+            type: 'integer',
+        },
+    }
+};

--- a/src/server/analytic_services/io_stats_store.js
+++ b/src/server/analytic_services/io_stats_store.js
@@ -1,0 +1,86 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+const moment = require('moment');
+
+const mongo_client = require('../../util/mongo_client');
+const io_stats_schema = require('./io_stats_schema');
+
+class IoStatsStore {
+
+    static instance(system) {
+        IoStatsStore._instance = IoStatsStore._instance || new IoStatsStore();
+        return IoStatsStore._instance;
+    }
+
+    constructor() {
+        this._io_stats = mongo_client.instance().define_collection({
+            name: 'iostats',
+            schema: io_stats_schema,
+            db_indexes: [{
+                fields: {
+                    system: 1,
+                    resource_id: 1,
+                    resource_type: 1,
+                    start_time: 1,
+                    end_time: 1
+                }
+            }],
+        });
+    }
+
+    ////////////////////
+    // IO Stats funcs //
+    ////////////////////
+
+    async update_node_io_stats({ system, stats, node_id }) {
+        const start_time = moment(Date.now()).startOf('day').valueOf();
+        const end_time = moment(Date.now()).endOf('day').valueOf();
+        const selector = {
+            system,
+            resource_id: node_id,
+            resource_type: 'NODE',
+            start_time,
+            end_time
+        };
+        const update = {
+            $set: selector,
+            $inc: _.pick(stats, 'read_count', 'write_count', 'read_bytes', 'write_bytes',
+                'error_read_count', 'error_write_count', 'error_read_bytes', 'error_write_bytes')
+        };
+
+        const res = await this._io_stats.col().findOneAndUpdate(selector, update, {
+            upsert: true,
+            returnOriginal: false
+        });
+
+        this._io_stats.validate(res.value, 'warn');
+    }
+
+    async get_all_nodes_stats({ system }) {
+        return this._io_stats.col().aggregate([{
+            $match: {
+                system,
+                resource_type: 'NODE'
+            }
+        }, {
+            $group: {
+                _id: '$resource_id',
+                read_count: { $sum: '$read_count' },
+                write_count: { $sum: '$write_count' },
+                read_bytes: { $sum: '$read_bytes' },
+                write_bytes: { $sum: '$write_bytes' },
+                error_read_count: { $sum: '$error_read_count' },
+                error_write_count: { $sum: '$error_write_count' },
+                error_read_bytes: { $sum: '$error_read_bytes' },
+                error_write_bytes: { $sum: '$error_write_bytes' },
+            },
+        }]).toArray();
+    }
+
+}
+
+
+// EXPORTS
+exports.IoStatsStore = IoStatsStore;

--- a/src/server/analytic_services/s3_usage_schema.js
+++ b/src/server/analytic_services/s3_usage_schema.js
@@ -6,6 +6,9 @@ module.exports = {
     type: 'object',
     required: ['system', 's3_usage_info', 's3_errors_info'],
     properties: {
+        _id: {
+            objectid: true
+        },
         system: {
             objectid: true
         },

--- a/src/server/analytic_services/usage_report_store.js
+++ b/src/server/analytic_services/usage_report_store.js
@@ -77,7 +77,7 @@ class UsageReportStore {
                 selector,
                 update, {
                     upsert: true,
-                    returnNewDocument: true
+                    returnOriginal: false
                 }
             );
             this._usage_reports.validate(res.value, 'warn');
@@ -124,7 +124,7 @@ class UsageReportStore {
         });
         if (_.isEmpty(update.$inc)) return;
         const res = await this._s3_usage.col().findOneAndUpdate({ system: system._id },
-            update, { upsert: true, returnNewDocument: true });
+            update, { upsert: true, returnOriginal: false });
         this._s3_usage.validate(res.value, 'warn');
     }
 

--- a/src/server/node_services/node_server.js
+++ b/src/server/node_services/node_server.js
@@ -67,20 +67,11 @@ function list_nodes(req) {
     return monitor.list_nodes(query, options);
 }
 
-function aggregate_nodes(req) {
+async function aggregate_nodes(req) {
     const query = _prepare_nodes_query(req);
     const res = req.rpc_params.aggregate_hosts ?
         monitor.aggregate_hosts(query, req.rpc_params.group_by) :
-        monitor.aggregate_nodes(query, req.rpc_params.group_by);
-    // if (res.groups) {
-    //     res.groups = _.map(res.groups, (group, group_key) => {
-    //         if (req.rpc_params.group_by === 'pool') {
-    //             const pool = system_store.data.get_by_id(group_key);
-    //             group.name = pool.name;
-    //         }
-    //         return group;
-    //     });
-    // }
+        monitor.aggregate_nodes(query, req.rpc_params.group_by, await monitor.get_nodes_stats(req.system._id));
     return res;
 }
 

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -555,7 +555,12 @@ function get_pool_info(pool, nodes_aggregate_pool, hosts_aggregate_pool) {
         // and does not consider number of replicas like in tier
         storage: _.defaults(size_utils.to_bigint_storage(p_nodes.storage), POOL_STORAGE_DEFAULTS),
         region: pool.region,
-        create_time: pool._id.getTimestamp().getTime()
+        create_time: pool._id.getTimestamp().getTime(),
+        io_stats: _.pick(p_nodes.io_stats,
+            'read_count',
+            'write_count',
+            'read_bytes',
+            'write_bytes') || { read_count: 0, write_count: 0, read_bytes: 0, write_bytes: 0 }
     };
     info.data_activities = {
         activities: p_nodes.data_activities || [],

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -444,7 +444,7 @@ function read_system(req) {
             }))
             .then(res => res.functions),
 
-        buckets_stats: BucketStatsStore.instance().get_all_buckets_stats({ system: system._id })
+        buckets_stats: BucketStatsStore.instance().get_all_buckets_stats({ system: system._id }),
 
     }).then(({
         nodes_aggregate_pool_no_cloud_and_mongo,


### PR DESCRIPTION
### Explain the changes
- collect read\write statistics in each block_store and return to nodes_monitor in get_agent_info
- store in io_stats collection aggregated per day
- return for each pool in read_system the total aggregated io_stats of the pools nodes. value is returned under io_stats in pool info

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
