### PR TITLE
Move most of APIClient interface to its promise chain

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -198,7 +198,7 @@ class Agent {
         );
 
         // register rpc n2n
-        this.n2n_agent = this.rpc.register_n2n_agent(this.client.node.n2n_signal);
+        this.n2n_agent = this.rpc.register_n2n_agent((...args) => this.client.node.n2n_signal(...args));
 
         // TODO these sample geolocations are just for testing
         this.geolocation = _.sample([

--- a/src/agent/block_store_speed.js
+++ b/src/agent/block_store_speed.js
@@ -40,7 +40,7 @@ async function main() {
     const rpc = api.new_rpc();
     const client = rpc.new_client();
     const signal_client = rpc.new_client();
-    const n2n_agent = rpc.register_n2n_agent(signal_client.node.n2n_signal);
+    const n2n_agent = rpc.register_n2n_agent(((...args) => signal_client.node.n2n_signal(...args)));
     n2n_agent.set_any_rpc_address();
     await client.create_auth_token({
         email: argv.email,

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,7 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const _ = require('lodash');
 const url = require('url');
 const { RPC, RPC_BUFFERS, RpcSchema } = require('../rpc');
 const { get_base_address, get_default_ports } = require('../util/addr_utils');
@@ -36,78 +35,84 @@ api_schema.register_api(require('./func_api'));
 api_schema.register_api(require('./func_node_api'));
 api_schema.compile();
 
-class APIClient {
+const client_factory = client_factory_from_schema(api_schema);
 
-    constructor(rpc, default_options) {
-        this.rpc = rpc;
-        this.options = _.create(default_options);
-        this.RPC_BUFFERS = RPC_BUFFERS;
+function client_factory_from_schema(schema) {
+    const client_proto = {
+        RPC_BUFFERS,
 
-        // define the client properties
-        this.auth = undefined;
-        this.account = undefined;
-        this.system = undefined;
-        this.tier = undefined;
-        this.node = undefined;
-        this.host = undefined;
-        this.bucket = undefined;
-        this.events = undefined;
-        this.object = undefined;
-        this.agent = undefined;
-        this.block_store = undefined;
-        this.stats = undefined;
-        this.scrubber = undefined;
-        this.debug = undefined;
-        this.redirector = undefined;
-        this.tiering_policy = undefined;
-        this.pool = undefined;
-        this.cluster_server = undefined;
-        this.cluster_internal = undefined;
-        this.server_inter_process = undefined;
-        this.hosted_agents = undefined;
-        this.frontend_notifications = undefined;
-        this.func = undefined;
-        this.func_node = undefined;
+        async create_auth_token(params) {
+            const res = await this.auth.create_auth(params);
+            this.options.auth_token = res.token;
+            return res;
+        },
 
-        _.each(rpc.schema, api => {
-            if (!api || !api.id || api.id[0] === '_') return;
-            const name = api.id.replace(/_api$/, '');
-            if (name === 'rpc' || name === 'options') throw new Error('ILLEGAL API ID');
-            this[name] = {};
-            _.each(api.methods, (method_api, method_name) => {
-                this[name][method_name] = (params, options) => {
-                    options = _.create(this.options, options);
-                    return rpc._request(api, method_api, params, options);
-                };
-            });
+        async create_access_key_auth(params) {
+            const res = await this.auth.create_access_key_auth(params);
+            this.options.auth_token = res.token;
+            return res;
+        },
+
+        async create_k8s_auth(params) {
+            const res = await this.auth.create_k8s_auth(params);
+            this.options.auth_token = res.token;
+            return res;
+        },
+
+        _invoke_api(api, method_api, params, options) {
+            options = Object.assign(
+                Object.create(this.options),
+                options
+            );
+            return this.rpc._request(api, method_api, params, options);
+        }
+    };
+
+    for (const api of Object.values(schema)) {
+        if (!api || !api.id || api.id[0] === '_') {
+             continue;
+        }
+
+        // Skip common api and other apis that do not define methods.
+        if (!api.methods) {
+            continue;
+        }
+
+        const name = api.id.replace(/_api$/, '');
+        if (name === 'rpc' || name === 'options') {
+            throw new Error('ILLEGAL API ID');
+        }
+
+        const api_proto = {};
+        for (const [method_name, method_api] of Object.entries(api.methods)) {
+            // The following getter is defined as a function and not as an arrow function
+            // to prevent the capture of "this" from the surrounding context.
+            // When invoked, "this" should be the client object. Using an arrow function
+            // will capture the "this" defined in the invocation of "new_client_factory"
+            // which is "undefined"
+            api_proto[method_name] = function(params, options) {
+                return this.client._invoke_api(api, method_api, params, options);
+            };
+        }
+
+        // The following getter is defined as a function and not as an arrow function
+        // on purpose. please see the last comment (above) for a detailed explanation.
+        Object.defineProperty(client_proto, name, {
+            enumerable: true,
+            get: function() {
+                const api_instance = Object.create(api_proto);
+                api_instance.client = this;
+                return Object.freeze(api_instance);
+            }
         });
     }
 
-    /**
-     * extend the rpc client prototype with convinient methods
-     */
-    create_auth_token(params) {
-        return this.auth.create_auth(params)
-            .then(res => {
-                this.options.auth_token = res.token;
-                return res;
-            });
-    }
-
-    create_access_key_auth(params) {
-        return this.auth.create_access_key_auth(params)
-            .then(res => {
-                this.options.auth_token = res.token;
-                return res;
-            });
-    }
-
-    async create_k8s_auth(params) {
-        const res = await this.auth.create_k8s_auth(params);
-        this.options.auth_token = res.token;
-        return res;
-    }
-
+    return (rpc, options) => {
+        const client = Object.create(client_proto);
+        client.rpc = rpc;
+        client.options = options ? Object.create(options) : {};
+        return client;
+    };
 }
 
 function new_router_from_base_address(base_address) {
@@ -156,7 +161,7 @@ function new_rpc_from_routing(routing_table) {
     }
 
     return new RPC({
-        APIClient,
+        client_factory,
         schema: api_schema,
         router: routing_table,
         api_routes: {
@@ -184,22 +189,20 @@ function new_rpc_from_routing(routing_table) {
  *
  */
 function new_rpc_default_only(base_address) {
-    let rpc = new RPC({
-        APIClient,
+    return new RPC({
+        client_factory,
         schema: api_schema,
         router: {
             default: base_address
         },
         api_routes: {}
     });
-    return rpc;
 }
 
-module.exports = {
-    new_rpc: new_rpc,
-    new_rpc_from_base_address: new_rpc_from_base_address,
-    new_rpc_from_routing: new_rpc_from_routing,
-    new_rpc_default_only: new_rpc_default_only,
-    new_router_from_address_list: new_router_from_address_list,
-    new_router_from_base_address: new_router_from_base_address
-};
+exports.client_factory_from_schema = client_factory_from_schema;
+exports.new_rpc = new_rpc;
+exports.new_rpc_from_base_address = new_rpc_from_base_address;
+exports.new_rpc_from_routing = new_rpc_from_routing;
+exports.new_rpc_default_only = new_rpc_default_only;
+exports.new_router_from_address_list = new_router_from_address_list;
+exports.new_router_from_base_address = new_router_from_base_address;

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -212,7 +212,7 @@ function create_endpoint_handler(rpc, internal_rpc_client, options) {
 
     if (options.n2n_agent) {
         const signal_client = rpc.new_client({ auth_token: server_rpc.client.options.auth_token });
-        const n2n_agent = rpc.register_n2n_agent(signal_client.node.n2n_signal);
+        const n2n_agent = rpc.register_n2n_agent(((...args) => signal_client.node.n2n_signal(...args)));
         n2n_agent.set_any_rpc_address();
     }
 

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -27,6 +27,10 @@ const RpcNtcpConnection = require('./rpc_ntcp');
 const RpcFcallConnection = require('./rpc_fcall');
 const RPC_BUFFERS = RpcRequest.RPC_BUFFERS;
 
+function empty_client_factory() {
+    return {};
+}
+
 // dbg.set_level(5, __dirname);
 
 /**
@@ -43,7 +47,6 @@ class RPC extends EventEmitter {
         this._connection_by_address = new Map();
         this._address_to_url_cache = new Map();
         // public properties
-        this.APIClient = options.APIClient;
         this.schema = options.schema;
         this.router = options.router;
         this.api_routes = options.api_routes;
@@ -52,6 +55,19 @@ class RPC extends EventEmitter {
         this.RPC_BUFFERS = RPC_BUFFERS;
         this._routing_authority = null;
         this._error_handler = null;
+        this._client_factory = options.client_factory || empty_client_factory;
+        this.routing_hint = undefined;
+    }
+
+    /**
+     *
+     * new_client
+     * @param {Object} [options]
+     * @returns {nb.APIClient}
+     *
+     */
+    new_client(options) {
+        return this._client_factory(this, options);
     }
 
     /**
@@ -142,11 +158,6 @@ class RPC extends EventEmitter {
         }
         return true;
     }
-
-    new_client(options) {
-        return new this.APIClient(this, options);
-    }
-
 
     /**
      *

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -177,7 +177,7 @@ function start() {
             target_addresses = _.times(argv.nconn, i => 'n2n://conn' + i);
 
             // register n2n and accept any peer_id
-            const n2n_agent = rpc.register_n2n_agent(client.rpcbench.n2n_signal);
+            const n2n_agent = rpc.register_n2n_agent((...args) => client.rpcbench.n2n_signal(...args));
             n2n_agent.set_any_rpc_address();
         })
         .then(() => {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -556,3 +556,41 @@ interface PartSchemaDB {
     uncommitted?: boolean;
 }
 
+/**********************************************************
+ *
+ * API CLIENT - client interface based on default schema
+ *
+ **********************************************************/
+
+interface APIClient {
+    RPC_BUFFERS: Symbol;
+
+    create_auth_token(params: object): Promise<object>;
+    create_access_key_auth(params: object): Promise<object>;
+    create_k8s_auth(params: object): Promise<object>;
+
+    readonly auth: object;
+    readonly account: object;
+    readonly system: object;
+    readonly tier: object;
+    readonly node: object;
+    readonly host: object;
+    readonly bucket: object;
+    readonly events: object;
+    readonly object: object;
+    readonly agent: object;
+    readonly block_store: object;
+    readonly stats: object;
+    readonly scrubber: object;
+    readonly debug: object;
+    readonly redirector: object;
+    readonly tiering_policy: object;
+    readonly pool: object;
+    readonly cluster_server: object;
+    readonly cluster_internal: object;
+    readonly server_inter_process: object;
+    readonly hosted_agents: object;
+    readonly frontend_notifications: object;
+    readonly func: object;
+    readonly func_node: object;
+}

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -201,7 +201,7 @@ class NodesMonitor extends EventEmitter {
         // This is used in order to test n2n connection from node_monitor to agents
         this.n2n_rpc = api.new_rpc();
         this.n2n_client = this.n2n_rpc.new_client({ auth_token: server_rpc.client.options.auth_token });
-        this.n2n_agent = this.n2n_rpc.register_n2n_agent(this.n2n_client.node.n2n_signal);
+        this.n2n_agent = this.n2n_rpc.register_n2n_agent((...args) => this.n2n_client.node.n2n_signal(...args));
         this._host_sequence_number = 0;
         // Notice that this is a mock up address just to ensure n2n connection authorization
         this.n2n_agent.set_rpc_address('n2n://nodes_monitor');
@@ -1884,7 +1884,7 @@ class NodesMonitor extends EventEmitter {
             !item.node.deleting &&
             !item.node.deleted);
         if (stat) {
-            dbg.log0_throttled(`${item.node.name} item has issues ${item.online} ${item.trusted} ${item.node_from_store} ${item.node.rpc_address} 
+            dbg.log0_throttled(`${item.node.name} item has issues ${item.online} ${item.trusted} ${item.node_from_store} ${item.node.rpc_address}
                 ${item.io_detention} ${item.node.migrating_to_pool} ${item.node.decommissioning} ${item.node.decommissioned} ${item.node.deleting} ${item.node.deleted}`);
         }
         return stat;
@@ -1904,7 +1904,7 @@ class NodesMonitor extends EventEmitter {
             !item.node.deleted
         );
         if (!readable) {
-            dbg.log0_throttled(`${item.node.name} not reasable ${item.online} ${item.trusted} ${item.node_from_store} ${item.node.rpc_address} ${!item.storage_not_exist} 
+            dbg.log0_throttled(`${item.node.name} not reasable ${item.online} ${item.trusted} ${item.node_from_store} ${item.node.rpc_address} ${!item.storage_not_exist}
                 ${!item.auth_failed} ${!item.io_detention} ${!item.node.decommissioned} ${!item.node.deleting} ${!item.node.deleted}`);
         }
         return readable;
@@ -1928,8 +1928,8 @@ class NodesMonitor extends EventEmitter {
         );
 
         if (!writable) {
-            dbg.log0_throttled(`${item.node.name} not readable ${item.online} ${item.trusted} ${item.node_from_store} ${item.node.rpc_address} ${!item.storage_not_exist} 
-                ${!item.auth_failed} ${!item.io_detention} ${!item.storage_full} ${!item.node.migrating_to_pool} ${!item.node.decommissioning} ${!item.node.decommissioned} 
+            dbg.log0_throttled(`${item.node.name} not readable ${item.online} ${item.trusted} ${item.node_from_store} ${item.node.rpc_address} ${!item.storage_not_exist}
+                ${!item.auth_failed} ${!item.io_detention} ${!item.storage_full} ${!item.node.migrating_to_pool} ${!item.node.decommissioning} ${!item.node.decommissioned}
                 ${!item.node.deleting} ${!item.node.deleted}`);
         }
         return writable;

--- a/src/server/server_rpc.js
+++ b/src/server/server_rpc.js
@@ -16,7 +16,7 @@ class ServerRpc {
         // n2n proxy allows any service reach n2n agents
         // without registering an n2n agent by proxying requests
         // using the node server
-        this.rpc.register_n2n_proxy(this.client.node.n2n_proxy);
+        this.rpc.register_n2n_proxy((...args) => this.client.node.n2n_proxy(...args));
     }
 
     get_base_address(base_hostname) {

--- a/src/test/system_tests/test_build_chunks.js
+++ b/src/test/system_tests/test_build_chunks.js
@@ -49,7 +49,7 @@ let rpc = api.new_rpc(); //'ws://' + argv.ip + ':8080');
 let client = rpc.new_client({
     address: `ws://${mgmt_ip}:${mgmt_port}`
 });
-let n2n_agent = rpc.register_n2n_agent(client.node.n2n_signal);
+let n2n_agent = rpc.register_n2n_agent((...args) => client.node.n2n_signal(...args));
 n2n_agent.set_any_rpc_address();
 
 /////// Aux Functions ////////


### PR DESCRIPTION
### Explain the changes

This change will decrease the size of an APiClient object to an object with a single field named `options`.
The interface objects (which contain the method declaration) will be generated on the fly on each access and will consist of a single field named `client` that point back to the client that created them.
The methods themselves are not implemented on the prototype of each API object.

A side effect of this change is that we cannot pass an API method directly as a callback because it loses its context. A workaround is to pass an arrow function that preserves the context as I did for node.n2n_signal

This PR is an alternative to the solution presented in PR #6017
