### PR TITLE
Add support for reporting didn't run test, fix some reporting OTW

### DIFF
--- a/src/test/framework/report.js
+++ b/src/test/framework/report.js
@@ -72,17 +72,19 @@ class Reporter {
     }
 
     success(step) {
-        if (_.findIndex(this._cases_map, c => c === step) === -1) {
-            assert(false, `Trying to add success for non existent case ${step}`);
+        const updated_step = this._prefix ? this._prefix + '_' + step : step;
+        if (_.findIndex(this._cases_map, c => c === updated_step) === -1) {
+            assert(false, `Trying to add success for non existent case ${updated_step}`);
         }
-        this._passed_cases.push(step);
+        this._passed_cases.push(updated_step);
     }
 
     fail(step) {
-        if (_.findIndex(this._cases_map, c => c === step) === -1) {
-            assert(false, `Trying to add failure for non existent case ${step}`);
+        const updated_step = this._prefix ? this._prefix + '_' + step : step;
+        if (_.findIndex(this._cases_map, c => c === updated_step) === -1) {
+            assert(false, `Trying to add failure for non existent case ${updated_step}`);
         }
-        this._failed_cases.push(step);
+        this._failed_cases.push(updated_step);
     }
 
     pause() {

--- a/src/test/pipeline/account_pipeline.js
+++ b/src/test/pipeline/account_pipeline.js
@@ -56,6 +56,14 @@ async function main() {
                 console.error(`${js_script} failed in ${TEST_CFG.version}, ${err}`);
             }
         }
+        server_ops.init_reporter({
+            suite_name: 'accounts',
+            cases: [
+                'upgrade',
+                'clean_ova',
+                'create_system'
+            ]
+        });
         await server_ops.upgrade_server(TEST_CFG.server_ip, TEST_CFG.upgrade);
         path = set_code_path('latest');
         await run_account_test(path, ['--cycles', 1, '--accounts_number', 2]);

--- a/src/test/pipeline/system_config_pipeline.js
+++ b/src/test/pipeline/system_config_pipeline.js
@@ -55,6 +55,12 @@ async function main() {
                 console.error(`${js_script} failed in ${TEST_CFG.version}, ${err}`);
             }
         }
+        server_ops.init_reporter({
+            suite_name: 'system_config',
+            cases: [
+                'upgrade',
+            ]
+        });
         await server_ops.upgrade_server(TEST_CFG.server_ip, TEST_CFG.upgrade);
         path = set_code_path('latest');
         await run_test(path, []);

--- a/src/test/qa/account_test.js
+++ b/src/test/qa/account_test.js
@@ -63,7 +63,17 @@ function usage() {
     `);
 }
 
-report.init_reporter({ suite: test_name, conf: TEST_CFG, mongo_report: true });
+//Define test cases
+const cases = [
+    'create_account',
+    'delete_account',
+    'regenerate_s3Access',
+    'edit_s3Access',
+    'edit_bucket_creation',
+    'restrict_ip_access',
+    'reset_password'
+];
+report.init_reporter({ suite: test_name, conf: TEST_CFG, mongo_report: true, cases: cases});
 
 function saveErrorAndResume(message) {
     console.error(message);

--- a/src/test/qa/cloud_test.js
+++ b/src/test/qa/cloud_test.js
@@ -317,7 +317,7 @@ async function run_dataset() {
         dataset_params.bucket = bucket_name;
         console.log(dataset_params);
         const report_params = {
-            suite_name: 'test_name',
+            suite_name: 'cloud_test',
             cases_prefix: `${bucket_name.slice(0, bucket_name.lastIndexOf('-'))}`
         };
         await dataset.init_parameters({ dataset_params: dataset_params, report_params: report_params });

--- a/src/test/qa/cluster_test.js
+++ b/src/test/qa/cluster_test.js
@@ -87,7 +87,35 @@ if (argv.help) {
 
 const osesSet = af.supported_oses();
 const report = new Report();
-report.init_reporter({ suite: testName, conf: { agents_number: agents_number }, mongo_report: true });
+const cases = [
+    'Add member no NTP master',
+    'Add member no NTP 2nd',
+    'Stop/start same member',
+    'succeeded config 2/3 down',
+    'Stop/start 2/3 of cluster',
+    'stop all start all',
+    'stop all start two',
+    'succeeded config 2/3 down',
+    'stop master',
+    'stop/start master',
+    'create bucket one srv down',
+    'ul and verify obj one srv down',
+    'create bucket all up after one down',
+    'ul and verify obj all up after one down',
+    'create bucket one srv down after 2 down',
+    'ul and verify obj one srv down after 2 down',
+    'create bucket all up after 2 down',
+    'ul and verify obj all up after 2 down',
+    'create bucket one down after all down',
+    'ul and verify obj one down after all down',
+    'create bucket all up after all down',
+    'ul and verify obj all up after all down',
+    'create bucket stop master',
+    'ul and verify obj stop master',
+    'create bucket stop/start master',
+    'ul and verify obj stop/start master',
+];
+report.init_reporter({ suite: testName, conf: { agents_number: agents_number }, mongo_report: true, cases: cases });
 
 
 function saveErrorAndResume(message) {
@@ -488,7 +516,7 @@ function runSecondFlow() {
                 .then(() => report.fail('succeeded config 2/3 down'))
                 .catch(err => {
                     console.log(`Couldn't create bucket with 2 disconnected clusters - as should ${err.message}`);
-                    report.success('fail config 2/3 down');
+                    report.success('succeeded config 2/3 down');
                 });
         })
         .then(() => startVirtualMachineWithStatus(1, 180))
