### PR TITLE
Agent.Dockerfile: reducing image size

### DIFF
--- a/src/deploy/NVA_build/run_agent_container.sh
+++ b/src/deploy/NVA_build/run_agent_container.sh
@@ -10,6 +10,7 @@ fix_non_root_user() {
   fi
 }
 
+tar -zxvf /noobaa.tar.gz
 fix_non_root_user
 # set ownership\mode of /noobaa_storage
 /usr/local/noobaa/build/Release/kube_pv_chown agent $(id -u)


### PR DESCRIPTION
### Explain the changes
Agent.Dockerfile:
- Reducing the agent image size from 1.11GB to 330MB

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
