### PR TITLE
init prometheus stats on nodes_monitor startup according to DB

### DIFF
--- a/src/server/analytic_services/prometheus_reporting.js
+++ b/src/server/analytic_services/prometheus_reporting.js
@@ -89,6 +89,18 @@ class PrometheusReporting {
         }
     }
 
+    set_cloud_bandwidth(type, write_size, read_size) {
+        if (!this.enabled()) return;
+        this._metrics.cloud_bandwidth.set({ type: type + '_write_size' }, write_size);
+        this._metrics.cloud_bandwidth.set({ type: type + '_read_size' }, read_size);
+    }
+
+    set_cloud_ops(type, write_num, read_num) {
+        if (!this.enabled()) return;
+        this._metrics.cloud_ops.set({ type: type + '_write_ops' }, write_num);
+        this._metrics.cloud_ops.set({ type: type + '_read_ops' }, read_num);
+    }
+
     update_cloud_bandwidth(type, write_size, read_size) {
         if (!this.enabled()) return;
         this._metrics.cloud_bandwidth.inc({ type: type + '_write_size' }, write_size, new Date());


### PR DESCRIPTION
### Explain the changes
- when starting nodes monitor - set Prometheus client stats according to existing count in DB

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
