### PR TITLE
Adding support for chunked upload

### DIFF
--- a/src/endpoint/lambda/lambda_rest.js
+++ b/src/endpoint/lambda/lambda_rest.js
@@ -108,9 +108,9 @@ function check_headers(req, res) {
         }
     }
 
-    req.content_sha256 = req.headers['x-amz-content-sha256'];
-    if (typeof req.content_sha256 === 'string') {
-        req.content_sha256_buf = Buffer.from(req.content_sha256, 'hex');
+    req.content_sha256_sig = req.headers['x-amz-content-sha256'];
+    if (typeof req.content_sha256_sig === 'string') {
+        req.content_sha256_buf = Buffer.from(req.content_sha256_sig, 'hex');
         if (req.content_sha256_buf.length !== 32) {
             throw new LambdaError(LambdaError.InvalidDigest);
         }

--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -22,6 +22,7 @@ async function put_object(req, res) {
         bucket: req.params.bucket,
         key: req.params.key,
         content_type: req.headers['content-type'],
+        chunked_content: req.chunked_content,
         copy_source,
         source_stream: req,
         size: copy_source ? undefined : s3_utils.parse_content_length(req),

--- a/src/endpoint/s3/ops/s3_put_object_uploadId.js
+++ b/src/endpoint/s3/ops/s3_put_object_uploadId.js
@@ -25,6 +25,7 @@ function put_object_uploadId(req, res) {
             num,
             copy_source,
             source_stream: req,
+            chunked_content: req.chunked_content,
             size: copy_source ? undefined : s3_utils.parse_content_length(req),
             md5_b64: req.content_md5 ? req.content_md5.toString('base64') : undefined,
             sha256_b64: req.content_sha256_buf ? req.content_sha256_buf.toString('base64') : undefined,

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -104,7 +104,7 @@ function _parse_sse_c_algo(sse_c_algo) {
 // }
 
 function parse_content_length(req) {
-    const size = Number(req.headers['content-length']);
+    const size = Number(req.headers['x-amz-decoded-content-length']) || Number(req.headers['content-length']);
     if (!Number.isInteger(size) || size < 0) {
         dbg.warn('Missing content-length', req.headers['content-length']);
         throw new S3Error(S3Error.MissingContentLength);

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -24,6 +24,7 @@ const promise_utils = require('../util/promise_utils');
 const ChunkSplitter = require('../util/chunk_splitter');
 const KeysSemaphore = require('../util/keys_semaphore');
 const CoalesceStream = require('../util/coalesce_stream');
+const ChunkedContentDecoder = require('../util/chunked_content_decoder');
 const block_store_client = require('../agent/block_store_services/block_store_client').instance();
 const { RpcError, RPC_BUFFERS } = require('../rpc');
 
@@ -273,7 +274,7 @@ class ObjectIO {
             });
     }
 
-    _upload_stream_internal(params, complete_params) {
+    async _upload_stream_internal(params, complete_params) {
 
         params.desc = _.pick(params, 'obj_id', 'num', 'bucket', 'key');
         dbg.log0('UPLOAD:', params.desc, 'streaming to', params.bucket, params.key);
@@ -328,16 +329,15 @@ class ObjectIO {
         });
 
         const pipeline = new Pipeline(params.source_stream);
-        return pipeline
-            .pipe(splitter)
-            .pipe(coder)
-            .pipe(coalescer)
-            .pipe(uploader)
-            .promise()
-            .then(() => {
-                complete_params.md5_b64 = splitter.md5.toString('base64');
-                if (splitter.sha256) complete_params.sha256_b64 = splitter.sha256.toString('base64');
-            });
+        if (params.chunked_content) pipeline.pipe(new ChunkedContentDecoder());
+        pipeline.pipe(splitter);
+        pipeline.pipe(coder);
+        pipeline.pipe(coalescer);
+        pipeline.pipe(uploader);
+        await pipeline.promise();
+
+        complete_params.md5_b64 = splitter.md5.toString('base64');
+        if (splitter.sha256) complete_params.sha256_b64 = splitter.sha256.toString('base64');
     }
 
 

--- a/src/test/unit_tests/test_signature_utils.js
+++ b/src/test/unit_tests/test_signature_utils.js
@@ -160,13 +160,14 @@ mocha.describe('signature_utils', function() {
             .then(sha256_buf => {
                 const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
                 const STREAMING_PAYLOAD = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';
-                req.content_sha256 = req.query['X-Amz-Signature'] ?
+                const content_sha256_hdr = req.headers['x-amz-content-sha256'];
+                req.content_sha256_sig = req.query['X-Amz-Signature'] ?
                     UNSIGNED_PAYLOAD :
-                    req.headers['x-amz-content-sha256'];
-                if (typeof req.content_sha256 === 'string' &&
-                    req.content_sha256 !== UNSIGNED_PAYLOAD &&
-                    req.content_sha256 !== STREAMING_PAYLOAD) {
-                    req.content_sha256_buf = Buffer.from(req.content_sha256, 'hex');
+                    content_sha256_hdr;
+                if (typeof content_sha256_hdr === 'string' &&
+                    content_sha256_hdr !== UNSIGNED_PAYLOAD &&
+                    content_sha256_hdr !== STREAMING_PAYLOAD) {
+                    req.content_sha256_buf = Buffer.from(content_sha256_hdr, 'hex');
                     if (req.content_sha256_buf.length !== 32) {
                         throw new Error('InvalidDigest');
                     }
@@ -177,7 +178,7 @@ mocha.describe('signature_utils', function() {
                     }
                 } else {
                     req.content_sha256_buf = sha256_buf;
-                    if (!req.content_sha256) req.content_sha256 = req.content_sha256_buf.toString('hex');
+                    if (!req.content_sha256_sig) req.content_sha256_sig = req.content_sha256_buf.toString('hex');
                 }
                 const auth_token = signature_utils.make_auth_token_from_request(req);
                 const signature = signature_utils.get_signature_from_auth_token(auth_token, SECRETS[auth_token.access_key]);

--- a/src/util/chunked_content_decoder.js
+++ b/src/util/chunked_content_decoder.js
@@ -1,0 +1,97 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const stream = require('stream');
+
+const STATE_READ_CHUNK_HEADER = 'STATE_READ_CHUNK_HEADER';
+const STATE_WAIT_NL_HEADER = 'STATE_WAIT_NL_HEADER';
+const STATE_SEND_DATA = 'STATE_SEND_DATA';
+const STATE_WAIT_CR_DATA = 'STATE_WAIT_CR_DATA';
+const STATE_WAIT_NL_DATA = 'STATE_WAIT_NL_DATA';
+const STATE_CONTENT_END = 'STATE_CONTENT_END';
+const STATE_ERROR = 'STATE_ERROR';
+
+const CR_CODE = '\r'.charCodeAt(0);
+const NL_CODE = '\n'.charCodeAt(0);
+
+/**
+ *
+ * ChunkedContentDecoder
+ *
+ * Take a data stream and removes chunking signatures from it
+ *
+ */
+class ChunkedContentDecoder extends stream.Transform {
+
+    constructor(params) {
+        super(params);
+        this.state = STATE_READ_CHUNK_HEADER;
+        this.chunk_header_str = '';
+        this.chunk_size = 0;
+        this.chunk_signature = '';
+    }
+
+    _transform(buf, encoding, callback) {
+        try {
+            this.parse(buf);
+            return callback();
+        } catch (err) {
+            return callback(err);
+        }
+    }
+
+    _flush(callback) {
+        if (this.state !== STATE_CONTENT_END) return this.error_state();
+        return callback();
+    }
+
+    parse(buf) {
+        for (let index = 0; index < buf.length; ++index) {
+            if (this.state === STATE_READ_CHUNK_HEADER) {
+                for (; index < buf.length; ++index) {
+                    if (buf[index] === CR_CODE) {
+                        const header_items = this.chunk_header_str.split(';');
+                        this.chunk_size = parseInt(header_items[0], 16);
+                        if (!(this.chunk_size >= 0)) return this.error_state();
+                        this.last_chunk = this.chunk_size === 0;
+                        const header1 = header_items[1].split('=');
+                        this.chunk_signature = header1[0] === 'chunk-signature' ? header1[1] : '';
+                        this.chunk_header_str = '';
+                        this.state = STATE_WAIT_NL_HEADER;
+                        break;
+                    } else {
+                        this.chunk_header_str += String.fromCharCode(buf[index]);
+                    }
+                }
+            } else if (this.state === STATE_WAIT_NL_HEADER) {
+                if (buf[index] !== NL_CODE) return this.error_state();
+                this.state = STATE_SEND_DATA;
+            } else if (this.state === STATE_SEND_DATA) {
+                const content = (index === 0 && buf.length <= this.chunk_size) ? buf : buf.slice(index, index + this.chunk_size);
+                this.chunk_size -= content.length;
+                index += content.length - 1;
+                if (content.length) this.push(content);
+                if (!this.chunk_size) this.state = STATE_WAIT_CR_DATA;
+            } else if (this.state === STATE_WAIT_CR_DATA) {
+                if (buf[index] !== CR_CODE) return this.error_state();
+                this.state = STATE_WAIT_NL_DATA;
+            } else if (this.state === STATE_WAIT_NL_DATA) {
+                if (buf[index] !== NL_CODE) return this.error_state();
+                if (this.last_chunk) {
+                    this.state = STATE_CONTENT_END;
+                } else {
+                    this.state = STATE_READ_CHUNK_HEADER;
+                }
+            } else {
+                return this.error_state();
+            }
+        }
+    }
+
+    error_state() {
+        this.state = STATE_ERROR;
+        this.emit('error', new Error('problem in parsing aws-chunked data'));
+    }
+}
+
+module.exports = ChunkedContentDecoder;

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -191,7 +191,6 @@ function read_request_body(req, options) {
                 }
             } else {
                 req.content_sha256_buf = sha256_buf;
-                if (!req.content_sha256) req.content_sha256 = req.content_sha256_buf.toString('hex');
             }
             return resolve();
         });

--- a/src/util/signature_utils.js
+++ b/src/util/signature_utils.js
@@ -106,7 +106,7 @@ function _string_to_sign_v4(req, signed_headers, xamzdate, region, service) {
         !signed_headers_set ||
         signed_headers_set.has(key.toLowerCase());
 
-    v4.hexEncodedBodyHash = () => req.content_sha256 || EMPTY_SHA256;
+    v4.hexEncodedBodyHash = () => req.content_sha256_sig || EMPTY_SHA256;
 
     const canonical_str = v4.canonicalString();
     const string_to_sign = v4.stringToSign(xamzdate);


### PR DESCRIPTION
### Explain the changes
#### 1. New Features / Capabilities (Sync with Liran):
- Adding basic support for aws-chunked content-type for both put-object and multi-part upload
- Adding new stream transformer called chunked_content_decoder which removes from the stream all the chunking overhead and returns a cleaned stream without chunking - currently we won't verify the chunks signature just remove them 

#### 2. Existing Behavior Changes (Sync with Liran):
-

#### 3. Other Changes:
-

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
