### PR TITLE
Updating ownership of mongo PV will now run recursively

### DIFF
--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -264,7 +264,7 @@ spec:
           # command: ['/noobaa_init_files/kube_pv_chown', 'server']
           command: ["/noobaa_init_files/noobaa_init.sh", "init_mongo"]
           volumeMounts:
-            - mountPath: /mongo_data
+            - mountPath: /data
               name: mongo-datadir
       serviceAccountName: noobaa-account
   volumeClaimTemplates:

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -110,14 +110,12 @@ prepare_server_pvs() {
 }
 
 prepare_mongo_pv() {
-  local dir="/mongo_data/mongo/cluster/shard1"
+  local dir="/data/mongo/cluster/shard1"
 
   # change ownership and permissions of mongo db path
   ${KUBE_PV_CHOWN} mongo
 
   mkdir -p ${dir}
-  chgrp 0 ${dir}
-  chmod g=u ${dir}
 }
 
 run_endpoint_container() {


### PR DESCRIPTION
### Explain the changes
1. kube_pv_chown will now recursively run over mongo directories tree - changing the owner uid
2. will run on /data instead of /mongo_data 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
