### PR TITLE
Removing "allowed buckets" functionality

### DIFF
--- a/frontend/src/app/action-creators/account-actions.js
+++ b/frontend/src/app/action-creators/account-actions.js
@@ -41,7 +41,6 @@ export function createAccount(
     password,
     defaultResource,
     hasAccessToAllBucekts,
-    allowedBuckets,
     allowBucketCreation
 ) {
     return {
@@ -52,7 +51,6 @@ export function createAccount(
             password,
             defaultResource,
             hasAccessToAllBucekts,
-            allowedBuckets,
             allowBucketCreation
         }
     };
@@ -76,7 +74,6 @@ export function updateAccountS3Access(
     accountName,
     defaultResource,
     hasAccessToAllBuckets,
-    allowedBuckets,
     allowBucketCreation
 ) {
     return {
@@ -85,7 +82,6 @@ export function updateAccountS3Access(
             accountName,
             defaultResource,
             hasAccessToAllBuckets,
-            allowedBuckets,
             allowBucketCreation
         }
     };

--- a/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.js
+++ b/frontend/src/app/components/account/account-s3-access-form/account-s3-access-form.js
@@ -23,76 +23,63 @@ function _getAllowedIpsInfo(allowedIps = []) {
     };
 }
 
-function _getAllowedBucketsInfo(hasAccessToAllBuckets, allowedBuckets) {
-    return {
-        tags: hasAccessToAllBuckets ? [] : allowedBuckets,
-        maxCount: boxCount,
-        emptyMessage: hasAccessToAllBuckets ?
-            'All current and future buckets' :
-            '(None)'
-    };
-}
-
-
 class AccountS3AccessFormViewModel extends ConnectableViewModel {
     dataReady = ko.observable();
     accountName = ko.observable();
     canEdit = ko.observable();
     actionsTooltip = ko.observable();
-    s3AccessInfo = [
-        {
-            label: 'Access Type',
-            value: ko.observable()
+    s3AccessInfo = [{
+        label: 'Access Type',
+        value: ko.observable()
+    },
+    {
+        label: 'Permitted Buckets',
+        template: 'tagList',
+        value: {
+            tags: ko.observableArray(),
+            maxCount: boxCount,
+            emptyMessage: ko.observable()
         },
-        {
-            label: 'Permitted Buckets',
-            template: 'tagList',
-            value: {
-                tags: ko.observableArray(),
-                maxCount: boxCount,
-                emptyMessage: ko.observable()
-            },
-            disabled: ko.observable()
+        disabled: ko.observable()
+    },
+    {
+        label: 'New Bucket Creation',
+        value: ko.observable(),
+        disabled: ko.observable()
+    },
+    {
+        label: 'Default Resource for S3 Applications',
+        value: ko.observable(),
+        disabled: ko.observable()
+    },
+    {
+        label: 'IP Restrictions',
+        value: ko.observable(),
+        disabled: ko.observable()
+    },
+    {
+        label: 'Allowed IPs',
+        template: 'tagList',
+        value: {
+            tags: ko.observableArray(),
+            maxCount: boxCount,
+            emptyMessage: ko.observable()
         },
-        {
-            label: 'New Bucket Creation',
-            value: ko.observable(),
-            disabled: ko.observable()
-        },
-        {
-            label: 'Default Resource for S3 Applications',
-            value: ko.observable(),
-            disabled: ko.observable()
-        },
-        {
-            label: 'IP Restrictions',
-            value: ko.observable(),
-            disabled: ko.observable()
-        },
-        {
-            label: 'Allowed IPs',
-            template: 'tagList',
-            value: {
-                tags: ko.observableArray(),
-                maxCount: boxCount,
-                emptyMessage: ko.observable()
-            },
-            visible: ko.observable()
-        }
+        visible: ko.observable()
+    }
     ];
-    credentials = [
-        {
-            label: 'Access Key',
-            allowCopy: true,
-            value: ko.observable(),
-            disabled: ko.observable()
-        },
-        {
-            label: 'Secret Key',
-            allowCopy: true,
-            value: ko.observable(),
-            disabled: ko.observable()
-        }
+    credentials = [{
+        label: 'Access Key',
+        allowCopy: true,
+        value: ko.observable(),
+        disabled: ko.observable()
+    },
+    {
+        label: 'Secret Key',
+        allowCopy: true,
+        value: ko.observable(),
+        disabled: ko.observable()
+    }
     ];
 
     selectState(state, params) {
@@ -115,8 +102,6 @@ class AccountS3AccessFormViewModel extends ConnectableViewModel {
             const {
                 defaultResource,
                 isAdmin,
-                hasAccessToAllBuckets,
-                allowedBuckets,
                 accessKeys,
                 allowedIps
             } = account;
@@ -135,7 +120,6 @@ class AccountS3AccessFormViewModel extends ConnectableViewModel {
                 actionsTooltip: canEdit ? '' : 'User has no permission to edit this account',
                 s3AccessInfo: [
                     { value: isAdmin ? 'Administator' : 'Application' },
-                    { value: _getAllowedBucketsInfo(hasAccessToAllBuckets, allowedBuckets) },
                     { value: account.canCreateBuckets ? 'Allowed' : 'Not Allowed' },
                     { value: defaultResourceName },
                     { value: allowedIps ? 'Enabled' : 'Not set' },

--- a/frontend/src/app/components/bucket/bucket-s3-access-policy-form/bucket-s3-access-policy-form.js
+++ b/frontend/src/app/components/bucket/bucket-s3-access-policy-form/bucket-s3-access-policy-form.js
@@ -101,7 +101,6 @@ class BucketS3AccessTableViewModel extends ConnectableViewModel {
 
             const connectedAccounts = Object.values(accounts)
                 .filter(account =>
-                    account.allowedBuckets.includes(params.bucket) &&
                     !account.roles.includes('operator')
                 );
 

--- a/frontend/src/app/components/modals/create-account-modal/create-account-modal.html
+++ b/frontend/src/app/components/modals/create-account-modal/create-account-modal.html
@@ -43,11 +43,7 @@
             </editor>
 
             <editor params="label: accountNameProps.label">
-                <input type="text"
-                    ko.validationCss="$form.accountName"
-                    ko.value="$form.accountName"
-                    ko.attr.placeholder="accountNameProps.placeholder"
-                />
+                <input type="text" ko.validationCss="$form.accountName" ko.value="$form.accountName" ko.attr.placeholder="accountNameProps.placeholder" />
                 <p class="remark" ko.visible="accountNameProps.isRemarkVisible">
                     3 - 32 characters
                 </p>
@@ -74,20 +70,14 @@
                         options: resourceOptions,
                         selected: $form.defaultResource,
                         subject: 'resource'
-                    "
-                    ko.validationCss="$form.defaultResource"
-                ></dropdown>
-                 <validation-message params="field: $form.defaultResource"></validation-message>
+                    " ko.validationCss="$form.defaultResource"></dropdown>
+                <validation-message params="field: $form.defaultResource"></validation-message>
             </editor>
 
             <!-- ko if:  $form.accessType.eq('APP') -->
             <editor params="label: 'Buckets Permissions'">
                 <dropdown class="push-next" params="
                     options: bucketOptions,
-                    selected: ko.pc(
-                        $form.allowedBuckets,
-                        buckets => onSelectAllowedBuckets(buckets)
-                    ),
                     filter: true,
                     subject: 'bucket',
                     placeholder: 'Choose Buckets',

--- a/frontend/src/app/components/modals/create-account-modal/create-account-modal.js
+++ b/frontend/src/app/components/modals/create-account-modal/create-account-modal.js
@@ -11,7 +11,6 @@ import { getFormValues, getFieldValue, isFieldTouched, isFieldValid, isFormValid
 import { isEmail } from 'validations';
 import {
     touchForm,
-    updateForm,
     closeModal,
     updateModal,
     createAccount
@@ -35,8 +34,8 @@ const steps = deepFreeze([
 ]);
 
 const fieldsByStep = deepFreeze({
-    0: [ 'accountName' ],
-    1: [ 'defaultResource' ]
+    0: ['accountName'],
+    1: ['defaultResource']
 });
 
 function _getAccountNameFieldProps(form) {
@@ -100,11 +99,9 @@ class CreateAccountModalViewModel extends ConnectableViewModel {
             });
 
         } else {
-            const bucketList = [...Object.keys(buckets), ...Object.keys(namespaceBuckets)];
             const {
                 accessType = 'ADMIN',
-                allowAccessToFutureBuckets = false,
-                allowedBuckets = bucketList
+                allowAccessToFutureBuckets = false
             } = form ? getFormValues(form) : {};
 
             const accountNames = Object.keys(accounts);
@@ -114,14 +111,11 @@ class CreateAccountModalViewModel extends ConnectableViewModel {
             ];
             const resourceOptions = resourceList.map(mapResourceToOptions);
             const systemHasResources = resourceList.length > 0;
-            const isAllowAccessToFutureBucketsDisabled = allowedBuckets.length < bucketList.length;
 
             ko.assignToProps(this, {
                 accountNames,
                 resourceOptions,
-                bucketOptions: bucketList,
                 accountNameProps: _getAccountNameFieldProps(form),
-                isAllowAccessToFutureBucketsDisabled,
                 systemHasResources,
                 isStepValid: form ? isFormValid(form) : false,
                 fields: !form ? {
@@ -129,20 +123,11 @@ class CreateAccountModalViewModel extends ConnectableViewModel {
                     accountName: '',
                     accessType,
                     defaultResource: undefined,
-                    allowedBuckets,
                     allowAccessToFutureBuckets,
                     allowBucketCreation: true
                 } : undefined
             });
         }
-    }
-
-    onSelectAllowedBuckets(allowedBuckets) {
-        const update = { allowedBuckets };
-        if (allowedBuckets.length < this.bucketOptions().length) {
-            update.allowAccessToFutureBuckets = false;
-        }
-        this.dispatch(updateForm(this.formName, update));
     }
 
     onWarn(values) {
@@ -221,13 +206,12 @@ class CreateAccountModalViewModel extends ConnectableViewModel {
             accessType,
             defaultResource,
             allowAccessToFutureBuckets,
-            allowedBuckets,
             allowBucketCreation
         } = values;
 
         const createAction = accessType === 'ADMIN' ?
             createAccount(accountName, true, this.password, defaultResource, true, null, true) :
-            createAccount(accountName, false, null, defaultResource, allowAccessToFutureBuckets, allowedBuckets, allowBucketCreation);
+            createAccount(accountName, false, null, defaultResource, allowAccessToFutureBuckets, allowBucketCreation);
 
         this.dispatch(
             updateModal({

--- a/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.html
+++ b/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.html
@@ -35,10 +35,6 @@
         <editor params="label: 'Buckets Permissions',">
             <dropdown class="push-next" params="
                 options: bucketOptions,
-                selected: ko.pc(
-                    $form.allowedBuckets,
-                    buckets => onSelectAllowedBuckets(buckets)
-                ),
                 filter: true,
                 subject: 'bucket',
                 placeholder: 'Choose Buckets',

--- a/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.js
+++ b/frontend/src/app/components/modals/edit-account-s3-access-modal/edit-account-s3-access-modal.js
@@ -5,10 +5,8 @@ import ConnectableViewModel from 'components/connectable';
 import { flatMap } from 'utils/core-utils';
 import { sumSize, formatSize } from 'utils/size-utils';
 import { getCloudServiceMeta } from 'utils/cloud-utils';
-import { getFormValues } from 'utils/form-utils';
 import ko from 'knockout';
 import {
-    updateForm,
     updateAccountS3Access,
     closeModal
 } from 'action-creators';
@@ -68,10 +66,10 @@ class EditAccountS3AccessModalViewModel extends ConnectableViewModel {
         }
 
         const resourceOptions = flatMap(
-            [ hostPools, cloudResources ],
+            [hostPools, cloudResources],
             resources => Object.values(resources).map(mapResourceToOption)
         );
-        const systemHasResources= resourceOptions.length > 0;
+        const systemHasResources = resourceOptions.length > 0;
 
         const allBuckets = [
             ...Object.keys(buckets),
@@ -81,15 +79,10 @@ class EditAccountS3AccessModalViewModel extends ConnectableViewModel {
         const bucketOptions = allBuckets
             .map(bucket => {
                 const value = bucket;
-                const tooltip =  { text: bucket, breakWords: true };
+                const tooltip = { text: bucket, breakWords: true };
                 return { value, tooltip };
             });
 
-        const {
-            allowedBuckets = account.allowedBuckets
-        } = form ? getFormValues(form) : {};
-
-        const isAllowAccessToFutureBucketsDisabled = allowedBuckets.length < bucketOptions.length;
         const defaultResource = account.defaultResource !== 'INTERNAL_STORAGE' ?
             account.defaultResource :
             undefined;
@@ -99,23 +92,13 @@ class EditAccountS3AccessModalViewModel extends ConnectableViewModel {
             resourceOptions: resourceOptions,
             systemHasResources,
             bucketOptions: bucketOptions,
-            isAllowAccessToFutureBucketsDisabled,
             fields: !form ? {
                 accountName: account.name,
                 allowAccessToFutureBuckets: account.hasAccessToAllBuckets,
-                allowedBuckets: account.allowedBuckets || [],
                 defaultResource,
                 allowBucketCreation: account.canCreateBuckets
             } : undefined
         });
-    }
-
-    onSelectAllowedBuckets(allowedBuckets) {
-        const update = { allowedBuckets };
-        if (allowedBuckets.length < this.bucketOptions().length) {
-            update.allowAccessToFutureBuckets = false;
-        }
-        this.dispatch(updateForm(this.formName, update));
     }
 
     onWarn() {
@@ -139,22 +122,10 @@ class EditAccountS3AccessModalViewModel extends ConnectableViewModel {
         return errors;
     }
 
-    onSelectAllBuckets() {
-        const allowedBuckets = this.bucketOptions()
-            .map(opt => opt.value);
-
-        this.dispatch(updateForm(this.formName, { allowedBuckets }));
-    }
-
-    onClearSelectedBuckets() {
-        this.dispatch(updateForm(this.formName, { allowedBuckets: [] }));
-    }
-
     onSubmit({
         accountName,
         defaultResource,
         allowAccessToFutureBuckets,
-        allowedBuckets,
         allowBucketCreation
     }) {
 
@@ -164,7 +135,6 @@ class EditAccountS3AccessModalViewModel extends ConnectableViewModel {
                 accountName,
                 defaultResource,
                 allowAccessToFutureBuckets,
-                allowedBuckets,
                 allowBucketCreation
             )
         );

--- a/frontend/src/app/components/modals/edit-bucket-s3-access-modal/edit-bucket-s3-access-modal.js
+++ b/frontend/src/app/components/modals/edit-bucket-s3-access-modal/edit-bucket-s3-access-modal.js
@@ -12,14 +12,12 @@ function _getAccountOption({ name, hasAccessToAllBuckets }) {
         value: name,
         disabled: hasAccessToAllBuckets,
         tooltip: hasAccessToAllBuckets ?
-            'This account access permissions is set to “all buckets” and cannot be edited' :
-            name
+            'This account access permissions is set to “all buckets” and cannot be edited' : name
     };
 }
 
-function _getSelectedAccounts(accountList, bucketName) {
+function _getSelectedAccounts(accountList) {
     return accountList
-        .filter(account => account.allowedBuckets.includes(bucketName))
         .map(account => account.name);
 }
 
@@ -54,7 +52,7 @@ class EditBucketS3AccessModalViewModel extends ConnectableViewModel {
                 .filter(account => !account.roles.includes('operator'))
                 .map(_getAccountOption),
             fields: !form ? {
-                selectedAccounts: _getSelectedAccounts(accountList, bucketName)
+                selectedAccounts: _getSelectedAccounts(accountList)
             } : undefined
         });
     }

--- a/frontend/src/app/components/namespace-bucket/namespace-bucket-s3-access-form/namespace-bucket-s3-access-form.js
+++ b/frontend/src/app/components/namespace-bucket/namespace-bucket-s3-access-form/namespace-bucket-s3-access-form.js
@@ -12,17 +12,16 @@ import {
     openS3AccessDetailsModal
 } from 'action-creators';
 
-const columns = deepFreeze([
-    {
-        name: 'name',
-        type: 'link',
-        sortable: true,
-        compareKey: account => account.name
-    },
-    {
-        name: 'credentialsDetails',
-        type: 'button'
-    }
+const columns = deepFreeze([{
+    name: 'name',
+    type: 'link',
+    sortable: true,
+    compareKey: account => account.name
+},
+{
+    name: 'credentialsDetails',
+    type: 'button'
+}
 ]);
 
 class AccountRowViewModel {
@@ -78,7 +77,6 @@ class NamespaceBucketS3AccessFormViewModel extends ConnectableViewModel {
             const baseRoute = realizeUri(routes.account, { system: location.params.system }, {}, true);
             const filteredAccounts = Object.values(accounts)
                 .filter(account =>
-                    account.allowedBuckets.includes(this.bucketName) &&
                     !account.roles.includes('operator')
                 );
 

--- a/frontend/src/app/epics/create-account.js
+++ b/frontend/src/app/epics/create-account.js
@@ -16,8 +16,6 @@ export default function(action$, { api }) {
                 isAdmin,
                 password,
                 defaultResource,
-                hasAccessToAllBucekts,
-                allowedBuckets,
                 allowBucketCreation
             } = action.payload;
 
@@ -31,10 +29,6 @@ export default function(action$, { api }) {
                         must_change_password: isAdmin || undefined,
                         s3_access: true,
                         default_resource: defaultResource,
-                        allowed_buckets: {
-                            full_permission: hasAccessToAllBucekts,
-                            permission_list: !hasAccessToAllBucekts ? allowedBuckets : undefined
-                        },
                         allow_bucket_creation: allowBucketCreation
                     }),
                     sleep(750)

--- a/frontend/src/app/epics/update-account-s3-access.js
+++ b/frontend/src/app/epics/update-account-s3-access.js
@@ -13,8 +13,6 @@ export default function(action$, { api }) {
             const {
                 accountName,
                 defaultResource,
-                hasAccessToAllBuckets,
-                allowedBuckets,
                 allowBucketCreation
             } = action.payload;
 
@@ -23,10 +21,6 @@ export default function(action$, { api }) {
                     email: accountName,
                     s3_access: true,
                     default_resource: defaultResource,
-                    allowed_buckets: {
-                        full_permission: hasAccessToAllBuckets,
-                        permission_list: hasAccessToAllBuckets ? undefined : allowedBuckets
-                    },
                     allow_bucket_creation: allowBucketCreation
                 });
 

--- a/frontend/src/app/reducers/accounts-reducer.js
+++ b/frontend/src/app/reducers/accounts-reducer.js
@@ -33,9 +33,7 @@ function _mapAccount(account, owner, systemName, pools, allBuckets, accountsOwni
         has_login,
         is_external,
         access_keys,
-        has_s3_access,
         default_resource,
-        allowed_buckets,
         can_create_buckets,
         allowed_ips,
         external_connections
@@ -45,11 +43,6 @@ function _mapAccount(account, owner, systemName, pools, allBuckets, accountsOwni
         access_key: accessKey,
         secret_key: secretKey
     } = access_keys[0];
-
-    const hasAccessToAllBuckets = has_s3_access && allowed_buckets.full_permission;
-    const allowedBuckets = has_s3_access ?
-        (hasAccessToAllBuckets ? allBuckets : allowed_buckets.permission_list) :
-        [];
 
     const externalConnections = _mapExternalConnections(external_connections);
 
@@ -73,12 +66,9 @@ function _mapAccount(account, owner, systemName, pools, allBuckets, accountsOwni
         isAdmin: has_login,
         isOwner,
         isExternal: Boolean(is_external), // is_external might be undefined
-        hasAccessToAllBuckets,
-        allowedBuckets,
-        canCreateBuckets: Boolean(has_s3_access && can_create_buckets),
-        defaultResource: default_resource !== internalResource.name  ?
-            default_resource:
-            'INTERNAL_STORAGE',
+        canCreateBuckets: Boolean(can_create_buckets),
+        defaultResource: default_resource !== internalResource.name ?
+            default_resource : 'INTERNAL_STORAGE',
         accessKeys: { accessKey, secretKey },
         allowedIps: allowed_ips,
         externalConnections,

--- a/frontend/src/app/schema/accounts.js
+++ b/frontend/src/app/schema/accounts.js
@@ -6,7 +6,6 @@ export default {
         type: 'object',
         required: [
             'accessKeys',
-            'allowedBuckets',
             'canCreateBuckets',
             'externalConnections',
             'isAdmin',
@@ -29,12 +28,6 @@ export default {
                     secretKey: {
                         type: 'string'
                     }
-                }
-            },
-            allowedBuckets: {
-                type: 'array',
-                items: {
-                    type: 'string'
                 }
             },
             canCreateBuckets: {

--- a/frontend/src/app/utils/func-utils.js
+++ b/frontend/src/app/utils/func-utils.js
@@ -8,29 +8,27 @@ const handlerFuncNameRegExp = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 
 export const funcSizeLimit = unitsInBytes.MEGABYTE * 100;
 export const handlerFileSuffix = '.js';
-export const memorySizeOptions = deepFreeze([
-    {
-        value: 128,
-        label: '128 MB'
-    },
-    {
-        value: 256,
-        label: '256 MB'
-    },
-    {
-        value: 512,
-        label: '512 MB'
-    }
+export const memorySizeOptions = deepFreeze([{
+    value: 128,
+    label: '128 MB'
+},
+{
+    value: 256,
+    label: '256 MB'
+},
+{
+    value: 512,
+    label: '512 MB'
+}
 ]);
 
-export function getFunctionOption(func, accounts, bucket) {
+export function getFunctionOption(func, accounts) {
     const { name, version } = func;
     const value = `${name}:${version}`;
     const icon = { name: 'healthy', css: 'success' };
     const label = name;
     const executor = accounts[func.executor];
-    const disabled = !executor.hasAccessToAllBuckets &&
-        !executor.allowedBuckets.includes(bucket);
+    const disabled = !executor.hasAccessToAllBuckets;
 
     let tooltip = '';
     if (disabled) {
@@ -41,7 +39,7 @@ export function getFunctionOption(func, accounts, bucket) {
 
     return { value, icon, label, disabled, tooltip };
 }
-export function isValidFuncName(name){
+export function isValidFuncName(name) {
     return funcNameRegExp.test(name);
 }
 
@@ -56,3 +54,4 @@ export function getFullHandlerName(handlerFile, handlerFunc) {
         handlerFunc
     }`;
 }
+

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -33,9 +33,6 @@ module.exports = {
                     s3_access: {
                         type: 'boolean'
                     },
-                    allowed_buckets: {
-                        $ref: '#/definitions/allowed_buckets'
-                    },
                     default_resource: {
                         type: 'string',
                     },
@@ -61,9 +58,6 @@ module.exports = {
                             },
                             account_id: {
                                 type: 'string'
-                            },
-                            allowed_buckets: {
-                                $ref: '#/definitions/allowed_buckets'
                             },
                             default_resource: {
                                 type: 'string',
@@ -271,9 +265,6 @@ module.exports = {
                     email: { $ref: 'common_api#/definitions/email' },
                     s3_access: {
                         type: 'boolean'
-                    },
-                    allowed_buckets: {
-                        $ref: '#/definitions/allowed_buckets'
                     },
                     default_resource: {
                         type: 'string'
@@ -576,7 +567,7 @@ module.exports = {
     definitions: {
         account_info: {
             type: 'object',
-            required: ['name', 'email', 'has_login', 'has_s3_access'],
+            required: ['name', 'email', 'has_login'],
             properties: {
                 name: { $ref: 'common_api#/definitions/account_name' },
                 email: { $ref: 'common_api#/definitions/email' },
@@ -596,22 +587,6 @@ module.exports = {
                     type: 'array',
                     items: {
                         $ref: 'common_api#/definitions/access_keys'
-                    }
-                },
-                has_s3_access: {
-                    type: 'boolean'
-                },
-                allowed_buckets: {
-                    type: 'object',
-                    required: ['full_permission'],
-                    properties: {
-                        full_permission: {
-                            type: 'boolean'
-                        },
-                        permission_list: {
-                            type: 'array',
-                            items: { $ref: 'common_api#/definitions/bucket_name' },
-                        }
                     }
                 },
                 can_create_buckets: {
@@ -714,21 +689,6 @@ module.exports = {
                 }
             },
         },
-
-        allowed_buckets: {
-            type: 'object',
-            required: ['full_permission'],
-            properties: {
-                full_permission: {
-                    type: 'boolean'
-                },
-                permission_list: {
-                    type: 'array',
-                    items: { $ref: 'common_api#/definitions/bucket_name' },
-                }
-            }
-        },
-
         account_acl: {
             anyOf: [{
                 type: 'null'

--- a/src/lambda_funcs/create_account_func.js
+++ b/src/lambda_funcs/create_account_func.js
@@ -8,13 +8,12 @@
         "password": "lala",
         "has_login": "false",
         "s3_access": false
-        "allowed_buckets": ["mybucket"]
     }
 */
 
 exports.handler = function(event, context, callback) {
     context.rpc_client.account.create_account(event)
-        .then(() => context.rpc_client.account.read_account({email: event.email}))
+        .then(() => context.rpc_client.account.read_account({ email: event.email }))
         .then(res => callback(null, JSON.stringify(res)))
         .catch(err => callback(err));
 };

--- a/src/lambda_funcs/set_account_bucket_permissions_func.js
+++ b/src/lambda_funcs/set_account_bucket_permissions_func.js
@@ -6,13 +6,12 @@
         "email": "email@email.com",
         "s3_access": true,
         "default_resource": "london",
-        "allowed_buckets": ["mybucket"]
     }
 */
 
 exports.handler = function(event, context, callback) {
     context.rpc_client.account.update_account_s3_access(event)
-        .then(() => context.rpc_client.account.read_account({email: event.email}))
+        .then(() => context.rpc_client.account.read_account({ email: event.email }))
         .then(res => callback(null, JSON.stringify(res)))
         .catch(err => callback(err));
 };

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -53,10 +53,6 @@ interface Account extends Base {
     email: SensitiveString;
     next_password_change: Date;
     is_support?: boolean;
-    allowed_buckets: {
-        full_permission: boolean;
-        permission_list: Bucket[];
-    };
     access_keys: Array<{
         access_key: SensitiveString;
         secret_key: SensitiveString;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -157,13 +157,6 @@ class ObjectSDK {
             if (!this.has_non_nsfs_bucket_access(this.requesting_account, ns)) {
                 throw new RpcError('UNAUTHORIZED', `No permission to access bucket`);
             }
-
-            const bucket_allowed = _.get(this.requesting_account, 'allowed_buckets.full_permission', false) ||
-                _.find(
-                    _.get(this.requesting_account, 'allowed_buckets.permission_list') || [],
-                    name => name.unwrap() === bucket
-                );
-            if (!bucket_allowed) throw new RpcError('UNAUTHORIZED', `No permission to access bucket`);
         }
     }
 

--- a/src/server/bg_services/buckets_reclaimer.js
+++ b/src/server/bg_services/buckets_reclaimer.js
@@ -109,16 +109,6 @@ class BucketsReclaimer {
             this.tiering_to_delete.push(tiering_policy._id);
             this.tiers_to_delete.push(...tiering_policy.tiers.map(t => t.tier._id));
         }
-        system_store.data.accounts.forEach(account => {
-            if (!account.allowed_buckets || (account.allowed_buckets && account.allowed_buckets.full_permission)) return;
-            if (!account.allowed_buckets.permission_list.includes(bucket)) return;
-            this.account_updates.push({
-                _id: account._id,
-                $pullAll: {
-                    'allowed_buckets.permission_list': [bucket._id]
-                }
-            });
-        });
     }
 
     _reset_delete_lists() {

--- a/src/server/func_services/func_server.js
+++ b/src/server/func_services/func_server.js
@@ -314,10 +314,6 @@ function check_event_permission(req) {
             if (typeof(bucket_name) === 'string') {
                 const bucket = req.system.buckets_by_name && req.system.buckets_by_name[bucket_name];
                 if (!bucket || bucket.deleting) throw new RpcError('UNAUTHORIZED', 'No such bucket');
-                const account = system_store.data.get_by_id(req.func.exec_account);
-                if (!auth_server.has_bucket_permission(bucket, account)) {
-                    throw new RpcError('UNAUTHORIZED', 'No bucket permission for trigger');
-                }
             }
         });
     }

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1386,7 +1386,6 @@ function load_bucket(req, { include_deleting } = {}) {
     if (!bucket || (bucket.deleting && !include_deleting)) {
         throw new RpcError('NO_SUCH_BUCKET', 'No such bucket: ' + req.rpc_params.bucket);
     }
-    req.check_s3_bucket_permission(bucket);
     req.bucket = bucket;
 }
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -25,7 +25,6 @@ const http_utils = require('../../util/http_utils');
 const cloud_utils = require('../../util/cloud_utils');
 const nodes_client = require('../node_services/nodes_client');
 const pool_server = require('../system_services/pool_server');
-const auth_server = require('../common_services/auth_server');
 const system_store = require('../system_services/system_store').get_instance();
 const func_store = require('../func_services/func_store');
 const replication_store = require('../system_services/replication_store');
@@ -215,16 +214,6 @@ async function create_bucket(req) {
             bucket: bucket._id,
             desc: `${bucket.name.unwrap()} was created by ${req.account && req.account.email.unwrap()}`,
         });
-
-        // Grant the account a full access for the newly created bucket.
-        if (req.account.allowed_buckets && !req.account.allowed_buckets.full_permission) {
-            changes.update.accounts = [{
-                _id: req.account._id,
-                $push: {
-                    'allowed_buckets.permission_list': bucket._id,
-                }
-            }];
-        }
 
         await system_store.make_changes(changes);
         req.load_auth();
@@ -714,39 +703,10 @@ async function update_buckets(req) {
  */
 function update_bucket_s3_access(req) {
     const bucket = find_bucket(req);
-    const allowed_accounts = req.rpc_params.allowed_accounts.map(
-        email => system_store.get_account_by_email(email)
-    );
 
     const added_accounts = [];
     const removed_accounts = [];
     const updates = [];
-    system_store.data.accounts.forEach(account => {
-        if (!account.allowed_buckets ||
-            (account.allowed_buckets && account.allowed_buckets.full_permission)) return;
-
-        const is_allowed = account.allowed_buckets.permission_list.includes(bucket);
-        const should_be_allowed = allowed_accounts.includes(account);
-
-        if (!is_allowed && should_be_allowed) {
-            added_accounts.push(account);
-            updates.push({
-                _id: account._id,
-                $push: {
-                    'allowed_buckets.permission_list': bucket._id
-                }
-            });
-        } else if (is_allowed && !should_be_allowed) {
-            removed_accounts.push(account);
-            updates.push({
-                _id: account._id,
-                $pullAll: {
-                    'allowed_buckets.permission_list': [bucket._id]
-                }
-            });
-        }
-    });
-
     return system_store.make_changes({
             update: {
                 accounts: updates
@@ -871,25 +831,6 @@ async function delete_bucket(req) {
         if (bucket.replication_policy_id) {
             // delete replication from replication collection
             await replication_store.instance().delete_replication_by_id(bucket.replication_policy_id);
-        }
-        const accounts_update = _.compact(_.map(system_store.data.accounts,
-            account => {
-                if (!account.allowed_buckets ||
-                    (account.allowed_buckets && account.allowed_buckets.full_permission)) return;
-                return {
-                    _id: account._id,
-                    $pullAll: {
-                        'allowed_buckets.permission_list': [bucket._id]
-                    }
-                };
-            }));
-
-        if (!_.isEmpty(accounts_update)) {
-            await system_store.make_changes({
-                update: {
-                    accounts: accounts_update
-                }
-            });
         }
         await BucketStatsStore.instance().delete_stats({
             system: req.system._id,
@@ -1316,10 +1257,6 @@ async function claim_bucket(req) {
             has_login: false,
             s3_access: true,
             allow_bucket_creation: false,
-            allowed_buckets: {
-                full_permission: false,
-                permission_list: [req.rpc_params.name],
-            }
         }, {
             auth_token: req.auth_token
         });
@@ -1423,13 +1360,7 @@ function validate_trigger_update(bucket, validated_trigger) {
         }
     });
     if (!validate_function) return P.resolve(); // if update doesn't change function - no need to validate access
-    return func_store.instance().read_func(bucket.system._id, validated_trigger.func_name, validated_trigger.func_version)
-        .then(func => {
-            const exec_account = system_store.data.get_by_id(func.exec_account);
-            if (!auth_server.has_bucket_permission(bucket, exec_account)) {
-                throw new RpcError('UNAUTHORIZED', 'No permission to access bucket');
-            }
-        });
+    return true;
 }
 
 function _inject_usage_to_cloud_bucket(target_name, endpoint, usage_list) {
@@ -1453,7 +1384,6 @@ function find_bucket(req, bucket_name = req.rpc_params.name) {
         dbg.error('BUCKET NOT FOUND', bucket_name);
         throw new RpcError('NO_SUCH_BUCKET', 'No such bucket: ' + bucket_name);
     }
-    req.check_s3_bucket_permission(bucket);
     return bucket;
 }
 
@@ -1551,12 +1481,6 @@ function get_bucket_info({
     info.triggers = _.map(bucket.lambda_triggers, trigger => {
         const ret_trigger = _.omit(trigger, '_id');
         ret_trigger.id = trigger._id.toString();
-        const func = _.find(func_configs, func_config =>
-            func_config.name === trigger.func_name &&
-            func_config.version === trigger.func_version
-        );
-        const exec_account = system_store.get_account_by_email(func.exec_account);
-        ret_trigger.permission_problem = !auth_server.has_bucket_permission(bucket, exec_account);
         return ret_trigger;
     });
 

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -46,18 +46,6 @@ module.exports = {
             }
         },
 
-        allowed_buckets: {
-            type: 'object',
-            required: ['full_permission'],
-            properties: {
-                full_permission: { type: 'boolean' },
-                permission_list: {
-                    type: 'array',
-                    items: { objectid: true },
-                }
-            }
-        },
-
         allowed_ips: {
             type: 'array',
             items: {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -362,7 +362,6 @@ async function create_system(req) {
             has_login: false,
             s3_access: true,
             allow_bucket_creation: true,
-            allowed_buckets: { full_permission: true },
             roles: ['operator']
         }, auth);
 
@@ -425,7 +424,6 @@ async function _create_owner_account(
             account_id: account_id.toString(),
             new_system_id: system_id.toString(),
             default_resource: default_resource.toString(),
-            allowed_buckets: { full_permission: true },
         },
     });
     return { auth_token };

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -239,7 +239,6 @@ class SystemStoreData {
         this.rebuild_idmap();
         this.rebuild_object_links();
         this.rebuild_indexes();
-        this.rebuild_allowed_buckets_links();
         this.rebuild_accounts_by_email_lowercase();
 
         // TODO: deep freeze the data once tested enough
@@ -295,20 +294,6 @@ class SystemStoreData {
                     }
                 });
             });
-        });
-    }
-
-    rebuild_allowed_buckets_links() {
-        _.each(this.accounts, account => {
-            // filter only the buckets that were resolved to existing buckets
-            // this is to handle deletions of buckets that currently do not
-            // update all the accounts.
-            if (account.allowed_buckets && account.allowed_buckets.permission_list) {
-                account.allowed_buckets.permission_list = _.filter(
-                    account.allowed_buckets.permission_list,
-                    bucket => Boolean(bucket._id)
-                );
-            }
         });
     }
 

--- a/src/test/lambda/dildos.js
+++ b/src/test/lambda/dildos.js
@@ -56,20 +56,16 @@ const dos_func = {
     }]
 };
 
+// const SA_EVENT = {
+//     "email": "test@noobaa.com",
+//     "ips": ["1.1.1.1"]
+// };
 
 const SP_EVENT = {
     "email": "new@aaa.com",
     "s3_access": true,
     "default_resource": "london",
-    "allowed_buckets": ['logs']
 };
-
-
-
-// const SA_EVENT = {
-//     "email": "test@noobaa.com",
-//     "ips": ["1.1.1.1"]
-// };
 
 const WC_EVENT = {
     text: 'a',
@@ -128,8 +124,8 @@ function install_func(fn) {
     return P.resolve()
         .then(() => prepare_func(fn))
         .then(() => P.fromCallback(callback => lambda.deleteFunction({
-            FunctionName: fn.FunctionName,
-        }, callback))
+                FunctionName: fn.FunctionName,
+            }, callback))
             .catch(err => {
                 console.log('Delete function if exist:', fn.FunctionName, err.message);
             }))
@@ -143,9 +139,9 @@ function clear() {
             f => P.fromCallback(callback => lambda.deleteFunction({
                 FunctionName: f.FunctionName,
             }, callback))
-                .catch(err => {
-                    console.log('Delete function if exist:.', f.FunctionName, err.message);
-                })
+            .catch(err => {
+                console.log('Delete function if exist:.', f.FunctionName, err.message);
+            })
         ));
 }
 
@@ -166,11 +162,11 @@ function test() {
         FunctionName: dos_func.FunctionName,
         Payload: JSON.stringify(DOS_EVENT),
     } : {
-            FunctionName: word_count_func.FunctionName,
-            Payload: JSON.stringify(SP_EVENT)
-            // FunctionName: create_account_func.FunctionName,
-            // Payload: JSON.stringify(CA_EVENT)
-        };
+        FunctionName: word_count_func.FunctionName,
+        Payload: JSON.stringify(SP_EVENT)
+        // FunctionName: create_account_func.FunctionName,
+        // Payload: JSON.stringify(CA_EVENT)
+    };
     console.log('Testing', params);
     return P.fromCallback(callback => lambda.invoke(params, callback))
         .then(res => console.log('Result:', res));

--- a/src/test/pipeline/account_test.js
+++ b/src/test/pipeline/account_test.js
@@ -117,7 +117,6 @@ async function get_s3_account_access(email) {
         const s3AccessKeys = {
             accessKeyId: account.access_keys[0].access_key.unwrap(),
             secretAccessKey: account.access_keys[0].secret_key.unwrap(),
-            access: account.has_s3_access
         };
         console.log("S3 access keys: " + s3AccessKeys.accessKeyId, s3AccessKeys.secretAccessKey);
         return s3AccessKeys;
@@ -138,26 +137,13 @@ async function get_account_create_bucket_status(email) {
     }
 }
 
-function get_allowed_buckets(s3_access) {
-    if (s3_access === true) {
-        return {
-            full_permission: true,
-            permission_list: undefined
-        };
-    } else {
-        return undefined;
-    }
-}
-
 function set_account_details(has_login, account_name, email, s3_access) {
-    const allowed_buckets = get_allowed_buckets(s3_access);
     return {
         name: account_name,
         email,
         password: TEST_CFG.password,
         has_login,
         s3_access: TEST_CFG.s3_access,
-        allowed_buckets,
     };
 }
 
@@ -205,12 +191,10 @@ async function regenerate_s3Access(email) {
 
 async function edit_s3Access(email, s3_access) {
     console.log(`Editing account s3 access: ${email} with access to bucket ${s3_access}`);
-    const allowed_buckets = get_allowed_buckets(s3_access);
     try {
         await client.account.update_account_s3_access({
             email,
             s3_access,
-            allowed_buckets
         });
         await report.success('edit_s3Access');
     } catch (err) {
@@ -227,12 +211,10 @@ async function edit_bucket_creation(email, allow_bucket_creation) {
         console.log(`Disabling bucket creation for ${email}`);
     }
     const s3_access = true;
-    const allowed_buckets = get_allowed_buckets(s3_access);
     try {
         await client.account.update_account_s3_access({
             email,
             s3_access,
-            allowed_buckets,
             allow_bucket_creation
         });
         await report.success('edit_bucket_creation');

--- a/src/test/system_tests/mongodb_defaults.js
+++ b/src/test/system_tests/mongodb_defaults.js
@@ -144,18 +144,6 @@ db.accounts.remove({
     }
 });
 
-// Update owner allowed_buckets to files bucket only
-db.accounts.update({
-    email: 'demo@noobaa.com'
-}, {
-    $set: {
-        allowed_buckets: {
-            full_permission: true
-        },
-        allow_bucket_creation: true
-    }
-});
-
 // Removing roles of the deleted accounts, except demo and support (which doesn't have a role)
 db.roles.remove({
     account: {

--- a/src/test/system_tests/sanity_build_test.js
+++ b/src/test/system_tests/sanity_build_test.js
@@ -192,12 +192,6 @@ async function _create_accounts() {
         has_login: false,
         s3_access: true,
         default_resource: 'COMP-S3-V2-Resource',
-        allowed_buckets: {
-            full_permission: false,
-            permission_list: [
-                'first.bucket'
-            ]
-        },
         allow_bucket_creation: true
     };
 
@@ -208,10 +202,6 @@ async function _create_accounts() {
         must_change_password: true,
         s3_access: true,
         default_resource: 'COMP-S3-V2-Resource',
-        allowed_buckets: {
-            full_permission: false,
-            permission_list: ['first.bucket', 'ec.no.quota', 'replica.with.quota']
-        },
         allow_bucket_creation: true
     };
 
@@ -222,7 +212,6 @@ async function _create_accounts() {
         must_change_password: false,
         s3_access: true,
         default_resource: 'COMP-S3-V2-Resource',
-        allowed_buckets: { full_permission: true },
         allow_bucket_creation: true
     };
 
@@ -234,7 +223,6 @@ async function _create_accounts() {
         must_change_password: false,
         s3_access: true,
         default_resource: 'COMP-S3-V2-Resource',
-        allowed_buckets: { full_permission: true },
         allow_bucket_creation: true
     };
 
@@ -245,7 +233,6 @@ async function _create_accounts() {
         must_change_password: false,
         s3_access: true,
         default_resource: 'COMP-S3-V2-Resource',
-        allowed_buckets: { full_permission: true },
         allow_bucket_creation: true
     };
     const ac5_update = {

--- a/src/test/system_tests/test_bucket_access.js
+++ b/src/test/system_tests/test_bucket_access.js
@@ -16,7 +16,6 @@ const test_utils = require('./test_utils');
 
 const fs = require('fs');
 const AWS = require('aws-sdk');
-const { v4: uuid } = require('uuid');
 const assert = require('assert');
 
 
@@ -42,10 +41,6 @@ const full_access_user = {
     email: 'full_access@noobaa.com',
     has_login: false,
     s3_access: true,
-    allowed_buckets: {
-        full_permission: false,
-        permission_list: ['bucket1', 'bucket2']
-    },
     default_resource: POOL_NAME
 };
 
@@ -54,10 +49,6 @@ const bucket1_user = {
     email: 'bucket1_access@noobaa.com',
     has_login: false,
     s3_access: true,
-    allowed_buckets: {
-        full_permission: false,
-        permission_list: ['bucket1']
-    },
     default_resource: POOL_NAME
 };
 
@@ -132,53 +123,18 @@ function get_new_server(user) {
 async function run_test() {
     await authenticate();
     await setup();
-    await test_list_buckets_returns_allowed_buckets();
     await test_bucket_write_allowed();
     await test_bucket_read_allowed();
     await test_bucket_list_allowed();
     await test_bucket_write_denied();
     await test_bucket_read_denied();
     await test_bucket_list_denied();
-    await test_create_bucket_add_creator_permissions();
-    await test_delete_bucket_deletes_permissions();
     await test_no_s3_access();
     await test_ip_restrictions();
     console.log('test_bucket_access PASSED');
 }
 
 /********************Tests:****************************/
-
-
-async function test_list_buckets_returns_allowed_buckets() {
-    let account;
-    let full_access_user_buckets = 0;
-    let bucket1_user_buckets = 0;
-    let server = get_new_server(full_access_user);
-
-    const system_info = await client.system.read_system();
-    account = account_by_name(system_info.accounts, full_access_user.email);
-    full_access_user_buckets = (account.allowed_buckets.permission_list || []).length;
-
-    account = account_by_name(system_info.accounts, bucket1_user.email);
-    bucket1_user_buckets = (account.allowed_buckets.permission_list || []).length;
-    let data = await server.listBuckets().promise();
-    assert(data.Buckets.length === full_access_user_buckets,
-        'expecting ' + full_access_user_buckets + ' buckets in the list, but got ' + data.Buckets.length);
-
-    let buckets = data.Buckets.map(bucket => bucket.Name);
-    assert(buckets.indexOf('bucket1') !== -1, 'expecting bucket1 to be in the list');
-    assert(buckets.indexOf('bucket2') !== -1, 'expecting bucket2 to be in the list');
-
-    server = get_new_server(bucket1_user);
-    data = await server.listBuckets().promise();
-
-    assert(data.Buckets.length === bucket1_user_buckets,
-        'expecting ' + bucket1_user_buckets + ' bucket in the list, but got ' + data.Buckets.length);
-
-    buckets = data.Buckets.map(bucket => bucket.Name);
-    assert(buckets.indexOf('bucket1') !== -1, 'expecting bucket1 to be in the list');
-    console.log('test_list_buckets_returns_allowed_buckets PASSED');
-}
 
 async function test_bucket_write_allowed() {
     console.log(`Starting test_bucket_write_allowed`);
@@ -319,45 +275,6 @@ async function test_bucket_list_denied() {
         assert(err.statusCode === 403, 'expecting read to fail with statusCode 403- AccessDenied');
     }
 
-}
-
-async function test_create_bucket_add_creator_permissions() {
-    console.log(`Starting test_create_bucket_add_creator_permissions`);
-    const server = get_new_server(full_access_user);
-    const unique_bucket_name = 'bucket' + uuid();
-    const params = {
-        Bucket: unique_bucket_name
-    };
-    await server.createBucket(params).promise();
-    // check account server for permissions of full_access_user
-    const system_info = await client.system.read_system();
-    const allowed_buckets = account_by_name(system_info.accounts, full_access_user.email).allowed_buckets.permission_list;
-    const has_access = Boolean(allowed_buckets.find(bucket_name => unique_bucket_name === bucket_name.unwrap()));
-    assert(has_access, 'expecting full_access_user to have permissions to access ' + unique_bucket_name);
-}
-
-async function test_delete_bucket_deletes_permissions() {
-    console.log(`Starting test_delete_bucket_deletes_permissions`);
-    const server = get_new_server(full_access_user);
-    const unique_bucket_name = 'bucket' + uuid();
-
-    await server.createBucket({ Bucket: unique_bucket_name }).promise();
-    let system_info = await client.system.read_system();
-
-    let user_has_access = Boolean(account_by_name(system_info.accounts, full_access_user.email)
-        .allowed_buckets
-        .permission_list
-        .find(bucket_name => unique_bucket_name === bucket_name.unwrap()));
-
-    assert(user_has_access, 'expecting full_access_user to have permissions to access ' + unique_bucket_name);
-    await server.deleteBucket({ Bucket: unique_bucket_name }).promise();
-    system_info = await client.system.read_system();
-    user_has_access = Boolean(account_by_name(system_info.accounts, full_access_user.email)
-        .allowed_buckets
-        .permission_list
-        .find(bucket_name => unique_bucket_name === bucket_name.unwrap()));
-
-    assert(!user_has_access, 'expecting full_access_user to not have permissions to access ' + unique_bucket_name);
 }
 
 async function test_no_s3_access() {

--- a/src/test/system_tests/test_bucket_lambda_triggers.js
+++ b/src/test/system_tests/test_bucket_lambda_triggers.js
@@ -47,10 +47,6 @@ let full_access_user = {
     password: 'master',
     has_login: true,
     s3_access: true,
-    allowed_buckets: {
-        full_permission: false,
-        permission_list: ['bucket1', 'bucket2', 'ns.external.bucket1']
-    },
     default_resource: POOL_NAME,
 };
 
@@ -60,10 +56,6 @@ let bucket1_user = {
     password: 'onlyb1',
     has_login: true,
     s3_access: true,
-    allowed_buckets: {
-        full_permission: false,
-        permission_list: ['bucket1', 'ns.external.bucket1']
-    },
     default_resource: POOL_NAME,
 };
 
@@ -226,7 +218,7 @@ async function setup() {
         await client.bucket.create_bucket({
             name: 'ns.external.bucket1',
             namespace: {
-                read_resources: [ nsr1 ],
+                read_resources: [nsr1],
                 write_resource: nsr2
             }
         });

--- a/src/test/system_tests/test_ceph_s3.js
+++ b/src/test/system_tests/test_ceph_s3.js
@@ -56,10 +56,6 @@ const CEPH_TEST = {
         email: 'ceph.alt@noobaa.com',
         //password: 'ceph',
         has_login: false,
-        allowed_buckets: {
-            full_permission: false,
-            permission_list: []
-        },
         s3_access: true,
     },
     new_account_params_tenant: {
@@ -67,10 +63,6 @@ const CEPH_TEST = {
         email: 'ceph.tenant@noobaa.com',
         //password: 'ceph',
         has_login: false,
-        allowed_buckets: {
-            full_permission: false,
-            permission_list: []
-        },
         s3_access: true,
     }
 };

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -22,9 +22,6 @@ const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null,
 let new_account_params = {
     has_login: false,
     s3_access: true,
-    allowed_buckets: {
-        full_permission: true
-    }
 };
 
 // currently will pass only when running locally
@@ -164,14 +161,13 @@ mocha.describe('bucket operations - namespace_fs', function() {
         const email = 'account_wrong_uid0@noobaa.com';
         const account = await rpc_client.account.read_account({ email: email });
         const default_resource = account.default_resource;
-        const allowed_buckets = account.allowed_buckets;
-        const arr = [{ nsfs_account_config: { uid: 26041993 }, default_resource, allowed_buckets, should_fail: false },
-            { nsfs_account_config: { new_buckets_path: 'dummy_dir1/' }, default_resource, allowed_buckets, should_fail: false },
-            { nsfs_account_config: {}, default_resource, allowed_buckets, should_fail: true },
-            { nsfs_account_config: { uid: 26041992 }, default_resource, allowed_buckets, should_fail: false }
+        const arr = [{ nsfs_account_config: { uid: 26041993 }, default_resource, should_fail: false },
+            { nsfs_account_config: { new_buckets_path: 'dummy_dir1/' }, default_resource, should_fail: false },
+            { nsfs_account_config: {}, default_resource, should_fail: true },
+            { nsfs_account_config: { uid: 26041992 }, default_resource, should_fail: false }
         ];
         await P.all(_.map(arr, async item =>
-            update_account_nsfs_config(email, item.default_resource, item.allowed_buckets, item.nsfs_account_config, item.should_fail)));
+            update_account_nsfs_config(email, item.default_resource, item.nsfs_account_config, item.should_fail)));
     });
     mocha.it('list namespace resources after creation', async function() {
         await rpc_client.create_auth_token({
@@ -208,9 +204,6 @@ mocha.describe('bucket operations - namespace_fs', function() {
                 email: 'account_s3_correct_uid1@noobaa.com',
                 name: 'account_s3_correct_uid1',
                 s3_access: true,
-                allowed_buckets: {
-                    full_permission: true
-                },
                 default_resource: nsr
             });
             assert.fail(inspect(res));
@@ -224,9 +217,6 @@ mocha.describe('bucket operations - namespace_fs', function() {
             email: 'account_s3_correct_uid1@noobaa.com',
             name: 'account_s3_correct_uid1',
             s3_access: true,
-            allowed_buckets: {
-                full_permission: true
-            },
             default_resource: nsr,
             nsfs_account_config: {
                 uid: process.getuid(),
@@ -257,9 +247,6 @@ mocha.describe('bucket operations - namespace_fs', function() {
             email: 'account_s3_correct_uid@noobaa.com',
             name: 'account_s3_correct_uid',
             s3_access: true,
-            allowed_buckets: {
-                full_permission: true
-            },
             default_resource: nsr,
             nsfs_account_config: {
                 uid: process.getuid(),
@@ -282,9 +269,6 @@ mocha.describe('bucket operations - namespace_fs', function() {
             email: 'account_s3_incorrect_uid@noobaa.com',
             name: 'account_s3_incorrect_uid',
             s3_access: true,
-            allowed_buckets: {
-                full_permission: true
-            },
             default_resource: nsr,
             nsfs_account_config: {
                 uid: 26041992,
@@ -502,13 +486,12 @@ function object_in_list(res, key) {
     return ans;
 }
 
-async function update_account_nsfs_config(email, default_resource, allowed_buckets, new_nsfs_account_config, should_fail) {
+async function update_account_nsfs_config(email, default_resource, new_nsfs_account_config, should_fail) {
     try {
         await rpc_client.account.update_account_s3_access({
             email,
             s3_access: true,
             default_resource,
-            allowed_buckets,
             nsfs_account_config: new_nsfs_account_config
         });
         if (should_fail) {

--- a/src/test/unit_tests/test_encryption.js
+++ b/src/test/unit_tests/test_encryption.js
@@ -124,10 +124,7 @@ mocha.describe('Encryption tests', function() {
             const db_system = await db_client.collection('systems').findOne({ name: SYSTEM });
             let new_account_params = {
                 has_login: false,
-                s3_access: true,
-                allowed_buckets: {
-                    full_permission: true
-                }
+                s3_access: true
             };
             let i;
             for (i = 0; i < 20; i++) {
@@ -623,9 +620,6 @@ mocha.describe('Rotation tests', function() {
         let new_account_params = {
             has_login: false,
             s3_access: true,
-            allowed_buckets: {
-                full_permission: true
-            },
             email: 'account-after-disable-ststem',
             name: 'account-after-disable-ststem'
         };
@@ -990,10 +984,7 @@ async function populate_system(rpc_client) {
 
     let new_account_params = {
         has_login: false,
-        s3_access: true,
-        allowed_buckets: {
-            full_permission: true
-        }
+        s3_access: true
     };
     const external_connection = {
         auth_method: 'AWS_V2',
@@ -1054,10 +1045,7 @@ async function create_delete_external_connections(rpc_client) {
 
     let new_account_params = {
         has_login: false,
-        s3_access: true,
-        allowed_buckets: {
-            full_permission: true
-        }
+        s3_access: true
     };
     const external_connection = {
         auth_method: 'AWS_V2',

--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -55,9 +55,6 @@ async function setup() {
     const account = {
         has_login: false,
         s3_access: true,
-        allowed_buckets: {
-            full_permission: true,
-        },
         default_resource: POOL_LIST[0].name
     };
     const admin_keys = (await rpc_client.account.read_account({

--- a/src/test/unit_tests/test_s3_worm.js
+++ b/src/test/unit_tests/test_s3_worm.js
@@ -51,7 +51,7 @@ mocha.describe('s3 worm', function() {
             region: 'us-east-1',
             httpOptions: { agent: new http.Agent({ keepAlive: false }) },
         };
-        const account = { has_login: false, s3_access: true, allowed_buckets: { full_permission: true } };
+        const account = { has_login: false, s3_access: true };
         const admin_keys = (await rpc_client.account.read_account({ email: EMAIL, })).access_keys;
         account.name = user_a;
         account.email = user_a;

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -39,20 +39,6 @@ mocha.describe('system_servers', function() {
         const accounts_status = await rpc_client.account.accounts_status();
         await assert(accounts_status.has_accounts, 'has_accounts');
 
-        try {
-            await rpc_client.account.create_account({
-                name: EMAIL1,
-                email: EMAIL1,
-                has_login: false,
-                s3_access: true,
-                allow_bucket_creation: false
-            });
-        } catch (err) {
-            if (err.rpc_code !== 'BAD_REQUEST') {
-                throw err;
-            }
-        }
-
         await rpc_client.account.create_account({
             name: EMAIL1,
             email: EMAIL1,
@@ -70,11 +56,7 @@ mocha.describe('system_servers', function() {
             email: EMAIL1,
             has_login: false,
             s3_access: true,
-            allow_bucket_creation: false,
-            allowed_buckets: {
-                full_permission: true,
-                permission_list: ['first.bucket']
-            },
+            allow_bucket_creation: false
         });
 
         await rpc_client.system.read_system();
@@ -109,10 +91,6 @@ mocha.describe('system_servers', function() {
             email: EMAIL1,
             has_login: false,
             s3_access: true,
-            allowed_buckets: {
-                full_permission: false,
-                permission_list: []
-            },
             default_resource: DEFAULT_POOL_NAME
         });
         await rpc_client.system.read_system();
@@ -143,10 +121,6 @@ mocha.describe('system_servers', function() {
             email: EMAIL1,
             has_login: false,
             s3_access: true,
-            allowed_buckets: {
-                full_permission: false,
-                permission_list: []
-            },
             default_resource: DEFAULT_POOL_NAME,
             nsfs_account_config: {
                 uid: UID,
@@ -160,10 +134,6 @@ mocha.describe('system_servers', function() {
             email: EMAIL2,
             has_login: false,
             s3_access: true,
-            allowed_buckets: {
-                full_permission: false,
-                permission_list: []
-            },
             default_resource: DEFAULT_POOL_NAME,
             nsfs_account_config: {
                 uid: UID + 1,
@@ -177,10 +147,6 @@ mocha.describe('system_servers', function() {
             email: EMAIL3,
             has_login: false,
             s3_access: true,
-            allowed_buckets: {
-                full_permission: false,
-                permission_list: []
-            },
             default_resource: DEFAULT_POOL_NAME,
         };
         try {

--- a/src/tools/mapper_speed.js
+++ b/src/tools/mapper_speed.js
@@ -155,7 +155,6 @@ async function main() {
                 check_indexes() { /*empty*/ },
                 rebuild() { /*empty*/ },
                 rebuild_accounts_by_email_lowercase() { /*empty*/ },
-                rebuild_allowed_buckets_links() { /*empty*/ },
                 rebuild_idmap() { /*empty*/ },
                 rebuild_indexes() { /*empty*/ },
                 rebuild_object_links() { /*empty*/ },


### PR DESCRIPTION
The "allowed buckets" functionality interferes with
another access control mechanism which was implemented
and thus needs to be removed

Signed-off-by: Barak Sason Rofman <sason922@gmail.com>