### PR TITLE
two_step_upgrade_test.js: Fixing the pipeline

### DIFF
--- a/src/test/qa/test-TUI.js
+++ b/src/test/qa/test-TUI.js
@@ -477,7 +477,7 @@ async function main() {
             ]
         });
         await server_ops.set_first_install_mark(server_ip, secret);
-        await server_ops.enable_nooba_login(server_ip, secret);
+        await server_ops.enable_noobaa_login(server_ip, secret);
         //will loop twice, one with system and the other without.
         for (let cycle = 0; cycle < cycles; ++cycle) {
             console.log(`${YELLOW}Starting cycle number: ${cycle}${NC}`);

--- a/src/test/utils/agent_functions.js
+++ b/src/test/utils/agent_functions.js
@@ -96,9 +96,9 @@ async function list_optimal_agents(server_ip, suffix = '') {
 }
 
 // Creates agent using map [agentName,agentOs]
-async function createAgentsFromMap(azf, server_ip, storage, vnet, exclude_drives = [], agentmap) {
+async function createAgentsFromMap(azf, server_ip, storage, vnet, exclude_drives = [], agent_map) {
     const created_agents = [];
-    const agents_to_create = Array.from(agentmap.keys());
+    const agents_to_create = Array.from(agent_map.keys());
     const agentConf = await getAgentConf(server_ip, exclude_drives);
     await P.map(agents_to_create, async name => {
         let retryCreate = true;
@@ -106,7 +106,7 @@ async function createAgentsFromMap(azf, server_ip, storage, vnet, exclude_drives
         const MAX_RETRIES = 5;
         while (retryCreate) {
             try {
-                const os = agentmap.get(name);
+                const os = agent_map.get(name);
                 const { hasImage } = await azf.getImagesfromOSname(os);
                 if (hasImage) {
                     console.log(`Creating ${name} using createAgentFromImage`);
@@ -490,13 +490,13 @@ async function startOfflineAgents(azf, server_ip, oses) {
 }
 
 async function createRandomAgents(azf, server_ip, storage, resource_vnet, amount, suffix, oses) {
-    const agentmap = new Map();
+    const agent_map = new Map();
     const createdAgents = getRandomOsesFromList(amount, oses);
     for (let i = 0; i < createdAgents.length; i++) {
-        agentmap.set(suffix + i, createdAgents[i]);
+        agent_map.set(suffix + i, createdAgents[i]);
     }
     try {
-        await createAgentsFromMap(azf, server_ip, storage, resource_vnet, [], agentmap);
+        await createAgentsFromMap(azf, server_ip, storage, resource_vnet, [], agent_map);
     } catch (e) {
         throw new Error('createAgentsFromMap::' + e);
     }
@@ -504,7 +504,7 @@ async function createRandomAgents(azf, server_ip, storage, resource_vnet, amount
     const node_number_after_create = listNodes.length;
     console.log(`${Yellow}Num nodes after create is: ${node_number_after_create}${NC}`);
     console.warn(`Node names are ${listNodes.map(node => node.name)}`);
-    return agentmap;
+    return agent_map;
 }
 
 /*

--- a/src/test/utils/server_functions.js
+++ b/src/test/utils/server_functions.js
@@ -31,7 +31,7 @@ function init_reporter(report_params) {
 }
 
 //will enable noobaa user login via ssh
-async function enable_nooba_login(server_ip, secret) {
+async function enable_noobaa_login(server_ip, secret) {
     const client_ssh = await ssh.ssh_connect({
         host: server_ip,
         //  port: 22,
@@ -279,7 +279,7 @@ async function add_server_to_cluster(master_ip, slave_ip, slave_secret, slave_na
         client.redirector.register_for_alerts();
     });
 
-    // 2 minutes timeout for add_memeber
+    // 2 minutes timeout for add_member
     const ADD_MEMBER_TIMEOUT = 120 * 1000;
     return P.resolve()
         .then(async () => {
@@ -307,8 +307,17 @@ async function add_server_to_cluster(master_ip, slave_ip, slave_secret, slave_na
         });
 }
 
+async function clean_pre_upgrade_leftovers(params) {
+    const ssh_client = await ssh.ssh_connect({
+        host: params.ip,
+        username: 'noobaaroot',
+        password: params.secret,
+        keepaliveInterval: 5000,
+    });
+    await ssh.ssh_exec(ssh_client, `sudo bash -c "rm -rf /tmp/test/ /tmp/new_version.tar.gz /tmp/nb_upgrade_*"`);
+}
 
-exports.enable_nooba_login = enable_nooba_login;
+exports.enable_noobaa_login = enable_noobaa_login;
 exports.set_first_install_mark = set_first_install_mark;
 exports.clean_ova = clean_ova;
 exports.wait_server_reconnect = wait_server_reconnect;
@@ -320,3 +329,4 @@ exports.upgrade_server = upgrade_server;
 exports.init_reporter = init_reporter;
 exports.add_server_to_cluster = add_server_to_cluster;
 exports.remove_swap_on_azure = remove_swap_on_azure;
+exports.clean_pre_upgrade_leftovers = clean_pre_upgrade_leftovers;


### PR DESCRIPTION
### Explain the changes

#### Existing Behavior Changes:

two_step_upgrade_test.js:
- Getting the min memory for upgrade from the config file
- Added printing.
- Fixed the timing after Reset time back to normal in first step
- When checking that the free space is under the threshold,  we are now
waiting up to 90 sec
- Moved the logic of  checking that the free space is under the
threshold from _fill_local_disk function to a new
_check_free_space_under_threshold function
- Calling clean_pre_upgrade_leftovers between first and second steps

agent_functions.js:
- Add function that cleans the pre upgrade leftovers

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
