### PR TITLE
Reset Unfitting Blob Marker In Namespace Bucket

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -48,7 +48,14 @@ class NamespaceBlob {
     // OBJECT LIST //
     /////////////////
 
-    async list_objects(params, object_sdk) {
+    async list_objects(param, object_sdk) {
+        const params = { ...param };
+        const regex = '^\\d{1,9}!\\d{1,9}!';
+        if (!(_.isUndefined(params.key_marker)) && params.key_marker.match(regex) === null) {
+            dbg.log0(`Got an invalid marker: ${params.key_marker}, changing the marker into null`);
+            params.key_marker = null;
+        }
+
         dbg.log0('NamespaceBlob.list_objects:',
             this.container,
             inspect(params)


### PR DESCRIPTION
### Explain the changes

When we do `listObject` in a namespace bucket and providing an invalid Marker We will change it to null.

### Limitations: 

This fix is copying the behavior of s3 list in namespace bucket for blob:
- When we get a wrong marker it will ignore it and get the whole list, Pagination can get hurt by that, but it is better the returning no list (and an Error).

### Testing Instructions:
1. Create namespace resource on Azure
2. Create a namespace bucket using the Azure resource
3. Called listObjects with an invalid blob marker (for example 'AAAAAAAA' )
4. See that we are getting a list and not an error.

Signed-off-by: liranmauda <liran.mauda@gmail.com>