### PR TITLE
NS-CACHE: WIP 2 - More caching scenarios

### DIFF
--- a/config.js
+++ b/config.js
@@ -253,6 +253,13 @@ config.DB_CLEANER = {
     MAX_TOTAL_DOCS: 10000
 };
 
+///////////////////////
+// NAMESPACE CACHING //
+///////////////////////
+config.NAMESPACE_CACHING = {
+    DEFAULT_CACHE_TTL_MS: 60000,
+};
+
 /////////////////////
 // CLOUD RESOURCES //
 /////////////////////

--- a/frontend/src/app/action-creators/bucket-actions.js
+++ b/frontend/src/app/action-creators/bucket-actions.js
@@ -149,10 +149,10 @@ export function failDeleteBucket(bucket, error) {
     };
 }
 
-export function createNamespaceBucket(name, readFrom, writeTo) {
+export function createNamespaceBucket(name, readFrom, writeTo, caching) {
     return {
         type: CREATE_NAMESPACE_BUCKET,
-        payload: { name, readFrom, writeTo }
+        payload: { name, readFrom, writeTo, caching }
     };
 }
 

--- a/frontend/src/app/components/modals/create-namespace-bucket-modal/create-namespace-bucket-modal.html
+++ b/frontend/src/app/components/modals/create-namespace-bucket-modal/create-namespace-bucket-modal.html
@@ -86,6 +86,42 @@
                 <wizard-controls></wizard-controls>
             </div>
         </section>
+
+        <section class="column greedy">
+            <div class="column greedy pad">
+                <h2 class="heading3">Caching Configuration</h2>
+                <p class="push-next">
+                    Caching configuration controls how data is cached in local storage
+                </p>
+                <checkbox params="label: 'Enable caching', checked: enableCaching">
+                </checkbox>
+                <editor params="label: 'Cache TTL in ms', disabled: !enableCaching()">
+                    <input type="number" min="-1"
+                        class="push-next-half"
+                        ko.value="$form.cacheTTL"
+                        ko.validationCss="$form.cacheTTL"
+                        ko.hasFocus="true"
+                        ko.disable="!enableCaching()"
+                    />
+                </editor>
+                <validation-message params="field: $form.cacheTTL"></validation-message>
+            </div>
+            <div class="row content-middle pad content-box">
+                <p class="remark greedy push-next">
+                    <svg-icon class="icon-small valign-bottom"
+                        params="name: 'notif-info'"
+                    ></svg-icon>
+                    Learn more about
+                    <a class="link"
+                        target=_blank"
+                        ko.attr.href="learnMoreHref">
+                        Namespace Buckets
+                    </a>
+                </p>
+                <wizard-controls></wizard-controls>
+            </div>
+        </section>
+
     </wizard>
 </managed-form>
 

--- a/frontend/src/app/components/modals/create-namespace-bucket-modal/create-namespace-bucket-modal.js
+++ b/frontend/src/app/components/modals/create-namespace-bucket-modal/create-namespace-bucket-modal.js
@@ -18,7 +18,8 @@ import { createNamespaceBucket as learnMoreHref } from 'knowledge-base-articles'
 
 const steps = deepFreeze([
     'Choose Name',
-    'Set Placement'
+    'Set Placement',
+    'Set Caching Policy'
 ]);
 
 const readPolicyTableColumns = deepFreeze([
@@ -47,7 +48,8 @@ const readPolicyTableColumns = deepFreeze([
 
 const fieldsByStep = deepFreeze({
     0: [ 'bucketName' ],
-    1: [ 'readPolicy', 'writePolicy' ]
+    1: [ 'readPolicy', 'writePolicy' ],
+    2: [ 'cacheTTL' ]
 });
 
 class ResourceRowViewModel {
@@ -87,11 +89,15 @@ class CreateNamespaceBucketModalViewModel extends ConnectableViewModel {
     resourceServiceMapping = {};
     readPolicy = [];
     writePolicy = '';
+    enableCaching = ko.observable(false);
+
     fields = {
         step: 0,
         bucketName: '',
         readPolicy: [],
-        writePolicy: undefined
+        writePolicy: undefined,
+        cacheTTL: 60000,
+        enableCaching: false
     };
 
     selectState(state) {
@@ -111,6 +117,7 @@ class CreateNamespaceBucketModalViewModel extends ConnectableViewModel {
         const bucketName = getFieldValue(form, 'bucketName');
         const readPolicy = getFieldValue(form, 'readPolicy');
         const writePolicy = getFieldValue(form, 'writePolicy');
+        const cacheTTL = getFieldValue(form, 'cacheTTL');
         const existingNames = [
             ...Object.keys(buckets),
             ...Object.keys(namespaceBuckets)
@@ -161,7 +168,8 @@ class CreateNamespaceBucketModalViewModel extends ConnectableViewModel {
             resourceServiceMapping,
             isStepValid: isFormValid(form),
             readPolicy,
-            writePolicy
+            writePolicy,
+            cacheTTL
         });
 
     }
@@ -237,10 +245,13 @@ class CreateNamespaceBucketModalViewModel extends ConnectableViewModel {
     }
 
     onSubmit(values) {
-        const { bucketName, readPolicy, writePolicy } = values;
+        const { bucketName, readPolicy, writePolicy, cacheTTL } = values;
         this.dispatch(
             closeModal(),
-            createNamespaceBucket(bucketName, readPolicy, writePolicy)
+            createNamespaceBucket(bucketName, readPolicy, writePolicy,
+                this.enableCaching() ? {
+                    ttl_ms: cacheTTL
+                } : undefined)
         );
     }
 

--- a/frontend/src/app/epics/create-namespace-bucket.js
+++ b/frontend/src/app/epics/create-namespace-bucket.js
@@ -10,12 +10,12 @@ export default function(action$, { api }) {
     return action$.pipe(
         ofType(CREATE_NAMESPACE_BUCKET),
         mergeMap(async action => {
-            const { name, readFrom, writeTo } = action.payload;
-
+            const { name, readFrom, writeTo, caching } = action.payload;
             try {
                 const namespace = {
                     read_resources: readFrom,
-                    write_resource: writeTo
+                    write_resource: writeTo,
+                    caching: caching
                 };
 
                 await api.bucket.create_bucket({ name, namespace });

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -69,6 +69,9 @@ module.exports = {
                                 items: {
                                     type: 'string'
                                 },
+                            },
+                            caching: {
+                                $ref: 'common_api#/definitions/bucket_cache_config'
                             }
                         }
                     },
@@ -1120,7 +1123,7 @@ module.exports = {
                 },
                 policy: {
                     $ref: 'common_api#/definitions/bucket_policy'
-                }
+                },
             }
         },
 
@@ -1139,6 +1142,9 @@ module.exports = {
                 },
                 write_resource: {
                     type: 'string'
+                },
+                caching: {
+                    $ref: 'common_api#/definitions/bucket_cache_config'
                 }
             }
         },
@@ -1190,7 +1196,10 @@ module.exports = {
                         },
                         write_resource: {
                             $ref: 'pool_api#/definitions/namespace_resource_extended_info'
-                        }
+                        },
+                        caching: {
+                            $ref: 'common_api#/definitions/bucket_cache_config'
+                        },
                     },
                 },
                 active_triggers: {

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -748,6 +748,25 @@ module.exports = {
                 'NO_RESOURCES'
             ]
         },
+
+        bucket_cache_ttl: {
+            type: 'integer',
+            // In milliseconds
+            // -1 means infinite ttl
+            // 0 means always re-validate
+            minimum: -1,
+        },
+
+        bucket_cache_config: {
+            type: 'object',
+            required: [ ],
+            properties: {
+                ttl_ms: {
+                    $ref: '#/definitions/bucket_cache_ttl'
+                }
+            }
+        },
+
         lock_settings: {
             type: 'object',
             properties: {

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -549,6 +549,7 @@ module.exports = {
                     key: { type: 'string' },
                     content_type: { type: 'string' },
                     xattr: { $ref: '#/definitions/xattr' },
+                    cache_last_valid_time: { idate: true },
                 }
             },
             auth: { system: ['admin', 'user'] }
@@ -1325,6 +1326,7 @@ module.exports = {
                 num_parts: { type: 'integer' },
                 content_type: { type: 'string' },
                 create_time: { idate: true },
+                cache_last_valid_time: { idate: true },
                 upload_started: { idate: true },
                 upload_size: { type: 'integer' },
                 etag: { type: 'string' },

--- a/src/endpoint/s3/ops/s3_head_object.js
+++ b/src/endpoint/s3/ops/s3_head_object.js
@@ -10,13 +10,18 @@ const http_utils = require('../../../util/http_utils');
  */
 async function head_object(req, res) {
     const encryption = s3_utils.parse_encryption(req);
-    const object_md = await req.object_sdk.read_object_md({
+    const params = {
         bucket: req.params.bucket,
         key: req.params.key,
         version_id: req.query.versionId,
         md_conditions: http_utils.get_md_conditions(req),
         encryption
-    });
+    };
+    if (req.query.get_from_cache !== undefined) {
+        params.get_from_cache = true;
+    }
+    const object_md = await req.object_sdk.read_object_md(params);
+
     s3_utils.set_response_object_md(res, object_md);
     s3_utils.set_encryption_response_headers(req, res, object_md.encryption);
 }

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -4,17 +4,42 @@
 const _ = require('lodash');
 const stream = require('stream');
 const assert = require('assert');
+const dbg = require('../util/debug_module')(__filename);
+const P = require('../util/promise');
 
 class NamespaceCache {
 
-    constructor({ namespace_hub, namespace_nb, active_triggers }) {
+    constructor({ namespace_hub, namespace_nb, caching, active_triggers }) {
         this.namespace_hub = namespace_hub;
         this.namespace_nb = namespace_nb;
         this.active_triggers = active_triggers;
+        this.caching = caching;
     }
 
     get_write_resource() {
         return this.namespace_hub;
+    }
+
+    async _delete_object_from_cache(params, object_sdk) {
+        try {
+            const delete_params = _.pick(params, 'bucket', 'key');
+            await this.namespace_nb.delete_object(delete_params, object_sdk);
+            dbg.log0('NamespaceCache: deleted object from cache', delete_params);
+        } catch (err) {
+            dbg.warn('NamespaceCache: error in deleting object from cache', params, err);
+        }
+    }
+
+    async _update_cache_last_valid_time(params, object_sdk) {
+        try {
+            const update_params = _.pick(_.defaults({ bucket: this.namespace_nb.target_bucket }, params), 'bucket', 'key');
+            update_params.cache_last_valid_time = (new Date()).getTime();
+
+            await object_sdk.rpc_client.object.update_object_md(update_params);
+            dbg.log0('NamespaceCache: updated cache valid time', update_params);
+        } catch (err) {
+            dbg.error('NamespaceCache: error in updating cache last valid time', err);
+        }
     }
 
     /////////////////
@@ -41,43 +66,95 @@ class NamespaceCache {
     /////////////////
 
     async read_object_md(params, object_sdk) {
+
+        let object_info_cache = null;
+        let cache_etag = '';
         try {
-            const object_info = await this.namespace_nb.read_object_md(params, object_sdk);
-
-            // TODO this is the wrong condition - object create_time should be preserved 
-            // from hub so not the validation time, so we need a custom cache metadata for that.
-            const cache_validation_time = object_info.create_time;
-            const time_since_validation = Date.now() - cache_validation_time;
-
-            const CACHE_TTL = 60000; // 1 minute
-            if (time_since_validation <= CACHE_TTL) {
-                object_info.should_read_from_cache = true; // mark it for read_object_stream
-                console.log('NamespaceCache.read_object_md: from cache', object_info);
-                return object_info;
+            const get_from_cache = params.get_from_cache;
+            // Remove get_from_cache if exists for maching RPC schema
+            params = _.omit(params, 'get_from_cache');
+            object_info_cache = await this.namespace_nb.read_object_md(params, object_sdk);
+            if (get_from_cache) {
+                dbg.log0('NamespaceCache.read_object_md get_from_cache is enabled', object_info_cache);
+                object_info_cache.should_read_from_cache = true;
+                return object_info_cache;
             }
 
+            const cache_validation_time = object_info_cache.cache_last_valid_time;
+            const time_since_validation = Date.now() - cache_validation_time;
+
+            if ((this.caching.ttl_ms > 0 && time_since_validation <= this.caching.ttl_ms) || this.caching.ttl_ms < 0) {
+                object_info_cache.should_read_from_cache = true; // mark it for read_object_stream
+                dbg.log0('NamespaceCache.read_object_md use md from cache', object_info_cache);
+                return object_info_cache;
+            }
+
+            cache_etag = object_info_cache.etag;
         } catch (err) {
-            console.warn('NamespaceCache.read_object_md: cache error', err);
+            dbg.log0('NamespaceCache.read_object_md: error in cache', err);
         }
 
-        // TODO do we have any benefit in caching just object mds?
-        return this.namespace_hub.read_object_md(params, object_sdk);
+        try {
+            const object_info_hub = await this.namespace_hub.read_object_md(params, object_sdk);
+            if (object_info_hub.etag === cache_etag) {
+                dbg.log0('NamespaceCache.read_object_md: same etags: updating cache valid time', object_info_hub);
+                setImmediate(() => this._update_cache_last_valid_time(params, object_sdk));
+                object_info_cache.should_read_from_cache = true;
+
+                return object_info_cache;
+
+            } else if (cache_etag === '') {
+                object_info_hub.should_read_from_cache = false;
+            } else {
+                dbg.log0('NamespaceCache.read_object_md: etags different',
+                    params, {hub_tag: object_info_hub.etag, cache_etag: cache_etag});
+            }
+
+            return object_info_hub;
+
+        } catch (err) {
+            if (err.code === 'NoSuchKey') {
+                if (object_info_cache) {
+                    setImmediate(() => this._delete_object_from_cache(params, object_sdk));
+                }
+            } else {
+                dbg.error('NamespaceCache.read_object_md: NOT NoSuchKey in hub', err);
+            }
+            throw (err);
+        }
     }
 
     async read_object_stream(params, object_sdk) {
 
-        if (params.object_md.should_read_from_cache) {
+        const get_from_cache = params.get_from_cache;
+        // Remove get_from_cache if exists for matching RPC schema in later API calls
+        params = _.omit(params, 'get_from_cache');
+
+        let read_response;
+        if (params.object_md.should_read_from_cache || get_from_cache) {
             try {
                 // params.missing_range_handler = async () => {
                 //     this._read_from_hub(params, object_sdk);
                 // };
-                return this.namespace_nb.read_object_stream(params, object_sdk);
+
+                dbg.log0('NamespaceCache.read_object_stream: read from cache', params);
+                read_response = await this.namespace_nb.read_object_stream(params, object_sdk);
             } catch (err) {
-                console.warn('NamespaceCache.read_object_stream: cache error', err);
+                dbg.warn('NamespaceCache.read_object_stream: cache error', err);
             }
         }
 
-        return this._read_from_hub(params, object_sdk);
+        read_response = read_response || await this._read_from_hub(params, object_sdk);
+
+        const operation = 'ObjectRead';
+        const load_for_trigger = !params.noobaa_trigger_agent &&
+            object_sdk.should_run_triggers({ active_triggers: this.active_triggers, operation });
+        if (load_for_trigger) {
+            object_sdk.dispatch_triggers({ active_triggers: this.active_triggers, operation,
+                obj: params.object_md, bucket: params.bucket });
+        }
+
+        return read_response;
     }
 
     async _read_from_hub(params, object_sdk) {
@@ -97,7 +174,7 @@ class NamespaceCache {
             xattr: params.object_md.xattr,
         };
 
-        console.log('NamespaceCache.read_object_stream: put to cache',
+        dbg.log0('NamespaceCache.read_object_stream: put to cache',
             _.omit(upload_params, 'source_stream'));
 
 
@@ -113,14 +190,18 @@ class NamespaceCache {
     ///////////////////
 
     async upload_object(params, object_sdk) {
+        dbg.log0("NamespaceCache.upload_object", _.omit(params, 'source_stream'));
+        const operation = 'ObjectCreated';
+        const load_for_trigger = object_sdk.should_run_triggers({ active_triggers: this.active_triggers, operation });
 
+        let upload_response;
+        let etag;
         if (params.size > 1024 * 1024) {
 
-            // TODO: INVALIDATE CACHE
-            // await this.namespace_nb.delete_object(TODO);
+            setImmediate(() => this._delete_object_from_cache(params, object_sdk));
 
-            // UPLOAD TO HUB ONLY
-            return this.namespace_hub.upload_object(params, object_sdk);
+            upload_response = await this.namespace_hub.upload_object(params, object_sdk);
+            etag = upload_response.etag;
 
         } else {
 
@@ -136,13 +217,58 @@ class NamespaceCache {
             const cache_params = { ...params, source_stream: cache_stream };
             const cache_promise = this.namespace_nb.upload_object(cache_params, object_sdk);
 
+            // One important caveat is that if the Readable stream emits an error during processing,
+            // the Writable destination is not closed automatically. If an error occurs, it will be
+            // necessary to manually close each stream in order to prevent memory leaks.
+            params.source_stream.on('error', err => {
+                dbg.log0("NamespaceCache.upload_object: error in read source", {params: _.omit(params, 'source_stream'), error: err});
+                hub_stream.destroy();
+                cache_stream.destroy();
+            });
+
             params.source_stream.pipe(hub_stream);
             params.source_stream.pipe(cache_stream);
 
-            const [hub_res, cache_res] = await Promise.all([hub_promise, cache_promise]);
-            assert.strictEqual(hub_res.etag, cache_res.etag);
-            return hub_res;
+            const [hub_res, cache_res] = await Promise.allSettled([ hub_promise, cache_promise ]);
+            const hub_ok = hub_res.status === 'fulfilled';
+            const cache_ok = cache_res.status === 'fulfilled';
+            if (!hub_ok) {
+                dbg.log0("NamespaceCache.upload_object: error in upload", { params: _.omit(params, 'source_stream'), hub_res, cache_res });
+                // handling the case where cache succeeded and cleanup.
+                // We can also just mark the cache object for re-validation
+                // to make sure any read will have to re-validate it,
+                // but writes (retries of the upload most likely) will be already in the cache
+                // and detected by dedup so we don't need to do anything.
+                if (cache_ok) {
+                    setImmediate(() => this._delete_object_from_cache(params, object_sdk));
+                }
+                // fail back to client with the hub reason
+                throw hub_res.reason;
+            }
+
+            if (cache_ok) {
+                assert.strictEqual(hub_res.value.etag, cache_res.value.etag);
+            } else {
+                // on error from cache, we ignore and let hub upload continue
+                dbg.log0("NamespaceCache.upload_object: error in cache upload", { params: _.omit(params, 'source_stream'), hub_res, cache_res });
+            }
+
+            upload_response = hub_res.value;
+            etag = upload_response.etag;
         }
+
+        if (load_for_trigger) {
+            const obj = {
+                bucket: params.bucket,
+                key: params.key,
+                size: params.size,
+                content_type: params.content_type,
+                etag
+            };
+            object_sdk.dispatch_triggers({ active_triggers: this.active_triggers, operation, obj, bucket: params.bucket });
+        }
+
+        return upload_response;
     }
 
     //////////////////////
@@ -202,11 +328,50 @@ class NamespaceCache {
             cache_res.reason.code !== 'NoSuchKey') {
             throw cache_res.reason;
         }
+
+        const operation = 'ObjectRemoved';
+        const load_for_trigger = object_sdk.should_run_triggers({ active_triggers: this.active_triggers, operation });
+        if (load_for_trigger) {
+            object_sdk.dispatch_triggers({ active_triggers: this.active_triggers, operation,
+                obj: params.object_md, bucket: params.bucket });
+        }
+
         return hub_res.value;
     }
 
     async delete_multiple_objects(params, object_sdk) {
-        return this.namespace_hub.delete_multiple_objects(params, object_sdk);
+        const deleted_res = await this.namespace_hub.delete_multiple_objects(params, object_sdk);
+
+        const operation = 'ObjectRemoved';
+        const load_for_trigger = object_sdk.should_run_triggers({ active_triggers: this.active_triggers, operation });
+        if (load_for_trigger) {
+
+            const head_res = await P.map(params.objects, async obj => {
+                const request = {
+                    bucket: params.bucket,
+                    key: obj.key,
+                    version_id: obj.version_id
+                };
+                let obj_md;
+                try {
+                    obj_md = _.defaults({ key: obj.key }, await this.namespace_hub.read_object_md(request, object_sdk));
+                } catch (err) {
+                    if (err.rpc_code !== 'NO_SUCH_OBJECT') throw err;
+                }
+                return obj_md;
+            });
+
+            for (let i = 0; i < deleted_res.length; ++i) {
+                const deleted_obj = deleted_res[i];
+                const head_obj = head_res[i];
+                if (_.isUndefined(deleted_obj && deleted_obj.err_code) && head_obj) {
+                    object_sdk.dispatch_triggers({ active_triggers: this.active_triggers, operation,
+                        obj: head_obj, bucket: params.bucket });
+                }
+            }
+        }
+
+        return deleted_res;
     }
 
     ////////////////////

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -358,6 +358,7 @@ interface ObjectMD {
     upload_size?: number;
     upload_started?: ID;
     create_time?: Date;
+    cache_last_valid_time?: Date;
     etag: string;
     md5_b64: string;
     sha256_b64: string;
@@ -382,6 +383,7 @@ interface ObjectInfo {
     upload_size?: number;
     upload_started?: number;
     create_time?: number;
+    cache_last_valid_time?: number;
     etag: string;
     md5_b64: string;
     sha256_b64: string;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -163,15 +163,14 @@ class ObjectSDK {
         try {
             if (bucket.namespace && bucket.namespace.read_resources && bucket.namespace.write_resource) {
 
-                // TODO: NAMESPACE_CACHE_DEV is temporarily used for manual override
-                bucket.namespace.cache = (process.env.NAMESPACE_CACHE_DEV === 'true');
-
-                if (bucket.namespace.cache) {
+                dbg.log0('_setup_bucket_namespace', bucket.namespace);
+                if (bucket.namespace.caching) {
                     return {
                         ns: new NamespaceCache({
                             namespace_hub: this._setup_single_namespace(_.extend({}, bucket.namespace.write_resource)),
                             namespace_nb: this.namespace_nb,
-                            active_triggers: bucket.namespace.write_resource,
+                            active_triggers: bucket.active_triggers,
+                            caching: bucket.namespace.caching,
                         }),
                         bucket,
                         valid_until: time + NAMESPACE_CACHE_EXPIRY,

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -54,7 +54,7 @@ module.exports = {
         // version_enabled = undefined  means 'null' version (backward compatible for objects that existed before introducing versioning)
         // version_enabled = false      unused!
         // We defined it instead of version_null for backward compatibility on upgrades.
-        // The reason we have to separate it from version_seq is that 'null' version 
+        // The reason we have to separate it from version_seq is that 'null' version
         // also has to be sorted by creation order when listing versions.
         version_enabled: { type: 'boolean' },
 
@@ -76,6 +76,7 @@ module.exports = {
         upload_size: { type: 'integer' },
         upload_started: { objectid: true },
         create_time: { date: true },
+        cache_last_valid_time: { date: true },
 
         // etag is the object md5 hex for objects uploaded in single action.
         // for multipart upload etag is a special aggregated md5 of the parts md5's.

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -154,12 +154,18 @@ async function create_bucket(req) {
             throw new RpcError('INVALID_WRITE_RESOURCES');
         }
 
+        const caching = req.rpc_params.namespace.caching && {
+            ttl_ms: config.NAMESPACE_CACHING.DEFAULT_CACHE_TTL_MS,
+            ...req.rpc_params.namespace.caching,
+        };
+
         // reorder read resources so that the write resource is the first in the list
         const ordered_read_resources = [write_resource].concat(read_resources.filter(resource => resource !== write_resource));
 
         bucket.namespace = {
             read_resources: ordered_read_resources,
-            write_resource
+            write_resource,
+            caching
         };
     }
     if (req.rpc_params.bucket_claim) {
@@ -466,7 +472,8 @@ async function read_bucket_sdk_info(req) {
             write_resource: pool_server.get_namespace_resource_extended_info(
                 system.namespace_resources_by_name[bucket.namespace.write_resource.name]
             ),
-            read_resources: _.map(bucket.namespace.read_resources, rs => pool_server.get_namespace_resource_extended_info(rs))
+            read_resources: _.map(bucket.namespace.read_resources, rs => pool_server.get_namespace_resource_extended_info(rs)),
+            caching: bucket.namespace.caching,
         };
     }
 
@@ -1400,7 +1407,8 @@ function get_bucket_info({
         namespace: bucket.namespace ? {
             write_resource: pool_server.get_namespace_resource_info(
                 bucket.namespace.write_resource).name,
-            read_resources: _.map(bucket.namespace.read_resources, rs => pool_server.get_namespace_resource_info(rs).name)
+            read_resources: _.map(bucket.namespace.read_resources, rs => pool_server.get_namespace_resource_info(rs).name),
+            caching: bucket.namespace.caching
         } : undefined,
         tiering: tiering,
         tag: bucket.tag ? bucket.tag : '',
@@ -1429,7 +1437,7 @@ function get_bucket_info({
         encryption: bucket.encryption,
         bucket_claim: bucket.bucket_claim,
         website: bucket.website,
-        policy: bucket.policy
+        policy: bucket.policy,
     };
 
     const metrics = _calc_metrics({ bucket, nodes_aggregate_pool, hosts_aggregate_pool, tiering_pools_status, info });

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -99,7 +99,10 @@ module.exports = {
                 },
                 write_resource: {
                     objectid: true // namespace resource id
-                }
+                },
+                caching: {
+                    $ref: 'common_api#/definitions/bucket_cache_config'
+                },
             }
         },
         tiering: {

--- a/src/test/framework/pipeline_tests_list.js
+++ b/src/test/framework/pipeline_tests_list.js
@@ -42,6 +42,14 @@ const tests = [{
     agent_cpu: '250m',
     agent_mem: '150Mi',
 }, {
+}, {
+    name: 'namespace-cache-test',
+    test: './src/test/pipeline/namespace_cache_test.js',
+    server_cpu: '400m',
+    server_mem: '400Mi',
+    agent_cpu: '250m',
+    agent_mem: '150Mi',
+}, {
     name: 'dataset-test',
     test: './src/test/pipeline/run_dataset.js',
     server_cpu: '400m',

--- a/src/test/pipeline/namespace_cache_test.js
+++ b/src/test/pipeline/namespace_cache_test.js
@@ -1,0 +1,492 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+const api = require('../../api');
+const crypto = require('crypto');
+//const P = require('../../util/promise');
+const { S3OPS } = require('../utils/s3ops');
+const Report = require('../framework/report');
+const argv = require('minimist')(process.argv);
+const dbg = require('../../util/debug_module')(__filename);
+const { CloudFunction } = require('../utils/cloud_functions');
+const { BucketFunctions } = require('../utils/bucket_functions');
+
+const test_name = 'namespace_cache';
+dbg.set_process_name(test_name);
+
+require('../../util/dotenv').load();
+
+const {
+    AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY,
+    COS_ACCESS_KEY_ID,
+    COS_SECRET_ACCESS_KEY,
+    CACHE_TTL_MS,
+    SYSTEM_NAME,
+} = process.env;
+
+const DEFAULT_CACHE_TTL_MS = 60000;
+
+const cloud_list = [];
+
+if (AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY) {
+    cloud_list.push('AWS');
+}
+
+if (COS_ACCESS_KEY_ID && COS_SECRET_ACCESS_KEY) {
+    cloud_list.push('COS');
+}
+
+if (cloud_list.length === 0) {
+    console.warn(`Missing cloud credentials, Exiting.`);
+    process.exit(0);
+}
+
+let errors = [];
+let failures_in_test = false;
+
+//define colors
+// const YELLOW = "\x1b[33;1m";
+const RED = "\x1b[31m";
+const NC = "\x1b[0m";
+
+const files_cloud = {
+    files_AWS: [],
+    files_COS: []
+};
+
+//defining the required parameters
+const {
+    mgmt_ip,
+    mgmt_port_https,
+    s3_ip,
+    s3_port,
+    skip_clean = false,
+    clean_start = true,
+    help = false
+} = argv;
+
+function usage() {
+    console.log(`
+    --mgmt_ip           -   noobaa management ip.
+    --mgmt_port_https   -   noobaa server management https port
+    --s3_ip             -   noobaa s3 ip
+    --s3_port           -   noobaa s3 port
+    --skip_clean        -   skipping cleaning env
+    --clean_start       -   fail the test if connection, resource or bucket exists
+    --help              -   show this help.
+    `);
+}
+
+if (help) {
+    usage();
+    process.exit(1);
+}
+
+const rpc = api.new_rpc_from_base_address(`wss://${mgmt_ip}:${mgmt_port_https}`, 'EXTERNAL');
+const client = rpc.new_client({});
+
+let report = new Report();
+
+const cases = [
+    'read via namespace AWS',
+    'read via namespace COS',
+    'verify list files AWS',
+    'verify list files COS',
+    'create namespace bucket AWS',
+    'create namespace bucket COS',
+    'update namespace bucket w resource',
+    'upload via noobaa to namespace AWS',
+    'upload via noobaa to namespace COS',
+    'delete via namespace AWS',
+    'delete via namespace COS',
+    'verify md5 via list on AWS',
+    'verify md5 via list on COS',
+    'create external connection AWS',
+    'create external connection COS',
+    'create namespace resource AWS',
+    'create namespace resource COS',
+    'delete namespace resource AWS',
+    'delete namespace resource COS',
+    'delete connection AWS',
+    'delete connection COS',
+    'delete namespace bucket',
+];
+// report.init_reporter({ suite: test_name, conf: { aws: true, cos: true }, mongo_report: true, cases: cases });
+report.init_reporter({ suite: test_name, conf: { cos: true }, mongo_report: true, cases: cases });
+
+let cf = new CloudFunction(client);
+const bucket_functions = new BucketFunctions(client);
+
+const AWSDefaultConnection = cf.getAWSConnection();
+const COSDefaultConnection = cf.getCOSConnection();
+
+// const s3ops = new S3OPS({ ip: s3_ip, port: s3_port });
+const s3ops = new S3OPS({ ip: s3_ip, port: s3_port, use_https: false, sig_ver: 'v2',
+        access_key: 'vZnfG4rgxGL9NP0a2sHh', secret_key: 'V19A8Fi3gsjD7w5OxjBH9WT3XJ3sSWCtNuvQmDys'});
+const s3opsAWS = new S3OPS({
+    ip: 's3.amazonaws.com',
+    access_key: AWSDefaultConnection.identity,
+    secret_key: AWSDefaultConnection.secret,
+    system_verify_name: 'AWS',
+});
+const s3opsCOS = new S3OPS({
+    ip: 's3.us-south.cloud-object-storage.appdomain.cloud',
+    access_key: COSDefaultConnection.identity,
+    secret_key: COSDefaultConnection.secret,
+    system_verify_name: 'COS',
+});
+
+const connections_mapping = { COS: COSDefaultConnection, AWS: AWSDefaultConnection };
+
+//variables for using creating namespace resource
+const namespace_mapping = {
+    AWS: {
+        s3ops: s3opsAWS,
+        pool: 'cloud-resource-aws',
+        bucket1: 'QA-Bucket',
+        bucket2: 'qa-aws-bucket',
+        namespace: 'aws-resource-namespace',
+        gateway: 'aws-gateway-bucket'
+    },
+    COS: {
+        s3ops: s3opsCOS,
+        pool: 'cloud-resource-cos',
+        bucket1: 'test-nb-ft1',
+        bucket2: 'test-nb-ft2',
+        namespace: 'cos-resource-namespace',
+        gateway: 'cos-gateway-bucket'
+    }
+};
+
+/*const dataSet = [
+    { size_units: 'KB', data_size: 1 },
+    { size_units: 'KB', data_size: 500 },
+    { size_units: 'MB', data_size: 1 },
+    { size_units: 'MB', data_size: 100 },
+];*/
+
+const baseUnit = 1024;
+const unit_mapping = {
+    KB: {
+        data_multiplier: baseUnit ** 1,
+        dataset_multiplier: baseUnit ** 2
+    },
+    MB: {
+        data_multiplier: baseUnit ** 2,
+        dataset_multiplier: baseUnit ** 1
+    },
+    GB: {
+        data_multiplier: baseUnit ** 3,
+        dataset_multiplier: baseUnit ** 0
+    }
+};
+
+async function getPropertiesFromS3Bucket(s3ops_arg, bucket, file_name, get_from_cache) {
+    try {
+        const object_list = await s3ops_arg.get_object(bucket, file_name, { get_from_cache: get_from_cache });
+        console.log('Getting md5 data from file ' + file_name);
+        return {
+            md5: crypto.createHash('md5').update(object_list.Body).digest('base64'),
+            size: object_list.Body.length
+        };
+    } catch (err) {
+        throw new Error(`Getting md5 data from file ${file_name} ${err}`);
+    }
+}
+
+async function compereMD5betweenCloudAndNooBaa(type, cloud_bucket, noobaa_bucket, force_cache_read, file_name) {
+    console.log(`Compering NooBaa cache bucket to ${type} for ${file_name}`);
+    const cloudProperties = await getPropertiesFromS3Bucket(namespace_mapping[type].s3ops, cloud_bucket, file_name, false);
+    const cloudMD5 = cloudProperties.md5;
+    const noobaaProperties = await getPropertiesFromS3Bucket(s3ops, noobaa_bucket, file_name, force_cache_read);
+    const noobaaMD5 = noobaaProperties.md5;
+    if (cloudMD5 === noobaaMD5) {
+        console.log(`Noobaa cache bucket for (${noobaa_bucket}) contains the md5 ${
+            noobaaMD5} and the cloud md5 is: ${JSON.stringify(cloudProperties)} for file ${file_name}`);
+    } else {
+        console.warn(`file: ${file_name} size is ${cloudProperties.size} on ${
+            type} and ${noobaaProperties.size} on noobaa`);
+        throw new Error(`Noobaa cache bucket for (${noobaa_bucket}) contains the md5 ${
+            noobaaMD5} instead of ${cloudProperties} for file ${file_name}`);
+    }
+}
+
+/*async function uploadDataSetToCloud(type, bucket) {
+    for (const size of dataSet) {
+        const { data_multiplier } = unit_mapping[size.size_units.toUpperCase()];
+        const file_name = 'file_' + size.data_size + size.size_units + (Math.floor(Date.now() / 1000));
+        files_cloud[`files_${type}`].push(file_name);
+        await namespace_mapping[type].s3ops.put_file_with_md5(bucket, file_name, size.data_size, data_multiplier);
+    }
+}
+
+async function upload_directly_to_cloud(type) {
+    console.log(`Uploading files into ${type}`);
+    const { data_multiplier } = unit_mapping.KB;
+    const file_name = 'file_namespace_test_' + (Math.floor(Date.now() / 1000));
+    files_cloud[`files_${type}`].push(file_name);
+    try {
+        await namespace_mapping[type].s3ops.put_file_with_md5(namespace_mapping[type].bucket2, file_name, 15, data_multiplier);
+    } catch (err) {
+        throw new Error(`Failed to upload directly into ${type}`);
+    }
+}
+
+async function isFilesAvailableInNooBaaBucket(gateway, files, type) {
+    console.log(`Checking uploaded files ${files} in noobaa s3 server bucket ${gateway}`);
+    const list_files = await s3ops.get_list_files(gateway);
+    const keys = list_files.map(key => key.Key);
+    let report_fail = false;
+    for (const file of files) {
+        if (keys.includes(file)) {
+            console.log('Server contains file ' + file);
+        } else {
+            report_fail = true;
+            report.fail(`verify list files ${type}`);
+            throw new Error(`Server is not contains uploaded file ${file} in bucket ${gateway}`);
+        }
+    }
+    if (!report_fail) {
+        report.success(`verify list files ${type}`);
+    }
+}*/
+
+async function uploadFileToNoobaaS3(bucket, file_name) {
+    let { data_multiplier } = unit_mapping.KB;
+    try {
+        await s3ops.put_file_with_md5(bucket, file_name, 15, data_multiplier);
+    } catch (err) {
+        throw new Error(`Failed upload file ${file_name} ${err}`);
+    }
+}
+
+async function _delete_namespace_bucket(bucket) {
+    console.log('Deleting namespace bucket ' + bucket);
+    try {
+        await bucket_functions.deleteBucket(bucket);
+        report.success('delete namespace bucket');
+    } catch (err) {
+        report.fail('delete namespace bucket');
+        throw new Error(`Failed to delete namespace bucket with error ${err}`);
+    }
+}
+
+async function set_rpc_and_create_auth_token() {
+    const auth_params = {
+        email: 'demo@noobaa.com',
+        password: 'DeMo1',
+        system: SYSTEM_NAME ? SYSTEM_NAME : 'demo'
+    };
+    return client.create_auth_token(auth_params);
+}
+
+async function _create_resource(type) {
+    try {
+        //create connection
+        await cf.createConnection(connections_mapping[type], type);
+        report.success(`create external connection ${type}`);
+    } catch (e) {
+        report.fail(`create external connection ${type}`);
+        if (!clean_start && e.rpc_code !== 'CONNECTION_ALREADY_EXIST') {
+            throw new Error(e);
+        }
+    }
+    try {
+        // create namespace resource
+        await cf.createNamespaceResource(connections_mapping[type].name,
+            namespace_mapping[type].namespace, namespace_mapping[type].bucket2);
+        report.success(`create namespace resource ${type}`);
+    } catch (e) {
+        report.fail(`create namespace resource ${type}`);
+        if (!clean_start && e.rpc_code !== 'IN_USE') {
+            throw new Error(e);
+        }
+    }
+    try {
+        //create a namespace bucket
+        await bucket_functions.createNamespaceBucket(namespace_mapping[type].gateway,
+            namespace_mapping[type].namespace, { ttl_ms: CACHE_TTL_MS ? CACHE_TTL_MS : DEFAULT_CACHE_TTL_MS });
+        report.success(`create namespace bucket ${type}`);
+    } catch (e) {
+        console.log("error:", e, "==", e.rpc_code);
+        report.fail(`create namespace bucket ${type}`);
+        if (!clean_start && e.rpc_code !== 'BUCKET_ALREADY_OWNED_BY_YOU') {
+            throw new Error(e);
+        }
+    }
+}
+
+/*async function _upload_check_cache_and_cloud(type) {
+    //upload dataset
+    await uploadDataSetToCloud(type, namespace_mapping[type].bucket2);
+    await upload_directly_to_cloud(type);
+    await isFilesAvailableInNooBaaBucket(namespace_mapping[type].gateway, files_cloud[`files_${type}`], type);
+    for (const file of files_cloud[`files_${type}`]) {
+        try {
+            await compereMD5betweenCloudAndNooBaa(type, namespace_mapping[type].bucket2, namespace_mapping[type].gateway, false, file);
+            report.success(`read via namespace ${type}`);
+        } catch (err) {
+            console.log('Failed upload via cloud , check via noobaa');
+            throw err;
+        }
+    }
+}*/
+
+async function upload_via_noobaa({ type, file_name, bucket }) {
+    //Try to upload a file to noobaa s3 server
+    if (!file_name) {
+        file_name = 'file_namespace_test_' + (Math.floor(Date.now() / 1000));
+    }
+    if (!bucket) {
+        bucket = namespace_mapping[type].gateway;
+    }
+    console.log(`uploading ${file_name} via noobaa bucket ${bucket}`);
+    files_cloud[`files_${type}`].push(file_name);
+    try {
+        await uploadFileToNoobaaS3(bucket, file_name);
+        report.success(`upload via noobaa to namespace ${type}`);
+    } catch (e) {
+        report.fail(`upload via noobaa to namespace ${type}`);
+        throw new Error(`Failed to upload files into ${type}: ${e}`);
+    }
+    return file_name;
+}
+
+async function list_files_in_cloud(type) {
+    const list_files_obj = await namespace_mapping[type].s3ops.get_list_files(namespace_mapping[type].bucket2);
+    return list_files_obj.map(file => file.Key);
+}
+
+async function check_via_cloud(type, file_name) {
+    console.log(`checking via ${type}: ${namespace_mapping[type].bucket2}`);
+    const list_files = await list_files_in_cloud(type);
+    console.log(`${type} files list ${list_files}`);
+    if (list_files.includes(file_name)) {
+        console.log(`${file_name} was uploaded via noobaa and found via ${type}`);
+    } else {
+        throw new Error(`${file_name} was uploaded via noobaa and was not found via ${type}`);
+    }
+    return true;
+}
+
+async function _upload_via_noobaa_check_via_cache_and_cloud({ type, file_name, bucket }) {
+    //Try to upload a file to noobaa s3 server, verify it was uploaded to the cloud
+    //Compare object in cache and cloud
+    const uploaded_file_name = await upload_via_noobaa({ type, file_name, bucket });
+    await check_via_cloud(type, uploaded_file_name);
+    await compereMD5betweenCloudAndNooBaa(type, namespace_mapping[type].bucket2,
+        namespace_mapping[type].gateway, true, uploaded_file_name);
+    await compereMD5betweenCloudAndNooBaa(type, namespace_mapping[type].bucket2,
+        namespace_mapping[type].gateway, false, uploaded_file_name);
+}
+
+/*async function update_read_write_and_check(clouds, name, read_resources, write_resource) {
+    let should_fail;
+    const run_on_clouds = _.clone(clouds);
+    try {
+        await bucket_functions.updateNamesapceBucket(name, write_resource, read_resources);
+        report.success('update namespace bucket w resource');
+    } catch (e) {
+        report.fail('update namespace bucket w resource');
+        throw new Error(e);
+    }
+    await P.delay(30 * 1000);
+    console.error(`${RED}TODO: REMOVE THIS DELAY, IT IS TEMP OVERRIDE FOR BUG #4831${NC}`);
+    const uploaded_file_name = await upload_via_noobaa({ type: run_on_clouds[0], bucket: name });
+    //checking that the file was written into the read/write cloud
+    await check_via_cloud(run_on_clouds[0], uploaded_file_name);
+    run_on_clouds.shift();
+    for (let cycle = 0; cycle < run_on_clouds.length; cycle++) {
+        //checking that the file was not written into the read only clouds
+        try {
+            should_fail = await check_via_cloud(run_on_clouds[cycle], uploaded_file_name);
+        } catch (e) {
+            console.log(`${e}, as should`);
+        }
+        if (should_fail) {
+            throw new Error(`Upload succeed To the read only cloud (${run_on_clouds[cycle]}) while it shouldn't`);
+        }
+    }
+}
+
+async function list_cloud_files_read_via_noobaa(type, noobaa_bucket) {
+    const files_in_cloud_bucket = await list_files_in_cloud(type);
+    for (const file of files_in_cloud_bucket) {
+        try {
+            await compereMD5betweenCloudAndNooBaa(type, namespace_mapping[type].bucket2, noobaa_bucket, file);
+            report.success(`verify md5 via list on ${type}`);
+        } catch (err) {
+            report.fail(`verify md5 via list on ${type}`);
+            throw err;
+        }
+    }
+}*/
+
+async function _clean_namespace_bucket(bucket, type) {
+    const list_files = await s3ops.get_list_files(bucket);
+    const keys = list_files.map(key => key.Key);
+    if (keys) {
+        for (const file of keys) {
+            try {
+                report.success(`delete via namespace ${type}`);
+                await s3ops.delete_file(bucket, file);
+            } catch (e) {
+                report.fail(`delete via namespace ${type}`);
+                console.error(`${RED}TODO: REMOVE THIS TRY CATCH, IT IS TEMP OVERRIDE FOR BUG #4832${NC}`);
+            }
+        }
+    }
+    await _delete_namespace_bucket(bucket);
+}
+
+async function clean_env(clouds) {
+    for (const type of clouds) {
+        try {
+            await cf.deleteNamespaceResource(namespace_mapping[type].namespace);
+            report.success(`delete namespace resource ${type}`);
+        } catch (err) {
+            report.fail(`delete namespace resource ${type}`);
+        }
+        try {
+            await cf.deleteConnection(connections_mapping[type].name);
+            report.success(`delete connection ${type}`);
+        } catch (err) {
+            report.fail(`delete connection ${type}`);
+        }
+    }
+}
+
+async function main(clouds) {
+    try {
+        await set_rpc_and_create_auth_token();
+        for (const type of clouds) {
+            await _create_resource(type);
+            //await _upload_check_cache_and_cloud(type);
+            await _upload_via_noobaa_check_via_cache_and_cloud({ type, file: 'file_cos_15KB', bucket: namespace_mapping[type].gateway });
+            await _clean_namespace_bucket(namespace_mapping[type].gateway, type);
+        }
+        if (!skip_clean) {
+            /*for (const type of clouds) {
+                await _clean_namespace_bucket(bucket, type);
+            }*/
+            await clean_env(clouds);
+        }
+        await report.report();
+        if (failures_in_test) {
+            console.error('Errors during namespace test');
+            console.error(`${JSON.stringify(_.countBy(errors), null, 4)}`);
+            process.exit(1);
+        } else {
+            console.log('namespace cache tests were successful!');
+            process.exit(0);
+        }
+    } catch (err) {
+        console.error('something went wrong', err);
+        await report.report();
+        process.exit(1);
+    }
+}
+
+main(cloud_list);

--- a/src/test/system_tests/sanity_build_test.js
+++ b/src/test/system_tests/sanity_build_test.js
@@ -24,7 +24,8 @@ const TEST_CTX = {
     mgmt_endpoint: '',
     bucket_mirror: 'ec.no.quota',
     bucket_spread: 'replica.with.quota',
-    ns_bucket: 'ns.over.azure.aws'
+    ns_bucket: 'ns.over.azure.aws',
+    ns_cache_bucket: 'ns.cache.over.azure.aws'
 };
 
 async function main() {
@@ -179,6 +180,7 @@ async function _create_resources_and_buckets() {
     console.info('Creating NS Buckets');
     await TEST_CTX.bucketfunc.createNamespaceBucket(TEST_CTX.ns_bucket, 'NSv2');
     await TEST_CTX.bucketfunc.updateNamesapceBucket(TEST_CTX.ns_bucket, 'NSv4', ['NSv2', 'NSv4']);
+    await TEST_CTX.bucketfunc.createNamespaceBucket(TEST_CTX.ns_cache_bucket, 'NSv2', { ttl_ms: 60000 });
 }
 
 async function _create_accounts() {

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -73,7 +73,7 @@ mocha.describe('s3_ops', function() {
         });
     });
 
-    function test_object_ops(bucket_name, bucket_type) {
+    function test_object_ops(bucket_name, bucket_type, caching) {
         const file_body = "TEXT-FILE-YAY!!!!-SO_COOL";
         const sliced_file_body = "TEXT-F";
         const sliced_file_body1 = "_COOL";
@@ -101,7 +101,7 @@ mocha.describe('s3_ops', function() {
                     connection: CONNECTION_NAME,
                     target_bucket: AWS_TARGET_BUCKET
                 });
-                await rpc_client.bucket.create_bucket({ name: bucket_name, namespace: { read_resources, write_resource } });
+                await rpc_client.bucket.create_bucket({ name: bucket_name, namespace: { read_resources, write_resource, caching } });
             }
             await s3.putObject({ Bucket: bucket_name, Key: text_file1, Body: file_body, ContentType: 'text/plain' }).promise();
         });
@@ -222,6 +222,9 @@ mocha.describe('s3_ops', function() {
     });
     mocha.describe('namespace-bucket-object-ops', function() {
         test_object_ops(BKT3, "namespace");
+    });
+    mocha.describe('namespace-bucket-caching-enabled-object-ops', function() {
+        test_object_ops(BKT3, "namespace", { ttl_ms: 60000 });
     });
 
 });

--- a/src/test/utils/bucket_functions.js
+++ b/src/test/utils/bucket_functions.js
@@ -151,18 +151,20 @@ class BucketFunctions {
         }
     }
 
-    async createNamespaceBucket(name, namespace) {
-        console.log(`Creating namespace bucket with namespace ${namespace}`);
+    async createNamespaceBucket(name, namespace, caching) {
+        console.log(`Creating namespace bucket ${name} with namespace ${namespace}`);
         try {
+            const namespaceConfig = {
+                read_resources: [namespace],
+                write_resource: namespace,
+                caching
+            };
             await this._client.bucket.create_bucket({
                 name,
-                namespace: {
-                    read_resources: [namespace],
-                    write_resource: namespace
-                }
+                namespace: namespaceConfig
             });
         } catch (e) {
-            console.error('Failed to create Namespace bucket', e);
+            console.error(`Failed to create Namespace bucket ${name}`, e);
             throw e;
         }
     }

--- a/src/test/utils/cloud_functions.js
+++ b/src/test/utils/cloud_functions.js
@@ -24,6 +24,21 @@ class CloudFunction {
         return AWSConnections;
     }
 
+    getCOSConnection() {
+        const {
+            COS_ACCESS_KEY_ID,
+            COS_SECRET_ACCESS_KEY,
+        } = process.env;
+        const COSConnections = {
+            name: 'COSConnection',
+            endpoint: "https://s3.us-south.cloud-object-storage.appdomain.cloud",
+            endpoint_type: "IBM_COS",
+            identity: COS_ACCESS_KEY_ID,
+            secret: COS_SECRET_ACCESS_KEY
+        };
+        return COSConnections;
+    }
+
     getAzureConnection() {
         const {
             AZURE_STORAGE_ACCOUNT_NAME,


### PR DESCRIPTION
### Explain the changes
Include PR #5977 changes done by @guymguym for caching. Additional changes is,
1. Add initial caching parameter to bucket API.
2. Add new property cache_valid_time to object for calculating TTL.
3. In read and head operations, cache valid time is updated if TTL expires and etag in hub and cache are same.
4. In read operation, object is read from hub and updated in cache if TTL expires and etag in hub and cache are different.
5. In read and head operations, 404 is returned and object is deleted from cache if it has been deleted from hub and TTL expires.
6. In upload operation, defer the finalizer of the cache stream until the hub upload completes. Clean up piped streams when error in read stream.
7. Update frontend to support creating namespace bucket with TTL. See 
![Screen Shot 2020-04-23 at 11 46 57 AM](https://user-images.githubusercontent.com/20991587/80807331-8913b180-8b82-11ea-9133-9ff95ddd78e0.png)
8. Added initial functional test file for namespace caching, namespace_cache_test.js.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
