### PR TITLE
changed default EC parity type from isa-c1 to cm256

### DIFF
--- a/config.js
+++ b/config.js
@@ -227,7 +227,7 @@ config.CHUNK_CODER_CIPHER_TYPE = 'aes-256-gcm';
 config.CHUNK_CODER_EC_DATA_FRAGS = 4;
 config.CHUNK_CODER_REPLICAS = 1;
 config.CHUNK_CODER_EC_PARITY_FRAGS = 2;
-config.CHUNK_CODER_EC_PARITY_TYPE = 'isa-c1';
+config.CHUNK_CODER_EC_PARITY_TYPE = 'cm256';
 config.CHUNK_CODER_EC_TOLERANCE_THRESHOLD = 2;
 
 //////////////////////////

--- a/src/test/unit_tests/test_chunk_coder.js
+++ b/src/test/unit_tests/test_chunk_coder.js
@@ -37,6 +37,10 @@ const FRAG_SPECS = [
     //{ data_frags: 4, parity_frags: 2, parity_type: 'isa-c1', },
     //{ data_frags: 6, parity_frags: 2, parity_type: 'isa-c1', },
     //{ data_frags: 8, parity_frags: 4, parity_type: 'isa-c1', },
+    { data_frags: 2, parity_frags: 2, parity_type: 'cm256', },
+    { data_frags: 4, parity_frags: 2, parity_type: 'cm256', },
+    { data_frags: 6, parity_frags: 2, parity_type: 'cm256', },
+    { data_frags: 8, parity_frags: 4, parity_type: 'cm256', },
 ];
 const DIGEST_TYPES = [
     'sha384',
@@ -228,7 +232,7 @@ mocha.describe('nb_native chunk_coder', function() {
                     const frags_by_index = _.keyBy(chunk.frags, _frag_index);
                     const max_parity_frags = 32;
                     for (let i = 0; i < max_parity_frags; ++i) {
-                        const chunk_coder_config2 = _.defaults({ parity_frags: i, parity_type: 'isa-c1' }, chunk_coder_config);
+                        const chunk_coder_config2 = _.defaults({ parity_frags: i, }, chunk_coder_config);
                         const chunk2 = prepare_chunk(chunk_coder_config2, chunk);
                         call_chunk_coder_must_succeed('dec', chunk2);
                         chunk2.frags.forEach(frag2 => {


### PR DESCRIPTION
### Explain the changes
1. changed default parity type to `cm256`
   * with both `isa-c1` and `cm256` EC rebuilds don't work properly.
   * with `cm256` reads are working when a data fragment is missing (date is decoded from parity fragments). With `isa-c1` reads with a missing data frag cause the endpoint to crash.

2. changed tests to use `cm256`

### Issues: Fixed #xxx / Gap #xxx
1. EC rebuilds don't work - #5975 

### Testing Instructions:
1. 
