### PR TITLE
Removing `make tester` from Jenkins unit tests

### DIFF
--- a/.jenkins/unit.groovy
+++ b/.jenkins/unit.groovy
@@ -50,7 +50,7 @@ node('cico-workspace') {
 
 		// real test start here
 		stage('Unit Tests') {
-			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE} ${CONTAINER_ENGINE}'"
+			//sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/noobaa-core && make tester ${NO_CACHE} ${CONTAINER_ENGINE}'"
 
 			// abort in case the test hangs
 			timeout(time:30, unit: 'MINUTES') {


### PR DESCRIPTION
### Explain the changes
For some reason, the noobaa-test image is not there when we run `make test` so removing `make tester` from Jenkins unit tests to shorten the cycle (reduce ~14 min).

Signed-off-by: liranmauda <liran.mauda@gmail.com>
