### PR TITLE
fix chunked upload

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -110,8 +110,10 @@ function decode_chunked_upload(source_stream) {
     // Previously were implemented using callback with error
     // Latest implementation of pipeline is async so chaining .catch would behave the same way as callback errors
     // We are not waiting for the pipeline to end like previously
-    stream_utils.pipeline([source_stream, decoder])
+    stream_utils.pipeline([source_stream, decoder], true)
         .catch(err => console.warn('decode_chunked_upload: pipeline error', err.stack || err));
+
+    decoder.on('error', err1 => dbg.error('s3_utils: error occured on stream ChunkedContentDecoder: ', err1));
     return decoder;
 }
 

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -811,6 +811,7 @@ class NamespaceFS {
                 rpc_client,
                 namespace_resource_id: this.namespace_resource_id
             });
+            chunk_fs.on('error', err1 => dbg.error('namespace_fs._upload_stream: error occured on stream ChunkFS: ', err1));
             await stream_utils.pipeline([source_stream, chunk_fs]);
             await stream_utils.wait_finished(chunk_fs);
             if (chunk_fs.digest) {
@@ -1373,7 +1374,7 @@ class NamespaceFS {
         dbg.log0('check_bucket_boundaries: fs_account_config', fs_account_config, 'file_path', entry_path);
         if (!entry_path.startsWith(this.bucket_path)) {
             dbg.log0('check_bucket_boundaries: the path', entry_path, 'is not in the bucket', this.bucket_path, 'boundaries');
-                return false;
+            return false;
         }
         try {
             // Returns the real path of the entry.


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Fixed panic when destroying stream - when calling destroy(err) the error is emitted but no one listens to that event- removed it
2.  Added a flag reuse_last_stream - used when we do not want to add resume() call to the last stream in the call to pipeline in decode_chunked_upload since we will reuse the decoder stream.
3. stream_utils.pipeline - removed tap stream addition to the end of the streams array and called resume() on the last stream in the array instead.
according to this issue in node JS (https://github.com/nodejs/node/issues/40685) and according to the docs 'The readable.resume() method can be used to fully consume the data from a stream without actually processing any of that data'

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ #2036211

### Testing Instructions:
1. 
