### PR TITLE
Fix deletion of pool when it was created as a backingstore - core side

### DIFF
--- a/frontend/src/app/bindings/tooltip-templates/delete-resource.html
+++ b/frontend/src/app/bindings/tooltip-templates/delete-resource.html
@@ -12,6 +12,10 @@
 <p class="highlight">Cannot delete a {{subject}} that is assigned to a bucket policy</p>
 <!-- /ko -->
 
+<!-- ko if: reason === 'IS_BACKINGSTORE' -->
+<p class="highlight">Cannot delete a {{subject}} that was created as a backingstore</p>
+<!-- /ko -->
+
 <!-- ko if: reason === 'CONNECTED_BUCKET_DELETING' -->
 <p class="highlight">Cannot delete a {{subject}} that is assigned to a bucket which is being deleted</p>
 <!-- /ko -->

--- a/frontend/src/app/schema/cloud-resources.js
+++ b/frontend/src/app/schema/cloud-resources.js
@@ -63,7 +63,8 @@ export default {
                     'NOT_EMPTY',
                     'IN_USE',
                     'DEFAULT_RESOURCE',
-                    'CONNECTED_BUCKET_DELETING'
+                    'CONNECTED_BUCKET_DELETING',
+                    'IS_BACKINGSTORE'
                 ]
             },
             usedBy: {

--- a/frontend/src/app/schema/host-pools.js
+++ b/frontend/src/app/schema/host-pools.js
@@ -150,7 +150,8 @@ export default {
                     'NOT_EMPTY',
                     'IN_USE',
                     'DEFAULT_RESOURCE',
-                    'BEING_DELETED'
+                    'BEING_DELETED',
+                    'IS_BACKINGSTORE'
                 ]
             },
             hostConfig: {

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -452,6 +452,7 @@ module.exports = {
                 'CONNECTED_BUCKET_DELETING',
                 'DEFAULT_RESOURCE',
                 'BEING_DELETED',
+                'IS_BACKINGSTORE'
             ],
             type: 'string',
         },

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -20,7 +20,7 @@ module.exports = {
                 required: [
                     'name',
                     'is_managed',
-                    'host_count'
+                    'host_count',
                 ],
                 properties: {
                     name: {
@@ -40,7 +40,10 @@ module.exports = {
                                 $ref: 'common_api#/definitions/bigint'
                             }
                         }
-                    }
+                    },
+                    backingstore: {
+                        $ref: '#/definitions/backingstore_definition'
+                    },
                 }
             },
             reply: {
@@ -66,7 +69,10 @@ module.exports = {
                     },
                     target_bucket: {
                         type: 'string',
-                    }
+                    },
+                    backingstore: {
+                        $ref: '#/definitions/backingstore_definition'
+                    },
                 }
             },
             auth: {
@@ -342,6 +348,18 @@ module.exports = {
     },
 
     definitions: {
+        backingstore_definition: {
+            type: 'object',
+            required: ['name', 'namespace'],
+            properties: {
+                name: {
+                    type: 'string',
+                },
+                namespace: {
+                    type: 'string',
+                }
+            }
+        },
         pool_definition: {
             type: 'object',
             required: ['name', 'nodes'],

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -99,6 +99,17 @@ module.exports = {
                     type: 'string',
                     enum: ['AWS_V2', 'AWS_V4']
                 },
+                backingstore: {
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'string'
+                        },
+                        namespace: {
+                            type: 'string'
+                        }
+                    }
+                },
                 access_keys: {
                     type: 'object',
                     required: ['access_key', 'secret_key', 'account_id'],
@@ -165,7 +176,18 @@ module.exports = {
                             $ref: 'common_api#/definitions/bigint'
                         },
                     }
-                }
+                },
+                backingstore: {
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'string'
+                        },
+                        namespace: {
+                            type: 'string'
+                        }
+                    }
+                },
             }
         }
     }


### PR DESCRIPTION
### Explain the changes
1. Add backingstore info to cloud_pool_info.
2. If pool was created as a backingstore - mark it "IN_USE" so it can not be deleted from the UI.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ : #1765866

### Testing Instructions:
1. 
