### PR TITLE
Backport to 5.7: fixing md5 for postgres_client.js in FIPS mode

### DIFF
--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const _ = require('lodash');
+require('../util/fips');
 
 const assert = require('assert');
 const Ajv = require('ajv');


### PR DESCRIPTION
- Fixing md5 for postgres_client.js in FIPS mode

Fixes: BZ1957639
Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit ec07dbf87149f6e788a25b18451960c5a10bf8c6)

