### PR TITLE
Add the ability in run_dataset.js to change the bucket's pool

### DIFF
--- a/src/deploy/NVA_build/Tests.Dockerfile
+++ b/src/deploy/NVA_build/Tests.Dockerfile
@@ -15,8 +15,8 @@ ENV TEST_CONTAINER true
 # python-virtualenv python-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel -- these are required by ceph tests
 RUN yum install -y -q ntpdate vim centos-release-scl && \
     yum install -y -q rh-mongodb36 && \
-    yum install -y python-virtualenv python-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel && \
-    yum install -y git && \
+    yum install -y -q python-virtualenv python-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel && \
+    yum install -y -q git && \
     yum clean all
 
 ##############################################################
@@ -59,6 +59,9 @@ RUN mkdir -p /noobaa-core/node_modules/.cache/nyc && \
 RUN mkdir -p /noobaa-core/coverage && \
     chmod 777 /noobaa-core/coverage
 RUN chmod -R 777 /noobaa-core/src/test
+
+# Making mocha accessible 
+RUN ln -s /noobaa-core/node_modules/mocha/bin/mocha /usr/local/bin
 
 ENV SPAWN_WRAP_SHIM_ROOT /data
 RUN mkdir -p /data && \

--- a/src/test/framework/test_job.yaml
+++ b/src/test/framework/test_job.yaml
@@ -20,6 +20,8 @@ spec:
         - NAMESPACE_PREFIX_PLACEHOLDER
         - --tests_list
         - TESTS_LIST_PLACEHOLDER
+        - --concurrency
+        - TESTS_CONCURRENCY_PLACEHOLDER
         env:
           - name: CONTAINER_PLATFORM
             value: KUBERNETES


### PR DESCRIPTION
### Explain the changes
1. Add the ability in run_dataset.js to change the bucket's pool

2. Tests.Dockerfile:
- Making mocha accessible when running docker run (added to the path)

3. test concurrency can now be changed

test_env_builder_kubernetes.js:
- Added test concurrency as a flag

test_job.yaml:
- Calling test_env_builder_kubernetes with --concurrency flag

run_test_job.sh:
- Add concurrency flag with default 1
