### PR TITLE
undo using ?. operator which fails in standalone executable

### DIFF
--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -180,7 +180,9 @@ class ObjectSDK {
         try {
             // NAMESPACE_FS HACK
             if (process.env.NAMESPACE_FS) {
-                const namespace_resource_id = bucket.namespace.write_resource?.resource.id;
+                const namespace_resource_id =
+                    bucket.namespace.write_resource &&
+                    bucket.namespace.write_resource.resource.id;
                 return {
                     ns: new NamespaceFS({
                         bucket_path: process.env.NAMESPACE_FS + '/' + bucket.name,


### PR DESCRIPTION
### Explain the changes
1. This operator is supported in node.js but for some reason it fails on linux standalone executable:
```
$ ./build/noobaa-core-linux nsfs .
load_config_local: NO LOCAL CONFIG
/snapshot/noobaa-core/src/sdk/object_sdk.js:183
        const namespace_resource_id = bucket.namespace.write_resource?.resource.id;
                                       ^
SyntaxError: Unexpected token .
  at Module._compile (internal/modules/cjs/loader.js:721:23)
  at Module._compile (pkg/prelude/bootstrap.js:1440:32)
  at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
  at Module.load (internal/modules/cjs/loader.js:651:32)
  at tryModuleLoad (internal/modules/cjs/loader.js:591:12)
  at Function.Module._load (internal/modules/cjs/loader.js:583:3)
  at Module.require (internal/modules/cjs/loader.js:690:17)
  at Module.require (pkg/prelude/bootstrap.js:1338:31)
  at require (internal/modules/cjs/helpers.js:25:18)
  at Object.<anonymous> (/snapshot/noobaa-core/src/core/nsfs.js:14:19)
```

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. `npm run build:core`
2. `./build/noobaa-core-linux nsfs .`
