### PR TITLE
delete_external_connection return rpc code IN_USE

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1015,7 +1015,7 @@ function delete_external_connection(req) {
             pool.cloud_pool_info.access_keys.account_id._id === account._id &&
             pool.cloud_pool_info.access_keys.access_key.unwrap() === connection_to_delete.access_key
         ))) {
-        throw new Error('Cannot delete connection as it is being used for a cloud pool');
+        throw new RpcError('IN_USE', 'Cannot delete connection as it is being used for a cloud pool');
     }
 
     return system_store.make_changes({


### PR DESCRIPTION
### Explain the changes
The case is when the connection is being used by one or more pools.
Needed for the operator.

### Issues: Fixed #xxx / Gap #xxx
NA
### Testing Instructions:
NA