### PR TITLE
Support followSymlinks on top of NS FS

### DIFF
--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -535,6 +535,7 @@ S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     SERVICE_UNAVAILABLE: S3Error.ServiceUnavailable,
     INVALID_RANGE: S3Error.InvalidRange,
     INVALID_OBJECT_STATE: S3Error.InvalidObjectState,
+    INTERNAL_ERROR: S3Error.InternalError,
 });
 
 exports.S3Error = S3Error;


### PR DESCRIPTION
Signed-off-by: Igor Pick <ipick@redhat.com>

### Requirements

1. Resolve symbolic links in a target entry path.
2. if the target entry path is outside of a bucket, returns an AccessDenied error.

Implemented in the following methods:
1. read object metadata - return ACCESS ERROR if an object path is outside of the bucket.
2. read object stream -  return ACCESS ERROR if an object path is outside of the bucket.
3. upload object - return ACCESS ERROR if an object destination/source path is outside of the bucket.
4. list multiparts -  return ACCESS ERROR if provided mpu_path is outside of the bucket.
5. complete object upload - return ACCESS ERROR if a multipart destination path is outside of the bucket.
6. Delete object - return ACCESS ERROR if an object path is outside of the bucket.
7. Delete multiple objects - return ACCESS ERROR if one of objects' paths is outside of the bucket.
8. List object - if bucket entry is a symbolic link and outside of the bucket, returns info of the symbolic link himself, otherwise, returns info of the target entry.

Note: Related issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1429472

