### PR TITLE
Fix db_cleaner

### DIFF
--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -76,11 +76,11 @@ async function clean_md_store(last_date_to_remove) {
     dbg.log0(`DB_CLEANER: removed ${objects_to_remove.length + blocks_to_remove.length + filtered_chunks.length} documents from md-store`);
 }
 
-async function db_delete_object_parts(obj) {
-    if (!obj) return;
+async function db_delete_object_parts(id) {
+    if (!id) return;
     return P.all([
-        MDStore.instance().db_delete_parts_of_object(obj),
-        MDStore.instance().db_delete_multiparts_of_object(obj)
+        MDStore.instance().db_delete_parts_of_object(id),
+        MDStore.instance().db_delete_multiparts_of_object(id)
     ]);
 }
 

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -964,12 +964,12 @@ class MDStore {
         });
     }
 
-    async db_delete_multiparts_of_object(obj) {
+    async db_delete_multiparts_of_object(id) {
         const res = await this._multiparts.deleteMany({
-            obj: { $eq: obj._id, $exists: true },
+            obj: { $eq: id, $exists: true },
             deleted: { $exists: true }
         });
-        dbg.warn(`Removed ${res.result.n} multiparts of object ${obj} from DB`);
+        dbg.warn(`Removed ${res.result.n} multiparts of object ${id} from DB`);
     }
 
     has_any_objects_for_bucket_including_deleted(bucket_id) {
@@ -1211,12 +1211,12 @@ class MDStore {
         });
     }
 
-    async db_delete_parts_of_object(obj) {
+    async db_delete_parts_of_object(id) {
         const res = await this._parts.deleteMany({
-            obj: { $eq: obj._id, $exists: true },
+            obj: { $eq: id, $exists: true },
             deleted: { $exists: true }
         });
-        dbg.warn(`Removed ${res.result.n} parts of object ${obj} from DB`);
+        dbg.warn(`Removed ${res.result.n} parts of object ${id} from DB`);
     }
 
 

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -314,8 +314,10 @@ class PgTransaction {
     }
 
     release() {
-        this.pg_client.release();
-        this.pg_client = null;
+        if (this.pg_client) {
+            this.pg_client.release();
+            this.pg_client = null;
+        }
     }
 
 }


### PR DESCRIPTION
1. Fix db_delete_parts_of_object and db_delete_parts_of_object
The methods get id string instead of obj. It caused to db_cleaner fail

### Explain the changes
1. Fix db_delete_parts_of_object and db_delete_multiparts_of_object resolve the error below:
```
[ERROR] core.util.postgres_client:: deleteMany failed { obj: undefined, deleted: { '$exists': true } } DELETE FROM objectparts WHERE ( and data ? 'deleted
') error: syntax error at or near "and"
```
