### PR TITLE
added test-postgres make target

### DIFF
--- a/.github/workflows/postgres-unit-tests.yaml
+++ b/.github/workflows/postgres-unit-tests.yaml
@@ -1,0 +1,15 @@
+name: Unit Tests with Postgres
+
+# Run on each new PR and each new push to existing PR
+on: [push, pull_request]
+
+jobs:
+  run-unit-tests-postgres:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Run Unit Tests with Postgres
+        id: run-test-postgres
+        run: make test-postgres || exit 1


### PR DESCRIPTION
for use in upstream unit-tests
* create a docker network noobaa-net
* run postgres container to host coretest DB, connected to noobaa-net
* run tester connected to noobaa-net and to coretest postgres

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
