### PR TITLE
Danny visualisation

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -405,8 +405,51 @@ module.exports = {
             auth: {
                 system: 'admin'
             }
-        }
+        },
+
+        get_account_usage: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['start_date', 'end_date'],
+                properties: {
+                    start_date: { idate: true },
+                    end_date: { idate: true },
+                }
+            },
+            reply: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        account: {
+                            type: 'string'
+                        },
+                        timestamp: {
+                            idate: true
+                        },
+                        read_count: {
+                            type: 'integer'
+                        },
+                        write_count: {
+                            type: 'integer'
+                        },
+                        read_bytes: {
+                            $ref: 'common_api#/definitions/bigint'
+                        },
+                        write_bytes: {
+                            $ref: 'common_api#/definitions/bigint'
+                        },
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
     },
+
 
 
     definitions: {

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -224,12 +224,10 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
-                required: ['period'],
+                required: ['start_date', 'end_date'],
                 properties: {
-                    period: {
-                        type: 'string',
-                        enum: ['DAY', 'WEEK', 'MONTH']
-                    },
+                    start_date: { idate: true },
+                    end_date: { idate: true },
                 }
             },
             reply: {

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -179,6 +179,44 @@ module.exports = {
             }
         },
 
+        get_nodes_stats_by_cloud_service: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                properties: {
+                    start_date: { idate: true },
+                    end_date: { idate: true },
+                }
+            },
+            reply: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        service: {
+                            type: 'string',
+                            enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE']
+                        },
+                        read_count: {
+                            type: 'integer'
+                        },
+                        write_count: {
+                            type: 'integer'
+                        },
+                        read_bytes: {
+                            $ref: 'common_api#/definitions/bigint'
+                        },
+                        write_bytes: {
+                            $ref: 'common_api#/definitions/bigint'
+                        },
+                    }
+                },
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
         aggregate_nodes: {
             method: 'GET',
             params: {

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -277,6 +277,7 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
+                required: ['start_date', 'end_date'],
                 properties: {
                     start_date: { idate: true },
                     end_date: { idate: true },

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -272,6 +272,46 @@ module.exports = {
             }
         },
 
+        get_cloud_services_stats: {
+            doc: 'Return cloud services usage',
+            method: 'GET',
+            params: {
+                type: 'object',
+                properties: {
+                    start_date: { idate: true },
+                    end_date: { idate: true },
+                }
+            },
+            reply: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        service: {
+                            type: 'string',
+                            enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE']
+                        },
+                        read_count: {
+                            type: 'integer'
+                        },
+                        write_count: {
+                            type: 'integer'
+                        },
+                        read_bytes: {
+                            $ref: 'common_api#/definitions/bigint'
+                        },
+                        write_bytes: {
+                            $ref: 'common_api#/definitions/bigint'
+                        },
+                    },
+
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
         get_pool_history: {
             doc: 'Return usage history for the specified pools',
             method: 'GET',

--- a/src/server/analytic_services/io_stats_store.js
+++ b/src/server/analytic_services/io_stats_store.js
@@ -58,12 +58,15 @@ class IoStatsStore {
         this._io_stats.validate(res.value, 'warn');
     }
 
-    async get_all_nodes_stats({ system }) {
+    async get_all_nodes_stats({ system, start_date, end_date }) {
+        let start_time;
+        if (start_date || end_date) start_time = _.omitBy({ $gte: start_date, $lte: end_date }, _.isUndefined);
         return this._io_stats.col().aggregate([{
-            $match: {
+            $match: _.omitBy({
                 system,
-                resource_type: 'NODE'
-            }
+                resource_type: 'NODE',
+                start_time
+            }, _.isUndefined)
         }, {
             $group: {
                 _id: '$resource_id',

--- a/src/server/node_services/node_server.js
+++ b/src/server/node_services/node_server.js
@@ -119,6 +119,7 @@ exports.list_nodes = list_nodes;
 exports.aggregate_nodes = aggregate_nodes;
 exports.get_test_nodes = req => monitor.get_test_nodes(req);
 exports.allocate_nodes = allocate_nodes;
+exports.get_nodes_stats_by_cloud_service = req => monitor.get_nodes_stats_by_cloud_service(req);
 exports.get_node_ids = req => monitor.get_node_ids(req);
 exports.aggregate_data_free_by_tier = req => nodes_aggregator.aggregate_data_free_by_tier(req);
 exports.migrate_nodes_to_pool = req => monitor.migrate_nodes_to_pool(req);

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -57,6 +57,15 @@ class NodesClient {
             .tap(res => mongo_utils.fix_id_type(res.nodes));
     }
 
+    get_nodes_stats_by_cloud_service(system_id, start_date, end_date) {
+        return server_rpc.client.node.get_nodes_stats_by_cloud_service({ start_date, end_date }, {
+            auth_token: auth_server.make_auth_token({
+                system_id: system_id,
+                role: 'admin'
+            })
+        });
+    }
+
     aggregate_nodes_by_pool(pool_names, system_id, skip_cloud_nodes, skip_mongo_nodes) {
         const nodes_aggregate_pool = server_rpc.client.node.aggregate_nodes({
             query: {

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -428,6 +428,11 @@ function get_associated_buckets(req) {
     return get_associated_buckets_int(pool);
 }
 
+async function get_cloud_services_stats(req) {
+    const { start_date, end_date } = req.rpc_params;
+    return nodes_client.instance().get_nodes_stats_by_cloud_service(req.system._id, start_date, end_date);
+}
+
 function get_pool_history(req) {
     let pool_list = req.rpc_params.pool_list;
     return HistoryDataStore.instance().get_pool_history()
@@ -557,9 +562,8 @@ function get_pool_info(pool, nodes_aggregate_pool, hosts_aggregate_pool) {
         storage: _.defaults(size_utils.to_bigint_storage(p_nodes.storage), POOL_STORAGE_DEFAULTS),
         region: pool.region,
         create_time: pool._id.getTimestamp().getTime(),
-        io_stats: Object.assign(
-             { read_count: 0, write_count: 0, read_bytes: 0, write_bytes: 0 },
-             _.pick(p_nodes.io_stats, 'read_count', 'write_count', 'read_bytes', 'write_bytes')
+        io_stats: Object.assign({ read_count: 0, write_count: 0, read_bytes: 0, write_bytes: 0 },
+            _.pick(p_nodes.io_stats, 'read_count', 'write_count', 'read_bytes', 'write_bytes')
         )
     };
     info.data_activities = {
@@ -774,5 +778,6 @@ exports.assign_hosts_to_pool = assign_hosts_to_pool;
 exports.assign_nodes_to_pool = assign_nodes_to_pool;
 exports.get_associated_buckets = get_associated_buckets;
 exports.get_pool_history = get_pool_history;
+exports.get_cloud_services_stats = get_cloud_services_stats;
 exports.get_namespace_resource_extended_info = get_namespace_resource_extended_info;
 exports.assign_pool_to_region = assign_pool_to_region;


### PR DESCRIPTION
### Explain the changes
#### 1. Added analytics:
- in `pool_api` - added `get_cloud_service_stats` which return read\write count\size for a given period of time
- in `bucket_api` - changed get_bucket_throughtput to get start\end date as parameter instead of DAY\WEEK\MONTH. returns in a resolution of hour if less than 30 days, and resolution of days if more.
- in `account_api` - added get_account_usage to return read\write usage stats for all counts, for a given period of time. returns in a resolution of hour if less than 30 days, and resolution of days if more.
#### 1. Missing(!!) analytics:
- in `bucket_api` - get_buckets_stats_by_content_type should return also the raw usage for each content type. this can only be calculated in md_aggregator


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages