### PR TITLE
Addition of JSON and Array to config overrides

### DIFF
--- a/config.js
+++ b/config.js
@@ -641,6 +641,10 @@ function load_config_env_overrides() {
                 console.log(`Overriding config.js from ENV with ${conf_name}=${val} (string)`);
                 config[conf_name] = val;
 
+            } else if (type === 'object') {
+                // TODO: Validation checks, more complex type casting for values if needed
+                config[conf_name] = Array.isArray(prev_val) ? val.split(',') : JSON.parse(val);
+                console.log(`Overriding config.js from ENV with ${conf_name}=${val} (object of type ${Array.isArray(prev_val) ? 'array' : 'json'})`);
             } else {
                 console.log(`Unknown type or mismatch between existing ${type} and provided type for ${conf_name}, skipping ...`);
             }


### PR DESCRIPTION
### Explain the changes
1. Added support for Array and JSON parsing to overrides of config values

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/6823
2. Fixed https://github.com/noobaa/noobaa-operator/issues/404

### Testing Instructions:
```
node
> process.env.CONFIG_JS_DEFAULT_ACCOUNT_PREFERENCES = '{"ui_theme":"WHITE"}';
'{"ui_theme":"WHITE"}'
> process.env.CONFIG_JS_OAUTH_REQUIRED_GROUPS = 'a,b,c';
'a,b,c'
> const config = require('./config.js');
load_config_local: NO LOCAL CONFIG
Overriding config.js from ENV with DEFAULT_ACCOUNT_PREFERENCES={"ui_theme":"WHITE"} (object of type json)
Overriding config.js from ENV with OAUTH_REQUIRED_GROUPS=a,b,c (object of type array)
undefined
> config.DEFAULT_ACCOUNT_PREFERENCES
{ ui_theme: 'WHITE' }
> config.OAUTH_REQUIRED_GROUPS
[ 'a', 'b', 'c' ]
```