### PR TITLE
NS-CACHE: Support non-latency metrics

### DIFF
--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -186,6 +186,7 @@ class NamespaceS3 {
                     const count_stream = stream_utils.get_tap_stream(data => {
                         stats_collector.instance(this.rpc_client).update_namespace_read_stats({
                             namespace_resource_id: this.namespace_resource_id,
+                            bucket_name: params.bucket,
                             size: data.length,
                             count
                         });
@@ -232,6 +233,7 @@ class NamespaceS3 {
             const count_stream = stream_utils.get_tap_stream(data => {
                 stats_collector.instance(this.rpc_client).update_namespace_write_stats({
                     namespace_resource_id: this.namespace_resource_id,
+                    bucket_name: params.bucket,
                     size: data.length,
                     count
                 });

--- a/src/test/utils/metrics.js
+++ b/src/test/utils/metrics.js
@@ -1,0 +1,16 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// Get metric from prometheus collector
+function get_metric(stat_collector, name) {
+    const metric_name = stat_collector.get_prefixed_name(name);
+    return stat_collector.registry.getSingleMetric(metric_name);
+}
+
+// Reset all metrics in prometheus collector
+function reset_metrics(stat_collector) {
+    return stat_collector.registry.resetMetrics();
+}
+
+exports.get_metric = get_metric;
+exports.reset_metrics = reset_metrics;


### PR DESCRIPTION
Signed-off-by: Paul-Zhang <Paul.Zhang@ibm.com>

### Explain the changes
1.  Support the following metrics for namespace caching
- cache_read_bytes
- cache_write_bytes
- cache_range_read_miss_count
- cache_object_read_miss_count
- cache_object_read_count
- cache_range_read_count
- hub_read_bytes
- hub_write_bytes

### Issues: Fixed #xxx / Gap #xxx
1.  Part of the namespace caching feature

### Testing Instructions:
1.  Create namespace caching bucket
2. Perform operations, upload object, read object (cached and non-cached), range read object (cached and non-cached)
3. Verify the metrics through the endpoint metric URL, e.g. curl http://127.0.0.1:7004 
