### PR TITLE
fixing 2 issues with namespace bucket on s3

### DIFF
--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -507,11 +507,12 @@ class NamespaceS3 {
         const xattr = _.extend(res.Metadata, {
             'noobaa-namespace-s3-bucket': this.bucket,
         });
+        const ranges = res.ContentRange ? Number(res.ContentRange.split('/')[1]) : 0;
         return {
             obj_id: res.UploadId || etag,
             bucket: bucket,
             key: res.Key,
-            size: res.ContentLength || res.Size || 0,
+            size: ranges || res.ContentLength || res.Size || 0,
             etag,
             create_time: new Date(res.LastModified),
             version_id: res.VersionId,
@@ -525,6 +526,7 @@ class NamespaceS3 {
     }
 
     _translate_error_code(err) {
+        if (err.code === 'NoSuchKey') err.rpc_code = 'NO_SUCH_OBJECT';
         if (err.code === 'NotFound') err.rpc_code = 'NO_SUCH_OBJECT';
     }
 


### PR DESCRIPTION
### Explain the changes
1. Added second error to translate as NO_SUCH_OBJECT - currently we didn't support it and when we had the file only in one bucket - we would still throw exception 
2. Added another caclulation for the size of the object - We use to do head on the file and then using size was the right thing to do, but know we are using get of the 1st 4K bytes so we need to take the size of the file from the ranges returned by the server as you can see in this example: 
```NamespaceS3.read_object_md: ns2demo { bucket: 'nsdemo', key: 'noobaa.yaml', version_id: undefined, md_conditions: undefined, encryption: undefined } res { AcceptRanges: 'bytes', LastModified: 20
20-03-26T19:53:27.000Z, ContentLength: 4096, ETag: '"4a7f5396990e2b28255218d189377f7e"', ContentRange: 'bytes 0-4095/**4550**', ContentType: 'application/octet-stream', Metadata: {}...
```

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Upload a file to a namespace bucket with 2 resources on s3 - one for RW and one just R
2. check that the file is only written to the 1st s3 bucket
3. try to download the file - successful - no Internal error or any other error 

#### for second issue:
1. Upload a file with size bigger than 4096 bytes to a namespace bucket on s3
2. try to download the same file
3. diff the files - no issues
  
