### PR TITLE
Skip allocations, serialization and deserialization of request data for in-memory requests

### DIFF
--- a/src/rpc/in_memory_rpc_request.js
+++ b/src/rpc/in_memory_rpc_request.js
@@ -1,0 +1,26 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const RpcRequest = require('./rpc_request');
+
+// Am im memory mapping request key to request data (using en empty buffer
+// as key to comply to current API).
+const req_data_map = new WeakMap();
+
+class InMemoryRpcRequest extends RpcRequest {
+
+    static encode_message(body, buffers) {
+        const empty = Buffer.alloc(0);
+        req_data_map.set(empty, { body, buffers });
+        return [empty];
+    }
+
+    static decode_message(msg_buffers) {
+        const empty = msg_buffers[0];
+        const ret = req_data_map.get(empty);
+        if (!ret) throw new Error('Could not find in memory request data');
+        return ret;
+    }
+}
+
+module.exports = InMemoryRpcRequest;

--- a/src/rpc/index.js
+++ b/src/rpc/index.js
@@ -9,5 +9,4 @@ const RpcRequest = require('./rpc_request');
 exports.RPC = RPC;
 exports.RpcError = RpcError;
 exports.RpcSchema = RpcSchema;
-exports.RpcRequest = RpcRequest;
 exports.RPC_BUFFERS = RpcRequest.RPC_BUFFERS;

--- a/src/rpc/rpc_base_conn.js
+++ b/src/rpc/rpc_base_conn.js
@@ -9,6 +9,7 @@ const dbg = require('../util/debug_module')(__filename);
 const config = require('../../config');
 const time_utils = require('../util/time_utils');
 const RpcError = require('./rpc_error');
+const RpcRequest = require('./rpc_request');
 
 const STATE_INIT = 'init';
 const STATE_CONNECTING = 'connecting';
@@ -16,6 +17,10 @@ const STATE_CONNECTED = 'connected';
 const STATE_CLOSED = 'closed';
 
 class RpcBaseConnection extends EventEmitter {
+
+    get RpcRequestType() {
+        return RpcRequest;
+    }
 
     constructor(addr_url) {
         super();

--- a/src/rpc/rpc_fcall.js
+++ b/src/rpc/rpc_fcall.js
@@ -1,12 +1,17 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-let _ = require('lodash');
-let RpcBaseConnection = require('./rpc_base_conn');
+const _ = require('lodash');
+const RpcBaseConnection = require('./rpc_base_conn');
+const InMemoryRpcRequest = require('./in_memory_rpc_request');
 
 require('setimmediate');
 
 class RpcFcallConnection extends RpcBaseConnection {
+
+    get RpcRequestType() {
+        return InMemoryRpcRequest;
+    }
 
     constructor(addr_url) {
         super(addr_url);

--- a/src/rpc/rpc_request.js
+++ b/src/rpc/rpc_request.js
@@ -107,7 +107,7 @@ class RpcRequest {
                 return { name, len: buf.length };
             });
         }
-        return RpcRequest.encode_message(body, buffers);
+        return this.constructor.encode_message(body, buffers);
     }
 
     _set_request(msg, api, method_api) {
@@ -149,7 +149,7 @@ class RpcRequest {
                 });
             }
         }
-        return RpcRequest.encode_message(body, buffers);
+        return this.constructor.encode_message(body, buffers);
     }
 
     _set_response(msg) {


### PR DESCRIPTION
### Explain the changes
Add  in-memory request type that holds the request data in memory
The new request type is used by in-process requests. to skip the buffer allocations, serialization, and deserialization of the request data and buffers.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
