### PR TITLE
issue #343 - handle more https servers that need honorCipherOrder:true

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -333,7 +333,7 @@ class Agent {
             .then(token => {
                 // use the token as authorization (either 'create_node' or 'agent' role)
                 this.client.options.auth_token = token.toString();
-                this.ssl_context = ssl_utils.generate_ssl_certificate();
+                this.ssl_context = { ...ssl_utils.generate_ssl_certificate(), honorCipherOrder: true };
                 // update the n2n ssl to use my certificate
                 this.n2n_agent.set_ssl_context(this.ssl_context);
             })

--- a/src/rpc/rpc_http_server.js
+++ b/src/rpc/rpc_http_server.js
@@ -49,7 +49,7 @@ class RpcHttpServer extends events.EventEmitter {
         dbg.log0('HTTP SERVER:', 'port', port, 'secure', secure, 'logging', logging);
 
         const server = secure ?
-            https.createServer(ssl_utils.generate_ssl_certificate()) :
+            https.createServer({ ...ssl_utils.generate_ssl_certificate(), honorCipherOrder: true }) :
             http.createServer();
         this.install_on_server(server, options.default_handler);
         return P.fromCallback(callback => server.listen(port, callback))

--- a/src/rpc/rpc_n2n_agent.js
+++ b/src/rpc/rpc_n2n_agent.js
@@ -139,7 +139,7 @@ class RpcN2NAgent extends EventEmitter {
 
     set_ssl_context(secure_context_params) {
         this.n2n_config.ssl_options.secureContext =
-            tls.createSecureContext({ honorCipherOrder: true, ...secure_context_params });
+            tls.createSecureContext({ ...secure_context_params, honorCipherOrder: true });
     }
 
     update_n2n_config(n2n_config) {

--- a/src/rpc/rpc_tcp_server.js
+++ b/src/rpc/rpc_tcp_server.js
@@ -22,7 +22,7 @@ class RpcTcpServer extends EventEmitter {
         super();
         this.protocol = (tls_options ? 'tls:' : 'tcp:');
         this.server = tls_options ?
-            tls.createServer({ honorCipherOrder: true, ...tls_options }, tcp_conn => this._on_tcp_conn(tcp_conn)) :
+            tls.createServer({ ...tls_options, honorCipherOrder: true }, tcp_conn => this._on_tcp_conn(tcp_conn)) :
             net.createServer(tcp_conn => this._on_tcp_conn(tcp_conn));
         this.server.on('close', err => {
             dbg.log0('on close:', err);


### PR DESCRIPTION
### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- NA

#### 2. Existing Behavior Changes (Sync with Liran):
- Update the webserver and s3 endpoint to pass the ssl option honorCipherOrder so that only the server will choose the SSL ciphers and not the client.

#### 3. Other Changes:
- NA

### Issues: Fixed #xxx / Gap #xxx
- issue #343 is not resolved yet, but better.

### Testing Instructions:
- Test SSL

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
