### PR TITLE
[Phase 1] jenkins: initial noobaa-core CentOS CI job converted from Travis CI

### DIFF
--- a/.jenkins/README.md
+++ b/.jenkins/README.md
@@ -1,0 +1,46 @@
+# Continuous Integration Jobs for the CentOS CI
+
+- [dedicated Jenkins instance][noobaa_ci] for NooBaa
+- Jenkins is hosted on [OpenShift in the CentOS CI][app_ci_centos_org]
+- scripts and Jenkins jobs are hosted in <some> repository
+- a Jenkins Pipeline is used to reserve bare metal system(s), and run jobs on
+  those systems
+
+## `.jenkins` Directory Structure
+
+This is the `.jenkins` directory, where all the scripts for the Jenkins jobs
+are maintained. The tests that are executed by the jobs are part of the normal
+project branches.
+
+As an example, the `noobaa-core` Jenkins job consists out of the following
+files:
+
+- `jobs/noobaa-core.yaml` is a [Jenkins Job Builder][jjb] configuration
+  that describes the events when the job should get run and fetches the
+  `.groovy` file from the git repository/branch
+- `noobaa-core.groovy` is the [Jenkins Pipeline][pipeline] that
+  contains the stages for the Jenkins Job itself. In order to work with [the
+  bare-metal machines from the CentOS CI][centos_ci_hw], it executes the
+  following stages:
+
+  1. dynamically allocate a Jenkins Slave (`node('cico-workspace')`) with tools
+     and configuration to request a bare-metal machine
+  1. checkout the repository, which contains scripts in the `.jenkins`
+     directory for provisioning and preparing the environment for running tests
+  1. reserve a bare-metal machine with `cico` (configured on the Jenkins Slave)
+  1. provision the reserved bare-metal machine with additional tools and
+     dependencies to run the test (see `prepare.sh` below)
+  1. run "Unit Tests" and "Build & Sanity Integration Tests" in parallel
+  1. as the final step, return the bare-metal machine to the CentOS CI for
+     other users (it will be re-installed with a minimal CentOS environment
+     again)
+
+- `prepare.sh` installs dependencies for the test, and checks out the git
+  repository and branch (or Pull Request) that contains the commits to be
+  tested (and the test itself)
+
+[noobaa_ci]: https://jenkins-noobaa.apps.ocp.ci.centos.org/
+[app_ci_centos_org]: https://console-openshift-console.apps.ocp.ci.centos.org/k8s/cluster/projects/noobaa
+[jjb]: https://jenkins-job-builder.readthedocs.io/en/latest/index.html
+[pipeline]: https://docs.openstack.org/infra/jenkins-job-builder/project_pipeline.html
+[centos_ci_hw]: https://wiki.centos.org/QaWiki/PubHardware

--- a/.jenkins/jobs/noobaa-core.yaml
+++ b/.jenkins/jobs/noobaa-core.yaml
@@ -1,0 +1,34 @@
+---
+- job:
+    name: noobaa-core
+    project-type: pipeline
+    sandbox: true
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/noobaa/noobaa-core
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    pipeline-scm:
+      scm:
+        - git:
+            name: origin
+            url: https://github.com/noobaa/noobaa-core
+            refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+            branches:
+              - origin/pr/${ghprbPullId}/head
+      script-path: .jenkins/noobaa-core.groovy
+      lightweight-checkout: true
+    triggers:
+      - github-pull-request:
+          status-context: ci/centos/noobaa-core
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/noobaa-core))'
+          permit-all: true
+          # TODO: set github-hooks to true when it is configured in GitHub
+          github-hooks: false
+          cron: 'H/5 * * * *'
+          admin-list:
+            - liranmauda
+          org-list:
+            - noobaa

