### PR TITLE
Add the ability to run a single unit test

### DIFF
--- a/src/test/unit_tests/run_npm_test_on_test_container.sh
+++ b/src/test/unit_tests/run_npm_test_on_test_container.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} \e[0m'
+
 function cleanup() {
     local rc
     local pid=$1
@@ -24,10 +26,37 @@ function start_mongo() {
 
 PATH=$PATH:/noobaa-core/node_modules/.bin
 
+command="npm test"
+
+function usage() {
+    echo -e "Usage:\n\t${0} [options]"
+    echo -e "\t-c|--command     -   Replace the unit test command (default: ${command})"
+    echo -e "\t-s|--single      -   Get the desired unit test to run and running it,"
+    echo -e "\t                     needs to get the file name for example test_object_io.js"
+    exit 0
+}
+
+while true
+do
+    if [ -z ${1} ]
+    then
+        break
+    fi
+
+    case ${1} in
+        -c|--command)   shift 1
+                        command=${*}
+                        command_array=(${command})
+                        shift ${#command_array[@]};;
+        -s|--single)    command="./node_modules/mocha/bin/mocha src/test/unit_tests/${2}"
+                        shift 2;;
+        *)              usage;;
+    esac
+done
+
 trap cleanup 1 2
 
 start_mongo
-command="npm test"
 echo "$(date) running ${command}"
 ${command}
 cleanup ${PID} ${?}


### PR DESCRIPTION
### Explain the changes
Add the ability to run a single unit test

- Added -c/--command that can state the command parameters
- Added -s/--single that allows you to state only the unit test file.

- We don't change the Tests.Dockerfile CMD to ENTRYPOINT because we would like to easily override the entire command and run different suits that do not require mongo.
