### PR TITLE
Adding jemalloc to docker build

### DIFF
--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -57,6 +57,7 @@ ENV ENDPOINT_NODE_OPTIONS ''
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
 
+RUN dnf install -y epel-release
 RUN dnf install -y -q bash \
     lsof \
     procps \
@@ -69,6 +70,7 @@ RUN dnf install -y -q bash \
     less \
     bash-completion \
     python3-setuptools \
+    jemalloc \
     xz && \
     dnf clean all
 
@@ -142,6 +144,9 @@ EXPOSE 8443
 EXPOSE 8444
 EXPOSE 27000
 EXPOSE 26050
+
+# Needs to be added only after installing jemalloc in dependencies section (our env section is before) - otherwise it will fail
+ENV LD_PRELOAD /usr/lib64/libjemalloc.so.2
 
 ###############
 # EXEC SETUP #


### PR DESCRIPTION
for better memory allocs performance

Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1.  Adding jemalloc as the new memory allocator. The default one doesn't handle the resident memory good enough causing the memory to grow up to OOM kiils in NooBaa's endpoint pods. 
2. LD_PRELOAD needs to point to where jemalloc is installed (curretly /usr/lib64/libjemalloc.so.2)

### Issues: Fixed #xxx / Gap #xxx
1.  https://bugzilla.redhat.com/show_bug.cgi?id=2089630

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
