### PR TITLE
add ignore_name_already_exist property to check_external_connection api

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -439,7 +439,7 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
-                required: ['identity', 'secret', 'endpoint'],
+                required: ['identity', 'secret', 'endpoint', 'endpoint_type'],
                 properties: {
                     name: {
                         type: 'string'
@@ -457,6 +457,9 @@ module.exports = {
                     },
                     endpoint_type: {
                         $ref: 'common_api#/definitions/endpoint_type'
+                    },
+                    ignore_name_already_exist: {
+                        type: 'boolean'
                     }
                 }
             },


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

related to https://github.com/noobaa/noobaa-operator/pull/688

### Explain the changes
1. Added ignore_name_already_exist property to check_external_connection api so we could check an external connection before updating it.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
