### PR TITLE
Backport to 5.4: Add a lock on the load semaphore during make_changes

### DIFF
--- a/src/api/server_inter_process_api.js
+++ b/src/api/server_inter_process_api.js
@@ -14,6 +14,12 @@ module.exports = {
     methods: {
         load_system_store: {
             method: 'POST',
+            params: {
+                type: 'object',
+                properties: {
+                    since: { idate: true }
+                }
+            },
             auth: {
                 system: false
             }

--- a/src/server/common_services/server_inter_process.js
+++ b/src/server/common_services/server_inter_process.js
@@ -18,7 +18,9 @@ const server_rpc = require('../server_rpc');
  *
  */
 async function load_system_store(req) {
-    await system_store.load();
+    await system_store.load(
+        req && req.rpc_params && req.rpc_params.since
+    );
 }
 
 function update_mongo_connection_string(req) {

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -467,12 +467,20 @@ class SystemStore extends EventEmitter {
         }
     }
 
-    async load() {
+    async load(since) {
         // serializing load requests since we have to run a fresh load after the previous one will finish
         // because it might not see the latest changes if we don't reload right after make_changes.
         return this._load_serial.surround(async () => {
             try {
                 dbg.log3('SystemStore: loading ...');
+
+                // If we get a load request with an timestamp older then our last update time
+                // we ensure we load everyting from that timestamp by updating our last_update_time.
+                if (!_.isUndefined(since) && since < this.last_update_time) {
+                    dbg.log0('SystemStore.load: Got load request with a timestamp older then my last update time');
+                    this.last_update_time = since;
+                }
+
                 let new_data = new SystemStoreData();
                 let millistamp = time_utils.millistamp();
                 await this._register_for_changes();
@@ -658,6 +666,28 @@ class SystemStore extends EventEmitter {
      *
      */
     async make_changes(changes) {
+        const { any_news, last_update } = await this._load_serial.surround(
+            () => this._make_changes_internal(changes)
+        );
+
+        // Reloading must be done outside the semapore lock because the load is
+        // locking on the same semaphore.
+        if (any_news) {
+            if (this.is_standalone) {
+                await this.load(last_update);
+            } else {
+                // notify all the cluster (including myself) to reload
+                await server_rpc.client.redirector.publish_to_cluster({
+                    method_api: 'server_inter_process_api',
+                    method_name: 'load_system_store',
+                    target: '',
+                    request_params: { since: last_update }
+                });
+            }
+        }
+    }
+
+    async _make_changes_internal(changes) {
         const bulk_per_collection = {};
         const now = new Date();
         const last_update = now.getTime();
@@ -768,18 +798,7 @@ class SystemStore extends EventEmitter {
             bulk => bulk.length && bulk.execute({ j: true })
         ));
 
-        if (any_news) {
-            if (this.is_standalone) {
-                await this.load();
-            } else {
-                // notify all the cluster (including myself) to reload
-                await server_rpc.client.redirector.publish_to_cluster({
-                    method_api: 'server_inter_process_api',
-                    method_name: 'load_system_store',
-                    target: ''
-                });
-            }
-        }
+        return { any_news, last_update };
     }
 
     make_changes_in_background(changes) {

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -146,7 +146,9 @@ function setup(options = {}) {
         await server_rpc.client.redirector.publish_to_cluster({
             method_api: 'server_inter_process_api',
             method_name: 'load_system_store',
-            target: ''
+            target: '',
+            request_params: {}
+
         });
         await announce('ensure_support_account()');
         await account_server.ensure_support_account();


### PR DESCRIPTION
Also publish the last_update_time for each make_changes so other processes could update thier last udpate time in order to prevent missing some of the changes during the incremental load process.

(cherry picked from commit b99edd15ef7c016d3a808f26c7c4cafb9c48771c)

