### PR TITLE
Remove all pg-client listeners before releasing to pg-pool

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -93,6 +93,8 @@ async function start_endpoint(options = {}) {
         dbg.log0('Configured Virtual Hosts:', virtual_hosts);
         dbg.log0('Configured Location Info:', location_info);
 
+        process.on('warning', e => dbg.warn(e.stack));
+
         let internal_rpc_client;
 
         let init_request_sdk = options.init_request_sdk;

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -352,6 +352,7 @@ class PgTransaction {
 
     release() {
         if (this.pg_client) {
+            this.pg_client.removeAllListeners('error');
             this.pg_client.release();
             this.pg_client = null;
         }


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. remove all pg-client listeners before releasing to pg-pool - to prevent possible memory leaks
2. print the stack trace in case of process warnings  

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2089630

### Testing Instructions:
1. Load the endpoint with S3 puts 
2. See you don't have any more this kind of messages in the log: 
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Client]. Use emitter.setMaxListeners() to increase limit
```


- [ ] Doc added/updated
- [ ] Tests added
