### PR TITLE
FIPS compliance for sha

### DIFF
--- a/config.js
+++ b/config.js
@@ -219,7 +219,7 @@ config.CHUNK_SPLIT_DELTA_CHUNK = config.CHUNK_SPLIT_AVG_CHUNK / 4;
 
 // CODER
 config.CHUNK_CODER_DIGEST_TYPE = 'sha384';
-config.CHUNK_CODER_FRAG_DIGEST_TYPE = 'sha1';
+config.CHUNK_CODER_FRAG_DIGEST_TYPE = 'sha512-256';
 config.CHUNK_CODER_COMPRESS_TYPE = process.env.NOOBAA_DISABLE_COMPRESSION === 'true' ? undefined : 'snappy';
 config.CHUNK_CODER_CIPHER_TYPE = 'aes-256-gcm';
 

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -599,7 +599,7 @@ module.exports = {
 
         digest_type: {
             type: 'string',
-            enum: ['sha1', 'sha256', 'sha384', 'sha512']
+            enum: ['sha1', 'sha256', 'sha384', 'sha512', 'sha512-256', 'sha512-224']
         },
 
         compress_type: {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -8,7 +8,7 @@ type SensitiveString = import('../util/sensitive_string');
 
 type BigInt = number | { n: number; peta: number; };
 type Region = string;
-type DigestType = 'sha1' | 'sha256' | 'sha384' | 'sha512';
+type DigestType = 'sha1' | 'sha256' | 'sha384' | 'sha512' | 'sha512-256' | 'sha512-224';
 type CompressType = 'snappy' | 'zlib';
 type CipherType = 'aes-256-gcm';
 type ParityType = 'isa-c1' | 'isa-rs' | 'cm256';

--- a/src/test/qa/agents_matrix.js
+++ b/src/test/qa/agents_matrix.js
@@ -8,7 +8,7 @@ const test_utils = require('../system_tests/test_utils');
 const { AgentFunctions } = require('../utils/agent_functions');
 
 // Environment Setup
-const shasum = crypto.createHash('sha1');
+const shasum = crypto.createHash('sha512-256');
 shasum.update(Date.now().toString());
 
 const testName = 'agents_matrix';

--- a/src/test/system_tests/test_build_chunks.js
+++ b/src/test/system_tests/test_build_chunks.js
@@ -481,7 +481,7 @@ async function test_rebuild_two_unavailable_blocks() {
 //     }
 //     return Promise.all(block_mds.map(block_md => {
 //         console.log(`corrupt_a_block: corrupted block_md:`, block_md);
-//         block_md.digest_type = 'sha1';
+//         block_md.digest_type = 'sha512-256';
 //         block_md.digest_b64 = crypto.createHash(block_md.digest_type).update(data).digest('base64');
 //         return client.block_store.write_block({
 //             [RPC_BUFFERS]: { data },

--- a/src/test/unit_tests/test_chunk_coder.js
+++ b/src/test/unit_tests/test_chunk_coder.js
@@ -47,7 +47,7 @@ const DIGEST_TYPES = [
     undefined,
 ];
 const FRAG_DIGEST_TYPES = [
-    'sha1',
+    'sha512-256',
     undefined,
 ];
 const COMPRESS_TYPES = [

--- a/src/test/utils/agent_functions.js
+++ b/src/test/utils/agent_functions.js
@@ -8,7 +8,7 @@ const crypto = require('crypto');
 const ssh_functions = require('./ssh_functions');
 
 // Environment Setup
-const shasum = crypto.createHash('sha1');
+const shasum = crypto.createHash('sha512-256');
 shasum.update(Date.now().toString());
 const auth_params = {
     email: 'demo@noobaa.com',

--- a/src/tools/mapper_speed.js
+++ b/src/tools/mapper_speed.js
@@ -41,7 +41,7 @@ async function main() {
         parity_frags: 0,
         lrc_frags: 0,
         digest_type: 'sha384',
-        frag_digest_type: 'sha1',
+        frag_digest_type: 'sha512-256',
         cipher_type: 'aes-256-gcm',
         compress_type: 'snappy',
         parity_type: 'isa-c1',


### PR DESCRIPTION
### Explain the changes
1. Replacing sha1 to sha512-256 in order to comply with FIPS

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
