### PR TITLE
FE 2.9 fixes (mainly regions)

### DIFF
--- a/frontend/src/app/components/application/main-layout/route-mapping.js
+++ b/frontend/src/app/components/application/main-layout/route-mapping.js
@@ -124,8 +124,8 @@ function _generateBucketsCrumbs(params) {
 function _generateDataBucketCrumbs(params) {
     return [
         ..._generateBucketsCrumbs({
-            ...params, tab:
-            'data-buckets'
+            ...params,
+            tab: 'data-buckets'
         }),
         {
             url: realizeUri(
@@ -140,7 +140,7 @@ function _generateDataBucketCrumbs(params) {
 function _generateNamespaceBucketCrumbs(params) {
     return [
         ..._generateBucketsCrumbs({
-            params,
+            ...params,
             tab: 'namespace-buckets'
         }),
         {

--- a/frontend/src/app/components/bucket/bucket-data-placement-policy-form/placement-row.js
+++ b/frontend/src/app/components/bucket/bucket-data-placement-policy-form/placement-row.js
@@ -7,6 +7,7 @@ import { deepFreeze, sumBy } from 'utils/core-utils';
 import { realizeUri } from 'utils/browser-utils';
 import { hostWritableModes, storageNodeWritableModes } from 'utils/host-utils';
 import {
+    unassignedRegionText,
     getHostsPoolStateIcon,
     getCloudResourceStateIcon,
     getCloudResourceTypeIcon
@@ -67,7 +68,7 @@ export default class PlacementRowViewModel {
         this.resourceName(resourceName);
         this.state(getHostsPoolStateIcon(pool));
         this.type(nodesPoolType);
-        this.region(pool.region || '(Unassigned)');
+        this.region(pool.region || unassignedRegionText);
         this.healthyHosts(_formatCounts(healthyHosts, hostCount));
         this.healthyNodes(_formatCounts(healthyNodes, storageNodeCount));
         this.bucketUsage({
@@ -86,7 +87,7 @@ export default class PlacementRowViewModel {
         this.resourceName(resourceName);
         this.state(getCloudResourceStateIcon(resource));
         this.type(getCloudResourceTypeIcon(resource));
-        this.region(resource.region || '(Unassigned)');
+        this.region(resource.region || unassignedRegionText);
         this.healthyHosts('---');
         this.healthyNodes('---');
         this.bucketUsage({

--- a/frontend/src/app/components/bucket/bucket-spillover-policy-form/spillover-row.js
+++ b/frontend/src/app/components/bucket/bucket-spillover-policy-form/spillover-row.js
@@ -4,6 +4,7 @@ import ko from 'knockout';
 import { realizeUri } from 'utils/browser-utils';
 import * as routes from 'routes';
 import {
+    unassignedRegionText,
     getResourceStateIcon,
     getInternalResourceDisplayName,
     getCloudResourceTypeIcon
@@ -69,7 +70,7 @@ export default class SpilloverRowViewModel {
 
     onResource(type, resource, bucketUsage, system) {
         this.resourceName(_getResourceName(type, resource, system));
-        this.region(resource.region || '(Unassigned)');
+        this.region(resource.region || unassignedRegionText);
         this.state(getResourceStateIcon(type, resource));
         this.type(_getResourceTypeIcon(type, resource));
         this.bucketUsage({

--- a/frontend/src/app/components/cloud-resource/cloud-resource-panel/cloud-resource-panel.html
+++ b/frontend/src/app/components/cloud-resource/cloud-resource-panel/cloud-resource-panel.html
@@ -44,7 +44,7 @@
 
         <host-parts-table class="tab column"
             ko.css.selected="selectedTab.eq('parts')"
-            params="hostName: hostName"
+            params="resourceType: 'CLOUD_RESOURCE', hostName: hostName"
         ></host-parts-table>
     </div>
 </div>

--- a/frontend/src/app/components/cloud-resource/cloud-resource-properties-form/cloud-resource-properties-form.js
+++ b/frontend/src/app/components/cloud-resource/cloud-resource-properties-form/cloud-resource-properties-form.js
@@ -3,6 +3,7 @@
 import template from './cloud-resource-properties-form.html';
 import ConnectableViewModel from 'components/connectable';
 import { formatSize } from 'utils/size-utils';
+import { unassignedRegionText } from 'utils/resource-utils';
 import { openAssignRegionModal } from 'action-creators';
 import ko from 'knockout';
 import { timeShortFormat } from 'config';
@@ -58,7 +59,7 @@ class CloudResourcePropertiesFormViewModel extends ConnectableViewModel {
                 properties: [
                     { value: resource.name },
                     { value: resource.target },
-                    { value: resource.region || '(Unassigned)' },
+                    { value: resource.region || unassignedRegionText },
                     { value: formatSize(resource.storage.used) },
                     { value: resource.createdBy },
                     { value: moment(resource.creationTime).format(timeShortFormat) }

--- a/frontend/src/app/components/host/host-endpoint-form/host-endpoint-form.js
+++ b/frontend/src/app/components/host/host-endpoint-form/host-endpoint-form.js
@@ -5,6 +5,7 @@ import ConnectableViewModel from 'components/connectable';
 import { deepFreeze } from 'utils/core-utils';
 import { getEndpointServiceStateIcon } from 'utils/host-utils';
 import { formatSize } from 'utils/size-utils';
+import { unassignedRegionText } from 'utils/resource-utils';
 import { timeShortFormat } from 'config';
 import ko from 'knockout';
 import moment from 'moment';
@@ -122,7 +123,7 @@ class HostEndpointFormViewModel extends ConnectableViewModel {
                         disabled: isDisabled
                     },
                     {
-                        value: pool.region || '(Unassigned)',
+                        value: pool.region || unassignedRegionText,
                         disabled: isDisabled
                     },
                     {

--- a/frontend/src/app/components/host/host-panel/host-panel.html
+++ b/frontend/src/app/components/host/host-panel/host-panel.html
@@ -58,7 +58,7 @@
 
         <host-parts-table class="tab"
             ko.css.selected="selectedTab.eq('parts')"
-            params="hostName: host"
+            params="resourceType: 'HOST', hostName: host"
         ></host-parts-table>
     </div>
 </div>

--- a/frontend/src/app/components/modals/assign-hosts-modal/assign-hosts-modal.js
+++ b/frontend/src/app/components/modals/assign-hosts-modal/assign-hosts-modal.js
@@ -9,6 +9,7 @@ import { formatSize, sumSize } from 'utils/size-utils';
 import { stringifyAmount } from 'utils/string-utils';
 import { getFormValues, getFieldValue } from 'utils/form-utils';
 import { inputThrottle, paginationPageSize } from 'config';
+import { unassignedRegionText } from 'utils/resource-utils';
 import {
     getHostModeListForStates,
     getHostDisplayName,
@@ -126,7 +127,7 @@ function _mapHostToRow(host, pools, selectedHosts, targetPoolName) {
                     },
                     {
                         label: 'Region',
-                        value: pool.region || '(Unassigned)'
+                        value: pool.region || unassignedRegionText
                     },
                     {
                         label: 'Free capacity',

--- a/frontend/src/app/components/modals/assign-region-modal/assign-region-modal.html
+++ b/frontend/src/app/components/modals/assign-region-modal/assign-region-modal.html
@@ -7,7 +7,7 @@
     onSubmit: onSubmit
 ">
     <p>
-        Region is a way to mark proximity of resources. Assigning a region can improve performance if working from the endpoints within the region. It may also help with cost savings such as egress in the case of cloud regions.
+        Regions are a way to mark proximity of resources. Assigning a region can improve performance if working from the endpoints within the region. It may also help with cost savings such as egress in the case of cloud regions.
     </p>
     <editor class="greedy" params="label: 'region'">
         <input type="text"

--- a/frontend/src/app/components/modals/assign-region-modal/assign-region-modal.js
+++ b/frontend/src/app/components/modals/assign-region-modal/assign-region-modal.js
@@ -2,6 +2,8 @@
 
 import template from './assign-region-modal.html';
 import ConnectableViewModel from 'components/connectable';
+import { equalIgnoreCase } from 'utils/string-utils';
+import { unassignedRegionText } from 'utils/resource-utils';
 import { closeModal, assignRegionToResource } from 'action-creators';
 import ko from 'knockout';
 
@@ -39,8 +41,14 @@ class AssignRegionModalViewModel extends ConnectableViewModel {
         const { region } = values;
         const errors = {};
 
-        if (region && (region.length < 3 || region.length > 32)) {
-            errors.region = 'Region tag must be between 3-32 characters';
+        if (region) {
+            if (region.length < 3 || region.length > 32) {
+                errors.region = 'Region tag must be between 3-32 characters';
+            }
+
+            if (equalIgnoreCase(region.trim(), unassignedRegionText)) {
+                errors.region = `"${unassignedRegionText}" is reserved and cannot be used as a region name`;
+            }
         }
 
         return errors;

--- a/frontend/src/app/components/modals/create-bucket-modal/create-bucket-modal.js
+++ b/frontend/src/app/components/modals/create-bucket-modal/create-bucket-modal.js
@@ -9,7 +9,7 @@ import ko from 'knockout';
 import { getFieldValue, isFieldTouched, isFormValid } from 'utils/form-utils';
 import { deepFreeze, keyBy } from 'utils/core-utils';
 import { realizeUri } from 'utils/browser-utils';
-import { getResourceId } from 'utils/resource-utils';
+import { unassignedRegionText, getResourceId } from 'utils/resource-utils';
 import * as routes from 'routes';
 import { createBucketMirrorTooltip, createBucketSpreadTooltip } from 'knowledge-base-articles';
 import {
@@ -277,7 +277,7 @@ class CreateBucketModalViewModel extends Observer {
 
         if (policyType === 'SPREAD') {
             const [first, ...rest] = selectedResources
-                .map(({ type, name }) => regionByResource[getResourceId(type, name)] || '(Unassigned)');
+                .map(({ type, name }) => regionByResource[getResourceId(type, name)] || unassignedRegionText);
 
             if (first && rest.some(region => region !== first)) {
                 warnings.selectedResources = 'Combining resources with different assigned regions is not recommended and might raise costs';

--- a/frontend/src/app/components/modals/create-bucket-modal/resource-row.js
+++ b/frontend/src/app/components/modals/create-bucket-modal/resource-row.js
@@ -1,8 +1,11 @@
+/* Copyright (C) 2016 NooBaa */
+
 import ko from 'knockout';
 import numeral from 'numeral';
 import { sumBy } from 'utils/core-utils';
 import { hostWritableModes, storageNodeWritableModes } from 'utils/host-utils';
 import {
+    unassignedRegionText,
     getHostsPoolStateIcon,
     getCloudResourceStateIcon,
     getCloudResourceTypeIcon
@@ -55,7 +58,7 @@ export default class ResourceRowViewModel {
     _onHostPool(pool, selected) {
         const {
             name,
-            region = '(Unassigned)',
+            region = unassignedRegionText,
             storage,
             hostCount,
             hostsByMode,
@@ -85,7 +88,7 @@ export default class ResourceRowViewModel {
     }
 
     _onCloudResource(resource, selected) {
-        const { name, region = '(Unassigned)', storage } = resource;
+        const { name, region = unassignedRegionText, storage } = resource;
         const isSelected = selected.some(record => record.type === 'CLOUD' && record.name === name);
         const state = getCloudResourceStateIcon(resource);
 

--- a/frontend/src/app/components/modals/create-pool-modal/create-pool-modal.js
+++ b/frontend/src/app/components/modals/create-pool-modal/create-pool-modal.js
@@ -6,6 +6,7 @@ import { deepFreeze, union, sumBy, throttle, memoize, pick } from 'utils/core-ut
 import { formatSize, sumSize } from 'utils/size-utils';
 import { stringifyAmount } from 'utils/string-utils';
 import { getFormValues, isFormValid, getFieldValue, isFieldTouched } from 'utils/form-utils';
+import { unassignedRegionText } from 'utils/resource-utils';
 import { paginationPageSize, inputThrottle } from 'config';
 import ko from 'knockout';
 import numeral from 'numeral';
@@ -14,8 +15,6 @@ import {
     getHostDisplayName,
     getHostStateIcon,
     getNodeOrHostCapacityBarValues
-
-
 } from 'utils/host-utils';
 import {
     fetchHosts,
@@ -170,7 +169,7 @@ function _mapHostToRow(host, pools, selectedHosts) {
                     },
                     {
                         label: 'Region',
-                        value: pool.region || '(Unassigned)'
+                        value: pool.region || unassignedRegionText
                     },
                     {
                         label: 'Free capacity',

--- a/frontend/src/app/components/modals/edit-bucket-placement-modal/edit-bucket-placement-modal.js
+++ b/frontend/src/app/components/modals/edit-bucket-placement-modal/edit-bucket-placement-modal.js
@@ -5,7 +5,7 @@ import Observer from 'observer';
 import ResourceRow from './resource-row';
 import { state$, action$ } from 'state';
 import { deepFreeze, pick, flatMap, createCompareFunc, keyBy } from 'utils/core-utils';
-import { getResourceId} from 'utils/resource-utils';
+import { unassignedRegionText, getResourceId } from 'utils/resource-utils';
 import { getFieldValue } from 'utils/form-utils';
 import { realizeUri } from 'utils/browser-utils';
 import { getMany } from 'rx-extensions';
@@ -264,7 +264,7 @@ class EditBucketPlacementModalViewModel extends Observer {
 
         if (policyType === 'SPREAD') {
             const [first, ...rest] = selectedResources
-                .map(({ type, name }) => regionByResource[getResourceId(type, name)] || '(Unassigned)');
+                .map(({ type, name }) => regionByResource[getResourceId(type, name)] || unassignedRegionText);
 
             if (first && rest.some(region => region !== first)) {
                 warnings.selectedResources = 'Combining resources with different assigned regions is not recommended and might raise costs';

--- a/frontend/src/app/components/modals/edit-bucket-placement-modal/resource-row.js
+++ b/frontend/src/app/components/modals/edit-bucket-placement-modal/resource-row.js
@@ -5,6 +5,7 @@ import numeral from 'numeral';
 import { sumBy } from 'utils/core-utils';
 import { hostWritableModes, storageNodeWritableModes } from 'utils/host-utils';
 import {
+    unassignedRegionText,
     getHostsPoolStateIcon,
     getCloudResourceStateIcon,
     getCloudResourceTypeIcon
@@ -66,7 +67,7 @@ export default class ResourceRowViewModel {
     _onHostPool(pool, selected) {
         const {
             name,
-            region = '(Unassigned)',
+            region = unassignedRegionText,
             storage,
             hostCount,
             hostsByMode,
@@ -97,7 +98,7 @@ export default class ResourceRowViewModel {
     }
 
     _onCloudResource(resource, selected) {
-        const { name, region = '(Unassigned)', storage } = resource;
+        const { name, region = unassignedRegionText, storage } = resource;
         const isSelected = selected.some(record => record.type === 'CLOUD' && record.name === name);
         const state = getCloudResourceStateIcon(resource);
 

--- a/frontend/src/app/components/modals/edit-bucket-spillover-modal/edit-bucket-spillover-modal.js
+++ b/frontend/src/app/components/modals/edit-bucket-spillover-modal/edit-bucket-spillover-modal.js
@@ -9,7 +9,7 @@ import { flatMap } from 'utils/core-utils';
 import { sumSize, formatSize } from 'utils/size-utils';
 import { getCloudResourceTypeIcon } from 'utils/resource-utils';
 import { getMany } from 'rx-extensions';
-import { getInternalResourceDisplayName } from 'utils/resource-utils';
+import { unassignedRegionText, getInternalResourceDisplayName } from 'utils/resource-utils';
 import { closeModal, updateBucketSpilloverPolicy } from 'action-creators';
 import { editBucketSpillover as learnMoreHref } from 'knowledge-base-articles';
 
@@ -70,7 +70,7 @@ function _getOptionTooltip(type, resource, isOptionDisabled) {
             },
             {
                 label: 'Region',
-                value: resource.region || '(Unassigned)',
+                value: resource.region || unassignedRegionText,
                 visible: type !== 'INTERNAL'
             },
             {

--- a/frontend/src/app/components/pool/pool-summary/pool-summary.js
+++ b/frontend/src/app/components/pool/pool-summary/pool-summary.js
@@ -8,7 +8,7 @@ import numeral from 'numeral';
 import { isNumber } from 'utils/core-utils';
 import { toBytes } from 'utils/size-utils';
 import { stringifyAmount } from 'utils/string-utils';
-import { getHostsPoolStateIcon } from 'utils/resource-utils';
+import { unassignedRegionText, getHostsPoolStateIcon } from 'utils/resource-utils';
 import { getActivityName, getActivityListTooltip } from 'utils/host-utils';
 import { get } from 'rx-extensions';
 import style from 'style';
@@ -108,7 +108,7 @@ class PoolSummaryViewModel extends Observer {
             this.state(getHostsPoolStateIcon(pool));
             this.hostCount(numeral(hostCount).format('0,0'));
             this.driveCount(numeral(storageNodeCount).format('0,0'));
-            this.region(region || '(Unassigned)');
+            this.region(region || unassignedRegionText);
         }
 
         { // Update pool storage and usage

--- a/frontend/src/app/components/resources/cloud-resources-table/cloud-resource-row.js
+++ b/frontend/src/app/components/resources/cloud-resources-table/cloud-resource-row.js
@@ -5,7 +5,11 @@ import { deepFreeze } from 'utils/core-utils';
 import { stringifyAmount } from 'utils/string-utils';
 import { formatSize } from 'utils/size-utils';
 import { realizeUri } from 'utils/browser-utils';
-import { getCloudResourceStateIcon, getCloudResourceTypeIcon } from 'utils/resource-utils';
+import {
+    unassignedRegionText,
+    getCloudResourceStateIcon,
+    getCloudResourceTypeIcon
+} from 'utils/resource-utils';
 import * as routes from 'routes';
 
 const undeletableReasons = deepFreeze({
@@ -36,7 +40,7 @@ export default class CloudResourceRowViewModel {
     }
 
     onState(resource, system, selectedForDelete) {
-        const { name, region = '(Unassigned)', usedBy, target, undeletable } = resource;
+        const { name, region = unassignedRegionText, usedBy, target, undeletable } = resource;
         const bucketCount = usedBy.length;
 
         const uri = realizeUri(routes.cloudResource, { system, resource: name });

--- a/frontend/src/app/components/resources/pools-table/pools-table.js
+++ b/frontend/src/app/components/resources/pools-table/pools-table.js
@@ -7,7 +7,7 @@ import { requestLocation, openCreatePoolModal, deleteResource } from 'action-cre
 import { realizeUri } from 'utils/browser-utils';
 import { deepFreeze, throttle, createCompareFunc, groupBy, flatMap, sumBy } from 'utils/core-utils';
 import { stringifyAmount } from 'utils/string-utils';
-import { getHostsPoolStateIcon } from 'utils/resource-utils';
+import { unassignedRegionText, getHostsPoolStateIcon } from 'utils/resource-utils';
 import { summrizeHostModeCounters } from 'utils/host-utils';
 import ko from 'knockout';
 import * as routes from 'routes';
@@ -108,7 +108,7 @@ function _mapPoolToRow(
 ) {
     const {
         name,
-        region = '(Unassigned)',
+        region = unassignedRegionText,
         storage,
         undeletable = '',
         storageNodeCount,

--- a/frontend/src/app/components/shared/host-parts-table/host-parts-table.html
+++ b/frontend/src/app/components/shared/host-parts-table/host-parts-table.html
@@ -1,14 +1,14 @@
 <!-- Copyright (C) 2016 NooBaa -->
 
 <h3 class="heading3 pad alt-bg">
-    Object parts stored on this node: {{partCountFormatted}}
+    Object parts stored on this {{subject}}: {{partCountFormatted}}
 </h3>
 
 <data-table class="parts-table greedy" params="
     columns: columns,
     data: rows,
     loading: !dataReady(),
-    emptyMessage: 'No object parts are stored on the node'
+    emptyMessage: emptyMessage
 "></data-table>
 
 <paginator params="

--- a/frontend/src/app/components/shared/host-parts-table/host-parts-table.js
+++ b/frontend/src/app/components/shared/host-parts-table/host-parts-table.js
@@ -66,6 +66,8 @@ class HostPartsTableViewModel extends ConnectableViewModel {
     pageSize = paginationPageSize;
     pathname = '';
     dataReady = ko.observable();
+    subject = ko.observable();
+    emptyMessage = ko.observable();
     partCount = ko.observable();
     partCountFormatted = ko.observable();
     page = ko.observable();
@@ -78,15 +80,21 @@ class HostPartsTableViewModel extends ConnectableViewModel {
             null;
 
         return [
+            params.resourceType,
             hostParts,
             state.location
         ];
     }
 
-    mapStateToProps(hostParts, location) {
+    mapStateToProps(resourceType, hostParts, location) {
+        const subject =
+            (resourceType === 'HOST' && 'node') ||
+            (resourceType === 'CLOUD_RESOURCE' && 'cloud resoruce');
+
         if (!hostParts || hostParts.fetching || !hostParts.parts) {
             ko.assignToProps(this, {
                 dataReady: false,
+                subject: subject,
                 rows: []
             });
         } else {
@@ -96,6 +104,8 @@ class HostPartsTableViewModel extends ConnectableViewModel {
 
             ko.assignToProps(this, {
                 dataReady: true,
+                subject: subject,
+                emptyMessage: `No object parts are stored on the ${subject}`,
                 pathname: location.pathname,
                 page: page,
                 partCount: partCount,

--- a/frontend/src/app/utils/resource-utils.js
+++ b/frontend/src/app/utils/resource-utils.js
@@ -206,6 +206,8 @@ const resourceTypeToDisplayName = deepFreeze({
     CLOUD: 'cloud resource'
 });
 
+export const unassignedRegionText = 'Not set';
+
 export function getResourceId(type, name) {
     return `${type}:${name}`;
 }


### PR DESCRIPTION
- Fix messages in stored parts of cloud resource page
- Fix explanation in assign region modal
- Change "(Unassigned)" to "Not set" and prohibit users from using "Not set" as a region name.
- Fix route matching for namespace bucket (prevented navigation to namespace buckets)  