### PR TITLE
Fix build native on Mac

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -50,7 +50,9 @@ const static std::map<std::string, int> flags_to_case = {
     { "rs+", O_RDWR | O_SYNC },
     { "sr+", O_RDWR | O_SYNC },
     { "w", O_TRUNC | O_CREAT | O_WRONLY },
-    { "wt", O_RDWR | O_TMPFILE },
+    #ifdef O_TMPFILE
+        { "wt", O_RDWR | O_TMPFILE },
+    #endif
     { "wx", O_TRUNC | O_CREAT | O_WRONLY | O_EXCL },
     { "xw", O_TRUNC | O_CREAT | O_WRONLY | O_EXCL },
     { "w+", O_TRUNC | O_CREAT | O_RDWR },


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Avoid using O_TMPFILE when it's not available( specifically in Mac)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
