### PR TITLE
allow self signed url in s3 delegation flow for non AWS s3 compatible

### DIFF
--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -144,7 +144,8 @@ class BlockStoreClient {
                         }
                         dbg.log1('got s3_params from block_store. writing using S3 sdk. s3_params =',
                             _.omit(s3_params, 'secretAccessKey'));
-                        s3_params.httpOptions = { agent: http_utils.get_unsecured_http_agent(s3_params.endpoint, proxy) };
+                        s3_params.httpOptions = _.omitBy({ agent: http_utils.get_unsecured_http_agent(s3_params.endpoint, proxy) },
+                            _.isUndefined);
                         const s3 = new AWS.S3(s3_params);
                         write_params.Body = data;
                         await s3.putObject(write_params).promise();
@@ -153,7 +154,8 @@ class BlockStoreClient {
                             url: signed_url,
                             method: 'PUT',
                             followAllRedirects: true,
-                            body: data
+                            body: data,
+                            rejectUnauthorized: http_utils.should_reject_unauthorized(signed_url, proxy)
                         };
                         if (proxy) {
                             req_options.proxy = proxy;
@@ -208,7 +210,8 @@ class BlockStoreClient {
                         dbg.log1('got s3_params from block_store. reading using S3 sdk. s3_params =',
                             _.omit(s3_params, 'secretAccessKey'));
 
-                        s3_params.httpOptions = { agent: http_utils.get_unsecured_http_agent(s3_params.endpoint, proxy) };
+                        s3_params.httpOptions = _.omitBy({ agent: http_utils.get_unsecured_http_agent(s3_params.endpoint, proxy) },
+                            _.isUndefined);
                         const s3 = new AWS.S3(s3_params);
 
                         const data = await s3.getObject(read_params).promise();
@@ -224,7 +227,8 @@ class BlockStoreClient {
                             url: signed_url,
                             method: 'GET',
                             encoding: null, // get a Buffer
-                            followAllRedirects: true
+                            followAllRedirects: true,
+                            rejectUnauthorized: http_utils.should_reject_unauthorized(signed_url, proxy)
                         };
 
                         if (proxy) {


### PR DESCRIPTION
### Explain the changes
- when using s3 delegation in block_store_client self signed certs were not allowed
- for compatible S3 and proxy servers - allow self-signed certificates

### Issues: Fixed #xxx / Gap #xxx
- opened #5375

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages