### PR TITLE
cluster_test.js: Making sure the servers does not have NTP when testing add server with no NTP

### DIFF
--- a/src/deploy/version_map.json
+++ b/src/deploy/version_map.json
@@ -1,7 +1,7 @@
 {
     "versions": [{
         "ver": "3.0.0",
-        "vhd": "3.0.0-22c87fc.vhd",
+        "vhd": "3.0.0-d90238a.vhd",
         "released": true
     }]
 }

--- a/src/test/framework/test_env_builder.js
+++ b/src/test/framework/test_env_builder.js
@@ -195,7 +195,7 @@ async function prepare_container_env() {
         password: server.secret,
         keepaliveInterval: 5000,
     });
-    await server_functions.enable_nooba_login(server.ip, server.secret);
+    await server_functions.enable_noobaa_login(server.ip, server.secret);
     // copy package to remote server
     console.log(`uploading package ${upgrade} to server ${server.ip}`);
     await promise_utils.exec(`scp -o "StrictHostKeyChecking no" ${upgrade} noobaaroot@${server.ip}:/tmp/noobaa-NVA.tar.gz`);


### PR DESCRIPTION
cluster_test.js:
- Making sure the servers does not have NTP when testing add server
with no NTP

cluster_test.js
- Add err printing when test_cluster_preconditions fails

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
