### PR TITLE
Fixing semaphore on large numbers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -152,9 +152,6 @@ module.exports = {
         // instead of expression (foo = function() {})
         'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
 
-        // use only x|0 for int casting, but avoid other bitwise operators
-        'no-bitwise': ['error', { int32Hint: true }],
-
         //////////////////////////////////////////////////////////////////////
         //                                                                  //
         // WARN                                                             //

--- a/src/rpc/stun.js
+++ b/src/rpc/stun.js
@@ -538,6 +538,7 @@ function encode_attr_xor_mapped_addr(addr, buffer, offset, end) {
  * encode ERROR-CODE attribute
  */
 function encode_attr_error_code(err, buffer, start, end) {
+    // eslint-disable-next-line no-bitwise
     var code = (((err.code / 100) | 0) << 8) | ((err.code % 100) & 0xff);
     buffer.writeUInt32BE(code, start);
     buffer.writeUInt32BE(err.reason, start + 4);

--- a/src/util/frame_stream.js
+++ b/src/util/frame_stream.js
@@ -27,6 +27,7 @@ class FrameStream {
         this._magic = (config && config.magic) || DEFAULT_MSG_MAGIC;
         this._magic_len = this._magic.length;
         this._max_len = (config && config.max_len) || DEFAULT_MAX_MSG_LEN;
+        // eslint-disable-next-line no-bitwise
         this._send_seq = (MAX_SEQ * Math.random()) | 0;
         this._recv_seq = NaN;
         this._header_len = this._magic_len + 8;

--- a/src/util/http_recorder.js
+++ b/src/util/http_recorder.js
@@ -32,6 +32,7 @@ class HTTPRecorder extends stream.Writable {
         // `url` is not set for response parsers but that's not applicable here since
         // all our parsers are request parsers.
         // eslint-disable-next-line max-params
+        // eslint-disable-next-line no-bitwise
         this._parser[HTTPParser.kOnHeadersComplete | 0] = (
             versionMajor, versionMinor, headers, method, url,
             //eslint-disable-next-line max-params
@@ -70,6 +71,7 @@ class HTTPRecorder extends stream.Writable {
         // processed in a single run. This method is also
         // called to process trailing HTTP headers.
         // Once we exceeded headers limit - stop collecting them
+        // eslint-disable-next-line no-bitwise
         this._parser[HTTPParser.kOnHeaders | 0] = (headers, url) => {
             console.log('kOnHeaders', headers, url);
             slow_url += url;
@@ -77,10 +79,12 @@ class HTTPRecorder extends stream.Writable {
             _cached_array_push.apply(slow_headers, add);
         };
 
+        // eslint-disable-next-line no-bitwise
         this._parser[HTTPParser.kOnBody | 0] = (buf, start, len) => {
             // console.log('kOnBody', buf.length, start, len);
         };
 
+        // eslint-disable-next-line no-bitwise
         this._parser[HTTPParser.kOnMessageComplete | 0] = () => {
             // console.log('kOnMessageComplete');
             this._start_message();

--- a/src/util/semaphore.js
+++ b/src/util/semaphore.js
@@ -206,7 +206,7 @@ class Semaphore {
 // if count is not a number (like undefined) or negative, we assume count of 1.
 // NOTE that count===0 is a special case for wait/release - see comments above.
 function to_sem_count(count) {
-    return (typeof(count) === 'number' && count >= 0) ? (count | 0) : 1;
+    return (typeof(count) === 'number' && count >= 0) ? Math.floor(count) : 1;
 }
 
 module.exports = Semaphore;


### PR DESCRIPTION
### Explain the changes
1. Currently, the semaphore would return 0 on numbers that are larger than 32bits
This is due to the "| 0" limitations of 32bit numbers.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
