### PR TITLE
Enable the setting of region for endpoint groups

### DIFF
--- a/frontend/src/app/action-creators/endpoint-actions.js
+++ b/frontend/src/app/action-creators/endpoint-actions.js
@@ -9,10 +9,10 @@ import {
     FAIL__UPDATE_ENDPOINT_GROUP
 } from 'action-types';
 
-export function generateEndpointGroupDeploymentYAML(endpointConf) {
+export function generateEndpointGroupDeploymentYAML(region, endpointConf) {
     return {
         type: GENERATE_ENDPOINT_GROUP_DEPLOYMENT_YAML,
-        payload: { endpointConf }
+        payload: { region, endpointConf }
     };
 }
 
@@ -32,11 +32,12 @@ export function failGenerateEndpointGroupDeploymentYAML(error) {
     };
 }
 
-export function updateEndpointGroup(name, endpointConf) {
+export function updateEndpointGroup(name, region, endpointConf) {
     return {
         type: UPDATE_ENDPOINT_GROUP,
         payload: {
             name,
+            region,
             endpointConf
         }
     };

--- a/frontend/src/app/components/endpoints/endpoint-groups-table/endpoint-groups-table.js
+++ b/frontend/src/app/components/endpoints/endpoint-groups-table/endpoint-groups-table.js
@@ -36,7 +36,7 @@ const columns = Object.freeze([
     {
         name: 'region',
         sortable: true,
-        compareKey: () => ''
+        compareKey: group => group.region
     },
     {
         name: 'cpuUsage',
@@ -129,7 +129,7 @@ class EndpointsTableViewModel extends ConnectableViewModel {
                         },
                         count: group.endpointCount,
                         range: `${min} - ${max}`,
-                        region: '(Not Set)',
+                        region: group.region || '(Not Set)',
                         cpuUsage: numeral(group.cpuUsage).format('%'),
                         memoryUsage: numeral(group.memoryUsage).format('%'),
                         edit: {

--- a/frontend/src/app/components/modals/deploy-remote-endpoint-group-modal/deploy-remote-endpoint-group-modal.html
+++ b/frontend/src/app/components/modals/deploy-remote-endpoint-group-modal/deploy-remote-endpoint-group-modal.html
@@ -7,6 +7,12 @@
     onSubmit: onSubmit
 ">
     <div class="column pad greedy">
+        <editor params="label: 'Region'">
+            <input type="text"
+                class="push-next-half"
+                ko.value="$form.region"
+            />
+        </editor>
         <editor params="label: 'Auto-scaling'">
             <toggle-switch params="
                 onLabel: 'Enabled',

--- a/frontend/src/app/components/modals/deploy-remote-endpoint-group-modal/deploy-remote-endpoint-group-modal.js
+++ b/frontend/src/app/components/modals/deploy-remote-endpoint-group-modal/deploy-remote-endpoint-group-modal.js
@@ -15,6 +15,7 @@ class DeployRemoteEndpointGroupModalViewModel extends ConnectableViewModel {
     toggleRemark = ko.observable();
     endpointCountLabel = ko.observable();
     formFields = {
+        region: '',
         useAutoScaling: true,
         minCount: 1,
         maxCount: 10
@@ -60,14 +61,14 @@ class DeployRemoteEndpointGroupModalViewModel extends ConnectableViewModel {
     }
 
     onSubmit(values) {
-        const { useAutoScaling, minCount, maxCount } = values;
+        const { region, useAutoScaling, minCount, maxCount } = values;
         const endpointConf = {
             minCount: minCount,
             maxCount: useAutoScaling ? maxCount : minCount
         };
 
         this.dispatch(
-            generateEndpointGroupDeploymentYAML(endpointConf),
+            generateEndpointGroupDeploymentYAML(region, endpointConf),
             closeModal()
         );
     }

--- a/frontend/src/app/components/modals/edit-endpoint-group-modal/edit-endpoint-group-modal.html
+++ b/frontend/src/app/components/modals/edit-endpoint-group-modal/edit-endpoint-group-modal.html
@@ -7,6 +7,12 @@
     onSubmit: onSubmit
 ">
     <div class="column pad greedy">
+        <editor params="label: 'Region'">
+            <input type="text"
+                class="push-next-half"
+                ko.value="$form.region"
+            />
+        </editor>
         <editor params="label: 'Auto-scaling'">
             <toggle-switch params="
                 onLabel: 'Enabled',

--- a/frontend/src/app/components/modals/edit-endpoint-group-modal/edit-endpoint-group-modal.js
+++ b/frontend/src/app/components/modals/edit-endpoint-group-modal/edit-endpoint-group-modal.js
@@ -31,6 +31,7 @@ class EditEndpointGroupModalViewModel extends ConnectableViewModel {
 
         const { endpointRange } = group;
         const {
+            region = group.region || '',
             useAutoScaling = endpointRange.min !== endpointRange.max,
             minCount = endpointRange.min,
             maxCount = endpointRange.max
@@ -50,7 +51,8 @@ class EditEndpointGroupModalViewModel extends ConnectableViewModel {
             formFields: !form ? {
                 useAutoScaling,
                 minCount,
-                maxCount
+                maxCount,
+                region
             } : undefined
         });
     }
@@ -72,7 +74,7 @@ class EditEndpointGroupModalViewModel extends ConnectableViewModel {
     }
 
     onSubmit(values) {
-        const { useAutoScaling, minCount, maxCount } = values;
+        const { region = '', useAutoScaling, minCount, maxCount } = values;
         const endpointConf = {
             minCount: minCount,
             maxCount: useAutoScaling ? maxCount : minCount
@@ -80,7 +82,7 @@ class EditEndpointGroupModalViewModel extends ConnectableViewModel {
 
         this.dispatch(
             closeModal(),
-            updateEndpointGroup(this.groupName, endpointConf)
+            updateEndpointGroup(this.groupName, region.trim(), endpointConf)
         );
     }
 

--- a/frontend/src/app/epics/generate-endpoint-group-deployment-yaml.js
+++ b/frontend/src/app/epics/generate-endpoint-group-deployment-yaml.js
@@ -13,10 +13,11 @@ export default function(action$, { api, browser }) {
     return action$.pipe(
         ofType(GENERATE_ENDPOINT_GROUP_DEPLOYMENT_YAML),
         mergeMap(async action => {
-            const { endpointConf } = action.payload;
+            const { region, endpointConf } = action.payload;
 
             try {
                 const yaml = await api.system.get_join_cluster_yaml({
+                    region,
                     endpoints: {
                         min_count: endpointConf.minCount,
                         max_count: endpointConf.maxCount

--- a/frontend/src/app/epics/update-endpoint-group.js
+++ b/frontend/src/app/epics/update-endpoint-group.js
@@ -10,11 +10,12 @@ export default function(action$, { api }) {
     return action$.pipe(
         ofType(UPDATE_ENDPOINT_GROUP),
         mergeMap(async action => {
-            const { name, endpointConf } = action.payload;
+            const { name, region, endpointConf } = action.payload;
 
             try {
                 await api.system.update_endpoint_group({
                     group_name: name,
+                    region,
                     endpoint_range: {
                         min: endpointConf.minCount,
                         max: endpointConf.maxCount

--- a/frontend/src/app/reducers/endpoint-groups-reducer.js
+++ b/frontend/src/app/reducers/endpoint-groups-reducer.js
@@ -18,6 +18,7 @@ function onCompleteFetchSystemInfo(state, { payload }) {
     return keyByProperty(payload.endpoint_groups, 'group_name', group => ({
         name: group.group_name,
         isRemote: group.is_remote,
+        region: group.region,
         endpointCount: group.endpoint_count,
         endpointRange: {
             min: group.min_endpoint_count,

--- a/frontend/src/app/schema/endpoint-groups.js
+++ b/frontend/src/app/schema/endpoint-groups.js
@@ -19,6 +19,9 @@ export default {
             isRemote: {
                 type: 'boolean'
             },
+            region: {
+                type: 'string'
+            },
             endpointCount: {
                 type: 'integer'
             },

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -301,6 +301,7 @@ module.exports = {
             params: {
                 type: 'object',
                 properties: {
+                    region: { type: 'string' },
                     endpoints: {
                         type: 'object',
                         required: [
@@ -333,6 +334,7 @@ module.exports = {
                 type: 'object',
                 required: [
                     'group_name',
+                    'region',
                     'endpoint_range'
                 ],
                 properties: {
@@ -341,6 +343,9 @@ module.exports = {
                     },
                     is_remote: {
                         type: 'boolean'
+                    },
+                    region: {
+                        type: 'string'
                     },
                     endpoint_range: {
                         type: 'object',
@@ -602,6 +607,7 @@ module.exports = {
                         properties: {
                             group_name: { type: 'string' },
                             is_remote: { type: 'boolean' },
+                            region: { type: 'string' },
                             endpoint_count: { type: 'number' },
                             min_endpoint_count: { type: 'integer' },
                             max_endpoint_count: { type: 'integer' },

--- a/src/server/system_services/schemas/cluster_schema.js
+++ b/src/server/system_services/schemas/cluster_schema.js
@@ -260,6 +260,9 @@ module.exports = {
                     is_remote: {
                         type: 'boolean'
                     },
+                    region: {
+                        type: 'string'
+                    },
                     endpoint_range: {
                         type: 'object',
                         required: ['min', 'max'],


### PR DESCRIPTION
### Explain the changes
1. Add support for region in cluster.endpoint_groups schema
2. Add support for setting region in system APIs
3. Add region field on update endpoint group modal (FE)
3. Add region field on deploy remote endpoint group modal (FE)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
