### PR TITLE
small fixes of errors from perf test logs

### DIFF
--- a/src/server/object_services/map_db_types.js
+++ b/src/server/object_services/map_db_types.js
@@ -77,7 +77,7 @@ class ChunkDB {
         return this.__frag_by_index;
     }
     get parts() {
-        if (!this.__parts) this.__parts = this.chunk_db.parts.map(new_part_db);
+        if (!this.__parts) this.__parts = this.chunk_db.parts ? this.chunk_db.parts.map(new_part_db) : [];
         return this.__parts;
     }
 

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1124,7 +1124,7 @@ class MDStore {
         const parts_by_chunk = _.groupBy(parts, 'chunk');
         const objects_by_id = _.keyBy(objects, '_id');
         for (const chunk of chunks) {
-            chunk.parts = parts_by_chunk[chunk._id.toHexString()];
+            chunk.parts = parts_by_chunk[chunk._id.toHexString()] || [];
             chunk.objects = _.uniq(_.compact(_.map(chunk.parts, part => objects_by_id[part.obj.toHexString()])));
         }
     }
@@ -1543,7 +1543,7 @@ class MDStore {
         for (const chunk of chunks) {
             const blocks_by_frag = _.groupBy(blocks_by_chunk[chunk._id.toHexString()], 'frag');
             for (const frag of chunk.frags) {
-                const frag_blocks = blocks_by_frag[frag._id.toHexString()];
+                const frag_blocks = blocks_by_frag[frag._id.toHexString()] || [];
                 frag.blocks = sorter ? frag_blocks.sort(sorter) : frag_blocks;
             }
         }


### PR DESCRIPTION
### Explain the changes
1. fixes for two recurring errors in the performance server logs: 
```Sep 14 00:27:50 noobaa-core-0 node: [Endpoint/96597] [ERROR] CONSOLE:: RPC._on_request: ERROR srv object_api.read_object_mapping reqid 1994@fcall://fcall(aub4fgk) connid fcall://fcall(aub4fgk) TypeError: Cannot read property 'sort' of undefined    at MDStore.load_blocks_for_chunks (/root/node_modules/noobaa-core/src/server/object_services/md_store.js:1547:52) ```
and
```Sep 14 00:09:54 noobaa-core-0 node: [BGWorkers/6968] [ERROR] core.server.object_services.map_builder:: failed to load chunk 5d7754656e18fcb3f44dd974 for builder TypeError: Cannot read property 'map' of undefined    at ChunkDB.get parts [as parts] (/root/node_modules/noobaa-core/src/server/object_services/map_db_types.js:80:63)    at P.map (/root/node_modules/noobaa-core/src/server/object_services/map_builder.js:132:28)```

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
