### PR TITLE
Stringify error codes before update_issues_report() in namespace_s3 flows

### DIFF
--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -179,7 +179,7 @@ class NamespaceS3 {
             dbg.warn('NamespaceS3.read_object_md:', inspect(err));
             object_sdk.rpc_client.pool.update_issues_report({
                 namespace_resource_id: this.namespace_resource_id,
-                error_code: err.code,
+                error_code: String(err.code),
                 time: Date.now(),
             });
             throw err;
@@ -292,7 +292,7 @@ class NamespaceS3 {
             } catch (err) {
                 object_sdk.rpc_client.pool.update_issues_report({
                     namespace_resource_id: this.namespace_resource_id,
-                    error_code: err.code,
+                    error_code: String(err.code),
                     time: Date.now(),
                 });
                 throw err;
@@ -386,7 +386,7 @@ class NamespaceS3 {
             } catch (err) {
                 object_sdk.rpc_client.pool.update_issues_report({
                     namespace_resource_id: this.namespace_resource_id,
-                    error_code: err.code,
+                    error_code: String(err.code),
                     time: Date.now(),
                 });
                 throw err;

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -81,7 +81,7 @@ class NamespaceMonitor {
         if (!err.code) return;
         await this.client.pool.update_issues_report({
             namespace_resource_id: nsr._id,
-            error_code: err.code,
+            error_code: String(err.code),
             time: Date.now(),
             monitoring: true
         }, {


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. In https://bugzilla.redhat.com/show_bug.cgi?id=2090968 we received an error from RGW and the error code was 502 which is a number and when calling update_issues_report() we pass this error code and validate that error_code is a string so we fail with INVALID_SCHEMA_PARAMS CLIENT on this rpc call.
RGW should not throw an error with a numeric error code but in order to secure this functionality, I added this casting.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
