### PR TITLE
Backport to 5.8: Update azure-storage from 2.10.3 to 2.10.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1911,9 +1911,9 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "azure-storage": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
-      "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.4.tgz",
+      "integrity": "sha512-zlfRPl4js92JC6+79C2EUmNGYjSknRl8pOiHQF78zy+pbOFOHtlBF6BU/OxPeHQX3gaa6NdEZnVydFxhhndkEw==",
       "requires": {
         "browserify-mime": "~1.2.9",
         "extend": "^3.0.2",
@@ -1921,7 +1921,7 @@
         "md5.js": "1.3.4",
         "readable-stream": "~2.0.0",
         "request": "^2.86.0",
-        "underscore": "~1.8.3",
+        "underscore": "^1.12.1",
         "uuid": "^3.0.0",
         "validator": "~9.4.1",
         "xml2js": "0.2.8",
@@ -4015,20 +4015,10 @@
         "safe-buffer": "^5.2.0"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@google-cloud/storage": "5.8.3",
     "ajv": "6.12.6",
     "aws-sdk": "2.884.0",
-    "azure-storage": "2.10.3",
+    "azure-storage": "2.10.4",
     "bcrypt": "5.0.1",
     "big-integer": "1.6.48",
     "bindings": "1.5.0",


### PR DESCRIPTION
### Explain the changes
- Update azure-storage from 2.10.3 to 2.10.4

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit 9605bf7eedf1c8346f85cd98b3026b12f72c7906)

### Issues: Fixed #xxx / Gap #xxx
1.  Fixes BZ1945625
