### PR TITLE
Backport dnf calls merge and python2 deprecation

### DIFF
--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -68,8 +68,10 @@ RUN dnf install -y -q bash \
     nc \
     less \
     bash-completion \
-    python2-setuptools && \
+    python3-setuptools && \
     dnf clean all
+
+RUN mkdir -p /usr/local/lib/python3.6/site-packages
 
 ##############################################################
 # Layers:

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -10,9 +10,9 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 ENV container docker
 RUN dnf install -y -q wget unzip which vim && \
     dnf group install -y -q "Development Tools" && \
-    dnf install -y -q python2 && \
+    dnf install -y -q python3 && \
     dnf clean all
-RUN alternatives --set python /usr/bin/python2
+RUN alternatives --set python /usr/bin/python3
 RUN version="1.3.0" && \
     wget -q -O yasm-${version}.tar.gz https://github.com/yasm/yasm/archive/v${version}.tar.gz && \
     tar -xf yasm-${version}.tar.gz && \

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -8,9 +8,9 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
 ENV container docker
-RUN dnf install -y -q wget unzip which vim && \
+RUN dnf update -y -q && \
+    dnf install -y -q wget unzip which vim python3 && \
     dnf group install -y -q "Development Tools" && \
-    dnf install -y -q python3 && \
     dnf clean all
 RUN alternatives --set python /usr/bin/python3
 RUN version="1.3.0" && \

--- a/src/deploy/NVA_build/setup_platform.sh
+++ b/src/deploy/NVA_build/setup_platform.sh
@@ -22,7 +22,7 @@ function install_supervisor {
     then
         deploy_log install_supervisor start
         # easy_install is for Supervisord and comes from python-setuptools
-        /usr/bin/easy_install-2 supervisor
+        /usr/bin/easy_install-3.6 supervisor
 	    deploy_log install_supervisor done
     fi
 
@@ -40,7 +40,8 @@ function install_supervisor {
 
     # Autostart supervisor
     deploy_log "setup_supervisors autostart"
-    mv /usr/bin/supervisord /usr/bin/supervisord_orig
+    bin_supervisord=$(find / -name supervisord | grep bin)
+    mv ${bin_supervisord} /usr/bin/supervisord_orig
     mv /tmp/supervisord /usr/bin/supervisord
 
     # Add NooBaa services configuration to supervisor


### PR DESCRIPTION
### Explain the changes
1.  We have an issue where downstream CI fails in the dnf installation steps. Updating the packages with dnf and merging the first and third dnf calls seemed to have helped downstream. Let's back-port it to 5.3 for inclusion downstream.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Run the upstream and downstream builds.
