### PR TITLE
remove unnecessary code from supervisord.orig

### DIFF
--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -138,4 +138,4 @@ EXPOSE 26050
 USER 10001:0
 # We are using CMD and not ENDPOINT so 
 # we can override it when we use this image as agent. 
-CMD ["/usr/bin/supervisord", "start_container"]
+CMD ["/usr/bin/supervisord", "start"]

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -93,7 +93,7 @@ run_agent_container() {
   # Providing an env variable with the name "LOOP_ON_FAIL=true" 
   # will trigger the condition below.
   # Currently we will loop on any exit of the agent_cli 
-  # regurdless to the exit code
+  # regardless to the exit code
   while [ "${LOOP_ON_FAIL}" == "true" ] 
   do
     echo "$(date) Failed to run agent_cli" 

--- a/src/deploy/NVA_build/supervisord.orig
+++ b/src/deploy/NVA_build/supervisord.orig
@@ -6,20 +6,19 @@ PIDFILE="/var/log/supervisord.pid"
 # chkconfig: 345 15 15
 
 start() {
-    #run noobaa_init script before start
+    #Run noobaa_init script before start
     local path="/root/node_modules/noobaa-core/src/deploy/NVA_build/"
     if [ "${container}" == "docker" ]
     then
         path="/noobaa_init_files/"
     fi
     ${path}/noobaa_init.sh
-    # abort pod start if noobaa_init fails
+    #Abort pod start if noobaa_init fails
     rc=$?
     if [ ${rc} -ne 0 ]; then
         echo "noobaa_init failed with exit code ${rc}. aborting"
         exit ${rc}
     fi
-
 
     if [ ! -x "$SUPERVISORD" ]; then
         echo "$SUPERVISORD is not executable."
@@ -28,11 +27,7 @@ start() {
     fi
     echo "Starting ..."
     logger -p local0.info -t Superd "Starting ..."
-    if [ $1 == "container" ]; then
-        ulimit -n 102400; $SUPERVISORD --pidfile $PIDFILE -n
-    else
-        ulimit -n 102400; $SUPERVISORD --pidfile $PIDFILE
-    fi
+    ulimit -n 102400; $SUPERVISORD --pidfile $PIDFILE -n
 
     return $?
 }
@@ -73,26 +68,15 @@ stop() {
     local p=$(cat $PIDFILE)
     kill -9 ${p}
     [ $? -eq 0 ] && rm -f $PIDFILE
-    return $retval
+    return
 }
 
 case $1 in
-    start)
-        start
-    ;;
-    start_container)
-        start container
-    ;;
-    stop)
-        stop
-    ;;
-    restart)
-        stop
-        sleep 1
-        start
-    ;;
-    *)
-        echo "$0 start|stop|restart"
-        exit 2
-    ;;
+    start)      start;;
+    stop)       stop;;
+    restart)    stop
+                sleep 1
+                start;;
+    *)          echo "$0 start|stop|restart"
+                exit 2;;
 esac


### PR DESCRIPTION
### Explain the changes

- We don't need start and start_container on supervisord.orig as we are supporting only containers.