### PR TITLE
Change node service storage counter's type number -> bigint

### DIFF
--- a/src/server/node_services/node_schema.js
+++ b/src/server/node_services/node_schema.js
@@ -6,24 +6,24 @@ const storage_stat_schema = {
     properties: {
         total: {
             // total amount of storage space on the node/drive
-            type: 'number',
+            $ref: 'common_api#/definitions/bigint',
         },
         free: {
             // amount of available storage on the node/drive
-            type: 'number',
+            $ref: 'common_api#/definitions/bigint',
         },
         used: {
             // amount of storage used by the system
             // computed from the data blocks owned by this node
-            type: 'number',
+            $ref: 'common_api#/definitions/bigint',
         },
         alloc: {
             // preallocated storage space
-            type: 'number',
+            $ref: 'common_api#/definitions/bigint',
         },
         limit: {
             // top limit for used storage
-            type: 'number',
+            $ref: 'common_api#/definitions/bigint',
         }
     }
 };


### PR DESCRIPTION
Define counters type to match storage_info definition ( "bigint" )
See for reference src/api/common_api.js:
   https://github.com/noobaa/noobaa-core/blob/f7ee1b2c4477464a3d050479ff7f3e8e58239b35/src/api/common_api.js#L24-L74

Avoid the following run-time errors:

```
    [WebServer/44]  [WARN] core.util.postgres_client:: INVALID_
    SCHEMA_DB nodes ERRORS [ { keyword: 'type', dataPath: '.storage.total', schema
    Path: '#/properties/storage/properties/total/type', params: { type: 'number' }
    , message: 'should be number', schema: 'number', parentSchema: { type: 'number
    ' }, data: { n: 0, peta: 1 } }, [length]: 1 ] DOC { _id: 61883096f322f5002c0d9
    4be, peer_id: 61883096f322f5002c0d94bf, system: 61882f7df322f5002c0d9493, pool
    : 6188308cf322f5002c0d94bd, heartbeat: 1636316438369, name: 'noobaa-internal-a
    gent-6188308cf322f5002c0d94bd', is_cloud_node: true, drives: [ { mount: '/', d
    rive_id: 'overlay', storage: { total: 135012552704, free: 22658498560, used: 0
     } }, [length]: 1 ], latency_to_server: [
        1499, 1865,
        1296, 2398,
        2000, 1108,
        1397, 2699,
        2703, [length]: 9
      ], latency_of_disk_read: [ 504.09840000001714, 133.8591000000015, 414.666199 .....
```

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>
