### PR TITLE
NSFS | Add checks for request/response aborted in namespace_fs read_object_stream() 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4717,6 +4717,11 @@
         "semver": "^5.4.1"
       }
     },
+    "node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
+    },
     "node-addon-api": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "nan": "2.15.0",
     "ncp": "2.0.0",
     "net-ping": "1.2.3",
+    "node-abort-controller": "3.0.1",
     "node-addon-api": "4.3.0",
     "node-df": "0.1.4",
     "node-gyp": "8.4.1",

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -27,6 +27,7 @@ const stats_collector = require('./endpoint_stats_collector');
 const { RpcError } = require('../rpc');
 const config = require('../../config');
 const path = require('path');
+const { AbortController } = require('node-abort-controller');
 
 const bucket_namespace_cache = new LRUCache({
     name: 'ObjectSDK-Bucket-Namespace-Cache',
@@ -64,6 +65,56 @@ class ObjectSDK {
             this.bucketspace_fs = new BucketSpaceFS({ fs_root: process.env.BUCKETSPACE_FS });
         }
         this.requesting_account = undefined;
+        this.abort_controller = new AbortController();
+    }
+
+    /**
+     * setup_abort_controller adds event handlers to the http request and response,
+     * in order to handle aborting requests gracefully. The `abort_controller` member will
+     * be used to signal async flows that abort was detected.
+     * @see {@link https://nodejs.org/docs/latest/api/globals.html#class-abortcontroller}
+     * @param {import('http').IncomingMessage} req 
+     * @param {import('http').ServerResponse} res 
+     */
+    setup_abort_controller(req, res) {
+        res.once('error', err => {
+            dbg.log0('response error:', err, req.url);
+            this.abort_controller.abort(err);
+        });
+
+        req.once('error', err => {
+            dbg.log0('request error:', err, req.url);
+            this.abort_controller.abort(err);
+        });
+
+        // TODO: aborted event is being deprecated since nodejs 16
+        // https://nodejs.org/dist/latest-v16.x/docs/api/http.html#event-aborted recommends on listening to close event
+        // req.once('close', () => {
+        //     dbg.log0('request aborted1', req.url);
+
+        //     if (req.destroyed) {
+        //         dbg.log0('request aborted', req.url);
+        //         this.abort_controller.abort(new Error('request aborted ' + req.url));
+        //     }
+        // });
+
+        req.once('aborted', () => {
+            dbg.log0('request aborted', req.url);
+            this.abort_controller.abort(new Error('request aborted ' + req.url));
+        });
+    }
+
+    throw_if_aborted() {
+        if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+    }
+
+    add_abort_handler(handler) {
+        const s = this.abort_controller.signal;
+        if (s.aborted) {
+            setImmediate(handler);
+        } else {
+            s.addEventListener('abort', handler, { once: true });
+        }
     }
 
     /**

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -190,7 +190,7 @@ class BuffersPool {
      * }>}
      */
     async get_buffer() {
-        dbg.log1('BufferPool.get_buffer', this);
+        dbg.log1('BufferPool.get_buffer: sem value', this.sem._value, 'waiting_value', this.sem._waiting_value, 'buffers length', this.buffers.length);
         let buffer = null;
         let warning_timer;
         // Lazy allocation of buffers pool, first cycle will take up buffers

--- a/src/util/stream_utils.js
+++ b/src/util/stream_utils.js
@@ -10,8 +10,8 @@ const events = require('events');
  * @param {stream.Writable} writable 
  * @returns {Promise}
  */
-async function wait_drain(writable) {
-    return events.once(writable, 'drain');
+async function wait_drain(writable, options) {
+    return events.once(writable, 'drain', options);
 }
 
 const wait_finished = util.promisify(stream.finished);


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Object_sdk - Added an abort controller property and added 2 functions:
   1.1. setup_abort_controller() - setup event listeners on the req/res that will call abort() of the abort_controller.
   1.2. throw_if_aborted() - will check if the abort_controller got the aborted signal and will throw error when true.
2. S3_get_object -
   2.1. Called setup_abort_controller() in order to hang the event listeners on each get_object request/response.
   2.2. Removed the previous event listeners code.
3. Namespace FS - 
   3.1. Added a call to object_sdk.throw_if_aborted() after each await in read_object_stream(). (see Note)
   3.2. Passed object_sdk.abort_controller.signal parameter to wait_finished() and to wait_drain().

NOTE - 
The whole purpose of this new abort_controller functionality was to fix the following situation -
1. A Client sends s3_get_object request, NooBaa is writing a buffer to the response, and the client reads it very slowly.
2. NooBaa in the meantime reads the next data from the fs and holds a new buffer, but NooBaa is not yet writing it to the socket and is awaiting for wait_drain() (because the client reads the data very slowly).
3. The user calls abort on the request, and the first buffer is released.
4. NooBaa still awaits on wait_drain() and therefore still holding the second buffer.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #https://github.com/noobaa/noobaa-core/issues/6934 hopefully

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
