### PR TITLE
Makefile Changes and Preview mode for Cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+CONTAINER_ENGINE?=$(shell docker version >/dev/null 2>&1 && echo docker)
+ifeq ($(CONTAINER_ENGINE), "")
+	CONTAINER_ENGINE==$(shell podman version >/dev/null 2>&1 && echo podman)
+endif
+
 GIT_COMMIT?="$(shell git rev-parse HEAD | head -c 7)"
 NAME_POSTFIX?="$(shell docker ps -a | wc -l | xargs)"
 BUILDER_TAG?="noobaa-builder"
@@ -19,48 +24,54 @@ endif
 
 export
 
+assert-container-engine:
+	@ if [ "${CONTAINER_ENGINE}" = "" ]; then \
+		echo "\n  Error: You must have container engine installed\n"; \
+		exit 1; \
+	fi
+
 all: tester noobaa
 	@echo "\033[1;32mAll done.\033[0m"
 .PHONY: all
 
-builder:
-	@echo "\033[1;34mStarting Builder docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder . $(REDIRECT_STDOUT)
-	docker tag noobaa-builder $(BUILDER_TAG)
+builder: assert-container-engine
+	@echo "\033[1;34mStarting Builder ${CONTAINER_ENGINE} build.\033[0m"
+	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder . $(REDIRECT_STDOUT)
+	${CONTAINER_ENGINE} tag noobaa-builder $(BUILDER_TAG)
 	@echo "\033[1;32mBuilder done.\033[0m"
 .PHONY: builder
 
 base: builder
-	@echo "\033[1;34mStarting Base docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
-	docker tag noobaa-base $(NOOBAA_BASE_TAG)
+	@echo "\033[1;34mStarting Base ${CONTAINER_ENGINE} build.\033[0m"
+	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
+	${CONTAINER_ENGINE} tag noobaa-base $(NOOBAA_BASE_TAG)
 	@echo "\033[1;32mBase done.\033[0m"
 .PHONY: base
 
 tester: base noobaa
-	@echo "\033[1;34mStarting Tester docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
-	docker tag noobaa-tester $(TESTER_TAG)
+	@echo "\033[1;34mStarting Tester ${CONTAINER_ENGINE} build.\033[0m"
+	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
+	${CONTAINER_ENGINE} tag noobaa-tester $(TESTER_TAG)
 	@echo "\033[1;32mTester done.\033[0m"
 .PHONY: tester
 
 test: tester
 	@echo "\033[1;34mRunning tests.\033[0m"
-	docker run --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" $(TESTER_TAG) 
+	${CONTAINER_ENGINE} run --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" $(TESTER_TAG) 
 .PHONY: test
 
 tests: test #alias for test
 .PHONY: tests
 
 noobaa: base
-	@echo "\033[1;34mStarting NooBaa docker build.\033[0m"
-	docker build -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
-	docker tag noobaa $(NOOBAA_TAG)
+	@echo "\033[1;34mStarting NooBaa ${CONTAINER_ENGINE} build.\033[0m"
+	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	${CONTAINER_ENGINE} tag noobaa $(NOOBAA_TAG)
 	@echo "\033[1;32mNooBaa done.\033[0m"
 .PHONY: noobaa
 
 clean:
 	@echo Stopping and Deleting containers
-	@docker ps -a | grep noobaa_ | awk '{print $$NF}' | xargs docker stop
-	@docker ps -a | grep noobaa_ | awk '{print $$NF}' | xargs docker rm
+	@${CONTAINER_ENGINE} ps -a | grep noobaa_ | awk '{print $1}' | xargs ${CONTAINER_ENGINE} stop &> /dev/null
+	@${CONTAINER_ENGINE} ps -a | grep noobaa_ | awk '{print $1}' | xargs ${CONTAINER_ENGINE} rm &> /dev/null
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -35,43 +35,43 @@ all: tester noobaa
 .PHONY: all
 
 builder: assert-container-engine
-	@echo "\033[1;34mStarting Builder ${CONTAINER_ENGINE} build.\033[0m"
-	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder . $(REDIRECT_STDOUT)
-	${CONTAINER_ENGINE} tag noobaa-builder $(BUILDER_TAG)
+	@echo "\033[1;34mStarting Builder $(CONTAINER_ENGINE) build.\033[0m"
+	$(CONTAINER_ENGINE) build -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) tag noobaa-builder $(BUILDER_TAG)
 	@echo "\033[1;32mBuilder done.\033[0m"
 .PHONY: builder
 
 base: builder
