### PR TITLE
Prevent OCP non system:cluster-admin members from using SSO to login FE

### DIFF
--- a/config.js
+++ b/config.js
@@ -402,6 +402,9 @@ config.PROMETHEUS_PREFIX = 'NooBaa_';
 
 config.OAUTH_REDIRECT_ENDPOINT = 'fe/oauth/callback';
 config.OAUTH_REQUIRED_SCOPE = 'user:info';
+config.OAUTH_REQUIRED_GROUPS = [
+    'system:cluster-admins'
+];
 
 //////////////////////////////
 // KUBERNETES RELATES       //

--- a/frontend/src/app/action-creators/modals-actions.js
+++ b/frontend/src/app/action-creators/modals-actions.js
@@ -888,7 +888,28 @@ export function openOAuthAccessDeniedModal() {
             options: {
                 title: 'Access Denied',
                 size: 'xsmall',
-                severity: 'info'
+                severity: 'info',
+                closeButton: 'hidden',
+                backdropClose: false
+            }
+        }
+    };
+}
+
+export function openOAuthUnauthorizedModal() {
+    return {
+        type: OPEN_MODAL,
+        payload: {
+            component: {
+                name: 'oauth-unauthorized-modal',
+                params: { }
+            },
+            options: {
+                title: 'Access Denied',
+                size: 'xsmall',
+                severity: 'info',
+                closeButton: 'hidden',
+                backdropClose: false
             }
         }
     };

--- a/frontend/src/app/actions-model-bridge.js
+++ b/frontend/src/app/actions-model-bridge.js
@@ -38,6 +38,7 @@ function onCompleteSignIn(payload) {
 function onFailSignIn({ error }) {
     if (error.rpc_code === 'UNAUTHORIZED') {
         model.loginInfo({
+            unauthorized: error.message,
             retryCount: model.loginInfo().retryCount + 1
         });
 

--- a/frontend/src/app/components/application/login-layout/login-layout.js
+++ b/frontend/src/app/components/application/login-layout/login-layout.js
@@ -4,11 +4,11 @@ import template from './login-layout.html';
 import BaseViewModel from 'components/base-view-model';
 import ko from 'knockout';
 import { supportedBrowsers, logo } from 'config';
-import { sessionInfo, serverInfo } from 'model';
+import { sessionInfo, serverInfo, loginInfo } from 'model';
 import { recognizeBrowser } from 'utils/browser-utils';
 import { loadServerInfo } from 'actions';
 import { isUndefined } from 'utils/core-utils';
-import { requestLocation } from 'action-creators';
+import { requestLocation, openOAuthUnauthorizedModal } from 'action-creators';
 import { action$ } from 'state';
 import * as routes from 'routes';
 
@@ -19,6 +19,7 @@ class LoginLayoutViewModel extends BaseViewModel {
         this.logo = logo;
         this.form = ko.pureComputed(
             () => {
+                console.warn('OMOMOM HERE', loginInfo());
                 if (!supportedBrowsers.includes(recognizeBrowser())) {
                     return 'unsupported-form';
                 }
@@ -40,8 +41,14 @@ class LoginLayoutViewModel extends BaseViewModel {
                         // Specific params to force login screen (to allow login using local users)
                         const skipOAuth = new URLSearchParams(location.search).get('skip-oauth');
                         if (serverInfo().supportOAuth && skipOAuth == null) {
-                            this.signInWithOAuth();
-                            return 'splash-screen';
+                            if (loginInfo().unauthorized) {
+                                action$.next(openOAuthUnauthorizedModal());
+                                return 'splash-screen';
+
+                            } else {
+                                this.signInWithOAuth();
+                                return 'splash-screen';
+                            }
                         }
 
                         return 'signin-form';

--- a/frontend/src/app/components/modals/oauth-access-denied-modal/oauth-access-denied-modal.html
+++ b/frontend/src/app/components/modals/oauth-access-denied-modal/oauth-access-denied-modal.html
@@ -1,7 +1,7 @@
 <!-- Copyright (C) 2016 NooBaa -->
 
 <div class="column greedy pad">
-    NooBaa needs access to you openshift account information,
+    NooBaa needs access to your OpenShift account information,
     please grant the proper access when requested.
 </div>
 

--- a/frontend/src/app/components/modals/oauth-unauthorized-modal/oauth-unauthorized-modal.html
+++ b/frontend/src/app/components/modals/oauth-unauthorized-modal/oauth-unauthorized-modal.html
@@ -1,0 +1,17 @@
+<!-- Copyright (C) 2016 NooBaa -->
+
+<div class="greedy column pad">
+    <p class="push-next">
+        In order to access the NooBaa Management Console using your OpenShift account you need to be a member
+        of the <span class="highlight">system:cluster-admins</span> group.
+    </p>
+
+    <p>Alternatively, You can use a NooBaa admin account</p>
+</div>
+
+<div class="column pad content-box">
+    <button class="btn align-end " ko.click="onBack">
+        OK, Take me to NooBaa Login
+    </button>
+</div>
+

--- a/frontend/src/app/components/modals/oauth-unauthorized-modal/oauth-unauthorized-modal.js
+++ b/frontend/src/app/components/modals/oauth-unauthorized-modal/oauth-unauthorized-modal.js
@@ -1,21 +1,20 @@
 /* Copyright (C) 2016 NooBaa */
 
-import template from './oauth-access-denied-modal.html';
+import template from './oauth-unauthorized-modal.html';
 import ConnectableViewModel from 'components/connectable';
 import { navigateTo } from 'utils/browser-utils';
 
-class OAuthAccessDeniedModalViewModel extends ConnectableViewModel {
-
+class OauthUnauthorizedModalViewModel extends ConnectableViewModel {
     onBack() {
         // Using navigateTo instead of requestLocation action because
         // login layout was not fully moved to new arch and will not react
         // to state location changes
         // TODO: move to requestLocation action after login layout rewrite
-        navigateTo('/fe');
+        navigateTo('/fe?skip-oauth');
     }
 }
 
 export default {
-    viewModel: OAuthAccessDeniedModalViewModel,
+    viewModel: OauthUnauthorizedModalViewModel,
     template: template
 };

--- a/frontend/src/app/components/modals/oauth-unauthorized-modal/oauth-unauthorized-modal.less
+++ b/frontend/src/app/components/modals/oauth-unauthorized-modal/oauth-unauthorized-modal.less
@@ -1,0 +1,5 @@
+/* Copyright (C) 2016 NooBaa */
+
+.oauth-unauthorized-modal {
+    display: block;
+}

--- a/frontend/src/app/components/register.js
+++ b/frontend/src/app/components/register.js
@@ -102,6 +102,7 @@ import completeSslCertificateInstallationModal from './modals/complete-ssl-certi
 import deployRemoteEndpointGroupModal from './modals/deploy-remote-endpoint-group-modal/deploy-remote-endpoint-group-modal';
 import editEndpointGroupModal from './modals/edit-endpoint-group-modal/edit-endpoint-group-modal';
 import oauthAccessDeniedModal from './modals/oauth-access-denied-modal/oauth-access-denied-modal';
+import oauthUnauthorizedModal from './modals/oauth-unauthorized-modal/oauth-unauthorized-modal';
 /** INJECT:modals.import **/
 
 // -------------------------------
@@ -455,6 +456,7 @@ export default function register(ko, services) {
         deployRemoteEndpointGroupModal,
         editEndpointGroupModal,
         oauthAccessDeniedModal,
+        oauthUnauthorizedModal,
         /** INJECT:modals.list **/
 
         overviewPanel,

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -17,6 +17,7 @@ const oauth_utils = require('../../util/oauth_utils');
 const addr_utils = require('../../util/addr_utils');
 const kube_utils = require('../../util/kube_utils');
 const jwt_utils = require('../../util/jwt_utils');
+const config = require('../../../config');
 
 
 /**
@@ -219,7 +220,15 @@ async function create_k8s_auth(req) {
         unauthorized_error
     );
 
-    const { username } = token_review.status.user;
+    const { username, groups = [] } = token_review.status.user;
+    const { OAUTH_REQUIRED_GROUPS = [] } = config;
+    if (
+        OAUTH_REQUIRED_GROUPS.length > 0 &&
+        groups.every(grp_name => !OAUTH_REQUIRED_GROUPS.includes(grp_name))
+    ) {
+        throw new RpcError('UNAUTHORIZED', `User must be a member of at least one of the following k8s groups: ${OAUTH_REQUIRED_GROUPS}`);
+    }
+
     const user_info = {
         name: new SensitiveString(username),
         email: new SensitiveString(username),

--- a/src/util/oauth_utils.js
+++ b/src/util/oauth_utils.js
@@ -45,7 +45,7 @@ async function trade_grant_code_for_access_token(
             'utf8'
         );
     } catch (err) {
-        throw make_error('OpenShift api endpoint does not response');
+        throw make_error(`OpenShift api endpoint does not response, got: ${err.message}`);
     }
 
     const status_code = response.statusCode;


### PR DESCRIPTION
### Explain the changes
1. create_k8s_auth login now also verify membership in `system:cluster-admin` group
2. In the case of SSO authorization failure, user is presented with a new modal that explains the situation and allows the user to skip the SSO flow and go directly to NooBaa login.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1833030

### Testing Instructions:
1. 
