### PR TITLE
NS-CACHE: Get object support partNumber query parameter and preconditions

### DIFF
--- a/src/endpoint/s3/ops/s3_head_object.js
+++ b/src/endpoint/s3/ops/s3_head_object.js
@@ -4,6 +4,7 @@
 // const S3Error = require('../s3_errors').S3Error;
 const s3_utils = require('../s3_utils');
 const http_utils = require('../../../util/http_utils');
+const S3Error = require('../s3_errors').S3Error;
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html
@@ -17,6 +18,9 @@ async function head_object(req, res) {
         md_conditions: http_utils.get_md_conditions(req),
         encryption
     };
+    if (req.query.partNumber) {
+        params.part_number = s3_utils.parse_part_number(req.query.partNumber, S3Error.InvalidArgument);
+    }
     if (req.query.get_from_cache !== undefined) {
         params.get_from_cache = true;
     }

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -263,7 +263,7 @@ function set_response_object_md(res, object_md) {
     res.setHeader('ETag', '"' + object_md.etag + '"');
     res.setHeader('Last-Modified', time_utils.format_http_header_date(new Date(object_md.create_time)));
     res.setHeader('Content-Type', object_md.content_type);
-    res.setHeader('Content-Length', object_md.size);
+    res.setHeader('Content-Length', object_md.content_length === undefined ? object_md.size : object_md.content_length);
     res.setHeader('Accept-Ranges', 'bytes');
     if (config.WORM_ENABLED && object_md.lock_settings) {
         if (object_md.lock_settings.legal_hold) {
@@ -277,6 +277,8 @@ function set_response_object_md(res, object_md) {
     if (object_md.version_id) res.setHeader('x-amz-version-id', object_md.version_id);
     set_response_xattr(res, object_md.xattr);
     if (object_md.tag_count) res.setHeader('x-amz-tagging-count', object_md.tag_count);
+    if (object_md.multipart_count) res.setHeader('x-amz-mp-parts-count', object_md.multipart_count);
+    if (object_md.content_range) res.setHeader('Content-Range', object_md.content_range);
     return object_md;
 }
 

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -64,6 +64,9 @@ class NamespaceNB {
 
     read_object_md(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
+        // Noobaa bucket does not currrently support partNumber query parameter. Ignore it for now.
+        // If set, part_number is positive integer from 1 to 10000
+        if (params.part_number) _.unset(params, 'part_number');
         return object_sdk.rpc_client.object.read_object_md(params);
     }
 
@@ -74,6 +77,9 @@ class NamespaceNB {
             client: object_sdk.rpc_client,
             bucket: this.target_bucket,
         }, params);
+        // Noobaa bucket does not currrently support partNumber query parameter. Ignore it for now.
+        // If set, part_number is positive integer from 1 to 10000
+        if (params.part_number) _.unset(params, 'part_number');
         const active_triggers = this.get_triggers_for_bucket(params.bucket);
         const load_for_trigger = !params.noobaa_trigger_agent && object_sdk.should_run_triggers({
             active_triggers,
@@ -226,7 +232,7 @@ class NamespaceNB {
         });
         // TODO: What should I do instead of failing on one failed head request?
         // I cannot exclude the files that failed from delete since it will be considered altering the request of the client
-        // TODO: Notice that we do not handle the md_conditions for the heads 
+        // TODO: Notice that we do not handle the md_conditions for the heads
         const head_res = load_for_trigger && await P.map(params.objects, async obj => {
             const request = {
                 bucket: params.bucket,

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -119,16 +119,36 @@ class NamespaceS3 {
     // OBJECT READ //
     /////////////////
 
+    _set_md_conditions(params, request) {
+        if (params.md_conditions) {
+            request.IfMatch = params.md_conditions.if_match_etag;
+            request.IfNoneMatch = params.md_conditions.if_none_match_etag;
+            if (params.md_conditions.if_modified_since) {
+                request.IfModifiedSince = new Date(params.md_conditions.if_modified_since);
+            }
+            if (params.md_conditions.if_unmodified_since) {
+                request.IfUnmodifiedSince = new Date(params.md_conditions.if_unmodified_since);
+            }
+        }
+    }
+
     async read_object_md(params, object_sdk) {
         try {
             dbg.log0('NamespaceS3.read_object_md:', this.bucket, inspect(params));
-            const request = { Key: params.key, Range: `bytes=0-${config.INLINE_MAX_SIZE - 1}` };
+            const request = { Key: params.key, PartNumber: params.part_number };
+            // If set, part_number is positive integer from 1 to 10000.
+            // Usually part number is not provided and then we read a small "inline" range
+            // to reduce the double latency for small objects.
+            if (!params.part_number) {
+                request.Range = `bytes=0-${config.INLINE_MAX_SIZE - 1}`;
+            }
+            this._set_md_conditions(params, request);
             this._assign_encryption_to_request(params, request);
             const res = await this.s3.getObject(request).promise();
             dbg.log0('NamespaceS3.read_object_md:', this.bucket, inspect(params), 'res', inspect(res));
             return this._get_s3_object_info(res, params.bucket);
         } catch (err) {
-            this._translate_error_code(err);
+            this._translate_error_code(params, err);
             dbg.warn('NamespaceS3.read_object_md:', inspect(err));
             throw err;
         }
@@ -140,12 +160,13 @@ class NamespaceS3 {
             const request = {
                 Key: params.key,
                 Range: params.end ? `bytes=${params.start}-${params.end - 1}` : undefined,
-                IfMatch: params.if_match_etag,
+                PartNumber: params.part_number,
             };
+            this._set_md_conditions(params, request);
             this._assign_encryption_to_request(params, request);
             const req = this.s3.getObject(request)
                 .on('error', err => {
-                    this._translate_error_code(err);
+                    this._translate_error_code(params, err);
                     dbg.warn('NamespaceS3.read_object_stream:', inspect(err));
                     reject(err);
                 })
@@ -523,13 +544,25 @@ class NamespaceS3 {
             xattr,
             tag_count: res.TagCount,
             first_range_data: res.Body,
+            multipart_count: res.PartsCount,
+            content_range: res.ContentRange,
+            content_length: res.ContentLength,
         };
     }
 
-    _translate_error_code(err) {
+    _translate_error_code(params, err) {
         if (err.code === 'NoSuchKey') err.rpc_code = 'NO_SUCH_OBJECT';
-        if (err.code === 'NotFound') err.rpc_code = 'NO_SUCH_OBJECT';
-        if (err.code === 'PreconditionFailed') err.rpc_code = 'IF_MATCH_ETAG';
+        else if (err.code === 'NotFound') err.rpc_code = 'NO_SUCH_OBJECT';
+        else if (params.md_conditions) {
+            const md_conditions = params.md_conditions;
+            if (err.code === 'PreconditionFailed') {
+                if (md_conditions.if_match_etag) err.rpc_code = 'IF_MATCH_ETAG';
+                else if (md_conditions.if_unmodified_since) err.rpc_code = 'IF_UNMODIFIED_SINCE';
+            } else if (err.code === 'NotModified') {
+                if (md_conditions.if_modified_since) err.rpc_code = 'IF_MODIFIED_SINCE';
+                else if (md_conditions.if_none_match_etag) err.rpc_code = 'IF_NONE_MATCH_ETAG';
+            }
+        }
     }
 
     _assign_encryption_to_request(params, request) {

--- a/src/test/utils/s3ops.js
+++ b/src/test/utils/s3ops.js
@@ -675,11 +675,15 @@ class S3OPS {
         }
     }
 
-    async get_object(bucket, key, query_params) {
+    async get_object(bucket, key, query_params, preconditions) {
         const params = {
             Bucket: bucket,
             Key: key
         };
+        if (preconditions) {
+            //IfMatch, IfModifiedSince, IfNoneMatch, IfUnmodifiedSince
+            _.assign(params, preconditions);
+        }
         console.log('Reading object ', key);
         try {
             //There can be an issue if the object size (length) is too large
@@ -699,13 +703,17 @@ class S3OPS {
         }
     }
 
-    async get_object_range(bucket, key, start_byte, finish_byte, versionid) {
+    async get_object_range(bucket, key, start_byte, finish_byte, versionid, preconditions) {
         const params = {
             Bucket: bucket,
             Key: key,
             Range: `bytes=${start_byte}-${finish_byte}`,
             VersionId: versionid ? versionid : undefined,
         };
+        if (preconditions) {
+            //IfMatch, IfModifiedSince, IfNoneMatch, IfUnmodifiedSince
+            _.assign(params, preconditions);
+        }
         try {
             console.log(`Reading object ${key} ${versionid ? versionid : ''} from ${start_byte} to ${finish_byte} from ${bucket}`);
             const obj = await this.s3.getObject(params).promise();


### PR DESCRIPTION
Signed-off-by: Paul-Zhang <Paul.Zhang@ibm.com>

### Explain the changes
1. If partNumber query parameter is set in get object request, bypass cache and proxy the request to hub. More info about partNumber can be found at
https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax

2. If the precondition headers (e.g. if-match) are set in get object request, evaluate the conditions on cache if cache ttl is expired, or proxy the request with the conditions to hub if object not cached or cache ttl has expired.

### Issues: Fixed #xxx / Gap #xxx
1.  Part of the namespace caching feature.

### Testing Instructions:
1. See the above description on the changes.
