### PR TITLE
store content_type stats in mongo as array instead of sub document

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1175,7 +1175,8 @@ function get_bucket_info({
             last_write: bucket_stats.last_write || 0,
         };
         // group stats by the first part of the content type and reduce
-        const size_by_content_type = _.get(bucket, 'storage_stats.stats_by_content_type', {});
+        const content_type_stats = _.get(bucket, 'storage_stats.stats_by_content_type', []);
+        const size_by_content_type = _.keyBy(content_type_stats, 'content_type');
         const full_stats = bucket_stats.stats.map(stat => ({
             data_type: stat.content_type.split('/')[0],
             reads: stat.reads || 0,

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -93,18 +93,20 @@ module.exports = {
                 blocks_size: bigint,
                 objects_size: bigint,
                 stats_by_content_type: {
-                    type: 'object',
-                    additionalProperties: {
+                    type: 'array',
+                    items: {
                         type: 'object',
                         required: ['size', 'count'],
                         properties: {
+                            content_type: {
+                                type: 'string'
+                            },
                             size: bigint,
                             count: {
                                 type: 'integer'
                             },
                         }
-                    },
-                    properties: {}
+                    }
                 },
                 objects_count: {
                     type: 'integer'

--- a/src/test/unit_tests/test_md_aggregator_unit.js
+++ b/src/test/unit_tests/test_md_aggregator_unit.js
@@ -166,7 +166,7 @@ mocha.describe('md_aggregator', function() {
                 blocks_size: storage_stats.blocks_size + added_block.buckets['123'].size - deleted_block.buckets['123'].size,
                 objects_size: storage_stats.objects_size + added_object['123'].size - deleted_object['123'].size,
                 objects_count: storage_stats.objects_count + added_object['123'].count - deleted_object['123'].count,
-                stats_by_content_type: {},
+                stats_by_content_type: [],
                 pools: {
                     '890': {
                         blocks_size: storage_stats.pools['890'].blocks_size +


### PR DESCRIPTION
### Explain the changes
- changed to array to avoid problems when content_type contains dots

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
