### PR TITLE
Handle BucketAlreadyOwnedByYou s3 error

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -65,6 +65,7 @@ const RPC_ERRORS_TO_S3 = Object.freeze({
     INVALID_BUCKET_NAME: S3Error.InvalidBucketName,
     NOT_EMPTY: S3Error.BucketNotEmpty,
     BUCKET_ALREADY_EXISTS: S3Error.BucketAlreadyExists,
+    BUCKET_ALREADY_OWNED_BY_YOU: S3Error.BucketAlreadyOwnedByYou,
     NO_SUCH_UPLOAD: S3Error.NoSuchUpload,
     BAD_DIGEST_MD5: S3Error.BadDigest,
     BAD_DIGEST_SHA256: S3Error.XAmzContentSHA256Mismatch,

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1284,9 +1284,16 @@ function validate_bucket_creation(req) {
         !VALID_BUCKET_NAME_REGEXP.test(req.rpc_params.name.unwrap())) {
         throw new RpcError('INVALID_BUCKET_NAME');
     }
-    if (req.system.buckets_by_name && req.system.buckets_by_name[req.rpc_params.name.unwrap()]) {
-        throw new RpcError('BUCKET_ALREADY_EXISTS');
+    const bucket = req.system.buckets_by_name && req.system.buckets_by_name[req.rpc_params.name.unwrap()];
+
+    if (bucket) {
+        if (system_store.has_same_id(bucket.owner_account, req.account)) {
+            throw new RpcError('BUCKET_ALREADY_OWNED_BY_YOU');
+        } else {
+            throw new RpcError('BUCKET_ALREADY_EXISTS');
+        }
     }
+
     if (req.account.allow_bucket_creation === false) {
         throw new RpcError('UNAUTHORIZED', 'Not allowed to create new buckets');
     }

--- a/src/test/system_tests/test_ceph_s3.js
+++ b/src/test/system_tests/test_ceph_s3.js
@@ -239,7 +239,6 @@ const S3_CEPH_TEST_BLACKLIST = [
     's3tests_boto3.functional.test_s3.test_bucket_create_naming_dns_dot_dot',
     's3tests_boto3.functional.test_s3.test_bucket_create_naming_dns_dot_dash',
     's3tests_boto3.functional.test_s3.test_bucket_create_naming_dns_dash_dot',
-    's3tests_boto3.functional.test_s3.test_bucket_create_exists',
     's3tests_boto3.functional.test_s3.test_bucket_acl_default',
     's3tests_boto3.functional.test_s3.test_bucket_acl_canned_during_create',
     's3tests_boto3.functional.test_s3.test_bucket_acl_canned',

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -48,6 +48,15 @@ mocha.describe('s3_ops', function() {
         mocha.it('should create bucket', async function() {
             await s3.createBucket({ Bucket: BKT1 }).promise();
         });
+        mocha.it('should not recreate bucket', async function() {
+            const func = async () => s3.createBucket({ Bucket: BKT1 }).promise();
+            const expected_err_props = {
+                name: 'BucketAlreadyOwnedByYou',
+                code: 'BucketAlreadyOwnedByYou',
+                statusCode: 409,
+            };
+            await assert.rejects(func, expected_err_props);
+        });
         mocha.it('should head bucket', async function() {
             await s3.headBucket({ Bucket: BKT1 }).promise();
         });


### PR DESCRIPTION
As per https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html,
in case a user tries to create a bucket which already exists
and owned by it, 'BucketAlreadyOwnedByYou' error should be returned
instead of 'BucketAlreadyExists'.

This patch is to address the same.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>

### Explain the changes
While validating bucket during creation, match the owner too 

### Issues: Fixed #xxx / Gap #xxx
Fixed #5980 

### Testing Instructions:
1.  Create a user with RW permissions to the noobaa end point or user admin user itself
2. Create a bucket via that user
3. Now try to create the bucket with same name.
- if its the same user, "BucketAlreadyOwnedByYou" error should be returned and 
- if it is different user, "BucketAlreadyExists" error should be returned.
