### PR TITLE
deploy_base.sh: fixing the SELinux directory context type to be the same as /var/log

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -376,6 +376,13 @@ function setup_supervisors {
 function setup_syslog {
 	deploy_log "setup_syslog start"
 
+    if [ "${container}" != "docker" ]; then
+        semanage fcontext -a -t syslogd_var_lib_t /log
+        restorecon -R -v /log
+
+        deploy_log "$(ls -Zd /log)"
+    fi
+
     # copy noobaa_syslog.conf to /etc/rsyslog.d/ which is included by rsyslog.conf
     cp -f ${CORE_DIR}/src/deploy/NVA_build/noobaa_syslog.conf /etc/rsyslog.d/
     cp -f ${CORE_DIR}/src/deploy/NVA_build/logrotate_noobaa.conf /etc/logrotate.d/noobaa


### PR DESCRIPTION
deploy_base.sh:
- fixing the SELinux directory context type to be the same as /var/log

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
