### PR TITLE
Added support for AWS STS for S3 operations

### DIFF
--- a/frontend/src/app/schema/cloud-resources.js
+++ b/frontend/src/app/schema/cloud-resources.js
@@ -36,6 +36,8 @@ export default {
             type: {
                 type: 'string',
                 enum: [
+                    //TODO Without AWSSTS option noobaa management console won't work
+                    'AWSSTS',
                     'AWS',
                     'AZURE',
                     'S3_COMPATIBLE',

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -105,7 +105,8 @@ class Agent {
                 this.cloud_path = params.cloud_path;
                 block_store_options.cloud_info = params.cloud_info;
                 block_store_options.cloud_path = params.cloud_path;
-                if (params.cloud_info.endpoint_type === 'AWS' ||
+                if (params.cloud_info.endpoint_type === 'AWSSTS' ||
+                    params.cloud_info.endpoint_type === 'AWS' ||
                     params.cloud_info.endpoint_type === 'S3_COMPATIBLE' ||
                     params.cloud_info.endpoint_type === 'FLASHBLADE' ||
                     params.cloud_info.endpoint_type === 'IBM_COS') {

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -395,7 +395,7 @@ module.exports = {
             method: 'PUT',
             params: {
                 type: 'object',
-                required: ['name', 'identity', 'secret', 'endpoint', 'endpoint_type'],
+                required: ['name', 'endpoint', 'endpoint_type'],
                 properties: {
                     name: {
                         type: 'string'
@@ -405,6 +405,12 @@ module.exports = {
                     },
                     identity: { $ref: 'common_api#/definitions/access_key' },
                     secret: { $ref: 'common_api#/definitions/secret_key' },
+                    aws_sts_arn: {
+                        type: 'string'
+                    },
+                    region: {
+                        type: 'string'
+                    },
                     auth_method: {
                         $ref: 'common_api#/definitions/cloud_auth_method'
                     },
@@ -445,7 +451,7 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
-                required: ['identity', 'secret', 'endpoint', 'endpoint_type'],
+                required: ['endpoint', 'endpoint_type'],
                 properties: {
                     name: {
                         type: 'string'
@@ -455,6 +461,12 @@ module.exports = {
                     },
                     identity: { $ref: 'common_api#/definitions/access_key' },
                     secret: { $ref: 'common_api#/definitions/secret_key' },
+                    aws_sts_arn: {
+                        type: 'string'
+                    },
+                    region: {
+                        type: 'string'
+                    },
                     auth_method: {
                         $ref: 'common_api#/definitions/cloud_auth_method'
                     },

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -459,7 +459,7 @@ module.exports = {
 
         endpoint_type: {
             type: 'string',
-            enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+            enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
         },
 
         block_md: {

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -163,6 +163,7 @@ class HostedAgents {
                 access_key: pool.cloud_pool_info.access_keys.access_key,
                 secret_key: pool.cloud_pool_info.access_keys.secret_key
             },
+            aws_sts_arn: pool.cloud_pool_info.aws_sts_arn,
             pool_name: pool.name
         } : {
             pool_name: pool.name
@@ -179,6 +180,7 @@ class HostedAgents {
         agent_params[pool_path_property] = pool_path;
         agent_params[pool_info_property] = pool_info;
         if (pool.cloud_pool_info && pool.cloud_pool_info.storage_limit) agent_params.storage_limit = pool.cloud_pool_info.storage_limit;
+        if (pool.cloud_pool_info && pool.cloud_pool_info.aws_sts_arn) agent_params.aws_sts_arn = pool.cloud_pool_info.aws_sts_arn;
         dbg.log0(`running agent with params ${util.inspect(agent_params)}`);
         const agent = new Agent(agent_params);
         this._started_agents[node_name] = {

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -327,6 +327,7 @@ async function create_cloud_pool(req) {
             secret_key,
             account_id: req.account._id
         },
+        aws_sts_arn: connection.aws_sts_arn,
         endpoint_type: connection.endpoint_type || 'AWS',
         backingstore: req.rpc_params.backingstore,
         available_capacity: req.rpc_params.available_capacity,
@@ -367,6 +368,7 @@ async function create_cloud_pool(req) {
     }
 
     const map_pool_type = {
+        AWSSTS: 'BLOCK_STORE_S3',
         AWS: 'BLOCK_STORE_S3',
         S3_COMPATIBLE: 'BLOCK_STORE_S3',
         FLASHBLADE: 'BLOCK_STORE_S3',

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -76,11 +76,14 @@ module.exports = {
             type: 'array',
             items: {
                 type: 'object',
-                required: ['name', 'endpoint', 'access_key', 'secret_key'],
+                required: ['name', 'endpoint'],
                 properties: {
                     name: { type: 'string' },
                     access_key: { $ref: 'common_api#/definitions/access_key' },
                     secret_key: { $ref: 'common_api#/definitions/secret_key' },
+                    aws_sts_arn: {
+                        type: 'string'
+                    },
                     auth_method: {
                         type: 'string',
                         enum: ['AWS_V2', 'AWS_V4']
@@ -89,7 +92,7 @@ module.exports = {
                     cp_code: { type: 'string' },
                     endpoint_type: {
                         type: 'string',
-                        enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                        enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                     },
                 }
             }

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -85,7 +85,7 @@ module.exports = {
         // cloud pool information - exist only for cloud pools
         cloud_pool_info: {
             type: 'object',
-            required: ['endpoint', 'target_bucket', 'access_keys'],
+            required: ['endpoint', 'target_bucket'],
             properties: {
                 // Target endpoint, location + bucket
                 endpoint: {
@@ -97,6 +97,9 @@ module.exports = {
                 auth_method: {
                     type: 'string',
                     enum: ['AWS_V2', 'AWS_V4']
+                },
+                aws_sts_arn: {
+                    type: 'string'
                 },
                 backingstore: {
                     type: 'object',
@@ -128,7 +131,7 @@ module.exports = {
                 },
                 endpoint_type: {
                     type: 'string',
-                    enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                    enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                 },
                 agent_info: {
                     type: 'object',


### PR DESCRIPTION
### Explain the changes
1. Added util function to create AWS STS based S3 client.
2. Changed pool and account schema to include 'AWSSTS' endpoint type
3. Added changes to include the STS based S3 client before every S3 operation
4. Added check for 'AWSSTS' endpoint type to see if the function works

- [ ] Add unit tests
Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>
### Testing Instructions:
1. Use noobaa cli to pass in the ARN for the role 
nb install --aws-sts-role-arn=arn:aws:iam::261532230807:role/kmajumder_noobaa_sts
2.Check if the default backing store reaches ready state and all S3 operations are performing well

