### PR TITLE
Add and expose the system state via API  (currently only initialization states)

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -14,6 +14,31 @@ module.exports = {
     id: 'system_api',
 
     methods: {
+        get_system_status: {
+            doc: 'Query for the status of a system',
+            method: 'GET',
+            reply: {
+                type: 'object',
+                required: ['state', 'last_state_change'],
+                properties: {
+                    state: {
+                        type: 'string',
+                        enum: [
+                            'DOES_NOT_EXIST',
+                            'INITIALIZING',
+                            'COULD_NOT_INITIALIZE',
+                            'READY',
+                        ]
+                    },
+                    last_state_change: { idate: true }
+                }
+            },
+            auth: {
+                account: false,
+                system: false,
+                anonymous: true,
+            },
+        },
 
         create_system: {
             doc: 'Create a new system',

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -15,6 +15,26 @@ module.exports = {
         deleted: { date: true },
         name: { type: 'string' },
         owner: { objectid: true }, // account id
+        state: {
+            type: 'object',
+            required: [
+                'mode',
+                'last_update'
+            ],
+            properties: {
+                mode: {
+                    type: 'string',
+                    enum: [
+                        'INITIALIZING',
+                        'COULD_NOT_INITIALIZE',
+                        'READY',
+                    ],
+                },
+                last_update: {
+                    idate: true
+                }
+            }
+        },
         default_chunk_config: { objectid: true },
 
         // links to system resources used for storing install packages


### PR DESCRIPTION
### Explain the changes
1. Add state field to system data
2. Trace the current state of the system and update the field
3. allow querying the state of the system via an API call

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
