### PR TITLE
Bump rsyslog version to 8.1911.0

### DIFF
--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -62,7 +62,7 @@ RUN dnf install -y -q bash \
     lsof \
     procps \
     openssl \
-    rsyslog-8.37.0 \
+    rsyslog-8.1911.0 \
     strace \
     wget \
     curl \


### PR DESCRIPTION
### Explain the changes
Bump rsyslog version from 8.37.0 to 8.1911.0
