### PR TITLE
Return heap allocated memory instead of stack allocated memory for Exception:what()

### DIFF
--- a/src/native/util/common.h
+++ b/src/native/util/common.h
@@ -99,13 +99,19 @@ class Exception : public std::exception
 public:
     Exception(std::string msg)
         : _msg(msg)
-        , _bt(new Backtrace()) {}
+        , _bt(new Backtrace()) {
+            std::string tmp = std::string("Exception: ") + _msg;
+            _c_str_msg = new char[tmp.length() + 1];
+            strcpy(_c_str_msg, tmp.c_str());
+        }
 
-    virtual ~Exception() throw() {}
+    virtual ~Exception() throw() {
+        delete [] _c_str_msg;
+    }
 
     virtual const char* what() const throw()
     {
-        return (std::string("Exception: ") + _msg).c_str();
+        return _c_str_msg;
     }
 
     friend std::ostream& operator<<(std::ostream& os, Exception& e)
@@ -115,6 +121,7 @@ public:
 
 private:
     std::string _msg;
+    char *_c_str_msg;
     std::shared_ptr<Backtrace> _bt;
 };
 


### PR DESCRIPTION
### Explain the changes
1. Allocate a c style string (char array) on the heap to hold the c style variant returned from the `what` function

This is NOT a full fix because the returned memory (the c style string memory) is tied to the lifetime of the exception object. 
If the call site will hold the memory after the deletion of the exception we will still have the same error. 
As of now, it seems that all call sites are not behaving in this manner. 

### Issues: Fixed #xxx / Gap #xxx
1. Prevent us from returning an invalid memory address, as the stack frame for the `what` function is invalid upon return
2. Fix a compile error when using clang 12 

### Testing Instructions:
1. 

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>