### PR TITLE
Collect read/write metrics for NSFS

### DIFF
--- a/src/server/bg_services/stats_collector.js
+++ b/src/server/bg_services/stats_collector.js
@@ -2,20 +2,19 @@
 'use strict';
 
 const _ = require('lodash');
-const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const system_store = require('../system_services/system_store').get_instance();
 const server_rpc = require('../server_rpc');
 const auth_server = require('../common_services/auth_server');
 const HistoryDataStore = require('../analytic_services/history_data_store').HistoryDataStore;
 
-function collect_all_stats() {
-    dbg.log0('STATS_COLLECTOR:', 'BEGIN');
-    return collect_system_stats()
-        .then(() => dbg.log0('STATS_COLLECTOR:', 'END'));
+async function collect_all_stats() {
+    dbg.log0('STATS_COLLECTOR: BEGIN');
+    await collect_system_stats();
+    dbg.log0('STATS_COLLECTOR: END');
 }
 
-function collect_system_stats() {
+async function collect_system_stats() {
     const support_account = _.find(system_store.data.accounts, account => account.is_support);
     if (!support_account) {
         dbg.warn('collect_system_stats: no support account yet');
@@ -26,16 +25,18 @@ function collect_system_stats() {
         dbg.warn('collect_system_stats: no system yet');
         return;
     }
-    return P.resolve()
-        .then(() => server_rpc.client.system.read_system({}, {
+    try {
+        const system_data = await server_rpc.client.system.read_system({}, {
             auth_token: auth_server.make_auth_token({
                 system_id: system._id,
                 role: 'admin',
                 account_id: support_account._id
             })
-        }))
-        .then(system_data => HistoryDataStore.instance().insert(system_data))
-        .catch(err => dbg.error('collect_system_stats: failed to collect system stats into history store,', err));
+        });
+        await HistoryDataStore.instance().insert(system_data);
+    } catch (err) {
+        dbg.error('collect_system_stats: failed to collect system stats into history store,', err);
+    }
 }
 
 exports.collect_all_stats = collect_all_stats;


### PR DESCRIPTION
### Explain the changes
- Collect read/write metrics for NSFS

Signed-off-by: liranmauda <liran.mauda@gmail.com>
```
nbcore=# select jsonb_pretty(data) from bucketstats;
                  jsonb_pretty
------------------------------------------------
 {                                             +
     "_id": "60dc18e4e8559a00098506a7",        +
     "reads": 0,                               +
     "bucket": "60dc18929c2f20002a177afd",     +
     "system": "60dc17df9c2f20002a177ad9",     +
     "writes": 4,                              +
     "last_write": 1625043991065,              +
     "content_type": "image/jpeg"              +
 }
 {                                             +
     "_id": "60dc294ea821940008264d05",        +
     "reads": 0,                               +
     "bucket": "60dc18929c2f20002a177afd",     +
     "system": "60dc17df9c2f20002a177ad9",     +
     "writes": 3,                              +
     "last_write": 1625044640864,              +
     "content_type": "image/png"               +
 }
 {                                             +
     "_id": "60dc36d146435d00088b9a0d",        +
     "reads": 2,                               +
     "bucket": "60dc18929c2f20002a177afd",     +
     "system": "60dc17df9c2f20002a177ad9",     +
     "writes": 0,                              +
     "last_read": 1625044689574,               +
     "content_type": "application/octet-stream"+
 }
(3 rows)
```

```
nbcore=# select jsonb_pretty(data) from iostats;
                  jsonb_pretty
------------------------------------------------
 {                                             +
     "_id": "60dc2925a821940008264d04",        +
     "system": "60dc17df9c2f20002a177ad9",     +
     "end_time": 1625097599999,                +
     "read_bytes": 58720256,                   +
     "read_count": 7,                          +
     "start_time": 1625011200000,              +
     "resource_id": "60dc187b9c2f20002a177af5",+
     "write_bytes": 85286118,                  +
     "write_count": 5195,                      +
     "resource_type": "NAMESPACE_RESOURCE",    +
     "error_read_bytes": 0,                    +
     "error_read_count": 0,                    +
     "error_write_bytes": 0,                   +
     "error_write_count": 0                    +
 }
 {                                             +
     "_id": "60dc18e39c2f20002a177b01",        +
     "system": "60dc17df9c2f20002a177ad9",     +
     "end_time": 1625097599999,                +
     "read_bytes": 235520,                     +
     "read_count": 230,                        +
     "start_time": 1625011200000,              +
     "resource_id": "60dc18539c2f20002a177af3",+
     "write_bytes": 235520,                    +
     "write_count": 230,                       +
     "resource_type": "NODE",                  +
     "error_read_bytes": 0,                    +
     "error_read_count": 0,                    +
     "error_write_bytes": 0,                   +
     "error_write_count": 0                    +
 }
(2 rows)
```
```
nbcore=# select jsonb_pretty(data) from namespace_resources;
                jsonb_pretty
--------------------------------------------
 {                                         +
     "_id": "60dc187b9c2f20002a177af5",    +
     "name": "ns",                         +
     "system": "60dc17df9c2f20002a177ad9", +
     "account": "60dc17ef9c2f20002a177ae9",+
     "last_update": 1625036923362,         +
     "nsfs_config": {                      +
         "fs_backend": "GPFS",             +
         "fs_root_path": "/nsfs/ns"        +
     },                                    +
     "namespace_store": {                  +
         "name": "ns",                     +
         "namespace": "default"            +
     }                                     +
 }
(1 row)
```