--- a/.jenkins/noobaa-core.groovy
+++ b/.jenkins/noobaa-core.groovy
@@ -1,0 +1,74 @@
+def cico_retries = 16
+def cico_retry_interval = 60
+def ci_git_repo = 'https://github.com/noobaa/noobaa-core'
+def ci_git_ref = 'master' // default, will be overwritten for PRs
+
+def HASH = '0123abcd' // default, will be overwritten
+def NO_CACHE = 'NO_CACHE=true'
+
+node('cico-workspace') {
+	if (params.ghprbPullId != null) {
+		ci_git_ref = "pull/${ghprbPullId}/head"
+	}
+
+	stage('checkout ci repository') {
+		// TODO: only need to fetch the .jenkins directory, no tags, ..
+		checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
+			userRemoteConfigs: [[url: "${ci_git_repo}", refspec: "${ci_git_ref}"]]])
+		// fetch the first 7 characters of the current commit hash
+		HASH = sh(
+			script: 'git log -1 --format=format:%H | cut -c-7',
+			returnStdout: true
+		).trim()
+		env.IMAGE_TAG = "noobaa-${HASH}"
+		env.TESTER_TAG = "noobaa-tester-${HASH}"
+	}
+
+	stage('reserve bare-metal machine') {
+		def firstAttempt = true
+		retry(30) {
+			if (!firstAttempt) {
+				sleep(time: 5, unit: "MINUTES")
+			}
+			firstAttempt = false
+			cico = sh(
+				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				returnStdout: true
+			).trim().tokenize(' ')
+			env.CICO_NODE = "${cico[0]}.ci.centos.org"
+			env.CICO_SSID = "${cico[1]}"
+		}
+	}
+
+	try {
+		stage('prepare bare-metal machine') {
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./.jenkins/prepare.sh root@${CICO_NODE}:'
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/noobaa-core --gitrepo=${ci_git_repo} --ref=${ci_git_ref}"
+		}
+
+		// real tests start here, and they run in parallel
+		parallel unit: {
+			stage ('Unit Tests') {
+				node ('cico-workspace') {
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE}'"
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test'"
+				}
+			}
+		},
+		build: {
+			stage ('Build & Sanity Integration Tests') {
+				node ('cico-workspace') {
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && ./.travis/deploy_minikube.sh'"
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester NOOBAA_TAG=${IMAGE_TAG} TESTER_TAG=${TESTER_TAG} ${NO_CACHE}'"
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && cd ./src/test/framework/ && ./run_test_job.sh --name ${HASH} --image ${IMAGE_TAG} --tester_image ${TESTER_TAG} --job_yaml ../../../.travis/travis_test_job.yaml --wait'"
+				}
+			}
+		}
+	}
+
+	finally {
+		stage('return bare-metal machine') {
+			sh 'cico node done ${CICO_SSID}'
+		}
+	}
+}

--- a/.jenkins/prepare.sh
+++ b/.jenkins/prepare.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+function usage() {
+    echo "Options:"
+    echo "--help|-h                 specify the flags"
+    echo "--ref                     specify the reference of pr"
+    echo "--workdir                 specify the working directory"
+    echo "--gitrepo                 specify the git repository"
+    echo "--base                    specify the base branch to checkout"
+    echo " "
+    echo "Sample Usage:"
+    echo "./prepare.sh --gitrepo=https://github.com/example --workdir=/opt/build --ref=pull/123/head"
+    exit 0
+}
+
+# In case no value is specified, default values will be used.
+gitrepo="https://github.com/noobaa/noobaa-core"
+workdir="tip/"
+ref="master"
+base="master"
+
+ARGUMENT_LIST=(
+    "ref"
+    "workdir"
+    "gitrepo"
+    "base"
+)
+
+opts=$(getopt \
+    --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")help" \
+    --name "$(basename "${0}")" \
+    --options "" \
+    -- "$@"
+)
+ret=$?
+
+if [ ${ret} -ne 0 ]
+then
+    echo "Try '--help' for more information."
+    exit 1
+fi
+
+eval set -- "${opts}"
+
+while true; do
+    case "${1}" in
+    --help)
+        usage
+        ;;
+    --gitrepo)
+        shift
+        gitrepo=${1}
+        ;;
+    --workdir)
+        shift
+        workdir=${1}
+        ;;
+    --ref)
+        shift
+        ref=${1}
+        echo "${ref}"
+        ;;
+    --base)
+        shift
+        base=${1}
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
+set -x
+
+dnf -y install git make podman
+
+git clone --depth=1 --branch="${base}" "${gitrepo}" "${workdir}"
+cd "${workdir}"
+git fetch origin "${ref}:tip/${ref}"
+git checkout "tip/${ref}"


### PR DESCRIPTION
The noobaa-core Jenkins job runs two tests in parallel on a bare metal
machine reserved through 'cico' in the CentOS CI. The jobs are based on
the configuration in `.travis.yml`.

Steps done in the `noobaa-core.groovy` Jenkins Pipeline:
  - checkout the repository (for scripts in the .jenkins/ directory)
  - reserve a bare metal machine in the CI
  - copy to and run the `prepare.sh` script on the bare metal machine
  - start the two jobs
    - unit test
    - build
  - return the bare metal machine to the CI pool

The `.jenkins/jobs/noobaa-core.yaml` is an example of how the Jenkins
Pipeline can be imported with Jenkins Jobs Builder. It is currently
unused.

This configuration of jobs is based on the Ceph-CSI projects' ci/centos
branch.

---
**Note:** A test Jenkins job does not succeed yet. This has to do with how Docker CE is configured and the CentOS CI restricts network access. A follow-up PR will address this shortcoming.