### PR TITLE
Bump ajv from 6.12.6 to 8.8.1

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -346,5 +346,7 @@ module.exports = {
 
         'no-promise-executor-return': 'off',
 
+        //Allow spacing between template tags and their literals
+        'template-tag-spacing': 'off',
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1299,6 +1299,18 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -1316,6 +1328,12 @@
           "requires": {
             "type-fest": "^0.20.2"
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         },
         "type-fest": {
           "version": "0.20.2",
@@ -1797,13 +1815,13 @@
       }
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
+      "integrity": "sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
     },
@@ -3058,6 +3076,18 @@
             "@babel/highlight": "^7.10.4"
           }
         },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -3126,6 +3156,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "semver": {
@@ -4535,9 +4571,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6519,8 +6555,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "5.13.0",
-    "ajv": "6.12.6",
+    "ajv": "8.8.1",
     "aws-sdk": "2.965.0",
     "azure-storage": "2.10.4",
     "bcrypt": "5.0.1",

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    id: 'account_api',
+    $id: 'account_api',
 
     methods: {
 

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -10,7 +10,7 @@
 
 module.exports = {
 
-    id: 'agent_api',
+    $id: 'agent_api',
 
     methods: {
 

--- a/src/api/auth_api.js
+++ b/src/api/auth_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    id: 'auth_api',
+    $id: 'auth_api',
 
     methods: {
 

--- a/src/api/block_store_api.js
+++ b/src/api/block_store_api.js
@@ -10,7 +10,7 @@
 
 module.exports = {
 
-    id: 'block_store_api',
+    $id: 'block_store_api',
 
     methods: {
 

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    id: 'bucket_api',
+    $id: 'bucket_api',
 
     methods: {
 

--- a/src/api/cluster_internal_api.js
+++ b/src/api/cluster_internal_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    id: 'cluster_internal_api',
+    $id: 'cluster_internal_api',
 
     methods: {
         join_to_cluster: {

--- a/src/api/cluster_server_api.js
+++ b/src/api/cluster_server_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    id: 'cluster_server_api',
+    $id: 'cluster_server_api',
 
     methods: {
         add_member_to_cluster: {

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -12,7 +12,7 @@ const SensitiveString = require('../util/sensitive_string');
  */
 module.exports = {
 
-    id: 'common_api',
+    $id: 'common_api',
 
     definitions: {
 

--- a/src/api/debug_api.js
+++ b/src/api/debug_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    id: 'debug_api',
+    $id: 'debug_api',
 
     methods: {
         set_debug_level: {

--- a/src/api/events_api.js
+++ b/src/api/events_api.js
@@ -10,7 +10,7 @@ const SensitiveString = require('../util/sensitive_string');
  */
 module.exports = {
 
-    id: 'events_api',
+    $id: 'events_api',
 
     methods: {
         read_activity_log: {

--- a/src/api/frontend_notifications_api.js
+++ b/src/api/frontend_notifications_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    id: 'frontend_notifications_api',
+    $id: 'frontend_notifications_api',
 
     methods: {
         alert: {

--- a/src/api/func_api.js
+++ b/src/api/func_api.js
@@ -8,7 +8,7 @@
  */
 module.exports = {
 
-    id: 'func_api',
+    $id: 'func_api',
 
     methods: {
 

--- a/src/api/func_node_api.js
+++ b/src/api/func_node_api.js
@@ -8,7 +8,7 @@
  */
 module.exports = {
 
-    id: 'func_node_api',
+    $id: 'func_node_api',
 
     methods: {
 

--- a/src/api/host_api.js
+++ b/src/api/host_api.js
@@ -9,7 +9,7 @@
 
 module.exports = {
 
-    id: 'host_api',
+    $id: 'host_api',
 
     methods: {
 

--- a/src/api/hosted_agents_api.js
+++ b/src/api/hosted_agents_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    id: 'hosted_agents_api',
+    $id: 'hosted_agents_api',
 
     methods: {
 

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -13,7 +13,7 @@
 
 module.exports = {
 
-    id: 'node_api',
+    $id: 'node_api',
 
     methods: {
 

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    id: 'object_api',
+    $id: 'object_api',
 
     methods: {
         create_object_upload: {
@@ -1376,7 +1376,7 @@ module.exports = {
                 content_type: { type: 'string' },
                 create_time: { idate: true },
                 cache_last_valid_time: { idate: true },
-                last_modified_time: { idate: true},
+                last_modified_time: { idate: true },
                 upload_started: { idate: true },
                 upload_size: { type: 'integer' },
                 etag: { type: 'string' },

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    id: 'pool_api',
+    $id: 'pool_api',
 
     methods: {
         create_hosts_pool: {

--- a/src/api/redirector_api.js
+++ b/src/api/redirector_api.js
@@ -8,7 +8,7 @@
  */
 module.exports = {
 
-    id: 'redirector_api',
+    $id: 'redirector_api',
 
     methods: {
 

--- a/src/api/replication_api.js
+++ b/src/api/replication_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    id: 'replication_api',
+    $id: 'replication_api',
 
     methods: {
 

--- a/src/api/scrubber_api.js
+++ b/src/api/scrubber_api.js
@@ -8,7 +8,7 @@
  */
 module.exports = {
 
-    id: 'scrubber_api',
+    $id: 'scrubber_api',
 
     methods: {
 

--- a/src/api/server_inter_process_api.js
+++ b/src/api/server_inter_process_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    id: 'server_inter_process_api',
+    $id: 'server_inter_process_api',
 
     methods: {
         load_system_store: {

--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    id: 'stats_api',
+    $id: 'stats_api',
 
     methods: {
 

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -11,7 +11,7 @@
  */
 module.exports = {
 
-    id: 'system_api',
+    $id: 'system_api',
 
     methods: {
         get_system_status: {

--- a/src/api/tier_api.js
+++ b/src/api/tier_api.js
@@ -10,7 +10,7 @@
  */
 module.exports = {
 
-    id: 'tier_api',
+    $id: 'tier_api',
 
     methods: {
 

--- a/src/api/tiering_policy_api.js
+++ b/src/api/tiering_policy_api.js
@@ -9,7 +9,7 @@
  */
 module.exports = {
 
-    id: 'tiering_policy_api',
+    $id: 'tiering_policy_api',
 
     methods: {
 

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -89,10 +89,10 @@ class RPC extends EventEmitter {
     register_service(api, server, options) {
         options = options || {};
 
-        dbg.log0('RPC register_service', api.id);
+        dbg.log0('RPC register_service', api.$id);
 
         _.each(api.methods, (method_api, method_name) => {
-            const srv = api.id + '.' + method_name;
+            const srv = api.$id + '.' + method_name;
             assert(!this._services[srv],
                 'RPC register_service: service already registered ' + srv);
             const func = server[method_name] ||
@@ -117,7 +117,7 @@ class RPC extends EventEmitter {
 
         //Service was registered, call _init (if exists)
         if (server._init) {
-            dbg.log2('RPC register_service: calling _init() for', api.id);
+            dbg.log2('RPC register_service: calling _init() for', api.$id);
             server._init();
         }
     }
@@ -125,10 +125,10 @@ class RPC extends EventEmitter {
     replace_service(api, server, options) {
         options = options || {};
 
-        dbg.log0('RPC replace_service', api.id);
+        dbg.log0('RPC replace_service', api.$id);
 
         _.each(api.methods, (method_api, method_name) => {
-            const srv = api.id + '.' + method_name;
+            const srv = api.$id + '.' + method_name;
             assert(this._services[srv],
                 'RPC replace_service: service is not registered ' + srv);
             const func = server[method_name] ||
@@ -153,7 +153,7 @@ class RPC extends EventEmitter {
 
         //Service was registered, call _init (if exists)
         if (server._init) {
-            dbg.log2('RPC replace_service: calling _init() for', api.id);
+            dbg.log2('RPC replace_service: calling _init() for', api.$id);
             server._init();
         }
     }
@@ -415,7 +415,7 @@ class RPC extends EventEmitter {
     _get_remote_address(req, options) {
         var address = options.address;
         if (!address) {
-            const domain = options.domain || this.api_routes[req.api.id] || 'default';
+            const domain = options.domain || this.api_routes[req.api.$id] || 'default';
             address = this.router[domain];
             dbg.log3('RPC ROUTER', domain, '=>', address);
         }
@@ -794,7 +794,7 @@ class RPC extends EventEmitter {
 
     _proxy(api, method, params, options) {
         const req = {
-            method_api: api.id,
+            method_api: api.$id,
             method_name: method.name,
             target: options.address,
             request_params: js_utils.omit_symbol(params, RPC_BUFFERS),

--- a/src/rpc/rpc_benchmark.js
+++ b/src/rpc/rpc_benchmark.js
@@ -75,7 +75,7 @@ dbg.set_module_level(argv.debug, __dirname);
 
 const schema = new RpcSchema();
 schema.register_api({
-    id: 'rpcbench',
+    $id: 'rpcbench',
     methods: {
         io: {
             method: 'POST',

--- a/src/rpc/rpc_request.js
+++ b/src/rpc/rpc_request.js
@@ -70,7 +70,7 @@ class RpcRequest {
         this.method_api = method_api;
         this.params = params;
         this.auth_token = auth_token;
-        this.srv = api.id + '.' + method_api.name;
+        this.srv = api.$id + '.' + method_api.name;
     }
 
     /**
@@ -82,7 +82,7 @@ class RpcRequest {
         const body = {
             op: 'req',
             reqid: this.reqid,
-            api: this.api.id,
+            api: this.api.$id,
             method: this.method_api.name,
             params: this.params && js_utils.omit_symbol(this.params, RPC_BUFFERS),
             auth_token: this.auth_token || undefined,
@@ -134,7 +134,7 @@ class RpcRequest {
         this.method_api = method_api;
         this.params = msg.body.params;
         this.auth_token = msg.body.auth_token;
-        this.srv = `${api ? api.id : '?'}.${method_api ? method_api.name : '?'}`;
+        this.srv = `${api ? api.$id : '?'}.${method_api ? method_api.name : '?'}`;
 
         if (msg.body.buffers) {
             const buffers = {};

--- a/src/server/analytic_services/activity_log_schema.js
+++ b/src/server/analytic_services/activity_log_schema.js
@@ -4,7 +4,7 @@
 const SensitiveString = require('../../util/sensitive_string');
 
 module.exports = {
-    id: 'activity_log_schema',
+    $id: 'activity_log_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/analytic_services/bucket_stats_schema.js
+++ b/src/server/analytic_services/bucket_stats_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'bucket_stats_schema',
+    $id: 'bucket_stats_schema',
     type: 'object',
     required: ['_id', 'system', 'bucket', 'content_type'],
     properties: {

--- a/src/server/analytic_services/endpoint_group_report_schema.js
+++ b/src/server/analytic_services/endpoint_group_report_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'endpoint_group_report_schema',
+    $id: 'endpoint_group_report_schema',
     type: 'object',
     properties: {
         _id: { objectid: true },

--- a/src/server/analytic_services/io_stats_schema.js
+++ b/src/server/analytic_services/io_stats_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'io_stats_schema',
+    $id: 'io_stats_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/analytic_services/s3_usage_schema.js
+++ b/src/server/analytic_services/s3_usage_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 's3_usage_schema',
+    $id: 's3_usage_schema',
     type: 'object',
     required: ['system', 's3_usage_info', 's3_errors_info'],
     properties: {

--- a/src/server/analytic_services/system_history_schema.js
+++ b/src/server/analytic_services/system_history_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'system_history_schema',
+    $id: 'system_history_schema',
     type: 'object',
     required: ['_id', 'time_stamp', 'history_type'],
     properties: {

--- a/src/server/analytic_services/usage_report_schema.js
+++ b/src/server/analytic_services/usage_report_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'usage_report_schema',
+    $id: 'usage_report_schema',
     type: 'object',
     required: ['_id', 'system', 'start_time', 'end_time'],
     properties: {

--- a/src/server/func_services/func_schema.js
+++ b/src/server/func_services/func_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'func_schema',
+    $id: 'func_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/func_services/func_stats_schema.js
+++ b/src/server/func_services/func_stats_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'func_stats_schema',
+    $id: 'func_stats_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/node_services/node_schema.js
+++ b/src/server/node_services/node_schema.js
@@ -29,7 +29,7 @@ const storage_stat_schema = {
 };
 
 module.exports = {
-    id: 'node_schema',
+    $id: 'node_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/notifications/alerts_log_schema.js
+++ b/src/server/notifications/alerts_log_schema.js
@@ -4,7 +4,7 @@
 const SensitiveString = require('../../util/sensitive_string');
 
 module.exports = {
-    id: 'alerts_log_schema',
+    $id: 'alerts_log_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/object_services/schemas/data_block_schema.js
+++ b/src/server/object_services/schemas/data_block_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'data_block_schema',
+    $id: 'data_block_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/object_services/schemas/data_chunk_schema.js
+++ b/src/server/object_services/schemas/data_chunk_schema.js
@@ -27,7 +27,7 @@
  *
  */
 module.exports = {
-    id: 'data_chunk_schema',
+    $id: 'data_chunk_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'object_md_schema',
+    $id: 'object_md_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/object_services/schemas/object_multipart_schema.js
+++ b/src/server/object_services/schemas/object_multipart_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'multipart_schema',
+    $id: 'multipart_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/object_services/schemas/object_part_schema.js
+++ b/src/server/object_services/schemas/object_part_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'object_part_schema',
+    $id: 'object_part_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -4,7 +4,7 @@
 const SensitiveString = require('../../../util/sensitive_string');
 
 module.exports = {
-    id: 'account_schema',
+    $id: 'account_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/agent_config_schema.js
+++ b/src/server/system_services/schemas/agent_config_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'agent_config_schema',
+    $id: 'agent_config_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -22,7 +22,7 @@ const bigint = {
 };
 
 module.exports = {
-    id: 'bucket_schema',
+    $id: 'bucket_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/chunk_config_schema.js
+++ b/src/server/system_services/schemas/chunk_config_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'chunk_config_schema',
+    $id: 'chunk_config_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/cluster_schema.js
+++ b/src/server/system_services/schemas/cluster_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'cluster_schema',
+    $id: 'cluster_schema',
     type: 'object',
     required: [
         'owner_secret',

--- a/src/server/system_services/schemas/config_file_schema.js
+++ b/src/server/system_services/schemas/config_file_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'certificate_schema',
+    $id: 'certificate_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/master_key_schema.js
+++ b/src/server/system_services/schemas/master_key_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'master_key_schema',
+    $id: 'master_key_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'namespace_resource_schema',
+    $id: 'namespace_resource_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -21,7 +21,7 @@ const bigint = {
 };
 
 module.exports = {
-    id: 'pool_schema',
+    $id: 'pool_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/replication_configuration_schema.js
+++ b/src/server/system_services/schemas/replication_configuration_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'replication_configuration_schema',
+    $id: 'replication_configuration_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/role_schema.js
+++ b/src/server/system_services/schemas/role_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'role_schema',
+    $id: 'role_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'system_schema',
+    $id: 'system_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/tier_schema.js
+++ b/src/server/system_services/schemas/tier_schema.js
@@ -4,7 +4,7 @@
 const SensitiveString = require('../../../util/sensitive_string');
 
 module.exports = {
-    id: 'tier_schema',
+    $id: 'tier_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/server/system_services/schemas/tiering_policy_schema.js
+++ b/src/server/system_services/schemas/tiering_policy_schema.js
@@ -4,7 +4,7 @@
 const SensitiveString = require('../../../util/sensitive_string');
 
 module.exports = {
-    id: 'tiering_policy_schema',
+    $id: 'tiering_policy_schema',
     type: 'object',
     required: [
         '_id',

--- a/src/test/framework/report_schema.js
+++ b/src/test/framework/report_schema.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-    id: 'test_report_schema',
+    $id: 'test_report_schema',
     type: 'object',
     required: [
         'date',

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -10,6 +10,9 @@ coretest.setup({ incomplete_rpc_coverage: 'show' });
 // Tests that does not require hosts pools
 // ---------------------------------------
 
+//JSON SCHEMA 
+require('./test_schema_keywords');
+
 // UTILS
 require('./test_linked_list');
 require('./test_keys_lock');

--- a/src/test/unit_tests/test_postgres_client.js
+++ b/src/test/unit_tests/test_postgres_client.js
@@ -16,7 +16,7 @@ const P = require('../../util/promise');
 
 
 const test_schema = {
-    id: 'test_postgres_client_schema',
+    $id: 'test_postgres_client_schema',
     type: 'object',
     required: [
         '_id',
@@ -68,7 +68,7 @@ async function get_postgres_client(params) {
     await pgc.dropDatabase();
     console.log('creating new database', params.database);
     await pgc.createDatabase();
-    console.log('created database succesfuly', params.database);
+    console.log('created database successfully', params.database);
     return pgc;
 }
 

--- a/src/test/unit_tests/test_rpc.js
+++ b/src/test/unit_tests/test_rpc.js
@@ -21,7 +21,7 @@ mocha.describe('RPC', function() {
 
     const test_api = {
 
-        id: 'test_api',
+        $id: 'test_api',
 
         methods: {
             get: {
@@ -135,7 +135,7 @@ mocha.describe('RPC', function() {
 
     const common_test_api = {
 
-        id: 'common_test_api',
+        $id: 'common_test_api',
 
         definitions: {
 
@@ -268,7 +268,7 @@ mocha.describe('RPC', function() {
             assert.throws(function() {
                 var bad_schema = new RpcSchema();
                 bad_schema.register_api({
-                    id: 'test_bad_api',
+                    $id: 'test_bad_api',
                     methods: {
                         a: {
                             method: 'POSTER',

--- a/src/test/unit_tests/test_schema_keywords.js
+++ b/src/test/unit_tests/test_schema_keywords.js
@@ -1,0 +1,136 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const mocha = require('mocha');
+const { default: Ajv } = require('ajv');
+const schema_keywords = require('../../util/schema_keywords');
+const SensitiveString = require('../../util/sensitive_string');
+const mongodb = require('mongodb');
+const assert = require('assert');
+
+/**
+ * @typedef {import('ajv').KeywordCxt} KeywordCxt
+ */
+
+const ajv = new Ajv({ verbose: true, allErrors: true });
+
+const test_schema_keywords = {
+    $id: 'test_schema_keywords',
+    methods: {
+        params: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                key1: {
+                    date: true,
+                },
+                key2: {
+                    idate: true,
+                },
+                key3: {
+                    objectid: true,
+                },
+                key4: {
+                    binary: true,
+                },
+                key5: {
+                    binary: 5,
+                },
+                key6: {
+                    wrapper: SensitiveString,
+                },
+            },
+        },
+    },
+};
+
+
+mocha.describe('Test Schema Keywords', function() {
+
+    mocha.before('Adding Schema And Keywords', async function() {
+        ajv.addSchema(test_schema_keywords);
+        ajv.addKeyword(schema_keywords.KEYWORDS.methods);
+        ajv.addKeyword(schema_keywords.KEYWORDS.date);
+        ajv.addKeyword(schema_keywords.KEYWORDS.idate);
+        ajv.addKeyword(schema_keywords.KEYWORDS.objectid);
+        ajv.addKeyword(schema_keywords.KEYWORDS.binary);
+        ajv.addKeyword(schema_keywords.KEYWORDS.wrapper);
+    });
+
+    mocha.it('Test keyword date', async function() {
+        const validator = ajv.getSchema('test_schema_keywords#/methods/params');
+        const should_pass = { key1: new Date() };
+        assert.strictEqual(validator(should_pass), true);
+        const should_fail = { key1: 'not_a_date' };
+        assert.strictEqual(validator(should_fail), false);
+    });
+
+    mocha.it('Test keyword idate', async function() {
+        const validator = ajv.getSchema('test_schema_keywords#/methods/params');
+        const should_pass = { key2: Date.now() };
+        assert.strictEqual(validator(should_pass), true);
+        const should_fail = { key2: 'not_an_idate' };
+        assert.strictEqual(validator(should_fail), false);
+    });
+
+    mocha.it('Test keyword objectid', async function() {
+        const validator = ajv.getSchema('test_schema_keywords#/methods/params');
+        const should_pass = { key3: new mongodb.ObjectId() };
+        assert.strictEqual(validator(should_pass), true);
+        const should_fail = { key3: 'not_an_objectid' };
+        assert.strictEqual(validator(should_fail), false);
+    });
+
+    mocha.it('Test keyword objectid as string', async function() {
+        const validator = ajv.getSchema('test_schema_keywords#/methods/params');
+        //Testing an objectId value as string with length = 24 and allowed characters
+        const should_pass = { key3: '1234567890abcdefABCDEF00' };
+        assert.strictEqual(validator(should_pass), true);
+        //Testing an objectId value as string with length < 24 and allowed characters
+        const should_fail1 = { key3: '1234567890abcdefABCDEF' };
+        assert.strictEqual(validator(should_fail1), false);
+        //Testing an objectId value as string with length > 24 and allowed characters
+        const should_fail2 = { key3: '1234567890abcdefABCDEF000' };
+        assert.strictEqual(validator(should_fail2), false);
+        //Testing an objectId value as string with length = 24 and not allowed characters
+        const should_fail3 = { key3: '1234567890abcdefABCDEG' };
+        assert.strictEqual(validator(should_fail3), false);
+    });
+
+    mocha.it('Test keyword binary', async function() {
+        const validator = ajv.getSchema('test_schema_keywords#/methods/params');
+        const should_pass = { key4: Buffer.from('buffer') };
+        assert.strictEqual(validator(should_pass), true);
+        const should_fail = { key4: 'not_a_buffer' };
+        assert.strictEqual(validator(should_fail), false);
+    });
+
+    mocha.it('Test keyword binary length', async function() {
+        const validator = ajv.getSchema('test_schema_keywords#/methods/params');
+        //Testing an exact stated size of buffer
+        const should_pass = { key5: Buffer.from('exact') };
+        assert.strictEqual(validator(should_pass), true);
+        //Testing a buffer larger then the stated size of buffer
+        const should_fail1 = { key5: Buffer.from('larger') };
+        assert.strictEqual(validator(should_fail1), false);
+        //Testing a buffer smaller then the stated size of buffer
+        const should_fail2 = { key5: Buffer.from('tiny') };
+        assert.strictEqual(validator(should_fail2), false);
+    });
+
+    mocha.it('Test keyword wrapper', async function() {
+        const validator = ajv.getSchema('test_schema_keywords#/methods/params');
+        //Testing a SensitiveString
+        const should_pass1 = { key6: new SensitiveString('text') };
+        assert.strictEqual(validator(should_pass1), true);
+        //Testing a string, and it should become a SensitiveString sting
+        const should_pass2 = { key6: 'can_be_wrapper' };
+        const been_wrapped = validator(should_pass2);
+        assert.strictEqual(been_wrapped, true);
+        assert.strictEqual(should_pass2.key6 instanceof SensitiveString, true);
+        //Testing an int, and it should fail becoming a SensitiveString sting
+        const should_fail = { key6: 1 };
+        assert.strictEqual(validator(should_fail), false);
+    });
+
+});

--- a/src/test/unit_tests/test_sensitive_wrapper.js
+++ b/src/test/unit_tests/test_sensitive_wrapper.js
@@ -3,22 +3,18 @@
 
 const mocha = require('mocha');
 // const _ = require('lodash');
-const Ajv = require('ajv');
+const { default: Ajv } = require('ajv');
 const util = require('util');
 const BSON = require('bson');
 const assert = require('assert');
-const { KEYWORDS } = require('../../util/schema_utils');
+const { KEYWORDS } = require('../../util/schema_keywords');
 const SensitiveString = require('../../util/sensitive_string');
 
 mocha.describe('SensitiveString', function() {
-    const ajv = new Ajv({
-        verbose: true,
-        schemaId: 'auto',
-        allErrors: true
-    });
-    ajv.addKeyword('wrapper', KEYWORDS.wrapper);
+    const ajv = new Ajv({ verbose: true, allErrors: true });
+    ajv.addKeyword(KEYWORDS.wrapper);
     ajv.addSchema({
-        id: 'system',
+        $id: 'system',
         type: 'object',
         required: ['users'],
         additionalProperties: false,
@@ -102,7 +98,7 @@ mocha.describe('SensitiveString', function() {
 
     mocha.it('Should throw on non string/undefined value', function() {
         assert.throws(function() {
-            const a = new SensitiveString({a: 1});
+            const a = new SensitiveString({ a: 1 });
             a.unwrap();
         }, Error);
     });

--- a/src/upgrade/migrator.js
+++ b/src/upgrade/migrator.js
@@ -5,15 +5,15 @@ const _ = require('lodash');
 const P = require('../util/promise');
 
 const migrate_schema = {
-    id: 'migrate_schema',
+    $id: 'migrate_schema',
     type: 'object',
     required: ['_id', 'collection_index'],
     properties: {
         _id: { objectid: true },
         collection_index: { type: 'number' },
-        collection_name: { type: 'string'},
-        last_move_size: { type: 'number'},
-        total_move_size: { type: 'number'},
+        collection_name: { type: 'string' },
+        last_move_size: { type: 'number' },
+        total_move_size: { type: 'number' },
         marker: { objectid: true },
         last_update: { idate: true }
     }
@@ -72,10 +72,10 @@ class Migrator {
             }
             this.migrate_status.collection_index = i;
             this.migrate_status.collection_name = collection_name;
-            await P.retry({ attempts: 3, delay_ms: 10000, func: async () => this._migrate_collection(collection_name)});
+            await P.retry({ attempts: 3, delay_ms: 10000, func: async () => this._migrate_collection(collection_name) });
             await this._verify_collection(collection_name);
             this.migrate_status.marker = undefined;
-            await this.upgrade_table.updateOne({}, { $set: { collection_index: i + 1, last_update: Date.now()}, $unset: { marker: 1}});
+            await this.upgrade_table.updateOne({}, { $set: { collection_index: i + 1, last_update: Date.now() }, $unset: { marker: 1 } });
         }
         await this.from_client.disconnect();
         await this.to_client.disconnect();
@@ -90,7 +90,7 @@ class Migrator {
         let total = 0;
         while (!done) {
             console.log(`_migrate_collection: start searching docs in ${collection_name}`);
-            const docs = await from_col.find({ _id: marker ? { $gt: marker } : undefined }, { limit: this.batch_size, sort: { _id: 1 }});
+            const docs = await from_col.find({ _id: marker ? { $gt: marker } : undefined }, { limit: this.batch_size, sort: { _id: 1 } });
             console.log(`_migrate_collection: found ${docs.length} docs in ${collection_name}`);
             if (docs.length > 0) {
                 try {
@@ -103,12 +103,14 @@ class Migrator {
                 total += docs.length;
                 console.log(`migrated ${total} documents to table ${collection_name}`);
                 marker = docs[docs.length - 1]._id;
-                await this.upgrade_table.updateOne({}, { $set: {
-                    marker,
-                    last_move_size: docs.length,
-                    total_move_size: total,
-                    last_update: Date.now()
-                }});
+                await this.upgrade_table.updateOne({}, {
+                    $set: {
+                        marker,
+                        last_move_size: docs.length,
+                        total_move_size: total,
+                        last_update: Date.now()
+                    }
+                });
             } else {
                 done = true;
             }
@@ -126,7 +128,7 @@ class Migrator {
             throw new Error(`Last migrate failed! collection ${collection_name} sizes don't match. 
                 FROM: ${from_documents_number}, 
                 TO: ${to_documents_number}`);
-}
+        }
     }
 }
 

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -3,7 +3,7 @@
 
 const _ = require('lodash');
 const fs = require('fs');
-const Ajv = require('ajv');
+const { default: Ajv } = require('ajv');
 const util = require('util');
 const mongodb = require('mongodb');
 const EventEmitter = require('events').EventEmitter;
@@ -15,6 +15,7 @@ const js_utils = require('./js_utils');
 const common_api = require('../api/common_api');
 const db_client = require('./db_client');
 const schema_utils = require('./schema_utils');
+const schema_keywords = require('./schema_keywords');
 const { RpcError } = require('../rpc');
 
 mongodb.Binary.prototype[util.inspect.custom] = function custom_inspect_binary() {
@@ -133,12 +134,14 @@ class MongoClient extends EventEmitter {
             //authSource: 'admin',
         };
 
-        this._ajv = new Ajv({ verbose: true, schemaId: 'auto', allErrors: true });
-        this._ajv.addKeyword('date', schema_utils.KEYWORDS.date);
-        this._ajv.addKeyword('idate', schema_utils.KEYWORDS.idate);
-        this._ajv.addKeyword('objectid', schema_utils.KEYWORDS.objectid);
-        this._ajv.addKeyword('binary', schema_utils.KEYWORDS.binary);
-        this._ajv.addKeyword('wrapper', schema_utils.KEYWORDS.wrapper);
+        this._ajv = new Ajv({ verbose: true, allErrors: true });
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.methods);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.doc);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.date);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.idate);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.objectid);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.binary);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.wrapper);
         this._ajv.addSchema(common_api);
 
         if (process.env.MONGO_RS_URL) {

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -6,7 +6,7 @@ const _ = require('lodash');
 require('../util/fips');
 
 const assert = require('assert');
-const Ajv = require('ajv');
+const { default: Ajv } = require('ajv');
 const crypto = require('crypto');
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
@@ -16,6 +16,7 @@ const P = require('./promise');
 const dbg = require('./debug_module')(__filename);
 const common_api = require('../api/common_api');
 const schema_utils = require('./schema_utils');
+const schema_keywords = require('./schema_keywords');
 const mongodb = require('mongodb');
 const mongo_to_pg = require('mongo-query-to-postgres-jsonb');
 const fs = require('fs');
@@ -1274,12 +1275,14 @@ class PostgresClient extends EventEmitter {
         };
 
         PostgresClient.implements_interface(this);
-        this._ajv = new Ajv({ verbose: true, schemaId: 'auto', allErrors: true });
-        this._ajv.addKeyword('date', schema_utils.KEYWORDS.date);
-        this._ajv.addKeyword('idate', schema_utils.KEYWORDS.idate);
-        this._ajv.addKeyword('objectid', schema_utils.KEYWORDS.objectid);
-        this._ajv.addKeyword('binary', schema_utils.KEYWORDS.binary);
-        this._ajv.addKeyword('wrapper', schema_utils.KEYWORDS.wrapper);
+        this._ajv = new Ajv({ verbose: true, allErrors: true });
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.methods);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.doc);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.date);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.idate);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.objectid);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.binary);
+        this._ajv.addKeyword(schema_keywords.KEYWORDS.wrapper);
         this._ajv.addSchema(common_api);
 
         // this.emit('reconnect');

--- a/src/util/schema_keywords.js
+++ b/src/util/schema_keywords.js
@@ -1,0 +1,171 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const js_utils = require('./js_utils');
+const { _: CG } = require('ajv');
+
+/**
+ * @typedef {import('ajv').KeywordCxt} KeywordCxt
+ */
+
+const KEYWORDS = js_utils.deep_freeze({
+
+    methods: {
+        keyword: 'methods',
+    },
+
+    doc: {
+        keyword: 'doc',
+    },
+
+    // schema: { date: true } will match (new Date())
+    date: {
+        keyword: 'date',
+        errors: false,
+        // schemaType: 'boolean',
+        /**
+         * 
+         * @param {KeywordCxt} cxt 
+         * 
+         */
+        code(cxt) {
+            const d = cxt.it.data;
+            cxt.pass(CG ` ${d} instanceof Date `);
+        }
+    },
+
+    // schema: { idate: true } will match (new Date()).getTime()
+    idate: {
+        keyword: 'idate',
+        // schemaType: 'boolean',
+        /**
+         * 
+         * @param {KeywordCxt} cxt 
+         * 
+         */
+        code(cxt) {
+            // TODO: Remove accepting instanceof Date after converting all uses of
+            // idates in the database schema into the date format (currently most of them are
+            // already saved in ISO format which is not idate)
+            const d = cxt.it.data;
+            cxt.gen
+                .if(CG `
+                    Number.isInteger(${d}) &&
+                    Number.isInteger(new Date(${d}).getTime())
+                `) // good idate
+                .elseIf(CG ` ${d} instanceof Date `) // ok but see todo ^
+                .else()
+                .code(() => cxt.error())
+                .endIf();
+        }
+    },
+
+    // schema: { objectid: true } will match (new mongodb.ObjectId()) or (new mongodb.ObjectId()).valueOf()
+    objectid: {
+        keyword: 'objectid',
+        // schemaType: 'boolean',
+        /**
+         * 
+         * @param {KeywordCxt} cxt 
+         * 
+         */
+        code(cxt) {
+            const d = cxt.it.data;
+            cxt.gen
+                .if(CG `
+                    typeof ${d} === 'object' &&
+                    ${d} && 
+                    ${d}.constructor && 
+                    ${d}.constructor.name === 'ObjectID'
+                `)
+                .elseIf(CG `
+                    typeof ${d} === 'string' &&
+                    /^[0-9a-fA-F]{24}$/.test(${d})
+                `)
+                .else()
+                .code(() => cxt.error())
+                .endIf();
+        }
+    },
+
+    // schema: { binary: 64 } will match Buffer.alloc(64)
+    // schema: { binary: true } will match Buffer.alloc(<any>)
+    binary: {
+        keyword: 'binary',
+        // schemaType: ['boolean', 'number'],
+        /**
+         * 
+         * @param {KeywordCxt} cxt 
+         * 
+         */
+        code(cxt) {
+            const d = cxt.data;
+            const s = cxt.schemaValue;
+            cxt.gen
+                .if(CG `
+                    Buffer.isBuffer(${d}) && (
+                        typeof ${s} === 'number' ? 
+                        ${d}.length === ${s} :
+                        ${s}
+                    )
+                `)
+                .elseIf(CG `
+                    ${d}._bsontype === 'Binary' && (
+                        typeof ${s} === 'number' ? 
+                        ${d}.length() === ${s} :
+                        ${s}
+                    )
+                `)
+                .else()
+                .code(() => cxt.error())
+                .endIf();
+        }
+    },
+
+    wrapper: {
+        keyword: 'wrapper',
+        errors: false,
+        modifying: true,
+        /**
+         * 
+         * @param {KeywordCxt} cxt 
+         * 
+         */
+        code(cxt) {
+            if (cxt.it.dataLevel <= 0) throw new Error('wrapper should not be in the root of the schema');
+            const d = cxt.data;
+            const s = cxt.schemaValue;
+            const p = cxt.it.parentData;
+            const pp = cxt.it.parentDataProperty;
+            cxt.gen
+                .if(CG ` ${d} instanceof ${s} `)
+                .elseIf(CG ` ${s}.can_wrap(${d}) `)
+                .assign(CG ` ${p}[${pp}] `, CG ` new ${s}(${d}) `)
+                .else()
+                .code(() => cxt.error())
+                .endIf();
+        }
+    },
+
+    wrapper_check_only: {
+        keyword: 'wrapper',
+        errors: false,
+        /**
+         * 
+         * @param {KeywordCxt} cxt 
+         * 
+         */
+        code(cxt) {
+            if (cxt.it.dataLevel <= 0) return;
+            const d = cxt.data;
+            const s = cxt.schemaValue;
+            cxt.pass(CG `
+                ${d} instanceof ${s} ||
+                ${s}.can_wrap(${d})
+            `);
+        }
+    }
+
+});
+
+exports.KEYWORDS = KEYWORDS;

--- a/src/util/schema_utils.js
+++ b/src/util/schema_utils.js
@@ -3,136 +3,8 @@
 
 const _ = require('lodash');
 const util = require('util');
-const js_utils = require('./js_utils');
 
-const KEYWORDS = js_utils.deep_freeze({
-
-    // schema: { date: true } will match (new Date())
-    date: {
-        errors: false,
-        statements: true,
-        inline: (it, keyword, schema, parent) => {
-            const v = `valid${it.level}`;
-            const d = `data${it.dataLevel || ''}`;
-            return `
-                ${v} = (${d} instanceof Date);
-            `;
-        }
-    },
-
-    // schema: { idate: true } will match (new Date()).getTime()
-    idate: {
-        errors: false,
-        statements: true,
-        inline: (it, keyword, schema, parent) => {
-            const v = `valid${it.level}`;
-            const d = `data${it.dataLevel || ''}`;
-            // TODO: Remove accepting instanceof Date after converting all uses of
-            // idates in the database schema into the date format (currently most of them are
-            // already saved in ISO format which is not idate)
-            return `
-                if (${d} instanceof Date) {
-                    ${v} = true;
-                } else {
-                    ${v} = Number.isInteger(${d}) && !isNaN((new Date(${d})).getTime());
-                }
-            `;
-        }
-    },
-
-    // schema: { objectid: true } will match (new mongodb.ObjectId()) or (new mongodb.ObjectId()).valueOf()
-    objectid: {
-        errors: false,
-        statements: true,
-        inline: (it, keyword, schema, parent) => {
-            const v = `valid${it.level}`;
-            const d = `data${it.dataLevel || ''}`;
-            return `
-                switch (typeof ${d}) {
-                    case 'object':
-                        ${v} = (${d} && ${d}.constructor && ${d}.constructor.name === 'ObjectID');
-                        break;
-                    case 'string':
-                        ${v} = /^[0-9a-fA-F]{24}$/.test(${d});
-                        break;
-                    default:
-                        ${v} = false;
-                        break;
-                }
-            `;
-        }
-    },
-
-    // schema: { binary: 64 } will match Buffer.alloc(64)
-    // schema: { binary: true } will match Buffer.alloc(<any>)
-    binary: {
-        errors: false,
-        statements: true,
-        inline: (it, keyword, schema, parent) => {
-            const v = `valid${it.level}`;
-            const d = `data${it.dataLevel || ''}`;
-            const is_bson = `(${d}._bsontype === 'Binary')`;
-            const is_buf = `(Buffer.isBuffer(${d}))`;
-            const bson_len = `(${d}.length() === ${schema})`;
-            const buf_len = `(${d}.length === ${schema})`;
-            if (typeof schema === 'number') {
-                return `
-                    ${v} = ${d} && ((${is_bson} && ${bson_len}) || (${is_buf} && ${buf_len}));
-                `;
-            } else {
-                return `
-                    ${v} = ${d} && (${is_bson} || ${is_buf});
-                `;
-            }
-        }
-    },
-
-    wrapper: {
-        errors: false,
-        statements: true,
-        modifying: true,
-        inline: (it, keyword, schema, parent) => {
-            if (it.dataLevel <= 0) return;
-            const valid = `valid${it.level}`;
-            const val = `data${it.dataLevel || ''}`;
-            const obj = `data${(it.dataLevel - 1) || ''}`;
-            const key = it.dataPathArr[it.dataLevel];
-            const field = `${obj}[${key}]`;
-            const wrapper = `validate.schema${it.schemaPath}.${keyword}`;
-            return `
-            if (${val} instanceof ${wrapper}) {
-                ${valid} = true;
-            } else if (${wrapper}.can_wrap(${val})) {
-                ${valid} = true;
-                ${field} = new ${wrapper}(${val});
-            } else {
-                ${valid} = false;
-            }
-        `;
-        }
-    },
-
-    wrapper_check_only: {
-        errors: false,
-        statements: true,
-        inline: (it, keyword, schema, parent) => {
-            if (it.dataLevel <= 0) return;
-            const valid = `valid${it.level}`;
-            const val = `data${it.dataLevel || ''}`;
-            const wrapper = `validate.schema${it.schemaPath}.${keyword}`;
-            return `
-            if (${wrapper}.can_wrap(${val})) {
-                ${valid} = true;
-            } else {
-                ${valid} = false;
-            }
-        `;
-        }
-    }
-
-});
-
-const COMMON_SCHEMA_KEYWORDS = ['doc', 'id'];
+const COMMON_SCHEMA_KEYWORDS = ['doc', '$id'];
 
 function strictify(schema, options, base) {
     if (!schema) return schema;
@@ -251,7 +123,6 @@ function is_object_id(id) {
     }
 }
 
-exports.KEYWORDS = KEYWORDS;
 exports.strictify = strictify;
 exports.empty_schema_validator = empty_schema_validator;
 exports.is_object_id_class = is_object_id_class;


### PR DESCRIPTION
### Explain the changes
- bump ajv from 6.12.6 to 8.8.1
- const { default: Ajv } = require('ajv');
- fixed addKeyword and update schema_utils
- schemaId: removed, as JSON Schema draft-04 is no longer supported.
- schema Keywords change "inline" keywords to "code"
- Fix the tests
- Added new tests
- Update the keywords code to the new format
- Fixed COMMON_SCHEMA_KEYWORDS
- Moving the Schema Keywords to its own file 

*addKeyword:*
- keyword name should be passed as property in definition object, not as the first parameter (old API works with "deprecated" warning).
- Also "inline" keywords support is removed, code generation keywords can now be defined with "code" keyword - the same definition format that is used by all pre-defined keywords.

*Calling the AJV constructor with strict: false*
- Methods `compile` and `compileAsync` now return type-guards
- https://ajv.js.org/strict-mode.html
- https://github.com/ajv-validator/ajv/blob/master/docs/v6-to-v8-migration.md#added-options
- strictDefaults, strictKeywords: it is default now, controlled with strict or strictSchema.

*Replaced the attributes "id" with "$id" in the API and in the schema*
- the support for JSON-Schema draft-04 is removed - if you have schemas using "id" attributes you have to replace them with "$id" (or continue using version 6 that will be supported until 06/30/2021).
