### PR TITLE
Handle add/remove/get tags from cache/hub buckets

### DIFF
--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -379,15 +379,34 @@ class NamespaceCache {
     ////////////////////
 
     async get_object_tagging(params, object_sdk) {
+
+        const object_md = await this.read_object_md(params, object_sdk);
+        if (object_md.should_read_from_cache) {
+            return this.namespace_nb.get_object_tagging(params, object_sdk);
+        }
         return this.namespace_hub.get_object_tagging(params, object_sdk);
     }
 
     async delete_object_tagging(params, object_sdk) {
-        return this.namespace_hub.delete_object_tagging(params, object_sdk);
+
+        const res = this.namespace_hub.delete_object_tagging(params, object_sdk);
+        try {
+            await this.namespace_nb.delete_object_tagging(params, object_sdk);
+        } catch (err) {
+            dbg.log0('failed to delete tags in cache', { params: _.omit(params, 'source_stream')});
+        }
+        return res;
     }
 
     async put_object_tagging(params, object_sdk) {
-        return this.namespace_hub.put_object_tagging(params, object_sdk);
+
+        const res = await this.namespace_hub.put_object_tagging(params, object_sdk);
+        try {
+            await this.namespace_nb.put_object_tagging(params, object_sdk);
+        } catch (err) {
+            dbg.log0('failed to store tags in cache', { params: _.omit(params, 'source_stream')});
+        }
+        return res;
     }
 
     //////////////////////////


### PR DESCRIPTION
### Explain the changes
1. Handle add/get/delete tags for cache buckets.
2. On an add tag, the tag is added to a cache bucket only if the tag is successfully added to the hub. This takes care of a hub bucket supporting a tag
3. A get tag will retrieve a tag from cache (cache hit) or the hub (cache miss)
4. Delete tag will remove the tag from hub and cache
Any errors encountered during tag operation on cache are logged but hub status is returned to the client.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
