### PR TITLE
STS | Session tokens generation and parsing

### DIFF
--- a/config.js
+++ b/config.js
@@ -587,6 +587,11 @@ config.NSFS_RENAME_RETRIES = 3;
 config.QUOTA_LOW_THRESHOLD = 80;
 config.QUOTA_MAX_OBJECTS = Number.MAX_SAFE_INTEGER;
 
+//////////////////////////
+//      STS CONFIG      //
+//////////////////////////
+config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+
 /////////////////////
 //                 //
 //    OVERRIDES    //

--- a/src/endpoint/sts/sts_errors.js
+++ b/src/endpoint/sts/sts_errors.js
@@ -134,5 +134,9 @@ StsError.NotImplemented = Object.freeze({
     message: 'A header you provided implies functionality that is not implemented.',
     http_code: 501,
 });
-
+StsError.ExpiredToken = Object.freeze({
+    code: 'ExpiredToken',
+    message: 'The security token included in the request is expired',
+    http_code: 400,
+});
 exports.StsError = StsError;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -136,8 +136,8 @@ class ObjectSDK {
                     throw error;
                 }
             }
-            const signature = signature_utils.get_signature_from_auth_token(
-                token, this.requesting_account.access_keys[0].secret_key.unwrap());
+            const signature_secret = token.temp_secret_key || this.requesting_account.access_keys[0].secret_key.unwrap();
+            const signature = signature_utils.get_signature_from_auth_token(token, signature_secret);
             if (token.signature !== signature) throw new RpcError('SIGNATURE_DOES_NOT_MATCH', `Signature that was calculated did not match`);
         }
         // check for a specific bucket

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -72,8 +72,8 @@ class StsSDK {
                     throw error;
                 }
             }
-            const signature = signature_utils.get_signature_from_auth_token(
-                token, this.requesting_account.access_keys[0].secret_key.unwrap());
+            const signature_secret = token.temp_secret_key || this.requesting_account.access_keys[0].secret_key.unwrap();
+            const signature = signature_utils.get_signature_from_auth_token(token, signature_secret);
             if (token.signature !== signature) throw new RpcError('SIGNATURE_DOES_NOT_MATCH', `Signature that was calculated did not match`);
             return;
         }

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -476,8 +476,8 @@ function _authorize_signature_token(req) {
         role: role.role,
         client_ip: auth_token_obj.client_ip,
     };
-
-    const signature = signature_utils.get_signature_from_auth_token(auth_token_obj, secret_key.unwrap());
+    const signature_secret = auth_token_obj.temp_secret_key || secret_key.unwrap();
+    const signature = signature_utils.get_signature_from_auth_token(auth_token_obj, signature_secret);
 
     if (auth_token_obj.signature !== signature) {
         dbg.error('Signature for access key:', auth_token_obj.access_key,

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -591,6 +591,20 @@ function parse_content_length(req, options) {
     return size;
 }
 
+function authorize_session_token(req, options) {
+    const jwt_utils = require('./jwt_utils'); // eslint-disable-line global-require
+    if (!req.headers['x-amz-security-token']) {
+        return;
+    }
+    try {
+        req.session_token = jwt_utils.authorize_jwt_token(req.headers['x-amz-security-token']);
+    } catch (err) {
+        dbg.error('http_utils.authorize_session_token JWT VERIFY FAILED', err);
+        if (err.name === 'TokenExpiredError') throw new options.ErrorClass(options.error_token_expired);
+        throw new options.ErrorClass(options.error_invalid_token);
+    }
+}
+
 exports.parse_url_query = parse_url_query;
 exports.parse_client_ip = parse_client_ip;
 exports.get_md_conditions = get_md_conditions;
@@ -611,3 +625,4 @@ exports.parse_xml_to_js = parse_xml_to_js;
 exports.check_headers = check_headers;
 exports.set_response_headers = set_response_headers;
 exports.parse_content_length = parse_content_length;
+exports.authorize_session_token = authorize_session_token;


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Added missing session tokens generation in sts_post_assume_role op. session token consists of the temp access keys 
   and the access key of the assumed role (the access_key that is saved in the DB).
2. Added in s3_rest and sts_rest calls to authorize_session_token() function that will authorize the session token when it's defined.
3. In authenticate_request() in both s3_rest and sts_rest:
    3.1.  Swapped the auth token access key with the assumed_role_access_key (the access_key that is saved in the DB) 
            from the session token properties - done in order to get the actual permissions. 
    3.2. Saved the temp access key and secret key on the auth token in order to compare correctly the signature calculation.

3. Added unit tests 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 
