### PR TITLE
Add bucket claim APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3308,12 +3308,12 @@
       }
     },
     "googleapis": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-40.0.0.tgz",
-      "integrity": "sha512-G4iUF6V141mbgbXmbXQDYP0pOYJAONvA8m+RzYfuVBcwfKm7Pn6Aes9LT0a6ddmW9CmydHmHdOgKZuWwkXueXg==",
+      "version": "42.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-42.0.0.tgz",
+      "integrity": "sha512-nQiKPDmzmMusnU8UOibmlC6hsgkm70SjqmLxSlBBb7i0z7/J6UPilSzo9tAMoHA8u3BUw3OXn13+p9YLmBH6Gg==",
       "requires": {
-        "google-auth-library": "^4.0.0",
-        "googleapis-common": "^2.0.0"
+        "google-auth-library": "^5.1.0",
+        "googleapis-common": "^3.0.0"
       },
       "dependencies": {
         "arrify": {
@@ -3333,25 +3333,25 @@
           }
         },
         "gcp-metadata": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.1.tgz",
-          "integrity": "sha512-nrbLj5O1MurvpLC/doFwzdTfKnmYGDYXlY/v7eQ4tJNVIvQXbOK672J9UFbradbtmuTkyHzjpzD8HD0Djz0LWw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.2.tgz",
+          "integrity": "sha512-dxPXBvjyfz5qFEBXzEwNmuZXwsGYfuASGYeg3CKZDaQRXdiWti9J3/Ezmtyon1OrCNpDO2YekyoSjEqMtsrcXw==",
           "requires": {
-            "gaxios": "^2.0.0",
+            "gaxios": "^2.0.1",
             "json-bigint": "^0.3.0"
           }
         },
         "google-auth-library": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-4.2.5.tgz",
-          "integrity": "sha512-Vfsr82M1KTdT0H0wjawwp0LHsT6mPKSolRp21ZpJ7Ydq63zRe8DbGKjRCCrhsRZHg+p17DuuSCMEznwk3CJRdw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.2.0.tgz",
+          "integrity": "sha512-I2726rgOedQ06HgTvoNvBeRCzy5iFe6z3khwj6ugfRd1b0VHwnTYKl/3t2ytOTo7kKc6KivYIBsCIdZf2ep67g==",
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
             "fast-text-encoding": "^1.0.0",
             "gaxios": "^2.0.0",
             "gcp-metadata": "^2.0.0",
-            "gtoken": "^3.0.0",
+            "gtoken": "^4.0.0",
             "jws": "^3.1.5",
             "lru-cache": "^5.0.0"
           }
@@ -3365,9 +3365,9 @@
           }
         },
         "gtoken": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-3.0.2.tgz",
-          "integrity": "sha512-BOBi6Zz31JfxhSHRZBIDdbwIbOPyux10WxJHdx8wz/FMP1zyN1xFrsAWsgcLe5ww5v/OZu/MePUEZAjgJXSauA==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.0.0.tgz",
+          "integrity": "sha512-XaRCfHJxhj06LmnWNBzVTAr85NfAErq0W1oabkdqwbq3uL/QTB1kyvGog361Uu2FMG/8e3115sIy/97Rnd4GjQ==",
           "requires": {
             "gaxios": "^2.0.0",
             "google-p12-pem": "^2.0.0",
@@ -3378,13 +3378,13 @@
       }
     },
     "googleapis-common": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-2.0.3.tgz",
-      "integrity": "sha512-gUObzhe0fnDkDPHsxseXCVt1JB9apaQfTomykGyoRXzvydHqXS0llGzaJnAC4JOvvL+TQDedwx2GETLibMUuUA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-3.1.0.tgz",
+      "integrity": "sha512-abnogPoWqv0cU6O/EFpkerCVsaUsKEG6XpCm4P1YgK44PxIRcGtalDwijqUErkcivM1Xy5MNyf1PDkKTLEjOZA==",
       "requires": {
         "extend": "^3.0.2",
         "gaxios": "^2.0.1",
-        "google-auth-library": "^4.2.0",
+        "google-auth-library": "^5.2.0",
         "qs": "^6.7.0",
         "url-template": "^2.0.8",
         "uuid": "^3.3.2"
@@ -3407,25 +3407,25 @@
           }
         },
         "gcp-metadata": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.1.tgz",
-          "integrity": "sha512-nrbLj5O1MurvpLC/doFwzdTfKnmYGDYXlY/v7eQ4tJNVIvQXbOK672J9UFbradbtmuTkyHzjpzD8HD0Djz0LWw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.2.tgz",
+          "integrity": "sha512-dxPXBvjyfz5qFEBXzEwNmuZXwsGYfuASGYeg3CKZDaQRXdiWti9J3/Ezmtyon1OrCNpDO2YekyoSjEqMtsrcXw==",
           "requires": {
-            "gaxios": "^2.0.0",
+            "gaxios": "^2.0.1",
             "json-bigint": "^0.3.0"
           }
         },
         "google-auth-library": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-4.2.5.tgz",
