### PR TITLE
builder: Merge first and third dnf calls

### DIFF
--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -8,9 +8,9 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
 ENV container docker
-RUN dnf install -y -q wget unzip which vim && \
+RUN dnf update -y -q && \
+    dnf install -y -q wget unzip which vim python3 && \
     dnf group install -y -q "Development Tools" && \
-    dnf install -y -q python3 && \
     dnf clean all
 RUN alternatives --set python /usr/bin/python3
 RUN version="1.3.0" && \


### PR DESCRIPTION
Having three separate calls causes issues when installing the packages
in our downstream builds. We can remove the third dnf call and install
python in the first call instead. This seemed to have solved the issue
in my testing downstream.

Signed-off-by: Boris Ranto <branto@redhat.com>

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
