### PR TITLE
account_pipeline.js: fixed a bug where sometimes the secret pass incorrectly

### DIFF
--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -1,7 +1,7 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const argv = require('minimist')(process.argv);
+const argv = require('minimist')(process.argv, { string: ['server_secret'] });
 const dbg = require('../../util/debug_module')(__filename);
 
 const fs = require('fs');

--- a/src/test/pipeline/account_pipeline.js
+++ b/src/test/pipeline/account_pipeline.js
@@ -2,9 +2,11 @@
 'use strict';
 
 const _ = require('lodash');
-const argv = require('minimist')(process.argv);
 const server_ops = require('../utils/server_functions');
 const promise_utils = require('../../util/promise_utils');
+const dbg = require('../../util/debug_module')(__filename);
+const argv = require('minimist')(process.argv, { string: ['server_secret'] });
+dbg.set_process_name('account_pipeline');
 
 const js_script = 'account_test.js';
 
@@ -14,7 +16,6 @@ const TEST_CFG_DEFAULTS = {
     upgrade: '',
     version: 'latest'
 };
-
 
 let TEST_CFG = _.defaults(_.pick(argv, _.keys(TEST_CFG_DEFAULTS)), TEST_CFG_DEFAULTS);
 Object.freeze(TEST_CFG);

--- a/src/test/qa/two_step_upgrade_test.js
+++ b/src/test/qa/two_step_upgrade_test.js
@@ -15,7 +15,7 @@ const server_function = require('../utils/server_functions');
 const AzureFunctions = require('../../deploy/azureFunctions');
 
 require('../../util/dotenv').load();
-const argv = require('minimist')(process.argv);
+const argv = require('minimist')(process.argv, { string: ['secret'] });
 
 
 const TEST_CFG_DEFAULTS = {

--- a/src/test/utils/server_functions.js
+++ b/src/test/utils/server_functions.js
@@ -149,11 +149,23 @@ async function create_system_and_check(server_ip) {
 async function clean_ova_and_create_system(server_ip, secret) {
     try {
         await clean_ova(server_ip, secret);
+    } catch (e) {
+        throw new Error('clean_ova::' + e);
+    }
+    try {
         await wait_server_recoonect(server_ip);
+    } catch (e) {
+        throw new Error('wait_server_recoonect::' + e);
+    }
+    try {
         await validate_activation_code(server_ip);
+    } catch (e) {
+        throw new Error('validate_activation_code::' + e);
+    }
+    try {
         await create_system_and_check(server_ip);
     } catch (e) {
-        throw new Error(e);
+        throw new Error('create_system_and_check::' + e);
     }
 }
 


### PR DESCRIPTION
### Explain the changes
account_pipeline.js:
- Fixed a bug where sometimes the secret pass incorrectly, when we get
a secret like this ”5e227177” the minimize turn it into infinity.
This bug apply on all the places that we pass secret.

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
