### PR TITLE
NSFS release buffers on break

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -535,7 +535,11 @@ class NamespaceFS {
                 count = 0;
 
                 const bytesRead = await file.read(fs_account_config, buffer, 0, read_size, pos);
-                if (!bytesRead) break;
+                if (!bytesRead) {
+                    buffer_pool_cleanup = null;
+                    callback();
+                    break;
+                }
                 const data = buffer.slice(0, bytesRead);
 
                 // update stats
@@ -688,7 +692,11 @@ class NamespaceFS {
                 const { buffer, callback } = await buffers_pool.get_buffer(config.NSFS_BUF_SIZE);
                 buffer_pool_cleanup = callback;
                 const bytesRead = await source_file.read(fs_account_config, buffer, 0, config.NSFS_BUF_SIZE, read_pos);
-                if (!bytesRead) break;
+                if (!bytesRead) {
+                    buffer_pool_cleanup = null;
+                    callback();
+                    break;
+                }
                 read_pos += bytesRead;
                 const data = buffer.slice(0, bytesRead);
                 if (MD5Async) await MD5Async.update(data);
@@ -887,7 +895,6 @@ class NamespaceFS {
                     buffer_pool_cleanup = callback;
                     const bytesRead = await read_file.read(fs_account_config, buffer, 0, config.NSFS_BUF_SIZE, read_pos);
                     if (!bytesRead) {
-                        // Returns the buffer to pool to avoid starvation
                         buffer_pool_cleanup = null;
                         callback();
                         break;


### PR DESCRIPTION
### Explain the changes
1. This code is added just in case that we will change the loop structures and create another buffer deallocation bug
2. Currently there is no leak in these places because we rely on finally to deallocate the buffers

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
