### PR TITLE
quick fix for create triggers not working with namespaced bucket #6575 [draft]

### DIFF
--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -232,7 +232,7 @@ class ObjectSDK {
                 }
                 if (bucket.namespace.write_resource && _.isEqual(bucket.namespace.read_resources, [bucket.namespace.write_resource])) {
                     return {
-                        ns: this._setup_single_namespace(_.extend({}, bucket.namespace.write_resource), bucket._id),
+                        ns: this._setup_single_namespace(_.extend({}, bucket.namespace.write_resource,bucket), bucket._id),
                         bucket,
                         valid_until: time + config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS,
                     };
@@ -283,7 +283,7 @@ class ObjectSDK {
         });
     }
 
-    _setup_single_namespace(namespace_resource_config, bucket_id) {
+    _setup_single_namespace(namespace_resource_config, bucket_id, bucket) {
         const ns_info = namespace_resource_config.resource;
         if (ns_info.endpoint_type === 'NOOBAA') {
             if (ns_info.target_bucket) {
@@ -314,7 +314,8 @@ class ObjectSDK {
                     s3ForcePathStyle: true,
                     // computeChecksums: false, // disabled by default for performance
                     httpOptions: { agent }
-                }
+                },
+                active_triggers: bucket.active_triggers
             });
         }
         if (ns_info.endpoint_type === 'AZURE') {


### PR DESCRIPTION
### Explain the changes
1. Quick implementation for missing create triggers on namespaced buckets

### Issues: Fixed #xxx / Gap #xxx
1. #6575 
2. Only fixes ObjectCreated triggers on simple upload and multipart upload

### Testing Instructions:
1. Create function
2. Create bucket
3. Add ObjectCreated trigger with function to trigger
4. Upload object to bucket, which fires trigger
5. Verify trigger was called
