### PR TITLE
disable metadata for all s3 compatible resources

### DIFF
--- a/config.js
+++ b/config.js
@@ -223,11 +223,12 @@ config.DB_CLEANER = {
 // connect directly to the cloud target (and not via a signed url)
 config.EXPERIMENTAL_DISABLE_S3_COMPATIBLE_DELEGATION = {
     DEFAULT: false,
-    FLASHBLADE: true
+    FLASHBLADE: true,
 };
 config.EXPERIMENTAL_DISABLE_S3_COMPATIBLE_METADATA = {
     DEFAULT: false,
-    FLASHBLADE: true
+    FLASHBLADE: true,
+    S3_COMPATIBLE: true,
 };
 
 config.DEFAULT_S3_AUTH_METHOD = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",

--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -163,7 +163,7 @@ class BlockStoreClient {
 
                         // if not OK parse the error and throw Error object
                         if (res.statusCode !== 200) {
-                            return this._throw_s3_err(res);
+                            await this._throw_s3_err(res);
                         }
 
                     }
@@ -249,7 +249,7 @@ class BlockStoreClient {
 
                         } else {
                             // parse the error and throw Error object
-                            return this._throw_s3_err(res);
+                            await this._throw_s3_err(res);
                         }
                     }
 
@@ -270,7 +270,7 @@ class BlockStoreClient {
 
     }
 
-    _throw_s3_err(res) {
+    async _throw_s3_err(res) {
         return P.fromCallback(callback => xml2js.parseString(res.body, callback))
             .then(xml_obj => {
                 let err;

--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -151,6 +151,8 @@ class BlockStoreS3 extends BlockStoreBase {
         this._update_read_stats(block_md.size);
 
         return {
+            disable_delegation: this.disable_delegation,
+            disable_metadata: this.disable_metadata,
             signed_url: this.s3cloud.getSignedUrl('getObject', params),
             proxy: this.proxy
         };
@@ -196,6 +198,8 @@ class BlockStoreS3 extends BlockStoreBase {
         const signed_url = this.s3cloud.getSignedUrl('putObject', params);
 
         return {
+            disable_delegation: this.disable_delegation,
+            disable_metadata: this.disable_metadata,
             usage,
             signed_url,
             proxy: this.proxy

--- a/src/api/block_store_api.js
+++ b/src/api/block_store_api.js
@@ -48,7 +48,7 @@ module.exports = {
             method: 'POST',
             params: {
                 type: 'object',
-                additionalProperties: true,
+                required: ['op_type'],
                 properties: {
                     error: {
                         type: 'object',
@@ -57,7 +57,7 @@ module.exports = {
                     },
                     usage: { // the usage that was counted for failed operation - need to undo
                         type: 'object',
-                        required: ['size', 'count', 'op_type'],
+                        required: ['size', 'count'],
                         properties: {
                             size: {
                                 type: 'integer'
@@ -65,12 +65,13 @@ module.exports = {
                             count: {
                                 type: 'integer'
                             },
-                            op_type: {
-                                type: 'string',
-                                enum: ['READ', 'WRITE']
-                            }
                         }
+                    },
+                    op_type: {
+                        type: 'string',
+                        enum: ['READ', 'WRITE']
                     }
+
                 }
             }
         },


### PR DESCRIPTION
### Explain the changes
- for all S3 compatible, don't write metadata to workaround a bug of validating signed urls with metadata (noobaa\ceph bug)

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
