### PR TITLE
fix unix permissions  of the PVs when the server\agent starts

### DIFF
--- a/src/deploy/Linux/setup.sh
+++ b/src/deploy/Linux/setup.sh
@@ -17,6 +17,8 @@ if [ ! -d "/usr/local/noobaa" ]; then
             AGENT_CONF_PATH=/usr/local/noobaa/agent_conf.json
             if [ "${container}" == "docker" ]; then
                 AGENT_CONF_PATH=/noobaa_storage/agent_conf.json
+                # we will need access to /etc/passwd to setup user on startup
+                chgrp 0 /etc/passwd && chmod -R g=u /etc/passwd
             fi
             mkdir /usr/local/noobaa
             echo "config is:" ${CONFIG}
@@ -35,3 +37,9 @@ else
 fi
 
 ./noobaa-installer --keep --target /usr/local/noobaa
+if [ "${container}" == "docker" ]; then
+    # setuid for kube_pv_chown so it can run as root
+    chown root:root /usr/local/noobaa/build/Release/kube_pv_chown
+    chmod 755 /usr/local/noobaa/build/Release/kube_pv_chown
+    chmod u+s /usr/local/noobaa/build/Release/kube_pv_chown
+fi

--- a/src/deploy/NVA_build/Agent.Dockerfile
+++ b/src/deploy/NVA_build/Agent.Dockerfile
@@ -35,4 +35,7 @@ EXPOSE 60101-60600
 # EXEC SETUP #
 ###############
 
+# run as non root user that belongs to root group
+USER 10001:0
+
 ENTRYPOINT ["./run_agent_container.sh"]

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -501,8 +501,15 @@ function setup_non_root_user() {
         # maybe we can make it more fine-grained - for now, give access to all /etc
         chgrp -R 0 /etc && chmod -R g=u /etc
 
+        # give access for logrotate
+        chgrp -R 0 /var/lib/logrotate && chmod -R g=u /var/lib/logrotate
+
         # setuid for rsyslog so it can run as root
         chmod u+s /sbin/rsyslogd
+        # setuid for kube_pv_chown so it can run as root
+        chown root:root /root/node_modules/noobaa-core/build/Release/kube_pv_chown
+        chmod 755 /root/node_modules/noobaa-core/build/Release/kube_pv_chown
+        chmod u+s /root/node_modules/noobaa-core/build/Release/kube_pv_chown
     fi
 }
 

--- a/src/deploy/NVA_build/fix_server_plat.sh
+++ b/src/deploy/NVA_build/fix_server_plat.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 NOOBAASEC="/data/noobaa_sec"

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -81,7 +81,7 @@ init_noobaa_server() {
 
   ############## run init scripts
   # change ownership and permissions of /data and /log. assuming that uid is not changed between reboots
-  /root/node_modules/noobaa-core/build/Release/kube_pv_chown $(id -u)
+  /root/node_modules/noobaa-core/build/Release/kube_pv_chown server $(id -u)
   /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_plat.sh
   /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_mongo_ssl.sh
   /root/node_modules/noobaa-core/src/deploy/NVA_build/setup_server_swap.sh

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -68,21 +68,20 @@ EOF
 
 fix_non_root_user() {
   # in openshift, when not running as root - ensure that assigned uid has entry in /etc/passwd.
-  if [ `id -u` -ne 0 ]; then
+  if [ $(id -u) -ne 0 ]; then
       local NOOBAA_USER=noob
       if ! grep -q ${NOOBAA_USER}:x /etc/passwd; then
-        echo "${NOOBAA_USER}:x:`id -u`:`id -g`:,,,:/home/$NOOBAA_USER:/bin/bash" >> /etc/passwd
+        echo "${NOOBAA_USER}:x:$(id -u):$(id -g):,,,:/home/$NOOBAA_USER:/bin/bash" >> /etc/passwd
       fi
   fi
 }
 
-init_noobaa_server() { 
-  # make sure /log has limited permissions. this is required by logrotate
-  chmod 755 /log
-
+init_noobaa_server() {
   fix_non_root_user
 
-  # run init scripts
+  ############## run init scripts
+  # change ownership and permissions of /data and /log. assuming that uid is not changed between reboots
+  /root/node_modules/noobaa-core/build/Release/kube_pv_chown $(id -u)
   /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_server_plat.sh
   /root/node_modules/noobaa-core/src/deploy/NVA_build/fix_mongo_ssl.sh
   /root/node_modules/noobaa-core/src/deploy/NVA_build/setup_server_swap.sh

--- a/src/deploy/NVA_build/run_agent_container.sh
+++ b/src/deploy/NVA_build/run_agent_container.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+fix_non_root_user() {
+  # in openshift, when not running as root - ensure that assigned uid has entry in /etc/passwd.
+  if [ $(id -u) -ne 0 ]; then
+      local NOOBAA_USER=noob
+      if ! grep -q ${NOOBAA_USER}:x /etc/passwd; then
+        echo "${NOOBAA_USER}:x:$(id -u):$(id -g):,,,:/home/$NOOBAA_USER:/bin/bash" >> /etc/passwd
+      fi
+  fi
+}
+
+fix_non_root_user
+# set ownership\mode of /noobaa_storage
+/usr/local/noobaa/build/Release/kube_pv_chown agent $(id -u)
+
 AGENT_CONF_FILE="/noobaa_storage/agent_conf.json"
 echo "Got base64 agent_conf: ${AGENT_CONFIG}"
 if [ ! -f $AGENT_CONF_FILE ]; then

--- a/src/native/nb_native.gyp
+++ b/src/native/nb_native.gyp
@@ -110,6 +110,11 @@
             'util/tpool.cpp',
             'util/tpool.h',
         ],
+    }, {
+        'target_name': 'kube_pv_chown',
+        'type': 'executable',
+        'sources': [
+            'tools/kube_pv_chown.c'
+        ]
     }],
