### PR TITLE
Allow anonymous access to object_api.list_objects

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -746,7 +746,10 @@ module.exports = {
                     }
                 }
             },
-            auth: { system: ['admin', 'user'] }
+            auth: {
+                system: ['admin', 'user'],
+                anonymous: true,
+            }
         },
 
         list_object_versions: {

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -66,6 +66,7 @@ const rpc_client = server_rpc.rpc.new_client({
     auth_token: auth_server.make_auth_token({}),
     tracker: req => api_coverage.delete(req.srv),
 });
+const anon_rpc_client = server_rpc.rpc.new_client({});
 
 const SYSTEM = CORETEST;
 const EMAIL = `${CORETEST}@noobaa.com`;
@@ -665,6 +666,7 @@ exports.POOL_LIST = POOL_LIST;
 exports.PASSWORD = PASSWORD;
 exports.rpc_client = rpc_client;
 exports.new_rpc_client = new_rpc_client;
+exports.anon_rpc_client = anon_rpc_client;
 exports.get_http_address = get_http_address;
 exports.get_https_address = get_https_address;
 exports.get_https_address_sts = get_https_address_sts;


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
This PR simply enables `anonymous` requests to the `list_objects` API. The implications of the changes being that:
1. If a user allows anonymous access to a bucket via a bucket policy then anyone will be able to access the data.
2. RPCs as have no longer any authorization requirement, will be able to access this data without offering _any_ credentials. Implying, the data won't be protected by the policy in case of RPCs.

### Issues: Fixes #7036

- [ ] Doc added/updated
- [x] Tests added
