### PR TITLE
run supervisord instead of systemd in a container + auto create system in kubernetes

### DIFF
--- a/gocode/src/noobaa-operator/pkg/controller/noobaa/noobaa_controller.go
+++ b/gocode/src/noobaa-operator/pkg/controller/noobaa/noobaa_controller.go
@@ -241,6 +241,7 @@ func (r *ReconcileNoobaa) statefulSetForNoobaa(nb *noobaav1alpha1.Noobaa) (*apps
 	statefulSet.ObjectMeta.Namespace = nb.Namespace
 	statefulSet.ObjectMeta.Name = nb.Name
 	statefulSet.Spec.Selector.MatchLabels = ls
+	statefulSet.Spec.ServiceName = nb.Name + "-services"
 	statefulSet.Spec.Template.ObjectMeta.Labels = ls
 	if nb.Spec.Image != "" {
 		statefulSet.Spec.Template.Spec.Containers[0].Image = nb.Spec.Image
@@ -253,6 +254,7 @@ func (r *ReconcileNoobaa) statefulSetForNoobaa(nb *noobaav1alpha1.Noobaa) (*apps
 			corev1.EnvVar{Name: "CREATE_SYS_NAME", Value: nb.Name},
 			corev1.EnvVar{Name: "CREATE_SYS_EMAIL", Value: nb.Spec.Email},
 			corev1.EnvVar{Name: "CREATE_SYS_CODE", Value: nb.Spec.ActivationCode},
+			corev1.EnvVar{Name: "CONTAINER_PLATFORM", Value: "KUBERNETES"},
 		}
 	}
 

--- a/src/deploy/NVA_build/Server.Dockerfile
+++ b/src/deploy/NVA_build/Server.Dockerfile
@@ -1,21 +1,6 @@
 FROM centos:7
 LABEL maintainer="Evgeniy Belyi (jeniawhite92@gmail.com)"
 
-#################
-# SYSTEMD SETUP #
-#################
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-    rm -f /lib/systemd/system/multi-user.target.wants/*;\
-    rm -f /etc/systemd/system/*.wants/*;\
-    rm -f /lib/systemd/system/local-fs.target.wants/*; \
-    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-    rm -f /lib/systemd/system/basic.target.wants/*;\
-    rm -f /lib/systemd/system/anaconda.target.wants/*;
-
-VOLUME ["/sys/fs/cgroup"]
-
-
 ################
 # NOOBAA SETUP #
 ################
@@ -43,4 +28,4 @@ EXPOSE 26050
 ###############
 # EXEC SETUP #
 ###############
-CMD ["/usr/sbin/init"]
+CMD ["/usr/bin/supervisord", "start_container"]

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -376,6 +376,9 @@ function setup_supervisors {
 function setup_syslog {
 	deploy_log "setup_syslog start"
 
+    # remove rsyslog from systemd
+    systemctl disable rsyslog
+
     if [ "${container}" != "docker" ]; then
         semanage fcontext -a -t syslogd_var_lib_t /log
         restorecon -R -v /log
@@ -384,11 +387,11 @@ function setup_syslog {
     fi
 
     # copy noobaa_syslog.conf to /etc/rsyslog.d/ which is included by rsyslog.conf
+    # remove rsyslog listen.conf
+    rm -f /etc/rsyslog.d/listen.conf
+    cp -f ${CORE_DIR}/src/deploy/NVA_build/rsyslog.conf /etc/rsyslog.conf
     cp -f ${CORE_DIR}/src/deploy/NVA_build/noobaa_syslog.conf /etc/rsyslog.d/
     cp -f ${CORE_DIR}/src/deploy/NVA_build/logrotate_noobaa.conf /etc/logrotate.d/noobaa
-
-    # setup crontab to run logrotate every 15 minutes.
-    echo "*/15 * * * * /usr/sbin/logrotate /etc/logrotate.d/noobaa >/dev/null 2>&1" > /var/spool/cron/root
 
 	deploy_log "setup_syslog done"
 }

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -241,6 +241,18 @@ function install_mongo {
     deploy_log "install_mongo done"
 }
 
+
+function setup_bash_completions {
+    deploy_log "setting up bash_completions"
+
+    echo "# Use bash-completion, if available
+[[ \$PS1 && -f /usr/share/bash-completion/bash_completion ]] &&
+    . /usr/share/bash-completion/bash_completion" >> ~/.bashrc
+
+    cp -f ${CORE_DIR}/src/deploy/NVA_build/supervisorctl.bash_completion /etc/bash_completion.d/supervisorctl
+}
+
+
 function general_settings {
 	deploy_log "general_settings start"
 
@@ -275,6 +287,8 @@ function general_settings {
     echo "export GREP_OPTIONS='--color=auto'" >> ~/.bashrc
     echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.bashrc
     echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm' >> ~/.bashrc
+
+    setup_bash_completions
 
     #Fix file descriptor limits, tcp timeout
     echo "root hard nofile 102400" >> /etc/security/limits.conf

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -50,13 +50,13 @@ function install_platform {
         systemctl disable firewalld
         systemctl disable NetworkManager
         systemctl enable iptables
+        # make network service run on boot
+        systemctl enable network
+        # enable random number generator daemon
+        # see https://www.certdepot.net/rhel7-get-started-random-number-generator/
+        systemctl enable rngd
     fi 
 
-    # make network service run on boot
-    systemctl enable network
-    # enable random number generator daemon
-    # see https://www.certdepot.net/rhel7-get-started-random-number-generator/
-    systemctl enable rngd
 
 	# make crontab start on boot
 	chkconfig crond on
@@ -230,9 +230,9 @@ function install_mongo {
     # pin mongo version in yum, so it won't auto update
     echo "exclude=mongodb-org,mongodb-org-server,mongodb-org-shell,mongodb-org-mongos,mongodb-org-tools" >> /etc/yum.conf
     rm -f /etc/init.d/mongod
-    systemctl disable mongod
 
     if [ "${container}" != "docker" ]; then
+        systemctl disable mongod
         systemctl stop mongod
         deploy_log "adding mongo ssl user"
         add_mongo_ssl_user
@@ -391,9 +391,9 @@ function setup_syslog {
 	deploy_log "setup_syslog start"
 
     # remove rsyslog from systemd
-    systemctl disable rsyslog
 
     if [ "${container}" != "docker" ]; then
+        systemctl disable rsyslog
         semanage fcontext -a -t syslogd_var_lib_t /log
         restorecon -R -v /log
 

--- a/src/deploy/NVA_build/logrotate.sh
+++ b/src/deploy/NVA_build/logrotate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# script to run logrotate every 15 minutes
+
+while true; do
+    echo "$(date): =================================== running logrotate ==================================="
+    /usr/sbin/logrotate -v /etc/logrotate.d/noobaa 2>&1
+    echo
+    sleep 900
+done

--- a/src/deploy/NVA_build/logrotate_noobaa.conf
+++ b/src/deploy/NVA_build/logrotate_noobaa.conf
@@ -9,7 +9,7 @@
         create 640 root root
         sharedscripts
         postrotate
-                systemctl kill -s HUP rsyslog.service 2> /dev/null || true
+                supervisorctl signal HUP rsyslog 2> /dev/null || true
         endscript
 }
 
@@ -24,6 +24,6 @@
         create 640 root root
         sharedscripts
         postrotate
-                systemctl kill -s HUP rsyslog.service 2> /dev/null || true
+                supervisorctl signal HUP rsyslog 2> /dev/null || true
         endscript
 }

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -65,7 +65,10 @@ EOF
     fi
 }
 
-init_noobaa_server() {
+init_noobaa_server() { 
+  # make sure /log has limited permissions. this is required by logrotate
+  chmod 755 /log
+
   # run init scripts
   /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_plat.sh
   /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_mongo_ssl.sh

--- a/src/deploy/NVA_build/noobaa_statefulset.yaml
+++ b/src/deploy/NVA_build/noobaa_statefulset.yaml
@@ -72,7 +72,9 @@ spec:
               name: datadir
             - mountPath: /log
               name: logdir
-
+          env:
+            - name: CONTAINER_PLATFORM
+              value: KUBERNETES
       volumes:
         - name: run-volume
           emptyDir: { medium: "Memory" }

--- a/src/deploy/NVA_build/noobaa_statefulset.yaml
+++ b/src/deploy/NVA_build/noobaa_statefulset.yaml
@@ -26,15 +26,13 @@ spec:
   selector:
     app: noobaa-server
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: noobaa-server
 spec:
   serviceName: noobaa-services
   replicas: 1
-  selector:
-    app: noobaa
   template:
     metadata:
       labels:
@@ -42,9 +40,6 @@ spec:
     spec:
       containers:
         - name: noobaa-server
-          securityContext:
-            capabilities: {}
-            privileged: true
           resources:
             requests:
               memory: "1Gi"
@@ -55,8 +50,7 @@ spec:
           # change image location before running
           # image: [image registry]/[image]
           # TODO: Need to update the tag in the build process
-          image: noobaaimages.azurecr.io/noobaa/nbserver:latest
-          imagePullPolicy: Always
+          image: noobaaimages.azurecr.io/noobaa/nbserver:1
           ports:
             - containerPort: 80
             - containerPort: 443
@@ -70,9 +64,6 @@ spec:
             - containerPort: 60104
             - containerPort: 60105
           volumeMounts:
-            - mountPath: /sys/fs/cgroup
-              name: cgroup-volume
-              readOnly: true
             - mountPath: /run
               name: run-volume
             - mountPath: /run/lock
@@ -81,13 +72,8 @@ spec:
               name: datadir
             - mountPath: /log
               name: logdir
+
       volumes:
-        - name: cgroup-volume
-          hostPath:
-            # directory location on host
-            path: /sys/fs/cgroup
-            # this field is optional
-            type: Directory
         - name: run-volume
           emptyDir: { medium: "Memory" }
         - name: run-lock-volume

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -55,3 +55,25 @@ priority=1
 stderr_logfile_backups=3
 stdout_logfile_backups=3
 #endprogram
+
+[program:rsyslog]
+stopsignal=KILL
+killasgroup=true
+stopasgroup=true
+autostart=true
+directory=/usr/sbin
+stderr_logfile_backups=3
+stdout_logfile_backups=3
+command=/usr/sbin/rsyslogd -n
+#endprogram
+
+[program:logrotate]
+stopsignal=KILL
+killasgroup=true
+stopasgroup=true
+autostart=true
+directory=/root/node_modules/noobaa-core
+stderr_logfile_backups=3
+stdout_logfile_backups=3
+command=/root/node_modules/noobaa-core/src/deploy/NVA_build/logrotate.sh
+#endprogram

--- a/src/deploy/NVA_build/rsyslog.conf
+++ b/src/deploy/NVA_build/rsyslog.conf
@@ -1,0 +1,91 @@
+# rsyslog configuration file
+
+# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+
+#### MODULES ####
+
+# The imjournal module bellow is now used as a message source instead of imuxsock.
+$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+#$ModLoad imjournal # provides access to the systemd journal
+#$ModLoad imklog # reads kernel messages (the same are read from journald)
+#$ModLoad immark  # provides --MARK-- message capability
+
+# Provides UDP syslog reception
+#$ModLoad imudp
+#$UDPServerRun 514
+
+# Provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+
+#### GLOBAL DIRECTIVES ####
+
+# Where to place auxiliary files
+$WorkDirectory /var/lib/rsyslog
+
+# Use default timestamp format
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# File syncing capability is disabled by default. This feature is usually not required,
+# not useful and an extreme performance hit
+#$ActionFileEnableSync on
+
+# Include all config files in /etc/rsyslog.d/
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+$OmitLocalLogging off
+
+# File to store the position in the journal
+#$IMJournalStateFile imjournal.state
+
+
+#### RULES ####
+
+# Log all kernel messages to the console.
+# Logging much else clutters up the screen.
+#kern.*                                                 /dev/console
+
+# Log anything (except mail) of level info or higher.
+# Don't log private authentication messages!
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+
+# The authpriv file has restricted access.
+authpriv.*                                              /var/log/secure
+
+# Log all the mail messages in one place.
+mail.*                                                  -/var/log/maillog
+
+
+# Log cron stuff
+cron.*                                                  /var/log/cron
+
+# Everybody gets emergency messages
+*.emerg                                                 :omusrmsg:*
+
+# Save news errors of level crit and higher in a special file.
+uucp,news.crit                                          /var/log/spooler
+
+# Save boot messages also to boot.log
+local7.*                                                /var/log/boot.log
+
+
+# ### begin forwarding rule ###
+# The statement between the begin ... end define a SINGLE forwarding
+# rule. They belong together, do NOT split them. If you create multiple
+# forwarding rules, duplicate the whole block!
+# Remote Logging (we use TCP for reliable delivery)
+#
+# An on-disk queue is created for this action. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+#$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+#$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+#$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+#$ActionQueueType LinkedList   # run asynchronously
+#$ActionResumeRetryCount -1    # infinite retries if host is down
+# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+#*.* @@remote-host:514
+# ### end of the forwarding rule ###

--- a/src/deploy/NVA_build/supervisorctl.bash_completion
+++ b/src/deploy/NVA_build/supervisorctl.bash_completion
@@ -1,0 +1,33 @@
+# pfreixes, 2012-07-27
+# Add to /etc/bash_completion.d/supervisorctl
+  
+_supervisor()
+{
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    #
+    #  The basic options we'll complete.
+    #
+    opts="add clear fg open quit remove restart start stop update avail exit maintail pid reload reread shutdown status tail version"
+
+
+    #
+    #  Complete the arguments to some of the basic commands.
+    #
+    case "${prev}" in
+        start|stop|restart)
+            local process=$(for x in `supervisorctl avail | awk '{print $1}'`; do echo ${x} ; done )
+            COMPREPLY=( $(compgen -W "${process}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+        ;;
+    esac
+
+   COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+   return 0
+}
+complete -F _supervisor supervisorctl

--- a/src/deploy/NVA_build/supervisord.orig
+++ b/src/deploy/NVA_build/supervisord.orig
@@ -16,7 +16,11 @@ start() {
     fi
     echo "Starting ..."
     logger -p local0.info -t Superd "Starting ..."
-    ulimit -n 102400; $SUPERVISORD --pidfile $PIDFILE
+    if [ $1 == "container" ]; then
+        ulimit -n 102400; $SUPERVISORD --pidfile $PIDFILE -n
+    else
+        ulimit -n 102400; $SUPERVISORD --pidfile $PIDFILE
+    fi
 
     return $?
 }
@@ -63,6 +67,9 @@ stop() {
 case $1 in
     start)
         start
+    ;;
+    start_container)
+        start container
     ;;
     stop)
         stop

--- a/src/deploy/build_operator.sh
+++ b/src/deploy/build_operator.sh
@@ -2,20 +2,23 @@
 
 export GOPATH=$PWD/gocode
 
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
 if [ ! -d "$GOPATH/src/github.com/operator-framework" ]; then
-    echo "getting operator-sdk code"
+    echo -e "${GREEN}getting operator-sdk code${NC}"
     mkdir -p $GOPATH/src/github.com/operator-framework
     cd $GOPATH/src/github.com/operator-framework
     git clone https://github.com/operator-framework/operator-sdk
     cd operator-sdk
     #git checkout master
-    echo "building opeartor-sdk"
+    echo -e "${GREEN}building opeartor-sdk${NC}"
     make dep
     make install
 fi
-echo "getting dependencies. might take some time.."
+echo -e "${GREEN}getting dependencies. might take some time..${NC}"
 cd $GOPATH/src/noobaa-operator
 dep ensure -v
-echo "building noobaa-operator.."
+echo -e "${GREEN}building noobaa-operator..${NC}"
 operator-sdk build noobaa-operator
-echo "completed!"
+echo -e "${GREEN}completed!${NC}"

--- a/src/deploy/rpm/noobaa.spec
+++ b/src/deploy/rpm/noobaa.spec
@@ -40,6 +40,7 @@ Requires:   ntp = 4.2.6p5
 Requires:   nc
 Requires:   vim
 Requires:   less
+Requires:   bash-completion
 Requires:   mongodb-org = 3.6.5
 Requires:   mongodb-org-server = 3.6.5
 Requires:   mongodb-org-shell = 3.6.5

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -362,7 +362,18 @@ function create_system(req) {
             }
 
             //DNS name, if supplied
-            if (req.rpc_params.dns_name) {
+            if (process.env.CONTAINER_PLATFORM === 'KUBERNETES') {
+                const dns_name = await os_utils.get_kubernetes_dns_name();
+                const base_address = `wss://${dns_name}:${process.env.SSL_PORT}`;
+                dbg.log0('updating base address according to kuberenets dns name:', base_address);
+                if (base_address) {
+                    await server_rpc.client.system.update_base_address({
+                        base_address: base_address
+                    }, {
+                        auth_token: reply_token
+                    });
+                }
+            } else if (req.rpc_params.dns_name) {
                 dbg.log0(`create_system: updating host name to ${req.rpc_params.dns_name}`);
                 try {
                     await server_rpc.client.system.update_hostname({

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -85,6 +85,16 @@ const SERVICES_INFO = Object.freeze([{
         proc: 'mongo_wrapper',
         stop: false,
     },
+    {
+        srv: 'rsyslog',
+        proc: 'rsyslogd',
+        stop: false,
+    },
+    {
+        srv: 'logrotate',
+        proc: 'logrotate.sh',
+        stop: false,
+    },
 ]);
 
 
@@ -92,10 +102,13 @@ async function stopped_services_during_upgrade() {
     const supervised_list = await supervisor.list();
     dbg.log0('UPGRADE: current services list is', supervised_list);
 
-    // stop all services but upgrade_manager and mongo
+    // stop all services but upgrade_manager mongo and syslog\logrotate
     return supervised_list.filter(srv => (
         srv !== 'mongo_wrapper' &&
-        srv !== 'upgrade_manager'));
+        srv !== 'upgrade_manager' &&
+        srv !== 'rsyslog' &&
+        srv !== 'logrotate'
+    ));
 }
 
 


### PR DESCRIPTION
### Explain the changes
- use supervisord instead of systemd as PID1 of a container 
  - added rsyslog and logrotate as supervisord services
- create system on startup when create system info passed in env
- some operator fixes
- added autocompletion to supervisorctl

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages