### PR TITLE
Jenkins: Adding some labels to the jobs

### DIFF
--- a/.jenkins/build-sanity.groovy
+++ b/.jenkins/build-sanity.groovy
@@ -1,13 +1,12 @@
 def cico_retries = 16
 def cico_retry_interval = 60
 def ci_git_ref = 'master' // default, will be overwritten for PRs
-def workdir = "/opt/build/noobaa-core"
 
 def HASH = '0123abcd' // default, will be overwritten
-def NO_CACHE = 'NO_CACHE=true'
 // Docker has some network conflicts in the CI, host-networking works
 def USE_HOSTNETWORK= 'USE_HOSTNETWORK=true'
 def CONTAINER_ENGINE = 'CONTAINER_ENGINE=docker'
+def workdir = "/opt/build/noobaa-core"
 
 node('cico-workspace') {
 	if (params.ghprbPullId != null) {
@@ -20,6 +19,7 @@ node('cico-workspace') {
 			userRemoteConfigs: [[url: "${GIT_REPO}", refspec: "${ci_git_ref}"]]])
 		// fetch the first 7 characters of the current commit hash
 		HASH = sh(
+			label:	'Getting The Hash',
 			script: 'git log -1 --format=format:%H | cut -c-7',
 			returnStdout: true
 		).trim()
@@ -35,6 +35,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
+				label:	"cico node get",
 				script: "cico node get -f value -c hostname -c comment --release=8 \
 							--retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
@@ -48,11 +49,15 @@ node('cico-workspace') {
 	try {
 		stage('prepare bare-metal machine') {
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./.jenkins/prepare.sh root@${CICO_NODE}:'
-			sh "${CICO_NODE_SSH} ./prepare.sh --workdir=${workdir} --gitrepo=${GIT_REPO} --ref=${ci_git_ref}"
+			sh(
+				label:	"Running prepare.sh --workdir=${workdir} --gitrepo=${GIT_REPO} --ref=${ci_git_ref}",
+				script:	"${CICO_NODE_SSH} ./prepare.sh --workdir=${workdir} --gitrepo=${GIT_REPO} --ref=${ci_git_ref}"
+			)
 		}
 
 		stage('stop jobs from the same PR') {
 			jobs = sh (
+				label:	"Running get_job_numbers.sh",
 				script: "${CICO_NODE_SSH} 'cd ${workdir}/.jenkins/ && ./get_job_numbers.sh --jobName ${JOB_NAME} \
 							--currentBuild ${currentBuild.number} --JENKINS_URL ${JENKINS_URL}'",
 				returnStdout: true
@@ -75,20 +80,33 @@ node('cico-workspace') {
 
 		// real test start here
 		stage('Build & Sanity Integration Tests') {
-			sh "${CICO_NODE_SSH} 'cd ${workdir} && ./.travis/deploy_minikube.sh'"
-			sh "${CICO_NODE_SSH} 'cd ${workdir} && make tester NOOBAA_TAG=localhost/${IMAGE_TAG} \
-					TESTER_TAG=localhost/${TESTER_TAG} ${USE_HOSTNETWORK} ${CONTAINER_ENGINE}'"
+			sh(
+				label:	"Running deploy_minikube.sh",
+				script:	"${CICO_NODE_SSH} 'cd ${workdir} && ./.travis/deploy_minikube.sh'"
+			)
+			sh(
+				label:	"Running make tester",
+				script:	"${CICO_NODE_SSH} 'cd ${workdir} && make tester NOOBAA_TAG=localhost/${IMAGE_TAG} \
+								TESTER_TAG=localhost/${TESTER_TAG} ${USE_HOSTNETWORK} ${CONTAINER_ENGINE}'"
+			)
 			// if images were built with podman, import them in Docker for use with minikube
 			//sh "${CICO_NODE_SSH} 'podman image save ${IMAGE_TAG} | docker image load'"
 			//sh "${CICO_NODE_SSH} 'podman image save ${TESTER_TAG} | docker image load'"
-			sh "${CICO_NODE_SSH} 'cd ${workdir} && cd ./src/test/framework/ && ./run_test_job.sh --name ${HASH} \
-						--image localhost/${IMAGE_TAG} --tester_image localhost/${TESTER_TAG} --job_yaml ../../../.travis/travis_test_job.yaml --wait'"
+			sh(
+				label: "Running Build & Sanity Integration Tests",
+				script:	"${CICO_NODE_SSH} 'cd ${workdir} && cd ./src/test/framework/ && ./run_test_job.sh --delete_on_fail \
+							--name ${HASH} --image localhost/${IMAGE_TAG} --tester_image localhost/${TESTER_TAG} \
+							--job_yaml ../../../.travis/travis_test_job.yaml --wait'"
+			)
 		}
 	}
 
 	finally {
 		stage('return bare-metal machine') {
-			sh 'cico node done ${CICO_SSID}'
+			sh(
+				label:	'cico node done',
+				script:	'cico node done ${CICO_SSID}'
+			)
 		}
 	}
 }

--- a/.jenkins/deploy/jjb.sh
+++ b/.jenkins/deploy/jjb.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Create a new Job in OCP that runs the jbb-validate container once. This
 # script will wait for completion of the validation, and uses the result of the
@@ -19,10 +19,10 @@ GIT_REPO="https://github.com/noobaa/noobaa-core"
 
 function usage() {
     echo "Options:"
-    echo "--cmd			the mod of this script. can be validate or deploy"
-    echo "--GIT_REF		specify the branch to build from (default: ${GIT_REF})"
-    echo "--GIT_REPO	specify the repo to build from (default: ${GIT_REPO})"
-    echo "--help|-h		specify the flags"
+    echo "--cmd         the mode of this script. can be validate or deploy"
+    echo "--GIT_REF     specify the branch to build from (default: ${GIT_REF})"
+    echo "--GIT_REPO    specify the repo to build from (default: ${GIT_REPO})"
+    echo "--help        specify the flags"
     echo " "
     exit 0
 }
@@ -51,16 +51,16 @@ eval set -- "${opts}"
 
 while true; do
     case "${1}" in
-        --cmd)			CMD=${2}
-                  	 	shift 2
-						if [ "${CMD}" != "deploy" ] && [ "${CMD}" != "validate" ]
-						then
-							echo "no such command: ${CMD}"
-							exit 1
-						fi ;;
-        --GIT_REF)  	GIT_REF=${2}
-						shift 2 ;;
-        --GIT_REPO)		GIT_REPO=${2}
+        --cmd)          CMD=${2}
+                        shift 2
+                        if [ "${CMD}" != "deploy" ] && [ "${CMD}" != "validate" ]
+                        then
+                            echo "no such command: ${CMD}"
+                            exit 1
+                        fi ;;
+        --GIT_REF)      GIT_REF=${2}
+                        shift 2 ;;
+        --GIT_REPO)     GIT_REPO=${2}
                         shift 2 ;;
         --help)         usage ;;
         --)             shift 1
