### PR TITLE
Prometheus reporting enhancements

### DIFF
--- a/config.js
+++ b/config.js
@@ -395,7 +395,15 @@ config.MIN_MEMORY_FOR_UPGRADE = 1200 * 1024 * 1024;
 
 config.SEND_EVENTS_REMOTESYS = true;
 config.PROMETHEUS_ENABLED = true;
+config.PROMETHEUS_SERVER_RETRY_COUNT = Infinity;
+config.PROMETHEUS_SERVER_RETRY_DELAY = 5 * 60 * 1000; // 5 min
 config.PROMETHEUS_PREFIX = 'NooBaa_';
+
+// Ports where prometheus metrics are served
+config.WS_METRICS_SERVER_PORT = 7001;
+config.BG_METRICS_SERVER_PORT = 7002;
+config.HA_METRICS_SERVER_PORT = 7003;
+config.EP_METRICS_SERVER_PORT = 7004;
 
 //////////////////////////////
 // OAUTH RELATES            //

--- a/package-lock.json
+++ b/package-lock.json
@@ -3721,6 +3721,16 @@
         }
       }
     },
+    "express-http-proxy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.6.0.tgz",
+      "integrity": "sha512-7Re6Lepg96NA2wiv7DC5csChAScn4K76/UgYnC71XiITCT1cgGTJUGK6GS0pIixudg3Fbx3Q6mmEW3mZv5tHFQ==",
+      "requires": {
+        "debug": "^3.0.1",
+        "es6-promise": "^4.1.1",
+        "raw-body": "^2.3.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "compression": "1.7.4",
     "express": "4.17.1",
     "ftp-srv": "4.3.4",
+    "express-http-proxy": "1.6.0",
     "get-folder-size": "2.0.1",
     "getos": "3.2.0",
     "glob-to-regexp": "0.4.1",

--- a/src/agent/agent_wrap.js
+++ b/src/agent/agent_wrap.js
@@ -10,13 +10,14 @@ const url = require('url');
 const request = require('request');
 const path = require('path');
 
+const dbg = require('../util/debug_module')(__filename);
+dbg.set_process_name('agent_wrapper');
+
 const P = require('../util/promise');
 const fs_utils = require('../util/fs_utils');
 const os_utils = require('../util/os_utils');
 const promise_utils = require('../util/promise_utils');
 const child_process = require('child_process');
-const dbg = require('../util/debug_module')(__filename);
-dbg.set_process_name('agent_wrapper');
 
 
 

--- a/src/server/analytic_services/prometheus_reporting.js
+++ b/src/server/analytic_services/prometheus_reporting.js
@@ -1,485 +1,101 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const _ = require('lodash');
-const prom_client = require('prom-client');
-const config = require('../../../config.js');
+const dbg = require('../../util/debug_module')(__filename);
+const http = require('http');
+const config = require('../../../config');
+const promise_utils = require('../../util/promise_utils');
 
-function get_metric_name(name) {
-    return config.PROMETHEUS_PREFIX + name;
+// Import the reports.
+const { NodeJsReport } = require('./prometheus_reports/nodejs_report');
+const { NooBaaCoreReport } = require('./prometheus_reports/noobaa_core_report');
+const { NooBaaEndpointReport } = require('./prometheus_reports/noobaa_endpoint_report');
+
+// Currenty supported reprots
+const reports = {
+    nodejs: new NodeJsReport(),
+    core: null, // optional
+    endpoint: null // optional
+};
+
+function get_nodejs_report() {
+    return reports.nodejs;
 }
 
-const METRIC_RECORDS = Object.freeze([{
-    metric_type: 'Gauge',
-    metric_variable: 'cloud_types',
-    configuration: {
-        name: get_metric_name('cloud_types'),
-        help: 'Cloud Resource Types in the System',
-        labelNames: ['type']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'projects_capacity_usage',
-    configuration: {
-        name: get_metric_name('projects_capacity_usage'),
-        help: 'Projects Capacity Usage',
-        labelNames: ['project']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'accounts_usage_read_count',
-    configuration: {
-        name: get_metric_name('accounts_usage_read_count'),
-        help: 'Accounts Usage Read Count',
-        labelNames: ['account']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'accounts_usage_write_count',
-    configuration: {
-        name: get_metric_name('accounts_usage_write_count'),
-        help: 'Accounts Usage Write Count',
-        labelNames: ['account']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'accounts_usage_logical',
-    configuration: {
-        name: get_metric_name('accounts_usage_logical'),
-        help: 'Accounts Usage Logical',
-        labelNames: ['account']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'bucket_class_capacity_usage',
-    configuration: {
-        name: get_metric_name('bucket_class_capacity_usage'),
-        help: 'Bucket Class Capacity Usage',
-        labelNames: ['bucket_class']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'unhealthy_cloud_types',
-    configuration: {
-        name: get_metric_name('unhealthy_cloud_types'),
-        help: 'Unhealthy Cloud Resource Types in the System',
-        labelNames: ['type']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'object_histo',
-    configuration: {
-        name: get_metric_name('object_histo'),
-        help: 'Object Sizes Histogram Across the System',
-        labelNames: ['size', 'avg']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'providers_bandwidth_write_size',
-    configuration: {
-        name: get_metric_name('providers_bandwidth_write_size'),
-        help: 'Providers bandwidth write size',
-        labelNames: ['type']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'providers_bandwidth_read_size',
-    configuration: {
-        name: get_metric_name('providers_bandwidth_read_size'),
-        help: 'Providers bandwidth read size',
-        labelNames: ['type']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'providers_ops_read_num',
-    configuration: {
-        name: get_metric_name('providers_ops_read_num'),
-        help: 'Providers number of read operations',
-        labelNames: ['type']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'providers_ops_write_num',
-    configuration: {
-        name: get_metric_name('providers_ops_write_num'),
-        help: 'Providers number of write operations',
-        labelNames: ['type']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'providers_physical_size',
-    configuration: {
-        name: get_metric_name('providers_physical_size'),
-        help: 'Providers Physical Stats',
-        labelNames: ['type']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'providers_logical_size',
-    configuration: {
-        name: get_metric_name('providers_logical_size'),
-        help: 'Providers Logical Stats',
-        labelNames: ['type']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'system_capacity',
-    configuration: {
-        name: get_metric_name('system_capacity'),
-        help: 'System capacity',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'system_info',
-    configuration: {
-        name: get_metric_name('system_info'),
-        help: 'System info',
-        labelNames: ['system_name', 'system_address']
-    }
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'num_buckets',
-    configuration: {
-        name: get_metric_name('num_buckets'),
-        help: 'Object Buckets',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'total_usage',
-    configuration: {
-        name: get_metric_name('total_usage'),
-        help: 'Total Usage',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'accounts_num',
-    configuration: {
-        name: get_metric_name('accounts_num'),
-        help: 'Accounts Number',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'num_objects',
-    configuration: {
-        name: get_metric_name('num_objects'),
-        help: 'Objects',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'num_unhealthy_buckets',
-    configuration: {
-        name: get_metric_name('num_unhealthy_buckets'),
-        help: 'Unhealthy Buckets',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'num_unhealthy_pools',
-    configuration: {
-        name: get_metric_name('num_unhealthy_pools'),
-        help: 'Unhealthy Resource Pools',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'num_pools',
-    configuration: {
-        name: get_metric_name('num_pools'),
-        help: 'Resource Pools',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'num_unhealthy_bucket_claims',
-    configuration: {
-        name: get_metric_name('num_unhealthy_bucket_claims'),
-        help: 'Unhealthy Bucket Claims',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'num_buckets_claims',
-    configuration: {
-        name: get_metric_name('num_buckets_claims'),
-        help: 'Object Bucket Claims',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'num_objects_buckets_claims',
-    configuration: {
-        name: get_metric_name('num_objects_buckets_claims'),
-        help: 'Objects On Object Bucket Claims',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'reduction_ratio',
-    configuration: {
-        name: get_metric_name('reduction_ratio'),
-        help: 'Object Efficiency Ratio',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'object_savings_logical_size',
-    configuration: {
-        name: get_metric_name('object_savings_logical_size'),
-        help: 'Object Savings Logical',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'object_savings_physical_size',
-    configuration: {
-        name: get_metric_name('object_savings_physical_size'),
-        help: 'Object Savings Physical',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'rebuild_progress',
-    configuration: {
-        name: get_metric_name('rebuild_progress'),
-        help: 'Rebuild Progress',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'rebuild_time',
-    configuration: {
-        name: get_metric_name('rebuild_time'),
-        help: 'Rebuild Time',
-    },
-    generate_default_set: true,
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'bucket_healthy',
-    configuration: {
-        name: get_metric_name('bucket_status'),
-        help: 'Bucket Health',
-        labelNames: ['bucket_name'],
-    },
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'bucket_capacity_precent',
-    configuration: {
-        name: get_metric_name('bucket_capacity'),
-        help: 'Bucket Capacity Precent',
-        labelNames: ['bucket_name'],
-    },
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'bucket_quota_precent',
-    configuration: {
-        name: get_metric_name('bucket_quota'),
-        help: 'Bucket Quota Precent',
-        labelNames: ['bucket_name'],
-    },
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'resource_healthy',
-    configuration: {
-        name: get_metric_name('resource_status'),
-        help: 'Resource Health',
-        labelNames: ['resource_name'],
-    },
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'system_links',
-    configuration: {
-        name: get_metric_name('system_links'),
-        help: 'System Links',
-        labelNames: ['resources', 'buckets', 'dashboard'],
-    },
-}, {
-    metric_type: 'Gauge',
-    metric_variable: 'health_status',
-    configuration: {
-        name: get_metric_name('health_status'),
-        help: 'Health status',
-    },
-    generate_default_set: true,
-}]);
+function get_core_report(peek = false) {
+    if (!reports.core_report && !peek) reports.core_report = new NooBaaCoreReport();
+    return reports.core_report;
+}
 
+function get_endpoint_report(peek = false) {
+    if (!reports.endpoint && !peek) reports.endpoint = new NooBaaEndpointReport();
+    return reports.endpoint;
+}
 
-class PrometheusReporting {
-    static instance() {
-        PrometheusReporting._instance = PrometheusReporting._instance || new PrometheusReporting();
-        return PrometheusReporting._instance;
+function export_all_metrics() {
+    return Object.values(reports)
+        .filter(Boolean)
+        .map(report => report.export_metrics())
+        .join('\n\n');
+}
+
+async function start_server(
+    port,
+    retry_count = config.PROMETHEUS_SERVER_RETRY_COUNT,
+    delay = config.PROMETHEUS_SERVER_RETRY_DELAY
+) {
+    if (!config.PROMETHEUS_ENABLED) {
+        return;
     }
 
-    constructor() {
-        METRIC_RECORDS.filter(metric => metric.generate_default_set).forEach(metric => {
-            this[`set_${metric.metric_variable}`] = function(data) {
-                if (!this.enabled()) return;
-                this._metrics[metric.metric_variable].set(data);
-            };
-        });
-        this._prom_client = prom_client;
-        if (this.enabled()) {
-            this.define_metrics();
+    const server = http.createServer((req, res) => {
+        // Serve all metrics on the root path.
+        if (req.url === '' || req.url === '/') {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end(export_all_metrics());
+            return;
         }
-    }
 
-    client() {
-        return this._prom_client;
-    }
-
-    enabled() {
-        return config.PROMETHEUS_ENABLED;
-    }
-
-    define_metrics() {
-        this._metrics = {};
-        prom_client.collectDefaultMetrics({ prefix: get_metric_name('defaults_') });
-
-        //Currently called from stats_aggregator, md_aggregator and other stats collectors are probebly as interesting to look at
-        METRIC_RECORDS.forEach(metric => {
-            this._metrics[metric.metric_variable] = new prom_client[metric.metric_type](metric.configuration);
-        });
-    }
-
-    export_metrics() {
-        const exported = _.map(METRIC_RECORDS, metric =>
-                this._prom_client.register.getSingleMetricAsString(metric.configuration.name))
-            .join('\n');
-
-        return exported;
-    }
-
-    set_cloud_types(types) {
-        if (!this.enabled()) return;
-        this._metrics.cloud_types.set({ type: 'AWS' }, types.pool_target.amazon);
-        this._metrics.cloud_types.set({ type: 'Azure' }, types.pool_target.azure);
-        this._metrics.cloud_types.set({ type: 'GCP' }, types.pool_target.gcp);
-        this._metrics.cloud_types.set({ type: 'Kubernetes' }, types.pool_target.kubernetes);
-        // TODO: Fill this up when we will know how to recognize
-        // this._metrics.cloud_types.set({ type: 'Ceph' }, types.pool_target.ceph);
-        this._metrics.cloud_types.set({ type: 'S3_Compatible' }, types.pool_target.s3_comp);
-    }
-
-    set_unhealthy_cloud_types(types) {
-        if (!this.enabled()) return;
-        this._metrics.unhealthy_cloud_types.set({ type: 'AWS' }, types.unhealthy_pool_target.amazon_unhealthy);
-        this._metrics.unhealthy_cloud_types.set({ type: 'Azure' }, types.unhealthy_pool_target.azure_unhealthy);
-        this._metrics.unhealthy_cloud_types.set({ type: 'GCP' }, types.unhealthy_pool_target.gcp_unhealthy);
-        this._metrics.unhealthy_cloud_types.set({ type: 'Kubernetes' }, types.unhealthy_pool_target.kubernetes_unhealthy);
-        // TODO: Fill this up when we will know how to recognize
-        // this._metrics.unhealthy_cloud_types.set({ type: 'Ceph' }, types.unhealthy_pool_target.ceph_unhealthy);
-        this._metrics.unhealthy_cloud_types.set({ type: 'S3_Compatible' }, types.unhealthy_pool_target.s3_comp_unhealthy);
-    }
-
-    set_bucket_class_capacity_usage(usage_info) {
-        if (!this.enabled()) return;
-        this._metrics.bucket_class_capacity_usage.reset();
-        for (let [bucket_class, value] of Object.entries(usage_info)) {
-            this._metrics.bucket_class_capacity_usage.set({ bucket_class }, value);
+        // Serve report's metrics on the report name path
+        const report_name = req.url.substr(1);
+        const report = reports[report_name];
+        if (report) {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end(report.export_metrics(report_name));
+            return;
         }
-    }
 
-    set_projects_capacity_usage(usage_info) {
-        if (!this.enabled()) return;
-        this._metrics.projects_capacity_usage.reset();
-        for (let [project, value] of Object.entries(usage_info)) {
-            this._metrics.projects_capacity_usage.set({ project }, value);
-        }
-    }
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end();
+    });
 
-    set_accounts_io_usage(accounts_info) {
-        if (!this.enabled()) return;
-        this._metrics.accounts_usage_logical.reset();
-        this._metrics.accounts_usage_read_count.reset();
-        this._metrics.accounts_usage_write_count.reset();
-        accounts_info.accounts.forEach(account_info => {
-            const { account, read_count, write_count, read_write_bytes } = account_info;
-            this._metrics.accounts_usage_logical.set({ account }, read_write_bytes);
-            this._metrics.accounts_usage_read_count.set({ account }, read_count);
-            this._metrics.accounts_usage_write_count.set({ account }, write_count);
-        });
-    }
+    // Try to open the port for listening, will retry then exist.
+    while (retry_count) {
+        try {
+            await new Promise((resolve, reject) => {
+                server.listen(port, err => (err ? reject(err) : resolve()));
+            });
 
-    set_object_sizes(sizes) {
-        if (!this.enabled()) return;
-        for (const bin of sizes) {
-            if (!_.isEmpty(bin.bins)) {
-                for (const cur of bin.bins) {
-                    this._metrics.object_histo.set({ size: cur.label, avg: cur.avg }, cur.count, new Date());
-                }
+            // Set retry_count to 0 to exit the loop
+            retry_count = 0;
+
+        } catch (err) {
+            if (retry_count) {
+                dbg.error(`Metrics server failed to listen on ${port} (retries left: ${retry_count}), got`, err);
+                await promise_utils.delay_unblocking(delay);
+            } else {
+                dbg.error(`Metrics server failed to listen on ${port} too many times, existing the process`);
+                process.exit();
             }
         }
     }
-
-    set_providers_bandwidth(type, write_size, read_size) {
-        if (!this.enabled()) return;
-        this._metrics.providers_bandwidth_read_size.set({ type }, read_size);
-        this._metrics.providers_bandwidth_write_size.set({ type }, write_size);
-    }
-
-    set_providers_ops(type, write_num, read_num) {
-        if (!this.enabled()) return;
-        this._metrics.providers_ops_read_num.set({ type }, read_num);
-        this._metrics.providers_ops_write_num.set({ type }, write_num);
-    }
-
-    set_providers_physical_logical(providers_stats) {
-        if (!this.enabled()) return;
-        for (let [type, value] of Object.entries(providers_stats)) {
-            const { logical_size, physical_size } = value;
-            this._metrics.providers_physical_size.set({ type }, physical_size);
-            this._metrics.providers_logical_size.set({ type }, logical_size);
-        }
-    }
-
-    set_system_info(info) {
-        if (!this.enabled()) return;
-        this._metrics.system_info.reset();
-        this._metrics.system_info.set({ system_name: info.name, system_address: info.address }, Date.now());
-    }
-
-    set_system_links(links) {
-        if (!this.enabled()) return;
-        this._metrics.system_links.reset();
-        this._metrics.system_links.set({ resources: links.resources, buckets: links.buckets, dashboard: links.dashboard }, Date.now());
-    }
-
-    set_bucket_status(buckets_info) {
-        if (!this.enabled()) return;
-        this._metrics.bucket_healthy.reset();
-        this._metrics.bucket_quota_precent.reset();
-        this._metrics.bucket_capacity_precent.reset();
-        buckets_info.forEach(bucket_info => {
-            this._metrics.bucket_healthy.set({ bucket_name: bucket_info.bucket_name }, Number(bucket_info.is_healthy));
-            this._metrics.bucket_quota_precent.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_precent);
-            this._metrics.bucket_capacity_precent.set({ bucket_name: bucket_info.bucket_name }, bucket_info.capacity_precent);
-        });
-    }
-
-    set_resource_status(resources_info) {
-        if (!this.enabled()) return;
-        this._metrics.resource_healthy.reset();
-        resources_info.forEach(resource_info => {
-            this._metrics.resource_healthy.set({ resource_name: resource_info.resource_name }, Number(resource_info.is_healthy));
-        });
-    }
-
-    update_providers_bandwidth(type, write_size, read_size) {
-        if (!this.enabled()) return;
-        this._metrics.providers_bandwidth_read_size.inc({ type }, read_size);
-        this._metrics.providers_bandwidth_write_size.inc({ type }, write_size);
-    }
-
-    update_providers_ops(type, write_num, read_num) {
-        if (!this.enabled()) return;
-        this._metrics.providers_ops_read_num.inc({ type }, read_num);
-        this._metrics.providers_ops_write_num.inc({ type }, write_num);
-    }
 }
 
-// EXPORTS
-exports.PrometheusReporting = PrometheusReporting;
+// -----------------------------------------
+// exports
+// -----------------------------------------
+exports.get_nodejs_report = get_nodejs_report;
+exports.get_core_report = get_core_report;
+exports.get_endpoint_report = get_endpoint_report;
+exports.export_all_metrics = export_all_metrics;
+exports.start_server = start_server;

--- a/src/server/analytic_services/prometheus_reports/base_prometheus_report.js
+++ b/src/server/analytic_services/prometheus_reports/base_prometheus_report.js
@@ -1,0 +1,38 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const prom_client = require('prom-client');
+const config = require('../../../../config.js');
+
+class BasePrometheusReport {
+    constructor() {
+        this._registry = new this.prom_client.Registry();
+    }
+
+    get prom_client() {
+        return prom_client;
+    }
+
+    get registry() {
+        return this._registry;
+    }
+
+    get metric_prefix() {
+        return config.PROMETHEUS_PREFIX;
+    }
+
+    get enabled() {
+        return config.PROMETHEUS_ENABLED;
+    }
+
+    get_prefixed_name(name) {
+        return `${this.metric_prefix}${name}`;
+    }
+
+    export_metrics() {
+        return this.registry.metrics();
+    }
+}
+
+exports.BasePrometheusReport = BasePrometheusReport;
+

--- a/src/server/analytic_services/prometheus_reports/nodejs_report.js
+++ b/src/server/analytic_services/prometheus_reports/nodejs_report.js
@@ -1,0 +1,28 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const { BasePrometheusReport } = require('./base_prometheus_report');
+const dbg = require('../../../util/debug_module')(__filename);
+
+// -----------------------------------------
+// Report containing node.js metrics
+// collected and provided by the prom client
+// -----------------------------------------
+class NodeJsReport extends BasePrometheusReport {
+    constructor() {
+        super();
+
+        if (this.enabled) {
+            this.prom_client.collectDefaultMetrics({
+                register: this.registry,
+                prefix: this.metric_prefix
+            });
+        }
+    }
+
+    get metric_prefix() {
+        return `${super.metric_prefix}${dbg.get_process_name()}_`;
+    }
+}
+
+exports.NodeJsReport = NodeJsReport;

--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -1,0 +1,451 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+const { BasePrometheusReport } = require('./base_prometheus_report');
+const js_utils = require('../../../util/js_utils');
+
+// -----------------------------------------
+// Report for collecting noobaa core metrics
+// Providing an interface to set/update said
+// metrics
+// -----------------------------------------
+const NOOBAA_CORE_METRICS = js_utils.deep_freeze([
+    {
+        type: 'Gauge',
+        name: 'cloud_types',
+        configuration: {
+            help: 'Cloud Resource Types in the System',
+            labelNames: ['type']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'projects_capacity_usage',
+        configuration: {
+            help: 'Projects Capacity Usage',
+            labelNames: ['project']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'accounts_usage_read_count',
+        configuration: {
+            help: 'Accounts Usage Read Count',
+            labelNames: ['account']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'accounts_usage_write_count',
+        configuration: {
+            help: 'Accounts Usage Write Count',
+            labelNames: ['account']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'accounts_usage_logical',
+        configuration: {
+            help: 'Accounts Usage Logical',
+            labelNames: ['account']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_class_capacity_usage',
+        configuration: {
+            help: 'Bucket Class Capacity Usage',
+            labelNames: ['bucket_class']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'unhealthy_cloud_types',
+        configuration: {
+            help: 'Unhealthy Cloud Resource Types in the System',
+            labelNames: ['type']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'object_histo',
+        configuration: {
+            help: 'Object Sizes Histogram Across the System',
+            labelNames: ['size', 'avg']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'providers_bandwidth_write_size',
+        configuration: {
+            help: 'Providers bandwidth write size',
+            labelNames: ['type'],
+        }
+    }, {
+        type: 'Gauge',
+        name: 'providers_bandwidth_read_size',
+        configuration: {
+            help: 'Providers bandwidth read size',
+            labelNames: ['type']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'providers_ops_read_num',
+        configuration: {
+            help: 'Providers number of read operations',
+            labelNames: ['type']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'providers_ops_write_num',
+        configuration: {
+            help: 'Providers number of write operations',
+            labelNames: ['type']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'providers_physical_size',
+        configuration: {
+            help: 'Providers Physical Stats',
+            labelNames: ['type']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'providers_logical_size',
+        configuration: {
+            help: 'Providers Logical Stats',
+            labelNames: ['type']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'system_capacity',
+        generate_default_set: true,
+        configuration: {
+            help: 'System capacity'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'system_info',
+        configuration: {
+            help: 'System info',
+            labelNames: ['system_name', 'system_address']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'num_buckets',
+        generate_default_set: true,
+        configuration: {
+            help: 'Object Buckets'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'total_usage',
+        generate_default_set: true,
+        configuration: {
+            help: 'Total Usage'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'accounts_num',
+        generate_default_set: true,
+        configuration: {
+            help: 'Accounts Number'
+        }
+
+    }, {
+        type: 'Gauge',
+        name: 'num_objects',
+        generate_default_set: true,
+        configuration: {
+            help: 'Objects',
+        }
+    }, {
+        type: 'Gauge',
+        name: 'num_unhealthy_buckets',
+        generate_default_set: true,
+        configuration: {
+            help: 'Unhealthy Buckets'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'num_unhealthy_pools',
+        generate_default_set: true,
+        configuration: {
+            help: 'Unhealthy Resource Pools'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'num_pools',
+        generate_default_set: true,
+        configuration: {
+            help: 'Resource Pools'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'num_unhealthy_bucket_claims',
+        generate_default_set: true,
+        configuration: {
+            help: 'Unhealthy Bucket Claims'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'num_buckets_claims',
+        generate_default_set: true,
+        configuration: {
+            help: 'Object Bucket Claims'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'num_objects_buckets_claims',
+        generate_default_set: true,
+        configuration: {
+            help: 'Objects On Object Bucket Claims'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'reduction_ratio',
+        generate_default_set: true,
+        configuration: {
+            help: 'Object Efficiency Ratio'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'object_savings_logical_size',
+        generate_default_set: true,
+        configuration: {
+            help: 'Object Savings Logical'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'object_savings_physical_size',
+        generate_default_set: true,
+        configuration: {
+            help: 'Object Savings Physical'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'rebuild_progress',
+        generate_default_set: true,
+        configuration: {
+            help: 'Rebuild Progress'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'rebuild_time',
+        generate_default_set: true,
+        configuration: {
+            help: 'Rebuild Time'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_status',
+        configuration: {
+            help: 'Bucket Health',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_capacity',
+        configuration: {
+            help: 'Bucket Capacity Precent',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_quota',
+        configuration: {
+            help: 'Bucket Quota Precent',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'resource_status',
+        configuration: {
+            help: 'Resource Health',
+            labelNames: ['resource_name']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'system_links',
+        configuration: {
+            help: 'System Links',
+            labelNames: ['resources', 'buckets', 'dashboard']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'health_status',
+        generate_default_set: true,
+        configuration: {
+            help: 'Health status'
+        }
+    }
+]);
+
+class NooBaaCoreReport extends BasePrometheusReport {
+    constructor() {
+        super();
+
+        this._metrics = null;
+
+        if (this.enabled) {
+            this._metrics = {};
+            for (const m of NOOBAA_CORE_METRICS) {
+                this._metrics[m.name] = new this.prom_client[m.type]({
+                    name: this.get_prefixed_name(m.name),
+                    registers: [this.registry],
+                    ...m.configuration,
+                });
+            }
+        }
+
+        // It is important to move the name into a local var
+        // in order to prevent the closure from capturing the entire
+        // metric definition
+        for (const { generate_default_set, name } of NOOBAA_CORE_METRICS) {
+            if (generate_default_set) {
+                // Create a default setter.
+                this[`set_${name}`] = data => {
+                    if (!this._metrics) return;
+                    this._metrics[name].set(data);
+                };
+            }
+        }
+    }
+
+    set_cloud_types(types) {
+        if (!this._metrics) return;
+
+        this._metrics.cloud_types.set({ type: 'AWS' }, types.pool_target.amazon);
+        this._metrics.cloud_types.set({ type: 'Azure' }, types.pool_target.azure);
+        this._metrics.cloud_types.set({ type: 'GCP' }, types.pool_target.gcp);
+        this._metrics.cloud_types.set({ type: 'Kubernetes' }, types.pool_target.kubernetes);
+        // TODO: Fill this up when we will know how to recognize
+        // this._metrics.cloud_types.set({ type: 'Ceph' }, types.pool_target.ceph);
+        this._metrics.cloud_types.set({ type: 'S3_Compatible' }, types.pool_target.s3_comp);
+    }
+
+    set_unhealthy_cloud_types(types) {
+        if (!this._metrics) return;
+
+        this._metrics.unhealthy_cloud_types.set({ type: 'AWS' }, types.unhealthy_pool_target.amazon_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'Azure' }, types.unhealthy_pool_target.azure_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'GCP' }, types.unhealthy_pool_target.gcp_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'Kubernetes' }, types.unhealthy_pool_target.kubernetes_unhealthy);
+        // TODO: Fill this up when we will know how to recognize
+        // this._metrics.unhealthy_cloud_types.set({ type: 'Ceph' }, types.unhealthy_pool_target.ceph_unhealthy);
+        this._metrics.unhealthy_cloud_types.set({ type: 'S3_Compatible' }, types.unhealthy_pool_target.s3_comp_unhealthy);
+    }
+
+    set_bucket_class_capacity_usage(usage_info) {
+        if (!this._metrics) return;
+
+        this._metrics.bucket_class_capacity_usage.reset();
+        for (const [bucket_class, value] of Object.entries(usage_info)) {
+            this._metrics.bucket_class_capacity_usage.set({ bucket_class }, value);
+        }
+    }
+
+    set_projects_capacity_usage(usage_info) {
+        if (!this._metrics) return;
+
+        this._metrics.projects_capacity_usage.reset();
+        for (const [project, value] of Object.entries(usage_info)) {
+            this._metrics.projects_capacity_usage.set({ project }, value);
+        }
+    }
+
+    set_accounts_io_usage(accounts_info) {
+        if (!this._metrics) return;
+
+        this._metrics.accounts_usage_logical.reset();
+        this._metrics.accounts_usage_read_count.reset();
+        this._metrics.accounts_usage_write_count.reset();
+        accounts_info.accounts.forEach(account_info => {
+            const { account, read_count, write_count, read_write_bytes } = account_info;
+            this._metrics.accounts_usage_logical.set({ account }, read_write_bytes);
+            this._metrics.accounts_usage_read_count.set({ account }, read_count);
+            this._metrics.accounts_usage_write_count.set({ account }, write_count);
+        });
+    }
+
+    set_object_sizes(sizes) {
+        if (!this._metrics) return;
+
+        for (const bin of sizes) {
+            if (!_.isEmpty(bin.bins)) {
+                for (const cur of bin.bins) {
+                    this._metrics.object_histo.set({ size: cur.label, avg: cur.avg }, cur.count, new Date());
+                }
+            }
+        }
+    }
+
+    set_providers_bandwidth(type, write_size, read_size) {
+        if (!this._metrics) return;
+
+        this._metrics.providers_bandwidth_read_size.set({ type }, read_size);
+        this._metrics.providers_bandwidth_write_size.set({ type }, write_size);
+    }
+
+    set_providers_ops(type, write_num, read_num) {
+        if (!this._metrics) return;
+
+        this._metrics.providers_ops_read_num.set({ type }, read_num);
+        this._metrics.providers_ops_write_num.set({ type }, write_num);
+    }
+
+    set_providers_physical_logical(providers_stats) {
+        if (!this._metrics) return;
+
+        for (let [type, value] of Object.entries(providers_stats)) {
+            const { logical_size, physical_size } = value;
+            this._metrics.providers_physical_size.set({ type }, physical_size);
+            this._metrics.providers_logical_size.set({ type }, logical_size);
+        }
+    }
+
+    set_system_info(info) {
+        if (!this._metrics) return;
+
+        this._metrics.system_info.reset();
+        this._metrics.system_info.set({ system_name: info.name, system_address: info.address }, Date.now());
+    }
+
+    set_system_links(links) {
+        if (!this._metrics) return;
+
+        this._metrics.system_links.reset();
+        this._metrics.system_links.set({ resources: links.resources, buckets: links.buckets, dashboard: links.dashboard }, Date.now());
+    }
+
+    set_bucket_status(buckets_info) {
+        if (!this._metrics) return;
+
+        this._metrics.bucket_status.reset();
+        this._metrics.bucket_quota.reset();
+        this._metrics.bucket_capacity.reset();
+        buckets_info.forEach(bucket_info => {
+            this._metrics.bucket_status.set({ bucket_name: bucket_info.bucket_name }, Number(bucket_info.is_healthy));
+            this._metrics.bucket_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_precent);
+            this._metrics.bucket_capacity.set({ bucket_name: bucket_info.bucket_name }, bucket_info.capacity_precent);
+        });
+    }
+
+    set_resource_status(resources_info) {
+        if (!this._metrics) return;
+
+        this._metrics.resource_status.reset();
+        resources_info.forEach(resource_info => {
+            this._metrics.resource_status.set({ resource_name: resource_info.resource_name }, Number(resource_info.is_healthy));
+        });
+    }
+
+    update_providers_bandwidth(type, write_size, read_size) {
+        if (!this._metrics) return;
+
+        this._metrics.providers_bandwidth_read_size.inc({ type }, read_size);
+        this._metrics.providers_bandwidth_write_size.inc({ type }, write_size);
+    }
+
+    update_providers_ops(type, write_num, read_num) {
+        if (!this._metrics) return;
+
+        this._metrics.providers_ops_read_num.inc({ type }, read_num);
+        this._metrics.providers_ops_write_num.inc({ type }, write_num);
+    }
+}
+
+exports.NooBaaCoreReport = NooBaaCoreReport;

--- a/src/server/analytic_services/prometheus_reports/noobaa_endpoint_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_endpoint_report.js
@@ -1,0 +1,49 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const { BasePrometheusReport } = require('./base_prometheus_report');
+
+// -----------------------------------------
+// A report for collecting endpoint metrics,
+// this class is a shim that should who ever
+// come next to add endpoint metrics reporting.
+// -----------------------------------------
+class NooBaaEndpointReport extends BasePrometheusReport {
+    constructor() {
+        super();
+
+        if (this.enabled) {
+            // Cache the client for ease of use.
+            const client = this.prom_client;
+
+            // Define storage for the metrics:
+            this._metrics = {
+                // This is a dummy metric that is used as an example, Gauge is use
+                // here forbut it can be any of the metric types defined in the prom
+                // client lib at https://github.com/siimon/prom-client with its
+                // specific configuration.
+                demo_metric: new client.Gauge({
+                    name: this.get_prefixed_name('demo_metric'),
+                    registers: [this.registry],
+                    help: 'Description line for demo_metric',
+                    // Other configurqation that should apply for this metric
+                }),
+            };
+        }
+    }
+
+    get metric_prefix() {
+        return `${super.metric_prefix}_Endpoint_`;
+    }
+
+    // Public interface to allow consuming code an interface for
+    // setting/updating values for the various metrics, more complex
+    // scenarios exists on the NooBaaCoreReport class
+    set_metric1(data) {
+        if (!this._metrics) return;
+
+        this._metrics.metric_1.set(data);
+    }
+}
+
+exports.NooBaaEndpointReport = NooBaaEndpointReport;

--- a/src/server/mongo_services/mongo_monitor.js
+++ b/src/server/mongo_services/mongo_monitor.js
@@ -2,11 +2,12 @@
 'use strict';
 
 const util = require('util');
+
 const dbg = require('../../util/debug_module')(__filename);
+dbg.set_process_name('MongoMonitor');
+
 const promise_utils = require('../../util/promise_utils');
 const P = require('../../util/promise');
-
-dbg.set_process_name('MongoMonitor');
 
 const TEST_STATUS_DELAY = 10000;
 

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -26,7 +26,7 @@ const size_utils = require('../../util/size_utils');
 const net_utils = require('../../util/net_utils');
 const fs_utils = require('../../util/fs_utils');
 const Dispatcher = require('../notifications/dispatcher');
-const prom_report = require('../analytic_services/prometheus_reporting').PrometheusReporting;
+const prom_reporting = require('../analytic_services/prometheus_reporting');
 const { HistoryDataStore } = require('../analytic_services/history_data_store');
 const { google } = require('googleapis');
 const google_storage = google.storage('v1');
@@ -910,43 +910,45 @@ function partial_cycle_parse_prometheus_metrics(payload) {
         (percentage_of_unhealthy_buckets > 0.5 && 4) ||
         (percentage_of_unhealthy_buckets > 0.3 && 3) || 0;
 
-    prom_report.instance().set_providers_physical_logical(providers_stats);
-    prom_report.instance().set_cloud_types(cloud_pool_stats);
-    prom_report.instance().set_num_unhealthy_pools(unhealthy_pool_count);
-    prom_report.instance().set_num_pools(pool_count);
-    prom_report.instance().set_unhealthy_cloud_types(cloud_pool_stats);
-    prom_report.instance().set_system_info({ name, address });
-    prom_report.instance().set_system_links(links);
-    prom_report.instance().set_num_buckets(buckets_num);
-    prom_report.instance().set_bucket_status(buckets);
-    prom_report.instance().set_resource_status(resources);
-    prom_report.instance().set_num_objects(objects_in_buckets);
-    prom_report.instance().set_num_unhealthy_buckets(unhealthy_buckets);
-    prom_report.instance().set_health_status(health_status);
-    prom_report.instance().set_num_unhealthy_bucket_claims(unhealthy_bucket_claims);
-    prom_report.instance().set_num_buckets_claims(bucket_claims);
-    prom_report.instance().set_num_objects_buckets_claims(objects_in_bucket_claims);
-    prom_report.instance().set_system_capacity(capacity);
-    prom_report.instance().set_reduction_ratio(reduction_ratio);
-    prom_report.instance().set_object_savings_physical_size(physical_size);
-    prom_report.instance().set_object_savings_logical_size(logical_size);
-    prom_report.instance().set_bucket_class_capacity_usage(usage_by_bucket_class);
-    prom_report.instance().set_projects_capacity_usage(usage_by_project);
-    prom_report.instance().set_accounts_io_usage(accounts_stats);
-    prom_report.instance().set_accounts_num(accounts_num);
-    prom_report.instance().set_total_usage(total_usage);
-    // TODO: Currently mock data, update with the relevant values.
-    prom_report.instance().set_rebuild_progress(100);
-    prom_report.instance().set_rebuild_time(0);
+    const core_report = prom_reporting.get_core_report();
+    core_report.set_providers_physical_logical(providers_stats);
+    core_report.set_cloud_types(cloud_pool_stats);
+    core_report.set_num_unhealthy_pools(unhealthy_pool_count);
+    core_report.set_num_pools(pool_count);
+    core_report.set_unhealthy_cloud_types(cloud_pool_stats);
+    core_report.set_system_info({ name, address });
+    core_report.set_system_links(links);
+    core_report.set_num_buckets(buckets_num);
+    core_report.set_bucket_status(buckets);
+    core_report.set_resource_status(resources);
+    core_report.set_num_objects(objects_in_buckets);
+    core_report.set_num_unhealthy_buckets(unhealthy_buckets);
+    core_report.set_health_status(health_status);
+    core_report.set_num_unhealthy_bucket_claims(unhealthy_bucket_claims);
+    core_report.set_num_buckets_claims(bucket_claims);
+    core_report.set_num_objects_buckets_claims(objects_in_bucket_claims);
+    core_report.set_system_capacity(capacity);
+    core_report.set_reduction_ratio(reduction_ratio);
+    core_report.set_object_savings_physical_size(physical_size);
+    core_report.set_object_savings_logical_size(logical_size);
+    core_report.set_bucket_class_capacity_usage(usage_by_bucket_class);
+    core_report.set_projects_capacity_usage(usage_by_project);
+    core_report.set_accounts_io_usage(accounts_stats);
+    core_report.set_accounts_num(accounts_num);
+    core_report.set_total_usage(total_usage);
+    // core_reportk data, update with the relevant values.
+    core_report.set_rebuild_progress(100);
+    core_report.set_rebuild_time(0);
 }
 
 /*
  * Prometheus Metrics Parsing, POC grade
  */
 function full_cycle_parse_prometheus_metrics(payload) {
-    prom_report.instance().set_cloud_types(payload.cloud_pool_stats);
-    prom_report.instance().set_unhealthy_cloud_types(payload.cloud_pool_stats);
-    prom_report.instance().set_object_sizes(payload.bucket_sizes_stats);
+    const core_report = prom_reporting.get_core_report();
+    core_report.set_cloud_types(payload.cloud_pool_stats);
+    core_report.set_unhealthy_cloud_types(payload.cloud_pool_stats);
+    core_report.set_object_sizes(payload.bucket_sizes_stats);
 }
 
 /*

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -569,6 +569,10 @@ DebugLogger.prototype.set_process_name = function(name) {
     int_dbg._proc_name = name;
 };
 
+DebugLogger.prototype.get_process_name = function() {
+    return int_dbg._proc_name;
+};
+
 DebugLogger.prototype.set_log_to_file = function(log_file) {
     if (log_file) {
         int_dbg._file_path = path.parse(log_file);


### PR DESCRIPTION
### Explain the changes
- Support multiple separate reports each with different metrics, which includes all built-in metrics under one report and any number of custom metrics under multiple other reports
- For each process dedicate a port to serve its reports
- Use proxying to serve all core container reports (from all processes) using the webserver and under a structured URL path tree
- Deprecate old metrics path in web server but still serve them for backward compatibility

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>