### PR TITLE
Adding installOptions to bower

### DIFF
--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -106,6 +106,14 @@ const apiBlackList = [
     'rpc_fcall'
 ];
 
+const installOptions = {
+    bower: {}
+};
+
+if (process.env.ALLOW_ROOT) {
+    installOptions.bower.allowRoot = true;
+}
+
 // ----------------------------------
 // Atomic Tasks
 // ----------------------------------
@@ -116,7 +124,7 @@ function clean() {
 
 function installDeps() {
     return gulp.src('./bower.json')
-        .pipe($.install());
+        .pipe($.install(installOptions));
 }
 
 function buildDeps(done) {
@@ -130,7 +138,7 @@ function buildDeps(done) {
         });
 
     gulp.src(libsToBuild.map(lib => lib.pkgFile))
-        .pipe($.install(() => {
+        .pipe($.install(installOptions, () => {
             const builds = libsToBuild
                 .map(lib => spawnAsync(lib.command, { cwd: lib.workingDir }));
 


### PR DESCRIPTION
### Explain the changes
When we are installing in an environment that we are not controlling it entirely, bower can fail if it runs as root.
Calling gulp-install with install options, to allow root when installing in an environment that has the ALLOW_ROOT variable set as "true".

Co-Authored-By: nb-ohad <14993359+nb-ohad@users.noreply.github.com>
Signed-off-by: liranmauda <liran.mauda@gmail.com>
