### PR TITLE
Fixing segmentation fault in NSFS (backport to 5.9)

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -13,6 +13,7 @@ const config = require('../../config');
 const s3_utils = require('../endpoint/s3/s3_utils');
 const stream_utils = require('../util/stream_utils');
 const buffer_utils = require('../util/buffer_utils');
+const ChunkFS = require('../util/chunk_fs');
 const stats_collector = require('./endpoint_stats_collector');
 // const http_utils = require('../util/http_utils');
 const LRUCache = require('../util/lru_cache');
@@ -717,47 +718,18 @@ class NamespaceFS {
     // Instead of wrapping the whole _upload_stream function (q_buffers lives outside of the data scope of the stream)
     async _upload_stream(source_stream, upload_path, fs_account_config, rpc_client, fs_xattr) {
         let target_file;
-        let MD5Async = config.NSFS_CALCULATE_MD5 ? new (nb_native().crypto.MD5Async)() : undefined;
         try {
-            let q_buffers = [];
-            let q_size = 0;
             target_file = await nb_native().fs.open(fs_account_config, upload_path, 'w', get_umasked_mode(config.BASE_MODE_FILE));
-            const flush = async () => {
-                if (q_buffers.length) {
-                    if (MD5Async) {
-                        for await (const buf of q_buffers) await MD5Async.update(buf);
-                    }
-                    await target_file.writev(fs_account_config, q_buffers);
-                    q_buffers = [];
-                    q_size = 0;
-                }
-            };
+            const MD5Async = config.NSFS_CALCULATE_MD5 ? new (nb_native().crypto.MD5Async)() : undefined;
             // Not using async iterators with ReadableStreams due to unsettled promises issues on abort/destroy
-            await new Promise((resolve, reject) => {
-                let count = 1;
-                source_stream.on('data', async data => {
-                    // Update the write stats
-                    stats_collector.instance(rpc_client).update_namespace_write_stats({
-                        namespace_resource_id: this.namespace_resource_id,
-                        size: data.length,
-                        count
-                    });
-                    // clear count for next updates
-                    count = 0;
-                    while (data && data.length) {
-                        const available_size = config.NSFS_BUF_SIZE - q_size;
-                        const buf = (available_size < data.length) ? data.slice(0, available_size) : data;
-                        q_buffers.push(buf);
-                        q_size += buf.length;
-                        if (q_size === config.NSFS_BUF_SIZE) await flush();
-                        data = (available_size < data.length) ? data.slice(available_size) : null;
-                    }
-                });
-                source_stream.on('end', resolve);
-                source_stream.on('close', () => reject(new Error('_upload_stream: source_stream closed')));
-                source_stream.on('error', err => reject(err));
+            const chunk_fs = new ChunkFS({
+                MD5Async,
+                target_file,
+                fs_account_config,
+                rpc_client,
+                namespace_resource_id: this.namespace_resource_id
             });
-            await flush();
+            await stream_utils.pipeline(source_stream, chunk_fs);
             if (MD5Async) {
                 fs_xattr = this._assign_md5_to_fs_xattr((await MD5Async.digest()).toString('hex'), fs_xattr);
             }

--- a/src/util/chunk_fs.js
+++ b/src/util/chunk_fs.js
@@ -1,0 +1,74 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const stream = require('stream');
+const config = require('../../config');
+const stats_collector = require('../../src/sdk/endpoint_stats_collector');
+
+/**
+ *
+ * ChunkNSFS
+ * 
+ * Calculates etag and writes stream data to the filesystem batching data buffers
+ *
+ */
+class ChunkFS extends stream.Transform {
+
+    constructor({ MD5Async, target_file, fs_account_config, rpc_client, namespace_resource_id }) {
+        super();
+        this.q_buffers = [];
+        this.q_size = 0;
+        this.MD5Async = MD5Async;
+        this.target_file = target_file;
+        this.fs_account_config = fs_account_config;
+        this.count = 1;
+        this.rpc_client = rpc_client;
+        this.namespace_resource_id = namespace_resource_id;
+    }
+
+    _transform(chunk, encoding, callback) {
+        try {
+            this._process_chunk(chunk, callback);
+        } catch (error) {
+            callback(error);
+        }
+    }
+
+    _flush(callback) {
+        try {
+            this._flush_buffers(callback);
+        } catch (error) {
+            callback(error);
+        }
+    }
+
+    async _flush_buffers(callback) {
+        if (this.q_buffers.length) {
+            await this.target_file.writev(this.fs_account_config, this.q_buffers);
+            this.q_buffers = [];
+            this.q_size = 0;
+        }
+        if (callback) callback();
+    }
+
+    async _process_chunk(data, callback) {
+        if (this.MD5Async) await this.MD5Async.update(data);
+        stats_collector.instance(this.rpc_client).update_namespace_write_stats({
+            namespace_resource_id: this.namespace_resource_id,
+            size: data.length,
+            count: this.count
+        });
+        this.count = 0;
+        while (data && data.length) {
+            const available_size = config.NSFS_BUF_SIZE - this.q_size;
+            const buf = (available_size < data.length) ? data.slice(0, available_size) : data;
+            this.q_buffers.push(buf);
+            this.q_size += buf.length;
+            if (this.q_size === config.NSFS_BUF_SIZE) await this._flush_buffers();
+            data = (available_size < data.length) ? data.slice(available_size) : null;
+        }
+        callback();
+    }
+}
+
+module.exports = ChunkFS;


### PR DESCRIPTION
### Explain the changes
1. Fixing the segmentation fault caused by the hash calculation

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2013198

### Testing Instructions:
1. 
