### PR TITLE
fix JWT creation for different openssl versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",

--- a/src/deploy/NVA_build/noobaa_deploy_k8s.sh
+++ b/src/deploy/NVA_build/noobaa_deploy_k8s.sh
@@ -410,7 +410,7 @@ function create_cred_secret {
 
 function create_noobaa_secrets {
     local SERVER_SECRET=$(openssl rand -hex 4)
-    local JWT_SECRET=$(openssl rand -base64 20 | openssl sha512 -hmac | cut -c10-44)
+    local JWT_SECRET=$(openssl rand -hex 20)
     ${KUBECTL} delete secret ${NOOBAA_SECRETS_NAME} &> /dev/null
     ${KUBECTL} create secret generic ${NOOBAA_SECRETS_NAME} \
         --from-literal=server_secret=${SERVER_SECRET} \


### PR DESCRIPTION
### Explain the changes
1. fix JWT creation for different openssl versions
2. Bump to 5.1.1

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5680

### Testing Instructions:
1. Run the deploy script with openssl version 1.1.0 
