### PR TITLE
noobaa.spec: rename the license from Apache License 2.0 to ASL 2.0

### DIFF
--- a/src/deploy/rpm/noobaa.spec
+++ b/src/deploy/rpm/noobaa.spec
@@ -9,7 +9,7 @@ Version:	%{noobaaver}
 Release:	%{revision}%{?dist}
 Summary:	noobaa rpm
 
-License:	Apache License 2.0
+License:	ASL 2.0
 URL:        https://www.noobaa.com/
 Source0:	%{tarfile}
 Source1:    %{installscript}


### PR DESCRIPTION
### Explain the changes
noobaa.spec:
- Rename the license from Apache License 2.0 to ASL 2.0

### Issues: Fixed #xxx / Gap #xxx
- 

### Testing Instructions:
-

### Reminders:
- Create a new test - the first is the hardest
- User Experience is top priority
- Design for failure
- Keep it simple
- `npm test`
- Imagine a support call - Add diagnostics info, phonehome info, activity log events, external syslog
- Upgrade - DB schema, server platform, agents install, npm packages
