### PR TITLE
Move RPC client creation to the RPC schema class

### DIFF
--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -31,10 +31,6 @@ const RpcNtcpConnection = require('./rpc_ntcp');
 const RpcFcallConnection = require('./rpc_fcall');
 const RPC_BUFFERS = RpcRequest.RPC_BUFFERS;
 
-function empty_client_factory() {
-    return {};
-}
-
 // dbg.set_level(5, __dirname);
 
 /**
@@ -59,7 +55,6 @@ class RPC extends EventEmitter {
         this.RPC_BUFFERS = RPC_BUFFERS;
         this._routing_authority = null;
         this._error_handler = null;
-        this._client_factory = options.client_factory || empty_client_factory;
         this.routing_hint = undefined;
     }
 
@@ -71,7 +66,9 @@ class RPC extends EventEmitter {
      *
      */
     new_client(options) {
-        return this._client_factory(this, options);
+        return this.schema ?
+            this.schema.new_client(this, options) :
+            null;
     }
 
     /**

--- a/src/test/unit_tests/test_rpc.js
+++ b/src/test/unit_tests/test_rpc.js
@@ -11,36 +11,11 @@ const assert = require('assert');
 const P = require('../../util/promise');
 const ssl_utils = require('../../util/ssl_utils');
 const { RPC, RpcError, RpcSchema, RPC_BUFFERS } = require('../../rpc');
-const { client_factory_from_schema } = require('../../api/api');
 
 function log(...args) {
     if (process.env.SUPPRESS_LOGS) return;
     console.log(...args);
 }
-
-// class APIClient {
-//     constructor(rpc, default_options) {
-//         this.rpc = rpc;
-//         this.options = _.create(default_options);
-//         this.RPC_BUFFERS = RPC_BUFFERS;
-
-//         this.test = undefined;
-//         this.common_test = undefined;
-
-//         _.each(rpc.schema, api => {
-//             if (!api || !api.id || api.id[0] === '_') return;
-//             const name = api.id.replace(/_api$/, '');
-//             if (name === 'rpc' || name === 'options') throw new Error('ILLEGAL API ID');
-//             this[name] = {};
-//             _.each(api.methods, (method_api, method_name) => {
-//                 this[name][method_name] = (params, options) => {
-//                     options = _.create(this.options, options);
-//                     return rpc._request(api, method_api, params, options);
-//                 };
-//             });
-//         });
-//     }
-// }
 
 mocha.describe('RPC', function() {
 
@@ -236,7 +211,6 @@ mocha.describe('RPC', function() {
     schema.register_api(test_api);
     schema.register_api(common_test_api);
     schema.compile();
-    const client_factory = client_factory_from_schema(schema);
 
     var rpc;
     var client;
@@ -271,8 +245,7 @@ mocha.describe('RPC', function() {
 
     mocha.beforeEach('test_rpc.beforeEach', function() {
         rpc = new RPC({
-            client_factory,
-            schema: schema,
+            schema,
             router: {
                 default: 'fcall://fcall'
             },


### PR DESCRIPTION
### Explain the changes
1.  Move `client_factory_from_schema` logic from `api.js` to `rpc_schema.js` and produce a client factory upon schema compilation. 
2. Expose client creation from schema objects via the new `new_client(rpc, options)` method
4. Mark complied API schemas, so we could assert changes made to the schema after compilation.  

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
