### PR TITLE
Disabling block_verifer and limiting cache to 100MB

### DIFF
--- a/config.js
+++ b/config.js
@@ -138,7 +138,7 @@ config.CLOUD_MAX_ALLOWED_IO_TEST_ERRORS = 3;
 // AGENT BLOCKS VERIFIER //
 ///////////////////////////
 
-config.AGENT_BLOCKS_VERIFIER_ENABLED = true;
+config.AGENT_BLOCKS_VERIFIER_ENABLED = false;
 // TODO: Should check what is the optiomal amount of batch
 config.AGENT_BLOCKS_VERIFIER_BATCH_SIZE = 1000;
 config.AGENT_BLOCKS_VERIFIER_BATCH_DELAY = 50;

--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -46,7 +46,7 @@ class BlockStoreBase {
         this.block_modify_lock = new KeysLock();
         this.block_cache = new LRUCache({
             name: 'BlockStoreCache',
-            max_usage: 200 * 1024 * 1024, // 200 MB
+            max_usage: 100 * 1024 * 1024, // 100 MB
             item_usage: block => block.data.length,
             make_key: block_md => block_md.id,
             load: async block_md => this._read_block_and_verify(block_md),


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. due to memory pressure in pvpool pods during excessive write - limiting cache size and temporarily disabling agent_block_veirfier - which seems to leak 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
