### PR TITLE
Fixed map_common_prefixes queries

### DIFF
--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -835,29 +835,21 @@ class PostgresTable {
         let mr_q;
         sql_query.where = mongo_to_pg('data', encode_json(this.schema, options.query), { disableContainmentQuery: true });
         sql_query.order_by = options.sort && convert_sort(options.sort);
-        sql_query.limit = options.limit;
-        let query_string = `SELECT * FROM ${this.name} WHERE ${sql_query.where}`;
-        if (sql_query.order_by) {
-            query_string += ` ORDER BY ${sql_query.order_by}`;
-        }
-        if (sql_query.limit) {
-            query_string += ` LIMIT ${sql_query.limit}`;
-        }
+        sql_query.limit = options.limit || 1000;
         try {
-            mr_q = `SELECT _id, json_agg(value) FROM map_common_prefixes('${options.scope.prefix || ''}', '${options.scope.delimiter || ''}', $$${query_string}$$) GROUP BY _id`;
+            mr_q = `SELECT _id, value FROM map_common_prefixes('${options.scope.prefix || ''}', '${options.scope.delimiter || ''}', $$${sql_query.where}$$, $$${sql_query.order_by}$$, ${sql_query.limit})`;
             const res = await this.single_query(mr_q);
             return res.rows.map(row => {
                 const r_row = { _id: row._id };
-                if (row.json_agg[0] === null) {
-                    // TODO: I know that the isn't beautiful and we have array of nulls
-                    return _.defaults(r_row, { value: row.json_agg.length });
+                if (row.value === null) {
+                    return _.defaults(r_row, { value: 1 });
                 } else {
                     // _id is unique per object
-                    return _.defaults(r_row, { value: decode_json(this.schema, row.json_agg[0]) });
+                    return _.defaults(r_row, { value: decode_json(this.schema, row.value) });
                 }
             });
         } catch (err) {
-            dbg.error('mapReduceListObjects failed', options, query_string, mr_q, err);
+            dbg.error('mapReduceListObjects failed', options, mr_q, err);
             throw err;
         }
     }

--- a/src/util/sql_functions/map_common_prefixes.sql
+++ b/src/util/sql_functions/map_common_prefixes.sql
@@ -1,35 +1,45 @@
-CREATE OR REPLACE FUNCTION map_common_prefixes(TEXT, TEXT, TEXT) RETURNS TABLE(_id TEXT[], value JSON) AS $$
+CREATE OR REPLACE FUNCTION map_common_prefixes(prefix TEXT, delimiter TEXT, query_filter TEXT, sort TEXT, max_keys INTEGER) RETURNS TABLE(_id TEXT[], value JSON) AS $$
 DECLARE
-    prefix ALIAS FOR $1;
-    delimiter ALIAS FOR $2;
-    cur_query ALIAS FOR $3;
+    total_count INTEGER := 0;
     suffix TEXT;
     pos INTEGER;
     cut_prefix TEXT;
     rec_key TEXT;
     rec_id TEXT;
+    cur_query TEXT;
+    next_marker_query TEXT;
+    next_marker TEXT;
     rec RECORD;
     cur REFCURSOR;
 BEGIN
+  cur_query := 'SELECT * FROM objectmds WHERE ' || query_filter || ' ORDER BY ' || sort;
   OPEN cur FOR EXECUTE cur_query; 
   FETCH NEXT FROM cur INTO rec;
-  WHILE FOUND 
-  LOOP
-    rec_key := rec.data->>'key';
-    suffix := substring(rec_key from length(prefix) + 1);
-    pos := position(delimiter in suffix);
-    IF pos > 0 THEN
-        cut_prefix := substring(suffix from 1 for pos);
-        _id := ARRAY [cut_prefix, 'common_prefix'];
-        value := null;
-    ELSE
-        rec_id := rec.data->>'_id';
-        _id := ARRAY [suffix, rec_id];
-        value := rec.data;
-    END IF;
-    RETURN NEXT;
-    FETCH NEXT FROM cur INTO rec; 
-  END LOOP;
+  WHILE FOUND AND total_count < max_keys
+    LOOP
+      rec_key := rec.data->>'key';
+      suffix := substring(rec_key from length(prefix) + 1);
+      pos := position(delimiter in suffix);
+
+      IF pos > 0 THEN
+          cut_prefix := substring(suffix from 1 for pos);
+          _id := ARRAY [cut_prefix, 'common_prefix'];
+          value := null;
+          -- a common prefix is found, so we can skip the rest of the keys with the same prefix
+          -- as the next_marker, use the common prefix "incremented" by 1 (inc the last char)
+          next_marker := prefix || substring(cut_prefix from 1 for length(cut_prefix) - 1) || chr(ascii(delimiter) + 1);
+          cur_query:= 'SELECT * FROM objectmds WHERE ' || query_filter || ' AND data->>' || quote_literal('key') || ' >= ' || quote_literal(next_marker) || ' ORDER BY ' || sort;
+          CLOSE cur;
+          OPEN cur FOR EXECUTE cur_query;
+      ELSE
+          rec_id := rec.data->>'_id';
+          _id := ARRAY [suffix, rec_id];
+          value := rec.data;
+      END IF;
+      total_count := total_count + 1;
+      RETURN NEXT;
+      FETCH NEXT FROM cur INTO rec; 
+    END LOOP;
   CLOSE cur; 
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Explain the changes
* Changed pl/sql function `map_common_prefixes` to fetch all required entries in one call.
* instead of querying for 1000 keys and then extracting the common prefixes from it (can be very few common prefixes if there are a lot of objects in that "dir"), it iterates over the objectmds until reaching the max keys or the end.
* To avoid unnecessary scanning of objects - if we find a common prefix, we set the marker to be the next possible value for a common prefix (by incrementing the last character by 1)
* These changes rely on the DB having collation of LC_COLLATE = 'C'. it will not work on DBs with utf8 collation

### Issues: Fixed #xxx / Gap #xxx
1. More cleanup can be done after this change. for example, it is probably unnecessary to redo the list_object queries in the object_server, since now it should return all of the required count
https://github.com/noobaa/noobaa-core/blob/5b6bcb568bbb699e735523067b83a37e622e8db9/src/server/object_services/object_server.js#L1028-L1031

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
