### PR TITLE
Dividing dnf update and dnf install to 2 layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ all: tester noobaa
 
 builder: assert-container-engine
 	@echo "\033[1;34mStarting Builder $(CONTAINER_ENGINE) build.\033[0m"
-	$(CONTAINER_ENGINE) build $(CPUSET) -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CPUSET) -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) -t noobaa-builder .
 	$(CONTAINER_ENGINE) tag noobaa-builder $(BUILDER_TAG)
 	@echo "\033[1;32mBuilder done.\033[0m"
 .PHONY: builder

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -9,7 +9,8 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 ##############################################################
 ENV container docker
 RUN dnf update -y -q && \
-    dnf install -y -q wget unzip which vim python3 && \
+    dnf clean all
+RUN dnf install -y -q wget unzip which vim python3 && \
     dnf --enablerepo=PowerTools install -y -q yasm && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all


### PR DESCRIPTION
### Explain the changes
- Dividing dnf update and dnf install to 2 layers.
We want to avoid "No output has been received in the last" travis error when there is a big dnf update

- Removing the redirection from `make builder`