### PR TITLE
arch != x64: rebase cm256, no -msse4.1, no isa-l/erasure_code

### DIFF
--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 ENV container docker
 RUN dnf update -y -q && \
     dnf clean all
-RUN dnf install -y -q wget unzip which vim python3 && \
+RUN dnf install -y -q wget unzip which vim python2 python3 && \
     dnf --enablerepo=PowerTools install -y -q yasm && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all

--- a/src/deploy/NVA_build/dev.Dockerfile
+++ b/src/deploy/NVA_build/dev.Dockerfile
@@ -1,3 +1,4 @@
+# dev.Dockerfile is meant to be used manually for developer testing
 FROM centos:8 
 
 ENV container docker

--- a/src/native/common.gypi
+++ b/src/native/common.gypi
@@ -1,5 +1,11 @@
 # Copyright (C) 2016 NooBaa
 {
+    'variables': {
+        # see https://nodejs.org/docs/latest-v12.x/api/process.html#process_process_arch
+        # Possible values are: 
+        # 'arm', 'arm64', 'ia32', 'mips','mipsel', 'ppc', 'ppc64', 's390', 's390x', 'x32', and 'x64'.
+        'node_arch': '''<!(node -p process.arch)''',
+    },
     'target_defaults': {
 
         'conditions' : [
@@ -13,7 +19,6 @@
                 ],
                 'cflags': [
                     '-std=c99',
-                    '-msse4.1', # tell the compiler we use SSE4.1 in cm256
                 ],
                 'cflags_cc': [
                     '-std=c++11'

--- a/src/native/third_party/cm256.gyp
+++ b/src/native/third_party/cm256.gyp
@@ -1,6 +1,17 @@
 # Copyright (C) 2016 NooBaa
 {
+
     'includes': ['common_third_party.gypi'],
+    'target_defaults': {
+        'conditions': [
+            [ 'node_arch=="x64"', {
+                'conditions' : [
+                    [ 'OS=="linux"', { 'cflags': ['-msse4.1'] }],
+                    [ 'OS=="mac"', { 'xcode_settings': { 'OTHER_CFLAGS': ['-msse4.1'] } }],
+                ],
+            }],
+        ],
+    },
     'targets': [{
         'target_name': 'cm256',
         'type': 'static_library',

--- a/src/native/third_party/cm256/gf256.cpp
+++ b/src/native/third_party/cm256/gf256.cpp
@@ -1,64 +1,367 @@
-/*
-	Copyright (c) 2015 Christopher A. Taylor.  All rights reserved.
+/** \file
+    \brief GF(256) Main C API Source
+    \copyright Copyright (c) 2017 Christopher A. Taylor.  All rights reserved.
 
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
 
-	* Redistributions of source code must retain the above copyright notice,
-	  this list of conditions and the following disclaimer.
-	* Redistributions in binary form must reproduce the above copyright notice,
-	  this list of conditions and the following disclaimer in the documentation
-	  and/or other materials provided with the distribution.
-	* Neither the name of CM256 nor the names of its contributors may be
-	  used to endorse or promote products derived from this software without
-	  specific prior written permission.
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of GF256 nor the names of its contributors may be
+      used to endorse or promote products derived from this software without
+      specific prior written permission.
 
-	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-	AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-	ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-	LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-	CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "gf256.h"
 
+#ifdef LINUX_ARM
+#include <unistd.h>
+#include <fcntl.h>
+#include <elf.h>
+#include <linux/auxvec.h>
+#endif
 
-// Context object for GF(256) math
+//------------------------------------------------------------------------------
+// Workaround for ARMv7 that doesn't provide vqtbl1_*
+// This comes from linux-raid (https://www.spinics.net/lists/raid/msg58403.html)
+//
+#ifdef GF256_TRY_NEON
+#if __ARM_ARCH <= 7 && !defined(__aarch64__)
+static GF256_FORCE_INLINE uint8x16_t vqtbl1q_u8(uint8x16_t a, uint8x16_t b)
+{
+    union {
+        uint8x16_t    val;
+        uint8x8x2_t    pair;
+    } __a = { a };
+
+    return vcombine_u8(vtbl2_u8(__a.pair, vget_low_u8(b)),
+                       vtbl2_u8(__a.pair, vget_high_u8(b)));
+}
+#endif
+#endif
+
+//------------------------------------------------------------------------------
+// Self-Test
+//
+// This is executed during initialization to make sure the library is working
+
+static const unsigned kTestBufferBytes = 32 + 16 + 8 + 4 + 2 + 1;
+static const unsigned kTestBufferAllocated = 64;
+struct SelfTestBuffersT
+{
+    GF256_ALIGNED uint8_t A[kTestBufferAllocated];
+    GF256_ALIGNED uint8_t B[kTestBufferAllocated];
+    GF256_ALIGNED uint8_t C[kTestBufferAllocated];
+};
+static GF256_ALIGNED SelfTestBuffersT m_SelfTestBuffers;
+
+static bool gf256_self_test()
+{
+    if ((uintptr_t)m_SelfTestBuffers.A % GF256_ALIGN_BYTES != 0)
+        return false;
+    if ((uintptr_t)m_SelfTestBuffers.A % GF256_ALIGN_BYTES != 0)
+        return false;
+    if ((uintptr_t)m_SelfTestBuffers.B % GF256_ALIGN_BYTES != 0)
+        return false;
+    if ((uintptr_t)m_SelfTestBuffers.C % GF256_ALIGN_BYTES != 0)
+        return false;
+
+    // Check multiplication/division
+    for (unsigned i = 0; i < 256; ++i)
+    {
+        for (unsigned j = 0; j < 256; ++j)
+        {
+            uint8_t prod = gf256_mul((uint8_t)i, (uint8_t)j);
+            if (i != 0 && j != 0)
+            {
+                uint8_t div1 = gf256_div(prod, (uint8_t)i);
+                if (div1 != j)
+                    return false;
+                uint8_t div2 = gf256_div(prod, (uint8_t)j);
+                if (div2 != i)
+                    return false;
+            }
+            else if (prod != 0)
+                return false;
+            if (j == 1 && prod != i)
+                return false;
+        }
+    }
+
+    // Check for overruns
+    m_SelfTestBuffers.A[kTestBufferBytes] = 0x5a;
+    m_SelfTestBuffers.B[kTestBufferBytes] = 0x5a;
+    m_SelfTestBuffers.C[kTestBufferBytes] = 0x5a;
+
+    // Test gf256_add_mem()
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+    {
+        m_SelfTestBuffers.A[i] = 0x1f;
+        m_SelfTestBuffers.B[i] = 0xf7;
+    }
+    gf256_add_mem(m_SelfTestBuffers.A, m_SelfTestBuffers.B, kTestBufferBytes);
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+        if (m_SelfTestBuffers.A[i] != (0x1f ^ 0xf7))
+            return false;
+
+    // Test gf256_add2_mem()
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+    {
+        m_SelfTestBuffers.A[i] = 0x1f;
+        m_SelfTestBuffers.B[i] = 0xf7;
+        m_SelfTestBuffers.C[i] = 0x71;
+    }
+    gf256_add2_mem(m_SelfTestBuffers.A, m_SelfTestBuffers.B, m_SelfTestBuffers.C, kTestBufferBytes);
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+        if (m_SelfTestBuffers.A[i] != (0x1f ^ 0xf7 ^ 0x71))
+            return false;
+
+    // Test gf256_addset_mem()
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+    {
+        m_SelfTestBuffers.A[i] = 0x55;
+        m_SelfTestBuffers.B[i] = 0xaa;
+        m_SelfTestBuffers.C[i] = 0x6c;
+    }
+    gf256_addset_mem(m_SelfTestBuffers.A, m_SelfTestBuffers.B, m_SelfTestBuffers.C, kTestBufferBytes);
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+        if (m_SelfTestBuffers.A[i] != (0xaa ^ 0x6c))
+            return false;
+
+    // Test gf256_muladd_mem()
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+    {
+        m_SelfTestBuffers.A[i] = 0xff;
+        m_SelfTestBuffers.B[i] = 0xaa;
+    }
+    const uint8_t expectedMulAdd = gf256_mul(0xaa, 0x6c);
+    gf256_muladd_mem(m_SelfTestBuffers.A, 0x6c, m_SelfTestBuffers.B, kTestBufferBytes);
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+        if (m_SelfTestBuffers.A[i] != (expectedMulAdd ^ 0xff))
+            return false;
+
+    // Test gf256_mul_mem()
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+    {
+        m_SelfTestBuffers.A[i] = 0xff;
+        m_SelfTestBuffers.B[i] = 0x55;
+    }
+    const uint8_t expectedMul = gf256_mul(0xa2, 0x55);
+    gf256_mul_mem(m_SelfTestBuffers.A, m_SelfTestBuffers.B, 0xa2, kTestBufferBytes);
+    for (unsigned i = 0; i < kTestBufferBytes; ++i)
+        if (m_SelfTestBuffers.A[i] != expectedMul)
+            return false;
+
+    if (m_SelfTestBuffers.A[kTestBufferBytes] != 0x5a)
+        return false;
+    if (m_SelfTestBuffers.B[kTestBufferBytes] != 0x5a)
+        return false;
+    if (m_SelfTestBuffers.C[kTestBufferBytes] != 0x5a)
+        return false;
+
+    return true;
+}
+
+
+//------------------------------------------------------------------------------
+// Runtime CPU Architecture Check
+//
+// Feature checks stolen shamelessly from
+// https://github.com/jedisct1/libsodium/blob/master/src/libsodium/sodium/runtime.c
+
+#if defined(HAVE_ANDROID_GETCPUFEATURES)
+#include <cpu-features.h>
+#endif
+
+#if defined(GF256_TRY_NEON)
+# if defined(IOS) && defined(__ARM_NEON__)
+// Requires iPhone 5S or newer
+static const bool CpuHasNeon = true;
+static const bool CpuHasNeon64 = true;
+# else // ANDROID or LINUX_ARM
+#  if defined(__aarch64__)
+static bool CpuHasNeon = true;      // if AARCH64, then we have NEON for sure...
+static bool CpuHasNeon64 = true;    // And we have ASIMD
+#  else
+static bool CpuHasNeon = false;     // if not, then we have to check at runtime.
+static bool CpuHasNeon64 = false;   // And we don't have ASIMD
+#  endif
+# endif
+#endif
+
+#if !defined(GF256_TARGET_MOBILE)
+
+#ifdef _MSC_VER
+    #include <intrin.h> // __cpuid
+    #pragma warning(disable: 4752) // found Intel(R) Advanced Vector Extensions; consider using /arch:AVX
+#endif
+
+#ifdef GF256_TRY_AVX2
+static bool CpuHasAVX2 = false;
+#endif
+static bool CpuHasSSSE3 = false;
+
+#define CPUID_EBX_AVX2    0x00000020
+#define CPUID_ECX_SSSE3   0x00000200
+
+static void _cpuid(unsigned int cpu_info[4U], const unsigned int cpu_info_type)
+{
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64) || defined(_M_IX86))
+    __cpuid((int *) cpu_info, cpu_info_type);
+#else //if defined(HAVE_CPUID)
+    cpu_info[0] = cpu_info[1] = cpu_info[2] = cpu_info[3] = 0;
+# ifdef __i386__
+    __asm__ __volatile__ ("pushfl; pushfl; "
+                          "popl %0; "
+                          "movl %0, %1; xorl %2, %0; "
+                          "pushl %0; "
+                          "popfl; pushfl; popl %0; popfl" :
+                          "=&r" (cpu_info[0]), "=&r" (cpu_info[1]) :
+                          "i" (0x200000));
+    if (((cpu_info[0] ^ cpu_info[1]) & 0x200000) == 0) {
+        return; /* LCOV_EXCL_LINE */
+    }
+# endif
+# ifdef __i386__
+    __asm__ __volatile__ ("xchgl %%ebx, %k1; cpuid; xchgl %%ebx, %k1" :
+                          "=a" (cpu_info[0]), "=&r" (cpu_info[1]),
+                          "=c" (cpu_info[2]), "=d" (cpu_info[3]) :
+                          "0" (cpu_info_type), "2" (0U));
+# elif defined(__x86_64__)
+    __asm__ __volatile__ ("xchgq %%rbx, %q1; cpuid; xchgq %%rbx, %q1" :
+                          "=a" (cpu_info[0]), "=&r" (cpu_info[1]),
+                          "=c" (cpu_info[2]), "=d" (cpu_info[3]) :
+                          "0" (cpu_info_type), "2" (0U));
+# else
+    __asm__ __volatile__ ("cpuid" :
+                          "=a" (cpu_info[0]), "=b" (cpu_info[1]),
+                          "=c" (cpu_info[2]), "=d" (cpu_info[3]) :
+                          "0" (cpu_info_type), "2" (0U));
+# endif
+#endif
+}
+
+#else
+#if defined(LINUX_ARM)
+static void checkLinuxARMNeonCapabilities( bool& cpuHasNeon )
+{
+    auto cpufile = open("/proc/self/auxv", O_RDONLY);
+    Elf32_auxv_t auxv;
+    if (cpufile >= 0)
+    {
+        const auto size_auxv_t = sizeof(Elf32_auxv_t);
+        while (read(cpufile, &auxv, size_auxv_t) == size_auxv_t)
+        {
+            if (auxv.a_type == AT_HWCAP)
+            {
+                cpuHasNeon = (auxv.a_un.a_val & 4096) != 0;
+                break;
+            }
+        }
+        close(cpufile);
+    }
+    else
+    {
+        cpuHasNeon = false;
+    }
+}
+#endif
+#endif // defined(GF256_TARGET_MOBILE)
+
+static void gf256_architecture_init()
+{
+#if defined(GF256_TRY_NEON)
+
+    // Check for NEON support on Android platform
+#if defined(HAVE_ANDROID_GETCPUFEATURES)
+    AndroidCpuFamily family = android_getCpuFamily();
+    if (family == ANDROID_CPU_FAMILY_ARM)
+    {
+        if (android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_NEON)
+            CpuHasNeon = true;
+    }
+    else if (family == ANDROID_CPU_FAMILY_ARM64)
+    {
+        CpuHasNeon = true;
+        if (android_getCpuFeatures() & ANDROID_CPU_ARM64_FEATURE_ASIMD)
+            CpuHasNeon64 = true;
+    }
+#endif
+
+#if defined(LINUX_ARM)
+    // Check for NEON support on other ARM/Linux platforms
+    checkLinuxARMNeonCapabilities(CpuHasNeon);
+#endif
+
+#endif //GF256_TRY_NEON
+
+#if !defined(GF256_TARGET_MOBILE)
+    unsigned int cpu_info[4];
+
+    _cpuid(cpu_info, 1);
+    CpuHasSSSE3 = ((cpu_info[2] & CPUID_ECX_SSSE3) != 0);
+
+#if defined(GF256_TRY_AVX2)
+    _cpuid(cpu_info, 7);
+    CpuHasAVX2 = ((cpu_info[1] & CPUID_EBX_AVX2) != 0);
+#endif // GF256_TRY_AVX2
+
+    // When AVX2 and SSSE3 are unavailable, Siamese takes 4x longer to decode
+    // and 2.6x longer to encode.  Encoding requires a lot more simple XOR ops
+    // so it is still pretty fast.  Decoding is usually really quick because
+    // average loss rates are low, but when needed it requires a lot more
+    // GF multiplies requiring table lookups which is slower.
+
+#endif // GF256_TARGET_MOBILE
+}
+
+
+//------------------------------------------------------------------------------
+// Context Object
+
+// Context object for GF(2^^8) math
 GF256_ALIGNED gf256_ctx GF256Ctx;
 static bool Initialized = false;
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Generator Polynomial
 
-// There are only 16 irreducible polynomials for GF(256)
+// There are only 16 irreducible polynomials for GF(2^^8)
 static const int GF256_GEN_POLY_COUNT = 16;
 static const uint8_t GF256_GEN_POLY[GF256_GEN_POLY_COUNT] = {
     0x8e, 0x95, 0x96, 0xa6, 0xaf, 0xb1, 0xb2, 0xb4,
-    0xb8, 0xc3, 0xc6, 0xd4, 0xe1, 0xe7, 0xf3, 0xfa,
+    0xb8, 0xc3, 0xc6, 0xd4, 0xe1, 0xe7, 0xf3, 0xfa
 };
 
-static const int DefaultPolynomialIndex = 3;
+static const int kDefaultPolynomialIndex = 3;
 
 // Select which polynomial to use
-static void gf255_poly_init(int polynomialIndex)
+static void gf256_poly_init(int polynomialIndex)
 {
     if (polynomialIndex < 0 || polynomialIndex >= GF256_GEN_POLY_COUNT)
-    {
-        polynomialIndex = 0;
-    }
+        polynomialIndex = kDefaultPolynomialIndex;
 
     GF256Ctx.Polynomial = (GF256_GEN_POLY[polynomialIndex] << 1) | 1;
 }
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Exponential and Log Tables
 
 // Construct EXP and LOG tables from polynomial
@@ -73,30 +376,23 @@ static void gf256_explog_init()
     for (unsigned jj = 1; jj < 255; ++jj)
     {
         unsigned next = (unsigned)exptab[jj - 1] * 2;
-        if (next >= 256) next ^= poly;
+        if (next >= 256)
+            next ^= poly;
 
         exptab[jj] = static_cast<uint8_t>( next );
         logtab[exptab[jj]] = static_cast<uint16_t>( jj );
     }
-
     exptab[255] = exptab[0];
     logtab[exptab[255]] = 255;
-
     for (unsigned jj = 256; jj < 2 * 255; ++jj)
-    {
         exptab[jj] = exptab[jj % 255];
-    }
-
     exptab[2 * 255] = 1;
-
     for (unsigned jj = 2 * 255 + 1; jj < 4 * 255; ++jj)
-    {
         exptab[jj] = 0;
-    }
 }
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Multiply and Divide Tables
 
 // Initialize MUL and DIV tables using LOG and EXP tables
@@ -108,11 +404,9 @@ static void gf256_muldiv_init()
 
     // Unroll y = 0 subtable
     for (int x = 0; x < 256; ++x)
-    {
         m[x] = d[x] = 0;
-    }
 
-    // For each other y value,
+    // For each other y value:
     for (int y = 1; y < 256; ++y)
     {
         // Calculate log(y) for mult and 255 - log(y) for div
@@ -120,12 +414,10 @@ static void gf256_muldiv_init()
         const uint8_t log_yn = 255 - log_y;
 
         // Next subtable
-        m += 256;
-        d += 256;
+        m += 256, d += 256;
 
         // Unroll x = 0
-        m[0] = 0;
-        d[0] = 0;
+        m[0] = 0, d[0] = 0;
 
         // Calculate x * y, x / y
         for (int x = 1; x < 256; ++x)
@@ -139,20 +431,29 @@ static void gf256_muldiv_init()
 }
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Inverse Table
 
 // Initialize INV table using DIV table
 static void gf256_inv_init()
 {
     for (int x = 0; x < 256; ++x)
-    {
         GF256Ctx.GF256_INV_TABLE[x] = gf256_div(1, static_cast<uint8_t>(x));
-    }
 }
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Square Table
+
+// Initialize SQR table using MUL table
+static void gf256_sqr_init()
+{
+    for (int x = 0; x < 256; ++x)
+        GF256Ctx.GF256_SQR_TABLE[x] = gf256_mul(static_cast<uint8_t>(x), static_cast<uint8_t>(x));
+}
+
+
+//------------------------------------------------------------------------------
 // Multiply and Add Memory Tables
 
 /*
@@ -243,13 +544,15 @@ static void gf256_inv_init()
         Computes the bitwise XOR of the 128-bit value in a and the 128-bit value in b.
 */
 
-// Initialize the MM256 tables using gf256_mul()
-static void gf256_muladd_mem_init()
+// Initialize the multiplication tables using gf256_mul()
+static void gf256_mul_mem_init()
 {
+    // Reuse aligned self test buffers to load table data
+    uint8_t* lo = m_SelfTestBuffers.A;
+    uint8_t* hi = m_SelfTestBuffers.B;
+
     for (int y = 0; y < 256; ++y)
     {
-        uint8_t lo[16], hi[16];
-
         // TABLE_LO_Y maps 0..15 to 8-bit partial product based on y.
         for (unsigned char x = 0; x < 16; ++x)
         {
@@ -257,93 +560,211 @@ static void gf256_muladd_mem_init()
             hi[x] = gf256_mul(x << 4, static_cast<uint8_t>( y ));
         }
 
-        const GF256_M128 table_lo = _mm_set_epi8(
-            lo[15], lo[14], lo[13], lo[12], lo[11], lo[10], lo[9], lo[8],
-            lo[7], lo[6], lo[5], lo[4], lo[3], lo[2], lo[1], lo[0]);
-        const GF256_M128 table_hi = _mm_set_epi8(
-            hi[15], hi[14], hi[13], hi[12], hi[11], hi[10], hi[9], hi[8],
-            hi[7], hi[6], hi[5], hi[4], hi[3], hi[2], hi[1], hi[0]);
-        _mm_store_si128(GF256Ctx.MM256_TABLE_LO_Y + y, table_lo);
-        _mm_store_si128(GF256Ctx.MM256_TABLE_HI_Y + y, table_hi);
+#if defined(GF256_TRY_NEON)
+        if (CpuHasNeon)
+        {
+            GF256Ctx.MM128.TABLE_LO_Y[y] = vld1q_u8(lo);
+            GF256Ctx.MM128.TABLE_HI_Y[y] = vld1q_u8(hi);
+        }
+#elif !defined(GF256_TARGET_MOBILE)
+        const GF256_M128 table_lo = _mm_loadu_si128((GF256_M128*)lo);
+        const GF256_M128 table_hi = _mm_loadu_si128((GF256_M128*)hi);
+        _mm_storeu_si128(GF256Ctx.MM128.TABLE_LO_Y + y, table_lo);
+        _mm_storeu_si128(GF256Ctx.MM128.TABLE_HI_Y + y, table_hi);
+# ifdef GF256_TRY_AVX2
+        if (CpuHasAVX2)
+        {
+            const GF256_M256 table_lo2 = _mm256_broadcastsi128_si256(table_lo);
+            const GF256_M256 table_hi2 = _mm256_broadcastsi128_si256(table_hi);
+            _mm256_storeu_si256(GF256Ctx.MM256.TABLE_LO_Y + y, table_lo2);
+            _mm256_storeu_si256(GF256Ctx.MM256.TABLE_HI_Y + y, table_hi2);
+        }
+# endif // GF256_TRY_AVX2
+#endif // GF256_TARGET_MOBILE
     }
 }
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Initialization
 
-static unsigned char LittleEndianTestData[4] = { 4, 3, 2, 1 };
+static unsigned char kLittleEndianTestData[4] = { 4, 3, 2, 1 };
+
+union UnionType
+{
+    uint32_t IntValue;
+    char CharArray[4];
+};
+
 static bool IsLittleEndian()
 {
-    return 0x01020304 == *reinterpret_cast<uint32_t*>(LittleEndianTestData);
+    UnionType type;
+    for (unsigned i = 0; i < 4; ++i)
+        type.CharArray[i] = kLittleEndianTestData[i];
+    return 0x01020304 == type.IntValue;
 }
 
 extern "C" int gf256_init_(int version)
 {
     if (version != GF256_VERSION)
-    {
-        // User's header does not match library version.
-        return -1;
-    }
+        return -1; // User's header does not match library version.
 
     // Avoid multiple initialization
     if (Initialized)
-    {
         return 0;
-    }
     Initialized = true;
 
     if (!IsLittleEndian())
-    {
-        // Architecture is not supported (code won't work without mods).
-        return -2;
-    }
+        return -2; // Architecture is not supported (code won't work without mods).
 
-    gf255_poly_init(DefaultPolynomialIndex);
+    gf256_architecture_init();
+    gf256_poly_init(kDefaultPolynomialIndex);
     gf256_explog_init();
     gf256_muldiv_init();
     gf256_inv_init();
-    gf256_muladd_mem_init();
+    gf256_sqr_init();
+    gf256_mul_mem_init();
+
+    if (!gf256_self_test())
+        return -3; // Self-test failed (perhaps untested configuration)
 
     return 0;
 }
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Operations
 
 extern "C" void gf256_add_mem(void * GF256_RESTRICT vx,
                               const void * GF256_RESTRICT vy, int bytes)
 {
-    GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<GF256_M128*>(vx);
-    const GF256_M128 * GF256_RESTRICT y16 = reinterpret_cast<const GF256_M128*>(vy);
+    GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<GF256_M128 *>(vx);
+    const GF256_M128 * GF256_RESTRICT y16 = reinterpret_cast<const GF256_M128 *>(vy);
 
+#if defined(GF256_TARGET_MOBILE)
+# if defined(GF256_TRY_NEON)
     // Handle multiples of 64 bytes
-    while (bytes >= 64)
+    if (CpuHasNeon)
     {
-        GF256_M128 x0 = _mm_loadu_si128(x16);
-        GF256_M128 x1 = _mm_loadu_si128(x16 + 1);
-        GF256_M128 x2 = _mm_loadu_si128(x16 + 2);
-        GF256_M128 x3 = _mm_loadu_si128(x16 + 3);
-        GF256_M128 y0 = _mm_loadu_si128(y16);
-        GF256_M128 y1 = _mm_loadu_si128(y16 + 1);
-        GF256_M128 y2 = _mm_loadu_si128(y16 + 2);
-        GF256_M128 y3 = _mm_loadu_si128(y16 + 3);
+        while (bytes >= 64)
+        {
+            GF256_M128 x0 = vld1q_u8((uint8_t*) x16);
+            GF256_M128 x1 = vld1q_u8((uint8_t*)(x16 + 1) );
+            GF256_M128 x2 = vld1q_u8((uint8_t*)(x16 + 2) );
+            GF256_M128 x3 = vld1q_u8((uint8_t*)(x16 + 3) );
+            GF256_M128 y0 = vld1q_u8((uint8_t*)y16);
+            GF256_M128 y1 = vld1q_u8((uint8_t*)(y16 + 1));
+            GF256_M128 y2 = vld1q_u8((uint8_t*)(y16 + 2));
+            GF256_M128 y3 = vld1q_u8((uint8_t*)(y16 + 3));
 
-        _mm_storeu_si128(x16,
-            _mm_xor_si128(x0, y0));
-        _mm_storeu_si128(x16 + 1,
-            _mm_xor_si128(x1, y1));
-        _mm_storeu_si128(x16 + 2,
-            _mm_xor_si128(x2, y2));
-        _mm_storeu_si128(x16 + 3,
-            _mm_xor_si128(x3, y3));
+            vst1q_u8((uint8_t*)x16,     veorq_u8(x0, y0));
+            vst1q_u8((uint8_t*)(x16 + 1), veorq_u8(x1, y1));
+            vst1q_u8((uint8_t*)(x16 + 2), veorq_u8(x2, y2));
+            vst1q_u8((uint8_t*)(x16 + 3), veorq_u8(x3, y3));
 
-        x16 += 4;
-        y16 += 4;
-        bytes -= 64;
+            bytes -= 64, x16 += 4, y16 += 4;
+        }
+
+        // Handle multiples of 16 bytes
+        while (bytes >= 16)
+        {
+            GF256_M128 x0 = vld1q_u8((uint8_t*)x16);
+            GF256_M128 y0 = vld1q_u8((uint8_t*)y16);
+
+            vst1q_u8((uint8_t*)x16, veorq_u8(x0, y0));
+
+            bytes -= 16, ++x16, ++y16;
+        }
     }
+    else
+# endif // GF256_TRY_NEON
+    {
+        uint64_t * GF256_RESTRICT x8 = reinterpret_cast<uint64_t *>(x16);
+        const uint64_t * GF256_RESTRICT y8 = reinterpret_cast<const uint64_t *>(y16);
 
+        const unsigned count = (unsigned)bytes / 8;
+        for (unsigned ii = 0; ii < count; ++ii)
+            x8[ii] ^= y8[ii];
+
+        x16 = reinterpret_cast<GF256_M128 *>(x8 + count);
+        y16 = reinterpret_cast<const GF256_M128 *>(y8 + count);
+
+        bytes -= (count * 8);
+    }
+#else // GF256_TARGET_MOBILE
+# if defined(GF256_TRY_AVX2)
+    if (CpuHasAVX2)
+    {
+        GF256_M256 * GF256_RESTRICT x32 = reinterpret_cast<GF256_M256 *>(x16);
+        const GF256_M256 * GF256_RESTRICT y32 = reinterpret_cast<const GF256_M256 *>(y16);
+
+        while (bytes >= 128)
+        {
+            GF256_M256 x0 = _mm256_loadu_si256(x32);
+            GF256_M256 y0 = _mm256_loadu_si256(y32);
+            x0 = _mm256_xor_si256(x0, y0);
+            GF256_M256 x1 = _mm256_loadu_si256(x32 + 1);
+            GF256_M256 y1 = _mm256_loadu_si256(y32 + 1);
+            x1 = _mm256_xor_si256(x1, y1);
+            GF256_M256 x2 = _mm256_loadu_si256(x32 + 2);
+            GF256_M256 y2 = _mm256_loadu_si256(y32 + 2);
+            x2 = _mm256_xor_si256(x2, y2);
+            GF256_M256 x3 = _mm256_loadu_si256(x32 + 3);
+            GF256_M256 y3 = _mm256_loadu_si256(y32 + 3);
+            x3 = _mm256_xor_si256(x3, y3);
+
+            _mm256_storeu_si256(x32, x0);
+            _mm256_storeu_si256(x32 + 1, x1);
+            _mm256_storeu_si256(x32 + 2, x2);
+            _mm256_storeu_si256(x32 + 3, x3);
+
+            bytes -= 128, x32 += 4, y32 += 4;
+        }
+
+        // Handle multiples of 32 bytes
+        while (bytes >= 32)
+        {
+            // x[i] = x[i] xor y[i]
+            _mm256_storeu_si256(x32,
+                _mm256_xor_si256(
+                    _mm256_loadu_si256(x32),
+                    _mm256_loadu_si256(y32)));
+
+            bytes -= 32, ++x32, ++y32;
+        }
+
+        x16 = reinterpret_cast<GF256_M128 *>(x32);
+        y16 = reinterpret_cast<const GF256_M128 *>(y32);
+    }
+    else
+# endif // GF256_TRY_AVX2
+    {
+        while (bytes >= 64)
+        {
+            GF256_M128 x0 = _mm_loadu_si128(x16);
+            GF256_M128 y0 = _mm_loadu_si128(y16);
+            x0 = _mm_xor_si128(x0, y0);
+            GF256_M128 x1 = _mm_loadu_si128(x16 + 1);
+            GF256_M128 y1 = _mm_loadu_si128(y16 + 1);
+            x1 = _mm_xor_si128(x1, y1);
+            GF256_M128 x2 = _mm_loadu_si128(x16 + 2);
+            GF256_M128 y2 = _mm_loadu_si128(y16 + 2);
+            x2 = _mm_xor_si128(x2, y2);
+            GF256_M128 x3 = _mm_loadu_si128(x16 + 3);
+            GF256_M128 y3 = _mm_loadu_si128(y16 + 3);
+            x3 = _mm_xor_si128(x3, y3);
+
+            _mm_storeu_si128(x16, x0);
+            _mm_storeu_si128(x16 + 1, x1);
+            _mm_storeu_si128(x16 + 2, x2);
+            _mm_storeu_si128(x16 + 3, x3);
+
+            bytes -= 64, x16 += 4, y16 += 4;
+        }
+    }
+#endif // GF256_TARGET_MOBILE
+
+#if !defined(GF256_TARGET_MOBILE)
     // Handle multiples of 16 bytes
     while (bytes >= 16)
     {
@@ -353,44 +774,38 @@ extern "C" void gf256_add_mem(void * GF256_RESTRICT vx,
                 _mm_loadu_si128(x16),
                 _mm_loadu_si128(y16)));
 
-        x16++;
-        y16++;
-        bytes -= 16;
+        bytes -= 16, ++x16, ++y16;
     }
+#endif
 
     uint8_t * GF256_RESTRICT x1 = reinterpret_cast<uint8_t *>(x16);
     const uint8_t * GF256_RESTRICT y1 = reinterpret_cast<const uint8_t *>(y16);
 
     // Handle a block of 8 bytes
-    if (bytes >= 8)
+    const int eight = bytes & 8;
+    if (eight)
     {
         uint64_t * GF256_RESTRICT x8 = reinterpret_cast<uint64_t *>(x1);
         const uint64_t * GF256_RESTRICT y8 = reinterpret_cast<const uint64_t *>(y1);
         *x8 ^= *y8;
-
-        x1 += 8;
-        y1 += 8;
-        bytes -= 8;
     }
 
     // Handle a block of 4 bytes
-    if (bytes >= 4)
+    const int four = bytes & 4;
+    if (four)
     {
-        uint32_t * GF256_RESTRICT x4 = reinterpret_cast<uint32_t *>(x1);
-        const uint32_t * GF256_RESTRICT y4 = reinterpret_cast<const uint32_t *>(y1);
+        uint32_t * GF256_RESTRICT x4 = reinterpret_cast<uint32_t *>(x1 + eight);
+        const uint32_t * GF256_RESTRICT y4 = reinterpret_cast<const uint32_t *>(y1 + eight);
         *x4 ^= *y4;
-
-        x1 += 4;
-        y1 += 4;
-        bytes -= 4;
     }
 
     // Handle final bytes
-    switch (bytes)
+    const int offset = eight + four;
+    switch (bytes & 3)
     {
-    case 3: x1[2] ^= y1[2];
-    case 2: x1[1] ^= y1[1];
-    case 1: x1[0] ^= y1[0];
+    case 3: x1[offset + 2] ^= y1[offset + 2];
+    case 2: x1[offset + 1] ^= y1[offset + 1];
+    case 1: x1[offset] ^= y1[offset];
     default:
         break;
     }
@@ -403,61 +818,114 @@ extern "C" void gf256_add2_mem(void * GF256_RESTRICT vz, const void * GF256_REST
     const GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<const GF256_M128*>(vx);
     const GF256_M128 * GF256_RESTRICT y16 = reinterpret_cast<const GF256_M128*>(vy);
 
+#if defined(GF256_TARGET_MOBILE)
+# if defined(GF256_TRY_NEON)
+    // Handle multiples of 64 bytes
+    if (CpuHasNeon)
+    {
+        // Handle multiples of 16 bytes
+        while (bytes >= 16)
+        {
+            // z[i] = z[i] xor x[i] xor y[i]
+            vst1q_u8((uint8_t*)z16,
+                veorq_u8(
+                    vld1q_u8((uint8_t*)z16),
+                    veorq_u8(
+                        vld1q_u8((uint8_t*)x16),
+                        vld1q_u8((uint8_t*)y16))));
+
+            bytes -= 16, ++x16, ++y16, ++z16;
+        }
+    }
+    else
+# endif // GF256_TRY_NEON
+    {
+        uint64_t * GF256_RESTRICT z8 = reinterpret_cast<uint64_t *>(z16);
+        const uint64_t * GF256_RESTRICT x8 = reinterpret_cast<const uint64_t *>(x16);
+        const uint64_t * GF256_RESTRICT y8 = reinterpret_cast<const uint64_t *>(y16);
+
+        const unsigned count = (unsigned)bytes / 8;
+        for (unsigned ii = 0; ii < count; ++ii)
+            z8[ii] ^= x8[ii] ^ y8[ii];
+
+        z16 = reinterpret_cast<GF256_M128 *>(z8 + count);
+        x16 = reinterpret_cast<const GF256_M128 *>(x8 + count);
+        y16 = reinterpret_cast<const GF256_M128 *>(y8 + count);
+
+        bytes -= (count * 8);
+    }
+#else // GF256_TARGET_MOBILE
+# if defined(GF256_TRY_AVX2)
+    if (CpuHasAVX2)
+    {
+        GF256_M256 * GF256_RESTRICT z32 = reinterpret_cast<GF256_M256 *>(z16);
+        const GF256_M256 * GF256_RESTRICT x32 = reinterpret_cast<const GF256_M256 *>(x16);
+        const GF256_M256 * GF256_RESTRICT y32 = reinterpret_cast<const GF256_M256 *>(y16);
+
+        const unsigned count = bytes / 32;
+        for (unsigned i = 0; i < count; ++i)
+        {
+            _mm256_storeu_si256(z32 + i,
+                _mm256_xor_si256(
+                    _mm256_loadu_si256(z32 + i),
+                    _mm256_xor_si256(
+                        _mm256_loadu_si256(x32 + i),
+                        _mm256_loadu_si256(y32 + i))));
+        }
+
+        bytes -= count * 32;
+        z16 = reinterpret_cast<GF256_M128 *>(z32 + count);
+        x16 = reinterpret_cast<const GF256_M128 *>(x32 + count);
+        y16 = reinterpret_cast<const GF256_M128 *>(y32 + count);
+    }
+# endif // GF256_TRY_AVX2
+
     // Handle multiples of 16 bytes
     while (bytes >= 16)
     {
-        // z[i] = x[i] xor y[i]
+        // z[i] = z[i] xor x[i] xor y[i]
         _mm_storeu_si128(z16,
             _mm_xor_si128(
-            _mm_loadu_si128(z16),
-            _mm_xor_si128(
-            _mm_loadu_si128(x16),
-            _mm_loadu_si128(y16))));
+                _mm_loadu_si128(z16),
+                _mm_xor_si128(
+                    _mm_loadu_si128(x16),
+                    _mm_loadu_si128(y16))));
 
-        x16++;
-        y16++;
-        z16++;
-        bytes -= 16;
+        bytes -= 16, ++x16, ++y16, ++z16;
     }
+#endif // GF256_TARGET_MOBILE
 
     uint8_t * GF256_RESTRICT z1 = reinterpret_cast<uint8_t *>(z16);
     const uint8_t * GF256_RESTRICT x1 = reinterpret_cast<const uint8_t *>(x16);
     const uint8_t * GF256_RESTRICT y1 = reinterpret_cast<const uint8_t *>(y16);
 
     // Handle a block of 8 bytes
-    if (bytes >= 8)
+    const int eight = bytes & 8;
+    if (eight)
     {
         uint64_t * GF256_RESTRICT z8 = reinterpret_cast<uint64_t *>(z1);
         const uint64_t * GF256_RESTRICT x8 = reinterpret_cast<const uint64_t *>(x1);
         const uint64_t * GF256_RESTRICT y8 = reinterpret_cast<const uint64_t *>(y1);
         *z8 ^= *x8 ^ *y8;
-
-        x1 += 8;
-        y1 += 8;
-        z1 += 8;
-        bytes -= 8;
     }
 
     // Handle a block of 4 bytes
-    if (bytes >= 4)
+    const int four = bytes & 4;
+    if (four)
     {
-        uint32_t * GF256_RESTRICT z4 = reinterpret_cast<uint32_t *>(z1);
-        const uint32_t * GF256_RESTRICT x4 = reinterpret_cast<const uint32_t *>(x1);
-        const uint32_t * GF256_RESTRICT y4 = reinterpret_cast<const uint32_t *>(y1);
+        uint32_t * GF256_RESTRICT z4 = reinterpret_cast<uint32_t *>(z1 + eight);
+        const uint32_t * GF256_RESTRICT x4 = reinterpret_cast<const uint32_t *>(x1 + eight);
+        const uint32_t * GF256_RESTRICT y4 = reinterpret_cast<const uint32_t *>(y1 + eight);
         *z4 ^= *x4 ^ *y4;
-
-        x1 += 4;
-        y1 += 4;
-        z1 += 4;
-        bytes -= 4;
     }
 
     // Handle final bytes
-    switch (bytes)
+    const int offset = eight + four;
+    switch (bytes & 3)
     {
-    case 3: z1[2] ^= x1[2] ^ y1[2];
-    case 2: z1[1] ^= x1[1] ^ y1[1];
-    case 1: z1[0] ^= x1[0] ^ y1[0];
+    case 3: z1[offset + 2] ^= x1[offset + 2] ^ y1[offset + 2];
+    case 2: z1[offset + 1] ^= x1[offset + 1] ^ y1[offset + 1];
+    case 1: z1[offset] ^= x1[offset] ^ y1[offset];
     default:
         break;
     }
@@ -470,27 +938,103 @@ extern "C" void gf256_addset_mem(void * GF256_RESTRICT vz, const void * GF256_RE
     const GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<const GF256_M128*>(vx);
     const GF256_M128 * GF256_RESTRICT y16 = reinterpret_cast<const GF256_M128*>(vy);
 
+#if defined(GF256_TARGET_MOBILE)
+# if defined(GF256_TRY_NEON)
     // Handle multiples of 64 bytes
-    while (bytes >= 64)
+    if (CpuHasNeon)
     {
-        GF256_M128 x0 = _mm_loadu_si128(x16);
-        GF256_M128 x1 = _mm_loadu_si128(x16 + 1);
-        GF256_M128 x2 = _mm_loadu_si128(x16 + 2);
-        GF256_M128 x3 = _mm_loadu_si128(x16 + 3);
-        GF256_M128 y0 = _mm_loadu_si128(y16);
-        GF256_M128 y1 = _mm_loadu_si128(y16 + 1);
-        GF256_M128 y2 = _mm_loadu_si128(y16 + 2);
-        GF256_M128 y3 = _mm_loadu_si128(y16 + 3);
+        while (bytes >= 64)
+        {
+            GF256_M128 x0 = vld1q_u8((uint8_t*)x16);
+            GF256_M128 x1 = vld1q_u8((uint8_t*)(x16 + 1));
+            GF256_M128 x2 = vld1q_u8((uint8_t*)(x16 + 2));
+            GF256_M128 x3 = vld1q_u8((uint8_t*)(x16 + 3));
+            GF256_M128 y0 = vld1q_u8((uint8_t*)(y16));
+            GF256_M128 y1 = vld1q_u8((uint8_t*)(y16 + 1));
+            GF256_M128 y2 = vld1q_u8((uint8_t*)(y16 + 2));
+            GF256_M128 y3 = vld1q_u8((uint8_t*)(y16 + 3));
 
-        _mm_storeu_si128(z16, _mm_xor_si128(x0, y0));
-        _mm_storeu_si128(z16 + 1, _mm_xor_si128(x1, y1));
-        _mm_storeu_si128(z16 + 2, _mm_xor_si128(x2, y2));
-        _mm_storeu_si128(z16 + 3, _mm_xor_si128(x3, y3));
+            vst1q_u8((uint8_t*)z16,     veorq_u8(x0, y0));
+            vst1q_u8((uint8_t*)(z16 + 1), veorq_u8(x1, y1));
+            vst1q_u8((uint8_t*)(z16 + 2), veorq_u8(x2, y2));
+            vst1q_u8((uint8_t*)(z16 + 3), veorq_u8(x3, y3));
 
-        x16 += 4;
-        y16 += 4;
-        z16 += 4;
-        bytes -= 64;
+            bytes -= 64, x16 += 4, y16 += 4, z16 += 4;
+        }
+
+        // Handle multiples of 16 bytes
+        while (bytes >= 16)
+        {
+            // z[i] = x[i] xor y[i]
+            vst1q_u8((uint8_t*)z16,
+                     veorq_u8(
+                         vld1q_u8((uint8_t*)x16),
+                         vld1q_u8((uint8_t*)y16)));
+
+            bytes -= 16, ++x16, ++y16, ++z16;
+        }
+    }
+    else
+# endif // GF256_TRY_NEON
+    {
+        uint64_t * GF256_RESTRICT z8 = reinterpret_cast<uint64_t *>(z16);
+        const uint64_t * GF256_RESTRICT x8 = reinterpret_cast<const uint64_t *>(x16);
+        const uint64_t * GF256_RESTRICT y8 = reinterpret_cast<const uint64_t *>(y16);
+
+        const unsigned count = (unsigned)bytes / 8;
+        for (unsigned ii = 0; ii < count; ++ii)
+            z8[ii] = x8[ii] ^ y8[ii];
+
+        x16 = reinterpret_cast<const GF256_M128 *>(x8 + count);
+        y16 = reinterpret_cast<const GF256_M128 *>(y8 + count);
+        z16 = reinterpret_cast<GF256_M128 *>(z8 + count);
+
+        bytes -= (count * 8);
+    }
+#else // GF256_TARGET_MOBILE
+# if defined(GF256_TRY_AVX2)
+    if (CpuHasAVX2)
+    {
+        GF256_M256 * GF256_RESTRICT z32 = reinterpret_cast<GF256_M256 *>(z16);
+        const GF256_M256 * GF256_RESTRICT x32 = reinterpret_cast<const GF256_M256 *>(x16);
+        const GF256_M256 * GF256_RESTRICT y32 = reinterpret_cast<const GF256_M256 *>(y16);
+
+        const unsigned count = bytes / 32;
+        for (unsigned i = 0; i < count; ++i)
+        {
+            _mm256_storeu_si256(z32 + i,
+                _mm256_xor_si256(
+                    _mm256_loadu_si256(x32 + i),
+                    _mm256_loadu_si256(y32 + i)));
+        }
+
+        bytes -= count * 32;
+        z16 = reinterpret_cast<GF256_M128 *>(z32 + count);
+        x16 = reinterpret_cast<const GF256_M128 *>(x32 + count);
+        y16 = reinterpret_cast<const GF256_M128 *>(y32 + count);
+    }
+    else
+# endif // GF256_TRY_AVX2
+    {
+        // Handle multiples of 64 bytes
+        while (bytes >= 64)
+        {
+            GF256_M128 x0 = _mm_loadu_si128(x16);
+            GF256_M128 x1 = _mm_loadu_si128(x16 + 1);
+            GF256_M128 x2 = _mm_loadu_si128(x16 + 2);
+            GF256_M128 x3 = _mm_loadu_si128(x16 + 3);
+            GF256_M128 y0 = _mm_loadu_si128(y16);
+            GF256_M128 y1 = _mm_loadu_si128(y16 + 1);
+            GF256_M128 y2 = _mm_loadu_si128(y16 + 2);
+            GF256_M128 y3 = _mm_loadu_si128(y16 + 3);
+
+            _mm_storeu_si128(z16,     _mm_xor_si128(x0, y0));
+            _mm_storeu_si128(z16 + 1, _mm_xor_si128(x1, y1));
+            _mm_storeu_si128(z16 + 2, _mm_xor_si128(x2, y2));
+            _mm_storeu_si128(z16 + 3, _mm_xor_si128(x3, y3));
+
+            bytes -= 64, x16 += 4, y16 += 4, z16 += 4;
+        }
     }
 
     // Handle multiples of 16 bytes
@@ -502,50 +1046,187 @@ extern "C" void gf256_addset_mem(void * GF256_RESTRICT vz, const void * GF256_RE
                 _mm_loadu_si128(x16),
                 _mm_loadu_si128(y16)));
 
-        x16++;
-        y16++;
-        z16++;
-        bytes -= 16;
+        bytes -= 16, ++x16, ++y16, ++z16;
     }
+#endif // GF256_TARGET_MOBILE
 
     uint8_t * GF256_RESTRICT z1 = reinterpret_cast<uint8_t *>(z16);
     const uint8_t * GF256_RESTRICT x1 = reinterpret_cast<const uint8_t *>(x16);
     const uint8_t * GF256_RESTRICT y1 = reinterpret_cast<const uint8_t *>(y16);
 
     // Handle a block of 8 bytes
-    if (bytes >= 8)
+    const int eight = bytes & 8;
+    if (eight)
     {
         uint64_t * GF256_RESTRICT z8 = reinterpret_cast<uint64_t *>(z1);
         const uint64_t * GF256_RESTRICT x8 = reinterpret_cast<const uint64_t *>(x1);
         const uint64_t * GF256_RESTRICT y8 = reinterpret_cast<const uint64_t *>(y1);
         *z8 = *x8 ^ *y8;
-
-        x1 += 8;
-        y1 += 8;
-        z1 += 8;
-        bytes -= 8;
     }
 
     // Handle a block of 4 bytes
-    if (bytes >= 4)
+    const int four = bytes & 4;
+    if (four)
     {
-        uint32_t * GF256_RESTRICT z4 = reinterpret_cast<uint32_t *>(z1);
-        const uint32_t * GF256_RESTRICT x4 = reinterpret_cast<const uint32_t *>(x1);
-        const uint32_t * GF256_RESTRICT y4 = reinterpret_cast<const uint32_t *>(y1);
+        uint32_t * GF256_RESTRICT z4 = reinterpret_cast<uint32_t *>(z1 + eight);
+        const uint32_t * GF256_RESTRICT x4 = reinterpret_cast<const uint32_t *>(x1 + eight);
+        const uint32_t * GF256_RESTRICT y4 = reinterpret_cast<const uint32_t *>(y1 + eight);
         *z4 = *x4 ^ *y4;
-
-        x1 += 4;
-        y1 += 4;
-        z1 += 4;
-        bytes -= 4;
     }
 
     // Handle final bytes
-    switch (bytes)
+    const int offset = eight + four;
+    switch (bytes & 3)
     {
-    case 3: z1[2] = x1[2] ^ y1[2];
-    case 2: z1[1] = x1[1] ^ y1[1];
-    case 1: z1[0] = x1[0] ^ y1[0];
+    case 3: z1[offset + 2] = x1[offset + 2] ^ y1[offset + 2];
+    case 2: z1[offset + 1] = x1[offset + 1] ^ y1[offset + 1];
+    case 1: z1[offset] = x1[offset] ^ y1[offset];
+    default:
+        break;
+    }
+}
+
+extern "C" void gf256_mul_mem(void * GF256_RESTRICT vz, const void * GF256_RESTRICT vx, uint8_t y, int bytes)
+{
+    // Use a single if-statement to handle special cases
+    if (y <= 1)
+    {
+        if (y == 0)
+            memset(vz, 0, bytes);
+        else if (vz != vx)
+            memcpy(vz, vx, bytes);
+        return;
+    }
+
+    GF256_M128 * GF256_RESTRICT z16 = reinterpret_cast<GF256_M128 *>(vz);
+    const GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<const GF256_M128 *>(vx);
+
+#if defined(GF256_TARGET_MOBILE)
+#if defined(GF256_TRY_NEON)
+    if (bytes >= 16 && CpuHasNeon)
+    {
+        // Partial product tables; see above
+        const GF256_M128 table_lo_y = vld1q_u8((uint8_t*)(GF256Ctx.MM128.TABLE_LO_Y + y));
+        const GF256_M128 table_hi_y = vld1q_u8((uint8_t*)(GF256Ctx.MM128.TABLE_HI_Y + y));
+
+        // clr_mask = 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
+        const GF256_M128 clr_mask = vdupq_n_u8(0x0f);
+
+        // Handle multiples of 16 bytes
+        do
+        {
+            // See above comments for details
+            GF256_M128 x0 = vld1q_u8((uint8_t*)x16);
+            GF256_M128 l0 = vandq_u8(x0, clr_mask);
+            x0 = vshrq_n_u8(x0, 4);
+            GF256_M128 h0 = vandq_u8(x0, clr_mask);
+            l0 = vqtbl1q_u8(table_lo_y, l0);
+            h0 = vqtbl1q_u8(table_hi_y, h0);
+            vst1q_u8((uint8_t*)z16, veorq_u8(l0, h0));
+
+            bytes -= 16, ++x16, ++z16;
+        } while (bytes >= 16);
+    }
+#endif
+#else
+# if defined(GF256_TRY_AVX2)
+    if (bytes >= 32 && CpuHasAVX2)
+    {
+        // Partial product tables; see above
+        const GF256_M256 table_lo_y = _mm256_loadu_si256(GF256Ctx.MM256.TABLE_LO_Y + y);
+        const GF256_M256 table_hi_y = _mm256_loadu_si256(GF256Ctx.MM256.TABLE_HI_Y + y);
+
+        // clr_mask = 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
+        const GF256_M256 clr_mask = _mm256_set1_epi8(0x0f);
+
+        GF256_M256 * GF256_RESTRICT z32 = reinterpret_cast<GF256_M256 *>(vz);
+        const GF256_M256 * GF256_RESTRICT x32 = reinterpret_cast<const GF256_M256 *>(vx);
+
+        // Handle multiples of 32 bytes
+        do
+        {
+            // See above comments for details
+            GF256_M256 x0 = _mm256_loadu_si256(x32);
+            GF256_M256 l0 = _mm256_and_si256(x0, clr_mask);
+            x0 = _mm256_srli_epi64(x0, 4);
+            GF256_M256 h0 = _mm256_and_si256(x0, clr_mask);
+            l0 = _mm256_shuffle_epi8(table_lo_y, l0);
+            h0 = _mm256_shuffle_epi8(table_hi_y, h0);
+            _mm256_storeu_si256(z32, _mm256_xor_si256(l0, h0));
+
+            bytes -= 32, ++x32, ++z32;
+        } while (bytes >= 32);
+
+        z16 = reinterpret_cast<GF256_M128 *>(z32);
+        x16 = reinterpret_cast<const GF256_M128 *>(x32);
+    }
+# endif // GF256_TRY_AVX2
+    if (bytes >= 16 && CpuHasSSSE3)
+    {
+        // Partial product tables; see above
+        const GF256_M128 table_lo_y = _mm_loadu_si128(GF256Ctx.MM128.TABLE_LO_Y + y);
+        const GF256_M128 table_hi_y = _mm_loadu_si128(GF256Ctx.MM128.TABLE_HI_Y + y);
+
+        // clr_mask = 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
+        const GF256_M128 clr_mask = _mm_set1_epi8(0x0f);
+
+        // Handle multiples of 16 bytes
+        do
+        {
+            // See above comments for details
+            GF256_M128 x0 = _mm_loadu_si128(x16);
+            GF256_M128 l0 = _mm_and_si128(x0, clr_mask);
+            x0 = _mm_srli_epi64(x0, 4);
+            GF256_M128 h0 = _mm_and_si128(x0, clr_mask);
+            l0 = _mm_shuffle_epi8(table_lo_y, l0);
+            h0 = _mm_shuffle_epi8(table_hi_y, h0);
+            _mm_storeu_si128(z16, _mm_xor_si128(l0, h0));
+
+            bytes -= 16, ++x16, ++z16;
+        } while (bytes >= 16);
+    }
+#endif
+
+    uint8_t * GF256_RESTRICT z1 = reinterpret_cast<uint8_t*>(z16);
+    const uint8_t * GF256_RESTRICT x1 = reinterpret_cast<const uint8_t*>(x16);
+    const uint8_t * GF256_RESTRICT table = GF256Ctx.GF256_MUL_TABLE + ((unsigned)y << 8);
+
+    // Handle blocks of 8 bytes
+    while (bytes >= 8)
+    {
+        uint64_t * GF256_RESTRICT z8 = reinterpret_cast<uint64_t *>(z1);
+        uint64_t word = table[x1[0]];
+        word |= (uint64_t)table[x1[1]] << 8;
+        word |= (uint64_t)table[x1[2]] << 16;
+        word |= (uint64_t)table[x1[3]] << 24;
+        word |= (uint64_t)table[x1[4]] << 32;
+        word |= (uint64_t)table[x1[5]] << 40;
+        word |= (uint64_t)table[x1[6]] << 48;
+        word |= (uint64_t)table[x1[7]] << 56;
+        *z8 = word;
+
+        bytes -= 8, x1 += 8, z1 += 8;
+    }
+
+    // Handle a block of 4 bytes
+    const int four = bytes & 4;
+    if (four)
+    {
+        uint32_t * GF256_RESTRICT z4 = reinterpret_cast<uint32_t *>(z1);
+        uint32_t word = table[x1[0]];
+        word |= (uint32_t)table[x1[1]] << 8;
+        word |= (uint32_t)table[x1[2]] << 16;
+        word |= (uint32_t)table[x1[3]] << 24;
+        *z4 = word;
+    }
+
+    // Handle single bytes
+    const int offset = four;
+    switch (bytes & 3)
+    {
+    case 3: z1[offset + 2] = table[x1[offset + 2]];
+    case 2: z1[offset + 1] = table[x1[offset + 1]];
+    case 1: z1[offset] = table[x1[offset]];
     default:
         break;
     }
@@ -558,169 +1239,205 @@ extern "C" void gf256_muladd_mem(void * GF256_RESTRICT vz, uint8_t y,
     if (y <= 1)
     {
         if (y == 1)
-        {
             gf256_add_mem(vz, vx, bytes);
-        }
         return;
     }
 
-    // Partial product tables; see above
-    const GF256_M128 table_lo_y = _mm_load_si128(GF256Ctx.MM256_TABLE_LO_Y + y);
-    const GF256_M128 table_hi_y = _mm_load_si128(GF256Ctx.MM256_TABLE_HI_Y + y);
+    GF256_M128 * GF256_RESTRICT z16 = reinterpret_cast<GF256_M128 *>(vz);
+    const GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<const GF256_M128 *>(vx);
 
-    // clr_mask = 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
-    const GF256_M128 clr_mask = _mm_set1_epi8(0x0f);
-
-    GF256_M128 * GF256_RESTRICT z16 = reinterpret_cast<GF256_M128*>(vz);
-    const GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<const GF256_M128*>(vx);
-
-    // Handle multiples of 16 bytes
-    while (bytes >= 16)
+#if defined(GF256_TARGET_MOBILE)
+#if defined(GF256_TRY_NEON)
+    if (bytes >= 16 && CpuHasNeon)
     {
-        // See above comments for details
-        GF256_M128 x0 = _mm_loadu_si128(x16);
-        GF256_M128 l0 = _mm_and_si128(x0, clr_mask);
-        x0 = _mm_srli_epi64(x0, 4);
-        GF256_M128 h0 = _mm_and_si128(x0, clr_mask);
-        l0 = _mm_shuffle_epi8(table_lo_y, l0);
-        h0 = _mm_shuffle_epi8(table_hi_y, h0);
-        const GF256_M128 p0 = _mm_xor_si128(l0, h0);
-        const GF256_M128 z0 = _mm_loadu_si128(z16);
-        _mm_storeu_si128(z16, _mm_xor_si128(p0, z0));
+        // Partial product tables; see above
+        const GF256_M128 table_lo_y = vld1q_u8((uint8_t*)(GF256Ctx.MM128.TABLE_LO_Y + y));
+        const GF256_M128 table_hi_y = vld1q_u8((uint8_t*)(GF256Ctx.MM128.TABLE_HI_Y + y));
 
-        x16++;
-        z16++;
-        bytes -= 16;
-    }
+        // clr_mask = 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
+        const GF256_M128 clr_mask = vdupq_n_u8(0x0f);
 
-    uint8_t * GF256_RESTRICT z8 = reinterpret_cast<uint8_t*>(z16);
-    const uint8_t * GF256_RESTRICT x8 = reinterpret_cast<const uint8_t*>(x16);
-    const uint8_t * GF256_RESTRICT table = GF256Ctx.GF256_MUL_TABLE + ((unsigned)y << 8);
-
-    // Handle a block of 8 bytes
-    if (bytes >= 8)
-    {
-        uint64_t word = table[x8[0]];
-        word |= (uint64_t)table[x8[1]] << 8;
-        word |= (uint64_t)table[x8[2]] << 16;
-        word |= (uint64_t)table[x8[3]] << 24;
-        word |= (uint64_t)table[x8[4]] << 32;
-        word |= (uint64_t)table[x8[5]] << 40;
-        word |= (uint64_t)table[x8[6]] << 48;
-        word |= (uint64_t)table[x8[7]] << 56;
-        *(uint64_t*)z8 ^= word;
-
-        x8 += 8;
-        z8 += 8;
-        bytes -= 8;
-    }
-
-    // Handle a block of 4 bytes
-    if (bytes >= 4)
-    {
-        uint32_t word = table[x8[0]];
-        word |= (uint32_t)table[x8[1]] << 8;
-        word |= (uint32_t)table[x8[2]] << 16;
-        word |= (uint32_t)table[x8[3]] << 24;
-        *(uint32_t*)z8 ^= word;
-
-        x8 += 4;
-        z8 += 4;
-        bytes -= 4;
-    }
-
-    // Handle single bytes
-    switch (bytes)
-    {
-    case 3: z8[2] ^= table[x8[2]];
-    case 2: z8[1] ^= table[x8[1]];
-    case 1: z8[0] ^= table[x8[0]];
-    default:
-        break;
-    }
-}
-
-extern "C" void gf256_mul_mem(void * GF256_RESTRICT vz, const void * GF256_RESTRICT vx, uint8_t y, int bytes)
-{
-    // Use a single if-statement to handle special cases
-    if (y <= 1)
-    {
-        if (y == 0)
+        // Handle multiples of 16 bytes
+        do
         {
-            memset(vz, 0, bytes);
-        }
-        return;
+            // See above comments for details
+            GF256_M128 x0 = vld1q_u8((uint8_t*)x16);
+            GF256_M128 l0 = vandq_u8(x0, clr_mask);
+
+            // x0 = vshrq_n_u8(x0, 4);
+            x0 = (GF256_M128)vshrq_n_u64( (uint64x2_t)x0, 4);
+            GF256_M128 h0 = vandq_u8(x0, clr_mask);
+            l0 = vqtbl1q_u8(table_lo_y, l0);
+            h0 = vqtbl1q_u8(table_hi_y, h0);
+            const GF256_M128 p0 = veorq_u8(l0, h0);
+            const GF256_M128 z0 = vld1q_u8((uint8_t*)z16);
+            vst1q_u8((uint8_t*)z16, veorq_u8(p0, z0));
+            bytes -= 16, ++x16, ++z16;
+        } while (bytes >= 16);
     }
-
-    // Partial product tables; see above
-    const GF256_M128 table_lo_y = _mm_load_si128(GF256Ctx.MM256_TABLE_LO_Y + y);
-    const GF256_M128 table_hi_y = _mm_load_si128(GF256Ctx.MM256_TABLE_HI_Y + y);
-
-    // clr_mask = 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
-    const GF256_M128 clr_mask = _mm_set1_epi8(0x0f);
-
-    GF256_M128 * GF256_RESTRICT z16 = reinterpret_cast<GF256_M128*>(vz);
-    const GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<const GF256_M128*>(vx);
-
-    // Handle multiples of 16 bytes
-    while (bytes >= 16)
+#endif
+#else // GF256_TARGET_MOBILE
+# if defined(GF256_TRY_AVX2)
+    if (bytes >= 32 && CpuHasAVX2)
     {
-        // See above comments for details
-        GF256_M128 x0 = _mm_loadu_si128(x16);
-        GF256_M128 l0 = _mm_and_si128(x0, clr_mask);
-        x0 = _mm_srli_epi64(x0, 4);
-        GF256_M128 h0 = _mm_and_si128(x0, clr_mask);
-        l0 = _mm_shuffle_epi8(table_lo_y, l0);
-        h0 = _mm_shuffle_epi8(table_hi_y, h0);
-        _mm_storeu_si128(z16, _mm_xor_si128(l0, h0));
+        // Partial product tables; see above
+        const GF256_M256 table_lo_y = _mm256_loadu_si256(GF256Ctx.MM256.TABLE_LO_Y + y);
+        const GF256_M256 table_hi_y = _mm256_loadu_si256(GF256Ctx.MM256.TABLE_HI_Y + y);
 
-        x16++;
-        z16++;
-        bytes -= 16;
+        // clr_mask = 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
+        const GF256_M256 clr_mask = _mm256_set1_epi8(0x0f);
+
+        GF256_M256 * GF256_RESTRICT z32 = reinterpret_cast<GF256_M256 *>(z16);
+        const GF256_M256 * GF256_RESTRICT x32 = reinterpret_cast<const GF256_M256 *>(x16);
+
+        // On my Reed Solomon codec, the encoder unit test runs in 640 usec without and 550 usec with the optimization (86% of the original time)
+        const unsigned count = bytes / 64;
+        for (unsigned i = 0; i < count; ++i)
+        {
+            // See above comments for details
+            GF256_M256 x0 = _mm256_loadu_si256(x32 + i * 2);
+            GF256_M256 l0 = _mm256_and_si256(x0, clr_mask);
+            x0 = _mm256_srli_epi64(x0, 4);
+            const GF256_M256 z0 = _mm256_loadu_si256(z32 + i * 2);
+            GF256_M256 h0 = _mm256_and_si256(x0, clr_mask);
+            l0 = _mm256_shuffle_epi8(table_lo_y, l0);
+            h0 = _mm256_shuffle_epi8(table_hi_y, h0);
+            const GF256_M256 p0 = _mm256_xor_si256(l0, h0);
+            _mm256_storeu_si256(z32 + i * 2, _mm256_xor_si256(p0, z0));
+
+            GF256_M256 x1 = _mm256_loadu_si256(x32 + i * 2 + 1);
+            GF256_M256 l1 = _mm256_and_si256(x1, clr_mask);
+            x1 = _mm256_srli_epi64(x1, 4);
+            const GF256_M256 z1 = _mm256_loadu_si256(z32 + i * 2 + 1);
+            GF256_M256 h1 = _mm256_and_si256(x1, clr_mask);
+            l1 = _mm256_shuffle_epi8(table_lo_y, l1);
+            h1 = _mm256_shuffle_epi8(table_hi_y, h1);
+            const GF256_M256 p1 = _mm256_xor_si256(l1, h1);
+            _mm256_storeu_si256(z32 + i * 2 + 1, _mm256_xor_si256(p1, z1));
+        }
+        bytes -= count * 64;
+        z32 += count * 2;
+        x32 += count * 2;
+
+        if (bytes >= 32)
+        {
+            GF256_M256 x0 = _mm256_loadu_si256(x32);
+            GF256_M256 l0 = _mm256_and_si256(x0, clr_mask);
+            x0 = _mm256_srli_epi64(x0, 4);
+            GF256_M256 h0 = _mm256_and_si256(x0, clr_mask);
+            l0 = _mm256_shuffle_epi8(table_lo_y, l0);
+            h0 = _mm256_shuffle_epi8(table_hi_y, h0);
+            const GF256_M256 p0 = _mm256_xor_si256(l0, h0);
+            const GF256_M256 z0 = _mm256_loadu_si256(z32);
+            _mm256_storeu_si256(z32, _mm256_xor_si256(p0, z0));
+
+            bytes -= 32;
+            z32++;
+            x32++;
+        }
+
+        z16 = reinterpret_cast<GF256_M128 *>(z32);
+        x16 = reinterpret_cast<const GF256_M128 *>(x32);
     }
+# endif // GF256_TRY_AVX2
+    if (bytes >= 16 && CpuHasSSSE3)
+    {
+        // Partial product tables; see above
+        const GF256_M128 table_lo_y = _mm_loadu_si128(GF256Ctx.MM128.TABLE_LO_Y + y);
+        const GF256_M128 table_hi_y = _mm_loadu_si128(GF256Ctx.MM128.TABLE_HI_Y + y);
 
-    uint8_t * GF256_RESTRICT z8 = reinterpret_cast<uint8_t*>(z16);
-    const uint8_t * GF256_RESTRICT x8 = reinterpret_cast<const uint8_t*>(x16);
+        // clr_mask = 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
+        const GF256_M128 clr_mask = _mm_set1_epi8(0x0f);
+
+        // This unroll seems to provide about 7% speed boost when AVX2 is disabled
+        while (bytes >= 32)
+        {
+            bytes -= 32;
+
+            GF256_M128 x1 = _mm_loadu_si128(x16 + 1);
+            GF256_M128 l1 = _mm_and_si128(x1, clr_mask);
+            x1 = _mm_srli_epi64(x1, 4);
+            GF256_M128 h1 = _mm_and_si128(x1, clr_mask);
+            l1 = _mm_shuffle_epi8(table_lo_y, l1);
+            h1 = _mm_shuffle_epi8(table_hi_y, h1);
+            const GF256_M128 z1 = _mm_loadu_si128(z16 + 1);
+
+            GF256_M128 x0 = _mm_loadu_si128(x16);
+            GF256_M128 l0 = _mm_and_si128(x0, clr_mask);
+            x0 = _mm_srli_epi64(x0, 4);
+            GF256_M128 h0 = _mm_and_si128(x0, clr_mask);
+            l0 = _mm_shuffle_epi8(table_lo_y, l0);
+            h0 = _mm_shuffle_epi8(table_hi_y, h0);
+            const GF256_M128 z0 = _mm_loadu_si128(z16);
+
+            const GF256_M128 p1 = _mm_xor_si128(l1, h1);
+            _mm_storeu_si128(z16 + 1, _mm_xor_si128(p1, z1));
+
+            const GF256_M128 p0 = _mm_xor_si128(l0, h0);
+            _mm_storeu_si128(z16, _mm_xor_si128(p0, z0));
+
+            x16 += 2, z16 += 2;
+        }
+
+        // Handle multiples of 16 bytes
+        while (bytes >= 16)
+        {
+            // See above comments for details
+            GF256_M128 x0 = _mm_loadu_si128(x16);
+            GF256_M128 l0 = _mm_and_si128(x0, clr_mask);
+            x0 = _mm_srli_epi64(x0, 4);
+            GF256_M128 h0 = _mm_and_si128(x0, clr_mask);
+            l0 = _mm_shuffle_epi8(table_lo_y, l0);
+            h0 = _mm_shuffle_epi8(table_hi_y, h0);
+            const GF256_M128 p0 = _mm_xor_si128(l0, h0);
+            const GF256_M128 z0 = _mm_loadu_si128(z16);
+            _mm_storeu_si128(z16, _mm_xor_si128(p0, z0));
+
+            bytes -= 16, ++x16, ++z16;
+        }
+    }
+#endif // GF256_TARGET_MOBILE
+
+    uint8_t * GF256_RESTRICT z1 = reinterpret_cast<uint8_t*>(z16);
+    const uint8_t * GF256_RESTRICT x1 = reinterpret_cast<const uint8_t*>(x16);
     const uint8_t * GF256_RESTRICT table = GF256Ctx.GF256_MUL_TABLE + ((unsigned)y << 8);
 
-    // Handle a block of 8 bytes
-    if (bytes >= 8)
+    // Handle blocks of 8 bytes
+    while (bytes >= 8)
     {
-        uint64_t word = table[x8[0]];
-        word |= (uint64_t)table[x8[1]] << 8;
-        word |= (uint64_t)table[x8[2]] << 16;
-        word |= (uint64_t)table[x8[3]] << 24;
-        word |= (uint64_t)table[x8[4]] << 32;
-        word |= (uint64_t)table[x8[5]] << 40;
-        word |= (uint64_t)table[x8[6]] << 48;
-        word |= (uint64_t)table[x8[7]] << 56;
-        *(uint64_t*)z8 = word;
+        uint64_t * GF256_RESTRICT z8 = reinterpret_cast<uint64_t *>(z1);
+        uint64_t word = table[x1[0]];
+        word |= (uint64_t)table[x1[1]] << 8;
+        word |= (uint64_t)table[x1[2]] << 16;
+        word |= (uint64_t)table[x1[3]] << 24;
+        word |= (uint64_t)table[x1[4]] << 32;
+        word |= (uint64_t)table[x1[5]] << 40;
+        word |= (uint64_t)table[x1[6]] << 48;
+        word |= (uint64_t)table[x1[7]] << 56;
+        *z8 ^= word;
 
-        x8 += 8;
-        z8 += 8;
-        bytes -= 8;
+        bytes -= 8, x1 += 8, z1 += 8;
     }
 
     // Handle a block of 4 bytes
-    if (bytes >= 4)
+    const int four = bytes & 4;
+    if (four)
     {
-        uint32_t word = table[x8[0]];
-        word |= (uint32_t)table[x8[1]] << 8;
-        word |= (uint32_t)table[x8[2]] << 16;
-        word |= (uint32_t)table[x8[3]] << 24;
-        *(uint32_t*)z8 = word;
-
-        x8 += 4;
-        z8 += 4;
-        bytes -= 4;
+        uint32_t * GF256_RESTRICT z4 = reinterpret_cast<uint32_t *>(z1);
+        uint32_t word = table[x1[0]];
+        word |= (uint32_t)table[x1[1]] << 8;
+        word |= (uint32_t)table[x1[2]] << 16;
+        word |= (uint32_t)table[x1[3]] << 24;
+        *z4 ^= word;
     }
 
     // Handle single bytes
-    switch (bytes)
+    const int offset = four;
+    switch (bytes & 3)
     {
-    case 3: z8[2] = table[x8[2]];
-    case 2: z8[1] = table[x8[1]];
-    case 1: z8[0] = table[x8[0]];
+    case 3: z1[offset + 2] ^= table[x1[offset + 2]];
+    case 2: z1[offset + 1] ^= table[x1[offset + 1]];
+    case 1: z1[offset] ^= table[x1[offset]];
     default:
         break;
     }
@@ -728,8 +1445,23 @@ extern "C" void gf256_mul_mem(void * GF256_RESTRICT vz, const void * GF256_RESTR
 
 extern "C" void gf256_memswap(void * GF256_RESTRICT vx, void * GF256_RESTRICT vy, int bytes)
 {
-    GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<GF256_M128*>(vx);
-    GF256_M128 * GF256_RESTRICT y16 = reinterpret_cast<GF256_M128*>(vy);
+#if defined(GF256_TARGET_MOBILE)
+    uint64_t * GF256_RESTRICT x16 = reinterpret_cast<uint64_t *>(vx);
+    uint64_t * GF256_RESTRICT y16 = reinterpret_cast<uint64_t *>(vy);
+
+    const unsigned count = (unsigned)bytes / 8;
+    for (unsigned ii = 0; ii < count; ++ii)
+    {
+        const uint64_t temp = x16[ii];
+        x16[ii] = y16[ii];
+        y16[ii] = temp;
+    }
+
+    x16 += count;
+    y16 += count;
+#else
+    GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<GF256_M128 *>(vx);
+    GF256_M128 * GF256_RESTRICT y16 = reinterpret_cast<GF256_M128 *>(vy);
 
     // Handle blocks of 16 bytes
     while (bytes >= 16)
@@ -739,16 +1471,16 @@ extern "C" void gf256_memswap(void * GF256_RESTRICT vx, void * GF256_RESTRICT vy
         _mm_storeu_si128(x16, y0);
         _mm_storeu_si128(y16, x0);
 
-        bytes -= 16;
-        ++x16;
-        ++y16;
+        bytes -= 16, ++x16, ++y16;
     }
+#endif
 
     uint8_t * GF256_RESTRICT x1 = reinterpret_cast<uint8_t *>(x16);
     uint8_t * GF256_RESTRICT y1 = reinterpret_cast<uint8_t *>(y16);
 
     // Handle a block of 8 bytes
-    if (bytes >= 8)
+    const int eight = bytes & 8;
+    if (eight)
     {
         uint64_t * GF256_RESTRICT x8 = reinterpret_cast<uint64_t *>(x1);
         uint64_t * GF256_RESTRICT y8 = reinterpret_cast<uint64_t *>(y1);
@@ -756,34 +1488,28 @@ extern "C" void gf256_memswap(void * GF256_RESTRICT vx, void * GF256_RESTRICT vy
         uint64_t temp = *x8;
         *x8 = *y8;
         *y8 = temp;
-
-        x1 += 8;
-        y1 += 8;
-        bytes -= 8;
     }
 
     // Handle a block of 4 bytes
-    if (bytes >= 4)
+    const int four = bytes & 4;
+    if (four)
     {
-        uint32_t * GF256_RESTRICT x4 = reinterpret_cast<uint32_t *>(x1);
-        uint32_t * GF256_RESTRICT y4 = reinterpret_cast<uint32_t *>(y1);
+        uint32_t * GF256_RESTRICT x4 = reinterpret_cast<uint32_t *>(x1 + eight);
+        uint32_t * GF256_RESTRICT y4 = reinterpret_cast<uint32_t *>(y1 + eight);
 
         uint32_t temp = *x4;
         *x4 = *y4;
         *y4 = temp;
-
-        x1 += 4;
-        y1 += 4;
-        bytes -= 4;
     }
 
     // Handle final bytes
+    const int offset = eight + four;
     uint8_t temp;
-    switch (bytes)
+    switch (bytes & 3)
     {
-    case 3: temp = x1[2]; x1[2] = y1[2]; y1[2] = temp;
-    case 2: temp = x1[1]; x1[1] = y1[1]; y1[1] = temp;
-    case 1: temp = x1[0]; x1[0] = y1[0]; y1[0] = temp;
+    case 3: temp = x1[offset + 2]; x1[offset + 2] = y1[offset + 2]; y1[offset + 2] = temp;
+    case 2: temp = x1[offset + 1]; x1[offset + 1] = y1[offset + 1]; y1[offset + 1] = temp;
+    case 1: temp = x1[offset]; x1[offset] = y1[offset]; y1[offset] = temp;
     default:
         break;
     }

--- a/src/native/third_party/cm256/gf256.h
+++ b/src/native/third_party/cm256/gf256.h
@@ -1,227 +1,283 @@
-/*
-	Copyright (c) 2015 Christopher A. Taylor.  All rights reserved.
+/** \file
+    \brief GF(256) Main C API Header
+    \copyright Copyright (c) 2017 Christopher A. Taylor.  All rights reserved.
 
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
 
-	* Redistributions of source code must retain the above copyright notice,
-	  this list of conditions and the following disclaimer.
-	* Redistributions in binary form must reproduce the above copyright notice,
-	  this list of conditions and the following disclaimer in the documentation
-	  and/or other materials provided with the distribution.
-	* Neither the name of CM256 nor the names of its contributors may be
-	  used to endorse or promote products derived from this software without
-	  specific prior written permission.
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of GF256 nor the names of its contributors may be
+      used to endorse or promote products derived from this software without
+      specific prior written permission.
 
-	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-	AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-	ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-	LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-	CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-	POSSIBILITY OF SUCH DAMAGE.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef GF256_H
-#define GF256_H
+#ifndef CAT_GF256_H
+#define CAT_GF256_H
+
+/** \page GF256 GF(256) Math Module
+
+    This module provides efficient implementations of bulk
+    GF(2^^8) math operations over memory buffers.
+
+    Addition is done over the base field in GF(2) meaning
+    that addition is XOR between memory buffers.
+
+    Multiplication is performed using table lookups via
+    SIMD instructions.  This is somewhat slower than XOR,
+    but fast enough to not become a major bottleneck when
+    used sparingly.
+*/
 
 #include <stdint.h> // uint32_t etc
-#include <string.h> // memcpy, memset
+#include <cstring> // memcpy, memset
 
-// Library version
+/// Library header version
 #define GF256_VERSION 2
 
-// TBD: Fix the polynomial at one value and use precomputed tables here to
-// simplify the API for GF256.h version 2.  Avoids user data alignment issues.
+//------------------------------------------------------------------------------
+// Platform/Architecture
 
+#if defined(ANDROID) || defined(IOS) || defined(LINUX_ARM)
+    #define GF256_TARGET_MOBILE
+#endif // ANDROID
 
-//-----------------------------------------------------------------------------
-// Platform-Specific Definitions
-//
-// Edit these to port to your architecture
+#if defined(__AVX2__) || (defined (_MSC_VER) && _MSC_VER >= 1900)
+    #define GF256_TRY_AVX2 /* 256-bit */
+    #include <immintrin.h>
+    #define GF256_ALIGN_BYTES 32
+#else // __AVX2__
+    #define GF256_ALIGN_BYTES 16
+#endif // __AVX2__
 
-#ifdef _MSC_VER
-
-    // Compiler-specific 128-bit SIMD register keyword
-    #define GF256_M128 __m128i
-
-    // Compiler-specific C++11 restrict keyword
-    #define GF256_RESTRICT __restrict
-
-    // Compiler-specific force inline keyword
-    #define GF256_FORCE_INLINE __forceinline
-
-    // Compiler-specific alignment keyword
-    #define GF256_ALIGNED __declspec(align(16))
-
-    // Compiler-specific SSE headers
-    #include <tmmintrin.h> // SSE3: _mm_shuffle_epi8
+#if !defined(GF256_TARGET_MOBILE)
+    // Note: MSVC currently only supports SSSE3 but not AVX2
+    #include <tmmintrin.h> // SSSE3: _mm_shuffle_epi8
     #include <emmintrin.h> // SSE2
+#endif // GF256_TARGET_MOBILE
 
+#if defined(HAVE_ARM_NEON_H)
+    #include <arm_neon.h>
+#endif // HAVE_ARM_NEON_H
+
+#if defined(GF256_TARGET_MOBILE)
+
+    #define GF256_ALIGNED_ACCESSES /* Inputs must be aligned to GF256_ALIGN_BYTES */
+
+# if defined(HAVE_ARM_NEON_H)
+    // Compiler-specific 128-bit SIMD register keyword
+    #define GF256_M128 uint8x16_t
+    #define GF256_TRY_NEON
 #else
+    #define GF256_M128 uint64_t
+# endif
+
+#else // GF256_TARGET_MOBILE
 
     // Compiler-specific 128-bit SIMD register keyword
     #define GF256_M128 __m128i
 
-    // Compiler-specific C++11 restrict keyword
-    #define GF256_RESTRICT __restrict
+#endif // GF256_TARGET_MOBILE
 
-    // Compiler-specific force inline keyword
-    #define GF256_FORCE_INLINE __attribute__((always_inline))
-
-    // Compiler-specific alignment keyword
-    #define GF256_ALIGNED __attribute__((aligned(16)))
-
-    #include <emmintrin.h> // SSE2
-    #include <tmmintrin.h> // SSE3: _mm_shuffle_epi8
-
+#ifdef GF256_TRY_AVX2
+    // Compiler-specific 256-bit SIMD register keyword
+    #define GF256_M256 __m256i
 #endif
 
+// Compiler-specific C++11 restrict keyword
+#define GF256_RESTRICT __restrict
+
+// Compiler-specific force inline keyword
+#ifdef _MSC_VER
+    #define GF256_FORCE_INLINE inline __forceinline
+#else
+    #define GF256_FORCE_INLINE inline __attribute__((always_inline))
+#endif
+
+// Compiler-specific alignment keyword
+// Note: Alignment only matters for ARM NEON where it should be 16
+#ifdef _MSC_VER
+    #define GF256_ALIGNED __declspec(align(GF256_ALIGN_BYTES))
+#else // _MSC_VER
+    #define GF256_ALIGNED __attribute__((aligned(GF256_ALIGN_BYTES)))
+#endif // _MSC_VER
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // __cplusplus
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Portability
+
+/// Swap two memory buffers in-place
+extern void gf256_memswap(void * GF256_RESTRICT vx, void * GF256_RESTRICT vy, int bytes);
+
+
+//------------------------------------------------------------------------------
 // GF(256) Context
-//
-// The context object stores tables required to perform library calculations.
-//
-// Usage Notes:
-// This struct should be aligned in memory, meaning that a pointer to it should
-// have the low 4 bits cleared.  To achieve this simply tag the gf256_ctx object
-// with the GF256_ALIGNED macro provided above.
 
 #ifdef _MSC_VER
     #pragma warning(push)
     #pragma warning(disable: 4324) // warning C4324: 'gf256_ctx' : structure was padded due to __declspec(align())
-#endif
+#endif // _MSC_VER
 
-struct gf256_ctx // 141,072 bytes
+/// The context object stores tables required to perform library calculations
+struct gf256_ctx
 {
-    // Polynomial used
-    unsigned Polynomial;
+    /// We require memory to be aligned since the SIMD instructions benefit from
+    /// or require aligned accesses to the table data.
+    struct
+    {
+        GF256_ALIGNED GF256_M128 TABLE_LO_Y[256];
+        GF256_ALIGNED GF256_M128 TABLE_HI_Y[256];
+    } MM128;
+#ifdef GF256_TRY_AVX2
+    struct
+    {
+        GF256_ALIGNED GF256_M256 TABLE_LO_Y[256];
+        GF256_ALIGNED GF256_M256 TABLE_HI_Y[256];
+    } MM256;
+#endif // GF256_TRY_AVX2
 
-    // Log/Exp tables
-    uint16_t GF256_LOG_TABLE[256];
-    uint8_t GF256_EXP_TABLE[512 * 2 + 1];
-
-    // Mul/Div/Inv tables
+    /// Mul/Div/Inv/Sqr tables
     uint8_t GF256_MUL_TABLE[256 * 256];
     uint8_t GF256_DIV_TABLE[256 * 256];
     uint8_t GF256_INV_TABLE[256];
+    uint8_t GF256_SQR_TABLE[256];
 
-    // Muladd_mem tables
-    // We require memory to be aligned since the SIMD instructions benefit from
-    // aligned accesses to the MM256_* table data.
-    GF256_M128 MM256_TABLE_LO_Y[256];
-    GF256_M128 MM256_TABLE_HI_Y[256];
+    /// Log/Exp tables
+    uint16_t GF256_LOG_TABLE[256];
+    uint8_t GF256_EXP_TABLE[512 * 2 + 1];
+
+    /// Polynomial used
+    unsigned Polynomial;
 };
 
 #ifdef _MSC_VER
     #pragma warning(pop)
-#endif
+#endif // _MSC_VER
 
-extern struct gf256_ctx GF256Ctx;
+extern gf256_ctx GF256Ctx;
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Initialization
-//
-// Initialize a context, filling in the tables.
-//
-// Thread-safety / Usage Notes:
-//
-// It is perfectly safe and encouraged to use a gf256_ctx object from multiple
-// threads.  The gf256_init() is relatively expensive and should only be done
-// once, though it will take less than a millisecond.
-//
-// The gf256_ctx object must be aligned to 16 byte boundary.
-// Simply tag the object with GF256_ALIGNED to achieve this.
-//
-// Example:
-//    static GF256_ALIGNED gf256_ctx TheGF256Context;
-//    gf256_init(&TheGF256Context, 0);
-//
-// Returns 0 on success and other values on failure.
 
+/**
+    Initialize a context, filling in the tables.
+    
+    Thread-safety / Usage Notes:
+    
+    It is perfectly safe and encouraged to use a gf256_ctx object from multiple
+    threads.  The gf256_init() is relatively expensive and should only be done
+    once, though it will take less than a millisecond.
+    
+    The gf256_ctx object must be aligned to 16 byte boundary.
+    Simply tag the object with GF256_ALIGNED to achieve this.
+    
+    Example:
+       static GF256_ALIGNED gf256_ctx TheGF256Context;
+       gf256_init(&TheGF256Context, 0);
+    
+    Returns 0 on success and other values on failure.
+*/
 extern int gf256_init_(int version);
 #define gf256_init() gf256_init_(GF256_VERSION)
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Math Operations
 
-// return x + y
+/// return x + y
 static GF256_FORCE_INLINE uint8_t gf256_add(uint8_t x, uint8_t y)
 {
-    return x ^ y;
+    return (uint8_t)(x ^ y);
 }
 
-// return x * y
-// For repeated multiplication by a constant, it is faster to put the constant in y.
+/// return x * y
+/// For repeated multiplication by a constant, it is faster to put the constant in y.
 static GF256_FORCE_INLINE uint8_t gf256_mul(uint8_t x, uint8_t y)
 {
     return GF256Ctx.GF256_MUL_TABLE[((unsigned)y << 8) + x];
 }
 
-// return x / y
-// Memory-access optimized for constant divisors in y.
+/// return x / y
+/// Memory-access optimized for constant divisors in y.
 static GF256_FORCE_INLINE uint8_t gf256_div(uint8_t x, uint8_t y)
 {
     return GF256Ctx.GF256_DIV_TABLE[((unsigned)y << 8) + x];
 }
 
-// return 1 / x
+/// return 1 / x
 static GF256_FORCE_INLINE uint8_t gf256_inv(uint8_t x)
 {
     return GF256Ctx.GF256_INV_TABLE[x];
 }
 
-// Performs "x[] += y[]" bulk memory XOR operation
+/// return x * x
+static GF256_FORCE_INLINE uint8_t gf256_sqr(uint8_t x)
+{
+    return GF256Ctx.GF256_SQR_TABLE[x];
+}
+
+
+//------------------------------------------------------------------------------
+// Bulk Memory Math Operations
+
+/// Performs "x[] += y[]" bulk memory XOR operation
 extern void gf256_add_mem(void * GF256_RESTRICT vx,
                           const void * GF256_RESTRICT vy, int bytes);
 
-// Performs "z[] += x[] + y[]" bulk memory operation
+/// Performs "z[] += x[] + y[]" bulk memory operation
 extern void gf256_add2_mem(void * GF256_RESTRICT vz, const void * GF256_RESTRICT vx,
                            const void * GF256_RESTRICT vy, int bytes);
 
-// Performs "z[] = x[] + y[]" bulk memory operation
+/// Performs "z[] = x[] + y[]" bulk memory operation
 extern void gf256_addset_mem(void * GF256_RESTRICT vz, const void * GF256_RESTRICT vx,
                              const void * GF256_RESTRICT vy, int bytes);
 
-// Performs "z[] += x[] * y" bulk memory operation
-extern void gf256_muladd_mem(void * GF256_RESTRICT vz, uint8_t y,
-                             const void * GF256_RESTRICT vx, int bytes);
-
-// Performs "z[] = x[] * y" bulk memory operation
+/// Performs "z[] = x[] * y" bulk memory operation
 extern void gf256_mul_mem(void * GF256_RESTRICT vz,
                           const void * GF256_RESTRICT vx, uint8_t y, int bytes);
 
-// Performs "x[] /= y" bulk memory operation
+/// Performs "z[] += x[] * y" bulk memory operation
+extern void gf256_muladd_mem(void * GF256_RESTRICT vz, uint8_t y,
+                             const void * GF256_RESTRICT vx, int bytes);
+
+/// Performs "x[] /= y" bulk memory operation
 static GF256_FORCE_INLINE void gf256_div_mem(void * GF256_RESTRICT vz,
                                              const void * GF256_RESTRICT vx, uint8_t y, int bytes)
 {
     // Multiply by inverse
-    gf256_mul_mem(vz, vx, GF256Ctx.GF256_INV_TABLE[y], bytes);
+    gf256_mul_mem(vz, vx, y == 1 ? (uint8_t)1 : GF256Ctx.GF256_INV_TABLE[y], bytes);
 }
 
 
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Misc Operations
 
-// Swap two memory buffers in-place
+/// Swap two memory buffers in-place
 extern void gf256_memswap(void * GF256_RESTRICT vx, void * GF256_RESTRICT vy, int bytes);
 
 
 #ifdef __cplusplus
 }
-#endif
+#endif // __cplusplus
 
-
-#endif // GF256_H
+#endif // CAT_GF256_H

--- a/src/native/third_party/isa-l.gyp
+++ b/src/native/third_party/isa-l.gyp
@@ -44,6 +44,10 @@
             'sources': [
                 'isa-l/erasure_code/ec_base.c',
                 'isa-l/erasure_code/ec_highlevel_func.c',
+            ],
+            # compile asm only for x64 until we have support for ppc
+            # see https://github.com/intel/isa-l/issues/7
+            'conditions': [ [ 'node_arch=="x64"', { 'sources': [
                 'isa-l/erasure_code/ec_multibinary.asm',
                 'isa-l/erasure_code/gf_vect_mul_sse.asm',
                 'isa-l/erasure_code/gf_vect_dot_prod_sse.asm',
@@ -91,7 +95,7 @@
                 'isa-l/erasure_code/gf_2vect_mad_avx512.asm',
                 'isa-l/erasure_code/gf_3vect_mad_avx512.asm',
                 'isa-l/erasure_code/gf_4vect_mad_avx512.asm',
-            ],
+            ]}]],
         },
 
         {


### PR DESCRIPTION
CC @liranmauda @yselkowitz @SaravanaStorageNetwork

### Explain the changes
1. Update g256 code from upstream cm256
2. Added condition to only use -msse4.1 when arch=x64
3. Skip isa-l/erasure_code compile on non x64

### Issues: Fixed #xxx / Gap #xxx
1. None

### Testing Instructions:
1. Build linux x64
2. Build s390x
