### PR TITLE
Fix unintended false value in XML reply

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -40,14 +40,14 @@ async function get_bucket(req) {
                 'MaxKeys': max_keys_received,
                 'IsTruncated': reply.is_truncated,
                 'Encoding-Type': req.query['encoding-type'],
-            }, !list_type && { // v1
-                'Marker': req.query.marker || '',
-                'NextMarker': reply.next_marker,
-            }, list_type === '2' && {
+            }, list_type === '2' ? {
                 'ContinuationToken': cont_tok,
                 'StartAfter': start_after,
                 'KeyCount': reply.objects.length,
                 'NextContinuationToken': key_marker_to_cont_tok(reply.next_marker),
+            } : { // list_type v1
+                'Marker': req.query.marker || '',
+                'NextMarker': reply.next_marker,
             },
             _.map(reply.objects, obj => ({
                 Contents: {


### PR DESCRIPTION
### Explain the changes
- Found on support call when connecting Starwind.
- The reply contained an accidental naked `false` string inside the `<ListBucketResult>` tag.

### Issues: Fixed #xxx / Gap #xxx
- NA

### Testing Instructions:
- Regression on list objects.

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
