### PR TITLE
version_map.json: bumped version to 2.10

### DIFF
--- a/src/deploy/version_map.json
+++ b/src/deploy/version_map.json
@@ -5,11 +5,6 @@
             "released": true
         },
         {
-            "ver": "2.6.3",
-            "vhd": "2.6.3-c63dc65.vhd",
-            "released": true
-        },
-        {
             "ver": "2.7.3",
             "vhd": "2.7.3-b1880ec.vhd",
             "released": true
@@ -22,6 +17,11 @@
         {
             "ver": "2.9.2",
             "vhd": "2.9.2-a09fff9.vhd",
+            "released": true
+        },
+        {
+            "ver": "2.10.0",
+            "vhd": "2.10.0-33fe3e2.vhd",
             "released": true
         }
     ]


### PR DESCRIPTION
### Explain the changes
version_map.json:
- Bumped version to 2.10
- Removed version 2.6.3

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
