### PR TITLE
Danny master

### DIFF
--- a/src/deploy/NVA_build/mongo_wrapper.sh
+++ b/src/deploy/NVA_build/mongo_wrapper.sh
@@ -63,15 +63,6 @@ function run_mongo {
   deploy_log "run_mongo: Mongo started"
 }
 
-case $1 in
-  --testsystem)
-    testsys="--testsystem"
-    shift
-    ;;
-  *)
-    ;;
-esac
-
 MONGO_EXEC="$@"
 deploy_log "mongo_wrapper was run with args ${MONGO_EXEC}"
 backoff=$(cat $BACKOFF_FILE)

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -372,7 +372,6 @@ function create_system(req) {
             }
         })
         .then(() => _init_system(system_id))
-        .then(() => system_utils.mongo_wrapper_system_created())
         .then(() => {
             dbg.log0(`sending first stats to phone home`);
             return server_rpc.client.stats.send_stats(null, {

--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -195,14 +195,6 @@ MongoCtrl.prototype.update_dotenv = function(name, IPs) {
 
 };
 
-MongoCtrl.prototype.update_wrapper_sys_check = function() {
-    let new_mongo_wrapper = _.clone(_.find(this._mongo_services, prog => prog.name === 'mongo_wrapper'));
-    new_mongo_wrapper.command = new_mongo_wrapper.command.replace(new RegExp('mongod'), 'mongod --testsystem ');
-    return this._remove_single_mongo_program()
-        .then(() => SupervisorCtl.add_program(new_mongo_wrapper))
-        .then(() => SupervisorCtl.apply_changes());
-};
-
 MongoCtrl.prototype.set_debug_level = function(level) {
     return mongo_client.instance().set_debug_level(level);
 };

--- a/src/server/utils/system_utils.js
+++ b/src/server/utils/system_utils.js
@@ -35,20 +35,10 @@ function get_bucket_quota_usage_percent(bucket, bucket_quota) {
     return used_percent.valueOf();
 }
 
-// Update mongo_wrapper on system created
-// This will cause more tests to be run in mongo_wrapper
-function mongo_wrapper_system_created() {
-    if (os_utils.is_supervised_env()) {
-        return MongoCtrl.init()
-            .then(() => console.log('Skipping mongo_wrapper update')); /*MongoCtrl.update_wrapper_sys_check()*/
-    }
-}
-
 function prepare_chunk_for_mapping(chunk) {
     chunk.chunk_coder_config = system_store.data.get_by_id(chunk.chunk_config).chunk_coder_config;
 }
 
 exports.system_in_maintenance = system_in_maintenance;
 exports.get_bucket_quota_usage_percent = get_bucket_quota_usage_percent;
-exports.mongo_wrapper_system_created = mongo_wrapper_system_created;
 exports.prepare_chunk_for_mapping = prepare_chunk_for_mapping;

--- a/src/server/utils/system_utils.js
+++ b/src/server/utils/system_utils.js
@@ -2,9 +2,7 @@
 'use strict';
 
 const size_utils = require('../../util/size_utils');
-const os_utils = require('../../util/os_utils');
 const system_store = require('../system_services/system_store').get_instance();
-const MongoCtrl = require('./mongo_ctrl');
 
 function system_in_maintenance(system_id) {
     const system = system_store.data.get_by_id(system_id);

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -141,7 +141,10 @@ class UpgradeManager {
             }]
         };
         dbg.log0('UPGRADE: updating upgrade in db', updates);
-        await system_store.make_changes({ update });
+        await system_store.make_changes_with_retries({ update }, {
+            max_retries: 10,
+            delay: 5000
+        });
     }
 
     async set_upgrade_stage(stage) {

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -560,3 +560,4 @@ if (require.main === module) {
 //Exports
 exports.pre_upgrade = pre_upgrade;
 exports.do_upgrade = do_upgrade;
+exports.pre_upgrade_failure_error = ERROR_MAPPING.COULD_NOT_RUN_TESTS;


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
- in `check_mongo_status`, which is used by mongo_wrapper to monitor mongodb - keep retrying the test for ~1 minute before failing the test and killing mongod
- added `make_changes_with_retries` to retry make_changes after failures.
   - in upgrade flows using make_changes_with_retries instead of the regular one

### Issues: Fixed #xxx / Gap #xxx
- Fixes #5151 

### Testing Instructions:
- upgrade tests
- in a clustered system, check that mongo is not being killed unnecessarily (e.g. when there are no mongo related errors in the services). 

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages