### PR TITLE
Backport to 5.6: disable md aggregator when env var field is set

### DIFF
--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -95,12 +95,12 @@ function run_master_workers() {
         delay: config.central_stats.partial_send_time_cycle,
         run_immediate: true
     }, stats_aggregator.background_worker);
-
-    register_bg_worker({
-        name: 'md_aggregator',
-        delay: config.MD_AGGREGATOR_INTERVAL
-    }, md_aggregator.background_worker);
-
+    if (process.env.NOOBAA_DISABLE_AGGREGATOR !== "true") {
+        register_bg_worker({
+            name: 'md_aggregator',
+            delay: config.MD_AGGREGATOR_INTERVAL
+        }, md_aggregator.background_worker);
+    }
     register_bg_worker({
         name: 'usage_aggregator',
         delay: config.USAGE_AGGREGATOR_INTERVAL


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>
(cherry picked from commit 49c3ea444e348649fc488ae7136ac047abb37507)

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
