### PR TITLE
metrics for namespace buckets

### DIFF
--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -329,6 +329,29 @@ module.exports = {
             }
         },
 
+        update_issues_report: {
+            doc: 'Add issue to the issues report',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['namespace_resource_id', 'time', 'error_code'],
+                properties: {
+                    time: {
+                        idate: true,
+                    },
+                    error_code: {
+                        type: 'string',
+                    },
+                    namespace_resource_id: {
+                        objectid: true
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
         scale_hosts_pool: {
             doc: 'Change the pool\'s underlaying host count',
             method: 'POST',

--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -549,6 +549,7 @@ module.exports = {
                             'savings',
                             'total_usage',
                             'buckets_stats',
+                            'namespace_buckets_stats',
                             'usage_by_project',
                             'usage_by_bucket_class',
                         ],
@@ -597,6 +598,9 @@ module.exports = {
                             },
                             buckets_stats: {
                                 $ref: '#/definitions/partial_buckets_stats'
+                            },
+                            namespace_buckets_stats: {
+                                $ref: '#/definitions/partial_namespace_buckets_stats'
                             },
                             // TODO: Fix the regex for the projects name
                             usage_by_project: {
@@ -705,6 +709,29 @@ module.exports = {
                 unhealthy_bucket_claims: { type: 'integer' },
             }
         },
-    },
 
+        partial_namespace_buckets_stats: {
+            type: 'object',
+            required: ['namespace_buckets', 'namespace_buckets_num', 'unhealthy_namespace_buckets'],
+            properties: {
+                namespace_buckets: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        required: ['bucket_name', 'is_healthy'],
+                        properties: {
+                            bucket_name: {
+                                type: 'string'
+                            },
+                            is_healthy: {
+                                type: 'boolean'
+                            },
+                        }
+                    }
+                },
+                namespace_buckets_num: { type: 'integer' },
+                unhealthy_namespace_buckets: { type: 'integer' },
+            },
+        },
+    },
 };

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -152,6 +152,11 @@ class NamespaceS3 {
         } catch (err) {
             this._translate_error_code(params, err);
             dbg.warn('NamespaceS3.read_object_md:', inspect(err));
+            object_sdk.rpc_client.pool.update_issues_report({
+                namespace_resource_id: this.namespace_resource_id,
+                error_code: err.code,
+                time: Date.now(),
+            });
             throw err;
         }
     }
@@ -250,8 +255,16 @@ class NamespaceS3 {
             };
 
             this._assign_encryption_to_request(params, request);
-
-            res = await this.s3.putObject(request).promise();
+            try {
+                res = await this.s3.putObject(request).promise();
+            } catch (err) {
+                object_sdk.rpc_client.pool.update_issues_report({
+                    namespace_resource_id: this.namespace_resource_id,
+                    error_code: err.code,
+                    time: Date.now(),
+                });
+                throw err;
+            }
         }
         dbg.log0('NamespaceS3.upload_object:', this.bucket, inspect(params), 'res', inspect(res));
         const etag = s3_utils.parse_etag(res.ETag);
@@ -333,8 +346,16 @@ class NamespaceS3 {
             };
 
             this._assign_encryption_to_request(params, request);
-
-            res = await this.s3.uploadPart(request).promise();
+            try {
+                res = await this.s3.uploadPart(request).promise();
+            } catch (err) {
+                object_sdk.rpc_client.pool.update_issues_report({
+                    namespace_resource_id: this.namespace_resource_id,
+                    error_code: err.code,
+                    time: Date.now(),
+                });
+                throw err;
+            }
         }
         dbg.log0('NamespaceS3.upload_multipart:', this.bucket, inspect(params), 'res', inspect(res));
         const etag = s3_utils.parse_etag(res.ETag);

--- a/src/server/analytic_services/prometheus_reporting.js
+++ b/src/server/analytic_services/prometheus_reporting.js
@@ -147,6 +147,14 @@ const METRIC_RECORDS = Object.freeze([{
     generate_default_set: true,
 }, {
     metric_type: 'Gauge',
+    metric_variable: 'num_namespace_buckets',
+    configuration: {
+        name: get_metric_name('num_namespace_buckets'),
+        help: 'Namespace Buckets',
+    },
+    generate_default_set: true,
+}, {
+    metric_type: 'Gauge',
     metric_variable: 'total_usage',
     configuration: {
         name: get_metric_name('total_usage'),
@@ -175,6 +183,14 @@ const METRIC_RECORDS = Object.freeze([{
     configuration: {
         name: get_metric_name('num_unhealthy_buckets'),
         help: 'Unhealthy Buckets',
+    },
+    generate_default_set: true,
+}, {
+    metric_type: 'Gauge',
+    metric_variable: 'num_unhealthy_namespace_buckets',
+    configuration: {
+        name: get_metric_name('num_unhealthy_namespace_buckets'),
+        help: 'Unhealthy Namespace Buckets',
     },
     generate_default_set: true,
 }, {
@@ -263,6 +279,14 @@ const METRIC_RECORDS = Object.freeze([{
     configuration: {
         name: get_metric_name('bucket_status'),
         help: 'Bucket Health',
+        labelNames: ['bucket_name'],
+    },
+}, {
+    metric_type: 'Gauge',
+    metric_variable: 'namespace_bucket_healthy',
+    configuration: {
+        name: get_metric_name('namespace_bucket_status'),
+        help: 'Namespace Bucket Health',
         labelNames: ['bucket_name'],
     },
 }, {
@@ -457,6 +481,14 @@ class PrometheusReporting {
             this._metrics.bucket_healthy.set({ bucket_name: bucket_info.bucket_name }, Number(bucket_info.is_healthy));
             this._metrics.bucket_quota_precent.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_precent);
             this._metrics.bucket_capacity_precent.set({ bucket_name: bucket_info.bucket_name }, bucket_info.capacity_precent);
+        });
+    }
+
+    set_namespace_bucket_status(buckets_info) {
+        if (!this.enabled()) return;
+        this._metrics.namespace_bucket_healthy.reset();
+        buckets_info.forEach(bucket_info => {
+            this._metrics.namespace_bucket_healthy.set({ bucket_name: bucket_info.bucket_name }, Number(bucket_info.is_healthy));
         });
     }
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -194,7 +194,7 @@ async function create_bucket(req) {
 
     await system_store.make_changes(changes);
     req.load_auth();
-    if (req.rpc_params.bucket_claim) {
+    if (req.rpc_params.bucket_claim || req.rpc_params.namespace) {
         try {
             // Trigger partial aggregation for the Prometheus metrics
             server_rpc.client.stats.get_partial_stats({

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -52,5 +52,19 @@ module.exports = {
                 }
             }
         },
+        issues_report: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    time: {
+                        idate: true
+                    },
+                    error_code: {
+                        type: 'string'
+                    }
+                }
+            }
+        },
     }
 };


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Added metrics: number of namespace buckets, number of unhealthy namespace buckets, for each namespace bucket printed its name and health status.
An unhealthy bucket is a namespace bucket that its read resources (includes the write resource too) had more than 3 bucket related errors in the last 5 minutes.
2. Added issues report for namespace resource - which is an array of size 10 max of the most recent issues on namespace resource that are related to bucket problems.
3. Added calls for updating the namespace resource issues reports on failures in namespace_s3 and namespace blob - on read_object_md, put object, and put part.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
