### PR TITLE
print log message for long running db queries

### DIFF
--- a/config.js
+++ b/config.js
@@ -369,6 +369,9 @@ config.on_premise = {
     nva_part: "NVA_Upgrade.tgz"
 };
 
+// the threshold in ms for logging long running queries
+config.LONG_DB_QUERY_THRESHOLD = parseInt(process.env.LONG_DB_QUERY_THRESHOLD, 10) || 5000;
+
 /*
   Central Stats Collection & Diagnostics
 */


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. if a query in Postgres is taking more than the defined threshold, print the query info to log.
2. added `config.DB_LOG_QUERY_THRESHOLD = 1000` as the threshold in ms


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
