### PR TITLE
NSFS | Folders extended attributes 

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -157,7 +157,7 @@ const static std::map<std::string, int> flags_to_case = {
 };
 
 const static std::vector<std::string> GPFS_XATTRS{ GPFS_ENCRYPTION_XATTR_NAME };
-const static std::vector<std::string> USER_XATTRS{ "user.content_md5", "user.version_id", "user.prev_version_id", "user.delete_marker"};
+const static std::vector<std::string> USER_XATTRS{ "user.content_md5", "user.version_id", "user.prev_version_id", "user.delete_marker", "user.dir_content"};
 
 struct Entry
 {

--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -468,14 +468,9 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
                     await put_allow_all_bucket_policy(s3_admin, delete_object_test_bucket_dm);
                 });
 
-            mocha.it('delete version id - fake id - should fail with NoSuchKey', async function() {
+            mocha.it('delete version id - fake id - nothing to remove', async function() {
                 const max_version1 = await find_max_version_past(full_path, key1, '');
-                try {
-                    await account_with_access.deleteObject({ Bucket: delete_object_test_bucket_reg, Key: key1, VersionId: 'mtime-123-ino-123'}).promise();
-                    assert.fail('delete object should have failed on ENOENT');
-                } catch (err) {
-                    assert.equal(err.code, 'NoSuchKey');
-                }
+                await account_with_access.deleteObject({ Bucket: delete_object_test_bucket_reg, Key: key1, VersionId: 'mtime-123-ino-123'}).promise();
                 const max_version2 = await find_max_version_past(full_path, key1, '');
                 assert.equal(max_version1, max_version2);
             });

--- a/src/test/unit_tests/test_ns_list_objects.js
+++ b/src/test/unit_tests/test_ns_list_objects.js
@@ -221,6 +221,17 @@ function test_ns_list_objects(ns, object_sdk, bucket) {
             assert.deepStrictEqual(r.objects.map(it => it.key), [...fd, ...files_in_utf_diff_delimiter]);
         });
 
+        mocha.it('key_marker=folder229', async function() {
+            const r = await ns.list_objects({
+                bucket,
+                key_marker: 'folder229'
+            }, object_sdk);
+            assert.deepStrictEqual(r.is_truncated, false);
+            assert.deepStrictEqual(r.common_prefixes, []);
+            const fd = folders_to_upload.filter(folder => folder >= 'folder229/');
+            assert.deepStrictEqual(r.objects.map(it => it.key), [...fd, ...files_in_utf_diff_delimiter]);
+        });
+
         mocha.it('key_marker=folder1/', async function() {
             const r = await ns.list_objects({
                 bucket,
@@ -371,7 +382,8 @@ function test_ns_list_objects(ns, object_sdk, bucket) {
                 bucket,
                 key,
                 content_type: 'application/octet-stream',
-                source_stream: buffer_utils.buffer_to_read_stream(null)
+                source_stream: buffer_utils.buffer_to_read_stream(null),
+                size: 0
             }, object_sdk);
         }));
     }


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. FS Napi - added dir_content xattr to the USER_XATTRS vector.
2. test_namespace_fs - added unit tests
3. namespace_fs - 

    b. **list objects -** 
        - Skipped processing entry when entry is .folder file. 
        - Checked existence of XATTR_DIR_CONTENT xattr in the dir's xattr in process_dir and when evaluated to true the entry will be added to the objects list (when no delimiter or in other corner cases)

    c. **read_object_md -** added true to the call of get_version_path in order to get the directory path and not the .folder file when object is a directory content object.

    d. **upload_object / complete_multipart_upload -** 
d.1. upload_object - 
        * Created the .folder file only when content size > 0 when the entry is a directory.
        * Created _create_empty_dir_content function for the creation of directory objects of size 0 -  this function created 
               the directory key, sets the xattr on the directory, deleted the old directory if exists, and returns directory info as a 
               upload_info response.
       * On non-empty dir content - added a check to finish_upload() to not set the xattr on the object itself but put it on the 
       directory instead.
d.2. mpu - 
        * we always create a .folder file as we assume the size is always > 0
        * when object is a dir content object - 
               - skipped set xattr on .folder. 
               - replaced old xattr with new xattr and added XATTR_DIR_OBJ xattr to the directory. 
               - no override case - as we assume size > 0.

    e. **delete_object / delete_multiple_objects -** 
        - Unlink - skipped when the file is .folder and error code is ENOENT (needed for directory objects of size 0)
        - Called clear xattr on directories ( needed for non-empty directory objects )
        
     f. **get_object -**  called stat when the file is .folder and checked if XATTR_DIR_CONTENT xattr exists, if yes, returned {};  (needed for directory objects of size 0)

### Issues: Fixed #xxx / Gap #xxx
1. gap - upgrade script for existing directory objects (need to copy .folder xattr to the folder itself)
2. Fixed #https://github.com/noobaa/noobaa-core/issues/6980

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
