### PR TITLE
change mongo kill signal from SIGKILL to SIGINT

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -261,7 +261,7 @@ function install_mongo {
     
     if [ "${container}" = "docker" ]; then
         local mongod_pid=$(pgrep -lf mongod | awk '{print $1}')
-        kill -9 ${mongod_pid}
+        kill -2 ${mongod_pid}
     fi
     deploy_log "install_mongo done"
 }

--- a/src/deploy/NVA_build/mongo_wrapper.sh
+++ b/src/deploy/NVA_build/mongo_wrapper.sh
@@ -11,71 +11,153 @@ deploy_log "MONGO_PORT is: ${MONGO_PORT}"
 BACKOFF_FILE="/tmp/mongo_wrapper_backoff"
 #Mongo uses two ports
 #27000 is currently the port for cluster
-#27015 is the port for a single server
+#27017 is the port for a single server
 if [ ${MONGO_PORT} -eq '27000' ]; then
-  set_mongo_cluster_mode
+  set_mongo_cluster_mode ${MONGO_PORT}
 fi
+
+
+trap stop_mongo INT
+
+function stop_mongo {
+  deploy_log "got SIGINT. stopping mongo and exit"
+  kill_mongo_services
+  deploy_log "mongo_wrapper exiting with code 0"
+  exit 0
+}
+
+
+function kill_mongo_services_with_signal {
+  local sig=$1
+  shift 1
+  local pids=$*
+  #only if there are pids to kill then send the signal
+  if [ ! -z "${pids}" ]; then 
+    deploy_log "killing mongo processes with signal ${sig}. PIDs=${pids}"
+    kill ${sig} ${pids}
+  fi
+}
+
+function get_live_pids {
+  local pids=$*
+  local live_pids=()
+  for pid in ${pids}; do
+    kill -0 ${pid} &> /dev/null
+    if [ $? -eq 0 ]; then
+      #if pid is still alive, make sure it's mongod\mongo_wrapper and add to live_pids
+      ps -elf | grep "${pid}.*mongo" | grep -v grep > /dev/null
+      if [ $? -eq 0 ]; then
+        live_pids+=($pid)
+      fi
+    fi
+  done
+  echo "${live_pids[@]}"
+}
 
 #Killing all of the procs that hold the desired port
 #Since mongo has a dedicated port nobody should hold it
 #Probably the only procs that will actually hold the ports
 #Are non supervised mongos, so we kill them in order to supervise
