### PR TITLE
changing the order of "getting the ceph tests" and "chmoding the test directory" in Tests.Dockerfile

### DIFF
--- a/src/deploy/NVA_build/Tests.Dockerfile
+++ b/src/deploy/NVA_build/Tests.Dockerfile
@@ -40,20 +40,6 @@ WORKDIR /noobaa-core/
 
 ##############################################################
 # Layers:
-#   Title: deploy ceph tests
-#   Size: ~ 83.9 MB
-#
-##############################################################
-
-
-RUN /noobaa-core/src/test/system_tests/ceph_s3_tests_deploy.sh
-RUN cd /noobaa-core/src/test/system_tests/s3-tests/ && \
-    ./bootstrap
-COPY .eslintrc.js /noobaa-core
-COPY .eslintignore /noobaa-core
-
-##############################################################
-# Layers:
 #   Title: npm install to add dev dependencies (noobaa is build with npm install --prod) 
 #   Size: ~ 33 MB
 #
@@ -68,6 +54,20 @@ RUN mkdir -p /noobaa-core/node_modules/.cache/nyc && \
 RUN mkdir -p /noobaa-core/coverage && \
     chmod 777 /noobaa-core/coverage
 RUN chmod -R 777 /noobaa-core/src/test
+
+##############################################################
+# Layers:
+#   Title: deploy ceph tests
+#   Size: ~ 83.9 MB
+#
+##############################################################
+
+
+RUN /noobaa-core/src/test/system_tests/ceph_s3_tests_deploy.sh
+RUN cd /noobaa-core/src/test/system_tests/s3-tests/ && \
+    ./bootstrap
+COPY .eslintrc.js /noobaa-core
+COPY .eslintignore /noobaa-core
 
 # Making mocha accessible 
 RUN ln -s /noobaa-core/node_modules/mocha/bin/mocha /usr/local/bin


### PR DESCRIPTION
### Explain the changes
Tests.Dockerfile:
- Fixing the list of ceph tests

test_ceph_s3.js:
- Removed the require 'os' and change the calls to process.platform
- Made "email" and "system" as args
- Add throw when failing to create auth token

Fixes: #5970 