### PR TITLE
throttle test_store_perf to once an hour and added test_store_validity

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -171,6 +171,7 @@ class Agent {
             'update_rpc_config',
             'n2n_signal',
             'test_store_perf',
+            'test_store_validity',
             'test_network_perf',
             'test_network_perf_to_peer',
             'collect_diagnostics',
@@ -1046,6 +1047,11 @@ class Agent {
     async test_store_perf(req) {
         if (!this.block_store) return {};
         return this.block_store.test_store_perf(req.rpc_params);
+    }
+
+    async test_store_validity(req) {
+        if (!this.block_store) return;
+        await this.block_store.test_store_validity();
     }
 
     test_network_perf(req) {

--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -401,6 +401,11 @@ class BlockStoreBase {
         return reply;
     }
 
+    async test_store_validity() {
+        // default behavior for test store validity is test_store_perf({count:1})
+        await this.test_store_perf({ count: 1 });
+    }
+
     /**
      * @param {nb.BlockMD} block_md
      */

--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -235,6 +235,22 @@ class BlockStoreGoogle extends BlockStoreBase {
         };
     }
 
+    async test_store_validity() {
+        const block_key = this._block_key(`test-delete-non-existing-key-${Date.now()}`);
+        try {
+            const file = this.bucket.file(block_key);
+            await file.delete();
+        } catch (err) {
+            if (err.code !== 404) {
+                dbg.error('in _test_cloud_service - delete failed:', err, _.omit(this.cloud_info, 'access_keys'));
+                if (err.code === 403) {
+                    throw new RpcError('AUTH_FAILED', `access denied to the s3 bucket ${this.cloud_info.target_bucket}. got error ${err}`);
+                }
+                dbg.warn(`unexpected error (code=${err.code}) from file.delete during test. ignoring..`);
+            }
+        }
+    }
+
 }
 
 // EXPORTS

--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -220,6 +220,27 @@ class BlockStoreS3 extends BlockStoreBase {
         if (res.VersionId) await this._delete_past_versions(this.usage_path);
     }
 
+
+    async test_store_validity() {
+        const block_key = this._block_key(`test-delete-non-existing-key-${Date.now()}`);
+        try {
+            // in s3 there is no error for non-existing object
+            await this.s3cloud.deleteObject({
+                Bucket: this.cloud_info.target_bucket,
+                Key: block_key
+            }).promise();
+        } catch (err) {
+            dbg.error('in _test_cloud_service - deleteObject failed:', err, _.omit(this.cloud_info, 'access_keys'));
+            if (err.code === 'NoSuchBucket') {
+                throw new RpcError('STORAGE_NOT_EXIST', `s3 bucket ${this.cloud_info.target_bucket} not found. got error ${err}`);
+            } else if (err.code === 'AccessDenied') {
+                throw new RpcError('AUTH_FAILED', `access denied to the s3 bucket ${this.cloud_info.target_bucket}. got error ${err}`);
+            }
+            dbg.warn(`unexpected error (code=${err.code}) from deleteObject during test. ignoring..`);
+        }
+    }
+
+
     /**
      * This is used for cleanup in BlockStoreBase.test_store_perf()
      * to keep only the latest versions of the test block.

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -274,6 +274,10 @@ module.exports = {
             }
         },
 
+        test_store_validity: {
+            method: 'POST',
+        },
+
         test_network_perf: {
             method: 'POST',
             params: {


### PR DESCRIPTION
### Explain the changes
1. throttle `test_store_perf` to be performed once an hour
2. perform `test_store_validity` every minute
   * for cloud resources perform `Delete` to test the target storage
   * for other resources performing `test_store_perf` with a count of 1 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
