### PR TITLE
Fix delete external connection

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1119,10 +1119,8 @@ function delete_external_connection(req) {
             update: {
                 accounts: [{
                     _id: account._id,
-                    sync_credentials_cache: _.filter(account.sync_credentials_cache,
-                        connection => (connection.name !== params.connection_name))
-                }]
-            }
+                    $pull: { sync_credentials_cache: { name: params.connection_name } }
+            }]}
         })
         .then(
             val => {


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1.  Changed in delete_external_connection - instead of filtering system store connections (which are plain), just pulled the connection by its name. 

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ#1931191

### Testing Instructions:
1. 
