### PR TITLE
Makefile: do not err if there are no containers to clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,6 @@ noobaa: base
 
 clean:
 	@echo Stopping and Deleting containers
-	@docker ps -a | grep noobaa_ | awk '{print $$NF}' | xargs docker stop
-	@docker ps -a | grep noobaa_ | awk '{print $$NF}' | xargs docker rm
+	@docker ps -a | grep noobaa_ | awk '{print $$NF}' | xargs -r docker stop
+	@docker ps -a | grep noobaa_ | awk '{print $$NF}' | xargs -r docker rm
 .PHONY: clean


### PR DESCRIPTION
xargs should just not do anything if there's no input to it.

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
