### PR TITLE
Implementing mapReduceFuncStats for postgres

### DIFF
--- a/src/server/func_services/func_stats_store.js
+++ b/src/server/func_services/func_stats_store.js
@@ -9,12 +9,7 @@ const db_client = require('../../util/db_client');
 
 const func_stats_schema = require('./func_stats_schema');
 const func_stats_indexes = require('./func_stats_indexes');
-const {
-    map_func_stats,
-    reduce_func_stats,
-    finalize_func_stats
-} = require('../../util/mongo_functions');
-
+const mongo_functions = require('../../util/mongo_functions');
 class FuncStatsStore {
 
     constructor() {
@@ -48,11 +43,12 @@ class FuncStatsStore {
     }
 
     async query_func_stats(params) {
+
         const records = await this._func_stats
             .mapReduce(
-                map_func_stats,
-                reduce_func_stats, {
-                    finalize: finalize_func_stats,
+                mongo_functions.map_func_stats,
+                mongo_functions.reduce_func_stats, {
+                    finalize: mongo_functions.finalize_func_stats,
                     query: {
                         system: params.system,
                         func: params.func,

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -358,7 +358,7 @@ class BulkOp {
 
         // find index of item to set in array
         const from = (arr_to_update && `FROM (SELECT pos- 1 as elem_index FROM ${this.name}, jsonb_array_elements(data->'${arr_to_update}')` +
-                ` with ordinality arr(elem, pos) WHERE ${array_where} ) SUB`) || '';
+            ` with ordinality arr(elem, pos) WHERE ${array_where} ) SUB`) || '';
 
         const query = `UPDATE ${this.name} SET data = ${latest_set} ${from} WHERE ${column_where}`;
         return query;
@@ -733,6 +733,110 @@ class PostgresTable {
         }
     }
 
+    async _reduceFinalizeFuncStats(rows, scope) {
+
+        let response_times;
+        // this is the reduce part of the map reduce
+        const values = [];
+        rows.map(row => values.push(row.value));
+
+        const reduced = values.reduce((bin, other) => {
+            bin.invoked += other.invoked;
+            bin.fulfilled += other.fulfilled;
+            bin.rejected += other.rejected;
+            bin.aggr_response_time += other.aggr_response_time;
+            bin.max_response_time = Math.max(
+                bin.max_response_time,
+                other.max_response_time
+            );
+            bin.completed_response_times = [
+                ...bin.completed_response_times,
+                ...other.completed_response_times
+            ];
+
+            return bin;
+        });
+
+        // Reduce the sample size to max_samples
+        response_times = reduced.completed_response_times;
+        if (response_times.length > scope.max_samples) {
+            reduced.completed_response_times = Array.from({ length: scope.max_samples },
+                () => response_times[
+                    Math.floor(Math.random() * response_times.length)
+                ]
+            );
+        }
+
+        // this is the finalize part of the map reduce
+        response_times = reduced.completed_response_times.sort((a, b) => a - b);
+
+        const return_value = {
+            invoked: reduced.invoked,
+            fulfilled: reduced.fulfilled,
+            rejected: reduced.rejected,
+            max_response_time: reduced.max_response_time,
+            aggr_response_time: reduced.aggr_response_time,
+            avg_response_time: reduced.fulfilled > 0 ?
+                Math.round(reduced.aggr_response_time / reduced.fulfilled) : 0,
+            response_percentiles: scope.percentiles.map(percentile => {
+                const index = Math.floor(response_times.length * percentile);
+                const value = response_times[index] || 0;
+                return { percentile, value };
+            })
+        };
+
+        return return_value;
+    }
+
+    async mapReduceFuncStats(func, options) {
+        let query_string;
+        let map_reduce_query;
+        let map;
+        const map_reduced_array = [];
+        try {
+            // this is the map part of the map reduce
+            query_string = `SELECT * FROM ${this.name} WHERE ${mongo_to_pg('data', encode_json(this.schema, options.query))}`;
+            map_reduce_query = `SELECT * FROM ${func}($$${query_string}$$)`;
+            map = await this.single_query(map_reduce_query);
+        } catch (err) {
+            dbg.error('mapReduceFuncStats failed', options, query_string, map_reduce_query, err);
+            throw err;
+        }
+
+        //If there are no matching results then returning an empty array
+        if (map.rows.length === 0) {
+            return map.rows;
+        }
+
+        //Working on all the results from the query
+        let return_value = await this._reduceFinalizeFuncStats(map.rows, options.scope);
+
+        map_reduced_array.push({
+            _id: -1,
+            value: return_value,
+        });
+
+        //Working on each column 
+        try {
+            map = await this.single_query(map_reduce_query);
+        } catch (err) {
+            dbg.error('mapReduceFuncStats failed', options, query_string, map_reduce_query, err);
+            throw err;
+        }
+        const step = options.scope.step;
+        const groupByKeys = _.groupBy(map.rows, r => Math.floor(new Date(r.time_stamp).valueOf() / step) * step);
+        for (const [key, rows] of Object.entries(groupByKeys)) {
+            return_value = await this._reduceFinalizeFuncStats(rows, options.scope);
+            map_reduced_array.push({
+                _id: key,
+                value: return_value,
+            });
+        }
+
+        return map_reduced_array;
+
+    }
+
     async mapReduce(map, reduce, params) {
         switch (map) {
             case mongo_functions.map_aggregate_objects:
@@ -743,6 +847,8 @@ class PostgresTable {
                 return this.mapReduceAggregate('map_aggregate_blocks', params);
             case mongo_functions.map_common_prefixes:
                 return this.mapReduceListObjects(params);
+            case mongo_functions.map_func_stats:
+                return this.mapReduceFuncStats('map_func_stats', params);
             default:
                 throw new Error('TODO mapReduce');
         }
@@ -1134,6 +1240,7 @@ class PostgresClient extends EventEmitter {
         return PostgresClient._instance;
     }
 
+    // Loading the postgres functions into the DB from sql_functions/
     async _load_sql_functions(pool) {
         let pg_client;
         try {

--- a/src/util/sql_functions/map_func_stats.sql
+++ b/src/util/sql_functions/map_func_stats.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION map_func_stats(TEXT) RETURNS TABLE(_id TEXT, time_stamp TEXT, value JSON) AS $$
+DECLARE
+    cur_query ALIAS FOR $1;
+    time_took NUMERIC; 
+    rec_err BOOLEAN;
+    rec RECORD;
+    cur REFCURSOR;
+BEGIN
+  OPEN cur FOR EXECUTE cur_query; 
+  FETCH NEXT FROM cur INTO rec;
+  WHILE FOUND 
+  LOOP
+    rec_err := rec.data->'error';
+    IF rec_err THEN
+        _id := 'rejected'; 
+        time_stamp := rec.data->>'time';  
+        value := json_build_object('invoked', 1, 'fulfilled', 0, 'rejected', 1, 'aggr_response_time', 0, 'max_response_time', 0, 'completed_response_times', ARRAY [time_took]);
+    ELSE
+        _id := 'fulfilled';
+        time_stamp := rec.data->>'time';
+        time_took := rec.data->>'took';
+        value := json_build_object('invoked', 1, 'fulfilled', 1, 'rejected', 0, 'aggr_response_time', time_took, 'max_response_time', time_took, 'completed_response_times', ARRAY [time_took]);
+    END IF;
+    RETURN NEXT;
+    FETCH NEXT FROM cur INTO rec; 
+  END LOOP;
+  CLOSE cur; 
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
### Explain the changes

- Implementing mapReduceFuncStats for postgres
- Adding map_func_stats.sql that does the map part

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Testing Instructions:
1. Run lambda functions when using postgres as db
2. See that the Monitoring in the UI is working.
3. Run the same with mongodb and see that the monitoring is working.
4. on postgres see that the table are there and the function is working:
```
nbcore=# SELECT * FROM func_stats;
           _id            |                                                                                                                data
--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 6061c794dcb625000b11e42f | {"_id": "6061c794dcb625000b11e42f", "func": "6061c75d0e1334002eb1d0ae", "time": "2021-03-29T12:26:55.228Z", "took": 4792, "error": true, "system": "6061c66c0e1334002eb1d092", "error_msg": "Func handler not a function main.a"}
 6061c7a4dcb625000b11e430 | {"_id": "6061c7a4dcb625000b11e430", "func": "6061c75d0e1334002eb1d0ae", "time": "2021-03-29T12:27:05.222Z", "took": 11511, "error": true, "system": "6061c66c0e1334002eb1d092", "error_msg": "Func handler not a function main.a"}
 6061c7e4dcb625000b11e436 | {"_id": "6061c7e4dcb625000b11e436", "func": "6061c75d0e1334002eb1d0ae", "time": "2021-03-29T12:27:56.222Z", "took": 24500, "system": "6061c66c0e1334002eb1d092"}
 6061fa17dcb625000b11e466 | {"_id": "6061fa17dcb625000b11e466", "func": "6061c75d0e1334002eb1d0ae", "time": "2021-03-29T16:02:09.328Z", "took": 22193, "system": "6061c66c0e1334002eb1d092"}
(4 rows)

nbcore=# SELECT * FROM map_func_stats($$SELECT * FROM func_stats WHERE (data->'system'='"6061c66c0e1334002eb1d092"'::jsonb and data->'func'='"6061c75d0e1334002eb1d0ae"'::jsonb and (data->'time'>='"2021-03-28T10:00:00.000Z"'::jsonb and data->'time'<'"2021-03-30T19:10:00.000Z"'::jsonb))$$);
    _id    |        time_stamp        |                                                                       value
-----------+--------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------
 rejected  | 2021-03-29T12:26:55.228Z | {"invoked" : 1, "fulfilled" : 0, "rejected" : 1, "aggr_response_time" : 0, "max_response_time" : 0, "completed_response_times" : [null]}
 rejected  | 2021-03-29T12:27:05.222Z | {"invoked" : 1, "fulfilled" : 0, "rejected" : 1, "aggr_response_time" : 0, "max_response_time" : 0, "completed_response_times" : [null]}
 fulfilled | 2021-03-29T12:27:56.222Z | {"invoked" : 1, "fulfilled" : 1, "rejected" : 0, "aggr_response_time" : 24500, "max_response_time" : 24500, "completed_response_times" : [24500]}
 fulfilled | 2021-03-29T16:02:09.328Z | {"invoked" : 1, "fulfilled" : 1, "rejected" : 0, "aggr_response_time" : 22193, "max_response_time" : 22193, "completed_response_times" : [22193]}
(4 rows)
```