### PR TITLE
RPC: Decouple message creation from message encoding/decoding

### DIFF
--- a/src/rpc/rpc_fcall.js
+++ b/src/rpc/rpc_fcall.js
@@ -1,18 +1,38 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-let _ = require('lodash');
-let RpcBaseConnection = require('./rpc_base_conn');
+const RpcBaseConnection = require('./rpc_base_conn');
 
 require('setimmediate');
 
 class RpcFcallConnection extends RpcBaseConnection {
+    _close() {
+        /* noop */
+    }
 
-    constructor(addr_url) {
-        super(addr_url);
-        this._close = _.noop;
-        this._connect = () => setImmediate(() => this.emit('connect'));
-        this._send = msg => setImmediate(() => this.emit('message', msg));
+    _connect() {
+        setImmediate(() => this.emit('connect'));
+    }
+
+    _send(msg) {
+        setImmediate(() => this.emit('message', msg));
+    }
+
+    /**
+     * @override
+     */
+    _encode_message(msg) {
+        // A clone is needed because an RPC connection lives inside the same process.
+        // If the and part of the msg content will change after the message is sent
+        // both the sender and reciver will e effected by the change.
+        return msg.clone();
+    }
+
+    /**
+     * @override
+     */
+    _decode_message(msg) {
+        return msg;
     }
 }
 

--- a/src/rpc/rpc_http.js
+++ b/src/rpc/rpc_http.js
@@ -10,7 +10,7 @@ const dbg = require('../util/debug_module')(__filename);
 const buffer_utils = require('../util/buffer_utils');
 const http_utils = require('../util/http_utils');
 const RpcBaseConnection = require('./rpc_base_conn');
-const { RPC_VERSION_NUMBER } = require('./rpc_request');
+const { RPC_VERSION_NUMBER } = require('./rpc_message');
 
 // dbg.set_level(5);
 

--- a/src/rpc/rpc_message.js
+++ b/src/rpc/rpc_message.js
@@ -1,0 +1,112 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+const buffer_utils = require('../util/buffer_utils');
+const mongo_utils = require('../util/mongo_utils');
+
+const RPC_VERSION_MAGIC = 0xba;
+const RPC_VERSION_MAJOR = 0;
+const RPC_VERSION_MINOR = 0;
+const RPC_VERSION_FLAGS = 0;
+const RPC_VERSION_NUMBER = Buffer.from([
+    RPC_VERSION_MAGIC,
+    RPC_VERSION_MAJOR,
+    RPC_VERSION_MINOR,
+    RPC_VERSION_FLAGS,
+]).readUInt32BE(0);
+
+// Encoding and decoding of rpc messages is a non-symmetric operation
+// when using cloning we need to replicate this non symmetry as much as
+// possible in order to ensure complaince on both sides of the RPC call.
+function clone_customizer(value) {
+    // Mongo object ids are always serialized into strings and never deserialized back.
+    if (mongo_utils.is_object_id(value)) {
+        return value.toJSON();
+    }
+
+    // Explicity returning undefined to empesis the need to return
+    // undefined and not the original value.
+    return undefined;
+}
+
+/**
+ * RpcMessage represents a self-contained message that rpc sends/receives over connections.
+ * The `body.op` property specifies the type of message but the message encoding is agnostic to it.
+ * Known message ops are: `req`, `res`, `ping`, `pong`, `routing_req`, `routing_res`.
+ *
+ * Buffers can be attached to any message in order to send raw bytes.
+ * Note that the message does not preserve the buffers on the receiver side.
+ * Multiple buffers might collapse to a single one or vice versa.
+ * The only guarantee is that `Buffer.concat(buffers)` will contain the same bytes.
+ * So the body itself should provide the information needed to parse the buffers.
+ * Refer to how RpcRequest is setting body.buffers to contain the size of every attachment.
+ */
+class RpcMessage {
+    static get RPC_VERSION_NUMBER() {
+        return RPC_VERSION_NUMBER;
+    }
+
+    /**
+     * @param {Object} body is the main payload of the message (json encoded)
+     * @param {Buffer[]} [buffers] optional list of buffers to append the body
+     */
+    constructor(body, buffers) {
+        this.body = body;
+        this.buffers = buffers || [];
+    }
+
+    /**
+     * @returns {RpcMessage}
+     */
+    clone() {
+        const { body, buffers } = this;
+        return new RpcMessage(
+            _.cloneDeepWith(body, clone_customizer),
+            buffers.map(Buffer.from)
+        );
+    }
+
+    /**
+     * @returns {Buffer[]}
+     */
+    encode() {
+        const { body, buffers = [] } = this;
+        const meta_buffer = Buffer.allocUnsafe(8);
+        const body_buffer = Buffer.from(JSON.stringify(body));
+        meta_buffer.writeUInt32BE(RPC_VERSION_NUMBER, 0);
+        meta_buffer.writeUInt32BE(body_buffer.length, 4);
+        const msg_buffers = [
+            meta_buffer,
+            body_buffer,
+            ...buffers
+        ];
+        return msg_buffers;
+    }
+
+    /**
+     * @param {Buffer[]} msg_buffers
+     * @returns {RpcMessage}
+     */
+    static decode(msg_buffers) {
+        const meta_buffer = buffer_utils.extract_join(msg_buffers, 8);
+        const version = meta_buffer.readUInt32BE(0);
+        if (version !== RPC_VERSION_NUMBER) {
+            const magic = meta_buffer.readUInt8(0);
+            const major = meta_buffer.readUInt8(1);
+            const minor = meta_buffer.readUInt8(2);
+            const flags = meta_buffer.readUInt8(3);
+            if (magic !== RPC_VERSION_MAGIC) throw new Error('RPC VERSION MAGIC MISMATCH');
+            if (major !== RPC_VERSION_MAJOR) throw new Error('RPC VERSION MAJOR MISMATCH');
+            if (minor !== RPC_VERSION_MINOR) throw new Error('RPC VERSION MINOR MISMATCH');
+            if (flags !== RPC_VERSION_FLAGS) throw new Error('RPC VERSION FLAGS MISMATCH');
+            throw new Error('RPC VERSION MISMATCH');
+        }
+        const body_length = meta_buffer.readUInt32BE(4);
+        const body = JSON.parse(buffer_utils.extract_join(msg_buffers, body_length));
+
+        return new RpcMessage(body, msg_buffers);
+    }
+}
+
+module.exports = RpcMessage;

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -3279,7 +3279,7 @@ class NodesMonitor extends EventEmitter {
                 }
             )
             .then(reply => ({
-                proxy_reply: reply,
+                proxy_reply: js_utils.omit_symbol(reply, RPC_BUFFERS),
                 [RPC_BUFFERS]: reply && reply[RPC_BUFFERS],
             }));
     }

