### PR TITLE
adding support of noobaa alpha versions release notes

### DIFF
--- a/frontend/src/app/epics/fetch-version-release-notes.js
+++ b/frontend/src/app/epics/fetch-version-release-notes.js
@@ -18,12 +18,16 @@ export default function(action$, { fetch }) {
             const { version } = action.payload;
             const [ versionWithNoBuildNumber ] = version.split('-');
             const url = `${baseUrl}/${versionWithNoBuildNumber}.${suffix}`;
+            const alpha_url = `${baseUrl}/${versionWithNoBuildNumber}-alpha.${suffix}`;
 
             try {
-                const res = await fetch(url);
-                if (!res.ok) throw new Error(`Got HTTP: ${res.status}`);
-
-                const notes = await(res).text();
+                let res1 = await fetch(url);
+                if (!res1.ok) { 
+                    const res2 = await fetch(alpha_url);
+                    if (!res2.ok) throw new Error(`Got HTTP: ${res1.status}`);
+                    res1 = res2;
+                }
+                const notes = await(res1).text();
                 return completeFetchVersionReleaseNotes(version, notes);
 
             } catch (error) {


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- we are adding support of adding the alpha suffix to release notes we want to share with the user downloading it especially, but not letting the user know of it automatically by getting an alert
- fixing a issue with the sorting of the list of versions - by splitting the  preparing of the list from the sorting of it

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
