### PR TITLE
Fixing issue with sorting by wrong fields - leads to very slow object listing

### DIFF
--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -195,8 +195,11 @@ async function log_query(pg_client, query, tag, millitook, should_explain) {
 
 function convert_sort(sort) {
     return mongo_to_pg.convertSort('data', sort)
-        // fix _id refs to text references (->> instead of ->) refer
+        // fix all json columns refs to text references (->> instead of ->) refer
         .replace("data->'_id'", "data->>'_id'")
+        .replace("data->'bucket'", "data->>'bucket'")
+        .replace("data->'key'", "data->>'key'")
+        .replace("data->'version_past'", "data->>'version_past'")
         // remove NULLS LAST or NULLS FIRST
         .replace(/ NULLS LAST| NULLS FIRST/g, "");
 }


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. When sorting the object list we use to sort by obj->key while the index is using obj->>key - that cause our sort to don't use the index and make it very slow. this fix will change the sorting to use the same op as the query so both will hit the index and listing will be faster.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2052079

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
