### PR TITLE
Jenkins: add configuration to verify and deploy CI jobs automatically

### DIFF
--- a/.jenkins/deploy/Dockerfile
+++ b/.jenkins/deploy/Dockerfile
@@ -1,0 +1,22 @@
+FROM centos:latest
+
+RUN true \
+ && yum -y install git make python3-pip \
+ && pip3 install jenkins-job-builder \
+ && yum -y clean all \
+ && true
+
+ENV MAKE_TARGET=${MAKE_TARGET:-test}
+
+# Environment that needs to be set before executing checkout-repo.sh
+# ENV GIT_REPO=https://github.com/noobaa/noobaa-core
+# ENV GIT_REF=master
+ADD checkout-repo.sh /opt/build/
+
+# make WORKDIR writable, otherwise git checkout fails
+RUN chmod ugo=rwx /opt/build
+
+ENV HOME=/opt/build
+WORKDIR /opt/build
+
+CMD ["sh", "-c", "./checkout-repo.sh && make -C .jenkins/deploy ${MAKE_TARGET}"]

--- a/.jenkins/deploy/Makefile
+++ b/.jenkins/deploy/Makefile
@@ -1,0 +1,10 @@
+WORKDIR ?= $(CURDIR)/../
+OUTPUT ?= $(WORKDIR)/_output/
+
+.PHONY: test deploy
+
+test:
+	cd $(WORKDIR) && jenkins-jobs test -o $(OUTPUT) jobs
+
+deploy:
+	cd $(WORKDIR) && jenkins-jobs update --delete-old jobs

--- a/.jenkins/deploy/README.md
+++ b/.jenkins/deploy/README.md
@@ -1,0 +1,46 @@
+# Deploying Jenkins Jobs through OpenShift
+
+This `.jenkins/deploy/` directory contains the configuration to prepare running
+Jenkins Job Builder on OpenShift and update/add Jenkins Jobs in an environment
+hosted in the same OpenShift project.
+
+The used Jenkins environment is expected to be deployed already. This is done
+by the CentOS CI team when a [request for CI resources](ci_request) is handled.
+The deploying and configuration of Jenkins is therefore not part of this
+document.
+
+## Building the Jenkins Job Builder container image
+
+OpenShift has a feature called ImageStreams. This can be used to build the
+container image that contains the `jenkins-jobs` executable to test and
+update/add jobs in a Jenkins environment.
+
+All `.yaml` files in this directory need to be pushed into OpenShift, use `oc
+create -f <file>` for that.
+
+- the `Dockerfile` uses `pip` to install `jenkins-jobs`, the BuildConfig object
+  in OpenShift can then be used to build the image
+- `checkout-repo.sh` will be included in the container image, and checks out
+  the `ci/centos` branch of the repository
+- together with the `Makefile` (checked out with `checkout-repo.sh`), the
+  Jenkins Jobs can be validated or deployed
+- `jjb-buildconfig.yaml` creates the ImageStream and the BuildConfig objects.
+  Once created with `oc create`, the OpenShift Console shows a `Build` button
+  for the `jjb` image under the Builds/Builds menu
+- `jjb-config.yaml` is the `/etc/jenkins_jobs/jenkins_jobs.ini` configuration
+  files that contains username, password/token and URL to the Jenkins instance
+  (**edit this file before pushing to OpenShift**)
+- `jjb-validate.yaml` is the OpenShift Job that creates a Pod, runs the
+  validation test and exits. The job needs to be deleted from OpenShift before
+  it can be run again.
+- `jjb-deploy.yaml` is the OpenShift Job that creates a Pod, runs
+  `jenkins-jobs` to push the new jobs to the Jenkins environment. This pod uses
+   the jjb-config ConfigMap to connect and login to the Jenkins instance. The
+   job needs to be deleted from OpenShift before it can be run again.
+- `jjb.sh` is a helper script that can be used to validate/deploy the Jenkins
+  Jobs in the parent directory. It creates the validate or deploy job, waits
+  until the job finishes, shows the log and exits with 0 on success. This
+  script can be used in Jenkins Jobs to automate the validation and deployment of
+  jobs.
+
+[ci_request]: https://wiki.centos.org/QaWiki/CI/GettingStarted

