### PR TITLE
Enforce debug level using  NOOBAA_LOG_LEVEL Env variable

### DIFF
--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -549,7 +549,7 @@ DebugLogger.prototype.set_level = function(level, mod) {
 };
 
 DebugLogger.prototype.should_log = function(level) {
-    if (this._cur_level.__level >= level) {
+    if (this._cur_level.__level >= level || (process.env.NOOBAA_LOG_LEVEL && process.env.NOOBAA_LOG_LEVEL >= level)) {
         return true;
     }
     return false;


### PR DESCRIPTION
### Explain the changes
Enforce debug level using  NOOBAA_LOG_LEVEL Env variable

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Testing Instructions:
1.  Add/Change the deployment-endpoint.yaml or the statefulset-core.yaml NOOBAA_LOG_LEVEL env variable to a higher number and see if it prints the logs 
