### PR TITLE
Provide access keys on account creation

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -73,6 +73,12 @@ module.exports = {
                     nsfs_account_config: {
                         $ref: 'common_api#/definitions/nsfs_account_config'
                     },
+                    access_keys: {
+                        type: 'array',
+                        items: {
+                            $ref: 'common_api#/definitions/access_keys'
+                        }
+                    },
                 },
             },
             reply: {

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -53,7 +53,6 @@ async function create_account(req) {
         email: req.rpc_params.email,
         has_login: req.rpc_params.has_login,
         is_external: req.rpc_params.is_external,
-        access_keys: undefined,
         nsfs_account_config: req.rpc_params.nsfs_account_config
     };
 
@@ -65,7 +64,9 @@ async function create_account(req) {
     if (account.name.unwrap() === 'demo' && account.email.unwrap() === 'demo@noobaa.com') {
         account.access_keys = [demo_access_keys];
     } else {
-        account.access_keys = [generate_access_keys()];
+        const access_keys = req.rpc_params.access_keys || [generate_access_keys()];
+        if (!access_keys.length) throw new RpcError('FORBIDDEN', 'cannot create account without access_keys');
+        account.access_keys = access_keys;
     }
 
     if (req.rpc_params.must_change_password) {


### PR DESCRIPTION
### Explain the changes
1. Allowing to provide user's custom access_keys when creating an account

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/6822

### Testing Instructions:
1. 
