### PR TITLE
Track backdrop mouse state manually

### DIFF
--- a/frontend/src/app/components/application/modal-manager/modal-manager.html
+++ b/frontend/src/app/components/application/modal-manager/modal-manager.html
@@ -3,7 +3,8 @@
 <!-- ko if: hasModals -->
 <div class="modals-backdrop fixed fade-in"
     ko.event.keydown="onKeyDown"
-    ko.click="(_, evt) => (evt.target === $element && onBackdrop(), true)"
+    ko.event.mousedown="(_, evt) => (evt.target === $element && onBackdropDown(), true)"
+    ko.event.mouseup="(_, evt) => (evt.target === $element && onBackdropUp(), true)"
 >
     <!-- ko foreach: modals -->
     <div class="modal column text-left pop-centered card-shadow"
@@ -26,8 +27,7 @@
                 ko.visible="xButton.visible"
                 ko.disable="xButton.disabled"
                 ko.click="onX"
-
-            ">
+            >
                 <svg-icon params="name: 'x'"></svg-icon>
             </button>
         </h1>

--- a/frontend/src/app/components/application/modal-manager/modal-manager.js
+++ b/frontend/src/app/components/application/modal-manager/modal-manager.js
@@ -54,6 +54,7 @@ class ModalViewModel {
 class ModalManagerViewModel extends ConnectableViewModel {
     hasModals = ko.observable();
     allowBackdropClose = ko.observable();
+    isMousePressedOnBackdrop = false
     modals = ko.observableArray()
         .ofType(ModalViewModel, { manager: this });
 
@@ -92,10 +93,19 @@ class ModalManagerViewModel extends ConnectableViewModel {
         });
     }
 
-    onBackdrop() {
+    onBackdropDown() {
+        this.isMousePressedOnBackdrop = true;
+    }
+
+    onBackdropUp() {
+        if (!this.isMousePressedOnBackdrop) {
+            return;
+        }
+
         if (this.allowBackdropClose()) {
             this.dispatch(closeModal());
         }
+        this.isMousePressedOnBackdrop = false;
     }
 
     onModalX() {


### PR DESCRIPTION
### Explain the changes
1. Use mouse down/up events to track backdrop mouse state manually and close only when the down and up occurred specifically on the backdrop.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1811709

### Testing Instructions:
1. 
