### PR TITLE
[Phase 2] jenkins: build container images with podman, run with minikube/docker

### DIFF
--- a/.jenkins/build-sanity.groovy
+++ b/.jenkins/build-sanity.groovy
@@ -1,0 +1,67 @@
+def cico_retries = 16
+def cico_retry_interval = 60
+def ci_git_repo = 'https://github.com/noobaa/noobaa-core'
+def ci_git_ref = 'master' // default, will be overwritten for PRs
+
+def HASH = '0123abcd' // default, will be overwritten
+def NO_CACHE = 'NO_CACHE=true'
+// building with Docker fails in the CI due to network restrictions
+def CONTAINER_ENGINE = 'CONTAINER_ENGINE=podman'
+
+node('cico-workspace') {
+	if (params.ghprbPullId != null) {
+		ci_git_ref = "pull/${ghprbPullId}/head"
+	}
+
+	stage('checkout ci repository') {
+		// TODO: only need to fetch the .jenkins directory, no tags, ..
+		checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
+			userRemoteConfigs: [[url: "${ci_git_repo}", refspec: "${ci_git_ref}"]]])
+		// fetch the first 7 characters of the current commit hash
+		HASH = sh(
+			script: 'git log -1 --format=format:%H | cut -c-7',
+			returnStdout: true
+		).trim()
+		env.IMAGE_TAG = "noobaa-${HASH}"
+		env.TESTER_TAG = "noobaa-tester-${HASH}"
+	}
+
+	stage('reserve bare-metal machine') {
+		def firstAttempt = true
+		retry(30) {
+			if (!firstAttempt) {
+				sleep(time: 5, unit: "MINUTES")
+			}
+			firstAttempt = false
+			cico = sh(
+				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				returnStdout: true
+			).trim().tokenize(' ')
+			env.CICO_NODE = "${cico[0]}.ci.centos.org"
+			env.CICO_SSID = "${cico[1]}"
+		}
+	}
+
+	try {
+		stage('prepare bare-metal machine') {
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./.jenkins/prepare.sh root@${CICO_NODE}:'
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/noobaa-core --gitrepo=${ci_git_repo} --ref=${ci_git_ref}"
+		}
+
+		// real test start here
+		stage('Build & Sanity Integration Tests') {
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && ./.travis/deploy_minikube.sh'"
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester NOOBAA_TAG=${IMAGE_TAG} TESTER_TAG=${TESTER_TAG} ${NO_CACHE} ${CONTAINER_ENGINE}'"
+			// images were built with podman, import them in Docker for use with minikube
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman image save ${IMAGE_TAG} | docker image load'"
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman image save ${TESTER_TAG} | docker image load'"
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && cd ./src/test/framework/ && ./run_test_job.sh --name ${HASH} --image localhost/${IMAGE_TAG} --tester_image localhost/${TESTER_TAG} --job_yaml ../../../.travis/travis_test_job.yaml --wait'"
+		}
+	}
+
+	finally {
+		stage('return bare-metal machine') {
+			sh 'cico node done ${CICO_SSID}'
+		}
+	}
+}

--- a/.jenkins/jobs/build-sanity.yaml
+++ b/.jenkins/jobs/build-sanity.yaml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: noobaa-core
+    name: noobaa-core_build-sanity
     project-type: pipeline
     sandbox: true
     concurrent: true
@@ -15,15 +15,15 @@
         - git:
             name: origin
             url: https://github.com/noobaa/noobaa-core
-            refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+            refspec: '+refs/pull/${ghprbPullId}/head:refs/remotes/origin/pr/${ghprbPullId}/head'
             branches:
               - origin/pr/${ghprbPullId}/head
-      script-path: .jenkins/noobaa-core.groovy
+      script-path: .jenkins/build-sanity.groovy
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          status-context: ci/centos/noobaa-core
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/noobaa-core))'
+          status-context: ci/centos/build-sanity
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/build-sanity))'
           permit-all: true
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false

--- a/.jenkins/jobs/unit.yaml
+++ b/.jenkins/jobs/unit.yaml
@@ -1,0 +1,34 @@
+---
+- job:
+    name: noobaa-core_unit
+    project-type: pipeline
+    sandbox: true
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/noobaa/noobaa-core
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    pipeline-scm:
+      scm:
+        - git:
+            name: origin
+            url: https://github.com/noobaa/noobaa-core
+            refspec: '+refs/pull/${ghprbPullId}/head:refs/remotes/origin/pr/${ghprbPullId}/head'
+            branches:
+              - origin/pr/${ghprbPullId}/head
+      script-path: .jenkins/unit.groovy
+      lightweight-checkout: true
+    triggers:
+      - github-pull-request:
+          status-context: ci/centos/unit
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/unit))'
+          permit-all: true
+          # TODO: set github-hooks to true when it is configured in GitHub
+          github-hooks: false
+          cron: 'H/5 * * * *'
+          admin-list:
+            - liranmauda
+          org-list:
+            - noobaa

