### PR TITLE
Allow setting cloud pool available capacity via an RPC call

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -811,7 +811,8 @@ class Agent {
             })
             .then(() => {
                 if (this.block_store) {
-                    return this.block_store.get_storage_info();
+                    const free = req.rpc_params.available_capacity;
+                    return this.block_store.get_storage_info({ free });
                 }
             })
             .then(storage_info => {
@@ -865,7 +866,8 @@ class Agent {
         const dbg = this.dbg;
         const info = {};
         if (this.block_store) {
-            const storage_info = await this.block_store.get_storage_info();
+            const free = req.rpc_params.available_capacity;
+            const storage_info = await this.block_store.get_storage_info({ free });
             const MIN_USED_STORAGE = 200 * 1024;
             if (storage_info.used < MIN_USED_STORAGE) {
                 dbg.log0(`used storage is under 200 KB (${storage_info.used}), treat as 0`);

--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -6,6 +6,7 @@ const _ = require('lodash');
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const buffer_utils = require('../../util/buffer_utils');
+const size_utils = require('../../util/size_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
 const { RpcError } = require('../../rpc');
 const Storage = require('../../util/google_storage_wrap');
@@ -54,12 +55,12 @@ class BlockStoreGoogle extends BlockStoreBase {
         }
     }
 
-    async get_storage_info() {
-        const PETABYTE = 1024 * 1024 * 1024 * 1024 * 1024;
+    async get_storage_info(external_info = {}) {
+        const { free = size_utils.PETABYTE } = external_info;
         const usage = await this._get_usage();
         return {
-            total: PETABYTE + usage.size,
-            free: PETABYTE,
+            total: size_utils.sum_bigint_json(free, usage.size),
+            free: free,
             used: usage.size
         };
     }

--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -9,6 +9,7 @@ const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const http_utils = require('../../util/http_utils');
 const cloud_utils = require('../../util/cloud_utils');
+const size_utils = require('../../util/size_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
 const { RpcError } = require('../../rpc');
 
@@ -99,12 +100,12 @@ class BlockStoreS3 extends BlockStoreBase {
         };
     }
 
-    async get_storage_info() {
-        const PETABYTE = 1024 * 1024 * 1024 * 1024 * 1024;
+    async get_storage_info(external_info = {}) {
+        const { free = size_utils.PETABYTE } = external_info;
         const usage = await this._get_usage();
         return {
-            total: PETABYTE + usage.size,
-            free: PETABYTE,
+            total: size_utils.sum_bigint_json(free, usage.size),
+            free: free,
             used: usage.size
         };
     }

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -31,6 +31,9 @@ module.exports = {
                             },
                         },
                     },
+                    available_capacity: {
+                        $ref: 'common_api#/definitions/bigint'
+                    }
                 },
             },
             reply: {
@@ -125,6 +128,14 @@ module.exports = {
 
         get_agent_storage_info: {
             method: 'GET',
+            params: {
+                type: 'object',
+                properties: {
+                    available_capacity: {
+                        $ref: 'common_api#/definitions/bigint'
+                    }
+                }
+            },
             reply: {
                 type: 'object',
                 properties: {

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -73,6 +73,9 @@ module.exports = {
                     backingstore: {
                         $ref: '#/definitions/backingstore_definition'
                     },
+                    available_capacity: {
+                        $ref: 'common_api#/definitions/bigint'
+                    },
                     storage_limit: {
                         $ref: 'common_api#/definitions/bigint'
                     }
@@ -384,8 +387,8 @@ module.exports = {
             }
         },
 
-        update_cloud_pool_limit: {
-            doc: 'Change the cloud pool\'s storage limit',
+        update_cloud_pool: {
+            doc: 'Update the cloud pool\'s properties',
             method: 'POST',
             params: {
                 type: 'object',
@@ -393,6 +396,9 @@ module.exports = {
                 properties: {
                     name: {
                         type: 'string',
+                    },
+                    available_capacity: {
+                        $ref: 'common_api#/definitions/bigint'
                     },
                     storage_limit: {
                         $ref: 'common_api#/definitions/bigint'

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -263,8 +263,16 @@ class NodesMonitor extends EventEmitter {
             if (item.node.deleted) continue;
             if (!item.connection) continue;
             if (!item.node_from_store) continue;
+
+            const pool = system_store.data.get_by_id(item.node.pool);
+            const available_capacity =
+                pool &&
+                pool.cloud_pool_info &&
+                pool.cloud_pool_info.available_capacity;
             const info = await P.timeout(AGENT_RESPONSE_TIMEOUT,
-                this.client.agent.get_agent_storage_info(undefined, {
+                this.client.agent.get_agent_storage_info({
+                    available_capacity
+                }, {
                     connection: item.connection
                 })
             );
@@ -1055,9 +1063,17 @@ class NodesMonitor extends EventEmitter {
             })
         }));
 
+
+        const pool = system_store.data.get_by_id(item.node.pool);
+        const available_capacity =
+            pool &&
+            pool.cloud_pool_info &&
+            pool.cloud_pool_info.available_capacity;
+
         return P.timeout(AGENT_RESPONSE_TIMEOUT,
                 this.client.agent.get_agent_info_and_update_masters({
-                    addresses: potential_masters
+                    addresses: potential_masters,
+                    available_capacity
                 }, {
                     connection: item.connection
                 })

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -317,6 +317,7 @@ async function create_cloud_pool(req) {
         },
         endpoint_type: connection.endpoint_type || 'AWS',
         backingstore: req.rpc_params.backingstore,
+        available_capacity: req.rpc_params.available_capacity,
         storage_limit: req.rpc_params.storage_limit,
     }, _.isUndefined);
 
@@ -391,11 +392,28 @@ async function create_cloud_pool(req) {
     });
 }
 
-async function update_cloud_pool_limit(req) {
+async function update_cloud_pool(req) {
     const pool = find_pool_by_name(req);
     if (!pool.cloud_pool_info) {
         throw new RpcError('INVALID_POOL_TYPE', `pool ${pool.name} is not a cloud pool`);
     }
+
+    const updates = {
+        _id: pool._id,
+        $set: {},
+        $unset: {},
+    };
+
+    // Handle total capacity changes
+    const new_available_capacity = req.rpc_params.available_capacity;
+    if (new_available_capacity !== 'undefined') {
+        if (new_available_capacity < 0) {
+            throw new RpcError('INVALID_AVAIL_CAPACITY', 'Available capacity must be a positive quantity');
+        }
+        updates.$set['cloud_pool_info.available_capacity'] = new_available_capacity;
+    }
+
+    // Handle storage limit changes
     const new_storage_limit = req.rpc_params.storage_limit;
     if (new_storage_limit) {
         const pool_info = await read_pool(req);
@@ -403,32 +421,29 @@ async function update_cloud_pool_limit(req) {
         if (new_storage_limit < storage_minimum) {
             throw new RpcError('INVALID_STORAGE_LIMIT', 'new storage limit is smaller than size already used by pool or the minimum allowed');
         }
-        dbg.log0(`update_cloud_pool_limit: updating ${pool.name} size limit to ${new_storage_limit}, current usage is ${storage_minimum}`);
-        await system_store.make_changes({
-            update: {
-                pools: [{
-                    _id: pool._id,
-                    'cloud_pool_info.storage_limit': new_storage_limit
-                }]
-            }
-        });
-    } else if (pool.cloud_pool_info.storage_limit) {
-        dbg.log0(`update_cloud_pool_limit: removing ${pool.name} size limit`);
-        await system_store.make_changes({
-            update: {
-                pools: [{
-                    _id: pool._id,
-                    $unset: { 'cloud_pool_info.storage_limit': 1 },
-                }]
-            }
+        dbg.log0(`update_cloud_pool: updating ${pool.name} storage limit to ${new_storage_limit}, current usage is ${storage_minimum}`);
+        updates.$set['cloud_pool_info.storage_limit'] = new_storage_limit;
+
+    } else if (new_storage_limit === null && pool.cloud_pool_info.storage_limit) {
+        dbg.log0(`update_cloud_pool: removing ${pool.name} storage limit`);
+        updates.$unset['cloud_pool_info.storage_limit'] = 1;
+    }
+
+    await system_store.make_changes({
+        update: {
+            pools: [updates],
+        }
+    });
+
+    // Update hosted agents in any case of storage limit changes
+    if (!_.isUndefined(new_storage_limit)) {
+        await server_rpc.client.hosted_agents.update_storage_limit({
+            pool_ids: [String(pool._id)],
+            storage_limit: new_storage_limit
+        }, {
+            auth_token: req.auth_token
         });
     }
-    await server_rpc.client.hosted_agents.update_storage_limit({
-        pool_ids: [String(pool._id)],
-        storage_limit: new_storage_limit
-    }, {
-        auth_token: req.auth_token
-    });
 }
 
 function create_mongo_pool(req) {
@@ -1351,7 +1366,7 @@ exports.set_namespace_store_info = set_namespace_store_info;
 exports.assign_pool_to_region = assign_pool_to_region;
 exports.scale_hosts_pool = scale_hosts_pool;
 exports.update_hosts_pool = update_hosts_pool;
-exports.update_cloud_pool_limit = update_cloud_pool_limit;
+exports.update_cloud_pool = update_cloud_pool;
 exports.get_optimal_non_mongo_pool_id = get_optimal_non_mongo_pool_id;
 exports.get_hosts_pool_agent_config = get_hosts_pool_agent_config;
 exports.update_issues_report = update_issues_report;

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -109,6 +109,9 @@ module.exports = {
                         }
                     }
                 },
+                available_capacity: {
+                    $ref: 'common_api#/definitions/bigint'
+                },
                 storage_limit: {
                     $ref: 'common_api#/definitions/bigint'
                 },


### PR DESCRIPTION
Some cloud-based providers have a limit on the available storage that they can service (e.g. Ceph RGW).
This PR enables an external component (e.g. NooBaa operator) to monitor the storage capacity available from the cloud provider and update the NooBaa cloud resource appropriately 

### Explain the changes
1. Add `available_capacity` to `pool.create_cloud_pool` API
2. New API `pool.update_cloud_pool` 
3. Merge `pool.update_cloud_pool_limit` into the new API
4. Allow setting cloud pool available capacity using the new API
5. Read cloud pool capacity in node_monitor and push the value all the way down to `block_store.get_storage_info` 
6. If available to the block store,  the new value will be used instead of the 1peta constant that we used up until now

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
