### PR TITLE
postgres performance improvements - Write path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5112,9 +5112,9 @@
       }
     },
     "mongo-query-to-postgres-jsonb": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/mongo-query-to-postgres-jsonb/-/mongo-query-to-postgres-jsonb-0.2.13.tgz",
-      "integrity": "sha512-3L1GD0MxGWz5V+3oe1Vfr4IcZFFqx6HBlOt8a5QRYTfDaT/0ElYEtL39+11RzlId+mh6iflE0OXZLuAvr0F6dA=="
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/mongo-query-to-postgres-jsonb/-/mongo-query-to-postgres-jsonb-0.2.14.tgz",
+      "integrity": "sha512-UEOfYs8g4Su0mxnnjIIa5wFp03+UuoJ9o3Tm5JAsJdQgDjY9RoOWiBYOkO9LEY+btOcLqV6b1jEa0bm7Nqzo1Q=="
     },
     "mongodb": {
       "version": "3.6.6",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "minimist": "1.2.5",
     "moment": "2.29.1",
     "moment-timezone": "0.5.33",
-    "mongo-query-to-postgres-jsonb": "0.2.13",
+    "mongo-query-to-postgres-jsonb": "0.2.14",
     "mongodb": "3.6.6",
     "morgan": "1.10.0",
     "nan": "2.14.2",

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -187,14 +187,14 @@ class MDStore {
 
     async find_object_or_upload_null_version(bucket_id, key) {
         return this._objects.findOne({
-                // index fields:
-                bucket: bucket_id,
-                key,
-                version_enabled: null,
-                // partialFilterExpression:
-                deleted: null,
-            }, {
-                sort: { bucket: 1, key: 1, version_enabled: 1 },
+            // index fields:
+            bucket: bucket_id,
+            key,
+            version_enabled: null,
+            // partialFilterExpression:
+            deleted: null,
+        }, {
+            sort: { bucket: 1, key: 1, version_enabled: 1 },
         });
     }
 
@@ -1152,11 +1152,11 @@ class MDStore {
     async load_parts_objects_for_chunks(chunks) {
         if (!chunks || !chunks.length) return;
         const parts = await this._parts.find({
-            chunk: { $in: db_client.instance().uniq_ids(chunks, '_id') },
+            chunk: { $in: db_client.instance().uniq_ids(chunks, '_id'), $exists: true },
             deleted: null
         });
         const objects = await this._objects.find({
-            _id: { $in: db_client.instance().uniq_ids(parts, 'obj') }
+            _id: { $in: db_client.instance().uniq_ids(parts, 'obj'), $exists: true }
         });
         const parts_by_chunk = _.groupBy(parts, 'chunk');
         const objects_by_id = _.keyBy(objects, '_id');
@@ -1171,7 +1171,7 @@ class MDStore {
      * @returns {Promise<nb.PartSchemaDB[]>}
      */
     async find_all_parts_of_object(obj) {
-        return this._parts.find({ obj: obj._id, deleted: null });
+        return this._parts.find({ obj: { $eq: obj._id, $exists: true }, deleted: null });
     }
 
     update_parts_in_bulk(parts_updates) {
@@ -1273,7 +1273,8 @@ class MDStore {
             system: bucket.system._id,
             bucket: bucket._id,
             dedup_key: {
-                $in: dedup_keys
+                $in: dedup_keys,
+                $exists: true
             },
             deleted: null,
         }, {
@@ -1582,7 +1583,7 @@ class MDStore {
     async load_blocks_for_chunks(chunks, sorter) {
         if (!chunks || !chunks.length) return;
         const blocks = await this._blocks.find({
-            chunk: { $in: db_client.instance().uniq_ids(chunks, '_id') },
+            chunk: { $in: db_client.instance().uniq_ids(chunks, '_id'), $exists: true },
             deleted: null,
         });
         const blocks_by_chunk = _.groupBy(blocks, 'chunk');

--- a/src/server/object_services/schemas/data_chunk_indexes.js
+++ b/src/server/object_services/schemas/data_chunk_indexes.js
@@ -2,6 +2,19 @@
 'use strict';
 
 module.exports = [{
+        postgres: true,
+        fields: {
+            _id: -1,
+        },
+        options: {
+            // iterate_all_chunks
+            name: 'id_desc',
+            partialFilterExpression: {
+                deleted: null,
+            }
+        }
+    },
+    {
         fields: {
             dedup_key: 1,
         },

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -64,6 +64,15 @@ const SYS_NODES_INFO_DEFAULTS = Object.freeze({
     by_mode: {},
 });
 
+
+// cached result from bucket_server.list_undeletable_buckets()
+const CACHED_UNDELETABLE_BUCKETS_TTL = 60 * 1000; // cache result for one minute
+const _cached_undeletable_buckets_list = {
+    last_called: 0,
+    cached_list: []
+};
+
+
 // called on rpc server init
 let _is_initialized = false;
 async function _init() {
@@ -430,6 +439,20 @@ async function _create_owner_account(
     return { auth_token };
 }
 
+
+
+// quick fix for postgres performance issues: the DB query to get undeletable buckets uses distinct query which takes
+// a long time if there is a large number of objects. cache the result of bucket_server.list_undeletable_buckets() 
+// instead of calling it on every read_system
+async function _get_undeletable_buckets_cached() {
+    const now = Date.now();
+    if (now - _cached_undeletable_buckets_list.last_called > CACHED_UNDELETABLE_BUCKETS_TTL) {
+        _cached_undeletable_buckets_list.cached_list = await bucket_server.list_undeletable_buckets();
+        _cached_undeletable_buckets_list.last_called = now;
+    }
+    return _cached_undeletable_buckets_list.cached_list;
+}
+
 async function _configure_system_address(system_id, account_id) {
     const system_address = (process.env.CONTAINER_PLATFORM === 'KUBERNETES') ?
         await os_utils.discover_k8s_services() : [];
@@ -501,7 +524,7 @@ async function read_system(req) {
 
         refresh_system_alloc_unused: node_allocator.refresh_system_alloc(system),
 
-        undeletable_buckets: bucket_server.list_undeletable_buckets(),
+        undeletable_buckets: _get_undeletable_buckets_cached(),
 
         funcs: P.resolve()
             // using default domain - will serve the list_funcs from web_server so if

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -455,6 +455,8 @@ class MongoClient extends EventEmitter {
         if (col.db_indexes) {
             try {
                 await Promise.all(col.db_indexes.map(async index => {
+                    // skip postgres indexes
+                    if (index.postgres) return;
                     try {
                         const res = await db.collection(col.name).createIndex(index.fields, _.extend({ background: true }, index.options));
                         dbg.log0('_init_collection: created index', col.name, res);


### PR DESCRIPTION
This PR improves most of the queries in the write path. Read path is not handled in this PR

### Explain the changes

#### in postgres_client
* Added option to enable query logging using env `PG_ENABLE_QUERY_LOG`. this will print for each query
  the time it took and if enabled (with `PG_EXPLAIN_QUERIES`) the EXPLAIN result of the query
* fixes in encode_json and handle_ops_encoding
  * encode mongo.objectid as string in postgres_client encode_json - when mongo object id is passed as object to mongo-to-postgres lib, it will convert the query to access data->_id as a jsonb struct. this causes queries to not hit the indexes. when passed as string the lib generates the query using `->>` that better matches the index
  * handle_ops_encoding - handle multiple ops in one query
  * handle comparison operators (`$eq`, `$ne`, etc.)
* add `{disableContainmentQuery: true}` when calling `mongo-query-to-postgres-jsonb`
* fix sorts to use indexes
  * access `_id` as text
  * remove NULLS FIRST\LAST and use default as we do in the indexes

#### other changes
* added datachunk index by _id descending for iterate_all_chunks
* in md_store - pass `$exists` in some queries to match indexes
* in system_server - cache result of list_undeletable_buckets
  to avoid calling it on each read_system
* bumped version of `mongo-query-to-postgres-jsonb` to `0.2.14` 


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
