### PR TITLE
Addition of metrics for OCS links

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -522,9 +522,22 @@ module.exports = {
                     type: 'array',
                     items: {
                         type: 'object',
-                        required: ['name', 'capacity', 'reduction_ratio', 'savings', 'total_usage', 'buckets_stats', 'usage_by_project', 'usage_by_bucket_class'],
+                        required: [
+                            'name',
+                            'address',
+                            'capacity',
+                            'reduction_ratio',
+                            'savings',
+                            'total_usage',
+                            'buckets_stats',
+                            'usage_by_project',
+                            'usage_by_bucket_class',
+                        ],
                         properties: {
                             name: {
+                                type: 'string'
+                            },
+                            address: {
                                 type: 'string'
                             },
                             capacity: {

--- a/src/server/analytic_services/prometheus_reporting.js
+++ b/src/server/analytic_services/prometheus_reporting.js
@@ -95,7 +95,7 @@ const METRIC_RECORDS = Object.freeze([{
     configuration: {
         name: get_metric_name('system_info'),
         help: 'System info',
-        labelNames: ['system_name']
+        labelNames: ['system_name', 'system_address']
     }
 }, {
     metric_type: 'Gauge',
@@ -342,7 +342,7 @@ class PrometheusReporting {
 
     set_system_info(info) {
         if (!this.enabled()) return;
-        this._metrics.system_info.set({ system_name: info.name }, 0);
+        this._metrics.system_info.set({ system_name: info.name, system_address: info.address }, 0);
     }
 
     update_providers_bandwidth(type, write_size, read_size) {


### PR DESCRIPTION
### Explain the changes
1. Added metrics under the system_info metric in order to get the system's address for OCS links to NooBaa 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
