### PR TITLE
Return NoSuchKey for directories head request.

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -353,6 +353,11 @@ class NamespaceFS {
             const file_path = this._get_file_path(params);
             const stat = await nb_native().fs.stat(DEFAULT_FS_CONFIG, file_path);
             console.log(file_path, stat);
+            if (isDirectory(stat)) {
+                const err = new Error('NoSuchKey');
+                err.code = 'ENOENT';
+                throw this._translate_object_error_codes(err);
+            }
             return this._get_object_info(params.bucket, params.key, stat);
         } catch (err) {
             throw this._translate_object_error_codes(err);


### PR DESCRIPTION
### Explain the changes
1. lookup for keys (get head) of directory should return not found since they are not real objects

### Issues: Fixed #xxx / Gap #xxx
1. no issue 

### Testing Instructions:
1. get head on a directory
