### PR TITLE
Defer MD5 calculation and assignment of the azure blob upload to prevent upload blocking

### DIFF
--- a/src/util/new_azure_storage_wrap.js
+++ b/src/util/new_azure_storage_wrap.js
@@ -6,36 +6,40 @@ const azure_storage = require('@azure/storage-blob');
 // needed only for enerateBlockIdPrefix() and get_block_id() functions
 const old_azure_storage = require('azure-storage');
 
-
 function new_md5_stream() {
     const md5_stream = new stream.Transform({
         transform(buf, encoding, next) {
             this.md5.update(buf);
             this.size += buf.length;
-            this.push(buf);
-            next();
+            next(null, buf);
         }
     });
+
     md5_stream.md5 = crypto.createHash('md5');
     md5_stream.size = 0;
+    md5_stream.md5_buf = null;
+
     return md5_stream;
 }
-
 
 azure_storage.get_container_client = (blob_service, container) => blob_service.getContainerClient(container);
 
 azure_storage.get_blob_client = (container_client, blob) => container_client.getBlobClient(blob).getBlockBlobClient();
 
-azure_storage.calc_body_md5 = async stream_file => {
+azure_storage.calc_body_md5 = stream_file => {
     const md5_stream = new_md5_stream();
     const new_stream = stream_file.pipe(md5_stream);
-    await new Promise((resolve, reject) => {
-        new_stream.once('error', reject);
-        new_stream.once('finish', resolve);
-    });
-    const final_md5 = md5_stream.md5.digest('hex');
-    const md5_buf = Buffer.from(final_md5, 'hex');
-    return { new_stream, md5_buf };
+    return {
+            new_stream,
+            md5_buf: () => {
+                if (md5_stream.md5_buf) return md5_stream.md5_buf;
+
+                const final_md5 = md5_stream.md5.digest('hex');
+                md5_stream.md5_buf = Buffer.from(final_md5, 'hex');
+
+                return md5_stream.md5_buf;
+            }
+    };
 };
 
 // create old lib blob service - needed for functions that do not exist in the new lib


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
1. Remove MD5 calculation of the azure blob upload to prevent upload blocking

### Issues: Fixed #xxx / Gap #xxx
1. Fixes [BZ - 2041494](https://bugzilla.redhat.com/show_bug.cgi?id=2041494)

### Testing Instructions:
1. Deploy new image of NooBaa in the kubernetes cluster.
2. Create a  `azure-blob` namespace store.
3. Create a bucketclass for the above namespace store.
4. Create an OBC with above mentioned bucketclass.
5. Try uploading objects to newly created bucket.
6. The upload should be successful.

### Notes for the reviewers
**What was wrong?**
An attempt to compute MD5 hash from the `file_stream` was being made so that this value could be passed on to the `azure-store` client. The issue was that either we can compute the MD5 hash and exhaust the stream, hence nothing left to upload or we can attempt to generate MD5 has we upload (but this isn't possible as we have to provide MD5 before uploading).

It should be noted that providing MD5 hash to the `azure-store` client is optional and the client does no verification, hence essentially rendering the hash useless.

### Correctness Tests
- [x] NooBaa computed MD5 of the blob matches with `md5 <object>`.
- [x] `aws s3api head-object --bucket <bucket> --key <object>` ETag matches with the computed MD5.
- [x] `x-ms-content-md5` header is attached to the object.