### PR TITLE
Update nsfs account config -  changed the uid/gid/new_buckets_path to be optional params 

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -187,7 +187,12 @@ module.exports = {
                         }]
                     },
                     nsfs_account_config: {
-                        $ref: 'common_api#/definitions/nsfs_account_config'
+                        type: 'object',
+                        properties: {
+                            uid: { type: 'number' },
+                            gid: { type: 'number' },
+                            new_buckets_path: { type: 'string' },
+                        }
                     },
                     preferences: {
                         type: 'object',

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -475,14 +475,17 @@ function update_account(req) {
     if (params.ips && !_.every(params.ips, ip_range => (net.isIP(ip_range.start) && net.isIP(ip_range.end)))) {
         throw new RpcError('FORBIDDEN', 'Non valid IPs');
     }
-
+    if (req.rpc_params.nsfs_account_config && _.isUndefined(req.rpc_params.nsfs_account_config.uid) &&
+            _.isUndefined(req.rpc_params.nsfs_account_config.gid) && !req.rpc_params.nsfs_account_config.new_buckets_path) {
+                throw new RpcError('FORBIDDEN', 'Invalid nsfs_account_config');
+    }
     let updates = {
         name: params.name,
         email: params.new_email,
         next_password_change: params.must_change_password === true ? new Date() : undefined,
         allowed_ips: (!_.isUndefined(params.ips) && params.ips !== null) ? params.ips : undefined,
         preferences: _.isUndefined(params.preferences) ? undefined : params.preferences,
-        nsfs_account_config: req.rpc_params.nsfs_account_config
+        nsfs_account_config: req.rpc_params.nsfs_account_config && _.assign(account.nsfs_account_config, req.rpc_params.nsfs_account_config)
     };
 
     let removals = {


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. removed required from API of update_account
2. Added check in update_account function for nsfs_account_config containing at least one of uid, gid, new_buckets_path.
3. added tests.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #6535 

### Testing Instructions:
1. 
