### PR TITLE
fixed test_build_chunks

### DIFF
--- a/src/test/framework/system_tests_list.js
+++ b/src/test/framework/system_tests_list.js
@@ -29,7 +29,7 @@ const tests = [{
 }, {
     name: 'test-build-chunks',
     test: './src/test/system_tests/test_build_chunks.js',
-    num_agents: 6,
+    num_agents: 7,
     server_cpu: '400m',
     server_mem: '400Mi',
     agent_cpu: '250m',

--- a/src/test/system_tests/test_build_chunks.js
+++ b/src/test/system_tests/test_build_chunks.js
@@ -496,7 +496,7 @@ function test_setup(bucket_name, pool_names, mirrored, cloud_pool, num_of_nodes_
                     })
                     .then(node_list => {
                         if (!node_list || !node_list.nodes) throw new Error('not enough nodes');
-                        const valid_nodes = node_list.nodes.filter(node => node.mode === 'OPTIMAL');
+                        const valid_nodes = node_list.nodes.filter(node => node.mode === 'OPTIMAL' && node.node_type === 'BLOCK_STORE_FS');
                         if (valid_nodes.length < num_of_nodes_per_pool[pool_name]) {
                             console.log(`list nodes returned ${valid_nodes.length} nodes. required number by ${pool_name} is ${num_of_nodes_per_pool[pool_name]}.`,
                                 node_list.nodes.map(node => ({ name: node.name, mode: node.mode })));


### PR DESCRIPTION
### Explain the changes
1. test_build_chunks is based on `list_nodes` in `nodes_api`
   - this API function returns all nodes including endpoint nodes
   -  the test is unaware that some nodes are not storage nodes, so it creates pools without enough storage nodes to support the test.
2. filtering out non-storage nodes during the test setup.


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
