### PR TITLE
remove "distinct on" query and flow

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -743,19 +743,6 @@ class MDStore {
         return Boolean(obj);
     }
 
-    async all_buckets_with_completed_objects() {
-        return this._objects.distinct('bucket', {
-            // prefix for stored blob blocks information. TODO: move somwhere like config.js
-            key: { $not: /^\.noobaa_blob_blocks/ },
-            // partialFilterExpression:
-            deleted: null,
-            upload_started: null,
-        }, {
-            hint: 'version_seq_index',
-            sort: { bucket: 1 }
-        });
-    }
-
     async count_objects_of_bucket(bucket_id) {
         return this._objects.countDocuments({
             bucket: bucket_id,

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1861,10 +1861,6 @@ function can_delete_bucket(bucket) {
         });
 }
 
-async function list_undeletable_buckets() {
-    return MDStore.instance().all_buckets_with_completed_objects();
-}
-
 async function get_object_lock_configuration(req) {
     const bucket = find_bucket(req);
     dbg.log0('get object lock configuration of bucket', req.rpc_params);
@@ -2017,7 +2013,6 @@ function normalize_replication(req) {
 // EXPORTS
 exports.new_bucket_defaults = new_bucket_defaults;
 exports.get_bucket_info = get_bucket_info;
-exports.list_undeletable_buckets = list_undeletable_buckets;
 //Bucket Management
 exports.create_bucket = create_bucket;
 exports.read_bucket = read_bucket;


### PR DESCRIPTION
### Explain the changes
1.  During the last postgres performance improvement, detected that the "distinct on" query is very expensive and may take 30 -40 sec and a lot of cpu in scale cluster. 
Additionally, the responded data is not in use due to a bug, since the 
```
if (undeletable_bucket_set.has(bucket_name)) {
                    b.undeletable = 'NOT_EMPTY';
                }
```
is always false. (undeletable_bucket_set has jsonb objects)

Found two components which should use the bucket.undeletable flag - fronted and noobaa cli.
Fronted uses the flag in order to disable "delete" button in bucket list. For now the button is always enabled, but user is not able to delete bucket, since the core makes the validation and returns to ui error if the bucket is not empty.
Cli uses the flag to show a bucket status.
