### PR TITLE
Add bucket claim APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3308,12 +3308,12 @@
       }
     },
     "googleapis": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-40.0.0.tgz",
-      "integrity": "sha512-G4iUF6V141mbgbXmbXQDYP0pOYJAONvA8m+RzYfuVBcwfKm7Pn6Aes9LT0a6ddmW9CmydHmHdOgKZuWwkXueXg==",
+      "version": "42.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-42.0.0.tgz",
+      "integrity": "sha512-nQiKPDmzmMusnU8UOibmlC6hsgkm70SjqmLxSlBBb7i0z7/J6UPilSzo9tAMoHA8u3BUw3OXn13+p9YLmBH6Gg==",
       "requires": {
-        "google-auth-library": "^4.0.0",
-        "googleapis-common": "^2.0.0"
+        "google-auth-library": "^5.1.0",
+        "googleapis-common": "^3.0.0"
       },
       "dependencies": {
         "arrify": {
@@ -3333,25 +3333,25 @@
           }
         },
         "gcp-metadata": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.1.tgz",
-          "integrity": "sha512-nrbLj5O1MurvpLC/doFwzdTfKnmYGDYXlY/v7eQ4tJNVIvQXbOK672J9UFbradbtmuTkyHzjpzD8HD0Djz0LWw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.2.tgz",
+          "integrity": "sha512-dxPXBvjyfz5qFEBXzEwNmuZXwsGYfuASGYeg3CKZDaQRXdiWti9J3/Ezmtyon1OrCNpDO2YekyoSjEqMtsrcXw==",
           "requires": {
-            "gaxios": "^2.0.0",
+            "gaxios": "^2.0.1",
             "json-bigint": "^0.3.0"
           }
         },
         "google-auth-library": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-4.2.5.tgz",
-          "integrity": "sha512-Vfsr82M1KTdT0H0wjawwp0LHsT6mPKSolRp21ZpJ7Ydq63zRe8DbGKjRCCrhsRZHg+p17DuuSCMEznwk3CJRdw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.2.0.tgz",
+          "integrity": "sha512-I2726rgOedQ06HgTvoNvBeRCzy5iFe6z3khwj6ugfRd1b0VHwnTYKl/3t2ytOTo7kKc6KivYIBsCIdZf2ep67g==",
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
             "fast-text-encoding": "^1.0.0",
             "gaxios": "^2.0.0",
             "gcp-metadata": "^2.0.0",
-            "gtoken": "^3.0.0",
+            "gtoken": "^4.0.0",
             "jws": "^3.1.5",
             "lru-cache": "^5.0.0"
           }
@@ -3365,9 +3365,9 @@
           }
         },
         "gtoken": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-3.0.2.tgz",
-          "integrity": "sha512-BOBi6Zz31JfxhSHRZBIDdbwIbOPyux10WxJHdx8wz/FMP1zyN1xFrsAWsgcLe5ww5v/OZu/MePUEZAjgJXSauA==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.0.0.tgz",
+          "integrity": "sha512-XaRCfHJxhj06LmnWNBzVTAr85NfAErq0W1oabkdqwbq3uL/QTB1kyvGog361Uu2FMG/8e3115sIy/97Rnd4GjQ==",
           "requires": {
             "gaxios": "^2.0.0",
             "google-p12-pem": "^2.0.0",
@@ -3378,13 +3378,13 @@
       }
     },
     "googleapis-common": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-2.0.3.tgz",
-      "integrity": "sha512-gUObzhe0fnDkDPHsxseXCVt1JB9apaQfTomykGyoRXzvydHqXS0llGzaJnAC4JOvvL+TQDedwx2GETLibMUuUA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-3.1.0.tgz",
+      "integrity": "sha512-abnogPoWqv0cU6O/EFpkerCVsaUsKEG6XpCm4P1YgK44PxIRcGtalDwijqUErkcivM1Xy5MNyf1PDkKTLEjOZA==",
       "requires": {
         "extend": "^3.0.2",
         "gaxios": "^2.0.1",
-        "google-auth-library": "^4.2.0",
+        "google-auth-library": "^5.2.0",
         "qs": "^6.7.0",
         "url-template": "^2.0.8",
         "uuid": "^3.3.2"
@@ -3407,25 +3407,25 @@
           }
         },
         "gcp-metadata": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.1.tgz",
