### PR TITLE
Export nsfs bucket and addition of uid and gid properties to account

### DIFF
--- a/frontend/src/app/epics/create-namespace-bucket.js
+++ b/frontend/src/app/epics/create-namespace-bucket.js
@@ -13,8 +13,8 @@ export default function(action$, { api }) {
             const { name, readFrom, writeTo, caching } = action.payload;
             try {
                 const namespace = {
-                    read_resources: readFrom,
-                    write_resource: writeTo,
+                    read_resources: readFrom.map(read_target => ({ resource: read_target })),
+                    write_resource: { resource: writeTo },
                     caching: caching
                 };
 

--- a/frontend/src/app/epics/update-namespace-bucket-placement.js
+++ b/frontend/src/app/epics/update-namespace-bucket-placement.js
@@ -14,7 +14,7 @@ export default function(action$, { api }) {
 
             try {
                 const namespace = {
-                    read_resources: readFrom,
+                    read_resources: readFrom.map(read_target => ({ resource: read_target })),
                     write_resource: writeTo
                 };
 

--- a/frontend/src/app/reducers/namespace-buckets-reducer.js
+++ b/frontend/src/app/reducers/namespace-buckets-reducer.js
@@ -33,8 +33,8 @@ function _mapBucket(bucket) {
 
 function _mapPlacement(namespace){
     return {
-        readFrom: namespace.read_resources,
-        writeTo: namespace.write_resource
+        readFrom: namespace.read_resources.map(read_target => read_target.resource),
+        writeTo: namespace.write_resource.resource
     };
 }
 

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -70,6 +70,9 @@ module.exports = {
                             },
                         },
                     },
+                    nsfs_account_config: {
+                        $ref: 'common_api#/definitions/nsfs_account_config'
+                    },
                 },
             },
             reply: {
@@ -182,6 +185,9 @@ module.exports = {
                                 $ref: 'common_api#/definitions/ip_range'
                             }
                         }]
+                    },
+                    nsfs_account_config: {
+                        $ref: 'common_api#/definitions/nsfs_account_config'
                     },
                     preferences: {
                         type: 'object',
@@ -647,6 +653,9 @@ module.exports = {
                             enum: ['DARK', 'LIGHT']
                         }
                     }
+                },
+                nsfs_account_config: {
+                    $ref: 'common_api#/definitions/nsfs_account_config'
                 }
             },
         },

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -27,24 +27,7 @@ module.exports = {
                     chunk_coder_config: { $ref: 'common_api#/definitions/chunk_coder_config' },
                     tag: { type: 'string' },
                     object_lock_configuration: { $ref: '#/definitions/object_lock_configuration' },
-                    namespace: {
-                        type: 'object',
-                        required: ['write_resource', 'read_resources'],
-                        properties: {
-                            write_resource: {
-                                type: 'string'
-                            },
-                            read_resources: {
-                                type: 'array',
-                                items: {
-                                    type: 'string'
-                                },
-                            },
-                            caching: {
-                                $ref: 'common_api#/definitions/bucket_cache_config'
-                            }
-                        }
-                    },
+                    namespace: { $ref: '#/definitions/namespace_bucket_config' },
                     lock_enabled: {
                         type: 'boolean'
                     },
@@ -919,7 +902,6 @@ module.exports = {
                 system: 'admin'
             },
         },
-
     },
 
     definitions: {
@@ -942,9 +924,7 @@ module.exports = {
                     }
                 },
                 versioning: { $ref: '#/definitions/versioning' },
-                namespace: {
-                    $ref: '#/definitions/bucket_namespace'
-                },
+                namespace: { $ref: '#/definitions/namespace_bucket_config' },
                 bucket_claim: { $ref: '#/definitions/bucket_claim' },
                 tiering: {
                     $ref: 'tiering_policy_api#/definitions/tiering_policy'
@@ -1130,28 +1110,6 @@ module.exports = {
             }
         },
 
