### PR TITLE
Normalize parsing of pool deploy yaml to always return list result

### DIFF
--- a/src/server/system_services/pool_controllers.js
+++ b/src/server/system_services/pool_controllers.js
@@ -281,7 +281,7 @@ function _get_statefulset_name(system_name, pool_name) {
 async function _get_k8s_conf(params) {
     const yaml_path = path.resolve(__dirname, '../../deploy/NVA_build/noobaa_pool.yaml');
     const yaml = (await fs.readFileAsync(yaml_path)).toString();
-    const conf_template = await yaml_utils.parse(yaml);
+    const conf_template = await yaml_utils.parse(yaml, true);
 
      // Find the noobaa-agent stateful set.
     const statefulset = conf_template.items

--- a/src/util/yaml_utils.js
+++ b/src/util/yaml_utils.js
@@ -3,20 +3,20 @@
 
 const yaml = require('yamljs');
 
-function parse(yaml_string) {
+function parse(yaml_string, forceListResult = false) {
     const docs = yaml_string.split(/\n\s*---\s*\n/g)
         .filter(Boolean)
         .map(yaml.parse);
 
-    if (docs.length === 1) {
-        return docs[0];
-    } else {
+    if (forceListResult || docs.length !== 1) {
         return {
             kind: 'List',
             apiVersion: 'v1',
             metadata: {},
             items: docs
         };
+    } else {
+        return docs[0];
     }
 }
 


### PR DESCRIPTION
### Explain the changes
The pool deploy YAML file was changed from a multi doc YAML (which also included an S3 service) to a single doc YAML (only statefulset). This change broke the code that parsed the YAML and tried to manipulate the result. 
To proof against future changes, a flag was added to the parse utils which enforce a list result even if the YAML contains only a single document.

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=1809112

### Testing Instructions:
1. 
