### PR TITLE
Added S3 WORM functionality

### DIFF
--- a/config.js
+++ b/config.js
@@ -480,3 +480,10 @@ config.OPERATOR_ACCOUNT_EMAIL = 'operator@noobaa.io';
 ///////////////////////////////
 
 config.INLINE_MAX_SIZE = 4096;
+
+
+///////////////////////////////
+//        WORM RELATED       //
+///////////////////////////////
+
+config.WORM_ENABLED = false;

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -14,6 +14,36 @@ module.exports = {
 
     methods: {
 
+        put_object_lock_configuration: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: ['name', 'object_lock_configuration'],
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    object_lock_configuration: { $ref: '#/definitions/object_lock_configuration' },
+                },
+            },
+            auth: {
+                system: 'admin'
+            },
+        },
+        get_object_lock_configuration: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                },
+            },
+            reply: {
+                $ref: '#/definitions/object_lock_configuration'
+            },
+            auth: {
+                system: 'admin'
+            },
+        },
         create_bucket: {
             method: 'POST',
             params: {
@@ -26,6 +56,7 @@ module.exports = {
                     chunk_split_config: { $ref: 'common_api#/definitions/chunk_split_config' },
                     chunk_coder_config: { $ref: 'common_api#/definitions/chunk_coder_config' },
                     tag: { type: 'string' },
+                    object_lock_configuration: { $ref: '#/definitions/object_lock_configuration' },
                     namespace: {
                         type: 'object',
                         required: ['write_resource', 'read_resources'],
@@ -40,6 +71,9 @@ module.exports = {
                                 },
                             }
                         }
+                    },
+                    lock_enabled: {
+                        type: 'boolean'
                     },
                     bucket_claim: { $ref: '#/definitions/bucket_claim' },
                 }