-          "integrity": "sha512-Vfsr82M1KTdT0H0wjawwp0LHsT6mPKSolRp21ZpJ7Ydq63zRe8DbGKjRCCrhsRZHg+p17DuuSCMEznwk3CJRdw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.2.0.tgz",
+          "integrity": "sha512-I2726rgOedQ06HgTvoNvBeRCzy5iFe6z3khwj6ugfRd1b0VHwnTYKl/3t2ytOTo7kKc6KivYIBsCIdZf2ep67g==",
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
             "fast-text-encoding": "^1.0.0",
             "gaxios": "^2.0.0",
             "gcp-metadata": "^2.0.0",
-            "gtoken": "^3.0.0",
+            "gtoken": "^4.0.0",
             "jws": "^3.1.5",
             "lru-cache": "^5.0.0"
           }
@@ -3439,9 +3439,9 @@
           }
         },
         "gtoken": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-3.0.2.tgz",
-          "integrity": "sha512-BOBi6Zz31JfxhSHRZBIDdbwIbOPyux10WxJHdx8wz/FMP1zyN1xFrsAWsgcLe5ww5v/OZu/MePUEZAjgJXSauA==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.0.0.tgz",
+          "integrity": "sha512-XaRCfHJxhj06LmnWNBzVTAr85NfAErq0W1oabkdqwbq3uL/QTB1kyvGog361Uu2FMG/8e3115sIy/97Rnd4GjQ==",
           "requires": {
             "gaxios": "^2.0.0",
             "google-p12-pem": "^2.0.0",
@@ -3450,9 +3450,9 @@
           }
         },
         "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
+          "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "get-folder-size": "2.0.1",
     "getos": "3.1.1",
     "glob-to-regexp": "0.4.1",
-    "googleapis": "40.0.0",
+    "googleapis": "42.0.0",
     "heapdump": "0.3.14",
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "2.2.2",

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -614,6 +614,7 @@ module.exports = {
                 system: 'admin'
             }
         },
+
         set_bucket_lifecycle_configuration_rules: {
             method: 'PUT',
             params: {
@@ -697,6 +698,7 @@ module.exports = {
                 system: 'admin'
             },
         },
+
         get_bucket_lifecycle_configuration_rules: {
             method: 'GET',
             params: {
@@ -783,6 +785,7 @@ module.exports = {
                 system: 'admin'
             }
         },
+
         add_bucket_lambda_trigger: {
             method: 'PUT',
             params: {
@@ -792,6 +795,7 @@ module.exports = {
                 system: 'admin'
             }
         },
+
         delete_bucket_lambda_trigger: {
             method: 'DELETE',
             required: ['id', 'bucket_name'],
@@ -808,6 +812,7 @@ module.exports = {
                 system: 'admin'
             }
         },
+
         update_bucket_lambda_trigger: {
             method: 'PUT',
             params: {
@@ -817,6 +822,7 @@ module.exports = {
                 system: 'admin'
             }
         },
+
         update_all_buckets_default_pool: {
             method: 'PUT',
             params: {
@@ -832,6 +838,49 @@ module.exports = {
                 system: 'admin'
             }
         },
+
+        claim_bucket: {
+            method: 'PUT',
+            required: ['name', 'tiering', 'email', 'create_bucket', 'namespace'],
+            params: {
+                type: 'object',
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    tiering: { $ref: 'common_api#/definitions/tiering_name' },
+                    email: { $ref: 'common_api#/definitions/email' },
+                    create_bucket: { type: 'boolean' },
+                    bucket_claim: { $ref: '#/definitions/bucket_claim' },
+                },
+            },
+            reply: {
+                type: 'object',
+                required: ['access_keys'],
+                properties: {
+                    access_keys: {
+                        $ref: 'common_api#/definitions/access_keys'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
+        delete_claim: {
+            method: 'PUT',
+            required: ['name', 'email', 'delete_bucket'],
+            params: {
+                type: 'object',
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    email: { $ref: 'common_api#/definitions/email' },
+                    delete_bucket: { type: 'boolean' }
+                },
+            },
+            auth: {
+                system: 'admin'
+            }
+        }
     },
 
     definitions: {


### PR DESCRIPTION
### Explain the changes
1. Instead of the OB/OBC provisioner creating TieringPolicy, Bucket, Account and connecting everything together provide a single API to create a bucket & account as well as delete a claim.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5676

### Testing Instructions:
1. rpc.bucket.claim_bucket
2. rpc.bucket.delete_claim
