### PR TITLE
Chunk fs | EINVAL error when writing more than 1024 buffers at one writev fix

### DIFF
--- a/config.js
+++ b/config.js
@@ -556,6 +556,7 @@ assert(config.NAMESPACE_CACHING.DEFAULT_BLOCK_SIZE > config.INLINE_MAX_SIZE);
 
 config.NSFS_BUF_SIZE = 8 * 1024 * 1024;
 config.NSFS_BUF_POOL_MEM_LIMIT = config.BUFFERS_MEM_LIMIT;
+config.NSFS_DEFAULT_IOV_MAX = 1024; // see IOV_MAX in https://man7.org/linux/man-pages/man0/limits.h.0p.html
 
 // the temporary path for uploads and other internal files
 config.NSFS_TEMP_DIR_NAME = '.noobaa-nsfs';

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -20,6 +20,7 @@
 #include <sys/xattr.h>
 #include <vector>
 #include <stdlib.h>
+#include <limits.h>
 
 #ifdef __APPLE__
     #include <sys/param.h>
@@ -1412,6 +1413,7 @@ fs_napi(Napi::Env env, Napi::Object exports)
     exports_fs["S_IFLNK"] = Napi::Number::New(env, S_IFLNK);
     exports_fs["DT_DIR"] = Napi::Number::New(env, DT_DIR);
     exports_fs["DT_LNK"] = Napi::Number::New(env, DT_LNK);
+    exports_fs["PLATFORM_IOV_MAX"] = Napi::Number::New(env, IOV_MAX);
 
     exports_fs["set_debug_level"] = Napi::Function::New(env, set_debug_level);
 

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -4,7 +4,6 @@
 
 
 const coretest = require('./coretest');
-const config = require('../../../config');
 coretest.setup({ incomplete_rpc_coverage: 'show' });
 
 // ---------------------------------------
@@ -60,7 +59,7 @@ require('./test_mirror_writer');
 require('./test_namespace_fs');
 require('./test_ns_list_objects');
 require('./test_bucketspace');
-if (config.NSFS_CALCULATE_MD5) require('./test_chunk_fs');
+require('./test_chunk_fs');
 
 // // SERVERS
 require('./test_agent');

--- a/src/test/unit_tests/test_chunk_fs.js
+++ b/src/test/unit_tests/test_chunk_fs.js
@@ -19,4 +19,16 @@ mocha.describe('ChunkFS', function() {
         self.timeout(RUN_TIMEOUT);
         await chunk_fs_hashing.file_target();
     });
+
+    mocha.it('Concurrent ChunkFS with file target - produce num_chunks > 1024 && total_chunks_size < config.NSFS_BUF_SIZE', async function() {
+        const self = this;
+        self.timeout(RUN_TIMEOUT);
+        // The goal of this test is to produce num_chunks > 1024 && total_chunks_size < config.NSFS_BUF_SIZE
+        // so we will flush buffers because of reaching max num of buffers and not because we reached the max NSFS buf size
+        // chunk size = 100, num_chunks = (10 * 1024 * 1024)/100 < 104587, 104587 = num_chunks > 1024 
+        // chunk size = 100, total_chunks_size after having 1024 chunks is = 100 * 1024 < config.NSFS_BUF_SIZE
+        const chunk_size = 100;
+        const parts_s = 50;
+        await chunk_fs_hashing.file_target(chunk_size, parts_s);
+    });
 });

--- a/src/util/chunk_fs.js
+++ b/src/util/chunk_fs.js
@@ -26,6 +26,8 @@ class ChunkFS extends stream.Transform {
         this.rpc_client = rpc_client;
         this.namespace_resource_id = namespace_resource_id;
         this._total_num_buffers = 0;
+        const platform_iov_max = nb_native().fs.PLATFORM_IOV_MAX;
+        this.iov_max = platform_iov_max ? Math.min(platform_iov_max, config.NSFS_DEFAULT_IOV_MAX) : config.NSFS_DEFAULT_IOV_MAX;
     }
 
     async _transform(chunk, encoding, callback) {
@@ -44,8 +46,9 @@ class ChunkFS extends stream.Transform {
                 const buf = (available_size < chunk.length) ? chunk.slice(0, available_size) : chunk;
                 this.q_buffers.push(buf);
                 this.q_size += buf.length;
-                // Should flush when equals, but added greater than just in case
-                if (this.q_size >= config.NSFS_BUF_SIZE) await this._flush_buffers();
+                // Should flush when num of chunks equals to max iov which is the limit according to https://linux.die.net/man/2/writev
+                // or when q_size equals to config.NSFS_BUF_SIZE, but added greater than just in case
+                if (this.q_buffers.length === this.iov_max || this.q_size >= config.NSFS_BUF_SIZE) await this._flush_buffers();
                 chunk = (available_size < chunk.length) ? chunk.slice(available_size) : null;
             }
             return callback();


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. According to https://linux.die.net/man/2/writev - calling writev() with iovcnt (buffer_len /  iov_vec.size() ) larger than 1024 will cause EINVAL (Invalid argument) error which we saw in https://github.com/noobaa/noobaa-core/issues/6896. 
2. In chunk_fs _transform() added ```this.q_buffers.length === config.NSFS_IOV_MAX``` to the if clause that will result flush_buffers() when evaluated to true.
3. Added a NSFS_IOV_MAX 1024 to config.
4. Added a unit test.

### Issues: Fixed #xxx / Gap #xxx
1. will fix https://github.com/noobaa/noobaa-core/issues/6896

### Testing Instructions:
1. 


- [ ] Doc added/updated
- Tests added
