### PR TITLE
always use /noobaa_storage as mount point when running in a container 

### DIFF
--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -315,6 +315,10 @@ function get_disk_mount_points() {
         .then(drives => remove_linux_readonly_drives(drives))
         .then(function(drives) {
             dbg.log0('drives:', drives, ' current location ', process.cwd());
+            if (IS_DOCKER) {
+                const storage_drives = _.filter(drives, drive => drive.mount === '/noobaa_storage');
+                if (storage_drives.length) return storage_drives;
+            }
             return _.filter(drives, drive => {
                 const { mount, drive_id } = drive;
                 if (IS_DOCKER && mount !== '/') return false;


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. in `os_utils. get_disk_mount_points() ` if `IS_DOCKER` is set then only filter for `/noobaa_storage`, which is the expected mount point of the volume

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
