### PR TITLE
NSFS Fix mtime compare in dir cache

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -76,7 +76,7 @@ const dir_cache = new LRUCache({
     },
     validate: async ({ stat }, dir_path) => {
         const new_stat = await fs.promises.stat(dir_path);
-        return (new_stat.ino === stat.ino && new_stat.mtime === stat.mtime);
+        return (new_stat.ino === stat.ino && new_stat.mtime.getTime() === stat.mtime.getTime());
     },
     item_usage: ({ usage }, dir_path) => usage,
     max_usage: config.NSFS_DIR_CACHE_MAX_TOTAL_SIZE,


### PR DESCRIPTION
### Explain the changes
1. Comparison was incorrect because mtime is Date object.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. Test list-objects with large (many thousands) of items to verify that readdir is done once into the cache.
2. Notice that we might also need to tweak config.NSFS_DIR_CACHE_MAX_DIR_SIZE to higher value for that to work, and we will probably want to bump it anyhow.