-function kill_services_on_mongo_ports {
-  local proc
-  proc=$(lsof -i TCP:27017,27000 -s TCP:LISTEN | awk '{print $2}' | grep -v PID)
-  #kill pids
-  for p in ${proc}; do
-    deploy_log "Killing process that listens on mongo ports - pid ${p} - $(cat /proc/${p}/cmdline)"
-    kill -9 ${p}
-  done
-
-  proc=$(ps -elf | grep mongo_wrapper | grep -v $$ | awk '{print $4}')
-  for p in ${proc}; do
-    deploy_log "Killing mongo_wrapper ${p}"
-    kill -9 ${p}
-  done
+function kill_mongo_services {
+  # list both mongod and mongo_wrapper processes
+  mongo_ports_procs=$(lsof -i TCP:27017,27000 -s TCP:LISTEN | awk '{print $2}' | grep -v PID)
+  mongo_wrapper_procs=$(ps -elf | grep "NVA_build/mongo_wrapper" | grep -v $$ | grep -v grep | awk '{print $4}')
+  deploy_log "killing mongo_wrapper and mongod processes ${mongo_ports_procs} ${mongo_wrapper_procs} ${MONGO_PID}"
+  #first attempt to kill using SIGINT. if process are still alive use SIGKILL
+  kill_mongo_services_with_signal -2 ${mongo_ports_procs} ${mongo_wrapper_procs} ${MONGO_PID}
+  #sleep for a second and then recheck. if not all mongo\wrappers are dead then wait some more and kill with -9
+  sleep 1
+  local live_pids=($(get_live_pids ${mongo_ports_procs} ${mongo_wrapper_procs} ${MONGO_PID}))
+  if [ ${#live_pids[@]} -ne 0 ]; then
+    echo "there are still live mongo services. pids=${live_pids[@]}"
+    sleep 5
+    kill_mongo_services_with_signal -9 $(get_live_pids ${live_pids[@]})
+  fi
 }
 
 #Testing mongo for sanity every 10 seconds
 #TODO: Maybe change the time?!
 function mongo_sanity_check {
-  while check_mongo_status $1 ${MONGO_PORT}
+  #make sure mongo pid exists
+  kill -0 ${MONGO_PID} &> /dev/null
+  if [ $? -ne 0 ]; then
+      deploy_log "could not find mongo pid ${MONGO_PID}"
+      return 1
+  fi
+  
+  #before starting sanity check, make sur mongod is up and listening on its port
+  wait_for_mongo_to_start
+  if [ $? -eq 1 ]; then
+    return 1
+  fi
+
+  local backoff=$(cat $BACKOFF_FILE)
+  while check_mongo_status ${MONGO_PORT} ${MONGO_PID}
   do
     echo 1 > ${BACKOFF_FILE}
     sleep 10
   done
   deploy_log "mongo_sanity_check: Failed"
-  if [ ${backoff} -lt 300 ]; then
-    echo $((backoff*2)) > ${BACKOFF_FILE}
+  if [ ${backoff} -lt 120 ]; then
+    backoff=$((backoff*2))
   fi
+  echo ${backoff} > ${BACKOFF_FILE}
   return 1
 }
 
-#MONGO_EXEC varies and can be either for cluster or single mongo
-function run_mongo {
-  local proc
-  deploy_log "run_mongo: Starting mongo process"
-  # running MONGO_EXEC & makes mongod son of init (ppid=1). this is ok (probably?) and it is still killed 
-  # when mongo_wrapper is killed by supervisord
-  proc=$($MONGO_EXEC &)
-  deploy_log "run_mongo: Mongo process pid: ${proc}"
-  wait_for_mongo
-  deploy_log "run_mongo: Mongo started"
+function min {
+  echo $(($1>$2?$2:$1))
+}
+
+
+function backoff_before_start {
+  local backoff=$(cat $BACKOFF_FILE)
+  local time_since_backoff_written=$(( $(date +%s) - $(stat ${BACKOFF_FILE} -c "%Y") ))
+  deploy_log "backoff file was written ${time_since_backoff_written} seconds ago. backoff is ${backoff}"
+  local sleep_time=$(( backoff - time_since_backoff_written ))
+  # sleep the time left since backoff is written
+  if [ ${sleep_time} -gt 0 ]; then
+    sleep_time=$(min ${sleep_time} ${backoff})
+    deploy_log "sleeping for ${sleep_time} seconds"
+    sleep ${sleep_time}
+  fi
+}
+
+
+function wait_for_mongo_to_start {
+  deploy_log "waiting for mongod (pid=${MONGO_PID}) to start listening on port ${MONGO_PORT}"
+  local mongo_listening_pid=$(lsof -i TCP:${MONGO_PORT} -s TCP:LISTEN | awk '{print $2}' | grep -v PID)
+  local retries=0
+  local MAX_RETRIES=120
+  local RETRY_DELAY=5
+  while [ "$mongo_listening_pid" != "${MONGO_PID}" ]; do
+    deploy_log "mongod is still not listening on port ${MONGO_PORT}. test again in 5 seconds"
+    retries=$((retries+1))
+    if [ $retries -eq ${MAX_RETRIES} ]; then
+      deploy_log "mongod failed to start for $((${MAX_RETRIES}*${RETRY_DELAY}/60)) minutes. aborting.."
+      return 1
+    fi
+    sleep ${RETRY_DELAY}
+    mongo_listening_pid=$(lsof -i TCP:${MONGO_PORT} -s TCP:LISTEN | awk '{print $2}' | grep -v PID)
+  done
+  deploy_log "mongod (pid=${MONGO_PID}) is now listening on port ${MONGO_PORT}"
 }
 
 MONGO_EXEC="$@"
 deploy_log "mongo_wrapper was run with args ${MONGO_EXEC}"
-backoff=$(cat $BACKOFF_FILE)
-deploy_log "backoff is ${backoff}, sleeping"
-sleep ${backoff}
+
+backoff_before_start
+
 #First of all we kill proc that hold the desired port
-kill_services_on_mongo_ports
-#Limit run time so it won't get stuck in infinite loop on waiting for mongo
-timeout --signal=SIGINT 60 cat <( run_mongo )
+kill_mongo_services
+$MONGO_EXEC &
+MONGO_PID=$!
+deploy_log "mongod pid is ${MONGO_PID}"
 #Test sanity of mongo in order to catch problems and reload
-mongo_sanity_check ${testsys}
+mongo_sanity_check
 if [ $? -eq 1 ]; then
   deploy_log "mongo_sanity_check failure: Killing services"
-  kill_services_on_mongo_ports
+  kill_mongo_services
+  deploy_log "mongo_wrapper exiting with code 1"
   exit 1
 fi

--- a/src/deploy/NVA_build/mongo_wrapper.sh
+++ b/src/deploy/NVA_build/mongo_wrapper.sh
@@ -109,7 +109,6 @@ function min {
   echo $(($1>$2?$2:$1))
 }
 
-
 function backoff_before_start {
   local backoff=$(cat $BACKOFF_FILE)
   local time_since_backoff_written=$(( $(date +%s) - $(stat ${BACKOFF_FILE} -c "%Y") ))

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -53,7 +53,8 @@ command=/usr/local/bin/node src/s3/s3rver_starter.js --address 'wss://127.0.0.1:
 #endprogram
 
 [program:mongo_wrapper]
-stopsignal=KILL
+stopsignal=INT
+stopwaitsecs=30
 killasgroup=true
 stopasgroup=true
 command=/root/node_modules/noobaa-core/src/deploy/NVA_build/mongo_wrapper.sh /usr/bin/mongod --port 27017 --bind_ip 127.0.0.1 --dbpath /var/lib/mongo/cluster/shard1 --syslog --syslogFacility local0

--- a/src/deploy/NVA_build/supervisord.orig
+++ b/src/deploy/NVA_build/supervisord.orig
@@ -49,7 +49,7 @@ stop() {
     local mongo_pids=$(pgrep -lf mongo | awk '{print $1}')
     echo "mongo_pids=$mongo_pids"
     logger -p local0.info "mongo_pids=$mongo_pids"
-    kill -9 ${mongo_pids}
+    kill -2 ${mongo_pids}
 
     local p=$(cat $PIDFILE)
     kill -9 ${p}

--- a/src/server/system_services/upgrade_server.js
+++ b/src/server/system_services/upgrade_server.js
@@ -435,7 +435,8 @@ function _wait_for_upgrade_state(ip, state) {
 }
 
 function _wait_for_upgrade_stage(ip, stage_req) {
-    let max_retries = 60;
+    // member upgrade can take some time. keep retrying for an hour
+    let max_retries = 360;
     const upgrade_retry_delay = 10 * 1000; // the delay between testing upgrade status
     return promise_utils.retry(max_retries, upgrade_retry_delay, () => system_store.load()
         .then(() => {

--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -240,7 +240,8 @@ MongoCtrl.prototype._add_replica_set_member_program = function(name, first_serve
         ' --bind_ip_all'; // in mongodb 3.6 bind_ip is by default 127.0.0.1 - bind to all interfaces
     program_obj.directory = '/usr/bin';
     program_obj.user = 'root';
-    program_obj.stopsignal = 'KILL';
+    program_obj.stopsignal = 'INT';
+    program_obj.stopwaitsecs = 30;
     program_obj.killasgroup = 'true';
     program_obj.stopasgroup = 'true';
     program_obj.autostart = 'true';

--- a/src/test/framework/send_logs.js
+++ b/src/test/framework/send_logs.js
@@ -13,9 +13,15 @@ const CONTAINER = 'vitaly-servers-logs';
 async function main() {
     const blob = azure_storage.createBlobService(process.env.AZURE_STORAGE_CONNECTION_STRING);
     const noobaa_log_files = (await fs.readdirAsync('/var/log')).filter(f => f.startsWith('noobaa'));
+    noobaa_log_files.push('/tmp/res_1.tgz'); // runner log files
+    noobaa_log_files.push('/tmp/ceph_deploy.log'); // ceph build and deploy log
     await P.map(noobaa_log_files, async log_file => {
-        const blob_key = process.env.TEST_RUN_NAME + '/' + log_file;
-        await P.fromCallback(callback => blob.createBlockBlobFromLocalFile(CONTAINER, blob_key, '/var/log/' + log_file, callback));
+        try {
+            const blob_key = process.env.TEST_RUN_NAME + '/' + log_file;
+            await P.fromCallback(callback => blob.createBlockBlobFromLocalFile(CONTAINER, blob_key, '/var/log/' + log_file, callback));
+        } catch (err) {
+            console.error(`Failed uploading ${log_file} to azure`, err);
+        }
     }, { concurrency: 10 });
 }
 


### PR DESCRIPTION
### Explain the changes
- changed kill signal of mongo_wrapper to `SIGINT`, and added `stopwaitsecs=30`
- changed in `noobaa_supervisor.conf` (for new systems)
- modify exisitng supervisor conf when upgrading
- changed mongo_wrapeer to first try to kill using `SIGINT` and then using `SIGKILL`

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages