### PR TITLE
cleanup cloud resource leftovers when deleted

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -252,6 +252,13 @@ class Agent {
         }
     }
 
+    // cleanup of all residues before deleting the agent
+    // for now only relevant for cloud resources
+    async cleanup_target_path() {
+        if (!this.cloud_info) return;
+        this.block_store.cleanup_target_path();
+    }
+
     async update_credentials(access_keys) {
         if (!this.cloud_info) return;
         this.cloud_info.access_keys = access_keys;

--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -334,6 +334,8 @@ class BlockStoreBase {
         }
     }
 
+    async cleanup_target_path() { _.noop(); }
+
     _handle_delegator_error() {
         throw new Error('this block store does not delegate');
     }

--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -201,6 +201,23 @@ class BlockStoreGoogle extends BlockStoreBase {
         });
     }
 
+    async cleanup_target_path() {
+        try {
+            dbg.log0(`cleaning up all objects with prefix ${this.base_path}`);
+            // delete files will delete all files with the given prefix
+            // deletion is done by the sdk in the client side in batvhes of 10
+            // force=true to avoid breaking on the first error
+            await this.bucket.deleteFiles({
+                prefix: this.base_path,
+                force: true
+            });
+        } catch (err) {
+            dbg.error('got error on cleanup_target_path', this.base_path, err);
+        }
+        dbg.log0(`completed cleanup of objects with perfix ${this.base_path}`);
+    }
+
+
     async _delete_blocks(block_ids) {
         // Todo: Assuming that all requested blocks were deleted, which a bit naive
         let deleted_storage = {


### PR DESCRIPTION
### Explain the changes
1. related to BZ https://bugzilla.redhat.com/show_bug.cgi?id=1763707
2. before deleting the agent by `hosted_agents`, call `cleanup_target_path `
3. `cleanup_target_path` performs deletion of all objects with the cloud resource prefix, specific to the cloud provider.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
