### PR TITLE
Fixing db unique enforcement for system store

### DIFF
--- a/src/server/system_services/schemas/account_indexes.js
+++ b/src/server/system_services/schemas/account_indexes.js
@@ -4,9 +4,11 @@
 module.exports = [{
     fields: {
         email: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }, ];

--- a/src/server/system_services/schemas/bucket_indexes.js
+++ b/src/server/system_services/schemas/bucket_indexes.js
@@ -5,9 +5,11 @@ module.exports = [{
     fields: {
         system: 1,
         name: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }, ];

--- a/src/server/system_services/schemas/namespace_resource_indexes.js
+++ b/src/server/system_services/schemas/namespace_resource_indexes.js
@@ -4,9 +4,11 @@
 module.exports = [{
     fields: {
         name: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }, ];

--- a/src/server/system_services/schemas/pool_indexes.js
+++ b/src/server/system_services/schemas/pool_indexes.js
@@ -5,9 +5,11 @@ module.exports = [{
     fields: {
         system: 1,
         name: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }, ];

--- a/src/server/system_services/schemas/system_indexes.js
+++ b/src/server/system_services/schemas/system_indexes.js
@@ -4,9 +4,11 @@
 module.exports = [{
     fields: {
         name: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }, ];

--- a/src/server/system_services/schemas/tier_indexes.js
+++ b/src/server/system_services/schemas/tier_indexes.js
@@ -5,9 +5,11 @@ module.exports = [{
     fields: {
         system: 1,
         name: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }, ];

--- a/src/server/system_services/schemas/tiering_policy_indexes.js
+++ b/src/server/system_services/schemas/tiering_policy_indexes.js
@@ -5,9 +5,11 @@ module.exports = [{
     fields: {
         system: 1,
         name: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }, ];

--- a/src/upgrade/migration_to_postgres.js
+++ b/src/upgrade/migration_to_postgres.js
@@ -44,20 +44,25 @@ const { Migrator } = require('./migrator');
 const name_deleted_indexes = [{
     fields: {
         name: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }];
 
-const name_system_deleted_indexes = [{
+const system_name_deleted_indexes = [{
     fields: {
+        system: 1,
         name: 1,
-        deleted: 1
     },
     options: {
         unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
     }
 }];
 
@@ -90,28 +95,30 @@ const COLLECTIONS = [{
     db_indexes: [{
         fields: {
             email: 1,
-            deleted: 1
         },
         options: {
             unique: true,
+            partialFilterExpression: {
+                deleted: null,
+            }
         }
     }],
 }, {
     name: 'buckets',
     schema: bucket_schema,
-    db_indexes: name_system_deleted_indexes,
+    db_indexes: system_name_deleted_indexes,
 }, {
     name: 'tieringpolicies',
     schema: tiering_policy_schema,
-    db_indexes: name_system_deleted_indexes,
+    db_indexes: system_name_deleted_indexes,
 }, {
     name: 'tiers',
     schema: tier_schema,
-    db_indexes: name_system_deleted_indexes,
+    db_indexes: system_name_deleted_indexes,
 }, {
     name: 'pools',
     schema: pool_schema,
-    db_indexes: name_system_deleted_indexes,
+    db_indexes: system_name_deleted_indexes,
 }, {
     name: 'agent_configs',
     schema: agent_config_schema,


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. As postgres doesn't restrict uniqueness as mongo does. (If part of the key - deleted in our case is not in the new row - it will not throw the insert operation) Will remove deleted from the key, but also will remove all deleted rows from the index so new row with same name can be created if previous one was already deleted.

### Issues: Fixed #xxx / Gap #xxx
1.  

### Testing Instructions:
1. 
