### PR TITLE
added INITIALIZING_FAILED mode to hosts pool

### DIFF
--- a/frontend/src/app/schema/host-pools.js
+++ b/frontend/src/app/schema/host-pools.js
@@ -32,6 +32,7 @@ export default {
                 enum: [
                     'BEING_CREATED',
                     'INITIALIZING',
+                    'INITIALIZING_FAILED',
                     'DELETING',
                     'HAS_NO_NODES',
                     'SCALING',
@@ -116,7 +117,7 @@ export default {
                 }
             },
             configuredHostCount: {
-                type:' integer'
+                type: 'integer'
             },
             storageNodeCount: {
                 type: 'integer'

--- a/frontend/src/app/utils/resource-utils.js
+++ b/frontend/src/app/utils/resource-utils.js
@@ -19,6 +19,11 @@ const hostsPoolModeToStateIcon = deepFreeze({
         css: 'warning',
         name: 'working'
     },
+    INITIALIZING_FAILED: {
+        tooltip: 'Initialization Failed',
+        css: 'error',
+        name: 'problem'
+    },
     DELETING: {
         tooltip: 'Deleting',
         css: 'warning',

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -323,7 +323,7 @@ module.exports = {
         scale_hosts_pool: {
             doc: 'Change the pool\'s underlaying host count',
             method: 'POST',
-             params: {
+            params: {
                 type: 'object',
                 required: ['name', 'host_count'],
                 properties: {
@@ -605,6 +605,7 @@ module.exports = {
             enum: [
                 'HAS_NO_NODES',
                 'INITIALIZING',
+                'INITIALIZING_FAILED',
                 'DELETING',
                 'ALL_NODES_OFFLINE',
                 'SCALING',

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -151,6 +151,9 @@ module.exports = {
                 initialized: {
                     type: 'boolean'
                 },
+                init_timeout: {
+                    idate: true,
+                },
                 host_count: {
                     type: 'integer',
                     minimum: 0


### PR DESCRIPTION
### Explain the changes
1. added a mode to hosts pool - `INITIALIZING_FAILED`
2. the pool can get to this mode after a timeout while in initializing state.
3. any change while in `INITIALIZING_FAILED` will cause the mode to change back to `INITIALIZING` until the next timeout or success.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5758 
2. Fixes Bug 1757500 https://bugzilla.redhat.com/show_bug.cgi?id=1757500

### Testing Instructions:
1. 