### PR TITLE
Fixed test_store_validity

### DIFF
--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -224,11 +224,19 @@ class BlockStoreS3 extends BlockStoreBase {
     async test_store_validity() {
         const block_key = this._block_key(`test-delete-non-existing-key-${Date.now()}`);
         try {
-            // in s3 there is no error for non-existing object
-            await this.s3cloud.deleteObject({
-                Bucket: this.cloud_info.target_bucket,
-                Key: block_key
-            }).promise();
+            const endpoint = this.cloud_info.endpoint;
+            if (cloud_utils.is_aws_endpoint(endpoint)) {
+                // in s3 there is no error for non-existing object
+                await this.s3cloud.deleteObjectTagging({
+                    Bucket: this.cloud_info.target_bucket,
+                    Key: block_key
+                }).promise();
+            } else {
+                await this.s3cloud.deleteObject({
+                    Bucket: this.cloud_info.target_bucket,
+                    Key: block_key
+                }).promise();
+            }
         } catch (err) {
             dbg.error('in _test_cloud_service - deleteObject failed:', err, _.omit(this.cloud_info, 'access_keys'));
             if (err.code === 'NoSuchBucket') {


### PR DESCRIPTION
### Explain the changes
1. changed deleteObject to deleteObjectTagging
After some investigations regarding the BZ, found out that deleteObject doesn't return an AccessDenied error when trying to delete an object without access permissions as it was in the past, instead it returns an empty object - {} .
deleteObjectTagging still returns AccessDenied when trying to delete an object without access permissions.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ #1827317

### Testing Instructions:
1. 
