### PR TITLE
Endpoint - Use auth_token from env + support running without an local MD server

### DIFF
--- a/config.js
+++ b/config.js
@@ -423,6 +423,11 @@ config.DEFAULT_ACCOUNT_PREFERENCES = {
     ui_theme: 'DARK'
 };
 
+///////////////////////////////////
+// REMOTE NOOBAA DEPLOYMENT INFO //
+///////////////////////////////////
+config.REMOTE_NOOAA_NAMESPACE = '';
+
 //Load overrides if exist
 try {
     // load a local config file that overwrites some of the config

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -951,6 +951,11 @@ module.exports = {
             method: 'PUT',
             params: {
                 type: 'object',
+                required: [
+                    'timestamp',
+                    'group_name',
+                    'hostname'
+                ],
                 properties: {
                     timestamp: {
                         idate: true

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -295,6 +295,34 @@ module.exports = {
                 system: 'admin',
             }
         },
+
+        get_join_cluster_yaml: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                properties: {
+                    endpoints: {
+                        type: 'object',
+                        properties: {
+                            min_count: {
+                                type: 'integer',
+                                minimum: 1
+                            },
+                            max_count: {
+                                type: 'integer',
+                                minimum: 1
+                            }
+                        }
+                    }
+                }
+            },
+            reply: {
+                type: 'string'
+            },
+            auth: {
+                system: 'admin',
+            }
+        }
     },
 
     definitions: {

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -804,8 +804,8 @@ class RPC extends EventEmitter {
             method_api: api.id,
             method_name: method.name,
             target: options.address,
-            request_params: params,
-            [RPC_BUFFERS]: params[RPC_BUFFERS],
+            request_params: params || undefined,
+            [RPC_BUFFERS]: params && params[RPC_BUFFERS],
         };
 
         return P.resolve()

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1075,7 +1075,7 @@ function read_s3_ops_counters(req) {
 
 async function add_endpoint_report(req) {
     const params = req.rpc_params;
-    const bandwidth = params.bandwidth.map(record => {
+    const bandwidth = (params.bandwidth || []).map(record => {
         const account = system_store.data.accounts.find(acc => {
             const access_key = acc.access_keys &&
                 acc.access_keys[0] &&

--- a/src/util/yaml_utils.js
+++ b/src/util/yaml_utils.js
@@ -21,14 +21,15 @@ function parse(yaml_string) {
 }
 
 function stringify(json) {
-    if (json.kind === 'List') {
-        return (json.items || [])
-            .map(item => yaml.stringify(item))
-            .join('---\n');
+    const docs =
+        (!json && []) ||
+        (Array.isArray(json) && json) ||
+        (json.kind === 'List' && (json.items || [])) ||
+        [json];
 
-    } else {
-        return yaml.strinify(json);
-    }
+    return docs
+        .map(doc => yaml.stringify(doc))
+        .join('---\n');
 }
 
 exports.parse = parse;


### PR DESCRIPTION
### Explain the changes
1. Try to acquire an auth token from a NOOBAA_AUTH_TOKEN env, fallback to generating an auth token from create_auth.
2. Externalize the decision to run a local MD server based on the value of the LOCAL_MD_SERVER env variable
3. Fix minor bandwidth report bug 
4. Add required fields to object_api schema

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
