### PR TITLE
2.10.4 Release - Backport fixes from master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",

--- a/src/deploy/Linux/Build-Package.sh
+++ b/src/deploy/Linux/Build-Package.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "=====> nvm install"
+source ~/.bashrc || exit 1
+source "$NVM_DIR/nvm.sh" || exit 1
+nvm install || exit 1
+
+echo "=====> get package for git commit $GIT_COMMIT"
+NB_VERSION=$(node << EOF
+    'use strict';
+    const fs = require('fs');
+    const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+    const git = process.env.GIT_COMMIT || 'DEVONLY';
+    const version = pkg.version.split('-')[0] + '-' + git.slice(0, 7);
+    console.log(version);
+EOF
+)
+echo "=====> version $NB_VERSION"
+
+echo "=====> update tar noobaa-NVA-${NB_VERSION}.tar.gz"
+gunzip build/public/noobaa-NVA-${NB_VERSION}.tar.gz || exit 1
+mv build/linux/noobaa-setup-${NB_VERSION}* build/public/ || exit 1
+mv build/windows/noobaa-setup-${NB_VERSION}.exe* build/public/ || exit 1
+tar --transform='s:^:noobaa-core/:' \
+    -rf build/public/noobaa-NVA-${NB_VERSION}.tar \
+    build/public/noobaa-setup-${NB_VERSION} \
+    build/public/noobaa-setup-${NB_VERSION}.md5 \
+    build/public/noobaa-setup-${NB_VERSION}.exe \
+    build/public/noobaa-setup-${NB_VERSION}.exe.md5 \
+    || exit 1
+gzip build/public/noobaa-NVA-${NB_VERSION}.tar

--- a/src/deploy/Linux/build_agent_linux.sh
+++ b/src/deploy/Linux/build_agent_linux.sh
@@ -98,6 +98,7 @@ verbose mkdir dist
 verbose cp ../../src/deploy/Linux/setup.sh ./dist/
 verbose mv noobaa-installer ./dist/noobaa-installer
 verbose ../../src/deploy/makeself/makeself.sh ./dist noobaa-setup-$current_package_version $current_package_version ./setup.sh
+md5sum noobaa-setup-$current_package_version | awk '{print $1}' > noobaa-setup-${current_package_version}.md5
 verbose popd
 
 echo "Done: build/linux/noobaa-setup-$current_package_version"

--- a/src/deploy/Linux/build_server.sh
+++ b/src/deploy/Linux/build_server.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+echo "$(date) =====> nvm install"
+source ~/.bashrc || exit 1
+source "$NVM_DIR/nvm.sh" || exit 1
+nvm install || exit 1
+NODEJS_VERSION=$(nvm current)
+
+echo "$(date) =====> mkdirs"
+mkdir -p build/public/
+
+echo "$(date) =====> update package.json for git commit $GIT_COMMIT"
+NB_VERSION=$(node << EOF
+    'use strict';
+    const fs = require('fs');
+    const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+    const git = process.env.GIT_COMMIT || 'DEVONLY';
+    const version = pkg.version.split('-')[0] + '-' + git.slice(0, 7);
+    const EXCLUDE_DEPS_REGEXP = /gulp|mocha|istanbul|eslint|vsphere/;
+    const INCLUDE_DEV_DEPS_REGEXP = /babel/;
+    const deps = Object.keys(pkg.dependencies);
+    const dev_deps = Object.keys(pkg.devDependencies);
+    const dependencies = {};
+    const devDependencies = {};
+    for (let i = 0; i < deps.length; ++i) {
+        if (EXCLUDE_DEPS_REGEXP.test(deps[i])) {
+            console.warn('exclude dependency:', deps[i]);
+        } else {
+            dependencies[deps[i]] = pkg.dependencies[deps[i]];
+        }
+    }
+    for (let i = 0; i < dev_deps.length; ++i) {
+        if (INCLUDE_DEV_DEPS_REGEXP.test(dev_deps[i])) {
+            devDependencies[dev_deps[i]] = pkg.devDependencies[dev_deps[i]];
+        }
+    }
+    const updated_pkg = {
+        name: 'noobaa-NVA',
+        version: version,
+        private: true,
+        license: 'Copyright (C) 2016 NooBaa all rights reserved',
+        scripts: pkg.scripts,
+        dependencies,
+        devDependencies,
+        browser: pkg.browser,
+    };
+    fs.writeFileSync('./package.json', JSON.stringify(updated_pkg, null, 2) + '\n');
+    console.log(version);
+EOF
+)
+echo "$(date) =====> version $NB_VERSION"
+
+echo "$(date) =====> npm install"
+npm install || exit 1
+
+echo "$(date) =====> npm install frontend"
+pushd frontend
+npm install || exit 1
+popd
+
+echo "$(date) =====> download node.js tarball ($NODEJS_VERSION} and nvm.sh (latest)"
+wget -P build/public/ https://nodejs.org/dist/${NODEJS_VERSION}/node-${NODEJS_VERSION}-linux-x64.tar.xz || exit 1
+wget -P build/public/ https://raw.githubusercontent.com/creationix/nvm/master/nvm.sh || exit 1
+
+echo "$(date) =====> tar noobaa-NVA-${NB_VERSION}.tar.gz"
+tar \
+    --transform='s:^:noobaa-core/:' \
+    --exclude='src/native' \
+    -czf noobaa-NVA-${NB_VERSION}.tar.gz \
+    LICENSE \
+    EULA.pdf \
+    package.json \
+    platform_restrictions.json \
+    config.js \
+    .nvmrc \
+    src/ \
+    frontend/dist/ \
+    build/public/ \
+    build/Release/ \
+    node_modules/ \
+    || exit 1
+mv noobaa-NVA-${NB_VERSION}.tar.gz build/public/

