### PR TITLE
Fixing agent connection in dns name change

### DIFF
--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -1138,7 +1138,9 @@ function update_hostname(req) {
     // Helper function used to solve missing infromation on the client (SSL_PORT)
     // during create system process
 
-    if (req.rpc_params.hostname !== null) {
+    // Patch in order to make sure that we won't push IP as base_address
+    // This is done since the FE doesn't send null (should be done on FE end and not here)
+    if (req.rpc_params.hostname !== null && !net.isIP(req.rpc_params.hostname)) {
         req.rpc_params.base_address = 'wss://' + req.rpc_params.hostname + ':' + process.env.SSL_PORT;
     }
 


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes

When setting back to use IP instead of DNS name we inserted the IP as the base_address of the system.

#### 1. New Features / Capabilities (Sync with Liran):
- 

#### 2. Existing Behavior Changes (Sync with Liran):
- Remove the base_address from the system configuration when going back to using IP instead of DNS name. Currently, we just saved the IP as the base_address.

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- Fixed #5084 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
