### PR TITLE
separate base_address and master_address in agent.js

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -53,7 +53,7 @@ const location_info = {};
 
 function start_all() {
     dbg.set_process_name('Endpoint');
-    if (cluster.isMaster && config.ENDPOINT_FORKS_ENABLED && argv.address) {
+    if (cluster.isMaster && config.ENDPOINT_FORKS_ENABLED && argv.address && !argv.s3_agent) {
         // Fork workers
         const NUM_OF_FORKS = (os.totalmem() >= (config.SERVER_MIN_REQUIREMENTS.RAM_GB * size_utils.GIGABYTE)) ? numCPUs : 1;
         for (let i = 0; i < NUM_OF_FORKS; i++) {


### PR DESCRIPTION
### Explain the changes
- in `agent.js` - separated `base_address` and `master_address` into 2 separate members.
- `base_address` is only used for the first connection and is updated in `agent_conf.json` when DNS name is changed in the system
- `master_address` is changed on every master change and is not stored in `agent_conf.json`


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
