### PR TITLE
Fix complete_object_multiparts on empty part list

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1927,7 +1927,7 @@ async function _complete_object_multiparts(obj, multipart_req) {
                 `multipart num=${num} etag=${etag} etag_md5_b64=${etag_md5_b64} not found in group ${util.inspect(group)}`);
         }
         md5.update(Buffer.from(mp.md5_b64, 'base64'));
-        const mp_parts = parts_by_mp[mp._id.toHexString()];
+        const mp_parts = parts_by_mp[mp._id.toHexString()] || [];
         _complete_next_parts(mp_parts, context);
         used_multiparts.push(mp);
         for (const part of mp_parts) {


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. fix for https://bugzilla.redhat.com/show_bug.cgi?id=2040682
2. user upload an empty multipart - so no parts could be found for mp. leading to failure when trying to sort an undefined array. 

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ2040682

### Testing Instructions:
1. 
