### PR TITLE
exposing storage_limit for cloud_pools

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -301,6 +301,13 @@ class Agent {
         await this.block_store.init();
     }
 
+    update_storage_limit(storage_limit) {
+        this.storage_limit = storage_limit;
+        if (this.block_store) {
+            return this.block_store.update_storage_limit(storage_limit);
+        }
+    }
+
     sample_stats() {
         if (this.block_store) {
             return this.block_store.sample_stats();

--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -105,6 +105,11 @@ class BlockStoreBase {
         }
     }
 
+    update_storage_limit(storage_limit) {
+        this.storage_limit = storage_limit;
+        this.usage_limit = this.storage_limit || Infinity;
+    }
+
     _get_block_store_info() {
         throw new Error('this block store does not support block_store_info');
     }

--- a/src/api/hosted_agents_api.js
+++ b/src/api/hosted_agents_api.js
@@ -110,6 +110,28 @@ module.exports = {
             }
         },
 
+        update_storage_limit: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['pool_ids'],
+                properties: {
+                    pool_ids: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                        }
+                    },
+                    storage_limit: {
+                        $ref: 'common_api#/definitions/bigint'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
         remove_agent: {
             method: 'POST',
             params: {

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -73,6 +73,9 @@ module.exports = {
                     backingstore: {
                         $ref: '#/definitions/backingstore_definition'
                     },
+                    storage_limit: {
+                        $ref: 'common_api#/definitions/bigint'
+                    }
                 }
             },
             auth: {
@@ -338,6 +341,26 @@ module.exports = {
                     },
                     host_count: {
                         type: 'integer'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
+        update_cloud_pool_limit: {
+            doc: 'Change the cloud pool\'s storage limit',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: {
+                        type: 'string',
+                    },
+                    storage_limit: {
+                        $ref: 'common_api#/definitions/bigint'
                     }
                 }
             },

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -109,6 +109,9 @@ module.exports = {
                         }
                     }
                 },
+                storage_limit: {
+                    $ref: 'common_api#/definitions/bigint'
+                },
                 access_keys: {
                     type: 'object',
                     required: ['access_key', 'secret_key', 'account_id'],


### PR DESCRIPTION
### Explain the changes
1. storage_limit which used to apply for different type of pools will now be exposed for cloud pools as well using the pool_api
2. it will limit the use of the cloud storage to a given storage_size - mainly for the use of tiering

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
