### PR TITLE
deploy_base.sh: making deploy base work on RHEL7

### DIFF
--- a/src/deploy/NVA_build/clean_ova.sh
+++ b/src/deploy/NVA_build/clean_ova.sh
@@ -136,7 +136,7 @@ sudo rm /etc/noobaa_sec
 echo Passw0rd | passwd noobaaroot --stdin
 #Clean log file
 rm -f /var/log/*.log
-rm -f /var/log/*-*
+rm -f /var/log/*-* || true
 rm -f /var/log/noobaa*
 rm -f /var/log/nbfedump/*
 rm -f /tmp/supervisor/*

--- a/src/deploy/NVA_build/common_funcs.sh
+++ b/src/deploy/NVA_build/common_funcs.sh
@@ -30,9 +30,9 @@ function set_mongo_cluster_mode {
 
 function update_noobaa_net {
     > ${NOOBAANET}
-    interfaces=$(ifconfig -a | grep ^eth | awk '{print $1}')
-    for int in ${interfaces//:/}; do
-        echo "${int}" >> ${NOOBAANET}
+    interfaces=$(ip addr | grep "state UP\|state DOWN" | awk '{print $2}' | sed 's/:/ /g')
+    for interface in ${interfaces//:/}; do
+        echo "${interface}" >> ${NOOBAANET}
     done
 }
 

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -2,9 +2,6 @@
 
 export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
 
-TURN_VER="4.5.0.6"
-TURN_CENTOS="7.2"
-TURN_DL="http://turnserver.open-sys.org/downloads/v${TURN_VER}/turnserver-${TURN_VER}-CentOS${TURN_CENTOS}-x86_64.tar.gz"
 CORE_DIR="/root/node_modules/noobaa-core"
 ENV_FILE="${CORE_DIR}/.env"
 LOG_FILE="/var/log/noobaa_deploy.log"
@@ -19,10 +16,24 @@ function deploy_log {
     logger -t UPGRADE -p local0.warn "$*"
 }
 
+function verify_noobaa_pre_requirements() {
+    if [ ! -f /tmp/noobaa-NVA.tar.gz ]
+    then
+        echo "There is no noobaa-NVA.tar.gz under /tmp/"
+        exit 1
+    fi
+    eval $(yum repolist | grep repolist | sed 's/: /=/g')
+    if [ ${repolist} -eq 0 ]
+    then
+        echo "yum does not have repolist, pleas add at-list one"
+        exit 1
+    fi
+}
+
 function clean_ifcfg() {
-    interfaces=$(ifconfig | grep ^eth | awk '{print $1}')
-    for int in ${interfaces//:/}; do
-        sudo rm -f /etc/sysconfig/network-scripts/ifcfg-${int}
+    local interfaces=$(ip addr | grep "state UP\|state DOWN" | awk '{print $2}' | sed 's/:/ /g')
+    for interface in ${interfaces//:/}; do
+        sudo rm -f /etc/sysconfig/network-scripts/ifcfg-${interface}
     done
     sudo echo -n > /etc/sysconfig/network
     sudo echo "HOSTNAME=noobaa" > /etc/sysconfig/network
@@ -32,12 +43,13 @@ function clean_ifcfg() {
 function install_platform {
     deploy_log install_platform start
 
-    #    wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    #    rpm -Uvh epel-release-latest-7*.rpm || ture
-    yum remove -y epel-release
-    yum --enablerepo=extras install -y epel-release
-    #yum install -y epel-release || true
+    yum install -y wget || true
+
+    local epel_rpm="epel-release-latest-7.noarch.rpm"
+    wget http://dl.fedoraproject.org/pub/epel/${epel_rpm}
+    yum install -y ${epel_rpm} || true
     yum clean expire-cache
+    yum repolist
 
     yum install -y \
         sudo \
@@ -52,7 +64,6 @@ function install_platform {
         expect \
         nc \
         tcpdump \
-        iperf \
         iperf3 \
         python-setuptools \
         bind-utils \
@@ -63,7 +74,6 @@ function install_platform {
         net-tools \
         iptables-services \
         rng-tools \
-        pv \
         initscripts
 
     # make iptables run on boot instead of firewalld
@@ -97,19 +107,21 @@ function install_platform {
         echo "GRUB_HIDDEN_TIMEOUT=0" >> /etc/default/grub
         echo "GRUB_FORCE_HIDDEN_MENU=true" >> /etc/default/grub
         grub2-mkconfig --output=/boot/grub2/grub.cfg
-        sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0' /etc/default/grub
+        #making sure that we have GRUB_TIMEOUT in the /etc/default/grub
+        set +e
+        grep GRUB_TIMEOUT /etc/default/grub &> /dev/null
+        if [ $? -eq 0 ]
+        then
+                sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0' /etc/default/grub
+        else
+                echo GRUB_TIMEOUT=0 >> /etc/default/grub
+        fi
+        set -e
         grub2-mkconfig –o /boot/grub2/grub.cfg
     fi
 
 	# easy_install is for Supervisord and comes from python-setuptools
 	easy_install supervisor
-
-    # Install STUN/TURN
-    cd /tmp
-    curl -sL ${TURN_DL} | tar -xzv
-    cd /tmp/turnserver-${TURN_VER}
-    /tmp/turnserver-${TURN_VER}/install.sh
-    cd ~
 
     # By Default, NTP is disabled, set local TZ to US Pacific
     echo "#NooBaa Configured NTP Server"     >> /etc/ntp.conf
@@ -189,7 +201,6 @@ function setup_linux_users {
 function install_nodejs {
     deploy_log "install_nodejs start"
 
-    yum remove epel-release-6-8.noarch
     yum -y groupinstall "Development Tools"
     export PATH=$PATH:/usr/local/bin
 
@@ -253,22 +264,9 @@ function install_mongo {
     systemctl stop mongod
     systemctl disable mongod
 
-    # In docker the service doesn't start unlike regular VM Centos
-    if [ "${container}" = "docker" ]; then
-        # This is a hack in order to perform the mongo_ssl_user creation
-        su - mongod -s /bin/bash -c "mongod --dbpath /var/lib/mongo/cluster/shard1 &"
-        # Replace with clever way to wait (for example like wait_for_mongo method that checks status)
-        sleep 10
-    fi
-
     deploy_log "adding mongo ssl user"
     add_mongo_ssl_user
 
-
-    if [ "${container}" = "docker" ]; then
-        local mongod_pid=$(pgrep -lf mongod | awk '{print $1}')
-        kill -2 ${mongod_pid}
-    fi
     deploy_log "install_mongo done"
 }
 
@@ -428,15 +426,9 @@ function setup_supervisors {
 function setup_syslog {
 	deploy_log "setup_syslog start"
 
-    deploy_log "setup_syslog - copy src/deploy/NVA_build/rsyslog.repo to /etc/yum.repos.d/rsyslog.repo"
-    cp -f ${CORE_DIR}/src/deploy/NVA_build/rsyslog.repo /etc/yum.repos.d/rsyslog.repo
-    deploy_log "yum update rsyslog..."
-    yum update rsyslog -y
-
     # copy noobaa_syslog.conf to /etc/rsyslog.d/ which is included by rsyslog.conf
     cp -f ${CORE_DIR}/src/deploy/NVA_build/noobaa_syslog.conf /etc/rsyslog.d/
     cp -f ${CORE_DIR}/src/deploy/NVA_build/logrotate_noobaa.conf /etc/logrotate.d/noobaa
-
 
     # setup crontab to run logrotate every 15 minutes.
     echo "*/15 * * * * /usr/sbin/logrotate /etc/logrotate.d/noobaa >/dev/null 2>&1" > /var/spool/cron/root
