### PR TITLE
NSFS | chunk_fs.flush_buffers() missing callback argument

### DIFF
--- a/src/util/chunk_fs.js
+++ b/src/util/chunk_fs.js
@@ -62,6 +62,8 @@ class ChunkFS extends stream.Transform {
         this._flush_buffers(callback);
     }
 
+    // callback will be passed only at the end of the stream by _flush()
+    // while this function is called without callback during _transform() and returns a promise.
     async _flush_buffers(callback) {
         try {
             if (this.q_buffers.length) {
@@ -78,7 +80,10 @@ class ChunkFS extends stream.Transform {
             }
         } catch (error) {
             console.error('ChunkFS _flush_buffers failed', this.q_size, this._total_num_buffers, error);
-            return callback(error);
+            if (callback) {
+                return callback(error);
+            }
+            throw error;
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Added a check for if(callback) before using it.
2. Emitted an error to the stream when catching an error and no callback was provided.

Fixing one symptom seen in https://github.com/noobaa/noobaa-core/issues/6950
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
