### PR TITLE
Removed stop_redirect from publish_to_cluster() params

### DIFF
--- a/src/api/redirector_api.js
+++ b/src/api/redirector_api.js
@@ -49,9 +49,6 @@ module.exports = {
                 method_name: {
                     type: 'string'
                 },
-                stop_redirect: {
-                    type: 'boolean',
-                },
                 request_params: {
                     type: 'object',
                     additionalProperties: true,


### PR DESCRIPTION
### Explain the changes
1. Removed the param `stop_redirect` from `publish_to_cluster` method

### Issues:
1. Fixed: #6997 

Signed-off-by: nik-redhat <nladha@redhat.com>