### PR TITLE
Add tag support to make command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ logs/
 metadata_storage/
 noobaa_storage/
 gocode/
+heapdump-*

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,34 @@
 GIT_COMMIT?="$(shell git rev-parse HEAD | head -c 7)"
+TESTSER_TAG?="noobaa/tester"
+SERVER_TAG?="noobaa/server"
+AGENT_TAG?="noobaa/agent"
 export
 
 all: builder tester server agent
 	@echo "\033[1;34mAll done.\033[0m"
 
 builder:
-	@echo "\033[1;34mStarting Builder docker build.\033[0m"	
+	@echo "\033[1;34mStarting Builder docker build.\033[0m"
 	docker build -f src/deploy/NVA_build/builder.Dockerfile -t noobaa/builder .
 	@echo "\033[1;34mBuilder done.\033[0m"
 
-tester: builder	
+tester: builder
 	@echo "\033[1;34mStarting Testser docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/Tests.Dockerfile -t noobaa/tester --build-arg GIT_COMMIT=$(GIT_COMMIT) .
+	docker build -f src/deploy/NVA_build/Tests.Dockerfile -t $(TESTSER_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 	@echo "\033[1;34mTester done.\033[0m"
 
 test: tester
 	@echo "\033[1;34mRunning tests.\033[0m"
-	docker run noobaa/tester 
+	docker run $(TESTSER_TAG)
 
-server: builder	
-	@echo "\033[1;34mStarting Server docker build.\033[0m"	
-	docker build -f src/deploy/NVA_build/Server.Dockerfile -t noobaa/server --build-arg GIT_COMMIT=$(GIT_COMMIT) .
+server: builder
+	@echo "\033[1;34mStarting Server docker build.\033[0m"
+	docker build -f src/deploy/NVA_build/Server.Dockerfile -t $(SERVER_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 	@echo "\033[1;34mServer done.\033[0m"
 
-agent: builder	
+agent: builder
 	@echo "\033[1;34mStarting Agent docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/Agent.Dockerfile -t noobaa/agent --build-arg GIT_COMMIT=$(GIT_COMMIT) .
+	docker build -f src/deploy/NVA_build/Agent.Dockerfile -t $(AGENT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 	@echo "\033[1;34mAgent done.\033[0m"
 
 clean:


### PR DESCRIPTION
### Explain the changes
1. Allow selecting a tag for the build artifact on the (instead of the default tag)
   ```make server SERVER_TAG="{tag_name}```
    for server use: SERVER_TAG
    for agent use: AGENT_TAG
    for tester use: TESTER_TAG

2. Ignore heap dump files when building

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
