### PR TITLE
aggregate objects size\count by content type

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -726,6 +726,7 @@ class MDStore {
         });
     }
 
+
     /**
      * _aggregate_objects_internal - counts the number of objects and sum of sizes,
      * both for the entire query, and per bucket.
@@ -742,9 +743,12 @@ class MDStore {
         );
         const buckets = {};
         _.forEach(res, r => {
-            const b = buckets[r._id[0]] || {};
-            buckets[r._id[0]] = b;
-            b[r._id[1]] = r.value;
+            r._id.reduce((o, s, i, arr) => {
+                o[s] = i < arr.length - 1 ?
+                    o[s] || {} :
+                    o[s] = r.value;
+                return o[s];
+            }, buckets);
         });
         return buckets;
     }

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -92,6 +92,20 @@ module.exports = {
                 chunks_capacity: bigint,
                 blocks_size: bigint,
                 objects_size: bigint,
+                stats_by_content_type: {
+                    type: 'object',
+                    additionalProperties: {
+                        type: 'object',
+                        required: ['size', 'count'],
+                        properties: {
+                            size: bigint,
+                            count: {
+                                type: 'integer'
+                            },
+                        }
+                    },
+                    properties: {}
+                },
                 objects_count: {
                     type: 'integer'
                 },

--- a/src/test/unit_tests/test_md_aggregator_unit.js
+++ b/src/test/unit_tests/test_md_aggregator_unit.js
@@ -166,6 +166,7 @@ mocha.describe('md_aggregator', function() {
                 blocks_size: storage_stats.blocks_size + added_block.buckets['123'].size - deleted_block.buckets['123'].size,
                 objects_size: storage_stats.objects_size + added_object['123'].size - deleted_object['123'].size,
                 objects_count: storage_stats.objects_count + added_object['123'].count - deleted_object['123'].count,
+                stats_by_content_type: {},
                 pools: {
                     '890': {
                         blocks_size: storage_stats.pools['890'].blocks_size +

--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -84,6 +84,8 @@ function map_aggregate_objects() {
     }
     emit([this.bucket, 'count_pow2_' + pow], 1);
     emit([this.bucket, 'size_pow2_' + pow], this.size);
+    emit([this.bucket, 'content_type', this.content_type, 'count'], 1);
+    emit([this.bucket, 'content_type', this.content_type, 'size'], this.size);
 }
 
 /**


### PR DESCRIPTION
### Explain the changes
- store in buckets collection the size\count of objects by their content-type
- added emit by content_type in `mongo_functions.map_aggregate_objects`
- added to support analytics\graphs in UI

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages