### PR TITLE
fixed agent issues with reconnecting to the server

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -371,9 +371,10 @@ class Agent {
                     timeout: MASTER_RESPONSE_TIMEOUT,
                 });
 
+                dbg.log0('heartbeat successful. connected to server. got reply', req.reply);
+
                 const res = req.reply;
                 const conn = req.connection;
-                const is_new_conn = (conn !== this._server_connection);
                 this._server_connection = conn;
                 this.connect_attempts = 0;
 
@@ -390,16 +391,15 @@ class Agent {
                     this.send_message_and_exit('UPGRADE', 0);
                 }
 
-                if (is_new_conn) {
-                    conn.on('close', async () => {
-                        if (this._server_connection === conn) {
-                            this._server_connection = null;
-                        }
-                        if (!this.is_started) return;
-                        await P.delay(1000);
-                        await this._do_heartbeat();
-                    });
-                }
+
+                conn.once('close', async () => {
+                    if (this._server_connection === conn) {
+                        this._server_connection = null;
+                    }
+                    if (!this.is_started) return;
+                    await P.delay(1000);
+                    await this._do_heartbeat();
+                });
 
                 done = true;
 

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -293,6 +293,8 @@ class NodesMonitor extends EventEmitter {
             delay_ms: 0 // delay_ms was required in 0.3.X
         };
 
+        dbg.log0(`got heartbeat ${node_id ? 'for node_id ' + node_id : 'for a new node'} `);
+
         // since the heartbeat api is dynamic through new versions
         // if we detect that this is a new version we return immediately
         // with the new version so that the agent will update the code first
@@ -307,6 +309,7 @@ class NodesMonitor extends EventEmitter {
 
         //If this server is not the master, redirect the agent to the master
         if (!this._is_master()) {
+            dbg.log0('this is not the master node - redirecting to master');
             return P.resolve(cluster_server.redirect_to_cluster_master())
                 .then(addr => {
                     reply.redirect = url.format({
@@ -315,6 +318,7 @@ class NodesMonitor extends EventEmitter {
                         hostname: addr,
                         port: process.env.SSL_PORT || 8443
                     });
+                    dbg.log0('return redirect respose to address', reply.redirect);
                     return reply;
                 });
         }
@@ -329,6 +333,7 @@ class NodesMonitor extends EventEmitter {
 
         // existing node heartbeat
         if (node_id && (req.role === 'agent' || req.role === 'admin')) {
+            dbg.log0('connecting exiting node with node_id =', node_id);
             this._connect_node(req.connection, node_id);
             return reply;
         }
@@ -338,6 +343,7 @@ class NodesMonitor extends EventEmitter {
         if (!node_id && (req.role === 'create_node' || req.role === 'admin')) {
             let agent_config = (extra.agent_config_id && system_store.data.get_by_id(extra.agent_config_id)) || {};
             this._add_new_node(req.connection, req.system._id, agent_config, req.rpc_params.pool_name);
+            dbg.log0('connecting new node with agent_config =', agent_config);
             return reply;
         }
 


### PR DESCRIPTION
### Explain the changes
- in agent.js `do_heartbeat` we did not add a listener to the close event if the connection was not chaged.
- for some reason after the connection was disconnected, in the cases a listener was not added, do_heartbeat was not called again (it should have since we used `connection.on('close') which should stay forever`)
- changed to always listen with `once` instead of `on`. now do_heartbeat is always called again after disconnections.

### Issues: Fixed #xxx / Gap #xxx
- Fixes #5103 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
