### PR TITLE
Fix data optimization when compression is disabled

### DIFF
--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -82,8 +82,9 @@ function map_aggregate_objects() {
  * @this mongodb doc being mapped
  */
 function map_aggregate_chunks() {
+    const compress_size = this.compress_size || this.size;
     emit(['', 'compress_size'], this.compress_size);
-    emit([this.bucket, 'compress_size'], this.compress_size);
+    emit([this.bucket, 'compress_size'], compress_size);
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. When compression is disabled pick the original size of the chunk instead of the compressed size.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ #1842254 (comment 4)

### Testing Instructions:
1. 
