### PR TITLE
Fixing dir streaming and issue 6558

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -900,26 +900,23 @@ struct DirReadEntry : public FSWrapWorker<DirWrap>
             SetError(XSTR() << "FS::DirReadEntry::Execute: ERROR not opened " << path);
             return;
         }
+        struct dirent* e = 0;
 
-        while (true) {
-            // need to set errno before the call to readdir() to detect between EOF and error
-            errno = 0;
-            struct dirent* e = readdir(dir);
-            if (e) {
-                // Ignore parent and current directories
-                if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0) {
-                    continue;
-                }
-                _entry.name = std::string(e->d_name);
-                _entry.ino = e->d_ino;
-                _entry.type = e->d_type;
-            } else {
-                if (errno) {
-                    SetSyscallError();
-                } else {
-                    _eof = true;
-                }
-                break;
+        // loop to skip parent and current directories 
+        do { 
+            // need to set errno before the call to readdir() to detect between EOF and error 
+            errno = 0; 
+            e = readdir(dir); 
+        } while (e && (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)); 
+        if (e) { 
+            _entry.name = std::string(e->d_name); 
+            _entry.ino = e->d_ino; 
+            _entry.type = e->d_type; 
+        } else { 
+            if (errno) { 
+                SetSyscallError(); 
+            } else { 
+                _eof = true; 
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. Fixing issue 6558 - The cache wasn't working so we keep on adding more and more dir list to the cache until we ran out of memory - it was because we used the whole object as the key - which doesn't work. Changed to fs_dir + uid + gid - I hope it's good enough please let me know if we need other variables as well.
2. A quick fix for a huge directories. When I tried with 100K objects I got to 3 MB cache - So to get to 64 MB I guess we will need 2M. Tried with 100K with NSFS_DIR_CACHE_MAX_DIR_SIZE set to 1MB - very slow but does work (~4.5 minutes for 100K. with caching ~31 seconds). Scanning 1M objects 100K times(for each default 1K objects) will probably take ages.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #6558

### Testing Instructions:
1. 
