### PR TITLE
S3 GET/HEAD Object - support partNumber query #6138 

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -23,6 +23,14 @@ module.exports = {
             maximum: 10000
         },
 
+        object_range: {
+            type: 'object',
+            properties: {
+                start: { type: 'integer' },
+                end: { type: 'integer' },
+            }
+        },
+
         bucket_trigger_event: { // Based on AWS: https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#supported-notification-event-types
             enum: ['ObjectCreated', 'ObjectRemoved', 'ObjectRead', /* 'ObjectCreated:Put', 'ObjectCreated:CompleteMultipartUpload', ... */ ],
             type: 'string',

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -16,6 +16,13 @@ module.exports = {
 
     definitions: {
 
+
+        multipart: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 10000
+        },
+
         bucket_trigger_event: { // Based on AWS: https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#supported-notification-event-types
             enum: ['ObjectCreated', 'ObjectRemoved', 'ObjectRead', /* 'ObjectCreated:Put', 'ObjectCreated:CompleteMultipartUpload', ... */ ],
             type: 'string',

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -17,7 +17,7 @@ module.exports = {
     definitions: {
 
 
-        multipart: {
+        multipart_num: {
             type: 'integer',
             minimum: 1,
             maximum: 10000

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1384,8 +1384,13 @@ module.exports = {
                 num_multiparts: {
                     $ref: 'common_api#/definitions/multipart'
                 },
-                multipart_start: { type: 'integer' },
-                multipart_end: { type: 'integer' },
+                multipart_range: {
+                    type: 'object',
+                    properties: {
+                        start: { type: 'integer' },
+                        end: { type: 'integer' },
+                    }
+                },
                 content_type: { type: 'string' },
                 content_encoding: { type: 'string' },
                 create_time: { idate: true },

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -152,7 +152,7 @@ module.exports = {
                             required: ['num', 'etag'],
                             properties: {
                                 num: {
-                                    $ref: 'common_api#/definitions/multipart'
+                                    $ref: 'common_api#/definitions/multipart_num'
                                 },
                                 etag: {
                                     type: 'string'
@@ -221,7 +221,7 @@ module.exports = {
                         type: 'string',
                     },
                     num: {
-                        $ref: 'common_api#/definitions/multipart'
+                        $ref: 'common_api#/definitions/multipart_num'
                     },
                     size: {
                         type: 'integer',
@@ -274,7 +274,7 @@ module.exports = {
                         type: 'string',
                     },
                     num: {
-                        $ref: 'common_api#/definitions/multipart'
+                        $ref: 'common_api#/definitions/multipart_num'
                     },
                     multipart_id: {
                         objectid: true
@@ -362,7 +362,7 @@ module.exports = {
                             ],
                             properties: {
                                 num: {
-                                    $ref: 'common_api#/definitions/multipart'
+                                    $ref: 'common_api#/definitions/multipart_num'
                                 },
                                 size: {
                                     type: 'integer'
@@ -570,7 +570,7 @@ module.exports = {
                     key: { type: 'string' },
                     md_conditions: { $ref: '#/definitions/md_conditions' },
                     multipart_number: {
-                        $ref: 'common_api#/definitions/multipart'
+                        $ref: 'common_api#/definitions/multipart_num'
                     },
                     encryption: { $ref: 'common_api#/definitions/object_encryption' },
                     adminfo: {
@@ -1382,7 +1382,7 @@ module.exports = {
                 delete_marker: { type: 'boolean' },
                 num_parts: { type: 'integer' },
                 num_multiparts: {
-                    $ref: 'common_api#/definitions/multipart'
+                    $ref: 'common_api#/definitions/multipart_num'
                 },
                 multipart_range: {
                     type: 'object',

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -152,9 +152,7 @@ module.exports = {
                             required: ['num', 'etag'],
                             properties: {
                                 num: {
-                                    type: 'integer',
-                                    minimum: 1,
-                                    maximum: 10000
+                                    $ref: 'common_api#/definitions/multipart'
                                 },
                                 etag: {
                                     type: 'string'
@@ -223,9 +221,7 @@ module.exports = {
                         type: 'string',
                     },
                     num: {
-                        type: 'integer',
-                        minimum: 1,
-                        maximum: 10000
+                        $ref: 'common_api#/definitions/multipart'
                     },
                     size: {
                         type: 'integer',
@@ -278,9 +274,7 @@ module.exports = {
                         type: 'string',
                     },
                     num: {
-                        type: 'integer',
-                        minimum: 1,
-                        maximum: 10000
+                        $ref: 'common_api#/definitions/multipart'
                     },
                     multipart_id: {
                         objectid: true
@@ -368,9 +362,7 @@ module.exports = {
                             ],
                             properties: {
                                 num: {
-                                    type: 'integer',
-                                    minimum: 1,
-                                    maximum: 10000
+                                    $ref: 'common_api#/definitions/multipart'
                                 },
                                 size: {
                                     type: 'integer'
@@ -578,9 +570,7 @@ module.exports = {
                     key: { type: 'string' },
                     md_conditions: { $ref: '#/definitions/md_conditions' },
                     multipart_number: {
-                        type: 'integer',
-                        minimum: 1,
-                        maximum: 10000
+                        $ref: 'common_api#/definitions/multipart'
                     },
                     encryption: { $ref: 'common_api#/definitions/object_encryption' },
                     adminfo: {
@@ -1392,9 +1382,7 @@ module.exports = {
                 delete_marker: { type: 'boolean' },
                 num_parts: { type: 'integer' },
                 num_multiparts: {
-                    type: 'integer',
-                    minimum: 1,
-                    maximum: 10000
+                    $ref: 'common_api#/definitions/multipart'
                 },
                 multipart_start: { type: 'integer' },
                 multipart_end: { type: 'integer' },

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -152,7 +152,9 @@ module.exports = {
                             required: ['num', 'etag'],
                             properties: {
                                 num: {
-                                    type: 'integer'
+                                    type: 'integer',
+                                    minimum: 1,
+                                    maximum: 10000
                                 },
                                 etag: {
                                     type: 'string'
@@ -222,6 +224,8 @@ module.exports = {
                     },
                     num: {
                         type: 'integer',
+                        minimum: 1,
+                        maximum: 10000
                     },
                     size: {
                         type: 'integer',
@@ -275,6 +279,8 @@ module.exports = {
                     },
                     num: {
                         type: 'integer',
+                        minimum: 1,
+                        maximum: 10000
                     },
                     multipart_id: {
                         objectid: true
@@ -362,7 +368,9 @@ module.exports = {
                             ],
                             properties: {
                                 num: {
-                                    type: 'integer'
+                                    type: 'integer',
+                                    minimum: 1,
+                                    maximum: 10000
                                 },
                                 size: {
                                     type: 'integer'
@@ -569,6 +577,11 @@ module.exports = {
                     bucket: { $ref: 'common_api#/definitions/bucket_name' },
                     key: { type: 'string' },
                     md_conditions: { $ref: '#/definitions/md_conditions' },
+                    multipart_number: {
+                        type: 'integer',
+                        minimum: 1,
+                        maximum: 10000
+                    },
                     encryption: { $ref: 'common_api#/definitions/object_encryption' },
                     adminfo: {
                         type: 'object',
@@ -1378,6 +1391,13 @@ module.exports = {
                 is_latest: { type: 'boolean' },
                 delete_marker: { type: 'boolean' },
                 num_parts: { type: 'integer' },
+                num_multiparts: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: 10000
+                },
+                multipart_start: { type: 'integer' },
+                multipart_end: { type: 'integer' },
                 content_type: { type: 'string' },
                 content_encoding: { type: 'string' },
                 create_time: { idate: true },

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1385,11 +1385,7 @@ module.exports = {
                     $ref: 'common_api#/definitions/multipart_num'
                 },
                 multipart_range: {
-                    type: 'object',
-                    properties: {
-                        start: { type: 'integer' },
-                        end: { type: 'integer' },
-                    }
+                    $ref: 'common_api#/definitions/object_range'
                 },
                 content_type: { type: 'string' },
                 content_encoding: { type: 'string' },

--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -81,6 +81,7 @@ async function get_object(req, res) {
         if (read_stream && read_stream.close) read_stream.close();
     });
 
+    dbg.log0('BAUM get_object response:', res);
     read_stream = await req.object_sdk.read_object_stream(params, res);
     if (read_stream) {
         read_stream.on('error', err => {

--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -55,7 +55,7 @@ async function get_object(req, res) {
     if (multipart_number) {
         params.multipart_number = multipart_number;
     }
-    s3_utils.s3_range(req, res, object_md, obj_size, params);
+    s3_utils.set_response_range(req, res, object_md, obj_size, params);
 
     // first_range_data are the first 4K data of the object
     // if the object's size or the end of range is smaller than 4K return it, else get the whole object

--- a/src/endpoint/s3/ops/s3_head_object.js
+++ b/src/endpoint/s3/ops/s3_head_object.js
@@ -1,7 +1,7 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-// const S3Error = require('../s3_errors').S3Error;
+const dbg = require('../../../util/debug_module')(__filename);
 const s3_utils = require('../s3_utils');
 const http_utils = require('../../../util/http_utils');
 const S3Error = require('../s3_errors').S3Error;
@@ -19,15 +19,39 @@ async function head_object(req, res) {
         encryption
     };
     if (req.query.partNumber) {
-        params.part_number = s3_utils.parse_part_number(req.query.partNumber, S3Error.InvalidArgument);
+        params.multipart_number = s3_utils.parse_part_number(req.query.partNumber, S3Error.InvalidArgument);
     }
     if (req.query.get_from_cache !== undefined) {
         params.get_from_cache = true;
     }
     const object_md = await req.object_sdk.read_object_md(params);
+    const obj_size = object_md.size;
 
     s3_utils.set_response_object_md(res, object_md);
     s3_utils.set_encryption_response_headers(req, res, object_md.encryption);
+    try {
+        // A 'ranged' GET/HEAD is performed if a  "part number"
+        // is specified in the S3 query or alternatively,
+        // ranges could be specified in HTTP header
+        const range = s3_utils.get_object_range(req, object_md);
+
+        // If range is specified, set it in the HTTP response headers
+        if (range) s3_utils.set_range_response_headers(req, res, range, obj_size);
+    } catch (err) {
+        if (err.ranges_code === 400) {
+            // return http 400 Bad Request
+            dbg.log1('bad range request', req.headers.range, req.path, obj_size);
+            throw new S3Error(S3Error.InvalidArgument);
+        }
+        if (err.ranges_code === 416) {
+            // return http 416 Requested Range Not Satisfiable
+            dbg.warn('invalid range', req.headers.range, req.path, obj_size);
+            // let the client know of the relevant range
+            res.setHeader('Content-Range', 'bytes */' + obj_size);
+            throw new S3Error(S3Error.InvalidRange);
+        }
+        throw err;
+    }
 }
 
 module.exports = {

--- a/src/endpoint/s3/ops/s3_head_object.js
+++ b/src/endpoint/s3/ops/s3_head_object.js
@@ -1,7 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const dbg = require('../../../util/debug_module')(__filename);
 const s3_utils = require('../s3_utils');
 const http_utils = require('../../../util/http_utils');
 const S3Error = require('../s3_errors').S3Error;
@@ -29,29 +28,7 @@ async function head_object(req, res) {
 
     s3_utils.set_response_object_md(res, object_md);
     s3_utils.set_encryption_response_headers(req, res, object_md.encryption);
-    try {
-        // A 'ranged' GET/HEAD is performed if a  "part number"
-        // is specified in the S3 query or alternatively,
-        // ranges could be specified in HTTP header
-        const range = s3_utils.get_object_range(req, object_md);
-
-        // If range is specified, set it in the HTTP response headers
-        if (range) s3_utils.set_range_response_headers(req, res, range, obj_size);
-    } catch (err) {
-        if (err.ranges_code === 400) {
-            // return http 400 Bad Request
-            dbg.log1('bad range request', req.headers.range, req.path, obj_size);
-            throw new S3Error(S3Error.InvalidArgument);
-        }
-        if (err.ranges_code === 416) {
-            // return http 416 Requested Range Not Satisfiable
-            dbg.warn('invalid range', req.headers.range, req.path, obj_size);
-            // let the client know of the relevant range
-            res.setHeader('Content-Range', 'bytes */' + obj_size);
-            throw new S3Error(S3Error.InvalidRange);
-        }
-        throw err;
-    }
+    s3_utils.s3_range(req, res, object_md, obj_size);
 }
 
 module.exports = {

--- a/src/endpoint/s3/ops/s3_head_object.js
+++ b/src/endpoint/s3/ops/s3_head_object.js
@@ -28,7 +28,7 @@ async function head_object(req, res) {
 
     s3_utils.set_response_object_md(res, object_md);
     s3_utils.set_encryption_response_headers(req, res, object_md.encryption);
-    s3_utils.s3_range(req, res, object_md, obj_size);
+    s3_utils.set_response_range(req, res, object_md, obj_size);
 }
 
 module.exports = {

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -293,8 +293,12 @@ function set_range_response_headers(req, res, range, obj_size) {
  */
 function get_object_range(req, object_md) {
     // S3 part number
-    if (req.query.partNumber && object_md.multipart_start !== undefined && object_md.multipart_end !== undefined) {
-        return { start: object_md.multipart_start, end: object_md.multipart_end };
+    if (req.query.partNumber) {
+        if (object_md.multipart_start !== undefined && object_md.multipart_end !== undefined) {
+            return { start: object_md.multipart_start, end: object_md.multipart_end };
+        } else {
+            throw new S3Error(S3Error.InvalidRange);
+        }
     // HTTP headers ranges
     } else {
         const ranges = http_utils.normalize_http_ranges(

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -684,7 +684,7 @@ function _is_statements_fit(statements, account, method, arn_path) {
     return false;
 }
 
-function s3_range(req, res, object_md, obj_size, params) {
+function set_response_range(req, res, object_md, obj_size, params) {
     try {
         // A 'ranged' GET/HEAD is performed if a  "part number"
         // is specified in the S3 query or alternatively,
@@ -749,4 +749,4 @@ exports.get_http_response_from_resp = get_http_response_from_resp;
 exports.get_http_response_date = get_http_response_date;
 exports.has_bucket_policy_permission = has_bucket_policy_permission;
 exports.XATTR_SORT_SYMBOL = XATTR_SORT_SYMBOL;
-exports.s3_range = s3_range;
+exports.set_response_range = set_response_range;

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -293,12 +293,8 @@ function set_range_response_headers(req, res, range, obj_size) {
  */
 function get_object_range(req, object_md) {
     // S3 part number
-    if (req.query.partNumber) {
-        if (object_md.multipart_start !== undefined && object_md.multipart_end !== undefined) {
-            return { start: object_md.multipart_start, end: object_md.multipart_end };
-        } else {
-            throw new S3Error(S3Error.InvalidRange);
-        }
+    if (req.query.partNumber && object_md.multipart_start !== undefined && object_md.multipart_end !== undefined) {
+        return { start: object_md.multipart_start, end: object_md.multipart_end };
     // HTTP headers ranges
     } else {
         const ranges = http_utils.normalize_http_ranges(

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -293,8 +293,12 @@ function set_range_response_headers(req, res, range, obj_size) {
  */
 function get_object_range(req, object_md) {
     // S3 part number
-    if (req.query.partNumber && object_md.multipart_start !== undefined && object_md.multipart_end !== undefined) {
-        return { start: object_md.multipart_start, end: object_md.multipart_end };
+    if (req.query.partNumber &&
+        object_md.multipart_range &&
+        object_md.multipart_range.start !== undefined &&
+        object_md.multipart_range.end !== undefined) {
+        return { start: object_md.multipart_range.start,
+                 end: object_md.multipart_range.end };
     // HTTP headers ranges
     } else {
         const ranges = http_utils.normalize_http_ranges(

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -212,10 +212,10 @@ class NamespaceCache {
         let object_info_cache = null;
         let cache_etag = '';
         const get_from_cache = params.get_from_cache;
-        // part_number is set to the query parameter partNumber in s3 request. If set,
+        // multipart_number is set to the query parameter partNumber in s3 request. If set,
         // it should be a positive integer between 1 and 10,000. We will bypass cache
         // and proxy request to hub.
-        if (!params.part_number) {
+        if (!params.multipart_number) {
             // partNumber is not set
             try {
                 // Remove get_from_cache if exists for maching RPC schema
@@ -544,10 +544,10 @@ class NamespaceCache {
 
 
     async read_object_stream(params, object_sdk) {
-        // part_number is set to the query parameter partNumber in request. If set,
+        // multipart_number is set to the query parameter partNumber in request. If set,
         // it should be a positive integer between 1 and 10,000. We will perform a 'ranged'
         // GET request for the part specified.
-        if (params.part_number) {
+        if (params.multipart_number) {
             // If the query parameter partNumber is set, the object was most likely
             // created by the multipart upload. Since we don't support MP in cache,
             // we proxy the read to hub.

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -73,9 +73,6 @@ class NamespaceNB {
 
     read_object_md(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        // Noobaa bucket does not currrently support partNumber query parameter. Ignore it for now.
-        // If set, part_number is positive integer from 1 to 10000
-        if (params.part_number) _.unset(params, 'part_number');
         return object_sdk.rpc_client.object.read_object_md(params);
     }
 
@@ -86,9 +83,6 @@ class NamespaceNB {
             client: object_sdk.rpc_client,
             bucket: this.target_bucket,
         }, params);
-        // Noobaa bucket does not currrently support partNumber query parameter. Ignore it for now.
-        // If set, part_number is positive integer from 1 to 10000
-        if (params.part_number) _.unset(params, 'part_number');
         const active_triggers = this.get_triggers_for_bucket(params.bucket);
         const load_for_trigger = !params.noobaa_trigger_agent && object_sdk.should_run_triggers({
             active_triggers,

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -162,7 +162,10 @@ class NamespaceS3 {
             this._assign_encryption_to_request(params, request);
             let res;
             try {
-                res = can_use_get_inline ?
+                // params.multipart_number was added, since head
+                // does not return Content-Range, which is needed
+                // for GetObject with part num.
+                res = (can_use_get_inline || params.multipart_number) ?
                     await this.s3.getObject(request).promise() :
                     await this.s3.headObject(request).promise();
             } catch (err) {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -370,8 +370,10 @@ interface ObjectMD {
     size: number;
     num_parts: number;
     num_multiparts?: number;
-    multipart_start?: number;
-    multipart_end?: number;
+    multipart_range: {
+        start?: number;
+        end?: number;
+    };
     content_type: string;
     content_encoding?: string;
     upload_size?: number;
@@ -399,8 +401,10 @@ interface ObjectInfo {
     delete_marker?: boolean;
     size: number;
     num_parts: number;
-    multipart_start?: number;
-    multipart_end?: number;
+    multipart_range: {
+        start?: number;
+        end?: number;
+    };
     content_type: string;
     content_encoding?: string;
     upload_size?: number;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -369,6 +369,9 @@ interface ObjectMD {
     delete_marker?: boolean;
     size: number;
     num_parts: number;
+    num_multiparts: number;
+    multipart_start?: number;
+    multipart_end?: number;
     content_type: string;
     content_encoding?: string;
     upload_size?: number;
@@ -396,6 +399,8 @@ interface ObjectInfo {
     delete_marker?: boolean;
     size: number;
     num_parts: number;
+    multipart_start?: number;
+    multipart_end?: number;
     content_type: string;
     content_encoding?: string;
     upload_size?: number;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -369,7 +369,7 @@ interface ObjectMD {
     delete_marker?: boolean;
     size: number;
     num_parts: number;
-    num_multiparts: number;
+    num_multiparts?: number;
     multipart_start?: number;
     multipart_end?: number;
     content_type: string;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -394,6 +394,7 @@ class ObjectSDK {
 
     async read_object_stream(params, res) {
         const ns = await this._get_bucket_namespace(params.bucket);
+        dbg.log("BAUM object_sdk read_object_stream response ", res);
         const reply = await ns.read_object_stream(params, this, res);
         // update bucket counters
         stats_collector.instance(this.internal_rpc_client).update_bucket_read_counters({

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -908,6 +908,23 @@ class MDStore {
 
     /**
      * @param {nb.ID} obj_id
+     * @returns {Promise<nb.ObjectMultipart[]>}
+     */
+    async find_commited_multiparts_of_object(obj_id) {
+        return this._multiparts.find({ obj: obj_id, deleted: null, uncommitted: null });
+    }
+
+    /**
+     * @param {nb.ID} obj_id
+     * @param part_number integer in 1..10000 range (S3 part number)
+     * @returns {Promise<nb.ObjectMultipart[]>}
+     */
+    async find_multiparts_of_object_lte_number(obj_id, part_number) {
+        return this._multiparts.find({ obj: obj_id, deleted: null, num: { $lte: part_number } });
+    }
+
+    /**
+     * @param {nb.ID} obj_id
      * @param {number} [num_gt]
      * @param {number} [limit]
      * @returns {Promise<nb.ObjectMultipart[]>}

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -910,8 +910,8 @@ class MDStore {
      * @param {nb.ID} obj_id
      * @returns {Promise<nb.ObjectMultipart[]>}
      */
-    async find_commited_multiparts_of_object(obj_id) {
-        return this._multiparts.find({ obj: obj_id, deleted: null, uncommitted: null });
+    async count_commited_multiparts_of_object(obj_id) {
+        return this._multiparts.count({ obj: obj_id, deleted: null, uncommitted: null });
     }
 
     /**

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1369,8 +1369,7 @@ function get_object_info(md, options = {}) {
         upload_size: _.isNumber(md.upload_size) ? md.upload_size : undefined,
         num_parts: md.num_parts,
         num_multiparts: md.num_multiparts,
-        multipart_start: md.multipart_start,
-        multipart_end: md.multipart_end,
+        multipart_range: md.multipart_range,
         version_id: bucket.versioning === 'DISABLED' ? undefined : MDStore.instance().get_object_version_id(md),
         lock_settings: config.WORM_ENABLED && options.role === 'admin' ? md.lock_settings : undefined,
         is_latest: !md.version_past,
@@ -1444,11 +1443,10 @@ async function calculate_multipart_range(multipart_number, obj) {
     // fetch the multiparts of this obj which are lte(<=) the requested part number
     // TODO: store the range inside each multipart in _complete_object_multiparts() so we can read just the requested multipart here
     const multiparts = await MDStore.instance().find_multiparts_of_object_lte_number(obj._id, multipart_number);
-    obj.multipart_start = 0;
-    obj.multipart_end = 0;
+    obj.multipart_range = {start: 0, end: 0};
     for (const mp of multiparts) {
-        if (mp.num < multipart_number) obj.multipart_start += mp.size;
-        obj.multipart_end += mp.size;
+        if (mp.num < multipart_number) obj.multipart_range.start += mp.size;
+        obj.multipart_range.end += mp.size;
     }
 }
 

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1368,6 +1368,9 @@ function get_object_info(md, options = {}) {
         upload_started: md.upload_started ? md.upload_started.getTimestamp().getTime() : undefined,
         upload_size: _.isNumber(md.upload_size) ? md.upload_size : undefined,
         num_parts: md.num_parts,
+        num_multiparts: md.num_multiparts,
+        multipart_start: md.multipart_start,
+        multipart_end: md.multipart_end,
         version_id: bucket.versioning === 'DISABLED' ? undefined : MDStore.instance().get_object_version_id(md),
         lock_settings: config.WORM_ENABLED && options.role === 'admin' ? md.lock_settings : undefined,
         is_latest: !md.version_past,
@@ -1421,7 +1424,48 @@ async function find_object_md(req) {
         obj = await MDStore.instance().find_object_latest(req.bucket._id, req.rpc_params.key);
     }
     check_object_mode(req, obj, 'NO_SUCH_OBJECT');
+
+    // if part number was specified in the S3 Query
+    if (req.rpc_params.multipart_number) {
+        await calculate_multipart_range(req.rpc_params.multipart_number, obj);
+        if (!obj.num_multiparts) await calculate_num_multiparts(obj);
+    }
+
     return obj;
+}
+
+/**
+ * calculate (start, end) range of the specified multipart_number
+ *
+ * @param multipart_number integer in 1..10000 range
+ * @param {nb.ObjectMD} obj
+ */
+async function calculate_multipart_range(multipart_number, obj) {
+    // fetch the multiparts of this obj which are lte(<=) the requested part number
+    // TODO: store the range inside each multipart in _complete_object_multiparts() so we can read just the requested multipart here
+    const multiparts = await MDStore.instance().find_multiparts_of_object_lte_number(obj._id, multipart_number);
+    obj.multipart_start = 0;
+    obj.multipart_end = 0;
+    for (const mp of multiparts) {
+        if (mp.num < multipart_number) obj.multipart_start += mp.size;
+        obj.multipart_end += mp.size;
+    }
+}
+
+/**
+ * Lazily calculate the number of object's multiparts from the multiparts in the DB
+ * and populate the object num_multiparts field in object md DB
+ *
+ * @param {nb.ObjectMD} obj
+ */
+ async function calculate_num_multiparts(obj) {
+    // fetch the commited multiparts of this obj
+    const multiparts = await MDStore.instance().find_commited_multiparts_of_object(obj._id);
+    if (multiparts.length) {
+        obj.num_multiparts = multiparts.length;
+
+        await MDStore.instance().update_object_by_id(obj._id, { num_multiparts: obj.num_multiparts });
+    }
 }
 
 /**
@@ -1955,6 +1999,7 @@ async function _complete_object_multiparts(obj, multipart_req) {
     await Promise.all([
         context.parts_updates.length && MDStore.instance().update_parts_in_bulk(context.parts_updates),
         used_multiparts_ids.length && MDStore.instance().update_multiparts_by_ids(used_multiparts_ids, undefined, { uncommitted: 1 }),
+        used_multiparts_ids.length && MDStore.instance().update_object_by_id(obj._id, { num_multiparts: used_multiparts_ids.length }),
         unused_parts.length && MDStore.instance().delete_parts(unused_parts),
         unused_multiparts.length && MDStore.instance().delete_multiparts(unused_multiparts),
         chunks_to_dereference.length && map_deleter.delete_chunks_if_unreferenced(chunks_to_dereference),

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1460,9 +1460,9 @@ async function calculate_multipart_range(multipart_number, obj) {
  */
  async function calculate_num_multiparts(obj) {
     // fetch the commited multiparts of this obj
-    const multiparts = await MDStore.instance().find_commited_multiparts_of_object(obj._id);
-    if (multiparts.length) {
-        obj.num_multiparts = multiparts.length;
+    const multiparts_count = await MDStore.instance().count_commited_multiparts_of_object(obj._id);
+    if (multiparts_count) {
+        obj.num_multiparts = multiparts_count;
 
         await MDStore.instance().update_object_by_id(obj._id, { num_multiparts: obj.num_multiparts });
     }

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -68,6 +68,10 @@ module.exports = {
         // NOTE: only updated once upload ends
         num_parts: { type: 'integer' },
 
+        // number of objects S3 multiparts for the object created by multipart upload
+        // NOTE: only updated once the upload of all parts is completed
+        num_multiparts: { type: 'integer' },
+
         // MIME
         content_type: { type: 'string' },
 

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -70,6 +70,9 @@ module.exports = {
 
         // number of objects S3 multiparts for the object created by multipart upload
         // NOTE: only updated once the upload of all parts is completed
+        //       or lazy update in calculate_num_multiparts upon reads
+        //       if upgraded from older version which does not support
+        //       partNumber in GET/HEAD
         num_multiparts: { type: 'integer' },
 
         // MIME

--- a/src/test/system_tests/test_get_object_part.js
+++ b/src/test/system_tests/test_get_object_part.js
@@ -1,0 +1,129 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const assert = require('assert');
+const AWS = require('aws-sdk');
+const crypto = require('crypto');
+
+// expected inputs
+assert(process.env.AWS_BUCKET, "Please set AWS_BUCKET env. variable, example 'first.bucket'");
+assert(process.env.AWS_ENDPOINT, "Please set AWS_ENDPOINT env. variable, example 'https://s3.amazonaws.com/'");
+assert(process.env.AWS_ACCESS_KEY_ID, "Please set AWS_ACCESS_KEY_ID env. variable, example 'XXXXXXXXXXXXXXXXXXXX'");
+assert(process.env.AWS_SECRET_ACCESS_KEY, "Please set AWS_SECRET_ACCESS_KEY env. variable, example 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'");
+
+const s3 = new AWS.S3({
+    endpoint: process.env.AWS_ENDPOINT, // 'https://s3.amazonaws.com/',
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+});
+
+async function main() {
+    const buckets = await s3.listBuckets().promise();
+    console.log('buckets', buckets);
+    assert(buckets.Buckets);
+
+    const Key = `test-get-object-part-${Date.now()}`;
+    const Bucket = process.env.AWS_BUCKET;
+    const part_size = 1024 * 1024 * 16;
+    const part1_range_expected = `bytes 0-${part_size - 1}/${part_size * 2}`;
+    // eslint-disable-next-line no-mixed-operators
+    const part2_range_expected = `bytes ${part_size}-${part_size * 2 - 1}/${part_size * 2}`;
+
+
+    const mp_init = await s3.createMultipartUpload({
+        Bucket,
+        Key,
+    }).promise();
+
+    const UploadId = mp_init.UploadId;
+    assert(UploadId);
+    console.log('created multipart upload', mp_init);
+
+    // upload 2 parts
+    const body1 = crypto.randomBytes(part_size);
+    const upload_part1 = await s3.uploadPart({
+        Bucket,
+        Key,
+        UploadId,
+        Body: body1,
+        PartNumber: 1
+    }).promise();
+    assert(upload_part1.ETag);
+    console.log('uploaded part 1', upload_part1);
+
+    const body2 = crypto.randomBytes(part_size);
+    const upload_part2 = await s3.uploadPart({
+        Bucket,
+        Key,
+        UploadId,
+        Body: body2,
+        PartNumber: 2
+    }).promise();
+    assert(upload_part1.ETag);
+    console.log('uploaded part 2', upload_part2);
+
+    const complete = await s3.completeMultipartUpload({
+        Bucket,
+        Key,
+        UploadId,
+        MultipartUpload: {
+            Parts: [{
+                ETag: upload_part1.ETag,
+                PartNumber: 1
+            }, {
+                ETag: upload_part2.ETag,
+                PartNumber: 2
+            }]
+        }
+    }).promise();
+    assert(complete.ETag);
+    console.log('completed multipart upload', complete);
+
+    const part1_req = {
+        Bucket,
+        Key,
+        PartNumber: 1
+    };
+    const head_part1 = await s3.headObject(part1_req).promise();
+    console.log('head part 1', head_part1);
+    assert(head_part1.ContentLength === part_size);
+    assert(head_part1.PartsCount === 2);
+
+    const get_part1 = await s3.getObject(part1_req).promise();
+    console.log('get part 1', get_part1);
+    assert(get_part1.ContentLength === part_size);
+    assert(get_part1.ContentRange === part1_range_expected);
+    // @ts-ignore
+    assert(body1.equals(get_part1.Body));
+
+    const part2_req = {
+        Bucket,
+        Key,
+        PartNumber: 2
+    };
+    const head_part2 = await s3.headObject(part2_req).promise();
+    console.log('head part 2', head_part2);
+    assert(head_part2.ContentLength === part_size);
+    assert(head_part2.PartsCount === 2);
+
+    const get_part2 = await s3.getObject(part2_req).promise();
+    console.log('get part 2', get_part2);
+    assert(get_part2.ContentLength === part_size);
+    assert(get_part2.ContentRange === part2_range_expected);
+    // @ts-ignore
+    assert(body2.equals(get_part2.Body));
+
+
+    // clean up
+    await s3.deleteObject({
+        Bucket,
+        Key
+    }).promise();
+    console.log('delete test object key', Key);
+
+    console.log('✅ The test was completed successfully');
+}
+
+if (require.main === module) {
+    main();
+}

--- a/src/test/unit_tests/test_namespace_cache.js
+++ b/src/test/unit_tests/test_namespace_cache.js
@@ -741,7 +741,7 @@ mocha.describe('namespace caching: proxy get request with partNumber query to hu
         const params = {
             bucket: obj.bucket,
             key: obj.key,
-            part_number: 1,
+            multipart_number: 1,
         };
 
         params.object_md = await ns_cache.read_object_md(params, object_sdk);


### PR DESCRIPTION
Effectively performs a 'ranged' GET request for the part specified.

    1. Include the requested multipart range in metadata as optional fields in ObjectMD/ObjectInfo.
    2. In Object service layer, while finding the object's metadata, calculate the multipart range
       using MDStore if a partNumber was requested in the S3 getObject query.
    3. In S3 Op layer, initiate a 'ranged' GET either if  partNumber
       was specified in the S3 ObjectGET query or alternatively, if ranges
       were specified in HTTP header.
    4. Remove namespace_nb part_number logic.
    5. Add system test for head/get object part functionality.
    6. Add CI unit test for head/get object part functionality which verifies NooBaa,
       Namespace & Namespace-Cache buckets.


### Issues: Fixed: #6138

### Testing Instructions:
> cd src/test/system_tests
> node test_get_object_part.js