### PR TITLE
Add claim_id tag to Prometheus metrics - buckets labels

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -728,7 +728,7 @@ module.exports = {
                     type: 'array',
                     items: {
                         type: 'object',
-                        required: ['bucket_name', 'quota_precent', 'capacity_precent', 'is_healthy'],
+                        required: ['bucket_name', 'quota_precent', 'capacity_precent', 'is_healthy', 'tagging'],
                         properties: {
                             bucket_name: {
                                 type: 'string'
@@ -741,6 +741,9 @@ module.exports = {
                             },
                             is_healthy: {
                                 type: 'boolean'
+                            },
+                            tagging: {
+                                $ref: 'common_api#/definitions/tagging',
                             },
                         }
                     }
@@ -762,13 +765,16 @@ module.exports = {
                     type: 'array',
                     items: {
                         type: 'object',
-                        required: ['bucket_name', 'is_healthy'],
+                        required: ['bucket_name', 'is_healthy', 'tagging'],
                         properties: {
                             bucket_name: {
                                 type: 'string'
                             },
                             is_healthy: {
                                 type: 'boolean'
+                            },
+                            tagging: {
+                                $ref: 'common_api#/definitions/tagging',
                             },
                         }
                     }

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -467,6 +467,7 @@ async function _partial_buckets_info(req) {
                 namespace_buckets_stats.namespace_buckets.push({
                     bucket_name: bucket_info.name.unwrap(),
                     is_healthy: ns_bucket_mode_optimal,
+                    tagging: bucket_info.tagging || []
                 });
                 if (!ns_bucket_mode_optimal) namespace_buckets_stats.unhealthy_namespace_buckets += 1;
                 continue;
@@ -510,6 +511,7 @@ async function _partial_buckets_info(req) {
                 capacity_precent: (is_capacity_relevant && bucket_total > 0) ? size_utils.bigint_to_json(bucket_used.multiply(100)
                     .divide(bucket_total)) : 0,
                 is_healthy: _.includes(OPTIMAL_MODES, bucket_info.mode),
+                tagging: bucket_info.tagging || []
             });
         }
 


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1.  bucket.tag is an unused field in bucket info. Exported it if exists in Prometheus metrics of buckets & namespace buckets.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
