### PR TITLE
Change loopback address to support IPv6

### DIFF
--- a/mongod.conf
+++ b/mongod.conf
@@ -2,7 +2,7 @@
 # see here - https://docs.mongodb.org/v3.2/reference/configuration-options/
 
 net:
-    bindIp: 127.0.0.1
+    bindIp: localhost
 
 storage:
     engine: wiredTiger

--- a/s3cmd-local.config
+++ b/s3cmd-local.config
@@ -1,6 +1,6 @@
 [default]
-host_base = 127.0.0.1
-host_bucket = 127.0.0.1
+host_base = localhost
+host_bucket = localhost
 access_key = 123
 secret_key = abc
 use_https = False

--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -217,7 +217,7 @@ spec:
             [
               "/bin/bash",
               "-c",
-              "/opt/rh/rh-mongodb36/root/usr/bin/mongod --port 27017 --bind_ip 127.0.0.1 --dbpath /data/mongo/cluster/shard1",
+              "/opt/rh/rh-mongodb36/root/usr/bin/mongod --port 27017 --bind_ip localhost --dbpath /data/mongo/cluster/shard1",
             ]
           resources:
             # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -181,7 +181,7 @@ function create_init_request_sdk(rpc, internal_rpc_client, object_io) {
 }
 
 function get_rpc_router(env) {
-    const hostname = '127.0.0.1';
+    const hostname = 'localhost';
     const ports = addr_utils.get_default_ports();
 
     // for dev (when env.MD_ADDR is not set) we increment md port to

--- a/src/native/aws-cpp-sdk/s3-demo.cpp
+++ b/src/native/aws-cpp-sdk/s3-demo.cpp
@@ -312,7 +312,7 @@ DemoOptions::DemoOptions(int ac, char** av) {
     if (content_type.empty()) content_type = "application/octet-stream";
 
     endpoint = flags["endpoint"];
-    if (endpoint.empty()) endpoint = "127.0.0.1";
+    if (endpoint.empty()) endpoint = "localhost";
 
     bucket = flags["bucket"];
     if (bucket.empty()) bucket = "first.bucket";

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -50,7 +50,7 @@ argv.nconn = argv.nconn || 1;
 argv.closeconn = Number(argv.closeconn) || 0;
 argv.addr = url.parse(argv.addr || '');
 argv.addr.protocol = (argv.proto && argv.proto + ':') || argv.addr.protocol || 'ws:';
-argv.addr.hostname = argv.host || argv.addr.hostname || '127.0.0.1';
+argv.addr.hostname = argv.host || argv.addr.hostname || 'localhost';
 argv.addr.port = Number(argv.port) || argv.addr.port || 5656;
 argv.novalidation = argv.novalidation || false;
 

--- a/src/rpc/rpc_n2n_agent.js
+++ b/src/rpc/rpc_n2n_agent.js
@@ -68,7 +68,7 @@ class RpcN2NAgent extends EventEmitter {
 
             // ip options
             offer_ipv4: true,
-            offer_ipv6: false,
+            offer_ipv6: true,
             accept_ipv4: true,
             accept_ipv6: true,
             offer_internal: config.N2N_OFFER_INTERNAL,

--- a/src/server/func_services/func_server.js
+++ b/src/server/func_services/func_server.js
@@ -340,7 +340,7 @@ async function _get_func_code_b64(req, func_code) {
         console.log(`reading function code from bucket ${func_code.s3_bucket} and key ${func_code.s3_key}`);
         const account_keys = req.account.access_keys[0];
         const s3_endpoint = new AWS.S3({
-            endpoint: 'http://127.0.0.1',
+            endpoint: 'http://localhost',
             accessKeyId: account_keys.access_key,
             secretAccessKey: account_keys.secret_key,
         });

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -3625,7 +3625,7 @@ function progress_by_time(time, now) {
 
 function is_localhost(address) {
     let addr_url = url.parse(address);
-    return addr_url.hostname === '127.0.0.1' || addr_url.hostname.toLowerCase() === 'localhost';
+    return net_utils.is_localhost(addr_url.hostname);
 }
 
 // EXPORTS

--- a/src/server/object_services/events_dispatcher.js
+++ b/src/server/object_services/events_dispatcher.js
@@ -75,7 +75,7 @@ function create_object_event({ bucket, object, time, actor, event_name, id }) {
                 principalId: String(actor.id)
             },
             requestParameters: {
-                sourceIPAddress: '127.0.0.1'
+                sourceIPAddress: 'localhost'
             },
             s3: {
                 s3SchemaVersion: 1.0,

--- a/src/server/system_services/cluster_server.js
+++ b/src/server/system_services/cluster_server.js
@@ -17,6 +17,7 @@ const config = require('../../../config.js');
 const MDStore = require('../object_services/md_store').MDStore;
 const fs_utils = require('../../util/fs_utils');
 const os_utils = require('../../util/os_utils');
+const net_utils = require('../../util/net_utils');
 const MongoCtrl = require('../utils/mongo_ctrl');
 const server_rpc = require('../server_rpc');
 const cluster_hb = require('../bg_services/cluster_hb');
@@ -135,7 +136,7 @@ function pre_add_member_to_cluster(req) {
                 dbg.log0('updating adding server ip in db');
                 let shard_idx = cutil.find_shard_index(req.rpc_params.shard);
                 let server_idx = _.findIndex(topology.shards[shard_idx].servers,
-                    server => server.address === '127.0.0.1');
+                    server => net_utils.is_localhost(server.address));
                 if (server_idx === -1) {
                     dbg.warn("db does not contain internal ip of master server");
                 } else {
@@ -895,7 +896,7 @@ function diagnose_system(req) {
     //In cases of a single server, address might not be publicly available and so using it might fail
     //This case does not happen when clusterized, but as a WA for a single server, use localhost (see #2803)
     if (!system_store.get_local_cluster_info().is_clusterized) {
-        target_servers[0].owner_address = '127.0.0.1';
+        target_servers[0].owner_address = 'localhost';
     }
 
     Dispatcher.instance().activity({

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -392,7 +392,7 @@ async function create_system(req) {
 }
 
 async function _get_cluster_info() {
-    const cluster_info = await cluster_server.new_cluster_info({ address: "127.0.0.1" });
+    const cluster_info = await cluster_server.new_cluster_info({ address: "localhost" });
     if (cluster_info) {
         const dns_config = await os_utils.get_dns_config();
         if (dns_config.dns_servers.length) {

--- a/src/server/utils/clustering_utils.js
+++ b/src/server/utils/clustering_utils.js
@@ -12,8 +12,9 @@ const moment = require('moment');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
-const size_utils = require('../../util/size_utils');
 const os_utils = require('../../util/os_utils');
+const net_utils = require('../../util/net_utils');
+const size_utils = require('../../util/size_utils');
 const server_rpc = require('../server_rpc');
 const auth_server = require('../common_services/auth_server');
 const system_store = require('../system_services/system_store').get_instance();
@@ -181,7 +182,8 @@ function get_cluster_info() {
             version: version,
             hostname: hostname,
             secret: cinfo.owner_secret,
-            addresses: cinfo.owner_address === '127.0.0.1' ? os_utils.get_local_ipv4_ips() : [cinfo.owner_address].concat(os_utils.get_local_ipv4_ips()),
+            addresses: net_utils.is_localhost(cinfo.owner_address) ?
+                os_utils.get_local_ipv4_ips() : [cinfo.owner_address].concat(os_utils.get_local_ipv4_ips()),
             status: is_connected,
             memory: memory,
             storage: storage,
@@ -280,7 +282,7 @@ function send_master_update(is_master, master_address) {
             }).catch(err => dbg.error('got error on set_webserver_master_state.', err)),
             hosted_agents_promise.catch(err => dbg.error('got error on hosted_agents_promise.', err)),
             update_master_promise.catch(err => dbg.error('got error on update_master_promise.', err))
-    ])
+        ])
         .then(() => {
             // do nothing. 
         });

--- a/src/server/utils/mongo_ctrl.js
+++ b/src/server/utils/mongo_ctrl.js
@@ -220,7 +220,7 @@ MongoCtrl.prototype._add_replica_set_member_program = async function(name, first
         ' --sslClusterFile ' + config.MONGO_DEFAULTS.SERVER_CERT_PATH +
         ' --syslog' +
         ' --syslogFacility local0' +
-        ' --bind_ip_all'; // in mongodb 3.6 bind_ip is by default 127.0.0.1 - bind to all interfaces
+        ' --bind_ip_all'; // in mongodb 3.6 bind_ip is by default localhost - bind to all interfaces
     program_obj.directory = '/usr/bin';
     program_obj.user = 'root';
     program_obj.stopsignal = 'INT';

--- a/src/test/framework/report.js
+++ b/src/test/framework/report.js
@@ -43,7 +43,7 @@ class Reporter {
         this._passed = 0;
         this._failed = 0;
         this._paused = false;
-        this.host = '127.0.0.1';
+        this.host = 'localhost';
         this.port = '38000';
         this._passed_cases = [];
         this._failed_cases = [];

--- a/src/test/lambda/dildos.js
+++ b/src/test/lambda/dildos.js
@@ -13,7 +13,7 @@ const zip_utils = require('../../util/zip_utils');
 
 const LAMBDA_CONF = {
     region: argv.region || 'us-east-1',
-    endpoint: argv.aws ? undefined : (argv.endpoint || 'http://127.0.0.1:6001'),
+    endpoint: argv.aws ? undefined : (argv.endpoint || 'http://localhost:6001'),
     accessKeyId: argv.access_key || process.env.AWS_ACCESS_KEY_ID || '123',
     secretAccessKey: argv.secret_key || process.env.AWS_SECRET_ACCESS_KEY || 'abc',
     sslEnabled: argv.ssl || false,
@@ -74,7 +74,7 @@ const SP_EVENT = {
 const WC_EVENT = {
     text: 'a',
     // random: 20,
-    // url: argv.url || 'http://127.0.0.1:5001',
+    // url: argv.url || 'http://localhost:5001',
     // return_text: argv.return_text,
 };
 

--- a/src/test/lambda/test_lambda.sh
+++ b/src/test/lambda/test_lambda.sh
@@ -1,5 +1,5 @@
 NAME="test_lambda"
-ENDPOINT="http://127.0.0.1:6001"
+ENDPOINT="http://localhost:6001"
 PROFILE="noobaa"
 AWS="aws --endpoint-url ${ENDPOINT} --profile ${PROFILE} --debug"
 

--- a/src/test/pipeline/README.md
+++ b/src/test/pipeline/README.md
@@ -19,4 +19,4 @@
 - Run
 
         cd src/test/pipeline
-        node run_namespace_cache_tests.js --mgmt_ip <mgmt_ip> --mgmt_port_https 8443 --s3_ip 127.0.0.1 --s3_port 6001 --skip_clean_con
+        node run_namespace_cache_tests.js --mgmt_ip <mgmt_ip> --mgmt_port_https 8443 --s3_ip localhost --s3_port 6001 --skip_clean_con

--- a/src/test/pipeline/run_dataset.js
+++ b/src/test/pipeline/run_dataset.js
@@ -13,7 +13,7 @@ const test_name = 'dataset';
 dbg.set_process_name(test_name);
 
 const TEST_CFG_DEFAULTS = {
-    mgmt_ip: '127.0.0.1',
+    mgmt_ip: 'localhost',
     mgmt_port_https: 8443,
     s3_ip: '',
     s3_port_https: 443,

--- a/src/test/qa/capacity.js
+++ b/src/test/qa/capacity.js
@@ -15,7 +15,7 @@ http.globalAgent.keepAlive = true;
 https.globalAgent.keepAlive = true;
 
 if (argv.endpoint) {
-    if (argv.endpoint === true) argv.endpoint = 'http://127.0.0.1';
+    if (argv.endpoint === true) argv.endpoint = 'http://localhost';
     argv.access_key = argv.access_key || '123';
     argv.secret_key = argv.secret_key || 'abc';
 }

--- a/src/test/qa/load.js
+++ b/src/test/qa/load.js
@@ -9,7 +9,7 @@ const os_utils = require('../util/os_utils');
 
 const basic_size = 5;
 const basic_name = 'file_' + Math.floor(Date.now() / 1000);
-const end_point = '127.0.0.1';
+const end_point = 'localhost';
 
 mocha.describe('UPLOAD TESTS:', function() {
 

--- a/src/test/system_tests/test_blob_api.js
+++ b/src/test/system_tests/test_blob_api.js
@@ -10,7 +10,7 @@ dotenv.load();
 
 const azure_storage = require('azure-storage');
 
-const blob_service = azure_storage.createBlobService('account', '1234', 'http://127.0.0.1:80');
+const blob_service = azure_storage.createBlobService('account', '1234', 'http://localhost:80');
 // const blob_service = azure_storage.createBlobService();
 
 

--- a/src/test/system_tests/test_bucket_access.js
+++ b/src/test/system_tests/test_bucket_access.js
@@ -24,9 +24,9 @@ dotenv.load();
 
 const {
     no_setup,
-    mgmt_ip = '127.0.0.1',
+    mgmt_ip = 'localhost',
     mgmt_port = '8080',
-    s3_ip = '127.0.0.1',
+    s3_ip = 'localhost',
     s3_port = '80',
 } = argv;
 

--- a/src/test/system_tests/test_bucket_lambda_triggers.js
+++ b/src/test/system_tests/test_bucket_lambda_triggers.js
@@ -24,9 +24,9 @@ const test_utils = require('./test_utils');
 dotenv.load();
 
 const {
-    mgmt_ip = '127.0.0.1',
+    mgmt_ip = 'localhost',
         mgmt_port = '8080',
-        s3_ip = '127.0.0.1',
+        s3_ip = 'localhost',
         s3_port = '80',
 } = argv;
 

--- a/src/test/system_tests/test_bucket_placement.js
+++ b/src/test/system_tests/test_bucket_placement.js
@@ -19,9 +19,9 @@ dotenv.load();
 
 
 const {
-    mgmt_ip = '127.0.0.1',
+    mgmt_ip = 'localhost',
         mgmt_port = '8080',
-        s3_ip = '127.0.0.1',
+        s3_ip = 'localhost',
 } = argv;
 
 argv.access_key = argv.access_key || '123';

--- a/src/test/system_tests/test_build_chunks.js
+++ b/src/test/system_tests/test_build_chunks.js
@@ -25,15 +25,15 @@ const test_utils = require('./test_utils');
 dotenv.load();
 
 const {
-    mgmt_ip = '127.0.0.1',
+    mgmt_ip = 'localhost',
         mgmt_port = '8080',
-        s3_ip = '127.0.0.1',
+        s3_ip = 'localhost',
         s3_port = '80',
 } = argv;
 
 
 let TEST_CTX = {
-    ip: '127.0.0.1',
+    ip: 'localhost',
     s3_endpoint: `http://${s3_ip}:${s3_port}/`,
     default_bucket: 'first.bucket',
     object_key: '',

--- a/src/test/system_tests/test_ceph_s3.js
+++ b/src/test/system_tests/test_ceph_s3.js
@@ -19,9 +19,9 @@ require('../../util/dotenv').load();
 const {
     pass = 'DeMo1',
         protocol = 'ws',
-        mgmt_ip = '127.0.0.1',
+        mgmt_ip = 'localhost',
         mgmt_port = '8080',
-        s3_ip = '127.0.0.1',
+        s3_ip = 'localhost',
         s3_acc_key = 123,
         s3_sec_key = 'abc',
 } = argv;

--- a/src/test/system_tests/test_cloud_pools.js
+++ b/src/test/system_tests/test_cloud_pools.js
@@ -26,7 +26,7 @@ const s3 = new AWS.S3({
 });
 
 let TEST_CTX = {
-    source_ip: '127.0.0.1',
+    source_ip: 'localhost',
     source_bucket: 'first.bucket',
     target_port: process.env.PORT || '5001',
     target_bucket: 'cloud-resource-jenkins-test',

--- a/src/test/system_tests/test_md_aggregator.js
+++ b/src/test/system_tests/test_md_aggregator.js
@@ -18,7 +18,7 @@ const SERVICES_WAIT_IN_SECONDS = 30;
 //This was implemented to work on local servers only
 // The reason is that there is no component to control the services remotely
 // If there will be a component in the future just change the method control_services
-argv.ip = argv.ip || '127.0.0.1';
+argv.ip = argv.ip || 'localhost';
 argv.access_key = argv.access_key || '123';
 argv.secret_key = argv.secret_key || 'abc';
 var rpc = api.new_rpc();
@@ -274,7 +274,7 @@ function wait_for_server_to_start(max_seconds_to_wait, port) {
             },
             function() {
                 return P.ninvoke(request, 'get', {
-                        url: 'http://127.0.0.1:' + port,
+                        url: 'http://localhost:' + port,
                         rejectUnauthorized: false,
                     })
                     .then(function() {

--- a/src/test/system_tests/test_node_failure.js
+++ b/src/test/system_tests/test_node_failure.js
@@ -20,9 +20,9 @@ dotenv.load();
 let suffix = uuid().split('-')[0];
 
 const {
-    mgmt_ip = '127.0.0.1',
+    mgmt_ip = 'localhost',
         mgmt_port = '8080',
-        s3_ip = '127.0.0.1',
+        s3_ip = 'localhost',
 } = argv;
 
 

--- a/src/test/system_tests/test_s3_authentication.js
+++ b/src/test/system_tests/test_s3_authentication.js
@@ -15,7 +15,7 @@ var http = require('http');
 dotenv.load();
 
 let TEST_PARAMS = {
-    ip: argv.ip || '127.0.0.1',
+    ip: argv.ip || 'localhost',
     bucket: argv.bucket || 'first.bucket',
     port: argv.target_port || process.env.PORT,
     access_key: argv.access_key || '123',
@@ -23,7 +23,7 @@ let TEST_PARAMS = {
 };
 
 var client = rpc.new_client({
-    address: 'ws://127.0.0.1:' + process.env.PORT
+    address: 'ws://localhost:' + process.env.PORT
 });
 
 module.exports = {

--- a/src/test/system_tests/upgradeonly.js
+++ b/src/test/system_tests/upgradeonly.js
@@ -8,7 +8,7 @@ var argv = require('minimist')(process.argv);
 
 function show_usage() {
     console.error('usage: node upgradeonly.js <--upgrade_pack path_to_upgrade_pack> <--target_ip ip>');
-    console.error('   example: node upgradeonly.js --target_ip 127.0.0.1 --upgrade_pack ../build/public/noobaa-NVA.tar.gz');
+    console.error('   example: node upgradeonly.js --target_ip localhost --upgrade_pack ../build/public/noobaa-NVA.tar.gz');
     console.error(' upgrade_pack -\t\tPath to upgrade pack to use in the upgrade process');
     console.error('\n');
 }

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -181,9 +181,9 @@ function setup(options = {}) {
         const http_port = http_net_address.port;
         const https_port = https_net_address.port;
 
-        base_address = `wss://127.0.0.1:${https_port}`;
-        http_address = `http://127.0.0.1:${http_port}`;
-        https_address = `https://127.0.0.1:${https_port}`;
+        base_address = `wss://localhost:${https_port}`;
+        http_address = `http://localhost:${http_port}`;
+        https_address = `https://localhost:${https_port}`;
 
         // update the nodes_monitor n2n_rpc to find the base_address correctly for signals
         await node_server.start_monitor();

--- a/src/test/unit_tests/test_postgres_client.js
+++ b/src/test/unit_tests/test_postgres_client.js
@@ -43,7 +43,7 @@ const test_schema = {
 
 
 const POSTGRES_PARAMS = {
-    host: '127.0.0.1',
+    host: 'localhost',
     port: 5432,
     user: 'postgres',
     password: 'noobaa',

--- a/src/test/unit_tests/test_rpc.js
+++ b/src/test/unit_tests/test_rpc.js
@@ -408,10 +408,10 @@ mocha.describe('RPC', function() {
             .then(http_server_arg => {
                 http_server = http_server_arg;
                 http_client = rpc.new_client({
-                    address: 'http://127.0.0.1:' + http_server.address().port
+                    address: 'http://localhost:' + http_server.address().port
                 });
                 ws_client = rpc.new_client({
-                    address: 'ws://127.0.0.1:' + http_server.address().port
+                    address: 'ws://localhost:' + http_server.address().port
                 });
             })
             .then(() => http_client.test.get(_.cloneDeep(PARAMS)))
@@ -432,10 +432,10 @@ mocha.describe('RPC', function() {
             .then(https_server_arg => {
                 https_server = https_server_arg;
                 https_client = rpc.new_client({
-                    address: 'https://127.0.0.1:' + https_server.address().port
+                    address: 'https://localhost:' + https_server.address().port
                 });
                 wss_client = rpc.new_client({
-                    address: 'wss://127.0.0.1:' + https_server.address().port
+                    address: 'wss://localhost:' + https_server.address().port
                 });
             })
             .then(() => https_client.test.get(_.cloneDeep(PARAMS)))
@@ -450,7 +450,7 @@ mocha.describe('RPC', function() {
             .then(tcp_server_arg => {
                 tcp_server = tcp_server_arg;
                 var tcp_client = rpc.new_client({
-                    address: 'tcp://127.0.0.1:' + tcp_server.port
+                    address: 'tcp://localhost:' + tcp_server.port
                 });
                 return tcp_client.test.get(_.cloneDeep(PARAMS));
             })
@@ -467,7 +467,7 @@ mocha.describe('RPC', function() {
             .then(tls_server_arg => {
                 tls_server = tls_server_arg;
                 var tls_client = rpc.new_client({
-                    address: 'tls://127.0.0.1:' + tls_server.port
+                    address: 'tls://localhost:' + tls_server.port
                 });
                 return tls_client.test.get(_.cloneDeep(PARAMS));
             })

--- a/src/test/unit_tests/test_tiering_upload.js
+++ b/src/test/unit_tests/test_tiering_upload.js
@@ -61,7 +61,7 @@ mocha.describe('tiering upload', function() {
         await node_server.sync_monitor_storage_info();
 
         // await first_agent.get_agent_info_and_update_masters({
-        //     addresses: '127.0.0.1'
+        //     addresses: 'localhost'
         // });
         await rpc_client.tier.create_tier({
             name: TIER0,

--- a/src/test/utils/s3ops.js
+++ b/src/test/utils/s3ops.js
@@ -18,7 +18,7 @@ const verify_md5_map = new Map();
 class S3OPS {
 
     constructor({
-        ip = '127.0.0.1',
+        ip = 'localhost',
         port = '80',
         ssl_port = '443',
         access_key = '123',

--- a/src/test/web/test_create_system.js
+++ b/src/test/web/test_create_system.js
@@ -14,7 +14,7 @@ mocha.describe('create_system', function() {
     const d = self.driver;
 
     mocha.it('should fill signup form and create system', function() {
-        const URL = 'http://127.0.0.1:5001';
+        const URL = 'http://localhost:5001';
         console.log('Loading URL:', URL);
         return d.get(URL)
             .then(() => console.log('Wait for page title ...'))

--- a/src/tools/fuse/mount-s3fs.sh
+++ b/src/tools/fuse/mount-s3fs.sh
@@ -12,7 +12,7 @@ function usage() {
     echo "  $SCRIPT"
     echo "      - show this usage"
     echo "  $SCRIPT /mnt/noobaa"
-    echo "      - url will fill with defaults: http://123:abc@127.0.0.1/files)"
+    echo "      - url will fill with defaults: http://123:abc@localhost/files)"
     echo "  $SCRIPT /mnt/noobaa https://my-noobaa-server/movies"
     echo "      - url will fill with defaults: https://123:abc@my-noobaa-server/movies)"
     echo "  "
@@ -41,7 +41,7 @@ S3FS_FLAGS="$*"
 
 # use url defaults
 [ -z "$S3FS_PROTO" ] && S3FS_PROTO=http
-[ -z "$S3FS_HOST" ] && S3FS_HOST=127.0.0.1
+[ -z "$S3FS_HOST" ] && S3FS_HOST=localhost
 [ -z "$S3FS_ACCESS_KEY" ] && S3FS_ACCESS_KEY=123
 [ -z "$S3FS_SECRET_KEY" ] && S3FS_SECRET_KEY=abc
 [ -z "$S3FS_BUCKET" ] && S3FS_BUCKET=files

--- a/src/tools/http_proxy.js
+++ b/src/tools/http_proxy.js
@@ -23,7 +23,7 @@ if (require.main === module) {
 function main() {
     // eslint-disable-next-line global-require
     const argv = require('minimist')(process.argv);
-    argv.host = argv.host || '127.0.0.1';
+    argv.host = argv.host || 'localhost';
     argv.port = Number(argv.port) || 80;
     argv.port2 = Number(argv.port2) || 6001;
     proxy_port(argv.port, 'http://' + argv.host + ':' + argv.port2);

--- a/src/tools/http_speed.go
+++ b/src/tools/http_speed.go
@@ -72,7 +72,7 @@ func runSender() {
 	var speedometer Speedometer
 
 	if *ssl {
-		addr = "https://127.0.0.1:" + strconv.Itoa(*port)
+		addr = "https://localhost:" + strconv.Itoa(*port)
 		client = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
@@ -81,7 +81,7 @@ func runSender() {
 			},
 		}
 	} else {
-		addr = "http://127.0.0.1:" + strconv.Itoa(*port)
+		addr = "http://localhost:" + strconv.Itoa(*port)
 		client = &http.Client{}
 	}
 

--- a/src/tools/http_speed.js
+++ b/src/tools/http_speed.js
@@ -24,7 +24,7 @@ argv.port = Number(argv.port) || 50505;
 argv.ssl = Boolean(argv.ssl);
 argv.forks = argv.forks || 1;
 // client
-argv.client = argv.client === true ? '127.0.0.1' : argv.client;
+argv.client = argv.client === true ? 'localhost' : argv.client;
 argv.size = argv.size || 100;
 argv.size_units = argv.size_units || 'MB';
 const size_bytes = argv.size * (size_units_mult[argv.size_units] || 1);

--- a/src/tools/ntcp_speed.js
+++ b/src/tools/ntcp_speed.js
@@ -16,7 +16,7 @@ function main() {
     if (argv.server) {
         run_server(argv.port);
     } else if (argv.client) {
-        argv.client = (typeof(argv.client) === 'string' && argv.client) || '127.0.0.1';
+        argv.client = (typeof(argv.client) === 'string' && argv.client) || 'localhost';
         run_client(argv.port, argv.client);
     } else {
         return usage();

--- a/src/tools/s3cat.js
+++ b/src/tools/s3cat.js
@@ -23,7 +23,7 @@ if (argv.presign && !_.isNumber(argv.presign)) {
 }
 
 if (argv.endpoint) {
-    if (argv.endpoint === true) argv.endpoint = 'http://127.0.0.1';
+    if (argv.endpoint === true) argv.endpoint = 'http://localhost';
     argv.access_key = argv.access_key || '123';
     argv.secret_key = argv.secret_key || 'abc';
     argv.bucket = argv.bucket || 'first.bucket';
@@ -485,7 +485,7 @@ Buckets Flags:
   --mb <name>          create bucket
   --rb <name>          delete bucket
 General S3 Flags:
-  --endpoint <host>    (default is 127.0.0.1)
+  --endpoint <host>    (default is localhost)
   --access_key <key>   (default is env.AWS_ACCESS_KEY_ID || 123)
   --secret_key <key>   (default is env.AWS_SECRET_ACCESS_KEY || abc)
   --bucket <name>      (default is "first.bucket")

--- a/src/tools/s3perf.js
+++ b/src/tools/s3perf.js
@@ -66,7 +66,7 @@ if (argv.help) {
 }
 
 if (argv.endpoint) {
-    if (argv.endpoint === true) argv.endpoint = 'http://127.0.0.1';
+    if (argv.endpoint === true) argv.endpoint = 'http://localhost';
     argv.access_key = argv.access_key || '123';
     argv.secret_key = argv.secret_key || 'abc';
     argv.bucket = argv.bucket || 'first.bucket';
@@ -277,7 +277,7 @@ Upload Flags:
   --part_size <MB>       multipart size
   --part_concur <num>    multipart concurrency
 General S3 Flags:
-  --endpoint <host>      (default is 127.0.0.1)
+  --endpoint <host>      (default is localhost)
   --access_key <key>     (default is env.AWS_ACCESS_KEY_ID || 123)
   --secret_key <key>     (default is env.AWS_SECRET_ACCESS_KEY || abc)
   --bucket <name>        (default is "first.bucket")

--- a/src/tools/tcp_speed.cpp
+++ b/src/tools/tcp_speed.cpp
@@ -69,7 +69,7 @@ public:
         _fd = fd;
     }
 
-    void connect(int port, const char* ip = "127.0.0.1")
+    void connect(int port, const char* ip = "localhost")
     {
         struct sockaddr_in sin;
         sin.sin_family = AF_INET;
@@ -78,7 +78,7 @@ public:
         SYSCALL(::connect(_fd, reinterpret_cast<struct sockaddr*>(&sin), sizeof(sin)));
     }
 
-    void bind(int port, const char* ip = "127.0.0.1")
+    void bind(int port, const char* ip = "localhost")
     {
         struct sockaddr_in sin;
         sin.sin_family = AF_INET;

--- a/src/tools/tcp_speed.go
+++ b/src/tools/tcp_speed.go
@@ -52,9 +52,9 @@ func runSender() {
 	var err error
 	if *ssl {
 		config := &tls.Config{InsecureSkipVerify: true}
-		conn, err = tls.Dial("tcp", "127.0.0.1:"+strconv.Itoa(*port), config)
+		conn, err = tls.Dial("tcp", "localhost:"+strconv.Itoa(*port), config)
 	} else {
-		conn, err = net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(*port))
+		conn, err = net.Dial("tcp", "localhost:"+strconv.Itoa(*port))
 	}
 	fatal(err)
 	buf := make([]byte, *bufsize)

--- a/src/tools/tcp_speed.js
+++ b/src/tools/tcp_speed.js
@@ -45,7 +45,7 @@ function main() {
         return run_server();
     }
     if (argv.client) {
-        argv.client = (typeof(argv.client) === 'string' && argv.client) || '127.0.0.1';
+        argv.client = (typeof(argv.client) === 'string' && argv.client) || 'localhost';
         return run_client();
     }
     return usage();

--- a/src/tools/tcp_tunnel.js
+++ b/src/tools/tcp_tunnel.js
@@ -49,7 +49,7 @@ Recording HTTP:
 `);
         return;
     }
-    const hostname = argv.host || '127.0.0.1';
+    const hostname = argv.host || 'localhost';
     const record_http = argv.record_http;
     const tunnels = argv._ || [];
     if (!tunnels.length) {

--- a/src/util/addr_utils.js
+++ b/src/util/addr_utils.js
@@ -8,7 +8,7 @@ const { construct_url } = require('./url_utils');
 const default_base_port = parseInt(process.env.SSL_PORT, 10) || 5443;
 const api_default_ports = Object.freeze(get_default_ports());
 
-function format_base_address(hostname = '127.0.0.1', port = default_base_port) {
+function format_base_address(hostname = 'localhost', port = default_base_port) {
     return url.format(`wss://${hostname}:${port}`);
 }
 
@@ -67,7 +67,7 @@ function get_base_address(address_list, options = {}) {
     }
 
     if (hint === 'LOOPBACK') {
-        const hostname = '127.0.0.1';
+        const hostname = 'localhost';
         const port = default_port;
         return construct_url({ protocol, hostname, port });
     }

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -98,9 +98,9 @@ class MongoClient extends EventEmitter {
             process.env.MONGODB_URL ||
             process.env.MONGOHQ_URL ||
             process.env.MONGOLAB_URI ||
-            'mongodb://127.0.0.1/nbcore';
+            'mongodb://localhost/nbcore';
         this.cfg_url =
-            'mongodb://127.0.0.1:' + config.MONGO_DEFAULTS.CFG_PORT + '/config0';
+            'mongodb://localhost:' + config.MONGO_DEFAULTS.CFG_PORT + '/config0';
         this.config = {
             // promoteBuffers makes the driver directly expose node.js Buffer's for bson binary fields
             // instead of mongodb.Binary, which is just a skinny buffer wrapper class.

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -77,6 +77,18 @@ function is_fqdn(target) {
     return false;
 }
 
+/**
+ * @param {string} address
+ * @returns {boolean}
+ */
+function is_localhost(address) {
+    return (
+        address === '127.0.0.1' ||
+        address === '::1' ||
+        address.toLowerCase() === 'localhost'
+    );
+}
+
 function unwrap_ipv6(ip) {
     if (net.isIPv6(ip)) {
         if (ip.startsWith('::ffff:')) return ip.slice('::ffff:'.length);
@@ -116,6 +128,7 @@ exports.dns_resolve = dns_resolve;
 exports.is_hostname = is_hostname;
 exports.is_ip = is_ip;
 exports.is_fqdn = is_fqdn;
+exports.is_localhost = is_localhost;
 exports.unwrap_ipv6 = unwrap_ipv6;
 exports.ip_to_long = ip_to_long;
 exports.retrieve_public_ip = retrieve_public_ip;

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1188,7 +1188,7 @@ class PostgresClient extends EventEmitter {
             // TODO: check the effect of max clients. default is 10
             // max: 50,
 
-            host: process.env.POSTGRES_HOST || '127.0.0.1',
+            host: process.env.POSTGRES_HOST || 'localhost',
             user: process.env.POSTGRES_USER || 'postgres',
             password: process.env.POSTGRES_PASSWORD || 'noobaa',
             database: process.env.POSTGRES_DBNAME || 'nbcore',

--- a/src/util/signature_utils.js
+++ b/src/util/signature_utils.js
@@ -317,7 +317,7 @@ function get_signature_from_auth_token(auth_token, secret_key) {
 
 function authorize_client_request(req) {
     req.port = req.port || 80;
-    req.host = req.host || '127.0.0.1';
+    req.host = req.host || 'localhost';
     req.body = req.body || '';
     req.key = req.key || 'first.key';
     req.bucket = req.bucket || 'first.bucket';

--- a/src/util/url_utils.js
+++ b/src/util/url_utils.js
@@ -59,7 +59,7 @@ function construct_url(def) {
 }
 
 function benchmark() {
-    var testing_url = process.argv[2] || "http://127.0.0.1:4545/";
+    var testing_url = process.argv[2] || "http://localhost:4545/";
     var url_parse_res = url.parse(testing_url, true);
     var quick_parse_res = quick_parse(testing_url, true);
     console.log('\nurl.parse("' + testing_url + '") = ', url_parse_res);


### PR DESCRIPTION
### Explain the changes
Change loopback address to support IPv6:
- Change loopback address from 127.0.0.1 to localhost
- Add `net_utils.is_localhost(address)`

Fixes: #5352

Signed-off-by: liranmauda <liran.mauda@gmail.com>

