### PR TITLE
Revert wrong changes that set wrong routing_hint

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -104,10 +104,8 @@ class AgentCLI {
                     secret_key: 'abc',
                     system: 'demo',
                     bucket: 'first.bucket',
+                    routing_hint: 'EXTERNAL'
                 });
-                if (!self.params.scale) {
-                    self.params.routing_hint = 'EXTERNAL';
-                }
                 if (self.params.address) {
                     self.client.options.address = self.params.address;
                 }


### PR DESCRIPTION
### Explain the changes
1. The EXTERNAL hint should be a default value and not inforced on all agents, in real agents the value should come from agent_conf

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
