### PR TITLE
added report info to upgrade error in read_system

### DIFF
--- a/frontend/src/app/reducers/topology-reducer.js
+++ b/frontend/src/app/reducers/topology-reducer.js
@@ -251,7 +251,7 @@ function _mapUpgradeState(state, upgrade) {
             return {
                 package: {
                     ...testedPkg,
-                    error
+                    error: error.message
                 }
             };
         }
@@ -280,7 +280,7 @@ function _mapUpgradeState(state, upgrade) {
         }
         case 'UPGRADE_FAILED': {
             return {
-                error,
+                error: error.message,
                 package: testedPkg
             };
         }

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -915,7 +915,15 @@ module.exports = {
                             ]
                         },
                         error: {
-                            type: 'string'
+                            type: 'object',
+                            properties: {
+                                message: {
+                                    type: 'string'
+                                },
+                                report_info: {
+                                    type: 'string'
+                                }
+                            }
                         },
                         initiator_email: {
                             type: 'string'

--- a/src/server/system_services/schemas/cluster_schema.js
+++ b/src/server/system_services/schemas/cluster_schema.js
@@ -153,6 +153,9 @@ module.exports = {
                 error: {
                     type: 'string'
                 },
+                report_info: {
+                    type: 'string'
+                },
                 initiator_email: {
                     type: 'string'
                 },

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -462,6 +462,16 @@ function read_system(req) {
         buckets_stats
     }) => {
         const cluster_info = cutil.get_cluster_info(rs_status);
+        for (const shard of cluster_info.shards) {
+            for (const server of shard.servers) {
+                const error = {
+                    message: server.upgrade.error,
+                    report_info: server.upgrade.report_info
+                };
+                server.upgrade.error = error;
+                delete server.upgrade.report_info;
+            }
+        }
         const objects_sys = {
             count: size_utils.BigInteger.zero,
             size: size_utils.BigInteger.zero,

--- a/src/server/system_services/upgrade_server.js
+++ b/src/server/system_services/upgrade_server.js
@@ -63,6 +63,8 @@ function member_pre_upgrade(req) {
                 dbg.error('UPGRADE HAD ERROR: ', res.error);
                 // TODO: Change that shit to more suitable error handler
                 upgrade.error = res.error;
+                upgrade.report_info = res.report_info;
+
                 if (req.rpc_params.stage === 'UPGRADE_STAGE') {
                     upgrade_in_process = false;
                 }


### PR DESCRIPTION
#### 1. New Features / Capabilities (Sync with Liran):
- in system_api changed upgrade error to an object with message and report_info fields

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
