### PR TITLE
Do not trigger empty make_changes update

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -812,11 +812,13 @@ async function delete_bucket(req) {
             };
         }));
 
-    await system_store.make_changes({
-        update: {
-            accounts: accounts_update
-        }
-    });
+    if (!_.isEmpty(accounts_update)) {
+        await system_store.make_changes({
+            update: {
+                accounts: accounts_update
+            }
+        });
+    }
 }
 
 /**


### PR DESCRIPTION
### Explain the changes
1. We do not want to trigger make_changes on an empty array of accounts

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
