### PR TITLE
Fixing issue with removing tiering policies of wrong buckets

### DIFF
--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -728,8 +728,10 @@ class SystemStore extends EventEmitter {
                 data.check_indexes(col, item);
                 let dont_change_last_update = Boolean(item.dont_change_last_update);
                 let updates = _.omit(item, '_id', '$find', 'dont_change_last_update');
-                let finds = item.$find || _.pick(item, '_id');
+                let find_id = _.pick(item, '_id');
+                let finds = item.$find || (mongo_utils.is_object_id(find_id._id) && find_id);
                 if (_.isEmpty(updates)) return;
+                if (!finds) throw new Error(`SystemStore: make_changes id is not of type object_id: ${find_id._id}`);
                 let keys = _.keys(updates);
 
                 if (_.first(keys)[0] === '$') {
@@ -768,6 +770,7 @@ class SystemStore extends EventEmitter {
         _.each(changes.remove, (list, name) => {
             get_collection(name);
             _.each(list, id => {
+                if (!mongo_utils.is_object_id(id)) throw new Error(`SystemStore: make_changes id is not of type object_id: ${id}`);
                 any_news = true;
                 get_bulk(name)
                     .find({
@@ -785,6 +788,7 @@ class SystemStore extends EventEmitter {
         _.each(changes.db_delete, (list, name) => {
             get_collection(name);
             _.each(list, id => {
+                if (!mongo_utils.is_object_id(id)) throw new Error(`SystemStore: make_changes id is not of type object_id: ${id}`);
                 get_bulk(name)
                     .find({
                         _id: id,


### PR DESCRIPTION
### Explain the changes
1. add to system_store check if id is of type object_id for both update and delete - otherwise it will throw exception
2. changed bucket reclaimer to use one make_changes for each run - instead of calling bucket_server multiple times

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed BZ1839117

### Testing Instructions:
1. write multiple files in multiple buckets
2. use delete_bucket_and_objects from bucket_api to delete some of the buckets
3. see the buckets deleted successfully 
4. No log errors and No undeleted buckets with deleted tiering_policy
