### PR TITLE
Adapting the code for possible joint tiering policies by 2 or more buckets

### DIFF
--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -59,8 +59,6 @@ class GetMapping {
         this.location_info = props.location_info;
 
         this.chunks_per_bucket = _.groupBy(this.chunks, chunk => chunk.bucket_id);
-        // assert move_to_tier is only used for chunks on the same bucket
-        if (this.move_to_tier) assert.strictEqual(Object.keys(this.chunks_per_bucket).length, 1);
         Object.seal(this);
     }
 
@@ -162,7 +160,7 @@ class GetMapping {
         const has_room = enough_room_in_tier(chunk.tier, chunk.bucket);
         for (const frag of chunk.frags) {
             for (const alloc of frag.allocations) {
-                const node = node_allocator.allocate_node({pools: alloc.pools, avoid_nodes, allocated_hosts});
+                const node = node_allocator.allocate_node({ pools: alloc.pools, avoid_nodes, allocated_hosts });
                 if (!node) {
                     dbg.warn(`GetMapping allocate_blocks: no nodes for allocation ` +
                         `avoid_nodes ${avoid_nodes.join(',')} ` +

--- a/src/server/system_services/tier_server.js
+++ b/src/server/system_services/tier_server.js
@@ -828,6 +828,13 @@ function get_associated_tiering_policies(tier) {
     return _.map(associated_tiering_policies, tiering_policies => tiering_policies._id);
 }
 
+function get_associated_buckets(policy) {
+    const associated_buckets = _.filter(policy.system.buckets_by_name,
+        bucket => String(bucket.tiering._id) === String(policy._id));
+
+    return _.map(associated_buckets, bucket => bucket._id);
+}
+
 function throw_on_invalid_pools_for_tier(pools) {
     const deleting_pools = pools.filter(pool =>
         pool.hosts_pool_info &&
@@ -840,6 +847,7 @@ function throw_on_invalid_pools_for_tier(pools) {
 
 // EXPORTS
 exports.get_associated_tiering_policies = get_associated_tiering_policies;
+exports.get_associated_buckets = get_associated_buckets;
 exports.new_tier_defaults = new_tier_defaults;
 exports.new_policy_defaults = new_policy_defaults;
 exports.get_tier_info = get_tier_info;

--- a/src/test/system_tests/ceph_s3_tests_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests_deploy.sh
@@ -16,7 +16,7 @@ DIRECTORY="s3-tests"
 CEPH_LINK="https://github.com/ceph/s3-tests.git"
 # using a fixed version (commit) of ceph tests to avoid sudden changes. 
 # we should retest and update the version once in a while
-CEPH_TESTS_VERSION=13452bd25fdc5307afba9e93599fbfc87b4669c1
+CEPH_TESTS_VERSION=5a8d0b8b0d2b474f04a097ca428304f7d682e7b0
 if [ ! -d $DIRECTORY ]; then
     echo "Downloading Ceph S3 Tests..."
     git clone $CEPH_LINK


### PR DESCRIPTION
### Explain the changes
1. Adapt bucket server to not delete the bucket tiering policy but to first check if it's not shared by other buckets
2. Adapt bucket_reclaimer to do the same
3. Allow tier moving for chunks using the same tiering policies but different buckets in map_server

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

Signed-off-by: jackyalbo <jalbo@redhat.com>