### PR TITLE
Fixing some new deepscan issues.

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -212,7 +212,7 @@ function parse_body_tagging_xml(req) {
             value: tag.Value && tag.Value[0]
         };
     });
-    if (!tag_set_map || tag_set_map.length > 10) throw new S3Error(S3Error.InvalidTag);
+    if (tag_set_map.length === 0 || tag_set_map.length > 10) throw new S3Error(S3Error.InvalidTag);
     const tag_map = new Map();
     tag_set_map.forEach(tag => {
         if (!_is_valid_tag_values(tag)) throw new S3Error(S3Error.InvalidTag);

--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -37,10 +37,10 @@ async function background_worker() {
         target_now: now,
         system_store: system_store
     });
-    dbg.log2('DB_CLEANER: md_aggreagator at', new Date(from_time));
+    dbg.log2('DB_CLEANER: md_aggregator at', new Date(from_time));
     if (from_time < last_date_to_remove) {
-        dbg.log0('DB_CLEANER: waiting for md_aggreagator to advance to later than', new Date(last_date_to_remove));
-        return config.DB_CLEANER.CYCLE; // if md_aggreagator is still working on more than 3 month old objects - exit
+        dbg.log0('DB_CLEANER: waiting for md_aggregator to advance to later than', new Date(last_date_to_remove));
+        return config.DB_CLEANER.CYCLE; // if md_aggregator is still working on more than 3 month old objects - exit
     }
     dbg.log0('DB_CLEANER:', 'START');
     await clean_md_store(last_date_to_remove);
@@ -98,7 +98,7 @@ async function clean_nodes_store(last_date_to_remove) {
         },
     };
     const nodes = await nodes_store.find_nodes(query, config.DB_CLEANER.DOCS_LIMIT, { _id: 1, deleted: 1 });
-    const node_ids = await mongo_utils.uniq_ids(nodes, '_id');
+    const node_ids = mongo_utils.uniq_ids(nodes, '_id');
     dbg.log2('DB_CLEANER: list nodes:', node_ids);
     const filtered_nodes = node_ids.filter(node => true); // place holder - should verify the agents are really deleted
     dbg.log2('DB_CLEANER: list nodes with no agents to be removed from DB', filtered_nodes);

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -921,7 +921,7 @@ function _list_limit(limit) {
     limit = _.isUndefined(limit) ? 1000 : limit;
     if (limit < 0) throw new Error('Limit must be a positive Integer');
     // In case that we've received max-keys 0, we should return an empty reply without is_truncated
-    // This is used in order to follow aws spec and bevaiour
+    // This is used in order to follow aws spec and behaviour
     return Math.min(limit, 1000);
 }
 
@@ -1358,7 +1358,7 @@ function check_quota(bucket) {
 async function dispatch_triggers(req) {
     load_bucket(req);
     const triggers_to_run = events_dispatcher.get_triggers_for_event(req.bucket, req.rpc_params.obj, req.rpc_params.event_name);
-    if (!triggers_to_run) return;
+    if (triggers_to_run.length === 0) return;
     setTimeout(() => events_dispatcher.run_bucket_triggers(
         triggers_to_run, req.bucket, req.rpc_params.obj, req.account._id, req.auth_token), 1000);
 }

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -94,7 +94,7 @@ async function load_required_scripts(server_version, container_version) {
         .sort(version_compare);
     dbg.log0(`found the following versions with upgrade scripts which are newer than server version (${server_version}):`, newer_versions);
     // get all scripts under new_versions
-    let upgrade_scripts = await _.flatMap(newer_versions, ver => {
+    let upgrade_scripts = _.flatMap(newer_versions, ver => {
         const full_path = path.join(upgrade_scripts_dir, ver);
         const scripts = fs.readdirSync(full_path);
         return scripts.map(script => path.join(full_path, script));


### PR DESCRIPTION
### Explain the changes
db_cleaner.js:
- Fixed typos
- removed the `await` from mongo_utils.uniq_ids as it returns an array and not promise.

upgrade_manager.js:
- Removing the `await` from the flatMap as it returns an array.

s3_utils.js
- tag_set_map always true becous map will return at list an empty array, replacing with (tag_set_map.length === 0)

object_server.js:
- replaced the condition using (!triggers_to_run) to  (triggers_to_run.length === 0) as triggers_to_run calls _.filter which returns an empty array at most.
- Fixed typos.

