### PR TITLE
deploy_minikube.sh: Adding support for Centos8

### DIFF
--- a/.travis/deploy_minikube.sh
+++ b/.travis/deploy_minikube.sh
@@ -14,34 +14,67 @@ set -x
 # NOTE: This script was originally copied from the Cojaeger-operator build
 # https://github.com/jaegertracing/jaeger-operator/blob/master/.travis/setupMinikube.sh
 
-# socat is needed for port forwarding
-sudo apt-get update && sudo apt-get install socat && sudo apt-get install conntrack
-
 export MINIKUBE_VERSION=v1.8.2
 export KUBERNETES_VERSION=v1.17.3
 
-sudo mount --make-rshared /
-sudo mount --make-rshared /proc
-sudo mount --make-rshared /sys
+source /etc/os-release
+
+if [ "${ID}" == "ubuntu" ]
+then 
+    # socat is needed for port forwarding
+    sudo apt-get update && sudo apt-get install socat && sudo apt-get install conntrack
+    sudo mount --make-rshared /
+    sudo mount --make-rshared /proc
+    sudo mount --make-rshared /sys
+elif [ "${ID}" == "centos" ]
+then
+    dnf install -y sudo
+    sudo dnf -y update && sudo dnf -y install socat conntrack 
+    dnf install -y dnf-plugins-core
+    sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    sudo dnf install -y docker-ce docker-ce-cli containerd.io --nobest
+    #disable SELinux
+    SELinux_status=$(sestatus | grep "SELinux status" | awk -F ":" '{print $2}' | xargs )
+    if [ "${SELinux_status}" == "enabled" ]
+    then
+        sudo setenforce 0
+    fi
+else
+    echo "${ID} is not supported for ${0}, Exiting."
+    exit 1
+fi
 
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x kubectl &&  \
-    sudo mv kubectl /usr/local/bin/
+    #moving kubectl to /usr/bin/ and not /usr/local/bin/ because on Centos it fails to sudo from /usr/local/bin/
+    # it fails to sudo from /usr/local/bin/ even if it is the ${PATH}
+    sudo mv kubectl /usr/bin/
 
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
     chmod +x minikube &&  \
-    sudo mv minikube /usr/local/bin/minikube
+    #moving minikube to /usr/bin/ and not /usr/local/bin/ because on Centos it fails to sudo from /usr/local/bin/
+    # it fails to sudo from /usr/local/bin/ even if it is the ${PATH}
+    sudo mv minikube /usr/bin/minikube
 
 mkdir "${HOME}"/.kube || true
 touch "${HOME}"/.kube/config
 
 # minikube config
+minikube config set WantUpdateNotification false
 minikube config set WantNoneDriverWarning false
 minikube config set vm-driver none
 
+cat ~/.minikube/config/config.json
+
 minikube version
-sudo minikube start --kubernetes-version=$KUBERNETES_VERSION #--insecure-registry="${LOCAL_IP}:5000" #TODO Remove insecure
-sudo chown -R travis: /home/travis/.minikube/
+#sudo minikube start --kubernetes-version=$KUBERNETES_VERSION #--insecure-registry="${LOCAL_IP}:5000" #TODO Remove insecure
+sudo minikube start --kubernetes-version=$KUBERNETES_VERSION
+
+current_user=$(whoami)
+if [ "${current_user}" != "root"  ]
+then
+    sudo chown -R ${current_user}: /home/${current_user}/.minikube/
+fi
 
 minikube update-context
 


### PR DESCRIPTION
### Explain the changes
deploy_minikube.sh:
- Adding support for Centos8
- Moving minikube and kubectl from /usr/local/bin to /usr/bin