### PR TITLE
 deploy_base.sh: adaptions to the rhel version

### DIFF
--- a/src/deploy/Linux/build_server.sh
+++ b/src/deploy/Linux/build_server.sh
@@ -65,7 +65,8 @@ wget -P build/public/ https://raw.githubusercontent.com/creationix/nvm/master/nv
 echo "$(date) =====> tar noobaa-NVA-${NB_VERSION}.tar.gz"
 tar \
     --transform='s:^:noobaa-core/:' \
-    --exclude='src/native' \
+    --exclude='src/native/aws-cpp-sdk' \
+    --exclude='src/native/third_party' \
     -czf noobaa-NVA-${NB_VERSION}.tar.gz \
     LICENSE \
     EULA.pdf \

--- a/src/deploy/rpm/install_noobaa.sh
+++ b/src/deploy/rpm/install_noobaa.sh
@@ -6,8 +6,6 @@ export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
 rpm_location="/tmp/"
 
 function config_mongo_repo {
-    mkdir -p /data/mongo/cluster/shard1
-
     # create a Mongo 3.6 Repo file
     cat > /etc/yum.repos.d/mongodb-org-3.6.repo << EOF
 [mongodb-org-3.6]


### PR DESCRIPTION
### Explain the changes
deploy_base.sh:
- Adaptions to the rhel version
- Adding debug
- Fixing the mongo username and groupname in rhel
- Skip install_kubectl in rhel

install_noobaa.sh:
- Moved the mkdir -p /data/mongo/cluster/shard1 to deploy base

build_server.sh:
- Wrapping the native in the tarball

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
