### PR TITLE
Removing the support for windows in the build

### DIFF
--- a/src/deploy/Linux/Build-Package.sh
+++ b/src/deploy/Linux/Build-Package.sh
@@ -20,12 +20,9 @@ echo "=====> version $NB_VERSION"
 echo "=====> update tar noobaa-NVA-${NB_VERSION}.tar.gz"
 gunzip build/public/noobaa-NVA-${NB_VERSION}.tar.gz || exit 1
 mv build/linux/noobaa-setup-${NB_VERSION}* build/public/ || exit 1
-mv build/windows/noobaa-setup-${NB_VERSION}.exe* build/public/ || exit 1
 tar --transform='s:^:noobaa-core/:' \
     -rf build/public/noobaa-NVA-${NB_VERSION}.tar \
     build/public/noobaa-setup-${NB_VERSION} \
     build/public/noobaa-setup-${NB_VERSION}.md5 \
-    build/public/noobaa-setup-${NB_VERSION}.exe \
-    build/public/noobaa-setup-${NB_VERSION}.exe.md5 \
     || exit 1
 gzip build/public/noobaa-NVA-${NB_VERSION}.tar

--- a/src/test/utils/agent_functions.js
+++ b/src/test/utils/agent_functions.js
@@ -21,23 +21,14 @@ const auth_params = {
 const Yellow = "\x1b[33;1m";
 const NC = "\x1b[0m";
 
-function supported_oses(flavor) {
+function supported_oses() {
     const LINUX_FLAVORS = [
         'ubuntu12', 'ubuntu14', 'ubuntu16', 'ubuntu18',
         'centos6', 'centos7',
         'redhat6', 'redhat7'
     ];
-    const WIN_FLAVORS = [
-        'win2008', 'win2012', 'win2016'
-    ];
 
-    if (flavor === 'WIN') {
-        return WIN_FLAVORS;
-    } else if (flavor === 'LINUX') {
-        return LINUX_FLAVORS;
-    } else {
-        return LINUX_FLAVORS.concat(WIN_FLAVORS);
-    }
+    return LINUX_FLAVORS;
 }
 
 async function list_nodes(server_ip) {


### PR DESCRIPTION
### Explain the changes
We are no longer calling the win build in Build-Package.sh and not creating an exe

Build-Package.sh:
- Removing the support for windows

agent_functions.js:
- Removing the Win flavors from the  supported_oses

reclaim_test.js:
- not calling Win agents anymore

### Gaps:
1. Need to remove the handling of Win in the agent code
2. need to remove the Win referral from the UI

