### PR TITLE
General UI Fixes

### DIFF
--- a/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.js
+++ b/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.js
@@ -126,6 +126,11 @@ class AccountS3AccessFormViewModel extends ConnectableViewModel {
                 text: disabledActionTooltip
             } : '';
 
+            const defaultResourceName =
+                (defaultResource === 'INTERNAL_STORAGE' && 'Internal Storage') ||
+                defaultResource ||
+                'Not Set';
+
             ko.assignToProps(this, {
                 dataReady: true,
                 accountName: account.name,
@@ -145,7 +150,7 @@ class AccountS3AccessFormViewModel extends ConnectableViewModel {
                         disabled: !hasS3Access
                     },
                     {
-                        value: defaultResource || 'Not set',
+                        value: defaultResourceName,
                         disabled: !hasS3Access
                     },
                     {

--- a/frontend/src/app/components/accounts/accounts-table/accounts-table.js
+++ b/frontend/src/app/components/accounts/accounts-table/accounts-table.js
@@ -163,7 +163,7 @@ class AccountsTableViewModel extends ConnectableViewModel {
             const { compareKey } = columns.find(column => column.name === sortBy);
             const compareAccounts = createCompareFunc(compareKey, order);
             const accountList = Object.values(accounts)
-                .filter(account => account.roles.every(role => role !== 'operator'));
+                .filter(account => !account.roles.includes('operator'));
             const pageStart = page * this.pageSize;
             const filteredRows = accountList.filter(account =>
                 !filter || account.name.toLowerCase().includes(filter.toLowerCase())

--- a/frontend/src/app/components/bucket/bucket-s3-access-policy-form/bucket-s3-access-policy-form.js
+++ b/frontend/src/app/components/bucket/bucket-s3-access-policy-form/bucket-s3-access-policy-form.js
@@ -99,9 +99,11 @@ class BucketS3AccessTableViewModel extends ConnectableViewModel {
         } else {
             if (route !== routes.bucket) return;
 
-            const conenctedAccounts = Object.values(accounts).filter(account =>
-                account.allowedBuckets.includes(params.bucket)
-            );
+            const conenctedAccounts = Object.values(accounts)
+                .filter(account =>
+                    account.allowedBuckets.includes(params.bucket) &&
+                    !account.roles.includes('operator')
+                );
 
             const accountCount = conenctedAccounts.length;
             const summary = `${

--- a/frontend/src/app/components/modals/connect-app-modal/connect-app-modal.js
+++ b/frontend/src/app/components/modals/connect-app-modal/connect-app-modal.js
@@ -80,7 +80,7 @@ class ConnectAppModalViewModel extends ConnectableViewModel {
         const accountList = Object.values(accounts)
             .filter(account =>
                 account.hasS3Access &&
-                account.roles.every(role => role !== 'operator')
+                !account.roles.includes('operator')
             );
         const accountOptions = accountList.map(account => account.name);
         const account = _getSelectedAccount(accountList, user, form);

--- a/frontend/src/app/components/modals/edit-bucket-s3-access-modal/edit-bucket-s3-access-modal.js
+++ b/frontend/src/app/components/modals/edit-bucket-s3-access-modal/edit-bucket-s3-access-modal.js
@@ -50,7 +50,9 @@ class EditBucketS3AccessModalViewModel extends ConnectableViewModel {
         ko.assignToProps(this, {
             bucketName,
             accountsHref: realizeUri(routes.accounts, { system }),
-            accountOptions: accountList.map(_getAccountOption),
+            accountOptions: accountList
+                .filter(account => !account.roles.includes('operator'))
+                .map(_getAccountOption),
             fields: !form ? {
                 selectedAccounts: _getSelectedAccounts(accountList, bucketName)
             } : undefined

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -107,6 +107,12 @@ module.exports = {
                 properties: {
                     token: {
                         type: 'string'
+                    },
+                    access_keys: {
+                        type: 'array',
+                        items: {
+                            $ref: 'common_api#/definitions/access_keys'
+                        }
                     }
                 }
             },

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -329,8 +329,6 @@ async function clear_test_pools() {
     // Prevent accounts from preventing pool deletions (by using a pool as default resource)
     // by disabling s3 access for all accounts.
     const { accounts } = await rpc_client.account.list_accounts({});
-    // add entry for operator account
-    accounts.push({ email: config.OPERATOR_ACCOUNT_EMAIL });
     await Promise.all(accounts.map(account =>
         rpc_client.account.update_account_s3_access({
             email: account.email,


### PR DESCRIPTION


### Explain the changes
1. Added missing schema to create_external_user_account API (the schema for create_account was changed with the operator account PR) - prevent crush on the first login for OpenShift user.
2. Remove operator account line for account list of bucket
3. Remove operator account from bucket audit s3 access modal
4. Change pool status to initializing when all nodes in the pool are in initializing state
5. Suppress audit entry for the creation of the account operator
6. Replace text INTERNAL_STORAGE with "Internal Storage" in account details for an account that uses the internal storage as the default resource

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
