### PR TITLE
Setting fs debug level on startup if there is `process.env.NOOBAA_LOG_LEVEL`

### DIFF
--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -600,3 +600,7 @@ if (console_wrapper) {
     var conlogger = new DebugLogger("CONSOLE.js");
     console_wrapper.register_logger(conlogger);
 }
+
+if (Number(process.env.NOOBAA_LOG_LEVEL)) {
+    nb_native().fs.set_debug_level(Number(process.env.NOOBAA_LOG_LEVEL));
+}


### PR DESCRIPTION
### Explain the changes
- Setting fs debug level on startup if there is `process.env.NOOBAA_LOG_LEVEL`

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Limitation
- This will only take effect if there is `process.env.NOOBAA_LOG_LEVEL`