### PR TITLE
in update_time_config - clear ntp setting when setting manual time

### DIFF
--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -808,16 +808,14 @@ function update_time_config(req) {
 }
 
 
-function apply_updated_time_config(req) {
+async function apply_updated_time_config(req) {
     var time_config = req.rpc_params;
-    return P.fcall(function() {
-            if (time_config.ntp_server) { //set NTP
-                return os_utils.set_ntp(time_config.ntp_server, time_config.timezone);
-            } else { //manual set
-                return os_utils.set_manual_time(time_config.epoch, time_config.timezone);
-            }
-        })
-        .return();
+    // in any case update the ntp configuration (either set new ntp or clear if manual time)
+    await os_utils.set_ntp(time_config.ntp_server, time_config.timezone);
+    if (!time_config.ntp_server) {
+        // if ntp server is not defined then set manual time
+        await os_utils.set_manual_time(time_config.epoch, time_config.timezone);
+    }
 }
 
 function install_vmtools(req) {

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -522,8 +522,9 @@ async function set_ntp(server, timez) {
         if (process.env.container === 'docker') {
             return;
         }
-        var command = "sed -i 's/.*NooBaa Configured NTP Server.*/server " + server +
-            " iburst #NooBaa Configured NTP Server/' /etc/ntp.conf";
+        // if server is undefined than clear the ntp server configuration in ntp.conf
+        const new_ntp_server_conf = server ? `server ${server} iburst ` : '';
+        let command = `sed -i 's/.*NooBaa Configured NTP Server.*/${new_ntp_server_conf}#NooBaa Configured NTP Server/' /etc/ntp.conf`;
         await _set_time_zone(timez);
         await promise_utils.exec(command);
         await promise_utils.exec('/sbin/chkconfig ntpd on 2345');


### PR DESCRIPTION
### Explain the changes
- fixed `os_utils.set_ntp` to clear ntp server when `server` is not defined, instead of setting the ntp server to be `undefined` in `/etc/ntp.conf`
- in `apply_updated_time_config` always call set_ntp to either set or clear in `/etc/ntp.conf`

### Issues: Fixed #xxx / Gap #xxx
- fix for cluster test

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages