### PR TITLE
NS-Cache:  make test_s3_ops unit test run with an external endpoint or default noobaa endpoint

### DIFF
--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -5,31 +5,32 @@ const _ = require('lodash');
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
 coretest.setup({ pools_to_create: coretest.POOL_LIST });
-
+const config = require('../../../config');
 const AWS = require('aws-sdk');
-const http = require('http');
+const http_utils = require('../../util/http_utils');
 const mocha = require('mocha');
 const assert = require('assert');
 const querystring = require('querystring');
-const SKIP_TEST = !process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY;
 
-const AWS_TARGET_BUCKET = 's3-ops-test-bucket';
-const AWS_SOURCE_BUCKET = 's3-ops-source';
+// If any of these variables are not defined,
+// use the noobaa endpoint to create buckets
+// for namespace and namespace cache bucket testing.
+const USE_REMOTE_ENDPOINT = process.env.USE_REMOTE_ENDPOINT === 'true';
 const { rpc_client, EMAIL } = coretest;
 const BKT1 = 'test-s3-ops-bucket-ops';
 const BKT2 = 'test-s3-ops-object-ops';
 const BKT3 = 'test2-s3-ops-object-ops';
 const BKT4 = 'test3-s3-ops-object-ops';
 const BKT5 = 'test5-s3-ops-objects-ops';
-const CONNECTION_NAME = 'aws_connection1';
-const RESOURCE_NAME = 'namespace_target_bucket';
-const RESOURCE_NAME_SOURCE = 'namespace_source_bucket';
-
+const CONNECTION_NAME = 's3_connection';
+const NAMESPACE_RESOURCE_SOURCE = 'namespace_target_bucket';
+const NAMESPACE_RESOURCE_TARGET = 'namespace_source_bucket';
+const TARGET_BUCKET = 's3-ops-target';
+const SOURCE_BUCKET = 's3-ops-source';
 const file_body = "TEXT-FILE-YAY!!!!-SO_COOL";
 const file_body2 = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 const sliced_file_body = "TEXT-F";
 const sliced_file_body1 = "_COOL";
-const source_bucket = 's3-ops-source';
 const text_file1 = 'text-file1';
 const text_file2 = 'text-file2';
 const text_file3 = 'text-file3';
