### PR TITLE
simple curl support for rpc http

### DIFF
--- a/src/deploy/azureFunctions.js
+++ b/src/deploy/azureFunctions.js
@@ -986,7 +986,7 @@ class AzureFunctions {
             .tap(() => console.log(`${serverName}_pip`))
             .then(() => this.getIpAddress(`${serverName}_pip`))
             .tap(ip => console.log(`server name: ${serverName}, ip: ${ip}`))
-            .tap(ip => ops.wait_for_server(ip).timeout(10 * 60 * 1000 * 1000))
+            .tap(ip => P.resolve(ops.wait_for_server(ip)).timeout(10 * 60 * 1000 * 1000))
             .then(ip => {
                 if (createSystem) {
                     rpc = api.new_rpc('wss://' + ip + ':8443');

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -690,6 +690,8 @@ RPC.prototype._on_message = function(conn, msg_buffer) {
             ' conn ' + conn.connid));
         return;
     }
+    if (!msg.header.op) msg.header.op = 'req';
+    if (!msg.header.reqid) msg.header.reqid = conn._alloc_reqid();
 
     switch (msg.header.op) {
         case 'req':

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -232,10 +232,10 @@ function call_next_io(req) {
 
 function io_service(req) {
     dbg.log1('IO SERVICE');
-    const data_in = req.params[RPC_BUFFERS].data;
+    const data_in = req.params[RPC_BUFFERS] && req.params[RPC_BUFFERS].data;
     const data = Buffer.alloc(req.params.rsize, 0x99);
     io_count += 1;
-    io_rbytes += data_in.length;
+    io_rbytes += data_in ? data_in.length : 0;
     io_wbytes += data.length;
     return {
         [RPC_BUFFERS]: { data },

--- a/src/rpc/rpc_request.js
+++ b/src/rpc/rpc_request.js
@@ -16,6 +16,7 @@ const RPC_VERSION_NUMBER = Buffer.from([
     RPC_VERSION_MINOR,
     RPC_VERSION_FLAGS,
 ]).readUInt32BE(0);
+const RPC_VERSION_HEX = `0x${RPC_VERSION_NUMBER.toString(16)}`;
 
 const RPC_BUFFERS = Symbol('RPC_BUFFERS');
 
@@ -182,5 +183,7 @@ class RpcRequest {
 }
 
 RpcRequest.RPC_BUFFERS = RPC_BUFFERS;
+RpcRequest.RPC_VERSION_NUMBER = RPC_VERSION_NUMBER;
+RpcRequest.RPC_VERSION_HEX = RPC_VERSION_HEX;
 
 module.exports = RpcRequest;

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -407,7 +407,7 @@ function getVersion(route) {
                             };
                         }
                         return server_rpc.client.system.read_system({}, {
-                                address: 'http://127.0.0.1:' + http_port,
+                                address: 'ws://127.0.0.1:' + http_port,
                                 auth_token: auth_server.make_auth_token({
                                     system_id: system._id,
                                     role: 'admin',

--- a/src/tools/rpc_shell.js
+++ b/src/tools/rpc_shell.js
@@ -17,6 +17,7 @@ var rpcshell = new RPCShell();
 argv.email = argv.email || 'demo@noobaa.com';
 argv.password = argv.password || 'DeMo1';
 argv.system = argv.system || 'demo';
+argv.options = argv.options || undefined;
 
 function RPCShell() {
     this.rpc = api.new_rpc();
@@ -159,7 +160,7 @@ RPCShell.prototype.call = function(str_args) {
 
     console.log('Invoking RPC', apiname + '.' + func + '(' + util.inspect(rpc_args) + ')');
     return P.fcall(function() {
-            return self.client[apiname][func](rpc_args);
+            return self.client[apiname][func](rpc_args, argv.options);
         })
         .catch(function(err) {
             console.warn('Recieved error', err.stack || err);


### PR DESCRIPTION
### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- Now you can use curl to invoke any RPC API.

I wrote a short Wiki with examples: 
https://github.com/noobaa/noobaa-core/wiki/RPC

(Note: I'm using `jq` to pretty print json. Install it on Mac with `brew install jq`)

Example 1: Create system example:
```
$ curl http://127.0.0.1:5001/rpc/ -sd '{
  "api": "system_api",
  "method": "create_system",
  "params": {
    "name": "demo",
    "email": "demo@noobaa.com",
    "password": "*****",
    "activation_code": "123"
  }
}' | jq

{
  "op": "res",
  "reqid": null,
  "took": 2017.9986989996396,
  "reply": {
    "token": "******************"
  }
}
```

Example 2: Read system
```
$ curl http://127.0.0.1:5001/rpc/ -sd '{
  "api": "system_api",
  "method": "read_system",
  "auth_token": "***********"
}' | jq

{
  "op": "res",
  "reqid": null,
  "took": 47.75764900026843,
  "reply": {
    "name": "demo",
    ...
    ...
  }
}
```

#### 2. Existing Behavior Changes (Sync with Liran):
- RPC over http has changed wire format a bit, but since we didn't use it before then nothing should break.

#### 3. Other Changes:
- NA

### Issues: Fixed #xxx / Gap #xxx
- NA

### Testing Instructions:
- Maybe add a simple test for regression.

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
