### PR TITLE
avoid updating default resource for operator account when creating first resource

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -269,7 +269,7 @@ function updates_if_first_resource(req, pool) {
     if (pools.length) return;
     // so this is the first resource to be added to the system
     _.each(system_store.data.accounts, account => {
-        if (account.default_pool) {
+        if (account.default_pool && account.email.unwrap() !== config.OPERATOR_ACCOUNT_EMAIL) {
             updates.push({
                 _id: account._id,
                 $set: {
@@ -558,9 +558,9 @@ async function delete_hosts_pool(req, pool) {
 
         dbg.log0(`delete_hosts_pool: removing pool ${pool.name} from the database`);
         await system_store.make_changes({
-             remove: {
-                 pools: [pool._id]
-             }
+            remove: {
+                pools: [pool._id]
+            }
         });
 
         Dispatcher.instance().activity({


### PR DESCRIPTION
### Explain the changes
1. when the first resource is created then the default resource of all accounts is changed to that resource.
2. this is also done for the operator account, but this account cannot be edited or deleted, which makes the first resource created undeletable.
3. for now, avoid updating the operator account. any buckets created by the operator (via the bucket provisioner) will be using the internal storage. in the future the operator will provide a better way to control the backing storage of the buckets.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5651 

### Testing Instructions:
1. 
