### PR TITLE
on upgrade - copy new node version instead of move

### DIFF
--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -375,8 +375,8 @@ async function update_node_version() {
     dbg.log0(`UPGRADE: pre_upgrade: Extracted node package`);
     await exec(`mkdir -p ~/.nvm/versions/node/v${nodever}/`);
     dbg.log0(`UPGRADE: pre_upgrade: Created node dir`);
-    await exec(`mv /tmp/v${nodever}/* ~/.nvm/versions/node/v${nodever}/`);
-    dbg.log0(`UPGRADE: pre_upgrade: Moved node dir from /tmp to /.nvm`);
+    await exec(`cp /tmp/v${nodever}/* ~/.nvm/versions/node/v${nodever}/`);
+    dbg.log0(`UPGRADE: pre_upgrade: copied node dir from /tmp to /.nvm`);
 
     // TODO: maybe backup the old node version in backup script
     try {


### PR DESCRIPTION
### Explain the changes
- on upgrade - copy new node version instead of move
   - upgrade manager failed to restart because node binaries were moved

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is a top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external Syslog
- Upgrade - DB schema, server platform, agents install, npm packages