### PR TITLE
Fix Function monitoring showing wrong timestamps

### DIFF
--- a/src/server/func_services/func_server.js
+++ b/src/server/func_services/func_server.js
@@ -215,6 +215,7 @@ async function read_func_stats(req) {
     });
 
     return {
+        //stats is counting the `-1` key that is used for "Request and Error Count Over Time"
         stats: {
             ...FUNC_STATS_DEFAULTS,
             since: normalized_since,
@@ -222,6 +223,7 @@ async function read_func_stats(req) {
             response_percentiles: emptyPercentilesArray,
             ...by_key[-1]
         },
+        //slices is per since time key for the candles charts
         slices: _.range(
             normalized_since,
             normalized_till,
@@ -229,7 +231,7 @@ async function read_func_stats(req) {
         ).map(since_time => ({
             ...FUNC_STATS_DEFAULTS,
             since: since_time,
-            till: since + step,
+            till: since_time + step,
             response_percentiles: emptyPercentilesArray,
             ...by_key[since_time]
         }))


### PR DESCRIPTION
### Explain the changes
Fix Function monitoring showing wrong timestamps

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1.  Fixes: #6433 

### Testing Instructions:
1. Open the monitoring tab 
2. See that in each time slice (60 min, 24 Hours, 7 days, 30 days) the range is correct.
