### PR TITLE
Return connections for self and operator accounts in read accout api

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -219,7 +219,14 @@ function read_account(req) {
         throw new RpcError('NO_SUCH_ACCOUNT', 'No such account email: ' + email);
     }
 
-    return get_account_info(account);
+    const is_self = req.account === account;
+    const self_roles = req.account.roles_by_system[req.system._id];
+    const is_operator = self_roles && self_roles.includes('operator');
+
+    return get_account_info(
+        account,
+        is_self || is_operator
+    );
 }
 
 


### PR DESCRIPTION
### Explain the changes
1.  Read account will return connections list for requests for self account (the account who made the request) and for the operator account.

### Issues: Fixed #xxx / Gap #xxx
1. fixes #5662 

### Testing Instructions:
1. 
