### PR TITLE
Fix postgres unique indexes for new deployments

### DIFF
--- a/src/server/object_services/schemas/object_md_indexes.js
+++ b/src/server/object_services/schemas/object_md_indexes.js
@@ -11,9 +11,9 @@ module.exports = [
         fields: {
             bucket: 1,
             key: 1,
-            // we include version_past as extra index field to separate from null_version_index.
+            // For MONGO deployments - we include version_past as extra index field to separate from null_version_index.
             // note that version_past is always null here by partialFilterExpression.
-            version_past: 1,
+            ...(process.env.DB_TYPE === 'postgres' ? {} : { version_past: 1 })
         },
         options: {
             name: 'latest_version_index',
@@ -36,9 +36,9 @@ module.exports = [
         fields: {
             bucket: 1,
             key: 1,
-            // we include version_enabled as extra index field to separate from latest_version_index.
+            // For MONGO deployments - we include version_enabled as extra index field to separate from latest_version_index.
             // note that version_enabled is always null here by partialFilterExpression.
-            version_enabled: 1,
+            ...(process.env.DB_TYPE === 'postgres' ? {} : { version_enabled: 1 })
         },
         options: {
             name: 'null_version_index',


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. Removed version_past from latest_version_index index because Postgres considers nulls as distinct, causing multiple latest versions of objectmds to be allowed.
2. Removed version_enabled from null_version_index index because Postgres considers nulls as distinct, causing multiple latest versions of objectmds to be allowed.

This is the same PR as https://github.com/noobaa/noobaa-core/pull/7031 & https://github.com/noobaa/noobaa-core/pull/7042 as we decided to not support upgrades.


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
