### PR TITLE
FE build - Change execution order of tasks to prevent dups

### DIFF
--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -344,12 +344,16 @@ const lint = gulp.parallel(
 
 const build = gulp.series(
     clean,
+    installDeps,
     gulp.parallel(
-        buildLib,
+        gulp.series(
+            buildDeps,
+            bundleLib
+        ),
         buildAPI,
         buildApp,
         buildDebug,
-        buildStyles,
+        compileStyles,
         generateSVGIcons,
         copy
     ),


### PR DESCRIPTION
### Explain the changes
Gulp 4 changed the semantics of task dependencies.
As such, each task should only be run once in each flow, the change
guarantee that installDeps will run only once in the build flow.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
