### PR TITLE
Adding wrap for SHA1

### DIFF
--- a/src/util/fips.js
+++ b/src/util/fips.js
@@ -58,6 +58,16 @@ function create_hash_md5_mb() {
 }
 
 /**
+ * @returns {crypto.Hash}
+ */
+function create_hash_sha1_mb() {
+    const { SHA1_MB } = nb_native();
+    const wrap = new HashWrap(new SHA1_MB());
+    // @ts-ignore
+    return wrap;
+}
+
+/**
  * @param {string} algorithm 
  * @param {object} options 
  * @returns {crypto.Hash}
@@ -66,6 +76,8 @@ function create_hash_fips(algorithm, options) {
     switch (algorithm) {
         case 'md5':
             return create_hash_md5_mb();
+        case 'sha1':
+            return create_hash_sha1_mb();
         default:
             return original_crypto.createHash(algorithm, options);
     }


### PR DESCRIPTION
### Explain the changes
Adding wrap for SHA1

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Testing Instructions:
1.  Run the tests on a FIPS enabled machine OR with an env variable FIPS=1
for example:
`docker run --rm --name delete --name noobaa_test --env "FIPS=1" noobaa-tester`
