### PR TITLE
Backport to 5.7: bump mongo to pg version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4417,9 +4417,9 @@
       }
     },
     "mongo-query-to-postgres-jsonb": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/mongo-query-to-postgres-jsonb/-/mongo-query-to-postgres-jsonb-0.2.10.tgz",
-      "integrity": "sha512-+V0ZzMHO8WOI+T9ybiX3MT62cxVkVtN6ZE/K/lxm4cwA7NHDra6ivJxhtxnD450nTetAaysvXeGjfyFq/EEagg=="
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/mongo-query-to-postgres-jsonb/-/mongo-query-to-postgres-jsonb-0.2.11.tgz",
+      "integrity": "sha512-Lf2NaNHkv8UnHPYuzvUkWQD1n5BzTtt6Zz09KgFuEYwffuxs9nVyUzQG5CbGfMeZ2cxn//qAyHzfZ6dLjSnPmw=="
     },
     "mongodb": {
       "version": "3.6.3",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "minimist": "1.2.5",
     "moment": "2.29.1",
     "moment-timezone": "0.5.32",
-    "mongo-query-to-postgres-jsonb": "0.2.10",
+    "mongo-query-to-postgres-jsonb": "0.2.11",
     "mongodb": "3.6.3",
     "morgan": "1.10.0",
     "nan": "2.14.2",


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>
(cherry picked from commit d3eb008ce5a43b5ada2457eb542e60879dd1dfd9)

Backport to 5.7
