### PR TITLE
fix for read_pool function - showing wrong mode

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -523,11 +523,11 @@ function create_mongo_pool(req) {
     // })
 }
 
-function read_pool(req) {
+async function read_pool(req) {
     var pool = find_pool_by_name(req);
-    return P.resolve()
-        .then(() => nodes_client.instance().aggregate_nodes_by_pool([pool.name], req.system._id))
-        .then(nodes_aggregate_pool => get_pool_info(pool, nodes_aggregate_pool));
+    const nodes_aggregate_pool = await nodes_client.instance().aggregate_nodes_by_pool([pool.name], req.system._id);
+    const hosts_aggregate_pool = await nodes_client.instance().aggregate_hosts_by_pool([pool.name], req.system._id);
+    return get_pool_info(pool, nodes_aggregate_pool, hosts_aggregate_pool);
 }
 
 function read_namespace_resource(req) {


### PR DESCRIPTION
### Explain the changes
1. read_pool didn't pass hosts information to get_pool_info 
2. cause a failure in the stats_aggreagator calling this function - and showing bad status on pool which really should be optimal. read_system was showing the correct status

### Issues: Fixed #xxx / Gap #xxx
1. fixing BZ1789844

### Testing Instructions:
from the BZ:
1. Go to Noobaa UI and create resource Kubernetes pool
2. Wait for the resource to become healthy in Noobaa UI and wait for 10 more minutes
3. Go to Dashboards/Object Service - see that it's healthy as well
