### PR TITLE
Fix endpoint hanging

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1857,14 +1857,14 @@ async function update_endpoint_stats(req) {
     const namespace_stats = req.rpc_params.namespace_stats || [];
     const bucket_counters = req.rpc_params.bucket_counters || [];
     await P.all([
-        P.map_with_concurrency(10, namespace_stats, stats =>
+        P.map_with_concurrency(5, namespace_stats, stats =>
             IoStatsStore.instance().update_namespace_resource_io_stats({
                 system: req.system._id,
                 namespace_resource_id: stats.namespace_resource_id,
                 stats: stats.io_stats
             })
         ),
-        P.map_with_concurrency(10, bucket_counters, counter =>
+        P.map_with_concurrency(5, bucket_counters, counter =>
             update_bucket_counters({ ...counter, system: req.system })
         )
     ]);

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1089,6 +1089,7 @@ class PostgresTable {
     }
 
     async _upsert(query, update, options) {
+        await this.init_promise;
         const MAX_RETRIES = 5;
         let retries = 0;
         // eslint-disable-next-line no-constant-condition


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. **PROBLEM**: When updating endpoint stats/ buckets stats we use upsert calls that acquire clients before the initiation of the table was completed. This situation caused a deadlock and the clients never released, other DB actions couldn't acquire clients because we already reached 10 (which is the default for each pg pool).
**SOLUTION**: I added an await for the init_promise of the table creation at the beginning of _upsert(), and reduces the number of concurrent calls in update_endpoint_stats() that will reduce the rate of concurrent queries from 10 to 5 to the DB (in this specific flow).

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #6856 

### Testing Instructions:
1. 
