### PR TITLE
Disable Centos Jenkins jobs

### DIFF
--- a/.jenkins/jobs/build-sanity.yaml
+++ b/.jenkins/jobs/build-sanity.yaml
@@ -28,6 +28,7 @@
       - github-pull-request:
           status-context: ci/centos/build-sanity
           trigger-phrase: "/(re)?test ((all)|(ci/centos/build-sanity))"
+          only-trigger-phrase: true
           status-url: $RUN_DISPLAY_URL
           permit-all: true
           github-hooks: true

--- a/.jenkins/jobs/unit.yaml
+++ b/.jenkins/jobs/unit.yaml
@@ -28,6 +28,7 @@
       - github-pull-request:
           status-context: ci/centos/unit
           trigger-phrase: "/(re)?test ((all)|(ci/centos/unit))"
+          only-trigger-phrase: true
           status-url: $RUN_DISPLAY_URL
           permit-all: true
           github-hooks: true


### PR DESCRIPTION
### Explain the changes
Disable Centos Jenkins jobs

Jenkins has an issue with pulling and GH Action is doing what we currently need, so we are disabling the Centos Jenkins jobs.
We might want to add to the Centos Jenkins jobs new tests (if GH Actions can’t handle the load) so we are keeping the code.

Signed-off-by: liranmauda <liran.mauda@gmail.com>

