### PR TITLE
call and set new error type mapping of INVALID_BUCKET_STATE error

### DIFF
--- a/src/agent/block_store_services/block_store_mongo.js
+++ b/src/agent/block_store_services/block_store_mongo.js
@@ -5,12 +5,10 @@ const _ = require('lodash');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
-const os_utils = require('../../util/os_utils');
 const size_utils = require('../../util/size_utils');
 const mongo_client = require('../../util/mongo_client');
 const buffer_utils = require('../../util/buffer_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
-const { SERVER_MIN_REQUIREMENTS } = require('../../../config');
 const mongo_utils = require('../../util/mongo_utils');
 const Semaphore = require('../../util/semaphore');
 
@@ -90,18 +88,6 @@ class BlockStoreMongo extends BlockStoreBase {
             });
     }
 
-    set_mongo_store_limit() {
-        return os_utils.get_raw_storage()
-            .then(total => {
-                dbg.log0(`total disk size ${total}, current used ${this._usage}`);
-                if (total < SERVER_MIN_REQUIREMENTS.STORAGE_GB * size_utils.GIGABYTE) {
-                    this.usage_limit = 5 * size_utils.GIGABYTE;
-                } else {
-                    this.usage_limit = 30 * size_utils.GIGABYTE;
-                }
-            });
-    }
-
     init() {
         return mongo_client.instance().connect()
             .then(() => this._init_chunks_collection())
@@ -112,7 +98,6 @@ class BlockStoreMongo extends BlockStoreBase {
                     dbg.log0('found usage data usage_data = ', this._usage);
                 }
             })
-            .then(() => this.set_mongo_store_limit())
             .catch(err => {
                 dbg.error('got error on init:', err);
                 throw err;

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -77,6 +77,8 @@ const RPC_ERRORS_TO_S3 = Object.freeze({
     OBJECT_IO_STREAM_ITEM_TIMEOUT: S3Error.SlowDown,
     INVALID_PART: S3Error.InvalidPart,
     INVALID_PORT_ORDER: S3Error.InvalidPartOrder,
+    INVALID_BUCKET_STATE: S3Error.InvalidBucketState,
+    NOT_ENOUGH_SPACE: S3Error.InvalidBucketState,
 });
 
 const S3_OPS = load_ops();

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -121,7 +121,11 @@ class GetMapping {
                 map_reporter.add_event(`allocate_chunks(${bucket.name})`, total_size, Date.now() - start_alloc_time);
                 if (!done) {
                     retries += 1;
-                    if (retries > config.IO_WRITE_BLOCK_RETRIES) throw new Error('Couldn\'t allocate chunk - Will stop retries');
+                    if (retries > config.IO_WRITE_BLOCK_RETRIES) {
+                        const err = new Error('Couldn\'t allocate chunk - Will stop retries');
+                        err.rpc_code = 'NOT_ENOUGH_SPACE';
+                        throw err;
+                    }
                     const uniq_tiers = _.uniq(_.map(chunks, 'tier'));
                     await P.map(uniq_tiers, tier => ensure_room_in_tier(tier, bucket));
                     await P.delay(config.ALLOCATE_RETRY_DELAY_MS);

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1322,7 +1322,7 @@ function check_quota(bucket) {
                 }, uploads to this bucket will be denied`,
             Dispatcher.rules.once_daily);
         dbg.error(message);
-        throw new RpcError('FORBIDDEN', message);
+        throw new RpcError('INVALID_BUCKET_STATE', message);
     } else if (used_percent >= 90) {
         Dispatcher.instance().alert('INFO',
             system_store.data.systems[0]._id,


### PR DESCRIPTION

### Explain the changes
1. deleted set_mongo_store_limit.
2. called new error type - INVALID_BUCKET_STATE instead of INTERNAL error
3.  mapped INVALID_BUCKET_STATE and NOT_ENOUGH_SPACE errors of rpc errors to INVALID_BUCKET_STATE of s3 error.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #3848 

### Testing Instructions:
1. 
