### PR TITLE
Ceph tests |  bumped max_days to 320

### DIFF
--- a/src/test/system_tests/ceph_s3_tests_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests_deploy.sh
@@ -29,7 +29,7 @@ commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}'
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
 
-max_days="270"
+max_days="320"
 if [ $((current_date-commit_date)) -gt $((3600*24*${max_days})) ]
 then
     echo "ceph tests were not updated for ${max_days} days, Exiting"


### PR DESCRIPTION
### Explain the changes
- Ceph tests |  bumped max_days to 320

Signed-off-by: liranmauda <liran.mauda@gmail.com>
