### PR TITLE
Add Retry To Lambda Functions and Add the Error to the DB

### DIFF
--- a/frontend/src/app/components/modals/add-bucket-trigger-modal/add-bucket-trigger-modal.html
+++ b/frontend/src/app/components/modals/add-bucket-trigger-modal/add-bucket-trigger-modal.html
@@ -69,6 +69,18 @@
             <p class="hint">optional</p>
         </editor>
 
+        <editor params=
+            "label: 'Retries', 
+            tooltip: retriesTooltip
+        ">
+            <input type="number"
+                min="0"
+                max="99"
+                ko.value="$form.attempts"
+                ko.validationCss="$form.attempts"
+            />
+        </editor>
+
         <editor params="label: 'Trigger Active'">
             <toggle-switch params="value: $form.active"></toggle-switch>
         </editor>

--- a/frontend/src/app/components/modals/edit-bucket-trigger-modal/edit-bucket-trigger-modal.html
+++ b/frontend/src/app/components/modals/edit-bucket-trigger-modal/edit-bucket-trigger-modal.html
@@ -67,6 +67,18 @@
             <p class="hint">optional</p>
         </editor>
 
+        <editor params=
+            "label: 'Retries',
+            tooltip: retriesTooltip
+        ">
+            <input type="number"
+                min="0"
+                max="99"
+                ko.value="$form.attempts"
+                ko.validationCss="$form.attempts"
+            />
+        </editor>
+
         <editor params="label: 'Trigger Active'">
             <toggle-switch params="value: $form.active"></toggle-switch>
         </editor>

--- a/frontend/src/app/epics/add-bucket-trigger.js
+++ b/frontend/src/app/epics/add-bucket-trigger.js
@@ -17,6 +17,7 @@ export default function(action$, { api }) {
                 event,
                 prefix,
                 suffix,
+                attempts,
                 enabled
             } = action.payload;
 
@@ -28,6 +29,7 @@ export default function(action$, { api }) {
                     event_name: event,
                     object_prefix: prefix,
                     object_suffix: suffix,
+                    attempts: attempts,
                     enabled: enabled
                 });
 

--- a/frontend/src/app/epics/update-bucket-trigger.js
+++ b/frontend/src/app/epics/update-bucket-trigger.js
@@ -25,6 +25,7 @@ export default function(action$, { api }) {
                         func_version: config.funcVersion,
                         object_prefix: config.prefix,
                         object_suffix: config.suffix,
+                        attempts: config.attempts,
                         enabled: config.enabled
                     });
                 } else {
@@ -36,10 +37,11 @@ export default function(action$, { api }) {
                         func_version: config.funcVersion,
                         object_prefix: config.prefix,
                         object_suffix: config.suffix,
+                        attempts: config.attempts,
                         enabled: config.enabled
                     });
                 }
-                
+
                 return completeUpdateBucketTrigger(displayEntity);
 
             } catch (error) {

--- a/frontend/src/app/reducers/bucket-triggers-reducer.js
+++ b/frontend/src/app/reducers/bucket-triggers-reducer.js
@@ -45,8 +45,7 @@ function _mapTrigger(bucket, trigger) {
         event: trigger.event_name,
         bucket: {
             kind: bucket.bucket_type === 'REGULAR' ?
-                'DATA_BUCKET' :
-                'NAMESPACE_BUCKET',
+                'DATA_BUCKET' : 'NAMESPACE_BUCKET',
             name: bucket.name
         },
         func: {
@@ -55,6 +54,7 @@ function _mapTrigger(bucket, trigger) {
         },
         prefix: trigger.object_prefix || '',
         suffix: trigger.object_suffix || '',
+        attempts: trigger.attempts - 1 || 0,
         lastRun: trigger.last_run
     };
 }

--- a/frontend/src/app/schema/bucket-triggers.js
+++ b/frontend/src/app/schema/bucket-triggers.js
@@ -9,7 +9,8 @@ export default {
             'bucket',
             'func',
             'prefix',
-            'suffix'
+            'suffix',
+            'attempts'
         ],
         properties: {
             id: {
@@ -24,7 +25,7 @@ export default {
                 ]
             },
             event: {
-                type:' string',
+                type: 'string',
                 enum: [
                     'ObjectCreated',
                     'ObjectRemoved',
@@ -72,7 +73,10 @@ export default {
                 type: 'string'
             },
             lastRun: {
-                type:' integer'
+                type: 'integer'
+            },
+            attempts: {
+                type: 'integer'
             }
         }
     }

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1341,6 +1341,9 @@ module.exports = {
                 object_suffix: {
                     type: 'string'
                 },
+                attempts: {
+                    type: 'integer'
+                },
             }
         },
 
@@ -1369,6 +1372,9 @@ module.exports = {
                 },
                 object_suffix: {
                     type: 'string'
+                },
+                attempts: {
+                    type: 'integer'
                 },
             }
         },
