### PR TITLE
Fixes for mongo_back_off visibility and cap to 5m

### DIFF
--- a/src/deploy/NVA_build/mongo_wrapper.sh
+++ b/src/deploy/NVA_build/mongo_wrapper.sh
@@ -45,7 +45,7 @@ function mongo_sanity_check {
     sleep 10
   done
   deploy_log "mongo_sanity_check: Failed"
-  if [ ${backoff} -lt 512 ]; then
+  if [ ${backoff} -lt 300 ]; then
     echo $((backoff*2)) > ${BACKOFF_FILE}
   fi
   return 1


### PR DESCRIPTION
![Tests](https://gdurl.com/jz2I)

### Explain the changes
#### 2. Existing Behavior Changes (Sync with Liran):
- Cap mongo_wrapper_backoff to 5m
- Show current backoff when running supervisorctl (overload a func in bashrc)


### Issues: Fixed #xxx / Gap #xxx
- Fixes #5149

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
