### PR TITLE
Adding support for node_extra_ca_certs in noobaa core

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -384,16 +384,18 @@ function update_account_s3_access(req) {
             update.allow_bucket_creation = req.rpc_params.allow_bucket_creation;
         }
 
-        if (req.rpc_params.nsfs_account_config && _.isUndefined(req.rpc_params.nsfs_account_config.uid) &&
-            _.isUndefined(req.rpc_params.nsfs_account_config.gid) && !req.rpc_params.nsfs_account_config.new_buckets_path &&
-            _.isUndefined(req.rpc_params.nsfs_account_config.nsfs_only)) {
-            throw new RpcError('FORBIDDEN', 'Invalid nsfs_account_config');
-        }
+        if (req.rpc_params.nsfs_account_config) {
+            if (_.isUndefined(req.rpc_params.nsfs_account_config.uid) &&
+                _.isUndefined(req.rpc_params.nsfs_account_config.gid) && !req.rpc_params.nsfs_account_config.new_buckets_path &&
+                _.isUndefined(req.rpc_params.nsfs_account_config.nsfs_only)) {
+                throw new RpcError('FORBIDDEN', 'Invalid nsfs_account_config');
+            }
 
-        update.nsfs_account_config = req.rpc_params.nsfs_account_config && {
-            ...account.nsfs_account_config,
-            ...req.rpc_params.nsfs_account_config
-        };
+            update.nsfs_account_config = {
+                ...account.nsfs_account_config,
+                ...req.rpc_params.nsfs_account_config
+            };
+        }
     } else {
         update.$unset = {
             allowed_buckets: true,

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -17,7 +17,7 @@ const xml_utils = require('./xml_utils');
 const cloud_utils = require('./cloud_utils');
 const config = require('../../config');
 
-const { HTTP_PROXY, HTTPS_PROXY, NO_PROXY } = process.env;
+const { HTTP_PROXY, HTTPS_PROXY, NO_PROXY, NODE_EXTRA_CA_CERTS } = process.env;
 const http_agent = new http.Agent();
 const https_agent = new https.Agent();
 const unsecured_https_agent = new https.Agent({ rejectUnauthorized: false });
@@ -393,7 +393,9 @@ function get_default_agent(endpoint) {
  */
 function get_unsecured_agent(endpoint) {
     const is_aws_address = cloud_utils.is_aws_endpoint(endpoint);
-    return _get_http_agent(endpoint, !is_aws_address);
+    const hostname = url.parse(endpoint) ? url.parse(endpoint).hostname : endpoint;
+    const is_localhost = _.isString(hostname) && hostname.toLowerCase() === 'localhost';
+    return _get_http_agent(endpoint, is_localhost || (!is_aws_address && _.isEmpty(NODE_EXTRA_CA_CERTS)));
 }
 
 function _get_http_agent(endpoint, request_unsecured) {


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. If we will get the NODE_EXTRA_CA_CERTS set we will use the normal https client and not the unsecured one
2. NODE_EXTRA_CA_CERTS will be set in the operator (in parallel PR) in case of having service_ca.crt like in OCP
3. If the https client is localhost we will keep using the unsecured client - as the https certificate is usually not signed as localhost, but as the server name. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
