### PR TITLE
fixed calc mode for host pools in get_optimal_non_mongo_pool_id()

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1320,8 +1320,9 @@ async function get_optimal_non_mongo_pool_id() {
             continue;
         }
 
-        const aggr = await nodes_client.instance().aggregate_nodes_by_pool([pool.name], pool.system._id);
-        const { mode = '' } = get_pool_info(pool, aggr);
+        const aggr_nodes = await nodes_client.instance().aggregate_nodes_by_pool([pool.name], pool.system._id);
+        const aggr_hosts = await nodes_client.instance().aggregate_hosts_by_pool([pool.name], pool.system._id);
+        const { mode = '' } = get_pool_info(pool, aggr_nodes, aggr_hosts);
         if (mode === 'OPTIMAL') {
             return pool._id;
         }


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Noobaa should find first optimal pool and set the default_pool property of all the accounts in the system to its id. The calculation of host pools (PV pools) mode was wrong, hosts_pools aggregation argument was missing.    

### Issues: Fixed #xxx / Gap #xxx
1. BZ #1939026

### Testing Instructions:
1. 
