### PR TITLE
read_system - major performance improvements

### DIFF
--- a/src/server/node_services/nodes_aggregator.js
+++ b/src/server/node_services/nodes_aggregator.js
@@ -1,76 +1,80 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const P = require('../../util/promise');
+const _ = require('lodash');
 // const dbg = require('../../util/debug_module')(__filename);
 const mapper = require('../object_services/mapper');
 const size_utils = require('../../util/size_utils');
 const server_rpc = require('../server_rpc');
-const auth_server = require('../common_services/auth_server');
 const system_store = require('../system_services/system_store').get_instance();
 
 const { BigInteger } = size_utils;
 
-function aggregate_data_free_by_tier(req) {
-    let available_by_tiers = [];
+async function aggregate_data_free_by_tier(req) {
+    const tiers = [];
+    const pool_set = new Set();
 
-    return P.each(req.rpc_params.tier_ids, tier_id => _aggregate_data_free_for_tier(tier_id, req.system)
-            .then(available_storage => {
-                available_by_tiers.push({
-                    tier_id: tier_id,
-                    mirrors_storage: available_storage
-                });
-            })
-            .catch(err => {
+    for (const tier_id of req.rpc_params.tier_ids) {
+        const tier = system_store.data.get_by_id(tier_id);
+        if (!tier) {
+            continue;
+        }
+
+        tiers.push(tier);
+        for (const mirror of tier.mirrors) {
+            for (const pool of mirror.spread_pools) {
+                pool_set.add(String(pool.name));
+            }
+        }
+    }
+
+    const { nodes } = await server_rpc.client.node.list_nodes({
+        query: {
+            pools: [...pool_set],
+        },
+    }, {
+        auth_token: req.auth_token
+    });
+
+    const nodes_by_pool = _.groupBy(nodes, node => node.pool);
+    return Promise.all(
+        tiers.map(async tier => {
+            const tier_id = String(tier._id);
+            try {
+                const mirrors_storage = await _aggregate_data_free_for_tier(tier, nodes_by_pool);
+                return { tier_id, mirrors_storage };
+
+            } catch (err) {
                 console.error(`Error getting available to upload of tier: ${tier_id}`, err);
-            }))
-        .return(available_by_tiers);
+            }
+        })
+    );
 }
 
-
-function _aggregate_data_free_for_tier(tier_id, system) {
-    const mirror_available_storage = [];
-    const tier = system_store.data.get_by_id(tier_id);
-
-    if (!tier) {
-        const err = new Error(`Tier ${tier_id} was not found`);
-        console.error(err);
-        return P.reject(err);
-    }
+function _aggregate_data_free_for_tier(tier, nodes_by_pool) {
     const num_blocks_per_chunk = mapper.get_num_blocks_per_chunk(tier);
+    return tier.mirrors.map(({ spread_pools }) => {
+        const nodes = _.flatMap(spread_pools, pool => nodes_by_pool[pool.name] || []);
+        let redundant_free = BigInteger.zero;
+        const spread_free = [];
+        for (const node of nodes) {
+            const node_free = size_utils.json_to_bigint(node.storage.free || 0);
+            if (!node_free.greater(BigInteger.zero)) continue;
+            if (node.is_cloud_node || node.is_mongo_node) {
+                redundant_free = redundant_free.plus(node_free);
+            } else {
+                spread_free.push(node_free);
+            }
+        }
+        const regular_free = _calculate_spread_free(spread_free, num_blocks_per_chunk);
+        const free = regular_free.plus(redundant_free);
 
-    return P.each(tier.mirrors, mirror_object => server_rpc.client.node.list_nodes({
-                query: {
-                    pools: mirror_object.spread_pools.map(pool => pool.name) || undefined,
-                },
-            }, {
-                auth_token: auth_server.make_auth_token({
-                    system_id: system._id,
-                    role: 'admin'
-                })
-            })
-            .then(res_nodes => {
-                let redundant_free = BigInteger.zero;
-                const spread_free = [];
-                for (let i = 0; i < res_nodes.nodes.length; ++i) {
-                    const node = res_nodes.nodes[i];
-                    const node_free = size_utils.json_to_bigint(node.storage.free || 0);
-                    if (!node_free.greater(BigInteger.zero)) continue;
-                    if (node.is_cloud_node || node.is_mongo_node) {
-                        redundant_free = redundant_free.plus(node_free);
-                    } else {
-                        spread_free.push(node_free);
-                    }
-                }
-                let regular_free = _calculate_spread_free(spread_free, num_blocks_per_chunk);
-                let free = regular_free.plus(redundant_free);
-                mirror_available_storage.push({
-                    free: size_utils.bigint_to_json(free),
-                    redundant_free: size_utils.bigint_to_json(redundant_free),
-                    regular_free: size_utils.bigint_to_json(regular_free),
-                });
-            }))
-        .return(mirror_available_storage);
+        return {
+            free: size_utils.bigint_to_json(free),
+            redundant_free: size_utils.bigint_to_json(redundant_free),
+            regular_free: size_utils.bigint_to_json(regular_free),
+        };
+    });
 }
 
 

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -403,7 +403,7 @@ class MDStore {
 
     /**
      * TODO define indexes used by find_objects()
-     * 
+     *
      * @typedef {Object} FindObjectsParams
      * @property {nb.ID} bucket_id
      * @property {string|RegExp} key
@@ -416,11 +416,11 @@ class MDStore {
      * @property {string} [sort]
      * @property {1|-1} [order]
      * @property {boolean} [pagination]
-     * 
+     *
      * @typedef {Object} FindObjectsReply
      * @property {nb.ObjectMD[]} objects
      * @property {{ non_paginated: Object, by_mode: Object }} counters
-     * 
+     *
      * @param {FindObjectsParams} params
      * @returns {Promise<FindObjectsReply>}
      */
@@ -729,6 +729,19 @@ class MDStore {
             sort: { bucket: 1, key: 1, version_seq: -1 },
         });
         return Boolean(obj);
+    }
+
+    async all_buckets_with_completed_objects() {
+        return this._objects.col().distinct('bucket', {
+            // prefix for stored blob blocks information. TODO: move somwhere like config.js
+            key: { $not: /^\.noobaa_blob_blocks/ },
+            // partialFilterExpression:
+            deleted: null,
+            upload_started: null,
+        }, {
+            hint: 'version_seq_index',
+            sort: { bucket: 1 }
+        });
     }
 
     async count_objects_of_bucket(bucket_id) {
@@ -1070,7 +1083,7 @@ class MDStore {
     }
 
     /**
-     * @param {nb.ID[]} chunk_ids 
+     * @param {nb.ID[]} chunk_ids
      * @returns {Promise<nb.ID[]>}
      */
     async find_parts_unreferenced_chunk_ids(chunk_ids) {
@@ -1108,7 +1121,7 @@ class MDStore {
     }
 
     /**
-     * @param {nb.ChunkSchemaDB[]} chunks 
+     * @param {nb.ChunkSchemaDB[]} chunks
      */
     async load_parts_objects_for_chunks(chunks) {
         if (!chunks || !chunks.length) return;
@@ -1354,7 +1367,7 @@ class MDStore {
     }
 
     /**
-     * @param {nb.ID[]} chunk_ids 
+     * @param {nb.ID[]} chunk_ids
      */
     async delete_chunks_by_ids(chunk_ids) {
         const delete_date = new Date();
@@ -1606,7 +1619,7 @@ class MDStore {
     }
 
     /**
-     * @param {nb.ID[]} block_ids 
+     * @param {nb.ID[]} block_ids
      */
     async delete_blocks_by_ids(block_ids) {
         const delete_date = new Date();
@@ -1774,7 +1787,7 @@ function sort_list_uploads_with_delimiter(a, b) {
 }
 
 /**
- * @param {string} id_str 
+ * @param {string} id_str
  * @returns {nb.ID}
  */
 function make_md_id(id_str) {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1582,11 +1582,15 @@ function can_delete_bucket(system, bucket) {
         });
 }
 
+async function list_undeletable_buckets() {
+    return MDStore.instance().all_buckets_with_completed_objects();
+}
 
 // EXPORTS
 exports.new_bucket_defaults = new_bucket_defaults;
 exports.get_bucket_info = get_bucket_info;
 exports.can_delete_bucket = can_delete_bucket;
+exports.list_undeletable_buckets = list_undeletable_buckets;
 //Bucket Management
 exports.create_bucket = create_bucket;
 exports.read_bucket = read_bucket;


### PR DESCRIPTION
### Explain the changes
Bring down read_system from ~12,000ms to ~700ms (5k bukcets)

List of changes (for N buckets):
- Change the way we check if buckets can be deleted - replace N queries to mongo with only 1 (see md_sotre.js, bucket_server.js)

- Replace the calls to refresh_teriing_allocation for each bucket in read_system with a new refresh_system_alloc for the whole system at once (see node_allocator.js)
1. Allow us to reduce the number of calls to  refresh_pool_alloc to 1 per pool instead of 1 per bucket who uses a pool (up to N times for the same pool)
2. Allow us to call aggregate_data_free_by_tier RPC call for all relevant tiers at once instead of 1 RPC call per bucket (up to N buckets)

- Change the implementation of aggregate_data_free_by_tier to list all relevant nodes in advance instead of per tier reducing the number of list_node RPC calls from N to 1 (see node_aggregator.js)


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
