### PR TITLE
Some fixes

### DIFF
--- a/frontend/src/app/components/application/main-layout/main-layout.js
+++ b/frontend/src/app/components/application/main-layout/main-layout.js
@@ -64,7 +64,6 @@ const navItems = deepFreeze([
         icon: 'line-chart',
         label: 'Analytics',
         beta: true
-
     }
 ]);
 

--- a/frontend/src/app/components/bucket/bucket-s3-access-policy-form/bucket-s3-access-policy-form.js
+++ b/frontend/src/app/components/bucket/bucket-s3-access-policy-form/bucket-s3-access-policy-form.js
@@ -89,6 +89,7 @@ class BucketS3AccessTableViewModel extends ConnectableViewModel {
     }
 
     mapStateToProps(accounts, location) {
+        const { params, route } = location;
         if (!accounts) {
             ko.assignToProps(this, {
                 dataReady: false,
@@ -96,7 +97,8 @@ class BucketS3AccessTableViewModel extends ConnectableViewModel {
             });
 
         } else {
-            const { params } = location;
+            if (route !== routes.bucket) return;
+
             const conenctedAccounts = Object.values(accounts).filter(account =>
                 account.allowedBuckets.includes(params.bucket)
             );
@@ -109,7 +111,7 @@ class BucketS3AccessTableViewModel extends ConnectableViewModel {
             } granted access to this bucket`;
 
             const isExpanded = params.section === policyName;
-            const toggleUri = realizeUri(routes.bucket, {
+            const toggleUri = realizeUri(route, {
                 system: params.system,
                 bucket: params.bucket,
                 tab: params.tab,

--- a/frontend/src/app/components/modals/create-bucket-modal/create-bucket-modal.js
+++ b/frontend/src/app/components/modals/create-bucket-modal/create-bucket-modal.js
@@ -125,7 +125,7 @@ class CreateBucketModalViewModel extends ConnectableViewModel {
     }
 
     onValidate(values) {
-        const { step, bucketName } = values;
+        const { step, bucketName, policyType, selectedResources } = values;
         const errors = {};
 
         if (step === 0) {
@@ -139,6 +139,12 @@ class CreateBucketModalViewModel extends ConnectableViewModel {
         } else if (step === 1) {
             if (this.systemResourceCount > 0) {
                 validatePlacementPolicy(values, errors);
+
+                // This rule should be inforced only on bucket creation, this is why it's not
+                // part of the generic validatePlacementPolicy check.
+                if (policyType === 'SPREAD' && selectedResources.length === 0) {
+                    errors.selectedResources = 'Spread policy requires at least 1 participating resources';
+                }
             }
         }
 

--- a/frontend/src/app/components/object/object-parts-list/object-parts-list.html
+++ b/frontend/src/app/components/object/object-parts-list/object-parts-list.html
@@ -81,16 +81,24 @@
                             <!-- ko with: storage -->
                             <!-- ko if: tierIndex -->
                             | Resides in tier {{tierIndex}}
-                            <!-- ko if: resources -->
+                            <!-- ko with: resources -->
                             on
+                            <!-- ko if: $data.href -->
                             <a class="box row content-middle cursor-pointer"
-                                ko.attr.href="resources().href"
+                                ko.attr.href="href"
                             >
                                 <svg-icon class="icon-small highlight push-next-half" params="
-                                    name: resources().icon
+                                    name: icon
                                 "></svg-icon>
-                                {{resources().text}}
+                                {{text}}
                             </a>
+                            <!-- /ko -->
+                            <!-- ko ifnot: $data.href -->
+                            <span class="box" ko.tooltip="tooltip">
+                                {{text}}
+                            </span>
+                            <!-- /ko -->
+
                             <!-- /ko -->
                             <!-- /ko -->
                             <!-- /ko -->

--- a/frontend/src/app/utils/bucket-utils.js
+++ b/frontend/src/app/utils/bucket-utils.js
@@ -44,7 +44,7 @@ const bucketStateToIcon = deepFreeze({
             align
         });
     },
-    TIER_ENOUGH_HEALTHY_RESOURCES: (bucket, align) => {
+    TIER_NOT_ENOUGH_HEALTHY_RESOURCES: (bucket, align) => {
         const i = _tierIndexForMode(bucket, 'NOT_ENOUGH_HEALTHY_RESOURCES');
         return warningIcon({
             text: `Not enough healthy storage resources in tier ${i +1}`,

--- a/src/server/object_services/mapper.js
+++ b/src/server/object_services/mapper.js
@@ -292,9 +292,13 @@ class MirrorMapper {
         const { spread_pools } = this;
         const picked_pool = spread_pools[Math.max(_.random(spread_pools.length - 1), 0)];
         if (picked_pool && _pool_has_redundancy(picked_pool)) {
-            return this.redundant_pools_valid ? this.redundant_pools : this.regular_pools;
+            return (this.redundant_pools_valid || !this.regular_pools_valid) ?
+                this.redundant_pools :
+                this.regular_pools;
         } else {
-            return this.regular_pools_valid ? this.regular_pools : this.redundant_pools;
+            return (this.regular_pools_valid && !this.redundant_pools_valid) ?
+                this.regular_pools :
+                this.redundant_pools;
         }
     }
 }
@@ -796,7 +800,7 @@ function should_rebuild_chunk_to_local_mirror(mapping, location_info) {
     for (const block of mapping.blocks_in_use) {
         if (block.is_local_mirror) return false;
     }
-    // check if a pool from the same region appear in the allocations list - 
+    // check if a pool from the same region appear in the allocations list -
     // if so then there is enough free space on the pool for this chunk and we should rebuild
     if (!mapping.allocations) return false;
     for (const allocation of mapping.allocations) {


### PR DESCRIPTION
- Do not allow empty spread policy on bucket creation.
- Order the tables in object part list - details pane
- Fix missing block group tooltips
- Fix wrong bucket.mode mapping
- Refine pool selection in in mapper, in case we cannot allocate -
fixes allocation prediction (now replica or no partiy frags in case the
only resources in the mirror set are cloud pools)

