### PR TITLE
Fix blob error codes extraction

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -140,7 +140,7 @@ class NamespaceBlob {
             dbg.warn('NamespaceBlob.read_object_md:', inspect(err));
             object_sdk.rpc_client.pool.update_issues_report({
                 namespace_resource_id: this.namespace_resource_id,
-                error_code: err.code,
+                error_code: err.code || (err.details && err.details.errorCode) || 'InternalError',
                 time: Date.now(),
             });
             throw err;
@@ -274,7 +274,7 @@ class NamespaceBlob {
                 dbg.warn('NamespaceBlob.upload_object:', inspect(err));
                 object_sdk.rpc_client.pool.update_issues_report({
                     namespace_resource_id: this.namespace_resource_id,
-                    error_code: err.code,
+                    error_code: err.code || (err.details && err.details.errorCode) || 'InternalError',
                     time: Date.now(),
                 });
                 throw err;
@@ -449,7 +449,7 @@ class NamespaceBlob {
             } catch (err) {
                 object_sdk.rpc_client.pool.update_issues_report({
                     namespace_resource_id: this.namespace_resource_id,
-                    error_code: err.code,
+                    error_code: err.code || (err.details && err.details.errorCode) || 'InternalError',
                     time: Date.now(),
                 });
                 throw err;
@@ -647,8 +647,8 @@ class NamespaceBlob {
     }
 
     _translate_error_code(err) {
-        if (err.code === 'NotFound') err.rpc_code = 'NO_SUCH_OBJECT';
-        if (err.code === 'InvalidMetadata') err.rpc_code = 'INVALID_REQUEST';
+        if (err.code || (err.details && err.details.errorCode) === 'BlobNotFound') err.rpc_code = 'NO_SUCH_OBJECT';
+        if (err.code || (err.details && err.details.errorCode) === 'InvalidMetadata') err.rpc_code = 'INVALID_REQUEST';
     }
 
     //////////

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1064,6 +1064,7 @@ async function _check_azure_connection_internal(params) {
         service_properties = await blob.getProperties();
     } catch (err) {
         dbg.warn(`got error on getServiceProperties with params`, _.omit(params, 'secret'), ` error: ${err}`);
+        err.code = err.code || (err.details && err.details.errorCode);
         throw err_to_status(err, 'NOT_SUPPORTED');
     }
 


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. read_object_md() in namespace blob calls Azure blob sdk function blob.getProperties() that throws an error, for example when authentication fails or blob not found, but error.code is undefined (error.code in other used functions contain value).
seems like a bug in Azure blob sdk but we can avoid for now by extracting also error.details.errorCode that does return a value.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #6898 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
