### PR TITLE
Makefile: prefer to use podman if available as a container engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GIT_COMMIT?="$(shell git rev-parse HEAD | head -c 7)"
-NAME_POSTFIX?="$(shell docker ps -a | wc -l | xargs)"
+CONTAINER_ENGINE?=$(shell podman version >/dev/null 2>&1 && echo podman || echo docker)
+NAME_POSTFIX?="$(shell ${CONTAINER_ENGINE} ps -a | wc -l | xargs)"
 BUILDER_TAG?="noobaa-builder"
 TESTER_TAG?="noobaa-tester"
 NOOBAA_TAG?="noobaa"
@@ -25,28 +26,28 @@ all: tester noobaa
 
 builder:
 	@echo "\033[1;34mStarting Builder docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder . $(REDIRECT_STDOUT)
-	docker tag noobaa-builder $(BUILDER_TAG)
+	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder . $(REDIRECT_STDOUT)
+	${CONTAINER_ENGINE} tag noobaa-builder $(BUILDER_TAG)
 	@echo "\033[1;32mBuilder done.\033[0m"
 .PHONY: builder
 
 base: builder
 	@echo "\033[1;34mStarting Base docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
-	docker tag noobaa-base $(NOOBAA_BASE_TAG)
+	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
+	${CONTAINER_ENGINE} tag noobaa-base $(NOOBAA_BASE_TAG)
 	@echo "\033[1;32mBase done.\033[0m"
 .PHONY: base
 
 tester: base noobaa
 	@echo "\033[1;34mStarting Tester docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
-	docker tag noobaa-tester $(TESTER_TAG)
+	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
+	${CONTAINER_ENGINE} tag noobaa-tester $(TESTER_TAG)
 	@echo "\033[1;32mTester done.\033[0m"
 .PHONY: tester
 
 test: tester
 	@echo "\033[1;34mRunning tests.\033[0m"
-	docker run --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" $(TESTER_TAG) 
+	${CONTAINER_ENGINE} run --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" $(TESTER_TAG) 
 .PHONY: test
 
 tests: test #alias for test
@@ -54,13 +55,13 @@ tests: test #alias for test
 
 noobaa: base
 	@echo "\033[1;34mStarting NooBaa docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
-	docker tag noobaa $(NOOBAA_TAG)
+	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	${CONTAINER_ENGINE} tag noobaa $(NOOBAA_TAG)
 	@echo "\033[1;32mNooBaa done.\033[0m"
 .PHONY: noobaa
 
 clean:
 	@echo Stopping and Deleting containers
-	@docker ps -a | grep noobaa_ | awk '{print $$NF}' | xargs docker stop
-	@docker ps -a | grep noobaa_ | awk '{print $$NF}' | xargs docker rm
+	@${CONTAINER_ENGINE} ps -a | grep noobaa_ | awk '{print $$NF}' | xargs ${CONTAINER_ENGINE} stop
+	@${CONTAINER_ENGINE} ps -a | grep noobaa_ | awk '{print $$NF}' | xargs ${CONTAINER_ENGINE} rm
 .PHONY: clean


### PR DESCRIPTION
in Makefile.

If podman is available, use it. Otherwise, use docker commands
in the Makefile

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
