### PR TITLE
Backport to 5.8: update path-parse from 1.0.6 to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5976,9 +5976,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",


### PR DESCRIPTION
### Explain the changes
- Update path-parse from 1.0.6 to 1.0.7

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit 4b3a89e4c486365111896c0e13924001aa9b5d62)

### Issues: Fixed #xxx / Gap #xxx
1. Fixes BZ1961974