--- a/.jenkins/noobaa-core.groovy
+++ b/.jenkins/noobaa-core.groovy
@@ -5,6 +5,8 @@ def ci_git_ref = 'master' // default, will be overwritten for PRs
 
 def HASH = '0123abcd' // default, will be overwritten
 def NO_CACHE = 'NO_CACHE=true'
+// building with Docker fails in the CI due to network restrictions
+def CONTAINER_ENGINE = 'CONTAINER_ENGINE=podman'
 
 node('cico-workspace') {
 	if (params.ghprbPullId != null) {
@@ -50,8 +52,8 @@ node('cico-workspace') {
 		parallel unit: {
 			stage ('Unit Tests') {
 				node ('cico-workspace') {
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE}'"
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test'"
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE} ${CONTAINER_ENGINE}'"
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test ${CONTAINER_ENGINE}'"
 				}
 			}
 		},
@@ -59,8 +61,11 @@ node('cico-workspace') {
 			stage ('Build & Sanity Integration Tests') {
 				node ('cico-workspace') {
 					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && ./.travis/deploy_minikube.sh'"
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester NOOBAA_TAG=${IMAGE_TAG} TESTER_TAG=${TESTER_TAG} ${NO_CACHE}'"
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && cd ./src/test/framework/ && ./run_test_job.sh --name ${HASH} --image ${IMAGE_TAG} --tester_image ${TESTER_TAG} --job_yaml ../../../.travis/travis_test_job.yaml --wait'"
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester NOOBAA_TAG=${IMAGE_TAG} TESTER_TAG=${TESTER_TAG} ${NO_CACHE} ${CONTAINER_ENGINE}'"
+					// images were built with podman, import them in Docker for use with minikube
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman image save ${IMAGE_TAG} | docker image load'"
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman image save ${TESTER_TAG} | docker image load'"
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && cd ./src/test/framework/ && ./run_test_job.sh --name ${HASH} --image localhost/${IMAGE_TAG} --tester_image localhost/${TESTER_TAG} --job_yaml ../../../.travis/travis_test_job.yaml --wait'"
 				}
 			}
 		}

--- a/.jenkins/unit.groovy
+++ b/.jenkins/unit.groovy
@@ -48,26 +48,10 @@ node('cico-workspace') {
 			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/noobaa-core --gitrepo=${ci_git_repo} --ref=${ci_git_ref}"
 		}
 
-		// real tests start here, and they run in parallel
-		parallel unit: {
-			stage ('Unit Tests') {
-				node ('cico-workspace') {
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE} ${CONTAINER_ENGINE}'"
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test ${CONTAINER_ENGINE}'"
-				}
-			}
-		},
-		build: {
-			stage ('Build & Sanity Integration Tests') {
-				node ('cico-workspace') {
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && ./.travis/deploy_minikube.sh'"
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester NOOBAA_TAG=${IMAGE_TAG} TESTER_TAG=${TESTER_TAG} ${NO_CACHE} ${CONTAINER_ENGINE}'"
-					// images were built with podman, import them in Docker for use with minikube
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman image save ${IMAGE_TAG} | docker image load'"
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman image save ${TESTER_TAG} | docker image load'"
-					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && cd ./src/test/framework/ && ./run_test_job.sh --name ${HASH} --image localhost/${IMAGE_TAG} --tester_image localhost/${TESTER_TAG} --job_yaml ../../../.travis/travis_test_job.yaml --wait'"
-				}
-			}
+		// real test start here
+		stage('Unit Tests') {
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE} ${CONTAINER_ENGINE}'"
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test ${CONTAINER_ENGINE}'"
 		}
 	}
 

--- a/.jenkins/unit.groovy
+++ b/.jenkins/unit.groovy
@@ -51,7 +51,11 @@ node('cico-workspace') {
 		// real test start here
 		stage('Unit Tests') {
 			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE} ${CONTAINER_ENGINE}'"
-			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test ${CONTAINER_ENGINE}'"
+
+			// abort in case the test hangs
+			timeout(time:30, unit: 'MINUTES') {
+				sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test ${CONTAINER_ENGINE}'"
+			}
 		}
 	}
 


### PR DESCRIPTION
Building container images with Docker in the CentOS CI fails due to some
network conflicts. The containers running under Docker do not have full
access to the internet.

Instead of reconfiguring the whole deployment, build the container
images with podman. After building, the images will not be available in
the local Docker registry, so export and import them.
