### PR TITLE
Send the nsfs stats from the endpoint to the core

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -580,6 +580,9 @@ class NamespaceFS {
                 const remain_size = Math.max(0, end - pos);
                 const read_size = Math.min(buffer.length, remain_size);
 
+                //TODO: We probably have an issue with counting the bytes in the read 
+                // We need to find it and fix
+
                 // Update the read stats               
                 stats_collector.instance(object_sdk.rpc_client).update_nsfs_read_stats({
                     namespace_resource_id: this.namespace_resource_id,


### PR DESCRIPTION
### Explain the changes

Send the nsfs stats from the endpoint to the core

This PR continues the work from #7026 and #7027 

Signed-off-by: liranmauda <liran.mauda@gmail.com>