-          "integrity": "sha512-nrbLj5O1MurvpLC/doFwzdTfKnmYGDYXlY/v7eQ4tJNVIvQXbOK672J9UFbradbtmuTkyHzjpzD8HD0Djz0LWw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.2.tgz",
+          "integrity": "sha512-dxPXBvjyfz5qFEBXzEwNmuZXwsGYfuASGYeg3CKZDaQRXdiWti9J3/Ezmtyon1OrCNpDO2YekyoSjEqMtsrcXw==",
           "requires": {
-            "gaxios": "^2.0.0",
+            "gaxios": "^2.0.1",
             "json-bigint": "^0.3.0"
           }
         },
         "google-auth-library": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-4.2.5.tgz",
-          "integrity": "sha512-Vfsr82M1KTdT0H0wjawwp0LHsT6mPKSolRp21ZpJ7Ydq63zRe8DbGKjRCCrhsRZHg+p17DuuSCMEznwk3CJRdw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.2.0.tgz",
+          "integrity": "sha512-I2726rgOedQ06HgTvoNvBeRCzy5iFe6z3khwj6ugfRd1b0VHwnTYKl/3t2ytOTo7kKc6KivYIBsCIdZf2ep67g==",
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
             "fast-text-encoding": "^1.0.0",
             "gaxios": "^2.0.0",
             "gcp-metadata": "^2.0.0",
-            "gtoken": "^3.0.0",
+            "gtoken": "^4.0.0",
             "jws": "^3.1.5",
             "lru-cache": "^5.0.0"
           }
@@ -3439,9 +3439,9 @@
           }
         },
         "gtoken": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-3.0.2.tgz",
-          "integrity": "sha512-BOBi6Zz31JfxhSHRZBIDdbwIbOPyux10WxJHdx8wz/FMP1zyN1xFrsAWsgcLe5ww5v/OZu/MePUEZAjgJXSauA==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.0.0.tgz",
+          "integrity": "sha512-XaRCfHJxhj06LmnWNBzVTAr85NfAErq0W1oabkdqwbq3uL/QTB1kyvGog361Uu2FMG/8e3115sIy/97Rnd4GjQ==",
           "requires": {
             "gaxios": "^2.0.0",
             "google-p12-pem": "^2.0.0",
@@ -3450,9 +3450,9 @@
           }
         },
         "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
+          "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "get-folder-size": "2.0.1",
     "getos": "3.1.1",
     "glob-to-regexp": "0.4.1",
