### PR TITLE
Add get_write_resource to namespace_blob

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -43,6 +43,10 @@ class NamespaceBlob {
         return this.container;
     }
 
+    get_write_resource() {
+        return this;
+    }
+
     /////////////////
     // OBJECT LIST //
     /////////////////
@@ -627,6 +631,9 @@ class NamespaceBlob {
     }
 
     // TODO: Implement tagging on objects
+    /**
+     * @returns {nb.ObjectInfo}
+     */
     _get_blob_object_info(obj, bucket) {
         const blob_etag = blob_utils.parse_etag(obj.etag);
         const md5_b64 = (obj.contentSettings && obj.contentSettings.contentMD5) || '';
@@ -680,6 +687,20 @@ class NamespaceBlob {
         throw new Error('TODO');
     }
     async put_object_retention() {
+        throw new Error('TODO');
+    }
+
+    ///////////////////
+    //    TAGGING    //
+    ///////////////////
+
+    async get_object_tagging(params, object_sdk) {
+        throw new Error('TODO');
+    }
+    async delete_object_tagging(params, object_sdk) {
+        throw new Error('TODO');
+    }
+    async put_object_tagging(params, object_sdk) {
         throw new Error('TODO');
     }
 


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. In the last nsfs changes, we changed the following: 
* when creating namespace bucket with 1 namespace resource as read and write targets we created single namespace (s3/blob etc) instead of namespaceMerge. 

A call to copyObject/uploadPartCopy which calls fix_copy_source_params failed on line 413 `const actual_target_ns = target_ns.get_write_resource();` because  get_write_resource didn't exist in namespace blob. added this function and now it works.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ #1969420

### Testing Instructions:
1. 
