### PR TITLE
Bump the version to 4.0+ Fix system_server._init problem in non cluster envs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",

--- a/src/server/bg_services/cluster_master.js
+++ b/src/server/bg_services/cluster_master.js
@@ -29,8 +29,7 @@ function background_worker() {
 
     dbg.log2(`checking cluster_master`);
 
-    let current_clustering = system_store.get_local_cluster_info();
-    if (current_clustering && current_clustering.is_clusterized) {
+    if (cutil.check_if_clusterized()) {
         // TODO: Currently checks the replica set master since we don't have shards
         // We always need to send so the webserver will be updated if the
         return P.resolve()

--- a/src/server/notifications/dispatcher.js
+++ b/src/server/notifications/dispatcher.js
@@ -16,6 +16,7 @@ const nodes_store = require('../node_services/nodes_store').NodesStore.instance(
 const func_store = require('../func_services/func_store').FuncStore.instance();
 const nodes_client = require('../node_services/nodes_client');
 const SensitiveString = require('../../util/sensitive_string');
+const cutil = require('../utils/clustering_utils');
 
 const SYSLOG_INFO_LEVEL = 5;
 const SYSLOG_LOG_LOCAL0 = 'LOG_LOCAL0';
@@ -157,8 +158,7 @@ class Dispatcher {
     publish_fe_notifications(params, api) {
         return P.resolve()
             .then(() => {
-                let current_clustering = system_store.get_local_cluster_info();
-                if (current_clustering && current_clustering.is_clusterized) {
+                if (cutil.check_if_clusterized()) {
                     return server_rpc.client.cluster_internal.redirect_to_cluster_master();
                 }
             })

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -27,6 +27,7 @@ const promise_utils = require('../../util/promise_utils');
 const net_utils = require('../../util/net_utils');
 const { RpcError, RPC_BUFFERS } = require('../../rpc');
 const upgrade_server = require('./upgrade_server');
+const cutils = require('../utils/clustering_utils');
 
 let add_member_in_process = false;
 
@@ -1117,8 +1118,7 @@ function _set_debug_level_internal(req, level) {
                 // Only master can update the whole system debug mode level
                 // TODO: If master falls in the process and we already passed him
                 // It means that nobody will update the system in the DB, yet it will be in debug
-                let current_clustering = system_store.get_local_cluster_info();
-                if ((current_clustering && current_clustering.is_clusterized) && !system_store.is_cluster_master) {
+                if (cutils.check_if_clusterized() && !system_store.is_cluster_master) {
                     return;
                 }
                 if (level > 0) {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -92,8 +92,11 @@ async function _init() {
                 // using clustering_utils.check_if_master(), because waiting for system
                 // store inital load does not guarantee that the bg updated and published
                 // the indication on the system store.
-                const { ismaster } = await MongoCtrl.is_master();
-                if (ismaster) {
+                const is_master =
+                    !cutil.check_if_clusterized() ||
+                    (await MongoCtrl.is_master()).ismaster;
+
+                if (is_master) {
                     // Only the muster should update the system address.
                     await _configure_system_address(system._id, system.owner.id);
                 }

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -23,7 +23,6 @@ function get_topology() {
     return system_store.get_local_cluster_info();
 }
 
-
 function update_host_address(address) {
     var current_clustering = system_store.get_local_cluster_info();
     //TODO:: publish changes to cluster!
@@ -366,10 +365,14 @@ function get_min_requirements() {
     };
 }
 
+function check_if_clusterized() {
+    const current_clustering = get_topology();
+    return current_clustering &&
+        current_clustering.is_clusterized;
+}
+
 function check_if_master() {
-    let current_clustering = get_topology();
-    return !current_clustering || // no cluster info => treat as master
-        !current_clustering.is_clusterized || // not clusterized => treat as master
+    return !check_if_clusterized() || // not clusterized => treat as master
         system_store.is_cluster_master; // clusterized and is master
 }
 
@@ -392,4 +395,5 @@ exports.get_min_requirements = get_min_requirements;
 exports.get_local_upgrade_path = get_local_upgrade_path;
 exports.get_member_upgrade_stage = get_member_upgrade_stage;
 exports.can_upload_package_in_cluster = can_upload_package_in_cluster;
+exports.check_if_clusterized = check_if_clusterized;
 exports.check_if_master = check_if_master;

--- a/src/server/utils/server_diagnostics.js
+++ b/src/server/utils/server_diagnostics.js
@@ -11,7 +11,7 @@ const base_diagnostics = require('../../util/base_diagnostics');
 const stats_aggregator = require('../system_services/stats_aggregator');
 const system_store = require('../system_services/system_store').get_instance();
 const server_rpc = require('../server_rpc');
-
+const cutil = require('../utils/clustering_utils');
 
 const TMP_WORK_DIR = '/tmp/diag';
 const DIAG_LOG_FILE = TMP_WORK_DIR + '/diagnostics_collection.log';
@@ -282,8 +282,7 @@ function collect_supervisor_logs() {
 
 function collect_statistics(req) {
     return P.resolve().then(function() {
-            let current_clustering = system_store.get_local_cluster_info();
-            if (stats_aggregator && !((current_clustering && current_clustering.is_clusterized) && !system_store.is_cluster_master)) {
+            if (stats_aggregator && cutil.check_if_master()) {
                 return stats_aggregator.get_all_stats(req);
             }
         })

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -161,9 +161,10 @@ app.use(function(req, res, next) {
     return next();
 });
 app.use(function(req, res, next) {
-    let current_clustering = system_store.get_local_cluster_info();
-    if ((current_clustering && current_clustering.is_clusterized) &&
-        !system_store.is_cluster_master && req.originalUrl !== '/upload_package' && req.originalUrl !== '/version') {
+    if (cutil.check_if_clusterized() &&
+        !system_store.is_cluster_master &&
+        req.originalUrl !== '/upload_package' && req.originalUrl !== '/version'
+    ) {
         P.fcall(() => server_rpc.client.cluster_internal.redirect_to_cluster_master())
             .then(host => {
                 res.status(307);
@@ -386,10 +387,8 @@ function getVersion(route) {
     return P.resolve()
         .then(() => {
             const registered = server_rpc.is_service_registered('system_api.read_system');
-            let current_clustering = system_store.get_local_cluster_info();
             let started;
-            if (system_store.data.systems.length === 0 ||
-                (current_clustering && !current_clustering.is_clusterized)) {
+            if (system_store.data.systems.length === 0 || cutil.check_if_clusterized()) {
                 // if no system or not clusterized then no need to wait
                 started = true;
             } else {

--- a/src/test/unit_tests/core_agent_control.js
+++ b/src/test/unit_tests/core_agent_control.js
@@ -91,6 +91,7 @@ function create_agent(howmany) {
                 }
             },
             host_id: uuid(),
+            routing_hint: 'LOOPBACK'
         });
         agntCtlConfig.allocated_agents[agent.node_name] = {
             agent: agent,


### PR DESCRIPTION
### Explain the changes
1. Bump the version to 4.0 
2. Fix misuse of MongoCtrl in non cluster envs. (should not be used when mongo is not running as replica set)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