--- a/.jenkins/deploy/checkout-repo.sh
+++ b/.jenkins/deploy/checkout-repo.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+fail() {
+	echo "$(date) ${@}" > /dev/stderr
+	exit 1
+}
+
+[ -n "${GIT_REPO}" ] || fail 'GIT_REPO environment variable not set'
+[ -n "${GIT_REF}" ] || fail 'GIT_REF environment variable not set'
+
+# exit in case a command fails
+set -e
+
+git init .
+git remote add origin "${GIT_REPO}"
+git fetch origin "${GIT_REF}"
+git checkout FETCH_HEAD

--- a/.jenkins/deploy/jjb-buildconfig.yaml
+++ b/.jenkins/deploy/jjb-buildconfig.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: jjb
+  labels:
+    app: jjb
+spec:
+  tags:
+    - name: latest
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: jjb
+  labels:
+    app: jjb
+spec:
+  runPolicy: Serial
+  source:
+    git:
+      uri: https://github.com/noobaa/noobaa-core
+      ref: master
+    contextDir: .jenkins/deploy
+  strategy:
+    dockerStrategy: {}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: jjb:latest

--- a/.jenkins/deploy/jjb-config.yaml
+++ b/.jenkins/deploy/jjb-config.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jenkins-jobs
+  labels:
+    app: jjb
+data:
+  jenkins_jobs.ini: |-
+    [jenkins]
+    user=<CENTOS-CI-JENKINS-USERNAME>
+    password=<JENKINS-USER-API-TOKEN>
+    url=https://jenkins-noobaa.apps.ocp.ci.centos.org

--- a/.jenkins/deploy/jjb-deploy.yaml
+++ b/.jenkins/deploy/jjb-deploy.yaml
@@ -1,0 +1,49 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: jjb-deploy
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      labels:
+        app: jjb
+        jjb/session: "${SESSION}"
+      name: jjb-deploy
+    spec:
+      ttlSecondsAfterFinished: 0
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: jjb-deploy
+            jjb/session: "${SESSION}"
+        spec:
+          containers:
+            - name: jjb
+              image: image-registry.openshift-image-registry.svc:5000/noobaa/jjb:latest
+              env:
+                - name: GIT_REPO
+                  value: https://github.com/noobaa/noobaa-core
+                - name: GIT_REF
+                  value: "${GIT_REF}"
+                - name: MAKE_TARGET
+                  value: deploy
+              volumeMounts:
+                - name: etc-jj
+                  mountPath: /etc/jenkins_jobs
+                  readOnly: true
+          volumes:
+            - name: etc-jj
+              configMap:
+                name: jenkins-jobs
+          restartPolicy: Never
+parameters:
+  - name: SESSION
+    description: unique ID for the session to track the pod for the job
+    required: true
+  - name: GIT_REF
+    description: the git branch or other ref to checkout and deploy
+    value: master
+    required: false

--- a/.jenkins/deploy/jjb-validate.yaml
+++ b/.jenkins/deploy/jjb-validate.yaml
@@ -1,0 +1,39 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: jjb-validate
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      labels:
+        app: jjb-validate
+        jjb/session: "${SESSION}"
+      name: jjb-validate
+    spec:
+      ttlSecondsAfterFinished: 0
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: jjb-validate
+            jjb/session: "${SESSION}"
+        spec:
+          containers:
+            - name: jjb-validate
+              image: image-registry.openshift-image-registry.svc:5000/noobaa/jjb:latest
+              env:
+                - name: GIT_REPO
+                  value: https://github.com/noobaa/noobaa-core
+                - name: GIT_REF
+                  value: "${GIT_REF}"
+          restartPolicy: Never
+parameters:
+  - name: SESSION
+    description: unique ID for the session to track the pod for the job
+    required: true
+  - name: GIT_REF
+    description: the git branch or other ref to checkout and validate
+    value: master
+    required: false

