### PR TITLE
Fix some few failing RGW tests

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -38,7 +38,7 @@ async function get_bucket(req) {
     return {
         ListBucketResult: [{
                 Name: req.params.bucket,
-                Prefix: req.query.prefix || undefined,
+                Prefix: req.query.prefix,
                 Delimiter: req.query.delimiter || undefined,
                 MaxKeys: max_keys_received,
                 IsTruncated: reply.is_truncated,
@@ -50,7 +50,7 @@ async function get_bucket(req) {
                     NextContinuationToken: key_marker_to_cont_tok(
                         reply.next_marker, reply.objects, reply.is_truncated),
                 } : { // list_type v1
-                    Marker: req.query.marker,
+                    Marker: req.query.marker || '',
                     NextMarker: req.query.delimiter ? reply.next_marker : undefined,
                 }),
             },


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
This PR attempts to fixes a few failing tests namely:
1. `test_bucket_list_prefix_empty`
2. `test_bucket_listv2_prefix_empty`
3. `test_bucket_listv2_prefix_none`
4. `test_bucket_list_prefix_none`
5. `test_bucket_list_marker_none`
6. `test_bucket_listv2_delimiter_basic`

### Testing Instructions:
Preq: These tests require `noobaa-tester` image to already present on the machine, to build the image run - `make tester`

1. Run `cd ./src/test/framework/ && ./run_test_job.sh --name utk --image noobaa --tester_image noobaa-tester --tests_list ./system_tests_list.js --job_yaml ../../../.travis/travis_test_job.yaml --wait`
2. Run `kubectl logs -f -n <namespace> <pod>` to get the logs immediately.



- [ ] Doc added/updated
- [ ] Tests added