-        bucket_namespace: {
-            type: 'object',
-            required: [
-                'read_resources',
-                'write_resource',
-            ],
-            properties: {
-                read_resources: {
-                    type: 'array',
-                    items: {
-                        type: 'string'
-                    }
-                },
-                write_resource: {
-                    type: 'string'
-                },
-                caching: {
-                    $ref: 'common_api#/definitions/bucket_cache_config'
-                }
-            }
-        },
-
         bucket_claim: {
             type: 'object',
             required: ['bucket_class', 'namespace'],
@@ -1194,11 +1152,25 @@ module.exports = {
                         read_resources: {
                             type: 'array',
                             items: {
-                                $ref: 'pool_api#/definitions/namespace_resource_extended_info'
+                                type: 'object',
+                                required: [
+                                    'resource',
+                                ],
+                                properties: {
+                                    resource: { $ref: 'pool_api#/definitions/namespace_resource_extended_info' },
+                                    path: { type: 'string' }
+                                }
                             }
                         },
                         write_resource: {
-                            $ref: 'pool_api#/definitions/namespace_resource_extended_info'
+                            type: 'object',
+                            required: [
+                                'resource',
+                            ],
+                            properties: {
+                                resource: { $ref: 'pool_api#/definitions/namespace_resource_extended_info' },
+                                path: { type: 'string' }
+                            }
                         },
                         caching: {
                             $ref: 'common_api#/definitions/bucket_cache_config'
@@ -1269,21 +1241,7 @@ module.exports = {
                 //         type: 'null'
                 //     }]
                 // },
-                namespace: {
-                    type: 'object',
-                    required: ['write_resource', 'read_resources'],
-                    properties: {
-                        write_resource: {
-                            type: 'string'
-                        },
-                        read_resources: {
-                            type: 'array',
-                            items: {
-                                type: 'string'
-                            },
-                        }
-                    }
-                },
+                namespace: { $ref: '#/definitions/namespace_bucket_config' },
                 versioning: { $ref: '#/definitions/versioning' },
             }
         },
@@ -1451,6 +1409,36 @@ module.exports = {
                             ]
                         }
                     }
+                }
+            }
+        },
+
+        // namespace bucket configuration
+
+        namespace_resource_config: {
+            type: 'object',
+            required: ['resource'],
+            properties: {
+                resource: { type: 'string' },
+                path: { type: 'string' }
+            }
+        },
+
+        namespace_bucket_config: {
+            type: 'object',
+            required: ['write_resource', 'read_resources'],
+            properties: {
+                write_resource: {
+                    $ref: '#/definitions/namespace_resource_config'
+                },
+                read_resources: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/definitions/namespace_resource_config'
+                    },
+                },
+                caching: {
+                    $ref: 'common_api#/definitions/bucket_cache_config'
                 }
             }
         },

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -790,9 +790,7 @@ module.exports = {
             }
         },
 
