### PR TITLE
added cache for test_store_perf reults to decrease public cloud requests

### DIFF
--- a/src/agent/block_store_services/block_store_azure.js
+++ b/src/agent/block_store_services/block_store_azure.js
@@ -193,6 +193,31 @@ class BlockStoreAzure extends BlockStoreBase {
             }));
     }
 
+    // test cloud service availability and credentials. 
+    // uses delete (sinc it's free) with a dummy object
+    async _test_store_target() {
+        const block_key = this._block_key(`test-delete-non-existing-key-${Date.now()}`);
+        try {
+            await P.fromCallback(callback =>
+                this.blob.deleteBlob(
+                    this.container_name,
+                    block_key,
+                    callback)
+            );
+        } catch (err) {
+            if (err.code !== 'BlobNotFound') {
+                dbg.error('in _test_cloud_service - deleteBlob failed:', err, _.omit(this.cloud_info, 'access_keys'));
+                if (err.code === 'ContainerNotFound') {
+                    throw new RpcError('STORAGE_NOT_EXIST', `s3 bucket ${this.cloud_info.target_bucket} not found. got error ${err}`);
+                } else if (err.code === 'AuthenticationFailed') {
+                    throw new RpcError('AUTH_FAILED', `access denied to the s3 bucket ${this.cloud_info.target_bucket}. got error ${err}`);
+                }
+                dbg.warn(`unexpected error (code=${err.code}) from deleteBlob during test. ignoring..`);
+            }
+        }
+    }
+
+
     _handle_delegator_error(err, usage, op_type) {
         if (usage) {
             if (op_type === 'WRITE') {

--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -235,6 +235,25 @@ class BlockStoreGoogle extends BlockStoreBase {
         };
     }
 
+    // test cloud service availability and credentials. 
+    // uses delete (sinc it's free) with a dummy object
+    async _test_store_target() {
+        const block_key = this._block_key(`test-delete-non-existing-key-${Date.now()}`);
+        try {
+            const file = this.bucket.file(block_key);
+            await file.delete();
+        } catch (err) {
+            if (err.code !== 404) {
+                dbg.error('in _test_cloud_service - delete failed:', err, _.omit(this.cloud_info, 'access_keys'));
+                if (err.code === 403) {
+                    throw new RpcError('AUTH_FAILED', `access denied to the s3 bucket ${this.cloud_info.target_bucket}. got error ${err}`);
+                }
+                dbg.warn(`unexpected error (code=${err.code}) from file.delete during test. ignoring..`);
+            }
+        }
+    }
+
+
 }
 
 // EXPORTS


### PR DESCRIPTION
### Explain the changes
1. `test_store_perf` generated a lot of read\write requests for cloud resources
2. to reduce the number of requests - added a cache layer that stores the test results for 1 hour. 
3. to test the availability of the target, performing a delete operation which is free

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 