@@ -68,7 +68,7 @@ while true; do
     esac
 done
 
-if [ -z ${CMD} ]
+if [ -z "${CMD}" ]
 then
 	echo "missing --cmd <command>."
 	usage

--- a/.jenkins/get_job_numbers.sh
+++ b/.jenkins/get_job_numbers.sh
@@ -52,7 +52,7 @@ done
 function get_pr_number() {
     local url=${1}
     curl -L ${url}/api/xml > /tmp/job.xml
-    pr_number=$(cat /tmp/job.xml | awk -F "<value>" '{print $2}' | awk -F "</value>" '{print $1}' | awk -F "/" '{print $3}')
+    pr_number=$(cat /tmp/job.xml | awk -F "<value>/origin" '{print $2}' | awk -F "</value>" '{print $1}' | awk -F "/" '{print $3}')
     echo ${pr_number}
 }
 
@@ -91,4 +91,4 @@ jobs_to_terminate=($(printf "%s\n" ${jobs_to_terminate[@]} | sort | uniq))
 
 rm -rf ${running_jobs_xml} /tmp/job.xml
 
-echo ${jobs_to_terminate}
+echo ${jobs_to_terminate[@]}

--- a/.jenkins/prepare.sh
+++ b/.jenkins/prepare.sh
@@ -35,12 +35,14 @@ gitrepo="https://github.com/noobaa/noobaa-core"
 workdir="tip/"
 ref="master"
 base="master"
+build_all="true" #TODO: change to false
 
 ARGUMENT_LIST=(
     "ref"
     "workdir"
     "gitrepo"
     "base"
+    "build_all"
 )
 
 opts=$(getopt \
@@ -61,32 +63,21 @@ eval set -- "${opts}"
 
 while true; do
     case "${1}" in
-    --help)
-        usage
-        ;;
-    --gitrepo)
-        shift
-        gitrepo=${1}
-        ;;
-    --workdir)
-        shift
-        workdir=${1}
-        ;;
-    --ref)
-        shift
-        ref=${1}
-        echo "${ref}"
-        ;;
-    --base)
-        shift
-        base=${1}
-        ;;
-    --)
-        shift
-        break
-        ;;
+    --help)         usage ;;
+    --gitrepo)      gitrepo=${2}
+                    shift 2 ;;
+    --workdir)      workdir=${2}
+                    shift 2 ;;
+    --ref)          ref=${2}
+                    echo "${ref}"
+                    shift 2 ;;
+    --base)         base=${2}
+                    shift 2 ;;
+    --build_all)    build_all="true"
+                    shift 1 ;;
+    --)             shift 1
+                    break ;;
     esac
-    shift
 done
 
 set -x
@@ -99,8 +90,11 @@ cd "${workdir}"
 git fetch origin "${ref}:tip/${ref}"
 git checkout "tip/${ref}"
 
-# Bypassing the building of base and noobaa-builder by pointing to noobaa/noobaa-base instead of noobaa-base
-# We don't want to build it, so we reduce the overall time for builds/test.
-# The base and noobaa-builder are not often changing. once they do We need to push into dockerhub.io 
-sed -i -e 's|FROM noobaa-base .*|FROM noobaa/noobaa-base as server_builder|' ${workdir}/src/deploy/NVA_build/NooBaa.Dockerfile
-sed -i -e 's|noobaa: base|noobaa:|' ${workdir}/Makefile
+if [ "${build_all}" == "false" ]
+then
+    # Bypassing the building of base and noobaa-builder by pointing to noobaa/noobaa-base instead of noobaa-base
+    # We don't want to build it, so we reduce the overall time for builds/test.
+    # The base and noobaa-builder are not often changing. once they do We need to push into dockerhub.io 
+    sed -i -e 's|FROM noobaa-base .*|FROM noobaa/noobaa-base as server_builder|' ${workdir}/src/deploy/NVA_build/NooBaa.Dockerfile
+    sed -i -e 's|noobaa: base|noobaa:|' ${workdir}/Makefile
+fi


### PR DESCRIPTION
### Explain the changes
- Adding labels to the jobs
- Fix a bug where it stopped all the jobs instead of just the ones from the same PR
- Add a flag in the .jenkins/prepare.sh to build all (skip pulling base and builder)

### Limitation:
- Currently, the build all is not exposed on the job

Signed-off-by: liranmauda <liran.mauda@gmail.com>
