### PR TITLE
md5_mb (multibuffer) using isa-l_crypto

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -2,6 +2,7 @@
 'use strict';
 
 require('../util/panic');
+require('../util/fips');
 
 const _ = require('lodash');
 const fs = require('fs');

--- a/src/deploy/NVA_build/dev.Dockerfile
+++ b/src/deploy/NVA_build/dev.Dockerfile
@@ -1,0 +1,35 @@
+FROM centos:8 
+
+ENV container docker
+
+RUN dnf update -y -q && \
+    dnf install -y -q \
+        bash bash-completion \
+        wget curl nc unzip which less vim \
+        python2 python2-setuptools \
+        python3 python3-setuptools \
+        gdb strace lsof \
+        openssl && \
+    dnf --enablerepo=PowerTools install -y -q yasm && \
+    dnf group install -y -q "Development Tools" && \
+    dnf clean all
+
+RUN mkdir -p /usr/local/lib/python3.6/site-packages
+RUN alternatives --set python /usr/bin/python3
+
+WORKDIR /noobaa
+
+COPY ./.nvmrc ./.nvmrc
+COPY ./src/deploy/NVA_build/install_nodejs.sh ./
+RUN chmod +x ./install_nodejs.sh && \
+    ./install_nodejs.sh $(cat .nvmrc) && \
+    npm config set unsafe-perm true && \
+    echo '{ "allow_root": true }' > /root/.bowerrc
+
+COPY ./package*.json ./
+RUN npm install && \
+    npm cache clean --force
+
+COPY . ./
+USER 0:0
+CMD [ "bash" ]

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -1,12 +1,12 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-require('../util/panic');
-
 // load .env file before any other modules so that it will contain
 // all the arguments even when the modules are loading.
 console.log('loading .env file');
 require('../util/dotenv').load();
+require('../util/panic');
+require('../util/fips');
 
 const http = require('http');
 const https = require('https');

--- a/src/hosted_agents/hosted_agents_starter.js
+++ b/src/hosted_agents/hosted_agents_starter.js
@@ -2,6 +2,8 @@
 'use strict';
 
 require('../util/dotenv').load();
+require('../util/panic');
+require('../util/fips');
 
 const url = require('url');
 

--- a/src/native/chunk/splitter.h
+++ b/src/native/chunk/splitter.h
@@ -7,6 +7,7 @@
 
 #include "../util/rabin.h"
 #include "../util/struct_buf.h"
+#include "../third_party/isa-l_crypto/include/md5_mb.h"
 
 namespace noobaa
 {
@@ -46,11 +47,23 @@ private:
     Points _split_points;
     Point _chunk_pos;
     Rabin::Hash _hash;
-    EVP_MD_CTX *_md5_ctx;
-    EVP_MD_CTX *_sha256_ctx;
+
+    EVP_MD_CTX* _md5_ctx;
+    EVP_MD_CTX* _sha256_ctx;
+    MD5_HASH_CTX* _md5_mb_ctx;
+    MD5_HASH_CTX_MGR* _md5_mb_mgr;
+
+    void md5_mb_submit_and_flush(const void* data, uint32_t size, HASH_CTX_FLAG flag)
+    {
+        md5_ctx_mgr_submit(_md5_mb_mgr, _md5_mb_ctx, data, size, flag);
+        while (hash_ctx_processing(_md5_mb_ctx)) {
+            md5_ctx_mgr_flush(_md5_mb_mgr);
+        }
+    }
 
     static Rabin _rabin;
 
     bool _next_point(const uint8_t** const p_data, int* const p_len);
 };
-}
+
+} // namespace noobaa

