### PR TITLE
K8s agents upgrade

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -203,6 +203,17 @@ function install_nodejs {
 
 }
 
+function install_kubectl {
+    if [ "${container}" == "docker" ]; then
+        deploy_log "install_kubectl start"
+        stable_version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/${stable_version}/bin/linux/amd64/kubectl
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
+        deploy_log "install_kubectl done"
+    fi
+}
+
 function install_noobaa_repos {
     deploy_log "install_noobaa_repos start"
 
@@ -459,6 +470,7 @@ function runinstall {
     install_noobaa_repos
     install_nodejs
     install_mongo
+    install_kubectl
     general_settings
     setup_supervisors
     setup_syslog

--- a/src/deploy/NVA_build/noobaa_agent.yaml
+++ b/src/deploy/NVA_build/noobaa_agent.yaml
@@ -5,42 +5,44 @@ metadata:
 spec:
   serviceName: noobaa-agent
   replicas: 3
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: noobaa-agent
     spec:
       containers:
-      - name: noobaa-agent
-        env:
-        # Insert the relevant config for the current agent
-        - name: AGENT_CONFIG
-          value: "AGENT_CONFIG_VALUE"
-        # Insert the relevant image for the agent
-        image: noobaaimages.azurecr.io/noobaa/nbagent:AGENT_IMAGE_VERSION
-        imagePullPolicy: Always
-        ports:
-        # This should change according to the allocation from the NooBaa server
-        - containerPort: 60101
-        # These volume mounts are persistent. Each pod in the PetSet
-        # gets a volume mounted based on this field.
-        volumeMounts:
-        - name: noobaastorage
-          mountPath: /noobaa_storage
-        - name: tmp-logs-vol
-          mountPath: /usr/local/noobaa/logs
+        - name: noobaa-agent
+          env:
+            # Insert the relevant config for the current agent
+            - name: AGENT_CONFIG
+              value: "AGENT_CONFIG_VALUE"
+          # Insert the relevant image for the agent
+          image: noobaaimages.azurecr.io/noobaa/nbagent:AGENT_IMAGE_VERSION
+          imagePullPolicy: Always
+          ports:
+            # This should change according to the allocation from the NooBaa server
+            - containerPort: 60101
+          # These volume mounts are persistent. Each pod in the PetSet
+          # gets a volume mounted based on this field.
+          volumeMounts:
+            - name: noobaastorage
+              mountPath: /noobaa_storage
+            - name: tmp-logs-vol
+              mountPath: /usr/local/noobaa/logs
       volumes:
-      - name: tmp-logs-vol
-        emptyDir: { }
+        - name: tmp-logs-vol
+          emptyDir: {}
   # These are converted to volume claims by the controller
   # and mounted at the paths mentioned above.
   volumeClaimTemplates:
-  - metadata:
-      name: noobaastorage
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 30Gi
-      # Uncomment and add storageClass specific to your requirements below. Read more https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
-      #storageClassName:
+    - metadata:
+        name: noobaastorage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 30Gi
+        # Uncomment and add storageClass specific to your requirements below. Read more https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+        #storageClassName:

--- a/src/deploy/NVA_build/noobaa_statefulset.yaml
+++ b/src/deploy/NVA_build/noobaa_statefulset.yaml
@@ -26,6 +26,64 @@ spec:
   selector:
     app: noobaa-server
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: noobaa-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: noobaa-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - "*"
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: noobaa-server
+subjects:
+  - kind: ServiceAccount
+    name: noobaa-server
+roleRef:
+  kind: Role
+  name: noobaa-server
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -80,6 +138,7 @@ spec:
           emptyDir: { medium: "Memory" }
         - name: run-lock-volume
           emptyDir: { medium: "Memory" }
+      serviceAccountName: noobaa-server
   volumeClaimTemplates:
     # this will provision a dynamic persistent volume (volume is automatically provisioned by a provisioner)
     # in minikube it is provisioned as hostPath volume under hosts /tmp which is not persistent between

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -67,6 +67,11 @@ class UpgradeManager {
                 func: () => this.update_data_version(),
                 should_run_unmanaged: true
             }, {
+                name: 'UPGRADE_AGENTS',
+                func: () => this.upgrade_agents(),
+                ignore_errors: true,
+                should_run_unmanaged: true
+            }, {
                 name: 'CLEANUP',
                 func: () => this.cleanup_stage(),
                 ignore_errors: true,
@@ -230,6 +235,10 @@ class UpgradeManager {
 
     async update_data_version() {
         await platform_upgrade.update_data_version();
+    }
+
+    async upgrade_agents() {
+        await platform_upgrade.upgrade_agents();
     }
 
     async cleanup_stage() {


### PR DESCRIPTION
### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- kubectl will now be installed on top of noobaa K8s version
- updating server yaml file to supply the right authorizations for accessing kubectl from the server 
- adding as last step in upgrade on K8s to use kubectl to update the agents yaml with the new image version
- changing the agents update strategy to rolling update so agents will be upgraded automatically on build change

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
