### PR TITLE
NS-CACHE: support multi deletes operation

### DIFF
--- a/src/test/utils/namespace_context.js
+++ b/src/test/utils/namespace_context.js
@@ -137,6 +137,12 @@ class NamespaceContext {
         }
     }
 
+    async delete_files_from_noobaa(type, file_names) {
+        const noobaa_bucket = this._ns_mapping[type].gateway;
+        await this._noobaa_s3ops.delete_multiple_files(noobaa_bucket,
+            _.map(file_names, filename => ({ filename })));
+    }
+
     async expect_not_found_in_cache(type, file_name) {
         const noobaa_bucket = this._ns_mapping[type].gateway;
         console.log(`expecting cache md not found for ${file_name} in ${noobaa_bucket}`);


### PR DESCRIPTION
### Explain the changes
1.  Support multi deletes procedure in namespace caching

### Issues: Fixed #xxx / Gap #xxx
1. Part of the namespace caching feature

### Testing Instructions:
1.  Delete multiple objects from namespace bucket enabled with caching, objects shall be deleted from both cache and hub.
2. If error happens in cache or hub delete operations, return error to client.
