### PR TITLE
Add Single Sign ON (SSO) support using OpenShift users

### DIFF
--- a/config.js
+++ b/config.js
@@ -383,10 +383,24 @@ config.PROMETHEUS_ENABLED = true;
 config.PROMETHEUS_PREFIX = 'NooBaa_';
 
 //////////////////////////////
+// OAUTH RELATES            //
+//////////////////////////////
+
+config.OAUTH_AUTHORIZATION_ENDPOINT = '/oauth/authorize';
+config.OAUTH_TOKEN_ENDPOINT = '/oauth/token';
+config.OAUTH_REDIRECT_ENDPOINT = 'fe/oauth/callback';
+config.OAUTH_REQUIRED_SCOPE = 'user:info';
+
+//////////////////////////////
 // KUBERNETES RELATES       //
 //////////////////////////////
 
 config.KUBE_APP_LABEL = 'noobaa';
+config.KUBE_SA_TOKEN_FILE = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+config.KUBE_NAMESPACE_FILE = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
+config.KUBE_API_ENDPOINTS = {
+    TOKEN_REVIEW: '/apis/authentication.k8s.io/v1/tokenreviews'
+};
 
 //////////////////////////////
 // ACCOUNT PREFERENCES      //

--- a/frontend/src/app/action-creators/location-actions.js
+++ b/frontend/src/app/action-creators/location-actions.js
@@ -23,4 +23,3 @@ export function changeLocation(location) {
         payload: location
     };
 }
-

--- a/frontend/src/app/action-creators/modals-actions.js
+++ b/frontend/src/app/action-creators/modals-actions.js
@@ -1014,5 +1014,21 @@ export function openCreateEmptyPoolModal() {
         }
     };
 }
+
+export function openSessionExpiredModal() {
+    return {
+        type: OPEN_MODAL,
+        payload: {
+            component: 'session-expired-modal',
+            options: {
+                title: 'Session Expired',
+                size: 'xsmall',
+                severity: 'info',
+                closeButton: 'hidden',
+                backdropClose: false
+            }
+        }
+    };
+}
 /** INJECT:actionCreator **/
 

--- a/frontend/src/app/action-creators/session-actions.js
+++ b/frontend/src/app/action-creators/session-actions.js
@@ -30,6 +30,7 @@ export function completeRestoreSession(
             user: account.email,
             system: system.name,
             passwordExpired: Boolean(account.must_change_password),
+            authorizedBy: sessionInfo.authorized_by,
             persistent: persistent,
             uiTheme
         }
@@ -65,7 +66,8 @@ export function completeSignIn(
             user: account.email,
             system: system.name,
             passwordExpired: Boolean(account.must_change_password),
-            persistent: persistent,
+            authorizedBy: sessionInfo.authorized_by,
+            persistent,
             uiTheme
         }
     };

--- a/frontend/src/app/action-creators/session-actions.js
+++ b/frontend/src/app/action-creators/session-actions.js
@@ -4,10 +4,12 @@ import {
     SIGN_IN,
     COMPLETE_SIGN_IN,
     FAIL_SIGN_IN,
+    SIGN_IN_WITH_OAUTH,
     SIGN_OUT,
     RESTORE_SESSION,
     COMPLETE_RESTORE_SESSION,
-    FAIL_RESTORE_SESSION
+    FAIL_RESTORE_SESSION,
+    EXPIRE_SESSION
 } from 'action-types';
 
 export function restoreSession() {
@@ -69,13 +71,24 @@ export function completeSignIn(
     };
 }
 
