### PR TITLE
chore: update ftp-srv to 4.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "dclassify": "1.1.2",
     "event-stream": "4.0.1",
     "express": "4.17.1",
-    "ftp-srv": "4.3.1",
+    "ftp-srv": "4.3.4",
     "get-folder-size": "2.0.1",
     "getos": "3.2.0",
     "glob-to-regexp": "0.4.1",


### PR DESCRIPTION
We've just fixed a critical security vulnerability in `ftp-srv`, and given that your dependencies are pinned, I thought I would bring this into your view directly.

https://github.com/autovance/ftp-srv/security/advisories/GHSA-jw37-5gqr-cf9j