### PR TITLE
noobaa_init.sh: Fixing "systemctl start supervisord" in docker

### DIFF
--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -34,7 +34,7 @@ update_services_autostart() {
 
 handle_unmanaged_upgrade() {
     #Container specific logic
-    if grep -q PLATFORM=docker /root/node_modules/noobaa-core/.env; then
+    if grep -q PLATFORM=docker /data/.env; then
         code_version=$(grep version ${NOOBAA_PACKAGE_PATH} | awk -F'["|"]' '{print $4}')
         if [ ! -f ${NOOBAA_DATA_VERSION} ]; then 
             #New system, update data version file

--- a/src/deploy/NVA_build/setup_server_swap.sh
+++ b/src/deploy/NVA_build/setup_server_swap.sh
@@ -9,7 +9,7 @@ if grep -q PLATFORM=azure /data/.env; then
     sed -i "s:ResourceDisk.SwapSizeMB=0:ResourceDisk.SwapSizeMB=${SWAP_SIZE_MB}:" /etc/waagent.conf
     service waagent restart
   fi
-elif [ "${container}" != "docker" ]; then
+elif ! grep -q PLATFORM=docker /data/.env ; then
   if ! grep -q swapfile /etc/fstab; then
     swapon -s
     dd if=/dev/zero bs=1M count=${SWAP_SIZE_MB} of=/swapfile


### PR DESCRIPTION
### Explain the changes
noobaa_init.sh:
- Fixing the env path in container

setup_server_swap.sh
- Fixing the condition of docker

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