-
 }

--- a/src/native/tools/kube_pv_chown.c
+++ b/src/native/tools/kube_pv_chown.c
@@ -1,47 +1,49 @@
 #ifndef WIN32
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 int
+change_path_permissions(const char* path, long uid)
+{
+    printf("setting permissions of %s for user %d\n", path, uid);
+    // change ownership
+    int res = chown(path, uid, 0);
+    if (res != 0) {
+        printf("got error when changing ownership of %s. Error: %s\n", path, strerror(errno));
+        exit(1);
+    }
+    // change mode to 755
+    res = chmod(path, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
+    if (res != 0) {
+        printf("got error when changing mode of %s. Error: %s\n", path, strerror(errno));
+        exit(1);
+    }
+    printf("changed permissions of %s succesfully\n", path);
+    return 0;
+}
+
+int
 main(int argc, char* argv[])
 {
-    if (argc != 2) {
-        printf("expected to get uid only\n");
+    if (argc != 3) {
+        printf("expected to get server\\agent and uid\n");
         return 1;
     }
 
-    long uid = atol(argv[1]);
+    long uid = atol(argv[2]);
     if (uid == 0) {
-        printf("got 0 as uid - only root will get access. uid passed in argument was %s\n", argv[1]);
+        printf("got 0 as uid - only root will get access. uid passed in argument was %s\n", argv[2]);
     }
 
-    const char* data_vol = "/data";
-    const char* log_vol = "/log";
-
-    // change ownership
-    int res = chown(data_vol, uid, 0);
-    if (res == -1) {
-        printf("got error when changing ownership of /data\n");
-        return 1;
-    }
-    res = chown(log_vol, uid, 0);
-    if (res == -1) {
-        printf("got error when changing ownership of /log\n");
-        return 1;
-    }
-
-    // change mode to 755
-    res = chmod(data_vol, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
-    if (res == -1) {
-        printf("got error when changing mode of /data\n");
-        return 1;
-}
-    res = chmod(log_vol, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
-    if (res == -1) {
-        printf("got error when changing mode of /log\n");
-        return 1;
+    if (strcmp(argv[1], "server") == 0) {
+        change_path_permissions("/data", uid);
+        change_path_permissions("/log", uid);
+    } else if (strcmp(argv[1], "agent") == 0) {
+        change_path_permissions("/noobaa_storage", uid);
     }
     return 0;
 }

--- a/src/native/tools/kube_pv_chown.c
+++ b/src/native/tools/kube_pv_chown.c
@@ -1,0 +1,55 @@
+#ifndef WIN32
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int
+main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        printf("expected to get uid only\n");
+        return 1;
+    }
+
+    long uid = atol(argv[1]);
+    if (uid == 0) {
+        printf("got 0 as uid - only root will get access. uid passed in argument was %s\n", argv[1]);
+    }
+
+    const char* data_vol = "/data";
+    const char* log_vol = "/log";
+
+    // change ownership
+    int res = chown(data_vol, uid, 0);
+    if (res == -1) {
+        printf("got error when changing ownership of /data\n");
+        return 1;
+    }
+    res = chown(log_vol, uid, 0);
+    if (res == -1) {
+        printf("got error when changing ownership of /log\n");
+        return 1;
+    }
+
+    // change mode to 755
+    res = chmod(data_vol, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
+    if (res == -1) {
+        printf("got error when changing mode of /data\n");
+        return 1;
+}
+    res = chmod(log_vol, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
+    if (res == -1) {
+        printf("got error when changing mode of /log\n");
+        return 1;
+    }
+    return 0;
+}
+
+#else
+int
+main(int argc, char* argv[])
+{
+    return 0;
+}
+#endif


### PR DESCRIPTION
### Explain the changes
- change /data and /log ownership\permissions on startup
- run noobaa agent container as a non-root user
   - change /noobaa_storage ownership\permissions on startup

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages