### PR TITLE
Add support to content_encoding

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -27,6 +27,9 @@ module.exports = {
                     content_type: {
                         type: 'string',
                     },
+                    content_encoding: {
+                        type: 'string',
+                    },
                     xattr: {
                         $ref: '#/definitions/xattr',
                     },
@@ -170,6 +173,7 @@ module.exports = {
                     version_id: { type: 'string' },
                     encryption: { $ref: 'common_api#/definitions/object_encryption' },
                     content_type: { type: 'string' },
+                    content_encoding: { type: 'string' },
                     size: { type: 'integer' },
                 }
             },
@@ -596,6 +600,7 @@ module.exports = {
                     bucket: { $ref: 'common_api#/definitions/bucket_name' },
                     key: { type: 'string' },
                     content_type: { type: 'string' },
+                    content_encoding: { type: 'string' },
                     xattr: { $ref: '#/definitions/xattr' },
                     cache_last_valid_time: { idate: true },
                     last_modified_time: { idate: true },
@@ -1374,6 +1379,7 @@ module.exports = {
                 delete_marker: { type: 'boolean' },
                 num_parts: { type: 'integer' },
                 content_type: { type: 'string' },
+                content_encoding: { type: 'string' },
                 create_time: { idate: true },
                 cache_last_valid_time: { idate: true },
                 last_modified_time: { idate: true },

--- a/src/endpoint/s3/ops/s3_post_object_uploads.js
+++ b/src/endpoint/s3/ops/s3_post_object_uploads.js
@@ -15,6 +15,7 @@ async function post_object_uploads(req, res) {
         bucket: req.params.bucket,
         key: req.params.key,
         content_type: req.headers['content-type'] || mime.getType(req.params.key) || 'application/octet-stream',
+        content_encoding: req.headers['content-encoding'],
         xattr: s3_utils.get_request_xattr(req),
         tagging,
         encryption

--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -36,6 +36,7 @@ async function put_object(req, res) {
         bucket: req.params.bucket,
         key: req.params.key,
         content_type: req.headers['content-type'] || (copy_source ? undefined : (mime.getType(req.params.key) || 'application/octet-stream')),
+        content_encoding: req.headers['content-encoding'],
         copy_source,
         source_stream,
         size,

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -307,6 +307,7 @@ function set_response_object_md(res, object_md) {
         res.setHeader('Last-Modified', time_utils.format_http_header_date(new Date(object_md.create_time)));
     }
     res.setHeader('Content-Type', object_md.content_type);
+    if (object_md.content_encoding) res.setHeader('Content-Encoding', object_md.content_encoding);
     res.setHeader('Content-Length', object_md.content_length === undefined ? object_md.size : object_md.content_length);
     res.setHeader('Accept-Ranges', 'bytes');
     if (config.WORM_ENABLED && object_md.lock_settings) {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -370,6 +370,7 @@ interface ObjectMD {
     size: number;
     num_parts: number;
     content_type: string;
+    content_encoding?: string;
     upload_size?: number;
     upload_started?: ID;
     create_time?: Date;
@@ -396,6 +397,7 @@ interface ObjectInfo {
     size: number;
     num_parts: number;
     content_type: string;
+    content_encoding?: string;
     upload_size?: number;
     upload_started?: number;
     create_time?: number;

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -201,6 +201,7 @@ class ObjectIO {
             'bucket',
             'key',
             'content_type',
+            'content_encoding',
             'size',
             'md5_b64',
             'sha256_b64',

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -108,6 +108,10 @@ async function create_object_upload(req) {
         info.xattr = _.mapKeys(req.rpc_params.xattr, (v, k) => k.replace(/\./g, '@'));
     }
 
+    if (req.rpc_params.content_encoding) {
+        info.content_encoding = req.rpc_params.content_encoding;
+    }
+
     const tier = await map_server.select_tier_for_write(req.bucket);
     await MDStore.instance().insert_object(info);
     object_md_cache.put_in_cache(String(info._id), info);
@@ -1357,6 +1361,7 @@ function get_object_info(md, options = {}) {
         md5_b64: md.md5_b64 || undefined,
         sha256_b64: md.sha256_b64 || undefined,
         content_type: md.content_type || 'application/octet-stream',
+        content_encoding: md.content_encoding,
         create_time: md.create_time ? md.create_time.getTime() : md._id.getTimestamp().getTime(),
         last_modified_time: md.last_modified_time ? (md.last_modified_time.getTime()) : undefined,
         cache_last_valid_time: md.cache_last_valid_time ? md.cache_last_valid_time.getTime() : undefined,

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -71,6 +71,8 @@ module.exports = {
         // MIME
         content_type: { type: 'string' },
 
+        content_encoding: { type: 'string' },
+
         // upload_size is filled for objects while uploading,
         // and ultimatly removed once the write is done
         upload_size: { type: 'integer' },


### PR DESCRIPTION
### Explain the changes
1. We didn't support content_encoding and didn't return it to the user in case the user supplied it when uploading the file.
Now, if provided, we will save the encoding in the DB and return it to the user on head/getObject.

Signed-off-by: jackyalbo <jacky.albo@gmail.com> 

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2054074

### Testing Instructions:
1. Run the commands in the BZ above - check that you have the same encoding you sent
