### PR TITLE
removed S3 service from noobaa_pool.yaml

### DIFF
--- a/src/deploy/NVA_build/noobaa_pool.yaml
+++ b/src/deploy/NVA_build/noobaa_pool.yaml
@@ -1,21 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: s3
-  labels:
-    app: noobaa
-spec:
-  type: LoadBalancer
-  ports:
-    - port: 80
-      targetPort: 6001
-      name: s3
-    - port: 443
-      targetPort: 6443
-      name: s3-https
-  selector:
-    noobaa-s3: "true"
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -36,16 +18,9 @@ spec:
       labels:
         app: noobaa
         noobaa-module: noobaa-agent
-        noobaa-s3: "true"
     spec:
       containers:
         - name: noobaa-agent
-          # readinessProbe:
-          #   # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-          #   # ready when s3 port is open
-          #   tcpSocket:
-          #     port: 6001
-          #   timeoutSeconds: 5
           imagePullPolicy: IfNotPresent
           resources:
             # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -61,10 +36,6 @@ spec:
               value: KUBERNETES
             - name: AGENT_CONFIG
               value: "AGENT_CONFIG_VALUE"
-            - name: ENDPOINT_PORT
-              value: "6001"
-            - name: ENDPOINT_SSL_PORT
-              value: "6443"
           command: ["/noobaa_init_files/noobaa_init.sh", "agent"]
           # Insert the relevant image for the agent
           ports:
@@ -96,4 +67,3 @@ spec:
             storage: 30Gi
         # storageClassName if needed will be added by the pool controller (via pool server),
         # Read more https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
-

--- a/src/test/framework/test_job.yaml
+++ b/src/test/framework/test_job.yaml
@@ -23,13 +23,13 @@ spec:
         - node
         - ./src/test/framework/test_env_builder_kubernetes.js
         - --image
-        - NOOBAA_IMAGE_PLACEHOLDER
+        - "NOOBAA_IMAGE_PLACEHOLDER"
         - --namespace_prefix 
-        - NAMESPACE_PREFIX_PLACEHOLDER
+        - "NAMESPACE_PREFIX_PLACEHOLDER"
         - --tests_list
-        - TESTS_LIST_PLACEHOLDER
+        - "TESTS_LIST_PLACEHOLDER"
         - --concurrency
-        - TESTS_CONCURRENCY_PLACEHOLDER
+        - "TESTS_CONCURRENCY_PLACEHOLDER"
         - --DELETE_ON_FAIL_PLACEHOLDER
         env:
           - name: CONTAINER_PLATFORM


### PR DESCRIPTION
### Explain the changes
1. after separating noobaa endpoints to a different deployment and removing s3 server from agents, the S3 service in `noobaa_pool.yaml` overrides the correct service settings.
2. This causes the s3 service to direct s3 traffic to agents, which does not serve s3 anymore
3. removed s3 service resource from `noobaa_pool.yaml`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
