### PR TITLE
Fix issues related to rpc routing

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -54,7 +54,10 @@ class Agent {
         const dbg = this.dbg;
         dbg.log0('Creating agent', params);
 
-        this.rpc = api.new_rpc_from_base_address(params.address, params.routing_hint);
+        this.rpc = params.routing_hint ?
+            api.new_rpc_from_base_address(params.address, params.routing_hint) :
+            api.new_rpc_from_routing(api.new_router_from_base_address(params.address));
+
         this.client = this.rpc.new_client();
 
         this.servers = params.servers || [{

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -108,7 +108,7 @@ class APIClient {
 
 function new_router_from_base_address(base_address) {
     const { protocol, hostname, port, slashes } = url.parse(base_address);
-    const ports = get_default_ports(port);
+    const ports = get_default_ports(Number(port));
 
     return {
         default: url.format({ protocol, slashes, hostname, port: port }),
@@ -124,7 +124,7 @@ function new_router_from_address_list(address_list, hint) {
         default: get_base_address(address_list, hint, 'mgmt').toString(),
         md: get_base_address(address_list, hint, 'md').toString(),
         bg: get_base_address(address_list, hint, 'bg').toString(),
-        hosted_agents: get_base_address(address_list, hint, 'hosted-agents').toString(),
+        hosted_agents: get_base_address(address_list, hint, 'hosted_agents').toString(),
         master: get_base_address(address_list, hint, 'mgmt').toString()
     };
 }

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -69,7 +69,7 @@ module.exports = {
                     port: { $ref: 'common_api#/definitions/port' },
                     api: {
                         type: 'string',
-                        enum: ['mgmt', 's3', 'md', 'bg', 'hosted-agents']
+                        enum: ['mgmt', 's3', 'md', 'bg', 'hosted_agents']
                     },
                     secure: { type: 'boolean' }
                 }

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -803,7 +803,7 @@ function add_role(req) {
     return system_store.make_changes({
         insert: {
             roles: [{
-                _id: system_store.generate_id(),
+                _id: system_store.new_system_store_id(),
                 account: account._id,
                 system: req.system._id,
                 role: req.rpc_params.role,

--- a/src/test/unit_tests/core_agent_control.js
+++ b/src/test/unit_tests/core_agent_control.js
@@ -90,8 +90,7 @@ function create_agent(howmany) {
                     create_node_token = _.cloneDeep(new_token);
                 }
             },
-            host_id: uuid(),
-            routing_hint: 'LOOPBACK'
+            host_id: uuid()
         });
         agntCtlConfig.allocated_agents[agent.node_name] = {
             agent: agent,

--- a/src/util/addr_utils.js
+++ b/src/util/addr_utils.js
@@ -10,7 +10,7 @@ const api_default_port_offset = {
      mgmt: 0,
      md: 1,
      bg: 2,
-     'hosted-agents': 3
+     'hosted_agents': 3
 };
 
 function format_base_address(hostname = '127.0.0.1', port = default_base_port) {

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -1323,10 +1323,14 @@ async function discover_k8s_services(app = config.KUBE_APP_LABEL) {
         ];
 
         return _.flatMap(spec.ports, portInfo => {
+            const api = portInfo.name
+                .replace('-https', '')
+                .replace(/-/g, '_');
+
             const common = {
                 service: metadata.name,
                 port: portInfo.port,
-                api: portInfo.name.replace('-https', ''),
+                api: api,
                 secure: portInfo.name.endsWith('https'),
             };
             return [


### PR DESCRIPTION
### Explain the changes
1. Fix concat issues in router creation (was using string concat of strings instead of number addition)
2. Rename api name from ‘hosted-agents’ to ‘hosted_agents’ and fix discovery code.
3. Allow Agent to create its own routing table from base address by not sending a routing_hint in the agent constructor (fix problem with unit testing)
4. Replace use of obsolete system_store.generate_id() with system_store.new_system_store_id()

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
