### PR TITLE
🧹 Fix event api export_activity_log reply schema

### DIFF
--- a/src/api/events_api.js
+++ b/src/api/events_api.js
@@ -207,7 +207,13 @@ module.exports = {
                 }
             },
             reply: {
-                type: 'string',
+                type: 'object',
+                required: ['out_path'],
+                properties: {
+                    out_path: {
+                        type: 'string'
+                    }
+                }
             },
             auth: {
                 system: 'admin',

--- a/src/server/notifications/event_server.js
+++ b/src/server/notifications/event_server.js
@@ -54,7 +54,7 @@ function export_activity_log(req) {
 
             return fs.promises.writeFile(inner_path, out_lines.join('\n'), 'utf8');
         })
-        .then(() => out_path)
+        .then(() => ({out_path}))
         .catch(err => {
             dbg.error('received error when writing to audit csv file:', inner_path, err);
             throw err;


### PR DESCRIPTION
# Fix event api export_activity_log reply schema

### Issue:
- https://github.com/noobaa/noobaa-core/issues/7071

### Test:
➜  noobaa-operator git:(6f571fd) ✗ ./build/_output/bin/noobaa-operator-local -n noobaa api events_api export_activity_log '{}' INFO[0000] ✅ Exists: NooBaa "noobaa"
INFO[0000] ✅ Exists: Service "noobaa-mgmt"
INFO[0000] ✅ Exists: Secret "noobaa-operator"
INFO[0000] ✅ Exists: Secret "noobaa-admin"
INFO[0000] ✈️  RPC: events.export_activity_log() Request: map[] WARN[0000] RPC: GetConnection creating connection to wss://localhost:63468/rpc/ 0xc000b9fc20 INFO[0000] RPC: Connecting websocket (0xc000b9fc20) &{RPC:0xc0003659a0 Address:wss://localhost:63468/rpc/ State:init WS:<nil> PendingRequests:map[] NextRequestID:0 Lock:{state:1 sema:0} ReconnectDelay:0s cancelPings:<nil>} INFO[0000] RPC: Connected websocket (0xc000b9fc20) &{RPC:0xc0003659a0 Address:wss://localhost:63468/rpc/ State:init WS:<nil> PendingRequests:map[] NextRequestID:0 Lock:{state:1 sema:0} ReconnectDelay:0s cancelPings:<nil>} ERRO[0001] RPC: HandleResponse for OP res API  raw bytes {"op":"res","reqid":"wss://localhost:63468/rpc/-0","took":898.633090000134,"reply":{"out_path":"/public/audit.csv"}} INFO[0001] ✅ RPC: events.export_activity_log() Response OK: took 898.6ms out_path: /public/audit.csv

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>