### PR TITLE
Danny openshift

### DIFF
--- a/src/deploy/NVA_build/Server.Dockerfile
+++ b/src/deploy/NVA_build/Server.Dockerfile
@@ -13,10 +13,11 @@ COPY ${install_script} /tmp/install_noobaa.sh
 RUN chmod +x /tmp/install_noobaa.sh
 RUN /bin/bash -xc "/tmp/install_noobaa.sh"
 
+
 ###############
 # PORTS SETUP #
 ###############
-EXPOSE 60100-60600
+EXPOSE 60100
 EXPOSE 80
 EXPOSE 443
 EXPOSE 8080
@@ -28,4 +29,6 @@ EXPOSE 26050
 ###############
 # EXEC SETUP #
 ###############
+# run as non root user that belongs to root 
+USER 10001:0
 CMD ["/usr/bin/supervisord", "start_container"]

--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -1,7 +1,7 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: noobaaimages.azurecr.io  
+  name: noobaaimages.azurecr.io
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: eyJhdXRocyI6eyJub29iYWFpbWFnZXMuYXp1cmVjci5pbyI6eyJ1c2VybmFtZSI6ImJkOTFiYjVjLTE4MTUtNGE4OC1iOWY3LTk1NWY1MWI1YTE0MyIsInBhc3N3b3JkIjoiMDhlOTJkZTAtZTk3YS00NjE4LWE1NTgtNDQ4YzA0MzlkMjk4IiwiZW1haWwiOiJlcmFuLnRhbWlyQG5vb2JhYS5jb20iLCJhdXRoIjoiWW1RNU1XSmlOV010TVRneE5TMDBZVGc0TFdJNVpqY3RPVFUxWmpVeFlqVmhNVFF6T2pBNFpUa3laR1V3TFdVNU4yRXRORFl4T0MxaE5UVTRMVFEwT0dNd05ETTVaREk1T0E9PSJ9fX0=
@@ -85,15 +85,17 @@ spec:
   type: LoadBalancer
   ports:
     - port: 80
+      targetPort: 6001
       name: s3
     - port: 443
+      targetPort: 6443
       name: s3-https
     - port: 8080
       name: mng
     - port: 8443
       name: mng-https
   selector:
-    app: noobaa-server    
+    app: noobaa-server
 ---
 kind: StatefulSet
 apiVersion: apps/v1
@@ -128,16 +130,7 @@ spec:
             - containerPort: 8443
             - containerPort: 8444
             - containerPort: 60100
-            - containerPort: 60101
-            - containerPort: 60102
-            - containerPort: 60103
-            - containerPort: 60104
-            - containerPort: 60105
           volumeMounts:
-            - mountPath: /run
-              name: run-volume
-            - mountPath: /run/lock
-              name: run-lock-volume
             - mountPath: /data
               name: datadir
             - mountPath: /log
@@ -145,11 +138,6 @@ spec:
           env:
             - name: CONTAINER_PLATFORM
               value: KUBERNETES
-      volumes:
-        - name: run-volume
-          emptyDir: { medium: "Memory" }
-        - name: run-lock-volume
-          emptyDir: { medium: "Memory" }
       serviceAccountName: noobaa-account
       imagePullSecrets:
         - name: noobaaimages.azurecr.io

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -65,9 +65,21 @@ EOF
     fi
 }
 
