### PR TITLE
Backport to 5.6 : fix data optimization when compression is disabled

### DIFF
--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -83,7 +83,7 @@ function map_aggregate_objects() {
  */
 function map_aggregate_chunks() {
     const compress_size = this.compress_size || this.size;
-    emit(['', 'compress_size'], this.compress_size);
+    emit(['', 'compress_size'], compress_size);
     emit([this.bucket, 'compress_size'], compress_size);
 }
 

--- a/src/util/mongo_functions.js
+++ b/src/util/mongo_functions.js
@@ -82,8 +82,9 @@ function map_aggregate_objects() {
  * @this mongodb doc being mapped
  */
 function map_aggregate_chunks() {
+    const compress_size = this.compress_size || this.size;
     emit(['', 'compress_size'], this.compress_size);
-    emit([this.bucket, 'compress_size'], this.compress_size);
+    emit([this.bucket, 'compress_size'], compress_size);
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>
(cherry picked from commit 2b55904682c066141d80deae26376a6593920dee)

### Explain the changes
1. Backport to 5.6
