### PR TITLE
Fixes #5993 - fixes unzipping a function package with node_modules

### DIFF
--- a/src/util/zip_utils.js
+++ b/src/util/zip_utils.js
@@ -91,9 +91,10 @@ function unzip_to_mem(zipfile) {
 
 function unzip_to_dir(zipfile, dir) {
     return unzip_to_callback(zipfile, (entry, stream) => {
-        const path_name = path.resolve(dir, '.' + path.sep + entry.fileName.toString());
+        const filename = entry.fileName.toString();
+        const path_name = path.resolve(dir, '.' + path.sep + filename);
         // directory ends with '/'
-        if (path_name.endsWith('/')) {
+        if (filename.endsWith('/')) {
             return fs_utils.create_path(path_name);
         }
         return P.resolve()


### PR DESCRIPTION
### Explain the changes
1. when a function package contained node_modules it was not recognized as a directory
2. the problem was that `path.resolve` omitted the `/` at the end of the `path_name`
3. testing the original `filename` for `/` instead of `path_name`

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #5993 

### Testing Instructions:
1. From the UI - create a new function and upload the attached `wc.zip` code package
2. Try to invoke (**Set Event And Invoke** under Code tab in Functions section)


[wc.zip](https://github.com/noobaa/noobaa-core/files/4926692/wc.zip)
