### PR TITLE
redirecting `/` into `/version` instead of `/fe` which ware removed

### DIFF
--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -150,9 +150,7 @@ if (config.PROMETHEUS_ENABLED) {
 }
 
 app.get('/', function(req, res) {
-    // Forward any query parameters
-    const [, query = ''] = req.url.split(/(?=\?)/);
-    return res.redirect(`/fe/${query}`);
+    return res.redirect(`/version`);
 });
 
 // Upgrade checks


### PR DESCRIPTION
### Explain the changes
Redirecting `/` into `/version` instead of `/fe` which ware removed

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Testing Instructions:
1. log into the mgmt URL and see that we are redirecting to `/version`