-        fs_path: {
-            type: 'string'
-        },
+        // nsfs 
 
         fs_backend: {
             type: 'string',
@@ -801,15 +799,23 @@ module.exports = {
 
         nsfs_config: {
             type: 'object',
-            required: ['fs_path'],
+            required: ['fs_root_path'],
             properties: {
-                fs_path: {
-                    $ref: '#/definitions/fs_path'
+                fs_root_path: {
+                    type: 'string'
                 },
                 fs_backend: {
                     $ref: '#/definitions/fs_backend'
                 }
             }
-        }
+        },
+        nsfs_account_config: {
+            type: 'object',
+            properties: {
+                uid: { type: 'number' },
+                gid: { type: 'number' },
+                new_buckets_path: { type: 'string' },
+            }
+        },
     }
 };

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -555,8 +555,8 @@ module.exports = {
                 identity: {
                     $ref: 'common_api#/definitions/access_key'
                 },
-                fs_path: {
-                    $ref: 'common_api#/definitions/fs_path'
+                fs_root_path: {
+                    type: 'string'
                 },
                 fs_backend: {
                     $ref: 'common_api#/definitions/fs_backend'
@@ -599,8 +599,8 @@ module.exports = {
                     type: 'string'
                 },
                 secret_key: { $ref: 'common_api#/definitions/secret_key' },
-                fs_path: {
-                    $ref: 'common_api#/definitions/fs_path'
+                fs_root_path: {
+                    type: 'string'
                 },
                 fs_backend: {
                     $ref: 'common_api#/definitions/fs_backend'

--- a/src/core/nsfs.js
+++ b/src/core/nsfs.js
@@ -89,7 +89,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         object_sdk._get_bucket_namespace = async bucket_name => {
             const existing_ns = namespaces[bucket_name];
             if (existing_ns) return existing_ns;
-            const ns_fs = new NamespaceFS({ fs_path: fs_root + '/' + bucket_name });
+            const ns_fs = new NamespaceFS({ bucket_path: fs_root + '/' + bucket_name });
             namespaces[bucket_name] = ns_fs;
             return ns_fs;
         };

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -1,6 +1,11 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const _ = require('lodash');
+const P = require('../util/promise');
+const nb_native = require('../util/nb_native');
+const dbg = require('../util/debug_module')(__filename);
+
 /**
  * @implements {nb.BucketSpace}
  */
@@ -14,8 +19,18 @@ class BucketSpaceNB {
     // BUCKET //
     ////////////
 
-    async list_buckets() {
-        return this.rpc_client.bucket.list_buckets();
+    async list_buckets(object_sdk) {
+        const { buckets } = (await this.rpc_client.bucket.list_buckets());
+        const has_access_buckets = (await P.all(_.map(
+            buckets,
+            async bucket => {
+                const namespace_bucket_config = await object_sdk.read_bucket_sdk_namespace_info(bucket.name.unwrap());
+                if (await this._has_access_to_nsfs_dir(namespace_bucket_config, object_sdk.requesting_account)) {
+                    return bucket;
+                }
+            }
+        ))).filter(bucket => bucket);
+        return { buckets: has_access_buckets };
     }
 
     async read_bucket(params) {
@@ -159,6 +174,33 @@ class BucketSpaceNB {
 
     async put_object_lock_configuration(params) {
         return this.rpc_client.bucket.put_object_lock_configuration(params);
+    }
+
+    //  nsfs
+
+
+    async _has_access_to_nsfs_dir(namespace_bucket_config, account) {
+        if (!namespace_bucket_config || !namespace_bucket_config.write_resource) return true;
+        console.log('_has_access_to_nsfs_dir0', namespace_bucket_config.write_resource);
+        if (namespace_bucket_config.write_resource.resource && !namespace_bucket_config.write_resource.resource.fs_root_path) return true;
+        dbg.log0('_has_access_to_nsfs_dir1', account.nsfs_account_config);
+
+        if (!account.nsfs_account_config || _.isUndefined(account.nsfs_account_config.uid) ||
+            _.isUndefined(account.nsfs_account_config.gid)) return false;
+        try {
+            dbg.log0('_has_access_to_nsfs_dir', namespace_bucket_config.write_resource, account.nsfs_account_config.uid, account.nsfs_account_config.gid);
+
+            await nb_native().fs.stat({
+                    uid: account.nsfs_account_config.uid,
+                    gid: account.nsfs_account_config.gid,
+                    backend: namespace_bucket_config.write_resource.resource.fs_backend
+                }, namespace_bucket_config.write_resource.resource.fs_root_path);
+
+            return true;
+        } catch (err) {
+            if (err.code === 'EPERM' && err.message === 'Operation not permitted') return false;
+            throw err;
+        }
     }
 }
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -197,6 +197,7 @@ interface NamespaceResource {
     system: System;
     account: Account;
     connection: object;
+    path: string;
 }
 
 interface ChunkConfig extends Base {
@@ -765,7 +766,7 @@ interface Namespace {
 
 interface BucketSpace {
 
-    list_buckets(): Promise<any>;
+    list_buckets(object_sdk: ObjectSDK): Promise<any>;
     read_bucket(params: object): Promise<any>;
     create_bucket(params: object): Promise<any>;
     delete_bucket(params: object): Promise<any>;

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -78,11 +78,11 @@ class NamespaceMonitor {
     }
 
     init_nsr_connection_to_target(nsr) {
-        const {endpoint, access_key, secret_key} = nsr.connection;
-        let conn;
         if (nsr.nsfs_config) {
             return;
         }
+        const {endpoint, access_key, secret_key} = nsr.connection;
+        let conn;
         switch (nsr.connection.endpoint_type) {
             case 'AWS' || 'S3_COMPATIBLE' || 'IBM_COS': {
                 conn = new AWS.S3({
@@ -114,6 +114,10 @@ class NamespaceMonitor {
     }
 
     async test_single_namespace_resource_validity(nsr_info) {
+        if (nsr_info.nsfs_config) {
+            dbg.log1('namespace_monitor: namespace resource of type FS, skipping validity test...');
+            return;
+        }
         const { endpoint_type, target_bucket} = nsr_info.connection;
         const block_key = `test-delete-non-existing-key-${Date.now()}`;
         const conn = this.nsr_connections_obj[nsr_info._id];
@@ -130,10 +134,8 @@ class NamespaceMonitor {
                     block_key,
                     callback)
             );
-        } else if (nsr_info.nsfs_config) {
-            dbg.log1('namespace_monitor: namespace resource of type FS, skipping validity test...');
         } else {
-                dbg.error('namespace_monitor: invalid endpoint type', endpoint_type);
+            dbg.error('namespace_monitor: invalid endpoint type', endpoint_type);
         }
     }
 }

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -54,6 +54,10 @@ async function create_account(req) {
         has_login: req.rpc_params.has_login,
         is_external: req.rpc_params.is_external,
         access_keys: undefined,
+        nsfs_account_config: req.rpc_params.nsfs_account_config && {
+            uid: req.rpc_params.nsfs_account_config.uid,
+            gid: req.rpc_params.nsfs_account_config.gid
+        }
     };
 
     const { roles: account_roles = ['admin'] } = req.rpc_params;
@@ -471,7 +475,11 @@ function update_account(req) {
         email: params.new_email,
         next_password_change: params.must_change_password === true ? new Date() : undefined,
         allowed_ips: (!_.isUndefined(params.ips) && params.ips !== null) ? params.ips : undefined,
-        preferences: _.isUndefined(params.preferences) ? undefined : params.preferences
+        preferences: _.isUndefined(params.preferences) ? undefined : params.preferences,
+        nsfs_account_config: req.rpc_params.nsfs_account_config && {
+            uid: req.rpc_params.nsfs_account_config.uid,
+            gid: req.rpc_params.nsfs_account_config.gid
+        }
     };
 
     let removals = {
@@ -1185,6 +1193,7 @@ function get_account_info(account, include_connection_cache) {
         }
     }
 
+    info.nsfs_account_config = account.nsfs_account_config;
     info.systems = _.compact(_.map(account.roles_by_system, function(roles, system_id) {
         var system = system_store.data.get_by_id(system_id);
         if (!system) {

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -252,9 +252,9 @@ async function create_namespace_resource(req) {
     if (req.rpc_params.nsfs_config) {
         namespace_resource = new_namespace_resource_defaults(name, req.system._id, req.account._id, undefined, req.rpc_params.nsfs_config);
         const already_used_by = system_store.data.namespace_resources.find(cur_nsr => cur_nsr.nsfs_config &&
-                (cur_nsr.nsfs_config.fs_path === namespace_resource.nsfs_config.fs_path));
+                (cur_nsr.nsfs_config.fs_root_path === namespace_resource.nsfs_config.fs_root_path));
         if (already_used_by) {
-            dbg.error(`fs path ${already_used_by.nsfs_config.fs_path} already exported by ${already_used_by.name}`);
+            dbg.error(`fs root path ${already_used_by.nsfs_config.fs_root_path} already exported by ${already_used_by.name}`);
             throw new RpcError('IN_USE', 'Target already in use');
         }
     } else {
@@ -1056,7 +1056,7 @@ function get_namespace_resource_info(namespace_resource) {
             identity: namespace_resource.connection.access_key,
     };
     const nsfs_info = namespace_resource.nsfs_config && {
-        fs_path: namespace_resource.nsfs_config.fs_path,
+        fs_root_path: namespace_resource.nsfs_config.fs_root_path,
         fs_backend: namespace_resource.nsfs_config.fs_backend
     };
     const info = _.omitBy({
@@ -1149,7 +1149,7 @@ function get_namespace_resource_extended_info(namespace_resource) {
         secret_key: namespace_resource.connection.secret_key,
     };
     const nsfs_info = namespace_resource.nsfs_config && {
-        fs_path: namespace_resource.nsfs_config.fs_path,
+        fs_root_path: namespace_resource.nsfs_config.fs_root_path,
         fs_backend: namespace_resource.nsfs_config.fs_backend
     };
     const info = _.omitBy({
@@ -1294,8 +1294,8 @@ function check_namespace_resource_deletion(ns) {
 function get_associated_buckets_ns(ns) {
     const associated_buckets = _.filter(ns.system.buckets_by_name, bucket => {
         if (!bucket.namespace) return;
-        return (_.find(bucket.namespace.read_resources, read_resource => String(ns._id) === String(read_resource._id)) ||
-            (String(ns._id) === String(bucket.namespace.write_resource._id)));
+        return (_.find(bucket.namespace.read_resources, read_resource => String(ns._id) === String(read_resource.resource._id)) ||
+            (String(ns._id) === String(bucket.namespace.write_resource.resource._id)));
     });
 
     return _.map(associated_buckets, 'name');

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -103,6 +103,10 @@ module.exports = {
                     enum: ['DARK', 'LIGHT']
                 }
             }
-        }
+        },
+        // nsfs properties for account
+        nsfs_account_config: {
+            $ref: 'common_api#/definitions/nsfs_account_config'
+        },
     }
 };

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -95,11 +95,25 @@ module.exports = {
                 read_resources: {
                     type: 'array',
                     items: {
-                        objectid: true // namespace resource id
+                        type: 'object',
+                        required: ['resource'],
+                        properties: {
+                            resource: {
+                                objectid: true // namespace resource id
+                            },
+                            path: { type: 'string' },
+                        }
                     }
                 },
                 write_resource: {
-                    objectid: true // namespace resource id
+                    type: 'object',
+                    required: ['resource'],
+                    properties: {
+                        resource: {
+                            objectid: true // namespace resource id
+                        },
+                        path: { type: 'string' },
+                    }
                 },
                 caching: {
                     $ref: 'common_api#/definitions/bucket_cache_config'

--- a/src/test/system_tests/test_bucket_lambda_triggers.js
+++ b/src/test/system_tests/test_bucket_lambda_triggers.js
@@ -221,12 +221,13 @@ async function setup() {
             name: 'ns.rsc.on.buck2',
             target_bucket: 'ns.internal.bucket2'
         });
-
+        const nsr1 = { resource: 'ns.rsc.on.buck1' };
+        const nsr2 = { resource: 'ns.rsc.on.buck2' };
         await client.bucket.create_bucket({
             name: 'ns.external.bucket1',
             namespace: {
-                read_resources: ['ns.rsc.on.buck1'],
-                write_resource: 'ns.rsc.on.buck2'
+                read_resources: [ nsr1 ],
+                write_resource: nsr2
             }
         });
 

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -54,6 +54,7 @@ require('./test_bucket_chunks_builder');
 require('./test_mirror_writer');
 require('./test_namespace_fs');
 require('./test_ns_list_objects');
+require('./test_bucketspace');
 
 // // SERVERS
 require('./test_agent');

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -1,0 +1,168 @@
+/* Copyright (C) 2020 NooBaa */
+'use strict';
+
+
+const mocha = require('mocha');
+const util = require('util');
+const AWS = require('aws-sdk');
+const http = require('http');
+const assert = require('assert');
+const coretest = require('./coretest');
+const { rpc_client, EMAIL, PASSWORD, SYSTEM} = coretest;
+const fs_utils = require('../../util/fs_utils');
+coretest.setup({ pools_to_create: [coretest.POOL_LIST[0]] });
+
+const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null, maxArrayLength: max_arr });
+
+let new_account_params = {
+    has_login: false,
+    s3_access: true,
+    allowed_buckets: {
+        full_permission: true
+    }
+};
+
+// currently will pass only when running locally
+mocha.describe('bucket operations - namespace_fs', function() {
+    const nsr = 'nsr';
+    const bucket_name = 'src-bucket';
+    const tmp_fs_root = '/tmp/test_bucket_namespace_fs';
+    const bucket_path = '/src';
+    let account_wrong_uid;
+    let account_correct_uid;
+    let s3_owner;
+    let s3_wrong_uid;
+    let s3_correct_uid;
+
+    let s3_creds = {
+        s3ForcePathStyle: true,
+        signatureVersion: 'v4',
+        computeChecksums: true,
+        s3DisableBodySigning: false,
+        region: 'us-east-1',
+        httpOptions: { agent: new http.Agent({ keepAlive: false }) },
+    };
+
+    mocha.before(async () => fs_utils.create_fresh_path(tmp_fs_root));
+    mocha.it('export dir as bucket', async function() {
+        await rpc_client.pool.create_namespace_resource({
+            name: nsr,
+            nsfs_config: {
+                fs_root_path: tmp_fs_root,
+                fs_backend: 'GPFS'
+            }
+        });
+        const obj_nsr = { resource: nsr, path: bucket_path };
+        await rpc_client.bucket.create_bucket({
+            name: bucket_name,
+            namespace: {
+                read_resources: [obj_nsr],
+                write_resource: obj_nsr
+            }
+        });
+    });
+    mocha.it('Init S3 owner connection', async function() {
+
+        const admin_keys = (await rpc_client.account.read_account({ email: EMAIL, })).access_keys;
+        s3_creds.accessKeyId = admin_keys[0].access_key.unwrap();
+        s3_creds.secretAccessKey = admin_keys[0].secret_key.unwrap();
+        s3_creds.endpoint = coretest.get_http_address();
+        s3_owner = new AWS.S3(s3_creds);
+    });
+
+    mocha.it('list buckets without uid, gid', async function() {
+        const res = await s3_owner.listBuckets().promise();
+        console.log(inspect(res));
+        const bucket = bucket_in_list(bucket_name, res.Buckets);
+        assert.ok(!bucket);
+        const first_bucket = bucket_in_list('first.bucket', res.Buckets);
+        assert.ok(first_bucket);
+    });
+
+    mocha.it('create account 1 with uid, gid', async function() {
+        account_wrong_uid = await rpc_client.account.create_account({...new_account_params,
+                email: 'account_wrong_uid@noobaa.com',
+                name: 'account_wrong_uid',
+                nsfs_account_config: {
+                    uid: 26041992,
+                    gid: 26041992,
+                }
+            }
+        );
+        console.log(inspect(account_wrong_uid));
+        s3_creds.accessKeyId = account_wrong_uid.access_keys[0].access_key.unwrap();
+        s3_creds.secretAccessKey = account_wrong_uid.access_keys[0].secret_key.unwrap();
+        s3_creds.endpoint = coretest.get_http_address();
+        s3_wrong_uid = new AWS.S3(s3_creds);
+    });
+
+    mocha.it('list buckets with wrong uid, gid', async function() {
+        const res = await s3_wrong_uid.listBuckets().promise();
+        console.log(inspect(res));
+        const bucket = bucket_in_list(bucket_name, res.Buckets);
+        assert.ok(!bucket);
+        const first_bucket = bucket_in_list('first.bucket', res.Buckets);
+        assert.ok(first_bucket);
+
+    });
+
+    mocha.it('list namespace resources after creation', async function() {
+        await rpc_client.create_auth_token({
+            email: EMAIL,
+            password: PASSWORD,
+            system: SYSTEM,
+        });
+        const res = await rpc_client.pool.read_namespace_resource({ name: nsr});
+        assert.ok(res.name === nsr && res.fs_root_path === tmp_fs_root);
+    });
+
+    mocha.it('create account 2 uid, gid', async function() {
+        account_correct_uid = await rpc_client.account.create_account({...new_account_params,
+                email: 'account_correct_uid@noobaa.com',
+                name: 'account_correct_uid',
+                nsfs_account_config: {
+                    uid: process.getuid(),
+                    gid: process.getgid(),
+                }
+            }
+        );
+        console.log(inspect(account_correct_uid));
+        s3_creds.accessKeyId = account_correct_uid.access_keys[0].access_key.unwrap();
+        s3_creds.secretAccessKey = account_correct_uid.access_keys[0].secret_key.unwrap();
+        s3_creds.endpoint = coretest.get_http_address();
+        s3_correct_uid = new AWS.S3(s3_creds);
+    });
+
+    mocha.it('list buckets with uid, gid', async function() {
+        const res = await s3_correct_uid.listBuckets().promise();
+        console.log(inspect(res));
+        const bucket = bucket_in_list(bucket_name, res.Buckets);
+        assert.ok(bucket);
+    });
+
+    mocha.it('delete bucket with uid, gid', async function() {
+        const res = await s3_owner.deleteBucket({ Bucket: bucket_name}).promise();
+        console.log(inspect(res));
+    });
+
+    mocha.it('list buckets after deletion', async function() {
+        const res = await s3_correct_uid.listBuckets().promise();
+        console.log(inspect(res));
+        const bucket = bucket_in_list(bucket_name, res.Buckets);
+        assert.ok(!bucket);
+    });
+
+    mocha.it('list namespace resources after deletion', async function() {
+        try {
+        const res = await rpc_client.pool.read_namespace_resource({ name: nsr });
+        assert.fail(`found namespace resource: ${res}`);
+        } catch (err) {
+            assert.ok('could not find namespace resource - as it should');
+        }
+        assert.ok(fs_utils.file_must_not_exist(tmp_fs_root));
+    });
+});
+
+function bucket_in_list(bucket_name, s3_buckets_list_response) {
+    return s3_buckets_list_response.find(bucket => bucket.Name === bucket_name);
+}

--- a/src/test/unit_tests/test_encryption.js
+++ b/src/test/unit_tests/test_encryption.js
@@ -483,7 +483,7 @@ mocha.describe('Rotation tests', function() {
             }
         }));
         await P.all(_.map(system_store.data.namespace_resources, async ns_resource => {
-            if (ns_resource.connection.target_bucket === BKT) return;
+            if (!ns_resource.connection || ns_resource.connection.target_bucket === BKT) return;
             const ns_resources_secrets = await get_ns_resources_secrets_from_system_store_and_db(ns_resource);
             if (is_connection_is_account_s3_creds(
                 ns_resource, 'ns', system_store_account._id, system_store_account.access_keys[0])) {
@@ -512,7 +512,7 @@ mocha.describe('Rotation tests', function() {
             }
         }));
         await P.all(_.map(system_store.data.namespace_resources, async ns_resource => {
-            if (ns_resource.connection.target_bucket === BKT) return;
+            if (!ns_resource.connection || ns_resource.connection.target_bucket === BKT) return;
             const ns_resources_secrets = await get_ns_resources_secrets_from_system_store_and_db(ns_resource);
             if (is_connection_is_account_s3_creds(
                 ns_resource, 'ns', system_store_account._id, system_store_account.access_keys[0])) {
@@ -556,7 +556,7 @@ mocha.describe('Rotation tests', function() {
         const secrets = await get_account_secrets_from_system_store_and_db(accounts[2].email, 's3_creds');
         await compare_secrets_disabled(secrets, system_store_account.master_key_id._id, original_secrets.system_store_secret);
         await P.all(_.map(system_store.data.namespace_resources, async ns_resource => {
-            if (ns_resource.connection.target_bucket === BKT) return;
+            if (!ns_resource.connection || ns_resource.connection.target_bucket === BKT) return;
             const ns_resources_secrets = await get_ns_resources_secrets_from_system_store_and_db(ns_resource);
             if (is_pool_of_account(ns_resource, 'ns', system_store_account._id)) {
                 await compare_secrets_disabled(ns_resources_secrets.secrets, ns_resources_secrets.owner_account_master_key_id);
@@ -596,7 +596,7 @@ mocha.describe('Rotation tests', function() {
         }));
 
         await P.all(_.map(system_store.data.namespace_resources, async ns_resource => {
-            if (ns_resource.connection.target_bucket === BKT) return;
+            if (!ns_resource.connection || ns_resource.connection.target_bucket === BKT) return;
             const ns_resources_secrets = await get_ns_resources_secrets_from_system_store_and_db(ns_resource);
             await compare_secrets_disabled(ns_resources_secrets.secrets, ns_resources_secrets.owner_account_master_key_id);
         }));
@@ -947,11 +947,12 @@ async function namespace_cache_tests(rpc_client, namespace_resources, sys_name, 
     let i = 0;
     for (i = 0; i < 1; i++) {
         const bucket_name = `namespace-bucket${i}`;
+        const nsr = { resource: namespace_resources[0].name };
         await rpc_client.bucket.create_bucket({
             name: bucket_name,
             namespace: {
-                read_resources: [namespace_resources[0].name],
-                write_resource: namespace_resources[0].name,
+                read_resources: [nsr],
+                write_resource: nsr,
                 caching: {
                     ttl_ms: 60000
                 }

--- a/src/test/unit_tests/test_namespace_auth.js
+++ b/src/test/unit_tests/test_namespace_auth.js
@@ -38,9 +38,9 @@ mocha.describe('Namespace Auth', function() {
             httpOptions: { agent: http_utils.get_unsecured_agent(coretest.get_http_address()) },
         });
         coretest.log('S3 CONFIG', s3.config);
-
-        const read_resources = [NAMESPACE_RESOURCE_NAME];
-        const write_resource = NAMESPACE_RESOURCE_NAME;
+        const nsr = { resource: NAMESPACE_RESOURCE_NAME };
+        const read_resources = [nsr];
+        const write_resource = nsr;
         await rpc_client.account.add_external_connection({
             name: CONNECTION_NAME,
             endpoint: coretest.get_http_address(),

--- a/src/test/unit_tests/test_s3_encryption.js
+++ b/src/test/unit_tests/test_s3_encryption.js
@@ -152,8 +152,9 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(60000);
         [aws_s3, local_s3] = Object.values(await get_s3_instances());
-        const read_resources = [RESOURCE_NAME];
-        const write_resource = RESOURCE_NAME;
+        const nsr = { resource: RESOURCE_NAME };
+        const read_resources = [nsr];
+        const write_resource = nsr;
         await aws_s3.createBucket({ Bucket: AWS_TARGET_BUCKET }).promise();
         await rpc_client.account.add_external_connection({
             name: CONNECTION_NAME,

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -147,20 +147,21 @@ mocha.describe('s3_ops', function() {
                     connection: CONNECTION_NAME,
                     target_bucket: source_namespace_bucket
                 });
-
+                const trgt_nsr = { resource: NAMESPACE_RESOURCE_TARGET };
                 await rpc_client.bucket.create_bucket({
                     name: source_bucket,
                     namespace: {
-                        read_resources: [NAMESPACE_RESOURCE_TARGET],
-                        write_resource: NAMESPACE_RESOURCE_TARGET,
+                        read_resources: [trgt_nsr],
+                        write_resource: trgt_nsr,
                         caching: caching
                     }
                 });
+                const src_nsr = { resource: NAMESPACE_RESOURCE_SOURCE };
                 await rpc_client.bucket.create_bucket({
                     name: bucket_name,
                     namespace: {
-                        read_resources: [NAMESPACE_RESOURCE_SOURCE],
-                        write_resource: NAMESPACE_RESOURCE_SOURCE,
+                        read_resources: [src_nsr],
+                        write_resource: src_nsr,
                         caching
                     }
                 });

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -387,11 +387,12 @@ mocha.describe('system_servers', function() {
             connection: NAMESPACE_RESOURCE_CONNECTION,
             target_bucket: BUCKET
         });
+        const nsr = { resource: NAMESPACE_RESOURCE_NAME };
         await rpc_client.bucket.create_bucket({
             name: NAMESPACE_BUCKET,
             namespace: {
-                read_resources: [NAMESPACE_RESOURCE_NAME],
-                write_resource: NAMESPACE_RESOURCE_NAME
+                read_resources: [nsr],
+                write_resource: nsr
             },
         });
         await rpc_client.bucket.delete_bucket({ name: NAMESPACE_BUCKET });

--- a/src/test/utils/bucket_functions.js
+++ b/src/test/utils/bucket_functions.js
@@ -154,9 +154,10 @@ class BucketFunctions {
     async createNamespaceBucket(name, namespace, caching) {
         console.log(`Creating namespace bucket ${name} with namespace ${namespace}`);
         try {
+            const nsr = { resource: namespace };
             const namespaceConfig = {
-                read_resources: [namespace],
-                write_resource: namespace,
+                read_resources: [nsr],
+                write_resource: nsr,
                 caching
             };
             await this._client.bucket.create_bucket({
@@ -175,8 +176,8 @@ class BucketFunctions {
             await this._client.bucket.update_bucket({
                 name,
                 namespace: {
-                    read_resources,
-                    write_resource
+                    read_resources: read_resources.map(rr => ({ resource: rr })),
+                    write_resource: { resource: write_resource }
                 }
             });
         } catch (e) {


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. addition of uid and gid properties to account api + schema.
2. Added set of uid and gid properties to create_account & update_account.
3. added export_dir_as_bucket to bucket_server + bucket_api.
4. list_buckets in bucket_server - added code that checks if it's an nsfs bucket and calls stat.
5. delete_bucket - added code that checks if it's an nsfs bucket and calls rmdir and delete namespace_resource.
6. added tests - currently will pass locally but not in a container. 
7. added check for fs_backend type in create_namespace_resource.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
