### PR TITLE
Provide full permissions to nsfs folder

### DIFF
--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -180,6 +180,12 @@ prepare_postgres_pv() {
 init_endpoint() {
   fix_non_root_user
 
+  # nsfs folder is a root folder of mount points to backing storages.
+  # In oder to avoid access denied of sub folders, configure nsfs with full permisions (777)  
+  if [ -d "/nsfs" ];then
+    chmod 777 /nsfs
+  fi
+
   cd /root/node_modules/noobaa-core/
   run_internal_process node ./src/s3/s3rver_starter.js
 }


### PR DESCRIPTION

### Explain the changes
1.  nsfs folder is a root folder of mount points to backing storages.
     In oder to avoid access denied of sub folders, configure nsfs with full permisions (777)

### Issues: Fixed #xxx / Gap #xxx
1. 6761

