### PR TITLE
Set postgres collation default to C - fixing BZ 2068110

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ run-single-test-postgres: tester
 	@echo "\033[1;34mCreating docker network\033[0m"
 	$(CONTAINER_ENGINE) network create noobaa-net || true
 	@echo "\033[1;34mRunning Postgres container\033[0m"
-	$(CONTAINER_ENGINE) run -d $(CPUSET) --network noobaa-net --name coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX) --env "POSTGRESQL_DATABASE=coretest" --env "POSTGRESQL_USER=noobaa" --env "POSTGRESQL_PASSWORD=noobaa" $(POSTGRES_IMAGE)
+	$(CONTAINER_ENGINE) run -d $(CPUSET) --network noobaa-net --name coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX) --env "POSTGRESQL_DATABASE=coretest" --env "POSTGRESQL_USER=noobaa" --env "POSTGRESQL_PASSWORD=noobaa" --env "LC_COLLATE=C" $(POSTGRES_IMAGE)
 	@echo "\033[1;34mRunning tests\033[0m"
 	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" --env "POSTGRES_HOST=coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "POSTGRES_USER=noobaa" --env "DB_TYPE=postgres" --env "PG_ENABLE_QUERY_LOG=true" --env "PG_EXPLAIN_QUERIES=true" $(TESTER_TAG) ./src/test/unit_tests/run_npm_test_on_test_container.sh -s $(testname)
 	@echo "\033[1;34mStopping/removing test container\033[0m"
@@ -111,7 +111,7 @@ test-postgres: tester
 	@echo "\033[1;34mCreating docker network\033[0m"
 	$(CONTAINER_ENGINE) network create noobaa-net || true
 	@echo "\033[1;34mRunning Postgres container\033[0m"
-	$(CONTAINER_ENGINE) run -d $(CPUSET) --network noobaa-net --name coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX) --env "POSTGRESQL_DATABASE=coretest" --env "POSTGRESQL_USER=noobaa" --env "POSTGRESQL_PASSWORD=noobaa" $(POSTGRES_IMAGE)
+	$(CONTAINER_ENGINE) run -d $(CPUSET) --network noobaa-net --name coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX) --env "POSTGRESQL_DATABASE=coretest" --env "POSTGRESQL_USER=noobaa" --env "POSTGRESQL_PASSWORD=noobaa" --env "LC_COLLATE=C" $(POSTGRES_IMAGE) 
 	@echo "\033[1;34mRunning tests\033[0m"
 	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" --env "POSTGRES_HOST=coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "POSTGRES_USER=noobaa" --env "DB_TYPE=postgres" $(TESTER_TAG)
 	@echo "\033[1;34mStopping/removing test container\033[0m"

--- a/src/test/unit_tests/test_s3_list_objects.js
+++ b/src/test/unit_tests/test_s3_list_objects.js
@@ -16,6 +16,7 @@ const ObjectIO = require('../../sdk/object_io');
 const { rpc_client } = coretest;
 let object_io = new ObjectIO();
 object_io.set_verification_mode();
+const assert = require('assert');
 
 const BKT = 'first.bucket'; // the default bucket name
 
