### PR TITLE
Upgrading  NooBaa from centos7 to centos8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
 
     rules: {
 
-         //////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////
         //                                                                  //
         // TODO FIX                                                         //
         //                                                                  //
@@ -110,8 +110,8 @@ module.exports = {
 
         'no-trailing-spaces': ['error', { ignoreComments: true }],
 
-        // do not allow code using varibles before they are defined and initialized,
-        // but ok for functions since function declerations are loaded before the code runs
+        // do not allow code using variables before they are defined and initialized,
+        // but ok for functions since function decelerations are loaded before the code runs
         'no-use-before-define': ['error', 'nofunc'],
 
         // break lines after operators, not before
@@ -148,7 +148,7 @@ module.exports = {
 
         'arrow-body-style': ['error', 'as-needed'],
 
-        // prefer to use function decleration (function foo() {})
+        // prefer to use function deceleration (function foo() {})
         // instead of expression (foo = function() {})
         'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
 
@@ -187,7 +187,7 @@ module.exports = {
         // This is not a relevant rule, we added it after the signature_utils query parsing errors
         'no-div-regex': 'off',
 
-        //not forcing u. as part of a uniocode regexp handling
+        //not forcing u. as part of a unicode regexp handling
         'require-unicode-regexp': 'off',
 
         'capitalized-comments': 'off',
@@ -315,7 +315,7 @@ module.exports = {
         'prefer-reflect': 'off',
         'prefer-rest-params': 'off',
 
-        // prefer using string template over string concatnation, but too much to fix
+        // prefer using string template over string concatenation, but too much to fix
         'prefer-template': 'off',
 
         // prefer using single quotes, but too much to fix
@@ -329,7 +329,7 @@ module.exports = {
         // don't verify the structure of jsdoc comments. let them be for now.
         'valid-jsdoc': ['off', { requireReturn: false }],
 
-        // accept var decleration in mid function, since we already check used before defined
+        // accept var deceleration in mid function, since we already check used before defined
         'vars-on-top': 'off',
 
         // Allow await in the body of loops.

--- a/Makefile
+++ b/Makefile
@@ -20,28 +20,28 @@ endif
 export
 
 all: tester noobaa
-	@echo "\033[1;34mAll done.\033[0m"
+	@echo "\033[1;32mAll done.\033[0m"
 .PHONY: all
 
 builder:
 	@echo "\033[1;34mStarting Builder docker build.\033[0m"
 	docker build -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder . $(REDIRECT_STDOUT)
 	docker tag noobaa-builder $(BUILDER_TAG)
-	@echo "\033[1;34mBuilder done.\033[0m"
+	@echo "\033[1;32mBuilder done.\033[0m"
 .PHONY: builder
 
 base: builder
 	@echo "\033[1;34mStarting Base docker build.\033[0m"
 	docker build -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
 	docker tag noobaa-base $(NOOBAA_BASE_TAG)
-	@echo "\033[1;34mBase done.\033[0m"
+	@echo "\033[1;32mBase done.\033[0m"
 .PHONY: base
 
 tester: base noobaa
 	@echo "\033[1;34mStarting Tester docker build.\033[0m"
 	docker build -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
 	docker tag noobaa-tester $(TESTER_TAG)
-	@echo "\033[1;34mTester done.\033[0m"
+	@echo "\033[1;32mTester done.\033[0m"
 .PHONY: tester
 
 test: tester
@@ -56,7 +56,7 @@ noobaa: base
 	@echo "\033[1;34mStarting NooBaa docker build.\033[0m"
 	docker build -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	docker tag noobaa $(NOOBAA_TAG)
-	@echo "\033[1;34mNooBaa done.\033[0m"
+	@echo "\033[1;32mNooBaa done.\033[0m"
 .PHONY: noobaa
 
 clean:

--- a/src/deploy/NVA_build/Attributes.Dockerfile
+++ b/src/deploy/NVA_build/Attributes.Dockerfile
@@ -9,8 +9,7 @@ RUN npm run clean && \
     npm cache clean --force
 
 COPY ./package*.json ./
-RUN source /opt/rh/devtoolset-7/enable && \
-    npm install
+RUN npm install
 
 RUN tar -zcf build_deps.tar.gz /root/.npm/ /root/.node-gyp
 
@@ -29,8 +28,7 @@ COPY ./src/rpc/ ./src/rpc/
 COPY ./src/api/ ./src/api/
 COPY ./src/util/ ./src/util/
 COPY ./config.js ./
-RUN source /opt/rh/devtoolset-7/enable && \
-    npm run build:fe
+RUN npm run build:fe
 
 FROM code 
 

--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -7,8 +7,7 @@ FROM noobaa-builder
 #   Cache: Rebuild when there is new package.json or package-lock.json
 ######################################################################
 COPY ./package*.json ./
-RUN source /opt/rh/devtoolset-7/enable && \
-    npm install --production && \
+RUN npm install --production && \
     npm cache clean --force
 
 ##############################################################
@@ -20,8 +19,7 @@ RUN source /opt/rh/devtoolset-7/enable && \
 ##############################################################
 COPY ./binding.gyp .
 COPY ./src/native ./src/native/
-RUN source /opt/rh/devtoolset-7/enable && \
-    npm run build:native
+RUN npm run build:native
 
 ######################################################################
 # Layers:
@@ -56,5 +54,4 @@ COPY ./src/rpc/ ./src/rpc/
 COPY ./src/api/ ./src/api/
 COPY ./src/util/ ./src/util/
 COPY ./config.js ./
-RUN source /opt/rh/devtoolset-7/enable && \
-    npm run build:fe
+RUN npm run build:fe

--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -39,7 +39,7 @@ RUN tar \
 #   Cache: Rebuild when any layer is changing
 ##############################################################
 
-FROM centos:7
+FROM centos:8
 
 ENV container docker
 ENV PORT 8080
@@ -57,18 +57,19 @@ ENV ENDPOINT_NODE_OPTIONS ''
 #   Size: ~ 379 MB
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
-RUN yum install -y -q bash \
+# RUN dnf install -y -q bash \
+RUN dnf install -y -q bash \
     lsof \
     openssl \
-    rsyslog-8.24.0 \
+    rsyslog-8.37.0 \
     strace \
     wget \
     curl \
     nc \
     less \
     bash-completion \
-    python-setuptools-0.9.8 && \
-    yum clean all
+    python2-setuptools && \
+    dnf clean all
 
 ##############################################################
 # Layers:

--- a/src/deploy/NVA_build/Tests.Dockerfile
+++ b/src/deploy/NVA_build/Tests.Dockerfile
@@ -13,11 +13,20 @@ ENV TEST_CONTAINER true
 ##############################################################
 
 # python-virtualenv python-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel -- these are required by ceph tests
-RUN yum install -y -q ntpdate vim centos-release-scl && \
-    yum install -y -q rh-mongodb36 && \
-    yum install -y -q python-virtualenv python-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel && \
-    yum install -y -q git && \
-    yum clean all
+# RUN dnf install -y ntpdate vim && \
+COPY ./src/deploy/NVA_build/set_mongo_repo.sh /tmp/
+RUN chmod +x /tmp/set_mongo_repo.sh && \
+    /bin/bash -xc "/tmp/set_mongo_repo.sh"
+
+RUN dnf install -y -q vim \
+    mongodb-org-3.6.3 \
+    mongodb-org-server-3.6.3 \
+    mongodb-org-shell-3.6.3 \
+    mongodb-org-mongos-3.6.3 \
+    mongodb-org-tools-3.6.3 \
+    which python2-virtualenv python2-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel \
+    git && \
+    dnf clean all
 
 ##############################################################
 # Layers:

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7 
+FROM centos:8 
 LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 
 ##############################################################
@@ -8,12 +8,12 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
 ENV container docker
-RUN yum install -y -q wget unzip which vim centos-release-scl && \
-    yum group install -y -q "Development Tools" && \ 
-    yum install -y -q devtoolset-7 && \
-    yum clean all
-RUN source /opt/rh/devtoolset-7/enable && \
-    version="1.3.0" && \
+RUN dnf install -y -q wget unzip which vim && \
+    dnf group install -y -q "Development Tools" && \
+    dnf install -y -q python2 && \
+    dnf clean all
+RUN alternatives --set python /usr/bin/python2
+RUN version="1.3.0" && \
     wget -q -O yasm-${version}.tar.gz https://github.com/yasm/yasm/archive/v${version}.tar.gz && \
     tar -xf yasm-${version}.tar.gz && \
     pushd yasm-${version} && \

--- a/src/deploy/NVA_build/set_mongo_repo.sh
+++ b/src/deploy/NVA_build/set_mongo_repo.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
+
+function config_mongo_repo {
+    # create a Mongo 3.6 Repo file
+    cat > /etc/yum.repos.d/mongodb-org-3.6.repo << EOF
+[mongodb-org-3.6]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/7Server/mongodb-org/3.6/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc
+EOF
+
+}
+
+config_mongo_repo

--- a/src/deploy/NVA_build/setup_platform.sh
+++ b/src/deploy/NVA_build/setup_platform.sh
@@ -22,7 +22,7 @@ function install_supervisor {
     then
         deploy_log install_supervisor start
         # easy_install is for Supervisord and comes from python-setuptools
-        easy_install supervisor
+        /usr/bin/easy_install-2 supervisor
 	    deploy_log install_supervisor done
     fi
 

--- a/src/test/system_tests/ceph_s3_tests_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests_deploy.sh
@@ -14,7 +14,7 @@ DIRECTORY="s3-tests"
 CEPH_LINK="https://github.com/ceph/s3-tests.git"
 # using a fixed version (commit) of ceph tests to avoid sudden changes. 
 # we should retest and update the version once in a while
-CEPH_TESTS_VERSION=5a67bab487504e35cb9c34648952df63d57f77a7 
+CEPH_TESTS_VERSION=6b553efbe16a7f74acdedc13ab2cae3b5949b6e8
 if [ ! -d $DIRECTORY ]; then
     echo "Downloading Ceph S3 Tests..."
     git clone $CEPH_LINK

--- a/src/test/unit_tests/run_npm_test_on_test_container.sh
+++ b/src/test/unit_tests/run_npm_test_on_test_container.sh
@@ -16,7 +16,6 @@ function cleanup() {
 }
 
 function start_mongo() {
-    source /opt/rh/rh-mongodb36/enable
     mkdir -p /data/db
     echo "$(date) starting mongod"
     mongod --logpath /dev/null &


### PR DESCRIPTION
## Upgrading  NooBaa from centos7 to centos8

- Added .eslintignore for skipping running eslint on the ceph tests directory
- Added set_mongo_repo.sh for adding a mongo 3.6 yum repo

builder.Dockerfile:
- Change  centos:7 to centos:8
- Removed the centos-release-scl
- Removed the devtoolset-7 and it's calls
- Replaced the yum with dnf
- Setting alternatives python

Base.Dockerfile:
- Remove the use of devtoolset-7

NooBaa.Dockerfile:
- Change  centos:7 to centos:8
- Removed the use of devtoolset-7
- Update rsyslog from 8.24.0 to 8.37.0
- Update python-setuptools to python2-setuptools

Tests.Dockerfile:
- Removed centos-release-scl
- Copying the set_mongo_repo.sh and .eslintignore into the container
- Installing the mongo from the added yum repo
- Updated the ceph test pre-requirements.
- Using dnf instead of yum

Attributes.Dockerfile:
- Removed the calls for devtoolset-7

setup_platform.sh:
- Calling easy_install-2 instead of easy_install

.eslintrc.js:
- Fix typos

Makefile:
- Painting the "done" message in green now.

run_npm_test_on_test_container.sh:
- Removed unneccessery call for enabling the mongo
