### PR TITLE
fixed upgrade script update_bucket_owner_account.js

### DIFF
--- a/src/upgrade/upgrade_scripts/5.3.0/update_bucket_owner_account.js
+++ b/src/upgrade/upgrade_scripts/5.3.0/update_bucket_owner_account.js
@@ -6,18 +6,18 @@ const _ = require('lodash');
 async function run({ dbg, mongo_client, system_store }) {
     try {
         const system_owner = _.get(system_store.data, 'systems.0.owner._id');
-        await system_store.make_changes({
-            update: {
-                buckets: [{
-                    $find: {
-                        owner_account: { $exists: false }
-                    },
-                    $set: {
-                        owner_account: system_owner
-                    }
-                }]
-            }
-        });
+        const buckets = system_store.data.buckets
+            .filter(b => !b.owner_account)
+            .map(b => ({
+                _id: b._id,
+                $set: { owner_account: system_owner }
+            }));
+        if (buckets.length > 0) {
+            dbg.log0(`updating owner_account (${system_owner}) to these buckets: ${buckets.map(b => b._id).join(', ')}`);
+            await system_store.make_changes({ update: { buckets } });
+        } else {
+            dbg.log0('there are no buckets that need owner_account update');
+        }
     } catch (err) {
         dbg.error('got error while updating bucket owner_account:', err);
         throw err;


### PR DESCRIPTION
### Explain the changes
1. the upgrade script used `$find` `$set` in `make_changes` which only updates a single document.
2. changed to update all necessary buckets

### Issues: Fixed #xxx / Gap #xxx
1. [BZ 1818147](https://bugzilla.redhat.com/show_bug.cgi?id=1818147)

### Testing Instructions:
1. create multiple buckets in a system with version `5.2`
2. upgrade to `5.3`
3. make sure that read_system works, and in the DB all buckets have `owner_account` property 