@@ -38,6 +39,11 @@ const text_file5 = 'text-file5';
 mocha.describe('s3_ops', function() {
 
     let s3;
+    // Bucket name for the source namespace resource
+    let source_namespace_bucket;
+    // Bucket name for the target namespace resource
+    let target_namespace_bucket;
+    let source_bucket;
 
     mocha.before(async function() {
         const self = this; // eslint-disable-line no-invalid-this
@@ -53,7 +59,7 @@ mocha.describe('s3_ops', function() {
             computeChecksums: true,
             s3DisableBodySigning: false,
             region: 'us-east-1',
-            httpOptions: { agent: new http.Agent({ keepAlive: false }) },
+            httpOptions: { agent: http_utils.get_unsecured_agent(coretest.get_http_address()) },
         });
         coretest.log('S3 CONFIG', s3.config);
     });
@@ -91,64 +97,72 @@ mocha.describe('s3_ops', function() {
 
         mocha.before(async function() {
             this.timeout(100000); // eslint-disable-line no-invalid-this
+            source_bucket = bucket_name + '-source';
             if (bucket_type === "regular") {
                 await s3.createBucket({ Bucket: bucket_name }).promise();
                 await s3.createBucket({ Bucket: source_bucket }).promise();
-            } else if (SKIP_TEST) {
-                this.skip(); // eslint-disable-line no-invalid-this
             } else {
-                const read_resources = [RESOURCE_NAME];
-                const write_resource = RESOURCE_NAME;
-                const read_resources1 = [RESOURCE_NAME_SOURCE];
-                const write_resource1 = RESOURCE_NAME_SOURCE;
-                const ENDPOINT = process.env.ENDPOINT ? process.env.ENDPOINT : 'https://s3.amazonaws.com';
-                const ENDPOINT_TYPE = process.env.ENDPOINT_TYPE ? process.env.ENDPOINT_TYPE : 'AWS';
+                source_namespace_bucket = caching ? SOURCE_BUCKET + '-caching' : SOURCE_BUCKET;
+                target_namespace_bucket = caching ? TARGET_BUCKET + '-caching' : TARGET_BUCKET;
+
+                const ENDPOINT = USE_REMOTE_ENDPOINT ? process.env.ENDPOINT : coretest.get_https_address();
+                const ENDPOINT_TYPE = USE_REMOTE_ENDPOINT ? process.env.ENDPOINT_TYPE : 'S3_COMPATIBLE';
+                const AWS_ACCESS_KEY_ID = USE_REMOTE_ENDPOINT ? process.env.AWS_ACCESS_KEY_ID : s3.config.accessKeyId;
+                const AWS_SECRET_ACCESS_KEY = USE_REMOTE_ENDPOINT ? process.env.AWS_SECRET_ACCESS_KEY : s3.config.secretAccessKey;
+
+                coretest.log("Using endpoint: ", ENDPOINT);
+
                 await rpc_client.account.add_external_connection({
-                        name: CONNECTION_NAME,
-                        endpoint: ENDPOINT,
-                        endpoint_type: ENDPOINT_TYPE,
-                        identity: process.env.AWS_ACCESS_KEY_ID,
-                        secret: process.env.AWS_SECRET_ACCESS_KEY,
+                    name: CONNECTION_NAME,
+                    endpoint: ENDPOINT,
+                    endpoint_type: ENDPOINT_TYPE,
+                    identity: AWS_ACCESS_KEY_ID,
+                    secret: AWS_SECRET_ACCESS_KEY,
                 });
 
+                /**
+                 * NOTE: Remote buckets are not created in the test. It is assumed that
+                 * a. The buckets exist
+                 * b. The buckets are empty
+                 * Following buckets need to exist on the remote endpoint:
+                 *
+                 * s3-ops-source-caching
+                 * s3-ops-target-caching
+                 */
+                if (!USE_REMOTE_ENDPOINT) {
+                    // Create buckets for the source and target namespaces
+                    await s3.createBucket({Bucket: target_namespace_bucket}).promise();
+                    await s3.createBucket({Bucket: source_namespace_bucket}).promise();
+                }
                 await rpc_client.pool.create_namespace_resource({
-                        name: RESOURCE_NAME,
+                        name: NAMESPACE_RESOURCE_SOURCE,
                         connection: CONNECTION_NAME,
-                        target_bucket: AWS_TARGET_BUCKET
+                        target_bucket: target_namespace_bucket
+                });
+                await rpc_client.pool.create_namespace_resource({
+                        name: NAMESPACE_RESOURCE_TARGET,
+                        connection: CONNECTION_NAME,
+                        target_bucket: source_namespace_bucket
                 });
 
-                /** Catch the exception here as this might exist */
-                try {
-                    await rpc_client.pool.create_namespace_resource({
-                        name: RESOURCE_NAME_SOURCE,
-                        connection: CONNECTION_NAME,
-                        target_bucket: AWS_SOURCE_BUCKET
-                    });
-                } catch (err) {
-                    coretest.log('Failed to create namespace resource', err);
-                }
-
-                try {
-                    const namespace1 = {
-                        read_resources: read_resources1,
-                        write_resource: write_resource1,
+                await rpc_client.bucket.create_bucket({
+                    name: source_bucket,
+                    namespace: {
+                        read_resources: [NAMESPACE_RESOURCE_TARGET],
+                        write_resource: NAMESPACE_RESOURCE_TARGET,
                         caching: caching
-                    };
-                    await rpc_client.bucket.create_bucket({ name: source_bucket, namespace: namespace1 });
-                } catch (err) {
-                    coretest.log('failed to create namespace bucket', err);
-                }
-
+                    }
+                });
                 await rpc_client.bucket.create_bucket({
                     name: bucket_name,
                     namespace: {
-                        read_resources,
-                        write_resource,
+                        read_resources: [NAMESPACE_RESOURCE_SOURCE],
+                        write_resource: NAMESPACE_RESOURCE_SOURCE,
                         caching
                     }
                 });
-
             }
+
             await s3.createBucket({
                 Bucket: BKT5
             }).promise();
@@ -173,6 +187,7 @@ mocha.describe('s3_ops', function() {
                 Body: file_body,
                 ContentType: 'text/plain'
             }).promise();
+
         });
 
         mocha.it('shoult tag text file', async function() {
@@ -334,8 +349,8 @@ mocha.describe('s3_ops', function() {
             assert.strictEqual(res.ContentLength, file_body.length);
         });
         mocha.it('should copy text-file', async function() {
-            this.timeout(60000); // eslint-disable-line no-invalid-this
-            await s3.listObjects({ Bucket: bucket_name }).promise();
+            this.timeout(120000); // eslint-disable-line no-invalid-this
+            const res1 = await s3.listObjects({ Bucket: bucket_name }).promise();
             await s3.copyObject({
                 Bucket: bucket_name,
                 Key: text_file2,
@@ -346,10 +361,8 @@ mocha.describe('s3_ops', function() {
                 Key: text_file3,
                 CopySource: `/${BKT5}/${text_file5}`,
                 }).promise();
-            await s3.listObjects({ Bucket: bucket_name }).promise();
-            // TODO: Commenting this out for now. This need to be investigate on why it works sometimes
-            // assert.strictEqual(res2.Contents.length, (res1.Contents.length + 2),
-            //        `bucket ${bucket_name} copy failed, expected: ${(res1.Contents.length + 2)}, found: ${(res2.Contents.length)}`);
+            const res2 = await s3.listObjects({ Bucket: bucket_name }).promise();
+            assert.strictEqual(res2.Contents.length, (res1.Contents.length + 2));
         });
         mocha.it('should copy text-file multi-part', async function() {
             // eslint-disable-next-line no-invalid-this
@@ -439,7 +452,18 @@ mocha.describe('s3_ops', function() {
         mocha.it('should list objects with text-file', async function() {
             // eslint-disable-next-line no-invalid-this
             this.timeout(60000);
+            const ORIG_INLINE_MAX_SIZE = config.INLINE_MAX_SIZE;
+            // Change the inline max size so the objects get cached.
+            if (caching) {
+                config.INLINE_MAX_SIZE = 1;
+            }
+
             const res1 = await s3.listObjects({ Bucket: bucket_name }).promise();
+            // populate cache
+            await s3.getObject({ Bucket: bucket_name, Key: text_file1 }).promise();
+            await s3.getObject({ Bucket: bucket_name, Key: text_file2 }).promise();
+            await s3.getObject({ Bucket: bucket_name, Key: text_file3 }).promise();
+
             const query_params = { get_from_cache: true };
             const res2 = await s3.listObjects({ Bucket: bucket_name }).on('build', req => {
                 if (!caching) return;
@@ -447,17 +471,18 @@ mocha.describe('s3_ops', function() {
                 const query_string = querystring.stringify(query_params);
                 const req_path = `${req.httpRequest.path}${sep}${query_string}`;
                 req.httpRequest.path = req_path;
-              }).promise();
-            /** TODO: Assumes the hub has one extra file to begin with.
-             *        Need to do an out of band upload of a file to the hub bucket.
-             */
+            }).promise();
+
             assert.strictEqual(res1.Contents[0].Key, text_file1);
             assert.strictEqual(res1.Contents[0].Size, file_body.length);
             assert.strictEqual(res1.Contents.length, 3);
+
             if (!caching) return;
-            assert.strictEqual(res2.Contents[0].Key, res1.Contents[0].Key);
-            assert.strictEqual(res2.Contents[0].Size, res1.Contents[0].Size);
-            assert.strictEqual(res2.Contents.length, 2);
+            assert.strictEqual(res2.Contents.length, 3);
+            assert.strictEqual(res2.Contents[0].Key, text_file1);
+            assert.strictEqual(res2.Contents[1].Key, text_file2);
+            assert.strictEqual(res2.Contents[2].Key, text_file3);
+            config.INLINE_MAX_SIZE = ORIG_INLINE_MAX_SIZE;
         });
 
         mocha.it('should delete text-file', async function() {
@@ -477,30 +502,26 @@ mocha.describe('s3_ops', function() {
         });
         mocha.it('should list objects after no objects left', async function() {
             // eslint-disable-next-line no-invalid-this
-            this.timeout(60000);
+            this.timeout(100000);
             const res = await s3.listObjects({ Bucket: bucket_name }).promise();
             assert.strictEqual(res.Contents.length, 0);
         });
         mocha.after(async function() {
-            if (SKIP_TEST) {
-                coretest.log('No AWS credentials found in env. Skipping test');
-                this.skip(); // eslint-disable-line no-invalid-this
-            }
             if (bucket_type === "regular") {
                 await s3.deleteBucket({ Bucket: source_bucket}).promise();
                 await s3.deleteBucket({Bucket: bucket_name}).promise();
                 await s3.deleteBucket({Bucket: BKT5}).promise();
             } else {
-
+                if (!USE_REMOTE_ENDPOINT) {
+                    await s3.deleteBucket({Bucket: source_namespace_bucket}).promise();
+                    await s3.deleteBucket({Bucket: target_namespace_bucket}).promise();
+                }
                 await s3.deleteBucket({Bucket: BKT5}).promise();
                 await rpc_client.bucket.delete_bucket({name: bucket_name});
-                await rpc_client.pool.delete_namespace_resource({name: RESOURCE_NAME});
-                /** Catch the exception here as this will not get deleted */
-                try {
-                    await rpc_client.pool.delete_namespace_resource({name: RESOURCE_NAME_SOURCE});
-                } catch (err) {
-                    coretest.log('Failed to delete namespace resource', err);
-                }
+                await rpc_client.pool.delete_namespace_resource({name: NAMESPACE_RESOURCE_SOURCE});
+
+                await s3.deleteBucket({ Bucket: source_bucket}).promise();
+                await rpc_client.pool.delete_namespace_resource({name: NAMESPACE_RESOURCE_TARGET});
                 await rpc_client.account.delete_external_connection({connection_name: CONNECTION_NAME});
             }
         });


### PR DESCRIPTION
-     Fix the s3 ops unit test so that if an external endpoint is provided
       via env variables, the endpoint is used for external buckets
       If non is provided, noobaa buckets are created for tests
- Check that GET and LIST objects works on cache bucket with the `get_from_cache` variable.

    Tests run on regular, namespace and namespace cache buckets

Following env variables need to be defined for external buckets to be used:

-  ENDPOINT 
-  ENDPOINT_TYPE 
-  AWS_ACCESS_KEY_ID  
-  AWS_SECRET_ACCESS_KEY  

In addition, following buckets need to already exist on the external endpoint:

-  remote-s3-ops-bucket
-  remote-s3-ops-bucket-caching
-  remote-s3-ops-source
-  remote-s3-ops-source-caching

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
