### PR TITLE
Add NSFS monitoring & refactor NS monitoring

### DIFF
--- a/src/core/nsfs.js
+++ b/src/core/nsfs.js
@@ -104,7 +104,11 @@ async function main(argv = minimist(process.argv.slice(2))) {
         object_sdk._get_bucket_namespace = async bucket_name => {
             const existing_ns = namespaces[bucket_name];
             if (existing_ns) return existing_ns;
-            const ns_fs = new NamespaceFS({ bucket_path: fs_root + '/' + bucket_name, bucket_id: '000000000000000000000000' });
+            const ns_fs = new NamespaceFS({
+                bucket_path: fs_root + '/' + bucket_name,
+                bucket_id: '000000000000000000000000',
+                namespace_resource_id: undefined
+            });
             namespaces[bucket_name] = ns_fs;
             return ns_fs;
         };

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -180,8 +180,13 @@ class ObjectSDK {
         try {
             // NAMESPACE_FS HACK
             if (process.env.NAMESPACE_FS) {
+                const namespace_resource_id = bucket.namespace.write_resource?.resource.id;
                 return {
-                    ns: new NamespaceFS({ bucket_path: process.env.NAMESPACE_FS + '/' + bucket.name, bucket_id: String(bucket._id) }),
+                    ns: new NamespaceFS({
+                        bucket_path: process.env.NAMESPACE_FS + '/' + bucket.name,
+                        bucket_id: String(bucket._id),
+                        namespace_resource_id,
+                    }),
                     bucket,
                     valid_until: time + (100 * 356 * 24 * 3600 * 1000), // 100 years
                 };
@@ -301,7 +306,8 @@ class ObjectSDK {
             return new NamespaceFS({
                 fs_backend: ns_info.fs_backend,
                 bucket_path: path.join(namespace_resource_config.resource.fs_root_path, namespace_resource_config.path || ''),
-                bucket_id: String(bucket_id)
+                bucket_id: String(bucket_id),
+                namespace_resource_id: ns_info.id,
             });
         }
         // TODO: Should convert to cp_code and target_bucket as folder inside

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -7,17 +7,25 @@ const auth_server = require('../common_services/auth_server');
 const dbg = require('../../util/debug_module')(__filename);
 const system_utils = require('../utils/system_utils');
 const cloud_utils = require('../../util/cloud_utils');
+const nb_native = require('../../util/nb_native');
 const config = require('../../../config');
 const P = require('../../util/promise');
 const AWS = require('aws-sdk');
-const _ = require('lodash');
 
 class NamespaceMonitor {
 
-    constructor({ name, client}) {
+    /**
+     * @param {{
+     *   name: string;
+     *   client: nb.APIClient;
+     *   should_monitor: (nsr: nb.NamespaceResource) => boolean;
+     * }} params
+     */
+    constructor({ name, client, should_monitor }) {
         this.name = name;
         this.client = client;
         this.nsr_connections_obj = {};
+        this.should_monitor = should_monitor;
     }
 
     async run_batch() {
@@ -46,96 +54,116 @@ class NamespaceMonitor {
     async test_namespace_resources_validity() {
 
         await P.map_with_concurrency(10, system_store.data.namespace_resources, async nsr => {
+            if (!this.should_monitor(nsr)) return;
+
+            const endpoint_type = nsr.nsfs_config ? 'NSFS' : nsr.connection.endpoint_type;
+
             try {
-                if (!this.nsr_connections_obj[nsr._id]) {
-                    this.init_nsr_connection_to_target(nsr);
+                if (endpoint_type === 'NSFS') {
+                    await this.test_nsfs_resource(nsr);
+                } else if (['AWS', 'S3_COMPATIBLE', 'IBM_COS'].includes(endpoint_type)) {
+                    await this.test_s3_resource(nsr);
+                } else if (endpoint_type === 'AZURE') {
+                    await this.test_blob_resource(nsr);
+                } else {
+                    dbg.error('namespace_monitor: invalid endpoint type', endpoint_type);
                 }
-                await this.test_single_namespace_resource_validity(nsr);
-
             } catch (err) {
-                if (err.code !== 'BlobNotFound' && err.code !== 'NoSuchKey') {
-                    const { endpoint, target_bucket } = nsr.connection;
-                    dbg.error('test_namespace_resource_validity failed:', err, endpoint, target_bucket);
-
-                    await this.client.pool.update_issues_report({
-                        namespace_resource_id: nsr._id,
-                        error_code: err.code,
-                        time: Date.now(),
-                        monitoring: true
-                    }, {
-                        auth_token: auth_server.make_auth_token({
-                            system_id: system_store.data.systems[0]._id,
-                            account_id: system_store.data.systems[0].owner._id,
-                            role: 'admin'
-                        })
-                    });
-                    dbg.warn(`unexpected error (code=${err.code}) from test_namespace_resource_validity during test. ignoring..`);
-                }
+                await this.run_update_issues_report(err, nsr);
                 dbg.log1(`test_namespace_resource_validity: namespace resource ${nsr.name} has error as expected`);
             }
         });
-        dbg.log1(`test_namespace_resource_validity finished successfuly..`);
+        dbg.log1(`test_namespace_resource_validity finished successfully..`);
     }
 
-    init_nsr_connection_to_target(nsr) {
-        if (nsr.nsfs_config) {
-            return;
-        }
-        const {endpoint, access_key, secret_key} = nsr.connection;
-        let conn;
-        switch (nsr.connection.endpoint_type) {
-            case 'AWS' || 'S3_COMPATIBLE' || 'IBM_COS': {
-                conn = new AWS.S3({
-                    endpoint: endpoint,
-                    credentials: {
-                        accessKeyId: access_key.unwrap(),
-                        secretAccessKey: secret_key.unwrap()
-                    },
-                    s3ForcePathStyle: true,
-                    sslEnabled: false
-                });
-                break;
-            }
-            case 'AZURE': {
-                const conn_string = cloud_utils.get_azure_connection_string({
-                    endpoint,
-                    access_key: access_key,
-                    secret_key: secret_key
-                });
-                conn = azure_storage.createBlobService(conn_string);
-                break;
-            }
-            default:
-                dbg.error('namespace_monitor: invalid endpoint type', nsr.endpoint_type);
-        }
-        if (conn) {
+    async run_update_issues_report(err, nsr) {
+        if (!err.code) return;
+        await this.client.pool.update_issues_report({
+            namespace_resource_id: nsr._id,
+            error_code: err.code,
+            time: Date.now(),
+            monitoring: true
+        }, {
+            auth_token: auth_server.make_auth_token({
+                system_id: system_store.data.systems[0]._id,
+                account_id: system_store.data.systems[0].owner._id,
+                role: 'admin'
+            })
+        });
+    }
+
+    async test_s3_resource(nsr) {
+        let conn = this.nsr_connections_obj[nsr._id];
+        if (!conn) {
+            const { endpoint, access_key, secret_key } = nsr.connection;
+            conn = new AWS.S3({
+                endpoint: endpoint,
+                credentials: {
+                    accessKeyId: access_key.unwrap(),
+                    secretAccessKey: secret_key.unwrap()
+                },
+                s3ForcePathStyle: true,
+                sslEnabled: false
+            });
             this.nsr_connections_obj[nsr._id] = conn;
         }
-    }
 
-    async test_single_namespace_resource_validity(nsr_info) {
-        if (nsr_info.nsfs_config) {
-            dbg.log1('namespace_monitor: namespace resource of type FS, skipping validity test...');
-            return;
-        }
-        const { endpoint_type, target_bucket} = nsr_info.connection;
+        const { target_bucket } = nsr.connection;
         const block_key = `test-delete-non-existing-key-${Date.now()}`;
-        const conn = this.nsr_connections_obj[nsr_info._id];
 
-        if (_.includes(['AWS', 'S3_COMPATIBLE', 'IBM_COS'], endpoint_type)) {
+        try {
             await conn.deleteObjectTagging({
                 Bucket: target_bucket,
                 Key: block_key
             }).promise();
-        } else if (endpoint_type === 'AZURE') {
+        } catch (err) {
+            dbg.log1('test_s3_resource: got error:', err);
+            if (err.code !== 'NoSuchKey') throw err;
+        }
+
+    }
+
+    async test_blob_resource(nsr) {
+        let conn = this.nsr_connections_obj[nsr._id];
+        if (!conn) {
+            const { endpoint, access_key, secret_key } = nsr.connection;
+            const conn_string = cloud_utils.get_azure_connection_string({
+                endpoint,
+                access_key: access_key,
+                secret_key: secret_key
+            });
+            conn = azure_storage.createBlobService(conn_string);
+            if (conn) this.nsr_connections_obj[nsr._id] = conn;
+        }
+        const { target_bucket } = nsr.connection;
+        const block_key = `test-delete-non-existing-key-${Date.now()}`;
+
+        try {
             await P.fromCallback(callback =>
                 conn.deleteBlob(
                     target_bucket,
                     block_key,
                     callback)
             );
-        } else {
-            dbg.error('namespace_monitor: invalid endpoint type', endpoint_type);
+        } catch (err) {
+            dbg.log1('test_blob_resource: got error:', err);
+            if (err.code !== 'BlobNotFound') throw err;
+        }
+    }
+
+    async test_nsfs_resource(nsr) {
+        try {
+            const fs_config_param = { backend: nsr.nsfs_config.fs_backend || '' };
+            await nb_native().fs.readdir(fs_config_param, nsr.nsfs_config.fs_root_path);
+            const stat = await nb_native().fs.stat(fs_config_param, nsr.nsfs_config.fs_root_path);
+            //In the event of deleting the nsr.nsfs_config.fs_root_path in the FS side, 
+            // The number of link will be 0, then we will throw ENOENT which translate to STORAGE_NOT_EXIST
+            if (stat.nlink === 0) {
+                throw Object.assign(new Error('FS root path has no links'), { code: 'ENOENT' });
+            }
+        } catch (err) {
+            dbg.log1('test_nsfs_resource: got error:', err, nsr.nsfs_config);
+            throw err;
         }
     }
 }

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -35,8 +35,8 @@ mocha.describe('namespace_fs', function() {
     const ns_src_bucket_path = `./${src_bkt}`;
     const ns_tmp_bucket_path = `${tmp_fs_path}/${src_bkt}`;
 
-    const ns_src = new NamespaceFS({ bucket_path: ns_src_bucket_path, bucket_id: '1'});
-    const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path, bucket_id: '2'});
+    const ns_src = new NamespaceFS({ bucket_path: ns_src_bucket_path, bucket_id: '1', namespace_resource_id: undefined });
+    const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path, bucket_id: '2', namespace_resource_id: undefined });
 
     mocha.before(async () => {
         await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
@@ -413,7 +413,7 @@ mocha.describe('namespace_fs copy object', function() {
 
     const ns_tmp_bucket_path = `${tmp_fs_path}/${src_bkt}`;
 
-    const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path, bucket_id: '3'});
+    const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path, bucket_id: '3', namespace_resource_id: undefined });
 
     mocha.before(async () => {
         await P.all(_.map([src_bkt, upload_bkt], async buck =>


### PR DESCRIPTION
### Explain the changes
1. Adding BG worker to the endpoint and running the `namespace_monitor` on it
2. Refractor `namespace_monitor`
3. Add the ability to decide if we should monitor a namespace or not (passing a `should_monitor` function to the `namespace_monitor` constructor.
4. Writing and deleting a small file into the `fs_root_path`
5. Reporting on a monitor fail and on an I/O fail
6. Adding namespace_resource_id to the namespaceFS constructor, and will not report if it is undefined.


