### PR TITLE
Updates to support larger amount of buckets

### DIFF
--- a/config.js
+++ b/config.js
@@ -85,6 +85,7 @@ config.MD_AGGREGATOR_MAX_CYCLES = 2880; // 1 day / 30 seconds
 // This grace is used since we can hold up an ObjectID and not push it inside the DB
 // Which will mean that it will be pushed later on with a previous date
 config.MD_GRACE_IN_MILLISECONDS = config.MD_AGGREGATOR_INTERVAL * 3;
+config.MD_AGGREGATOR_BATCH = 100;
 
 ///////////////
 // IO CONFIG //

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -136,7 +136,8 @@ const PARTIAL_SINGLE_SYS_DEFAULTS = {
 //Aggregate bucket configuration and policies
 function _aggregate_buckets_config(system) {
     let bucket_config = [];
-    for (const cbucket of system.buckets) {
+    const sorted_1k_buckets = system.buckets.sort((bucket_a, bucket_b) => bucket_b.num_objects - bucket_a.num_objects).slice(0, 1000);
+    for (const cbucket of sorted_1k_buckets) {
         let current_config = {};
         current_config.num_objects = cbucket.num_objects;
         current_config.versioning = cbucket.versioning;

--- a/src/tools/s3perf.js
+++ b/src/tools/s3perf.js
@@ -58,6 +58,9 @@ if (argv.help) {
 } else if (argv.upload) {
     op_func = upload_object;
     op_size = data_size;
+} else if (argv.mb) {
+    op_func = create_bucket;
+    op_size = 0;
 } else {
     print_usage();
 }
@@ -252,6 +255,11 @@ async function upload_object() {
         .promise();
 }
 
+async function create_bucket() {
+    const new_bucket = argv.mb + '-' + Date.now().toString(36);
+    return s3.createBucket({ Bucket: new_bucket }).promise();
+}
+
 function print_usage() {
     console.log(`
 Usage:
@@ -260,6 +268,7 @@ Usage:
   --get <key>            get key name
   --put <key>            put (single) to key (key can be omited
   --upload <key>         upload (multipart) to key (key can be omited
+  --mb <bucket>          creates a new bucket (bucket can be omitted)
 Upload Flags:
   --concur <num>         concurrent operations to run from each process (default is 1)
   --forks <num>          number of forked processes to run (default is 1)


### PR DESCRIPTION
### Explain the changes
1. Md aggregator will limit the size of db update to 100
2. Stats aggregator will send ph a compressed status instead of regular one

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. I created a little tool to simulate phone home - that can be used: 
```
/* Copyright (C) 2016 NooBaa */
'use strict';

var http = require('http');
var formidable = require('formidable');
var zip_utils = require('./util/zip_utils');

http.createServer(function(req, res) {
    if (req.url === '/phdata') {
        var form = new formidable.IncomingForm();
        form.parse(req, async function(err, fields, files) {
            var zipfile = await zip_utils.unzip_from_buffer(Buffer.from(fields.payload.data));
            var zip = await zip_utils.unzip_to_mem(zipfile);
            console.log('Received buffer', JSON.parse(zip[0].data.toString()));
            res.write('File uploaded and moved!');
            return res.end();
        });
    } else {
        res.writeHead(200, { 'Content-Type': 'text/html' });
        res.write('ok');
        return res.end();
    }
}).listen(9090);
```
