### PR TITLE
fixing issue with agents' rpc

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -70,7 +70,7 @@ function client_factory_from_schema(schema) {
 
     for (const api of Object.values(schema)) {
         if (!api || !api.id || api.id[0] === '_') {
-             continue;
+            continue;
         }
 
         // Skip common api and other apis that do not define methods.
@@ -115,9 +115,31 @@ function client_factory_from_schema(schema) {
     };
 }
 
+function get_protocol_port(protocol) {
+    switch (protocol.toLowerCase()) {
+        case 'http:':
+        case 'ws:': {
+            return '80';
+        }
+        case 'https:':
+        case 'wss:': {
+            return '443';
+        }
+        default: {
+            return '';
+        }
+    }
+}
+
 function new_router_from_base_address(base_address) {
-    const { protocol, hostname, port, slashes } = url.parse(base_address);
-    const ports = get_default_ports(Number(port) || undefined);
+    const {
+        protocol,
+        hostname,
+        port,
+        slashes,
+    } = url.parse(base_address);
+
+    const ports = get_default_ports(Number(port || get_protocol_port(protocol)) || undefined);
 
     return {
         default: url.format({ protocol, slashes, hostname, port: ports.mgmt }),


### PR DESCRIPTION
### Explain the changes
1. After the last changes in  PR #5977 we fixed a issue that was covering on a issue of getting server address without port
2. Now we added a new function that will check if we get a null port when the protocol is a well known one and returns the protocol official port:
ws/http - port 80
wss/http - port 443 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
