### PR TITLE
Lowering keep alive for s3

### DIFF
--- a/config.js
+++ b/config.js
@@ -107,7 +107,7 @@ config.N2N_OFFER_INTERNAL = false;
 config.AMZ_DATE_MAX_TIME_SKEW_MILLIS = 15 * 60 * 1000;
 config.ENDPOINT_MONITOR_INTERVAL = 10 * 60 * 1000; // 10min
 // Keep connection on long requests
-config.S3_KEEP_ALIVE_WHITESPACE_INTERVAL = 30 * 1000;
+config.S3_KEEP_ALIVE_WHITESPACE_INTERVAL = 15 * 1000;
 
 ///////////////
 // MD CONFIG //


### PR DESCRIPTION
### Explain the changes
1. Older AWS CLI clients wait for 30 seconds instead of 1 minute

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
