### PR TITLE
fixed coretest stuck on tests cleanup

### DIFF
--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -200,36 +200,40 @@ function setup(options = {}) {
     mocha.after('coretest-after', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
 
-        console.log('Database', process.env.CORETEST_MONGODB_URL, 'is intentionally',
-            'left for debugging and will be deleted before next test run');
+        try {
+            console.log('Database', process.env.CORETEST_MONGODB_URL, 'is intentionally',
+                'left for debugging and will be deleted before next test run');
 
-        if (_incomplete_rpc_coverage) {
-            let had_missing = false;
-            for (let srv of api_coverage) {
-                console.warn('API was not covered:', srv);
-                had_missing = true;
-            }
-            if (had_missing) {
-                if (_incomplete_rpc_coverage === 'fail') {
-                    throw new Error('INCOMPLETE RPC COVERAGE');
-                } else {
-                    console.warn('INCOMPLETE RPC COVERAGE');
+            if (_incomplete_rpc_coverage) {
+                let had_missing = false;
+                for (let srv of api_coverage) {
+                    console.warn('API was not covered:', srv);
+                    had_missing = true;
+                }
+                if (had_missing) {
+                    if (_incomplete_rpc_coverage === 'fail') {
+                        throw new Error('INCOMPLETE RPC COVERAGE');
+                    } else {
+                        console.warn('INCOMPLETE RPC COVERAGE');
+                    }
                 }
             }
-        }
-        await announce('clear_test_pools()');
-        await clear_test_pools();
-        await P.delay(1000);
-        await announce('rpc set_disconnected_state()');
-        server_rpc.rpc.set_disconnected_state(true);
-        await announce('mongo_client disconnect()');
-        await mongo_client.instance().disconnect();
-        await announce('http_server close()');
-        if (http_server) http_server.close();
-        await announce('https_server close()');
-        if (https_server) https_server.close();
-        await announce('coretest done ...');
+            await announce('clear_test_pools()');
+            await clear_test_pools();
+            await P.delay(1000);
+            await announce('rpc set_disconnected_state()');
+            server_rpc.rpc.set_disconnected_state(true);
+            await announce('mongo_client disconnect()');
+            await mongo_client.instance().disconnect();
+            await announce('http_server close()');
+            if (http_server) http_server.close();
+            await announce('https_server close()');
+            if (https_server) https_server.close();
+            await announce('coretest done ...');
 
+        } catch (err) {
+            dbg.error('got error on mocha.after', err);
+        }
         let tries_left = 3;
         setInterval(function check_dangling_handles() {
             tries_left -= 1;
@@ -245,6 +249,7 @@ function setup(options = {}) {
                 process.exit(1);
             }
         }, 30000).unref();
+
     });
 }
 
@@ -368,19 +373,28 @@ async function clear_test_pools() {
 
     // Delete all pools (will stop all agents managed by the pool)
     if (CREATED_POOLS) {
-        await promise_utils.wait_until(async () => {
+        console.log(`cleaning pools`, CREATED_POOLS.map(p => p.name));
+
+        await Promise.all(CREATED_POOLS.map(async pool => {
             try {
-                await Promise.all(CREATED_POOLS.map(pool =>
-                    rpc_client.pool.delete_pool({ name: pool.name })
-                ));
+                await promise_utils.wait_until(async () => {
+                    try {
+                        console.log(`deleting pool`, pool.name);
+                        await rpc_client.pool.delete_pool({ name: pool.name });
+                    } catch (err) {
+                        if (err.rpc_code === 'NO_SUCH_POOL') {
+                            console.log(`deleted pool ${pool.name}`);
+                            return true;
+                        }
+                        console.log(`got error on delete_pool for pool ${pool.name}`, err.rpc_code);
+                    }
+                    return false;
+                }, 2 * 60 * 1000, 2500);
             } catch (err) {
-                if (err.rpc_code !== 'BEING_DELETED') throw err;
+                dbg.error('failed on pool cleanup', err);
             }
-            const { pools } = await rpc_client.system.read_system({});
-            const existing_pools = new Set(pools.map(pool => pool.name));
-            console.log('Waiting until all pools are deleted (including hosts)', existing_pools);
-            return CREATED_POOLS.every(pool => !existing_pools.has(pool.name));
-        }, 5 * 60 * 1000, 2500);
+        }));
+        console.log(`finished pools cleanup`);
     }
 
     console.log('STOP MONITOR');


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. when an error was thrown from `delete_pool` which is not a `BEING_DELETE` error, it caused the cleanup process to bail, and exit was not called.
2. refactored the pool cleanup code to catch and handle errors

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `make test`