### PR TITLE
Collecting ops stats and sending it to the to `/metrics/nsfs_stats`

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -839,6 +839,45 @@ module.exports = {
             }
         },
 
+        op_stats: {
+            type: 'object',
+            properties: {
+                create_bucket: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                delete_bucket: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                upload_object: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                delete_object: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+            }
+        },
+
+        op_stats_val: {
+            type: 'object',
+            properties: {
+                min_time: {
+                    type: 'integer'
+                },
+                max_time: {
+                    type: 'integer'
+                },
+                sum_time: {
+                    type: 'integer'
+                },
+                count: {
+                    type: 'integer'
+                },
+                error_count: {
+                    type: 'integer'
+                },
+            },
+        },
+
         bucket_name: {
             wrapper: SensitiveString,
         },

--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -156,6 +156,9 @@ module.exports = {
                             },
                             io_stats: {
                                 $ref: 'common_api#/definitions/io_stats'
+                            },
+                            op_stats: {
+                                $ref: 'common_api#/definitions/op_stats'
                             }
                         }
                     },

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -555,9 +555,23 @@ class ObjectSDK {
     }
 
     async upload_object(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        if (params.copy_source) await this.fix_copy_source_params(params, ns);
-        const reply = await ns.upload_object(params, this);
+        const start_time = Date.now();
+        let reply;
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            if (params.copy_source) await this.fix_copy_source_params(params, ns);
+            reply = await ns.upload_object(params, this);
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `upload_object`,
+                error,
+            });
+        }
         // update bucket counters
         stats_collector.instance(this.internal_rpc_client).update_bucket_write_counters({
             bucket_name: params.bucket,
@@ -629,8 +643,22 @@ class ObjectSDK {
     ///////////////////
 
     async delete_object(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        return ns.delete_object(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            const reply = await ns.delete_object(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `delete_object`,
+                error,
+            });
+        }
     }
 
     async delete_multiple_objects(params) {
@@ -672,13 +700,41 @@ class ObjectSDK {
     }
 
     async create_bucket(params) {
-        const bs = this._get_bucketspace();
-        return bs.create_bucket(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const bs = this._get_bucketspace();
+            const reply = await bs.create_bucket(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `create_bucket`,
+                error,
+            });
+        }
     }
 
     async delete_bucket(params) {
-        const bs = this._get_bucketspace();
-        return bs.delete_bucket(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const bs = this._get_bucketspace();
+            const reply = await bs.delete_bucket(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `delete_bucket`,
+                error,
+            });
+        }
     }
 
     //////////////////////

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -295,11 +295,25 @@ app.get('/metrics/nsfs_stats', async (req, res) => {
 });
 
 function _create_nsfs_report() {
-    const nsfs_counters = stats_aggregator.get_nsfs_stats();
     let nsfs_report = '';
+
+    const nsfs_counters = stats_aggregator.get_nsfs_io_stats();
+    // Building the report per io and value
     for (const [key, value] of Object.entries(nsfs_counters)) {
         nsfs_report += `NooBaa_nsfs_${key}: ${value}<br>`;
     }
+
+    const op_stats = stats_aggregator.get_op_stats();
+    // Building the report per op name key and value
+    for (const [op_name, obj] of Object.entries(op_stats)) {
+        nsfs_report += `<br>`;
+        for (const [key, value] of Object.entries(obj)) {
+            nsfs_report += `NooBaa_nsfs_${op_name}_${key}: ${value}<br>`;
+        }
+    }
+
+    dbg.log1(`_create_nsfs_report: nsfs_report ${nsfs_report}`);
+
     return nsfs_report;
 }
 


### PR DESCRIPTION
### Explain the changes

**_This PR is only about the ops, FS timing will be added in a later PR_**

Collecting ops stats and sending them to the `metrics/nsfs_stats`

- Added `op_stats` to `stats_api`
- Added Timing in `object_sdk`
- Added function that creates the report with the op stats

### Gaps:
1. ~Error is not being counted yet.~
2. Added only create a bucket, delete a bucket,  put an object, delete object ops.
3. Each op (and each io) is calling the `_trigger_send_stats` We want to consider changing that and make it a BG worker.

### Testing Instructions:
1. Create a bucket/upload object/delete and object/delete a bucket
2. go to `/metrics/nsfs_stats` see that the stats exists.

![https___192_168_64_179_32750_metrics_nsfs_stats](https://user-images.githubusercontent.com/28217223/188309920-8a3477e0-7481-4de0-b547-5452300336a7.png)