@@ -518,7 +546,7 @@ function runThirdFlow() {
                 .then(() => report.fail('succeeded config 2/3 down'))
                 .catch(err => {
                     console.log(`Couldn't create bucket with 2 disconnected clusters - as should ${err.message}`);
-                    report.success('fail config 2/3 down');
+                    report.success('succeeded config 2/3 down');
                 });
         })
         .then(() => {

--- a/src/test/qa/cluster_test.js
+++ b/src/test/qa/cluster_test.js
@@ -98,6 +98,8 @@ const cases = [
     'succeeded config 2/3 down',
     'stop master',
     'stop/start master',
+    'create bucket pre test',
+    'ul and verify obj pre test',
     'create bucket one srv down',
     'ul and verify obj one srv down',
     'create bucket all up after one down',
@@ -437,18 +439,18 @@ function verifyS3Server(topic) {
         .then(() => s3ops.get_list_buckets())
         .then(res => {
             if (res.includes(bucket)) {
-                report.success(`create bucket ${topic ? '- ' + topic : ''}`);
+                report.success(`create bucket${topic ? ' ' + topic : ''}`);
                 console.log('Bucket is successfully added');
             } else {
-                report.fail(`create bucket ${topic ? '- ' + topic : ''}`);
+                report.fail(`create bucket${topic ? ' ' + topic : ''}`);
                 saveErrorAndResume(`Created bucket ${master_ip} bucket is not returns on list`, res);
             }
         })
         .then(() => s3ops.put_file_with_md5(bucket, '100MB_File', 100, 1048576)
             .then(() => s3ops.get_file_check_md5(bucket, '100MB_File')))
-        .then(() => report.success(`ul and verify obj ${topic ? '- ' + topic : ''}`))
+        .then(() => report.success(`ul and verify obj${topic ? ' ' + topic : ''}`))
         .catch(err => {
-            report.fail(`ul and verify obj ${topic ? '- ' + topic : ''}`);
+            report.fail(`ul and verify obj${topic ? ' ' + topic : ''}`);
             saveErrorAndResume(`${master_ip} FAILED verification s3 server`, err);
             failures_in_test = true;
             throw err;
@@ -618,7 +620,7 @@ return azf.authenticate()
     .then(() => delayInSec(90))
     .then(() => checkClusterStatus(servers, masterIndex)) //TODO: remove... ??
     .then(() => af.createRandomAgents(azf, master_ip, storage, vnet, agents_number, suffix, osesSet))
-    .then(res => verifyS3Server())
+    .then(res => verifyS3Server('pre test'))
     .then(() => checkClusterStatus(servers, masterIndex))
     .then(runFirstFlow)
     .then(runSecondFlow)

--- a/src/test/qa/dataset.js
+++ b/src/test/qa/dataset.js
@@ -81,7 +81,21 @@ const s3ops = new S3OPS({ ip: TEST_CFG.server_ip });
 update_dataset_sizes();
 
 let report = new Report();
-report.init_reporter({ suite: test_name, conf: TEST_CFG, mongo_report: true });
+const cases = [
+    'RANDOM',
+    'UPLOAD_NEW',
+    'SERVER_SIDE_COPY',
+    'CLIENT_SIDE_COPY',
+    'UPLOAD_OVERWRITE',
+    'UPLOAD_AND_ABORT',
+    'RENAME',
+    'SET_ATTR',
+    'READ',
+    'READ_RANGE',
+    'DELETE',
+    'MULTI_DELETE',
+];
+report.init_reporter({ suite: test_name, conf: TEST_CFG, mongo_report: true, cases: cases});
 
 /*
 ActionTypes defines the operations which will be used in the test
@@ -680,12 +694,14 @@ async function run_multi_delete(params) {
 /*********
  * MAIN
  *********/
-function init_parameters(params) {
+function init_parameters({ dataset_params, report_params }) {
     TEST_STATE = Object.assign({}, TEST_STATE_INITIAL);
-    TEST_CFG = _.defaults(_.pick(params, _.keys(TEST_CFG)), TEST_CFG);
-    update_dataset_sizes();
+    TEST_CFG = _.defaults(_.pick(dataset_params, _.keys(TEST_CFG)), TEST_CFG);
 
-    report.init_reporter({ suite: test_name, conf: TEST_CFG, mongo_report: true });
+    update_dataset_sizes();
+    const suite_name = report_params.suite_name || test_name;
+
+    report.init_reporter({ suite: suite_name, conf: TEST_CFG, mongo_report: true, cases: cases, prefix: report_params.cases_prefix});
 }
 
 async function upload_new_files() {

--- a/src/test/qa/dataset.js
+++ b/src/test/qa/dataset.js
@@ -95,7 +95,7 @@ const cases = [
     'DELETE',
     'MULTI_DELETE',
 ];
-report.init_reporter({ suite: test_name, conf: TEST_CFG, mongo_report: true, cases: cases});
+report.init_reporter({ suite: test_name, conf: TEST_CFG, mongo_report: true, cases: cases });
 
 /*
 ActionTypes defines the operations which will be used in the test
@@ -701,7 +701,7 @@ function init_parameters({ dataset_params, report_params }) {
     update_dataset_sizes();
     const suite_name = report_params.suite_name || test_name;
 
-    report.init_reporter({ suite: suite_name, conf: TEST_CFG, mongo_report: true, cases: cases, prefix: report_params.cases_prefix});
+    report.init_reporter({ suite: suite_name, conf: TEST_CFG, mongo_report: true, cases: cases, prefix: report_params.cases_prefix });
 }
 
 async function upload_new_files() {

--- a/src/test/qa/system_config.js
+++ b/src/test/qa/system_config.js
@@ -62,8 +62,20 @@ if (help) {
 }
 
 let report = new Report();
-
-report.init_reporter({ suite: test_name, conf: {}, mongo_report: true });
+const cases = [
+    'set_DNS',
+    'set_NTP',
+    'set_Proxy',
+    'disable_Proxy',
+    'TCP_Remote_Syslog',
+    'UDP_Remote_Syslog',
+    'set_maintenance_mode',
+    'update_n2n_config_single_port',
+    'update_n2n_config_range',
+    'set_debug_level_and_check',
+    'set_diagnose_system',
+];
+report.init_reporter({ suite: test_name, conf: {}, mongo_report: true, cases: cases});
 
 function saveErrorAndResume(message) {
     console.error(message);
@@ -553,13 +565,13 @@ async function set_debug_level(level) {
         const debug_level = system_info.debug.level;
         if (debug_level === level) {
             console.log(`The debug level is: ${level} - as should`);
-            await report.success(`set_debug_level_and_check `);
+            await report.success(`set_debug_level_and_check`);
         } else {
             saveErrorAndResume(`The debug level is ${debug_level}`);
             throw new Error('Test set_debug_level_and_check Failed');
         }
     } catch (e) {
-        await report.fail(`set_debug_level_and_check `);
+        await report.fail(`set_debug_level_and_check`);
         throw new Error('Test set_debug_level_and_check Failed');
     }
 }

--- a/src/test/qa/system_config.js
+++ b/src/test/qa/system_config.js
@@ -75,7 +75,7 @@ const cases = [
     'set_debug_level_and_check',
     'set_diagnose_system',
 ];
-report.init_reporter({ suite: test_name, conf: {}, mongo_report: true, cases: cases});
+report.init_reporter({ suite: test_name, conf: {}, mongo_report: true, cases: cases });
 
 function saveErrorAndResume(message) {
     console.error(message);
@@ -627,6 +627,15 @@ async function main() {
         const secret = system_info.cluster.shards[0].servers[0].secret;
         console.log('Secret is ' + secret);
         rpc.disconnect_all();
+
+        server_ops.init_reporter({
+            suite_name: 'system_config',
+            cases: [
+                'clean_ova',
+                'create_system'
+            ]
+        });
+
         if (skip_create_system) {
             console.log(`Skipping clean ova and create system`);
         } else {

--- a/src/test/qa/test-TUI.js
+++ b/src/test/qa/test-TUI.js
@@ -76,7 +76,7 @@ const cases = [
     'DNS_primary_empty',
     'DNS_primary_reachable',
 ];
-report.init_reporter({ suite: test_name, conf: {}, mongo_report: true, cases: cases});
+report.init_reporter({ suite: test_name, conf: {}, mongo_report: true, cases: cases });
 
 //class Expect, should move to a util.
 class Expect {
@@ -468,6 +468,13 @@ async function authenticate() {
 async function main() {
     try {
         await authenticate();
+        server_ops.init_reporter({
+            suite_name: 'TUI',
+            cases: [
+                'clean_ova',
+                'create_system'
+            ]
+        });
         await server_ops.set_first_install_mark(server_ip, secret);
         await server_ops.enable_nooba_login(server_ip, secret);
         //will loop twice, one with system and the other without.

--- a/src/test/qa/test-TUI.js
+++ b/src/test/qa/test-TUI.js
@@ -55,8 +55,28 @@ const YELLOW = "\x1b[33;1m";
 //const RED = "\x1b[31m";
 
 let report = new Report();
-
-report.init_reporter({ suite: test_name, conf: {}, mongo_report: true });
+const cases = [
+    'NTP_only_TZ',
+    'NTP_reachable_with_TZ',
+    'NTP_reachable_without_TZ',
+    'NTP_unreachable_with_TZ',
+    'NTP_unreachable_without_TZ',
+    'NTP_reachable_with_TZ',
+    'set_valid_hostname_dialog',
+    'set_empty_hostname_dialog',
+    'DNS_primary_invalid',
+    'DNS_primary_reachable',
+    'DNS_primary_reachable',
+    'DNS_secondary_unreachable',
+    'DNS_primary_unreachable',
+    'DNS_secondary_unreachable',
+    'DNS_primary_reachable',
+    'DNS_primary_unreachable',
+    'DNS_primary_empty',
+    'DNS_primary_empty',
+    'DNS_primary_reachable',
+];
+report.init_reporter({ suite: test_name, conf: {}, mongo_report: true, cases: cases});
 
 //class Expect, should move to a util.
 class Expect {

--- a/src/test/qa/two_step_upgrade_test.js
+++ b/src/test/qa/two_step_upgrade_test.js
@@ -49,11 +49,24 @@ function usage() {
     `);
 }
 
+const cases = [
+    'blocked downgrade patch',
+    'blocked downgrade minor',
+    'blocked downgrade major',
+    'non-package',
+    'disk space',
+    'time skew',
+    'preconditions met',
+    'stage package',
+    'disk space 2nd step',
+    'time skew 2nd step',
+    'preconditions met 2nd step',
+];
 //Init Clients
 function init_clients() {
     //Init ssh client and rpc client
     report = new Report();
-    report.init_reporter({ suite: 'upgrade', conf: TEST_CFG, mongo_report: true });
+    report.init_reporter({ suite: 'upgrade', conf: TEST_CFG, mongo_report: true, cases: cases});
     return ssh_functions.ssh_connect({
             host: TEST_CFG.ip,
             username: 'noobaaroot',

--- a/src/test/utils/bucket_functions.js
+++ b/src/test/utils/bucket_functions.js
@@ -1,30 +1,16 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
+
 class BucketFunctions {
 
-    constructor(client, report) {
+    constructor(client) {
         this._client = client;
-        this._report = report;
-    }
-
-    async report_success(params) {
-        if (this._report) {
-            await this._report.success(params);
-        }
-    }
-
-    async report_fail(params) {
-        if (this._report) {
-            await this._report.fail(params);
-        }
     }
 
     async listBuckets(server_ip) {
         try {
             await this._client.bucket.list_buckets();
-            await this.report_success(`List_Bucket`);
         } catch (err) {
-            await this.report_fail(`List_Bucket`);
             console.log(`${server_ip} FAILED to get bucket list`, err);
             throw err;
         }
@@ -33,10 +19,8 @@ class BucketFunctions {
     async createBucket(name) {
         try {
             let buck = await this._client.bucket.create_bucket({ name });
-            await this.report_success(`Create_Bucket`);
             return buck;
         } catch (err) {
-            await this.report_fail(`Create_Bucket`);
             console.log('Create bucket ERR', err);
             throw err;
         }
@@ -45,9 +29,7 @@ class BucketFunctions {
     async deleteBucket(name) {
         try {
             await this._client.bucket.delete_bucket({ name });
-            await this.report_success(`Delete_Bucket`);
         } catch (err) {
-            await this.report_fail(`Delete_Bucket`);
             console.log('Delete bucket ERR', err);
             throw err;
         }
@@ -74,9 +56,7 @@ class BucketFunctions {
                 name: read_bucket.tiering.tiers[0].tier,
                 chunk_coder_config: chunk_coder_config
             });
-            await this.report_success(`Update_Tier`);
         } catch (err) {
-            await this.report_fail(`Update_Tier`);
             console.log('Update tier ERR', err);
             throw err;
         }
@@ -93,9 +73,7 @@ class BucketFunctions {
                     unit //'GIGABYTE', 'TERABYTE', 'PETABYTE'
                 }
             });
-            await this.report_success(`Set_Quota_Bucket`);
         } catch (err) {
-            await this.report_fail(`Set_Quota_Bucket`);
             console.log(`$FAILED setting quota bucket `, err);
             throw err;
         }
@@ -108,9 +86,7 @@ class BucketFunctions {
                 name: bucket_name,
                 quota: null
             });
-            await this.report_success(`Disable_Quota_Bucket`);
         } catch (err) {
-            await this.report_fail(`Disable_Quota_Bucket`);
             console.log(`${server_ip} FAILED disable quota bucket `, err);
             throw err;
         }
@@ -168,9 +144,7 @@ class BucketFunctions {
                 name: bucket_name,
                 spillover: pool
             });
-            await this.report_success(`Set_Spillover`);
         } catch (err) {
-            await this.report_fail(`Set_Spillover`);
             console.log('Failed to set spillover ' + pool + ' for bucket ' + bucket_name + err);
             throw err;
         }
@@ -193,9 +167,7 @@ class BucketFunctions {
                 data_placement,
                 name: tier
             });
-            await this.report_success(`Change_DataPlacement`);
         } catch (err) {
-            await this.report_fail(`Change_DataPlacement`);
             console.log('Failed to set data placement for bucket ' + bucket_name + err);
             throw err;
         }
@@ -239,9 +211,7 @@ class BucketFunctions {
                     write_resource: namespace
                 }
             });
-            await this.report_success(`Create_Namespace_Bucket`);
         } catch (err) {
-            await this.report_fail(`Create_Namespace_Bucket`);
             throw new Error('Failed to create Namespace bucket ', err);
         }
     }
@@ -256,9 +226,7 @@ class BucketFunctions {
                     write_resource
                 }
             });
-            await this.report_success(`Update_Namespace_Bucket`);
         } catch (err) {
-            await this.report_fail(`Update_Namespace_Bucket`);
             throw new Error('Failed to update Namespace bucket ', err);
         }
     }

--- a/src/test/utils/cloud_functions.js
+++ b/src/test/utils/cloud_functions.js
@@ -5,21 +5,8 @@ const P = require('../../util/promise');
 
 class CloudFunction {
 
-    constructor(client, report) {
+    constructor(client) {
         this._client = client;
-        this._report = report;
-    }
-
-    async report_success(params) {
-        if (this._report) {
-            await this._report.success(params);
-        }
-    }
-
-    async report_fail(params) {
-        if (this._report) {
-            await this._report.fail(params);
-        }
     }
 
     getAWSConnection() {
@@ -41,9 +28,7 @@ class CloudFunction {
                 name,
                 target_bucket
             });
-            await this.report_success(`Create_Cloud_Pool_${connection}`);
         } catch (err) {
-            await this.report_fail(`Create_Cloud_Pool_${connection}`);
             throw new Error('Failed to create cloud pool ', err);
         }
     }
@@ -54,9 +39,7 @@ class CloudFunction {
             await this._client.pool.delete_pool({
                 name: pool
             });
-            await this.report_success(`Delete_Cloud_Pool_${pool}`);
         } catch (err) {
-            await this.report_fail(`Delete_Cloud_Pool_${pool}`);
             throw new Error(`Failed to delete cloud pool error`, err);
         }
     }
@@ -87,13 +70,7 @@ class CloudFunction {
 
     async createConnection(connection, type) {
         console.log(`Creating ${type} connection`);
-        try {
-            await this._client.account.add_external_connection(connection);
-            await this.report_success(`Create_Connection_${type}`);
-        } catch (err) {
-            await this.report_fail(`Create_Connection_${type}`);
-            throw new Error('Failed to create connection ', err);
-        }
+        await this._client.account.add_external_connection(connection);
     }
 
     async deleteConnection(connection_name) {
@@ -102,9 +79,7 @@ class CloudFunction {
             await this._client.account.delete_external_connection({
                 connection_name
             });
-            await this.report_success(`Delete_Connection_${connection_name}`);
         } catch (err) {
-            await this.report_fail(`Delete_Connection_${connection_name}`);
             throw new Error('Failed to delete connection ', err);
         }
     }
@@ -117,9 +92,7 @@ class CloudFunction {
                 name,
                 target_bucket
             });
-            await this.report_success(`Create_Namespace_Resource_${connection}`);
         } catch (err) {
-            await this.report_fail(`Create_Namespace_Resource_${connection}`);
             throw new Error('Failed to create namespace resource ', err);
         }
     }
@@ -130,9 +103,7 @@ class CloudFunction {
             await this._client.pool.delete_namespace_resource({
                 name: namespace
             });
-            await this.report_success(`Delete_Namespace_Resource_${namespace}`);
         } catch (err) {
-            await this.report_fail(`Delete_Namespace_Resource_${namespace}`);
             throw new Error(`Failed to delete cloud pool error`, err);
         }
     }

--- a/src/test/utils/server_functions.js
+++ b/src/test/utils/server_functions.js
@@ -16,6 +16,18 @@ const activation_code = "pe^*pT%*&!&kmJ8nj@jJ6h3=Ry?EVns6MxTkz+JBwkmk_6e" +
     "zLVbAhqRWHW-JZ=_NCAE!7BVU_t5pe#deWy*d37q6m?KU?VQm?@TqE+Srs9TSGjfv94=32e_a#" +
     "3H5Q7FBgMZd=YSh^J=!hmxeXtFZE$6bG+^r!tQh-Hy2LEk$+V&33e3Z_mDUVd";
 
+//Enable reporter and set parameters
+function init_reporter(report_params) {
+    const suite_name = report_params.suite_name || 'UNKNW_server_func';
+    report.init_reporter({
+        suite: suite_name,
+        conf: {},
+        mongo_report: true,
+        cases: report_params.cases,
+        prefix: report_params.cases_prefix
+    });
+}
+
 //will enable noobaa user login via ssh
 async function enable_nooba_login(server_ip, secret) {
     const client_ssh = await ssh.ssh_connect({
@@ -220,3 +232,4 @@ exports.create_system_and_check = create_system_and_check;
 exports.clean_ova_and_create_system = clean_ova_and_create_system;
 exports.upload_upgrade_package = upload_upgrade_package;
 exports.upgrade_server = upgrade_server;
+exports.init_reporter = init_reporter;


### PR DESCRIPTION
### Explain the changes

#### 2. Existing Behavior Changes (Sync with Liran):
- Add cases map for each test
   - Reporter will assert if trying to report success/fail on a case which is not in the cases map
   - On report(), reporter will report didn't run tests (cases with count 0)

- Remove bucket_functions and cloud_functions inner reporting and move it to the upper level logic (the calling test suite)

- For server_functions, inner reporting is needed for pipeline tests (for example run sys config, upgrade, run sys config). Add init_reporter() in server_functions to connect to the correct suit and mark actual called cases

- Fix some reporting (better resolution, added cases for report etc.) for existing tests

- Add reporting for rebuild_replica, reclaim_test, TUI

### Testing Instructions:
- Run manual pipeline

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