--- a/.jenkins/deploy/jjb.sh
+++ b/.jenkins/deploy/jjb.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+#
+# Create a new Job in OCP that runs the jbb-validate container once. This
+# script will wait for completion of the validation, and uses the result of the
+# container to report the status.
+#
+# Usage:
+# - arguments to the script can be "validate" or "deploy"
+# - the GIT_REF environment variable is injected in the batch job so that it
+#   can use a particular GitHub PR
+#
+
+# error out in case a command fails
+set -e
+
+CMD="${1}"
+GIT_REF=${GIT_REF:-"master"}
+
+get_pod_status() {
+	oc get "pod/${1}" --no-headers -o=jsonpath='{.status.phase}'
+}
+
+case "${CMD}" in
+	"validate")
+		;;
+	"deploy")
+		;;
+	*)
+		echo "no such command: ${CMD}"
+		exit 1
+		;;
+esac
+
+# make sure there is a valid OCP session
+oc version
+
+# the deploy directory where this script is located, contains files we need
+cd "$(dirname "${0}")"
+
+# unique ID for the session
+SESSION=$(uuidgen)
+
+oc process -f "jjb-${CMD}.yaml" -p=SESSION="${SESSION}" -p=GIT_REF="${GIT_REF}"
+oc process -f "jjb-${CMD}.yaml" -p=SESSION="${SESSION}" -p=GIT_REF="${GIT_REF}" | oc create -f -
+
+# loop until pod is available
+while true
+do
+	jjb_pod=$(oc get pods --no-headers -l "jjb/session=${SESSION}" -o=jsonpath='{.items[0].metadata.name}')
+	ret=${?}
+
+	# break the loop when the command returned success and jjb_pod is not empty
+	[ ${ret} = 0 ] && [ -n "${jjb_pod}" ] && break
+	sleep 1
+done
+
+# loop until the pod has finished
+while true
+do
+	status=$(get_pod_status "${jjb_pod}")
+	ret=${?}
+
+	# TODO: is Running as a status sufficient, did it terminate yet?
+	[ ${ret} = 0 ] && { [ "${status}" = "Succeeded" ] || [ "${status}" = "Failed" ]; } && break
+	sleep 0.5
+done
+
+# show the log of the finished pod
+oc logs "${jjb_pod}"
+
+# delete the job, so a next run can create it again
+oc process -f "jjb-${CMD}.yaml" -p=SESSION="${SESSION}" | oc delete --wait -f -
+# depending on the OpenShift version, the pod gets deleted automatically
+oc delete --ignore-not-found pod "${jjb_pod}"
+
+# return the exit status of the pod
+[ "${status}" = 'Succeeded' ]

--- a/.jenkins/jobs/build-sanity.yaml
+++ b/.jenkins/jobs/build-sanity.yaml
@@ -2,7 +2,6 @@
 - job:
     name: noobaa-core_build-sanity
     project-type: pipeline
-    sandbox: true
     concurrent: true
     properties:
       - github:
@@ -23,11 +22,9 @@
     triggers:
       - github-pull-request:
           status-context: ci/centos/build-sanity
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/build-sanity))'
+          trigger-phrase: '/(re)?test ci/centos/build-sanity'
           permit-all: true
-          # TODO: set github-hooks to true when it is configured in GitHub
-          github-hooks: false
-          cron: 'H/5 * * * *'
+          github-hooks: true
           admin-list:
             - liranmauda
           org-list:

--- a/.jenkins/jobs/build-sanity.yaml
+++ b/.jenkins/jobs/build-sanity.yaml
@@ -23,6 +23,7 @@
       - github-pull-request:
           status-context: ci/centos/build-sanity
           trigger-phrase: '/(re)?test ci/centos/build-sanity'
+          only-trigger-phrase: true
           permit-all: true
           github-hooks: true
           admin-list:

