### PR TITLE
NSFS | Set endpoint process default umask to 0o000

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -45,6 +45,10 @@ if (process.env.NOOBAA_LOG_LEVEL) {
     dbg_conf.endpoint.map(module => dbg.set_module_level(dbg_conf.level, module));
 }
 
+const new_umask = process.env.NOOBAA_ENDPOINT_UMASK || 0o000;
+const old_umask = process.umask(new_umask);
+dbg.log0('endpoint: replacing old umask: ', old_umask.toString(8), 'with new umask: ', new_umask.toString(8));
+
 /**
  * @typedef {http.IncomingMessage & {
  *  object_sdk?: ObjectSDK;

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -55,7 +55,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
             this.skip(); // eslint-disable-line no-invalid-this
         }
     });
-    mocha.before(async () => fs_utils.create_fresh_path(tmp_fs_root + '/new_s3_buckets_dir', 0o777));
+    mocha.before(async () => fs_utils.create_fresh_path(tmp_fs_root + '/new_s3_buckets_dir', 0o770));
     mocha.before(async () => fs_utils.create_fresh_path(tmp_fs_root + bucket_path, 0o770));
     mocha.before(async () => fs_utils.create_fresh_path(tmp_fs_root + other_bucket_path, 0o770));
     mocha.after(async () => fs_utils.folder_delete(tmp_fs_root));


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Setting endpoint process default umask is needed for NSFS flows in order to override the umask when creating folders/objects with 770/660 permissions.
2. default umask of the endpoint pod is 002. when calling mkdir (using NSFS flows) created of a folder with 750 permissions while we wanted 770 (same for objects with 640 permissions while we wanted 660 permissions), resetting the default umask of the endpoint pod helped to set the permissions correctly.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
