### PR TITLE
Initial STS support

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -79,6 +79,9 @@ module.exports = {
                             $ref: 'common_api#/definitions/access_keys'
                         }
                     },
+                    role_config: {
+                        $ref: 'common_api#/definitions/role_config'
+                    },
                 },
             },
             reply: {
@@ -200,7 +203,10 @@ module.exports = {
                                 enum: ['DARK', 'LIGHT']
                             }
                         }
-                    }
+                    },
+                    role_config: {
+                        $ref: 'common_api#/definitions/role_config'
+                    },
                 }
             },
             auth: {
@@ -625,6 +631,9 @@ module.exports = {
                             items: { $ref: 'common_api#/definitions/bucket_name' },
                         }
                     }
+                },
+                role_config: {
+                    $ref: 'common_api#/definitions/role_config'
                 },
                 can_create_buckets: {
                     type: 'boolean'

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -105,7 +105,39 @@ module.exports = {
             }
         },
 
-        // TODO: Update to the relevant schema
+        assume_role_policy: {
+            type: 'object',
+            required: ['statement'],
+            properties: {
+                version: { type: 'string' },
+                statement: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        required: ['effect', 'action', 'principal'],
+                        properties: {
+                            effect: {
+                                enum: ['allow', 'deny'],
+                                type: 'string'
+                            },
+                            action: {
+                                type: 'array',
+                                items: {
+                                    type: 'string'
+                                }
+                            },
+                            principal: {
+                                type: 'array',
+                                items: {
+                                    $ref: '#/definitions/email',
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        },
+
         bucket_policy: {
             type: 'object',
             required: ['statement'],
@@ -848,5 +880,17 @@ module.exports = {
                 }
             }
         },
+        role_config: {
+            type: 'object',
+            required: ['role_name', 'assume_role_policy'],
+            properties: {
+                role_name: {
+                    type: 'string'
+                },
+                assume_role_policy: {
+                    $ref: '#/definitions/assume_role_policy'
+                }
+            }
+        }
     }
 };

--- a/src/endpoint/s3/ops/s3_put_object_uploadId.js
+++ b/src/endpoint/s3/ops/s3_put_object_uploadId.js
@@ -6,6 +6,10 @@ const S3Error = require('../s3_errors').S3Error;
 const s3_utils = require('../s3_utils');
 const http_utils = require('../../../util/http_utils');
 
+const s3_error_options = {
+    ErrorClass: S3Error,
+    error_missing_content_length: S3Error.MissingContentLength
+};
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
  * http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html
@@ -18,7 +22,7 @@ async function put_object_uploadId(req, res) {
 
     // Copy request sends empty content and not relevant to the object data
     const { size, md5_b64, sha256_b64 } = copy_source ? {} : {
-        size: s3_utils.parse_content_length(req),
+        size: http_utils.parse_content_length(req, s3_error_options),
         md5_b64: req.content_md5 && req.content_md5.toString('base64'),
         sha256_b64: req.content_sha256_buf && req.content_sha256_buf.toString('base64'),
     };
@@ -69,7 +73,7 @@ function get_bucket_usage(req, res) {
     return {
         bucket: req.params.bucket,
         access_key: req.object_sdk.get_auth_token().access_key,
-        write_bytes: s3_utils.parse_content_length(req),
+        write_bytes: http_utils.parse_content_length(req, s3_error_options),
     };
 }
 

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -241,16 +241,6 @@ function parse_sse(req) {
     };
 }
 
-function parse_content_length(req) {
-    const size = Number(req.headers['x-amz-decoded-content-length'] || req.headers['content-length']);
-    const copy = req.headers['x-amz-copy-source'];
-    if (!copy && (!Number.isInteger(size) || size < 0)) {
-        dbg.warn('Missing content-length', req.headers['content-length']);
-        throw new S3Error(S3Error.MissingContentLength);
-    }
-    return size;
-}
-
 function parse_part_number(num_str, err) {
     const num = Number(num_str);
     if (!Number.isInteger(num) || num < 1 || num > 10000) {
@@ -665,7 +655,6 @@ exports.format_s3_xml_date = format_s3_xml_date;
 exports.get_request_xattr = get_request_xattr;
 exports.set_response_xattr = set_response_xattr;
 exports.parse_etag = parse_etag;
-exports.parse_content_length = parse_content_length;
 exports.parse_part_number = parse_part_number;
 exports.parse_copy_source = parse_copy_source;
 exports.format_copy_source = format_copy_source;

--- a/src/endpoint/sts/ops/sts_post_assume_role.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role.js
@@ -1,0 +1,52 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const { StsError } = require('../sts_errors');
+
+/**
+ * https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+ */
+async function assume_role(req) {
+    dbg.log1('sts_post_assume_role body: ', req.body);
+    let assumed_role;
+    try {
+        assumed_role = await req.sts_sdk.get_assumed_role(req);
+    } catch (err) {
+        if (err.code === 'ACCESS_DENIED') {
+            throw new StsError(StsError.AccessDeniedException);
+        }
+        throw new StsError(StsError.InternalFailure);
+    }
+    // Temporary credentials are NOT stored in noobaa
+    // TODO: need to generate session token and store in it 
+    // the temporary credentials and expiry
+    const access_keys = await req.sts_sdk.generate_temp_access_keys();
+    return {
+        AssumeRoleResponse: {
+            AssumeRoleResult: {
+                AssumedRoleUser: {
+                    Arn: `arn:aws:sts::${assumed_role.access_key}:assumed-role/${assumed_role.role_config.role_name}/${req.body.role_session_name}`,
+                    AssumedRoleId: `${assumed_role.access_key}:${req.body.role_session_name}`
+                },
+                Credentials: {
+                    AccessKeyId: access_keys.access_key.unwrap(),
+                    SecretAccessKey: access_keys.secret_key.unwrap(),
+                    Expiration: '',
+                    SessionToken: ''
+                },
+                PackedPolicySize: 0
+            }
+        }
+    };
+}
+
+module.exports = {
+    handler: assume_role,
+    body: {
+        type: 'application/x-www-form-urlencoded',
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/endpoint/sts/sts_errors.js
+++ b/src/endpoint/sts/sts_errors.js
@@ -1,0 +1,138 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+const xml_utils = require('../../util/xml_utils');
+
+// https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html
+/**
+ * @typedef {{
+ *      code?: string, 
+ *      message: string, 
+ *      http_code: number,
+ *      detail?: string
+ * }} StsErrorSpec
+ */
+
+class StsError extends Error {
+
+    /**
+     * @param {StsErrorSpec} error_spec 
+     */
+    constructor({ code, message, http_code, detail }) {
+        super(message); // sets this.message
+        this.code = code;
+        this.http_code = http_code;
+        this.detail = detail;
+    }
+
+    reply(resource, request_id) {
+        const xml = {
+            Error: {
+                Code: this.code,
+                Message: this.message,
+                Resource: resource || '',
+                RequestId: request_id || '',
+                Detail: this.detail,
+            }
+        };
+        return xml_utils.encode_xml(xml);
+    }
+
+}
+
+StsError.AccessDeniedException = Object.freeze({
+    code: 'AccessDeniedException',
+    message: 'You do not have sufficient access to perform this action.',
+    http_code: 400,
+});
+StsError.IncompleteSignature = Object.freeze({
+    code: 'IncompleteSignature',
+    message: 'The request signature does not conform to AWS standards.',
+    http_code: 400,
+});
+StsError.InternalFailure = Object.freeze({
+    code: 'InternalFailure',
+    message: 'The request processing has failed because of an unknown error, exception or failure.',
+    http_code: 500,
+});
+StsError.InvalidAction = Object.freeze({
+    code: 'InvalidAction',
+    message: 'The action or operation requested is invalid. Verify that the action is typed correctly.',
+    http_code: 400,
+});
+StsError.InvalidClientTokenId = Object.freeze({
+    code: 'InvalidClientTokenId',
+    message: 'The X.509 certificate or AWS access key ID provided does not exist in our records.',
+    http_code: 403,
+});
+StsError.InvalidParameterCombination = Object.freeze({
+    code: 'InvalidParameterCombination',
+    message: 'Parameters that must not be used together were used together.',
+    http_code: 400,
+});
+StsError.InvalidParameterValue = Object.freeze({
+    code: 'InvalidParameterValue',
+    message: 'An invalid or out-of-range value was supplied for the input parameter.',
+    http_code: 400,
+});
+StsError.InvalidQueryParameter = Object.freeze({
+    code: 'InvalidQueryParameter',
+    message: 'The AWS query string is malformed or does not adhere to AWS standards.',
+    http_code: 400,
+});
+StsError.MalformedQueryString = Object.freeze({
+    code: 'MalformedQueryString',
+    message: 'The query string contains a syntax error.',
+    http_code: 404,
+});
+StsError.MissingAction = Object.freeze({
+    code: 'MissingAction',
+    message: 'The request is missing an action or a required parameter.',
+    http_code: 400,
+});
+StsError.MissingAuthenticationToken = Object.freeze({
+    code: 'MissingAuthenticationToken',
+    message: 'The request must contain either a valid (registered) AWS access key ID or X.509 certificate.',
+    http_code: 403,
+});
+StsError.MissingParameter = Object.freeze({
+    code: 'MissingParameter',
+    message: 'A required parameter for the specified action is not supplied.',
+    http_code: 400,
+});
+StsError.NotAuthorized = Object.freeze({
+    code: 'NotAuthorized',
+    message: 'You do not have permission to perform this action.',
+    http_code: 400,
+});
+StsError.OptInRequired = Object.freeze({
+    code: 'OptInRequired',
+    message: 'The AWS access key ID needs a subscription for the service.',
+    http_code: 403,
+});
+StsError.RequestExpired = Object.freeze({
+    code: 'RequestExpired',
+    message: 'The request reached the service more than 15 minutes after the date stamp on the request or more than 15 minutes after the request expiration date (such as for pre-signed URLs), or the date stamp on the request is more than 15 minutes in the future.',
+    http_code: 400,
+});
+StsError.ServiceUnavailable = Object.freeze({
+    code: 'ServiceUnavailable',
+    message: 'The request has failed due to a temporary failure of the server.',
+    http_code: 503,
+});
+StsError.ThrottlingException = Object.freeze({
+    code: 'ThrottlingException',
+    message: 'The request was denied due to request throttling.',
+    http_code: 400,
+});
+StsError.ValidationError = Object.freeze({
+    code: 'ValidationError',
+    message: 'The input fails to satisfy the constraints specified by an AWS service.',
+    http_code: 400,
+});
+StsError.NotImplemented = Object.freeze({
+    code: 'NotImplemented',
+    message: 'A header you provided implies functionality that is not implemented.',
+    http_code: 501,
+});
+
+exports.StsError = StsError;

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -1,0 +1,234 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+const dbg = require('../../util/debug_module')(__filename);
+const StsError = require('./sts_errors').StsError;
+const js_utils = require('../../util/js_utils');
+const http_utils = require('../../util/http_utils');
+const signature_utils = require('../../util/signature_utils');
+const system_store = require('../../server/system_services/system_store').get_instance();
+
+const STS_MAX_BODY_LEN = 4 * 1024 * 1024;
+
+const STS_XML_ROOT_ATTRS = Object.freeze({
+    xmlns: 'http://sts.amazonaws.com/doc/2011-06-15/'
+});
+
+const RPC_ERRORS_TO_STS = Object.freeze({
+    UNAUTHORIZED: StsError.AccessDeniedException,
+    INVALID_ACCESS_KEY_ID: StsError.AccessDeniedException,
+    NO_SUCH_ACCOUNT: StsError.AccessDeniedException,
+    NO_SUCH_ROLE: StsError.AccessDeniedException
+});
+
+const ACTIONS = Object.freeze({
+    'AssumeRole': 'assume_role'
+});
+
+const OP_NAME_TO_ACTION = Object.freeze({
+    post_assume_role: 'sts:AssumeRole',
+});
+
+const STS_OPS = load_ops();
+
+async function sts_rest(req, res) {
+    try {
+        await handle_request(req, res);
+    } catch (err) {
+        handle_error(req, res, err);
+    }
+}
+
+async function handle_request(req, res) {
+
+    http_utils.set_response_headers(req, res, { expose_headers: 'ETag' });
+
+    if (req.method === 'OPTIONS') {
+        dbg.log1('OPTIONS!');
+        res.statusCode = 200;
+        res.end();
+        return;
+    }
+
+    const headers_options = {
+        ErrorClass: StsError,
+        error_invalid_argument: StsError.InvalidParameterValue,
+        error_access_denied: StsError.AccessDeniedException,
+        error_bad_request: StsError.InternalFailure,
+        error_invalid_digest: StsError.InternalFailure,
+        error_request_time_too_skewed: StsError.InternalFailure,
+        error_missing_content_length: StsError.InternalFailure,
+        auth_token: () => signature_utils.make_auth_token_from_request(req)
+    };
+    http_utils.check_headers(req, headers_options);
+
+    const options = {
+        body: { type: req.headers['content-type'] },
+        MAX_BODY_LEN: STS_MAX_BODY_LEN,
+        XML_ROOT_ATTRS: STS_XML_ROOT_ATTRS,
+        ErrorClass: StsError,
+        error_max_body_len_exceeded: StsError.InternalFailure,
+        error_missing_body: StsError.InternalFailure,
+        error_invalid_body: StsError.InternalFailure,
+        error_body_sha256_mismatch: StsError.InternalFailure,
+    };
+    await http_utils.read_and_parse_body(req, options);
+
+    const op_name = parse_op_name(req, req.body.action);
+    req.op_name = op_name;
+
+    authenticate_request(req);
+    await authorize_request(req);
+
+    dbg.log1('STS REQUEST', req.method, req.originalUrl, 'op', op_name, 'request_id', req.request_id, req.headers);
+
+    const op = STS_OPS[op_name];
+    if (!op || !op.handler) {
+        dbg.error('STS TODO (NotImplemented)', op_name, req.method, req.originalUrl);
+        throw new StsError(StsError.NotImplemented);
+    }
+
+    const reply = await op.handler(req, res);
+    http_utils.send_reply(req, res, reply, {
+        ...options,
+        body: op.body,
+        reply: op.reply
+    });
+}
+
+function authenticate_request(req) {
+    try {
+        const auth_token = signature_utils.make_auth_token_from_request(req);
+        if (auth_token) {
+            auth_token.client_ip = http_utils.parse_client_ip(req);
+        }
+        req.sts_sdk.set_auth_token(auth_token);
+        signature_utils.check_request_expiry(req);
+    } catch (err) {
+        dbg.error('authenticate_request: ERROR', err.stack || err);
+        if (err.code) {
+            throw err;
+        } else {
+            throw new StsError(StsError.AccessDeniedException);
+        }
+    }
+}
+
+// authorize_request_account authorizes the account of the requeser
+// authorize_request_policy checks that the requester is allowed to assume a role 
+// by the role's assume role policy permissions
+async function authorize_request(req) {
+    await req.sts_sdk.authorize_request_account(req);
+    await authorize_request_policy(req);
+}
+
+async function authorize_request_policy(req) {
+    if (req.op_name !== 'post_assume_role') return;
+    const account_info = await req.sts_sdk.get_assumed_role(req);
+    const assume_role_policy = account_info.role_config && account_info.role_config.assume_role_policy;
+    if (!assume_role_policy) throw new StsError(StsError.AccessDeniedException);
+    const method = _get_method_from_req(req);
+    const cur_account_email = req.sts_sdk.requesting_account && req.sts_sdk.requesting_account.email.unwrap();
+    // system owner by design can always assume role policy of any account
+    if ((cur_account_email === _get_system_owner().unwrap()) && req.op_name.endsWith('assume_role')) return;
+
+    const permission = has_assume_role_permission(assume_role_policy, method, cur_account_email);
+    dbg.log0('sts_rest.authorize_request_policy permission is: ', permission);
+    if (permission === 'DENY' || permission === 'IMPLICIT_DENY') {
+        throw new StsError(StsError.AccessDeniedException);
+    }
+    // permission is ALLOW, can return without error
+}
+
+function _get_system_owner() {
+    const system = system_store.data.systems[0];
+    return system.owner.email;
+}
+
+function _get_method_from_req(req) {
+    const sts_op = OP_NAME_TO_ACTION[req.op_name];
+    if (!sts_op) {
+        dbg.error(`Got a not supported STS op ${req.op_name} - doesn't suppose to happen`);
+        throw new StsError(StsError.InternalFailure);
+    }
+    return sts_op;
+}
+
+function parse_op_name(req, action) {
+    const method = req.method.toLowerCase();
+    if (ACTIONS[action]) {
+        return `${method}_${ACTIONS[action]}`;
+    }
+    throw new StsError(StsError.NotImplemented);
+}
+
+function handle_error(req, res, err) {
+    let stserr =
+        ((err instanceof StsError) && err) ||
+        new StsError(RPC_ERRORS_TO_STS[err.rpc_code] || StsError.InternalFailure);
+
+    const reply = stserr.reply(req.originalUrl, req.request_id);
+    dbg.error('STS ERROR', reply,
+        req.method, req.originalUrl,
+        JSON.stringify(req.headers),
+        err.stack || err);
+    if (res.headersSent) {
+        dbg.log0('Sending error xml in body, but too late for headers...');
+    } else {
+        res.statusCode = stserr.http_code;
+        res.setHeader('Content-Type', 'application/xml');
+        res.setHeader('Content-Length', Buffer.byteLength(reply));
+    }
+    res.end(reply);
+}
+
+function load_ops() {
+    /* eslint-disable global-require */
+    return js_utils.deep_freeze({
+        post_assume_role: require('./ops/sts_post_assume_role'),
+    });
+}
+
+function has_assume_role_permission(policy, method, cur_account_email) {
+    const [allow_statements, deny_statements] = _.partition(policy.statement, statement => statement.effect === 'allow');
+
+    // look for explicit denies
+    if (_is_statements_fit(deny_statements, method, cur_account_email)) return 'DENY';
+
+    // look for explicit allows
+    if (_is_statements_fit(allow_statements, method, cur_account_email)) return 'ALLOW';
+
+    // implicit deny
+    return 'IMPLICIT_DENY';
+}
+
+function _is_statements_fit(statements, method, cur_account_email) {
+    for (const statement of statements) {
+        let action_fit = false;
+        let principal_fit = false;
+        dbg.log0('assume_role_policy: statement', statement);
+
+        // what action can be done
+        for (const action of statement.action) {
+            dbg.log0('assume_role_policy: action fit?', action, method);
+            if ((action === '*') || (action === 'sts:*') || (action === method)) {
+                action_fit = true;
+            }
+        }
+        // who can do that action
+        for (const principal of statement.principal) {
+            dbg.log0('assume_role_policy: principal fit?', principal.unwrap().toString(), cur_account_email);
+            if (principal.unwrap() === cur_account_email) {
+                principal_fit = true;
+            }
+        }
+        dbg.log0('assume_role_policy: is_statements_fit', action_fit, principal_fit);
+        if (action_fit && principal_fit) return true;
+    }
+    return false;
+}
+
+// EXPORTS
+module.exports = sts_rest;
+module.exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -42,7 +42,7 @@ const bucket_namespace_cache = new LRUCache({
 const account_cache = new LRUCache({
     name: 'AccountCache',
     // TODO: Decide on a time that we want to invalidate
-    expiry_ms: 10 * 60 * 1000,
+    expiry_ms: Number(process.env.ACCOUNTS_CACHE_EXPIRY) || 10 * 60 * 1000,
     make_key: ({ access_key }) => access_key,
     load: async ({ rpc_client, access_key }) => rpc_client.account.read_account_by_access_key({ access_key }),
 });
@@ -807,3 +807,4 @@ class ObjectSDK {
 }
 
 module.exports = ObjectSDK;
+module.exports.account_cache = account_cache;

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -1,0 +1,84 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const cloud_utils = require('../util/cloud_utils');
+const dbg = require('../util/debug_module')(__filename);
+const { RpcError } = require('../rpc');
+const signature_utils = require('../util/signature_utils');
+const { account_cache } = require('./object_sdk');
+
+class StsSDK {
+
+    constructor(rpc_client, internal_rpc_client) {
+        this.rpc_client = rpc_client;
+        this.internal_rpc_client = internal_rpc_client;
+        this.requesting_account = undefined;
+    }
+
+    set_auth_token(auth_token) {
+        this.rpc_client.options.auth_token = auth_token;
+    }
+
+    get_auth_token() {
+        return this.rpc_client.options.auth_token;
+    }
+
+    async get_assumed_role(req) {
+        dbg.log1('sts_sdk.get_assumed_role body', req.body);
+        // arn:aws:sts::access_key:role/role_name
+        const role_name_idx = req.body.role_arn.lastIndexOf('/') + 1;
+        const role_name = req.body.role_arn.slice(role_name_idx);
+        const access_key = req.body.role_arn.split(':')[4];
+
+        const account = await account_cache.get_with_cache({
+            rpc_client: this.internal_rpc_client,
+            access_key
+        });
+        if (!account) {
+            throw new RpcError('NO_SUCH_ACCOUNT', 'No such account with access_key: ' + access_key);
+        }
+        if (!account.role_config || account.role_config.role_name !== role_name) {
+            throw new RpcError('NO_SUCH_ROLE', `Role not found`);
+        }
+        dbg.log0('sts_sdk.get_assumed_role res', account,
+            'account.role_config: ', account.role_config);
+
+        return {
+            access_key,
+            role_config: account.role_config
+        };
+    }
+
+    generate_temp_access_keys() {
+        return cloud_utils.generate_access_keys();
+    }
+
+    // similar function to object_sdk - should we merge them?
+    // where should we put the account_cache
+    async authorize_request_account(req) {
+        const token = this.get_auth_token();
+        // If the request is signed (authenticated)
+        if (token) {
+            try {
+                this.requesting_account = await account_cache.get_with_cache({
+                    rpc_client: this.internal_rpc_client,
+                    access_key: token.access_key
+                });
+            } catch (error) {
+                dbg.error('authorize_request_account error:', error);
+                if (error.rpc_code && error.rpc_code === 'NO_SUCH_ACCOUNT') {
+                    throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
+                } else {
+                    throw error;
+                }
+            }
+            const signature = signature_utils.get_signature_from_auth_token(
+                token, this.requesting_account.access_keys[0].secret_key.unwrap());
+            if (token.signature !== signature) throw new RpcError('SIGNATURE_DOES_NOT_MATCH', `Signature that was calculated did not match`);
+            return;
+        }
+        throw new RpcError('UNAUTHORIZED', `No permission to access bucket`);
+    }
+}
+
+module.exports = StsSDK;

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -111,5 +111,9 @@ module.exports = {
         nsfs_account_config: {
             $ref: 'common_api#/definitions/nsfs_account_config'
         },
+
+        role_config: {
+            $ref: 'common_api#/definitions/role_config'
+        },
     }
 };

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -78,7 +78,7 @@ module.exports = {
                 properties: {
                     service: {
                         type: 'string',
-                        enum: ['noobaa-mgmt', 's3', 'noobaa-db', 'noobaa-db-pg']
+                        enum: ['noobaa-mgmt', 's3', 'sts', 'noobaa-db', 'noobaa-db-pg']
                     },
                     kind: {
                         type: 'string',
@@ -88,7 +88,7 @@ module.exports = {
                     port: { $ref: 'common_api#/definitions/port' },
                     api: {
                         type: 'string',
-                        enum: ['mgmt', 's3', 'md', 'bg', 'hosted_agents', 'mongodb', 'metrics', 'postgres']
+                        enum: ['mgmt', 's3', 'sts', 'md', 'bg', 'hosted_agents', 'mongodb', 'metrics', 'postgres']
                     },
                     secure: { type: 'boolean' },
                     weight: { type: 'integer' }

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -89,6 +89,7 @@ require('./test_namespace_cache');
 require('./test_namespace_auth');
 require('./test_encryption');
 require('./test_bucket_replication');
+require('./test_sts');
 // require('./test_tiering_upload');
 //require('./test_s3_worm');
 

--- a/src/test/unit_tests/test_sts.js
+++ b/src/test/unit_tests/test_sts.js
@@ -1,0 +1,447 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('./coretest');
+coretest.setup({ pools_to_create: coretest.POOL_LIST });
+const AWS = require('aws-sdk');
+const https = require('https');
+const mocha = require('mocha');
+const assert = require('assert');
+const stsErr = require('../../endpoint/sts/sts_errors').StsError;
+const http_utils = require('../../util/http_utils');
+const dbg = require('../../util/debug_module')(__filename);
+const cloud_utils = require('../../util/cloud_utils');
+
+const errors = {
+    access_denied: {
+        code: stsErr.AccessDeniedException.code,
+        message: stsErr.AccessDeniedException.message
+    },
+    invalid_action: {
+        code: stsErr.InvalidAction.code,
+        message: stsErr.InvalidAction.message
+    },
+    invalid_schema_params: {
+        code: 'INVALID_SCHEMA_PARAMS',
+        message: 'INVALID_SCHEMA_PARAMS CLIENT account_api#/methods/create_account'
+    },
+    malformed_policy: {
+        rpc_code: 'MALFORMED_POLICY',
+        message_principal: 'Invalid principal in policy',
+        message_action: 'Policy has invalid action'
+    }
+};
+
+mocha.describe('STS tests', function() {
+    const { rpc_client, EMAIL } = coretest;
+    const user_a = 'alice1';
+    const user_b = 'bob1';
+    const user_c = 'charlie1';
+
+    let sts_admin;
+    let sts;
+    let sts_c;
+    let anon_sts;
+    let admin_keys;
+    let user_b_key;
+    const role_b = 'RoleB';
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        const sts_creds = {
+            endpoint: coretest.get_https_address_sts(),
+            region: 'us-east-1',
+            sslEnabled: true,
+            computeChecksums: true,
+            httpOptions: { agent: new https.Agent({ keepAlive: false, rejectUnauthorized: false }) },
+            s3ForcePathStyle: true,
+            signatureVersion: 'v4',
+            s3DisableBodySigning: false,
+        };
+        const account = { has_login: false, s3_access: true, allowed_buckets: { full_permission: true } };
+        admin_keys = (await rpc_client.account.read_account({ email: EMAIL })).access_keys;
+        sts_admin = new AWS.STS({
+            ...sts_creds,
+            accessKeyId: admin_keys[0].access_key.unwrap(),
+            secretAccessKey: admin_keys[0].secret_key.unwrap()
+        });
+        account.name = user_a;
+        account.email = user_a;
+        const policy = {
+            version: '2012-10-17',
+            statement: [{
+                effect: 'allow',
+                principal: [user_c],
+                action: ['sts:AssumeRole'],
+            }]
+        };
+        const user_a_keys = (await rpc_client.account.create_account(account)).access_keys;
+        const user_c_keys = (await rpc_client.account.create_account({ ...account, email: user_c, name: user_c })).access_keys;
+        user_b_key = (await rpc_client.account.create_account({
+            ...account,
+            email: user_b,
+            name: user_b,
+            role_config: {
+                role_name: role_b,
+                assume_role_policy: policy
+            }
+        })).access_keys[0].access_key.unwrap();
+
+        sts = new AWS.STS({
+            ...sts_creds,
+            accessKeyId: user_a_keys[0].access_key.unwrap(),
+            secretAccessKey: user_a_keys[0].secret_key.unwrap()
+        });
+        sts_c = new AWS.STS({
+            ...sts_creds,
+            accessKeyId: user_c_keys[0].access_key.unwrap(),
+            secretAccessKey: user_c_keys[0].secret_key.unwrap()
+        });
+        const random_access_keys = cloud_utils.generate_access_keys();
+        anon_sts = new AWS.STS({
+            ...sts_creds,
+            accessKeyId: random_access_keys.access_key.unwrap(),
+            secretAccessKey: random_access_keys.secret_key.unwrap()
+        });
+    });
+
+    mocha.it('user a assume role of admin - should be rejected', async function() {
+        await assert_throws_async(sts.assumeRole({
+            RoleArn: `arn:aws:sts::${admin_keys[0].access_key.unwrap()}:role/${'dummy_role'}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+
+    mocha.it('admin assume role of user b - should be allowed', async function() {
+        const params = {
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        };
+        const json = await assume_role_and_parse_xml(sts_admin, params);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_key}:${params.RoleSessionName}`, '');
+    });
+
+    mocha.it('admin assume non existing role of user b - should be rejected', async function() {
+        await assert_throws_async(sts_admin.assumeRole({
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${'dummy_role2'}`,
+            RoleSessionName: 'just_a_dummy_session_name1'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+
+    mocha.it('admin assume non existing role of non existing user - should be rejected', async function() {
+        await assert_throws_async(sts_admin.assumeRole({
+            RoleArn: `arn:aws:sts::${12345}:role/${'dummy_role3'}`,
+            RoleSessionName: 'just_a_dummy_session_name2'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+
+    mocha.it('anonymous user a assume role of user b - should be rejected', async function() {
+        await assert_throws_async(anon_sts.assumeRole({
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+
+    mocha.it('user c assume role of user b - should be allowed', async function() {
+        const params = {
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        };
+        const json = await assume_role_and_parse_xml(sts_c, params);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_key}:${params.RoleSessionName}`, '');
+    });
+
+    mocha.it('user a assume role of user b - should be rejected', async function() {
+        await assert_throws_async(sts.assumeRole({
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+
+    mocha.it('update assume role policy of user b to allow user a', async function() {
+        const policy = {
+            version: '2012-10-17',
+            statement: [{
+                effect: 'allow',
+                principal: [user_c, user_a],
+                action: ['sts:AssumeRole']
+            }]
+        };
+        await rpc_client.account.update_account({
+            email: user_b,
+            role_config: {
+                role_name: role_b,
+                assume_role_policy: policy
+            }
+        });
+    });
+
+    mocha.it('user a assume role of user b - should be allowed', async function() {
+        const params = {
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        };
+        const json = await assume_role_and_parse_xml(sts, params);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_key}:${params.RoleSessionName}`, '');
+    });
+
+    mocha.it('update assume role policy of user b to allow user a', async function() {
+        const policy = {
+            version: '2012-10-17',
+            statement: [{
+                effect: 'deny',
+                principal: [user_a],
+                action: ['sts:AssumeRole']
+            },
+            {
+                effect: 'allow',
+                principal: [user_c],
+                action: ['sts:AssumeRole']
+            }]
+        };
+        await rpc_client.account.update_account({
+            email: user_b,
+            role_config: {
+                role_name: role_b,
+                assume_role_policy: policy
+            }
+        });
+    });
+
+    mocha.it('user a assume role of user b - should be rejected', async function() {
+        await assert_throws_async(sts.assumeRole({
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+
+    mocha.it('user c assume role of user b - should be allowed', async function() {
+        const params = {
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        };
+        const json = await assume_role_and_parse_xml(sts_c, params);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_key}:${params.RoleSessionName}`, '');
+    });
+
+    mocha.it('update assume role policy of user b to allow user a sts:*', async function() {
+        const policy = {
+            version: '2012-10-17',
+            statement: [{
+                effect: 'deny',
+                principal: [user_a],
+                action: ['sts:*']
+            },
+            {
+                effect: 'allow',
+                principal: [user_c],
+                action: ['sts:AssumeRole']
+            }]
+        };
+        await rpc_client.account.update_account({
+            email: user_b,
+            role_config: {
+                role_name: role_b,
+                assume_role_policy: policy
+            }
+        });
+    });
+
+    mocha.it('user a assume role of user b - should be rejected sts:*', async function() {
+        await assert_throws_async(sts.assumeRole({
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+
+    mocha.it('user c assume role of user b - should be allowed sts:*', async function() {
+        const params = {
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        };
+        const json = await assume_role_and_parse_xml(sts_c, params);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_key}:${params.RoleSessionName}`, '');
+    });
+
+    mocha.it('update assume role policy of user b to allow user a *', async function() {
+        const policy = {
+            version: '2012-10-17',
+            statement: [{
+                effect: 'deny',
+                principal: ['*'],
+                action: ['sts:AssumeRole']
+            }]
+        };
+        await rpc_client.account.update_account({
+            email: user_b,
+            role_config: {
+                role_name: role_b,
+                assume_role_policy: policy
+            }
+        });
+    });
+
+    mocha.it('user a assume role of user b - should be rejected *', async function() {
+        await assert_throws_async(sts.assumeRole({
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+
+    mocha.it('user c assume role of user b - should be rejected *', async function() {
+        await assert_throws_async(sts_c.assumeRole({
+            RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
+            RoleSessionName: 'just_a_dummy_session_name'
+        }).promise(), errors.access_denied.code, errors.access_denied.message);
+    });
+});
+
+async function assume_role_and_parse_xml(sts, params) {
+    const req = sts.assumeRole(params);
+    let json;
+    req.on('complete', async function(resp) {
+        json = await http_utils.parse_xml_to_js(resp.httpResponse.body);
+    });
+    await req.promise();
+    return json;
+}
+
+function validate_assume_role_response(json, expected_arn, expected_role_id, expected_session_token) {
+    dbg.log0('test.sts.validate_assume_role_response: ', json);
+    assert.ok(json && json.AssumeRoleResponse && json.AssumeRoleResponse.AssumeRoleResult);
+    let result = json.AssumeRoleResponse.AssumeRoleResult[0];
+    assert.ok(result);
+
+    // validate credentials
+    let credentials = result.Credentials[0];
+    assert.ok(credentials && credentials.AccessKeyId[0] && credentials.SecretAccessKey[0]);
+    assert.equal(credentials.Expiration[0], '');
+    assert.equal(credentials.SessionToken[0], expected_session_token);
+
+    // validate assumed role user
+    let assumed_role_user = result.AssumedRoleUser[0];
+    assert.equal(assumed_role_user.Arn[0], expected_arn);
+    assert.equal(assumed_role_user.AssumedRoleId[0], expected_role_id);
+
+    assert.equal(result.PackedPolicySize[0], '0');
+}
+
+async function assert_throws_async(promise,
+    expected_code,
+    expected_message) {
+    try {
+        await promise;
+        assert.fail('Test was suppose to fail on ' + expected_message);
+    } catch (err) {
+        dbg.log0('assert_throws_async err', err);
+        dbg.log0('assert_throws_async err.message', err.message, expected_message, err.message !== expected_message);
+        dbg.log0('assert_throws_async err.code', err.code, expected_code, err.code !== expected_code);
+        dbg.log0('assert_throws_async err.code', err.rpc_code, expected_code, err.rpc_code !== expected_code);
+        const code_or_rpc_code = err.code || err.rpc_code;
+        if (err.message !== expected_message || code_or_rpc_code !== expected_code) throw err;
+    }
+}
+
+mocha.describe('Assume role policy tests', function() {
+    const { rpc_client, EMAIL } = coretest;
+    const valid_assume_policy = {
+        version: '2012-10-17',
+        statement: [{
+            effect: 'allow',
+            principal: [EMAIL],
+            action: ['sts:AssumeRole'],
+        }]
+    };
+    const account_defaults = { has_login: false, s3_access: true, allowed_buckets: { full_permission: true } };
+
+    mocha.it('create account with role policy - missing role_config', async function() {
+        const empty_role_config = {};
+        const email = 'assume_email1';
+        await assert_throws_async(rpc_client.account.create_account({
+            ...account_defaults,
+            email,
+            name: email,
+            role_config: empty_role_config
+        }), errors.invalid_schema_params.code, errors.invalid_schema_params.message);
+    });
+
+    mocha.it('create account with role policy - missing assume role policy', async function() {
+        const empty_assume_role_policy = { role_name: 'role_name2' };
+        const email = 'assume_email2';
+        await assert_throws_async(rpc_client.account.create_account({
+            ...account_defaults,
+            email,
+            name: email,
+            role_config: empty_assume_role_policy
+        }), errors.invalid_schema_params.code, errors.invalid_schema_params.message);
+    });
+
+    mocha.it('create account with role policy- invalid principal', async function() {
+        const invalid_action = { principal: ['non_existing_email'] };
+        const email = 'assume_email3';
+        let assume_role_policy = {
+            ...valid_assume_policy,
+            statement: [{
+                ...valid_assume_policy.statement[0],
+                ...invalid_action
+            }]
+        };
+        await assert_throws_async(rpc_client.account.create_account({
+            ...account_defaults,
+            email,
+            name: email,
+            role_config: {
+                role_name: 'role_name3',
+                assume_role_policy
+            }
+        }), errors.malformed_policy.rpc_code, errors.malformed_policy.message_principal);
+    });
+
+    mocha.it('create account with role policy- invalid effect', async function() {
+        const invalid_action = { effect: 'non_existing_effect' };
+        const email = 'assume_email3';
+        let assume_role_policy = {
+            ...valid_assume_policy,
+            statement: [{
+                ...valid_assume_policy.statement[0],
+                ...invalid_action
+            }]
+        };
+        await assert_throws_async(rpc_client.account.create_account({
+            ...account_defaults,
+            email,
+            name: email,
+            role_config: {
+                role_name: 'role_name3',
+                assume_role_policy
+            }
+        }), errors.invalid_schema_params.code, errors.invalid_schema_params.message);
+    });
+
+    mocha.it('create account with role policy - invalid action', async function() {
+        const invalid_action = { action: ['sts:InvalidAssumeRole'] };
+        const email = 'assume_email3';
+        let assume_role_policy = {
+            ...valid_assume_policy,
+            statement: [{
+                ...valid_assume_policy.statement[0],
+                ...invalid_action
+            }]
+        };
+        await assert_throws_async(rpc_client.account.create_account({
+            ...account_defaults,
+            email,
+            name: email,
+            role_config: {
+                role_name: 'role_name3',
+                assume_role_policy
+            }
+        }), errors.malformed_policy.rpc_code, errors.malformed_policy.message_action);
+    });
+});

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -4,9 +4,11 @@ const dbg = require('./debug_module')(__filename);
 const fs = require('fs');
 const { RpcError } = require('../rpc');
 const http_utils = require('./http_utils');
+const string_utils = require('./string_utils');
 const AWS = require('aws-sdk');
 const url = require('url');
 const _ = require('lodash');
+const SensitiveString = require('./sensitive_string');
 
 const projectedServiceAccountToken = "/var/run/secrets/openshift/serviceaccount/oidc-token";
 const defaultRoleSessionName = 'default_noobaa_s3_ops';
@@ -183,6 +185,13 @@ function set_noobaa_s3_connection(sys) {
     });
 }
 
+function generate_access_keys() {
+    return {
+        access_key: new SensitiveString(string_utils.crypto_random_string(20, string_utils.ALPHA_NUMERIC_CHARSET)),
+        secret_key: new SensitiveString(string_utils.crypto_random_string(40, string_utils.ALPHA_NUMERIC_CHARSET + '+/')),
+    };
+}
+
 exports.find_cloud_connection = find_cloud_connection;
 exports.get_azure_connection_string = get_azure_connection_string;
 exports.get_azure_new_connection_string = get_azure_new_connection_string;
@@ -194,3 +203,4 @@ exports.disable_s3_compatible_bodysigning = disable_s3_compatible_bodysigning;
 exports.set_noobaa_s3_connection = set_noobaa_s3_connection;
 exports.createSTSS3Client = createSTSS3Client;
 exports.generate_aws_sts_creds = generate_aws_sts_creds;
+exports.generate_access_keys = generate_access_keys;


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Added sts_rest, sts_utils, sts_errors, sts_sdk to the endpoint and handle requests and errors.
2. Added to endpoint the ability to accept sts.assumeRole operation and currently just generate random s3 credentials (session token will be handled in the follow-up PR)
3. Added role_config to account schema and to create_account/update_account API calls and implementation in account_server.
4. added assume_role_policy as part of the role_config, 
    4.1. this policy will be tested when a user tries to call sts.assumeRole according to the assume_role_policy of the 
           assumed role (assumed_account).
    4.2. on create_account/update_account this policy will be validated.
4. Added test_sts.js file that tests role_config in account and sts.assumeRole

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
