### PR TITLE
Backport to 5.3 : Add missing value to enum

### DIFF
--- a/frontend/src/app/schema/host-pools.js
+++ b/frontend/src/app/schema/host-pools.js
@@ -151,6 +151,7 @@ export default {
                     'IN_USE',
                     'DEFAULT_RESOURCE',
                     'BEING_DELETED',
+                    'CONNECTED_BUCKET_DELETING',
                     'IS_BACKINGSTORE'
                 ]
             },


### PR DESCRIPTION
(cherry picked from commit 506dfd6498a85c553cd78850f56952ac4e247fa5)

### Explain the changes
1. Backport to 5.3

