### PR TITLE
Remove unsupported aggregated endpoint mode

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -2653,7 +2653,6 @@ class NodesMonitor extends EventEmitter {
             'UNTRUSTED',
             'INITIALIZING',
             'DECOMMISSIONED',
-            'GATEWAY_ERRORS',
             'OPTIMAL',
             'HTTP_PORT_ACCESS_ERROR',
             'HTTP_SRV_ERRORS',


### PR DESCRIPTION
### Explain the changes
1.  The mode was never supported in the API (as an aggregated s3 mode)  schemes or FE and is too specific as an aggregated mode, after the fix it will be translated  to HTTP_SRV_ERRORS

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