--- a/src/native/chunk/splitter_napi.cpp
+++ b/src/native/chunk/splitter_napi.cpp
@@ -5,6 +5,7 @@
 
 namespace noobaa
 {
+
 #define SPLITTER_JS_SIGNATURE "function chunk_splitter(state, buffers, callback?)"
 
 static Napi::Value _chunk_splitter(const Napi::CallbackInfo& info);
@@ -60,7 +61,7 @@ public:
     virtual void OnOK()
     {
         auto result = _splitter_result(Env(), _splitter);
-        Callback().MakeCallback(Env().Global(), {Env().Null(), result});
+        Callback().MakeCallback(Env().Global(), { Env().Null(), result });
     }
 
 private:
@@ -167,4 +168,5 @@ _splitter_result(Napi::Env env, Splitter* splitter)
     }
     return arr;
 }
-}
+
+} // namespace noobaa

--- a/src/native/nb_native.cpp
+++ b/src/native/nb_native.cpp
@@ -5,7 +5,7 @@ namespace noobaa
 {
 
 void b64_napi(Napi::Env env, Napi::Object exports);
-void ssl_napi(napi_env env, napi_value exports);
+void ssl_napi(Napi::Env env, Napi::Object exports);
 void syslog_napi(Napi::Env env, Napi::Object exports);
 void splitter_napi(Napi::Env env, Napi::Object exports);
 void chunk_coder_napi(napi_env env, napi_value exports);

--- a/src/native/nb_native.gyp
+++ b/src/native/nb_native.gyp
@@ -36,6 +36,8 @@
             'third_party/cm256.gyp:cm256',
             'third_party/snappy.gyp:snappy',
             'third_party/isa-l.gyp:isa-l-ec',
+            'third_party/isa-l.gyp:isa-l-md5',
+            'third_party/isa-l.gyp:isa-l-sha1',
         ],
         'sources': [
             # module

--- a/src/native/third_party/isa-l.gyp
+++ b/src/native/third_party/isa-l.gyp
@@ -120,26 +120,43 @@
                 'isa-l_crypto/md5_mb/',
             ],
             'sources': [
+                # include
+                'isa-l_crypto/include/md5_mb.h',
+                'isa-l_crypto/include/types.h',
+                'isa-l_crypto/include/multi_buffer.h',
+                'isa-l_crypto/include/intrinreg.h',
+                'isa-l_crypto/include/reg_sizes.asm',
+                'isa-l_crypto/include/multibinary.asm',
+                'isa-l_crypto/include/datastruct.asm',
+                # asm
+                'isa-l_crypto/md5_mb/md5_multibinary.asm',
+                'isa-l_crypto/md5_mb/md5_job.asm',
+                'isa-l_crypto/md5_mb/md5_mb_mgr_datastruct.asm',
+                # ctx
+                # 'isa-l_crypto/md5_mb/md5_ctx_base.c',
                 'isa-l_crypto/md5_mb/md5_ctx_sse.c',
                 'isa-l_crypto/md5_mb/md5_ctx_avx.c',
                 'isa-l_crypto/md5_mb/md5_ctx_avx2.c',
+                'isa-l_crypto/md5_mb/md5_ctx_avx512.c',
+                # mgr_init
                 'isa-l_crypto/md5_mb/md5_mb_mgr_init_sse.c',
                 'isa-l_crypto/md5_mb/md5_mb_mgr_init_avx2.c',
                 'isa-l_crypto/md5_mb/md5_mb_mgr_init_avx512.c',
-                'isa-l_crypto/md5_mb/md5_mb_mgr_submit_sse.asm',
-                'isa-l_crypto/md5_mb/md5_mb_mgr_submit_avx.asm',
-                'isa-l_crypto/md5_mb/md5_mb_mgr_submit_avx2.asm',
+                # mgr_flush
                 'isa-l_crypto/md5_mb/md5_mb_mgr_flush_sse.asm',
                 'isa-l_crypto/md5_mb/md5_mb_mgr_flush_avx.asm',
                 'isa-l_crypto/md5_mb/md5_mb_mgr_flush_avx2.asm',
+                'isa-l_crypto/md5_mb/md5_mb_mgr_flush_avx512.asm',
+                # mgr_submit
+                'isa-l_crypto/md5_mb/md5_mb_mgr_submit_sse.asm',
+                'isa-l_crypto/md5_mb/md5_mb_mgr_submit_avx.asm',
+                'isa-l_crypto/md5_mb/md5_mb_mgr_submit_avx2.asm',
+                'isa-l_crypto/md5_mb/md5_mb_mgr_submit_avx512.asm',
+                # x4x2
                 'isa-l_crypto/md5_mb/md5_mb_x4x2_sse.asm',
                 'isa-l_crypto/md5_mb/md5_mb_x4x2_avx.asm',
                 'isa-l_crypto/md5_mb/md5_mb_x8x2_avx2.asm',
-                'isa-l_crypto/md5_mb/md5_multibinary.asm',
-                'isa-l_crypto/md5_mb/md5_mb_mgr_submit_avx512.asm',
-                'isa-l_crypto/md5_mb/md5_mb_mgr_flush_avx512.asm',
                 'isa-l_crypto/md5_mb/md5_mb_x16x2_avx512.asm',
-                'isa-l_crypto/md5_mb/md5_ctx_avx512.c',
             ],
         },
 
