### PR TITLE
Fixing multipart copy uploads

### DIFF
--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -35,7 +35,9 @@ async function put_object(req, res) {
         res.setHeader('x-amz-version-id', reply.version_id);
     }
     if (copy_source) {
-        if (reply.copy_source.version_id) res.setHeader('x-amz-copy-source-version-id', reply.copy_source.version_id);
+        // TODO: This needs to be checked regarding copy between diff namespaces
+        // In that case we do not have the copy_source property and just read and upload the stream
+        if (reply.copy_source && reply.copy_source.version_id) res.setHeader('x-amz-copy-source-version-id', reply.copy_source.version_id);
         return {
             CopyObjectResult: {
                 // TODO S3 last modified and etag should be for the new part

--- a/src/endpoint/s3/ops/s3_put_object_uploadId.js
+++ b/src/endpoint/s3/ops/s3_put_object_uploadId.js
@@ -31,6 +31,7 @@ function put_object_uploadId(req, res) {
             source_md_conditions: http_utils.get_md_conditions(req, 'x-amz-copy-source-'),
         })
         .then(reply => {
+            // TODO: We do not return the VersionId of the object that was copied
             res.setHeader('ETag', `"${reply.etag}"`);
             if (copy_source) {
                 return {

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -3039,7 +3039,7 @@ class NodesMonitor extends EventEmitter {
         _.each(list, item => {
             count += 1;
             if (item.node.node_type === 'ENDPOINT_S3') {
-                s3_count += 1;
+                if (item.node.enabled) s3_count += 1;
                 s3_by_mode[item.mode] = (s3_by_mode[item.mode] || 0) + 1;
                 if (item.online) s3_online += 1;
             } else {

--- a/src/test/unit_tests/test_map_builder.js
+++ b/src/test/unit_tests/test_map_builder.js
@@ -198,7 +198,7 @@ coretest.describe_mapper_test_case({
     }
 
     async function assert_fully_built(obj) {
-        const { key, data, chunks } = obj;
+        const { key, data, chunks, obj_id } = obj;
         _.forEach(chunks, chunk => {
             console.log('Checking chunk fully built', chunk);
             const tiering = system_store.data.systems[0].buckets_by_name[bucket].tiering;
@@ -222,7 +222,7 @@ coretest.describe_mapper_test_case({
             assert.strictEqual(mapping.missing_frags, undefined);
         });
 
-        const read_data = await object_io.read_entire_object({ client: rpc_client, bucket, key });
+        const read_data = await object_io.read_entire_object({ client: rpc_client, bucket, key, obj_id });
 
         assert.deepStrictEqual(read_data, data);
     }


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
Added the loading of object_md in case of multipart upload copy from existing objects.

#### 1. New Features / Capabilities (Sync with Liran):
- 

#### 2. Existing Behavior Changes (Sync with Liran):
- We did not load the object in order to copy parts from him
- We always copied the last undefined-ranges keys from the cache
- Which means that when we had multiple parallel multipart copy uploads we just took different content.
- Existing unit tests validation and verification of data was wrong as well.
- Namespace copy included.

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- Fixes #5111
- Gep #5156 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
