### PR TITLE
Adding option to loop on panic and loop on fail when provided env variable "LOOP_ON_FAIL"

### DIFF
--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -171,15 +171,12 @@ spec:
                   name: noobaa-create-sys-creds
                   key: password
                   optional: true
-            # replacing the empty value with any value will set the cotainer to dbg mode
-            - name: container_dbg
-              value: ""
       serviceAccountName: noobaa-account
 
   volumeClaimTemplates:
     # this will provision a dynamic persistent volume (volume is automatically provisioned by a provisioner)
     # in minikube it is provisioned as hostPath volume under hosts /tmp which is not persistent between
-    # minkube restarts. if we want it to be persistent between restarts we need to statically provision a
+    # minikube restarts. if we want it to be persistent between restarts we need to statically provision a
     # volume according to this https://kubernetes.io/docs/setup/minikube/#persistent-volumes
     - metadata:
         name: logdir

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -1,7 +1,6 @@
-
 #!/bin/bash
 
-if [ ${container_dbg} ] ;
+if [ "${LOOP_ON_FAIL}" == "true" ]
 then
   debug="bash -x"
   export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} \e[0m'
@@ -121,11 +120,13 @@ run_init_scripts() {
   for script in ${scripts[@]} ; do
     ${debug} ./${script}
     if [ $? -ne 0 ] ; then
-      #Providing in the yaml env variable with the name "container_dbg" 
+      #Providing an env variable with the name "LOOP_ON_FAIL=true" 
       #will trigger the condition below.
-      [ ${container_dbg} ] && sleep 120m
-      echo "Failed to run ${script}"
-      exit 1
+      while [ "${LOOP_ON_FAIL}" == "true" ]
+      do
+        echo "$(date) Failed to run ${script}"
+        sleep 10
+      done
     fi
   done
   cd - > /dev/null

--- a/src/deploy/NVA_build/run_agent_container.sh
+++ b/src/deploy/NVA_build/run_agent_container.sh
@@ -22,4 +22,13 @@ if [ ! -f $AGENT_CONF_FILE ]; then
 fi
 echo "Written agent_conf.json: $(cat ${AGENT_CONF_FILE})"
 cd /usr/local/noobaa
-./node ./src/agent/agent_cli
+./node ./src/agent/agent_cli 
+# Providing an env variable with the name "LOOP_ON_FAIL=true" 
+# will trigger the condition below.
+# Currently we will loop on any exit of the agent_cli 
+# regurdless to the exit code
+while [ "${LOOP_ON_FAIL}" == "true" ] 
+do
+  echo "$(date) Failed to run ${script}" 
+  sleep 10
+done

--- a/src/util/panic.js
+++ b/src/util/panic.js
@@ -1,12 +1,18 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const child_process = require('child_process');
+
 // catch process uncaught exceptions, and treat as a panic and exit after logging
 // since restarting the process is the most stable way of recovery
 process.on('uncaughtException', err => panic('process uncaughtException', err));
 
 function panic(message, err) {
     console.error('PANIC:', message, err.stack || err);
+    while (process.env.LOOP_ON_FAIL === 'true') {
+        console.warn('Encountered an error, holding the process on an infinite loop');
+        child_process.execSync('sleep 10');
+    }
     process.exit(1);
 }
 


### PR DESCRIPTION
### Explain the changes
noobaa_core.yaml:
- Removed the container_dbg from the yaml

noobaa_init.sh:
- Renamed the env variable from container_dbg to LOOP_ON_FAIL
- looping forever instead of grace time of 120 min

run_agent_container.sh:
- Providing in an env variable with the name "LOOP_ON_FAIL=true" will loop
forever on any agent_cli exit code

panic.js:
- Providing in an env variable with the name "LOOP_ON_FAIL=true" will loop on panic

