### PR TITLE
Sending the report of nsfs_stats to `/metrics/nsfs_stats`

### DIFF
--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -33,6 +33,7 @@ const db_client = require('../util/db_client');
 const system_store = require('./system_services/system_store').get_instance();
 const prom_reporting = require('./analytic_services/prometheus_reporting');
 const account_server = require('./system_services/account_server');
+const stats_aggregator = require('./system_services/stats_aggregator');
 const addr_utils = require('../util/addr_utils');
 const kube_utils = require('../util/kube_utils');
 const http_utils = require('../util/http_utils');
@@ -284,6 +285,23 @@ app.get('/version', (req, res) => getVersion(req.url)
         res.end();
     })
 );
+
+
+// Get the NSFS stats
+app.get('/metrics/nsfs_stats', async (req, res) => {
+    const report = _create_nsfs_report();
+    res.send(report);
+    res.status(200).end();
+});
+
+function _create_nsfs_report() {
+    const nsfs_counters = stats_aggregator.get_nsfs_stats();
+    let nsfs_report = '';
+    for (const [key, value] of Object.entries(nsfs_counters)) {
+        nsfs_report += `NooBaa_nsfs_${key}: ${value}<br>`;
+    }
+    return nsfs_report;
+}
 
 ////////////
 // STATIC //


### PR DESCRIPTION
### Explain the changes
Sending the report of nsfs_stats to `/metrics/nsfs_stats`

Signed-off-by: liranmauda <liran.mauda@gmail.com>

### Testing Instructions:
1. [ create nsfs bucket](https://github.com/noobaa/noobaa-core/wiki/NSFS-on-Kubernetes)
2. Write and read files from the bucket
3. Go to the mgmt URL in the `/metrics/nsfs_stats` and see the nsfs stats

![https___192_168_64_169_30291_metrics_nsfs_stats](https://user-images.githubusercontent.com/28217223/184126640-06681c3f-0a24-4d77-a7df-96510afdd826.png)

