### PR TITLE
hack n2n_signal to include public ip as ice candidate

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -206,6 +206,12 @@ module.exports = {
                     items: {
                         type: 'string'
                     }
+                },
+                public_ips: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    }
                 }
             }
         },

--- a/src/rpc/ice.js
+++ b/src/rpc/ice.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/* eslint max-lines: ['error', 1520] */
+/* eslint max-lines: ['error', 1550] */
 'use strict';
 
 module.exports = Ice;
@@ -141,6 +141,17 @@ function Ice(connid, config, signal_target) {
             if (self.config.offer_ipv6 === false && n.family === 'IPv6') return;
             n.ifcname = name;
             self.networks.push(n);
+            // for the nodes internal ip - add public_ips as another network interface. take same parameters as internal ip
+            if (n.address === ip_module.address() &&
+                config.public_ips.length) {
+                config.public_ips.forEach(ip => {
+                    if (ip === n.address) return;
+                    const public_n = _.clone(n);
+                    public_n.address = ip;
+                    public_n.ifcname = 'public_' + name;
+                    self.networks.push(public_n);
+                });
+            }
         });
     });
 

--- a/src/rpc/rpc_n2n_agent.js
+++ b/src/rpc/rpc_n2n_agent.js
@@ -31,6 +31,7 @@ const N2N_CONFIG_FIELDS_PICK = [
     'udp_port',
     'udp_dtls',
     'stun_servers',
+    'public_ips'
 ];
 
 let global_tcp_permanent_passive;
@@ -92,6 +93,8 @@ class RpcN2NAgent extends EventEmitter {
                 // read_on_premise_stun_server()
                 // 'stun://64.233.184.127:19302' // === 'stun://stun.l.google.com:19302'
             ],
+
+            public_ips: [],
 
             // ssl options - apply for both tcp-tls and udp-dtls
             ssl_options: {

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -155,13 +155,13 @@ class ObjectIO {
                 if (!params.obj_id) throw err;
                 return params.client.object.abort_object_upload(_.pick(params, 'bucket', 'key', 'obj_id'))
                     .then(() => {
-                        dbg.log0('upload_object: aborted object upload', complete_params);
-                        throw err; // still throw to the calling request
-                    })
-                    .catch(err2 => {
-                        dbg.warn('upload_object: Failed to abort object upload', complete_params, err2);
-                        throw err; // throw the original error
-                    });
+                            dbg.log0('upload_object: aborted object upload', complete_params);
+                            throw err; // still throw to the calling request
+                        },
+                        err2 => {
+                            dbg.warn('upload_object: Failed to abort object upload', complete_params, err2);
+                            throw err; // throw the original error
+                        });
             });
     }
 

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1461,9 +1461,10 @@ class NodesMonitor extends EventEmitter {
             rpc_config.base_address = system.base_address;
         }
         // make sure we don't modify the system's n2n_config
+        const public_ips = item.node.public_ip ? [item.node.public_ip] : [];
         const n2n_config = _.extend(null,
             item.agent_info.n2n_config,
-            _.cloneDeep(system.n2n_config));
+            _.cloneDeep(system.n2n_config), { public_ips });
         if (item.node.is_cloud_node) {
             n2n_config.tcp_permanent_passive = {
                 port: config.CLOUD_AGENTS_N2N_PORT
@@ -3432,6 +3433,7 @@ class NodesMonitor extends EventEmitter {
             connection: item.connection,
         });
     }
+
 
     /**
      * n2n_proxy sends an rpc call to the target node like a proxy.


### PR DESCRIPTION
public_ip

### Explain the changes
- in n2n_signal - adding as a candidate the public IP identified by the agent.
- this will not work behind NAT but should work if the agent has a public ip in azure
- can be enabled in config.js with the flag `EXPERIMENTAL_HACK_PUBLIC_IP_CANDIDATE_IN_ICE` (false by default)

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages