### PR TITLE
tools: fs_speed improved for nsfs perf troubleshooting

### DIFF
--- a/src/test/unrelated/test_pipeline_stuck_on_destroyed_stream.js
+++ b/src/test/unrelated/test_pipeline_stuck_on_destroyed_stream.js
@@ -1,0 +1,53 @@
+/* Copyright (C) 2020 NooBaa */
+'use strict';
+
+const stream = require('stream');
+
+async function main() {
+    await new Promise(r => setTimeout(r, 100));
+
+    const source = new stream.Readable({
+        read() {
+            setTimeout(() => this.push(Buffer.from(`hello world ${process.hrtime.bigint()}}`)), 100);
+        }
+    });
+    source.on('error', err => console.log('*** SOURCE CLOSED', err.message));
+
+    await new Promise(r => setTimeout(r, 100));
+    setTimeout(() => source.destroy(new Error('DIE')), 1000);
+    // source.destroy(new Error('DIE'));
+    await new Promise(r => setTimeout(r, 100));
+
+    // See https://github.com/nodejs/node/issues/36674
+    console.log('*** PIPELINE', source.destroyed ? 'already destroyed !!!' : 'still not destroyed.');
+    const strm = stream.pipeline(
+        source,
+        new stream.PassThrough(),
+        err => console.log('*** PIPELINE:', err),
+    );
+
+    await write_stream_to_file(strm, '/dev/null');
+}
+
+/**
+ * @param {stream.Readable} strm
+ * @param {string} fname
+ * @returns {Promise<void>}
+ */
+async function write_stream_to_file(strm, fname) {
+    try {
+        console.log('*** STREAM', strm.destroyed ? 'already destroyed !!!' : 'still not destroyed.');
+        for await (const buf of strm) {
+            console.log('*** READ', buf.toString());
+        }
+    } catch (err) {
+        console.log('*** CATCH', err);
+    } finally {
+        // we expect this finally block to be executed in any case
+        // but the async function can get "cancelled" if it awaits
+        // a promise that is pending and gets garbage collected.
+        console.log('*** FINALLY');
+    }
+}
+
+main();

--- a/src/test/unrelated/test_pipeline_vs_pipe.js
+++ b/src/test/unrelated/test_pipeline_vs_pipe.js
@@ -1,0 +1,142 @@
+/* Copyright (C) 2020 NooBaa */
+'use strict';
+
+const util = require('util');
+const stream = require('stream');
+const assert = require('assert');
+
+const finished_async = util.promisify(stream.finished);
+const pipeline_async = util.promisify(stream.pipeline);
+const delay_async = util.promisify(setTimeout);
+const inspect_readable_state = readable => util.inspect(readable._readableState, {
+    breakLength: Infinity,
+    colors: true,
+    depth: null,
+});
+
+async function test_pipe(use_pipeline) {
+
+    const N_READ_MAX = 100;
+    const N_DECODE_MAX = 10;
+    const TICK = 50;
+
+    let n_read = 0;
+    let n_decode = 0;
+
+    const source = new stream.Readable({
+        async read() {
+            await delay_async(TICK);
+            if (n_read < N_READ_MAX) {
+                console.log('source:', n_read);
+                const data = Buffer.allocUnsafe(4);
+                data.writeInt32BE(n_read, 0);
+                this.push(data);
+                n_read += 1;
+            } else {
+                console.log('source: *** end ***');
+                this.push(null);
+            }
+        },
+        destroy(err, callback) {
+            console.error('source: *** DESTROYED ***', err.message);
+            return callback();
+        },
+    });
+
+    const decoder = new stream.Transform({
+        async transform(data, enc, callback) {
+            await delay_async(TICK);
+            console.log('decoder:', n_decode);
+            const n = data.readInt32BE(0);
+            assert.strictEqual(n, n_decode);
+            this.push(data, enc);
+            n_decode += 1;
+            return n_decode > N_DECODE_MAX ?
+                callback(new Error('INJECT ERROR')) :
+                callback();
+        },
+        destroy(err, callback) {
+            console.error('decoder: *** DESTROYED ***', err.message);
+            return callback();
+        },
+    });
+
+    const target = new stream.Writable({
+        async write(data, enc, callback) {
+            await delay_async(TICK);
+            return callback();
+        },
+        destroy(err, callback) {
+            console.error('target: *** DESTROYED ***', err.message);
+            return callback();
+        },
+    });
+
+    try {
+        if (use_pipeline) {
+            await pipeline_async(
+                source,
+                decoder,
+                target
+            );
+        } else {
+            source.pipe(decoder).pipe(target);
+            console.error('main: waiting streams to finish ...');
+            await Promise.all([
+                finished_async(source),
+                finished_async(decoder),
+                finished_async(target),
+            ]);
+        }
+    } catch (err) {
+        console.error('main: caught', err);
+    }
+
+    // eslint-disable-next-line no-unmodified-loop-condition
+    while (!source.destroyed && n_read < N_READ_MAX) {
+        if (source.readableEnded) {
+            console.error('main: source ended but not destroyed', inspect_readable_state(source));
+        } else {
+            console.error('main: source is still reading ...');
+        }
+        await delay_async(1000);
+    }
+}
+
+async function main() {
+
+    console.log('');
+    console.log('*********************************');
+    console.log('***          CASE 1           ***');
+    console.log('***                           ***');
+    console.log('*** test WITH stream.pipeline ***');
+    console.log('***                           ***');
+    console.log('*********************************');
+    console.log('');
+
+    await test_pipe(true);
+
+    console.log('');
+    console.log('************************************');
+    console.log('***          CASE 2              ***');
+    console.log('***                              ***');
+    console.log('*** test WITHOUT stream.pipeline ***');
+    console.log('***                              ***');
+    console.log('************************************');
+    console.log('');
+
+    await test_pipe(false);
+
+    console.log('');
+    console.log('**************************************************************');
+    console.log('***                                                        ***');
+    console.log('***                                                        ***');
+    console.log('***    NOTICE HOW THE ENTIRE SOURCE IS READ IN CASE 2 ...  ***');
+    console.log('***                                                        ***');
+    console.log('***                                                        ***');
+    console.log('**************************************************************');
+    console.log('');
+}
+
+
+main().catch(console.error);

