### PR TITLE
fixed get_time_config for containers

### DIFF
--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -739,7 +739,7 @@ function get_time_config() {
         status: false
     };
 
-    if (IS_LINUX_VM) {
+    if (IS_LINUX) {
         return promise_utils.exec('/usr/bin/ntpstat | head -1', {
                 ignore_rc: false,
                 return_stdout: true,


### PR DESCRIPTION
### Explain the changes
1. fixed the error thrown from `get_time_config` in docker

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
