### PR TITLE
🌸🍒 mdsequence cherries

### DIFF
--- a/config.js
+++ b/config.js
@@ -596,6 +596,11 @@ config.QUOTA_MAX_OBJECTS = Number.MAX_SAFE_INTEGER;
 //////////////////////////
 config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
 
+///////////////////////////////////////////
+//      PostgreSQL client pool size      //
+///////////////////////////////////////////
+config.POSTGRES_MAX_CLIENTS = (process.env.LOCAL_MD_SERVER === 'true') ? 80 : 10;
+
 /////////////////////
 //                 //
 //    OVERRIDES    //

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -656,6 +656,7 @@ interface DBClient {
     get_db_name(): string;
 
     define_collection(params: object): DBCollection;
+    define_sequence(params: object): DBSequence;
     collection(name: string): DBCollection;
     validate(name: string, doc: object, warn?: 'warn'): object;
 
@@ -684,6 +685,10 @@ interface DBClient {
     check_entity_not_deleted(doc: object, entity: string): object;
     check_update_one(res: object, entity: string): void;
     make_object_diff(current: object, prev: object): object;
+}
+
+interface DBSequence {
+    nextsequence(): Promise<number>;
 }
 
 interface DBCollection {

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -55,7 +55,7 @@ class MDStore {
             schema: data_block_schema,
             db_indexes: data_block_indexes,
         });
-        this._sequences = db_client.instance().define_collection({
+        this._sequences = db_client.instance().define_sequence({
             name: 'mdsequences' + test_suffix,
         });
     }
@@ -397,12 +397,7 @@ class MDStore {
      * @returns {Promise<number>}
      */
     async alloc_object_version_seq() {
-        // empty query, we maintain a single doc in this collection
-        const query = {};
-        const update = { $inc: { object_version_seq: 1 } };
-        const options = { upsert: true, returnOriginal: false };
-        let res = await this._sequences.findOneAndUpdate(query, update, options);
-        return res.value.object_version_seq;
+        return this._sequences.nextsequence();
     }
 
     /**

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -181,7 +181,7 @@ class MDStore {
             upload_started: null,
         }, {
             hint: 'null_version_index',
-            sort: { bucket: 1, key: 1, version_enabled: 1 },
+            sort: { bucket: 1, key: 1 },
         });
     }
 
@@ -194,7 +194,7 @@ class MDStore {
             // partialFilterExpression:
             deleted: null,
         }, {
-            sort: { bucket: 1, key: 1, version_enabled: 1 },
+            sort: { bucket: 1, key: 1 },
         });
     }
 

--- a/src/test/unit_tests/test_postgres_client.js
+++ b/src/test/unit_tests/test_postgres_client.js
@@ -13,6 +13,7 @@ const _ = require('lodash');
 const wtf = require('wtfnode');
 const P = require('../../util/promise');
 // const { date } = require('azure-storage');
+const { MongoSequence } = require('../../util/mongo_client');
 
 
 const test_schema = {
@@ -199,7 +200,18 @@ mocha.describe('postgres_client', function() {
         assert.strictEqual(find_res.length, 1, 'number of inserted documents must be 1');
     });
 
-
+    mocha.it('should migrate from mongo sequence', async function() {
+        const name = 'testsequence';
+        if (!postgres_client.is_connected) await postgres_client.connect();
+        const mongoSeq = new MongoSequence({ name, client: postgres_client });
+        let start;
+        for (let i = 0; i < Math.floor(Math.random() * 100) + 1; i++) {
+            start = await mongoSeq.nextsequence();
+        }
+        const nativeSeq = postgres_client.define_sequence({name});
+        const nativestart = await nativeSeq.nextsequence();
+        assert.equal(start + 2, nativestart);
+    });
 
 
     // mocha.it('should find by sort order', async function() {

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1323,7 +1323,7 @@ class PostgresClient extends EventEmitter {
         this.new_pool_params = {
 
             // TODO: check the effect of max clients. default is 10
-            // max: 50,
+            max: config.POSTGRES_MAX_CLIENTS,
 
             host: process.env.POSTGRES_HOST || 'localhost',
             user: process.env.POSTGRES_USER || 'postgres',


### PR DESCRIPTION
# PostgreSQL-related performance optimization.

Those changes were 🌸🍒 cherry-picked from [dannyzaken/noobaa-core/tree/danny-mdsequence](https://github.com/dannyzaken/noobaa-core/tree/danny-mdsequence)

- Use PostgreSQL sequence
   - currently mdsequence is using a counter inside a jsonb field, which has very bad performance in parallel writes. 
   - changed to use postgres native SEQUENCE.
- Increase  PostgreSQL client connections pool size if `LOCAL_MD_SERVER`
   - for the endpoints, we saw that when a large number of small writes is done in parallel, a lot of queries are waiting for clients. the DB has max connections of 600, so it should be able to handle more connections.
- Remove sort by version_enabled in find_object_null_version
   - For some reason, the generated query is causing Postgres to perform a sort according to `version_enabled`, even though the index is also on `version_enabled`.
   - `version_enabled` is always null in this case, and the sort is redundant. removing it solved the issue. 