### PR TITLE
Bug fixes

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -215,7 +215,8 @@ function parse_sse(req) {
 
 function parse_content_length(req) {
     const size = Number(req.headers['x-amz-decoded-content-length'] || req.headers['content-length']);
-    if (!Number.isInteger(size) || size < 0) {
+    const copy = req.headers['x-amz-copy-source'];
+    if (!copy && (!Number.isInteger(size) || size < 0)) {
         dbg.warn('Missing content-length', req.headers['content-length']);
         throw new S3Error(S3Error.MissingContentLength);
     }

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -245,10 +245,10 @@ async function get_agent_install_conf(system, pool, account, routing_hint) {
     return Buffer.from(install_string).toString('base64');
 }
 
-function create_namespace_resource(req) {
+async function create_namespace_resource(req) {
     const name = req.rpc_params.name;
     const connection = cloud_utils.find_cloud_connection(req.account, req.rpc_params.connection);
-    connection.secret_key = system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
+    const secret_key = system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
         connection.secret_key, req.account.master_key_id._id);
 
     const namespace_resource = new_namespace_resource_defaults(name, req.system._id, req.account._id, _.omitBy({
@@ -257,10 +257,19 @@ function create_namespace_resource(req) {
         access_key: connection.access_key,
         auth_method: connection.auth_method,
         cp_code: connection.cp_code || undefined,
-        secret_key: connection.secret_key,
+        secret_key,
         endpoint_type: connection.endpoint_type || 'AWS'
     }, _.isUndefined));
 
+    const cloud_buckets = await server_rpc.client.bucket.get_cloud_buckets({
+        connection: connection.name,
+    }, {
+        auth_token: req.auth_token
+    });
+    if (!cloud_buckets.find(bucket_name => bucket_name.name.unwrap() === req.rpc_params.target_bucket)) {
+        dbg.error('This endpoint target bucket does not exist');
+        throw new RpcError('INVALID_TARGET', 'Target bucket doesn\'t exist');
+    }
     const already_used_by = cloud_utils.get_used_cloud_targets([namespace_resource.connection.endpoint_type],
             system_store.data.buckets, system_store.data.pools, system_store.data.namespace_resources)
         .find(candidate_target => (candidate_target.endpoint === namespace_resource.connection.endpoint &&
@@ -294,7 +303,7 @@ function create_namespace_resource(req) {
 async function create_cloud_pool(req) {
     var name = req.rpc_params.name;
     var connection = cloud_utils.find_cloud_connection(req.account, req.rpc_params.connection);
-    connection.secret_key = system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
+    const secret_key = system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
         connection.secret_key, req.account.master_key_id._id);
 
     var cloud_info = _.omitBy({
@@ -303,7 +312,7 @@ async function create_cloud_pool(req) {
         auth_method: connection.auth_method,
         access_keys: {
             access_key: connection.access_key,
-            secret_key: connection.secret_key,
+            secret_key,
             account_id: req.account._id
         },
         endpoint_type: connection.endpoint_type || 'AWS',
@@ -311,7 +320,15 @@ async function create_cloud_pool(req) {
         storage_limit: req.rpc_params.storage_limit,
     }, _.isUndefined);
 
-
+    const cloud_buckets = await server_rpc.client.bucket.get_cloud_buckets({
+        connection: connection.name,
+    }, {
+        auth_token: req.auth_token
+    });
+    if (!cloud_buckets.find(bucket_name => bucket_name.name.unwrap() === cloud_info.target_bucket)) {
+        dbg.error('This endpoint target bucket does not exist');
+        throw new RpcError('INVALID_TARGET', 'Target bucket doesn\'t exist');
+    }
     const already_used_by = cloud_utils.get_used_cloud_targets([cloud_info.endpoint_type],
             system_store.data.buckets, system_store.data.pools, system_store.data.namespace_resources)
         .find(candidate_target => (candidate_target.endpoint === cloud_info.endpoint &&

--- a/src/test/system_tests/sanity_build_test.js
+++ b/src/test/system_tests/sanity_build_test.js
@@ -173,8 +173,8 @@ async function _create_resources_and_buckets() {
 
     //Create namespace resources
     console.info('Creating NS Resources');
-    await TEST_CTX.cloudfunc.createNamespaceResource(TEST_CTX.compatible_v2.name, 'NSv2', 'first-bucket');
-    await TEST_CTX.cloudfunc.createNamespaceResource(TEST_CTX.compatible_v4.name, 'NSv4', 'first-bucket');
+    await TEST_CTX.cloudfunc.createNamespaceResource(TEST_CTX.compatible_v2.name, 'NSv2', 'first.bucket');
+    await TEST_CTX.cloudfunc.createNamespaceResource(TEST_CTX.compatible_v4.name, 'NSv4', 'first.bucket');
 
     //Create namespace bucket
     console.info('Creating NS Buckets');


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. Added a check for RPC calls for creating namespace/cloud resource that will verify if the target-bucket is indeed valid - if not it will throw INVALID_TARGET 
2. We used to reject copy methods with empty body and content-length. content-length is a mandatory only to messages with body - we will now check if this is a copy method where body suppose to be empty

### Issues: Fixed #xxx / Gap #xxx
1. BZ1902685 - Too strict Content-Length header check refuses valid upload requests
2. BZ1900760 - RPC call for Namespace resource creation allows invalid target bucket names 

### Testing Instructions:
1. 
