### PR TITLE
Using Docker BuildKit as a default

### DIFF
--- a/.travis/travis_test_job.yaml
+++ b/.travis/travis_test_job.yaml
@@ -10,7 +10,7 @@ spec:
       - name: noobaa-test
         image: TESTER_IMAGE_PLACEHOLDER
         imagePullPolicy: Never
-        workingDir: /noobaa-core
+        # workingDir: /root/node_modules/noobaa-core/
         args:
           # - /bin/bash
           #  - -c
@@ -23,7 +23,7 @@ spec:
           - --namespace_prefix
           - "NAMESPACE_PREFIX_PLACEHOLDER"
           - --tests_list
-          - /noobaa-core/src/test/framework/sanity_tests_list.js
+          - /root/node_modules/noobaa-core/src/test/framework/sanity_tests_list.js
         env:
           - name: CONTAINER_PLATFORM
             value: KUBERNETES

--- a/src/deploy/NVA_build/Tests.Dockerfile
+++ b/src/deploy/NVA_build/Tests.Dockerfile
@@ -29,15 +29,7 @@ RUN dnf group install -y -q "Development Tools" && \
     git && \
     dnf clean all
 
-##############################################################
-# Layers:
-#   Title: extract noobaa code 
-#   Size: ~ 239 MB
-#
-##############################################################
-
-RUN tar -xzf /tmp/noobaa-NVA.tar.gz
-WORKDIR /noobaa-core/
+WORKDIR /root/node_modules/noobaa-core/
 
 ##############################################################
 # Layers:
@@ -46,8 +38,8 @@ WORKDIR /noobaa-core/
 #
 ##############################################################
 
-RUN /noobaa-core/src/test/system_tests/ceph_s3_tests_deploy.sh
-RUN cd /noobaa-core/src/test/system_tests/s3-tests/ && \
+RUN ./src/test/system_tests/ceph_s3_tests_deploy.sh $(pwd)
+RUN cd ./src/test/system_tests/s3-tests/ && \
     ./bootstrap
 
 ##############################################################
@@ -58,21 +50,11 @@ RUN cd /noobaa-core/src/test/system_tests/s3-tests/ && \
 ##############################################################
 RUN npm install
 
-RUN chmod 777 /noobaa-core/
-RUN mkdir -p /noobaa-core/.nyc_output && \
-    chmod 777 /noobaa-core/.nyc_output
-# create dirs and fix permissions required by tests
-RUN mkdir -p /noobaa-core/node_modules/.cache/nyc && \
-    chmod 777 /noobaa-core/node_modules/.cache/nyc
-RUN mkdir -p /noobaa-core/coverage && \
-    chmod 777 /noobaa-core/coverage
-RUN chmod -R 777 /noobaa-core/src/test
-
-COPY .eslintrc.js /noobaa-core
-COPY .eslintignore /noobaa-core
+COPY .eslintrc.js /root/node_modules/noobaa-core
+COPY .eslintignore /root/node_modules/noobaa-core
 
 # Making mocha accessible 
-RUN ln -s /noobaa-core/node_modules/mocha/bin/mocha /usr/local/bin
+RUN ln -s /root/node_modules/noobaa-core/node_modules/mocha/bin/mocha /usr/local/bin
 
 ENV SPAWN_WRAP_SHIM_ROOT /data
 RUN mkdir -p /data && \

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos:8 
+FROM centos:8 
 LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 
 ##############################################################


### PR DESCRIPTION
### Explain the changes
Using Docker BuildKit as a default

- In the Makefile we can pass `DOCKER_BUILDKIT="DOCKER_BUILDKIT=0"` to disable BuildKit
- When we use podman we will not use BuildKit as it is not supported
- The test image will now use the untar Directory of noobaa.

Signed-off-by: liranmauda <liran.mauda@gmail.com>