### PR TITLE
Prevent external accounts (OAuth accounts) from editing/deleting other accounts

### DIFF
--- a/frontend/src/app/components/account/account-details-form/account-details-form.js
+++ b/frontend/src/app/components/account/account-details-form/account-details-form.js
@@ -3,6 +3,7 @@
 import template from './account-details-form.html';
 import ConnectableViewModel from 'components/connectable';
 import ko from 'knockout';
+import { canEditAccount } from 'utils/account-utils';
 import {
     openChangePasswordModal,
     openResetPasswordModal
@@ -29,16 +30,18 @@ class AccountDetailsFormViewModel extends ConnectableViewModel {
     ];
 
     selectState(state, params) {
-        const { accounts, session } = state;
+        const { accounts = {}, session } = state;
 
         return [
-            accounts && accounts[params.accountName],
-            session
+            accounts[params.accountName],
+            session && accounts[session.user],
+            session && session.authorizedBy
+
         ];
     }
 
-    mapStateToProps(account, session) {
-        if (!account || !session) {
+    mapStateToProps(account, user, authorizedBy) {
+        if (!account || !user) {
             ko.assignToProps(this, {
                 button: {
                     label: 'Reset Password',
@@ -48,11 +51,12 @@ class AccountDetailsFormViewModel extends ConnectableViewModel {
             });
 
         } else {
-            const { user, authorizedBy } = session;
             const { isAdmin } = account;
-            const isCurrentUser = user === account.name;
-            const allowResetPassword = authorizedBy === 'noobaa';
+            const isCurrentUser = user === account;
             const role  = isAdmin ? 'Administator' : 'Application';
+            const allowResetPassword =
+                authorizedBy === 'noobaa' &&
+                canEditAccount(user, account);
 
             ko.assignToProps(this, {
                 accountName: account.name,

--- a/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.html
+++ b/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.html
@@ -5,18 +5,23 @@
         Account S3 Access
     </h2>
 
-    <button class="btn push-next"
-        ko.click="onSetIPRestrictions"
-    >
-        Set IP Restrictions
-    </button>
+    <div class="push-next" ko.tooltip="actionsTooltip">
+        <button class="btn"
+            ko.click="onSetIPRestrictions"
+            ko.enable="canEdit"
+        >
+            Set IP Restrictions
+        </button>
+    </div>
 
-    <button class="btn"
-        ko.click="onEditS3Access"
-        ko.disable="!dataReady()"
-    >
-        Edit S3 Access
-    </button>
+    <div ko.tooltip="actionsTooltip">
+        <button class="btn"
+            ko.click="onEditS3Access"
+            ko.enable="canEdit"
+        >
+            Edit S3 Access
+        </button>
+    </div>
 </div>
 
 <property-sheet class="s3-access-details pad push-next " params="
@@ -39,9 +44,14 @@
         Account Security Credentials
     </h2>
 
-    <button class="btn" ko.click="onRegenerateAccountCredentials">
-        Regenerate Credentials
-    </button>
+    <div ko.tooltip="actionsTooltip">
+        <button class="btn"
+            ko.click="onRegenerateAccountCredentials"
+            ko.enable="canEdit"
+        >
+            Regenerate Credentials
+        </button>
+    </div>
 </div>
 
 <loading-indicator class="align-start pad"

--- a/frontend/src/app/reducers/accounts-reducer.js
+++ b/frontend/src/app/reducers/accounts-reducer.js
@@ -31,6 +31,7 @@ function _mapAccount(account, owner, systemName, pools, allBuckets, accountsOwni
     const {
         email,
         has_login,
+        is_external,
         access_keys,
         has_s3_access,
         default_pool,
@@ -61,8 +62,9 @@ function _mapAccount(account, owner, systemName, pools, allBuckets, accountsOwni
     );
 
     const isOwner = Boolean(email === owner.email);
-    const undeletable =  (isOwner && 'OWNER') || 
-        (accountsOwningBuckets.has(email) && 'OWN_BUCKET') || 
+    const undeletable =
+        (isOwner && 'OWNER') ||
+        (accountsOwningBuckets.has(email) && 'OWN_BUCKET') ||
         undefined;
 
 
@@ -70,6 +72,7 @@ function _mapAccount(account, owner, systemName, pools, allBuckets, accountsOwni
         name: email,
         isAdmin: has_login,
         isOwner,
+        isExternal: Boolean(is_external), // is_external might be undefined
         hasAccessToAllBuckets,
         allowedBuckets,
         canCreateBuckets: Boolean(has_s3_access && can_create_buckets),

--- a/frontend/src/app/schema/accounts.js
+++ b/frontend/src/app/schema/accounts.js
@@ -11,6 +11,7 @@ export default {
             'externalConnections',
             'isAdmin',
             'isOwner',
+            'isExternal',
             'name',
             'roles'
         ],
@@ -137,6 +138,9 @@ export default {
                 type: 'boolean'
             },
             isOwner: {
+                type: 'boolean'
+            },
+            isExternal: {
                 type: 'boolean'
             },
             name: {

--- a/frontend/src/app/utils/account-utils.js
+++ b/frontend/src/app/utils/account-utils.js
@@ -1,0 +1,9 @@
+/* Copyright (C) 2016 NooBaa */
+
+export function canEditAccount(user, account) {
+    return !user.isExternal || user == account;
+}
+
+export function canDeleteAccount(user, account) {
+    return !account.undeletable && canEditAccount(user, account);
+}

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -502,6 +502,9 @@ module.exports = {
                 is_support: {
                     type: 'boolean',
                 },
+                is_external: {
+                    type: 'boolean'
+                },
                 has_login: {
                     type: 'boolean',
                 },

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -49,12 +49,13 @@ async function create_account(req) {
     const account = {
         _id: (
             req.rpc_params.new_system_parameters ?
-            system_store.parse_system_store_id(req.rpc_params.new_system_parameters.account_id) :
-            system_store.new_system_store_id()
+                system_store.parse_system_store_id(req.rpc_params.new_system_parameters.account_id) :
+                system_store.new_system_store_id()
         ),
         name: req.rpc_params.name,
         email: req.rpc_params.email,
         has_login: req.rpc_params.has_login,
+        is_external: req.rpc_params.is_external,
         access_keys: undefined,
     };
 
@@ -194,6 +195,7 @@ function create_external_user_account(req) {
         internalStorage[0];
 
     Object.assign(req.rpc_params, {
+        is_external: true,
         password: new SensitiveString(chance.string({ length: 16 })),
         must_change_password: false,
         has_login: true,
@@ -1089,10 +1091,14 @@ function delete_external_connection(req) {
 // UTILS //////////////////////////////////////////////////////////
 
 function get_account_info(account, include_connection_cache) {
-    var info = _.pick(account, 'name', 'email', 'access_keys');
-
-    info.has_login = account.has_login;
-    info.allowed_ips = account.allowed_ips;
+    var info = _.pick(account,
+        'name',
+        'email',
+        'is_external',
+        'access_keys',
+        'has_login',
+        'allowed_ips',
+    );
 
     if (account.is_support) {
         info.is_support = true;

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -20,6 +20,7 @@ module.exports = {
         name: { wrapper: SensitiveString },
         email: { wrapper: SensitiveString },
         is_support: { type: 'boolean' },
+        is_external: { type: 'boolean' },
 
         // password login
         has_login: { type: 'boolean' },


### PR DESCRIPTION
External accounts are accounts inside NooBaa that are created by the OAuth2 flow in order to represent an account that is authenticated outside of NooBaa. They are automatically created upon the first login of said user.

### Explain the changes
1. Mark external account with is_external flag to allow the Management Console to disable all edit/delete operation on other accounts.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes (as a workaround) https://bugzilla.redhat.com/show_bug.cgi?id=1833030

### Testing Instructions:
1. 
