### PR TITLE
Adding yasm back to builder image

### DIFF
--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -11,7 +11,7 @@ ENV container docker
 RUN dnf update -y -q && \
     dnf clean all
 RUN dnf install -y -q wget unzip which vim python2 python3 && \
-    dnf --enablerepo=PowerTools install -y -q nasm && \
+    dnf --enablerepo=PowerTools install -y -q nasm yasm && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
 RUN alternatives --set python /usr/bin/python3

--- a/src/deploy/NVA_build/dev.Dockerfile
+++ b/src/deploy/NVA_build/dev.Dockerfile
@@ -5,13 +5,13 @@ ENV container docker
 
 RUN dnf update -y -q && \
     dnf install -y -q \
-        bash bash-completion \
-        wget curl nc unzip which less vim \
-        python2 python2-setuptools \
-        python3 python3-setuptools \
-        gdb strace lsof \
-        openssl && \
-    dnf --enablerepo=PowerTools install -y -q nasm && \
+    bash bash-completion \
+    wget curl nc unzip which less vim \
+    python2 python2-setuptools \
+    python3 python3-setuptools \
+    gdb strace lsof \
+    openssl && \
+    dnf --enablerepo=PowerTools install -y -q nasm yasm && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
 


### PR DESCRIPTION
### Explain the changes
- As we can't compile on Mac, we will use yasm. We will install yasm and nasm on the builder image.

Signed-off-by: liranmauda <liran.mauda@gmail.com>
