### PR TITLE
Fix some issues with encryption tests in postgres

### DIFF
--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -255,7 +255,7 @@ class MapBuilder {
 
         // check if bucket master_key is enabled and chunk master keys disabled
         } else if (!chunk_master_key_id && bucket_m_key && bucket_m_key.disabled === false) {
-            const encrypted_cipher = mkm.encrypt_buffer_with_master_key_id(chunk.cipher_key.buffer, bucket_m_key._id);
+            const encrypted_cipher = mkm.encrypt_buffer_with_master_key_id(chunk.cipher_key.buffer.toString('base64'), bucket_m_key._id);
             await MDStore.instance().update_chunk_by_id(chunk._id,
                 { cipher_key: encrypted_cipher, master_key_id: bucket_m_key._id });
             chunk.cipher_key = encrypted_cipher;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1260,7 +1260,7 @@ class MDStore {
             system: bucket.system._id,
             bucket: bucket._id,
             dedup_key: {
-                $in: config.DB_TYPE === 'postgres' ? _.map(dedup_keys, k => k.toString('base64')) : dedup_keys
+                $in: dedup_keys
             },
             deleted: null,
         }, {

--- a/src/server/system_services/schemas/master_key_schema.js
+++ b/src/server/system_services/schemas/master_key_schema.js
@@ -13,18 +13,7 @@ module.exports = {
         // If missing - encrypted with root key
         // 1. ENV - Mounted key from Kubernetes secret
         // 2. HSM configuration TBD - Get key from Vault
-        master_key_id: {
-            oneOf: [{
-                    type: 'string',
-                    enum: [
-                        'noobaa-root-master-key',
-                    ]
-                },
-                {
-                    objectid: true
-                }
-            ]
-        },
+        master_key_id: { objectid: true },
         // cipher used to provide confidentiality - computed on the compressed data
         cipher_type: { $ref: 'common_api#/definitions/cipher_type' },
         cipher_key: { binary: true },

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -1318,7 +1318,7 @@ async function rotate_master_key(req) {
     // create the new master key and update in db
     const ROOT_KEY = system_store.master_key_manager.get_root_key_id();
     const master_key_base_props = {
-        'master_key_id': old_master_key.master_key_id === ROOT_KEY ? ROOT_KEY :
+        'master_key_id': system_store.master_key_manager.is_root_key(old_master_key.master_key_id) ? ROOT_KEY :
             old_master_key.master_key_id._id,
         'description': old_master_key.description,
         'cipher_type': old_master_key.cipher_type
@@ -1395,7 +1395,7 @@ async function _disable_master_key(entity, entity_type) {
         throw new Error(`_disable_master_key: can not disable master key, current master key is: ${util.inspect(entity_info)}`);
     }
 
-    await upsert_master_key({ _id: entity_info.master_key_id._id, update: {disabled: true}});
+    await upsert_master_key({ _id: entity_info.master_key_id._id, update: { disabled: true }});
     system_store.master_key_manager.set_m_key_disabled_val(entity_info.master_key_id._id, true);
 
     await system_store.load();


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Support mongo queries that contain '.$.' in postgres. 
2. Add more calls for encode_json() in postgres_client.
3. Support more cases in encode_json() function.
4. Delete $oneOf operator from master keys schema.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
