### PR TITLE
NO_SUCH_ACCOUNT when no accounts with given uid/gid

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -703,6 +703,10 @@ function delete_account(req) {
             return account_to_delete._id;
         });
 
+    if (!accounts_to_delete.length) {
+        throw new RpcError('NO_SUCH_ACCOUNT', 'No account with provided uid/gid: ' +
+            req.rpc_params.nsfs_account_config.uid + '/' + req.rpc_params.nsfs_account_config.gid);
+    }
     return system_store.make_changes({
             remove: {
                 accounts: accounts_to_delete,

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -465,17 +465,12 @@ mocha.describe('bucket operations - namespace_fs', function() {
     mocha.it('delete account by uid, gid - no such account', async function() {
         let list_account_resp1 = (await rpc_client.account.list_accounts({})).accounts;
         assert.ok(list_account_resp1.length > 0);
-        await rpc_client.account.delete_account_by_property({
-                nsfs_account_config: {
-                    uid: 26041993,
-                    gid: 26041993,
-                }
-            }
-        );
-        let list_account_resp2 = (await rpc_client.account.list_accounts({})).accounts;
-        assert.deepStrictEqual(list_account_resp1, list_account_resp2);
-        assert.ok(list_account_resp2.length > 0);
-
+        try {
+            await rpc_client.account.delete_account_by_property({ nsfs_account_config: { uid: 26041993, gid: 26041993 } });
+            assert.fail(`delete account succeeded for none existing account`);
+        } catch (err) {
+            assert.ok(err.rpc_code === 'NO_SUCH_ACCOUNT');
+        }
     });
 });
 


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. will check if no accounts was found and if so will throw NO_SUCH_ACCOUNT

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #6563 

### Testing Instructions:
1. delete an account with uid/gid that doesn't exist in the system - see that you get NO_SUCH_ACCOUNT instead of null
