### PR TITLE
Semaphore improvement and addition to upload flows

### DIFF
--- a/src/test/unit_tests/test_semaphore.js
+++ b/src/test/unit_tests/test_semaphore.js
@@ -134,4 +134,25 @@ mocha.describe('semaphore', function() {
         assert.strictEqual(sem.waiting_value, 0);
     });
 
+    mocha.it('should release value on non settled worker', async function() {
+        const sem = new Semaphore(1, {
+            work_timeout: 1,
+            work_timeout_error_code: 'MAJESTIC_SLOTH_TIMEOUT'
+        });
+        assert.strictEqual(sem.length, 0);
+        assert.strictEqual(sem.value, 1);
+        try {
+            await sem.surround_count(1, async function() {
+                return new Promise((resolve, reject) => setTimeout(resolve, 2));
+            });
+            throw new Error('Semaphore did not throw an error on non settled worker');
+        } catch (error) {
+            assert.strictEqual(error.code, 'MAJESTIC_SLOTH_TIMEOUT');
+            assert.strictEqual(error.message, 'Semaphore Worker Timeout');
+        }
+        assert.strictEqual(sem.length, 0);
+        assert.strictEqual(sem.value, 1);
+        assert.strictEqual(sem.waiting_value, 0);
+    });
+
 });

--- a/src/util/semaphore.js
+++ b/src/util/semaphore.js
@@ -4,6 +4,8 @@
 const WaitQueue = require('./wait_queue');
 const dbg = require('./debug_module')(__filename);
 
+const DEFAULT_WORK_TIMEOUT = 2 * 60 * 1000;
+
 class Semaphore {
 
     /**
@@ -24,8 +26,22 @@ class Semaphore {
             if (params.timeout) {
                 this._timeout = params.timeout;
             }
+            if (params.work_timeout) {
+                this._work_timeout = params.work_timeout;
+            }
             this._timeout_error_code = params.timeout_error_code || 'SEMAPHORE_TIMEOUT';
+            this._work_timeout_error_code = params.work_timeout_error_code || 'SEMAPHORE_WORKER_TIMEOUT';
+
         }
+    }
+
+    async _work_cap() {
+        return new Promise((resolve, reject) => {
+            const err = new Error('Semaphore Worker Timeout');
+            err.code = this._work_timeout_error_code;
+            const t = setTimeout(() => reject(err), this._work_timeout || DEFAULT_WORK_TIMEOUT);
+            t.unref();
+        });
     }
 
     /**
@@ -37,7 +53,8 @@ class Semaphore {
     async surround(func) {
         await this.wait();
         try {
-            return await func();
+            // May lead to unaccounted work in the background on timeout
+            return Promise.race([func(), this._work_cap()]);
         } finally {
             // Release should be called only when the wait was successful
             // If the item did not take any "resources"/value from the semaphore
@@ -56,7 +73,8 @@ class Semaphore {
     async surround_count(count, func) {
         await this.wait(count);
         try {
-            return await func();
+            // May lead to unaccounted work in the background on timeout
+            return Promise.race([func(), this._work_cap()]);
         } finally {
             // Release should be called only when the wait was successful
             // If the item did not take any "resources"/value from the semaphore


### PR DESCRIPTION
### Explain the changes
1. Accounted PUT Object / Upload Part in the global semaphore.
Gap: The current implementation takes up a buffer of 8 megabytes for every PUT, Part Upload even if they are small. 
2. Changes to semaphore cleanup logic on non settled working items

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/6707

### Testing Instructions:
1. 
