### PR TITLE
skip tiering creation for namespace buckets

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -111,7 +111,7 @@ async function create_bucket(req) {
             };
             should_create_underlying_storage = true;
 
-        } else {
+        } else if (_.isUndefined(req.rpc_params.namespace) || req.rpc_params.namespace.caching) {
             // we create dedicated tier and tiering policy for the new bucket
             // that uses the default_resource of that account
             const default_pool = req.account.default_resource;


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

related to https://github.com/noobaa/noobaa-operator/pull/686

### Explain the changes
1. in `create_bucket` if the created bucket is a namespace bucket, skip the tiering\tier creation

### Issues: Fixed #xxx / Gap #xxx
1. fix for https://bugzilla.redhat.com/show_bug.cgi?id=1981331

### Testing Instructions:
1. 
