### PR TITLE
some fixes to analytics in BE

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -224,7 +224,7 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
-                required: ['since', 'till', 'resolution'],
+                required: ['since', 'till', 'resolution', 'buckets'],
                 properties: {
                     buckets: {
                         type: 'array',


### PR DESCRIPTION
### Explain the changes
- sum aggregated sizes as bigint
- normalize account usage since\till queries to start\end of an hour
- require buckets in `get_bucket_throughput_usage`

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
