### PR TITLE
prints improvements and addition of jemalloc prints

### DIFF
--- a/src/native/nb_native.cpp
+++ b/src/native/nb_native.cpp
@@ -7,6 +7,7 @@ namespace noobaa
 void b64_napi(Napi::Env env, Napi::Object exports);
 void ssl_napi(Napi::Env env, Napi::Object exports);
 void syslog_napi(Napi::Env env, Napi::Object exports);
+void malloc_napi(Napi::Env env, Napi::Object exports);
 void splitter_napi(Napi::Env env, Napi::Object exports);
 void chunk_coder_napi(napi_env env, napi_value exports);
 void fs_napi(Napi::Env env, Napi::Object exports);
@@ -17,6 +18,7 @@ nb_native_napi(Napi::Env env, Napi::Object exports)
     b64_napi(env, exports);
     ssl_napi(env, exports);
     syslog_napi(env, exports);
+    malloc_napi(env, exports);
     splitter_napi(env, exports);
     chunk_coder_napi(env, exports);
     fs_napi(env, exports);

--- a/src/native/nb_native.gyp
+++ b/src/native/nb_native.gyp
@@ -53,6 +53,7 @@
             'tools/b64_napi.cpp',
             'tools/ssl_napi.cpp',
             'tools/syslog_napi.cpp',
+            'tools/malloc_napi.cpp',
             # util
             'util/b64.h',
             'util/b64.cpp',

--- a/src/native/tools/malloc_napi.cpp
+++ b/src/native/tools/malloc_napi.cpp
@@ -1,0 +1,54 @@
+/* Copyright (C) 2016 NooBaa */
+#include "../util/napi.h"
+#include "../util/common.h"
+
+#include <stdlib.h>
+#include <uv.h>
+#include <dlfcn.h>
+#include <malloc.h>
+
+namespace noobaa
+{
+
+DBG_INIT(0);
+
+static void (*malloc_stats_print)
+(
+    void (*write_cb) (void *, const char *), 
+    void *cbopaque, 
+    const char *opts
+) = 0;
+
+static void _print_malloc_stats(const Napi::CallbackInfo& info);
+static void _print_jemalloc_stats(const Napi::CallbackInfo& info);
+
+void
+malloc_napi(Napi::Env env, Napi::Object exports)
+{
+    auto exports_malloc = Napi::Object::New(env);
+    uv_lib_t *lib = (uv_lib_t*) malloc(sizeof(uv_lib_t));
+    lib->handle = RTLD_DEFAULT;
+    lib->errmsg = NULL;
+    if (uv_dlsym(lib, "malloc_stats_print", (void **) &malloc_stats_print)) {
+        DBG1("Error: " << uv_dlerror(lib));
+    }
+    if (malloc_stats_print == NULL) {
+        exports_malloc["print_stats"] = Napi::Function::New(env, _print_malloc_stats);
+    } else {
+        exports_malloc["print_stats"] = Napi::Function::New(env, _print_jemalloc_stats);
+    }
+    exports["malloc"] = exports_malloc;
+}
+
+static void
+_print_jemalloc_stats(const Napi::CallbackInfo& info)
+{
+    malloc_stats_print(NULL, NULL, NULL);
+}
+
+static void
+_print_malloc_stats(const Napi::CallbackInfo& info)
+{
+    malloc_stats();
+}
+}


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1.  adding jemalloc prints using malloc_stats_print
2. setting down the logging threshold to 512MB
3. checking the threshold against RSS memory and not heap

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
