### PR TITLE
build-rpm.sh: adding the ability to run several RPM jobs in the Jenkins in parallel

### DIFF
--- a/src/deploy/rpm/build-rpm.sh
+++ b/src/deploy/rpm/build-rpm.sh
@@ -26,6 +26,25 @@ cp build/public/noobaa-NVA-${NB_VERSION}.tar.gz ${build_rpm_location}
 cp ./src/deploy/NVA_build/deploy_base.sh ${build_rpm_location}
 cp ./src/deploy/rpm/{create_rpm.sh,noobaa.spec} ${build_rpm_location}
 chmod 777 ${build_rpm_location}/create_rpm.sh
+if [ -d ~/rpmbuild ] 
+then
+    will_wait=true
+else 
+    will_wait=false
+fi
+if ${will_wait}
+then
+    while [ -d ~/rpmbuild ]
+    do
+        sleep 10
+    done
+    #sleeping randomally to verify that no other build has started.
+    sleep $((10+RANDOM%60))
+    if [ ! -d ~/rpmbuild ]
+    then
+        will_wait=false
+    fi
+fi
 build/rpm/create_rpm.sh -l ${build_rpm_location}
 if [ $? -eq 0 ]
 then
@@ -35,3 +54,6 @@ else
     rm -rf ${build_rpm_location}
     exit 1
 fi
+
+#deleting the whole tree of rpmbuild to start clean
+rm -rf ~/rpmbuild

--- a/src/deploy/rpm/create_rpm.sh
+++ b/src/deploy/rpm/create_rpm.sh
@@ -45,9 +45,8 @@ function create_rpm(){
     #yum install -y tree dnf
     #dnf install rpm-build rpm-devel rpmlint rpmdevtools
 
-    #deleting the whole tree of rpmbuild to start clean
-    rm -rf ~/rpmbuild
     rpmdev-setuptree
+    echo "time for ${0} in sec: ${SECONDS}"
     cp ${files_location}/${spec_name} ~/rpmbuild/SPECS/
    
     cp  ${files_location}/noobaa-NVA-${version}-${revision}.tar.gz ~/rpmbuild/SOURCES/


### PR DESCRIPTION
### Explain the changes

build-rpm.sh:
- Adding the ability to run several RPM jobs in the Jenkins in parallel.

The Jenkins structure hold all main jobs under the RPM build, we need
to be able to run the RPM job, in parallel and wait only on the create
itself.

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
