### PR TITLE
fix small mem leaks that accumulate

### DIFF
--- a/src/native/chunk/splitter_napi.cpp
+++ b/src/native/chunk/splitter_napi.cpp
@@ -11,6 +11,7 @@ namespace noobaa
 static Napi::Value _chunk_splitter(const Napi::CallbackInfo& info);
 static Napi::Value _splitter_finish(Napi::Env env, Splitter* splitter);
 static Napi::Value _splitter_result(Napi::Env env, Splitter* splitter);
+static void _free_splitter(Napi::Env env, Splitter* splitter);
 
 void
 splitter_napi(Napi::Env env, Napi::Object exports)
@@ -111,7 +112,7 @@ _chunk_splitter(const Napi::CallbackInfo& info)
             throw Napi::Error::New(info.Env(), "Invalid splitter config");
         }
         splitter = new Splitter(min_chunk, max_chunk, avg_chunk_bits, calc_md5, calc_sha256);
-        state["splitter"] = Napi::External<Splitter>::New(info.Env(), splitter);
+        state["splitter"] = Napi::External<Splitter>::New(info.Env(), splitter, _free_splitter);
     }
 
     auto buffers = info[1].As<Napi::Array>();
@@ -167,6 +168,12 @@ _splitter_result(Napi::Env env, Splitter* splitter)
         arr[i] = Napi::Number::New(env, split_points[i]);
     }
     return arr;
+}
+
+static void 
+_free_splitter(Napi::Env env, Splitter* splitter)
+{
+    delete splitter;
 }
 
 } // namespace noobaa

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -1186,21 +1186,30 @@ struct RealPath : public FSWorker
 
     RealPath(const Napi::CallbackInfo& info)
         : FSWorker(info)
+        , _full_path(0)
     {
         _path = info[1].As<Napi::String>();
         Begin(XSTR() << DVAL(_path));
     }
 
+    ~RealPath() {
+        if (_full_path) {
+            free(_full_path);
+            _full_path = 0;
+        }
+    }
+
     virtual void Work()
     {
+        // realpath called with resolved_path = NULL so it will malloc as needed for the result
+        // and we just need to make sure to capture this result and remember to free it on dtor.
         _full_path = realpath(_path.c_str(), NULL);
-        if (_full_path == NULL) SetSyscallError();
+        if (!_full_path) SetSyscallError();
     }
 
     virtual void OnOK()
     {
         DBG1("FS::RealPath::OnOK: " << DVAL(_path) << DVAL(_full_path));
-        
         Napi::Env env = Env();
         auto res = Napi::String::New(env, _full_path);
         _deferred.Resolve(res);


### PR DESCRIPTION
### Explain the changes
1. fix one leak in chunking flow that affects backing stores (leaked external splitter).
2. fix another unrelated leak in nsfs (leaked realpath response).

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. Stress test PUT small files (even 1 byte is enough and the leak amount is fixed per put so more bytes don't help, only slows the rate of reproduction).
2. The endpoint's memory RSS should not increase overtime as the test is running.

---

I used MacOs `leaks` CLI tool with `MallocStackLogging` - see [FindingLeaks](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/FindingLeaks.html).

Here is the test flow I used:

```
# set env
cat <<EOF >>.env
LOCAL_MD_SERVER=true
CREATE_SYS_NAME=demo
CREATE_SYS_EMAIL=demo@noobaa.com
CREATE_SYS_PASSWD=DeMo1
NOOBAA_ROOT_SECRET='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
JWT_SECRET=123
EOF

mkdir -p memleak/db
mkdir -p memleak/storage

# start db
initdb -D memleak/db
postgres -D memleak/db
createuser postgres
createdb nbcore

# start core
npm run web
npm run bg
npm run hosted_agents

# start endpoint with malloc stack logging enabled
MallocStackLogging=1 npm run s3

# start nsfs (for s3 compat backing store)
node src/core nsfs --http_port 6003 --https_port 6004 --https_port_sts 6005 memleak/

# call apis to set up the bucket with nsfs backing store (token + conn + pool + tier + policy + bucket)
function nbapi() {
    curl localhost:5001/rpc -sd '{
        "api": "'$1'",
        "method": "'$2'",
        "params": '$3',
        "auth_token": "'$TOKEN'"
    }'
}
TOKEN=$(nbapi auth_api create_auth '{
    "role": "admin",
    "system": "demo",
    "email": "demo@noobaa.com",
    "password": "DeMo1"
}' | jq -r '.reply.token')
nbapi account_api add_external_connection '{
    "name": "conn1",
    "endpoint": "http://localhost:6003",
    "endpoint_type": "S3_COMPATIBLE",
    "identity": "unused",
    "secret": "unused"
}'
nbapi pool_api create_cloud_pool '{
    "name": "pool1",
    "connection": "conn1",
    "target_bucket": "storage"
}'
nbapi tier_api create_tier '{
    "name": "tier1",
    "attached_pools": ["pool1"]
}'
nbapi tiering_policy_api create_policy '{
    "name": "policy1",
    "tiers": [{ "order": 1, "tier": "tier1" }]
}'
nbapi bucket_api create_bucket '{
    "name": "bucket1",
    "tiering": "policy1"
}'

# put objects
alias s3='AWS_ACCESS_KEY_ID=123 AWS_SECRET_ACCESS_KEY=abc aws --endpoint http://localhost:6001 s3'
s3 ls
for i in `seq 33`; do echo "hello $i" | s3 cp - s3://bucket1/file$i; done
s3 ls bucket1

# find leaks
leaks $(pgrep -f "node src/s3")
```

