### PR TITLE
Replace Bluebird with Promise - next stage

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -329,8 +329,8 @@ class AgentCLI {
             current_path = current_path.replace('./', '');
             //hiding storage folder
             return child_process.execAsync('attrib +H ' + current_path)
-                .then(() => P.join(os_utils.is_folder_permissions_set(current_path), fs.readdirAsync(current_path)))
-                .spread(function(permissions_set, noobaa_storage_initialization) {
+                .then(() => Promise.all([os_utils.is_folder_permissions_set(current_path), fs.readdirAsync(current_path)]))
+                .then(([permissions_set, noobaa_storage_initialization]) => {
                     if (!permissions_set) {
                         if (_.isEmpty(noobaa_storage_initialization)) {
                             dbg.log0('First time icacls configuration');

--- a/src/agent/agent_diagnostics.js
+++ b/src/agent/agent_diagnostics.js
@@ -68,7 +68,7 @@ function collect_agent_diagnostics(storage_path) {
                 });
         })
         .finally(() => diag_log.end())
-        .return()
+        .then(() => undefined)
         .catch(err => {
             console.error('Error in collecting server diagnostics', err);
             throw new Error('Error in collecting server diagnostics ' + err);

--- a/src/agent/agent_wrap.js
+++ b/src/agent/agent_wrap.js
@@ -49,7 +49,7 @@ let address = "";
 let new_backup_dir = CONFIGURATION.BACKUP_DIR;
 
 function _download_file(request_url, output) {
-    return new P((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         request.get({
                 url: request_url,
                 strictSSL: false,
@@ -66,7 +66,7 @@ function _download_file(request_url, output) {
 }
 
 async function run_agent_cli(agent_args = []) {
-    return new P((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         const args = [CONFIGURATION.AGENT_CLI, ...agent_args];
         const agent_cli_proc = child_process.spawn('./node', args, {
             stdio: ['ignore', 'ignore', 'ignore', 'ipc'],

--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -150,9 +150,10 @@ class BlockStoreClient {
                 bucket = google.bucket(bs_info.target_bucket);
                 const block_key = `${bs_info.blocks_path}/${block_dir}/${block_id}`;
                 const file = bucket.file(block_key);
-                const [data, md_res] = await P.join(
+                const [data, md_res] = await Promise.all([
                     buffer_utils.read_stream_join(file.createReadStream()),
-                    file.getMetadata());
+                    file.getMetadata()
+                ]);
                 const block_md_b64 =
                     _.get(md_res[0], 'metadata.noobaablockmd') ||
                     _.get(md_res[0], 'metadata.noobaa_block_md');

--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -120,9 +120,10 @@ class BlockStoreGoogle extends BlockStoreBase {
         try {
             const block_key = this._block_key(block_md.id);
             const file = this.bucket.file(block_key);
-            const [data, md_res] = await P.join(
+            const [data, md_res] = await Promise.all([
                 buffer_utils.read_stream_join(file.createReadStream()),
-                file.getMetadata());
+                file.getMetadata()
+            ]);
             const block_md_b64 =
                 _.get(md_res[0], 'metadata.noobaablockmd') ||
                 _.get(md_res[0], 'metadata.noobaa_block_md');

--- a/src/agent/func_services/func_node.js
+++ b/src/agent/func_services/func_node.js
@@ -30,7 +30,7 @@ class FuncNode {
 
     invoke_func(req) {
         return this._load_func_code(req)
-            .then(func => new P((resolve, reject) => {
+            .then(func => new Promise((resolve, reject) => {
                 const proc = child_process.fork(FUNC_PROC_PATH, [], {
                         cwd: func.code_dir,
                         stdio: 'inherit',

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -15,7 +15,6 @@ const http = require('http');
 const https = require('https');
 const FtpSrv = require('ftp-srv');
 const os = require('os');
-const P = require('../util/promise');
 const FuncSDK = require('../sdk/func_sdk');
 const ObjectIO = require('../sdk/object_io');
 const ObjectSDK = require('../sdk/object_sdk');
@@ -304,7 +303,7 @@ function unavailable_handler(req, res) {
 }
 
 function listen_http(port, server) {
-    return new P((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         setup_http_server(server);
         server.listen(port, err => {
             if (err) {

--- a/src/endpoint/ftp/ftp_filesystem.js
+++ b/src/endpoint/ftp/ftp_filesystem.js
@@ -90,7 +90,6 @@ class FtpFileSystemNB {
                 delimiter: '/',
                 limit: 100
             }))
-            .tap(console.log)
             .then(res => {
                 console.log(`in get - got res = `, res);
                 if (res.objects.length) {
@@ -101,7 +100,10 @@ class FtpFileSystemNB {
                     return this._get_new_file_stats_object(name, true, 0, new Date());
                 }
             })
-            .tap(console.log)
+            .then(res => {
+                console.log(res);
+                return res;
+            })
             .catch(err => {
                 dbg.error('got error in get(). ', err);
                 err.code = 'ENOENT';
@@ -123,12 +125,18 @@ class FtpFileSystemNB {
         console.log(`calling list_objects with params =`, params);
 
         return this.authenticate.then(() => this.object_sdk.list_objects(params))
-            .tap(console.log)
+            .then(res => {
+                console.log(res);
+                return res;
+            })
             .then(res => [this._get_new_file_stats_object('.', true, 0, new Date())]
                 .concat(res.objects.filter(obj => !obj.key.endsWith('/')) // filter out dirs
                     .map(obj => this._get_new_file_stats_object(path.parse(obj.key).base, false, obj.size, obj.create_time)))
                 .concat(res.common_prefixes.map(prefix => this._get_new_file_stats_object(path.parse(prefix).base, true, 0, new Date()))))
-            .tap(list => console.log(`retruning list`, list));
+            .then(list => {
+                console.log(`returning list`, list);
+                return list;
+            });
     }
 
     chdir(dir_path = '.') {

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -52,7 +52,9 @@ class HostedAgents {
                 dbg.error(`failed starting hosted_agents: ${err.stack}`);
                 throw err;
             })
-            .return();
+            .then(() => {
+                // do nothing. 
+            });
     }
 
     /**

--- a/src/rpc/ice.js
+++ b/src/rpc/ice.js
@@ -276,13 +276,13 @@ Ice.prototype.accept = function(remote_info) {
  */
 Ice.prototype._add_local_candidates = function() {
     var self = this;
-    return P.join(
+    return Promise.all([
             self._add_udp_candidates(),
             self._add_tcp_active_candidates(),
             self._add_tcp_permanent_passive_candidates(),
             self._add_tcp_transient_passive_candidates(),
             self._add_tcp_simultaneous_open_candidates()
-        )
+        ])
         .then(function() {
             return {
                 credentials: self.local_credentials,
@@ -1496,7 +1496,7 @@ function listen_on_port_range(port_range) {
         server.listen(port);
         // wait for listen even, while also watching for error/close.
         return promise_utils.wait_for_event(server, 'listening')
-            .return(server)
+            .then(() => server)
             .catch(function(err) {
                 dbg.log1('ICE listen_on_port_range: FAILED', port, err);
                 server.close();

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -904,7 +904,8 @@ class RPC extends EventEmitter {
         dbg.log0('RPC register_tcp_transport');
         const tcp_server = new RpcTcpServer(tls_options);
         tcp_server.on('connection', conn => this._accept_new_connection(conn));
-        return P.resolve(tcp_server.listen(port)).return(tcp_server);
+        return Promise.resolve(tcp_server.listen(port))
+            .then(() => tcp_server);
     }
 
 
@@ -917,7 +918,8 @@ class RPC extends EventEmitter {
         dbg.log0('RPC register_ntcp_transport');
         const ntcp_server = new RpcNtcpServer(tls_options);
         ntcp_server.on('connection', conn => this._accept_new_connection(conn));
-        return P.resolve(ntcp_server.listen(port)).return(ntcp_server);
+        return Promise.resolve(ntcp_server.listen(port))
+            .then(() => ntcp_server);
     }
 
 

--- a/src/rpc/rpc_http_server.js
+++ b/src/rpc/rpc_http_server.js
@@ -53,7 +53,7 @@ class RpcHttpServer extends events.EventEmitter {
             http.createServer();
         this.install_on_server(server, options.default_handler);
         return P.fromCallback(callback => server.listen(port, callback))
-            .return(server);
+            .then(() => server);
     }
 
     /**

--- a/src/rpc/stun.js
+++ b/src/rpc/stun.js
@@ -5,6 +5,7 @@
 var _ = require('lodash');
 var util = require('util');
 var P = require('../util/promise');
+const promise_utils = require('../util/promise_utils');
 var url = require('url');
 // var util = require('util');
 var dgram = require('dgram');
@@ -614,10 +615,10 @@ function test() {
                 if (argv.random) {
                     stun_url = chance.pick(stun.PUBLIC_SERVERS);
                 }
-                return P.join(
+                return Promise.all([
                         P.ninvoke(socket, 'send', req, 0, req.length, stun_url.port, stun_url.hostname),
-                        P.ninvoke(socket, 'send', ind, 0, ind.length, stun_url.port, stun_url.hostname))
-                    .delay(stun.INDICATION_INTERVAL * chance.floating(stun.INDICATION_JITTER))
+                        P.ninvoke(socket, 'send', ind, 0, ind.length, stun_url.port, stun_url.hostname)])
+                    .then(promise_utils.delay(stun.INDICATION_INTERVAL * chance.floating(stun.INDICATION_JITTER)))
                     .then(loop);
             }
         });

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -133,7 +133,7 @@ class NamespaceBlob {
             this.container,
             inspect(_.omit(params, 'object_md.ns'))
         );
-        return new P((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             let count = 1;
             const count_stream = stream_utils.get_tap_stream(data => {
                 stats_collector.instance(this.rpc_client).update_namespace_read_stats({

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -5,7 +5,6 @@ const _ = require('lodash');
 const AWS = require('aws-sdk');
 const util = require('util');
 
-const P = require('../util/promise');
 const dbg = require('../util/debug_module')(__filename);
 const stream_utils = require('../util/stream_utils');
 const s3_utils = require('../endpoint/s3/s3_utils');
@@ -169,7 +168,7 @@ class NamespaceS3 {
 
     async read_object_stream(params, object_sdk) {
         dbg.log0('NamespaceS3.read_object_stream:', this.bucket, inspect(_.omit(params, 'object_md.ns')));
-        return new P((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const request = {
                 Key: params.key,
                 Range: params.end ? `bytes=${params.start}-${params.end - 1}` : undefined,

--- a/src/server/bg_services/agent_blocks_verifier.js
+++ b/src/server/bg_services/agent_blocks_verifier.js
@@ -108,7 +108,9 @@ class AgentBlocksVerifier {
                         });
                 });
             })
-            .return();
+            .then(() => {
+                // return nothing. 
+            });
     }
 
 

--- a/src/server/bg_services/dedup_indexer.js
+++ b/src/server/bg_services/dedup_indexer.js
@@ -34,10 +34,10 @@ function background_worker() {
         .then(() => {
             if (this.last_check && Date.now() - this.last_check < config.DEDUP_INDEXER_CHECK_INDEX_CYCLE) return;
             dbg.log0('DEDUP_INDEXER: checking index size ...');
-            return P.join(
+            return Promise.all([
                     MDStore.instance().get_dedup_index_size(),
                     MDStore.instance().get_aprox_dedup_keys_number()
-                )
+                ])
                 .then(([dedup_index_size, dedup_aprox_keys]) => {
                     dbg.log0('DEDUP_INDEXER: dedup_index_size', dedup_index_size, 'dedup_aprox_keys', dedup_aprox_keys);
                     this.last_check = Date.now();

--- a/src/server/bg_services/md_aggregator.js
+++ b/src/server/bg_services/md_aggregator.js
@@ -254,22 +254,21 @@ function range_md_aggregator({
     const buckets = filtered_buckets.slice(0, config.MD_AGGREGATOR_BATCH);
     const pools = filtered_pools.slice(0, config.MD_AGGREGATOR_BATCH);
 
-    return P.join(
+    return Promise.all([
             md_store.aggregate_chunks_by_create_dates(from_time, till_time),
             md_store.aggregate_chunks_by_delete_dates(from_time, till_time),
             md_store.aggregate_objects_by_create_dates(from_time, till_time),
             md_store.aggregate_objects_by_delete_dates(from_time, till_time),
             md_store.aggregate_blocks_by_create_dates(from_time, till_time),
             md_store.aggregate_blocks_by_delete_dates(from_time, till_time)
-        )
-        .spread((
-            existing_chunks_aggregate,
+        ])
+        .then(([existing_chunks_aggregate,
             deleted_chunks_aggregate,
             existing_objects_aggregate,
             deleted_objects_aggregate,
             existing_blocks_aggregate,
-            deleted_blocks_aggregate) => {
-
+            deleted_blocks_aggregate
+        ]) => {
             dbg.log3('range_md_aggregator:',
                 'from_time', from_time,
                 'till_time', till_time,

--- a/src/server/common_services/server_inter_process.js
+++ b/src/server/common_services/server_inter_process.js
@@ -33,7 +33,9 @@ function update_mongo_connection_string(req) {
                 load_system_store();
             }
         })
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 function update_master_change(req) {

--- a/src/server/func_services/func_server.js
+++ b/src/server/func_services/func_server.js
@@ -291,7 +291,7 @@ function invoke_func(req) {
                 took: Date.now() - time.getTime(),
                 error: res.error ? true : undefined,
             })
-            .return(res)
+            .then(() => res)
         );
 }
 
@@ -344,7 +344,7 @@ function _get_func_code_stream(req, func_code) {
         });
         return get_object_req.createReadStream();
     } else if (func_code.url) {
-        return new P((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             console.log(`reading function code from ${func_code.url}`);
             request({
                     url: func_code.url,

--- a/src/server/func_services/func_store.js
+++ b/src/server/func_services/func_store.js
@@ -128,7 +128,7 @@ class FuncStore {
         const code_stream = params.code_stream;
         const sha256 = crypto.createHash('sha256');
         var size = 0;
-        return new P((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const upload_stream = this._func_code.gridfs().openUploadStream(
                 this.code_filename(system, name, version));
             code_stream

--- a/src/server/node_services/node_allocator.js
+++ b/src/server/node_services/node_allocator.js
@@ -127,10 +127,10 @@ async function refresh_tiering_alloc(tiering, force) {
             })
         });
     }
-    await P.join(
+    await Promise.all([
         P.map(pools, pool => refresh_pool_alloc(pool, force)).then(() => { /*void*/ }),
         refresh_tiers_alloc([tiering], force),
-    );
+    ]);
 }
 
 /**

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -37,7 +37,10 @@ class NodesClient {
                     role: 'admin'
                 })
             })
-            .tap(res => db_client.instance().fix_id_type(res.nodes));
+            .then(res => {
+                db_client.instance().fix_id_type(res.nodes);
+                return res;
+            });
     }
 
     list_nodes_by_pool(pool_name, system_id) {
@@ -52,7 +55,10 @@ class NodesClient {
                     role: 'admin'
                 })
             })
-            .tap(res => db_client.instance().fix_id_type(res.nodes));
+            .then(res => {
+                db_client.instance().fix_id_type(res.nodes);
+                return res;
+            });
     }
 
     list_nodes_by_identity(system_id, nodes_identities, fields) {
@@ -65,7 +71,10 @@ class NodesClient {
                     role: 'admin'
                 })
             })
-            .tap(res => db_client.instance().fix_id_type(res.nodes));
+            .then(res => {
+                db_client.instance().fix_id_type(res.nodes);
+                return res;
+            });
     }
 
     get_nodes_stats_by_cloud_service(system_id, start_date, end_date) {
@@ -148,7 +157,10 @@ class NodesClient {
                     role: 'admin'
                 })
             })
-            .tap(node => db_client.instance().fix_id_type(node));
+            .then(node => {
+                db_client.instance().fix_id_type(node);
+                return node;
+            });
     }
 
     read_node_by_id(system_id, node_id) {
@@ -164,7 +176,10 @@ class NodesClient {
                     role: 'admin'
                 })
             })
-            .tap(node => db_client.instance().fix_id_type(node));
+            .then(node => {
+                db_client.instance().fix_id_type(node);
+                return node;
+            });
     }
 
     get_node_ids_by_name(system_id, identity, by_host) {
@@ -215,7 +230,10 @@ class NodesClient {
                     role: 'admin'
                 })
             }))
-            .tap(res => res.latency_groups.forEach(group => db_client.instance().fix_id_type(group.nodes)));
+            .then(res => {
+                res.latency_groups.forEach(group => db_client.instance().fix_id_type(group.nodes));
+                return res;
+            });
     }
 
     /**

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -253,7 +253,9 @@ class NodesMonitor extends EventEmitter {
     sync_to_store() {
         return P.resolve()
             .then(() => this._run())
-            .return();
+            .then(() => {
+                // do nothing. 
+            });
     }
 
     async sync_storage_to_store() {
@@ -1024,7 +1026,9 @@ class NodesMonitor extends EventEmitter {
                 this._update_status(item);
             })
             .then(() => this._update_nodes_store('force'))
-            .return();
+            .then(() => {
+                // do nothing. 
+            });
     }
 
     _hide_node(item) {
@@ -1499,11 +1503,11 @@ class NodesMonitor extends EventEmitter {
         if (!item.node_from_store) return;
         dbg.log0('_test_nodes_validity::', item.node.name);
         return P.resolve()
-            .then(() => P.join(
+            .then(() => Promise.all([
                 this._test_network_perf(item),
                 this._test_store(item),
                 this._test_network_to_server(item)
-            ))
+            ]))
             .then(() => {
                 if (item.io_reported_errors &&
                     Date.now() - item.io_reported_errors > config.NODE_IO_DETENTION_THRESHOLD) {
@@ -1561,11 +1565,11 @@ class NodesMonitor extends EventEmitter {
             // the set is cleared to collect new changes during the update
             this._set_need_update = new Set();
 
-            return P.join(
+            return Promise.all([
                     this._update_existing_nodes(existing_nodes),
                     this._update_new_nodes(new_nodes),
                     this._update_deleted_nodes(deleted_nodes)
-                )
+            ])
                 .catch(err => {
                     dbg.warn('_update_nodes_store: had errors', err);
                 });

--- a/src/server/notifications/dispatcher.js
+++ b/src/server/notifications/dispatcher.js
@@ -94,7 +94,7 @@ class Dispatcher {
                     l.desc = log_item.desc.split('\n');
                 }
                 return P.resolve(self._resolve_activity_item(log_item, l))
-                    .return(l);
+                    .then(() => l);
             }))
             .then(logs => ({ logs }));
     }

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1945,13 +1945,13 @@ async function _complete_object_multiparts(obj, multipart_req) {
     // for (const mp of unused_multiparts) dbg.log0('TODO GGG DELETE UNUSED MULTIPART', JSON.stringify(mp));
     // for (const part of unused_parts) dbg.log0('TODO GGG DELETE UNUSED PART', JSON.stringify(part));
 
-    await P.join(
+    await Promise.all([
         context.parts_updates.length && MDStore.instance().update_parts_in_bulk(context.parts_updates),
         used_multiparts_ids.length && MDStore.instance().update_multiparts_by_ids(used_multiparts_ids, undefined, { uncommitted: 1 }),
         unused_parts.length && MDStore.instance().delete_parts(unused_parts),
         unused_multiparts.length && MDStore.instance().delete_multiparts(unused_multiparts),
         chunks_to_dereference.length && map_deleter.delete_chunks_if_unreferenced(chunks_to_dereference),
-    );
+    ]);
 
     return {
         size: context.pos,

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -568,7 +568,9 @@ function reset_password(req) {
             account: account._id,
             desc: `${account.email.unwrap()} was updated by ${req.account.email.unwrap()}: reset password`,
         }))
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 
 }
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1156,7 +1156,9 @@ function add_bucket_lambda_trigger(req) {
                 }
             });
         })
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 /**
@@ -1184,7 +1186,9 @@ function delete_bucket_lambda_trigger(req) {
                     }
                 }]
             }
-        })).return();
+        })).then(() => {
+            // do nothing. 
+        });
 }
 
 function update_bucket_lambda_trigger(req) {
@@ -1208,7 +1212,9 @@ function update_bucket_lambda_trigger(req) {
                 }]
             }
         }))
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -583,7 +583,9 @@ function delete_namespace_resource(req) {
                 }
             });
         })
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 async function delete_hosts_pool(req, pool) {
@@ -719,7 +721,9 @@ function delete_resource_pool(req, pool) {
                 });
             }
         })
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 function get_associated_buckets(req) {

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -554,7 +554,7 @@ function get_nodes_stats(req) {
     const system = system_store.data.systems[0];
     const support_account = _.find(system_store.data.accounts, account => account.is_support);
 
-    return P.join(
+    return Promise.all([
             server_rpc.client.node.list_nodes({}, {
                 auth_token: auth_server.make_auth_token({
                     system_id: system._id,
@@ -568,8 +568,8 @@ function get_nodes_stats(req) {
                     role: 'admin',
                     account_id: support_account._id
                 })
-            }))
-        .spread((nodes_results, hosts_results) => {
+            })])
+        .then(([nodes_results, hosts_results]) => {
             //Collect nodes stats
             for (const node of nodes_results.nodes) {
                 if (node.has_issues) {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -906,7 +906,7 @@ function attempt_server_resolve(req) {
                 return P.fromCallback(callback => request(options, callback), {
                         multiArgs: true
                     })
-                    .spread(function(response, reply) {
+                    .then(([response, reply]) => {
                         dbg.log0('Received Response From DNS Name', response.statusCode);
                         if (response.statusCode !== 200 || String(reply) !== pkg.version) {
                             dbg.error('version failed');

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -299,7 +299,7 @@ function send_master_update(is_master, master_address) {
         target: '', // required but irrelevant
         request_params: { master_address, is_master }
     });
-    return P.join(
+    return Promise.all([
             server_rpc.client.system.set_webserver_master_state({
                 is_master: is_master
             }, {
@@ -310,8 +310,10 @@ function send_master_update(is_master, master_address) {
             }).catch(err => dbg.error('got error on set_webserver_master_state.', err)),
             hosted_agents_promise.catch(err => dbg.error('got error on hosted_agents_promise.', err)),
             update_master_promise.catch(err => dbg.error('got error on update_master_promise.', err))
-        )
-        .return();
+    ])
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 function get_min_requirements() {

--- a/src/test/pipeline/dataset.js
+++ b/src/test/pipeline/dataset.js
@@ -782,7 +782,7 @@ function run_replay() {
         input: fs.createReadStream(argv.replay),
         terminal: false
     });
-    return new P((resolve, reject) => {
+    return new Promise((resolve, reject) => {
             readfile
                 .on('line', line => journal.push(line))
                 .once('error', reject)

--- a/src/test/system_tests/test_md_aggregator.js
+++ b/src/test/system_tests/test_md_aggregator.js
@@ -37,7 +37,9 @@ function create_auth() {
     return P.fcall(function() {
             return client.create_auth_token(auth_params);
         })
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 // Services is an array of strings for each service or ['all']
@@ -125,7 +127,7 @@ function prepare_buckets_with_objects() {
         })
         .then(() => control_services('restart', ['all']))
         .then(() => wait_for_s3_and_web(SERVICES_WAIT_IN_SECONDS))
-        .return(buckets_used);
+        .then(() => buckets_used);
 }
 
 function calculate_expected_storage_stats_for_buckets(buckets_array, storage_read_by_bucket) {
@@ -225,7 +227,9 @@ function wait_for_s3_and_web(max_seconds_to_wait) {
             wait_for_server_to_start(max_seconds_to_wait, String(process.env.PORT) || 8080),
             wait_for_mongodb_to_start(max_seconds_to_wait)
         ])
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 function wait_for_mongodb_to_start(max_seconds_to_wait) {
@@ -262,7 +266,9 @@ function wait_for_mongodb_to_start(max_seconds_to_wait) {
                         return P.delay(1000);
                     });
             })
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 function wait_for_server_to_start(max_seconds_to_wait, port) {
@@ -295,5 +301,7 @@ function wait_for_server_to_start(max_seconds_to_wait, port) {
                         return P.delay(1000);
                     });
             })
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }

--- a/src/test/unit_tests/test_agent_blocks_reclaimer.js
+++ b/src/test/unit_tests/test_agent_blocks_reclaimer.js
@@ -240,7 +240,7 @@ mocha.describe('not mocked agent_blocks_reclaimer', function() {
     }
 
     function verify_nodes_mapping() {
-        return P.all(_.map(nodes_list, node => P.join(
+        return Promise.all([_.map(nodes_list, node => Promise.all([
             rpc_client.object.read_node_mapping({
                 name: node.name,
                 adminfo: true,
@@ -250,7 +250,7 @@ mocha.describe('not mocked agent_blocks_reclaimer', function() {
                 by_host: true,
                 adminfo: true,
             })
-        )));
+        ]))]);
     }
 
 });

--- a/src/test/unit_tests/test_fs_utils.js
+++ b/src/test/unit_tests/test_fs_utils.js
@@ -5,7 +5,6 @@
 var mocha = require('mocha');
 var assert = require('assert');
 
-var P = require('../../util/promise');
 var fs_utils = require('../../util/fs_utils');
 
 function log(...args) {
@@ -22,10 +21,9 @@ mocha.describe('fs_utils', function() {
     mocha.describe('disk_usage', function() {
 
         mocha.it('should work on the src', function() {
-            return P.join(
-                fs_utils.disk_usage('src/server'),
+            return Promise.all([fs_utils.disk_usage('src/server'),
                 fs_utils.disk_usage('src/test')
-            ).spread((server_usage, test_usage) => {
+            ]).then(([server_usage, test_usage]) => {
                 log('disk_usage of src:', server_usage);
                 log('disk_usage of src/test:', test_usage);
                 assert(test_usage.size / server_usage.size > 0.50,

--- a/src/test/unit_tests/test_map_builder.js
+++ b/src/test/unit_tests/test_map_builder.js
@@ -14,7 +14,6 @@ const assert = require('assert');
 const crypto = require('crypto');
 const config = require('../../../config');
 
-const P = require('../../util/promise');
 const MDStore = require('../../server/object_services/md_store').MDStore;
 const ObjectIO = require('../../sdk/object_io');
 // const map_writer = require('../../server/object_services/map_writer');
@@ -251,10 +250,10 @@ coretest.describe_mapper_test_case({
 
     async function delete_blocks(blocks) {
         coretest.log('Deleting blocks', blocks.map(block => _.pick(block, '_id', 'size', 'frag.id')));
-        return P.join(
+        return Promise.all([
             map_deleter.delete_blocks_from_nodes(blocks),
             MDStore.instance().update_blocks_by_ids(_.map(blocks, '_id'), { deleted: new Date() })
-        );
+        ]);
     }
 
     /**

--- a/src/test/unit_tests/test_promise_utils.js
+++ b/src/test/unit_tests/test_promise_utils.js
@@ -14,7 +14,7 @@ mocha.describe('promise_utils', function() {
 
         mocha.it('should handle small array', function() {
             return promise_utils.iterate([1, 2, 3, 4], function(i) {
-                return P.delay();
+                return promise_utils.delay();
             });
         });
 

--- a/src/test/unit_tests/test_s3_list_objects.js
+++ b/src/test/unit_tests/test_s3_list_objects.js
@@ -530,14 +530,15 @@ function clean_up_after_case(array_of_names, abort_upload) {
 
 function run_case(array_of_names, case_func, only_initiate) {
     let response_array = [];
-    return P.resolve()
+    return Promise.resolve()
         .then(function() {
             return only_initiate ?
                 initiate_upload_multiple_files(array_of_names) :
                 upload_multiple_files(array_of_names);
         })
-        .tap(response => {
+        .then(response => {
             response_array = response;
+            return response;
         })
         .then(response => case_func(response))
         .then(() => clean_up_after_case(only_initiate ? response_array : array_of_names, only_initiate));
@@ -597,6 +598,6 @@ function truncated_listing(params, use_upload_id_marker, upload_mode) {
 
                             });
                     })
-                .return(listObjectsResponse);
+                .then(() => listObjectsResponse);
         });
 }

--- a/src/test/unit_tests/test_signature_utils.js
+++ b/src/test/unit_tests/test_signature_utils.js
@@ -10,7 +10,6 @@ const http = require('http');
 const mocha = require('mocha');
 const crypto = require('crypto');
 
-const P = require('../../util/promise');
 const signature_utils = require('../../util/signature_utils');
 
 function log(...args) {
@@ -30,7 +29,7 @@ mocha.describe('signature_utils', function() {
     const http_server = http.createServer(accept_signed_request);
 
     mocha.before(function() {
-        return new P((resolve, reject) =>
+        return new Promise((resolve, reject) =>
             http_server
             .once('listening', resolve)
             .once('error', reject)
@@ -103,7 +102,7 @@ mocha.describe('signature_utils', function() {
             }
         });
         let reply = '';
-        return new P((resolve, reject) => socket
+        return new Promise((resolve, reject) => socket
                 .setEncoding('utf8')
                 .on('data', data => {
                     reply += data;
@@ -147,7 +146,7 @@ mocha.describe('signature_utils', function() {
             'Handle:', req.method, req.originalUrl,
             'query', req.query,
             'headers', req.headers);
-        return new P((resolve, reject) => {
+        return new Promise((resolve, reject) => {
                 const hasher = crypto.createHash('sha256');
                 req.on('data', data => {
                         hasher.update(data);

--- a/src/test/utils/s3ops.js
+++ b/src/test/utils/s3ops.js
@@ -588,7 +588,9 @@ class S3OPS {
                 await this.s3.deleteBucket({ Bucket }).promise().catch(_.noop);
             })
             .timeout(timeout)
-            .return();
+            .then(() => {
+                // do nothing. 
+            });
     }
 
     async create_bucket(bucket_name, print_error = true) {
@@ -688,14 +690,14 @@ class S3OPS {
         try {
             //There can be an issue if the object size (length) is too large
             const obj = await this.s3.getObject(params)
-            .on('build', req => {
-                if (!query_params) return;
-                const sep = req.httpRequest.search() ? '&' : '?';
-                const query_string = querystring.stringify(query_params);
-                const req_path = `${req.httpRequest.path}${sep}${query_string}`;
-                console.log(`Added query params ${query_params} to path ${req_path}`);
-                req.httpRequest.path = req_path;
-            }).promise();
+                .on('build', req => {
+                    if (!query_params) return;
+                    const sep = req.httpRequest.search() ? '&' : '?';
+                    const query_string = querystring.stringify(query_params);
+                    const req_path = `${req.httpRequest.path}${sep}${query_string}`;
+                    console.log(`Added query params ${query_params} to path ${req_path}`);
+                    req.httpRequest.path = req_path;
+                }).promise();
             return obj;
         } catch (err) {
             this.log_error(`get_object:: getObject ${JSON.stringify(params)} failed!`, err);

--- a/src/test/utils/ssh_functions.js
+++ b/src/test/utils/ssh_functions.js
@@ -7,7 +7,7 @@ const P = require('../../util/promise');
 //will connect the ssh session
 function ssh_connect(options) {
     let client = new ssh2.Client();
-    return new P((resolve, reject) => client
+    return new Promise((resolve, reject) => client
         .once('ready', () => resolve(client))
         .once('error', reject)
         .connect(options));
@@ -17,7 +17,7 @@ function ssh_connect(options) {
 function ssh_exec(client, command, ignore_rc = false) {
     console.log('Execute ssh command ' + command);
     return P.fromCallback(callback => client.exec(command, { pty: true }, callback))
-        .then(stream => new P((resolve, reject) => {
+        .then(stream => new Promise((resolve, reject) => {
             stream.on('data', data => console.log(data.toString()))
                 .once('error', reject)
                 .once('close', code => {

--- a/src/test/web/test_create_system.js
+++ b/src/test/web/test_create_system.js
@@ -6,7 +6,8 @@
 const mocha = require('mocha');
 const wd = require('selenium-webdriver');
 
-const P = require('../../util/promise');
+const promise_utils = require('../../util/promise_utils');
+
 const selenium = require('./selenium');
 
 selenium.init_mocha();
@@ -30,17 +31,17 @@ mocha.describe('create_system', function() {
             .then(inputs => {
                 self.inputs = inputs;
             })
-            .then(() => P.join(
+            .then(() => Promise.all([
                 self.inputs[0].sendKeys('123'),
                 self.inputs[1].sendKeys('demo@noobaa.com'),
                 self.inputs[2].sendKeys('DeMo1'),
                 self.inputs[3].sendKeys('DeMo1')
-            ))
+            ]))
             .then(() => d.findElements(wd.By.tagName('button')))
             .then(buttons => {
                 self.buttons = buttons;
             })
-            .delay(500)
+            .then(() => promise_utils.delay(500))
             .then(() => console.log('Wait for button to click next ...'))
             .then(() => d.wait(wd.until.elementIsVisible(self.buttons[1]), 1000))
             .then(() => self.buttons[1].click())
@@ -49,7 +50,7 @@ mocha.describe('create_system', function() {
             .then(() => console.log('Wait for button to create system ...'))
             .then(() => d.wait(wd.until.elementIsVisible(self.buttons[2]), 1000))
             .then(() => self.inputs[4].sendKeys('demo'))
-            .delay(500)
+            .then(() => promise_utils.delay(500))
             .then(() => self.buttons[2].click())
             .then(() => console.log('Wait for url to open the created system ...'))
             .then(() => d.wait(wd.until.urlIs(URL + '/fe/systems/demo'), 3000))

--- a/src/tools/node_ssh.js
+++ b/src/tools/node_ssh.js
@@ -19,8 +19,8 @@ let nodes_left;
 if (require.main === module) main();
 
 function main() {
-    return P.join(get_nodes_ips(), read_stdin())
-        .spread(nodes_ssh);
+    return Promise.all([get_nodes_ips(), read_stdin()])
+        .then(([nodes]) => (nodes_ssh(nodes)));
 }
 
 function get_nodes_ips() {
@@ -63,7 +63,7 @@ function nodes_ssh(nodes) {
 function node_ssh(node) {
     const client = new ssh2.Client();
     client.can_continue = true;
-    return new P((resolve, reject) => client
+    return new Promise((resolve, reject) => client
             .once('ready', resolve)
             .once('error', reject)
             .once('close', () => reject(new Error(`${node.ip} SSH CLOSED`)))
@@ -87,7 +87,7 @@ function node_ssh(node) {
 }
 
 function node_exec(node, client) {
-    return new P((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         client.can_continue = client.exec(argv.exec, (err, channel) => {
             if (err) return reject(err);
             channel.once('error', reject);
@@ -106,7 +106,7 @@ function node_exec(node, client) {
 
 function ssh_continue(client) {
     if (client.can_continue) return;
-    return new P((resolve, reject) => client
+    return new Promise((resolve, reject) => client
         .once('continue', () => {
             client.can_continue = true;
             return resolve();

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const stream = require('stream');
-const P = require('./promise');
 
 const EMPTY_BUFFER = Buffer.allocUnsafeSlow(0);
 
@@ -152,7 +151,7 @@ function count_length(buffers) {
 }
 
 function write_to_stream(writable, buf) {
-    return new P((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         writable.once('error', reject);
         writable.write(buf, err => {
             if (err) {

--- a/src/util/chunk_coder.js
+++ b/src/util/chunk_coder.js
@@ -53,7 +53,7 @@ class ChunkCoder extends stream.Transform {
                 if (this.cipher_key_b64) chunk.cipher_key_b64 = this.cipher_key_b64;
                 const chunk_promise = P.fromCallback(cb => nb_native().chunk_coder(this.coder, chunk, cb));
                 // TODO: Need to remove the cipher_key in case of SSE-C
-                this.stream_promise = P.join(chunk_promise, this.stream_promise).then(() => this.push(chunk));
+                this.stream_promise = Promise.all([chunk_promise, this.stream_promise]).then(() => this.push(chunk));
                 callback();
                 return chunk_promise;
             }))

--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -38,7 +38,9 @@ function file_must_not_exist(file_path) {
  *
  */
 function file_must_exist(file_path) {
-    return fs.statAsync(file_path).return();
+    return fs.statAsync(file_path).then(() => {
+        // do nothing. 
+    });
 }
 
 
@@ -106,7 +108,9 @@ function read_dir_recursive(options) {
                                 'entry error', entry_path, err);
                         });
                 })
-                .return();
+                .then(() => {
+                    // do nothing. 
+                });
         })
         .then(() => {
             // second step: recurse to sub dirs
@@ -213,7 +217,9 @@ function folder_delete(dir) {
 function file_delete(file_name) {
     return fs.unlinkAsync(file_name)
         .catch(ignore_enoent)
-        .return();
+        .then(() => {
+            // do nothing. 
+        });
 }
 
 function full_dir_copy(src, dst, filter_regex) {
@@ -238,7 +244,9 @@ function full_dir_copy(src, dst, filter_regex) {
             throw new Error('Both src and dst must be given');
         }
         ncp(src, dst, ncp_options, callback);
-    }).return();
+    }).then(() => {
+        // do nothing. 
+    });
 }
 
 function tar_pack(tar_file_name, source, ignore_file_changes) {
@@ -255,7 +263,7 @@ function tar_pack(tar_file_name, source, ignore_file_changes) {
 }
 
 function write_file_from_stream(file_path, read_stream) {
-    return new P((resolve, reject) => read_stream
+    return new Promise((resolve, reject) => read_stream
         .once('error', reject)
         .pipe(fs.createWriteStream(file_path))
         .once('error', reject)

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -221,7 +221,7 @@ function read_and_parse_body(req, options) {
 }
 
 function read_request_body(req, options) {
-    return new P((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         let data = '';
         let content_len = 0;
         const sha256 = crypto.createHash('sha256');

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -86,7 +86,7 @@ function _calculate_free_mem() {
                 .then(cached_mem_in_kb => {
                     res += (cached_mem_in_kb * KB_TO_BYTE);
                 }))
-            .return(res);
+            .then(() => res);
     }
     return res;
 }

--- a/src/util/pipeline.js
+++ b/src/util/pipeline.js
@@ -1,7 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const P = require('../util/promise');
 const stream = require('stream');
 
 /**
@@ -14,7 +13,7 @@ const stream = require('stream');
 class Pipeline {
 
     constructor(input) {
-        this._promise = new P((resolve, reject) => {
+        this._promise = new Promise((resolve, reject) => {
             this._resolve = resolve;
             this._reject = reject;
         });

--- a/src/util/zip_utils.js
+++ b/src/util/zip_utils.js
@@ -23,7 +23,7 @@ function zip_from_files(files) {
             }
         }))
         .then(() => zipfile.end())
-        .return(zipfile);
+        .then(() => zipfile);
 }
 
 function zip_from_dir(dir) {
@@ -41,7 +41,7 @@ function zip_from_dir(dir) {
             }
         }))
         .then(() => zipfile.end())
-        .return(zipfile);
+        .then(() => zipfile);
 }
 
 function zip_to_buffer(zipfile) {
@@ -65,7 +65,7 @@ function unzip_from_file(file_path) {
 }
 
 function unzip_to_callback(zipfile, on_entry) {
-    return new P((resolve, reject) => zipfile
+    return new Promise((resolve, reject) => zipfile
         .once('error', reject)
         .once('end', resolve)
         .on('entry', entry => P.resolve()
@@ -86,7 +86,7 @@ function unzip_to_mem(zipfile) {
                     data: buffer,
                 });
             }))
-        .return(files);
+        .then(() => files);
 }
 
 function unzip_to_dir(zipfile, dir) {


### PR DESCRIPTION
### Explain the changes
- Using delay in a native way (new delay function at promise_utils)
- Removed all `.tap()`, `.spread()` and `.return()`
- Removed most of `P.join`
- Wrapped with bluebird some of the timeout and catch

### Out of scope
- Did not replaced `.timeout()`
- Did not replaced `.cancel()`
- Did not replaced `.isPending()`
- Did not replaced `.isRejected()`
- Did not replaced `.props()`
- Did not replaced 2 `.delay()`

Step 1 for #6070 

Signed-off-by: liranmauda <liran.mauda@gmail.com>