### PR TITLE
Adding md5sum for the agents

### DIFF
--- a/src/deploy/Linux/Build-Package.sh
+++ b/src/deploy/Linux/Build-Package.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "=====> nvm install"
+source ~/.bashrc || exit 1
+source "$NVM_DIR/nvm.sh" || exit 1
+nvm install || exit 1
+
+echo "=====> get package for git commit $GIT_COMMIT"
+NB_VERSION=$(node << EOF
+    'use strict';
+    const fs = require('fs');
+    const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+    const git = process.env.GIT_COMMIT || 'DEVONLY';
+    const version = pkg.version.split('-')[0] + '-' + git.slice(0, 7);
+    console.log(version);
+EOF
+)
+echo "=====> version $NB_VERSION"
+
+echo "=====> update tar noobaa-NVA-${NB_VERSION}.tar.gz"
+gunzip build/public/noobaa-NVA-${NB_VERSION}.tar.gz || exit 1
+mv build/linux/noobaa-setup-${NB_VERSION}* build/public/ || exit 1
+mv build/windows/noobaa-setup-${NB_VERSION}.exe* build/public/ || exit 1
+tar --transform='s:^:noobaa-core/:' \
+    -rf build/public/noobaa-NVA-${NB_VERSION}.tar \
+    build/public/noobaa-setup-${NB_VERSION} \
+    build/public/noobaa-setup-${NB_VERSION}.md5 \
+    build/public/noobaa-setup-${NB_VERSION}.exe \
+    build/public/noobaa-setup-${NB_VERSION}.exe.md5 \
+    || exit 1
+gzip build/public/noobaa-NVA-${NB_VERSION}.tar

--- a/src/deploy/Linux/build_agent_linux.sh
+++ b/src/deploy/Linux/build_agent_linux.sh
@@ -98,6 +98,7 @@ verbose mkdir dist
 verbose cp ../../src/deploy/Linux/setup.sh ./dist/
 verbose mv noobaa-installer ./dist/noobaa-installer
 verbose ../../src/deploy/makeself/makeself.sh ./dist noobaa-setup-$current_package_version $current_package_version ./setup.sh
+md5sum noobaa-setup-$current_package_version | awk '{print $1}' > noobaa-setup-${current_package_version}.md5
 verbose popd
 
 echo "Done: build/linux/noobaa-setup-$current_package_version"

--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -111,6 +111,8 @@ if exist "%SIGNTOOL_PATH%" (
     "%SIGNTOOL_PATH%" sign /v /s my /t http://timestamp.comodoca.com /a %FINAL_SETUP_FILE_NAME% || exit 1
 )
 
+md5sum %FINAL_SETUP_FILE_NAME% | awk '{print $1}' > %FINAL_SETUP_FILE_NAME%.md5
+
 echo "%FINAL_SETUP_FILE_NAME% installer available under build\windows"
 
 cd ..\..

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -452,7 +452,7 @@ async function copy_new_code() {
     await fs_utils.full_dir_copy(NEW_VERSION_DIR, CORE_DIR);
 }
 
-// make sure that all the file which are requiered by the new version (.env, etc.) are in the new dir
+// make sure that all the file which are required by the new version (.env, etc.) are in the new dir
 async function prepare_new_dir() {
     await _build_dotenv();
     await _create_packages_md5();
@@ -467,7 +467,7 @@ async function _build_dotenv() {
         _.pick(old_env, DOTENV_VARS_FROM_OLD_VER),
     );
 
-    dbg.log0('UPGRADE: genertaing .env file for new version:', new_env);
+    dbg.log0('UPGRADE: generating .env file for new version:', new_env);
 
     await fs.writeFileAsync(`${NEW_VERSION_DIR}/.env`, dotenv.stringify(new_env));
 }
@@ -810,7 +810,7 @@ async function set_upgrade_info(new_upgrade_info) {
     try {
         const upgrade_data = JSON.stringify(new_upgrade_info);
         await fs.writeFileAsync(UPGRADE_INFO_FILE_PATH, upgrade_data);
-        dbg.log0('UPGRADE: upgrade info updated successfuly with upgrade_info =', new_upgrade_info);
+        dbg.log0('UPGRADE: upgrade info updated successfully with upgrade_info =', new_upgrade_info);
     } catch (err) {
         dbg.error(`got unexpected error when writing upgrade info file ${UPGRADE_INFO_FILE_PATH}`, err);
     }


### PR DESCRIPTION
### Explain the changes
build_windows_agent.bat and build_agent_linux.sh

- Adding md5sum for the agents

platform_upgrade.js:
- Typo

- Add src/deploy/Linux/Build-Package.sh

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
