### PR TITLE
Switch to CentOS Stream 8 as base image

### DIFF
--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -39,7 +39,7 @@ RUN tar \
 #   Cache: Rebuild when any layer is changing
 ##############################################################
 
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 ENV container docker
 ENV PORT 8080
@@ -69,7 +69,8 @@ RUN dnf install -y -q bash \
     nc \
     less \
     bash-completion \
-    python3-setuptools && \
+    python3-setuptools \
+    xz && \
     dnf clean all
 
 RUN mkdir -p /usr/local/lib/python3.6/site-packages

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8 
+FROM quay.io/centos/centos:stream8 
 LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 
 ##############################################################

--- a/src/deploy/NVA_build/dev.Dockerfile
+++ b/src/deploy/NVA_build/dev.Dockerfile
@@ -1,5 +1,5 @@
 # dev.Dockerfile is meant to be used manually for developer testing
-FROM centos:8 
+FROM quay.io/centos/centos:stream8
 
 ENV container docker
 


### PR DESCRIPTION
### Explain the changes
1. Changed the base image for CI operations from CentOS 8 to CentOS Stream 8

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #6865 

### Testing Instructions:
1. If GitHub Actions succeeds it is safe to assume everything is fine
