### PR TITLE
fix race condition between endpoint process creation\deletion in agent.js

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -211,7 +211,8 @@ function handle_server_error(err) {
         process.send({
             code: 'SRV_ERROR',
             err_code: err.code,
-            err_msg: err.message
+            err_msg: err.message,
+            pid: process.pid,
         });
     } else {
         process.exit(1);


### PR DESCRIPTION
### Explain the changes
1. on process exit - only clear `this.endpoint_info.s3rver_process ` if the pid of the terminated process matches the current one
2. validate `this.endpoint_info.s3rver_process !== null` before sending messages to `s3rver_process`
3. on server error - kill process only if pid matches

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5800 

### Testing Instructions:
1. 