-    "googleapis": "40.0.0",
+    "googleapis": "42.0.0",
     "heapdump": "0.3.14",
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "2.2.2",

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -677,6 +677,50 @@ module.exports = {
             auth: {
                 system: 'admin'
             }
+        },
+
+        claim_bucket: {
+            method: 'PUT',
+            required: ['name', 'tiering', 'email', 'create_bucket', 'namespace'],
+            params: {
+                type: 'object',
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    tiering: { $ref: 'common_api#/definitions/tiering_name' },
+                    email: { $ref: 'common_api#/definitions/email' },
+                    create_bucket: { type: 'boolean' },
+                    namespace: { type: 'string' },
+                    bucket_class: { type: 'string' },
+                },
+            },
+            reply: {
+                type: 'object',
+                required: ['access_keys'],
+                properties: {
+                    access_keys: {
+                        $ref: 'common_api#/definitions/access_keys'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
+        delete_claim: {
+            method: 'PUT',
+            required: ['name', 'email', 'delete_bucket'],
+            params: {
+                type: 'object',
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    email: { $ref: 'common_api#/definitions/email' },
+                    delete_bucket: { type: 'boolean' }
+                },
+            },
+            auth: {
+                system: 'admin'
+            }
         }
     },
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -72,18 +72,9 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, tag) {
  *
  */
 async function create_bucket(req) {
-    if (req.rpc_params.name.unwrap().length < 3 ||
-        req.rpc_params.name.unwrap().length > 63 ||
-        net.isIP(req.rpc_params.name.unwrap()) ||
-        !VALID_BUCKET_NAME_REGEXP.test(req.rpc_params.name.unwrap())) {
-        throw new RpcError('INVALID_BUCKET_NAME');
-    }
-    if (req.system.buckets_by_name && req.system.buckets_by_name[req.rpc_params.name.unwrap()]) {
-        throw new RpcError('BUCKET_ALREADY_EXISTS');
-    }
-    if (req.account.allow_bucket_creation === false) {
-        throw new RpcError('UNAUTHORIZED', 'Not allowed to create new buckets');
-    }
+
+    validate_bucket_creation(req);
+
     let tiering_policy;
     const changes = {
         insert: {},
@@ -1008,6 +999,105 @@ function update_bucket_lambda_trigger(req) {
         .return();
 }
 
+
+// OB/OBC Related
+async function claim_bucket(req) {
+    dbg.log0('claim bucket', req.rpc_params);
+
+    if (req.rpc_params.create_bucket) {
+        try {
+            validate_bucket_creation(req);
+        } catch (err) {
+            dbg.log0('claim_bucket failed validating bucket', err);
+            throw err;
+        }
+        try {
+            await server_rpc.client.bucket.create_bucket({
+                name: req.rpc_params.name,
+                tiering: req.rpc_params.tiering,
+                bucket_claim: {
+                    policy_type: req.rpc_params.bucket_class || 'empty',
+                    namespace: req.rpc_params.namespace
+                }
+            }, {
+                auth_token: req.auth_token
+            });
+        } catch (err) {
+            dbg.log0('claim_bucket failed creating bucket', err);
+            throw err;
+        }
+    }
+
+    try {
+        const internal_pool = pool_server.get_internal_mongo_pool(req.system);
+        const response = await server_rpc.client.account.create_account({
+            name: req.rpc_params.email,
+            email: req.rpc_params.email,
+            default_pool: internal_pool.name,
+            has_login: false,
+            s3_access: true,
+            allow_bucket_creation: false,
+            allowed_buckets: {
+                full_permission: false,
+                permission_list: [req.rpc_params.name],
+            }
+        }, {
+            auth_token: req.auth_token
+        });
+        const ret = {
+            access_keys: {
+                access_key: response.access_keys[0].access_key.unwrap(),
+                secret_key: response.access_keys[0].secret_key.unwrap()
+            }
+        };
+        return ret;
+    } catch (err) {
+        dbg.log0('claim_bucket failed creating account', err);
+        if (req.rpc_params.create_bucket) {
+            await server_rpc.client.bucket.delete_bucket({
+                name: req.rpc_params.name
+            }, {
+                auth_token: req.auth_token
+            });
+        }
+    }
+}
+
+async function delete_claim(req) {
+    dbg.log0('delete claim', req.rpc_params);
+
+    await server_rpc.client.account.delete_account({
+        email: req.rpc_params.email
+    }, {
+        auth_token: req.auth_token
+    });
+
+    if (req.rpc_params.delete_bucket) {
+        await server_rpc.client.bucket.delete_bucket({
+            name: req.rpc_params.name
+        }, {
+            auth_token: req.auth_token
+        });
+    }
+}
+
+// UTILS //////////////////////////////////////////////////////////
+
+function validate_bucket_creation(req) {
+    if (req.rpc_params.name.unwrap().length < 3 ||
+        req.rpc_params.name.unwrap().length > 63 ||
+        net.isIP(req.rpc_params.name.unwrap()) ||
+        !VALID_BUCKET_NAME_REGEXP.test(req.rpc_params.name.unwrap())) {
+            throw new RpcError('INVALID_BUCKET_NAME');
+    }
+    if (req.system.buckets_by_name && req.system.buckets_by_name[req.rpc_params.name.unwrap()]) {
+        throw new RpcError('BUCKET_ALREADY_EXISTS');
+    }
+    if (req.account.allow_bucket_creation === false) {
+        throw new RpcError('UNAUTHORIZED', 'Not allowed to create new buckets');
+    }
+}
+
 function validate_trigger_update(req, bucket, validated_trigger) {
     dbg.log0('validate_trigger_update: Chekcing new trigger is legal:', validated_trigger);
     let validate_function = true;
@@ -1049,10 +1139,6 @@ function _inject_usage_to_cloud_bucket(target_name, endpoint, usage_list) {
     }
     return res;
 }
-
-
-// UTILS //////////////////////////////////////////////////////////
-
 
 function find_bucket(req, bucket_name = req.rpc_params.name) {
     var bucket = req.system.buckets_by_name && req.system.buckets_by_name[bucket_name.unwrap()];
@@ -1457,6 +1543,9 @@ exports.check_for_lambda_permission_issue = check_for_lambda_permission_issue;
 exports.delete_bucket_tagging = delete_bucket_tagging;
 exports.put_bucket_tagging = put_bucket_tagging;
 exports.get_bucket_tagging = get_bucket_tagging;
+//OB/OBC
+exports.claim_bucket = claim_bucket;
+exports.delete_claim = delete_claim;
 
 exports.delete_bucket_encryption = delete_bucket_encryption;
 exports.put_bucket_encryption = put_bucket_encryption;


### PR DESCRIPTION
### Explain the changes
1. Instead of the OB/OBC provisioner creating TieringPolicy, Bucket, Account and connecting everything together provide a single API to create a bucket & account as well as delete a claim.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5676

### Testing Instructions:
1. rpc.bucket.claim_bucket
2. rpc.bucket.delete_claim