--- a/src/deploy/build_windows_agent.bat
+++ b/src/deploy/build_windows_agent.bat
@@ -111,6 +111,8 @@ if exist "%SIGNTOOL_PATH%" (
     "%SIGNTOOL_PATH%" sign /v /s my /t http://timestamp.comodoca.com /a %FINAL_SETUP_FILE_NAME% || exit 1
 )
 
+md5sum %FINAL_SETUP_FILE_NAME% | awk '{print $1}' > %FINAL_SETUP_FILE_NAME%.md5
+
 echo "%FINAL_SETUP_FILE_NAME% installer available under build\windows"
 
 cd ..\..

--- a/src/endpoint/lambda/lambda_rest.js
+++ b/src/endpoint/lambda/lambda_rest.js
@@ -108,9 +108,9 @@ function check_headers(req, res) {
         }
     }
 
-    req.content_sha256 = req.headers['x-amz-content-sha256'];
-    if (typeof req.content_sha256 === 'string') {
-        req.content_sha256_buf = Buffer.from(req.content_sha256, 'hex');
+    req.content_sha256_sig = req.headers['x-amz-content-sha256'];
+    if (typeof req.content_sha256_sig === 'string') {
+        req.content_sha256_buf = Buffer.from(req.content_sha256_sig, 'hex');
         if (req.content_sha256_buf.length !== 32) {
             throw new LambdaError(LambdaError.InvalidDigest);
         }

--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -40,14 +40,14 @@ async function get_bucket(req) {
                 'MaxKeys': max_keys_received,
                 'IsTruncated': reply.is_truncated,
                 'Encoding-Type': req.query['encoding-type'],
-            }, !list_type && { // v1
-                'Marker': req.query.marker || '',
-                'NextMarker': reply.next_marker,
-            }, list_type === '2' && {
+            }, list_type === '2' ? {
                 'ContinuationToken': cont_tok,
                 'StartAfter': start_after,
                 'KeyCount': reply.objects.length,
                 'NextContinuationToken': key_marker_to_cont_tok(reply.next_marker),
+            } : { // list_type v1
+                'Marker': req.query.marker || '',
+                'NextMarker': reply.next_marker,
             },
             _.map(reply.objects, obj => ({
                 Contents: {

--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -21,6 +21,7 @@ async function put_object(req, res) {
         bucket: req.params.bucket,
         key: req.params.key,
         content_type: req.headers['content-type'],
+        chunked_content: req.chunked_content,
         copy_source,
         source_stream: req,
         size: copy_source ? undefined : s3_utils.parse_content_length(req),

--- a/src/endpoint/s3/ops/s3_put_object_uploadId.js
+++ b/src/endpoint/s3/ops/s3_put_object_uploadId.js
@@ -25,6 +25,7 @@ function put_object_uploadId(req, res) {
             num,
             copy_source,
             source_stream: req,
+            chunked_content: req.chunked_content,
             size: copy_source ? undefined : s3_utils.parse_content_length(req),
             md5_b64: req.content_md5 ? req.content_md5.toString('base64') : undefined,
             sha256_b64: req.content_sha256_buf ? req.content_sha256_buf.toString('base64') : undefined,

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -178,17 +178,23 @@ function check_headers(req, res) {
         }
     }
 
-    req.content_sha256 = req.query['X-Amz-Signature'] ?
+    const content_sha256_hdr = req.headers['x-amz-content-sha256'];
+    req.content_sha256_sig = req.query['X-Amz-Signature'] ?
         UNSIGNED_PAYLOAD :
-        req.headers['x-amz-content-sha256'];
-    if (typeof req.content_sha256 === 'string' &&
-        req.content_sha256 !== UNSIGNED_PAYLOAD &&
-        req.content_sha256 !== STREAMING_PAYLOAD) {
-        req.content_sha256_buf = Buffer.from(req.content_sha256, 'hex');
+        content_sha256_hdr;
+    if (typeof content_sha256_hdr === 'string' &&
+        content_sha256_hdr !== UNSIGNED_PAYLOAD &&
+        content_sha256_hdr !== STREAMING_PAYLOAD) {
+        req.content_sha256_buf = Buffer.from(content_sha256_hdr, 'hex');
         if (req.content_sha256_buf.length !== 32) {
             throw new S3Error(S3Error.InvalidDigest);
         }
     }
+
+    const content_encoding = req.headers['content-encoding'] || '';
+    req.chunked_content =
+        content_encoding.split(',').includes('aws-chunked') ||
+        content_sha256_hdr === STREAMING_PAYLOAD;
 
     const req_time =
         time_utils.parse_amz_date(req.headers['x-amz-date'] || req.query['X-Amz-Date']) ||

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -49,7 +49,7 @@ function parse_etag(etag, err) {
 }
 
 function parse_content_length(req) {
-    const size = Number(req.headers['content-length']);
+    const size = Number(req.headers['x-amz-decoded-content-length']) || Number(req.headers['content-length']);
     if (!Number.isInteger(size) || size < 0) {
         dbg.warn('Missing content-length', req.headers['content-length']);
         throw new S3Error(S3Error.MissingContentLength);

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -240,7 +240,7 @@ function create_bucket(req) {
  * READ_BUCKET
  *
  */
-function read_bucket(req) {
+function read_bucket(req, dont_count_objects) {
     var bucket = find_bucket(req);
     var pools = [];
 
@@ -258,7 +258,7 @@ function read_bucket(req) {
             hosts_aggregate_pool: nodes_client.instance().aggregate_hosts_by_pool(null, req.system._id),
             aggregate_data_free_by_tier: nodes_client.instance().aggregate_data_free_by_tier(
                 bucket.tiering.tiers.map(tiers_object => String(tiers_object.tier._id)), req.system._id),
-            num_of_objects: MDStore.instance().count_objects_of_bucket(bucket._id),
+            num_of_objects: dont_count_objects === 'dont_count_objects' ? 0 : MDStore.instance().count_objects_of_bucket(bucket._id),
             func_configs: get_bucket_func_configs(req, bucket),
             unused_refresh_tiering_alloc: node_allocator.refresh_tiering_alloc(bucket.tiering),
         })
@@ -283,7 +283,7 @@ function get_bucket_namespaces(req) {
                     proxy: system.phone_home_proxy_address
                 };
             } else {
-                return read_bucket(req);
+                return read_bucket(req, 'dont_count_objects');
             }
         });
 }

--- a/src/test/unit_tests/test_signature_utils.js
+++ b/src/test/unit_tests/test_signature_utils.js
@@ -160,13 +160,14 @@ mocha.describe('signature_utils', function() {
             .then(sha256_buf => {
                 const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
                 const STREAMING_PAYLOAD = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';
-                req.content_sha256 = req.query['X-Amz-Signature'] ?
+                const content_sha256_hdr = req.headers['x-amz-content-sha256'];
+                req.content_sha256_sig = req.query['X-Amz-Signature'] ?
                     UNSIGNED_PAYLOAD :
-                    req.headers['x-amz-content-sha256'];
-                if (typeof req.content_sha256 === 'string' &&
-                    req.content_sha256 !== UNSIGNED_PAYLOAD &&
-                    req.content_sha256 !== STREAMING_PAYLOAD) {
-                    req.content_sha256_buf = Buffer.from(req.content_sha256, 'hex');
+                    content_sha256_hdr;
+                if (typeof content_sha256_hdr === 'string' &&
+                    content_sha256_hdr !== UNSIGNED_PAYLOAD &&
+                    content_sha256_hdr !== STREAMING_PAYLOAD) {
+                    req.content_sha256_buf = Buffer.from(content_sha256_hdr, 'hex');
                     if (req.content_sha256_buf.length !== 32) {
                         throw new Error('InvalidDigest');
                     }
@@ -177,7 +178,7 @@ mocha.describe('signature_utils', function() {
                     }
                 } else {
                     req.content_sha256_buf = sha256_buf;
-                    if (!req.content_sha256) req.content_sha256 = req.content_sha256_buf.toString('hex');
+                    if (!req.content_sha256_sig) req.content_sha256_sig = req.content_sha256_buf.toString('hex');
                 }
                 const auth_token = signature_utils.make_auth_token_from_request(req);
                 const signature = signature_utils.get_signature_from_auth_token(auth_token, SECRETS[auth_token.access_key]);

--- a/src/upgrade/platform_upgrade.js
+++ b/src/upgrade/platform_upgrade.js
@@ -457,7 +457,7 @@ async function copy_new_code() {
     await fs_utils.full_dir_copy(NEW_VERSION_DIR, CORE_DIR);
 }
 
-// make sure that all the file which are requiered by the new version (.env, etc.) are in the new dir
+// make sure that all the file which are required by the new version (.env, etc.) are in the new dir
 async function prepare_new_dir() {
     await _build_dotenv();
     await _create_packages_md5();
@@ -472,7 +472,7 @@ async function _build_dotenv() {
         _.pick(old_env, DOTENV_VARS_FROM_OLD_VER),
     );
 
-    dbg.log0('UPGRADE: genertaing .env file for new version:', new_env);
+    dbg.log0('UPGRADE: generating .env file for new version:', new_env);
 
     await fs.writeFileAsync(`${NEW_VERSION_DIR}/.env`, dotenv.stringify(new_env));
 }
@@ -815,7 +815,7 @@ async function set_upgrade_info(new_upgrade_info) {
     try {
         const upgrade_data = JSON.stringify(new_upgrade_info);
         await fs.writeFileAsync(UPGRADE_INFO_FILE_PATH, upgrade_data);
-        dbg.log0('UPGRADE: upgrade info updated successfuly with upgrade_info =', new_upgrade_info);
+        dbg.log0('UPGRADE: upgrade info updated successfully with upgrade_info =', new_upgrade_info);
     } catch (err) {
         dbg.error(`got unexpected error when writing upgrade info file ${UPGRADE_INFO_FILE_PATH}`, err);
     }

--- a/src/util/chunked_content_decoder.js
+++ b/src/util/chunked_content_decoder.js
@@ -1,0 +1,97 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const stream = require('stream');
+
+const STATE_READ_CHUNK_HEADER = 'STATE_READ_CHUNK_HEADER';
+const STATE_WAIT_NL_HEADER = 'STATE_WAIT_NL_HEADER';
+const STATE_SEND_DATA = 'STATE_SEND_DATA';
+const STATE_WAIT_CR_DATA = 'STATE_WAIT_CR_DATA';
+const STATE_WAIT_NL_DATA = 'STATE_WAIT_NL_DATA';
+const STATE_CONTENT_END = 'STATE_CONTENT_END';
+const STATE_ERROR = 'STATE_ERROR';
+
+const CR_CODE = '\r'.charCodeAt(0);
+const NL_CODE = '\n'.charCodeAt(0);
+
+/**
+ *
+ * ChunkedContentDecoder
+ *
+ * Take a data stream and removes chunking signatures from it
+ *
+ */
+class ChunkedContentDecoder extends stream.Transform {
+
+    constructor(params) {
+        super(params);
+        this.state = STATE_READ_CHUNK_HEADER;
+        this.chunk_header_str = '';
+        this.chunk_size = 0;
+        this.chunk_signature = '';
+    }
+
+    _transform(buf, encoding, callback) {
+        try {
+            this.parse(buf);
+            return callback();
+        } catch (err) {
+            return callback(err);
+        }
+    }
+
+    _flush(callback) {
+        if (this.state !== STATE_CONTENT_END) return this.error_state();
+        return callback();
+    }
+
+    parse(buf) {
+        for (let index = 0; index < buf.length; ++index) {
+            if (this.state === STATE_READ_CHUNK_HEADER) {
+                for (; index < buf.length; ++index) {
+                    if (buf[index] === CR_CODE) {
+                        const header_items = this.chunk_header_str.split(';');
+                        this.chunk_size = parseInt(header_items[0], 16);
+                        if (!(this.chunk_size >= 0)) return this.error_state();
+                        this.last_chunk = this.chunk_size === 0;
+                        const header1 = header_items[1].split('=');
+                        this.chunk_signature = header1[0] === 'chunk-signature' ? header1[1] : '';
+                        this.chunk_header_str = '';
+                        this.state = STATE_WAIT_NL_HEADER;
+                        break;
+                    } else {
+                        this.chunk_header_str += String.fromCharCode(buf[index]);
+                    }
+                }
+            } else if (this.state === STATE_WAIT_NL_HEADER) {
+                if (buf[index] !== NL_CODE) return this.error_state();
+                this.state = STATE_SEND_DATA;
+            } else if (this.state === STATE_SEND_DATA) {
+                const content = (index === 0 && buf.length <= this.chunk_size) ? buf : buf.slice(index, index + this.chunk_size);
+                this.chunk_size -= content.length;
+                index += content.length - 1;
+                if (content.length) this.push(content);
+                if (!this.chunk_size) this.state = STATE_WAIT_CR_DATA;
+            } else if (this.state === STATE_WAIT_CR_DATA) {
+                if (buf[index] !== CR_CODE) return this.error_state();
+                this.state = STATE_WAIT_NL_DATA;
+            } else if (this.state === STATE_WAIT_NL_DATA) {
+                if (buf[index] !== NL_CODE) return this.error_state();
+                if (this.last_chunk) {
+                    this.state = STATE_CONTENT_END;
+                } else {
+                    this.state = STATE_READ_CHUNK_HEADER;
+                }
+            } else {
+                return this.error_state();
+            }
+        }
+    }
+
+    error_state() {
+        this.state = STATE_ERROR;
+        this.emit('error', new Error('problem in parsing aws-chunked data'));
+    }
+}
+
+module.exports = ChunkedContentDecoder;

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -190,7 +190,6 @@ function read_request_body(req, options) {
                 }
             } else {
                 req.content_sha256_buf = sha256_buf;
-                if (!req.content_sha256) req.content_sha256 = req.content_sha256_buf.toString('hex');
             }
             return resolve();
         });

--- a/src/util/signature_utils.js
+++ b/src/util/signature_utils.js
@@ -105,7 +105,7 @@ function _string_to_sign_v4(req, signed_headers, xamzdate, region, service) {
         !signed_headers_set ||
         signed_headers_set.has(key.toLowerCase());
 
-    v4.hexEncodedBodyHash = () => req.content_sha256 || EMPTY_SHA256;
+    v4.hexEncodedBodyHash = () => req.content_sha256_sig || EMPTY_SHA256;
 
     const canonical_str = v4.canonicalString();
     const string_to_sign = v4.stringToSign(xamzdate);

--- a/src/util/time_utils.js
+++ b/src/util/time_utils.js
@@ -60,8 +60,11 @@ function parse_http_header_date(str) {
  */
 function parse_amz_date(str) {
     if (!str) return NaN;
-    const iso = `${str.slice(0, 4)}-${str.slice(4, 6)}-${str.slice(6, 11)}:${str.slice(11, 13)}:${str.slice(13)}`;
-    return Date.parse(iso);
+    const match_ISO_8601 = (/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/).exec(str);
+    if (match_ISO_8601) {
+        return Date.parse(`${match_ISO_8601[1]}-${match_ISO_8601[2]}-${match_ISO_8601[3]}T${match_ISO_8601[4]}:${match_ISO_8601[5]}:${match_ISO_8601[6]}Z`);
+    }
+    return Date.parse(str);
 }
 
 function format_time_duration(millis, show_millis) {


### PR DESCRIPTION
### Explain the changes
#### 3. Other Changes:
- Backport Fixes from Master to 2.10.4:
  - Fix AMZ date parsing
  - Fix unintended false value in XML reply
  - Adding support for chunked upload
  - Fix ObjectMDCache issue
  - read_bucket - only count objects in read_system
  - Build Code (Jenkins job changes)


### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
