### PR TITLE
Reducing the size of the server image

### DIFF
--- a/src/deploy/NVA_build/Server.Dockerfile
+++ b/src/deploy/NVA_build/Server.Dockerfile
@@ -13,7 +13,6 @@ COPY ${install_script} /tmp/install_noobaa.sh
 RUN chmod +x /tmp/install_noobaa.sh
 RUN /bin/bash -xc "/tmp/install_noobaa.sh"
 
-
 ###############
 # PORTS SETUP #
 ###############

--- a/src/deploy/NVA_build/Server.Dockerfile
+++ b/src/deploy/NVA_build/Server.Dockerfile
@@ -12,6 +12,15 @@ COPY ${noobaa_rpm} /tmp/noobaa.rpm
 COPY ${install_script} /tmp/install_noobaa.sh
 RUN chmod +x /tmp/install_noobaa.sh
 RUN /bin/bash -xc "/tmp/install_noobaa.sh"
+RUN yum install -y /tmp/noobaa.rpm && \ 
+    yum clean all && \ 
+    /usr/bin/deploy_base.sh runinstall && \
+    mkdir -m 775 /noobaa_init_files/ && \
+    chgrp -R 0 /noobaa_init_files/ && \
+    chmod -R g=u /noobaa_init_files/ && \
+    cp -p /root/node_modules/noobaa-core/src/deploy/NVA_build/noobaa_init.sh /noobaa_init_files/  && \
+    cp -p /root/node_modules/noobaa-core/build/Release/kube_pv_chown /noobaa_init_files/  && \
+    rm -rf /root/node_modules/noobaa-core/
 
 ###############
 # PORTS SETUP #

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -207,24 +207,11 @@ function install_kubectl {
 
 function install_noobaa_repos {
     deploy_log "install_noobaa_repos start"
-
     mkdir -p /root/node_modules
     cd /root/node_modules
     tar -xzf /tmp/noobaa-NVA.tar.gz
     cd ~
     rm -rf /tmp/noobaa-NVA.tar.gz
-
-    # Setup Repos
-    if [ "${container}" == "docker" ]; then
-        sed -i -e "\$aPLATFORM=docker" ${CORE_DIR}/src/deploy/NVA_build/env.orig
-    fi
-    # in a container set the endpoint\ssl ports to 6001\6443 since we are not running as root
-    if [ "${container}" == "docker" ]; then
-        echo "ENDPOINT_PORT=6001" >> ${CORE_DIR}/src/deploy/NVA_build/env.orig
-        echo "ENDPOINT_SSL_PORT=6443" >> ${CORE_DIR}/src/deploy/NVA_build/env.orig
-    fi
-    cp -f ${CORE_DIR}/src/deploy/NVA_build/env.orig /data/.env
-
     deploy_log "install_noobaa_repos done"
 }
 

--- a/src/deploy/NVA_build/deploy_base.sh
+++ b/src/deploy/NVA_build/deploy_base.sh
@@ -26,7 +26,7 @@ function deploy_log {
 function verify_noobaa_pre_requirements() {
     if [ ! -f /tmp/noobaa-NVA.tar.gz ]
     then
-        echo "There is no noobaa-NVA.tar.gz under /tmp/"
+        deploy_log "There is no noobaa-NVA.tar.gz under /tmp/"
         exit 1
     fi
 }
@@ -209,10 +209,10 @@ function install_noobaa_repos {
     deploy_log "install_noobaa_repos start"
 
     mkdir -p /root/node_modules
-    mv /tmp/noobaa-NVA.tar.gz /root/node_modules
     cd /root/node_modules
-    tar -xzf ./noobaa-NVA.tar.gz
+    tar -xzf /tmp/noobaa-NVA.tar.gz
     cd ~
+    rm -rf /tmp/noobaa-NVA.tar.gz
 
     # Setup Repos
     if [ "${container}" == "docker" ]; then
@@ -485,7 +485,7 @@ function setup_non_root_user() {
 
         # in openshift the container will run as a random user which belongs to root group
         # set permissions for group to be same as owner to allow access to necessary files
-        echo "setting file permissions for root group"
+        deploy_log "setting file permissions for root group"
         # allow root group same permissions as root user so it can run supervisord
         chgrp -R 0 /bin/supervisor* && chmod -R g=u /bin/supervisor*
         # supervisord needs to write supervisor.sock file in /var/log

--- a/src/deploy/NVA_build/fix_mongo_ssl.sh
+++ b/src/deploy/NVA_build/fix_mongo_ssl.sh
@@ -3,7 +3,9 @@ CORE_DIR="/root/node_modules/noobaa-core"
 if [ ! -d /data/mongo/ssl/ ]; then
   mkdir -p /data/mongo/ssl/
   mkdir -p /data/bin
-  . ${CORE_DIR}/src/deploy/NVA_build/setup_mongo_ssl.sh
+  cd ${CORE_DIR}/src/deploy/NVA_build/
+  . ./setup_mongo_ssl.sh
+  cd - > /dev/null
   chown -R mongod:mongod /data/mongo/
   chmod 400 -R /data/mongo/ssl/*
   chmod 500 /data/mongo/ssl

--- a/src/deploy/NVA_build/fix_server_plat.sh
+++ b/src/deploy/NVA_build/fix_server_plat.sh
@@ -9,7 +9,7 @@ if [ ! -f ${NOOBAASEC} ]; then
     # ensure existence of folders such as mongo, supervisor, etc.
     mkdir -p /log/supervisor
     mkdir -p /data/mongo/cluster/shard1
-    chown -R mongod:mongod /data/mongo/
+    [ "${container}" != "docker" ] && chown -R mongod:mongod /data/mongo/
     cp -f /root/node_modules/noobaa-core/src/deploy/NVA_build/noobaa_supervisor.conf /data &>> /data/mylog
     cp -f /root/node_modules/noobaa-core/src/deploy/NVA_build/env.orig /data/.env &>> /data/mylog
   fi

--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -165,6 +165,9 @@ spec:
                   name: noobaa-create-sys-creds
                   key: password
                   optional: true
+            # replacing the empty value with any value will set the cotainer to dbg mode
+            - name: container_dbg
+              value: ""
       serviceAccountName: noobaa-account
       imagePullSecrets:
         - name: noobaaimages.azurecr.io

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -86,7 +86,8 @@ fix_non_root_user() {
 extract_noobaa_in_docker() {
   local file
   local files=(deploy_base.sh noobaa-NVA.tar.gz noobaa.rpm)
-  if [ "${container}" == "docker" ] ; then
+  local noobaa_core_path="/root/node_modules/noobaa-core/"
+  if [ "${container}" == "docker" ] && [ ! -d ${noobaa_core_path} ] ; then
     cd /tmp/
     rpm2cpio noobaa.rpm | cpio -idmv
     rm -rf /tmp/deploy_base.sh
@@ -101,7 +102,8 @@ extract_noobaa_in_docker() {
 }
 
 run_kube_pv_chown() {
-  # change ownership and permissions of /data and /log. assuming that uid is not changed between reboots
+  # change ownership and permissions of /data and /log. 
+  # assuming that uid is not changed between reboots.
   local path="/root/node_modules/noobaa-core/build/Release/"
   if [ "${container}" == "docker" ] ; then
       path="/noobaa_init_files/"

--- a/src/deploy/NVA_build/setup_mongo_ssl.sh
+++ b/src/deploy/NVA_build/setup_mongo_ssl.sh
@@ -9,23 +9,23 @@ ou_client="MyClients"
 mongodb_server_hosts=( "server" )
 mongodb_client_hosts=( "client" )
 
-echo "##### creating ssl certificates for mongo authentication "
-echo "##### STEP 1: Generate root CA "
-openssl genrsa -out ${MONGO_SSL_PATH}/root-ca.key 2048
-# !!! In production you will want to use -aes256 to password protect the keys
-# openssl genrsa -aes256 -out root-ca.key 2048
+function generate_root_CA() {
+	openssl genrsa -out ${MONGO_SSL_PATH}/root-ca.key 2048
+	# !!! In production you will want to use -aes256 to password protect the keys
+	# openssl genrsa -aes256 -out root-ca.key 2048
 
-openssl req -new -x509 -days 7300 -key ${MONGO_SSL_PATH}/root-ca.key -out ${MONGO_SSL_PATH}/root-ca.crt -subj "$dn_prefix/CN=ROOTCA"
+	openssl req -new -x509 -days 7300 -key ${MONGO_SSL_PATH}/root-ca.key -out ${MONGO_SSL_PATH}/root-ca.crt -subj "$dn_prefix/CN=ROOTCA"
 
-mkdir -p ${MONGO_SSL_PATH}/RootCA/ca.db.certs
-echo "01" >> ${MONGO_SSL_PATH}/RootCA/ca.db.serial
-touch ${MONGO_SSL_PATH}/RootCA/ca.db.index
-echo $RANDOM >> ${MONGO_SSL_PATH}/RootCA/ca.db.rand
-mv ${MONGO_SSL_PATH}/root-ca* ${MONGO_SSL_PATH}/RootCA/
+	mkdir -p ${MONGO_SSL_PATH}/RootCA/ca.db.certs
+	echo "01" >> ${MONGO_SSL_PATH}/RootCA/ca.db.serial
+	touch ${MONGO_SSL_PATH}/RootCA/ca.db.index
+	echo $RANDOM >> ${MONGO_SSL_PATH}/RootCA/ca.db.rand
+	mv ${MONGO_SSL_PATH}/root-ca* ${MONGO_SSL_PATH}/RootCA/
+}
 
-echo "##### STEP 2: Create CA config"
-# Generate CA config
-cat >> ${MONGO_SSL_PATH}/root-ca.cfg <<EOF
+function create_CA_config() {
+	# Generate CA config
+	cat >> ${MONGO_SSL_PATH}/root-ca.cfg <<EOF
 [ RootCA ]
 dir             = ${MONGO_SSL_PATH}/RootCA
 certs           = \$dir/ca.db.certs
@@ -76,48 +76,61 @@ subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always,issuer:always
 basicConstraints = CA:true
 EOF
+}
 
-echo "##### STEP 3: Generate signing key"
-# We do not use root key to sign certificate, instead we generate a signing key
-openssl genrsa -out ${MONGO_SSL_PATH}/signing-ca.key 2048
-# !!! In production you will want to use -aes256 to password protect the keys
-# openssl genrsa -aes256 -out signing-ca.key 2048
+function generate_signing_key(){
+	# We do not use root key to sign certificate, instead we generate a signing key
+	openssl genrsa -out ${MONGO_SSL_PATH}/signing-ca.key 2048
+	# !!! In production you will want to use -aes256 to password protect the keys
+	# openssl genrsa -aes256 -out signing-ca.key 2048
 
-openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/signing-ca.key -out ${MONGO_SSL_PATH}/signing-ca.csr -subj "$dn_prefix/CN=CA-SIGNER"
-openssl ca -batch -name RootCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -extensions v3_ca -out ${MONGO_SSL_PATH}/signing-ca.crt -infiles ${MONGO_SSL_PATH}/signing-ca.csr 
+	openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/signing-ca.key -out ${MONGO_SSL_PATH}/signing-ca.csr -subj "$dn_prefix/CN=CA-SIGNER"
+	openssl ca -batch -name RootCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -extensions v3_ca -out ${MONGO_SSL_PATH}/signing-ca.crt -infiles ${MONGO_SSL_PATH}/signing-ca.csr 
 
-mkdir -p ${MONGO_SSL_PATH}/SigningCA/ca.db.certs
-echo "01" >> ${MONGO_SSL_PATH}/SigningCA/ca.db.serial
-touch ${MONGO_SSL_PATH}/SigningCA/ca.db.index
-# Should use a better source of random here..
-echo $RANDOM >> ${MONGO_SSL_PATH}/SigningCA/ca.db.rand
-mv ${MONGO_SSL_PATH}/signing-ca* ${MONGO_SSL_PATH}/SigningCA/
+	mkdir -p ${MONGO_SSL_PATH}/SigningCA/ca.db.certs
+	echo "01" >> ${MONGO_SSL_PATH}/SigningCA/ca.db.serial
+	touch ${MONGO_SSL_PATH}/SigningCA/ca.db.index
+	# Should use a better source of random here..
+	echo $RANDOM >> ${MONGO_SSL_PATH}/SigningCA/ca.db.rand
+	mv ${MONGO_SSL_PATH}/signing-ca* ${MONGO_SSL_PATH}/SigningCA/
 
-# Create root-ca.pem
-cat ${MONGO_SSL_PATH}/RootCA/root-ca.crt ${MONGO_SSL_PATH}/SigningCA/signing-ca.crt > ${MONGO_SSL_PATH}/root-ca.pem
+	# Create root-ca.pem
+	cat ${MONGO_SSL_PATH}/RootCA/root-ca.crt ${MONGO_SSL_PATH}/SigningCA/signing-ca.crt > ${MONGO_SSL_PATH}/root-ca.pem
+}
 
-
-
-echo "##### STEP 4: Create server certificates"
+function create_server_certificates() {
 # Now create & sign keys for each mongod server 
 # Pay attention to the OU part of the subject in "openssl req" command
 # You may want to use FQDNs instead of short hostname
-for host in "${mongodb_server_hosts[@]}"; do
-	echo "Generating key for $host"
-  	openssl genrsa  -out ${MONGO_SSL_PATH}/${host}.key 2048
-	openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/${host}.key -out ${MONGO_SSL_PATH}/${host}.csr -subj "$dn_prefix/OU=$ou_member/CN=${host}"
-	openssl ca -batch -name SigningCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -out ${MONGO_SSL_PATH}/${host}.crt -infiles ${MONGO_SSL_PATH}/${host}.csr
-	cat ${MONGO_SSL_PATH}/${host}.crt ${MONGO_SSL_PATH}/${host}.key > ${MONGO_SSL_PATH}/${host}.pem	
-done 
+	for host in "${mongodb_server_hosts[@]}"; do
+		echo "Generating key for $host"
+		openssl genrsa  -out ${MONGO_SSL_PATH}/${host}.key 2048
+		openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/${host}.key -out ${MONGO_SSL_PATH}/${host}.csr -subj "$dn_prefix/OU=$ou_member/CN=${host}"
+		openssl ca -batch -name SigningCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -out ${MONGO_SSL_PATH}/${host}.crt -infiles ${MONGO_SSL_PATH}/${host}.csr
+		cat ${MONGO_SSL_PATH}/${host}.crt ${MONGO_SSL_PATH}/${host}.key > ${MONGO_SSL_PATH}/${host}.pem	
+	done 
+}
 
+function create_client_certificates() {
+	# Now create & sign keys for each client
+	# Pay attention to the OU part of the subject in "openssl req" command
+	for host in "${mongodb_client_hosts[@]}"; do
+		echo "Generating key for $host"
+		openssl genrsa  -out ${MONGO_SSL_PATH}/${host}.key 2048
+		openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/${host}.key -out ${MONGO_SSL_PATH}/${host}.csr -subj "$dn_prefix/OU=$ou_client/CN=${host}"
+		openssl ca -batch -name SigningCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -out ${MONGO_SSL_PATH}/${host}.crt -infiles ${MONGO_SSL_PATH}/${host}.csr
+		cat ${MONGO_SSL_PATH}/${host}.crt ${MONGO_SSL_PATH}/${host}.key > ${MONGO_SSL_PATH}/${host}.pem
+	done 
+	}
+
+echo "##### creating ssl certificates for mongo authentication "
+echo "##### STEP 1: Generate root CA "
+generate_root_CA
+echo "##### STEP 2: Create CA config"
+create_CA_config
+echo "##### STEP 3: Generate signing key"
+generate_signing_key
+echo "##### STEP 4: Create server certificates"
+create_server_certificates
 echo "##### STEP 5: Create client certificates"
-# Now create & sign keys for each client
-# Pay attention to the OU part of the subject in "openssl req" command
-for host in "${mongodb_client_hosts[@]}"; do
-	echo "Generating key for $host"
-  	openssl genrsa  -out ${MONGO_SSL_PATH}/${host}.key 2048
-	openssl req -new -days 7300 -key ${MONGO_SSL_PATH}/${host}.key -out ${MONGO_SSL_PATH}/${host}.csr -subj "$dn_prefix/OU=$ou_client/CN=${host}"
-	openssl ca -batch -name SigningCA -startdate 201708010000Z -config ${MONGO_SSL_PATH}/root-ca.cfg -out ${MONGO_SSL_PATH}/${host}.crt -infiles ${MONGO_SSL_PATH}/${host}.csr
-	cat ${MONGO_SSL_PATH}/${host}.crt ${MONGO_SSL_PATH}/${host}.key > ${MONGO_SSL_PATH}/${host}.pem
-done 
-
+create_client_certificates

--- a/src/deploy/NVA_build/supervisord.orig
+++ b/src/deploy/NVA_build/supervisord.orig
@@ -7,7 +7,12 @@ PIDFILE="/var/log/supervisord.pid"
 
 start() {
     #run noobaa_init script before start
-    /root/node_modules/noobaa-core/src/deploy/NVA_build/noobaa_init.sh
+    local path="/root/node_modules/noobaa-core/src/deploy/NVA_build/"
+    if [ "${container}" == "docker" ]
+    then
+        path="/noobaa_init_files/"
+    fi
+    ${path}/noobaa_init.sh
 
     if [ ! -x "$SUPERVISORD" ]; then
         echo "$SUPERVISORD is not executable."

--- a/src/deploy/rpm/build-rpm.sh
+++ b/src/deploy/rpm/build-rpm.sh
@@ -58,10 +58,16 @@ fi
 build/rpm/create_rpm.sh -l ${build_rpm_location}
 if [ $? -eq 0 ]
 then
-    mv ~/rpmbuild/RPMS/noarch/*.rpm build/public/ || exit 1
+    mv ~/rpmbuild/RPMS/noarch/*.rpm build/public/
+    if [ $? -ne 0 ]
+    then
+        rm -rf ~/rpmbuild
+        exit 1
+    fi
     rm -rf ${build_rpm_location}
 else
     rm -rf ${build_rpm_location}
+    rm -rf ~/rpmbuild
     exit 1
 fi
 

--- a/src/deploy/rpm/install_noobaa.sh
+++ b/src/deploy/rpm/install_noobaa.sh
@@ -43,10 +43,3 @@ function verify_rpm_exist() {
 verify_rpm_exist
 #config_scl
 config_mongo_repo
-yum install -y ${rpm_location}/noobaa*.rpm
-
-#clean
-yum clean all
-rm -f ${rpm_location}/noobaa*.rpm
-
-

--- a/src/deploy/rpm/noobaa.spec
+++ b/src/deploy/rpm/noobaa.spec
@@ -68,8 +68,8 @@ This is noobaa rpm
 %build
 
 %install
-mkdir -p %{_tmppath}/%{name}-%{version}-%{release}
-cp %{SOURCE0} %{SOURCE1} %{_tmppath}/%{name}-%{version}-%{release}
+%{__mkdir_p} %{_tmppath}/%{name}-%{version}-%{release}
+%{__cp} %{SOURCE0} %{SOURCE1} %{_tmppath}/%{name}-%{version}-%{release}
 cd %{_tmppath}/%{name}-%{version}-%{release}
 
 %clean
@@ -77,9 +77,9 @@ cd %{_tmppath}/%{name}-%{version}-%{release}
 
 %post
 echo "Starting to install noobaa"
-mv %{tarfile} /tmp/noobaa-NVA.tar.gz
-chmod +x %{installscript}
-install -m 0755 %{installscript} %{_bindir}/%{installscript}
+%{__mv} %{tarfile} /tmp/noobaa-NVA.tar.gz
+%{__chmod} +x %{installscript}
+%{__install} -m 0755 %{installscript} %{_bindir}/%{installscript}
 %{installscript} runinstall
 echo -e "\e[31m\nWait for prompt and then we need to reboot...\n\e[0m"
 

--- a/src/deploy/rpm/noobaa.spec
+++ b/src/deploy/rpm/noobaa.spec
@@ -76,11 +76,12 @@ cd %{_tmppath}/%{name}-%{version}-%{release}
 [ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
 
 %post
-echo "Starting to install noobaa"
 %{__mv} %{tarfile} /tmp/noobaa-NVA.tar.gz
 %{__chmod} +x %{installscript}
 %{__install} -m 0755 %{installscript} %{_bindir}/%{installscript}
-%{installscript} runinstall
+# removed this as we use docker, we should note that downstream applaince will need this
+# echo "Starting to install noobaa"
+# %{installscript} runinstall
 echo -e "\e[31m\nWait for prompt and then we need to reboot...\n\e[0m"
 
 %files


### PR DESCRIPTION
### Explain the changes
build-rpm.sh:
- Fixed a bug that caused rpm builds to stuck.

noobaa.spec:
- Updating the spec

deploy_base.sh:
- Deleting the NooBaa tarball

noobaa_init.sh
- In Docker we are extracting the noobaa tar
- Add function extract_noobaa_in_docker
- Running kube_pv_chown from a function
- Adding some debug

fix_server_plat.sh
- Adding some debug

Server.Dockerfile
- running deploy base
- copying some files to /noobaa_init_files/

noobaa.spec
- removed the run of deploy base

install_noobaa.sh
- no longer yum installing the rpm

supervisord.orig
- In docker running the noobaa_init.sh from a different path

fix_server_plat.sh
- Add get_env_in_docker function that will return the .env that we
copied out in the Server.Dockerfile

setup_mongo_ssl.sh:
- Divided into functions

fix_mongo_ssl.sh:
- minor fix for debug

noobaa_core.yaml:
- Add the ability to set the container in dbg
