### PR TITLE
added initializing flag to pool and timout on pool scale

### DIFF
--- a/src/deploy/NVA_build/noobaa_pool.yaml
+++ b/src/deploy/NVA_build/noobaa_pool.yaml
@@ -29,7 +29,6 @@ spec:
       noobaa-module: noobaa-agent
   serviceName: noobaa-agent
   replicas: 3
-  podManagementPolicy: Parallel
   updateStrategy:
     type: RollingUpdate
   template:

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -152,6 +152,9 @@ module.exports = {
                     type: 'integer',
                     minimum: 0
                 },
+                initializing: {
+                    type: 'boolean'
+                },
                 host_config: {
                     type: 'object',
                     properties: {


### PR DESCRIPTION
### Explain the changes
1. added `initializing` flag to pool
2. had to remove `podManagementPolicy: Parallel` and use the default `rderedReady` policy
3. if scale times out then set the host count to the new count

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5640 

### Testing Instructions:
1. 