### PR TITLE
include system_id and role in access tokens returned by create_account

### DIFF
--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -533,7 +533,8 @@ function _prepare_auth_request(req) {
         // check that auth contains valid system role or the account is support
         if (!ignore_missing_system) {
             if (!(req.account && req.account.is_support) &&
-                !_.includes(options.system, req.auth.role)) {
+                !_.includes(options.system, req.auth.role) &&
+                req.auth.role !== 'operator') {
                 dbg.warn('role not allowed in system', options, req.auth, req.account, req.system);
                 throw new RpcError('UNAUTHORIZED', 'role not allowed in system');
             }

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -163,18 +163,16 @@ function create_account(req) {
             var auth = {
                 account_id: created_account._id
             };
-            if (req.rpc_params.new_system_parameters) {
-                // since we created the first system for this account
-                // we expect just one system, but use _.each to get it from the map
-                var current_system = (req.system && req.system._id) || sys_id;
-                _.each(created_account.roles_by_system, (roles, system_id) => {
-                    //we cannot assume only one system.
-                    if (current_system.toString() === system_id) {
-                        auth.system_id = system_id;
-                        auth.role = roles[0];
-                    }
-                });
-            }
+            // since we created the first system for this account
+            // we expect just one system, but use _.each to get it from the map
+            var current_system = (req.system && req.system._id) || sys_id;
+            _.each(created_account.roles_by_system, (roles, system_id) => {
+                //we cannot assume only one system.
+                if (current_system.toString() === system_id) {
+                    auth.system_id = system_id;
+                    auth.role = roles[0];
+                }
+            });
             return {
                 token: auth_server.make_auth_token(auth),
             };


### PR DESCRIPTION
### Explain the changes
1. `role` and `system_id` were only added to the first account of the new system. changed to add it to all tokens returned by create_account
2. allow all operations to the operator role

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5635 

### Testing Instructions:
1. 
