### PR TITLE
fixed #5368 - _get_nodes_stats_by_cloud_service failed on deleted nodes

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -121,8 +121,8 @@ class Agent {
                 } else if (params.cloud_info.endpoint_type === 'AZURE') {
                     let connection_string = cloud_utils.get_azure_connection_string({
                         endpoint: params.cloud_info.endpoint,
-                        access_key: params.cloud_info.access_keys.access_key,
-                        secret_key: params.cloud_info.access_keys.secret_key
+                        access_key: params.cloud_info.access_keys.access_key.unwrap(),
+                        secret_key: params.cloud_info.access_keys.secret_key.unwrap()
                     });
                     block_store_options.cloud_info.azure = {
                         connection_string: connection_string,
@@ -132,7 +132,7 @@ class Agent {
                     this.block_store = new BlockStoreAzure(block_store_options);
                 } else if (params.cloud_info.endpoint_type === 'GOOGLE') {
                     this.node_type = 'BLOCK_STORE_GOOGLE';
-                    const { project_id, private_key, client_email } = JSON.parse(params.cloud_info.access_keys.secret_key);
+                    const { project_id, private_key, client_email } = JSON.parse(params.cloud_info.access_keys.secret_key.unwrap());
                     block_store_options.cloud_info.google = { project_id, private_key, client_email };
                     this.block_store = new BlockStoreGoogle(block_store_options);
                 }

--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -38,8 +38,8 @@ class BlockStoreS3 extends BlockStoreBase {
             } : undefined;
             this.s3cloud = new AWS.S3({
                 endpoint: endpoint,
-                accessKeyId: this.cloud_info.access_keys.access_key,
-                secretAccessKey: this.cloud_info.access_keys.secret_key,
+                accessKeyId: this.cloud_info.access_keys.access_key.unwrap(),
+                secretAccessKey: this.cloud_info.access_keys.secret_key.unwrap(),
                 s3ForcePathStyle: true,
                 httpOptions,
                 signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint, this.cloud_info.auth_method),
@@ -53,8 +53,8 @@ class BlockStoreS3 extends BlockStoreBase {
             this.s3cloud = new AWS.S3({
                 endpoint: endpoint,
                 s3ForcePathStyle: true,
-                accessKeyId: this.cloud_info.access_keys.access_key,
-                secretAccessKey: this.cloud_info.access_keys.secret_key,
+                accessKeyId: this.cloud_info.access_keys.access_key.unwrap(),
+                secretAccessKey: this.cloud_info.access_keys.secret_key.unwrap(),
                 signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint, this.cloud_info.auth_method),
                 s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(endpoint),
                 httpOptions: {
@@ -139,7 +139,7 @@ class BlockStoreS3 extends BlockStoreBase {
                     endpoint: endpoint,
                     s3ForcePathStyle: true,
                     accessKeyId: this.cloud_info.access_keys.access_key,
-                    secretAccessKey: this.cloud_info.access_keys.secret_key,
+                    secretAccessKey: this.cloud_info.access_keys.secret_key.unwrap(),
                     signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint, this.cloud_info.auth_method),
                     s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(endpoint),
                 },
@@ -186,7 +186,7 @@ class BlockStoreS3 extends BlockStoreBase {
                     endpoint: endpoint,
                     s3ForcePathStyle: true,
                     accessKeyId: this.cloud_info.access_keys.access_key,
-                    secretAccessKey: this.cloud_info.access_keys.secret_key,
+                    secretAccessKey: this.cloud_info.access_keys.secret_key.unwrap(),
                     signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(endpoint, this.cloud_info.auth_method),
                     s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(endpoint),
                 },


### PR DESCRIPTION
### Explain the changes
- fixed the case where statistics entry was referencing a deleted node or pool
- if node\pool is not found in nodes\system stores than look directly in DB including deleted records


### Issues: Fixed #xxx / Gap #xxx
- Fixes #5368

### Testing Instructions:
- create cloud resource
- do some reads\writes
- delete cloud resource
- it should not cause errors and the counts should be as before the deletion

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
