### PR TITLE
NS-CACHE: Cache object with size <= config.INLINE_MAX_SIZE

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -54,6 +54,9 @@ module.exports = {
                     complete_upload: {
                         type: 'boolean'
                     },
+                    last_modified_time: {
+                        idate: true
+                    },
                 }
             },
             reply: {
@@ -151,7 +154,10 @@ module.exports = {
                                 },
                             }
                         }
-                    }
+                    },
+                    last_modified_time: {
+                        idate: true
+                    },
                 }
             },
             reply: {

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -78,7 +78,11 @@ async function create_object_upload(req) {
         if (!req.rpc_params.etag) {
             throw new RpcError('INVALID_REQUEST', 'etag must be provided when using complete_upload');
         }
+        if (!req.rpc_params.last_modified_time) {
+            throw new RpcError('INVALID_REQUEST', 'last_modified_time must be provided when using complete_upload');
+        }
         info.etag = req.rpc_params.etag;
+        info.last_modified_time = new Date(req.rpc_params.last_modified_time);
     } else {
         info.upload_size = 0;
         info.upload_started = obj_id;
@@ -421,6 +425,10 @@ async function complete_object_upload(req) {
     set_updates.version_seq = await MDStore.instance().alloc_object_version_seq();
     if (req.bucket.versioning === 'ENABLED') {
         set_updates.version_enabled = true;
+    }
+
+    if (req.rpc_params.last_modified_time) {
+        set_updates.last_modified_time = new Date(req.rpc_params.last_modified_time);
     }
 
     await _put_object_handle_latest({ req, put_obj: obj, set_updates, unset_updates });

--- a/src/test/unit_tests/test_object_io.js
+++ b/src/test/unit_tests/test_object_io.js
@@ -406,7 +406,7 @@ coretest.describe_mapper_test_case({
         const content_type = 'test/test';
         const etag = crypto_random_string(32);
         const { obj_id } = await rpc_client.object.create_object_upload({ bucket, key, content_type,
-            complete_upload: true, size: 12345, etag});
+            complete_upload: true, size: 12345, etag, last_modified_time: (new Date()).getTime() });
 
         const { cached_parts, read_range } = params;
         for (const part of cached_parts) {

--- a/src/test/utils/namespace_context.js
+++ b/src/test/utils/namespace_context.js
@@ -209,6 +209,14 @@ class NamespaceContext {
                 cloud_md5} in hub bucket ${cloud_bucket} for ${file_name}`);
         }
 
+        if (expect_same && cloud_md.last_modified_time.getTime() !== noobaa_md.last_modified_time.getTime()) {
+            throw new Error(`Expect last_modified_time (${noobaa_md.last_modified_time}) in noobaa cache bucket (${noobaa_bucket})
+                is the same as last_modified_time (${cloud_md.last_modified_time}) in hub bucket ${cloud_bucket} for ${file_name}`);
+        } else if (!expect_same && cloud_md.last_modified_time.getTime() === noobaa_md.last_modified_time.getTime()) {
+            throw new Error(`Expect last_modified_time (${noobaa_md.last_modified_time}) in noobaa cache bucket (${noobaa_bucket})
+                is different than last_modified_time (${cloud_md.last_modified_time}) in hub bucket ${cloud_bucket} for ${file_name}`);
+        }
+
         console.log(`validation passed: noobaa cache bucket ${noobaa_bucket} and ${type} bucket have same md5 for ${file_name}`);
         return { cloud_md, noobaa_md };
     }


### PR DESCRIPTION
Signed-off-by: Paul-Zhang <Paul.Zhang@ibm.com>

### Explain the changes
1. Fix the issue that object with size <= config.INLINE_MAX_SIZE does not get cached.

2. Fix issue in updating last_modified_time
It appears that updating last_modified_time does not fully work. In the existing implementation, updating last_modified_time happens in the finalizer of cache stream and before complete_object_upload gets called. The update fails because the db operation looks for object with "upload_started" NOT set, while it can only happen after  complete_object_upload() gets called, so the update eventually fails with upload not found.

### Issues: Fixed #xxx / Gap #xxx
1.  Fix the issue #6150 

### Testing Instructions:
1.  upload object with size <= config.INLINE_MAX_SIZE and validate that it is cached.
