### PR TITLE
[backport to 5.6] ci: switch to CentOS Stream 8 as base image

### DIFF
--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -39,7 +39,7 @@ RUN tar \
 #   Cache: Rebuild when any layer is changing
 ##############################################################
 
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 ENV container docker
 ENV PORT 8080
@@ -69,7 +69,8 @@ RUN dnf install -y -q bash \
     nc \
     less \
     bash-completion \
-    python3-setuptools && \
+    python3-setuptools \
+    xz && \
     dnf clean all
 
 RUN mkdir -p /usr/local/lib/python3.6/site-packages

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos:8 
+FROM quay.io/centos/centos:stream8 
 LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 
 ##############################################################

--- a/src/deploy/NVA_build/dev.Dockerfile
+++ b/src/deploy/NVA_build/dev.Dockerfile
@@ -1,5 +1,5 @@
 # dev.Dockerfile is meant to be used manually for developer testing
-FROM centos:8 
+FROM quay.io/centos/centos:stream8
 
 ENV container docker
 


### PR DESCRIPTION
Signed-off-by: Daniel Sel <daniel.sel@rohde-schwarz.com>
(cherry picked from commit f0acc4f4fa2ae495590335571720414c7a59c817)

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
