### PR TITLE
Fixing sensitive string issue

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -115,8 +115,8 @@ class Agent {
                 } else if (params.cloud_info.endpoint_type === 'AZURE') {
                     let connection_string = cloud_utils.get_azure_connection_string({
                         endpoint: params.cloud_info.endpoint,
-                        access_key: params.cloud_info.access_keys.access_key.unwrap(),
-                        secret_key: params.cloud_info.access_keys.secret_key.unwrap()
+                        access_key: params.cloud_info.access_keys.access_key,
+                        secret_key: params.cloud_info.access_keys.secret_key
                     });
                     block_store_options.cloud_info.azure = {
                         connection_string: connection_string,
@@ -276,8 +276,8 @@ class Agent {
         } else if (this.node_type === 'BLOCK_STORE_AZURE') {
             const connection_string = cloud_utils.get_azure_connection_string({
                 endpoint: block_store_options.cloud_info.endpoint,
-                access_key: this.cloud_info.access_keys.access_key.unwrap(),
-                secret_key: this.cloud_info.access_keys.secret_key.unwrap(),
+                access_key: this.cloud_info.access_keys.access_key,
+                secret_key: this.cloud_info.access_keys.secret_key,
             });
             block_store_options.cloud_info.azure = {
                 connection_string: connection_string,

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -416,7 +416,7 @@ module.exports = {
                     type: 'string'
                 },
                 identity: {
-                    type: 'string'
+                    $ref: 'common_api#/definitions/access_key'
                 },
                 mode: {
                     type: 'string',

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1030,8 +1030,8 @@ function get_cloud_buckets(req) {
 
                 const ns = new NetStorage({
                     hostname: connection.endpoint,
-                    keyName: connection.access_key,
-                    key: connection.secret_key,
+                    keyName: connection.access_key.unwrap(),
+                    key: connection.secret_key.unwrap(),
                     cpCode: connection.cp_code,
                     // Just used that in order to not handle certificate mess
                     // TODO: Should I use SSL with HTTPS instead of HTTP?
@@ -1051,7 +1051,7 @@ function get_cloud_buckets(req) {
                     system_store.data.buckets, system_store.data.pools, system_store.data.namespace_resources);
                 let key_file;
                 try {
-                    key_file = JSON.parse(connection.secret_key);
+                    key_file = JSON.parse(connection.secret_key.unwrap());
                 } catch (err) {
                     throw new RpcError('BAD_REQUEST', 'connection does not contain a key_file in json format');
                 }
@@ -1068,8 +1068,8 @@ function get_cloud_buckets(req) {
                     system_store.data.buckets, system_store.data.pools, system_store.data.namespace_resources);
                 var s3 = new AWS.S3({
                     endpoint: connection.endpoint,
-                    accessKeyId: connection.access_key,
-                    secretAccessKey: connection.secret_key,
+                    accessKeyId: connection.access_key.unwrap(),
+                    secretAccessKey: connection.secret_key.unwrap(),
                     signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(connection.endpoint, connection.auth_method),
                     s3DisableBodySigning: cloud_utils.disable_s3_compatible_bodysigning(connection.endpoint),
                     httpOptions: {

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -39,8 +39,8 @@ module.exports = {
                 type: 'object',
                 required: ['access_key', 'secret_key'],
                 properties: {
-                    access_key: { wrapper: SensitiveString },
-                    secret_key: { wrapper: SensitiveString },
+                    access_key: { $ref: 'common_api#/definitions/access_key' },
+                    secret_key: { $ref: 'common_api#/definitions/secret_key' },
                 }
             }
         },
@@ -76,8 +76,8 @@ module.exports = {
                 required: ['name', 'endpoint', 'access_key', 'secret_key'],
                 properties: {
                     name: { type: 'string' },
-                    access_key: { type: 'string' },
-                    secret_key: { type: 'string' },
+                    access_key: { $ref: 'common_api#/definitions/access_key' },
+                    secret_key: { $ref: 'common_api#/definitions/secret_key' },
                     auth_method: {
                         type: 'string',
                         enum: ['AWS_V2', 'AWS_V4']

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -45,12 +45,8 @@ module.exports = {
                 target_bucket: {
                     type: 'string'
                 },
-                access_key: {
-                    type: 'string'
-                },
-                secret_key: {
-                    type: 'string'
-                },
+                access_key: { $ref: 'common_api#/definitions/access_key' },
+                secret_key: { $ref: 'common_api#/definitions/secret_key' },
                 cp_code: {
                     type: 'string'
                 }

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -1,7 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const SensitiveString = require('../../../util/sensitive_string');
 const node_schema = require('../../node_services/node_schema');
 const bigint = {
     oneOf: [{
@@ -114,12 +113,8 @@ module.exports = {
                     type: 'object',
                     required: ['access_key', 'secret_key', 'account_id'],
                     properties: {
-                        access_key: {
-                            wrapper: SensitiveString
-                        },
-                        secret_key: {
-                            wrapper: SensitiveString
-                        },
+                        access_key: { $ref: 'common_api#/definitions/access_key' },
+                        secret_key: { $ref: 'common_api#/definitions/secret_key' },
                         account_id: {
                             objectid: true
                         }

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -53,8 +53,8 @@ function get_azure_connection_string(params) {
     let protocol = (endpoint_url.protocol ? endpoint_url.protocol : 'http:');
     protocol = protocol.slice(0, protocol.length - 1);
     let connection_string = 'DefaultEndpointsProtocol=' + protocol + ';';
-    connection_string += 'AccountName=' + params.access_key + ';';
-    connection_string += 'AccountKey=' + params.secret_key + ';';
+    connection_string += 'AccountName=' + params.access_key.unwrap() + ';';
+    connection_string += 'AccountKey=' + params.secret_key.unwrap() + ';';
 
     const AZURE_BLOB_ENDPOINT = 'blob.core.windows.net';
     if (endpoint_url.host !== AZURE_BLOB_ENDPOINT) {


### PR DESCRIPTION
### Explain the changes
1. sync_credentials_cache will now save creds as sensitive strings (BZ1846759)
2. namespace resource will be using sensitive strings for the resource creds
3. updating pool_api to use sensitive for identity of namespace resource
4. removing unneeded unwraps and moving the unwrap as close to the comparisons as possible

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ1846759

### Testing Instructions:
1. 