--- a/.jenkins/jobs/jjb-deploy.yaml
+++ b/.jenkins/jobs/jjb-deploy.yaml
@@ -1,0 +1,31 @@
+---
+- job:
+    name: jjb-deploy
+    project-type: pipeline
+    concurrent: false
+    properties:
+      - github:
+          url: https://github.com/noobaa/noobaa-core
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    dsl: |
+      def GIT_REPO = 'http://github.com/noobaa/noobaa-core'
+      def GIT_BRANCH = 'master'
+      node {
+        stage('checkout ci repository') {
+          git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
+        }
+        stage('deployment') {
+          sh './.jenkins/deploy/jjb.sh deploy'
+        }
+      }
+    scm:
+      - git:
+          name: origin
+          url: https://github.com/noobaa/noobaa-core
+          branches:
+            - master
+    triggers:
+      - pollscm:
+          cron: "H/5 * * * *"

--- a/.jenkins/jobs/jjb-validate.yaml
+++ b/.jenkins/jobs/jjb-validate.yaml
@@ -1,0 +1,42 @@
+---
+- job:
+    name: jjb-validate
+    project-type: pipeline
+    # the jjb-validate template does not allow concurrent usage
+    concurrent: false
+    properties:
+      - github:
+          url: https://github.com/noobaa/noobaa-core
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    dsl: |
+      def GIT_REPO = 'https://github.com/noobaa/noobaa-core'
+      def GIT_BRANCH = 'master'
+
+      if (params.ghprbPullId != null) {
+          GIT_BRANCH = "pull/${ghprbPullId}/head"
+      }
+
+      node {
+        stage('checkout ci repository') {
+          checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
+            userRemoteConfigs: [[url: "${GIT_REPO}",
+              refspec: "${GIT_BRANCH}"]]])
+        }
+        stage('validation') {
+          sh "GIT_REF=${GIT_BRANCH} ./.jenkins/deploy/jjb.sh validate"
+        }
+      }
+    triggers:
+      - github-pull-request:
+          status-context: ci/centos/jjb-validate
+          trigger-phrase: '/(re)?test ci/centos/jjb-validate'
+          only-trigger-phrase: true
+          permit-all: true
+          github-hooks: false
+          white-list-target-branches:
+            - master
+          org-list:
+            - noobaa
+          allow-whitelist-orgs-as-admins: true

--- a/.jenkins/jobs/unit.yaml
+++ b/.jenkins/jobs/unit.yaml
@@ -2,7 +2,6 @@
 - job:
     name: noobaa-core_unit
     project-type: pipeline
-    sandbox: true
     concurrent: true
     properties:
       - github:
@@ -25,9 +24,7 @@
           status-context: ci/centos/unit
           trigger-phrase: '/(re)?test ((all)|(ci/centos/unit))'
           permit-all: true
-          # TODO: set github-hooks to true when it is configured in GitHub
-          github-hooks: false
-          cron: 'H/5 * * * *'
+          github-hooks: true
           admin-list:
             - liranmauda
           org-list:


### PR DESCRIPTION
### Explain the changes
1. add artefacts for configuring the Jenkins deployment in OpenShift
2. add [jjb-validate](https://jenkins-noobaa.apps.ocp.ci.centos.org/job/jjb-validate/) and [jjb-deploy](https://jenkins-noobaa.apps.ocp.ci.centos.org/job/jjb-deploy/) Jenkins Jobs Builder files
3. add Dockerfile for a jjb container to verify/deploy the `.jenkins/jobs/*.yaml` jobs

### Testing Instructions:
1. manual deployment has been done, PRs trigger jobs in the [Jenkins CentOS CI](https://jenkins-noobaa.apps.ocp.ci.centos.org/)
2. a change to the `.jenkins/jobs/*.yaml` files can be tested with the new jjb-validate job. The job can be triggered by leaving a comment with the contents `/test ci/centos/jjb-validate`
3. jobs do not report a status to the PRs _yet_, check the Jenkins WebUI for results of the tests

### TODO
1. once this PR is merged, it is needed to manually run the [jjb-deploy job](https://jenkins-noobaa.apps.ocp.ci.centos.org/job/jjb-deploy/) to update the jobs from the noobaa-core repository (now running from the source of this PR)
2. "Build & Sanity" job will fail because there is currently a conflict between Podman and minikube/Docker on CentOS 8
3. in order to have the status of the CI jobs report to PRs, credentials of a user with admin permissions need to be added to Jenkins