### PR TITLE
snappy.gyp : Adding cflags -DSNAPPY_IS_BIG_ENDIAN for s390x

### DIFF
--- a/src/native/third_party/snappy.gyp
+++ b/src/native/third_party/snappy.gyp
@@ -1,6 +1,13 @@
 # Copyright (C) 2016 NooBaa
 {
     'includes': ['common_third_party.gypi'],
+    'target_defaults': {
+        'conditions': [
+            ['node_arch=="s390x" or node_arch=="s390"', {
+                'cflags': ['-DSNAPPY_IS_BIG_ENDIAN']
+            }],
+        ],
+    },
     'targets': [{
         'target_name': 'snappy',
         'type': 'static_library',


### PR DESCRIPTION
### Explain the changes
snappy.gyp: 
- Adding cflags -DSNAPPY_IS_BIG_ENDIAN for s390x

Co-Authored-By: jackyalbo <20266280+jackyalbo@users.noreply.github.com>
Signed-off-by: liranmauda <liran.mauda@gmail.com>
