### PR TITLE
Removing aggregate data free from get_bucket_info

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -294,14 +294,11 @@ function read_bucket(req) {
         });
     });
     pools = _.compact(pools);
-
     let pool_names = pools.map(pool => pool.name);
     return P.props({
             bucket,
             nodes_aggregate_pool: nodes_client.instance().aggregate_nodes_by_pool(pool_names, req.system._id),
             hosts_aggregate_pool: nodes_client.instance().aggregate_hosts_by_pool(null, req.system._id),
-            aggregate_data_free_by_tier: nodes_client.instance().aggregate_data_free_by_tier(
-                bucket.tiering.tiers.map(tiers_object => String(tiers_object.tier._id)), req.system._id),
             num_of_objects: MDStore.instance().count_objects_of_bucket(bucket._id),
             func_configs: get_bucket_func_configs(req, bucket),
             unused_refresh_tiering_alloc: node_allocator.refresh_tiering_alloc(bucket.tiering),
@@ -1069,14 +1066,13 @@ function get_bucket_info({
     bucket,
     nodes_aggregate_pool,
     hosts_aggregate_pool,
-    aggregate_data_free_by_tier,
     num_of_objects,
     func_configs,
-    bucket_stats
+    bucket_stats,
 }) {
     const tiering_pools_status = node_allocator.get_tiering_status(bucket.tiering);
     const tiering = tier_server.get_tiering_policy_info(bucket.tiering, tiering_pools_status,
-        nodes_aggregate_pool, hosts_aggregate_pool, aggregate_data_free_by_tier);
+        nodes_aggregate_pool, hosts_aggregate_pool);
     const info = {
         name: bucket.name,
         namespace: bucket.namespace ? {

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -554,6 +554,19 @@ function get_associated_buckets_int(pool) {
     });
 }
 
+function has_associated_buckets_int(pool) {
+    const associated_bucket = _.find(pool.system.buckets_by_name, function(bucket) {
+        return _.find(bucket.tiering.tiers, function(tier_and_order) {
+            return _.find(tier_and_order.tier.mirrors, function(mirror) {
+                return _.find(mirror.spread_pools, function(spread_pool) {
+                    return String(pool._id) === String(spread_pool._id);
+                });
+            });
+        });
+    });
+    return Boolean(associated_bucket);
+}
+
 function get_associated_accounts(pool) {
     return system_store.data.accounts
         .filter(account => (!account.is_support &&
@@ -784,8 +797,7 @@ function check_pool_deletion(pool, nodes_aggregate_pool) {
     }
 
     //Verify pool is not used by any bucket/tier
-    var buckets = get_associated_buckets_int(pool);
-    if (buckets.length) {
+    if (has_associated_buckets_int(pool)) {
         return 'IN_USE';
     }
 
@@ -800,8 +812,7 @@ function check_pool_deletion(pool, nodes_aggregate_pool) {
 function check_resrouce_pool_deletion(pool) {
 
     //Verify pool is not used by any bucket/tier
-    var buckets = get_associated_buckets_int(pool);
-    if (buckets.length) {
+    if (has_associated_buckets_int(pool)) {
         return 'IN_USE';
     }
 

--- a/src/tools/mongodb_bucket_blow.js
+++ b/src/tools/mongodb_bucket_blow.js
@@ -1,0 +1,73 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-env mongo */
+'use strict';
+
+/*
+ * mongodb script to add massive ammount of buckets to DB
+ *
+ * usage: mongo nbcore mongodb_bucket_blow.js
+ *
+ */
+
+let system_id = db.systems.findOne()._id;
+let pool_id = db.pools.findOne({ resource_type: { $ne: "INTERNAL" } })._id;
+let ccc = db.chunk_configs.findOne()._id;
+
+for (let j = 0; j < 5; ++j) {
+    let array_of_tiers = [];
+    let array_of_policies = [];
+    let array_of_buckets = [];
+    for (let i = 0; i < 1000; ++i) {
+        let tier_id = new ObjectId();
+        let policy_id = new ObjectId();
+        let bucket_id = new ObjectId();
+        array_of_tiers.push({
+            _id: tier_id,
+            name: 'tier' + ((j * 1000) + i),
+            system: system_id,
+            chunk_config: ccc,
+            data_placement: 'SPREAD',
+            mirrors: [{
+                _id: new ObjectId(),
+                spread_pools: [pool_id],
+            }],
+        });
+        array_of_policies.push({
+            _id: policy_id,
+            name: 'policy' + ((j * 1000) + i),
+            system: system_id,
+            tiers: [{
+                tier: tier_id,
+                order: 0,
+                spillover: false,
+                disabled: false
+            }],
+            chunk_split_config: {
+                avg_chunk: 4194304,
+                delta_chunk: 1048576
+            }
+        });
+        array_of_buckets.push({
+            _id: bucket_id,
+            name: 'bucket' + ((j * 1000) + i),
+            tag: "",
+            system: system_id,
+            tiering: policy_id,
+            storage_stats: {
+                chunks_capacity: 0,
+                objects_size: 0,
+                objects_count: 0,
+                stats_by_content_type: [],
+                blocks_size: 0,
+                pools: {},
+                objects_hist: [],
+                last_update: Date.now() - (2 * 90000)
+            },
+            lambda_triggers: [],
+            versioning: "DISABLED"
+        });
+    }
+    db.tiers.insert(array_of_tiers);
+    db.tieringpolicies.insert(array_of_policies);
+    db.buckets.insert(array_of_buckets);
+}

--- a/src/tools/s3perf.js
+++ b/src/tools/s3perf.js
@@ -204,7 +204,7 @@ async function run_worker_loop() {
             }
         }
     } catch (err) {
-        console.error('WORKER', cluster.worker.process.pid, 'ERROR', err.stack || err);
+        console.error('WORKER', process.pid, 'ERROR', err.stack || err);
         process.exit();
     }
 }


### PR DESCRIPTION
### Explain the changes
1. Waiting on aggregate_data_free_by_tier take a lot of time, in nodes_allocator we use a sort of caching to save the tiering status (updates every 10 seconds) - so we will use it instead for saving time for read_system/bucket/policy
2. added a tool for adding quickly 5K buckets to the system 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
