### PR TITLE
NSFS cleanup empty dirs on objects delete

### DIFF
--- a/src/test/unit_tests/test_ns_list_objects.js
+++ b/src/test/unit_tests/test_ns_list_objects.js
@@ -226,7 +226,7 @@ function test_ns_list_objects(ns, object_sdk, bucket) {
                 limit: 7,
             });
             assert.deepStrictEqual(r.is_truncated, false);
-            assert.deepStrictEqual(r.common_prefixes, folders_to_upload);
+            assert.deepStrictEqual(r.common_prefixes, []);
             assert.deepStrictEqual(r.objects.map(it => it.key), max_keys_objects);
         });
 


### PR DESCRIPTION
### Explain the changes

- Cleanup empty dirs on objects delete
- Add delete path to test_namespace_fs.js

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: #6425 

### Testing Instructions:
1. Create a file with a path (`/a/b/c/<filename>`)
2. Delete the file 
3. See that all the path was deleted.
4. Create 2 files: (`/a/b/c/<filename>` and `/a/<filename_2>`)
5. Delete the file `/a/b/c/<filename>`
6. See that only the empty path was deleted  and the `/a/<filename_2>` remains
