### PR TITLE
[Fix]: allow admin account to perform any action on the system

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -218,9 +218,8 @@ async function authorize_request_policy(req) {
     const account = await req.object_sdk.rpc_client.account.read_account({});
     const is_system_owner = account.email.unwrap() === system_owner.unwrap();
 
-    // system owner by design can always change bucket policy
-    // bucket owner and bucket claim owner has FC ACL by design - so no need to check bucket policy
-    if (is_system_owner && req.op_name.endsWith('bucket_policy')) return;
+    // @TODO: System owner as a construct should be removed - Temporary
+    if (is_system_owner) return;
 
     const is_owner = (function() {
         if (account.bucket_claim_owner && account.bucket_claim_owner.unwrap() === req.params.bucket) return true;

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -658,6 +658,8 @@ function _get_auth_info(account, system, authorized_by, role, extra) {
  * the given action on the given bucket.
  * 
  * The evaluation takes into account
+ *  @TODO: System owner as a construct needs to be removed 
+ *  - system owner must be able to access all buckets 
  *  - the bucket's owner account
  *  - the bucket claim owner
  *  - the bucket policy
@@ -669,6 +671,10 @@ function _get_auth_info(account, system, authorized_by, role, extra) {
  */
 function has_bucket_action_permission(bucket, account, action, bucket_path = "") {
     dbg.log0('has_bucket_action_permission:', bucket.name, account.email, bucket.owner_account.email);
+
+    // If the system owner account wants to access the bucket, allow it
+    if (bucket.system.owner.email.unwrap() === account.email.unwrap()) return true;
+
     const is_owner = (bucket.owner_account.email.unwrap() === account.email.unwrap()) ||
         (account.bucket_claim_owner && account.bucket_claim_owner.name.unwrap() === bucket.name.unwrap());
     const bucket_policy = bucket.s3_policy;


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
`allowed_buckets` PR did not give any special privilege to system owner account which was **not** desirable. This PR restores _super_ privileges for the system owner account.

- [ ] Doc added/updated
- [ ] Tests added
