### PR TITLE
Fixed multipart upload on namespace bucket (Azure as resource)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "5.3.1",
+  "version": "5.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2208,7 +2208,8 @@
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.1.0",
@@ -4240,12 +4241,30 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        }
       }
     },
     "hash-stream-validation": {

--- a/src/endpoint/s3/ops/s3_put_object_uploadId.js
+++ b/src/endpoint/s3/ops/s3_put_object_uploadId.js
@@ -46,6 +46,7 @@ async function put_object_uploadId(req, res) {
             dbg.warn('Invalid Argument');
             throw new S3Error(S3Error.InvalidArgument);
         }
+        throw e;
     }
     s3_utils.set_encryption_response_headers(req, res, reply.encryption);
 

--- a/src/sdk/namespace_merge.js
+++ b/src/sdk/namespace_merge.js
@@ -415,7 +415,9 @@ class NamespaceMerge {
             'NoSuchBucket': S3Error.NoSuchBucket,
             'ContainerNotFound': S3Error.NoSuchBucket,
         };
-        let s3error = new S3Error(err_to_s3err_map[err.code]);
+        let exist = err_to_s3err_map[err.code];
+        if (!exist) return err;
+        let s3error = new S3Error(exist);
         s3error.message = err.message;
         return s3error;
     }


### PR DESCRIPTION
### Explain the changes
1. Changed the ETag at the answer to the upload_multipart request to be the hex representation of the block_id instead of the content-md5 header.   
2. Added the { UncommittedBlocks: block_list, CommittedBlocks: [], LatestBlocks: [] } object instead of an array of the ETags.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #4203 

### Testing Instructions:
1. 
