### PR TITLE
Fix error handler to return a correct error code

### DIFF
--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -351,7 +351,7 @@ app.use(function(err, req, res, next) {
     } else {
         e = _.pick(err, 'statusCode', 'message', 'reload');
     }
-    e.statusCode = err.statusCode || res.statusCode;
+    e.statusCode = err.status || res.statusCode;
     if (e.statusCode < 400) {
         e.statusCode = 500;
     }


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

fix to https://bugzilla.redhat.com/show_bug.cgi?id=1965322

### Explain the changes
1. Fix error handler to retrieve the correct error code returned from `error_404()`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
