### PR TITLE
Force `rpc_address` to use `ws` as the protocol to avoid using ICE

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -609,12 +609,17 @@ class Agent {
             throw new RpcError('FORBIDDEN', 'AGENT API requests only allowed from server');
         }
 
-        if (req.connection && req.connection.url && req.connection.url.protocol !== 'n2n:') {
-            dbg.error('AGENT API auth requires n2n connection', req.connection.connid);
-            // close the connection but after sending the error response, for supportability of the caller
-            setTimeout(() => req.connection.close(), 1000);
-            throw new RpcError('FORBIDDEN', 'AGENT API auth requires n2n connection');
-        }
+        // TODO: remove this block as part of the clean up of ICE code. 
+        // For some reason we used to forbid none 'n2n' protocol on the agents commenting this out will enable that.
+
+        // if (req.connection && req.connection.url && req.connection.url.protocol !== 'n2n:') {
+        // if (req.connection && req.connection.url) {
+        //     dbg.error('AGENT API auth requires n2n connection', req.connection.connid);
+        //     // close the connection but after sending the error response, for supportability of the caller
+        //     setTimeout(() => req.connection.close(), 1000);
+        //     throw new RpcError('FORBIDDEN', 'AGENT API auth requires n2n connection');
+        // }
+
         // otherwise it's good
     }
 

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1303,10 +1303,15 @@ class NodesMonitor extends EventEmitter {
         if (!item.agent_info) return;
         if (!item.node_from_store) return;
         const system = system_store.data.get_by_id(item.node.system);
-        const rpc_proto = process.env.AGENTS_PROTOCOL || 'n2n';
-        const rpc_address = rpc_proto === 'n2n' ?
-            'n2n://' + item.node.peer_id :
-            rpc_proto + '://' + item.node.ip + ':' + (process.env.AGENT_PORT || 9999);
+        // TODO: remove this block as part of the clean up of ICE code. 
+        // We will set the rpc protocol to be 'ws' and the port to be 60101
+
+        // const rpc_proto = process.env.AGENTS_PROTOCOL || 'n2n';
+        // const rpc_address = rpc_proto === 'n2n' ?
+        //     'n2n://' + item.node.peer_id :
+        //     rpc_proto + '://' + item.node.ip + ':' + (process.env.AGENT_PORT || 60101);
+        const rpc_proto = 'ws';
+        const rpc_address = rpc_proto + '://' + item.node.ip + ':' + (process.env.AGENT_PORT || 60101);
         const rpc_config = {};
         if (rpc_address !== item.agent_info.rpc_address) {
             rpc_config.rpc_address = rpc_address;


### PR DESCRIPTION
### Explain the changes

- Force rpc_address to use ws as the protocol to avoid using ICE
- Fixing the agent port to 60101

As decided we will leave the ICE code in for now and we will do a cleanup once we are 100% about it.
We want to clean the code in a later version, probably at 4.11

Signed-off-by: liranmauda <liran.mauda@gmail.com>

