### PR TITLE
[Backport to 5.12] namespase STS and additional NSFS ops metrics

### DIFF
--- a/config.js
+++ b/config.js
@@ -339,7 +339,7 @@ config.STATISTICS_COLLECTOR_EXPIRATION = 31 * 24 * 60 * 60 * 1000; // 1 month
 ///////////////////
 // USAGE REPORTS //
 ///////////////////
-config.SERVICES_TYPES = Object.freeze(['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'IBM_COS']);
+config.SERVICES_TYPES = Object.freeze(['AWS', 'AWSSTS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'IBM_COS']);
 config.USAGE_AGGREGATOR_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
 
 config.BLOCK_STORE_USAGE_INTERVAL = 1 * 60 * 1000; // 1 minute

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -854,6 +854,21 @@ module.exports = {
                 delete_object: {
                     $ref: 'common_api#/definitions/op_stats_val'
                 },
+                list_objects: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                head_object: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                initiate_multipart: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                upload_part: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                complete_object_upload: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
             }
         },
 

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -195,7 +195,7 @@ module.exports = {
                     properties: {
                         service: {
                             type: 'string',
-                            enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                            enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                         },
                         read_count: {
                             type: 'integer'

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -260,7 +260,7 @@ module.exports = {
                     properties: {
                         service: {
                             type: 'string',
-                            enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                            enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                         },
                         read_count: {
                             type: 'integer'
@@ -616,6 +616,9 @@ module.exports = {
                 access_mode: {
                     type: 'string',
                     enum: ['READ_ONLY', 'READ_WRITE']
+                },
+                aws_sts_arn: {
+                    type: 'string'
                 },
             }
         },

--- a/src/sdk/endpoint_stats_collector.js
+++ b/src/sdk/endpoint_stats_collector.js
@@ -139,9 +139,11 @@ class EndpointStatsCollector {
             error_count: 0,
         };
         const ops_stats = this.op_stats[op_name];
-        ops_stats.min_time = Math.min(ops_stats.min_time, time);
-        ops_stats.max_time = Math.max(ops_stats.max_time, time);
-        ops_stats.sum_time += time;
+        if (error === 0) {
+            ops_stats.min_time = Math.min(ops_stats.min_time, time);
+            ops_stats.max_time = Math.max(ops_stats.max_time, time);
+            ops_stats.sum_time += time;
+        }
         ops_stats.count += 1;
         ops_stats.error_count += error;
         this._trigger_send_stats();

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -329,6 +329,7 @@ class ObjectSDK {
     }
 
     _setup_single_namespace(namespace_resource_config, bucket_id) {
+
         const ns_info = namespace_resource_config.resource;
         if (ns_info.endpoint_type === 'NOOBAA') {
             if (ns_info.target_bucket) {
@@ -337,7 +338,8 @@ class ObjectSDK {
                 return this.namespace_nb;
             }
         }
-        if (ns_info.endpoint_type === 'AWS' ||
+        if (ns_info.endpoint_type === 'AWSSTS' ||
+            ns_info.endpoint_type === 'AWS' ||
             ns_info.endpoint_type === 'S3_COMPATIBLE' ||
             ns_info.endpoint_type === 'FLASHBLADE' ||
             ns_info.endpoint_type === 'IBM_COS') {
@@ -352,6 +354,7 @@ class ObjectSDK {
                 s3_params: {
                     params: { Bucket: ns_info.target_bucket },
                     endpoint: ns_info.endpoint,
+                    aws_sts_arn: ns_info.aws_sts_arn,
                     accessKeyId: ns_info.access_key.unwrap(),
                     secretAccessKey: ns_info.secret_key.unwrap(),
                     // region: 'us-east-1', // TODO needed?

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -436,8 +436,22 @@ class ObjectSDK {
     /////////////////
 
     async list_objects(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        return ns.list_objects(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            const reply = await ns.list_objects(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `list_objects`,
+                error,
+            });
+        }
     }
 
     async list_uploads(params) {
@@ -455,8 +469,22 @@ class ObjectSDK {
     /////////////////
 
     async read_object_md(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        return ns.read_object_md(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            const reply = await ns.read_object_md(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `head_object`,
+                error,
+            });
+        }
     }
 
     async read_object_stream(params, res) {
@@ -599,9 +627,23 @@ class ObjectSDK {
     /////////////////////////////
 
     async create_object_upload(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        this._check_is_readonly_namespace(ns);
-        const reply = await ns.create_object_upload(params, this);
+        const start_time = Date.now();
+        let reply;
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            this._check_is_readonly_namespace(ns);
+            reply = await ns.create_object_upload(params, this);
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `initiate_multipart`,
+                error,
+            });
+        }
         // update bucket counters
         stats_collector.instance(this.internal_rpc_client).update_bucket_write_counters({
             bucket_name: params.bucket,
@@ -612,10 +654,24 @@ class ObjectSDK {
     }
 
     async upload_multipart(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        this._check_is_readonly_namespace(ns);
-        if (params.copy_source) await this.fix_copy_source_params(params, ns);
-        return ns.upload_multipart(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            this._check_is_readonly_namespace(ns);
+            if (params.copy_source) await this.fix_copy_source_params(params, ns);
+            const reply = ns.upload_multipart(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `upload_part`,
+                error,
+            });
+        }
     }
 
     async list_multiparts(params) {
@@ -624,9 +680,23 @@ class ObjectSDK {
     }
 
     async complete_object_upload(params) {
-        const ns = await this._get_bucket_namespace(params.bucket);
-        this._check_is_readonly_namespace(ns);
-        return ns.complete_object_upload(params, this);
+        const start_time = Date.now();
+        let error = 0;
+        try {
+            const ns = await this._get_bucket_namespace(params.bucket);
+            this._check_is_readonly_namespace(ns);
+            const reply = await ns.complete_object_upload(params, this);
+            return reply;
+        } catch (e) {
+            error = 1;
+            throw e;
+        } finally {
+            stats_collector.instance(this.internal_rpc_client).update_ops_counters({
+                time: Date.now() - start_time,
+                op_name: `complete_object_upload`,
+                error,
+            });
+        }
     }
 
     async abort_object_upload(params) {

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -61,7 +61,7 @@ class NamespaceMonitor {
             try {
                 if (endpoint_type === 'NSFS') {
                     await this.test_nsfs_resource(nsr);
-                } else if (['AWS', 'S3_COMPATIBLE', 'IBM_COS'].includes(endpoint_type)) {
+                } else if (['AWS', 'AWSSTS', 'S3_COMPATIBLE', 'IBM_COS'].includes(endpoint_type)) {
                     await this.test_s3_resource(nsr);
                 } else if (endpoint_type === 'AZURE') {
                     await this.test_blob_resource(nsr);

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -512,7 +512,6 @@ async function read_bucket_sdk_info(req) {
             should_create_underlying_storage: bucket.namespace.should_create_underlying_storage
         };
     }
-
     return reply;
 }
 
@@ -1075,7 +1074,7 @@ function get_cloud_buckets(req) {
                         agent: http_utils.get_unsecured_agent(connection.endpoint)
                     }
                 });
-                const used_cloud_buckets = cloud_utils.get_used_cloud_targets(['AWS', 'AWS_STS', 'S3_COMPATIBLE', 'FLASHBLADE', 'IBM_COS'],
+                const used_cloud_buckets = cloud_utils.get_used_cloud_targets(['AWS', 'AWSSTS', 'AWS_STS', 'S3_COMPATIBLE', 'FLASHBLADE', 'IBM_COS'],
                     system_store.data.buckets, system_store.data.pools, system_store.data.namespace_resources);
                 return P.timeout(EXTERNAL_BUCKET_LIST_TO, P.ninvoke(s3, 'listBuckets'))
                     .then(data => data.Buckets.map(bucket =>

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -266,6 +266,7 @@ async function create_namespace_resource(req) {
             connection.secret_key, req.account.master_key_id._id);
 
         namespace_resource = new_namespace_resource_defaults(name, req.system._id, req.account._id, _.omitBy({
+            aws_sts_arn: connection.aws_sts_arn,
             endpoint: connection.endpoint,
             target_bucket: req.rpc_params.target_bucket,
             access_key: connection.access_key,
@@ -1156,7 +1157,8 @@ function get_namespace_resource_extended_info(namespace_resource) {
         target_bucket: namespace_resource.connection.target_bucket,
         access_key: namespace_resource.connection.access_key,
         secret_key: namespace_resource.connection.secret_key,
-        access_mode: namespace_resource.access_mode
+        access_mode: namespace_resource.access_mode,
+        aws_sts_arn: namespace_resource.connection.aws_sts_arn || undefined,
     };
     const nsfs_info = namespace_resource.nsfs_config && {
         fs_root_path: namespace_resource.nsfs_config.fs_root_path,

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -30,9 +30,12 @@ module.exports = {
             type: 'object',
             required: ['endpoint_type', 'endpoint', 'target_bucket', 'access_key', 'secret_key'],
             properties: {
+                aws_sts_arn: {
+                    type: 'string'
+                },
                 endpoint_type: {
                     type: 'string',
-                    enum: ['AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                    enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                 },
                 auth_method: {
                     type: 'string',

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -1253,7 +1253,17 @@ function _update_io_stats(io_stats) {
 
 function _update_ops_stats(ops_stats) {
     // Predefined op_names
-    const op_names = [`upload_object`, `delete_object`, `create_bucket`, `delete_bucket`];
+    const op_names = [
+        `upload_object`,
+        `delete_object`,
+        `create_bucket`,
+        `delete_bucket`,
+        `list_objects`,
+        `head_object`,
+        `initiate_multipart`,
+        `upload_part`,
+        `complete_object_upload`
+    ];
     //Go over the op_stats
     for (const op_name of op_names) {
         if (op_name in ops_stats) {
@@ -1263,17 +1273,27 @@ function _update_ops_stats(ops_stats) {
 }
 
 function _set_op_stats(op_name, stats) {
+    //In the event of all of the same ops are failing (count = error_count) we will not masseur the op times
+    // As this is intended as a timing masseur and not a counter. 
     if (op_stats[op_name]) {
-        const new_count = op_stats[op_name].count + stats.count;
+        const count = op_stats[op_name].count + stats.count;
+        const error_count = op_stats[op_name].error_count + stats.error_count;
         const old_sum_time = op_stats[op_name].avg_time_milisec * op_stats[op_name].count;
+        //Min time and Max time are not being counted in the endpoint stat collector if it was error
+        const min_time_milisec = Math.min(op_stats[op_name].min_time_milisec, stats.min_time);
+        const max_time_milisec = Math.max(op_stats[op_name].max_time_milisec, stats.max_time);
+        // At this point, as we populate only when there is at least one successful op, there must be old_sum_time
+        const avg_time_milisec = Math.floor((old_sum_time + stats.sum_time) / (count - error_count));
         op_stats[op_name] = {
-            min_time_milisec: Math.min(op_stats[op_name].min_time_milisec, stats.min_time),
-            max_time_milisec: Math.max(op_stats[op_name].max_time_milisec, stats.max_time),
-            avg_time_milisec: Math.floor((old_sum_time + stats.sum_time) / new_count),
-            count: new_count,
-            error_count: op_stats[op_name].error_count + stats.error_count,
+            min_time_milisec,
+            max_time_milisec,
+            avg_time_milisec,
+            count,
+            error_count,
         };
-    } else {
+        // When it is the first time we populate the op_stats with op_name we do it 
+        // only if there are more successful ops than errors.
+    } else if (stats.count > stats.error_count) {
         op_stats[op_name] = {
             min_time_milisec: stats.min_time,
             max_time_milisec: stats.max_time,

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -289,6 +289,7 @@ async function get_partial_providers_stats(req) {
     const provider_stats = {};
     const supported_cloud_types = [
         'AWS',
+        'AWSSTS',
         'AZURE',
         'S3_COMPATIBLE',
         'GOOGLE',
@@ -719,6 +720,12 @@ async function get_cloud_pool_stats(req) {
             cloud_pool_stats.cloud_pool_count += 1;
             switch (pool.cloud_pool_info.endpoint_type) {
                 case 'AWS':
+                    cloud_pool_stats.pool_target.amazon += 1;
+                    if (!_.includes(OPTIMAL_MODES, pool_info.mode)) {
+                        cloud_pool_stats.unhealthy_pool_target.amazon_unhealthy += 1;
+                    }
+                    break;
+                case 'AWSSTS':
                     cloud_pool_stats.pool_target.amazon += 1;
                     if (!_.includes(OPTIMAL_MODES, pool_info.mode)) {
                         cloud_pool_stats.unhealthy_pool_target.amazon_unhealthy += 1;

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -300,7 +300,8 @@ function _create_nsfs_report() {
     const nsfs_counters = stats_aggregator.get_nsfs_io_stats();
     // Building the report per io and value
     for (const [key, value] of Object.entries(nsfs_counters)) {
-        nsfs_report += `NooBaa_nsfs_${key}: ${value}<br>`;
+        const metric = `NooBaa_nsfs_${key}`.toLowerCase();
+        nsfs_report += `${metric}: ${value}<br>`;
     }
 
     const op_stats = stats_aggregator.get_op_stats();
@@ -308,7 +309,8 @@ function _create_nsfs_report() {
     for (const [op_name, obj] of Object.entries(op_stats)) {
         nsfs_report += `<br>`;
         for (const [key, value] of Object.entries(obj)) {
-            nsfs_report += `NooBaa_nsfs_${op_name}_${key}: ${value}<br>`;
+            const metric = `NooBaa_nsfs_${op_name}_${key}`.toLowerCase();
+            nsfs_report += `${metric}: ${value}<br>`;
         }
     }
 

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -13,6 +13,7 @@ const SensitiveString = require('./sensitive_string');
 const projectedServiceAccountToken = "/var/run/secrets/openshift/serviceaccount/oidc-token";
 const defaultRoleSessionName = 'default_noobaa_s3_ops';
 const defaultSTSCredsValidity = 3600;
+
 function find_cloud_connection(account, conn_name) {
     let conn = (account.sync_credentials_cache || [])
         .filter(sync_conn => sync_conn.name === conn_name)[0];
@@ -24,8 +25,9 @@ function find_cloud_connection(account, conn_name) {
 
     return conn;
 }
+
 async function createSTSS3Client(params, additionalParams) {
-   const creds = await generate_aws_sts_creds(params, additionalParams.RoleSessionName);
+    const creds = await generate_aws_sts_creds(params, additionalParams.RoleSessionName);
     return new AWS.S3({
         credentials: creds,
         region: params.region,
@@ -45,15 +47,15 @@ async function generate_aws_sts_creds(params, roleSessionName) {
         WebIdentityToken: (await fs.promises.readFile(projectedServiceAccountToken)).toString(),
         DurationSeconds: defaultSTSCredsValidity
     }).promise());
-        if (_.isEmpty(creds.Credentials)) {
+    if (_.isEmpty(creds.Credentials)) {
         dbg.error(`AWS STS empty creds ${params.RoleArn}, RolesessionName: ${params.RoleSessionName},Projected service Account Token Path : ${projectedServiceAccountToken}`);
         throw new RpcError('AWS_STS_ERROR', 'Empty AWS STS creds retrieved for Role "' + params.RoleArn + '"');
-        }
-        return new AWS.Credentials(
-            creds.Credentials.AccessKeyId,
-            creds.Credentials.SecretAccessKey,
-            creds.Credentials.SessionToken
-        );
+    }
+    return new AWS.Credentials(
+        creds.Credentials.AccessKeyId,
+        creds.Credentials.SecretAccessKey,
+        creds.Credentials.SessionToken
+    );
 }
 
 function get_signed_url(params) {


### PR DESCRIPTION
### Explain the changes
- Adding namespace sts
- Adding `list_objects`, `head_object`, `initiate_multipart`, `upload_part`, and `complete_object_upload`.
- Ops metrics will not masseur error times
- Changed all metrics to lower case (e.g. NooBaa_nsfs_checkAccess_avg_time to noobaa_nsfs_checkaccess_avg_time)

Signed-off-by: liranmauda <liran.mauda@gmail.com>