### PR TITLE
NSFS - s3 create and delete bucket flows + support namespace resource as account default resource

### DIFF
--- a/frontend/src/app/epics/create-account.js
+++ b/frontend/src/app/epics/create-account.js
@@ -30,7 +30,7 @@ export default function(action$, { api }) {
                         password: isAdmin ? password : undefined,
                         must_change_password: isAdmin || undefined,
                         s3_access: true,
-                        default_pool: defaultResource,
+                        default_resource: defaultResource,
                         allowed_buckets: {
                             full_permission: hasAccessToAllBucekts,
                             permission_list: !hasAccessToAllBucekts ? allowedBuckets : undefined

--- a/frontend/src/app/epics/update-account-s3-access.js
+++ b/frontend/src/app/epics/update-account-s3-access.js
@@ -22,7 +22,7 @@ export default function(action$, { api }) {
                 await api.account.update_account_s3_access({
                     email: accountName,
                     s3_access: true,
-                    default_pool: defaultResource,
+                    default_resource: defaultResource,
                     allowed_buckets: {
                         full_permission: hasAccessToAllBuckets,
                         permission_list: hasAccessToAllBuckets ? undefined : allowedBuckets

--- a/frontend/src/app/reducers/accounts-reducer.js
+++ b/frontend/src/app/reducers/accounts-reducer.js
@@ -34,7 +34,7 @@ function _mapAccount(account, owner, systemName, pools, allBuckets, accountsOwni
         is_external,
         access_keys,
         has_s3_access,
-        default_pool,
+        default_resource,
         allowed_buckets,
         can_create_buckets,
         allowed_ips,
@@ -76,8 +76,8 @@ function _mapAccount(account, owner, systemName, pools, allBuckets, accountsOwni
         hasAccessToAllBuckets,
         allowedBuckets,
         canCreateBuckets: Boolean(has_s3_access && can_create_buckets),
-        defaultResource: default_pool !== internalResource.name  ?
-            default_pool :
+        defaultResource: default_resource !== internalResource.name  ?
+            default_resource:
             'INTERNAL_STORAGE',
         accessKeys: { accessKey, secretKey },
         allowedIps: allowed_ips,

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -36,7 +36,7 @@ module.exports = {
                     allowed_buckets: {
                         $ref: '#/definitions/allowed_buckets'
                     },
-                    default_pool: {
+                    default_resource: {
                         type: 'string',
                     },
                     allow_bucket_creation: {
@@ -65,7 +65,7 @@ module.exports = {
                             allowed_buckets: {
                                 $ref: '#/definitions/allowed_buckets'
                             },
-                            default_pool: {
+                            default_resource: {
                                 type: 'string',
                             },
                         },
@@ -272,7 +272,7 @@ module.exports = {
                     allowed_buckets: {
                         $ref: '#/definitions/allowed_buckets'
                     },
-                    default_pool: {
+                    default_resource: {
                         type: 'string'
                     },
                     allow_bucket_creation: {
@@ -307,7 +307,14 @@ module.exports = {
                 type: 'object',
                 required: ['nsfs_account_config'],
                 properties: {
-                    nsfs_account_config: { $ref: 'common_api#/definitions/nsfs_account_config' },
+                    nsfs_account_config: {
+                        type: 'object',
+                        required: ['uid', 'gid'],
+                        properties: {
+                            uid: { type: 'number' },
+                            gid: { type: 'number' },
+                        }
+                    }
                 }
             },
             auth: {
@@ -601,7 +608,7 @@ module.exports = {
                         $ref: 'common_api#/definitions/ip_range'
                     }
                 },
-                default_pool: {
+                default_resource: {
                     type: 'string',
                 },
                 bucket_claim_owner: {

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -830,7 +830,7 @@ module.exports = {
 
         claim_bucket: {
             method: 'PUT',
-            required: ['name', 'tiering', 'email', 'create_bucket', 'namespace'],
+            required: ['name', 'email', 'create_bucket', 'namespace'],
             params: {
                 type: 'object',
                 properties: {
@@ -908,7 +908,7 @@ module.exports = {
 
         bucket_info: {
             type: 'object',
-            required: ['name', 'bucket_type', 'tiering', 'versioning', 'usage_by_pool', 'storage', 'data', 'num_objects', 'host_tolerance', 'node_tolerance', 'writable', 'mode'],
+            required: ['name', 'bucket_type', 'versioning', 'usage_by_pool', 'storage', 'data', 'num_objects', 'mode'],
             properties: {
                 name: { $ref: 'common_api#/definitions/bucket_name' },
                 bucket_type: {
@@ -1175,6 +1175,9 @@ module.exports = {
                         caching: {
                             $ref: 'common_api#/definitions/bucket_cache_config'
                         },
+                        should_create_underlying_storage: {
+                            type: 'boolean'
+                        },
                     },
                 },
                 active_triggers: {
@@ -1439,7 +1442,8 @@ module.exports = {
                 },
                 caching: {
                     $ref: 'common_api#/definitions/bucket_cache_config'
-                }
+                },
+                should_create_underlying_storage: { type: 'boolean' } // should create underlying storage
             }
         },
     }

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -811,6 +811,7 @@ module.exports = {
         },
         nsfs_account_config: {
             type: 'object',
+            required: ['uid', 'gid', 'new_buckets_path'],
             properties: {
                 uid: { type: 'number' },
                 gid: { type: 'number' },

--- a/src/lambda_funcs/set_account_bucket_permissions_func.js
+++ b/src/lambda_funcs/set_account_bucket_permissions_func.js
@@ -5,7 +5,7 @@
     {
         "email": "email@email.com",
         "s3_access": true,
-        "default_pool": "london",
+        "default_resource": "london",
         "allowed_buckets": ["mybucket"]
     }
 */

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -683,6 +683,16 @@ class NamespaceBlob {
         throw new Error('TODO');
     }
 
+    ///////////////////
+    //      ULS      //
+    ///////////////////
+
+    async create_uls() {
+        throw new Error('TODO');
+    }
+    async delete_uls() {
+        throw new Error('TODO');
+    }
 
 }
 

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -967,6 +967,16 @@ class NamespaceCache {
         throw new Error('TODO');
     }
 
+    ///////////////////
+    //      ULS      //
+    ///////////////////
+
+    async create_uls() {
+        throw new Error('TODO');
+    }
+    async delete_uls() {
+        throw new Error('TODO');
+    }
 }
 
 

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -346,6 +346,17 @@ class NamespaceNB {
             version_id: params.versionId
         }, object_sdk);
     }
+
+    ///////////////////
+    //      ULS      //
+    ///////////////////
+
+    async create_uls() {
+        throw new Error('TODO');
+    }
+    async delete_uls() {
+        throw new Error('TODO');
+    }
 }
 
 module.exports = NamespaceNB;

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -642,6 +642,16 @@ class NamespaceS3 {
         throw new Error('TODO');
     }
 
+    ///////////////////
+    //      ULS      //
+    ///////////////////
+
+    async create_uls() {
+        throw new Error('TODO');
+    }
+    async delete_uls() {
+        throw new Error('TODO');
+    }
 
     ///////////////
     // INTERNALS //

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -768,8 +768,8 @@ interface BucketSpace {
 
     list_buckets(object_sdk: ObjectSDK): Promise<any>;
     read_bucket(params: object): Promise<any>;
-    create_bucket(params: object): Promise<any>;
-    delete_bucket(params: object): Promise<any>;
+    create_bucket(params: object, object_sdk: ObjectSDK): Promise<any>;
+    delete_bucket(params: object, object_sdk: ObjectSDK): Promise<any>;
 
     get_bucket_lifecycle_configuration_rules(params: object): Promise<any>;
     set_bucket_lifecycle_configuration_rules(params: object): Promise<any>;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -581,12 +581,12 @@ class ObjectSDK {
 
     async create_bucket(params) {
         const bs = this._get_bucketspace();
-        return bs.create_bucket(params);
+        return bs.create_bucket(params, this);
     }
 
     async delete_bucket(params) {
         const bs = this._get_bucketspace();
-        return bs.delete_bucket(params);
+        return bs.delete_bucket(params, this);
     }
 
     //////////////////////

--- a/src/server/bg_services/mirror_writer.js
+++ b/src/server/bg_services/mirror_writer.js
@@ -179,7 +179,7 @@ class MirrorWriter {
         return system_store.data.buckets
             .filter(bucket =>
                 _.isUndefined(bucket.deleting) &&
-                bucket.tiering.tiers.some(tier => tier.tier.mirrors.length > 1))
+                bucket.tiering && bucket.tiering.tiers.some(tier => tier.tier.mirrors.length > 1))
             .map(bucket => ({
                 name: bucket.name,
                 _id: MDStore.instance().make_md_id(bucket._id),

--- a/src/server/bg_services/tier_spillback_worker.js
+++ b/src/server/bg_services/tier_spillback_worker.js
@@ -50,7 +50,7 @@ class TieringSpillbackWorker {
     _get_spillback_buckets() {
         return system_store.data.buckets.filter(bucket =>
             _.isUndefined(bucket.deleting) &&
-            _.some(bucket.tiering.tiers, t => t.spillover));
+            _.some(bucket.tiering && bucket.tiering.tiers, t => t.spillover));
     }
 
     async _spillback_need_to_move_chunks(buckets) {

--- a/src/server/bg_services/tier_ttf_worker.js
+++ b/src/server/bg_services/tier_ttf_worker.js
@@ -54,7 +54,7 @@ class TieringTTFWorker {
         return system_store.data.buckets.filter(bucket =>
             !bucket.deleting && (
                 // including buckets that have 2 or more tiers
-                bucket.tiering.tiers.length > 1 ||
+                (bucket.tiering && bucket.tiering.tiers.length > 1) ||
                 // including cache buckets to handle chunk eviction
                 (bucket.namespace && bucket.namespace.caching)
             ));

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -621,7 +621,7 @@ class NodesMonitor extends EventEmitter {
             agent_config.pool ||
             system.pools_by_name[pool_name] ||
             _.filter(system.pools_by_name, p => (!_.get(p, 'mongo_pool_info') && (!_.get(p, 'cloud_pool_info'))))[0]; // default - the 1st host pool in the system
-        // system_store.get_account_by_email(system.owner.email).default_pool; //This should not happen, but if it does, use owner's default
+        // system_store.get_account_by_email(system.owner.email).default_resource; //This should not happen, but if it does, use owner's default
 
         if (!pool) {
             throw new Error('Cannot find eligible pool');
@@ -2674,7 +2674,7 @@ class NodesMonitor extends EventEmitter {
     //     const classifier = new dclassify.Classifier({
     //         applyInverse: true
     //     });
-    //     const pools_to_classify = ['default_pool', config.NEW_SYSTEM_POOL_NAME];
+    //     const pools_to_classify = ['default_resource', config.NEW_SYSTEM_POOL_NAME];
     //     let num_trained_pools = 0;
     //     for (const pool_data of pools_data_map.values()) {
     //         // don't train by the nodes that we need to classify
@@ -2698,7 +2698,7 @@ class NodesMonitor extends EventEmitter {
     //     dbg.log3('_suggest_pool_assign: Trained:', classifier,
     //         'probabilities', JSON.stringify(classifier.probabilities));
 
-    //     // for nodes in the default_pool use the classifier to suggest a pool
+    //     // for nodes in the default_resource use the classifier to suggest a pool
     //     const system = system_store.data.systems[0];
     //     const target_pool = system.pools_by_name[config.NEW_SYSTEM_POOL_NAME];
     //     const target_pool_data = pools_data_map.get(String(target_pool._id));

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -901,7 +901,7 @@ function get_associated_buckets_int(pool) {
 function has_associated_buckets_int(pool, { exclude_deleting_buckets } = {}) {
     const associated_bucket = _.find(pool.system.buckets_by_name, function(bucket) {
         if (bucket.deleting && exclude_deleting_buckets) return false;
-        return _.find(bucket.tiering.tiers, function(tier_and_order) {
+        return _.find(bucket.tiering && bucket.tiering.tiers, function(tier_and_order) {
             return _.find(tier_and_order.tier.mirrors, function(mirror) {
                 return _.find(mirror.spread_pools, function(spread_pool) {
                     return String(pool._id) === String(spread_pool._id);
@@ -915,8 +915,8 @@ function has_associated_buckets_int(pool, { exclude_deleting_buckets } = {}) {
 function get_associated_accounts(pool) {
     return system_store.data.accounts
         .filter(account => (!account.is_support &&
-            account.default_pool &&
-            account.default_pool._id === pool._id
+            account.default_resource &&
+            account.default_resource._id === pool._id
         ))
         .map(associated_account => associated_account.email);
 }
@@ -1340,13 +1340,13 @@ async function update_account_default_resource() {
                     const updates = system_store.data.accounts
                         .filter(account =>
                             account.email.unwrap() !== config.OPERATOR_ACCOUNT_EMAIL &&
-                            account.default_pool &&
-                            _is_mongo_pool(account.default_pool)
+                            account.default_resource &&
+                            _is_mongo_pool(account.default_resource)
                         )
                         .map(account => ({
                             _id: account._id,
                             $set: {
-                                'default_pool': optimal_pool_id
+                                'default_resource': optimal_pool_id
                             }
                         }));
 

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -29,7 +29,7 @@ module.exports = {
         next_password_change: { date: true },
 
         // default policy for new buckets
-        default_pool: { objectid: true },
+        default_resource: { objectid: true },
         default_chunk_config: { objectid: true },
 
         allow_bucket_creation: { type: 'boolean' },

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -28,7 +28,6 @@ module.exports = {
         '_id',
         'system',
         'name',
-        'tiering',
         'versioning'
     ],
     properties: {
@@ -115,6 +114,7 @@ module.exports = {
                         path: { type: 'string' },
                     }
                 },
+                should_create_underlying_storage: { type: 'boolean' }, // should create underlying storage
                 caching: {
                     $ref: 'common_api#/definitions/bucket_cache_config'
                 },

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -165,17 +165,19 @@ function _aggregate_buckets_config(system) {
         current_config.versioning = cbucket.versioning;
         current_config.quota = Boolean(cbucket.quota);
         current_config.tiers = [];
-        for (const ctier of cbucket.tiering.tiers) {
-            let current_tier = _.find(system.tiers, t => ctier.tier === t.name);
-            if (current_tier) {
-                current_config.tiers.push({
-                    placement_type: current_tier.data_placement,
-                    mirrors: current_tier.mirror_groups.length,
-                    // spillover_enabled: Boolean(ctier.spillover && !ctier.disabled),
-                    replicas: current_tier.chunk_coder_config.replicas,
-                    data_frags: current_tier.chunk_coder_config.data_frags,
-                    parity_frags: current_tier.chunk_coder_config.parity_frags,
-                });
+        if (cbucket.tiering) {
+            for (const ctier of cbucket.tiering.tiers) {
+                let current_tier = _.find(system.tiers, t => ctier.tier === t.name);
+                if (current_tier) {
+                    current_config.tiers.push({
+                        placement_type: current_tier.data_placement,
+                        mirrors: current_tier.mirror_groups.length,
+                        // spillover_enabled: Boolean(ctier.spillover && !ctier.disabled),
+                        replicas: current_tier.chunk_coder_config.replicas,
+                        data_frags: current_tier.chunk_coder_config.data_frags,
+                        parity_frags: current_tier.chunk_coder_config.parity_frags,
+                    });
+                }
             }
         }
         bucket_config.push(current_config);

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -178,7 +178,7 @@ function new_system_defaults(name, owner_account_id) {
 }
 
 function new_system_changes(name, owner_account_id) {
-    // const default_pool_name = config.NEW_SYSTEM_POOL_NAME;
+    // const default_resource_name = config.NEW_SYSTEM_POOL_NAME;
     const default_bucket_name = 'first.bucket';
     const bucket_with_suffix = default_bucket_name + '#' + Date.now().toString(36);
 
@@ -192,7 +192,7 @@ function new_system_changes(name, owner_account_id) {
     });
     system.master_key_id = m_key._id;
 
-    // const pool = pool_server.new_pool_defaults(default_pool_name, system._id, 'HOSTS', 'BLOCK_STORE_FS');
+    // const pool = pool_server.new_pool_defaults(default_resource_name, system._id, 'HOSTS', 'BLOCK_STORE_FS');
     const internal_pool_name = `${config.INTERNAL_STORAGE_POOL_NAME}-${system._id}`;
     const mongo_pool = pool_server.new_pool_defaults(internal_pool_name, system._id, 'INTERNAL', 'BLOCK_STORE_MONGO');
     mongo_pool.mongo_pool_info = {};
@@ -410,7 +410,7 @@ async function _create_owner_account(
     must_change_password,
     account_id,
     system_id,
-    default_pool
+    default_resource
 ) {
     dbg.log0(`create_system: creating account for ${name}, ${email}`);
     const { token: auth_token } = await server_rpc.client.account.create_account({
@@ -423,7 +423,7 @@ async function _create_owner_account(
         new_system_parameters: {
             account_id: account_id.toString(),
             new_system_id: system_id.toString(),
-            default_pool: default_pool.toString(),
+            default_resource: default_resource.toString(),
             allowed_buckets: { full_permission: true },
         },
     });

--- a/src/server/system_services/tier_server.js
+++ b/src/server/system_services/tier_server.js
@@ -583,7 +583,7 @@ function find_bucket_by_tier(req) {
     }
 
     const bucket = _.find(system_store.data.buckets,
-        bkt => String(bkt.tiering._id) === String(policy._id)
+        bkt => bkt.tiering && String(bkt.tiering._id) === String(policy._id)
     );
 
     if (!bucket || bucket.deleting) {
@@ -837,8 +837,9 @@ function get_associated_tiering_policies(tier) {
 }
 
 function get_associated_buckets(policy) {
+    if (!policy) return [];
     const associated_buckets = _.filter(policy.system.buckets_by_name,
-        bucket => String(bucket.tiering._id) === String(policy._id));
+        bucket => bucket.tiering && String(bucket.tiering._id) === String(policy._id));
 
     return _.map(associated_buckets, bucket => bucket._id);
 }

--- a/src/test/lambda/dildos.js
+++ b/src/test/lambda/dildos.js
@@ -60,7 +60,7 @@ const dos_func = {
 const SP_EVENT = {
     "email": "new@aaa.com",
     "s3_access": true,
-    "default_pool": "london",
+    "default_resource": "london",
     "allowed_buckets": ['logs']
 };
 

--- a/src/test/system_tests/sanity_build_test.js
+++ b/src/test/system_tests/sanity_build_test.js
@@ -191,7 +191,7 @@ async function _create_accounts() {
         email: 'ac_nologin_hasaccess',
         has_login: false,
         s3_access: true,
-        default_pool: 'COMP-S3-V2-Resource',
+        default_resource: 'COMP-S3-V2-Resource',
         allowed_buckets: {
             full_permission: false,
             permission_list: [
@@ -207,7 +207,7 @@ async function _create_accounts() {
         has_login: false,
         must_change_password: true,
         s3_access: true,
-        default_pool: 'COMP-S3-V2-Resource',
+        default_resource: 'COMP-S3-V2-Resource',
         allowed_buckets: {
             full_permission: false,
             permission_list: ['first.bucket', 'ec.no.quota', 'replica.with.quota']
@@ -221,7 +221,7 @@ async function _create_accounts() {
         has_login: false,
         must_change_password: false,
         s3_access: true,
-        default_pool: 'COMP-S3-V2-Resource',
+        default_resource: 'COMP-S3-V2-Resource',
         allowed_buckets: { full_permission: true },
         allow_bucket_creation: true
     };
@@ -233,7 +233,7 @@ async function _create_accounts() {
         password: "c1QiGkl2",
         must_change_password: false,
         s3_access: true,
-        default_pool: 'COMP-S3-V2-Resource',
+        default_resource: 'COMP-S3-V2-Resource',
         allowed_buckets: { full_permission: true },
         allow_bucket_creation: true
     };
@@ -244,7 +244,7 @@ async function _create_accounts() {
         has_login: false,
         must_change_password: false,
         s3_access: true,
-        default_pool: 'COMP-S3-V2-Resource',
+        default_resource: 'COMP-S3-V2-Resource',
         allowed_buckets: { full_permission: true },
         allow_bucket_creation: true
     };

--- a/src/test/system_tests/test_bucket_access.js
+++ b/src/test/system_tests/test_bucket_access.js
@@ -46,7 +46,7 @@ const full_access_user = {
         full_permission: false,
         permission_list: ['bucket1', 'bucket2']
     },
-    default_pool: POOL_NAME
+    default_resource: POOL_NAME
 };
 
 const bucket1_user = {
@@ -58,7 +58,7 @@ const bucket1_user = {
         full_permission: false,
         permission_list: ['bucket1']
     },
-    default_pool: POOL_NAME
+    default_resource: POOL_NAME
 };
 
 const no_access_user = {

--- a/src/test/system_tests/test_bucket_lambda_triggers.js
+++ b/src/test/system_tests/test_bucket_lambda_triggers.js
@@ -51,7 +51,7 @@ let full_access_user = {
         full_permission: false,
         permission_list: ['bucket1', 'bucket2', 'ns.external.bucket1']
     },
-    default_pool: POOL_NAME,
+    default_resource: POOL_NAME,
 };
 
 let bucket1_user = {
@@ -64,7 +64,7 @@ let bucket1_user = {
         full_permission: false,
         permission_list: ['bucket1', 'ns.external.bucket1']
     },
-    default_pool: POOL_NAME,
+    default_resource: POOL_NAME,
 };
 
 const external_connection = {

--- a/src/test/system_tests/test_build_chunks.js
+++ b/src/test/system_tests/test_build_chunks.js
@@ -41,7 +41,7 @@ let TEST_CTX = {
     default_tier_name: 'test_tier',
     default_tier_policy_name: 'tiering1',
     cloud_pool_name: 'cloud-pool-aws',
-    accounts_default_pool: 'accounts_default_pool'
+    accounts_default_resource: 'accounts_default_resource'
 };
 
 let rpc = api.new_rpc(); //'ws://' + argv.ip + ':8080');

--- a/src/test/system_tests/test_ceph_s3.js
+++ b/src/test/system_tests/test_ceph_s3.js
@@ -485,12 +485,12 @@ async function ceph_test_setup() {
     const internal_pool = system.pools.filter(p => p.resource_type === 'INTERNAL');
     await client.account.create_account({
         ...CEPH_TEST.new_account_params,
-        default_pool: internal_pool.name
+        default_resource: internal_pool.name
     });
 
     await client.account.create_account({
         ...CEPH_TEST.new_account_params_tenant,
-        default_pool: internal_pool.name
+        default_resource: internal_pool.name
     });
     system = await client.system.read_system();
     const ceph_account = system.accounts.find(account =>

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -476,7 +476,7 @@ function set_pool_as_default_resource(pool_name) {
         update: {
             accounts: _.map(system_store.data.accounts, account => ({
                 _id: account._id,
-                default_pool: pool_id,
+                default_resource: pool_id,
             }))
         }
     });

--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -58,7 +58,7 @@ async function setup() {
         allowed_buckets: {
             full_permission: true,
         },
-        default_pool: POOL_LIST[0].name
+        default_resource: POOL_LIST[0].name
     };
     const admin_keys = (await rpc_client.account.read_account({
         email: EMAIL,

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -113,7 +113,7 @@ mocha.describe('system_servers', function() {
                 full_permission: false,
                 permission_list: []
             },
-            default_pool: DEFAULT_POOL_NAME
+            default_resource: DEFAULT_POOL_NAME
         });
         await rpc_client.system.read_system();
         await rpc_client.system.add_role({
@@ -147,7 +147,7 @@ mocha.describe('system_servers', function() {
                 full_permission: false,
                 permission_list: []
             },
-            default_pool: DEFAULT_POOL_NAME,
+            default_resource: DEFAULT_POOL_NAME,
             nsfs_account_config: {
                 uid: UID,
                 gid: GID,
@@ -163,7 +163,7 @@ mocha.describe('system_servers', function() {
                 full_permission: false,
                 permission_list: []
             },
-            default_pool: DEFAULT_POOL_NAME,
+            default_resource: DEFAULT_POOL_NAME,
             nsfs_account_config: {
                 uid: UID + 1,
                 gid: GID + 1,
@@ -179,7 +179,7 @@ mocha.describe('system_servers', function() {
                 full_permission: false,
                 permission_list: []
             },
-            default_pool: DEFAULT_POOL_NAME,
+            default_resource: DEFAULT_POOL_NAME,
         });
         await rpc_client.system.read_system();
         const accountlistnofilter = await rpc_client.account.list_accounts({});

--- a/src/upgrade/upgrade_scripts/5.9.0/upgrade_accounts_ns_resources.js
+++ b/src/upgrade/upgrade_scripts/5.9.0/upgrade_accounts_ns_resources.js
@@ -1,0 +1,31 @@
+/* Copyright (C) 2016 NooBaa */
+"use strict";
+
+async function run({ dbg, system_store, system_server}) {
+
+    try {
+        dbg.log0('starting upgrade accounts...');
+        const accounts = system_store.data.accounts
+            .map(a => a.default_pool && ({
+                _id: a._id,
+                $set: { default_resource: a.default_pool._id },
+                $unset: { default_pool: true }
+            }))
+            .filter(account => account);
+        if (accounts.length > 0) {
+            dbg.log0(`replacing account default_pool by default_resource: ${accounts.map(b => b._id).join(', ')}`);
+            await system_store.make_changes({ update: { accounts } });
+        } else {
+            dbg.log0('upgrade accounts: no upgrade needed...');
+        }
+    } catch (err) {
+        dbg.error('got error while upgrading accounts:', err);
+        throw err;
+    }
+}
+
+
+module.exports = {
+    run,
+    description: 'Update accounts default_pool to default_resource and namespace bucket structure'
+};


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. bucketspace_nb:
1.1.  in create_bucket() if default resource is namespace resource -> will mark `should_create_uls = true; ` in namespace bucket config -> create underlying storage (currently implememnted in namespace_fs only).
1.2. in delete_bucket()  if `should_create_uls = true; ` in namespace bucket config -> delete underlying storage (currently implememnted in namespace_fs only) 

2. renamed default_pool to default_resource.
3. Added s3 create and delete bucket on nsfs as default resource unit tests. 
4. removed tiering from being required in bucket schema + api since when having namespace resource as default resource, tiering is redundant and can not be configured.
5. Added new_buckets_path as a posssible argument for  create_account and update_account.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
