### PR TITLE
Reuse RPC clients for endpoint requests

### DIFF
--- a/config.js
+++ b/config.js
@@ -61,6 +61,7 @@ config.N2N_OFFER_INTERNAL = false;
 
 config.AMZ_DATE_MAX_TIME_SKEW_MILLIS = 15 * 60 * 1000;
 config.ENDPOINT_MONITOR_INTERVAL = 10 * 60 * 1000; // 10min
+config.ENDPOINT_PRE_ALLOCATED_RPC_CLIENTS = 20;
 
 ///////////////
 // MD CONFIG //


### PR DESCRIPTION
### Explain the changes
1. creating a new RPC client for each endpoint request induces a measurable memory pressure when doing a lot of small requests in a row by shorting the time between GC cycles.
Reusing the same RPC client for non-overlapping requests prevents that

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
