### PR TITLE
Running Stats Aggregator BG immediately

### DIFF
--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -95,6 +95,7 @@ function run_master_workers() {
         register_bg_worker({
             name: 'system_server_stats_aggregator',
             delay: config.central_stats.partial_send_time_cycle,
+            run_immediate: true
         }, stats_aggregator.background_worker);
     }
 


### PR DESCRIPTION
### Explain the changes
1. Changing the bg_worker to initiate the run of stats aggregator bg worker immediately on startup.
This will allow the metrics to be delivered as fast as possible without waiting the cycle time.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
