### PR TITLE
fixed delete_object_version to also find and delete uncompleted multipart uploads 

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -185,6 +185,19 @@ class MDStore {
         });
     }
 
+    async find_object_or_upload_null_version(bucket_id, key) {
+        return this._objects.findOne({
+                // index fields:
+                bucket: bucket_id,
+                key,
+                version_enabled: null,
+                // partialFilterExpression:
+                deleted: null,
+            }, {
+                sort: { bucket: 1, key: 1, version_enabled: 1 },
+        });
+    }
+
     async find_object_by_version(bucket_id, key, version_seq) {
         return this._objects.findOne({
             // index fields:

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1720,7 +1720,8 @@ async function _delete_object_version(req) {
     }
 
     if (bucket_versioning === 'DISABLED') {
-        const obj = version_id === 'null' && await MDStore.instance().find_object_null_version(req.bucket._id, req.rpc_params.key);
+        const obj = version_id === 'null' && await MDStore.instance().find_object_or_upload_null_version(req.bucket._id, req.rpc_params.key);
+
         if (!obj) return { reply: {} };
         if (obj.delete_marker) dbg.error('versioning disabled bucket null objects should not have delete_markers', obj);
         check_md_conditions(req.rpc_params.md_conditions, obj);
@@ -1731,7 +1732,7 @@ async function _delete_object_version(req) {
 
     if (bucket_versioning === 'ENABLED' || bucket_versioning === 'SUSPENDED') {
         const obj = version_id === 'null' ?
-            await MDStore.instance().find_object_null_version(req.bucket._id, req.rpc_params.key) :
+            await MDStore.instance().find_object_or_upload_null_version(req.bucket._id, req.rpc_params.key) :
             await MDStore.instance().find_object_by_version(req.bucket._id, req.rpc_params.key, version_seq);
         if (!obj) return { reply: {} };
 


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. when calling delete_object_version, we used to findOne while using upload_started: null and 'null_version_index' index which filters entries contains upload_started property. this fact caused an infinite loop when deleting a bucket (and it's objects, for example when deleting OBC) that has uncompleted multipart upload attached to it. Added another function that doesn't use filter uncompleted multipart uploads. 

### Issues: Fixed #xxx / Gap #xxx
1. BZ #1940476

### Testing Instructions:
1. 
