### PR TITLE
fix overriding config.js from env to false (bool)

### DIFF
--- a/config.js
+++ b/config.js
@@ -632,7 +632,7 @@ function load_config_env_overrides() {
                     config[conf_name] = true;
                 } else if (val === 'false') {
                     console.log(`Overriding config.js from ENV with ${conf_name}=false (bool)`);
-                    config[conf_name] = true;
+                    config[conf_name] = false;
                 } else {
                     throw new Error(`${val} should be true|false`);
                 }


### PR DESCRIPTION
### Explain the changes
1. seems like a copy-pasta bug - the code always sets to true, also in the false case.

### Issues: Fixed #xxx / Gap #xxx
NA

### Testing Instructions:
1. run nsfs standalone with an override to false: 
```
CONFIG_JS_NSFS_CALCULATE_MD5=false node src/core .
```
2. Check that we don't calculate md5 on upload (I used a debugger but we can also see if the file xattr `user.content_md5` exists on the file.
