### PR TITLE
fixed /etc/mongo_ssl ownership on new OVAs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",

--- a/src/deploy/NVA_build/fix_mongo_ssl.sh
+++ b/src/deploy/NVA_build/fix_mongo_ssl.sh
@@ -3,6 +3,7 @@ CORE_DIR="/root/node_modules/noobaa-core"
 if [ ! -d /etc/mongo_ssl/ ]; then
   mkdir /etc/mongo_ssl/
   . ${CORE_DIR}/src/deploy/NVA_build/setup_mongo_ssl.sh
+  chown -R mongod:mongod /etc/mongo_ssl/
   chmod 400 -R /etc/mongo_ssl/*
   chmod 500 /etc/mongo_ssl
   client_subject=`openssl x509 -in /etc/mongo_ssl/client.pem -inform PEM -subject -nameopt RFC2253 | grep subject | awk '{sub("subject= ",""); print}'`


### PR DESCRIPTION
### Explain the changes
- added chown to mongod in `fix_mongo_ssl.sh`

### Testing Instructions:
- check that `/etc/mongo_ssl` is owned by mongod:mongod after running clean_ova and restarting

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages