### PR TITLE
moving pvpool responsibility to noobaa operator

### DIFF
--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -344,6 +344,23 @@ module.exports = {
             auth: {
                 system: 'admin'
             }
+        },
+
+        update_hosts_pool: {
+            doc: 'Update the pool\'s underlaying host count from the operator',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: {
+                        type: 'string',
+                    },
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
         }
     },
 

--- a/src/deploy/NVA_build/noobaa_pool.yaml
+++ b/src/deploy/NVA_build/noobaa_pool.yaml
@@ -1,69 +1,18 @@
-apiVersion: apps/v1
-kind: StatefulSet
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
 metadata:
-  name: noobaa-agent
+  name: backingstore
   labels:
     app: noobaa
-    noobaa-module: noobaa-pool-impl
+  finalizers:
+    - noobaa.io/finalizer
 spec:
-  selector:
-    matchLabels:
-      noobaa-module: noobaa-agent
-  serviceName: noobaa-agent
-  replicas: 3
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app: noobaa
-        noobaa-module: noobaa-agent
-    spec:
-      containers:
-        - name: noobaa-agent
-          imagePullPolicy: IfNotPresent
-          resources:
-            # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-            requests:
-              cpu: "100m"
-              memory: "500Mi"
-            limits:
-              cpu: "2"
-              memory: "2Gi"
-          env:
-            # Insert the relevant config for the current agent
-            - name: CONTAINER_PLATFORM
-              value: KUBERNETES
-            - name: AGENT_CONFIG
-              value: "AGENT_CONFIG_VALUE"
-          command: ["/noobaa_init_files/noobaa_init.sh", "agent"]
-          # Insert the relevant image for the agent
-          ports:
-            # This should change according to the allocation from the NooBaa server
-            - containerPort: 60101
-          # These volume mounts are persistent. Each pod in the PetSet
-          # gets a volume mounted based on this field.
-          volumeMounts:
-            - name: noobaastorage
-              mountPath: /noobaa_storage
-            - name: tmp-logs-vol
-              mountPath: /usr/local/noobaa/logs
-      volumes:
-        - name: tmp-logs-vol
-          emptyDir: {}
-  # These are converted to volume claims by the controller
-  # and mounted at the paths mentioned above.
-  volumeClaimTemplates:
-    - metadata:
-        name: noobaastorage
-        labels:
-          app: noobaa
-          # Custom labels cannot be added, see https://github.com/kubernetes/kubernetes/issues/58987
-          # noobaa-module: noobaa-storage
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 30Gi
-        # storageClassName if needed will be added by the pool controller (via pool server),
-        # Read more https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+  pvPool:
+    secret:
+      name: SECRET_NAME
+    numVolumes: 3
+    resources:
+      requests:
+        storage: 16Gi
+    storageClass: standard
+  type: pv-pool

--- a/src/deploy/NVA_build/noobaa_pool_secret.yaml
+++ b/src/deploy/NVA_build/noobaa_pool_secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: SECRET_NAME
+  labels:
+    app: noobaa
+data:
+  AGENT_CONFIG: AGENT_CONFIG_VALUE

--- a/src/server/bg_services/buckets_reclaimer.js
+++ b/src/server/bg_services/buckets_reclaimer.js
@@ -37,7 +37,7 @@ class BucketsReclaimer {
                 }, {
                     auth_token: auth_server.make_auth_token({
                         system_id: system._id,
-                        account_id: system.owner,
+                        account_id: system.owner._id,
                         role: 'admin'
                     })
                 });
