### PR TITLE
Fixed error in create system in OpenShift

### DIFF
--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -115,7 +115,9 @@ function read_drives() {
 }
 
 function get_raw_storage() {
-    if (os.type() === 'Linux') {
+    // on containered environments the disk name is not consistent, just return the root mount size.
+    //later on we want to change it to return the size of the perstistent volume mount
+    if (os.type() === 'Linux' && process.env.PLATFORM !== 'docker') {
         return P.fromCallback(callback => blockutils.getBlockInfo({}, callback))
             .then(res => _.find(res, function(disk) {
                 let expected_name = 'sda';


### PR DESCRIPTION
### Explain the changes
-  in `os_utils.get_raw_storage` handle containers like non-linux systems
  - disk names are not consistent in contained environments so on some platforms we don't find the expected name. for now we return the size of the root mount

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages