### PR TITLE
namespace_test.js: Fixing the use of md5 according to the changes in s3ops

### DIFF
--- a/src/test/utils/s3ops.js
+++ b/src/test/utils/s3ops.js
@@ -664,7 +664,8 @@ class S3OPS {
         console.log('Reading object ', key);
         try {
             //There can be an issue if the object size (length) is too large
-            await this.s3.getObject(params).promise();
+            const obj = await this.s3.getObject(params).promise();
+            return obj;
         } catch (err) {
             console.error(`get_object:: getObject ${JSON.stringify(params)} failed!`, err);
             throw err;
@@ -686,6 +687,10 @@ class S3OPS {
             console.error(`get_object_range:: getObject ${JSON.stringify(params)} failed!`, err);
             throw err;
         }
+    }
+
+    get_file_md5(bucket, file_name) {
+        return verify_md5_map.get(`${this.system_verify_name}/${bucket}/${file_name}`);
     }
 
     async abort_multipart_upload(bucket, file_name, uploadId) {


### PR DESCRIPTION
### Explain the changes
namespace_test.js:
- Fixing the use of md5 according to the changes in s3ops

s3ops.js:
- Add get_file_md5 function that return the md5 of a file.

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
