### PR TITLE
Addition of Kubernetes to pools and removing mongo pools to prometheus metrics

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -341,7 +341,7 @@ module.exports = {
 
         cloud_pool_stats: {
             type: 'object',
-            required: ['pool_count', 'unhealthy_pool_count', 'cloud_pool_count', 'cloud_pool_target', 'unhealthy_cloud_pool_target', 'resources'],
+            required: ['pool_count', 'unhealthy_pool_count', 'cloud_pool_count', 'pool_target', 'unhealthy_pool_target', 'resources'],
             properties: {
                 pool_count: {
                     type: 'integer'
@@ -352,23 +352,25 @@ module.exports = {
                 cloud_pool_count: {
                     type: 'integer'
                 },
-                cloud_pool_target: {
+                pool_target: {
                     type: 'object',
                     properties: {
                         amazon: { type: 'integer' },
                         azure: { type: 'integer' },
                         gcp: { type: 'integer' },
                         s3_comp: { type: 'integer' },
+                        kubernetes: { type: 'integer' },
                         other: { type: 'integer' },
                     }
                 },
-                unhealthy_cloud_pool_target: {
+                unhealthy_pool_target: {
                     type: 'object',
                     properties: {
                         amazon_unhealthy: { type: 'integer' },
                         azure_unhealthy: { type: 'integer' },
                         gcp_unhealthy: { type: 'integer' },
                         s3_comp_unhealthy: { type: 'integer' },
+                        kubernetes_unhealthy: { type: 'integer' },
                         other_unhealthy: { type: 'integer' },
                     }
                 },

--- a/src/server/analytic_services/prometheus_reporting.js
+++ b/src/server/analytic_services/prometheus_reporting.js
@@ -347,22 +347,24 @@ class PrometheusReporting {
 
     set_cloud_types(types) {
         if (!this.enabled()) return;
-        this._metrics.cloud_types.set({ type: 'AWS' }, types.cloud_pool_target.amazon);
-        this._metrics.cloud_types.set({ type: 'Azure' }, types.cloud_pool_target.azure);
-        this._metrics.cloud_types.set({ type: 'GCP' }, types.cloud_pool_target.gcp);
+        this._metrics.cloud_types.set({ type: 'AWS' }, types.pool_target.amazon);
+        this._metrics.cloud_types.set({ type: 'Azure' }, types.pool_target.azure);
+        this._metrics.cloud_types.set({ type: 'GCP' }, types.pool_target.gcp);
+        this._metrics.cloud_types.set({ type: 'Kubernetes' }, types.pool_target.kubernetes);
         // TODO: Fill this up when we will know how to recognize
-        // this._metrics.cloud_types.set({ type: 'Ceph' }, types.cloud_pool_target.ceph);
-        this._metrics.cloud_types.set({ type: 'S3_Compatible' }, types.cloud_pool_target.s3_comp);
+        // this._metrics.cloud_types.set({ type: 'Ceph' }, types.pool_target.ceph);
+        this._metrics.cloud_types.set({ type: 'S3_Compatible' }, types.pool_target.s3_comp);
     }
 
     set_unhealthy_cloud_types(types) {
         if (!this.enabled()) return;
-        this._metrics.unhealthy_cloud_types.set({ type: 'AWS' }, types.unhealthy_cloud_pool_target.amazon_unhealthy);
-        this._metrics.unhealthy_cloud_types.set({ type: 'Azure' }, types.unhealthy_cloud_pool_target.azure_unhealthy);
-        this._metrics.unhealthy_cloud_types.set({ type: 'GCP' }, types.unhealthy_cloud_pool_target.gcp_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'AWS' }, types.unhealthy_pool_target.amazon_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'Azure' }, types.unhealthy_pool_target.azure_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'GCP' }, types.unhealthy_pool_target.gcp_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'Kubernetes' }, types.unhealthy_pool_target.kubernetes_unhealthy);
         // TODO: Fill this up when we will know how to recognize
-        // this._metrics.unhealthy_cloud_types.set({ type: 'Ceph' }, types.unhealthy_cloud_pool_target.ceph_unhealthy);
-        this._metrics.unhealthy_cloud_types.set({ type: 'S3_Compatible' }, types.unhealthy_cloud_pool_target.s3_comp_unhealthy);
+        // this._metrics.unhealthy_cloud_types.set({ type: 'Ceph' }, types.unhealthy_pool_target.ceph_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'S3_Compatible' }, types.unhealthy_pool_target.s3_comp_unhealthy);
     }
 
     set_bucket_class_capacity_usage(usage_info) {

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -3795,7 +3795,7 @@ class NodesMonitor extends EventEmitter {
 
     _is_kubernetes_node(item) {
         const kubernetes_node_types = [
-            'BLOCK_STORE_MONGO',
+            // 'BLOCK_STORE_MONGO',
             'BLOCK_STORE_FS',
         ];
         return kubernetes_node_types.includes(item.node.node_type);


### PR DESCRIPTION
### Explain the changes
1. Removed the calculation of mongo pools in the Prometheus metrics as Kubernetes provider.
2. Added Kubernetes resource provider

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