-export function failSignIn(email, error) {
+export function failSignIn(error) {
     return {
         type: FAIL_SIGN_IN,
         payload: { error }
     };
 }
 
+export function signInWithOAuth(oauthGrantCode, returnUrl) {
+    return {
+        type: SIGN_IN_WITH_OAUTH,
+        payload: { oauthGrantCode, returnUrl }
+    };
+}
+
 export function signOut() {
     return { type: SIGN_OUT };
+}
+
+export function expireSession() {
+    return { type: EXPIRE_SESSION };
 }

--- a/frontend/src/app/action-types.js
+++ b/frontend/src/app/action-types.js
@@ -9,10 +9,12 @@ export const CHANGE_LOCATION = 'CHANGE_LOCATION';
 export const RESTORE_SESSION = 'RESTORE_SESSION';
 export const COMPLETE_RESTORE_SESSION = 'COMPLETE_RESTORE_SESSION';
 export const FAIL_RESTORE_SESSION = 'FAIL_RESTORE_SESSION';
+export const EXPIRE_SESSION = 'EXPIRE_SESSION';
 export const SIGN_IN = 'SIGN_IN';
 export const COMPLETE_SIGN_IN = 'COMPLETE_SIGN_IN';
 export const FAIL_SIGN_IN = 'FAIL_SIGN_IN';
 export const SIGN_OUT = 'SIGN_OUT';
+export const SIGN_IN_WITH_OAUTH = 'SIGN_IN_WITH_OAUTH';
 
 // Drawer related actions.
 export const OPEN_DRAWER = 'OPEN_DRAWER';

--- a/frontend/src/app/actions.js
+++ b/frontend/src/app/actions.js
@@ -62,9 +62,26 @@ export async function loadServerInfo(testPhonehomeConnectvity, phonehomeProxy) {
 
     const { has_accounts } = await api.account.accounts_status();
     if (has_accounts) {
-        serverInfo({
-            initialized: true
-        });
+        try {
+            const res = await fetch('/oauth/authorize', {
+                method: 'HEAD',
+                redirect: 'manual'
+            });
+
+            serverInfo({
+                initialized: true,
+                supportOAuth:
+                    res.type === 'opaqueredirect' &&
+                    res.status === 0
+            });
+
+        } catch (err) {
+            serverInfo({
+                initialized: true,
+                supportOAuth: false
+            });
+        }
+
     } else {
         const config = await api.cluster_server.read_server_config({
             test_ph_connectivity: testPhonehomeConnectvity,

--- a/frontend/src/app/components/account/account-details-form/account-details-form.html
+++ b/frontend/src/app/components/account/account-details-form/account-details-form.html
@@ -7,6 +7,7 @@
 
     <div ko.tooltip="button.tooltip">
         <button class="btn"
+            ko.visible="button.isVisible"
             ko.disable="button.isDisabled"
             ko.click="onChangeOrResetPassword"
         >

--- a/frontend/src/app/components/account/account-details-form/account-details-form.js
+++ b/frontend/src/app/components/account/account-details-form/account-details-form.js
@@ -20,6 +20,7 @@ class AccountDetailsFormViewModel extends ConnectableViewModel {
     button = {
         label: ko.observable(),
         tooltip: ko.observable(),
+        isVisible: ko.observable(),
         isDisabled: ko.observable()
     };
     profileInfo = [
@@ -38,12 +39,12 @@ class AccountDetailsFormViewModel extends ConnectableViewModel {
 
         return [
             accounts && accounts[params.accountName],
-            session && session.user
+            session
         ];
     }
 
-    mapStateToProps(account, currentUser) {
-        if (!account) {
+    mapStateToProps(account, session) {
+        if (!account || !session) {
             ko.assignToProps(this, {
                 button: {
                     label: 'Reset Password',
@@ -53,8 +54,10 @@ class AccountDetailsFormViewModel extends ConnectableViewModel {
             });
 
         } else {
+            const { user, authorizedBy } = session;
             const { isOwner, hasLoginAccess } = account;
-            const isCurrentUser = currentUser === account.name;
+            const isCurrentUser = user === account.name;
+            const allowResetPassword = authorizedBy === 'noobaa';
             const role  = !isOwner ?
                 (account.hasLoginAccess ? 'Admin' : 'Application') :
                 'Owner';
@@ -64,6 +67,7 @@ class AccountDetailsFormViewModel extends ConnectableViewModel {
                 isCurrentUser,
                 button: {
                     label: isCurrentUser ? 'Change Password' : 'Reset Password',
+                    isVisible: allowResetPassword,
                     isDisabled: !hasLoginAccess,
                     tooltip: hasLoginAccess ? actionUnavailableTooltip : ''
                 },

--- a/frontend/src/app/components/application/main-layout/main-layout.js
+++ b/frontend/src/app/components/application/main-layout/main-layout.js
@@ -9,12 +9,13 @@ import { realizeUri } from 'utils/browser-utils';
 import { registerForAlerts } from 'actions';
 import * as routes from 'routes';
 import routeMapping from './route-mapping';
-import { get, getMany } from 'rx-extensions';
+import { getMany } from 'rx-extensions';
 import { logo } from 'config';
 import {
     fetchSystemInfo,
     openFinalizeUpgradeModal,
-    openWelcomeModal
+    openWelcomeModal,
+    openSessionExpiredModal
 } from 'action-creators';
 
 const navItems = deepFreeze([
@@ -87,7 +88,10 @@ class MainLayoutViewModel extends Observer {
         this.isUploadButtonVisible = ko.observable(false);
 
         this.observe(
-            state$.pipe(get('location')),
+            state$.pipe(getMany(
+                'location',
+                'session'
+            )),
             this.onLocation
         );
 
@@ -104,7 +108,7 @@ class MainLayoutViewModel extends Observer {
         registerForAlerts();
     }
 
-    onLocation(location) {
+    onLocation([location, session]) {
         const { route, params, query } = location;
         const { system } = params;
         const { panel, area, crumbsGenerator } = routeMapping[route] || {};
@@ -121,6 +125,9 @@ class MainLayoutViewModel extends Observer {
 
         } else if (welcome) {
             action$.next(openWelcomeModal());
+
+        } else if (session && session.expired) {
+            action$.next(openSessionExpiredModal());
         }
 
         action$.next(fetchSystemInfo());

--- a/frontend/src/app/components/login/oauth-callback/oauth-callback.html
+++ b/frontend/src/app/components/login/oauth-callback/oauth-callback.html
@@ -1,0 +1,7 @@
+<!-- Copyright (C) 2016 NooBaa -->
+
+<h1 class="heading1">
+    Loading
+    <loading-indicator></loading-indicator>
+</h1>
+

--- a/frontend/src/app/components/login/oauth-callback/oauth-callback.js
+++ b/frontend/src/app/components/login/oauth-callback/oauth-callback.js
@@ -1,0 +1,31 @@
+/* Copyright (C) 2016 NooBaa */
+
+import template from './oauth-callback.html';
+import ConnectableViewModel from 'components/connectable';
+import { requestLocation, signInWithOAuth } from 'action-creators';
+
+class OAuthCallbackViewModel extends ConnectableViewModel {
+    selectState(state) {
+        return [
+            state.location
+        ];
+    }
+
+    mapStateToProps(location) {
+        const { pathname, query } = location;
+        if (query.code) {
+            // Redirect back to requested location.
+            if (query.state && pathname !== query.state) {
+                this.dispatch(requestLocation(query.state, true));
+            }
+
+            // Sign in with the outh grant code.
+            this.dispatch(signInWithOAuth(query.code));
+        }
+    }
+}
+
+export default {
+    viewModel: OAuthCallbackViewModel,
+    template: template
+};

--- a/frontend/src/app/components/login/oauth-callback/oauth-callback.less
+++ b/frontend/src/app/components/login/oauth-callback/oauth-callback.less
@@ -1,0 +1,16 @@
+/* Copyright (C) 2016 NooBaa */
+
+.oauth-callback {
+    .heading1 {
+        color: rgb(var(--color02));
+        position: absolute;
+        top: 40%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+    }
+
+    loading-indicator .circle {
+        background-color: rgb(var(--color02));
+    }
+}
+

--- a/frontend/src/app/components/main/account-menu/account-menu.html
+++ b/frontend/src/app/components/main/account-menu/account-menu.html
@@ -57,10 +57,20 @@
             <!-- workaround using target black to allow the link to resolve even so the upper div loses the focus -->
             <a class="menu-item"
                 href="javascript:void(0)"
+                ko.css.disabled="!allowSignOut()"
+                ko.preventBubble="['click']"
                 ko.click="onSignOut"
             >
-                Sign Out
+                <div class="column">
+                    <span>Sign Out</span>
+                    <span class="remark"
+                        ko.visible="!allowSignOut()"
+                    >
+                        Not available for OpenShift users
+                    </span>
+                </div>
             </a>
         </li>
+
     </ul>
 </div>

--- a/frontend/src/app/components/main/account-menu/account-menu.js
+++ b/frontend/src/app/components/main/account-menu/account-menu.js
@@ -19,6 +19,7 @@ class AccountMenuViewModel extends ConnectableViewModel {
     helpDeskHref = support.helpDesk;
     oppositeTheme = '';
     switchThemeText = ko.observable();
+    allowSignOut = ko.observable();
 
     selectState(state) {
         const { session, location } = state;
@@ -46,7 +47,8 @@ class AccountMenuViewModel extends ConnectableViewModel {
                 { system, account, tab: 'connections' }
             ) ,
             oppositeTheme,
-            switchThemeText: `Switch to ${capitalize(oppositeTheme)} Theme`
+            switchThemeText: `Switch to ${capitalize(oppositeTheme)} Theme`,
+            allowSignOut: session.authorizedBy === 'noobaa'
         });
     }
 
@@ -72,7 +74,9 @@ class AccountMenuViewModel extends ConnectableViewModel {
     }
 
     onSignOut() {
-        this.dispatch(signOut());
+        if (this.allowSignOut()) {
+            this.dispatch(signOut());
+        }
     }
 }
 

--- a/frontend/src/app/components/main/account-menu/account-menu.less
+++ b/frontend/src/app/components/main/account-menu/account-menu.less
@@ -10,7 +10,7 @@ account-menu {
         height: 60px;
 
         > .user-email {
-            min-width: 100px;
+            min-width: 130px;
             max-width: 150px;
         }
     }

--- a/frontend/src/app/components/main/account-menu/account-menu.less
+++ b/frontend/src/app/components/main/account-menu/account-menu.less
@@ -10,8 +10,8 @@ account-menu {
         height: 60px;
 
         > .user-email {
-            min-width: 130px;
-            max-width: 150px;
+            min-width: 140px;
+            max-width: 140px;
         }
     }
 
@@ -36,13 +36,19 @@ account-menu {
             all: unset;
             box-sizing: border-box;
             width: 100%;
-            padding:  0 @gutter;
-            line-height: 44px;
+            padding:  2/3*@gutter @gutter;
+            vertical-align: middle;
             display: block;
             border: none;
             background: none;
 
-            &:hover {
+            &.disabled {
+                cursor: default;
+                color: rgb(var(--color11));
+                opacity: .5;
+            }
+
+            &:not(.disabled):hover {
                 background-color: rgb(var(--color15));
             }
         }

--- a/frontend/src/app/components/modals/session-expired-modal/session-expired-modal.html
+++ b/frontend/src/app/components/modals/session-expired-modal/session-expired-modal.html
@@ -1,0 +1,13 @@
+<!-- Copyright (C) 2016 NooBaa -->
+<section class="column greedy pad">
+    <p>
+        Your session has expired. Please login again to continue working.
+    </p>
+</section>
+<div class="column pad content-box">
+    <button class="btn align-end"
+        ko.click="onBackToLogin"
+    >
+        Back to Login Screen
+    </button>
+</div>

--- a/frontend/src/app/components/modals/session-expired-modal/session-expired-modal.js
+++ b/frontend/src/app/components/modals/session-expired-modal/session-expired-modal.js
@@ -1,0 +1,20 @@
+/* Copyright (C) 2016 NooBaa */
+
+import template from './session-expired-modal.html';
+import ConnectableViewModel from 'components/connectable';
+import { closeModal, signOut } from 'action-creators';
+
+class sessionExpiredModal extends ConnectableViewModel {
+    onBackToLogin() {
+        this.dispatch(
+            closeModal(),
+            signOut()
+        );
+    }
+
+}
+
+export default {
+    viewModel: sessionExpiredModal,
+    template: template
+};

--- a/frontend/src/app/components/modals/session-expired-modal/session-expired-modal.less
+++ b/frontend/src/app/components/modals/session-expired-modal/session-expired-modal.less
@@ -1,0 +1,5 @@
+/* Copyright (C) 2016 NooBaa */
+
+.session-expired-modal {
+    display: block;
+}

--- a/frontend/src/app/components/modals/upgrading-system-modal/upgrading-system-modal.js
+++ b/frontend/src/app/components/modals/upgrading-system-modal/upgrading-system-modal.js
@@ -107,7 +107,6 @@ class SystemUpgradingModalViewModel extends ConnectableViewModel {
     }
 
     onFakeProgress(fakeProgress) {
-        // console.warn(fakeProgress);
         const progress = Math.max(this.progress.peek(), fakeProgress);
         ko.assignToProps(this, {
             progress,

--- a/frontend/src/app/components/register.js
+++ b/frontend/src/app/components/register.js
@@ -21,6 +21,7 @@ import createSystemForm from './login/create-system-form/create-system-form';
 import unsupportedForm from './login/unsupported-form/unsupported-form';
 import changePasswordForm from './login/change-password-form/change-password-form';
 import splashScreen from './login/splash-screen/splash-screen';
+import oauthCallback from './login/oauth-callback/oauth-callback';
 /** INJECT:login.import **/
 
 // -------------------------------
@@ -111,6 +112,7 @@ import createEmptyPoolModal from './modals/create-empty-pool-modal/create-empty-
 import regenerateAccountCredentialsModal from './modals/regenerate-account-credentials-modal/regenerate-account-credentials-modal';
 import editTierDataPlacementModal from './modals/edit-tier-data-placement-modal/edit-tier-data-placement-modal';
 import addTierModal from './modals/add-tier-modal/add-tier-modal';
+import sessionExpiredModal from './modals/session-expired-modal/session-expired-modal';
 /** INJECT:modals.import **/
 
 // -------------------------------
@@ -390,6 +392,7 @@ export default function register(ko, services) {
         unsupportedForm,
         changePasswordForm,
         splashScreen,
+        oauthCallback,
         /** INJECT:login.list **/
 
         commandsBar,
@@ -471,6 +474,7 @@ export default function register(ko, services) {
         regenerateAccountCredentialsModal,
         editTierDataPlacementModal,
         addTierModal,
+        sessionExpiredModal,
         /** INJECT:modals.list **/
 
         overviewPanel,

--- a/frontend/src/app/epics/handle-location-requests.js
+++ b/frontend/src/app/epics/handle-location-requests.js
@@ -3,13 +3,22 @@
 import { map } from 'rxjs/operators';
 import { ofType } from 'rx-extensions';
 import { REQUEST_LOCATION } from 'action-types';
+import * as routes from 'routes';
 
-export default function(action$, { router }) {
+export default function(action$, { browser, router }) {
     return action$.pipe(
         ofType(REQUEST_LOCATION),
         map(action => {
             const { url, redirect } = action.payload;
-            redirect ? router.redirect(url) : router.show(url);
+            if (url.startsWith(routes.root)) {
+                if (redirect) {
+                    router.redirect(url);
+                } else {
+                    router.show(url);
+                }
+            } else {
+                browser.navigateTo(url);
+            }
         })
     );
 }

--- a/frontend/src/app/epics/redirect-after-sign-out.js
+++ b/frontend/src/app/epics/redirect-after-sign-out.js
@@ -4,6 +4,7 @@ import { map, delay } from 'rxjs/operators';
 import { ofType } from 'rx-extensions';
 import { SIGN_OUT } from 'action-types';
 import { requestLocation } from 'action-creators';
+import * as routes from 'routes';
 
 export default function(action$) {
     // Adding the delay in order to enusre that the UI has refreshed before changing to the new location,
@@ -12,6 +13,6 @@ export default function(action$) {
     return action$.pipe(
         ofType(SIGN_OUT),
         delay(1),
-        map(() => requestLocation('/'))
+        map(() => requestLocation(routes.root))
     );
 }

--- a/frontend/src/app/epics/sign-in.js
+++ b/frontend/src/app/epics/sign-in.js
@@ -1,33 +1,49 @@
 /* Copyright (C) 2016 NooBaa */
 
-import { mergeMap } from 'rxjs/operators';
+import { merge, of } from 'rxjs';
+import { mergeMap, catchError } from 'rxjs/operators';
 import { ofType } from 'rx-extensions';
 import { mapErrorObject } from 'utils/state-utils';
-import { SIGN_IN } from 'action-types';
+import { SIGN_IN, SIGN_IN_WITH_OAUTH } from 'action-types';
 import { completeSignIn, failSignIn } from 'action-creators';
 
 export default function(action$, { api }) {
-    return action$.pipe(
+    // handles sign in request with email and password.
+    const credentialsBasedSignIn$ = action$.pipe(
         ofType(SIGN_IN),
         mergeMap(async action => {
             const { email, password, persistent } = action.payload;
+            await api.create_auth_token({ email, password });
+            const { systems } = await api.system.list_systems();
+            const { name: system } = systems[0];
+            const res  = await api.create_auth_token({ system, email, password });
+            return { ...res, persistent };
+        })
+    );
 
-            try {
-                await api.create_auth_token({ email, password });
-                const { systems } = await api.system.list_systems();
-                const { name: system } = systems[0];
-                const { token, info } = await api.create_auth_token({ system, email, password });
-                const account = await api.account.read_account({ email: info.account.email });
+    // handles sign in request from an oauth srouce.
+    const k8sBasedSignIn$ =  action$.pipe(
+        ofType(SIGN_IN_WITH_OAUTH),
+        mergeMap(async action => {
+            const { oauthGrantCode: grant_code } = action.payload;
+            const res = await api.create_k8s_auth({ grant_code });
+            return { ...res, persistent: false };
+        })
+    );
 
-                const theme = account.preferences.ui_theme.toLowerCase();
-                return completeSignIn(token, info, persistent, theme);
-
-            } catch (error) {
-                return failSignIn(
-                    email,
-                    mapErrorObject(error)
-                );
-            }
+    return merge(
+        credentialsBasedSignIn$,
+        k8sBasedSignIn$,
+    ).pipe(
+        mergeMap(async res => {
+            const { info, token, persistent } = res;
+            const account = await api.account.read_account({ email: info.account.email });
+            const theme = account.preferences.ui_theme.toLowerCase();
+            return completeSignIn(token, info, persistent, theme);
+        }),
+        catchError(error => {
+            if (error.rpc_code !== 'UNAUTHORIZED') throw error;
+            return of(failSignIn(mapErrorObject(error)));
         })
     );
 }

--- a/frontend/src/app/main.js
+++ b/frontend/src/app/main.js
@@ -29,7 +29,9 @@ import {
     httpWaitForResponse,
     createBroadcastChannel,
     getDocumentMetaTag,
-    getWindowName
+    getWindowName,
+    hasSameOrigin,
+    navigateTo
 } from 'utils/browser-utils';
 
 
@@ -69,7 +71,9 @@ function registerSideEffects(action$, state$) {
         httpWaitForResponse: httpWaitForResponse,
         createBroadcastChannel: createBroadcastChannel,
         getDocumentMetaTag: getDocumentMetaTag,
-        getWindowName: getWindowName
+        getWindowName: getWindowName,
+        hasSameOrigin: hasSameOrigin,
+        navigateTo: navigateTo
     };
 
     const injectedServices = {

--- a/frontend/src/app/reducers/session-reducer.js
+++ b/frontend/src/app/reducers/session-reducer.js
@@ -5,6 +5,7 @@ import {
     COMPLETE_CREATE_SYSTEM,
     COMPLETE_RESTORE_SESSION,
     FAIL_RESTORE_SESSION,
+    EXPIRE_SESSION,
     COMPLETE_SIGN_IN,
     SIGN_OUT,
     COMPLETE_CHANGE_ACCOUNT_PASSWORD,
@@ -29,6 +30,17 @@ function onCompleteRestoreSession(_, { payload }) {
 
 function onFailRestoreSession() {
     return null;
+}
+
+function onExpireSession(state) {
+    if (!state || state.expired) {
+        return state;
+    }
+
+    return {
+        ...state,
+        expired: true
+    };
 }
 
 function onCompleteSignIn(_, { payload }) {
@@ -65,6 +77,7 @@ export default createReducer(initialState, {
     [COMPLETE_CREATE_SYSTEM]: onCompleteCreateSystem,
     [COMPLETE_RESTORE_SESSION]: onCompleteRestoreSession,
     [FAIL_RESTORE_SESSION]: onFailRestoreSession,
+    [EXPIRE_SESSION]: onExpireSession,
     [COMPLETE_SIGN_IN]: onCompleteSignIn,
     [SIGN_OUT]: onSignOut,
     [COMPLETE_CHANGE_ACCOUNT_PASSWORD]: onCompleteChangeAccountPassword,

--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -1,8 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 
-const root = '/fe';
-
+export const root               = '/fe';
 export const asset              = `${root}/assets/:asset`;
+export const oauthCallback      = `${root}/oauth/callback`;
 export const system             = `${root}/systems/:system`;
 export const buckets            = `${root}/systems/:system/buckets/:tab?`;
 export const bucket             = `${root}/systems/:system/buckets/data-buckets/:bucket/:tab?/:section?`;

--- a/frontend/src/app/schema/session.js
+++ b/frontend/src/app/schema/session.js
@@ -19,6 +19,9 @@ export default {
                 token: {
                     type: 'string'
                 },
+                expired: {
+                    type: 'boolean'
+                },
                 user: {
                     type: 'string'
                 },

--- a/frontend/src/app/schema/session.js
+++ b/frontend/src/app/schema/session.js
@@ -13,6 +13,7 @@ export default {
                 'system',
                 'persistent',
                 'passwordExpired',
+                'authorizedBy',
                 'uiTheme'
             ],
             properties: {
@@ -33,6 +34,13 @@ export default {
                 },
                 passwordExpired: {
                     type: 'boolean'
+                },
+                authorizedBy: {
+                    type: 'string',
+                    enum: [
+                        'noobaa',
+                        'k8s'
+                    ]
                 },
                 uiTheme: {
                     type: 'string',

--- a/frontend/src/app/services/api.js
+++ b/frontend/src/app/services/api.js
@@ -1,21 +1,29 @@
 /* Copyright (C) 2016 NooBaa */
 
+import NotificationApiImpl from './notifications';
 import { new_rpc_default_only } from 'nb-api';
-import * as notifications from './notifications';
+import { action$ } from 'state';
+import { expireSession } from 'action-creators';
 
-const { location, WebSocket } = global;
-const rpc_proto = WebSocket ?
+const rpc_proto = global.WebSocket ?
     (location.protocol === 'https:' ? 'wss:' : 'ws:') :
     location.protocol;
 
-const base_address = `${rpc_proto}//${location.host}`;
+const base_address = `${rpc_proto}//${global.location.host}`;
+
 const rpc = new_rpc_default_only(base_address);
 
 rpc.register_service(
     rpc.schema.frontend_notifications_api,
-    notifications,
+    new NotificationApiImpl(action$),
     {}
 );
+
+rpc.set_error_handler(err => {
+    if (err.rpc_code === 'UNAUTHORIZED') {
+        action$.next(expireSession());
+    }
+});
 
 const api = rpc.new_client();
 rpc.on('reconnect', () => api.redirector.register_for_alerts());

--- a/frontend/src/app/services/notifications.js
+++ b/frontend/src/app/services/notifications.js
@@ -1,28 +1,36 @@
-/* Copyright (C) 2016 NooBaa */
+import {
+    fetchUnreadAlertsCount,
+    showNotification,
+    removeHost,
+    fetchSystemInfo
+} from 'action-creators';
 
-import { action$ } from 'state';
-import { fetchUnreadAlertsCount, showNotification, removeHost, fetchSystemInfo } from 'action-creators';
+export default class NotificationApiImpl {
+    constructor(action$) {
+        this.dispatch = action => action$.next(action);
+    }
 
-export function alert() {
-    action$.next(fetchUnreadAlertsCount());
-}
+    alert() {
+        this.dispatch(fetchUnreadAlertsCount());
+    }
 
-export function add_memeber_to_cluster(req) {
-    const { result } = req.rpc_params;
+    add_memeber_to_cluster(req) {
+        const { result } = req.rpc_params;
 
-    //TODO: This is a W/A until we move attach server to the new arch
-    const action = result ?
-        showNotification('Server was successfully added to the cluster', 'success') :
-        showNotification('Adding server to the cluster failed', 'error');
+        //TODO: This is a W/A until we move attach server to the new arch
+        const action = result ?
+            showNotification('Server was successfully added to the cluster', 'success') :
+            showNotification('Adding server to the cluster failed', 'error');
 
-    action$.next(action);
-}
+        this.dispatch(action);
+    }
 
-export function remove_host(req) {
-    const { name: host } = req.rpc_params;
-    action$.next(removeHost(host));
-}
+    remove_host(req) {
+        const { name: host } = req.rpc_params;
+        this.dispatch(removeHost(host));
+    }
 
-export function change_upgrade_status() {
-    action$.next(fetchSystemInfo());
+    change_upgrade_status() {
+        this.dispatch(fetchSystemInfo());
+    }
 }

--- a/frontend/src/app/utils/browser-utils.js
+++ b/frontend/src/app/utils/browser-utils.js
@@ -175,7 +175,7 @@ export function isUri(str, inforceHttp = true) {
         //Strip whitespace
         str.replace(/^\s+|\s+$/, '')
     }`;
-    
+
     //Regex by Diego Perini from: http://mathiasbynens.be/demo/url-regex
     //Modified regex - removed the restrictions for private ip ranges
     const regExp = new RegExp(
@@ -264,4 +264,12 @@ export function readFileAsArrayBuffer(file) {
         reader.onerror = err => reject(err);
         reader.readAsArrayBuffer(file);
     });
+}
+
+export function hasSameOrigin(url) {
+    return new URL(url).origin === window.location.origin;
+}
+
+export function navigateTo(url) {
+    return window.location = url;
 }

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -77,6 +77,31 @@ module.exports = {
             }
         },
 
+        create_external_user_account: {
+            doc: 'Create a account based on an openshift user identity',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['name', 'email'],
+                properties: {
+                   name: { $ref: 'common_api#/definitions/account_name' },
+                   email: { $ref: 'common_api#/definitions/email' }
+                }
+            },
+            reply: {
+                type: 'object',
+                required: ['token'],
+                properties: {
+                    token: {
+                        type: 'string'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin',
+                account: true
+            }
+        },
 
         read_account: {
             doc: 'Read the info of the authorized account',
@@ -422,8 +447,6 @@ module.exports = {
         },
 
     },
-
-
 
     definitions: {
         account_info: {

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -78,7 +78,7 @@ module.exports = {
         },
 
         create_external_user_account: {
-            doc: 'Create a account based on an openshift user identity',
+            doc: 'Create an account based on an oauth user identity',
             method: 'POST',
             params: {
                 type: 'object',

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -104,6 +104,12 @@ class APIClient {
             });
     }
 
+    async create_k8s_auth(params) {
+        const res = await this.auth.create_k8s_auth(params);
+        this.options.auth_token = res.token;
+        return res;
+    }
+
 }
 
 function new_router_from_base_address(base_address) {
@@ -121,11 +127,11 @@ function new_router_from_base_address(base_address) {
 
 function new_router_from_address_list(address_list, hint) {
     return {
-        default: get_base_address(address_list, hint, 'mgmt').toString(),
-        md: get_base_address(address_list, hint, 'md').toString(),
-        bg: get_base_address(address_list, hint, 'bg').toString(),
-        hosted_agents: get_base_address(address_list, hint, 'hosted_agents').toString(),
-        master: get_base_address(address_list, hint, 'mgmt').toString()
+        default: get_base_address(address_list, { hint, api: 'mgmt' }).toString(),
+        md: get_base_address(address_list, { hint, api: 'md' }).toString(),
+        bg: get_base_address(address_list, { hint, api: 'bg' }).toString(),
+        hosted_agents: get_base_address(address_list, { hint, api: 'hosted_agents' }).toString(),
+        master: get_base_address(address_list, { hint, api: 'mgmt' }).toString()
     };
 }
 

--- a/src/api/auth_api.js
+++ b/src/api/auth_api.js
@@ -69,6 +69,29 @@ module.exports = {
             }
         },
 
+        create_k8s_auth: {
+            doc: 'Authenticate a k8s account using an OAuth grant code and return an access token.',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['grant_code'],
+                properties: {
+                    grant_code: {
+                        type: 'string'
+                    }
+                }
+            },
+            reply: {
+                type: 'object',
+                additionalProperties: true,
+                properties: {}
+            },
+            auth: {
+                account: false,
+                system: false,
+            }
+        },
+
         create_access_key_auth: {
             doc: 'Authenticate account with access key, ' +
                 'and returns an access token. ' +

--- a/src/api/auth_api.js
+++ b/src/api/auth_api.js
@@ -34,6 +34,13 @@ module.exports = {
                             'should be permitted to delegate such authorization (e.g. admin).',
                         $ref: 'common_api#/definitions/password',
                     },
+                    authorized_by: {
+                        type: 'string',
+                        enum: [
+                            'noobaa',
+                            'oauth'
+                        ]
+                    },
                     system: {
                         type: 'string',
                     },
@@ -83,8 +90,15 @@ module.exports = {
             },
             reply: {
                 type: 'object',
-                additionalProperties: true,
-                properties: {}
+                required: ['token', 'info'],
+                properties: {
+                    token: {
+                        type: 'string',
+                    },
+                    info: {
+                        $ref: '#/definitions/auth_info'
+                    }
+                }
             },
             auth: {
                 account: false,
@@ -176,6 +190,13 @@ module.exports = {
                             type: 'string',
                         },
                     }
+                },
+                authorized_by: {
+                    type: 'string',
+                    enum: [
+                        'noobaa',
+                        'k8s'
+                    ]
                 },
                 role: {
                     type: 'string',

--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -32,6 +32,12 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+    - authentication.k8s.io
+    resources:
+    - tokenreviews
+    verbs:
+    - create
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -171,6 +177,15 @@ spec:
                   name: noobaa-create-sys-creds
                   key: password
                   optional: true
+            - name: OAUTH_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: noobaa-config-map
+                  key: oauth_service_host
+                  optional: true
+            # replacing the empty value with any value will set the cotainer to dbg mode
+            - name: container_dbg
+              value: ""
       serviceAccountName: noobaa-account
 
   volumeClaimTemplates:

--- a/src/deploy/NVA_build/noobaa_deploy_k8s.sh
+++ b/src/deploy/NVA_build/noobaa_deploy_k8s.sh
@@ -392,7 +392,7 @@ function create_config_map {
     local OAUTH_SERVICE_HOST=$(${KUBECTL} get route openshift-authentication -n openshift-authentication -o jsonpath='{.spec.host}')
     ${KUBECTL} delete configmap ${NOOBAA_CONFIGMAP_NAME} &> /dev/null
     ${KUBECTL} create configmap ${NOOBAA_CONFIGMAP_NAME} \
-        --from-literal=oauth_service_host=OAUTH_SERVICE_HOST
+        --from-literal=oauth_service_host=${OAUTH_SERVICE_HOST}
 }
 
 function set_oauth_redirect_uri {

--- a/src/deploy/NVA_build/noobaa_deploy_k8s.sh
+++ b/src/deploy/NVA_build/noobaa_deploy_k8s.sh
@@ -20,7 +20,8 @@ NUM_AGENTS=3
 PV_SIZE_GB=50
 INSTALL_AGENTS=false
 STORAGE_CLASS=""
-
+NOOBAA_CONFIGMAP_NAME="noobaa-config-map"
+NOOBAA_ACCOUNT_NAME="noobaa-account"
 
 jq --version &> /dev/null
 if [ $? -ne 0 ]; then
@@ -118,15 +119,21 @@ function deploy_noobaa {
         error_and_exit "NooBaa is already deployed in the namespace '${NAMESPACE}'. delete it first or deploy in a different namespace"
     fi
 
-
     PASSWD=$(openssl rand -base64 10)
     echo -e "${GREEN}Creating NooBaa resources in namespace ${NAMESPACE}${NC}"
-    ${KUBECTL} delete secret ${CREDS_SECRET_NAME} &> /dev/null
-    ${KUBECTL} create secret generic ${CREDS_SECRET_NAME} --from-literal=name=${SYS_NAME} --from-literal=email=${EMAIL} --from-literal=password=${PASSWD}
+
+    # Pre apply actions
+    create_cred_secret
+    create_config_map
+
     # apply noobaa_core.yaml in the cluster
     ${KUBECTL} apply -f ${NOOBAA_CORE_YAML}
     echo -e "\n${GREEN}Waiting for external IPs to be allocated for NooBaa services. this might take several minutes${NC}"
     sleep 2
+
+    # Post apply actions
+    get_all_ips
+    set_oauth_redirect_uri
     print_noobaa_info
 
     # if [ "${INSTALL_AGENTS}" == "true" ]; then
@@ -134,7 +141,6 @@ function deploy_noobaa {
     # fi
 
 }
-
 
 function verify_noobaa_deployed {
     #make sure noobaa exist
@@ -179,21 +185,16 @@ function get_all_ips {
 }
 
 function print_noobaa_info {
-
-    verify_noobaa_deployed
-
-    get_all_ips
-
     # if management external ip is not found assume there is no external ip and don't try find S3
     if [ "${MGMT_IP}" == "" ]; then
-        get_access_keys 
+        get_access_keys
         echo -e "\n\n================================================================================"
         echo "Could not identify an external IP to connect from outside the cluster"
         echo "External IP is usually allocated automatically for Kubernetes clusters deployed on public cloud providers"
         echo "You can try again later to see if an external IP was allocated using '${SCRIPT_NAME} info'"
         echo
         echo "Node port based management URL: http://${NODE_PORT_MGMT_FALLBACK}"
-        echo 
+        echo
         echo
         echo "      login email             : ${EMAIL}"
         echo "      login password          : ${PASSWD}"
@@ -208,8 +209,8 @@ function print_noobaa_info {
         echo -e "================================================================================\n"
     else
         S3_IP=$(get_service_external_ip s3)
-        get_access_keys 
-        # if [[ "${NODE_PORT_MGMT_FALLBACK}" == *"mini"* ]]; then  
+        get_access_keys
+        # if [[ "${NODE_PORT_MGMT_FALLBACK}" == *"mini"* ]]; then
         #    get_access_keys ${NODE_PORT_MGMT_FALLBACK}
         # else
         #    get_access_keys ${MGMT_IP}:8080
@@ -235,7 +236,7 @@ function print_noobaa_info {
         echo -e "================================================================================\n"
         echo "Please consider logging in to the management console and changing the initial password"
     fi
-        
+
 }
 
 
@@ -243,6 +244,7 @@ function delete_noobaa {
     echo "Deleting NooBaa resources in namespace ${NAMESPACE}"
     ${KUBECTL} delete secret ${TOKEN_SECRET_NAME}
     ${KUBECTL} delete secret ${CREDS_SECRET_NAME}
+    ${KUBECTL} delete configmap ${NOOBAA_CONFIGMAP_NAME}
     ${KUBECTL} delete -f ${NOOBAA_CORE_YAML}
     ${KUBECTL} delete pvc datadir-${NOOBAA_POD_NAME}
     ${KUBECTL} delete pvc logdir-${NOOBAA_POD_NAME}
@@ -289,7 +291,7 @@ function get_node_port_ip_and_port {
         echo $(minikube ip):${NODE_PORT}
     elif [ "${CLUSTER_NAME}" == "minishift" ]; then
         echo  $(minishift ip):${NODE_PORT}
-    else 
+    else
        echo ${HOST_NAME}:${NODE_PORT}
     fi
 }
@@ -321,7 +323,7 @@ function get_auth_token {
     PASSWD=$(${KUBECTL} get secret ${CREDS_SECRET_NAME} -o jsonpath='{.data.password}' | base64 --decode;printf "\n")
     SYS_NAME=$(${KUBECTL} get secret ${CREDS_SECRET_NAME} -o jsonpath='{.data.name}' | base64 --decode;printf "\n")
     TOKEN=$(${KUBECTL} get secret ${CREDS_SECRET_NAME} -o jsonpath='{.data.token}' | base64 --decode;printf "\n")
-    if [ "${TOKEN}" == "" ]; then 
+    if [ "${TOKEN}" == "" ]; then
         local MAX_RETRIES=50
         local RETRIES=0
         # repeat until access_keys are returned
@@ -378,13 +380,40 @@ function get_access_keys {
     done
 }
 
-case ${COMMAND} in 
+function create_cred_secret {
+    ${KUBECTL} delete secret ${CREDS_SECRET_NAME} &> /dev/null
+    ${KUBECTL} create secret generic ${CREDS_SECRET_NAME} \
+        --from-literal=name=${SYS_NAME} \
+        --from-literal=email=${EMAIL} \
+        --from-literal=password=${PASSWD}
+}
+
+function create_config_map {
+    local OAUTH_SERVICE_HOST=$(${KUBECTL} get route openshift-authentication -n openshift-authentication -o jsonpath='{.spec.host}')
+    ${KUBECTL} delete configmap ${NOOBAA_CONFIGMAP_NAME} &> /dev/null
+    ${KUBECTL} create configmap ${NOOBAA_CONFIGMAP_NAME} \
+        --from-literal=oauth_service_host=OAUTH_SERVICE_HOST
+}
+
+function set_oauth_redirect_uri {
+    local OAUTH_ANNOTATION_KEY=serviceaccounts.openshift.io/oauth-redirecturi.nbconsole
+    local OAUTH_REDIRECT_URI=https://${MGMT_IP}:8443/fe/oauth/callback
+    ${KUBECTL} annotate serviceaccount ${NOOBAA_ACCOUNT_NAME} ${OAUTH_ANNOTATION_KEY}=${OAUTH_REDIRECT_URI}
+}
+
+function get_info {
+    echo -e "${GREEN}Collecting NooBaa services information. this might take some time${NC}"
+    verify_noobaa_deployed
+    get_all_ips
+    print_noobaa_info
+}
+
+case ${COMMAND} in
     NONE)       usage;;
     DEPLOY)     deploy_noobaa;;
     DELETE)     delete_noobaa;;
     STORAGE)    install_storage_agents;;
-    INFO)       echo -e "${GREEN}Collecting NooBaa services information. this might take some time${NC}"
-                print_noobaa_info;;
+    INFO)       get_info;;
     *)          usage;;
 esac
 

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -5,7 +5,6 @@ const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
 const ip_module = require('ip');
-const fs = require('fs');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -18,7 +17,6 @@ const SensitiveString = require('../../util/sensitive_string');
 const oauth_utils = require('../../util/oauth_utils');
 const addr_utils = require('../../util/addr_utils');
 const kube_utils = require('../../util/kube_utils');
-const config = require('../../../config');
 
 /**
  *
@@ -135,19 +133,22 @@ function create_auth(req) {
                 }
             }
 
-            let token = make_auth_token({
+            const token = make_auth_token({
                 account_id: target_account._id,
                 system_id: system && system._id,
                 role: role_name,
                 extra: req.rpc_params.extra,
             });
 
-            let info = _get_auth_info(target_account, system, role_name, req.rpc_params.extra);
+            const info = _get_auth_info(
+                target_account,
+                system,
+                'noobaa',
+                role_name,
+                req.rpc_params.extra
+            );
 
-            return {
-                token: token,
-                info: info
-            };
+            return { token, info };
         });
 }
 
@@ -200,7 +201,6 @@ async function create_k8s_auth(req) {
 
     const sa_token = await kube_utils.read_sa_token(unauthorized_error);
     const kube_namespace = await kube_utils.read_namespace(unauthorized_error);
-    console.warn('OMOMOM', sa_token, kube_namespace);
     const oauth_client = `system:serviceaccount:${kube_namespace}:noobaa-account`;
     const { access_token, expires_in } = await oauth_utils.trade_grant_code_for_access_token(
         OAUTH_SERVICE_HOST,
@@ -230,7 +230,7 @@ async function create_k8s_auth(req) {
         const owner_token = make_auth_token({
             account_id: system.owner._id,
             system_id: system._id,
-            role: 'admin'
+            role: 'admin',
         });
 
         await server_rpc.client.account.create_external_user_account(
@@ -253,14 +253,23 @@ async function create_k8s_auth(req) {
         throw new RpcError('UNAUTHORIZED', 'account does not have an admin role');
     }
 
+    const authorized_by = 'k8s';
     const token = make_auth_token({
         account_id: account._id,
         system_id: system._id,
         expiry: Math.floor(expires_in * 1000),
-        role: 'admin'
+        role: 'admin',
+        authorized_by
     });
 
-    const info = _get_auth_info(account, system, 'admin', req.rpc_params.extra);
+    const info = _get_auth_info(
+        account,
+        system,
+        authorized_by,
+        'admin',
+        req.rpc_params.extra
+    );
+
     return { token, info };
 }
 
@@ -377,7 +386,13 @@ function read_auth(req) {
         return {};
     }
 
-    return _get_auth_info(req.account, req.system, req.auth.role, req.auth.extra);
+    return _get_auth_info(
+        req.account,
+        req.system,
+        req.auth.authorized_by,
+        req.auth.role,
+        req.auth.extra
+    );
 }
 
 
@@ -577,11 +592,8 @@ function _prepare_auth_request(req) {
 
 }
 
-function _get_auth_info(account, system, role, extra) {
-    let response = {
-        role: role,
-        extra: extra
-    };
+function _get_auth_info(account, system, authorized_by, role, extra) {
+    const response = { authorized_by, role, extra };
 
     if (account) {
         response.account = _.pick(account, 'name', 'email');
@@ -626,6 +638,7 @@ function has_bucket_permission(bucket, account) {
  */
 function make_auth_token(options) {
     var auth = _.pick(options, 'account_id', 'system_id', 'role', 'extra');
+    auth.authorized_by = options.authorized_by || 'noobaa';
 
     // don't incude keys if value is falsy, to minimize the token size
     auth = _.omitBy(auth, value => !value);

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
 const ip_module = require('ip');
-
+const fs = require('fs');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -13,7 +13,12 @@ const { RpcError } = require('../../rpc');
 const net_utils = require('../../util/net_utils');
 const system_store = require('../system_services/system_store').get_instance();
 const signature_utils = require('../../util/signature_utils');
-
+const server_rpc = require('../server_rpc');
+const SensitiveString = require('../../util/sensitive_string');
+const oauth_utils = require('../../util/oauth_utils');
+const addr_utils = require('../../util/addr_utils');
+const kube_utils = require('../../util/kube_utils');
+const config = require('../../../config');
 
 /**
  *
@@ -146,6 +151,122 @@ function create_auth(req) {
         });
 }
 
+/**
+ *
+ * CREATE_K8S_AUTH
+ *
+ * authenticate a user using a k8s OAuth server then match that
+ * user with a equivalent NooBaa user (or create a new one if one does not exists)
+ * and return an authorized token for that user.
+  *
+ */
+async function create_k8s_auth(req) {
+    const { grant_code } = req.rpc_params;
+
+    // Curretly I have no means to get the system name in the FE witout an email and password.
+    // So i default to the first (and currently only system)
+    let system = system_store.data.systems[0];
+    if (!system || system.deleted) {
+        throw new RpcError('UNAUTHORIZED', 'system not found');
+    }
+
+    const {
+        KUBERNETES_SERVICE_HOST,
+        KUBERNETES_SERVICE_PORT,
+        OAUTH_SERVICE_HOST,
+        DEV_MODE,
+        HTTPS_PORT = 5443
+    } = process.env;
+
+    if (!KUBERNETES_SERVICE_HOST || !KUBERNETES_SERVICE_PORT) {
+        throw new RpcError('UNAUTHORIZED', 'Authentication using oauth is supported only on kubernetes deployments');
+    }
+
+    if (!OAUTH_SERVICE_HOST) {
+        throw new RpcError('UNAUTHORIZED', 'Authentication using oauth is not supported');
+    }
+
+    let redirect_host;
+    if (DEV_MODE === 'true') {
+        redirect_host = `https://localhost:${HTTPS_PORT}`;
+
+    } else {
+        const { system_address } = system;
+        redirect_host = addr_utils.get_base_address(system_address, {
+            hint: 'EXTERNAL',
+            protocol: 'https'
+        }).toString();
+    }
+
+    const sa_token = await kube_utils.read_sa_token(unauthorized_error);
+    const kube_namespace = await kube_utils.read_namespace(unauthorized_error);
+    console.warn('OMOMOM', sa_token, kube_namespace);
+    const oauth_client = `system:serviceaccount:${kube_namespace}:noobaa-account`;
+    const { access_token, expires_in } = await oauth_utils.trade_grant_code_for_access_token(
+        OAUTH_SERVICE_HOST,
+        oauth_client,
+        sa_token,
+        redirect_host,
+        grant_code,
+        unauthorized_error
+    );
+
+    const token_review = await oauth_utils.review_token(
+        KUBERNETES_SERVICE_HOST,
+        KUBERNETES_SERVICE_PORT,
+        sa_token,
+        access_token,
+        unauthorized_error
+    );
+
+    const { username } = token_review.status.user;
+    const user_info = {
+        name: new SensitiveString(username),
+        email: new SensitiveString(username),
+    };
+
+    let account = system_store.get_account_by_email(user_info.email);
+    if (!account) {
+        const owner_token = make_auth_token({
+            account_id: system.owner._id,
+            system_id: system._id,
+            role: 'admin'
+        });
+
+        await server_rpc.client.account.create_external_user_account(
+            user_info,
+            { auth_token: owner_token }
+        );
+        account = system_store.get_account_by_email(user_info.email);
+    }
+
+
+    // For some reason in the case of a new account the account role cannot be found
+    // using system.roles_by_account so I search for it directly on the roles collection.
+    const is_admin = system_store.data.roles.some(r =>
+        String(r.system._id) === String(system._id) &&
+        String(r.account._id) === String(account._id) &&
+        r.role === 'admin'
+    );
+
+    if (!is_admin) {
+        throw new RpcError('UNAUTHORIZED', 'account does not have an admin role');
+    }
+
+    const token = make_auth_token({
+        account_id: account._id,
+        system_id: system._id,
+        expiry: Math.floor(expires_in * 1000),
+        role: 'admin'
+    });
+
+    const info = _get_auth_info(account, system, 'admin', req.rpc_params.extra);
+    return { token, info };
+}
+
+function unauthorized_error(reason) {
+    return new RpcError('UNAUTHORIZED', reason);
+}
 
 /**
  *
@@ -285,8 +406,9 @@ function authorize(req) {
 
 
 function _authorize_jwt_token(req) {
+    const { JWT_SECRET } = process.env;
     try {
-        req.auth = jwt.verify(req.auth_token, process.env.JWT_SECRET);
+        req.auth = jwt.verify(req.auth_token, JWT_SECRET);
     } catch (err) {
         dbg.error('AUTH JWT VERIFY FAILED', req, err);
         throw new RpcError('UNAUTHORIZED', 'verify auth failed');
@@ -521,6 +643,7 @@ function make_auth_token(options) {
 // EXPORTS
 exports.create_auth = create_auth;
 exports.read_auth = read_auth;
+exports.create_k8s_auth = create_k8s_auth;
 exports.create_access_key_auth = create_access_key_auth;
 // authorize is exported to be used as an express middleware
 // it reads and prepares the authorized info on the request (req.auth).

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1527,7 +1527,7 @@ class NodesMonitor extends EventEmitter {
         // don't update local agents which are using local host
 
         const { routing_hint } = system_store.data.get_by_id(item.node.agent_config) || {};
-        const base_address = addr_utils.get_base_address(system.system_address, routing_hint).toString();
+        const base_address = addr_utils.get_base_address(system.system_address, { hint: routing_hint }).toString();
         const address_configured = system.system_address.some(addr => addr.service === 'noobaa-mgmt');
         if (address_configured &&
             !item.node.is_internal_node &&

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -588,7 +588,7 @@ async function read_object_md(req) {
         // or when the intention is to use dns name.
         const endpoint =
             adminfo.signed_url_endpoint ||
-            addr_utils.get_base_address(req.system.system_address, 'EXTERNAL').hostname;
+            addr_utils.get_base_address(req.system.system_address, { hint: 'EXTERNAL' }).hostname;
 
         const account_keys = req.account.access_keys[0];
         info.s3_signed_url = cloud_utils.get_signed_url({
@@ -982,7 +982,7 @@ async function list_objects_admin(req) {
         const { adminfo } = req.rpc_params;
         const endpoint =
             (adminfo && adminfo.signed_url_endpoint) ||
-            addr_utils.get_base_address(req.system.system_address, 'EXTERNAL').hostname;
+            addr_utils.get_base_address(req.system.system_address, { hint: 'EXTERNAL' }).hostname;
 
         const account_keys = req.account.access_keys[0];
         object_info.s3_signed_url = cloud_utils.get_signed_url({

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -891,7 +891,7 @@ function _get_base64_install_conf(address, routing_hint, system, create_node_tok
 async function _get_install_conf(req, hint) {
     const conf_id = await _get_agent_conf_id(req, hint);
     const create_node_token = _get_create_node_token(req.system._id, req.account._id, conf_id);
-    const addr = addr_utils.get_base_address(req.system.system_address, hint);
+    const addr = addr_utils.get_base_address(req.system.system_address, { hint });
     const install_conf = _get_base64_install_conf(addr.toString(), hint, req.system.name, create_node_token);
     return install_conf;
 }

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -439,7 +439,7 @@ function getVersion(route) {
         });
 }
 
-// An oauth authorize endpoint that forwards to the OpenShift authorization server.
+// An oauth authorize endpoint that forwards to the OAuth authorization server.
 app.get('/oauth/authorize', async (req, res) => {
     const {
         KUBERNETES_SERVICE_HOST,

--- a/src/util/addr_utils.js
+++ b/src/util/addr_utils.js
@@ -17,8 +17,13 @@ function format_base_address(hostname = '127.0.0.1', port = default_base_port) {
     return url.format(`wss://${hostname}:${port}`);
 }
 
-function get_base_address(address_list, hint = 'INTERNAL', api = 'mgmt') {
-    const protocol = 'wss';
+function get_base_address(address_list, options = {}) {
+    let {
+        hint = 'INTERNAL',
+        api = 'mgmt',
+        protocol = 'wss'
+    } = options;
+
     const api_list = address_list.filter(addr => addr.api === api);
     let default_port = default_base_port + api_default_port_offset[api];
 

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -315,6 +315,13 @@ function should_reject_unauthorized(endpoint, proxy) {
     }
 }
 
+function make_http_request(options, body, body_encoding) {
+    return new Promise((resolve, reject) => {
+        https.request(options, resolve)
+            .on('error', reject)
+            .end(body, body_encoding);
+    });
+}
 
 
 exports.parse_url_query = parse_url_query;
@@ -328,3 +335,4 @@ exports.read_and_parse_body = read_and_parse_body;
 exports.send_reply = send_reply;
 exports.get_unsecured_http_agent = get_unsecured_http_agent;
 exports.should_reject_unauthorized = should_reject_unauthorized;
+exports.make_http_request = make_http_request;

--- a/src/util/kube_utils.js
+++ b/src/util/kube_utils.js
@@ -8,23 +8,23 @@ function _default_error_factory(message) {
     return new Error(message);
 }
 
-async function read_namespace(makeError = _default_error_factory) {
+async function read_namespace(make_error = _default_error_factory) {
     try {
         const buffer = await fs.readFileAsync(config.KUBE_NAMESPACE_FILE);
         return buffer.toString('utf8').trim();
 
     } catch (err) {
-        throw makeError(`Could not read service account token file at "${config.KUBE_NAMESPACE_FILE}"`);
+        throw make_error(`Could not read service account token file at "${config.KUBE_NAMESPACE_FILE}"`);
     }
 }
 
-async function read_sa_token(makeError = _default_error_factory) {
+async function read_sa_token(make_error = _default_error_factory) {
     try {
        const buffer = await fs.readFileAsync(config.KUBE_SA_TOKEN_FILE);
        return buffer.toString('utf8').trim();
 
     } catch (err) {
-        throw makeError(`Could not namespace file at "${config.KUBE_SA_TOKEN_FILE}"`);
+        throw make_error(`Could not namespace file at "${config.KUBE_SA_TOKEN_FILE}"`);
     }
 }
 

--- a/src/util/kube_utils.js
+++ b/src/util/kube_utils.js
@@ -1,0 +1,32 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const fs = require('fs');
+const config = require('../../config');
+
+function _default_error_factory(message) {
+    return new Error(message);
+}
+
+async function read_namespace(makeError = _default_error_factory) {
+    try {
+        const buffer = await fs.readFileAsync(config.KUBE_NAMESPACE_FILE);
+        return buffer.toString('utf8').trim();
+
+    } catch (err) {
+        throw makeError(`Could not read service account token file at "${config.KUBE_NAMESPACE_FILE}"`);
+    }
+}
+
+async function read_sa_token(makeError = _default_error_factory) {
+    try {
+       const buffer = await fs.readFileAsync(config.KUBE_SA_TOKEN_FILE);
+       return buffer.toString('utf8').trim();
+
+    } catch (err) {
+        throw makeError(`Could not namespace file at "${config.KUBE_SA_TOKEN_FILE}"`);
+    }
+}
+
+exports.read_namespace = read_namespace;
+exports.read_sa_token = read_sa_token;

--- a/src/util/oauth_utils.js
+++ b/src/util/oauth_utils.js
@@ -126,7 +126,7 @@ async function review_token(
         return JSON.parse(body);
 
     } catch (err) {
-        throw make_error('mailformed token review json response');
+        throw make_error('malformed token review json response');
     }
 }
 

--- a/src/util/oauth_utils.js
+++ b/src/util/oauth_utils.js
@@ -1,0 +1,134 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const querystring = require('querystring');
+const config = require('../../config');
+const { make_http_request } = require('./http_utils');
+const { read_stream_join } = require('./buffer_utils');
+
+function _default_error_factory(message) {
+    return new Error(message);
+}
+
+async function trade_grant_code_for_access_token(
+    oauth_service,
+    client_id,
+    client_secret,
+    redirect_host,
+    grant_code,
+    make_error = _default_error_factory
+) {
+    const token_endpoint = new URL(config.OAUTH_TOKEN_ENDPOINT, `https://${oauth_service}`);
+    const redirect_uri = new URL(config.OAUTH_REDIRECT_ENDPOINT, redirect_host);
+    let response;
+
+    try {
+        response = await make_http_request(
+            {
+                method: 'POST',
+                port: token_endpoint.port || '443',
+                hostname: token_endpoint.hostname,
+                path: token_endpoint.pathname,
+                rejectUnauthorized: false,
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+                    'X-CSRF-Token': 'not-empty'
+                }
+            },
+            querystring.stringify({
+                grant_type: 'authorization_code',
+                code: grant_code,
+                client_id: client_id,
+                client_secret: client_secret,
+                redirect_uri: redirect_uri.toString()
+            }),
+            'utf8'
+        );
+    } catch (err) {
+        throw make_error('OpenShift api endpoint does not response');
+    }
+
+    const status_code = response.statusCode;
+    const buffer = await read_stream_join(response);
+    const body = buffer.toString('utf8');
+
+    if (status_code !== 200) {
+        throw make_error(`could not acquire an oauth access token, response status code was ${
+            status_code
+        } with a body of ${
+            body
+        }`);
+    }
+
+    try {
+        const token_info = JSON.parse(body);
+        const required_scope = config.OAUTH_REQUIRED_SCOPE;
+        if (token_info.scope !== required_scope) {
+             throw make_error(`user did not grant access for "${required_scope}" scope`);
+        }
+        if (token_info.token_type !== 'Bearer') {
+            throw make_error('access token is not a of type "Bearer"');
+        }
+        return token_info;
+
+    } catch (err) {
+        throw make_error('mailformed access token json response');
+    }
+}
+
+async function review_token(
+    api_hostname,
+    api_port = '443',
+    sa_token,
+    oauth_access_token,
+    make_error = _default_error_factory
+) {
+    let response;
+    try {
+        response = await make_http_request(
+            {
+                method: 'POST',
+                hostname: api_hostname,
+                port: api_port,
+                path: config.KUBE_API_ENDPOINTS.TOKEN_REVIEW,
+                rejectUnauthorized: false,
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: `Bearer ${sa_token}`
+                }
+            },
+            JSON.stringify({
+                apiVersion: 'authentication.k8s.io/v1',
+                kind: 'TokenReview',
+                spec: { token: oauth_access_token }
+            }),
+            'utf8'
+       );
+
+    } catch (err) {
+        throw make_error('token review api endpoint does not response');
+    }
+
+    const status_code = response.statusCode;
+    const buffer = await read_stream_join(response);
+    const body = buffer.toString('utf8');
+
+    if (status_code !== 200 && status_code !== 201) {
+        throw make_error(`could not review oauth access token, response status code was ${
+            status_code
+        } with a body of ${
+            body
+        }`);
+    }
+
+    try {
+        return JSON.parse(body);
+
+    } catch (err) {
+        throw make_error('mailformed token review json response');
+    }
+}
+
+exports.trade_grant_code_for_access_token = trade_grant_code_for_access_token;
+exports.review_token = review_token;


### PR DESCRIPTION
### Explain the changes
- Add BE support for OAuth authorization against OpenShift
- Add initial FE support for OAuth login (using OpenShift OAuth service)
- Refactor get_base_address to accept an options args
- Add support for  base address creation for protocols other than CSS
- Remove hardcoded address from the code base the only hard-coded address left is the address for the .well_known OAuth server in the config file.
- Normalization of SSO UX/UI
- Use env vars for OAuth discovery + allow skipping of OAuth, the env variables will be set form the deploy script/rook operator
- Add support for setting an error handler in the RPC
- Support handling of expired sessions
- Support deployment of NooBaa with OAuth support
- Add a session expired prompt to the management console
- Changes to OAuth token flow
  - Use the NooBaa service account as an OAuth client
  - Use the users API with the review token API in order to get the OAuth user identity
- Remove .env var in favor of server discovery
  - Using service account as OAuth client so no need for CLIENT_ID or CLIENT_SECRET
  - Read namespace from a local file so no more need for KUBE_NAMESPACE
  - Move OAUTH_SERVICE_HOST from secret to config map
- Fix deploy script to insert an annotation for OAuth redirect URI 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 