### PR TITLE
Remove linux installation command from FE

### DIFF
--- a/frontend/src/app/components/modals/install-nodes-modal/install-nodes-modal.html
+++ b/frontend/src/app/components/modals/install-nodes-modal/install-nodes-modal.html
@@ -88,27 +88,22 @@
                 </p>
 
                 <div class="greedy tabs">
-                    <nav ko.foreach="osTypes">
-                        <a tabindex="0"
-                            ko.keysToClicks="['space', 'enter']"
-                            ko.css.selected="$form.selectedOs.eq(value)"
-                            ko.click="() => $parent.onTab(value)"
-                            ko.hasFocus="$index.eq(0)"
-                        >{{label}}</a>
+                    <nav>
+                        <a class="selected">
+                            Kubernetes
+                        </a>
                     </nav>
-
-                    <div class="tabs-row" ko.foreach="osTypes">
-                        <div class="tab pad row content-box config-box"
-                            ko.css.selected="$form.selectedOs.eq(value)"
-                            ko.let.command="($form.commands() || {})[value]"
-                        >
-                            <p class="text-tech greedy">{{command}}</p>
-                            <copy-to-clipboard-button params="value: command">
+                    <div class="tabs-row">
+                        <div class="tab pad row content-box config-box selected">
+                            <p class="text-tech greedy">{{$form.command}}</p>
+                            <copy-to-clipboard-button params="value: $form.command">
                             </copy-to-clipboard-button>
                         </div>
                     </div>
                 </div>
-                <p class="remark">{{osHint}}</p>
+                <p class="remark">
+                    Copy into a noobaa.yaml file and run using the command "kubectl apply -f noobaa.yaml"
+                </p>
             </div>
             <div class="row content-middle pad content-box">
                 <p class="remark greedy push-next">

--- a/frontend/src/app/components/modals/install-nodes-to-pool-modal/install-nodes-to-pool-modal.html
+++ b/frontend/src/app/components/modals/install-nodes-to-pool-modal/install-nodes-to-pool-modal.html
@@ -53,29 +53,24 @@
             </p>
 
             <div class="greedy tabs push-next-half">
-                <nav ko.foreach="osTypes">
-                    <a tabindex="0"
-                        ko.keysToClicks="['space', 'enter']"
-                        ko.css.selected="$form.selectedOs.eq(value)"
-                        ko.click="() => $parent.onTab(value)"
-                        ko.hasFocus="$index.eq(0)"
-                    >{{label}}</a>
+                <nav>
+                    <a class="selected">
+                        Kubernetes
+                    </a>
                 </nav>
-
-                <div class="tabs-row" ko.foreach="osTypes">
-                    <div class="tab pad row content-box config-box"
-                        ko.css.selected="$form.selectedOs.eq(value)"
-                        ko.let.command="($form.commands() || {})[value]"
-                    >
-                        <p class="text-tech greedy">{{command}}</p>
-                        <copy-to-clipboard-button params="value: command">
+                <div class="tabs-row">
+                    <div class="tab pad row content-box config-box selected">
+                        <p class="text-tech greedy">{{$form.command}}</p>
+                        <copy-to-clipboard-button params="value: $form.command">
                         </copy-to-clipboard-button>
                     </div>
                 </div>
             </div>
             <p class="remark">
                 <svg-icon class="icon-small" params="name: 'notif-info'"></svg-icon>
-                <span class="os-hint" ko.text="osHint"></span>
+                <span class="os-hint">
+                    Copy into a noobaa.yaml file and run using the command "kubectl apply -f noobaa.yaml"
+                </span>
             </p>
         </section>
     </wizard>

--- a/frontend/src/app/components/modals/install-nodes-to-pool-modal/install-nodes-to-pool-modal.js
+++ b/frontend/src/app/components/modals/install-nodes-to-pool-modal/install-nodes-to-pool-modal.js
@@ -16,19 +16,6 @@ const steps = deepFreeze([
     'Install'
 ]);
 
-const osTypes = deepFreeze([
-    {
-        value: 'LINUX',
-        label: 'Linux',
-        hint: 'Run using a privileged user'
-    },
-    {
-        value: 'KUBERNETES',
-        label: 'Kubernetes',
-        hint: 'Copy into a noobaa.yaml file and run using the command "kubectl apply -f noobaa.yaml"'
-    }
-]);
-
 const drivesInputPlaceholder =
     `e.g., /mnt or c:\\ and click enter ${String.fromCodePoint(0x23ce)}`;
 
@@ -36,21 +23,15 @@ const drivesInputPlaceholder =
 class InstallNodeModalViewModel extends ConnectableViewModel {
     formName = this.constructor.name;
     steps = steps;
-    osTypes = osTypes;
     targetPool = '';
     drivesInputPlaceholder = drivesInputPlaceholder;
-    osHint = ko.observable();
     targetPool = '';
     excludeDrives = [];
     fields = {
         step: 0,
         excludeDrives: false,
         excludedDrives: [],
-        selectedOs: 'LINUX',
-        commands: {
-            LINUX: '',
-            KUBERNETES: ''
-        }
+        command: ''
     };
 
     selectState(state, params) {
@@ -66,12 +47,8 @@ class InstallNodeModalViewModel extends ConnectableViewModel {
             return;
         }
 
-        const selectedOs = getFieldValue(form, 'selectedOs');
-        const { hint } = osTypes.find(os => os.value === selectedOs);
-
         ko.assignToProps(this, {
             targetPool,
-            osHint: hint,
             excludedDrives: getFieldValue(form, 'excludedDrives')
         });
     }
@@ -86,10 +63,6 @@ class InstallNodeModalViewModel extends ConnectableViewModel {
         }
 
         return true;
-    }
-
-    onTab(osType) {
-        this.dispatch(updateForm(this.formName, { selectedOs: osType }));
     }
 
     onDone() {

--- a/frontend/src/app/epics/update-install-nodes-form-commands-field.js
+++ b/frontend/src/app/epics/update-install-nodes-form-commands-field.js
@@ -8,9 +8,9 @@ import { updateForm } from 'action-creators';
 export default function(action$) {
     return action$.pipe(
         ofType(COMPLETE_FETCH_NODE_INSTALLATION_COMMANDS),
-        map(action => updateForm(
-            'InstallNodeModalViewModel',
-            { commands: action.payload.commands }
-        ))
+        map(action => {
+            const command = action.payload.commands['KUBERNETES'];
+            return updateForm('InstallNodeModalViewModel', { command });
+        })
     );
 }

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -255,12 +255,6 @@ module.exports = {
             reply: {
                 type: 'object',
                 properties: {
-                    LINUX: {
-                        type: 'string'
-                    },
-                    WINDOWS: {
-                        type: 'string'
-                    },
                     KUBERNETES: {
                         type: 'string'
                     }


### PR DESCRIPTION
### Explain the changes
1. Removed Linux node installation tab from the "Install Nodes" modal 
1. Removed Linux node installation tab from the "Install Nodes to Pool" modal 
2. Removed Linux node installation string generation from the BE (system_server)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
