### PR TITLE
Removed returned next marker when no delimiter described

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -55,7 +55,7 @@ async function get_bucket(req) {
                 'NextContinuationToken': key_marker_to_cont_tok(reply.next_marker, reply.objects, reply.is_truncated),
             } : { // list_type v1
                 'Marker': req.query.marker || '',
-                'NextMarker': reply.next_marker,
+                'NextMarker': req.query.delimiter ? reply.next_marker : undefined,
             },
             _.map(reply.objects, obj => ({
                 Contents: {


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. According to https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html, next marker is returned only if you have delimiter request parameter specified. when using namespace resource on Azure blob we return this field even when a delimiter is not specified.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ #1901943

### Testing Instructions:
1. 