@@ -1408,6 +1414,9 @@ module.exports = {
                 },
                 object_suffix: {
                     type: 'string'
+                },
+                attempts: {
+                    type: 'integer'
                 },
             }
         },

--- a/src/server/func_services/func_server.js
+++ b/src/server/func_services/func_server.js
@@ -291,6 +291,7 @@ async function invoke_func(req) {
         time: time,
         took: Date.now() - time.getTime(),
         error: res.error ? true : undefined,
+        error_msg: res.error ? res.error.message : undefined,
     });
     if (!_.isUndefined(res.error)) {
         throw res.error;

--- a/src/server/func_services/func_server.js
+++ b/src/server/func_services/func_server.js
@@ -50,6 +50,7 @@ const FUNC_STATS_DEFAULTS = {
 };
 
 async function create_func(req) {
+    dbg.log0('create_func::', req.params.config);
     const { config: func_config, code: func_code } = req.params;
     const { _id: system, pools_by_name } = req.system;
     const { _id: exec_account } = req.account;
@@ -158,10 +159,11 @@ async function update_func(req) {
     return _get_func_info(func);
 }
 
-function delete_func(req) {
-    return _load_func(req)
-        .then(() => func_store.instance().delete_code_gridfs(req.func.code_gridfs_id))
-        .then(() => func_store.instance().delete_func(req.func._id));
+async function delete_func(req) {
+    dbg.log0('delete_func::', req.params.name);
+    await _load_func(req);
+    await func_store.instance().delete_code_gridfs(req.func.code_gridfs_id);
+    await func_store.instance().delete_func(req.func._id);
 }
 
 async function read_func(req) {
@@ -234,23 +236,21 @@ async function read_func_stats(req) {
     };
 }
 
-function list_funcs(req) {
-    return P.resolve()
-        .then(() => func_store.instance().list_funcs(req.system._id))
-        .then(funcs => ({
-            functions: _.map(funcs, _get_func_info)
-        }));
+async function list_funcs(req) {
+    const funcs = await func_store.instance().list_funcs(req.system._id);
+    return {
+        functions: _.map(funcs, _get_func_info)
+    };
 }
 
-function list_func_versions(req) {
-    return P.resolve()
-        .then(() => func_store.instance().list_func_versions(
-            req.system._id,
-            req.params.name
-        ))
-        .then(funcs => ({
-            versions: _.map(funcs, _get_func_info)
-        }));
+async function list_func_versions(req) {
+    const funcs = await func_store.instance().list_func_versions(
+        req.system._id,
+        req.params.name
+    );
+    return {
+        versions: _.map(funcs, _get_func_info)
+    };
 }
 
 const server_func_node = new FuncNode({
@@ -258,41 +258,44 @@ const server_func_node = new FuncNode({
     storage_path: '/tmp/',
 });
 
-function invoke_func(req) {
+async function invoke_func(req) {
+    let res;
+    dbg.log0('invoke_func::', req.params.name);
     const time = new Date();
-    return _load_func(req)
-        .then(() => check_event_permission(req))
-        .then(() => P.map(req.func.pools,
-            pool => node_allocator.refresh_pool_alloc(pool)))
-        .then(() => {
-            const func = req.func;
-            const node = node_allocator.allocate_node({ pools: func.pools });
-            const params = {
-                config: _get_func_info(func).config,
-                event: req.params.event,
-                aws_config: _make_aws_config(req),
-                rpc_options: _make_rpc_options(req),
-            };
-            if (!node) {
-                dbg.log0('invoking on server', func.name, req.params.event);
-                return server_func_node.invoke_func({ params });
-            }
-            dbg.log0('invoking on node',
-                func.name, req.params.event,
-                node.name, node.pool);
-            return server_rpc.client.func_node.invoke_func(params, {
-                address: node.rpc_address
-            });
-        })
-        .then(res => func_stats_store.instance().create_func_stat({
-                system: req.func.system,
-                func: req.func._id,
-                time: time,
-                took: Date.now() - time.getTime(),
-                error: res.error ? true : undefined,
-            })
-            .then(() => res)
-        );
+    await _load_func(req);
+    check_event_permission(req);
+    await P.map(req.func.pools, pool => node_allocator.refresh_pool_alloc(pool));
+
+    const func = req.func;
+    const node = node_allocator.allocate_node({ pools: func.pools });
+    const params = {
+        config: _get_func_info(func).config,
+        event: req.params.event,
+        aws_config: _make_aws_config(req),
+        rpc_options: _make_rpc_options(req),
+    };
+    if (node) {
+        dbg.log0('invoking on node',
+            func.name, req.params.event,
+            node.name, node.pool);
+        res = await server_rpc.client.func_node.invoke_func(params, {
+            address: node.rpc_address
+        });
+    } else {
+        dbg.log0('invoking on server', func.name, req.params.event);
+        res = await server_func_node.invoke_func({ params });
+    }
+    await func_stats_store.instance().create_func_stat({
+        system: req.func.system,
+        func: req.func._id,
+        time: time,
+        took: Date.now() - time.getTime(),
+        error: res.error ? true : undefined,
+    });
+    if (!_.isUndefined(res.error)) {
+        throw res.error;
+    }
+    return res;
 }
 
 function check_event_permission(req) {
@@ -365,17 +368,14 @@ function _get_func_code_stream(req, func_code) {
     }
 }
 
-function _load_func(req) {
+async function _load_func(req) {
     const system = req.system._id;
     const name = req.params.name || _.get(req, 'params.config.name');
     const version = req.params.version || _.get(req, 'params.config.version');
-    return P.resolve()
-        .then(() => func_store.instance().read_func(system, name, version))
-        .then(func => {
-            req.func = func;
-            func.pools = _.map(func.pools, pool_id => system_store.data.get_by_id(pool_id));
-            return func;
-        });
+    const func = await func_store.instance().read_func(system, name, version);
+    req.func = func;
+    func.pools = _.map(func.pools, pool_id => system_store.data.get_by_id(pool_id));
+    return func;
 }
 
 function _get_func_info(func) {

--- a/src/server/func_services/func_stats_schema.js
+++ b/src/server/func_services/func_stats_schema.js
@@ -30,5 +30,8 @@ module.exports = {
         error: {
             type: 'boolean'
         },
+        error_msg: {
+            type: 'string'
+        },
     }
 };

--- a/src/server/func_services/func_stats_store.js
+++ b/src/server/func_services/func_stats_store.js
@@ -6,7 +6,6 @@ const mongodb = require('mongodb');
 
 // const dbg = require('../../util/debug_module')(__filename);
 const db_client = require('../../util/db_client');
-const P = require('../../util/promise');
 
 const func_stats_schema = require('./func_stats_schema');
 const func_stats_indexes = require('./func_stats_indexes');
@@ -35,19 +34,17 @@ class FuncStatsStore {
         return new mongodb.ObjectId(id_str);
     }
 
-    create_func_stat(stat) {
-        return P.resolve().then(async () => {
-            if (!stat._id) {
-                stat._id = this.make_func_stat_id();
-            }
-            try {
-                this._func_stats.validate(stat);
-                await this._func_stats.insertOne(stat);
-            } catch (err) {
-                db_client.instance().check_duplicate_key_conflict(err, 'func stat');
-            }
-            return stat;
-        });
+    async create_func_stat(stat) {
+        if (!stat._id) {
+            stat._id = this.make_func_stat_id();
+        }
+        try {
+            this._func_stats.validate(stat);
+            await this._func_stats.insertOne(stat);
+        } catch (err) {
+            db_client.instance().check_duplicate_key_conflict(err, 'func stat');
+        }
+        return stat;
     }
 
     async query_func_stats(params) {

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -319,6 +319,9 @@ module.exports = {
                     object_suffix: {
                         type: 'string'
                     },
+                    attempts: {
+                        type: 'integer'
+                    },
                 }
             }
         },

--- a/src/test/lambda/create_backup_file_func.js
+++ b/src/test/lambda/create_backup_file_func.js
@@ -1,26 +1,39 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-var AWS = require('aws-sdk');
+/* sample event - trigger structure:
+{
+    "Records": [{
+        "s3": {
+            "bucket": { "name": "first.bucket" },
+            "object": { "key": "Apple.jpg" }
+        }
+    }]
+}
+*/
 
-exports.handler = function(event, context, callback) {
-    var srcBucket = event.Records[0].s3.bucket.name;
-    var key = event.Records[0].s3.object.key;
-    var s3 = new AWS.S3();
+const AWS = require('aws-sdk');
 
-    s3.headObject({
-            Bucket: srcBucket,
-            Key: key
-        })
-        .promise()
-        .then(head => s3.putObject({
+exports.handler = async function(event, context, callback) {
+    const srcBucket = event.Records[0].s3.bucket.name;
+    const key = event.Records[0].s3.object.key;
+    const s3 = new AWS.S3();
+
+    try {
+        const head = await s3.headObject({
+                Bucket: srcBucket,
+                Key: key
+            })
+            .promise();
+        await s3.putObject({
                 Bucket: srcBucket,
                 Key: key + '.json',
                 ContentType: 'text/json',
                 Body: JSON.stringify({ event, head }, null, 4),
             })
-            .promise()
-        )
-        .then(() => callback(null))
-        .catch(err => callback(err));
+            .promise();
+        return callback(null);
+    } catch (err) {
+        return callback(err);
+    }
 };


### PR DESCRIPTION
### Explain the changes
Add retry to lambda functions:
- Added retries (default is 2)
- Added UI Field in the add/edit retries
- async/await some flows

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: 
~1. Edit form is not loading the current number of attempts~
~2. There is no tooltip that explains the attempts field~ 

### out of scope
~1. Writing a failed invoke log into the DB~
2. converting the lambda function and save it in the DB

### Testing Instructions:
For the retries: 
1. Add/Edit a trigger With 1 or more retires
2. See that on "fail" it retries
3. See that on "success" It does not retry
4. Check that if 0 retries are set, then the trigger runs once.

For the failed error in the db:
1. run a failed function
2. see in the db that the `error_msg` is there:
    run `db.func_stats.find({'error':true}).pretty()`
```
{
	"_id" : ObjectId("601ab5ac0d4f4c000d395964"),
	"system" : ObjectId("60196a75933e03002de1f296"),
	"func" : ObjectId("60196c60933e03002de1f2b7"),
	"time" : ISODate("2021-02-03T14:39:18.870Z"),
	"took" : 21597,
	"error" : true,
	"error_msg" : "Func handler not a function main.no"
}
```