### PR TITLE
Support optional namespace write resource

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1083,7 +1083,6 @@ module.exports = {
                     type: 'object',
                     required: [
                         'read_resources',
-                        'write_resource',
                     ],
                     properties: {
                         read_resources: {
@@ -1356,7 +1355,7 @@ module.exports = {
 
         namespace_bucket_config: {
             type: 'object',
-            required: ['write_resource', 'read_resources'],
+            required: ['read_resources'],
             properties: {
                 write_resource: {
                     $ref: '#/definitions/namespace_resource_config'

--- a/src/sdk/namespace_merge.js
+++ b/src/sdk/namespace_merge.js
@@ -34,10 +34,8 @@ class NamespaceMerge {
     }
 
     is_readonly_namespace() {
-        if (!_.isEmpty(this.namespaces.write_resource)) {
-            return this.namespaces.write_resource.is_readonly_namespace();
-        }
-        return true;
+        if (_.isUndefined(this.namespaces.write_resource)) return true;
+        return this.namespaces.write_resource.is_readonly_namespace();
     }
 
     /////////////////

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -88,7 +88,6 @@ module.exports = {
             type: 'object',
             required: [
                 'read_resources',
-                'write_resource',
             ],
             properties: {
                 read_resources: {

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -24,12 +24,15 @@ mocha.describe('system_servers', function() {
     const TIERING_POLICY = `${PREFIX}-tiering-policy`;
     const BUCKET = `${PREFIX}-bucket`;
     const NAMESPACE_BUCKET = `${PREFIX}-namespace-bucket`;
+    const NAMESPACE_BUCKET_SINGLE_NO_WR = `${PREFIX}-namespace-bucket-single-no-wr`;
+    const NAMESPACE_BUCKET_MERGE_NO_WR = `${PREFIX}-namespace-bucket-merge-no-wr`;
     const SYS1 = `${PREFIX}-${SYSTEM}-1`;
     const EMAIL1 = `${PREFIX}-${EMAIL}`;
     const EMAIL2 = `${PREFIX}-${EMAIL}2`;
     const EMAIL3 = `${PREFIX}-${EMAIL}3`;
     const NAMESPACE_RESOURCE_CONNECTION = 'Majestic Namespace Sloth';
     const NAMESPACE_RESOURCE_NAME = `${PREFIX}-namespace-resource`;
+    const NAMESPACE_RESOURCE_NAME_2 = `${PREFIX}-namespace-resource-2`;
     ///////////////
     //  ACCOUNT  //
     ///////////////
@@ -485,6 +488,7 @@ mocha.describe('system_servers', function() {
             target_bucket: BUCKET
         });
         const nsr = { resource: NAMESPACE_RESOURCE_NAME };
+        const nsr2 = { resource: NAMESPACE_RESOURCE_NAME_2 };
         await rpc_client.bucket.create_bucket({
             name: NAMESPACE_BUCKET,
             namespace: {
@@ -492,7 +496,21 @@ mocha.describe('system_servers', function() {
                 write_resource: nsr
             },
         });
+        await rpc_client.bucket.create_bucket({
+            name: NAMESPACE_BUCKET_SINGLE_NO_WR,
+            namespace: {
+                read_resources: [nsr]
+            },
+        });
+        await rpc_client.bucket.create_bucket({
+            name: NAMESPACE_BUCKET_MERGE_NO_WR,
+            namespace: {
+                read_resources: [nsr, nsr2]
+            },
+        });
         await rpc_client.bucket.delete_bucket({ name: NAMESPACE_BUCKET });
+        await rpc_client.bucket.delete_bucket({ name: NAMESPACE_BUCKET_SINGLE_NO_WR });
+        await rpc_client.bucket.delete_bucket({ name: NAMESPACE_BUCKET_MERGE_NO_WR });
         await rpc_client.pool.delete_namespace_resource({ name: NAMESPACE_RESOURCE_NAME });
         await rpc_client.account.delete_external_connection({ connection_name: NAMESPACE_RESOURCE_CONNECTION });
     });


### PR DESCRIPTION
Signed-off-by: Kfir Payne <kfirpayne@gmail.com>

### Explain the changes
1. Setup single namespace based on the first read resource.
2. Setup merge namespace with support of optional write resource.
3. Remove write resource from the `required` rules in the bucket_api.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
