### PR TITLE
in retrieve_public_ip (net_utils.js) - verifying that the returned value is an ip

### DIFF
--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -91,6 +91,9 @@ async function retrieve_public_ip() {
         const res = await P.fromCallback(callback =>
             request.get('http://api.ipify.org/', callback)
         );
+        if (!is_ip(res.body)) {
+            return undefined;
+        }
         return res.body;
     } catch (err) {
         return undefined;


### PR DESCRIPTION
### Explain the changes
1. verifying that the returned value in retrieve_public_ip is an IP

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5815 

### Testing Instructions:
1. 
