### PR TITLE
Fix small schema issue with encryption

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -187,7 +187,7 @@ function parse_sse_c(req, copy_source) {
 function parse_sse(req) {
     const algorithm = req.headers['x-amz-server-side-encryption'];
     const kms_key_id = req.headers['x-amz-server-side-encryption-aws-kms-key-id'];
-    const context_b64 = (algorithm === 'aws:kms') && req.headers['x-amz-server-side-encryption-context'];
+    const context_b64 = algorithm === 'aws:kms' ? req.headers['x-amz-server-side-encryption-context'] : undefined;
 
     if (!algorithm) {
         if (kms_key_id) {


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. the schema checks that context_b64 is string - the issue was that instead of setting it to undefined we set it to false - which is not a string

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
