### PR TITLE
Fix wrong calc of lastPageIndex

### DIFF
--- a/frontend/src/app/components/shared/paginator/paginator.html
+++ b/frontend/src/app/components/shared/paginator/paginator.html
@@ -11,14 +11,14 @@
     <button class="btn-flat"
         ko.click="onJumpToFirstPage"
         ko.disable="isFirstPage"
-    ">
+    >
         <svg-icon class="icon-small" params="name: 'dbl-angle-left'"></svg-icon>
     </button>
 
     <button class="btn-flat"
         ko.click="onPageBackward"
         ko.disable="isFirstPage"
-    ">
+    >
         <svg-icon class="icon-small" params="name: 'angle-left'"></svg-icon>
     </button>
 
@@ -27,14 +27,14 @@
     <button class="btn-flat"
         ko.click="onPageForward"
         ko.disable="isLastPage"
-    ">
+    >
         <svg-icon class="icon-small rotate deg180" params="name: 'angle-left'"></svg-icon>
     </button>
 
     <button class="btn-flat"
         ko.click="onJumpToLastPage"
         ko.disable="isLastPage"
-    ">
+    >
         <svg-icon class="icon-small rotate deg180" params="name: 'dbl-angle-left'"></svg-icon>
     </button>
 </div>

--- a/frontend/src/app/components/shared/paginator/paginator.js
+++ b/frontend/src/app/components/shared/paginator/paginator.js
@@ -42,7 +42,7 @@ class PaginatorViewModel {
         );
 
         this.lastPageIndex = ko.pureComputed(() =>
-            Math.floor(this.count() / pageSize)
+            this.count() > 0 ? Math.floor((this.count() - 1) / pageSize) : 0
         );
 
         this.isFirstPage = ko.pureComputed(() =>


### PR DESCRIPTION
### Explain the changes
1.  The calculation was wrong on page boundaries (when the count was an exact divider of the page size)

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5525 

### Testing Instructions:
1. 