--- a/src/util/js_utils.js
+++ b/src/util/js_utils.js
@@ -196,6 +196,41 @@ function map_get_or_create(map, key, item_initializer) {
     }
 }
 
+/**
+ * Enable easier usage of Object.hasOwnProperty
+ *
+ * @param {Object} obj
+ * @param {String|Symbol} prop_name_or_sym
+ * @returns {Boolean}
+ */
+function hasOwnProperty(obj, prop_name_or_sym) {
+    return Object.prototype.hasOwnProperty.call(obj, prop_name_or_sym);
+}
+
+/**
+ * Unlike lodash omit, this omit will not convert null, undefined, value typed,
+ * arrays or functions into an object (empty or not) and will not clone the passed
+ * object if the symbol does not exists on the object own properties
+ *
+ * @template T
+ * @param {T} maybe_obj
+ * @param {symbol} sym
+ * @returns {Omit<T,symbol> | T}
+ */
+ function omit_symbol(maybe_obj, sym) {
+     if (
+         !_.isObjectLike(maybe_obj) ||
+         Array.isArray(maybe_obj) ||
+         !hasOwnProperty(maybe_obj, sym)
+     ) {
+         return maybe_obj;
+     }
+
+     const obj = /** @type {object} */ (maybe_obj);
+     return _.omit(obj, sym);
+ }
+
+
 exports.self_bind = self_bind;
 exports.array_push_all = array_push_all;
 exports.array_push_keep_latest = array_push_keep_latest;
@@ -208,3 +243,4 @@ exports.PackedObject = PackedObject;
 exports.inspect_lazy = inspect_lazy;
 exports.make_array = make_array;
 exports.map_get_or_create = map_get_or_create;
+exports.omit_symbol = omit_symbol;


### PR DESCRIPTION
### Explain the changes
1.  Create a new RpcMessage class to represent a generic non-encoded RPC message that can describe any op (in contrast to RpcReqeust that can be used solely for requests and responses).
2. Move encoding/decoding responsibilities (from and to transit representation) into rpc_connection where the base class just delegate to the old encode/decode code inside RpcRequest.
4. Decode on "message" and emit a "decoded_message" event with the decoded RpcMessage.
5. Override the encoding and decoding for `fcall` connections to passthrough the RpcMessage without encoding or decoding.


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
