### PR TITLE
Fix rpc http missing defaults - lost in "Tiering BE - phase 3"

### DIFF
--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -688,6 +688,10 @@ class RPC extends EventEmitter {
             return;
         }
 
+        // provide defaults to simplify rpc http with curl
+        if (!msg.body.op) msg.body.op = 'req';
+        if (!msg.body.reqid) msg.body.reqid = conn._alloc_reqid();
+
         switch (msg.body.op) {
             case 'req': {
                 P.resolve()


### PR DESCRIPTION
### Explain the changes
1. Was introduced in ff5e05060d59af7d6f6579fdd164c6c5d84ef956
2. Was lost in "Tiering BE - phase 3" b760d36136f17d1dcb18b9f283bb92dd8ff96ea2
3. Need it back.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. use noobaa_deploy_k8s.sh which uses curl.
