### PR TITLE
Management Console - Add missing enum value to host pool schema

### DIFF
--- a/frontend/src/app/schema/host-pools.js
+++ b/frontend/src/app/schema/host-pools.js
@@ -151,6 +151,7 @@ export default {
                     'IN_USE',
                     'DEFAULT_RESOURCE',
                     'BEING_DELETED',
+                    'CONNECTED_BUCKET_DELETING',
                     'IS_BACKINGSTORE'
                 ]
             },


### PR DESCRIPTION
### Explain the changes
1. A host-pool can have an undeletable value of CONNECTED_BUCKET_DELETING which is saved on the Console's state. The FE schemas didn't allow for this value in the undeletable enum causing a Console crush. 

The fix was to add the missing value to the enum (in the schema). 

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=1810585

### Testing Instructions:
1. 
