### PR TITLE
Jenkins: Podman and Docker have conflicts, only install Docker

### DIFF
--- a/.jenkins/jobs/build-sanity.yaml
+++ b/.jenkins/jobs/build-sanity.yaml
@@ -23,7 +23,6 @@
       - github-pull-request:
           status-context: ci/centos/build-sanity
           trigger-phrase: '/(re)?test ci/centos/build-sanity'
-          only-trigger-phrase: true
           permit-all: true
           github-hooks: true
           admin-list:

--- a/.jenkins/unit.groovy
+++ b/.jenkins/unit.groovy
@@ -5,8 +5,9 @@ def ci_git_ref = 'master' // default, will be overwritten for PRs
 
 def HASH = '0123abcd' // default, will be overwritten
 def NO_CACHE = 'NO_CACHE=true'
-// building with Docker fails in the CI due to network restrictions
-def CONTAINER_ENGINE = 'CONTAINER_ENGINE=podman'
+// Docker has some network conflicts in the CI, host-networking works
+def USE_HOSTNETWORK = 'USE_HOSTNETWORK=true'
+def CONTAINER_ENGINE = 'CONTAINER_ENGINE=docker'
 
 node('cico-workspace') {
 	if (params.ghprbPullId != null) {
@@ -50,11 +51,11 @@ node('cico-workspace') {
 
 		// real test start here
 		stage('Unit Tests') {
-			//sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE} ${CONTAINER_ENGINE}'"
+			//sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE} ${USE_HOSTNETWORK} ${CONTAINER_ENGINE}'"
 
 			// abort in case the test hangs
 			timeout(time:30, unit: 'MINUTES') {
-				sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test ${CONTAINER_ENGINE}'"
+				sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make test ${USE_HOSTNETWORK} ${CONTAINER_ENGINE}'"
 			}
 		}
 	}


### PR DESCRIPTION
### Explain the changes
1. use Docker CE instead of Podman for Jenkins CI jobs, Podman and Docker have conflicts on CentOS-8
2. this enables the **ci/centos/build-sanity** job to run on new/updated PRs automatically

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: #6199

### Testing Instructions:
1. the **ci/centos/unit** job should continue to pass with Docker enabled
2. the **ci/centos/build-sanity** should not pass again without Podman getting installed
    this job need manual starting, leave a comment `/test ci/centos/build-sanity` to do so
