### PR TITLE
cluster_test fixes

### DIFF
--- a/src/test/utils/s3ops.js
+++ b/src/test/utils/s3ops.js
@@ -565,6 +565,32 @@ class S3OPS {
             });
     }
 
+    // test if service is up by putting small object.
+    // default timeout of 2 minutes
+    test_s3_put(timeout = 120000, tag) {
+        return P.resolve()
+            .then(async () => {
+                const now = Date.now();
+                const Bucket = `test.s3.put.${now}`;
+                const Key = `test_s3_put_${tag}_${now}`;
+                try {
+                    await this.s3.createBucket({ Bucket }).promise();
+                    await this.s3.putObject({
+                        Bucket,
+                        Key,
+                        Body: crypto.randomBytes(128)
+                    }).promise();
+                    await this.s3.deleteObject({ Bucket, Key }).promise();
+                } catch (err) {
+                    console.warn('S3 test failed. got error:', err.message);
+                    throw err;
+                }
+                await this.s3.deleteBucket({ Bucket }).promise().catch(_.noop);
+            })
+            .timeout(timeout)
+            .return();
+    }
+
     create_bucket(bucket_name) {
 
         let params = {


### PR DESCRIPTION
### Explain the changes
- changed `startVirtualMachineWithStatus` to test s3 service periodically instead of waiting for the maximum wait time
- increased timeout for `startVirtualMachineWithStatus` to 10 minutes after returning from no service

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages