### PR TITLE
fixed path of operator-sdk in build_operator.sh

### DIFF
--- a/gocode/src/noobaa-operator/deploy/noobaa-operator.yaml
+++ b/gocode/src/noobaa-operator/deploy/noobaa-operator.yaml
@@ -35,13 +35,13 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: noobaa-operator
+  name: noobaa-operator-account
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: noobaa-operator
+  name: noobaa-operator-role
 rules:
   - apiGroups:
       - ""
@@ -87,13 +87,13 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: noobaa-operator
+  name: noobaa-operator-role-binding
 subjects:
   - kind: ServiceAccount
-    name: noobaa-operator
+    name: noobaa-operator-account
 roleRef:
   kind: Role
-  name: noobaa-operator
+  name: noobaa-operator-role
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1
@@ -110,7 +110,7 @@ spec:
       labels:
         name: noobaa-operator
     spec:
-      serviceAccountName: noobaa-operator
+      serviceAccountName: noobaa-operator-account
       containers:
         - name: noobaa-operator
           # Replace this with the built image name

--- a/src/deploy/build_operator.sh
+++ b/src/deploy/build_operator.sh
@@ -20,5 +20,5 @@ echo -e "${GREEN}getting dependencies. might take some time..${NC}"
 cd $GOPATH/src/noobaa-operator
 dep ensure -v
 echo -e "${GREEN}building noobaa-operator..${NC}"
-operator-sdk build noobaa-operator
+$GOPATH/bin/operator-sdk build noobaa-operator
 echo -e "${GREEN}completed!${NC}"


### PR DESCRIPTION
### Explain the changes
- fixed for cases where `operator-sdk` is not in `$PATH`

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages