### PR TITLE
Add a "none" option to chunk code config fields

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -599,17 +599,17 @@ module.exports = {
 
         digest_type: {
             type: 'string',
-            enum: ['sha1', 'sha256', 'sha384', 'sha512']
+            enum: ['sha1', 'sha256', 'sha384', 'sha512', 'none']
         },
 
         compress_type: {
             type: 'string',
-            enum: ['snappy', 'zlib']
+            enum: ['snappy', 'zlib', 'none']
         },
 
         cipher_type: {
             type: 'string',
-            enum: ['aes-256-gcm']
+            enum: ['aes-256-gcm', 'none']
         },
 
         parity_type: {

--- a/src/server/utils/chunk_config_utils.js
+++ b/src/server/utils/chunk_config_utils.js
@@ -12,7 +12,8 @@ function new_chunk_code_config_defaults(chunk_coder_config) {
             cipher_type: config.CHUNK_CODER_CIPHER_TYPE,
             ...chunk_coder_config
         },
-        _.isUndefined);
+        // omit entries with undefined or 'none' values to disable features
+        val => val === undefined || val === 'none');
 
     if (ccc.parity_frags) {
         // Erasure Codes

--- a/src/test/system_tests/ceph_s3_tests_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests_deploy.sh
@@ -29,8 +29,8 @@ commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}'
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
 
-if [ $((current_date-commit_date)) -gt $((3600*24*180)) ]
+if [ $((current_date-commit_date)) -gt $((3600*24*240)) ]
 then
-    echo "ceph tests were not updated for 180 days, Exiting"
+    echo "ceph tests were not updated for 240 days, Exiting"
     exit 1
 fi


### PR DESCRIPTION
### Explain the changes
1. digest_type, compress_type, and cipher_type will now have a 'none' option - meaning no digest/compression or encryption is asked for chunks in this tier 

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #5934 

### Testing Instructions:
1. Set a 'none' on the above fields, for example: 
```
nb.api.tier.update_tier({name: "bvl#kbqlne8r", chunk_coder_config: { compress_type: "none", cipher_type: "none"}})
```
check in DB a new ccc is created with all the above fields not set, but default do: 
```
{ "_id" : ObjectId("5ef0c44bc226db0024923b93"), "system" : ObjectId("5eef0ddf65636b0029b918e2"), "chunk_coder_config" : { "digest_type" : "sha384", "frag_digest_type" : "sha1", "replicas" : 1, "data_frags" : 1, "parity_frags" : 0 }, "last_update" : 1592837195393 }
```