### PR TITLE
Added bucket id to NSFS_TEMP_DIR_NAME per bucket

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1130,6 +1130,9 @@ module.exports = {
                 'name', 'system_owner', 'bucket_owner'
             ],
             properties: {
+                _id: {
+                    objectid: true
+                },
                 name: {
                     $ref: 'common_api#/definitions/bucket_name'
                 },

--- a/src/core/nsfs.js
+++ b/src/core/nsfs.js
@@ -97,7 +97,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         object_sdk._get_bucket_namespace = async bucket_name => {
             const existing_ns = namespaces[bucket_name];
             if (existing_ns) return existing_ns;
-            const ns_fs = new NamespaceFS({ bucket_path: fs_root + '/' + bucket_name });
+            const ns_fs = new NamespaceFS({ bucket_path: fs_root + '/' + bucket_name, bucket_id: '000000000000000000000000' });
             namespaces[bucket_name] = ns_fs;
             return ns_fs;
         };

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -181,7 +181,7 @@ class ObjectSDK {
             // NAMESPACE_FS HACK
             if (process.env.NAMESPACE_FS) {
                 return {
-                    ns: new NamespaceFS({ bucket_path: process.env.NAMESPACE_FS + '/' + bucket.name }),
+                    ns: new NamespaceFS({ bucket_path: process.env.NAMESPACE_FS + '/' + bucket.name, bucket_id: String(bucket._id) }),
                     bucket,
                     valid_until: time + (100 * 356 * 24 * 3600 * 1000), // 100 years
                 };
@@ -202,7 +202,7 @@ class ObjectSDK {
                 }
                 if (bucket.namespace.write_resource && _.isEqual(bucket.namespace.read_resources, [bucket.namespace.write_resource])) {
                     return {
-                        ns: this._setup_single_namespace(_.extend({}, bucket.namespace.write_resource)),
+                        ns: this._setup_single_namespace(_.extend({}, bucket.namespace.write_resource), bucket._id),
                         bucket,
                         valid_until: time + config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS,
                     };
@@ -253,7 +253,7 @@ class ObjectSDK {
         });
     }
 
-    _setup_single_namespace(namespace_resource_config) {
+    _setup_single_namespace(namespace_resource_config, bucket_id) {
         const ns_info = namespace_resource_config.resource;
         if (ns_info.endpoint_type === 'NOOBAA') {
             if (ns_info.target_bucket) {
@@ -300,7 +300,8 @@ class ObjectSDK {
         if (ns_info.fs_root_path) {
             return new NamespaceFS({
                 fs_backend: ns_info.fs_backend,
-                bucket_path: path.join(namespace_resource_config.resource.fs_root_path, namespace_resource_config.path || '')
+                bucket_path: path.join(namespace_resource_config.resource.fs_root_path, namespace_resource_config.path || ''),
+                bucket_id: String(bucket_id)
             });
         }
         // TODO: Should convert to cp_code and target_bucket as folder inside

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -477,6 +477,7 @@ async function read_bucket_sdk_info(req) {
     const system = req.system;
 
     const reply = {
+        _id: bucket._id,
         name: bucket.name,
         website: bucket.website,
         s3_policy: bucket.s3_policy,

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -35,8 +35,8 @@ mocha.describe('namespace_fs', function() {
     const ns_src_bucket_path = `./${src_bkt}`;
     const ns_tmp_bucket_path = `${tmp_fs_path}/${src_bkt}`;
 
-    const ns_src = new NamespaceFS({ bucket_path: ns_src_bucket_path });
-    const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path });
+    const ns_src = new NamespaceFS({ bucket_path: ns_src_bucket_path, bucket_id: '1'});
+    const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path, bucket_id: '2'});
 
     mocha.before(async () => {
         await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
@@ -413,7 +413,7 @@ mocha.describe('namespace_fs copy object', function() {
 
     const ns_tmp_bucket_path = `${tmp_fs_path}/${src_bkt}`;
 
-    const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path });
+    const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path, bucket_id: '3'});
 
     mocha.before(async () => {
         await P.all(_.map([src_bkt, upload_bkt], async buck =>


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Added _id to read_bucket_sdk_info reply.
2. Added bucket_id to namespaceFS constructor and passed it where new instance of namespaceFS created (including test_namespace_fs.js and nsfs.js standalone).
3. In namespaceFS, replaced config.NSFS_TEMP_DIR_NAME with a call to  get_bucket_tmpdir() which concatinates config.NSFS_TEMP_DIR_NAME and this.bucket_id.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #6484 

### Testing Instructions:
1. 
