### PR TITLE
Minor fixes related to operator account

### DIFF
--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -126,6 +126,8 @@ function create_auth(req) {
                     String(system.owner._id) === String(authenticated_account._id) ||
                     // system admin can do anything
                     _.includes(roles, 'admin') ||
+                    // operator can do anything
+                    _.includes(roles, 'operator') ||
                     // non admin is not allowed to delegate roles to other accounts
                     (role_name && _.includes(roles, role_name) &&
                         String(target_account._id) === String(authenticated_account._id))) {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -906,7 +906,9 @@ async function get_join_cluster_yaml(req) {
     }
 
     const operator_account = system_store.data.accounts.find(account =>
-        (account.roles_by_system[req.system._id] || []).includes('operator')
+        account.roles_by_system && // This will protect against support account
+        account.roles_by_system[req.system._id] &&
+        account.roles_by_system[req.system._id].includes('operator')
     );
     if (!operator_account) {
         throw new RpcError('NO_OPERATOR_ACCOUNT', 'Cannot find operator account');


### PR DESCRIPTION


### Explain the changes
1. Allow operator account to always create_auth
2. also handle support account when downloading deploy YAML

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
