### PR TITLE
Several upgrade fixes

### DIFF
--- a/src/deploy/mongo_upgrade/mongo_upgrade_2_10_0.js
+++ b/src/deploy/mongo_upgrade/mongo_upgrade_2_10_0.js
@@ -76,5 +76,15 @@ function fix_bucketstats_null_content_type() {
 }
 
 
+function unset_upgrade_stage_changed_date() {
+    db.clusters.updateMany({}, {
+        $unset: {
+            "upgrade.stage_changed_date": 1
+        }
+    });
+}
+
+
 fix_bucket_stats_writes();
 fix_bucketstats_null_content_type();
+unset_upgrade_stage_changed_date();

--- a/src/server/system_services/schemas/cluster_schema.js
+++ b/src/server/system_services/schemas/cluster_schema.js
@@ -147,9 +147,6 @@ module.exports = {
                         'UPGRADE_COMPLETED',
                     ]
                 },
-                stage_changed_date: {
-                    idate: true
-                },
                 error: {
                     type: 'string'
                 },

--- a/src/test/utils/basic_server_ops.js
+++ b/src/test/utils/basic_server_ops.js
@@ -118,6 +118,13 @@ function upload_and_upgrade(ip, upgrade_pack, dont_verify_version) {
         })
         .then(() => client.system.read_system())
         .then(res => {
+            // make sure that upgrade is succesful by checking it is marked as completed
+            const upgrade_successful = res.cluster.shards[0].servers.every(server => server.upgrade.status === 'COMPLETED');
+            if (!upgrade_successful) {
+                console.error('some servers did not reach to upgrade COMPLETED status:',
+                    res.cluster.shards[0].servers.map(server => server.upgrade));
+                throw new Error('not all servers completed upgrade successfuly');
+            }
             //Server is up, check returned version to verify the server was upgraded
             if (dont_verify_version) {
                 console.warn('Skipping version check - probably upgrading to the same version intensionly');

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -28,7 +28,6 @@ const NVM_DIR = `${HOME}/.nvm`;
 
 const SWAP_SIZE_MB = 8 * 1024;
 
-const MONGO_RECONNECT_TIMEOUT = 120000;
 
 // in clustered mongo it can take time before all members are operational. wait up to 10 minutes
 const WAIT_FOR_MONGO_TIMEOUT = 10 * 60000;

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -134,7 +134,6 @@ class UpgradeManager {
     async update_db(updates) {
 
         let server = system_store.get_local_cluster_info(); //Update path in DB
-        updates['upgrade.stage_changed_date'] = Date.now();
         const update = {
             clusters: [{
                 _id: server._id,

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const argv = require('minimist')(process.argv);
-const _ = require('lodash');
 
 const promise_utils = require('../util/promise_utils');
 const mongo_client = require('../util/mongo_client');

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -9,7 +9,6 @@ const mongodb = require('mongodb');
 const EventEmitter = require('events').EventEmitter;
 
 const P = require('./promise');
-const promise_utils = require('./promise_utils');
 const dbg = require('./debug_module')(__filename);
 const config = require('../../config.js');
 const js_utils = require('./js_utils');

--- a/src/util/promise_utils.js
+++ b/src/util/promise_utils.js
@@ -306,7 +306,7 @@ function wait_for_event(emitter, event, timeout) {
             emitter.once('error', err => reject(err || new Error('wait_for_event: error')));
         }
         if (timeout) {
-            setTimeout(reject, timeout);
+            setTimeout(() => reject(new Error(`timedout waiting for event ${event} `)), timeout);
         }
     });
 }


### PR DESCRIPTION
### Explain the changes
- removed all occurrences of `stage_changed_date`  in the code (wasn't read anywhere, it was just written during upgrade)
   - the reason for it is that it caused INVALID_SCHEMA if upgrading from 2.7 and the upgrade was failed and rolled back (2.7 did not allow stage_changed_date in read_system)
- changed upgrade_manager to store current stage in local filesystem instead of mongo
- when taking mongo down (upgrade to 3.6 and changing kill signal) 
   - disconnect mongo client before
   - connect again after the operation is completed
   - wait for all members to be operational (primary or secondary) and make sure mongo client can access DB by calling `db.stats()`
- changed `upload_and_upgrade` in basic server ops to verify upgrade  is marked as `COMPLETED` on all members

### Issues: Fixed #xxx 
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages