### PR TITLE
Get rid of discovering virtual appliance address

### DIFF
--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -124,7 +124,7 @@ async function _check_address_changes(container_platform) {
         const [system] = system_store.data.systems;
         const system_address = container_platform === 'KUBERNETES' ?
             await os_utils.discover_k8s_services() :
-            await os_utils.discover_virtual_appliance_address();
+            [];
 
         // This works because the lists are always sorted, see discover_k8s_services().
         if (!_.isEqual(system.system_address, system_address)) {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -361,7 +361,7 @@ async function _create_owner_account(
 async function _configure_system_address(system_id, account_id) {
     const system_address = (process.env.CONTAINER_PLATFORM === 'KUBERNETES') ?
         await os_utils.discover_k8s_services() :
-        await os_utils.discover_virtual_appliance_address();
+        [];
 
     // This works because the lists are always sorted, see discover_k8s_services().
     const { system_address: curr_address } = system_store.data.systems[0] || {};
@@ -996,7 +996,7 @@ async function update_endpoint_group(req) {
         }
 
         // call make_changes only if there are actual changes to make.
-        // this check fixes a bug where make_changes sends a load_system_store notification 
+        // this check fixes a bug where make_changes sends a load_system_store notification
         // to the operator, which in its own reconcile sends back update_endpoint_group, and so forth
         if (group.region !== region || !_.isEqual(group.endpoint_range, endpoint_range)) {
             await system_store.make_changes({


### PR DESCRIPTION
### Explain the changes
1.  Disable discovering virtual appliance address if not in k8s deployment.

### Issues: Fixed #xxx / Gap #xxx
1. During local testing (the services started with npm on local machine), the IP address for the services will not be overwritten to public IP as result of discovering virtual appliance address, as the services don't listen to the public IP address.

### Testing Instructions:
1. The "hostname" for each service will stay as "127.0.0.1" in db.systems table.
