### PR TITLE
fixing 2 issue with bucket polices

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -587,13 +587,13 @@ function has_bucket_policy_permission(policy, account, method, arn_path) {
     const [allow_statements, deny_statements] = _.partition(policy.statement, statement => statement.effect === 'allow');
 
     // look for explicit denies
-    if (_is_statements_fit(deny_statements, account, method, arn_path)) return false;
+    if (_is_statements_fit(deny_statements, account, method, arn_path)) return 'DENY';
 
     // look for explicit allows
-    if (_is_statements_fit(allow_statements, account, method, arn_path)) return true;
+    if (_is_statements_fit(allow_statements, account, method, arn_path)) return 'ALLOW';
 
     // implicit deny
-    return false;
+    return 'IMPLICIT_DENY';
 }
 
 function _is_statements_fit(statements, account, method, arn_path) {

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -688,7 +688,7 @@ function has_bucket_anonymous_permission(bucket) {
         // for object - GetObject, GetObjectVersion, GetObjectTorrent
         `s3:getobject`,
         `arn:aws:s3:::${bucket.name.unwrap()}/*`
-    );
+    ) === 'ALLOW';
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. fixed issue of when adding an allow statement in bucket policy denied already given access to the bucket - only deny should do it (BZ1891117)
2. fixed an issue where bucket_owner was allowed access even is specific deny access appeared 
3. created a beginning of support to specific allow will allow access even if the bucket is not allowed in the account

### Issues: Fixed #xxx / Gap #xxx
1. GAP #6251
2. Fixed BZ#1891117

### Testing Instructions:
1. 