@@ -470,12 +462,20 @@ function setup_mongodb {
 }
 
 function add_mongo_ssl_user {
-    local client_subject=$(openssl x509 -in /etc/mongo_ssl/client.pem -inform PEM -subject -nameopt RFC2253 | grep subject | awk '{sub("subject= ",""); print}')
+    su - mongod -s /bin/bash -c "mongod --dbpath /var/lib/mongo/cluster/shard1 &"
+    # Replace with clever way to wait (for example like wait_for_mongo method that checks status)
+    sleep 20
+
+    local client_subject="CN=client,OU=MyClients,O=NOOBAA,L=NYC,ST=NY,C=US"
     /usr/bin/mongo --eval "var param_client_subject='${client_subject}'" ${CORE_DIR}/src/deploy/NVA_build/add_mongo_ssl_user.js
+
+    local mongod_pid=$(pgrep -lf mongod | awk '{print $1}')
+    kill -2 ${mongod_pid}
 }
 
 function runinstall {
     deploy_log "runinstall start"
+    verify_noobaa_pre_requirements
     set -e
 	install_platform
 	setup_linux_users

--- a/src/deploy/NVA_build/first_install_diaglog.sh
+++ b/src/deploy/NVA_build/first_install_diaglog.sh
@@ -106,14 +106,14 @@ function configure_interface_ip() {
       dialog --colors --backtitle "NooBaa First Install" --title "IP Configuration" --infobox "Requesting IP from DHCP server. \nDepending on network connectivity and DHCP server availability, this might take a while." 6 40
     fi
 
-    # Surpressing messages to the console for the cases where DHCP is unreachable.
+    # Suppressing messages to the console for the cases where DHCP is unreachable.
     # In these cases the network service cries to the log like a little bi#@h
     # and we don't want that.
     if [ ! "${dynamic}" -eq "3" ]; then
       sudo dmesg -n 1
       sudo service network restart &> /dev/null
       sudo dmesg -n 3
-      ifcfg=$(ifconfig | grep -w inet | grep -v 127.0.0.1) # ipv4
+      local ifcfg=$(ifconfig | grep -w inet | grep -v 127.0.0.1) # ipv4
       if [[ "${dynamic}" -eq "2" && "${ifcfg}" == "" ]]; then
         dialog --colors --nocancel --backtitle "NooBaa First Install" --title "\Zb\Z1ERROR" --msgbox "\Zb\Z1Was unable to get dynamically allocated IP via DHCP" 5 55
       fi
@@ -127,7 +127,7 @@ function configure_interface_ip() {
 }
 
 function configure_ips_dialog {
-    local interfaces=$(ifconfig -a | grep ^eth | awk '{print $1}')
+    local interfaces=$(ip addr | grep "state UP\|state DOWN" | awk '{print $2}' | sed 's/:/ /g')
     interfaces=${interfaces//:/}
     local str=""
     IFS=$'\n'
@@ -212,7 +212,7 @@ function configure_dns_dialog {
         fi
         
         sudo bash -c "echo \"forward only;\" >> /etc/noobaa_configured_dns.conf"
-        sudo dmesg -n 1 # need to restart network to update /etc/resolv.conf - supressing too much logs
+        sudo dmesg -n 1 # need to restart network to update /etc/resolv.conf - suppressing too much logs
         sudo bash -c "${command}" > /dev/null 2>&1
         sudo systemctl restart named &> /dev/null
         sudo /usr/bin/supervisorctl restart all 1> /dev/null
@@ -388,10 +388,10 @@ function update_ips_etc_issue {
 
 function update_noobaa_net {
   sudo bash -c "> ${NOOBAANET}"
-  interfaces=$(ifconfig -a | grep ^eth | awk '{print $1}')
+  local interfaces=$(ip addr | grep "state UP\|state DOWN" | awk '{print $2}' | sed 's/:/ /g')
   interfaces=${interfaces//:/}
-  for int in ${interfaces}; do
-      sudo bash -c "echo ${int} >> ${NOOBAANET}"
+  for interface in ${interfaces}; do
+      sudo bash -c "echo ${interface} >> ${NOOBAANET}"
   done
 }
 

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -1,13 +1,3 @@
-[program:STUN]
-directory=/usr/bin
-command=/usr/bin/turnserver
-user=root
-autostart=true
-autorestart=true
-stderr_logfile_backups=3
-stdout_logfile_backups=3
-#endprogram
-
 [program:webserver]
 stopsignal=KILL
 killasgroup=true

--- a/src/deploy/NVA_build/rsyslog.repo
+++ b/src/deploy/NVA_build/rsyslog.repo
@@ -1,7 +1,0 @@
-[rsyslog_v8]
-name=Adiscon CentOS-$releasever - local packages for $basearch
-baseurl=http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch
-enabled=1
-gpgcheck=1
-gpgkey=file:///root/node_modules/noobaa-core/src/deploy/NVA_build/RPM-GPG-KEY-Adiscon
-protect=1

--- a/src/test/system_tests/ceph_s3_tests_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests_deploy.sh
@@ -25,7 +25,6 @@
 logger -p local0.info "ceph_s3_tests_deploy.sh executed."
 DIRECTORY="s3-tests"
 CEPH_LINK="https://github.com/ceph/s3-tests.git"
-TURN_DL="http://turnserver.open-sys.org/downloads/v4.3.1.3/turnserver-4.3.1.3-CentOS6.6-x86_64.tar.gz"
 if [ ! -d $DIRECTORY ]; then
     echo "Remove centos-release-scl..."
     logger -p local0.info "Remove centos-release-scl..."
@@ -69,24 +68,4 @@ if [ ! -d $DIRECTORY ]; then
     touch ./s3tests/tests/__init__.py
     echo "Finished Running Bootstrap..."
     logger -p local0.info "Finished Running Bootstrap..."
-
-    echo "Downloading turnserver package and unpacking..."
-    logger -p local0.info "Downloading turnserver package and unpacking..."
-    cd /tmp
-    curl -sL ${TURN_DL} | tar -xzv
-    echo "Finished Downloading turnserver package and unpacking..."
-    logger -p local0.info "Finished Downloading turnserver package and unpacking..."
-
-    cd /tmp/turnserver-4.3.1.3
-    echo "Installing turnserver..."
-    logger -p local0.info "Installing turnserver..."
-    ./install.sh
-    echo "Finished Installing turnserver..."
-    logger -p local0.info "Finished Installing turnserver..."
-    
-    echo "Starting turnserver..."
-    logger -p local0.info "Starting turnserver..."
-    supervisorctl start STUN
-    echo "Finished Starting turnserver..."
-    logger -p local0.info "Finished Starting turnserver..."
 fi

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -50,11 +50,6 @@ const EXEC_DEFAULTS = Object.freeze({
 
 // map process name (in ps) to service name (in supervisor.conf)
 const SERVICES_INFO = Object.freeze([{
-        srv: 'STUN',
-        proc: 'turnserver',
-        stop: true,
-    },
-    {
         srv: 'webserver',
         proc: 'web_server',
         stop: true,

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -453,14 +453,16 @@ async function packages_upgrade() {
             'wget',
             'curl',
             'ntp',
-            'rsyslog',
+            //TODO: if we will need to upgrade the syslog we need this
+            //'rsyslog',
             'cronie',
             'openssh-server',
             'dialog',
             'expect',
             'nc',
             'tcpdump',
-            'iperf',
+            //TODO: if we will need to upgrade the ipref we need this
+            //'iperf', //We might need to remove it as we dont have the proper repo on RHEL7 
             'iperf3',
             'python-setuptools',
             'bind-utils',
@@ -471,7 +473,8 @@ async function packages_upgrade() {
             'net-tools',
             'iptables-services',
             'rng-tools', // random number generator tools
-            'pv', // pipe viewer
+            //TODO: if we will need to upgrade the pv we need this
+            //'pv', // pipe viewer
         ];
         dbg.log0(`install additional packages`);
         const res = await promise_utils.exec(`yum install -y ${packages_to_install.join(' ')}`, {

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -767,7 +767,7 @@ function get_networking_info() {
 }
 
 function get_all_network_interfaces() {
-    return promise_utils.exec('ifconfig -a | grep ^eth | awk -F":" \'{print $1}\'', {
+    return promise_utils.exec('ip addr | grep "state UP\\|state DOWN" | awk \'{print $2}\' | sed \'s/:/ /g\'', {
             ignore_rc: false,
             return_stdout: true,
         })


### PR DESCRIPTION
deploy_base.sh:
- Making deploy base work on RHEL7
- Removed turnserver
- Verifying that /tmp/noobaa-NVA.tar.gz exists
- Verifying that we have at list one repo
- Changed the way we get interfaces in clean_ifcfg
- Getting epel repo for RHEL
- Fixing the add_mongo_ssl_user
- Removed the yum upgrade of rsyslog

Removed rsyslog.repo

### Explain the changes
#### 1. New Features / Capabilities:
- Making the noobaa os RHEL7

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
