### PR TITLE
GitHub actions - multiarch

### DIFF
--- a/.github/workflows/manual-full-build.yaml
+++ b/.github/workflows/manual-full-build.yaml
@@ -1,5 +1,7 @@
-name: Manual Build Dispatch
-on: 
+#
+# Multiplatform amd64/arm64/ppc64le image build w/ manifest
+#
+name: Manual Buildah Dispatch
   workflow_dispatch:
     inputs:
       branch:
@@ -10,13 +12,30 @@ on:
         default: ''
 
 jobs:
-  manual-build-and-publish-image:
-    runs-on: ubuntu-latest
+  manual-buildah-and-publish-image:
+    runs-on: ubuntu-22.04
+    env:
+      PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le"
+      GIT_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.branch }}
+
+      - name: Enable emulation
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            qemu qemu-user-static
+          sudo update-binfmts --display
+          echo "ℹ️ podman"
+          podman version
+          echo "ℹ️ buildah"
+          buildah version
+          echo "ℹ️ skopeo"
+          skopeo -v
+
 
       - name: Get Current Date
         id: date
@@ -46,41 +65,65 @@ jobs:
           echo ::set-output name=ocsdevlatest::${CORE_OCS_DEV_TAG}
 
       - name: Login to DockerHub Registry
-        run: echo ${{ secrets.GHACTIONSDOCKERHUB }} | docker login -u ${{ secrets.GHACTIONSDOCKERHUBNAME }} --password-stdin
+        run: echo ${{ secrets.GHACTIONSDOCKERHUB }} | podman login -u ${{ secrets.GHACTIONSDOCKERHUBNAME }} --password-stdin
 
-      - name: Build & Push Docker Images to DockerHub
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.GHACTIONQUAYTOKEN }} | podman login quay.io -u ${{ secrets.GHACTIONQUAYNAME }} --password-stdin
+
+      - name: Build Builder Images
+        run: |
+          buildah build \
+            -f src/deploy/NVA_build/builder.Dockerfile \
+            --platform=$PLATFORMS \
+            --manifest localhost/noobaa-builder
+          echo "ℹ️ Inspect noobaa-builder manifest"
+          skopeo inspect --raw containers-storage:localhost/noobaa-builder
+
+      - name: Build Base Images
+        run: |
+          buildah build \
+            -f src/deploy/NVA_build/Base.Dockerfile \
+            --platform=$PLATFORMS \
+            --manifest localhost/noobaa-base
+          echo "ℹ️ Inspect noobaa-base manifest"
+          skopeo inspect --raw containers-storage:localhost/noobaa-base
+
+      - name: Build NooBaa Images
+        run: |
+          buildah build \
+            -f src/deploy/NVA_build/NooBaa.Dockerfile \
+            --build-arg GIT_COMMIT=$GIT_COMMIT \
+            --platform=$PLATFORMS \
+            --manifest localhost/noobaa
+          echo "ℹ️ Inspect noobaa manifest"
+          skopeo inspect --raw containers-storage:localhost/noobaa
+
+      - name: Push Docker Images to DockerHub
         env:
           DOCKERHUB_OWNER: ${{ secrets.GHACTIONSDOCKERHUBNAME }}
         run: |
-            make noobaa
-            docker tag noobaa-base ${{ steps.prep.outputs.basetags }}
-            docker push ${{ steps.prep.outputs.basetags }}
-            docker tag noobaa-builder ${{ steps.prep.outputs.buildertags }}
-            docker push ${{ steps.prep.outputs.buildertags }}
-            docker tag noobaa ${{ steps.prep.outputs.coretags }}
-            docker push ${{ steps.prep.outputs.coretags }}
+          buildah tag localhost/noobaa-base ${{ steps.prep.outputs.basetags }}
+          podman manifest push --all  ${{ steps.prep.outputs.basetags }} docker://${{ steps.prep.outputs.basetags }}
+          buildah tag localhost/noobaa-builder ${{ steps.prep.outputs.buildertags }}
+          podman manifest push --all  ${{ steps.prep.outputs.buildertags }} docker://${{ steps.prep.outputs.buildertags }}
+          buildah tag localhost/noobaa ${{ steps.prep.outputs.coretags }}
+          podman manifest push --all  ${{ steps.prep.outputs.coretags }} docker://${{ steps.prep.outputs.coretags }}
 
-      - name: Login to Quay Registry
-        run: echo ${{ secrets.GHACTIONQUAYTOKEN }} | docker login quay.io -u ${{ secrets.GHACTIONQUAYNAME }} --password-stdin
-      
       - name: Push Docker Images to Quay
         env:
           DOCKERHUB_OWNER: ${{ secrets.GHACTIONQUAYNAME }}
         run: |
-            docker tag ${{ steps.prep.outputs.coretags }} quay.io/${{ steps.prep.outputs.coretags }}
-            docker push quay.io/${{ steps.prep.outputs.coretags }}
+          buildah tag ${{ steps.prep.outputs.coretags }} quay.io/${{ steps.prep.outputs.coretags }}
+          podman manifest push --all  quay.io/${{ steps.prep.outputs.coretags }} docker://quay.io/${{ steps.prep.outputs.coretags }}
 
       - name: Push to ocs-dev as latest
         env:
           DOCKERHUB_OWNER: ${{ secrets.GHACTIONQUAYNAME }}
         run: |
-          docker login -u="${{ secrets.OCSDEVCIUSER }}" -p="${{ secrets.OCSDEVCITOKEN }}" quay.io
-          docker tag ${{ steps.prep.outputs.coretags }} quay.io/${{ steps.prep.outputs.ocsdevlatest }} 
-          docker push quay.io/${{ steps.prep.outputs.ocsdevlatest }}
-          
-      - name: Sleep for 180 seconds
-        run: sleep 180s
-        shell: bash
+          podman login -u="${{ secrets.OCSDEVCIUSER }}" -p="${{ secrets.OCSDEVCITOKEN }}" quay.io
+
+          buildah tag ${{ steps.prep.outputs.coretags }} quay.io/${{ steps.prep.outputs.ocsdevlatest }}
+          podman manifest push --all  quay.io/${{ steps.prep.outputs.ocsdevlatest }} docker://quay.io/${{ steps.prep.outputs.ocsdevlatest }}
 
       - name: Invoke Build on Operator Repo
         uses: benc-uk/workflow-dispatch@v1
@@ -89,6 +132,3 @@ jobs:
           repo: noobaa/noobaa-operator
           token: ${{ secrets.GHACCESSTOKEN }}
           inputs: '{ "branch": "${{ github.event.inputs.branch }}", "tag": "${{ github.event.inputs.tag }}" }'
-      
-
-            


### PR DESCRIPTION
Based on [buildah](https://buildah.io/) and Linux [binfmt](https://github.com/multiarch/qemu-user-static) emulation

- multiarch build with a manifest
- depends on https://github.com/noobaa/noobaa-core/pull/7028

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>