### PR TITLE
Skip md aggregator when NOOBAA_DISABLE_AGGREGATOR env variable is true

### DIFF
--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -97,12 +97,12 @@ function run_master_workers() {
         delay: config.central_stats.partial_send_time_cycle,
         run_immediate: true
     }, stats_aggregator.background_worker);
-
-    register_bg_worker({
-        name: 'md_aggregator',
-        delay: config.MD_AGGREGATOR_INTERVAL
-    }, md_aggregator.background_worker);
-
+    if (process.env.NOOBAA_DISABLE_AGGREGATOR !== "true") {
+        register_bg_worker({
+            name: 'md_aggregator',
+            delay: config.MD_AGGREGATOR_INTERVAL
+        }, md_aggregator.background_worker);
+    }
     register_bg_worker({
         name: 'usage_aggregator',
         delay: config.USAGE_AGGREGATOR_INTERVAL


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Added condition before registration to md_aggregator bg worker, for skipping the registration if the NOOBAA_DISABLE_AGGREGATOR env variable is true

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