@@ -306,6 +323,24 @@
             'dependencies': ['isa-l-ec'],
             'include_dirs': ['isa-l/include/'],
             'sources': ['isa-l/erasure_code/erasure_code_test.c']
+        },
+
+        {
+            'target_name': 'md5_mb_test',
+            'type': 'executable',
+            'dependencies': ['isa-l-md5'],
+            'include_dirs': ['isa-l_crypto/include/'],
+            'sources': ['isa-l_crypto/md5_mb/md5_mb_test.c']
+        },
+
+        {
+            # TODO: dynamic linking to openssl usually needs more CFLAGS(-I) and LDFLAGS(-L)
+            'target_name': 'md5_mb_vs_ossl_perf',
+            'type': 'executable',
+            'dependencies': ['isa-l-md5'],
+            'include_dirs': ['isa-l_crypto/include/'],
+            'ldflags': ['-lssl','-lcrypto'],
+            'sources': ['isa-l_crypto/md5_mb/md5_mb_vs_ossl_perf.c']
         },
 
         {

--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -5,9 +5,9 @@
 // all the arguments even when the modules are loading.
 console.log('loading .env file');
 require('../util/dotenv').load();
-
 require('../util/coverage_utils');
 require('../util/panic');
+require('../util/fips');
 
 var _ = require('lodash');
 var url = require('url');

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1244,7 +1244,7 @@ async function add_endpoint_report(req) {
             const access_key = acc.access_keys &&
                 acc.access_keys[0] &&
                 acc.access_keys[0].access_key;
-            return access_key !== null && (access_key.unwrap() === record.access_key.unwrap());
+            return access_key && (access_key.unwrap() === record.access_key.unwrap());
         });
         const bucket = system_store.data.buckets.find(bkt =>
             bkt.name.unwrap() === record.bucket.unwrap()

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -9,6 +9,7 @@ dotenv.load();
 
 require('../util/coverage_utils');
 require('../util/panic');
+require('../util/fips');
 
 const _ = require('lodash');
 const path = require('path');

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -3,11 +3,10 @@
 
 const wtf = require("wtfnode");
 
-const panic = require('../../util/panic');
-panic.enable_heapdump('coretest');
-
 console.log('loading .env file');
 require('../../util/dotenv').load();
+require('../../util/panic').enable_heapdump('coretest');
+require('../../util/fips');
 
 const CORETEST = 'coretest';
 process.env.JWT_SECRET = CORETEST;

--- a/src/test/unit_tests/test_chunk_splitter.js
+++ b/src/test/unit_tests/test_chunk_splitter.js
@@ -17,25 +17,21 @@ function log(...args) {
 
 mocha.describe('ChunkSplitter', function() {
 
-    mocha.it('is consistent', function() {
+    mocha.it('is consistent', async function() {
         this.timeout(100000); // eslint-disable-line no-invalid-this
-        const options = {
+        const res = await Promise.all(_.times(30, i => split_stream({
             avg_chunk: 4503,
             delta_chunk: 1231,
             len: 1517203,
             cipher_seed: Buffer.from('ChunkSplitter is consistent!'),
-        };
-        return P.all(_.times(30, i => split_stream(options)))
-            .then(res => {
-                const points = res[0];
-                for (let i = 1; i < res.length; ++i) {
-                    const points2 = res[i];
-                    assert.deepStrictEqual(points, points2);
-                }
-            });
+        })));
+        for (let i = 1; i < res.length; ++i) {
+            assert.deepStrictEqual(res[i].points, res[0].points);
+            assert.deepStrictEqual(res[i].md5, res[0].md5);
+        }
     });
 
-    mocha.it.skip('splits almost the same when pushing bytes at the start', function() {
+    mocha.it.skip('splits almost the same when pushing bytes at the start', async function() {
         const avg_chunk = 1000;
         const delta_chunk = 500;
         // random buffer from fixed seed
@@ -50,28 +46,25 @@ mocha.describe('ChunkSplitter', function() {
             Buffer.concat([crypto.randomBytes(3), buf]),
             Buffer.concat([crypto.randomBytes(4), buf]),
         ];
-        return P.map(bufs, data => split_buffer({ avg_chunk, delta_chunk, data }))
-            .then(res => {
-                res.forEach(p => log(p));
-                // remove the first and last points from the comparison
-                const points = res[0].slice(1, -1);
-                for (let i = 1; i < res.length; ++i) {
-                    const points2 = res[i];
-                    let found = false;
-                    for (let j = 0; j <= points2.length - points.length; ++j) {
-                        if (_.isEqual(points, points2.slice(j, j + points.length))) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    assert(found, `points ${points.join(',')} not found in ${points2.join(',')}`);
+        const res = await P.map(bufs, data => split_buffer({ avg_chunk, delta_chunk, data }));
+        res.forEach(p => log(p.points));
+        // remove the first and last points from the comparison
+        const points = res[0].points.slice(1, -1);
+        for (let i = 1; i < res.length; ++i) {
+            const points2 = res[i].points;
+            let found = false;
+            for (let j = 0; j <= points2.length - points.length; ++j) {
+                if (_.isEqual(points, points2.slice(j, j + points.length))) {
+                    found = true;
+                    break;
                 }
-            });
+            }
+            assert(found, `points ${points.join(',')} not found in ${points2.join(',')}`);
+        }
     });
 
     function split_stream({ avg_chunk, delta_chunk, len, cipher_seed }) {
         return new Promise((resolve, reject) => {
-            const points = [];
             const input = new RandStream(len, { cipher_seed });
             const splitter = new ChunkSplitter({
                 watermark: 100,
@@ -79,10 +72,11 @@ mocha.describe('ChunkSplitter', function() {
                 calc_sha256: false,
                 chunk_split_config: { avg_chunk, delta_chunk }
             });
+            splitter.points = [];
             input.once('error', reject);
             splitter.once('error', reject);
-            splitter.once('end', () => resolve(points));
-            splitter.on('data', chunk => points.push(chunk.size));
+            splitter.once('end', () => resolve(splitter));
+            splitter.on('data', chunk => splitter.points.push(chunk.size));
             input.pipe(splitter);
         });
     }

--- a/src/tools/coding_speed.js
+++ b/src/tools/coding_speed.js
@@ -1,6 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+require('../util/fips');
+
 // const _ = require('lodash');
 const argv = require('minimist')(process.argv);
 const stream = require('stream');

--- a/src/tools/cpu_speed.js
+++ b/src/tools/cpu_speed.js
@@ -1,6 +1,7 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+require('../util/fips');
 const crypto = require('crypto');
 const cluster = require('cluster');
 const argv = require('minimist')(process.argv);
@@ -9,7 +10,7 @@ const Speedometer = require('../util/speedometer');
 require('../util/console_wrapper').original_console();
 
 argv.forks = argv.forks || 1;
-argv.size = argv.size || 1024;
+argv.size = argv.size || (10 * 1024);
 argv.hash = argv.hash || 'sha256';
 
 if (argv.forks > 1 && cluster.isMaster) {

--- a/src/util/fips.js
+++ b/src/util/fips.js
@@ -1,0 +1,96 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const fs = require('fs');
+const crypto = require('crypto');
+const stream = require('stream');
+const nb_native = require('./nb_native');
+
+const original_crypto = Object.freeze({ ...crypto });
+let fips_mode = false;
+
+/**
+ * @returns {Boolean}
+ */
+function get_fips_mode() {
+    return fips_mode;
+}
+
+class HashWrap extends stream.Transform {
+    constructor(hash) {
+        super();
+        this.hash = hash;
+    }
+    update(data, encoding) {
+        if (encoding || !Buffer.isBuffer(data)) {
+            data = Buffer.from(data, encoding);
+        }
+        this.hash.update(data);
+        return this;
+    }
+    digest(encoding) {
+        const buf = this.hash.digest();
+        const res = encoding ? buf.toString(encoding) : buf;
+        return res;
+    }
+    _transform(data, encoding, callback) {
+        this.update(data, encoding);
+        callback();
+    }
+    _flush(callback) {
+        this.push(this.digest());
+        callback();
+    }
+    copy() {
+        // unimplemented
+        return null;
+    }
+}
+
+/**
+ * @param {Boolean} mode
+ */
+function set_fips_mode(mode = detect_fips_mode()) {
+    fips_mode = mode;
+    nb_native().set_fips_mode(mode);
+    if (mode) {
+        // monkey-patch the crypto.createHash() function to provide a non-crypto md5 flow
+        crypto.createHash = function(algorithm, options) {
+            switch (algorithm) {
+                case 'md5': {
+                    return new HashWrap(new(nb_native().MD5_MB)());
+                }
+                default:
+                    return original_crypto.createHash(algorithm, options);
+            }
+        };
+    } else if (crypto.createHash !== original_crypto.createHash) {
+        crypto.createHash = original_crypto.createHash;
+    }
+}
+
+
+/**
+ * @returns {Boolean}
+ */
+function detect_fips_mode() {
+    if (process.env.FIPS) return true;
+    const fips_proc_file = process.env.FIPS_PROC_FILE || '/proc/sys/crypto/fips_enabled';
+    try {
+        const value = fs.readFileSync(fips_proc_file, 'utf8').trim();
+        console.log(`detect_fips_mode: found ${fips_proc_file} with value ${value}`);
+        return value === '1';
+    } catch (err) {
+        if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
+            console.warn(`detect_fips_mode: failed to read ${fips_proc_file}:`, err);
+        }
+    }
+    return false;
+}
+
+set_fips_mode();
+
+exports.get_fips_mode = get_fips_mode;
+exports.set_fips_mode = set_fips_mode;
+exports.detect_fips_mode = detect_fips_mode;
+exports.original_crypto = original_crypto;


### PR DESCRIPTION
### Explain the changes
All mains now import `src/util/fips` module on startup which auto detects if running in fips mode based on `/proc/crypto/fips`. This can also be forced using the FIPS=1 env.

In fips mode in order to allow md5 for non cryptographic use cases needed for the S3 protocol, we use md5_mb from isa-l_crypto. Since crypto.createHash is called from our code and also node modules, we monkey-patch the crypto library and replace the createHash('md5'), and also use it natively in the upload pipeline (ChunkSplitter).

NOTE: Using md5_mb with a single stream provides lower performance compared to openssl MD5. See this issue on single buffer performance - https://github.com/intel/isa-l_crypto/issues/45. We try to leverage the multibuffer capability by sharing a thread_local ctx mgr and deferring the flushing of contexes so that if multiple streams are processed concurrently it will be flushed together. The single CPU core performance gain can be very significant - see the performance report here - https://github.com/intel/isa-l/wiki/Documentation.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. Run on FIPS enabled host.
