### PR TITLE
Add Etag-MD5 compatibility mode to calc MD5 on PUT-object

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -763,7 +763,7 @@ module.exports = {
 
         bucket_cache_config: {
             type: 'object',
-            required: [ ],
+            required: [],
             properties: {
                 ttl_ms: {
                     $ref: '#/definitions/bucket_cache_ttl'
@@ -806,7 +806,10 @@ module.exports = {
                 },
                 fs_backend: {
                     $ref: '#/definitions/fs_backend'
-                }
+                },
+                etag_md5: {
+                    type: 'boolean'
+                },
             }
         },
         nsfs_account_config: {

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -561,6 +561,9 @@ module.exports = {
                 fs_backend: {
                     $ref: 'common_api#/definitions/fs_backend'
                 },
+                etag_md5: {
+                    type: 'boolean'
+                },
                 mode: {
                     type: 'string',
                     enum: ['OPTIMAL', 'STORAGE_NOT_EXIST', 'AUTH_FAILED', 'IO_ERRORS']
@@ -604,6 +607,9 @@ module.exports = {
                 },
                 fs_backend: {
                     $ref: 'common_api#/definitions/fs_backend'
+                },
+                etag_md5: {
+                    type: 'boolean'
                 },
             }
         },

--- a/src/util/stream_utils.js
+++ b/src/util/stream_utils.js
@@ -4,7 +4,7 @@
 const util = require('util');
 const stream = require('stream');
 const events = require('events');
-
+const crypto = require('crypto');
 
 /**
  * @param {stream.Writable} writable 
@@ -28,9 +28,24 @@ function get_tap_stream(func) {
 
 }
 
+// get a stream and returns it's md5
+function get_stream_md5() {
+    const md5_stream = new stream.Transform({
+        transform(buf, encoding, next) {
+            this.md5.update(buf);
+            this.push(buf);
+            next();
+        }
+    });
+    md5_stream.md5 = crypto.createHash('md5');
+    return md5_stream;
+}
+
+
 const pipeline = util.promisify(stream.pipeline);
 
 exports.wait_drain = wait_drain;
 exports.wait_finished = wait_finished;
 exports.get_tap_stream = get_tap_stream;
+exports.get_stream_md5 = get_stream_md5;
 exports.pipeline = pipeline;


### PR DESCRIPTION
### Explain the changes
1. Add a `get_stream_md5` function in `stream_utils.js` that gets the md5 out of a stream
2. Calling `get_stream_md5` where needed on the put object (upload/multipart upload/copy)

***Still Draft***
Currently as a temp step, hanging it on the pool 
and also on the contractor setting this to true
We probably do not need to do it in the contractor and check the field wherever we decide to place it.

### Testing Instructions:
***Will be set after Draft***

