### PR TITLE
Support for prometheus scrape_configs

### DIFF
--- a/config.js
+++ b/config.js
@@ -354,7 +354,7 @@ config.MIN_MEMORY_FOR_UPGRADE = 1200 * 1024 * 1024;
 //////////////////////////////
 
 config.SEND_EVENTS_REMOTESYS = true;
-config.PROMETHEUS_ENABLED = false;
+config.PROMETHEUS_ENABLED = true;
 
 
 // load a local config file that overwrites some of the config

--- a/src/deploy/NVA_build/noobaa_statefulset.yaml
+++ b/src/deploy/NVA_build/noobaa_statefulset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: noobaa-services
   labels:
     app: noobaa
+  annotations: 
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: http
+    prometheus.io/port: "8080"
 spec:
 # LoadBalancer service will alocate an external ip automatically on public cloud providers (aws\azure\gcp, etc.)
 # for on premise kuberenets clusters there are 3rd party solutions that provide the same functionality. e.g: metalLB (https://metallb.universe.tf)


### PR DESCRIPTION
Prometheus running on top of open shift/k8s will discover automatically
NooBaa send matrixes.

### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- adding prometheus annotation to our yaml
- change to send prometheus matrixes by default

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
