### PR TITLE
Ohad k8s pool changes

### DIFF
--- a/frontend/src/app/components/accounts/accounts-table/accounts-table.js
+++ b/frontend/src/app/components/accounts/accounts-table/accounts-table.js
@@ -162,7 +162,8 @@ class AccountsTableViewModel extends ConnectableViewModel {
             const order = Number(location.query.order || 0);
             const { compareKey } = columns.find(column => column.name === sortBy);
             const compareAccounts = createCompareFunc(compareKey, order);
-            const accountList = Object.values(accounts);
+            const accountList = Object.values(accounts)
+                .filter(account => account.roles.every(role => role !== 'operator'));
             const pageStart = page * this.pageSize;
             const filteredRows = accountList.filter(account =>
                 !filter || account.name.toLowerCase().includes(filter.toLowerCase())

--- a/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.html
+++ b/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.html
@@ -29,8 +29,10 @@
 
         <div ko.tooltip="uploadButton().tooltip">
             <button class="upload-btn btn"
+                ko.visible="uploadButton().visible"
                 ko.disable="uploadButton().disabled"
-                ko.click="() => fileSelectorExpanded.toggle()">
+                ko.click="() => fileSelectorExpanded.toggle()
+            ">
                 Upload Objects
             </button>
         </div>

--- a/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.js
+++ b/frontend/src/app/components/bucket/bucket-objects-table/bucket-objects-table.js
@@ -277,6 +277,7 @@ class BucketObjectsTableViewModel extends Observer {
         const httpsNoCert = location.protocol === 'https' && !sslCert;
         const isReadOnly = !isBucketWritable(bucket);
         const uploadButton = {
+            visible: false, // WE may renable this when we fix the cert issues.
             disabled: !account.isOwner || isReadOnly || httpsNoCert,
             tooltip: _getUploadTooltip(account.isOwner, isReadOnly, httpsNoCert)
         };

--- a/frontend/src/app/components/modals/account-created-modal/account-created-modal.less
+++ b/frontend/src/app/components/modals/account-created-modal/account-created-modal.less
@@ -6,5 +6,6 @@
     .message{
         font-family: roboto;
         line-height: 1.5;
+        white-space: pre-line;
     }
 }

--- a/frontend/src/app/components/modals/connect-app-modal/connect-app-modal.html
+++ b/frontend/src/app/components/modals/connect-app-modal/connect-app-modal.html
@@ -24,6 +24,11 @@
 
         <div class="content-box pad greedy push-next">
             <property-sheet class="greedy" params="properties: details">
+                <template name="valueWithTooltip">
+                    <div ko.tooltip="$data">
+                        <div class="no-wrap">{{$data}}</div>
+                    </div>
+                </template>
             </property-sheet>
         </div>
     </div>

--- a/frontend/src/app/components/modals/deploy-k8s-pool-modal/deploy-k8s-pool-modal.html
+++ b/frontend/src/app/components/modals/deploy-k8s-pool-modal/deploy-k8s-pool-modal.html
@@ -41,7 +41,7 @@
                     ></svg-icon>
                     <span class="remark">
                         If you wish to scale up an existing kubernetes pool go to <br>
-                        Resources > Pools > kubernetes pool
+                        <a class="link" ko.attr.href="poolTableHref">Resources > Pools</a>
                     </span>
                 </p>
                 <wizard-controls></wizard-controls>
@@ -88,7 +88,15 @@
                     <p class="remark" ko.visible="$form.isValid()">This cannot be changed later on</p>
                 </editor>
             </div>
-            <div class="content-box pad column content-end">
+            <div class="content-box pad row content-middle">
+                <p class="greedy push-next row">
+                    <svg-icon class="icon-small push-next-quarter"
+                        params="name: 'notif-info'"
+                    ></svg-icon>
+                    <span class="remark">
+                        For each new node one PV will be created
+                    </span>
+                </p>
                 <wizard-controls></wizard-controls>
             </div>
         </section>

--- a/frontend/src/app/components/modals/deploy-k8s-pool-modal/deploy-k8s-pool-modal.js
+++ b/frontend/src/app/components/modals/deploy-k8s-pool-modal/deploy-k8s-pool-modal.js
@@ -7,8 +7,10 @@ import { isFormValid, getFormValues, isFieldTouched } from 'utils/form-utils';
 import { validateName } from 'utils/validation-utils';
 import { deepFreeze, throttle } from 'utils/core-utils';
 import { fromSizeAndUnit, unitsInBytes, formatSize } from 'utils/size-utils';
+import { realizeUri } from 'utils/browser-utils';
 import { inputThrottle } from 'config';
 import numeral from 'numeral';
+import * as routes from 'routes';
 import {
     updateForm,
     touchForm,
@@ -50,6 +52,7 @@ class DeployK8SPoolModalViewModel extends ConnectableViewModel {
     formattedNodeCount = ko.observable();
     formattedCapacity = ko.observable()
     deployBtnLabel = ko.observable();
+    poolTableHref = ko.observable();
     fields = {
         step: 0,
         poolName: '',
@@ -63,11 +66,12 @@ class DeployK8SPoolModalViewModel extends ConnectableViewModel {
         return [
             state.hostPools,
             state.cloudResources,
+            state.system && state.system.name,
             state.forms[this.formName]
         ];
     }
 
-    mapStateToProps(hostPools, cloudResources, form) {
+    mapStateToProps(hostPools, cloudResources, systemName, form) {
         if (!hostPools || !cloudResources || !form) {
             return;
         }
@@ -92,13 +96,19 @@ class DeployK8SPoolModalViewModel extends ConnectableViewModel {
                 (deployMethod === 'YAML' && 'Download YAML') ||
                 '';
 
+        const poolTableHref = realizeUri(routes.resources, {
+            system: systemName,
+            tab: 'pools'
+        });
+
         ko.assignToProps(this, {
             existingNames,
             nameRestrictionList,
             isStepValid: isFormValid(form),
             formattedNodeCount,
             formattedCapacity,
-            deployBtnLabel
+            deployBtnLabel,
+            poolTableHref
         });
     }
 

--- a/frontend/src/app/components/shared/resource-associated-account-list/resource-associated-account-list.js
+++ b/frontend/src/app/components/shared/resource-associated-account-list/resource-associated-account-list.js
@@ -67,13 +67,15 @@ class ResourceAssociatedAccountListViewModel extends ConnectableViewModel {
                 dataReady: true,
                 subject: subject,
                 accountCount: numeral(accountList.length || 0).format(','),
-                accounts: accountList.map(account => ({
-                    name: account.name,
-                    href: realizeUri(
-                        routes.account,
-                        { system, account: account.name }
-                    )
-                }))
+                accounts: accountList
+                    .filter(account => account.roles.every(role => role !== 'operator'))
+                    .map(account => ({
+                        name: account.name,
+                        href: realizeUri(
+                            routes.account,
+                            { system, account: account.name }
+                        )
+                    }))
             });
         }
     }

--- a/frontend/src/app/schema/accounts.js
+++ b/frontend/src/app/schema/accounts.js
@@ -12,7 +12,8 @@ export default {
             'hasLoginAccess',
             'hasS3Access',
             'isOwner',
-            'name'
+            'name',
+            'roles'
         ],
         properties: {
             accessKeys: {
@@ -136,6 +137,12 @@ export default {
             },
             name: {
                 type: 'string'
+            },
+            roles: {
+                type: 'array',
+                items: {
+                    type: 'string'
+                }
             }
         }
     }


### PR DESCRIPTION
### Explain the changes
1. Add Info remark  for pv size
2. Return operator account in list accounts (but ignore it in the UI) - prevent pool/node/delete tooltip crushes
3. Add a link to deploy k8s pool remark (back to pools table)
4. Handle long endpoint names in "connect application"
5. Handle long endpoint names in "User create successfully"
6. Block uploading from the UI (hide the upload button)
7. Change default account for "connect application" to be the logged in user or the first account with s3 access (if the user does not have s3 access).

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
