### PR TITLE
fixed findOneAndUpdate with upserts

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -387,12 +387,8 @@ class MDStore {
         // empty query, we maintain a single doc in this collection
         const query = {};
         const update = { $inc: { object_version_seq: 1 } };
-        const options = { upsert: true };
-        // if the first update returns null it means we just inserted the doc for the first time
-        // so we just call again in order to increase the sequence and get the first seq.
+        const options = { upsert: true, returnOriginal: false };
         let res = await this._sequences.findOneAndUpdate(query, update, options);
-        if (res && res.value && res.value.object_version_seq) return res.value.object_version_seq;
-        res = await this._sequences.findOneAndUpdate(query, update, options);
         return res.value.object_version_seq;
     }
 

--- a/src/test/unit_tests/test_postgres_client.js
+++ b/src/test/unit_tests/test_postgres_client.js
@@ -8,7 +8,10 @@ const { PostgresClient } = require('../../util/postgres_client');
 const SensitiveString = require('../../util/sensitive_string');
 // const db_client = require('../../util/db_client');
 const assert = require('assert');
-// const _ = require('lodash');
+// const { find } = require('tslint/lib/utils');
+const _ = require('lodash');
+const wtf = require('wtfnode');
+const P = require('../../util/promise');
 // const { date } = require('azure-storage');
 
 
@@ -57,23 +60,55 @@ const test_binary = Buffer.from('this is a test buffer');
 const additional_properties = { a: 1, b: '2', c: 3.14 };
 
 
