### PR TITLE
Remove the `req.originalUrl` from web server error 404

### DIFF
--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -130,7 +130,7 @@ app.use(function(req, res, next) {
     return next();
 });
 app.use(function(req, res, next) {
-        return next();
+    return next();
 });
 app.use(express_compress());
 
@@ -391,7 +391,7 @@ app.use(function(err, req, res, next) {
 function error_404(req, res, next) {
     return next({
         status: 404, // not found
-        message: 'We dug the earth, but couldn\'t find ' + req.originalUrl
+        message: 'We dug the earth, but couldn\'t find your requested URL'
     });
 }
 


### PR DESCRIPTION
### Explain the changes
Remove the `req.originalUrl` from web server error 404

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ1943388

![https___192_168_64_73_32193__some_script_](https://user-images.githubusercontent.com/28217223/113503414-66301100-953a-11eb-88e3-fe54e47ba206.png)
