### PR TITLE
Upgrade master keys implementation

### DIFF
--- a/src/server/system_services/master_key_manager.js
+++ b/src/server/system_services/master_key_manager.js
@@ -215,9 +215,9 @@ class MasterKeysManager {
         let updated_value = cipher.update(Buffer.from(value.unwrap()));
         if (m_key.cipher_type !== 'aes-256-gcm') updated_value = Buffer.concat([updated_value, cipher.final()]);
 
-        const ciphered_value = new SensitiveString(updated_value.toString('base64'));
+        const ciphered_value = updated_value.toString('base64');
         this.secret_keys_cache.put_in_cache(ciphered_value, value);
-        return ciphered_value;
+        return new SensitiveString(ciphered_value);
     }
 
     is_m_key_disabled(id) {
@@ -245,10 +245,9 @@ class MasterKeysManager {
                 if (this.is_m_key_disabled(account.master_key_id._id)) {
                     continue;
                 }
-                const decipher = crypto.createDecipheriv(m_key.cipher_type, m_key.cipher_key, m_key.cipher_iv);
-
                 if (account.access_keys) {
                     for (const keys of account.access_keys) {
+                        const decipher = crypto.createDecipheriv(m_key.cipher_type, m_key.cipher_key, m_key.cipher_iv);
                         keys.secret_key = await this.secret_keys_cache.get_with_cache({
                             encrypted_value: keys.secret_key.unwrap(),
                             decipher
@@ -257,6 +256,7 @@ class MasterKeysManager {
                 }
                 if (account.sync_credentials_cache) {
                     for (const keys of account.sync_credentials_cache) {
+                        const decipher = crypto.createDecipheriv(m_key.cipher_type, m_key.cipher_key, m_key.cipher_iv);
                         keys.secret_key = await this.secret_keys_cache.get_with_cache({
                             encrypted_value: keys.secret_key.unwrap(),
                             decipher

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -440,15 +440,15 @@ class SystemStore extends EventEmitter {
                 this.data = _.cloneDeep(this.old_db_data);
                 millistamp = time_utils.millistamp();
                 this.data.rebuild();
+                dbg.log1('SystemStore: rebuild took', time_utils.millitook(millistamp));
                 if (this.data.master_keys_by_id) {
                     this.master_key_manager.update_master_keys(this.data.master_keys_by_id);
+                    await this.master_key_manager.decrypt_all_accounts_secret_keys({
+                        accounts: this.data.accounts,
+                        pools: this.data.pools,
+                        namespace_resources: this.data.namespace_resources
+                    });
                 }
-                dbg.log1('SystemStore: rebuild took', time_utils.millitook(millistamp));
-                await this.master_key_manager.decrypt_all_accounts_secret_keys({
-                    accounts: this.data.accounts,
-                    pools: this.data.pools,
-                    namespace_resources: this.data.namespace_resources
-                });
                 this.emit('load');
                 this.is_finished_initial_load = true;
                 return this.data;

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const path = require('path');
 
 const system_store = require('../server/system_services/system_store').get_instance({ standalone: true });
+const system_server = require('../server/system_services/system_server');
 const dbg = require('../util/debug_module')('UPGRADE');
 const db_client = require('../util/db_client');
 
@@ -140,7 +141,7 @@ async function run_upgrade() {
             for (const script of upgrade_scripts) {
                 dbg.log0(`running upgrade script ${script.file}: ${script.description}`);
                 try {
-                    await script.run({ dbg, db_client, system_store });
+                    await script.run({ dbg, db_client, system_store, system_server });
                     this_upgrade.completed_scripts.push(script.file);
                 } catch (err) {
                     dbg.log0(`failed running upgrade script ${script.file}`, err);

--- a/src/upgrade/upgrade_scripts/5.7.0/update_master_keys.js
+++ b/src/upgrade/upgrade_scripts/5.7.0/update_master_keys.js
@@ -1,0 +1,23 @@
+/* Copyright (C) 2016 NooBaa */
+"use strict";
+const _ = require('lodash');
+
+async function run({ dbg, system_store, system_server}) {
+    try {
+        dbg.log0('starting upgrade master keys...');
+        if (_.isEmpty(system_store.data.master_keys_by_id)) {
+            await system_server.upgrade_master_keys();
+                dbg.log0('finished upgrading master keys.');
+        }
+        dbg.log0('upgrade master keys: no upgrade needed...');
+    } catch (err) {
+        dbg.error('got error while upgrading master keys:', err);
+        throw err;
+    }
+}
+
+
+module.exports = {
+    run,
+    description: 'Create master keys for existing entities (system, account, bucket) and encrypt secrets'
+};


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Added upgrade script for upgrading master keys.
2. In the upgrade function created master keys for each existing entity in the system.
system master key is inserted to the DB encrypted by the root master key.
accounts/buckets master keys inserted to the DB encrypted by the system master key.
3. specific actions of entities: 
a. if the entity is an account - encrypted its secrets in access keys and sync credentials by its master key, and encrypted the secrets of the associated pools and namespace resources of the account.
b. if the entity is a bucket - added master key for the bucket (the map builder BG worker will encrypt the chunks cipher keys in the bucket and will attach them the bucket's master key.
 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
