### PR TITLE
changed readiness probe in server and agents to check if s3 port is open

### DIFF
--- a/frontend/src/app/components/modals/install-nodes-to-pool-modal/install-nodes-to-pool-modal.js
+++ b/frontend/src/app/components/modals/install-nodes-to-pool-modal/install-nodes-to-pool-modal.js
@@ -6,7 +6,6 @@ import ko from 'knockout';
 import { deepFreeze } from 'utils/core-utils';
 import { getFieldValue } from 'utils/form-utils';
 import {
-    updateForm,
     fetchNodeInstallationCommands,
     closeModal
 } from 'action-creators';

--- a/src/deploy/NVA_build/noobaa_agent.yaml
+++ b/src/deploy/NVA_build/noobaa_agent.yaml
@@ -39,6 +39,12 @@ spec:
     spec:
       containers:
         - name: noobaa-agent
+          readinessProbe:
+            # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+            # ready when s3 port is open
+            tcpSocket:
+              port: 6001
+            timeoutSeconds: 5
           image: noobaa/noobaa-agent:AGENT_IMAGE_VERSION
           imagePullPolicy: IfNotPresent
           resources:

--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -121,9 +121,10 @@ spec:
       containers:
         - name: noobaa-server
           readinessProbe:
-            httpGet:
-              port: 8080
-              path: "/version"
+            # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+            # ready when s3 port is open
+            tcpSocket:
+              port: 6001
             timeoutSeconds: 5
           image: noobaa/noobaa-core:3.0.0
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
### Explain the changes
1. readiness probe used to `GET` from `/version` path. this was wrong because we really want to check the readiness of s3 servers for all pods that the S3 service sends traffic to
2. `/version` also does read_system, and the probe is executed every 10 seconds with a short timeout. in many occasions, that caused the server pod to fail the probe.
3. changed the probe to test when S3 port is open for both the server and the agents

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