@@ -46,7 +46,7 @@ class BucketsReclaimer {
                     await this.client.bucket.delete_bucket({ name: bucket.name, internal_call: true }, {
                         auth_token: auth_server.make_auth_token({
                             system_id: system._id,
-                            account_id: system.owner,
+                            account_id: system.owner._id,
                             role: 'admin'
                         })
                     });

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -61,7 +61,7 @@ function background_worker() {
                                     return server_rpc.client.object.delete_multiple_objects_by_prefix(deletion_params, {
                                         auth_token: auth_server.make_auth_token({
                                             system_id: system._id,
-                                            account_id: system.owner,
+                                            account_id: system.owner._id,
                                             role: 'admin'
                                         })
                                     }).then(function() {

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -324,11 +324,6 @@ class NodesClient {
 
         const { hosts } = await this.list_hosts_by_pool(pool_name, system_id, auth_token);
         const promise_list = hosts
-            .sort((host1, host2) => {
-                const host1_seq = Number(host1.name.match(/-(\d+)#/)[1]);
-                const host2_seq = Number(host2.name.match(/-(\d+)#/)[1]);
-                return host1_seq - host2_seq;
-            })
             .slice(-count)
             .map(async host => {
                 if (host.mode === 'DELETING') {
@@ -336,7 +331,7 @@ class NodesClient {
                 }
 
                 try {
-                   await server_rpc.client.host.delete_host({ name: host.name }, { auth_token });
+                    await server_rpc.client.host.delete_host({ name: host.name }, { auth_token });
                 } catch (err) {
                     console.error(`delete_hosts_by_pool: could not initiate delete for host ${host.name}, got: ${err.message}`);
                 }

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1241,8 +1241,8 @@ class NodesMonitor extends EventEmitter {
             node_id: String(item.node._id),
             host_id: String(item.node.host_id),
             pool_id: String(item.node.pool),
-            region: item_pool.region
         };
+        if (item_pool) location_info.region = item_pool.region;
         const service_enabled_not_changed = (item.node.enabled && should_enable) || (!item.node.enabled && !should_enable);
         const location_info_not_changed = _.isEqual(item.agent_info.location_info, location_info);
         if (service_enabled_not_changed && location_info_not_changed) {
@@ -1904,7 +1904,7 @@ class NodesMonitor extends EventEmitter {
             !item.node.deleted
         );
         if (!readable) {
-            dbg.log0_throttled(`${item.node.name} not reasable ${item.online} ${item.trusted} ${item.node_from_store} ${item.node.rpc_address} ${!item.storage_not_exist}
+            dbg.log0_throttled(`${item.node.name} not readable ${item.online} ${item.trusted} ${item.node_from_store} ${item.node.rpc_address} ${!item.storage_not_exist}
                 ${!item.auth_failed} ${!item.io_detention} ${!item.node.decommissioned} ${!item.node.deleting} ${!item.node.deleted}`);
         }
         return readable;

--- a/src/server/system_services/tier_server.js
+++ b/src/server/system_services/tier_server.js
@@ -829,14 +829,6 @@ function get_associated_tiering_policies(tier) {
 }
 
 function throw_on_invalid_pools_for_tier(pools) {
-    const uninitialized_pools = pools.filter(pool =>
-        pool.hosts_pool_info &&
-        !pool.hosts_pool_info.initialized
-    );
-    if (uninitialized_pools.length > 0) {
-        throw new Error(`Invalid attached pools, ${uninitialized_pools.join(', ')} are not initialized yet`);
-    }
-
     const deleting_pools = pools.filter(pool =>
         pool.hosts_pool_info &&
         pool.hosts_pool_info.host_count === 0

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -193,10 +193,6 @@ mocha.describe('system_servers', function() {
             name: pool_name,
             host_count: 3
         });
-        await rpc_client.pool.scale_hosts_pool({
-            name: pool_name,
-            host_count: 2
-        });
         await rpc_client.system.read_system();
         await rpc_client.pool.delete_pool({ name: pool_name });
 


### PR DESCRIPTION
### Explain the changes
1. creating pvpool using operator's pvpool backing store and not by  statefulset
2. returning agent_config to the operator on new pvpool creation
3. fixes to kube_utils and pool_controllers to support new method  

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #5960 
2. Fixed #5942 

### Testing Instructions:
1. 
