### PR TITLE
increased timeout for server readiness probe

### DIFF
--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -110,6 +110,7 @@ spec:
             httpGet:
               port: 8080
               path: "/version"
+            timeoutSeconds: 5
           image: noobaa/noobaa-core:3.0.0
           imagePullPolicy: IfNotPresent
           resources:


### PR DESCRIPTION
### Explain the changes
1. default timeout is 1 second
2. for some reason it sometimes takes more than that to respond on `/version`, which is our path to check readiness
3. increased timeout to 5 seconds

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
