### PR TITLE
 separated service to s3 and management + agent fixes for k8s

### DIFF
--- a/frontend/src/app/components/modals/install-nodes-modal/install-nodes-modal.js
+++ b/frontend/src/app/components/modals/install-nodes-modal/install-nodes-modal.js
@@ -37,7 +37,7 @@ const osTypes = deepFreeze([
     {
         value: 'KUBERNETES',
         label: 'Kubernetes',
-        hint: 'Copy into a noobaa.yaml file and run using the command "kubectl create -f noobaa.yaml"'
+        hint: 'Copy into a noobaa.yaml file and run using the command "kubectl apply -f noobaa.yaml"'
     }
 ]);
 

--- a/frontend/src/app/components/modals/install-nodes-to-pool-modal/install-nodes-to-pool-modal.js
+++ b/frontend/src/app/components/modals/install-nodes-to-pool-modal/install-nodes-to-pool-modal.js
@@ -32,7 +32,7 @@ const osTypes = deepFreeze([
     {
         value: 'KUBERNETES',
         label: 'Kubernetes',
-        hint: 'Copy into a noobaa.yaml file and run using the command "kubectl create -f noobaa.yaml"'
+        hint: 'Copy into a noobaa.yaml file and run using the command "kubectl apply -f noobaa.yaml"'
     }
 ]);
 

--- a/src/deploy/NVA_build/noobaa_agent.yaml
+++ b/src/deploy/NVA_build/noobaa_agent.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: noobaa-agent
+        noobaa-s3: "true"
     spec:
       imagePullSecrets:
         - name: noobaaimages.azurecr.io
@@ -33,6 +34,10 @@ spec:
             # Insert the relevant config for the current agent
             - name: AGENT_CONFIG
               value: "AGENT_CONFIG_VALUE"
+            - name: ENDPOINT_PORT
+              value: "6001"
+            - name: ENDPOINT_SSL_PORT
+              value: "6443"
           # Insert the relevant image for the agent
           ports:
             # This should change according to the allocation from the NooBaa server

--- a/src/deploy/NVA_build/noobaa_agent.yaml
+++ b/src/deploy/NVA_build/noobaa_agent.yaml
@@ -32,6 +32,8 @@ spec:
               memory: "2Gi"
           env:
             # Insert the relevant config for the current agent
+            - name: CONTAINER_PLATFORM
+              value: KUBERNETES
             - name: AGENT_CONFIG
               value: "AGENT_CONFIG_VALUE"
             - name: ENDPOINT_PORT

--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -41,15 +41,7 @@ metadata:
   name: s3
   labels:
     app: noobaa-server
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/scheme: http
-    prometheus.io/port: "8080"
 spec:
-  # LoadBalancer service will alocate an external ip automatically on public cloud providers (aws\azure\gcp, etc.)
-  # for on premise kuberenets clusters there are 3rd party solutions that provide the same functionality. e.g: metalLB (https://metallb.universe.tf)
-  # metalLB installs a controller in the cluster that handles LoadBalancer services and allocates an external ip
-  # without a controller handling LoadBalancer service, it will be handled as a NodePort (can be accessed through the node ip and a random port allocated by kubernetes)
   type: LoadBalancer
   ports:
     - port: 80
@@ -58,12 +50,34 @@ spec:
     - port: 443
       targetPort: 6443
       name: s3-https
-    - port: 8080
-      name: mng
-    - port: 8443
-      name: mng-https
   selector:
+    noobaa-s3: "true"
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: noobaa-mgmt
+  labels:
     app: noobaa-server
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: http
+    prometheus.io/port: "8080"
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 8080
+      name: mgmt
+    - port: 8443
+      name: mgmt-https
+    - port: 80
+      targetPort: 6001
+      name: s3
+    - port: 443
+      targetPort: 6443
+      name: s3-https
+  selector:
+    noobaa-mgmt: "true"
 ---
 kind: StatefulSet
 apiVersion: apps/v1
@@ -73,12 +87,14 @@ spec:
   selector:
     matchLabels:
       app: noobaa-server
-  serviceName: s3
+  serviceName: noobaa-mgmt
   replicas: 1
   template:
     metadata:
       labels:
         app: noobaa-server
+        noobaa-s3: "true"
+        noobaa-mgmt: "true"
     spec:
       containers:
         - name: noobaa-server

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -338,6 +338,10 @@ function setup_http_server(server) {
 }
 
 function update_virtual_host_suffix(base_address) {
+    if (process.env.CONTAINER_PLATFORM === 'KUBERNETES') {
+        dbg.warn(`skip update of virtual host suffix in kuberentes. support will be added in the future`);
+        return;
+    }
     const suffix = base_address && url.parse(base_address).hostname;
     const new_virtual_suffix = net_utils.is_fqdn(suffix) ? '.' + suffix : undefined;
     if (new_virtual_suffix !== virtual_host_suffix) {

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -53,7 +53,11 @@ const location_info = {};
 
 function start_all() {
     dbg.set_process_name('Endpoint');
-    if (cluster.isMaster && config.ENDPOINT_FORKS_ENABLED && argv.address && !argv.s3_agent) {
+    if (cluster.isMaster &&
+        config.ENDPOINT_FORKS_ENABLED &&
+        argv.address &&
+        !argv.s3_agent &&
+        process.env.container !== 'docker') {
         // Fork workers
         const NUM_OF_FORKS = (os.totalmem() >= (config.SERVER_MIN_REQUIREMENTS.RAM_GB * size_utils.GIGABYTE)) ? numCPUs : 1;
         for (let i = 0; i < NUM_OF_FORKS; i++) {

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -318,7 +318,7 @@ function read_kubernetes_agent_drives() {
     return P.fromCallback(callback => node_df({
             // this is a hack to make node_df append the -l flag to the df command
             // in order to get only local file systems.
-            file: '-la'
+            file: '-a'
         }, callback))
         .then(volumes => P.all(_.map(volumes, async function(vol) {
                 return P.resolve()


### PR DESCRIPTION
### Explain the changes
- separated service to s3 and management services
   - S3 service should select also endpoint agents, which doesn't serve the management - had to separate to prevent from management request to get to agents
   - management service is also exposing S3 ports to allow uploads\downlods from the management console
- removed `-l` flag in read_drive in kuberenetes. some volumes in kuberenetes are mounted as nfs mounts, and `-l` causes them to be ignored by the agent
- force s3 agents on kubernetes
- prevent fork of endpoint process in kubernetes 
   - in one case the number of cpus that the node process identified was 40, which caused 40 endpoint processes to be spawned and the container was not able to run

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages