### PR TITLE
Fix unit test infrastructure, and unref blocking loops in the code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "5.2.5",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7047,6 +7047,11 @@
       "requires": {
         "async-limiter": "^1.0.0"
       }
+    },
+    "wtfnode": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.0.tgz",
+      "integrity": "sha512-A5jm/0REykxUac1q4Q5kv+hDIiacvqVpwIoXzCQcRL7syeEKucVVOxyLLrt+jIiZoXfla3lnsxUw/cmWXIaGWA=="
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "istanbul-lib-report": "2.0.8",
     "istanbul-reports": "2.2.6",
     "mocha": "6.2.0",
-    "nyc": "14.1.1"
+    "nyc": "14.1.1",
+    "wtfnode": "0.8.0"
   }
 }

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -3,82 +3,77 @@
 'use strict';
 
 
-if (process.env.TESTS_SUITE === 'WITHOUT_POOL' || !process.env.TESTS_SUITE) {
-    // setup coretest first to prepare the env
-    const coretest = require('./coretest');
-    coretest.setup({
-        incomplete_rpc_coverage: 'show',
-        pools_to_create: []
-    });
+const coretest = require('./coretest');
+coretest.setup({ incomplete_rpc_coverage: 'show' });
 
-    // UTILS
-    require('./test_job_queue');
-    require('./test_linked_list');
-    require('./test_keys_lock');
-    require('./test_lru');
-    require('./test_prefetch');
-    require('./test_promise_utils');
-    require('./test_rpc');
-    require('./test_semaphore');
-    require('./test_fs_utils');
-    require('./test_signature_utils');
-    require('./test_http_utils');
-    require('./test_v8_optimizations');
-    require('./test_ssl_utils');
-    require('./test_zip_utils');
-    require('./test_wait_queue');
-    require('./test_kmeans');
-    require('./test_sensitive_wrapper');
-    // require('./test_debug_module');
+// ---------------------------------------
+// Tests that does not require hosts pools
+// ---------------------------------------
 
-    // STORES
-    require('./test_md_store');
-    require('./test_nodes_store');
-    require('./test_system_store');
+// UTILS
+require('./test_job_queue');
+require('./test_linked_list');
+require('./test_keys_lock');
+require('./test_lru');
+require('./test_prefetch');
+require('./test_promise_utils');
+require('./test_rpc');
+require('./test_semaphore');
+require('./test_fs_utils');
+require('./test_signature_utils');
+require('./test_http_utils');
+require('./test_v8_optimizations');
+// require('./test_ssl_utils');
+require('./test_zip_utils');
+require('./test_wait_queue');
+require('./test_kmeans');
+require('./test_sensitive_wrapper');
+// require('./test_debug_module');
 
+// // STORES
+require('./test_md_store');
+require('./test_nodes_store');
+require('./test_system_store');
 
 
-    // CORE
-    // require('./test_mapper');
-    // require('./test_map_client');
-    //require('./test_map_reader');
-    require('./test_map_builder');
-    require('./test_map_deleter');
-    require('./test_chunk_coder');
-    require('./test_chunk_splitter');
-    require('./test_chunk_config_utils');
-    //require('./test_md_aggregator_unit');
-    require('./test_agent_blocks_verifier');
-    require('./test_s3_list_objects');
-    require('./test_nb_native_b64');
-    require('./test_bucket_chunks_builder');
-    require('./test_mirror_writer');
+// // CORE
+// require('./test_mapper');
+// require('./test_map_client');
+//require('./test_map_reader');
+require('./test_map_builder');
+require('./test_map_deleter');
+require('./test_chunk_coder');
+require('./test_chunk_splitter');
+require('./test_chunk_config_utils');
+//require('./test_md_aggregator_unit');
+require('./test_agent_blocks_verifier');
+require('./test_s3_list_objects');
+require('./test_nb_native_b64');
+require('./test_bucket_chunks_builder');
+require('./test_mirror_writer');
 
-    // SERVERS
-    require('./test_agent');
-    require('./test_system_servers');
+// // SERVERS
+require('./test_agent');
 
-    coretest.setup_pools(coretest.POOL_LIST);
-}
-if (process.env.TESTS_SUITE === 'WITH_POOL' || !process.env.TESTS_SUITE) {
-    // Tests that require pools
-    // setup coretest first to prepare the env
-    const coretest = require('./coretest');
-    coretest.setup({
-        incomplete_rpc_coverage: 'show',
-        pools_to_create: coretest.POOL_LIST
-    });
+// ------------------------------------
+// A test that initialize the pool list
+// ------------------------------------
+require('./test_system_servers');
 
-    // SERVERS
-    require('./test_host_server');
-    require('./test_node_server');
+// ------------------------------
+// Tests that require hosts pools
+// ------------------------------
 
-    // CORE
-    require('./test_map_reader'); /////////////
-    require('./test_object_io');
-    require('./test_agent_blocks_reclaimer');
-    require('./test_s3_ops');
-    require('./test_s3_encryption');
-    require('./test_node_allocator');
-    // require('./test_tiering_upload');
-}
+// SERVERS
+require('./test_host_server');
+require('./test_node_server');
+
+// CORE
+require('./test_map_reader'); /////////////
+require('./test_object_io');
+require('./test_agent_blocks_reclaimer');
+require('./test_s3_ops');
+require('./test_s3_encryption');
+require('./test_node_allocator');
+// require('./test_tiering_upload');
+

