### PR TITLE
Mongo pool to be removed from cloud_pool_stats

### DIFF
--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -691,6 +691,7 @@ async function get_cloud_pool_stats(req) {
     ];
     //Per each system fill out the needed info
     for (const pool of system_store.data.pools) {
+        if (pool.mongo_pool_info) continue;
         const pool_info = await server_rpc.client.pool.read_pool({ name: pool.name }, {
             auth_token: req.auth_token
         });
@@ -740,7 +741,7 @@ async function get_cloud_pool_stats(req) {
                     }
                     break;
             }
-        } else if (!pool.mongo_pool_info) {
+        } else {
             cloud_pool_stats.pool_target.kubernetes += 1;
             if (!_.includes(OPTIMAL_MODES, pool_info.mode)) {
                 cloud_pool_stats.unhealthy_pool_target.kubernetes_unhealthy += 1;


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. mongo_pool won't be counted in num_pools, in unhealthy_num_pools and in resource_status

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ#1924185

### Testing Instructions:
1. 
