### PR TITLE
dataset.js: handling a case when dataset fails when it run as a function

### DIFF
--- a/src/test/qa/cloud_test.js
+++ b/src/test/qa/cloud_test.js
@@ -323,7 +323,11 @@ async function run_dataset() {
             cases_prefix: `${bucket_name.slice(0, bucket_name.lastIndexOf('-'))}`
         };
         await dataset.init_parameters({ dataset_params: dataset_params, report_params: report_params });
-        await dataset.run_test();
+        try {
+            await dataset.run_test(true);
+        } catch (e) {
+            throw e;
+        }
     }
 }
 

--- a/src/test/qa/cluster_test.js
+++ b/src/test/qa/cluster_test.js
@@ -633,7 +633,7 @@ async function main() {
         failures_in_test = true;
     }
 
-    report.report();
+    await report.report();
 
     if (failures_in_test) {
         console.error(`Errors during cluster test ${errors}`);

--- a/src/test/qa/dataset.js
+++ b/src/test/qa/dataset.js
@@ -712,7 +712,7 @@ async function upload_new_files() {
     console.timeEnd('dataset upload');
 }
 
-function run_test() {
+function run_test(throw_on_fail) {
     return P.resolve()
         .then(() => log_journal_file(`${CFG_MARKER}${DATASET_NAME}-${JSON.stringify(TEST_CFG)}`))
         .then(() => upload_new_files()
@@ -754,7 +754,11 @@ function run_test() {
             .catch(async err => {
                 await report.report();
                 console.error(`Errors during test`, err);
-                process.exit(4);
+                if (throw_on_fail) {
+                    throw new Error(`dataset failed`);
+                } else {
+                    process.exit(4);
+                }
             }));
 }
 
@@ -828,7 +832,7 @@ async function main() {
         if (argv.replay) {
             await run_replay();
         } else {
-            await run_test();
+            await run_test(false);
         }
         if (!TEST_CFG.no_exit_on_success) process.exit(0);
     } catch (err) {


### PR DESCRIPTION
### Explain the changes
dataset.js:
- Handling a case when dataset fails when it run as a function,
throwing error instead of exiting

cloud_test.js:
- Catching when dataset fails reporting and exiting.

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