+fix_non_root_user() {
+  # in openshift, when not running as root - ensure that assigned uid has entry in /etc/passwd.
+  if [ `id -u` -ne 0 ]; then
+      local NOOBAA_USER=noob
+      if ! grep -q ${NOOBAA_USER}:x /etc/passwd; then
+        echo "${NOOBAA_USER}:x:`id -u`:`id -g`:,,,:/home/$NOOBAA_USER:/bin/bash" >> /etc/passwd
+      fi
+  fi
+}
+
 init_noobaa_server() { 
   # make sure /log has limited permissions. this is required by logrotate
   chmod 755 /log
+
+  fix_non_root_user
 
   # run init scripts
   /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_plat.sh

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -4,8 +4,10 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/root/node_modules/noobaa-core
-stderr_logfile_backups=3
-stdout_logfile_backups=3
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
 command=/usr/local/bin/node src/server/web_server.js
 #endprogram
 
@@ -15,8 +17,10 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/root/node_modules/noobaa-core
-stderr_logfile_backups=3
-stdout_logfile_backups=3
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
 command=/usr/local/bin/node src/server/bg_workers.js
 #endprogram
 
@@ -26,8 +30,10 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/root/node_modules/noobaa-core
-stderr_logfile_backups=3
-stdout_logfile_backups=3
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
 command=/usr/local/bin/node src/hosted_agents/hosted_agents_starter.js
 #endprogram
 
@@ -37,8 +43,10 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/root/node_modules/noobaa-core
-stderr_logfile_backups=3
-stdout_logfile_backups=3
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
 command=/usr/local/bin/node src/s3/s3rver_starter.js --address 'wss://127.0.0.1:8443'
 #endprogram
 
@@ -51,8 +59,10 @@ command=/root/node_modules/noobaa-core/src/deploy/NVA_build/mongo_wrapper.sh /us
 directory=/usr/bin
 autostart=true
 priority=1
-stderr_logfile_backups=3
-stdout_logfile_backups=3
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
 #endprogram
 
 [program:rsyslog]
@@ -61,8 +71,10 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/usr/sbin
-stderr_logfile_backups=3
-stdout_logfile_backups=3
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
 command=/usr/sbin/rsyslogd -n
 #endprogram
 
@@ -72,7 +84,9 @@ killasgroup=true
 stopasgroup=true
 autostart=true
 directory=/root/node_modules/noobaa-core
-stderr_logfile_backups=3
-stdout_logfile_backups=3
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
 command=/root/node_modules/noobaa-core/src/deploy/NVA_build/logrotate.sh
 #endprogram

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -49,7 +49,6 @@ killasgroup=true
 stopasgroup=true
 command=/root/node_modules/noobaa-core/src/deploy/NVA_build/mongo_wrapper.sh /usr/bin/mongod --port 27017 --bind_ip 127.0.0.1 --dbpath /data/mongo/cluster/shard1 --syslog --syslogFacility local0
 directory=/usr/bin
-user=root
 autostart=true
 priority=1
 stderr_logfile_backups=3

--- a/src/deploy/rpm/install_noobaa.sh
+++ b/src/deploy/rpm/install_noobaa.sh
@@ -50,3 +50,5 @@ yum install -y ${rpm_location}/noobaa*.rpm
 #clean
 yum clean all
 rm -f ${rpm_location}/noobaa*.rpm
+
+

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -40,7 +40,9 @@ const DOTENV_VARS_FROM_OLD_VER = Object.freeze([
     'MONGO_RS_URL',
     'MONGO_SSL_USER',
     'ENDPOINT_BLOB_ENABLED',
-    'PLATFORM'
+    'PLATFORM',
+    'ENDPOINT_PORT',
+    'ENDPOINT_SSL_PORT'
 ]);
 
 const EXEC_DEFAULTS = Object.freeze({

--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -96,7 +96,7 @@ async function read_rand_seed(seed_bytes) {
 }
 
 async function generate_entropy(loop_cond) {
-    if (process.platform !== 'linux') return;
+    if (process.platform !== 'linux' || process.env.container === 'docker') return;
     while (loop_cond()) {
         try {
             await async_delay(1000);


### PR DESCRIPTION
### Explain the changes
- openshift fixes - support running as non-root
  - openshift run a random user which belongs to root group. fix files group permissions to allow rw for root group
  - ensure entry in `/etc/passwd` for assigned non-root user 
  - don't `su mongod` in mongo_wrapper when not running as root
  - set `suid` bit for `rsyslog` so it can run as root (can't open `/dev/log` if not root)
- redirect supervised services output to stdout so it can be examined with `kubectl logs`

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