@@ -66,280 +67,239 @@ mocha.describe('s3_list_objects', function() {
         prefix_infinite_loop_test.push(`d/f`);
     }
 
+    mocha.it('issue use case', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(10 * 60 * 1000);
+        let issue_files_folders_to_upload = ['20220323/99/test.txt', '20220323/990/test.txt'];
+        let expected_files_uploaded = ['20220323/99/', '20220323/990/'];
+
+        return run_case(issue_files_folders_to_upload,
+            async function(server_upload_response) {
+                // Uploading zero size objects from the key arrays that were provide
+                const list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    delimiter: '/',
+                    prefix: '20220323/'
+                });
+                // We should get the folder names in common_prefixes
+                // And we should get no objects inside objects
+                // Also we check that the response is not truncated
+                assert.strictEqual(_.difference(expected_files_uploaded, list_reply.common_prefixes).length, 0,
+                    'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.map(list_reply.objects, obj => obj.key).length, 0, 'objects: ' + list_reply.objects);
+                assert(is_sorted_array(list_reply.objects), 'not sorted objects');
+                assert(is_sorted_array(list_reply.common_prefixes), 'not sorted prefixes');
+                assert(!list_reply.is_truncated, 'truncated');
+            });
+    });
+
     mocha.it('general use case', function() {
-        if (process.env.DB_TYPE === 'postgres') this.skip(); // eslint-disable-line no-invalid-this
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(10 * 60 * 1000);
 
         return run_case(_.concat(folders_to_upload,
                 files_in_folders_to_upload,
                 files_without_folders_to_upload,
-                files_in_utf_diff_delimiter,
             ),
-            function(server_upload_response) {
+            async function(server_upload_response) {
                 // Uploading zero size objects from the key arrays that were provided
-                return P.resolve()
-                    .then(function() {
-                        return rpc_client.object.list_objects({
-                                bucket: BKT,
-                                delimiter: '#',
-                            })
-                            .then(function(list_reply) {
-                                // We should get the folder names in common_prefixes
-                                // And we should get the objects without folders inside objects
-                                // Also we check that the response is not truncated
-                                if (!(list_reply &&
-                                        _.difference(['תיקיה#'], list_reply.common_prefixes).length === 0 &&
-                                        _.difference(_.concat(folders_to_upload,
-                                                files_in_folders_to_upload,
-                                                files_without_folders_to_upload),
-                                            _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`Delimiter Test Failed! Got list: ${util.inspect(list_reply)}
-                                            Wanted list: ${_.concat(folders_to_upload, files_in_folders_to_upload,
-                                                files_without_folders_to_upload)},תיקיה#`);
-                                }
-                            });
-                    })
-                    .then(function() {
-                        return rpc_client.object.list_objects({
-                                bucket: BKT,
-                                delimiter: '/',
-                                prefix: 'folder'
-                            })
-                            .then(function(list_reply) {
-                                // In case we don't fully spell the name of the common prefix
-                                // We should get all the common prefixes that begin with that prefix
-                                if (!(list_reply &&
-                                        _.difference(folders_to_upload, list_reply.common_prefixes).length === 0 &&
-                                        list_reply.objects.length === 0 &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`Partial Prefix Failed! Got list: ${util.inspect(list_reply)}
-                            Wanted list: ${folders_to_upload}`);
-                                }
-                            });
-                    })
-                    .then(function() {
-                        return rpc_client.object.list_objects({
-                                bucket: BKT,
-                                delimiter: '/',
-                            })
-                            .then(function(list_reply) {
-                                // We should get the folder names in common_prefixes
-                                // And we should get the objects without folders inside objects
-                                // Also we check that the response is not truncated
-                                if (!(list_reply &&
-                                        _.difference(folders_to_upload, list_reply.common_prefixes).length === 0 &&
-                                        _.difference(files_without_folders_to_upload,
-                                            _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`Delimiter Test Failed! Got list: ${util.inspect(list_reply)}
-                                Wanted list: ${folders_to_upload}, ${files_without_folders_to_upload}`);
-                                }
-                            });
-                    })
-                    .then(function() {
-                        return rpc_client.object.list_objects({
-                                bucket: BKT,
-                                delimiter: '/',
-                                prefix: 'folder1/'
-                            })
-                            .then(function(list_reply) {
-                                // We should get nothing in common_prefixes
-                                // And we should get the objects inside folder1 in objects
-                                // Also we check that the response is not truncated
-                                if (!(list_reply &&
-                                        list_reply.common_prefixes.length === 0 &&
-                                        _.difference(files_in_folders_to_upload,
-                                            _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`Folder Test Failed! Got list: ${util.inspect(list_reply)}
-                                Wanted list: ${files_in_folders_to_upload}`);
-                                }
-                            });
-                    })
-                    .then(function() {
-                        return rpc_client.object.list_objects({
-                                bucket: BKT,
-                                delimiter: '/',
-                                limit: 5
-                            })
-                            .then(function(list_reply) {
-                                // Should be like the first check, but because of limit 5 we should only
-                                // Receive the first 5 files without folders under root and not all the folders
-                                // Which means that the common_prefixes should be zero, and only 5 objects
-                                // This tests the sorting algorithm of the response, and also the max-keys limit
-                                if (!(list_reply &&
-                                        list_reply.common_prefixes.length === 0 &&
-                                        _.difference([
-                                                'file_without_folder0',
-                                                'file_without_folder1',
-                                                'file_without_folder10',
-                                                'file_without_folder100',
-                                                'file_without_folder101',
-                                            ],
-                                            _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        list_reply.is_truncated)) {
-                                    throw new Error(`Limit Test Failed! Got list: ${util.inspect(list_reply)}
-                                Wanted list: ${files_without_folders_to_upload.slice(0, 5)}`);
-                                }
-                            });
-                    })
-                    .then(function() {
-                        return rpc_client.object.list_objects({
-                                bucket: BKT,
-                                prefix: 'file_without',
-                            })
-                            .then(function(list_reply) {
-                                // Should be like the first check, but because of limit 5 we should only
-                                // Receive the first 5 files without folders under root and not all the folders
-                                // Which means that the common_prefixes should be zero, and only 5 objects
-                                // This tests the sorting algorithm of the response, and also the max-keys limit
-                                if (!(list_reply &&
-                                        list_reply.common_prefixes.length === 0 &&
-                                        _.difference(files_without_folders_to_upload,
-                                            _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`Limit Test Failed! Got list: ${util.inspect(list_reply)}
-                                Wanted list: ${files_without_folders_to_upload.slice(0, 5)}`);
-                                }
-                            });
-                    })
-                    .then(function() {
-                        return rpc_client.object.list_objects({
-                                bucket: BKT,
-                                prefix: 'file_without_folder0',
-                            })
-                            .then(function(list_reply) {
-                                // Checking that we return object that complies fully to the prefix and don't skip it
-                                // This test was added after Issue #2600
-                                if (!(list_reply &&
-                                        list_reply.common_prefixes.length === 0 &&
-                                        _.isEqual([files_without_folders_to_upload[0]],
-                                            _.map(list_reply.objects, obj => obj.key)) &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`Limit Test Failed! Got list: ${util.inspect(list_reply)}
-                                        Wanted list: ${files_without_folders_to_upload[0]}`);
-                                }
-                            });
-                    })
-                    .then(function() {
-                        return rpc_client.object.list_objects({
-                                bucket: BKT,
-                                limit: 0
-                            })
-                            .then(function(list_reply) {
-                                if (!(list_reply &&
-                                        list_reply.common_prefixes.length === 0 &&
-                                        list_reply.objects.length === 0 &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`Limit Test Failed! Got list: ${util.inspect(list_reply)}
-                            Wanted list: ${files_without_folders_to_upload[0]}`);
-                                }
-                            });
-                    })
-                    .then(() => truncated_listing({
-                        bucket: BKT,
-                        delimiter: '/',
-                        limit: 1,
-                    }))
-                    .then(listObjectsResponse => {
-                        // Should be like the first check, but because of limit 1
-                        // We loop and ask to list several times to get all of the objects/common_prefixes
-                        // This checks the correctness of max-keys/next-marker/sort
-                        if (!(listObjectsResponse &&
-                                _.difference(folders_to_upload, listObjectsResponse.common_prefixes).length === 0 &&
-                                _.difference(_.concat(files_without_folders_to_upload, files_in_utf_diff_delimiter),
-                                    _.map(listObjectsResponse.objects, obj => obj.key)).length === 0 &&
-                                is_sorted_array(listObjectsResponse.objects) &&
-                                is_sorted_array(listObjectsResponse.common_prefixes) &&
-                                !listObjectsResponse.is_truncated)) {
-                            throw new Error(`Marker Test Failed! Got list: ${util.inspect(listObjectsResponse)}
-                                                Wanted list: ${folders_to_upload}, ${files_without_folders_to_upload}`);
-                        }
-                    });
+                let list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    delimiter: '/',
+                    prefix: 'folder'
+                });
+                // In case we don't fully spell the name of the common prefix
+                // We should get all the common prefixes that begin with that prefix
+                assert.strictEqual(_.difference(folders_to_upload, list_reply.common_prefixes).length, 0,
+                    'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(list_reply.objects.length, 0, 'objects: ' + list_reply.objects);
+                assert(is_sorted_array(list_reply.objects), 'not sorted objects');
+                assert(is_sorted_array(list_reply.common_prefixes), 'not sorted prefixes');
+                assert(!list_reply.is_truncated, 'truncated');
+
+                list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    delimiter: '/',
+                });
+                // We should get the folder names in common_prefixes
+                // And we should get the objects without folders inside objects
+                // Also we check that the response is not truncated
+                let objects = _.map(list_reply.objects, obj => obj.key);
+                assert.strictEqual(_.difference(folders_to_upload, list_reply.common_prefixes).length, 0,
+                    'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.difference(files_without_folders_to_upload, objects).length, 0, 'objects: ' + objects);
+                assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
+
+                list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    delimiter: '/',
+                    prefix: 'folder1/'
+                });
+                // We should get nothing in common_prefixes
+                // And we should get the objects inside folder1 in objects
+                // Also we check that the response is not truncated
+                objects = _.map(list_reply.objects, obj => obj.key);
+                assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.difference(files_in_folders_to_upload, objects).length, 0, 'objects: ' + objects);
+                assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
+
+                list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    delimiter: '/',
+                    limit: 5
+                });
+                // Should be like the first check, but because of limit 5 we should only
+                // Receive the first 5 files without folders under root and not all the folders
+                // Which means that the common_prefixes should be zero, and only 5 objects
+                // This tests the sorting algorithm of the response, and also the max-keys limit
+                objects = _.map(list_reply.objects, obj => obj.key);
+                assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.difference([
+                    'file_without_folder0',
+                    'file_without_folder1',
+                    'file_without_folder10',
+                    'file_without_folder100',
+                    'file_without_folder101',
+                ], objects).length, 0, 'objects:' + objects);
+                assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(list_reply.is_truncated, 'not truncated');
+            });
+
+    });
+
+    mocha.it('general use case 2', function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(10 * 60 * 1000);
+        return run_case(_.concat(folders_to_upload,
+            files_in_folders_to_upload,
+            files_without_folders_to_upload,
+            files_in_utf_diff_delimiter,
+            ),
+            async function(server_upload_response) {
+                let list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    delimiter: '#',
+                });
+                let objects = _.map(list_reply.objects, obj => obj.key);
+                // We should get the folder names in common_prefixes
+                // And we should get the objects without folders inside objects
+                // Also we check that the response is not truncated
+                assert.strictEqual(_.difference(['תיקיה#'], list_reply.common_prefixes).length, 0,
+                    'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.difference(_.concat(folders_to_upload, files_in_folders_to_upload,
+                    files_without_folders_to_upload), objects).length, 0, 'objects:' + objects);
+                assert(is_sorted_array(list_reply.objects), 'objects not sorted');
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
+
+                list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    prefix: 'file_without',
+                });
+                // Should be like the first check, but because of limit 5 we should only
+                // Receive the first 5 files without folders under root and not all the folders
+                // Which means that the common_prefixes should be zero, and only 5 objects
+                // This tests the sorting algorithm of the response, and also the max-keys limit
+                objects = _.map(list_reply.objects, obj => obj.key);
+                assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.difference(files_without_folders_to_upload, objects).length, 0, 'objects:' + objects);
+                assert(is_sorted_array(objects), 'objects not sorted' + objects);
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
+
+                list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    prefix: 'file_without_folder0',
+                });
+                // Checking that we return object that complies fully to the prefix and don't skip it
+                // This test was added after Issue #2600
+                objects = _.map(list_reply.objects, obj => obj.key);
+                assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(files_without_folders_to_upload[0], objects[0], 'objects:' + objects);
+                assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
+
+                list_reply = await rpc_client.object.list_objects({
+                    bucket: BKT,
+                    limit: 0
+                });
+                assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(list_reply.objects.length, 0, 'objects:' + list_reply.objects);
+                assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
+
+                list_reply = await truncated_listing({
+                    bucket: BKT,
+                    delimiter: '/',
+                    limit: 1,
+                });
+                // Should be like the first check, but because of limit 1
+                // We loop and ask to list several times to get all of the objects/common_prefixes
+                // This checks the correctness of max-keys/next-marker/sort
+                objects = _.map(list_reply.objects, obj => obj.key);
+                assert.strictEqual(_.difference(folders_to_upload, list_reply.common_prefixes).length, 0,
+                    'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.difference(_.concat(files_without_folders_to_upload, files_in_utf_diff_delimiter), objects).length, 0,
+                    'objects:' + list_reply.objects);
+                assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
             });
     });
 
     mocha.it('max keys test', function() {
-        if (process.env.DB_TYPE === 'postgres') this.skip(); // eslint-disable-line no-invalid-this
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(10 * 60 * 1000);
 
-        return run_case(max_keys_objects, function(server_upload_response) {
+        return run_case(max_keys_objects, async function(server_upload_response) {
             // Uploading zero size objects from the key arrays that were provided
-            return P.resolve()
-                .then(function() {
-                    return rpc_client.object.list_objects({
-                            bucket: BKT,
-                            limit: 2604
-                        })
-                        .then(function(list_reply) {
-                            if (!(list_reply &&
-                                    list_reply.common_prefixes.length === 0 &&
-                                    list_reply.objects.length === 1000 &&
-                                    is_sorted_array(list_reply.objects) &&
-                                    is_sorted_array(list_reply.common_prefixes) &&
-                                    list_reply.is_truncated)) {
-                                throw new Error(`Limit Test Failed! Got list: ${util.inspect(list_reply)}
-                                Wanted list: Includes only 1000 objects`);
-                            }
-                        });
-                })
-                .then(function() {
-                    // Note that in case of S3Controller we return an appropriate error value to the client
-                    return rpc_client.object.list_objects({
-                            bucket: BKT,
-                            limit: -2604
-                        })
-                        .then(function(list_reply) {
-                            throw new Error(`Limit Test Failed! Got list: ${util.inspect(list_reply)},
-                            Wanted to receive an error`);
-                        })
-                        .catch(function(err) {
-                            console.error(err);
-                            if (String(err.message) !== 'Limit must be a positive Integer') {
-                                throw new Error(`Limit Test Failed! Got error: ${err},
-                                Wanted to receive an error`);
-                            }
-                        });
-                })
-                .then(() => truncated_listing({
+            let list_reply = await rpc_client.object.list_objects({
+                bucket: BKT,
+                limit: 2604
+            });
+            let objects = _.map(list_reply.objects, obj => obj.key);
+            assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+            assert.strictEqual(objects.length, 1000, 'objects:' + objects);
+            assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+            assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+            assert(list_reply.is_truncated, 'not truncated');
+
+            // Note that in case of S3Controller we return an appropriate error value to the client
+            try {
+                list_reply = await rpc_client.object.list_objects({
                     bucket: BKT,
-                    delimiter: '/',
-                    limit: 1,
-                }))
-                .then(listObjectsResponse => {
-                    // Should be like the first check, but because of limit 1
-                    // We loop and ask to list several times to get all of the objects/common_prefixes
-                    // This checks the correctness of max-keys/next-marker/sort
-                    if (!(listObjectsResponse &&
-                            listObjectsResponse.common_prefixes.length === 0 &&
-                            _.difference(max_keys_objects,
-                                _.map(listObjectsResponse.objects, obj => obj.key)).length === 0 &&
-                            is_sorted_array(listObjectsResponse.objects) &&
-                            is_sorted_array(listObjectsResponse.common_prefixes) &&
-                            !listObjectsResponse.is_truncated)) {
-                        throw new Error(`Max keys truncated Test Failed! Got list: ${util.inspect(listObjectsResponse)}
-                                                Wanted list: ${folders_to_upload}, ${max_keys_objects}`);
-                    }
+                    limit: -2604
                 });
+                throw new Error(`Limit Test Failed! Got list: ${util.inspect(list_reply)},
+                Wanted to receive an error`);
+            } catch (err) {
+                console.error(err);
+                if (String(err.message) !== 'Limit must be a positive Integer') {
+                    throw new Error(`Limit Test Failed! Got error: ${err},
+                        Wanted to receive an error`);
+                }
+            }
+            list_reply = await truncated_listing({
+                bucket: BKT,
+                delimiter: '/',
+                limit: 1,
+            });
+            // Should be like the first check, but because of limit 1
+            // We loop and ask to list several times to get all of the objects/common_prefixes
+            // This checks the correctness of max-keys/next-marker/sort
+            objects = _.map(list_reply.objects, obj => obj.key);
+            assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+            assert.strictEqual(_.difference(max_keys_objects, objects).length, 0, 'objects:' + list_reply.objects);
+            assert(is_sorted_array(list_reply.objects), 'objcets not sorted' + list_reply.objects);
+            assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+            assert(!list_reply.is_truncated, 'truncated');
         });
     });
 
@@ -347,62 +307,45 @@ mocha.describe('s3_list_objects', function() {
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(10 * 60 * 1000);
 
-        return run_case(files_in_multipart_folders_to_upload, function(server_upload_response) {
+        return run_case(files_in_multipart_folders_to_upload, async function(server_upload_response) {
             // Uploading zero size objects from the key arrays that were provided
-            return P.resolve()
-                .then(function() {
-                    return rpc_client.object.list_uploads({
-                            bucket: BKT,
-                            delimiter: '/',
-                            prefix: 'multipart/'
-                        })
-                        .then(function(list_reply) {
-                            if (!(list_reply &&
-                                    list_reply.common_prefixes.length === 0 &&
-                                    _.difference(server_upload_response.map(obj => obj.key),
-                                        _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                    is_sorted_array(list_reply.objects) &&
-                                    is_sorted_array(list_reply.common_prefixes) &&
-                                    !list_reply.is_truncated)) {
-                                throw new Error(`Multipart uploads failed on basic list`);
-                            }
-                        });
-                })
-                .then(function() {
-                    return rpc_client.object.list_uploads({
-                            bucket: BKT,
-                            delimiter: '/',
-                            prefix: 'multipart/',
-                            limit: 1
-                        })
-                        .then(function(list_reply) {
-                            if (!(list_reply &&
-                                    list_reply.common_prefixes.length === 0 &&
-                                    _.difference([server_upload_response[0].key],
-                                        _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                    is_sorted_array(list_reply.objects) &&
-                                    is_sorted_array(list_reply.common_prefixes) &&
-                                    String(server_upload_response[0].obj_id) === String(list_reply.next_upload_id_marker) &&
-                                    list_reply.is_truncated)) {
-                                throw new Error(`Multipart uploads failed on next_upload_id_marker`);
-                            }
-                        });
-                })
-                .then(() => truncated_listing({
-                    bucket: BKT,
-                    limit: 1,
-                }, /* use_upload_id_marker = */ true, /* upload_mode = */ true))
-                .then(listObjectsResponse => {
-                    if (!(listObjectsResponse &&
-                            listObjectsResponse.common_prefixes.length === 0 &&
-                            _.difference(server_upload_response.map(obj => obj.key),
-                                _.map(listObjectsResponse.objects, obj => obj.key)).length === 0 &&
-                            is_sorted_array(listObjectsResponse.objects) &&
-                            is_sorted_array(listObjectsResponse.common_prefixes) &&
-                            !listObjectsResponse.is_truncated)) {
-                        throw new Error(`Multipart uploads failed list with markers`);
-                    }
-                });
+            let list_reply = await rpc_client.object.list_uploads({
+                bucket: BKT,
+                delimiter: '/',
+                prefix: 'multipart/'
+            });
+            let objects = _.map(list_reply.objects, obj => obj.key);
+            assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+            assert.strictEqual(_.difference(server_upload_response.map(obj => obj.key),
+                objects).length, 0, 'objects:' + objects);
+            assert(is_sorted_array(list_reply.objects), 'objcets not sorted' + list_reply.objects);
+            assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+            assert(!list_reply.is_truncated, 'truncated');
+
+            list_reply = await rpc_client.object.list_uploads({
+                bucket: BKT,
+                delimiter: '/',
+                prefix: 'multipart/',
+                limit: 1
+            });
+            objects = _.map(list_reply.objects, obj => obj.key);
+            assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+            assert.strictEqual(_.difference([server_upload_response[0].key], objects).length, 0, 'objects:' + objects);
+            assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+            assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+            assert.strictEqual(String(server_upload_response[0].obj_id), String(list_reply.next_upload_id_marker));
+            assert(list_reply.is_truncated, 'not truncated');
+
+            list_reply = await truncated_listing({
+                bucket: BKT,
+                limit: 1,
+            }, /* use_upload_id_marker = */ true, /* upload_mode = */ true);
+            objects = _.map(list_reply.objects, obj => obj.key);
+            assert.strictEqual(list_reply.common_prefixes.length, 0, 'prefixes: ' + list_reply.common_prefixes);
+            assert.strictEqual(_.difference(server_upload_response.map(obj => obj.key), objects).length, 0, 'objects:' + objects);
+            assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+            assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+            assert(!list_reply.is_truncated, 'truncated');
         }, /* only_initiate = */ true);
     });
 
@@ -414,28 +357,22 @@ mocha.describe('s3_list_objects', function() {
             _.concat(small_folder_with_multipart,
                 same_multipart_file1,
                 same_multipart_file2),
-            function(server_upload_response) {
+            async function(server_upload_response) {
                 // Uploading zero size objects from the key arrays that were provided
-                return P.resolve()
-                    .then(function() {
-                        return rpc_client.object.list_uploads({
-                                bucket: BKT,
-                                delimiter: '/',
-                                limit: 25
-                            })
-                            .then(function(list_reply) {
-                                if (!(list_reply &&
-                                        _.difference(['multipart2/'], list_reply.common_prefixes).length === 0 &&
-                                        _.difference(_.concat(same_multipart_file1, same_multipart_file2),
-                                            _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                        (list_reply.common_prefixes.length + list_reply.objects.length === 21) &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`Multipart uploads failed on basic list`);
-                                }
-                            });
-                    });
+                let list_reply = await rpc_client.object.list_uploads({
+                    bucket: BKT,
+                    delimiter: '/',
+                    limit: 25
+                });
+                let objects = _.map(list_reply.objects, obj => obj.key);
+                assert.strictEqual(_.difference(['multipart2/'], list_reply.common_prefixes).length, 0,
+                    'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.difference(_.concat(same_multipart_file1, same_multipart_file2),
+                         objects).length, 0, 'objects:' + objects);
+                assert.strictEqual(list_reply.common_prefixes.length + objects.length, 21, util.inspect(list_reply));
+                assert(is_sorted_array(objects), 'objcets not sorted');
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
             }, /* only_initiate = */ true);
     });
 
@@ -445,62 +382,56 @@ mocha.describe('s3_list_objects', function() {
 
         return run_case(
             prefix_infinite_loop_test,
-            function(server_upload_response) {
+            async function(server_upload_response) {
                 // Uploading zero size objects from the key arrays that were provided
-                return P.resolve()
-                    .then(function() {
-                        return truncated_listing({
-                                bucket: BKT,
-                                prefix: 'd/',
-                                delimiter: '/',
-                                limit: 1,
-                            }, /* use_upload_id_marker = */ false, /* upload_mode = */ false)
-                            .then(function(list_reply) {
-                                if (!(list_reply &&
-                                        _.difference(['d/d/'], list_reply.common_prefixes).length === 0 &&
-                                        _.difference(['d/f'],
-                                            _.map(list_reply.objects, obj => obj.key)).length === 0 &&
-                                        (list_reply.common_prefixes.length + list_reply.objects.length === 2) &&
-                                        is_sorted_array(list_reply.objects) &&
-                                        is_sorted_array(list_reply.common_prefixes) &&
-                                        !list_reply.is_truncated)) {
-                                    throw new Error(`prefix infinite loop failed on basic list`);
-                                }
-                            });
-                    });
+                let list_reply = await truncated_listing({
+                    bucket: BKT,
+                    prefix: 'd/',
+                    delimiter: '/',
+                    limit: 1,
+                }, /* use_upload_id_marker = */ false, /* upload_mode = */ false);
+                let objects = _.map(list_reply.objects, obj => obj.key);
+                assert.strictEqual(_.difference(['d/d/'], list_reply.common_prefixes).length, 0, 'prefixes: ' + list_reply.common_prefixes);
+                assert.strictEqual(_.difference(['d/f'], objects).length, 0, 'objects:' + objects);
+                assert.strictEqual((list_reply.common_prefixes.length + objects.length), 2);
+                assert(is_sorted_array(objects), 'objcets not sorted' + objects);
+                assert(is_sorted_array(list_reply.common_prefixes), 'prefixes not sorted');
+                assert(!list_reply.is_truncated, 'truncated');
             }, /* only_initiate = */ false);
     });
 });
 
 function upload_multiple_files(array_of_names) {
-    return P.map(array_of_names, name => P.resolve()
-        .then(() => rpc_client.object.create_object_upload({
+    return P.map(array_of_names, async name => {
+        const create_reply = await rpc_client.object.create_object_upload({
             bucket: BKT,
             key: name,
             content_type: 'application/octet-stream',
-        }))
-        .then(create_reply => rpc_client.object.complete_object_upload({
+        });
+        return rpc_client.object.complete_object_upload({
             obj_id: create_reply.obj_id,
             bucket: BKT,
             key: name,
-        })));
+        });
+    });
 }
 
 function initiate_upload_multiple_files(array_of_names) {
-    return P.map(array_of_names, name => P.resolve()
-        .then(() => rpc_client.object.create_object_upload({
+    return P.map(array_of_names, async name => {
+        const create_reply = await rpc_client.object.create_object_upload({
             bucket: BKT,
             key: name,
             content_type: 'application/octet-stream',
-        }))
-        .then(create_reply => ({
+        });
+        return {
             obj_id: create_reply.obj_id,
             key: name,
-        })));
+        };
+    });
 }
 
 function is_sorted_array(arr) {
-    return _.every(arr, function(value, index, array) {
+    return _.every(arr, (value, index, array) => {
         if (index === 0) return true;
         // either it is the first element, or otherwise this element should
         // not be smaller than the previous element.
@@ -517,88 +448,70 @@ function is_sorted_array(arr) {
 
 function clean_up_after_case(array_of_names, abort_upload) {
     return abort_upload ?
-        P.map(array_of_names, obj => P.resolve()
-            .then(() => rpc_client.object.abort_object_upload({
+        P.map(array_of_names, async obj => {
+            await rpc_client.object.abort_object_upload({
                 bucket: BKT,
                 key: obj.key,
                 obj_id: obj.obj_id,
-            }))) :
+            });
+        }) :
         rpc_client.object.delete_multiple_objects({
             bucket: BKT,
             objects: array_of_names.map(key => ({ key })),
         });
 }
 
-function run_case(array_of_names, case_func, only_initiate) {
-    let response_array = [];
-    return Promise.resolve()
-        .then(function() {
-            return only_initiate ?
-                initiate_upload_multiple_files(array_of_names) :
-                upload_multiple_files(array_of_names);
-        })
-        .then(response => {
-            response_array = response;
-            return response;
-        })
-        .then(response => case_func(response))
-        .then(() => clean_up_after_case(only_initiate ? response_array : array_of_names, only_initiate));
+async function run_case(array_of_names, case_func, only_initiate) {
+    const response = only_initiate ? await initiate_upload_multiple_files(array_of_names) :
+                await upload_multiple_files(array_of_names);
+    const response_array = response;
+    await case_func(response);
+    await clean_up_after_case(only_initiate ? response_array : array_of_names, only_initiate);
 }
 
-function truncated_listing(params, use_upload_id_marker, upload_mode) {
-    return P.resolve()
-        .then(function() {
-            // Initialization of IsTruncated in order to perform the first while cycle
-            var listObjectsResponse = {
-                is_truncated: true,
-                objects: [],
-                common_prefixes: [],
-                key_marker: ''
-            };
+async function truncated_listing(params, use_upload_id_marker, upload_mode) {
+        // Initialization of IsTruncated in order to perform the first while cycle
+        var listObjectsResponse = {
+            is_truncated: true,
+            objects: [],
+            common_prefixes: [],
+            key_marker: ''
+        };
 
-            var query_obj = {
-                key_marker: listObjectsResponse.key_marker
-            };
+        var query_obj = {
+            key_marker: listObjectsResponse.key_marker
+        };
 
-            if (use_upload_id_marker) {
-                listObjectsResponse.upload_id_marker = '';
-                query_obj.upload_id_marker = listObjectsResponse.upload_id_marker;
+        if (use_upload_id_marker) {
+            listObjectsResponse.upload_id_marker = '';
+            query_obj.upload_id_marker = listObjectsResponse.upload_id_marker;
+        }
+
+        while (listObjectsResponse.is_truncated) {
+            listObjectsResponse.is_truncated = false;
+            const func_params = _.defaults(query_obj, params);
+            const res = upload_mode ?
+                await rpc_client.object.list_uploads(func_params) :
+                await rpc_client.object.list_objects(func_params);
+
+            listObjectsResponse.is_truncated = res.is_truncated;
+            let res_list = {
+                objects: res.objects,
+                common_prefixes: res.common_prefixes
+            };
+            if (res_list.objects.length) {
+                listObjectsResponse.objects = _.concat(listObjectsResponse.objects, res_list.objects);
             }
-
-            return P.pwhile(
-                    function() {
-                        return listObjectsResponse.is_truncated;
-                    },
-                    function() {
-                        listObjectsResponse.is_truncated = false;
-                        const func_params = _.defaults(query_obj, params);
-                        return (
-                                upload_mode ?
-                                rpc_client.object.list_uploads(func_params) :
-                                rpc_client.object.list_objects(func_params)
-                            )
-                            .then(function(res) {
-                                listObjectsResponse.is_truncated = res.is_truncated;
-                                let res_list = {
-                                    objects: res.objects,
-                                    common_prefixes: res.common_prefixes
-                                };
-                                if (res_list.objects.length) {
-                                    listObjectsResponse.objects = _.concat(listObjectsResponse.objects, res_list.objects);
-                                }
-                                if (res_list.common_prefixes.length) {
-                                    listObjectsResponse.common_prefixes =
-                                        _.concat(listObjectsResponse.common_prefixes, res_list.common_prefixes);
-                                }
-                                listObjectsResponse.key_marker = res.next_marker;
-                                query_obj.key_marker = res.next_marker;
-                                if (use_upload_id_marker) {
-                                    listObjectsResponse.upload_id_marker = res.next_upload_id_marker;
-                                    query_obj.upload_id_marker = res.next_upload_id_marker;
-                                }
-
-                            });
-                    })
-                .then(() => listObjectsResponse);
-        });
+            if (res_list.common_prefixes.length) {
+                listObjectsResponse.common_prefixes =
+                    _.concat(listObjectsResponse.common_prefixes, res_list.common_prefixes);
+            }
+            listObjectsResponse.key_marker = res.next_marker;
+            query_obj.key_marker = res.next_marker;
+            if (use_upload_id_marker) {
+                listObjectsResponse.upload_id_marker = res.next_upload_id_marker;
+                query_obj.upload_id_marker = res.next_upload_id_marker;
+            }
+        }
+        return listObjectsResponse;
 }

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1282,7 +1282,7 @@ class PostgresClient extends EventEmitter {
         try {
             pg_client = new Client({ ...this.new_pool_params, database: undefined });
             await pg_client.connect();
-            await pg_client.query(`CREATE DATABASE ${this.new_pool_params.database}`);
+            await pg_client.query(`CREATE DATABASE ${this.new_pool_params.database} WITH LC_COLLATE = 'C' TEMPLATE template0`);
         } catch (err) {
             if (err.code === '3D000') return;
             throw err;


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. fixing collate to be C instead of system default for postgres
2. returning back the test_s3_list_objects that we moved out for postgres 
- moving all the tests to async-await
- making the errors more clear - assert instead of regular throws
3. adding the ability to run only one test with postgres in makefile  

### Issues: Fixed #xxx / Gap #xxx
1. Fixed BZ2068110

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
