### PR TITLE
fixed failure in _communicate_license_server during create_system

### DIFF
--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -1425,7 +1425,7 @@ function _communicate_license_server(params, proxy_address) {
         code: params.code.trim(),
     };
     if (params.email) {
-        body['Business Email'] = params.email.trim();
+        body['Business Email'] = params.email.unwrap().trim();
     }
     if (params.command === 'perform_activation') {
         body.system_info = params.system_info || {};


### PR DESCRIPTION
#### 1. New Features / Capabilities (Sync with Liran):
- addition of sensitive strings wrapper failed create system when trying to communicate with license server.
- trying to do `.trim()` caused an exception. unwrapping the value to fix it

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
