### PR TITLE
Fix compiler error in Exception::what() on mac

### DIFF
--- a/src/native/util/common.h
+++ b/src/native/util/common.h
@@ -98,24 +98,25 @@ class Exception : public std::exception
 {
 public:
     Exception(std::string msg)
-        : _msg(msg)
+        : _msg(std::string("Exception: ") + msg)
         , _bt(new Backtrace()) {}
 
     virtual ~Exception() throw() {}
 
     virtual const char* what() const throw()
     {
-        return (std::string("Exception: ") + _msg).c_str();
+        return _msg.c_str();
     }
 
-    friend std::ostream& operator<<(std::ostream& os, Exception& e)
+    friend std::ostream& operator<<(std::ostream& os, const Exception& e)
     {
-        return os << "Exception: " << e._msg << " " << *e._bt;
+        return os << e._msg << " " << *e._bt;
     }
 
 private:
-    std::string _msg;
-    std::shared_ptr<Backtrace> _bt;
+    const std::string _msg;
+    // using shared_ptr to hold the backtrace in order to avoid copying it when the exception is passed by value
+    const std::shared_ptr<Backtrace> _bt;
 };
 
 } // namespace noobaa


### PR DESCRIPTION
### Explain the changes
1. Exception::what() returned a pointer to local string memory.
2. Fixed to keep the combined string on the class.

### Issues: Fixed #xxx / Gap #xxx
1. Replacing #6197 - thanks @nb-ohad for pushing this, I'll close your PR.

### Testing Instructions:
1. compile on mac.