+
+async function get_postgres_client(params) {
+    let pgc = new PostgresClient(params);
+    await pgc.connect();
+    console.log('deleting old database', params.database);
+    await pgc.dropDatabase();
+    console.log('creating new database', params.database);
+    await pgc.createDatabase();
+    console.log('created database succesfuly', params.database);
+    return pgc;
+}
+
+
+
+
+
 mocha.describe('postgres_client', function() {
 
-    mocha.before(async function() {
-        postgres_client = new PostgresClient(POSTGRES_PARAMS);
-        await postgres_client.connect();
-        console.log('deleting old database', POSTGRES_PARAMS.database);
-        await postgres_client.dropDatabase();
-        console.log('creating new database', POSTGRES_PARAMS.database);
-        await postgres_client.createDatabase();
-        console.log('created database succesfuly', POSTGRES_PARAMS.database);
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(10000);
 
+    mocha.before('postgres-client-test-before-all', async function() {
+        postgres_client = await get_postgres_client(POSTGRES_PARAMS);
         test_table = postgres_client.define_collection({
             name: test_table_name,
             schema: test_schema,
             // db_indexes: test_indexes,
         });
         await test_table.init_promise;
+    });
+
+    mocha.after('postgres-client-test-after-all', async function() {
+        postgres_client.disconnect();
+        let tries_left = 3;
+        setInterval(function check_dangling_handles() {
+            tries_left -= 1;
+            console.info(`Waiting for dangling handles to release, re-sample in 30s (tries left: ${tries_left})`);
+            wtf.dump();
+
+            if (tries_left === 0) {
+                console.error('Tests cannot complete successfully, running tests resulted in dangling handles');
+
+                // Force the test suite to fail (ignoring the exist handle that mocha sets up in order to return a fail
+                // exit code)
+                process.removeAllListeners('exit');
+                process.exit(1);
+            }
+        }, 30000).unref();
+
     });
 
     mocha.it('should insert_one data without errors', async function() {
@@ -107,30 +142,65 @@ mocha.describe('postgres_client', function() {
         };
         await test_table.insertOne(data);
         const find_res = await test_table.find({ _id: String(data._id) });
-        assert.deepEqual(find_res[0], data, 'the returned data should match the inserted data');
+        assert.deepStrictEqual(find_res[0], data, 'the returned data should match the inserted data');
     });
 
-    // mocha.it('should update one', async function() {
-    //     const data = {
-    //         _id: postgres_client.generate_id(),
-    //         system: postgres_client.generate_id(),
-    //         version: 2,
-    //         name: 'test_record'
-    //     };
-    //     await test_table.insert_one(data);
-    //     const now = new Date();
-    //     await test_table.update_one({ _id: data._id }, { $set: { deleted: now }, $unset: { name: true }, $inc: { version: 3 } });
-    //     const find_res = await test_table.find({ _id: String(data._id) });
-    //     const actual = {
-    //         _id: db_client.instance().parse_object_id(find_res[0]._id),
-    //         system: db_client.instance().parse_object_id(find_res[0].system),
-    //         // name: find_res[0].name,
-    //         deleted: find_res[0].deleted,
-    //         version: find_res[0].version
-    //     };
-    //     const expected = { _id: data._id, system: data.system, deleted: now, version: 5 };
-    //     assert.deepEqual(actual, expected, 'the returned data should match the inserted data');
-    // });
+    mocha.it('should update one', async function() {
+        const data = {
+            _id: postgres_client.generate_id(),
+            objectid_field: postgres_client.generate_id(),
+            string_field: 'test update',
+            date_field: test_date,
+            int_field: 1,
+            bool_field: true,
+            bin_field: test_binary,
+            idate_field: test_idate,
+            sensitive_string: new SensitiveString('sensitive data'),
+            other: additional_properties
+        };
+        await test_table.insertOne(data);
+        const now = new Date();
+        await test_table.updateOne({ _id: data._id }, {
+            $set: { date_field: now },
+            $unset: { string_field: true },
+            $inc: { int_field: 3 }
+        });
+        const find_res = await test_table.find({ _id: data._id });
+        // const actual = {
+        //     _id: db_client.instance().parse_object_id(find_res[0]._id),
+        //     system: db_client.instance().parse_object_id(find_res[0].system),
+        //     // name: find_res[0].name,
+        //     deleted: find_res[0].deleted,
+        //     version: find_res[0].version
+        // };
+        const expected = _.omit({ ...data, date_field: now, int_field: 4 }, 'string_field');
+
+        assert.deepStrictEqual(find_res[0], expected, 'the returned data should match the inserted data');
+    });
+
+
+
+    mocha.it('should insert a single doc on multiple parallel upserts', async function() {
+        let upsert_table = postgres_client.define_collection({
+            name: `upsert_${test_table_name}`,
+            schema: test_schema,
+            // db_indexes: test_indexes,
+        });
+        await upsert_table.init_promise;
+        const query = {};
+        const update = { $inc: { int_field: 1 } };
+        const options = { upsert: true, returnOriginal: false };
+
+        // perform parallel upserts
+        const num_upserts = 40;
+        await P.map(_.times(num_upserts), async i => upsert_table.findOneAndUpdate(query, update, options));
+        // check that there is only one doc and the int_field is as num_upserts
+        let find_res = await upsert_table.find({});
+        assert.strictEqual(find_res.length, 1, 'number of inserted documents must be 1');
+    });
+
+
+
 
     // mocha.it('should find by sort order', async function() {
     //     const data1 = {
@@ -155,9 +225,9 @@ mocha.describe('postgres_client', function() {
     //     await test_table.insert_one(data2);
     //     await test_table.insert_one(data3);
     //     const find_asc = await test_table.find({ name: 'test_sort' }, { sort: { version: 1 } });
-    //     assert.deepEqual(find_asc.map(doc => doc.version), [1, 2, 3], 'the returned data should be sorted by ascending version');
+    //     assert.deepStrictEqual(find_asc.map(doc => doc.version), [1, 2, 3], 'the returned data should be sorted by ascending version');
     //     const find_des = await test_table.find({ name: 'test_sort' }, { sort: { version: -1 } });
-    //     assert.deepEqual(find_des.map(doc => doc.version), [3, 2, 1], 'the returned data should be sorted by descending version');
+    //     assert.deepStrictEqual(find_des.map(doc => doc.version), [3, 2, 1], 'the returned data should be sorted by descending version');
     // });
 
     // mocha.it('should find with limit', async function() {
@@ -183,7 +253,7 @@ mocha.describe('postgres_client', function() {
     //     await test_table.insert_one(data2);
     //     await test_table.insert_one(data3);
     //     const find_res = await test_table.find({ name: 'test_limit' }, { limit: 1 });
-    //     assert.deepEqual(find_res, [data1], 'the returned data should be only data1');
+    //     assert.deepStrictEqual(find_res, [data1], 'the returned data should be only data1');
     // });
 
     // mocha.it('should find with skip', async function() {
@@ -209,7 +279,7 @@ mocha.describe('postgres_client', function() {
     //     await test_table.insert_one(data2);
     //     await test_table.insert_one(data3);
     //     const find_res = await test_table.find({ name: 'test_skip' }, { skip: 1 });
-    //     assert.deepEqual(find_res, [data2, data3], 'the returned data should be only data2 and data3');
+    //     assert.deepStrictEqual(find_res, [data2, data3], 'the returned data should be only data2 and data3');
     // });
 
     // mocha.it('should find with projection', async function() {
@@ -221,7 +291,7 @@ mocha.describe('postgres_client', function() {
     //     };
     //     await test_table.insert_one(data1);
     //     const find_res = await test_table.find({ name: 'test_projection' }, { projection: { name: 1, version: 1 } });
-    //     assert.deepEqual(find_res, [_.pick(data1, ['_id', 'name', 'version'])], 'the returned data should contain only id, name and version');
+    //     assert.deepStrictEqual(find_res, [_.pick(data1, ['_id', 'name', 'version'])], 'the returned data should contain only id, name and version');
     // });
 
 

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -66,6 +66,8 @@ mocha.describe('s3_ops', function() {
     });
 
     mocha.describe('bucket-ops', function() {
+        // eslint-disable-next-line no-invalid-this
+        this.timeout(60000);
         mocha.it('should create bucket', async function() {
             await s3.createBucket({ Bucket: BKT1 }).promise();
         });


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. changed upserts implementation to use an advisory lock to avoid multiple inserts
2. the advisory lock is not specifically locking any row or table in the DB. it is an application-level lock and the locking logic must be handled by the application
3. for each table creating a 32 bits id from the table name hash, to be used as the advisory_lock key
4. changed mongo_client to always pass `{returnOriginal: false}`, to be aligned with Postgres behavior. forcing any call to `findOneAndUpdate` to explicitly set `{returnOriginal: false}`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
