### PR TITLE
NSFS | Adding additional ops

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -854,6 +854,21 @@ module.exports = {
                 delete_object: {
                     $ref: 'common_api#/definitions/op_stats_val'
                 },
+                list_objects: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                head_object: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                initiate_multipart: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                upload_part: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                complete_object_upload: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
             }
         },
 

--- a/src/sdk/endpoint_stats_collector.js
+++ b/src/sdk/endpoint_stats_collector.js
@@ -139,9 +139,11 @@ class EndpointStatsCollector {
             error_count: 0,
         };
         const ops_stats = this.op_stats[op_name];
-        ops_stats.min_time = Math.min(ops_stats.min_time, time);
-        ops_stats.max_time = Math.max(ops_stats.max_time, time);
-        ops_stats.sum_time += time;
+        if (error === 0) {
+            ops_stats.min_time = Math.min(ops_stats.min_time, time);
+            ops_stats.max_time = Math.max(ops_stats.max_time, time);
+            ops_stats.sum_time += time;
+        }
         ops_stats.count += 1;
         ops_stats.error_count += error;
         this._trigger_send_stats();

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -436,8 +436,22 @@ class ObjectSDK {
     /////////////////
 
     async list_objects(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        return ns.list_objects(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            const reply = await ns.list_objects(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `list_objects`,
+                error,
+            });
+        }
     }
 
     async list_uploads(params) {
@@ -455,8 +469,22 @@ class ObjectSDK {
     /////////////////
 
     async read_object_md(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        return ns.read_object_md(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            const reply = await ns.read_object_md(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `head_object`,
+                error,
+            });
+        }
     }
 
     async read_object_stream(params, res) {
@@ -599,9 +627,23 @@ class ObjectSDK {
     /////////////////////////////
 
     async create_object_upload(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        this._check_is_readonly_namespace(ns);
-        const reply = await ns.create_object_upload(params, this);
+        const start_time = Date.now();
+        let reply;
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            this._check_is_readonly_namespace(ns);
+            reply = await ns.create_object_upload(params, this);
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `initiate_multipart`,
+                error,
+            });
+        }
         // update bucket counters
         stats_collector.instance(this.internal_rpc_client).update_bucket_write_counters({
             bucket_name: params.bucket,
@@ -612,10 +654,24 @@ class ObjectSDK {
     }
 
     async upload_multipart(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        this._check_is_readonly_namespace(ns);
-        if (params.copy_source) await this.fix_copy_source_params(params, ns);
-        return ns.upload_multipart(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            this._check_is_readonly_namespace(ns);
+            if (params.copy_source) await this.fix_copy_source_params(params, ns);
+            const reply = ns.upload_multipart(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `upload_part`,
+                error,
+            });
+        }
     }
 
     async list_multiparts(params) {
@@ -624,9 +680,23 @@ class ObjectSDK {
     }
 
     async complete_object_upload(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        this._check_is_readonly_namespace(ns);
-        return ns.complete_object_upload(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            this._check_is_readonly_namespace(ns);
+            const reply = await ns.complete_object_upload(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `complete_object_upload`,
+                error,
+            });
+        }
     }
 
     async abort_object_upload(params) {

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -1253,7 +1253,17 @@ function _update_io_stats(io_stats) {
 
 function _update_ops_stats(ops_stats) {
     // Predefined op_names
-    const op_names = [`upload_object`, `delete_object`, `create_bucket`, `delete_bucket`];
+    const op_names = [
+        `upload_object`,
+        `delete_object`,
+        `create_bucket`,
+        `delete_bucket`,
+        `list_objects`,
+        `head_object`,
+        `initiate_multipart`,
+        `upload_part`,
+        `complete_object_upload`
+    ];
     //Go over the op_stats
     for (const op_name of op_names) {
         if (op_name in ops_stats) {
@@ -1263,17 +1273,27 @@ function _update_ops_stats(ops_stats) {
 }
 
 function _set_op_stats(op_name, stats) {
+    //In the event of all of the same ops are failing (count = error_count) we will not masseur the op times
+    // As this is intended as a timing masseur and not a counter. 
     if (op_stats[op_name]) {
-        const new_count = op_stats[op_name].count + stats.count;
+        const count = op_stats[op_name].count + stats.count;
+        const error_count = op_stats[op_name].error_count + stats.error_count;
         const old_sum_time = op_stats[op_name].avg_time_milisec * op_stats[op_name].count;
+        //Min time and Max time are not being counted in the endpoint stat collector if it was error
+        const min_time_milisec = Math.min(op_stats[op_name].min_time_milisec, stats.min_time);
+        const max_time_milisec = Math.max(op_stats[op_name].max_time_milisec, stats.max_time);
+        // At this point, as we populate only when there is at least one successful op, there must be old_sum_time
+        const avg_time_milisec = Math.floor((old_sum_time + stats.sum_time) / (count - error_count));
         op_stats[op_name] = {
-            min_time_milisec: Math.min(op_stats[op_name].min_time_milisec, stats.min_time),
-            max_time_milisec: Math.max(op_stats[op_name].max_time_milisec, stats.max_time),
-            avg_time_milisec: Math.floor((old_sum_time + stats.sum_time) / new_count),
-            count: new_count,
-            error_count: op_stats[op_name].error_count + stats.error_count,
+            min_time_milisec,
+            max_time_milisec,
+            avg_time_milisec,
+            count,
+            error_count,
         };
-    } else {
+        // When it is the first time we populate the op_stats with op_name we do it 
+        // only if there are more successful ops than errors.
+    } else if (stats.count > stats.error_count) {
         op_stats[op_name] = {
             min_time_milisec: stats.min_time,
             max_time_milisec: stats.max_time,

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -300,7 +300,8 @@ function _create_nsfs_report() {
     const nsfs_counters = stats_aggregator.get_nsfs_io_stats();
     // Building the report per io and value
     for (const [key, value] of Object.entries(nsfs_counters)) {
-        nsfs_report += `NooBaa_nsfs_${key}: ${value}<br>`;
+        const metric = `NooBaa_nsfs_${key}`.toLowerCase();
+        nsfs_report += `${metric}: ${value}<br>`;
     }
 
     const op_stats = stats_aggregator.get_op_stats();
@@ -308,7 +309,8 @@ function _create_nsfs_report() {
     for (const [op_name, obj] of Object.entries(op_stats)) {
         nsfs_report += `<br>`;
         for (const [key, value] of Object.entries(obj)) {
-            nsfs_report += `NooBaa_nsfs_${op_name}_${key}: ${value}<br>`;
+            const metric = `NooBaa_nsfs_${op_name}_${key}`.toLowerCase();
+            nsfs_report += `${metric}: ${value}<br>`;
         }
     }
 


### PR DESCRIPTION
### Explain the changes
- Adding `list_objects`, `head_object`, `initiate_multipart`, `upload_part`, and `complete_object_upload`.
- Ops metrics will not masseur error times
- Changed all metrics to lower case (e.g. `NooBaa_nsfs_delete_object_avg_time` to `noobaa_nsfs_delete_object_avg_time`)

Signed-off-by: liranmauda <liran.mauda@gmail.com>


![https___192_168_64_185_32080_metrics_nsfs_stats](https://user-images.githubusercontent.com/28217223/192756378-efb181d1-78f0-4be4-94b8-714f8c3fd76e.png)
