### PR TITLE
deploy_base.sh: skipping iptables set in rhel

### DIFF
--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -279,7 +279,7 @@ function setup_bash_completions {
 function general_settings {
 	deploy_log "general_settings start"
 
-    if [ "${container}" != "docker" ]; then
+    if [ "${container}" != "docker" ] && [ "${ID}" != "rhel" ]; then
         #Open n2n ports
         iptables -I INPUT 1 -p tcp --match multiport --dports 60100:60600 -j ACCEPT      
         iptables -I INPUT 1 -p tcp --dport 80 -j ACCEPT

--- a/src/test/qa/dataset.js
+++ b/src/test/qa/dataset.js
@@ -12,7 +12,7 @@ const Report = require('../framework/report');
 const argv = require('minimist')(process.argv);
 const promise_utils = require('../../util/promise_utils');
 const dbg = require('../../util/debug_module')(__filename);
-require('seedrandom');
+var seedrandom = require('seedrandom');
 
 const test_name = 'dataset';
 dbg.set_process_name(test_name);
@@ -827,7 +827,7 @@ function run_replay() {
 
 async function main() {
     console.log(`Starting dataset. seeding randomness with seed ${TEST_CFG.seed}`);
-    Math.seedrandom(TEST_CFG.seed);
+    seedrandom(TEST_CFG.seed);
     try {
         if (argv.replay) {
             await run_replay();


### PR DESCRIPTION
### Explain the changes

 deploy_base.sh:
- Skipping iptables set in rhel.

dataset.js:
- Fix for seedrandom

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is a top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
