### PR TITLE
NS-CACHE: Added support for GET and PUT object ACL

### DIFF
--- a/config.js
+++ b/config.js
@@ -456,6 +456,8 @@ config.NAMESPACE_CACHING = {
     MIN_OBJECT_AGE_FOR_GC: 1000 * 60 * 60 * 24,
     UPLOAD_SEMAPHORE_CAP: Math.floor(
         Number(process.env.CONTAINER_MEM_REQUEST ? process.env.CONTAINER_MEM_REQUEST : os.totalmem()) / 8),
+    /** @type string 'reject' | 'pass-through' | '' */
+    ACL_HANDLING: "",
 };
 
 assert(config.NAMESPACE_CACHING.DEFAULT_BLOCK_SIZE <= config.NAMESPACE_CACHING.DEFAULT_MAX_CACHE_OBJECT_SIZE);

--- a/src/endpoint/s3/ops/s3_put_object_acl.js
+++ b/src/endpoint/s3/ops/s3_put_object_acl.js
@@ -1,18 +1,22 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const S3Error = require('../s3_errors').S3Error;
+
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html
  */
-function put_object_acl(req) {
-    return req.object_sdk.read_object_md({
-            bucket: req.params.bucket,
-            key: req.params.key,
-            version_id: req.query.versionId,
-        })
-        .then(object_md => {
-            // TODO S3 ignoring put_object_acl for now
-        });
+async function put_object_acl(req) {
+    if (!req.headers['x-amz-acl']) {
+        throw new S3Error(S3Error.AccessDenied);
+    }
+
+    await req.object_sdk.put_object_acl({
+        bucket: req.params.bucket,
+        key: req.params.key,
+        version_id: req.query.versionId,
+        acl: req.headers['x-amz-acl']
+    });
 }
 
 module.exports = {

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -18,6 +18,14 @@ const DEFAULT_S3_USER = Object.freeze({
     DisplayName: 'NooBaa'
 });
 
+const DEFAULT_OBJECT_ACL = Object.freeze({
+    owner: DEFAULT_S3_USER,
+    access_control_list: [{
+        Grantee: { ...DEFAULT_S3_USER, Type: "CanonicalUser" },
+        Permission: "FULL_CONTROL"
+    }]
+});
+
 const OP_NAME_TO_ACTION = Object.freeze({
     delete_bucket_analytics: { regular: "s3:putanalyticsconfiguration" },
     delete_bucket_cors: { regular: "s3:putbucketcors" },
@@ -358,7 +366,6 @@ function parse_lock_header(req) {
     return lock_settings;
 }
 
-
 function parse_tagging_header(req) {
     const tagging_header = req.headers['x-amz-tagging'];
     if (!tagging_header) return;
@@ -568,6 +575,7 @@ function get_http_response_from_resp(res) {
 
 exports.STORAGE_CLASS_STANDARD = STORAGE_CLASS_STANDARD;
 exports.DEFAULT_S3_USER = DEFAULT_S3_USER;
+exports.DEFAULT_OBJECT_ACL = DEFAULT_OBJECT_ACL;
 exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;
 exports.format_s3_xml_date = format_s3_xml_date;
 exports.get_request_xattr = get_request_xattr;

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -12,6 +12,7 @@ const blob_utils = require('../endpoint/blob/blob_utils');
 const azure_storage = require('../util/azure_storage_wrap');
 const stream_utils = require('../util/stream_utils');
 const stats_collector = require('./endpoint_stats_collector');
+const s3_utils = require('../endpoint/s3/s3_utils');
 const mongodb = require('mongodb');
 
 const MAP_BLOCK_LIST_TYPE = Object.freeze({
@@ -622,6 +623,19 @@ class NamespaceBlob {
     _translate_error_code(err) {
         if (err.code === 'NotFound') err.rpc_code = 'NO_SUCH_OBJECT';
         if (err.code === 'InvalidMetadata') err.rpc_code = 'INVALID_REQUEST';
+    }
+
+    //////////
+    // ACLs //
+    //////////
+
+    async get_object_acl(params, object_sdk) {
+        await this.read_object_md(params, object_sdk);
+        return s3_utils.DEFAULT_OBJECT_ACL;
+    }
+
+    async put_object_acl(params, object_sdk) {
+        await this.read_object_md(params, object_sdk);
     }
 
 }

--- a/src/sdk/namespace_merge.js
+++ b/src/sdk/namespace_merge.js
@@ -282,6 +282,18 @@ class NamespaceMerge {
         return this._ns_put(ns => ns.put_object_tagging(params, object_sdk));
     }
 
+    //////////
+    // ACLs //
+    //////////
+
+    get_object_acl(params, object_sdk) {
+        return this._ns_get(ns => ns.get_object_acl(params, object_sdk));
+    }
+
+    put_object_acl(params, object_sdk) {
+        return this._ns_put(ns => ns.put_object_acl(params, object_sdk));
+    }
+
     //////////////
     // INTERNAL //
     //////////////

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 
 const P = require('../util/promise');
 const blob_translator = require('./blob_translator');
+const s3_utils = require('../endpoint/s3/s3_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 
 const EXCEPT_REASONS = [
@@ -311,6 +312,31 @@ class NamespaceNB {
 
     put_object_retention(params, object_sdk) {
         return object_sdk.rpc_client.object.put_object_retention(params);
+    }
+
+    ////////////
+    //  ACLs  //
+    ////////////
+
+    async get_object_acl(params, object_sdk) {
+        await this.read_object_md({
+            bucket: params.bucket,
+            key: params.key,
+            version_id: params.versionId
+        }, object_sdk);
+
+        return s3_utils.DEFAULT_OBJECT_ACL;
+    }
+
+    async put_object_acl(params, object_sdk) {
+        // TODO S3 ignoring put_object_acl for now
+        // For now we just call read_object_md() to check if the object and bucket 
+        // even exist or throw proper errors.
+        await this.read_object_md({
+            bucket: params.bucket,
+            key: params.key,
+            version_id: params.versionId
+        }, object_sdk);
     }
 }
 

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -448,6 +448,37 @@ class NamespaceS3 {
         };
     }
 
+    //////////
+    // ACLs //
+    //////////
+
+    async get_object_acl(params, object_sdk) {
+        dbg.log0('NamespaceS3.get_object_acl:', this.bucket, inspect(params));
+
+        const res = await this.s3.getObjectAcl({
+            Key: params.key,
+            VersionId: params.version_id
+        }).promise();
+
+        dbg.log0('NamespaceS3.get_object_acl:', this.bucket, inspect(params), 'res', inspect(res));
+
+        return {
+            owner: res.Owner,
+            access_control_list: res.Grants
+        };
+    }
+
+    async put_object_acl(params, object_sdk) {
+        dbg.log0('NamespaceS3.put_object_acl:', this.bucket, inspect(params));
+
+        const res = await this.s3.putObjectAcl({
+            Key: params.key,
+            VersionId: params.version_id,
+            ACL: params.acl
+        }).promise();
+
+        dbg.log0('NamespaceS3.put_object_acl:', this.bucket, inspect(params), 'res', inspect(res));
+    }
 
     ///////////////////
     // OBJECT DELETE //

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -721,6 +721,20 @@ class ObjectSDK {
         const ns = this.namespace_nb;
         return ns.put_object_retention(params, this);
     }
+
+    ////////////////////
+    //  OBJECT ACLS   //
+    ////////////////////
+
+    async get_object_acl(params) {
+        const ns = await this._get_bucket_namespace(params.bucket);
+        return ns.get_object_acl(params, this);
+    }
+
+    async put_object_acl(params) {
+        const ns = await this._get_bucket_namespace(params.bucket);
+        return ns.put_object_acl(params, this);
+    }
 }
 
 module.exports = ObjectSDK;


### PR DESCRIPTION
### Explain the changes
1. Added support for PUT object ACL
2. Added support for GET object ACL
3. Added configuration param to define behavior: "reject", "pass-through", else default behavior will apply

### Issues: Fixed #xxx / Gap #xxx
1. Missing unit tests

### Testing Instructions:
1. Set the config.ACL_HANDLING parameter to either "reject", "pass-through" or anything else
2. Make PUT or GET object ACL request
