### PR TITLE
PowerTools repo was renamed in CentOS 8

### DIFF
--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
 ENV container docker
-RUN dnf --enablerepo=PowerTools install -y -q yasm && \
+RUN dnf --enablerepo='?ower?ools' install -y -q yasm && \
     dnf clean all
 RUN dnf update -y -q && \
     dnf clean all

--- a/src/deploy/NVA_build/dev.Dockerfile
+++ b/src/deploy/NVA_build/dev.Dockerfile
@@ -11,7 +11,7 @@ RUN dnf update -y -q && \
         python3 python3-setuptools \
         gdb strace lsof \
         openssl && \
-    dnf --enablerepo=PowerTools install -y -q yasm && \
+    dnf --enablerepo='?ower?ools' install -y -q yasm && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
 


### PR DESCRIPTION
CentOS recently (as of 8.3) rename the PowerTools repo ID to powertools.

We can use a glob to match both of these when enabling it though.

Signed-off-by: Boris Ranto <branto@redhat.com>

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
