### PR TITLE
bulk updates changes for postgres_client

### DIFF
--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -796,9 +796,16 @@ class SystemStore extends EventEmitter {
             });
         });
 
-        await Promise.all(Object.values(bulk_per_collection).map(
+        const bulk_results = await Promise.all(Object.values(bulk_per_collection).map(
             bulk => bulk.length && bulk.execute({ j: true })
         ));
+
+        for (const res of bulk_results) {
+            if (res && !res.ok) {
+                dbg.error('got error on bulk execute', res.err);
+                // should we throw here? retry?
+            }
+        }
 
         return { any_news, last_update };
     }

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -93,6 +93,7 @@ function init_all_collections() {
     require('../../server/analytic_services/io_stats_store').IoStatsStore.instance();
     require('../../server/analytic_services/bucket_stats_store').BucketStatsStore.instance();
     require('../../server/analytic_services/history_data_store').HistoryDataStore.instance();
+    require('../../server/analytic_services/activity_log_store').ActivityLogStore.instance();
     // eslint-disable-next-line no-unused-expressions
     require('../../server/analytic_services/endpoint_stats_store').EndpointStatsStore.instance;
 }

--- a/src/test/unit_tests/test_system_store.js
+++ b/src/test/unit_tests/test_system_store.js
@@ -15,6 +15,7 @@ const assert = require('assert');
 const system_store = require('../../server/system_services/system_store').get_instance();
 
 mocha.describe('system_store', function() {
+    this.timeout(90000); // eslint-disable-line no-invalid-this
 
     // eslint-disable-next-line no-undef
     afterEach(function() {


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. changed `PgTransaction` to a more generic class that only handles transactions
2. change bulk operations to use PgTransaction` instead of extending it.
3. use `PgTransaction` in other places that use transactions (e.g. `findOneAndUpdate`)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