--- a/src/tools/fs_speed.js
+++ b/src/tools/fs_speed.js
@@ -2,71 +2,204 @@
 'use strict';
 
 const fs = require('fs');
-const argv = require('minimist')(process.argv);
+const util = require('util');
 const path = require('path');
-const crypto = require('crypto');
+const argv = require('minimist')(process.argv);
 const cluster = require('cluster');
+const execAsync = util.promisify(require('child_process').exec);
 const Speedometer = require('../util/speedometer');
+const RandStream = require('../util/rand_stream');
 
-argv.size = argv.size || 1;
-argv.size_units = argv.size_units || 'MB';
+function print_usage() {
+    console.log(`
+Usage:
+  --help            show this usage
+  --dir <path>      (default "./fs_speed_output") where to write the files
+  --time <sec>      (default 10) limit time to run
+  --concur <n>      (default 1) number of concurrent writers
+  --forks <n>       (default 1) number of forks to create (total writers is concur * forks).
+Sizes:
+  --file_size  <n>          (default 1024 MB) file size to write 
+  --block_size <n>          (default 8 MB) block size to write 
+  --file_size_units <unit>  (default is "MB") options are "GB", "MB", "KB", "B"
+  --block_size_units <unit> (default is "MB") options are "GB", "MB", "KB", "B"
+Write modes:
+  --fsync           trigger fsync at the end of each file
+  --mode <mode>     (default is "nsfs") options are
+         "nsfs"     use the native fs_napi module used in nsfs
+         "nodejs"   use nodejs fs module
+         "dd"       execute dd commands
+Advanced:
+  --device <path>   (default is "/dev/zero") input device to use for dd mode
+  --generator <x>   (default is "zeros") options are from rand stream (not for dd mode)
+  --nvec <num>      (default is 1) split blocks to use writev if > 1 (not for dd mode)
+
+Example:
+    node src/tools/fs_speed --dir /mnt/fs/fs_speed_output --time 30 --concur 4 --file_size 256 --block_size 4 --fsync --mode dd
+`);
+}
+
+if (argv.help) {
+    print_usage();
+    process.exit(0);
+}
+
+argv.dir = argv.dir || 'fs_speed_output';
+argv.time = argv.time || 10; // stop after X seconds
 argv.concur = argv.concur || 1;
 argv.forks = argv.forks || 1;
-argv.dir = argv.dir || 'fs_speed';
+argv.file_size = argv.file_size || 1024;
+argv.block_size = argv.block_size || 8;
+argv.file_size_units = argv.file_size_units || 'MB';
+argv.block_size_units = argv.block_size_units || 'MB';
+argv.fsync = Boolean(argv.fsync);
+argv.mode = argv.mode || 'nsfs';
+if (argv.mode === 'dd') {
+    argv.device = argv.device || '/dev/zero';
+} else {
+    // flags that are ignored on dd mode
+    // nvec larger than 1 will use writev instead of write
+    argv.nvec = argv.nvec || 1;
+    // generator value should be one that RandStream supports - 'crypto' | 'cipher' | 'fake' | 'zeros' | 'fill' | 'noinit'
+    argv.generator = argv.generator || 'zeros';
+}
 
+Object.freeze(argv);
+console.log(argv);
+
+if (!['nsfs', 'nodejs', 'dd'].includes(argv.mode)) {
+    throw new Error('Invalid mode ' + argv.mode);
+}
 const size_units_table = {
+    B: 1,
     KB: 1024,
     MB: 1024 * 1024,
     GB: 1024 * 1024 * 1024,
 };
-
-if (!size_units_table[argv.size_units]) {
-    throw new Error('Invalid size_units ' + argv.size_units);
+if (!size_units_table[argv.file_size_units]) {
+    throw new Error('Invalid file_size_units ' + argv.file_size_units);
+}
+if (!size_units_table[argv.block_size_units]) {
+    throw new Error('Invalid block_size_units ' + argv.block_size_units);
 }
 
-const size = argv.size * size_units_table[argv.size_units];
-const zero_buffer = Buffer.alloc(size);
-const master_speedometer = new Speedometer('Total Speed');
-const speedometer = new Speedometer('FS Speed');
+const block_size = argv.block_size * size_units_table[argv.block_size_units];
+const file_size = argv.file_size * size_units_table[argv.file_size_units];
+const block_count = Math.ceil(file_size / block_size);
+const file_size_aligned = block_count * block_size;
+const nb_native = argv.mode === 'nsfs' && require('../util/nb_native');
+const is_master = cluster.isMaster;
+const speedometer = new Speedometer(is_master ? 'Total Speed' : 'FS Speed');
+const start_time = Date.now();
+const end_time = start_time + (argv.time * 1000);
 
 let file_id = 0;
-let cipher;
-let cipher_bytes = 0;
-let cipher_limit = 0;
 
-try {
-    fs.mkdirSync(argv.dir);
-} catch (err) {
-    if (err.code !== 'EEXIST') throw err;
-}
-
-if (argv.forks > 1 && cluster.isMaster) {
-    master_speedometer.fork(argv.forks);
+if (argv.forks > 1 && is_master) {
+    speedometer.fork(argv.forks);
 } else {
-    for (let i = 0; i < argv.concur; ++i) {
-        setImmediate(worker);
+    main();
+}
+
+async function main() {
+    const promises = [];
+    fs.mkdirSync(argv.dir, { recursive: true });
+    for (let i = 0; i < argv.concur; ++i) promises.push(writer(i));
+    await Promise.all(promises);
+    speedometer.clear_interval();
+    if (is_master) speedometer.report();
+    process.exit(0);
+}
+
+/**
+ * @param {number} id
+ */
+async function writer(id) {
+    const dir = path.join(
+        argv.dir,
+        `${id}`, // first level is id so that repeating runs will be collected together
+        `pid-${process.pid}`,
+    );
+    await fs.promises.mkdir(dir, { recursive: true });
+
+    for (;;) {
+        const file_start_time = Date.now();
+        if (file_start_time >= end_time) break;
+        const file_path = path.join(dir, `file-${file_id}`);
+        file_id += 1;
+        if (argv.mode === 'nsfs') {
+            await write_nb_native(file_path);
+        } else if (argv.mode === 'nodejs') {
+            await write_node_fs(file_path);
+        } else if (argv.mode === 'dd') {
+            await write_dd(file_path);
+        }
+        const took_ms = Date.now() - file_start_time;
+        speedometer.add_op(took_ms);
     }
 }
 
-function worker() {
-    const buf = generate_data();
-    const fname = `file-${file_id}-worker-${process.pid}`;
-    file_id += 1;
-    fs.writeFile(path.join(argv.dir, fname), buf, err => {
-        if (err) throw err;
-        speedometer.update(size);
-        setImmediate(worker);
+async function write_dd(file_path) {
+    const cmd = `dd if=${argv.device} of=${file_path} bs=${block_size} count=${block_count}`;
+    // console.log(cmd);
+    await execAsync(cmd);
+    if (argv.fsync) await execAsync(`sync ${file_path}`);
+    speedometer.update(file_size_aligned);
+}
+
+async function write_nb_native(file_path) {
+    const rand_stream = new RandStream(file_size_aligned, {
+        highWaterMark: 2 * block_size,
+        generator: argv.generator,
     });
+    const fs_account_config = {
+        // uid: 666,
+        // gid: 666,
+        backend: 'GPFS',
+        warn_threshold_ms: 1000,
+    };
+    const file = await nb_native().fs.open(fs_account_config, file_path, 'w', 0x660);
+    for (let pos = 0; pos < file_size_aligned; pos += block_size) {
+        const buf_start_time = Date.now();
+        if (buf_start_time >= end_time) break;
+        const buf = rand_stream.generator(block_size);
+        if (argv.nvec > 1) {
+            await file.writev(fs_account_config, split_to_nvec(buf, argv.nvec));
+        } else {
+            await file.write(fs_account_config, buf);
+        }
+        speedometer.update(block_size);
+    }
+    if (argv.fsync) await file.fsync(fs_account_config);
+    await file.close(fs_account_config);
 }
 
-function generate_data() {
-    if (!cipher || cipher_bytes > cipher_limit) {
-        cipher_bytes = 0;
-        cipher_limit = 1024 * 1024 * 1024;
-        // aes-128-gcm requires 96 bits IV (12 bytes) and 128 bits key (16 bytes)
-        cipher = crypto.createCipheriv('aes-128-gcm',
-            crypto.randomBytes(16), crypto.randomBytes(12));
+async function write_node_fs(file_path) {
+    const rand_stream = new RandStream(file_size_aligned, {
+        highWaterMark: 2 * block_size,
+        generator: argv.generator,
+    });
+    const file = await fs.promises.open(file_path, 'w', 0x660);
+    for (let pos = 0; pos < file_size_aligned; pos += block_size) {
+        const buf_start_time = Date.now();
+        if (buf_start_time >= end_time) break;
+        const buf = rand_stream.generator(block_size);
+        if (argv.nvec > 1) {
+            await file.writev(split_to_nvec(buf, argv.nvec));
+        } else {
+            await file.write(buf);
+        }
+        speedometer.update(block_size);
     }
-    cipher_bytes += size;
-    return cipher.update(zero_buffer);
+    if (argv.fsync) await file.sync();
+    await file.close();
+}
+
+function split_to_nvec(buf, nvec) {
+    const len = Math.ceil(buf.length / nvec);
+    const bufs = [];
+    for (let p = 0; p < buf.length; p += len) {
+        bufs.push(buf.slice(p, p + len));
+    }
+    return bufs;
 }

--- a/src/util/speedometer.js
+++ b/src/util/speedometer.js
@@ -23,6 +23,9 @@ class Speedometer {
         this.max_latency = -Infinity;
 
         this.worker_mode = cluster.isWorker;
+    }
+
+    fork(count) {
         if (cluster.isMaster) {
             cluster.on('message', (worker, bytes) => this.update(bytes));
             cluster.on('exit', worker => {
@@ -33,9 +36,6 @@ class Speedometer {
                 }
             });
         }
-    }
-
-    fork(count) {
         for (var i = 0; i < count; ++i) {
             const worker = cluster.fork();
             console.warn('Worker start', worker.process.pid);
@@ -76,9 +76,9 @@ class Speedometer {
             process.send(this.num_bytes - this.last_bytes);
         } else {
             const speed = (this.num_bytes - this.last_bytes) /
-                (now - this.last_time) * 1000 / 1024 / 1024;
+                Math.max(0.001, now - this.last_time) * 1000 / 1024 / 1024;
             const avg_speed = this.num_bytes /
-                (now - this.start_time) * 1000 / 1024 / 1024;
+                Math.max(0.001, now - this.start_time) * 1000 / 1024 / 1024;
             const ops = this.num_ops - this.last_ops;
             const avg_latency = this.sum_latency - this.last_latency;
             console.log(


### PR DESCRIPTION
### Explain the changes
1. Added a bunch of options to troubleshoot filesystem performance for nsfs.
2. Use `node src/tools/fs_speed --help` for details

### Issues: Fixed #xxx / Gap #xxx
NA

### Testing Instructions:

To use on existing performance machines - go into a noobaa pod, put the fs_speed script to this path inside the pod /root/node_modules/noobaa-core/src/tools/fs_speed.js and then run with --help:

```
$ oc rsh noobaa-endpoint-...
$ cd /root/node_modules/noobaa-core/
$ node src/tools/fs_speed --help

Usage:
  --help            show this usage
  --dir <path>      (default "./fs_speed_output") where to write the files
  --time <sec>      (default 10) limit time to run
  --concur <n>      (default 1) number of concurrent writers
  --forks <n>       (default 1) number of forks to create (total writers is concur * forks).
Sizes:
  --file_size  <n>          (default 1024 MB) file size to write 
  --block_size <n>          (default 8 MB) block size to write 
  --file_size_units <unit>  (default is "MB") options are "GB", "MB", "KB", "B"
  --block_size_units <unit> (default is "MB") options are "GB", "MB", "KB", "B"
Write modes:
  --fsync           trigger fsync at the end of each file
  --mode <mode>     (default is "nsfs") options are
         "nsfs"     use the native fs_napi module used in nsfs
         "nodejs"   use nodejs fs module
         "dd"       execute dd commands
Advanced:
  --device <path>   (default is "/dev/zero") input device to use for dd mode
  --generator <x>   (default is "zeros") options are from rand stream (not for dd mode)
  --nvec <num>      (default is 1) split blocks to use writev if > 1 (not for dd mode)

Example:
    node src/tools/fs_speed --dir /mnt/fs/fs_speed_output --time 30 --concur 4 --file_size 256 --block_size 4 --fsync --mode dd

```
