### PR TITLE
Adding 2.23 fixes needed for Z

### DIFF
--- a/src/native/third_party/isa-l.gyp
+++ b/src/native/third_party/isa-l.gyp
@@ -150,7 +150,11 @@
                 'isa-l_crypto/md5_mb/md5_mb_mgr_flush_avx512.asm',
                 'isa-l_crypto/md5_mb/md5_mb_x16x2_avx512.asm',
                 'isa-l_crypto/md5_mb/md5_ctx_avx512.c',
-            ]}]],
+            ]}, {
+                'sources': [
+                    'isa-l_crypto/md5_mb/md5_ctx_base_aliases.c',
+                ]
+            }]],
         },
 
         {

--- a/src/native/third_party/isa-l_crypto/md5_mb/md5_ctx_base.c
+++ b/src/native/third_party/isa-l_crypto/md5_mb/md5_ctx_base.c
@@ -70,16 +70,19 @@ MD5_HASH_CTX *md5_ctx_mgr_submit_base(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx
 	if (flags & (~HASH_ENTIRE)) {
 		// User should not pass anything other than FIRST, UPDATE, or LAST
 		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_PROCESSING) && (flags == HASH_ENTIRE)) {
 		// Cannot submit a new entire job to a currently processing job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
 		// Cannot update a finished job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
 	}
 
 	if (flags == HASH_FIRST) {
@@ -140,6 +143,7 @@ static uint32_t md5_update(MD5_HASH_CTX * ctx, const void *buffer, uint32_t len)
 		ctx->total_length += 64;
 	}
 
+	ctx->status = HASH_CTX_STS_IDLE;
 	ctx->incoming_buffer = buffer;
 	return remain_len;
 }

--- a/src/native/third_party/isa-l_crypto/md5_mb/md5_ctx_base_aliases.c
+++ b/src/native/third_party/isa-l_crypto/md5_mb/md5_ctx_base_aliases.c
@@ -1,0 +1,50 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <string.h>
+#include "md5_mb.h"
+extern void md5_ctx_mgr_init_base(MD5_HASH_CTX_MGR * mgr);
+extern MD5_HASH_CTX *md5_ctx_mgr_flush_base(MD5_HASH_CTX_MGR * mgr);
+extern MD5_HASH_CTX *md5_ctx_mgr_submit_base(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx,
+					     const void *buffer, uint32_t len,
+					     HASH_CTX_FLAG flags);
+void md5_ctx_mgr_init(MD5_HASH_CTX_MGR * mgr)
+{
+	md5_ctx_mgr_init_base(mgr);
+}
+
+MD5_HASH_CTX *md5_ctx_mgr_flush(MD5_HASH_CTX_MGR * mgr)
+{
+	return md5_ctx_mgr_flush_base(mgr);
+}
+
+MD5_HASH_CTX *md5_ctx_mgr_submit(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx,
+				 const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	return md5_ctx_mgr_submit_base(mgr, ctx, buffer, len, flags);
+}

--- a/src/native/third_party/isa-l_crypto/sha1_mb/sha1_ctx_base.c
+++ b/src/native/third_party/isa-l_crypto/sha1_mb/sha1_ctx_base.c
@@ -86,16 +86,19 @@ SHA1_HASH_CTX *sha1_ctx_mgr_submit_base(SHA1_HASH_CTX_MGR * mgr, SHA1_HASH_CTX *
 	if (flags & (~HASH_ENTIRE)) {
 		// User should not pass anything other than FIRST, UPDATE, or LAST
 		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_PROCESSING) && (flags == HASH_ENTIRE)) {
 		// Cannot submit a new entire job to a currently processing job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
 		// Cannot update a finished job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
 	}
 
 	if (flags == HASH_FIRST) {
@@ -157,6 +160,7 @@ static uint32_t sha1_update(SHA1_HASH_CTX * ctx, const void *buffer, uint32_t le
 		ctx->total_length += SHA1_BLOCK_SIZE;
 	}
 
+	ctx->status = HASH_CTX_STS_IDLE;
 	ctx->incoming_buffer = buffer;
 	return remain_len;
 }

--- a/src/native/third_party/isa-l_crypto/sha256_mb/sha256_ctx_base.c
+++ b/src/native/third_party/isa-l_crypto/sha256_mb/sha256_ctx_base.c
@@ -77,16 +77,19 @@ SHA256_HASH_CTX *sha256_ctx_mgr_submit_base(SHA256_HASH_CTX_MGR * mgr, SHA256_HA
 	if (flags & (~HASH_ENTIRE)) {
 		// User should not pass anything other than FIRST, UPDATE, or LAST
 		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_PROCESSING) && (flags == HASH_ENTIRE)) {
 		// Cannot submit a new entire job to a currently processing job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
 		// Cannot update a finished job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
 	}
 
 	if (flags == HASH_FIRST) {
@@ -147,7 +150,7 @@ static uint32_t sha256_update(SHA256_HASH_CTX * ctx, const void *buffer, uint32_
 		remain_len -= SHA256_BLOCK_SIZE;
 		ctx->total_length += SHA256_BLOCK_SIZE;
 	}
-
+	ctx->status = HASH_CTX_STS_IDLE;
 	ctx->incoming_buffer = buffer;
 	return remain_len;
 }

--- a/src/native/third_party/isa-l_crypto/sha512_mb/sha512_ctx_base.c
+++ b/src/native/third_party/isa-l_crypto/sha512_mb/sha512_ctx_base.c
@@ -96,16 +96,19 @@ SHA512_HASH_CTX *sha512_ctx_mgr_submit_base(SHA512_HASH_CTX_MGR * mgr, SHA512_HA
 	if (flags & (~HASH_ENTIRE)) {
 		// User should not pass anything other than FIRST, UPDATE, or LAST
 		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_PROCESSING) && (flags == HASH_ENTIRE)) {
 		// Cannot submit a new entire job to a currently processing job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
 		// Cannot update a finished job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
 	}
 
 	if (flags == HASH_FIRST) {
@@ -166,7 +169,7 @@ static uint32_t sha512_update(SHA512_HASH_CTX * ctx, const void *buffer, uint32_
 		remain_len -= SHA512_BLOCK_SIZE;
 		ctx->total_length += SHA512_BLOCK_SIZE;
 	}
-
+	ctx->status = HASH_CTX_STS_IDLE;
 	ctx->incoming_buffer = buffer;
 	return remain_len;
 }


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1.  Added missing files for 2.23 in order to allow build and correct md5 digest on top of Z
2. Was contributed by Ulrich Weigand

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1.  md5 unit test in Z
