### PR TITLE
[Backport to 5.11] Bump moment from 2.29.3 to 2.29.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4560,9 +4560,9 @@
       }
     },
     "moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
       "version": "0.5.34",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "lodash": "4.17.21",
     "mime": "3.0.0",
     "minimist": "1.2.6",
-    "moment": "2.29.3",
+    "moment": "2.29.4",
     "moment-timezone": "0.5.34",
     "mongo-query-to-postgres-jsonb": "0.2.14",
     "mongodb": "3.7.3",

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -150,9 +150,7 @@ if (config.PROMETHEUS_ENABLED) {
 }
 
 app.get('/', function(req, res) {
-    // Forward any query parameters
-    const [, query = ''] = req.url.split(/(?=\?)/);
-    return res.redirect(`/fe/${query}`);
+    return res.redirect(`/version`);
 });
 
 // Upgrade checks


### PR DESCRIPTION
### Explain the changes
1. Bump moment from 2.29.3 to 2.29.4

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2108751
2. https://bugzilla.redhat.com/show_bug.cgi?id=2108754

