### PR TITLE
fix listobjectsV2 continuation token

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -52,7 +52,7 @@ async function get_bucket(req) {
                 'ContinuationToken': cont_tok,
                 'StartAfter': start_after,
                 'KeyCount': reply.objects.length,
-                'NextContinuationToken': key_marker_to_cont_tok(reply.next_marker),
+                'NextContinuationToken': key_marker_to_cont_tok(reply.next_marker, reply.objects, reply.is_truncated),
             } : { // list_type v1
                 'Marker': req.query.marker || '',
                 'NextMarker': reply.next_marker,
@@ -88,9 +88,11 @@ function cont_tok_to_key_marker(cont_tok) {
     }
 }
 
-function key_marker_to_cont_tok(key_marker) {
-    if (!key_marker) return;
-    const j = JSON.stringify({ key: key_marker });
+function key_marker_to_cont_tok(key_marker, objects_arr, is_truncated) {
+    if (!key_marker && !is_truncated) return;
+    // next marker is the key marker we got or the key of the last item in the objects list.
+    const next_marker = key_marker || objects_arr[objects_arr.length - 1].key;
+    const j = JSON.stringify({ key: next_marker });
     return Buffer.from(j).toString('base64');
 }
 


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. According to https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html - when calling listObjects without delimiter param and the reply is truncated, AWS won't return next marker. as a next marker, we should use the key of the last item of the returned objects list.
2. when calling to listObjectsV2 we expect to get continuationToken.
 fixed the translation from listObjects to listObjectsV2 of next marker to continuation token in the case described in 1.

### Issues: Fixed #xxx / Gap #xxx
1. BZ #1897058

### Testing Instructions:
1. 
