### PR TITLE
[backport to 5.6] Installing nasm via wget instead of PowerTools repo

### DIFF
--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -8,14 +8,24 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
 ENV container docker
-RUN dnf --enablerepo='?ower?ools' install -y -q yasm && \
-    dnf clean all
+# RUN dnf --enablerepo=PowerTools install -y -q nasm && \
+#     dnf clean all
 RUN dnf update -y -q && \
     dnf clean all
 RUN dnf install -y -q wget unzip which vim python2 python3 && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
 RUN alternatives --set python /usr/bin/python3
+RUN version="2.15.05" && \
+    wget -q -O nasm-${version}.tar.gz https://github.com/netwide-assembler/nasm/archive/nasm-${version}.tar.gz && \
+    tar -xf nasm-${version}.tar.gz && \
+    pushd nasm-nasm-${version} && \
+    ./autogen.sh && \
+    ./configure && \
+    make && \
+    make install || true && \
+    popd && \
+    rm -rf nasm-${version} nasm-${version}.tar.gz
 
 ##############################################################
 # Layers:


### PR DESCRIPTION
Installing nasm via wget instead of PowerTools repo. Currently, we are pacing some issues with centos PowerTools repo and as a resault, the tests are failing on build. This PR will switch to installing nasm via wget to avoid those issues. Once PowerTools repo is stable again we can switch back to it.

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