@@ -912,6 +946,7 @@ module.exports = {
                 spillover: {
                     type: 'string'
                 },
+                object_lock_configuration: { $ref: '#/definitions/object_lock_configuration' },
                 storage: {
                     type: 'object',
                     properties: {
@@ -1359,6 +1394,40 @@ module.exports = {
                 object_suffix: {
                     type: 'string'
                 },
+            }
+        },
+        object_lock_configuration: {
+            type: 'object',
+            properties: {
+                object_lock_enabled: { type: 'string' },
+                rule: {
+                    type: 'object',
+                    properties: {
+                        default_retention: {
+                            oneOf: [{
+                                    type: 'object',
+                                    properties: {
+                                        years: { type: 'integer' },
+                                        mode: {
+                                            type: 'string',
+                                            enum: ['GOVERNANCE', 'COMPLIANCE']
+                                        }
+                                    }
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        days: { type: 'integer' },
+                                        mode: {
+                                            type: 'string',
+                                            enum: ['GOVERNANCE', 'COMPLIANCE']
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
             }
         },
     }

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -747,6 +747,24 @@ module.exports = {
                 'NOT_ENOUGH_RESOURCES',
                 'NO_RESOURCES'
             ]
-        }
+        },
+        lock_settings: {
+            type: 'object',
+            properties: {
+                retention: {
+                    type: 'object',
+                    properties: {
+                        mode: { type: 'string' },
+                        retain_until_date: { date: true },
+                    }
+                },
+                legal_hold: {
+                    type: 'object',
+                    properties: {
+                        status: { type: 'string' },
+                    },
+                }
+            }
+        },
     }
 };

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -13,7 +13,6 @@ module.exports = {
     id: 'object_api',
 
     methods: {
-
         create_object_upload: {
             method: 'POST',
             params: {
@@ -45,6 +44,9 @@ module.exports = {
                     },
                     encryption: {
                         $ref: 'common_api#/definitions/object_encryption'
+                    },
+                    lock_settings: {
+                        $ref: 'common_api#/definitions/lock_settings'
                     }
                 }
             },
@@ -57,7 +59,7 @@ module.exports = {
                     tier_id: { objectid: true },
                     chunk_split_config: { $ref: 'common_api#/definitions/chunk_split_config' },
                     chunk_coder_config: { $ref: 'common_api#/definitions/chunk_coder_config' },
-                    encryption: { $ref: 'common_api#/definitions/object_encryption' }
+                    encryption: { $ref: 'common_api#/definitions/object_encryption' },
                 }
             },
             auth: { system: ['admin', 'user'] }
@@ -586,6 +588,7 @@ module.exports = {
                     obj_id: { objectid: true },
                     version_id: { type: 'string' },
                     md_conditions: { $ref: '#/definitions/md_conditions' },
+                    bypass_governance: { type: 'boolean' },
                 }
             },
             reply: {
@@ -1088,7 +1091,131 @@ module.exports = {
             },
             auth: { system: 'admin' }
         },
-
+        put_object_legal_hold: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: [
+                    'key',
+                    'bucket',
+                    'legal_hold'
+                ],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    key: {
+                        type: 'string',
+                    },
+                    version_id: { type: 'string' },
+                    legal_hold: {
+                        type: 'object',
+                        properties: {
+                            status: {
+                                type: 'string',
+                                enum: ['ON', 'OFF'],
+                            },
+                        },
+                    }
+                }
+            },
+            auth: { system: 'admin' }
+        },
+        get_object_legal_hold: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: [
+                    'key',
+                    'bucket'
+                ],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    key: {
+                        type: 'string',
+                    },
+                    version_id: { type: 'string' },
+                }
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    legal_hold: {
+                        type: 'object',
+                        properties: {
+                            status: {
+                                type: 'string',
+                                enum: ['ON', 'OFF'],
+                            },
+                        },
+                    }
+                }
+            },
+            auth: { system: 'admin' }
+        },
+        put_object_retention: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: [
+                    'key',
+                    'bucket',
+                    'retention'
+                ],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    key: {
+                        type: 'string',
+                    },
+                    version_id: { type: 'string' },
+                    retention: {
+                        type: 'object',
+                        properties: {
+                            mode: {
+                                type: 'string',
+                                enum: ['GOVERNANCE', 'COMPLIANCE'],
+                            },
+                            retain_until_date: { date: true },
+                        },
+                    },
+                    bypass_governance: {
+                        type: 'boolean',
+                    },
+                }
+            },
+            auth: { system: 'admin' }
+        },
+        get_object_retention: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: [
+                    'key',
+                    'bucket'
+                ],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    key: {
+                        type: 'string',
+                    },
+                    version_id: { type: 'string' },
+                }
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    retention: {
+                        type: 'object',
+                        properties: {
+                            mode: {
+                                type: 'string',
+                                enum: ['GOVERNANCE', 'COMPLIANCE'],
+                            },
+                            retain_until_date: { date: true },
+                        },
+                    }
+                }
+            },
+            auth: { system: 'admin' }
+        },
         put_object_tagging: {
             method: 'PUT',
             params: {
@@ -1217,7 +1344,8 @@ module.exports = {
                 // This is the physical size (aggregation of all blocks)
                 // It does not pay attention to dedup
                 capacity_size: { type: 'integer' },
-                s3_signed_url: { type: 'string' }
+                s3_signed_url: { type: 'string' },
+                lock_settings: { $ref: 'common_api#/definitions/lock_settings' }
             }
         },
 

--- a/src/endpoint/s3/ops/s3_delete_object.js
+++ b/src/endpoint/s3/ops/s3_delete_object.js
@@ -3,6 +3,7 @@
 
 // const s3_utils = require('../s3_utils');
 const http_utils = require('../../../util/http_utils');
+const config = require('../../../../config');
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html
@@ -13,6 +14,8 @@ async function delete_object(req, res) {
         key: req.params.key,
         version_id: req.query.versionId,
         md_conditions: http_utils.get_md_conditions(req),
+        bypass_governance: config.WORM_ENABLED ? req.headers['x-amz-bypass-governance-retention'] &&
+            req.headers['x-amz-bypass-governance-retention'].toUpperCase() === 'TRUE' : undefined,
     });
     if (req.query.versionId) {
         res.setHeader('x-amz-version-id', req.query.versionId);

--- a/src/endpoint/s3/ops/s3_get_bucket_object_lock.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_object_lock.js
@@ -1,0 +1,27 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+const s3_utils = require('../s3_utils');
+const config = require('../../../../config');
+const S3Error = require('../s3_errors').S3Error;
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLockConfiguration.html
+ */
+async function get_bucket_object_lock(req) {
+    if (!config.WORM_ENABLED) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+    const object_lock_configuration = await req.object_sdk.get_object_lock_configuration({ name: req.params.bucket });
+    const parsed = s3_utils.parse_to_camel_case(object_lock_configuration, 'ObjectLockConfiguration');
+    return parsed;
+}
+
+module.exports = {
+    handler: get_bucket_object_lock,
+    body: {
+        type: 'empty',
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/endpoint/s3/ops/s3_get_object_legal_hold.js
+++ b/src/endpoint/s3/ops/s3_get_object_legal_hold.js
@@ -1,0 +1,30 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+const s3_utils = require('../s3_utils');
+const S3Error = require('../s3_errors').S3Error;
+const config = require('../../../../config');
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLegalHold.html
+ */
+async function get_object_legal_hold(req, res) {
+    if (!config.WORM_ENABLED) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+    const object_legal_hold = await req.object_sdk.get_object_legal_hold({
+        bucket: req.params.bucket,
+        key: req.params.key,
+        version_id: req.query.versionId
+    });
+    const parsed = s3_utils.parse_to_camel_case(object_legal_hold);
+    return parsed;
+}
+module.exports = {
+    handler: get_object_legal_hold,
+    body: {
+        type: 'empty',
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/endpoint/s3/ops/s3_get_object_retention.js
+++ b/src/endpoint/s3/ops/s3_get_object_retention.js
@@ -1,0 +1,32 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+const s3_utils = require('../s3_utils');
+const S3Error = require('../s3_errors').S3Error;
+const config = require('../../../../config');
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectRetention.html
+ */
+async function get_object_retention(req) {
+    if (!config.WORM_ENABLED) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+    const object_retention = await req.object_sdk.get_object_retention({
+        bucket: req.params.bucket,
+        key: req.params.key,
+        version_id: req.query.versionId
+    });
+
+    const parsed = s3_utils.parse_to_camel_case(object_retention);
+    return parsed;
+}
+
+module.exports = {
+    handler: get_object_retention,
+    body: {
+        type: 'empty',
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/endpoint/s3/ops/s3_put_bucket.js
+++ b/src/endpoint/s3/ops/s3_put_bucket.js
@@ -1,11 +1,14 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
+const config = require('../../../../config');
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html
  */
 async function put_bucket(req, res) {
-    await req.object_sdk.create_bucket({ name: req.params.bucket });
+    const lock_enabled = config.WORM_ENABLED ? req.headers['x-amz-bucket-object-lock-enabled'] &&
+        req.headers['x-amz-bucket-object-lock-enabled'].toUpperCase() === 'TRUE' : undefined;
+    await req.object_sdk.create_bucket({ name: req.params.bucket, lock_enabled: lock_enabled });
     res.setHeader('Location', '/' + req.params.bucket);
 }
 

--- a/src/endpoint/s3/ops/s3_put_bucket_object_lock.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_object_lock.js
@@ -1,0 +1,34 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+const S3Error = require('../s3_errors').S3Error;
+const s3_utils = require('../s3_utils');
+const config = require('../../../../config');
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLockConfiguration.html
+ */
+async function put_bucket_object_lock(req, res) {
+    if (!config.WORM_ENABLED) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+    // TODO: may require at the future Content-MD5 & bucket-object-lock-token support
+    if (req.body.ObjectLockConfiguration.ObjectLockEnabled[0] !== 'Enabled') {
+        throw new S3Error(S3Error.MalformedXML);
+    }
+    const lock_configuration = s3_utils.parse_body_object_lock_conf_xml(req);
+
+    await req.object_sdk.put_object_lock_configuration({
+        name: req.params.bucket,
+        object_lock_configuration: lock_configuration,
+    });
+}
+
+module.exports = {
+    handler: put_bucket_object_lock,
+    body: {
+        type: 'xml',
+    },
+    reply: {
+        type: 'empty',
+    },
+};

--- a/src/endpoint/s3/ops/s3_put_object_legal_hold.js
+++ b/src/endpoint/s3/ops/s3_put_object_legal_hold.js
@@ -1,0 +1,35 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+const S3Error = require('../s3_errors').S3Error;
+const config = require('../../../../config');
+
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html
+ */
+async function put_object_legal_hold(req) {
+    if (!config.WORM_ENABLED) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+    // TODO: may require at the future Content-MD5 support
+    const legal_hold_status = req.body.LegalHold.Status[0];
+    if (legal_hold_status !== 'ON' && legal_hold_status !== 'OFF') {
+        throw new S3Error(S3Error.MalformedXML);
+    }
+    await req.object_sdk.put_object_legal_hold({
+        bucket: req.params.bucket,
+        key: req.params.key,
+        version_id: req.query.versionId,
+        legal_hold: { status: legal_hold_status }
+    });
+}
+
+module.exports = {
+    handler: put_object_legal_hold,
+    body: {
+        type: 'xml',
+    },
+    reply: {
+        type: 'empty',
+    },
+};

--- a/src/endpoint/s3/ops/s3_put_object_retention.js
+++ b/src/endpoint/s3/ops/s3_put_object_retention.js
@@ -1,0 +1,46 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+const S3Error = require('../s3_errors').S3Error;
+const s3_utils = require('../s3_utils');
+const config = require('../../../../config');
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html
+ */
+async function put_object_retention(req) {
+    if (!config.WORM_ENABLED) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+    // TODO: may require at the future Content-MD5 support
+    if (!req.body.Retention) throw new S3Error(S3Error.MalformedXML);
+    const mode = req.body.Retention.Mode[0];
+    let retain_until_date = req.body.Retention.RetainUntilDate[0];
+    if (!mode && !retain_until_date) throw new S3Error(S3Error.AccessDenied);
+    if (!mode || !retain_until_date) throw new S3Error(S3Error.MalformedXML);
+    retain_until_date = new Date(req.body.Retention.RetainUntilDate[0]);
+
+    let bypass_governance = req.headers['x-amz-bypass-governance-retention'] && req.headers['x-amz-bypass-governance-retention'].toUpperCase() === 'TRUE';
+
+    if (s3_utils._is_valid_retention(mode, retain_until_date)) {
+        await req.object_sdk.put_object_retention({
+            bucket: req.params.bucket,
+            key: req.params.key,
+            version_id: req.query.versionId,
+            bypass_governance,
+            retention: {
+                mode,
+                retain_until_date,
+            }
+        });
+    }
+}
+
+module.exports = {
+    handler: put_object_retention,
+    body: {
+        type: 'xml',
+    },
+    reply: {
+        type: 'empty',
+    },
+};

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -394,6 +394,17 @@ const errors_defs = [{
     message: 'Invalid principal in policy',
     http_code: 400,
     detail: '...',
+}, {
+    // not defined in AWS docs but this is what they return
+    code: 'NoSuchObjectLockConfiguration',
+    message: 'The specified object does not have a ObjectLock configuration',
+    http_code: 404,
+}, {
+    // not defined in AWS docs but this is what they return
+    code: 'ObjectLockConfigurationNotFoundError',
+    message: 'Object Lock configuration does not exist for this bucket',
+    http_code: 404,
+
 }];
 
 for (const err_def of errors_defs) {

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -22,35 +22,40 @@ const S3_XML_ROOT_ATTRS = Object.freeze({
 });
 
 const BUCKET_SUB_RESOURCES = Object.freeze({
-    accelerate: 1,
-    acl: 1,
-    analytics: 1,
-    cors: 1,
-    delete: 1,
-    inventory: 1,
-    lifecycle: 1,
-    location: 1,
-    logging: 1,
-    metrics: 1,
-    notification: 1,
-    policy: 1,
-    replication: 1,
-    requestPayment: 1,
-    tagging: 1,
-    uploads: 1,
-    versioning: 1,
-    versions: 1,
-    website: 1,
-    encryption: 1,
+    'accelerate': 'accelerate',
+    'acl': 'acl',
+    'analytics': 'analytics',
+    'cors': 'cors',
+    'delete': 'delete',
+    'inventory': 'inventory',
+    'lifecycle': 'lifecycle',
+    'location': 'location',
+    'logging': 'logging',
+    'metrics': 'metrics',
+    'notification': 'notification',
+    'policy': 'policy',
+    'replication': 'replication',
+    'requestPayment': 'requestPayment',
+    'tagging': 'tagging',
+    'uploads': 'uploads',
+    'versioning': 'versioning',
+    'versions': 'versions',
+    'website': 'website',
+    'encryption': 'encryption',
+    'object-lock': 'object_lock',
+    'legal-hold': 'legal_hold',
+    'retention': 'retention'
 });
 
 const OBJECT_SUB_RESOURCES = Object.freeze({
-    acl: 1,
-    restore: 1,
-    tagging: 1,
-    torrent: 1,
-    uploads: 1,
-    uploadId: 1,
+    'acl': 'acl',
+    'restore': 'restore',
+    'tagging': 'tagging',
+    'torrent': 'torrent',
+    'uploads': 'uploads',
+    'uploadId': 'uploadId',
+    'legal-hold': 'legal_hold',
+    'retention': 'retention'
 });
 
 const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
@@ -80,6 +85,9 @@ const RPC_ERRORS_TO_S3 = Object.freeze({
     INVALID_BUCKET_STATE: S3Error.InvalidBucketState,
     NOT_ENOUGH_SPACE: S3Error.InvalidBucketState,
     MALFORMED_POLICY: S3Error.MalformedPolicy,
+    NO_SUCH_OBJECT_LOCK_CONFIGURATION: S3Error.NoSuchObjectLockConfiguration,
+    OBJECT_LOCK_CONFIGURATION_NOT_FOUND_ERROR: S3Error.ObjectLockConfigurationNotFoundError,
+    INVALID_REQUEST: S3Error.InvalidRequest,
 });
 
 const S3_OPS = load_ops();
@@ -139,6 +147,7 @@ async function handle_request(req, res) {
     dbg.log0('S3 REQUEST', req.method, req.originalUrl, 'op', op_name, 'request_id', req.request_id, req.headers);
     usage_report.s3_usage_info.total_calls += 1;
     usage_report.s3_usage_info[op_name] = (usage_report.s3_usage_info[op_name] || 0) + 1;
+
     const op = S3_OPS[op_name];
     if (!op || !op.handler) {
         dbg.error('S3 TODO (NotImplemented)', op_name, req.method, req.originalUrl);
@@ -429,7 +438,7 @@ function parse_op_name(req) {
     if (!key) {
         const query_keys = Object.keys(req.query);
         for (let i = 0; i < query_keys.length; ++i) {
-            if (BUCKET_SUB_RESOURCES[query_keys[i]]) return `${method}_bucket_${query_keys[i]}`;
+            if (BUCKET_SUB_RESOURCES[query_keys[i]]) return `${method}_bucket_${BUCKET_SUB_RESOURCES[query_keys[i]]}`;
         }
         return `${method}_bucket`;
     }
@@ -437,7 +446,7 @@ function parse_op_name(req) {
     // object url
     const query_keys = Object.keys(req.query);
     for (let i = 0; i < query_keys.length; ++i) {
-        if (OBJECT_SUB_RESOURCES[query_keys[i]]) return `${method}_object_${query_keys[i]}`;
+        if (OBJECT_SUB_RESOURCES[query_keys[i]]) return `${method}_object_${OBJECT_SUB_RESOURCES[query_keys[i]]}`;
     }
     return `${method}_object`;
 }

--- a/src/sdk/accountspace_nb.js
+++ b/src/sdk/accountspace_nb.js
@@ -150,6 +150,17 @@ class AccountSpaceNB {
         });
     }
 
+    /////////////////////////
+    // DEFAULT OBJECT LOCK //
+    /////////////////////////
+
+    get_object_lock_configuration(params) {
+        return this.rpc_client.bucket.get_object_lock_configuration(params);
+    }
+
+    put_object_lock_configuration(params) {
+        return this.rpc_client.bucket.put_object_lock_configuration(params);
+    }
 }
 
 module.exports = AccountSpaceNB;

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -287,6 +287,25 @@ class NamespaceNB {
         return object_sdk.rpc_client.object.get_object_tagging(params);
     }
 
+    ///////////////////
+    //  OBJECT LOCK  //
+    ///////////////////
+
+    get_object_legal_hold(params, object_sdk) {
+        return object_sdk.rpc_client.object.get_object_legal_hold(params);
+    }
+
+    put_object_legal_hold(params, object_sdk) {
+        return object_sdk.rpc_client.object.put_object_legal_hold(params);
+    }
+
+    get_object_retention(params, object_sdk) {
+        return object_sdk.rpc_client.object.get_object_retention(params);
+    }
+
+    put_object_retention(params, object_sdk) {
+        return object_sdk.rpc_client.object.put_object_retention(params);
+    }
 }
 
 module.exports = NamespaceNB;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -350,6 +350,7 @@ interface ObjectMD {
     version_seq: number;
     version_past: boolean;
     version_enabled: boolean;
+    lock_enabled: boolean;
     delete_marker?: boolean;
     size: number;
     num_parts: number;
@@ -364,6 +365,7 @@ interface ObjectMD {
     stats: { reads: number; last_read: Date; };
     encryption: { algorithm: string; kms_key_id: string; context_b64: string; key_md5_b64: string; key_b64: string; };
     tagging: { key: string; value: string; }[],
+    lock_settings: { retention: { mode: string; retain_until_date: Date; }, legal_hold: { status: string } };
 }
 
 interface ObjectInfo {
@@ -371,6 +373,7 @@ interface ObjectInfo {
     bucket: string;
     key: string;
     version_id: string;
+    lock_settings: { retention: { mode: string; retain_until_date: Date; }, legal_hold: { status: string } };
     is_latest: boolean;
     delete_marker?: boolean;
     size: number;

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -169,7 +169,8 @@ class ObjectIO {
             'sha256_b64',
             'xattr',
             'tagging',
-            'encryption'
+            'encryption',
+            'lock_settings'
         );
         const complete_params = _.pick(params,
             'obj_id',

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -599,7 +599,37 @@ class ObjectSDK {
             });
         }
     }
+    ////////////////////
+    //  OBJECT LOCK   //
+    ////////////////////
 
+    async get_object_lock_configuration(params) {
+        const ns = this._get_account_namespace();
+        return ns.get_object_lock_configuration(params, this);
+    }
+
+    async put_object_lock_configuration(params) {
+        const ns = this._get_account_namespace();
+        return ns.put_object_lock_configuration(params, this);
+    }
+    async get_object_legal_hold(params) {
+        const ns = this.namespace_nb;
+        return ns.get_object_legal_hold(params, this);
+    }
+
+    async put_object_legal_hold(params) {
+        const ns = this.namespace_nb;
+        return ns.put_object_legal_hold(params, this);
+    }
+    async get_object_retention(params) {
+        const ns = this.namespace_nb;
+        return ns.get_object_retention(params, this);
+    }
+
+    async put_object_retention(params) {
+        const ns = this.namespace_nb;
+        return ns.put_object_retention(params, this);
+    }
 }
 
 module.exports = ObjectSDK;

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -23,7 +23,28 @@ module.exports = {
         key: { type: 'string' },
 
         version_seq: { type: 'integer' },
-
+        // lock_settings are the settings of the locked object version
+        lock_settings: {
+            type: 'object',
+            properties: {
+                retention: {
+                    type: 'object',
+                    properties: {
+                        mode: { type: 'string' },
+                        retain_until_date: { date: true },
+                    }
+                },
+                legal_hold: {
+                    type: 'object',
+                    properties: {
+                        status: {
+                            type: 'string',
+                            enum: ['ON', 'OFF'],
+                        },
+                    },
+                }
+            }
+        },
         // version_past = undefined  means latest version.
         // version_past = true       means non latest.
         // version_past = false      unused!

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -50,6 +50,40 @@ module.exports = {
         owner_account: {
             objectid: true
         },
+        object_lock_configuration: {
+            type: 'object',
+            properties: {
+                object_lock_enabled: { type: 'string' },
+                rule: {
+                    type: 'object',
+                    properties: {
+                        default_retention: {
+                            oneOf: [{
+                                    type: 'object',
+                                    properties: {
+                                        years: { type: 'integer' },
+                                        mode: {
+                                            type: 'string',
+                                            enum: ['GOVERNANCE', 'COMPLIANCE']
+                                        }
+                                    }
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        days: { type: 'integer' },
+                                        mode: {
+                                            type: 'string',
+                                            enum: ['GOVERNANCE', 'COMPLIANCE']
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         namespace: {
             type: 'object',
             required: [

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -77,3 +77,4 @@ require('./test_s3_encryption');
 require('./test_s3_bucket_policy');
 require('./test_node_allocator');
 // require('./test_tiering_upload');
+//require('./test_s3_worm');

--- a/src/test/unit_tests/test_s3_worm.js
+++ b/src/test/unit_tests/test_s3_worm.js
@@ -1,0 +1,420 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('./coretest');
+coretest.setup({ pools_to_create: coretest.POOL_LIST });
+const AWS = require('aws-sdk');
+const http = require('http');
+const mocha = require('mocha');
+const assert = require('assert');
+const today = new Date();
+const tomorrow = new Date(today);
+tomorrow.setDate(tomorrow.getDate() + 1);
+const todayPlus15 = new Date(today);
+todayPlus15.setDate(todayPlus15.getDate() + 15);
+const malformedXML_message = 'This happens when the user sends malformed xml (xml that doesn\'t conform to the published xsd) for the configuration. The error message is, "The XML you provided was not well-formed or did not validate against our published schema."';
+async function assert_throws_async(promise, expected_code = 'AccessDenied', expected_message = 'Access Denied') {
+    try {
+        await promise;
+        assert.fail('Test was suppose to fail on ' + expected_message);
+    } catch (err) {
+        if (err.message !== expected_message || err.code !== expected_code) throw err;
+    }
+}
+mocha.describe('s3 worm', function() {
+    const { rpc_client, EMAIL } = coretest;
+    const BKT = 'wormbucket';
+    const BKT1 = 'wormbucket1';
+    const OBJ1 = 'text-file1';
+    const OBJ2 = 'text-file2';
+    const OBJ3 = 'text-file3';
+    const OBJ4 = 'text-file4';
+    const file_body = "TEXT-FILE-YAY!!!!-SO_COOL";
+    const file_body2 = "TEXT-FILE-YAY!!!!-SO_COOL2";
+    let version_id1;
+    let version_id2;
+    let version_id3;
+    let version_id4;
+    const user_a = 'alice';
+    let s3_owner;
+    //let s3_a;
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        const s3_creds = {
+            endpoint: coretest.get_http_address(),
+            s3ForcePathStyle: true,
+            signatureVersion: 'v4',
+            computeChecksums: true,
+            s3DisableBodySigning: false,
+            region: 'us-east-1',
+            httpOptions: { agent: new http.Agent({ keepAlive: false }) },
+        };
+        const account = { has_login: false, s3_access: true, allowed_buckets: { full_permission: true } };
+        const admin_keys = (await rpc_client.account.read_account({ email: EMAIL, })).access_keys;
+        account.name = user_a;
+        account.email = user_a;
+        const user_a_keys = (await rpc_client.account.create_account(account)).access_keys;
+        s3_creds.accessKeyId = user_a_keys[0].access_key.unwrap();
+        s3_creds.secretAccessKey = user_a_keys[0].secret_key.unwrap();
+        //s3_a = new AWS.S3(s3_creds);
+        s3_creds.accessKeyId = admin_keys[0].access_key.unwrap();
+        s3_creds.secretAccessKey = admin_keys[0].secret_key.unwrap();
+        s3_owner = new AWS.S3(s3_creds);
+    });
+    mocha.describe('buckets creation', function() {
+        mocha.it('create bucket BKT & enable lock', async function() {
+            const res = await s3_owner.createBucket({ Bucket: BKT, ObjectLockEnabledForBucket: true }).promise();
+            assert.equal(res.Location, `/${BKT}`);
+        });
+        mocha.it('create bucket BKT1 & enable lock', async function() {
+            const res = await s3_owner.createBucket({ Bucket: BKT1, ObjectLockEnabledForBucket: true }).promise();
+            assert.equal(res.Location, `/${BKT1}`);
+        });
+        mocha.it('list buckets with BKT & BKT1', async function() {
+            const res = await s3_owner.listBuckets().promise();
+            assert(res.Buckets.find(bucket => bucket.Name === BKT));
+            assert(res.Buckets.find(bucket => bucket.Name === BKT1));
+        });
+        mocha.it('should fail suspend versioning on locked bucket', async function() {
+            await assert_throws_async(s3_owner.putBucketVersioning({
+                Bucket: BKT,
+                VersioningConfiguration: { MFADelete: 'Disabled', Status: 'Suspended' }
+            }).promise(), 'InvalidBucketState', 'The request is not valid with the current state of the bucket.');
+        });
+    });
+    mocha.describe('object OBJ1 creation before having lock config on BKT', function() {
+        mocha.it('create object OBJ1 in BKT', async function() {
+            const put_object_res = await s3_owner.putObject({ Bucket: BKT, Key: OBJ1, Body: file_body, ContentType: 'text/plain' }).promise();
+            version_id1 = put_object_res.VersionId;
+            assert.ok(put_object_res.VersionId);
+        });
+        mocha.it('IT6. should list objects in BKT', async function() {
+            const res = await s3_owner.listObjects({ Bucket: BKT }).promise();
+            assert(res.Contents.find(object => object.Key === OBJ1));
+        });
+    });
+    mocha.describe('bucket object lock configuration on BKT', function() {
+        mocha.it('should fail put lock configuration with boch days and years', async function() {
+            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+                Bucket: BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                    Rule: { DefaultRetention: { Years: 1, Days: 15, Mode: 'COMPLIANCE' } }
+                }
+            }).promise(), 'MalformedXML', malformedXML_message);
+        });
+        mocha.it('should fail put lock configuration with 0 years', async function() {
+            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+                Bucket: BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                    Rule: { DefaultRetention: { Years: 0, Mode: 'GOVERNANCE' } }
+                }
+            }).promise(), 'InvalidArgument', 'Default retention period must be a positive integer value');
+        });
+        mocha.it('should fail put faulty lock configuration', async function() {
+            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+                Bucket: BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                    Rule: { DefaultRetention: { Days: 1, Mode: 'GOVERNANCE1' } }
+                }
+            }).promise(), 'MalformedXML', malformedXML_message);
+        });
+        mocha.it('should get empty lock configuration', async function() {
+            const conf = await s3_owner.getObjectLockConfiguration({ Bucket: BKT }).promise();
+            assert.equal(conf.ObjectLockEnabled, 'Enabled');
+            assert.strictEqual(conf.ObjectLockConfiguration.Rule, undefined);
+        });
+        mocha.it('should fail put lock configuration with disabled lock', async function() {
+            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+                Bucket: BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Disabled',
+                    Rule: { DefaultRetention: { Days: 15, Mode: 'COMPLIANCE' } }
+                }
+            }).promise(), 'MalformedXML', malformedXML_message);
+        });
+        mocha.it('should put lock configuration', async function() {
+            const conf = await s3_owner.putObjectLockConfiguration({
+                Bucket: BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                    Rule: { DefaultRetention: { Days: 15, Mode: 'COMPLIANCE' } }
+                }
+            }).promise();
+            assert.deepEqual(conf, {});
+        });
+        mocha.it('should get non empty lock configuration', async function() {
+            const conf = await s3_owner.getObjectLockConfiguration({ Bucket: BKT }).promise();
+            assert.ok(conf.ObjectLockConfiguration.Rule.DefaultRetention);
+            assert.strictEqual(conf.ObjectLockConfiguration.Rule.DefaultRetention.Mode, 'COMPLIANCE');
+            assert.strictEqual(conf.ObjectLockConfiguration.Rule.DefaultRetention.Days, 15);
+        });
+    });
+    mocha.describe('OBJ1 checks', function() {
+        mocha.it('should head object without default values of the BKT conf', async function() {
+            const conf = await s3_owner.headObject({ Bucket: BKT, Key: OBJ1 }).promise();
+            assert.ok(!conf.ObjectLockLegalHoldStatus && !conf.ObjectLockRetainUntilDate && !conf.ObjectLockMode);
+        });
+        mocha.it('should put legal hold', async function() {
+            const conf = await s3_owner.putObjectLegalHold({
+                Bucket: BKT,
+                Key: OBJ1,
+                LegalHold: {
+                    Status: 'ON'
+                },
+                VersionId: version_id1,
+            }).promise();
+            assert.deepEqual(conf, {});
+        });
+        mocha.it('should get object with legal hold', async function() {
+            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            assert.equal(conf.LegalHold.Status, 'ON');
+        });
+        const today2 = new Date();
+        const MinusOneMin = new Date(today2);
+        MinusOneMin.setMinutes(MinusOneMin.getMinutes() - 1);
+        mocha.it('should fail put retention at the past', async function() {
+            await assert_throws_async(s3_owner.putObjectRetention({
+                Bucket: BKT,
+                Key: OBJ1,
+                BypassGovernanceRetention: true,
+                Retention: {
+                    Mode: 'GOVERNANCE',
+                    RetainUntilDate: MinusOneMin,
+                },
+                VersionId: version_id1
+            }).promise(), 'InvalidArgument', 'The retain until date must be in the future!');
+        });
+        mocha.it('should put retention', async function() {
+            const today1 = new Date();
+            const oneSec = new Date(today1);
+            oneSec.setSeconds(today1.getSeconds() + 10);
+            const conf = await s3_owner.putObjectRetention({
+                Bucket: BKT,
+                Key: OBJ1,
+                BypassGovernanceRetention: true,
+                Retention: { Mode: 'GOVERNANCE', RetainUntilDate: oneSec },
+                VersionId: version_id1
+            }).promise();
+            assert.deepEqual(conf, {});
+        });
+        mocha.it('should get retention 1', async function() {
+            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            assert.ok(conf.Retention.RetainUntilDate);
+            assert.equal(conf.Retention.Mode, 'GOVERNANCE');
+        });
+        mocha.it('should put retention', async function() {
+            const conf = await s3_owner.putObjectRetention({
+                Bucket: BKT,
+                Key: OBJ1,
+                BypassGovernanceRetention: true,
+                Retention: { Mode: 'GOVERNANCE', RetainUntilDate: tomorrow },
+                VersionId: version_id1
+            }).promise();
+            assert.deepEqual(conf, {});
+        });
+        mocha.it('should get retention 2', async function() {
+            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            assert.ok(conf.Retention.RetainUntilDate);
+            assert.equal(conf.Retention.Mode, 'GOVERNANCE');
+        });
+        mocha.it('should get legal hold (check if legal hold overridden)', async function() {
+            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            assert.equal(conf.LegalHold.Status, 'ON');
+        });
+        mocha.it('should put retention (compliance mode)', async function() {
+            const today3 = new Date();
+            const oneSec3 = new Date(today3);
+            oneSec3.setSeconds(oneSec3.getSeconds() + 30);
+            await assert_throws_async(s3_owner.putObjectRetention({
+                Bucket: BKT,
+                Key: OBJ1,
+                BypassGovernanceRetention: false,
+                Retention: { Mode: 'COMPLIANCE', RetainUntilDate: oneSec3 },
+                VersionId: version_id1
+            }).promise(), 'AccessDenied', 'Access Denied');
+            const conf = await s3_owner.putObjectRetention({
+                Bucket: BKT,
+                Key: OBJ1,
+                BypassGovernanceRetention: true,
+                Retention: { Mode: 'COMPLIANCE', RetainUntilDate: oneSec3 },
+                VersionId: version_id1
+            }).promise();
+            assert.deepEqual(conf, {});
+        });
+        mocha.it('IT25. should get object with retention (compliance mode)', async function() {
+            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            assert.ok(conf.Retention.RetainUntilDate);
+            assert.equal(conf.Retention.Mode, 'COMPLIANCE');
+        });
+        mocha.it('fail delete object with retention COMPLIANCE', async function() {
+            await assert_throws_async(s3_owner.deleteObject({
+                Bucket: BKT,
+                Key: OBJ1,
+                BypassGovernanceRetention: true,
+                VersionId: version_id1,
+            }).promise(), 'AccessDenied', 'Access Denied');
+        });
+        mocha.it('put object with retention mode and without date', async function() {
+            const params = { Bucket: BKT, Key: OBJ1, Body: file_body, ContentType: 'text/plain', ObjectLockMode: 'GOVERNANCE' };
+            await assert_throws_async(s3_owner.putObject(params).promise(), 'InvalidArgument',
+                'x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied');
+        });
+    });
+    mocha.describe('put object OBJ3 after bucket configuration exist', function() {
+        mocha.it('should create object OBJ3 in BKT', async function() {
+            const conf = await s3_owner.putObject({ Bucket: BKT, Key: OBJ3, Body: file_body, ContentType: 'text/plain' }).promise();
+            assert.ok(conf.VersionId);
+            version_id3 = conf.VersionId;
+        });
+        mocha.it('should list objects in BKT contains OBJ3', async function() {
+            const res = await s3_owner.listObjects({ Bucket: BKT }).promise();
+            assert(res.Contents.find(object => object.Key === OBJ3));
+        });
+        mocha.it('should fail get slegal hold', async function() {
+            await assert_throws_async(s3_owner.getObjectLegalHold({
+                Bucket: BKT,
+                Key: OBJ3,
+                VersionId: version_id3
+            }).promise(), 'InvalidRequest', 'SOAP requests must be made over an HTTPS connection.');
+        });
+        mocha.it('should put legal hold on OBJ3', async function() {
+            const conf = await s3_owner.putObjectLegalHold({ Bucket: BKT, Key: OBJ3, LegalHold: { Status: 'OFF' } }).promise();
+            assert.deepEqual(conf, {});
+        });
+        mocha.it('should get object', async function() {
+            const conf = await s3_owner.getObject({ Bucket: BKT, Key: OBJ3 }).promise();
+            assert.ok(conf.ObjectLockRetainUntilDate);
+            assert.strictEqual(conf.ObjectLockMode, 'COMPLIANCE');
+        });
+        mocha.it('should head object', async function() {
+            const conf = await s3_owner.headObject({ Bucket: BKT, Key: OBJ3 }).promise();
+            assert.equal(conf.ObjectLockLegalHoldStatus, 'OFF');
+            assert.ok(conf.ObjectLockRetainUntilDate);
+            assert.strictEqual(conf.ObjectLockMode, 'COMPLIANCE');
+        });
+        mocha.it('should fail put retention (compliance mode)', async function() {
+            await assert_throws_async(s3_owner.putObjectRetention({
+                Bucket: BKT,
+                Key: OBJ3,
+                Retention: { Mode: 'COMPLIANCE', RetainUntilDate: tomorrow },
+                VersionId: version_id3,
+            }).promise(), 'AccessDenied', 'Access Denied');
+        });
+    });
+    mocha.describe('put object', function() {
+        mocha.it('IT26. should put object with retention', async function() {
+            const put_object_res = await s3_owner.putObject({
+                Bucket: BKT,
+                Key: OBJ4,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockLegalHoldStatus: 'OFF',
+                ObjectLockMode: 'GOVERNANCE',
+                ObjectLockRetainUntilDate: tomorrow,
+            }).promise();
+            version_id4 = put_object_res.VersionId;
+            assert.ok(put_object_res.VersionId);
+        });
+        mocha.it('should list objects in BKT contains OBJ4', async function() {
+            const res = await s3_owner.listObjects({ Bucket: BKT }).promise();
+            assert(res.Contents.find(object => object.Key === OBJ4));
+        });
+        mocha.it('should get retention', async function() {
+            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ4, VersionId: version_id4 }).promise();
+            assert.ok(conf.Retention.RetainUntilDate);
+            assert.equal(conf.Retention.Mode, 'GOVERNANCE');
+        });
+        mocha.it('should get LegalHold', async function() {
+            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ4, VersionId: version_id4 }).promise();
+            assert.equal(conf.LegalHold.Status, 'OFF');
+        });
+        mocha.it('should fail delete object with retention (governanceBypass=false)', async function() {
+            await assert_throws_async(s3_owner.deleteObject({
+                Bucket: BKT,
+                Key: OBJ4,
+                BypassGovernanceRetention: false,
+                VersionId: version_id4,
+            }).promise(), 'AccessDenied', 'Access Denied');
+        });
+        mocha.it('should delete object with retention (governanceBypass=trues)', async function() {
+            const deleted = await s3_owner.deleteObject({
+                Bucket: BKT,
+                Key: OBJ4,
+                BypassGovernanceRetention: true,
+                VersionId: version_id4,
+            }).promise();
+            assert.ok(deleted.VersionId);
+        });
+    });
+    mocha.describe('overwrite versions and check', function() {
+        mocha.it('should create object OBJs in BKT', async function() {
+            const conf = await s3_owner.putObject({ Bucket: BKT1, Key: OBJ2, Body: file_body, ContentType: 'text/plain' }).promise();
+            assert.ok(conf.VersionId);
+            version_id2 = conf.VersionId;
+        });
+        mocha.it('should head object', async function() { //get object version2 = latest
+            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 }).promise();
+            assert.ok(!conf.ObjectLockLegalHoldStatus && !conf.ObjectLockRetainUntilDate && !conf.ObjectLockMode);
+        });
+        mocha.it('IT29. should not overwrite object with retention', async function() {
+            const put_object_res = await s3_owner.putObject({ // now version5 is latest
+                Bucket: BKT1,
+                Key: OBJ2,
+                Body: file_body2,
+                ContentType: 'text/plain',
+            }).promise();
+            assert.ok(put_object_res.VersionId);
+        });
+        mocha.it('should put legal hold on OBJ2', async function() {
+            await s3_owner.putObjectLegalHold({ Bucket: BKT1, Key: OBJ2, LegalHold: { Status: 'ON' } }).promise();
+        });
+        mocha.it('should put retention', async function() {
+            await s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: OBJ2,
+                Retention: { Mode: 'GOVERNANCE', RetainUntilDate: tomorrow },
+            }).promise();
+        });
+        mocha.it('should head object', async function() { //get object version5 = latest
+            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 }).promise();
+            assert.ok(conf.ObjectLockLegalHoldStatus);
+            assert.ok(conf.ObjectLockRetainUntilDate);
+            assert.strictEqual(conf.ObjectLockMode, 'GOVERNANCE');
+        });
+        mocha.it('should get legal hold on OBJ2', async function() {
+            await assert_throws_async(s3_owner.getObjectLegalHold({
+                Bucket: BKT1,
+                Key: OBJ2,
+                VersionId: version_id2
+            }).promise(), 'InvalidRequest', 'SOAP requests must be made over an HTTPS connection.');
+        });
+        mocha.it('should get retention on OBJ2', async function() {
+            await assert_throws_async(s3_owner.getObjectRetention({
+                Bucket: BKT1,
+                Key: OBJ2,
+                VersionId: version_id2
+            }).promise(), 'NoSuchObjectLockConfiguration', 'The specified object does not have a ObjectLock configuration');
+        });
+        mocha.it('should put legal hold on OBJ2 version_id', async function() {
+            await s3_owner.putObjectLegalHold({ Bucket: BKT1, Key: OBJ2, LegalHold: { Status: 'OFF' }, VersionId: version_id2 }).promise();
+        });
+        mocha.it('should put retention (compliance mode) version_id', async function() {
+            await s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: OBJ2,
+                Retention: { Mode: 'COMPLIANCE', RetainUntilDate: tomorrow },
+                VersionId: version_id2
+            }).promise();
+        });
+        mocha.it('should head object', async function() { //get object version5 = latest
+            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 }).promise();
+            assert.strictEqual(conf.ObjectLockLegalHoldStatus, 'ON');
+            assert.strictEqual(conf.ObjectLockMode, 'GOVERNANCE');
+        });
+    });
+});


### PR DESCRIPTION
### Explain the changes
1. Added S3 WORM functionality:
1.1 Added support in put bucket with enable lock option.
1.2 Added support in put/get object lock configuration on bucket.
1.3 Added support of put/get retention (mode & period).
1.4 Added  support of put/get legal hold.
1.5 Added support to put/get object.
2. Added worm tests.

### Issues: Fixed #xxx / Gap #xxx
1. Gap MD5 of put_object, see last note:
https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html 

### Testing Instructions:
1. 
