### PR TITLE
Enable SHA-NI and AVX512 extensions in isa-l_crypto

### DIFF
--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -11,7 +11,7 @@ ENV container docker
 RUN dnf update -y -q && \
     dnf clean all
 RUN dnf install -y -q wget unzip which vim python2 python3 && \
-    dnf --enablerepo=PowerTools install -y -q yasm && \
+    dnf --enablerepo=PowerTools install -y -q nasm && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
 RUN alternatives --set python /usr/bin/python3

--- a/src/deploy/NVA_build/dev.Dockerfile
+++ b/src/deploy/NVA_build/dev.Dockerfile
@@ -11,7 +11,7 @@ RUN dnf update -y -q && \
         python3 python3-setuptools \
         gdb strace lsof \
         openssl && \
-    dnf --enablerepo=PowerTools install -y -q yasm && \
+    dnf --enablerepo=PowerTools install -y -q nasm && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
 

--- a/src/native/asm.gypi
+++ b/src/native/asm.gypi
@@ -2,6 +2,10 @@
 {
     'conditions': [
 
+        [ 'node_arch=="x64"', {
+            'defines': ['HAVE_AS_KNOWS_AVX512', 'HAVE_AS_KNOWS_SHANI'],
+        }],
+
         # LINUX
         [ 'OS=="linux"', {
             'rules': [{
@@ -9,15 +13,17 @@
                 'extension': 'asm',
                 'outputs': ['<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).o'],
                 'action': [
-                    'yasm',
+                    'nasm',
                     '-felf64',
                     '-DPIC',
+                    '-DHAVE_AS_KNOWS_AVX512',
+                    '-DHAVE_AS_KNOWS_SHANI',
                     '<!@(for i in <(_include_dirs); do echo -I $i; done)',
                     '-o', '<@(_outputs)',
                     '<(RULE_INPUT_PATH)',
                 ],
                 'process_outputs_as_sources': 1,
-                'message': 'YASM <(RULE_INPUT_PATH)',
+                'message': 'NASM <(RULE_INPUT_PATH)',
             }],
         }],
 
@@ -28,15 +34,17 @@
                 'extension': 'asm',
                 'outputs': ['<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).o'],
                 'action': [
-                    'yasm',
+                    'nasm',
                     '-fmacho64',
+                    '-DHAVE_AS_KNOWS_AVX512',
+                    '-DHAVE_AS_KNOWS_SHANI',
                     '--prefix=_',
                     '<!@(for i in <(_include_dirs); do echo -I $i; done)',
                     '-o', '<@(_outputs)',
                     '<(RULE_INPUT_PATH)',
                 ],
                 'process_outputs_as_sources': 1,
-                'message': 'YASM <(RULE_INPUT_PATH)',
+                'message': 'NASM <(RULE_INPUT_PATH)',
             }],
         }],
 
@@ -47,14 +55,16 @@
                 'extension': 'asm',
                 'outputs': ['<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj'],
                 'action': [
-                    'C:/cygwin64/bin/yasm.exe',
+                    'C:/cygwin64/bin/nasm.exe',
                     '-fwin64',
+                    '-DHAVE_AS_KNOWS_AVX512',
+                    '-DHAVE_AS_KNOWS_SHANI',
                     '<!@(for /D %i in (<(_include_dirs)) do @echo -I %i)',
                     '-o', '<@(_outputs)',
                     '<(RULE_INPUT_PATH)',
                 ],
                 'process_outputs_as_sources': 1,
-                'message': 'YASM <(RULE_INPUT_PATH)',
+                'message': 'NASM <(RULE_INPUT_PATH)',
             }],
         }],
 


### PR DESCRIPTION
YASM does not support these extensions, so NASM must be used instead,
and preprocessor defines are required to enable as well.


### Explain the changes
1. Use NASM instead of YASM to compile the x86 assembly.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #1878714

### Testing Instructions:
1. Install nasm instead of yasm, then npm run build:native.