### PR TITLE
in agent.js discover public ip in the background instead of blocking get_agent_info

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -354,7 +354,21 @@ class Agent {
         });
     }
 
+    // refresh the public_ip in background if enough time passed from last time
+    _refresh_public_ip() {
+        const now = Date.now();
+        const GET_PUBLIC_IP_PERIOD = 10 * 60 * 1000; // 10 minutes between retrieve_public_ip
+        if (this.last_retrieve_public_ip && now < this.last_retrieve_public_ip + GET_PUBLIC_IP_PERIOD) return;
+        this.last_retrieve_public_ip = now;
+        net_utils.retrieve_public_ip()
+            .then(public_ip => {
+                this.public_ip = public_ip;
+            })
+            .catch(err => this.dbg.error('got error in _refresh_public_ip', err));
+    }
+
     _init_node() {
+        this._refresh_public_ip();
         return P.resolve()
             .then(() => {
                 if (this.storage_path) {
@@ -744,7 +758,9 @@ class Agent {
             cpu_usage: cpu_percent,
             location_info: this.location_info,
             io_stats: this.block_store && this.block_store.get_and_reset_io_stats(),
+            public_ip: this.public_ip
         };
+        this._refresh_public_ip();
         if (this.cloud_info && this.cloud_info.pool_name) {
             reply.pool_name = this.cloud_info.pool_name;
         }
@@ -826,12 +842,6 @@ class Agent {
                 //         drive.storage.used = used_size;
                 //     }
                 // });
-            })
-            .then(() => net_utils.retrieve_public_ip())
-            .then(public_ip => {
-                if (public_ip) {
-                    reply.public_ip = public_ip;
-                }
             })
             .return(reply);
     }

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -90,7 +90,7 @@ function ip_to_long(ip) {
 async function retrieve_public_ip() {
     const IPIFY_TIMEOUT = 30 * 1000;
     try {
-        await promise_utils.timeout(async () => {
+        return promise_utils.timeout(async () => {
             const res = await P.fromCallback(callback =>
                 request.get('http://api.ipify.org/', callback)
             );


### PR DESCRIPTION
### Explain the changes
1. get_agent_info is waiting for `ipify.org` to return the public ip.
2. this can take the time or even be blocked in some envs. 
3. changed to fetch the public ip in the background and not block `get_agent_info`

### Issues: Fixed #xxx / Gap #xxx
1. Fixing BZ https://bugzilla.redhat.com/show_bug.cgi?id=1788520

### Testing Instructions:
1. 
