### PR TITLE
Fix upgrade from 5.8 to 5.9

### DIFF
--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -41,6 +41,7 @@ handle_server_upgrade() {
   then
     UPGRADE_SCRIPTS_DIR=/root/node_modules/noobaa-core/src/upgrade/upgrade_scripts
   fi
+  echo "Running /usr/local/bin/node src/upgrade/upgrade_manager.js --upgrade_scripts_dir ${UPGRADE_SCRIPTS_DIR}"
   /usr/local/bin/node src/upgrade/upgrade_manager.js --upgrade_scripts_dir ${UPGRADE_SCRIPTS_DIR}
   rc=$?
   if [ ${rc} -ne 0 ]; then

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -134,8 +134,6 @@ prepare_agent_conf() {
 }
 
 prepare_server_pvs() {
-  # change ownership and permissions of /data and /log.
-  ${KUBE_PV_CHOWN} server
   # when running in kubernetes\openshift we mount PV under /data and /log
   # ensure existence of folders such as mongo, supervisor, etc.
   mkdir -p /log/supervisor

--- a/src/deploy/NVA_build/supervisord.orig
+++ b/src/deploy/NVA_build/supervisord.orig
@@ -12,11 +12,16 @@ start() {
     then
         path="/noobaa_init_files/"
     fi
+    echo "calling noobaa_init.sh"
+    logger -p local0.info -t Superd "calling noobaa_init.sh"
     ${path}/noobaa_init.sh
-    #Abort pod start if noobaa_init fails
     rc=$?
+    echo "noobaa_init.sh finished"
+    logger -p local0.info -t Superd "noobaa_init.sh finished"
+    #Abort pod start if noobaa_init fails
     if [ ${rc} -ne 0 ]; then
         echo "noobaa_init failed with exit code ${rc}. aborting"
+        logger -p local0.info -t Superd "noobaa_init failed with exit code ${rc}. aborting"
         exit ${rc}
     fi
 

--- a/src/native/tools/kube_pv_chown.cpp
+++ b/src/native/tools/kube_pv_chown.cpp
@@ -87,7 +87,7 @@ main(int argc, char* argv[])
     } else if (deployment_type == "agent") {
         change_path_permissions_recursive("/noobaa_storage", uid);
     } else {
-        cout << "Error:  expected to get server/agent as first parameter" << endl;
+        cout << "Error:  expected to get mongo/postgres/agent as first parameter" << endl;
         return 1;
     }
     return 0;

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -12,6 +12,7 @@ const system_store = require('../server/system_services/system_store').get_insta
 const system_server = require('../server/system_services/system_server');
 const dbg = require('../util/debug_module')('UPGRADE');
 const db_client = require('../util/db_client');
+dbg.set_process_name('Upgrade');
 
 function parse_ver(ver) {
     const stripped_ver = ver.split('-')[0];

--- a/src/upgrade/upgrade_scripts/5.9.0/upgrade_accounts_ns_resources.js
+++ b/src/upgrade/upgrade_scripts/5.9.0/upgrade_accounts_ns_resources.js
@@ -1,14 +1,14 @@
 /* Copyright (C) 2016 NooBaa */
 "use strict";
 
-async function run({ dbg, system_store, system_server}) {
+async function run({ dbg, system_store, system_server }) {
 
     try {
         dbg.log0('starting upgrade accounts...');
         const accounts = system_store.data.accounts
             .map(a => a.default_pool && ({
                 _id: a._id,
-                $set: { default_resource: a.default_pool._id },
+                $set: { default_resource: a.default_pool },
                 $unset: { default_pool: true }
             }))
             .filter(account => account);


### PR DESCRIPTION
### Explain the changes
- Fixing an issue with the upgrade script from 5.8 to 5.9
- Add process name in the logs for upgrade
- Adding printings for the supervisour and noobaa_init
- Fix connect in postgres client, where we are not retrying to connect
- As kube_pv_chown is not supporting (and not needed) server, removing this call and fixing the error message in kube_pv_chown.cpp

### Issues: Fixed #xxx / Gap #xxx
1.  Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1981080

### Testing Instructions:
1. Upgrade from 5.8 to 5.9