--- a/src/test/unit_tests/test_agent_blocks_verifier.js
+++ b/src/test/unit_tests/test_agent_blocks_verifier.js
@@ -5,7 +5,7 @@
 
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
-coretest.setup({ pools_to_create: [coretest.POOL_LIST[0]] });
+coretest.setup();
 
 const _ = require('lodash');
 const mocha = require('mocha');
@@ -19,12 +19,12 @@ const { ChunkDB, BlockDB } = require('../../server/object_services/map_db_types'
 
 class VerifierMock extends AgentBlocksVerifier {
     /**
-     * 
-     * @param {nb.BlockSchemaDB[]} blocks 
-     * @param {nb.NodeAPI[]} nodes 
-     * @param {nb.ChunkSchemaDB[]} chunks 
-     * @param {nb.Pool[]} pools 
-     * @param {string} test_suffix 
+     *
+     * @param {nb.BlockSchemaDB[]} blocks
+     * @param {nb.NodeAPI[]} nodes
+     * @param {nb.ChunkSchemaDB[]} chunks
+     * @param {nb.Pool[]} pools
+     * @param {string} test_suffix
      */
     constructor(blocks = [], nodes = [], chunks = [], pools = [], test_suffix = '') {
         super(`VerifierMock-${test_suffix}`);
@@ -38,10 +38,10 @@ class VerifierMock extends AgentBlocksVerifier {
     }
 
     /**
-     * 
-     * @param {nb.ID} marker 
-     * @param {number} limit 
-     * @param {boolean} deleted_only 
+     *
+     * @param {nb.ID} marker
+     * @param {number} limit
+     * @param {boolean} deleted_only
      * @returns {Promise<nb.BlockSchemaDB[]>}
      */
     async iterate_all_blocks(marker, limit, deleted_only) {
@@ -58,8 +58,8 @@ class VerifierMock extends AgentBlocksVerifier {
     }
 
     /**
-     * 
-     * @param {nb.BlockSchemaDB[]} blocks 
+     *
+     * @param {nb.BlockSchemaDB[]} blocks
      * @returns {Promise<nb.Block[]>}
      */
     async populate_and_prepare_for_blocks(blocks) {
@@ -201,9 +201,9 @@ mocha.describe('mocked agent_blocks_verifier', function() {
     });
 
     /**
-     * 
-     * @param {nb.ID} frag_id 
-     * @param {nb.ID} chunk_id 
+     *
+     * @param {nb.ID} frag_id
+     * @param {nb.ID} chunk_id
      * @returns {nb.BlockSchemaDB}
      */
     function make_schema_block(frag_id, chunk_id, node_id, pool_id) {
@@ -220,7 +220,7 @@ mocha.describe('mocked agent_blocks_verifier', function() {
     }
 
     /**
-     * 
+     *
      * @returns {nb.FragSchemaDB}
      */
     function make_schema_frag() {
@@ -231,7 +231,7 @@ mocha.describe('mocked agent_blocks_verifier', function() {
     }
 
     /**
-     * 
+     *
      * @returns {nb.ChunkSchemaDB}
      */
     function make_schema_chunk(cc_id, frags) {
@@ -255,10 +255,10 @@ mocha.describe('mocked agent_blocks_verifier', function() {
     }
 
     /**
-     * 
-     * @param {string} node_name 
+     *
+     * @param {string} node_name
      * @param {boolean} offline
-     * @returns {nb.NodeAPI} 
+     * @returns {nb.NodeAPI}
      */
     function make_node(node_name, offline) {
         return {
@@ -285,8 +285,8 @@ mocha.describe('mocked agent_blocks_verifier', function() {
     }
 
     /**
-     * 
-     * @param {string} name 
+     *
+     * @param {string} name
      * @returns {nb.Pool}
      */
     function make_schema_pool(name) {

--- a/src/test/unit_tests/test_map_builder.js
+++ b/src/test/unit_tests/test_map_builder.js
@@ -5,7 +5,7 @@
 
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
-coretest.setup({ pools_to_create: [coretest.POOL_LIST[0]] });
+coretest.setup();
 
 const _ = require('lodash');
 // const util = require('util');
@@ -219,8 +219,8 @@ coretest.describe_mapper_test_case({
     }
 
     /**
-     * 
-     * @param {BuilderObject} obj 
+     *
+     * @param {BuilderObject} obj
      */
     async function assert_fully_built(obj) {
         const chunks = await map_reader.read_object_mapping({ _id: MDStore.instance().make_md_id(obj.obj_id) });

--- a/src/test/unit_tests/test_map_deleter.js
+++ b/src/test/unit_tests/test_map_deleter.js
@@ -3,7 +3,7 @@
 
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
-coretest.setup({ pools_to_create: [coretest.POOL_LIST[0]] });
+coretest.setup();
 
 // const _ = require('lodash');
 // const util = require('util');

--- a/src/test/unit_tests/test_s3_list_objects.js
+++ b/src/test/unit_tests/test_s3_list_objects.js
@@ -4,7 +4,7 @@
 
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
-coretest.setup({ pools_to_create: [coretest.POOL_LIST[0]] });
+coretest.setup();
 
 const _ = require('lodash');
 const util = require('util');

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -80,6 +80,7 @@ mocha.describe('s3_ops', function() {
         const text_file1 = 'text-file1';
         const text_file2 = 'text-file2';
         mocha.before(async function() {
+            this.timeout(10000); // eslint-disable-line no-invalid-this
             if (bucket_type === "regular") {
                 await s3.createBucket({ Bucket: bucket_name }).promise();
             } else if (SKIP_TEST) {

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -4,7 +4,7 @@
 
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
-coretest.setup({ pools_to_create: [] });
+coretest.setup();
 
 const _ = require('lodash');
 const mocha = require('mocha');


### PR DESCRIPTION
### Explain the changes
- Change code requesting hosts_pool.
- Prevent duplicate calls to setup_pools
- Fail tests on dangling handles
- Changed the timeout loop in block_store_client to keep Timer after test code finished.
- Change the way we fix account with an internal pool so it will not create dangling Timers + fix some misbehaved code.
- Remove hosts_pool requests from all tests that do not use host pools.
- Disabled test_ssl_utils and part of test_s3_ops (namespace-bucket-object-ops), to be resolved in another commit


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
