### PR TITLE
Adding bucket_claim_owner support for accounts created by operator

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -49,6 +49,9 @@ module.exports = {
                             enum: ['admin', 'user', 'viewer', 'operator']
                         }
                     },
+                    bucket_claim_owner: {
+                        $ref: 'common_api#/definitions/bucket_name'
+                    },
                     //Special handling for the first account created with create_system
                     new_system_parameters: {
                         type: 'object',
@@ -561,6 +564,9 @@ module.exports = {
                 },
                 default_pool: {
                     type: 'string',
+                },
+                bucket_claim_owner: {
+                    $ref: 'common_api#/definitions/bucket_name',
                 },
                 external_connections: {
                     type: 'object',

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -315,8 +315,9 @@ async function authorize_request_policy(req) {
         const method = _get_method_from_req(req);
         const account = await req.object_sdk.rpc_client.account.read_account({});
         // system owner by design can always change bucket policy
-        // bucket owner has FC ACL by design - so no need to check bucket policy
+        // bucket owner and bucket claim owner has FC ACL by design - so no need to check bucket policy
         if (((account.email.unwrap() === system_owner.unwrap()) && req.op_name.endsWith('bucket_policy')) ||
+            (account.bucket_claim_owner && account.bucket_claim_owner.unwrap() === req.params.bucket) ||
             account.email.unwrap() === bucket_owner.unwrap()) return;
         if (!has_bucket_policy_permission(s3_policy, account.email, method, arn_path)) {
             throw new S3Error(S3Error.AccessDenied);

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -69,6 +69,8 @@ module.exports = {
             }
         },
 
+        bucket_claim_owner: { objectid: true },
+
         sync_credentials_cache: {
             type: 'array',
             items: {


### PR DESCRIPTION
### Explain the changes
1. Introducing support to bucket_claim_owner for account created by the noobaa operator as part of the obc flow
2. adapting both account api and schema to support the bucket_claim_owner property
3. if an account has bucket_claim_owner in it - this account will get FC access to the bucket set in this property and will act as another bucket owner to the operator account itself
4. Only the operator account could set such a property on a new account - for other request such a property will be ignored

### Issues: Fixed #xxx / Gap #xxx
1. Partially Fixes BZ#1849771

### Testing Instructions:
1. 
