### PR TITLE
Adding api call for getting the pool agent config

### DIFF
--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -384,6 +384,26 @@ module.exports = {
             auth: {
                 system: 'admin'
             }
+        },
+
+        get_hosts_pool_agent_config: {
+            doc: 'Read the hosts pool\'s agent config',
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: {
+                        type: 'string',
+                    },
+                }
+            },
+            reply: {
+                type: 'string'
+            },
+            auth: {
+                system: 'admin'
+            }
         }
     },
 

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -189,6 +189,15 @@ async function create_hosts_pool(req) {
     }
 }
 
+async function get_hosts_pool_agent_config(req) {
+    const pool = find_pool_by_name(req);
+    if (!pool.hosts_pool_info) {
+        throw new RpcError('INVALID_POOL_TYPE', `pool ${pool.name} not a hosts pool`);
+    }
+    const agent_install_string = await get_agent_install_conf(req.system, pool, req.account, 'INTERNAL');
+    return agent_install_string;
+}
+
 async function get_agent_install_conf(system, pool, account, routing_hint) {
     let cfg = system_store.data.agent_configs
         .find(conf => conf.pool === pool._id);
@@ -1231,3 +1240,4 @@ exports.scale_hosts_pool = scale_hosts_pool;
 exports.update_hosts_pool = update_hosts_pool;
 exports.update_cloud_pool_limit = update_cloud_pool_limit;
 exports.get_optimal_non_mongo_pool_id = get_optimal_non_mongo_pool_id;
+exports.get_hosts_pool_agent_config = get_hosts_pool_agent_config;


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1.  As part of fixing a issue with creating pvpool but failing to get his agent_config
we will add to the operator the option to recheck the agent-config if it is later available 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
