### PR TITLE
added running single test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,11 @@ test: tester
 	$(CONTAINER_ENGINE) run $(CPUSET) --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" $(TESTER_TAG) 
 .PHONY: test
 
+run-single-test: tester
+	@echo "\033[1;34mRunning single test.\033[0m"
+	$(CONTAINER_ENGINE) run $(CPUSET) --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" $(TESTER_TAG) ./src/test/unit_tests/run_npm_test_on_test_container.sh -s $(testname)
+.PHONY: run-single-test
+
 test-postgres: tester
 	@echo "\033[1;34mRunning tests with Postgres.\033[0m"
 	@echo "\033[1;34mCreating docker network\033[0m"


### PR DESCRIPTION
Signed-off-by: Igor Pick <ipick@redhat.com>

### Explain the changes
To run a single core test:
```
make run-single-test testname=<test name>
```
for example:
```
make run-single-test testname=test_system_servers.js
```