-	@echo "\033[1;34mStarting Base ${CONTAINER_ENGINE} build.\033[0m"
-	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
-	${CONTAINER_ENGINE} tag noobaa-base $(NOOBAA_BASE_TAG)
+	@echo "\033[1;34mStarting Base $(CONTAINER_ENGINE) build.\033[0m"
+	$(CONTAINER_ENGINE) build -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) tag noobaa-base $(NOOBAA_BASE_TAG)
 	@echo "\033[1;32mBase done.\033[0m"
 .PHONY: base
 
 tester: base noobaa
-	@echo "\033[1;34mStarting Tester ${CONTAINER_ENGINE} build.\033[0m"
-	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
-	${CONTAINER_ENGINE} tag noobaa-tester $(TESTER_TAG)
+	@echo "\033[1;34mStarting Tester $(CONTAINER_ENGINE) build.\033[0m"
+	$(CONTAINER_ENGINE) build -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) tag noobaa-tester $(TESTER_TAG)
 	@echo "\033[1;32mTester done.\033[0m"
 .PHONY: tester
 
 test: tester
 	@echo "\033[1;34mRunning tests.\033[0m"
-	${CONTAINER_ENGINE} run --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" $(TESTER_TAG) 
+	$(CONTAINER_ENGINE) run --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" $(TESTER_TAG) 
 .PHONY: test
 
 tests: test #alias for test
 .PHONY: tests
 
 noobaa: base
-	@echo "\033[1;34mStarting NooBaa ${CONTAINER_ENGINE} build.\033[0m"
-	${CONTAINER_ENGINE} build -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
-	${CONTAINER_ENGINE} tag noobaa $(NOOBAA_TAG)
+	@echo "\033[1;34mStarting NooBaa $(CONTAINER_ENGINE) build.\033[0m"
+	$(CONTAINER_ENGINE) build -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) tag noobaa $(NOOBAA_TAG)
 	@echo "\033[1;32mNooBaa done.\033[0m"
 .PHONY: noobaa
 
 clean:
 	@echo Stopping and Deleting containers
-	@${CONTAINER_ENGINE} ps -a | grep noobaa_ | awk '{print $1}' | xargs ${CONTAINER_ENGINE} stop &> /dev/null
-	@${CONTAINER_ENGINE} ps -a | grep noobaa_ | awk '{print $1}' | xargs ${CONTAINER_ENGINE} rm &> /dev/null
+	@$(CONTAINER_ENGINE) ps -a | grep noobaa_ | awk '{print $1}' | xargs $(CONTAINER_ENGINE) stop &> /dev/null
+	@$(CONTAINER_ENGINE) ps -a | grep noobaa_ | awk '{print $1}' | xargs $(CONTAINER_ENGINE) rm &> /dev/null
 .PHONY: clean

--- a/frontend/src/app/components/application/main-layout/main-layout.js
+++ b/frontend/src/app/components/application/main-layout/main-layout.js
@@ -53,7 +53,8 @@ const navItems = deepFreeze([
     {
         route: 'cluster',
         icon: 'cluster',
-        label: 'Cluster'
+        label: 'Cluster',
+        preview: true
     },
     {
         route: 'accounts',

--- a/frontend/src/app/components/overview/cluster-overview/cluster-overview.html
+++ b/frontend/src/app/components/overview/cluster-overview/cluster-overview.html
@@ -9,9 +9,9 @@
             params="name: clusterIcon().name"
         ></svg-icon>
         <span class="greedy highlight">Cluster</span>
-        <a class="link" ko.attr.href="clusterHref">
-            View Cluster
-        </a>
+        <!-- <a class="link" ko.attr.href="clusterHref"> -->
+        <!----    View Cluster  -->
+        <!-- </a> -->
     </div>
     <hr>
     <div class="pad greedy column">

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -4,7 +4,6 @@
 
 const _ = require('lodash');
 const url = require('url');
-const util = require('util');
 const chance = require('chance')();
 // const dclassify = require('dclassify');
 const EventEmitter = require('events').EventEmitter;
@@ -1682,7 +1681,7 @@ class NodesMonitor extends EventEmitter {
         if (!deleted_nodes.length) return;
         const items_to_update = [];
         return P.map(deleted_nodes, item => {
-                dbg.log0('_update_nodes_store deleted_node:', util.inspect(item));
+                dbg.log0('_update_nodes_store deleted_node:', item);
 
                 if (item.node.deleted) {
                     if (!item.node_from_store.deleted) {


### PR DESCRIPTION
### Explain the changes
1. Makefile Changes
  1.1 Support Podman builds - detect if docker/podman available and use the installed engine, fail if no engine exists
  1.2 Suppress cleanup errors
2. Set cluster in preview mode (UI)
3. Remove a util.inspect from a dbg logging in nodes_monitor

Based on @mykaul PRs #5861 and #5860


