### PR TITLE
Create debug_config that set debug level according to a set of modules predefined. 

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -314,7 +314,7 @@ class Agent {
     }
 
     suppress_logs() {
-        this.dbg.set_level(-5, 'core');
+        this.dbg.set_module_level(-5, 'core');
     }
 
     _update_servers_list(new_list) {
@@ -1041,10 +1041,10 @@ class Agent {
     async set_debug_node(req) {
         const dbg = this.dbg;
         dbg.log0('Received set debug req ', req.rpc_params.level);
-        dbg.set_level(req.rpc_params.level, 'core');
+        dbg.set_module_level(req.rpc_params.level, 'core');
         if (req.rpc_params.level > 0) { //If level was set, unset it after a T/O
             await P.delay_unblocking(config.DEBUG_MODE_PERIOD);
-            dbg.set_level(0, 'core');
+            dbg.set_module_level(0, 'core');
         }
     }
 

--- a/src/core/nsfs.js
+++ b/src/core/nsfs.js
@@ -70,7 +70,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         if (argv.help || argv.h) return print_usage();
         if (argv.debug) {
             const debug_level = Number(argv.debug) || 5;
-            dbg.set_level(debug_level, 'core');
+            dbg.set_module_level(debug_level, 'core');
             nb_native().fs.set_debug_level(debug_level);
         }
         const http_port = Number(argv.http_port) || 6001;

--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -75,6 +75,9 @@ fix_non_root_user() {
 run_internal_process() {
   while true
   do
+    local package_path="/root/node_modules/noobaa-core/package.json"
+    local version=$(cat ${package_path} | grep version | awk '{print $2}' | sed 's/[",]//g')
+    echo "Version is: ${version}"
     echo "Running: $*"
     $*
     rc=$?

--- a/src/deploy/NVA_build/supervisord.orig
+++ b/src/deploy/NVA_build/supervisord.orig
@@ -6,6 +6,10 @@ PIDFILE="/var/log/supervisord.pid"
 # chkconfig: 345 15 15
 
 start() {
+    local package_path="/root/node_modules/noobaa-core/package.json"
+    local version=$(cat ${package_path} | grep version | awk '{print $2}' | sed 's/[",]//g')
+    echo "Version is: ${version}"
+    logger -p local0.info -t Superd "Version is: ${version}"
     #Run noobaa_init script before start
     local path="/root/node_modules/noobaa-core/src/deploy/NVA_build/"
     if [ "${container}" == "docker" ]

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -31,11 +31,17 @@ const net_utils = require('../util/net_utils');
 const addr_utils = require('../util/addr_utils');
 const md_server = require('../server/md_server');
 const server_rpc = require('../server/server_rpc');
+const debug_config = require('../util/debug_config');
 const auth_server = require('../server/common_services/auth_server');
 const system_store = require('../server/system_services/system_store');
 const prom_reporting = require('../server/analytic_services/prometheus_reporting');
 const background_scheduler = require('../util/background_scheduler').get_instance();
 const { NamespaceMonitor } = require('../server/bg_services/namespace_monitor');
+
+if (process.env.NOOBAA_LOG_LEVEL) {
+    let dbg_conf = debug_config.get_debug_config(process.env.NOOBAA_LOG_LEVEL);
+    dbg_conf.endpoint.map(module => dbg.set_module_level(dbg_conf.level, module));
+}
 
 /**
  * @typedef {http.IncomingMessage & {

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -32,7 +32,7 @@ const RpcNtcpConnection = require('./rpc_ntcp');
 const RpcFcallConnection = require('./rpc_fcall');
 const RPC_BUFFERS = RpcRequest.RPC_BUFFERS;
 
-// dbg.set_level(5, __dirname);
+// dbg.set_module_level(5, __dirname);
 
 /**
  *

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -71,7 +71,7 @@ let heapdiff;
 argv.heap = argv.heap || false;
 
 dbg.log('Arguments', argv);
-dbg.set_level(argv.debug, __dirname);
+dbg.set_module_level(argv.debug, __dirname);
 
 const schema = new RpcSchema();
 schema.register_api({

--- a/src/rpc/rpc_http.js
+++ b/src/rpc/rpc_http.js
@@ -12,7 +12,7 @@ const http_utils = require('../util/http_utils');
 const RpcBaseConnection = require('./rpc_base_conn');
 const { RPC_VERSION_NUMBER } = require('./rpc_message');
 
-// dbg.set_level(5);
+// dbg.set_module_level(5);
 
 const BASE_PATH = '/rpc/';
 const browser_location = global.window && global.window.location;

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -21,7 +21,7 @@ const { RpcError } = require('../rpc');
 
 Object.isFrozen(RpcError); // otherwise unused
 
-// dbg.set_level(5, 'core');
+// dbg.set_module_level(5, 'core');
 
 /**
  * @typedef {Object} UploadParams

--- a/src/server/bg_services/dedup_indexer.js
+++ b/src/server/bg_services/dedup_indexer.js
@@ -9,7 +9,7 @@ const MDStore = require('../object_services/md_store').MDStore;
 const system_store = require('../system_services/system_store').get_instance();
 const system_utils = require('../utils/system_utils');
 
-// dbg.set_level(5);
+// dbg.set_module_level(5);
 
 /**
  *

--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -11,6 +11,7 @@ require('../util/fips');
 
 const dbg = require('../util/debug_module')(__filename);
 dbg.set_process_name('BGWorkers');
+const debug_config = require('../util/debug_config');
 
 const url = require('url');
 const http_utils = require('../util/http_utils');
@@ -52,6 +53,11 @@ const MASTER_BG_WORKERS = [
     'agent_blocks_verifier',
     'agent_blocks_reclaimer'
 ];
+
+if (process.env.NOOBAA_LOG_LEVEL) {
+    let dbg_conf = debug_config.get_debug_config(process.env.NOOBAA_LOG_LEVEL);
+    dbg_conf.core.map(module => dbg.set_module_level(dbg_conf.level, module));
+}
 
 db_client.instance().connect();
 register_rpc();

--- a/src/server/common_services/debug_server.js
+++ b/src/server/common_services/debug_server.js
@@ -22,7 +22,7 @@ const FE_DUMP_DIR_SIZE_LIMIT = 40 * (1024 ** 2); // 40MB
 
 function set_debug_level(req) {
     dbg.log0('Received set_debug_level req for level', req.rpc_params.level, 'mod', req.rpc_params.module);
-    dbg.set_level(req.rpc_params.level, req.rpc_params.module);
+    dbg.set_module_level(req.rpc_params.level, req.rpc_params.module);
     nb_native().fs.set_debug_level(req.rpc_params.level);
 }
 

--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -21,7 +21,7 @@ const { ChunkDB } = require('./map_db_types');
 
 const builder_lock = new KeysLock();
 
-// dbg.set_level(5);
+// dbg.set_module_level(5);
 
 /**
  *

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -13,6 +13,7 @@ require('../util/fips');
 
 const dbg = require('../util/debug_module')(__filename);
 dbg.set_process_name('WebServer');
+const debug_config = require('../util/debug_config');
 
 const _ = require('lodash');
 const path = require('path');
@@ -40,6 +41,11 @@ const http_utils = require('../util/http_utils');
 const rootdir = path.join(__dirname, '..', '..');
 const dev_mode = (process.env.DEV_MODE === 'true');
 const app = express();
+
+if (process.env.NOOBAA_LOG_LEVEL) {
+    let dbg_conf = debug_config.get_debug_config(process.env.NOOBAA_LOG_LEVEL);
+    dbg_conf.core.map(module => dbg.set_module_level(dbg_conf.level, module));
+}
 
 db_client.instance().connect();
 
@@ -180,7 +186,7 @@ app.post('/set_log_level*', function(req, res) {
     }
 
     dbg.log0('Change log level requested for', req.param('module'), 'to', req.param('level'));
-    dbg.set_level(req.param('level'), req.param('module'));
+    dbg.set_module_level(req.param('level'), req.param('module'));
 
     return server_rpc.client.redirector.publish_to_cluster({
             target: '', // required but irrelevant

--- a/src/test/framework/test_env_builder_kubernetes.js
+++ b/src/test/framework/test_env_builder_kubernetes.js
@@ -20,7 +20,7 @@ const RED = "\x1b[31;1m";
 const NC = "\x1b[0m";
 
 if (process.env.SUPPRESS_LOGS) {
-    dbg.set_level(-5, 'core');
+    dbg.set_module_level(-5, 'core');
 }
 
 const {
@@ -39,9 +39,9 @@ const {
 } = argv;
 
 if (debug) {
-    dbg.set_level(3, 'core');
+    dbg.set_module_level(3, 'core');
 } else {
-    dbg.set_level(-1, 'core');
+    dbg.set_module_level(-1, 'core');
 }
 
 const deleted_namespaces = [];

--- a/src/test/system_tests/sanity_build_test.js
+++ b/src/test/system_tests/sanity_build_test.js
@@ -7,7 +7,7 @@ const dbg = require('../../util/debug_module')(__filename);
 const argv = require('minimist')(process.argv);
 
 if (process.env.SUPPRESS_LOGS) {
-    dbg.set_level(-5, 'core');
+    dbg.set_module_level(-5, 'core');
 }
 
 const { CloudFunction } = require('../utils/cloud_functions');

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -29,7 +29,7 @@ const dbg_level =
     (process.env.SUPPRESS_LOGS && -5) ||
     (argv.verbose && 5) ||
     0;
-dbg.set_level(dbg_level, 'core');
+dbg.set_module_level(dbg_level, 'core');
 
 const P = require('../../util/promise');
 const ObjectIO = require('../../sdk/object_io');

--- a/src/test/unit_tests/test_bucket_chunks_builder.js
+++ b/src/test/unit_tests/test_bucket_chunks_builder.js
@@ -12,10 +12,10 @@ const dbg = require('../../util/debug_module')(__filename);
 
 // argv.verbose = true;
 if (argv.verbose) {
-    dbg.set_level(5, 'core');
+    dbg.set_module_level(5, 'core');
 } else {
     // disable dbg messages by default
-    dbg.set_level(-1, 'core');
+    dbg.set_module_level(-1, 'core');
 }
 
 

--- a/src/test/unit_tests/test_debug_module.js
+++ b/src/test/unit_tests/test_debug_module.js
@@ -80,7 +80,7 @@ mocha.describe('debug_module', function() {
 
     mocha.it('should set level for windows style module and propogate', function() {
         var dbg = new DebugModule('C:\\Program Files\\NooBaa\\src\\agent\\agent_cli.js');
-        dbg.set_level(3, 'C:\\Program Files\\NooBaa\\src\\agent');
+        dbg.set_module_level(3, 'C:\\Program Files\\NooBaa\\src\\agent');
         assert.strictEqual(dbg._cur_level.__level, 3);
     });
 
@@ -107,7 +107,7 @@ mocha.describe('debug_module', function() {
 
     mocha.it('should log after changing level of module', function() {
         var dbg = new DebugModule('/web/noise/noobaa-core/src/blabla.asd/lll.asd');
-        dbg.set_level(4);
+        dbg.set_module_level(4);
         var a = {
             out: "out",
             second: {
@@ -115,7 +115,7 @@ mocha.describe('debug_module', function() {
             }
         };
         dbg.log4("test_debug_module: log4 should appear after level change", a);
-        dbg.set_level(0);
+        dbg.set_module_level(0);
         return file_content_verify("text", "core.blabla.asd.lll:: test_debug_module: log4 should appear after level change");
     });
 
@@ -127,9 +127,9 @@ mocha.describe('debug_module', function() {
 
     mocha.it('setting a higher module should affect sub module', function() {
         var dbg = new DebugModule('/web/noise/noobaa-core/src/blabla.asd/lll.asd');
-        dbg.set_level(2, 'core');
+        dbg.set_module_level(2, 'core');
         dbg.log2("test_debug_module: log2 setting a higher level module level should affect current");
-        dbg.set_level(0, 'core');
+        dbg.set_module_level(0, 'core');
         return file_content_verify("text", "core.blabla.asd.lll:: test_debug_module: log2 setting a higher level module level should affect current");
     });
 

--- a/src/test/unit_tests/test_mirror_writer.js
+++ b/src/test/unit_tests/test_mirror_writer.js
@@ -16,10 +16,10 @@ const argv = require('minimist')(process.argv);
 const dbg = require('../../util/debug_module')(__filename);
 // argv.verbose = true;
 if (argv.verbose) {
-    dbg.set_level(5, 'core');
+    dbg.set_module_level(5, 'core');
 } else {
     // disable dbg messages by default
-    dbg.set_level(-1, 'core');
+    dbg.set_module_level(-1, 'core');
 }
 
 

--- a/src/tools/nbcat.js
+++ b/src/tools/nbcat.js
@@ -6,7 +6,7 @@ var size_utils = require('../util/size_utils');
 var api = require('../api');
 var ObjectIO = require('../sdk/object_io');
 var dbg = require('../util/debug_module')(__filename);
-dbg.set_level(5);
+dbg.set_module_level(5);
 
 var bkt = process.argv[2];
 var key = process.argv[3];

--- a/src/util/README.md
+++ b/src/util/README.md
@@ -11,8 +11,8 @@
   By using __filename upon creation, the created nested modules tree would reflect the source directory structure.
   Provides the following API:
 
-    - .set_level(level) change current module logging level
-    - .set_level(level,module) change given module logging level and all its sub-tree
+    - .set_module_level(level) change current module logging level
+    - .set_module_level(level,module) change given module logging level and all its sub-tree
     - .logX (...) logs if current module level or any of its parents >= X
     - .logX_withbt logs and adds backtrace if current module level or any of its parents >= X
     - trace / log / info / error / warn will always log. They exist to comply with syslog levels
@@ -38,8 +38,8 @@
 
   4) A level of a module can be set by using the set_level API.
 
-     ___dbg.set_level(3); //This will cause the current module level to be 3___
+     ___dbg.set_module_level(3); //This will cause the current module level to be 3___
 
      Another options is so set another module's level, this is especially beneficial when we want to catch all logs under a certain component. For example, setting level 3 for for every module under the "some" directory (including sub directories):
 
-     ___dbg.set_level("core.some",3);___
+     ___dbg.set_module_level("core.some",3);___

--- a/src/util/debug_config.js
+++ b/src/util/debug_config.js
@@ -1,0 +1,51 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const nsfs = {
+    level: 5,
+    core: [
+        'core.server.system_services.bucket_server',
+        'core.server.system_services.pool_server'
+    ],
+    endpoint: [
+        'core.endpoint.s3',
+        'core.util.http_utils',
+        'core.util.semaphore',
+        'core.util.buffer_utils',
+        'core.sdk.object_sdk',
+        'core.sdk.namespace_fs',
+        'core.sdk.bucketspace_nb'
+    ],
+};
+
+const all = {
+    level: 5,
+    core: ['core'],
+    endpoint: ['core'],
+};
+
+const warn = {
+    level: -1,
+    core: ['core'],
+    endpoint: ['core'],
+};
+
+const default_level = {
+    level: 0,
+    core: ['core'],
+    endpoint: ['core'],
+};
+
+function get_debug_config(conf) {
+    if (conf === 'all') {
+        return all;
+    } else if (conf === 'nsfs') {
+        return nsfs;
+    } else if (conf === 'warn') {
+        return warn;
+    } else {
+        return default_level;
+    }
+}
+
+exports.get_debug_config = get_debug_config;


### PR DESCRIPTION
### Explain the changes
- Create debug_config that set debug level according to a set of modules predefined. 

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: #6665

### Testing Instructions:
1. Set `process.env.NOOBAA_LOG_LEVEL` as `all`, `nsfs`,  `warn` or  `default_level` and see that the appropriate logs are being printed. 
