### PR TITLE
fixed native build on mac

### DIFF
--- a/src/native/common.gypi
+++ b/src/native/common.gypi
@@ -61,7 +61,7 @@
             [ 'OS=="mac"', {
                 'xcode_settings': {
                     # Reference - http://help.apple.com/xcode/mac/8.0/#/itcaec37c2a6
-                    'MACOSX_DEPLOYMENT_TARGET': '10.15',
+                    'MACOSX_DEPLOYMENT_TARGET': '12.4',
                     'CLANG_CXX_LIBRARY': 'libc++',
                     'CLANG_CXX_LANGUAGE_STANDARD': 'c++17', # -std=c++17
                     'GCC_C_LANGUAGE_STANDARD': 'c99', # -std=c99

--- a/src/native/nb_native.gyp
+++ b/src/native/nb_native.gyp
@@ -8,6 +8,7 @@
             [ 'OS=="mac"', {
                 'xcode_settings': {
                     'WARNING_CFLAGS': ['<@(cflags_warnings)'],
+                     'OTHER_CFLAGS': ['-DUSE_SSSE3', '-msse4.1'],
                 },
             }],
             [ 'node_arch=="x64"', {

--- a/src/native/third_party/cm256.gyp
+++ b/src/native/third_party/cm256.gyp
@@ -7,7 +7,7 @@
             [ 'node_arch=="x64"', {
                 'conditions' : [
                     [ 'OS=="linux"', { 'cflags': ['-DUSE_SSSE3', '-mssse3'] }],
-                    [ 'OS=="mac"', { 'xcode_settings': { 'OTHER_CFLAGS': ['-msse4.1'] } }],
+                    [ 'OS=="mac"', { 'xcode_settings': { 'OTHER_CFLAGS': ['-DUSE_SSSE3', '-msse4.1'] } }],
                 ],
             }],
             [ 'node_arch=="arm64"', {


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
1. Fixed native build after third party updates
2. Gap - in M1 macs (arm), the build still produces x86 binaries (running with rosetta). 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
