### PR TITLE
Fix issues with create/edit account with when there are no resources in the system

### DIFF
--- a/frontend/src/app/components/modals/create-account-modal/create-account-modal.html
+++ b/frontend/src/app/components/modals/create-account-modal/create-account-modal.html
@@ -79,7 +79,10 @@
                             "
                             ko.validationCss="$form.defaultResource"
                         ></dropdown>
-                         <validation-message params="field: $form.defaultResource"></validation-message>
+                         <validation-message
+                            ko.css.disabled="isS3AccessDisabled"
+                            params="field: $form.defaultResource"
+                        ></validation-message>
                     </editor>
                 </div>
 

--- a/frontend/src/app/components/modals/create-account-modal/create-account-modal.js
+++ b/frontend/src/app/components/modals/create-account-modal/create-account-modal.js
@@ -69,7 +69,7 @@ class CreateAccountModalViewModel extends ConnectableViewModel {
     s3PlacementToolTip = s3PlacementToolTip;
     allowBucketCreationTooltip = allowBucketCreationTooltip;
     accountNames = null;
-    systemHasResources = null;
+    systemHasResources = false;
     resourceOptions = ko.observable();
     bucketOptions = ko.observable();
     password = randomString();
@@ -154,7 +154,6 @@ class CreateAccountModalViewModel extends ConnectableViewModel {
         const warnings = {};
         const { hasS3Access, step } = values;
 
-        // console.warn(values, this.systemHasResources);
         if (step === 1) {
             if (hasS3Access && !this.systemHasResources) {
                 warnings.defaultResource = 'Until connecting resources, internal storage will be used';

--- a/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.html
+++ b/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.html
@@ -3,6 +3,7 @@
 <managed-form class="column greedy" params="
     name: formName,
     fields: fields,
+    onWarn: onWarn,
     onValidate: onValidate,
     onSubmit: onSubmit
 ">

--- a/frontend/src/app/styles/site.less
+++ b/frontend/src/app/styles/site.less
@@ -265,7 +265,13 @@ pre {
 }
 
 .disabled {
-    color: rgb(var(--color09));
+    &,
+    .success,
+    .warning,
+    .error,
+    .info {
+        color: rgb(var(--color09));
+    }
 }
 
 .bullet-list {


### PR DESCRIPTION
Includes 2 fixes:
- FE fix for missing warning for system with no resources (using internal storage)
- BE fix for allowing editing of policy in a system with no actual resources (continue using internal storage after edit)
