### PR TITLE
Jenkins: Change the default for building the base and builder image

### DIFF
--- a/.jenkins/prepare.sh
+++ b/.jenkins/prepare.sh
@@ -35,7 +35,7 @@ gitrepo="https://github.com/noobaa/noobaa-core"
 workdir="tip/"
 ref="master"
 base="master"
-build_all="true" #TODO: change to false
+build_all="false"
 
 ARGUMENT_LIST=(
     "ref"


### PR DESCRIPTION
### Explain the changes
Changing build_all to false to avoid "You have reached your pull rate limit " for centos image form dockerhub

Signed-off-by: liranmauda <liran.mauda@gmail.com>
