### PR TITLE
Fix delete nsfs bucket - s3 workflow

### DIFF
--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -47,7 +47,8 @@ class BucketSpaceNB {
                 const namespace_bucket_config = await object_sdk.read_bucket_sdk_namespace_info(params.name.unwrap());
                 await ns.create_uls({
                     name: params.name,
-                    fs_root_path: namespace_bucket_config.write_resource.resource.fs_root_path
+                    full_path: path.join(namespace_bucket_config.write_resource.resource.fs_root_path,
+                        namespace_bucket_config.write_resource.path) // includes write_resource.path + bucket name (s3 flow)
                 }, object_sdk);
             }
         } catch (err) {
@@ -65,7 +66,8 @@ class BucketSpaceNB {
             const ns = await object_sdk._get_bucket_namespace(params.name);
             await ns.delete_uls({
                 name: params.name,
-                fs_root_path: namespace_bucket_config.write_resource.resource.fs_root_path
+                full_path: path.join(namespace_bucket_config.write_resource.resource.fs_root_path,
+                    namespace_bucket_config.write_resource.path) // includes write_resource.path + bucket name (s3 flow)
             }, object_sdk);
         }
         return this.rpc_client.bucket.delete_bucket(params);

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1140,11 +1140,9 @@ class NamespaceFS {
 
     async create_uls(params, object_sdk) {
         const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-        const new_dir_path = path.join(params.fs_root_path,
-            fs_account_config.new_buckets_path, params.name.unwrap());
-
+        dbg.log0('NamespaceFS: create_uls fs_account_config:', fs_account_config, 'new_dir_path: ', params.full_path);
         try {
-            await nb_native().fs.mkdir(fs_account_config, new_dir_path, get_umasked_mode(0o777));
+            await nb_native().fs.mkdir(fs_account_config, params.full_path, get_umasked_mode(0o777));
         } catch (err) {
             throw this._translate_object_error_codes(err);
         }
@@ -1152,8 +1150,7 @@ class NamespaceFS {
 
     async delete_uls(params, object_sdk) {
         const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-        const to_delete_dir_path = path.join(params.fs_root_path,
-            fs_account_config.new_buckets_path, params.name);
+        dbg.log0('NamespaceFS: delete_uls fs_account_config:', fs_account_config, 'to_delete_dir_path: ', params.full_path);
 
         try {
             const list = await this.list_objects({ ...params, limit: 1 }, object_sdk);
@@ -1164,7 +1161,7 @@ class NamespaceFS {
                 throw err;
             }
 
-            await this._folder_delete(to_delete_dir_path, fs_account_config);
+            await this._folder_delete(params.full_path, fs_account_config);
         } catch (err) {
             throw this._translate_object_error_codes(err);
         }


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. when creating/deleting underlying storage in nsfs - use the original path of the bucket (being set on bucket creation) and not the current nsfs_account_config.new_buckets_path + bucket_name.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-operator/issues/676

### Testing Instructions:
1. 
