### PR TITLE
Ref FSWorker parameters in NSFS native

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -145,6 +145,12 @@ set_statfs_res(Napi::Object res, Napi::Env env, struct statfs &statfs_res)
 struct FSWorker : public Napi::AsyncWorker
 {
     Napi::Promise::Deferred _deferred;
+    // _args_ref is used to keep refs to all the args for the worker lifetime,
+    // which is needed for workers that receive buffers,
+    // because in their ctor they copy the pointers to the buffer's memory,
+    // and if the JS caller scope does not keep a ref to the buffers until after the call,
+    // then the worker may access invalid memory...
+    Napi::ObjectReference _args_ref;
     pid_t _tid;
     uid_t _uid;
     gid_t _gid;
@@ -156,12 +162,14 @@ struct FSWorker : public Napi::AsyncWorker
     FSWorker(const Napi::CallbackInfo& info)
         : AsyncWorker(info.Env())
         , _deferred(Napi::Promise::Deferred::New(info.Env()))
+        , _args_ref(Napi::Persistent(Napi::Object::New(info.Env())))
         , _tid(0)
         , _uid(ThreadScope::orig_uid)
         , _gid(ThreadScope::orig_gid)
         , _errno(0)
         , _warn_threshold_ms(0)
     {
+        for (int i = 0; i < (int)info.Length(); ++i) _args_ref.Set(i, info[i]);
         Napi::Object config = info[0].As<Napi::Object>();
         if (config.Has("uid")) _uid = config.Get("uid").ToNumber();
         if (config.Has("gid")) _gid = config.Get("gid").ToNumber();

--- a/src/util/chunk_fs.js
+++ b/src/util/chunk_fs.js
@@ -25,6 +25,7 @@ class ChunkFS extends stream.Transform {
         this.count = 1;
         this.rpc_client = rpc_client;
         this.namespace_resource_id = namespace_resource_id;
+        this._total_num_buffers = 0;
     }
 
     _transform(chunk, encoding, callback) {
@@ -49,6 +50,8 @@ class ChunkFS extends stream.Transform {
             this.q_buffers = [];
             this.q_size = 0;
             await this.target_file.writev(this.fs_account_config, buffers_to_write);
+            // Hold the ref on the buffers from the JS side
+            this._total_num_buffers += buffers_to_write.length;
         }
         if (callback) {
             if (this.MD5Async) this.digest = (await this.MD5Async.digest()).toString('hex');


### PR DESCRIPTION
### Explain the changes
1. Holding up a ref for the parameters of the FSWorker
2. This avoids NodeJS garbage collection or movement of buffers and other parameters that are being used by the native worker

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/6830

### Testing Instructions:
1. 
