### PR TITLE
Remove verification password from regenerate credential flow

### DIFF
--- a/frontend/src/app/action-creators/account-actions.js
+++ b/frontend/src/app/action-creators/account-actions.js
@@ -243,10 +243,10 @@ export function failDeleteExternalConnection(connection, error) {
     };
 }
 
-export function regenerateAccountCredentials(accountName, verificationPassword) {
+export function regenerateAccountCredentials(accountName) {
     return {
         type: REGENERATE_ACCOUNT_CREDENTIALS,
-        payload: { accountName, verificationPassword }
+        payload: { accountName }
     };
 }
 

--- a/frontend/src/app/components/modals/regenerate-account-credentials-modal/regenerate-account-credentials-modal.html
+++ b/frontend/src/app/components/modals/regenerate-account-credentials-modal/regenerate-account-credentials-modal.html
@@ -4,7 +4,6 @@
     name: formName,
     fields: fields,
     onValidate: onValidate,
-    onValidateSubmit: onValidateSubmit,
     onSubmit: onSubmit,
     owner: $component
 ">
@@ -18,15 +17,13 @@
             </span>
         </p>
 
-        <editor params="label: 'Enter your password'">
-            <password-field
-                ko.validationCss="$form.userPassword"
-                params="
-                    value: $form.userPassword,
-                    hasFocus: true
-                "
-            ></password-field>
-            <validation-message params="field: $form.userPassword"></validation-message>
+        <editor params="label: 'Type &#34regenerate&#34'">
+            <input class="input"
+                ko.value="$form.confirm"
+                ko.hasFocus="true"
+                ko.validationCss="$form.confirm"
+            />
+            <validation-message params="field: $form.confirm"></validation-message>
         </editor>
     </div>
     <div class="column pad content-box">

--- a/frontend/src/app/components/modals/regenerate-account-credentials-modal/regenerate-account-credentials-modal.js
+++ b/frontend/src/app/components/modals/regenerate-account-credentials-modal/regenerate-account-credentials-modal.js
@@ -3,14 +3,13 @@
 import template from './regenerate-account-credentials-modal.html';
 import ConnectableViewModel from 'components/connectable';
 import { closeModal, regenerateAccountCredentials } from 'action-creators';
-import { api } from 'services';
 import ko from 'knockout';
 
 class RegenerateAccountCredentialsModalViewModel extends ConnectableViewModel {
     formName = this.constructor.name;
     targetAccount = '';
     fields = {
-        userPassword: ''
+        confirm: ''
     };
 
     selectState(_, params) {
@@ -26,33 +25,20 @@ class RegenerateAccountCredentialsModalViewModel extends ConnectableViewModel {
     }
 
     onValidate(values) {
-        const { userPassword } = values;
+        const { confirm } = values;
         const errors = {};
 
-        if (!userPassword) {
-            errors.userPassword = 'Password is required for security purposes';
+        if (confirm.trim().toLowerCase() !== 'regenerate') {
+            errors.confirm = 'Please type "regenerate" to confirm your action';
         }
 
         return errors;
     }
 
-    async onValidateSubmit(values) {
-        const { userPassword: verification_password } = values;
-        const errors = {};
-
-        const verified = await api.account.verify_authorized_account({ verification_password });
-        if (!verified) {
-            errors.userPassword = 'Please make sure your password is correct';
-        }
-
-        return errors;
-    }
-
-    onSubmit(values) {
-        const { userPassword } = values;
+    onSubmit() {
         this.dispatch(
             closeModal(),
-            regenerateAccountCredentials(this.targetAccount, userPassword)
+            regenerateAccountCredentials(this.targetAccount)
         );
     }
 

--- a/frontend/src/app/epics/regenerate-account-credentials.js
+++ b/frontend/src/app/epics/regenerate-account-credentials.js
@@ -13,12 +13,11 @@ export default function(action$, { api }) {
     return action$.pipe(
         ofType(REGENERATE_ACCOUNT_CREDENTIALS),
         mergeMap(async action => {
-            const { accountName, verificationPassword } = action.payload;
+            const { accountName } = action.payload;
 
             try {
                 await  api.account.generate_account_keys({
-                    email: accountName,
-                    verification_password: verificationPassword
+                    email: accountName
                 });
 
                 return completeRegenerateAccountCredentials(accountName);

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -204,10 +204,9 @@ module.exports = {
             method: 'PUT',
             params: {
                 type: 'object',
-                required: ['email', 'verification_password'],
+                required: ['email'],
                 properties: {
                     email: { $ref: 'common_api#/definitions/email' },
-                    verification_password: { $ref: 'common_api#/definitions/password' },
                 },
             },
             auth: {

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -223,8 +223,8 @@ function read_account(req) {
  * GENERATE_ACCOUNT_KEYS
  *
  */
-function generate_account_keys(req) {
-    let account = system_store.get_account_by_email(req.rpc_params.email);
+async function generate_account_keys(req) {
+    const account = system_store.get_account_by_email(req.rpc_params.email);
     if (!account) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + req.rpc_params.email);
     }
@@ -236,31 +236,26 @@ function generate_account_keys(req) {
     if (account.is_support) {
         throw new RpcError('FORBIDDEN', 'Cannot update support account');
     }
-    let updates = _.pick(account, '_id');
 
-    return verify_authorized_account(req)
-        .then(res => {
-            if (!res) throw new RpcError('UNAUTHORIZED', 'Invalid verification password');
-        })
-        .then(() => {
-            updates.access_keys = [generate_access_keys()];
-            return system_store.make_changes({
-                update: {
-                    accounts: [updates]
-                }
-            });
-        })
-        .then(() => {
-            Dispatcher.instance().activity({
-                event: 'account.generate_credentials',
-                level: 'info',
-                system: req.system && req.system._id,
-                actor: req.account && req.account._id,
-                account: account._id,
-                desc: `Credentials for ${account.email.unwrap()} were regenerated ${req.account && 'by ' + req.account.email.unwrap()}`,
-            });
-        })
-        .return();
+    await system_store.make_changes({
+        update: {
+            accounts: [{
+                _id: account._id,
+                access_keys: [
+                    generate_access_keys()
+                ]
+            }]
+        }
+    });
+
+    Dispatcher.instance().activity({
+        event: 'account.generate_credentials',
+        level: 'info',
+        system: req.system && req.system._id,
+        actor: req.account && req.account._id,
+        account: account._id,
+        desc: `Credentials for ${account.email.unwrap()} were regenerated ${req.account && 'by ' + req.account.email.unwrap()}`,
+    });
 }
 
 


### PR DESCRIPTION
### Explain the changes
1.  Removing the need for verification password allows us to support this action for OAuth users who don't have a NooBaa password, to begin with.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
