### PR TITLE
Collecting FS worker stats and sending it to the to `/metrics/nsfs_stats`

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -875,6 +875,102 @@ module.exports = {
             }
         },
 
+        fs_workers_stats: {
+            type: 'object',
+            properties: {
+                stat: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                lstat: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                statfs: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                checkaccess: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                unlink: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                unlinkat: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                link: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                linkat: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                mkdir: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                rmdir: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                rename: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                writefile: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                readfile: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                readdir: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                fsync: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                fileopen: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                fileclose: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                fileread: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                filewrite: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                filewritev: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                filereplacexattr: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                finkfileat: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                filegetxattr: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                filestat: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                filefsync: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                realpath: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                getsinglexattr: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                diropen: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                dirclose: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                dirreadentry: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+            }
+        },
+
         op_stats_val: {
             type: 'object',
             properties: {

--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -159,7 +159,11 @@ module.exports = {
                             },
                             op_stats: {
                                 $ref: 'common_api#/definitions/op_stats'
+                            },
+                            fs_workers_stats: {
+                                $ref: 'common_api#/definitions/fs_workers_stats'
                             }
+
                         }
                     },
                 }

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -151,6 +151,13 @@ set_statfs_res(Napi::Object res, Napi::Env env, struct statfs &statfs_res)
 
 }
 
+void 
+set_fs_worker_stats(Napi::Env env, Napi::Object fs_worker_stats, std::string work_name, double took_time, int error){
+    fs_worker_stats["name"] = Napi::String::New(env, work_name);
+    fs_worker_stats["took_time"] = Napi::Number::New(env, took_time);
+    fs_worker_stats["error"] = Napi::Number::New(env, error);
+}
+
 /**
  * FSWorker is a general async worker for our fs operations
  */
@@ -168,8 +175,11 @@ struct FSWorker : public Napi::AsyncWorker
     gid_t _gid;
     std::string _backend;
     std::string _desc;
+    std::string _work_name;
     int _errno;
     int _warn_threshold_ms;
+    double _took_time;
+    Napi::FunctionReference _report_fs_stats;
 
     FSWorker(const Napi::CallbackInfo& info)
         : AsyncWorker(info.Env())
@@ -180,17 +190,21 @@ struct FSWorker : public Napi::AsyncWorker
         , _gid(ThreadScope::orig_gid)
         , _errno(0)
         , _warn_threshold_ms(0)
+        , _took_time(0)
     {
         for (int i = 0; i < (int)info.Length(); ++i) _args_ref.Set(i, info[i]);
-        Napi::Object config = info[0].As<Napi::Object>();
-        if (config.Has("uid")) _uid = config.Get("uid").ToNumber();
-        if (config.Has("gid")) _gid = config.Get("gid").ToNumber();
-        if (config.Has("backend")) _backend = config.Get("backend").ToString();
-        if (config.Has("warn_threshold_ms")) _warn_threshold_ms = config.Get("warn_threshold_ms").ToNumber();
+        Napi::Object fs_context = info[0].As<Napi::Object>();
+        if (fs_context.Has("uid")) _uid = fs_context.Get("uid").ToNumber();
+        if (fs_context.Has("gid")) _gid = fs_context.Get("gid").ToNumber();
+        if (fs_context.Has("backend")) _backend = fs_context.Get("backend").ToString();
+        if (fs_context.Has("warn_threshold_ms")) _warn_threshold_ms = fs_context.Get("warn_threshold_ms").ToNumber();
+        if (fs_context.Has("report_fs_stats")) _report_fs_stats = Napi::Persistent(fs_context.Get("report_fs_stats").As<Napi::Function>());
+
     }
     void Begin(std::string desc)
     {
         _desc = desc;
+        _work_name = _desc.substr(0, _desc.find(" "));
         DBG1("FS::FSWorker::Begin: " << _desc);
     }
     virtual void Work() = 0;
@@ -202,11 +216,11 @@ struct FSWorker : public Napi::AsyncWorker
         auto start_time = std::chrono::high_resolution_clock::now();
         Work();
         auto end_time = std::chrono::high_resolution_clock::now();
-        double took_time = std::chrono::duration<double, std::milli>(end_time - start_time).count();
-        if (_warn_threshold_ms && took_time > _warn_threshold_ms) {
-            DBG0("FS::FSWorker::Execute: WARNING " << _desc << " took too long: " << took_time << " ms");
+        _took_time = std::chrono::duration<double, std::milli>(end_time - start_time).count();
+        if (_warn_threshold_ms && _took_time > _warn_threshold_ms) {
+            DBG0("FS::FSWorker::Execute: WARNING " << _desc << " took too long: " << _took_time << " ms");
         } else {
-            DBG1("FS::FSWorker::Execute: " << _desc << " took: " << took_time << " ms");
+            DBG1("FS::FSWorker::Execute: " << _desc << " took: " << _took_time << " ms");
         }
     }
     void SetSyscallError()
@@ -223,12 +237,19 @@ struct FSWorker : public Napi::AsyncWorker
     virtual void OnOK() override
     {
         DBG1("FS::FSWorker::OnOK: undefined " << _desc);
+        Napi::Env env = Env();
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         _deferred.Resolve(Env().Undefined());
     }
     virtual void OnError(Napi::Error const& error) override
     {
         Napi::Env env = Env();
         DBG1("FS::FSWorker::OnError: " << _desc << " " << DVAL(error.Message()));
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 1);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         auto obj = error.Value();
         if (_errno) {
             obj.Set("code", Napi::String::New(env, uv_err_name(uv_translate_sys_error(_errno))));
@@ -282,6 +303,9 @@ struct Stat : public FSWorker
         Napi::Env env = Env();
         auto res = Napi::Object::New(env);
         set_stat_res(res, env, _stat_res);
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
 
         _deferred.Resolve(res);
     }
@@ -312,6 +336,9 @@ struct LStat : public FSWorker
         Napi::Env env = Env();
         auto res = Napi::Object::New(env);
         set_stat_res(res, env, _stat_res);
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         
         _deferred.Resolve(res);
     }
@@ -342,6 +369,9 @@ struct Statfs : public FSWorker
         Napi::Env env = Env();
         auto res = Napi::Object::New(env);
         set_statfs_res(res, env, _statfs_res);
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
 
         _deferred.Resolve(res);
     }
@@ -409,7 +439,7 @@ struct Unlinkat : public FSWorker
         _dirfd = info[1].As<Napi::Number>();
         _path = info[2].As<Napi::String>();
         _flags = info[3].As<Napi::Number>();
-        Begin(XSTR() << DVAL(_path) << DVAL(_dirfd) << DVAL(_flags));
+        Begin(XSTR() << "Unlinkat " << DVAL(_path) << DVAL(_dirfd) << DVAL(_flags));
     }
     virtual void Work()
     {
@@ -430,7 +460,7 @@ struct Link : public FSWorker
     {
         _oldpath = info[1].As<Napi::String>();
         _newpath = info[2].As<Napi::String>();
-        Begin(XSTR() << DVAL(_oldpath) << DVAL(_newpath));
+        Begin(XSTR() << "Link " << DVAL(_oldpath) << DVAL(_newpath));
     }
     virtual void Work()
     {
@@ -460,7 +490,7 @@ struct Linkat : public FSWorker
         _newdirfd = info[3].As<Napi::Number>();
         _newpath = info[4].As<Napi::String>();
         _flags = info[5].As<Napi::Number>();
-        Begin(XSTR() << DVAL(_oldpath) << DVAL(_olddirfd) << DVAL(_newpath) << DVAL(_newdirfd) << DVAL(_flags));
+        Begin(XSTR() << "Linkat " << DVAL(_oldpath) << DVAL(_olddirfd) << DVAL(_newpath) << DVAL(_newdirfd) << DVAL(_flags));
     }
     virtual void Work()
     {
@@ -637,6 +667,10 @@ struct Readfile : public FSWorker
     {
         DBG1("FS::FSWorker::OnOK: Readfile " << DVAL(_path));
         auto buf = Napi::Buffer<uint8_t>::Copy(Env(), _data, _len);
+        Napi::Env env = Env();
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         _deferred.Resolve(buf);
     }
 };
@@ -710,6 +744,10 @@ struct Readdir : public FSWorker
         //         index += 1;
         //     }
         // }
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
+
         _deferred.Resolve(res);
     }
 };
@@ -829,6 +867,10 @@ struct FileOpen : public FSWorker
         FileWrap* w = FileWrap::Unwrap(res);
         w->_path = _path;
         w->_fd = _fd;
+        Napi::Env env = Env();
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         _deferred.Resolve(res);
     }
 };
@@ -890,6 +932,9 @@ struct FileRead : public FSWrapWorker<FileWrap>
     {
         DBG1("FS::FSWorker::OnOK: FileRead " << DVAL(_wrap->_path));
         Napi::Env env = Env();
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         _deferred.Resolve(Napi::Number::New(env, _br));
     }
 };
@@ -1201,6 +1246,9 @@ struct FileGetxattr : public FSWrapWorker<FileWrap>
         for (auto it = _md.begin(); it != _md.end(); ++it) {
             res.Set(it->first, it->second);
         }
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         _deferred.Resolve(res);
     }
 };
@@ -1231,6 +1279,9 @@ struct FileStat : public FSWrapWorker<FileWrap>
         Napi::Env env = Env();
         auto res = Napi::Object::New(env);
         set_stat_res(res, env, _stat_res);
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         
         _deferred.Resolve(res);
     }
@@ -1266,7 +1317,7 @@ struct RealPath : public FSWorker
         , _full_path(0)
     {
         _path = info[1].As<Napi::String>();
-        Begin(XSTR() << DVAL(_path));
+        Begin(XSTR() << "RealPath " << DVAL(_path));
     }
 
     ~RealPath() {
@@ -1289,6 +1340,9 @@ struct RealPath : public FSWorker
         DBG1("FS::RealPath::OnOK: " << DVAL(_path) << DVAL(_full_path));
         Napi::Env env = Env();
         auto res = Napi::String::New(env, _full_path);
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         _deferred.Resolve(res);
     }
 };
@@ -1304,7 +1358,7 @@ struct GetSingleXattr : public FSWorker
     {
         _path = info[1].As<Napi::String>();
         _key = info[2].As<Napi::String>();
-        Begin(XSTR() << DVAL(_path) << DVAL(_key));
+        Begin(XSTR() << "GetSingleXattr" << DVAL(_path) << DVAL(_key));
     }
 
     virtual void Work()
@@ -1345,6 +1399,9 @@ struct GetSingleXattr : public FSWorker
         DBG1("FS::GetSingleXattr::OnOK: " << DVAL(_path) << DVAL(_val));
         Napi::Env env = Env();
         auto res = Napi::String::New(env, _val);
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         _deferred.Resolve(res);
     }
 };
@@ -1466,6 +1523,10 @@ struct DirOpen : public FSWorker
         DirWrap* w = DirWrap::Unwrap(res);
         w->_path = _path;
         w->_dir = _dir;
+        Napi::Env env = Env();
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         _deferred.Resolve(res);
     }
 };
@@ -1528,6 +1589,9 @@ struct DirReadEntry : public FSWrapWorker<DirWrap>
     virtual void OnOK()
     {
         Napi::Env env = Env();
+        auto fs_worker_stats = Napi::Object::New(env);
+        set_fs_worker_stats(env, fs_worker_stats, _work_name, _took_time, 0);
+        if (!_report_fs_stats.IsEmpty()) _report_fs_stats.Call({ fs_worker_stats });
         if (_eof) {
             _deferred.Resolve(env.Null());
         } else {

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -27,7 +27,7 @@ class BucketSpaceFS {
 
     constructor({ fs_root }) {
         this.fs_root = fs_root;
-        this.fs_config_param = {
+        this.fs_context = {
             uid: process.getuid(),
             gid: process.getgid(),
             backend: '',
@@ -41,7 +41,7 @@ class BucketSpaceFS {
 
     async list_buckets() {
         try {
-            const entries = await nb_native().fs.readdir(this.fs_config_param, this.fs_root);
+            const entries = await nb_native().fs.readdir(this.fs_context, this.fs_root);
             const dirs_only = entries.filter(entree => isDirectory(entree));
             const buckets = dirs_only.map(e => ({ name: new SensitiveString(e.name) }));
             return { buckets };
@@ -59,7 +59,7 @@ class BucketSpaceFS {
             const { name } = params;
             const bucket_path = path.join(this.fs_root, name);
             console.log(`BucketSpaceFS: read_bucket ${bucket_path}`);
-            const bucket_dir_stat = await nb_native().fs.stat(this.fs_config_param, bucket_path);
+            const bucket_dir_stat = await nb_native().fs.stat(this.fs_context, bucket_path);
             if (!isDirectory(bucket_dir_stat)) {
                 throw new S3Error(S3Error.NoSuchBucket);
             }
@@ -109,7 +109,7 @@ class BucketSpaceFS {
             console.log(`BucketSpaceFS: create_bucket ${bucket_path}`);
             // eslint-disable-next-line no-bitwise
             const unmask_mode = config.BASE_MODE_DIR & ~config.NSFS_UMASK;
-            await nb_native().fs.mkdir(this.fs_config_param, bucket_path, unmask_mode);
+            await nb_native().fs.mkdir(this.fs_context, bucket_path, unmask_mode);
         } catch (err) {
             if (err.code === 'ENOENT') {
                 console.error('BucketSpaceFS: root dir not found', err);
@@ -124,7 +124,7 @@ class BucketSpaceFS {
             const { name } = params;
             const bucket_path = path.join(this.fs_root, name);
             console.log(`BucketSpaceFS: delete_fs_bucket ${bucket_path}`);
-            await nb_native().fs.rmdir(this.fs_config_param, bucket_path);
+            await nb_native().fs.rmdir(this.fs_context, bucket_path);
         } catch (err) {
             if (err.code === 'ENOENT') {
                 console.error('BucketSpaceFS: root dir not found', err);

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -62,15 +62,15 @@ function isDirectory(ent) {
 /**
  * 
  * @param {*} stat - entity stat yo check
- * @param {*} fs_account_config - account config using to check symbolic links
+ * @param {*} fs_context - account config using to check symbolic links
  * @param {*} entry_path - path of symbolic link
  * @returns 
  */
-async function is_directory_or_symlink_to_directory(stat, fs_account_config, entry_path) {
+async function is_directory_or_symlink_to_directory(stat, fs_context, entry_path) {
     try {
         let r = isDirectory(stat);
         if (!r && is_symbolic_link(stat)) {
-            let targetStat = await nb_native().fs.stat(fs_account_config, entry_path);
+            let targetStat = await nb_native().fs.stat(fs_context, entry_path);
             if (!targetStat) throw new Error('is_directory_or_symlink_to_directory: targetStat is empty');
             r = isDirectory(targetStat);
         }
@@ -145,13 +145,13 @@ function to_fs_xattr(xattr) {
 const dir_cache = new LRUCache({
     name: 'nsfs-dir-cache',
     make_key: ({ dir_path }) => dir_path,
-    load: async ({ dir_path, fs_account_config }) => {
+    load: async ({ dir_path, fs_context }) => {
         const time = Date.now();
-        const stat = await nb_native().fs.stat(fs_account_config, dir_path);
+        const stat = await nb_native().fs.stat(fs_context, dir_path);
         let sorted_entries;
         let usage = config.NSFS_DIR_CACHE_MIN_DIR_SIZE;
         if (stat.size <= config.NSFS_DIR_CACHE_MAX_DIR_SIZE) {
-            sorted_entries = await nb_native().fs.readdir(fs_account_config, dir_path);
+            sorted_entries = await nb_native().fs.readdir(fs_context, dir_path);
             sorted_entries.sort(sort_entries_by_name);
             for (const ent of sorted_entries) {
                 usage += ent.name.length + 4;
@@ -159,8 +159,8 @@ const dir_cache = new LRUCache({
         }
         return { time, stat, sorted_entries, usage };
     },
-    validate: async ({ stat }, { dir_path, fs_account_config }) => {
-        const new_stat = await nb_native().fs.stat(fs_account_config, dir_path);
+    validate: async ({ stat }, { dir_path, fs_context }) => {
+        const new_stat = await nb_native().fs.stat(fs_context, dir_path);
         return (new_stat.ino === stat.ino && new_stat.mtimeMs === stat.mtimeMs);
     },
     item_usage: ({ usage }, dir_path) => usage,
@@ -191,18 +191,19 @@ class NamespaceFS {
         this.access_mode = access_mode;
     }
 
-    set_cur_fs_account_config(object_sdk) {
-        const fs_config_param = object_sdk &&
+    prepare_fs_context(object_sdk) {
+        const fs_context = object_sdk &&
             object_sdk.requesting_account && object_sdk.requesting_account.nsfs_account_config;
-        if (!fs_config_param) {
+        if (!fs_context) {
             const err = new Error('nsfs_account_config is missing');
             err.rpc_code = 'UNAUTHORIZED';
             throw err;
         }
 
-        fs_config_param.backend = this.fs_backend || '';
-        fs_config_param.warn_threshold_ms = config.NSFS_WARN_THRESHOLD_MS;
-        return fs_config_param;
+        fs_context.backend = this.fs_backend || '';
+        fs_context.warn_threshold_ms = config.NSFS_WARN_THRESHOLD_MS;
+        fs_context.report_fs_stats = stats_collector.report_fs_stats;
+        return fs_context;
     }
 
     get_bucket_tmpdir() {
@@ -272,8 +273,8 @@ class NamespaceFS {
      */
     async list_objects(params, object_sdk) {
         try {
-            const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-            await this._load_bucket(params, fs_account_config);
+            const fs_context = this.prepare_fs_context(object_sdk);
+            await this._load_bucket(params, fs_context);
 
             const {
                 bucket,
@@ -353,7 +354,7 @@ class NamespaceFS {
                         return;
                     }
 
-                    const isDir = await is_directory_or_symlink_to_directory(ent, fs_account_config, path.join(dir_path, ent.name));
+                    const isDir = await is_directory_or_symlink_to_directory(ent, fs_context, path.join(dir_path, ent.name));
 
                     const r = {
                         key: this._get_entry_key(dir_key, ent, isDir),
@@ -387,10 +388,10 @@ class NamespaceFS {
                     }
                 };
 
-                if (!(await this.check_access(fs_account_config, dir_path))) return;
+                if (!(await this.check_access(fs_context, dir_path))) return;
 
                 try {
-                    cached_dir = await dir_cache.get_with_cache({ dir_path, fs_account_config });
+                    cached_dir = await dir_cache.get_with_cache({ dir_path, fs_context });
                 } catch (err) {
                     if (err.code === 'ENOENT') {
                         dbg.log0('NamespaceFS: no keys for non existing dir', dir_path);
@@ -415,7 +416,7 @@ class NamespaceFS {
                         if (marker_curr.startsWith(prev_dir_name) && dir_key !== prev_dir.name) {
                             if (!delimiter) {
                                 const isDir = await is_directory_or_symlink_to_directory(
-                                    prev_dir, fs_account_config, path.join(dir_path, prev_dir_name));
+                                    prev_dir, fs_context, path.join(dir_path, prev_dir_name));
                                 if (isDir) {
                                     await process_dir(path.join(dir_key, prev_dir_name));
                                 }
@@ -441,21 +442,21 @@ class NamespaceFS {
                 // so we have to stream the entries one by one while filtering only the needed ones.
                 try {
                     dbg.warn('NamespaceFS: open dir streaming', dir_path, 'size', cached_dir.stat.size);
-                    dir_handle = await nb_native().fs.opendir(fs_account_config, dir_path); //, { bufferSize: 128 });
+                    dir_handle = await nb_native().fs.opendir(fs_context, dir_path); //, { bufferSize: 128 });
                     for (;;) {
-                        const dir_entry = await dir_handle.read(fs_account_config);
+                        const dir_entry = await dir_handle.read(fs_context);
                         if (!dir_entry) break;
                         await process_entry(dir_entry);
                         // since we dir entries streaming order is not sorted,
                         // we have to keep scanning all the keys before we can stop.
                     }
-                    await dir_handle.close(fs_account_config);
+                    await dir_handle.close(fs_context);
                     dir_handle = null;
                 } finally {
                     if (dir_handle) {
                         try {
                             dbg.warn('NamespaceFS: close dir streaming', dir_path, 'size', cached_dir.stat.size);
-                            await dir_handle.close(fs_account_config);
+                            await dir_handle.close(fs_context);
                         } catch (err) {
                             dbg.error('NamespaceFS: close dir failed', err);
                         }
@@ -470,13 +471,13 @@ class NamespaceFS {
                 if (r.common_prefix) return;
                 const entry_path = path.join(this.bucket_path, r.key);
                 //If entry is outside of bucket, returns stat of symbolic link
-                if (await this._is_path_in_bucket_boundaries(fs_account_config, entry_path)) {
-                    r.stat = await nb_native().fs.stat(fs_account_config, entry_path);
+                if (await this._is_path_in_bucket_boundaries(fs_context, entry_path)) {
+                    r.stat = await nb_native().fs.stat(fs_context, entry_path);
                 } else {
-                    r.stat = await nb_native().fs.lstat(fs_account_config, entry_path);
+                    r.stat = await nb_native().fs.lstat(fs_context, entry_path);
                 }
                 // This is done to get the MD5 for the response, should find a more efficient way
-                // r.fs_xattr = config.NSFS_CALCULATE_MD5 ? await this._get_fs_xattr_from_path(fs_account_config, entry_path) : undefined;
+                // r.fs_xattr = config.NSFS_CALCULATE_MD5 ? await this._get_fs_xattr_from_path(fs_context, entry_path) : undefined;
             }));
             const res = {
                 objects: [],
@@ -511,31 +512,31 @@ class NamespaceFS {
 
     async read_object_md(params, object_sdk) {
         let file;
-        const fs_account_config = this.set_cur_fs_account_config(object_sdk);
+        const fs_context = this.prepare_fs_context(object_sdk);
         try {
             const file_path = this._get_file_path(params);
-            await this._check_path_in_bucket_boundaries(fs_account_config, file_path);
-            await this._load_bucket(params, fs_account_config);
-            file = await nb_native().fs.open(fs_account_config, file_path, undefined, get_umasked_mode(config.BASE_MODE_FILE));
-            const stat = await file.stat(fs_account_config);
+            await this._check_path_in_bucket_boundaries(fs_context, file_path);
+            await this._load_bucket(params, fs_context);
+            file = await nb_native().fs.open(fs_context, file_path, undefined, get_umasked_mode(config.BASE_MODE_FILE));
+            const stat = await file.stat(fs_context);
             if (isDirectory(stat)) throw Object.assign(new Error('NoSuchKey'), { code: 'ENOENT' });
-            const fs_xattr = await file.getxattr(fs_account_config);
-            await file.close(fs_account_config);
+            const fs_xattr = await file.getxattr(fs_context);
+            await file.close(fs_context);
             file = null;
             return this._get_object_info(params.bucket, params.key, stat, fs_xattr);
         } catch (err) {
             this.run_update_issues_report(object_sdk, err);
             throw this._translate_object_error_codes(err);
         } finally {
-            if (file) await file.close(fs_account_config);
+            if (file) await file.close(fs_context);
         }
     }
 
     /*
     async read_object_stream_SLOW(params, object_sdk, res) {
         try {
-            const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-            await this._load_bucket(params, fs_account_config);
+            const fs_context = this.prepare_fs_context(object_sdk);
+            await this._load_bucket(params, fs_context);
             const file_path = this._get_file_path(params);
             return fs.createReadStream(file_path, {
                 highWaterMark: config.NSFS_BUF_SIZE,
@@ -553,14 +554,14 @@ class NamespaceFS {
     async read_object_stream(params, object_sdk, res) {
         let file;
         let buffer_pool_cleanup = null;
-        const fs_account_config = this.set_cur_fs_account_config(object_sdk);
+        const fs_context = this.prepare_fs_context(object_sdk);
         let file_path;
         try {
-            await this._load_bucket(params, fs_account_config);
+            await this._load_bucket(params, fs_context);
             file_path = this._get_file_path(params);
-            await this._check_path_in_bucket_boundaries(fs_account_config, file_path);
-            await this._fail_if_archived_or_sparse_file(fs_account_config, file_path);
-            file = await nb_native().fs.open(fs_account_config, file_path, undefined, get_umasked_mode(config.BASE_MODE_FILE));
+            await this._check_path_in_bucket_boundaries(fs_context, file_path);
+            await this._fail_if_archived_or_sparse_file(fs_context, file_path);
+            file = await nb_native().fs.open(fs_context, file_path, undefined, get_umasked_mode(config.BASE_MODE_FILE));
 
             const start = Number(params.start) || 0;
             const end = isNaN(Number(params.end)) ? Infinity : Number(params.end);
@@ -600,7 +601,7 @@ class NamespaceFS {
                 // clear count for next updates
                 count = 0;
 
-                const bytesRead = await file.read(fs_account_config, buffer, 0, read_size, pos);
+                const bytesRead = await file.read(fs_context, buffer, 0, read_size, pos);
                 if (!bytesRead) {
                     buffer_pool_cleanup = null;
                     callback();
@@ -633,7 +634,7 @@ class NamespaceFS {
                 }
             }
 
-            await file.close(fs_account_config);
+            await file.close(fs_context);
             file = null;
             object_sdk.throw_if_aborted();
 
@@ -668,7 +669,7 @@ class NamespaceFS {
             try {
                 if (file) {
                     dbg.log0('NamespaceFS: read_object_stream finally closing file', file_path);
-                    await file.close(fs_account_config);
+                    await file.close(fs_context);
                 }
             } catch (err) {
                 dbg.warn('NamespaceFS: read_object_stream file close error', err);
@@ -691,76 +692,76 @@ class NamespaceFS {
     ///////////////////
 
     async upload_object(params, object_sdk) {
-        const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-        await this._load_bucket(params, fs_account_config);
+        const fs_context = this.prepare_fs_context(object_sdk);
+        await this._load_bucket(params, fs_context);
 
-        const can_use_temp_file = Boolean(fs_account_config.backend === 'GPFS' && nb_native().fs.gpfs);
+        const can_use_temp_file = Boolean(fs_context.backend === 'GPFS' && nb_native().fs.gpfs);
         const file_path = this._get_file_path(params);
         let fs_xattr = to_fs_xattr(params.xattr);
         try {
             const upload_id = uuidv4();
             const upload_path = path.join(this.bucket_path, this.get_bucket_tmpdir(), 'uploads', upload_id);
-            await this._check_path_in_bucket_boundaries(fs_account_config, file_path);
+            await this._check_path_in_bucket_boundaries(fs_context, file_path);
             if (can_use_temp_file) {
                 const open_mode = 'wt';
                 // dbg.log0('NamespaceFS.upload_object:', this.upload_path, '->', file_path);
                 if (params.copy_source) {
                     const source_file_path = path.join(this.bucket_path, params.copy_source.key);
-                    await this._make_path_dirs(upload_path, fs_account_config);
-                    await this._check_path_in_bucket_boundaries(fs_account_config, source_file_path);
-                    await this._fail_if_archived_or_sparse_file(fs_account_config, source_file_path);
+                    await this._make_path_dirs(upload_path, fs_context);
+                    await this._check_path_in_bucket_boundaries(fs_context, source_file_path);
+                    await this._fail_if_archived_or_sparse_file(fs_context, source_file_path);
                     try {
-                        const same_inode = await this._is_same_inode(fs_account_config, source_file_path, file_path, fs_xattr);
+                        const same_inode = await this._is_same_inode(fs_context, source_file_path, file_path, fs_xattr);
                         if (same_inode) return same_inode;
                         // Doing a hard link.
-                        await nb_native().fs.link(fs_account_config, source_file_path, upload_path);
+                        await nb_native().fs.link(fs_context, source_file_path, upload_path);
                     } catch (e) {
                         dbg.warn('NamespaceFS: COPY using link failed with:', e);
-                        fs_xattr = await this._copy_stream(source_file_path, upload_path, fs_account_config, fs_xattr);
+                        fs_xattr = await this._copy_stream(source_file_path, upload_path, fs_context, fs_xattr);
                     }
                 } else {
                     // TODO: Take up only as much as we need (requires fine-tune of the semaphore inside the _upload_stream)
                     // Currently we are taking config.NSFS_BUF_SIZE for any sized upload (1KB upload will take a full buffer from semaphore)
                     fs_xattr = await buffers_pool_sem.surround_count(
                         config.NSFS_BUF_SIZE,
-                        async () => this._upload_stream(params, this.bucket_path, file_path, open_mode, fs_account_config,
+                        async () => this._upload_stream(params, this.bucket_path, file_path, open_mode, fs_context,
                             object_sdk.rpc_client, fs_xattr)
                     );
                     // TODO use file xattr to store md5_b64 xattr, etc.
-                    const stat = await nb_native().fs.stat(fs_account_config, file_path);
+                    const stat = await nb_native().fs.stat(fs_context, file_path);
                     return { etag: this._get_etag(stat, fs_xattr) };
                 }
             } else {
                 const open_mode = 'w';
                 // Uploading to a temp file then we will rename it.
                 // dbg.log0('NamespaceFS.upload_object:', upload_path, '->', file_path);
-                await this._make_path_dirs(upload_path, fs_account_config);
+                await this._make_path_dirs(upload_path, fs_context);
                 if (params.copy_source) {
                     const source_file_path = path.join(this.bucket_path, params.copy_source.key);
-                    await this._check_path_in_bucket_boundaries(fs_account_config, source_file_path);
-                    await this._fail_if_archived_or_sparse_file(fs_account_config, source_file_path);
+                    await this._check_path_in_bucket_boundaries(fs_context, source_file_path);
+                    await this._fail_if_archived_or_sparse_file(fs_context, source_file_path);
                     try {
-                        const same_inode = await this._is_same_inode(fs_account_config, source_file_path, file_path, fs_xattr);
+                        const same_inode = await this._is_same_inode(fs_context, source_file_path, file_path, fs_xattr);
                         if (same_inode) return same_inode;
                         // Doing a hard link.
-                        await nb_native().fs.link(fs_account_config, source_file_path, upload_path);
+                        await nb_native().fs.link(fs_context, source_file_path, upload_path);
                     } catch (e) {
                         dbg.warn('NamespaceFS: COPY using link failed with:', e);
-                        fs_xattr = await this._copy_stream(source_file_path, upload_path, fs_account_config, fs_xattr);
+                        fs_xattr = await this._copy_stream(source_file_path, upload_path, fs_context, fs_xattr);
                     }
                 } else {
                     // TODO: Take up only as much as we need (requires fine-tune of the semaphore inside the _upload_stream)
                     // Currently we are taking config.NSFS_BUF_SIZE for any sized upload (1KB upload will take a full buffer from semaphore)
                     fs_xattr = await buffers_pool_sem.surround_count(
                         config.NSFS_BUF_SIZE,
-                        async () => this._upload_stream(params, upload_path, file_path, open_mode, fs_account_config, object_sdk.rpc_client,
+                        async () => this._upload_stream(params, upload_path, file_path, open_mode, fs_context, object_sdk.rpc_client,
                             fs_xattr)
                     );
                 }
                 // TODO use file xattr to store md5_b64 xattr, etc.
-                const stat = await nb_native().fs.stat(fs_account_config, upload_path);
-                await this._move_to_dest(fs_account_config, upload_path, file_path);
-                if (config.NSFS_TRIGGER_FSYNC) await nb_native().fs.fsync(fs_account_config, path.dirname(upload_path));
+                const stat = await nb_native().fs.stat(fs_context, upload_path);
+                await this._move_to_dest(fs_context, upload_path, file_path);
+                if (config.NSFS_TRIGGER_FSYNC) await nb_native().fs.fsync(fs_context, path.dirname(upload_path));
                 return { etag: this._get_etag(stat, fs_xattr) };
             }
         } catch (err) {
@@ -769,20 +770,20 @@ class NamespaceFS {
         }
     }
 
-    async _move_to_dest(fs_account_config, source_path, dest_path) {
+    async _move_to_dest(fs_context, source_path, dest_path) {
         let retries = config.NSFS_RENAME_RETRIES;
         // will retry renaming a file in case of parallel deleting of the destination path
         for (;;) {
             try {
-                await this._make_path_dirs(dest_path, fs_account_config);
-                await nb_native().fs.rename(fs_account_config, source_path, dest_path);
+                await this._make_path_dirs(dest_path, fs_context);
+                await nb_native().fs.rename(fs_context, source_path, dest_path);
                 break;
             } catch (err) {
                 retries -= 1;
                 if (retries <= 0) throw err;
                 if (err.code !== 'ENOENT') throw err;
                 // checking that the source_path still exists
-                if (!await this.check_access(fs_account_config, source_path)) throw err;
+                if (!await this.check_access(fs_context, source_path)) throw err;
                 dbg.warn(`NamespaceFS: Retrying failed move to dest retries=${retries}` +
                     ` source_path=${source_path} dest_path=${dest_path}`, err);
             }
@@ -792,13 +793,13 @@ class NamespaceFS {
     // Comparing both device and inode number (st_dev and st_ino returned by stat) 
     // will tell you whether two different file names refer to the same thing.
     // If so, we will return the etag of the file_path
-    async _is_same_inode(fs_account_config, source_file_path, file_path, fs_xattr) {
+    async _is_same_inode(fs_context, source_file_path, file_path, fs_xattr) {
         try {
             dbg.log2('NamespaceFS: checking _is_same_inode');
-            const file_path_stat = await nb_native().fs.stat(fs_account_config, file_path);
+            const file_path_stat = await nb_native().fs.stat(fs_context, file_path);
             const file_path_inode = file_path_stat.ino.toString();
             const file_path_device = file_path_stat.dev.toString();
-            const source_file_stat = await nb_native().fs.stat(fs_account_config, source_file_path);
+            const source_file_stat = await nb_native().fs.stat(fs_context, source_file_path);
             const source_file_inode = source_file_stat.ino.toString();
             const source_file_device = source_file_stat.dev.toString();
             dbg.log2('NamespaceFS: file_path_inode:', file_path_inode, 'source_file_inode:', source_file_inode,
@@ -812,7 +813,7 @@ class NamespaceFS {
         }
     }
 
-    async _copy_stream(source_file_path, upload_path, fs_account_config, fs_xattr) {
+    async _copy_stream(source_file_path, upload_path, fs_context, fs_xattr) {
         let target_file;
         let source_file;
         let buffer_pool_cleanup = null;
@@ -820,15 +821,15 @@ class NamespaceFS {
             let MD5Async =
                 config.NSFS_CALCULATE_MD5 && !(fs_xattr && fs_xattr[XATTR_MD5_KEY]) ? new (nb_native().crypto.MD5Async)() : undefined;
             //Opening the source and target files
-            source_file = await nb_native().fs.open(fs_account_config, source_file_path);
-            target_file = await nb_native().fs.open(fs_account_config, upload_path, 'w');
+            source_file = await nb_native().fs.open(fs_context, source_file_path);
+            target_file = await nb_native().fs.open(fs_context, upload_path, 'w');
             //Reading the source_file and writing into the target_file
             let read_pos = 0;
 
             for (;;) {
                 const { buffer, callback } = await buffers_pool.get_buffer();
                 buffer_pool_cleanup = callback;
-                const bytesRead = await source_file.read(fs_account_config, buffer, 0, config.NSFS_BUF_SIZE, read_pos);
+                const bytesRead = await source_file.read(fs_context, buffer, 0, config.NSFS_BUF_SIZE, read_pos);
                 if (!bytesRead) {
                     buffer_pool_cleanup = null;
                     callback();
@@ -837,7 +838,7 @@ class NamespaceFS {
                 read_pos += bytesRead;
                 const data = buffer.slice(0, bytesRead);
                 if (MD5Async) await MD5Async.update(data);
-                await target_file.write(fs_account_config, data);
+                await target_file.write(fs_context, data);
                 // Returns the buffer to pool to avoid starvation
                 buffer_pool_cleanup = null;
                 callback();
@@ -846,13 +847,13 @@ class NamespaceFS {
                 fs_xattr = this._assign_md5_to_fs_xattr((await MD5Async.digest()).toString('hex'), fs_xattr);
             }
             if (fs_xattr) {
-                await target_file.replacexattr(fs_account_config, fs_xattr);
+                await target_file.replacexattr(fs_context, fs_xattr);
             }
             //Closing the source_file and target files
-            await source_file.close(fs_account_config);
+            await source_file.close(fs_context);
             source_file = null;
-            if (config.NSFS_TRIGGER_FSYNC) await target_file.fsync(fs_account_config);
-            await target_file.close(fs_account_config);
+            if (config.NSFS_TRIGGER_FSYNC) await target_file.fsync(fs_context);
+            await target_file.close(fs_context);
             target_file = null;
             // Used for etag
             return fs_xattr;
@@ -867,12 +868,12 @@ class NamespaceFS {
                 dbg.warn('NamespaceFS: upload_object - copy_source buffer pool cleanup error', err);
             }
             try {
-                if (source_file) await source_file.close(fs_account_config);
+                if (source_file) await source_file.close(fs_context);
             } catch (err) {
                 dbg.warn('NamespaceFS: upload_object - copy_source source_file close error', err);
             }
             try {
-                if (target_file) await target_file.close(fs_account_config);
+                if (target_file) await target_file.close(fs_context);
             } catch (err) {
                 dbg.warn('NamespaceFS: upload_object - copy_source target_file close error', err);
             }
@@ -883,7 +884,7 @@ class NamespaceFS {
     // This is due to MD5 calculation and data buffers
     // Can be finetuned further on if needed and inserting the Semaphore logic inside
     // Instead of wrapping the whole _upload_stream function (q_buffers lives outside of the data scope of the stream)
-    async _upload_stream(params, upload_path, file_path, open_mode, fs_account_config, rpc_client, fs_xattr) {
+    async _upload_stream(params, upload_path, file_path, open_mode, fs_context, rpc_client, fs_xattr) {
         let target_file;
         const { source_stream, md5_b64, key, bucket, upload_id } = params;
         try {
@@ -891,16 +892,16 @@ class NamespaceFS {
                 const dir_path = path.dirname(file_path);
                 dbg.log1('NamespaceFS.upload_stream:', file_path, dir_path, upload_path);
                 if (dir_path !== upload_path) {
-                    await this._make_path_dirs(file_path, fs_account_config);
+                    await this._make_path_dirs(file_path, fs_context);
                 }
-                target_file = await nb_native().fs.open(fs_account_config, dir_path, open_mode, get_umasked_mode(config.BASE_MODE_FILE));
+                target_file = await nb_native().fs.open(fs_context, dir_path, open_mode, get_umasked_mode(config.BASE_MODE_FILE));
             } else {
-                target_file = await nb_native().fs.open(fs_account_config, upload_path, open_mode, get_umasked_mode(config.BASE_MODE_FILE));
+                target_file = await nb_native().fs.open(fs_context, upload_path, open_mode, get_umasked_mode(config.BASE_MODE_FILE));
             }
             // Not using async iterators with ReadableStreams due to unsettled promises issues on abort/destroy
             const chunk_fs = new ChunkFS({
                 target_file,
-                fs_account_config,
+                fs_context,
                 rpc_client,
                 namespace_resource_id: this.namespace_resource_id
             });
@@ -915,12 +916,12 @@ class NamespaceFS {
                 fs_xattr = this._assign_md5_to_fs_xattr(chunk_fs.digest, fs_xattr);
             }
             if (fs_xattr) {
-                await target_file.replacexattr(fs_account_config, fs_xattr);
+                await target_file.replacexattr(fs_context, fs_xattr);
             }
-            if (config.NSFS_TRIGGER_FSYNC) await target_file.fsync(fs_account_config);
+            if (config.NSFS_TRIGGER_FSYNC) await target_file.fsync(fs_context);
             dbg.log1('NamespaceFS.upload_stream:', open_mode, file_path, upload_path);
             if (open_mode === 'wt') {
-                await target_file.linkfileat(fs_account_config, file_path);
+                await target_file.linkfileat(fs_context, file_path);
             }
             // Used for etag
             return fs_xattr;
@@ -929,7 +930,7 @@ class NamespaceFS {
             throw error;
         } finally {
             try {
-                if (target_file) await target_file.close(fs_account_config);
+                if (target_file) await target_file.close(fs_context);
             } catch (err) {
                 dbg.warn('NamespaceFS: _upload_stream file close error', err);
             }
@@ -954,14 +955,14 @@ class NamespaceFS {
 
     async create_object_upload(params, object_sdk) {
         try {
-            const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-            await this._load_bucket(params, fs_account_config);
+            const fs_context = this.prepare_fs_context(object_sdk);
+            await this._load_bucket(params, fs_context);
             params.obj_id = uuidv4();
             params.mpu_path = this._mpu_path(params);
-            await this._create_path(params.mpu_path, fs_account_config);
+            await this._create_path(params.mpu_path, fs_context);
             const create_params = JSON.stringify({ ...params, source_stream: null });
             await nb_native().fs.writeFile(
-                fs_account_config,
+                fs_context,
                 path.join(params.mpu_path, 'create_object_upload'),
                 Buffer.from(create_params),
                 get_umasked_mode(config.BASE_MODE_FILE)
@@ -977,15 +978,15 @@ class NamespaceFS {
             // We can use 'wt' for open mode like we do for upload_object() when
             // we figure out how to create multipart upload using temp files.
             const open_mode = 'w';
-            const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-            await this._load_multipart(params, fs_account_config);
+            const fs_context = this.prepare_fs_context(object_sdk);
+            await this._load_multipart(params, fs_context);
             const upload_path = path.join(params.mpu_path, `part-${params.num}`);
             // Will get populated in _upload_stream with the MD5 (if MD5 calculation is enabled)
             const fs_xattr = await buffers_pool_sem.surround_count(
                 config.NSFS_BUF_SIZE,
-                async () => this._upload_stream(params, upload_path, '', open_mode, fs_account_config, object_sdk.rpc_client)
+                async () => this._upload_stream(params, upload_path, '', open_mode, fs_context, object_sdk.rpc_client)
             );
-            const stat = await nb_native().fs.stat(fs_account_config, upload_path);
+            const stat = await nb_native().fs.stat(fs_context, upload_path);
             return { etag: this._get_etag(stat, fs_xattr) };
         } catch (err) {
             this.run_update_issues_report(object_sdk, err);
@@ -995,19 +996,19 @@ class NamespaceFS {
 
     async list_multiparts(params, object_sdk) {
         try {
-            const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-            await this._load_multipart(params, fs_account_config);
-            await this._check_path_in_bucket_boundaries(fs_account_config, params.mpu_path);
-            const entries = await nb_native().fs.readdir(fs_account_config, params.mpu_path);
+            const fs_context = this.prepare_fs_context(object_sdk);
+            await this._load_multipart(params, fs_context);
+            await this._check_path_in_bucket_boundaries(fs_context, params.mpu_path);
+            const entries = await nb_native().fs.readdir(fs_context, params.mpu_path);
             const multiparts = await Promise.all(
                 entries
                 .filter(e => e.name.startsWith('part-'))
                 .map(async e => {
                     const num = Number(e.name.slice('part-'.length));
                     const part_path = path.join(params.mpu_path, e.name);
-                    const stat = await nb_native().fs.stat(fs_account_config, part_path);
+                    const stat = await nb_native().fs.stat(fs_context, part_path);
                     const fs_xattr =
-                        config.NSFS_CALCULATE_MD5 ? await this._get_fs_xattr_from_path(fs_account_config, part_path) : undefined;
+                        config.NSFS_CALCULATE_MD5 ? await this._get_fs_xattr_from_path(fs_context, part_path) : undefined;
                     return {
                         num,
                         size: stat.size,
@@ -1030,22 +1031,22 @@ class NamespaceFS {
         let read_file;
         let write_file;
         let buffer_pool_cleanup = null;
-        const fs_account_config = this.set_cur_fs_account_config(object_sdk);
+        const fs_context = this.prepare_fs_context(object_sdk);
         try {
             let MD5Async = config.NSFS_CALCULATE_MD5 ? new (nb_native().crypto.MD5Async)() : undefined;
             const { multiparts = [] } = params;
             multiparts.sort((a, b) => a.num - b.num);
-            await this._load_multipart(params, fs_account_config);
+            await this._load_multipart(params, fs_context);
             const file_path = this._get_file_path(params);
-            await this._check_path_in_bucket_boundaries(fs_account_config, file_path);
+            await this._check_path_in_bucket_boundaries(fs_context, file_path);
             const upload_path = path.join(params.mpu_path, 'final');
-            write_file = await nb_native().fs.open(fs_account_config, upload_path, 'w', get_umasked_mode(config.BASE_MODE_FILE));
+            write_file = await nb_native().fs.open(fs_context, upload_path, 'w', get_umasked_mode(config.BASE_MODE_FILE));
             for (const { num, etag } of multiparts) {
                 const part_path = path.join(params.mpu_path, `part-${num}`);
-                const part_stat = await nb_native().fs.stat(fs_account_config, part_path);
-                read_file = await nb_native().fs.open(fs_account_config, part_path, undefined, get_umasked_mode(config.BASE_MODE_FILE));
+                const part_stat = await nb_native().fs.stat(fs_context, part_path);
+                read_file = await nb_native().fs.open(fs_context, part_path, undefined, get_umasked_mode(config.BASE_MODE_FILE));
                 // Assuming that a every multipart upload object uses the same NSFS_CALCULATE_MD5 configuration
-                const fs_xattr = MD5Async ? await read_file.getxattr(fs_account_config) : undefined;
+                const fs_xattr = MD5Async ? await read_file.getxattr(fs_context) : undefined;
                 // TODO: Should we seperate to two cases and save the open if we do not use NSFS_CALCULATE_MD5?
                 if (etag !== this._get_etag(part_stat, fs_xattr)) {
                     throw new Error('mismatch part etag: ' + util.inspect({ num, etag, part_path, part_stat, params }));
@@ -1054,7 +1055,7 @@ class NamespaceFS {
                 for (;;) {
                     const { buffer, callback } = await buffers_pool.get_buffer();
                     buffer_pool_cleanup = callback;
-                    const bytesRead = await read_file.read(fs_account_config, buffer, 0, config.NSFS_BUF_SIZE, read_pos);
+                    const bytesRead = await read_file.read(fs_context, buffer, 0, config.NSFS_BUF_SIZE, read_pos);
                     if (!bytesRead) {
                         buffer_pool_cleanup = null;
                         callback();
@@ -1062,40 +1063,40 @@ class NamespaceFS {
                     }
                     read_pos += bytesRead;
                     const data = buffer.slice(0, bytesRead);
-                    await write_file.write(fs_account_config, data);
+                    await write_file.write(fs_context, data);
                     // Returns the buffer to pool to avoid starvation
                     buffer_pool_cleanup = null;
                     callback();
                 }
-                await read_file.close(fs_account_config);
+                await read_file.close(fs_context);
                 read_file = null;
                 if (MD5Async) await MD5Async.update(Buffer.from(etag, 'hex'));
             }
             const create_params_buffer = await nb_native().fs.readFile(
-                fs_account_config,
+                fs_context,
                 path.join(params.mpu_path, 'create_object_upload')
             );
             const { xattr } = JSON.parse(create_params_buffer);
             let fs_xattr = to_fs_xattr(xattr);
             if (MD5Async) fs_xattr = this._assign_md5_to_fs_xattr(((await MD5Async.digest()).toString('hex')) + '-' + multiparts.length, fs_xattr);
-            if (fs_xattr) await write_file.replacexattr(fs_account_config, fs_xattr);
-            if (config.NSFS_TRIGGER_FSYNC) await write_file.fsync(fs_account_config);
-            const stat = await write_file.stat(fs_account_config);
-            await write_file.close(fs_account_config);
+            if (fs_xattr) await write_file.replacexattr(fs_context, fs_xattr);
+            if (config.NSFS_TRIGGER_FSYNC) await write_file.fsync(fs_context);
+            const stat = await write_file.stat(fs_context);
+            await write_file.close(fs_context);
             write_file = null;
-            await this._move_to_dest(fs_account_config, upload_path, file_path);
-            if (config.NSFS_REMOVE_PARTS_ON_COMPLETE) await this._folder_delete(params.mpu_path, fs_account_config);
+            await this._move_to_dest(fs_context, upload_path, file_path);
+            if (config.NSFS_REMOVE_PARTS_ON_COMPLETE) await this._folder_delete(params.mpu_path, fs_context);
             return { etag: this._get_etag(stat, fs_xattr) };
         } catch (err) {
             dbg.error(err);
             throw this._translate_object_error_codes(err);
         } finally {
-            await this.complete_object_upload_finally(buffer_pool_cleanup, read_file, write_file, fs_account_config);
+            await this.complete_object_upload_finally(buffer_pool_cleanup, read_file, write_file, fs_context);
         }
     }
 
     // complete_object_upload method has too many statements
-    async complete_object_upload_finally(buffer_pool_cleanup, read_file, write_file, fs_account_config) {
+    async complete_object_upload_finally(buffer_pool_cleanup, read_file, write_file, fs_context) {
         try {
             // release buffer back to pool if needed
             if (buffer_pool_cleanup) buffer_pool_cleanup();
@@ -1103,22 +1104,22 @@ class NamespaceFS {
             dbg.warn('NamespaceFS: complete_object_upload buffer pool cleanup error', err);
         }
         try {
-            if (read_file) await read_file.close(fs_account_config);
+            if (read_file) await read_file.close(fs_context);
         } catch (err) {
             dbg.warn('NamespaceFS: complete_object_upload read file close error', err);
         }
         try {
-            if (write_file) await write_file.close(fs_account_config);
+            if (write_file) await write_file.close(fs_context);
         } catch (err) {
             dbg.warn('NamespaceFS: complete_object_upload write file close error', err);
         }
     }
 
     async abort_object_upload(params, object_sdk) {
-        const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-        await this._load_multipart(params, fs_account_config);
+        const fs_context = this.prepare_fs_context(object_sdk);
+        await this._load_multipart(params, fs_context);
         dbg.log0('NamespaceFS: abort_object_upload', params.mpu_path);
-        await this._folder_delete(params.mpu_path, fs_account_config);
+        await this._folder_delete(params.mpu_path, fs_context);
     }
 
     ///////////////////
@@ -1127,13 +1128,13 @@ class NamespaceFS {
 
     async delete_object(params, object_sdk) {
         try {
-            const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-            await this._load_bucket(params, fs_account_config);
+            const fs_context = this.prepare_fs_context(object_sdk);
+            await this._load_bucket(params, fs_context);
             const file_path = this._get_file_path(params);
-            await this._check_path_in_bucket_boundaries(fs_account_config, file_path);
+            await this._check_path_in_bucket_boundaries(fs_context, file_path);
             dbg.log0('NamespaceFS: delete_object', file_path);
-            await nb_native().fs.unlink(fs_account_config, file_path);
-            await this._delete_path_dirs(file_path, fs_account_config);
+            await nb_native().fs.unlink(fs_context, file_path);
+            await this._delete_path_dirs(file_path, fs_context);
             return {};
         } catch (err) {
             throw this._translate_object_error_codes(err);
@@ -1142,14 +1143,14 @@ class NamespaceFS {
 
     async delete_multiple_objects(params, object_sdk) {
         try {
-            const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-            await this._load_bucket(params, fs_account_config);
+            const fs_context = this.prepare_fs_context(object_sdk);
+            await this._load_bucket(params, fs_context);
             for (const { key } of params.objects) {
                 const file_path = this._get_file_path({ key });
-                await this._check_path_in_bucket_boundaries(fs_account_config, file_path);
+                await this._check_path_in_bucket_boundaries(fs_context, file_path);
                 dbg.log0('NamespaceFS: delete_multiple_objects', file_path);
-                await nb_native().fs.unlink(fs_account_config, file_path);
-                await this._delete_path_dirs(file_path, fs_account_config);
+                await nb_native().fs.unlink(fs_context, file_path);
+                await this._delete_path_dirs(file_path, fs_context);
             }
             // TODO return deletion reponse per key
             return params.objects.map(() => ({}));
@@ -1245,18 +1246,18 @@ class NamespaceFS {
     }
 
     // TODO: Can be changed to get MD5 attributes only
-    async _get_fs_xattr_from_path(fs_account_config, file_path) {
+    async _get_fs_xattr_from_path(fs_context, file_path) {
         let file;
         try {
-            file = await nb_native().fs.open(fs_account_config, file_path, undefined, get_umasked_mode(config.BASE_MODE_FILE));
-            const fs_xattr = await file.getxattr(fs_account_config);
-            await file.close(fs_account_config);
+            file = await nb_native().fs.open(fs_context, file_path, undefined, get_umasked_mode(config.BASE_MODE_FILE));
+            const fs_xattr = await file.getxattr(fs_context);
+            await file.close(fs_context);
             file = null;
             return fs_xattr;
         } catch (error) {
             throw this._translate_object_error_codes(error);
         } finally {
-            if (file) await file.close(fs_account_config);
+            if (file) await file.close(fs_context);
         }
     }
 
@@ -1270,9 +1271,9 @@ class NamespaceFS {
         return dir_key + ent.name + (isDir ? '/' : '');
     }
 
-    async _make_path_dirs(file_path, fs_account_config) {
+    async _make_path_dirs(file_path, fs_context) {
         const last_dir_pos = file_path.lastIndexOf('/');
-        if (last_dir_pos > 0) return this._create_path(file_path.slice(0, last_dir_pos), fs_account_config);
+        if (last_dir_pos > 0) return this._create_path(file_path.slice(0, last_dir_pos), fs_context);
     }
 
     /**
@@ -1335,9 +1336,9 @@ class NamespaceFS {
         return err;
     }
 
-    async _load_bucket(params, fs_account_config) {
+    async _load_bucket(params, fs_context) {
         try {
-            await nb_native().fs.stat(fs_account_config, this.bucket_path);
+            await nb_native().fs.stat(fs_context, this.bucket_path);
         } catch (err) {
             throw this._translate_object_error_codes(err);
         }
@@ -1352,11 +1353,11 @@ class NamespaceFS {
         );
     }
 
-    async _load_multipart(params, fs_account_config) {
-        await this._load_bucket(params, fs_account_config);
+    async _load_multipart(params, fs_context) {
+        await this._load_bucket(params, fs_context);
         params.mpu_path = this._mpu_path(params);
         try {
-            await nb_native().fs.stat(fs_account_config, params.mpu_path);
+            await nb_native().fs.stat(fs_context, params.mpu_path);
         } catch (err) {
             // TOOD: Error handling
             if (err.code === 'ENOENT') err.rpc_code = 'NO_SUCH_UPLOAD';
@@ -1364,25 +1365,25 @@ class NamespaceFS {
         }
     }
 
-    async _create_path(dir, fs_account_config) {
+    async _create_path(dir, fs_context) {
         let dir_path = path.isAbsolute(dir) ? path.sep : '';
         for (const item of dir.split(path.sep)) {
             dir_path = path.join(dir_path, item);
             try {
-                await nb_native().fs.mkdir(fs_account_config, dir_path, get_umasked_mode(config.BASE_MODE_DIR));
+                await nb_native().fs.mkdir(fs_context, dir_path, get_umasked_mode(config.BASE_MODE_DIR));
             } catch (err) {
                 const ERR_CODES = ['EISDIR', 'EEXIST'];
                 if (!ERR_CODES.includes(err.code)) throw err;
             }
         }
-        if (config.NSFS_TRIGGER_FSYNC) await nb_native().fs.fsync(fs_account_config, dir_path);
+        if (config.NSFS_TRIGGER_FSYNC) await nb_native().fs.fsync(fs_context, dir_path);
     }
 
-    async _delete_path_dirs(file_path, fs_account_config) {
+    async _delete_path_dirs(file_path, fs_context) {
         try {
             let dir = path.dirname(file_path);
             while (dir !== this.bucket_path) {
-                await nb_native().fs.rmdir(fs_account_config, dir);
+                await nb_native().fs.rmdir(fs_context, dir);
                 dir = path.dirname(dir);
             }
         } catch (err) {
@@ -1396,34 +1397,34 @@ class NamespaceFS {
         }
     }
 
-    async _folder_delete(dir, fs_account_config) {
-        let entries = await nb_native().fs.readdir(fs_account_config, dir);
+    async _folder_delete(dir, fs_context) {
+        let entries = await nb_native().fs.readdir(fs_context, dir);
         let results = await Promise.all(entries.map(entry => {
             let fullPath = path.join(dir, entry.name);
-            let task = isDirectory(entry) ? this._folder_delete(fullPath, fs_account_config) :
-                nb_native().fs.unlink(fs_account_config, fullPath);
+            let task = isDirectory(entry) ? this._folder_delete(fullPath, fs_context) :
+                nb_native().fs.unlink(fs_context, fullPath);
             return task.catch(error => ({ error }));
         }));
         results.forEach(result => {
             // Ignore missing files/directories; bail on other errors
             if (result && result.error && result.error.code !== 'ENOENT') throw result.error;
         });
-        await nb_native().fs.rmdir(fs_account_config, dir);
+        await nb_native().fs.rmdir(fs_context, dir);
     }
 
     async create_uls(params, object_sdk) {
-        const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-        dbg.log0('NamespaceFS: create_uls fs_account_config:', fs_account_config, 'new_dir_path: ', params.full_path);
+        const fs_context = this.prepare_fs_context(object_sdk);
+        dbg.log0('NamespaceFS: create_uls fs_context:', fs_context, 'new_dir_path: ', params.full_path);
         try {
-            await nb_native().fs.mkdir(fs_account_config, params.full_path, get_umasked_mode(0o777));
+            await nb_native().fs.mkdir(fs_context, params.full_path, get_umasked_mode(0o777));
         } catch (err) {
             throw this._translate_object_error_codes(err);
         }
     }
 
     async delete_uls(params, object_sdk) {
-        const fs_account_config = this.set_cur_fs_account_config(object_sdk);
-        dbg.log0('NamespaceFS: delete_uls fs_account_config:', fs_account_config, 'to_delete_dir_path: ', params.full_path);
+        const fs_context = this.prepare_fs_context(object_sdk);
+        dbg.log0('NamespaceFS: delete_uls fs_context:', fs_context, 'to_delete_dir_path: ', params.full_path);
 
         try {
             const list = await this.list_objects({ ...params, limit: 1 }, object_sdk);
@@ -1434,17 +1435,17 @@ class NamespaceFS {
                 throw err;
             }
 
-            await this._folder_delete(params.full_path, fs_account_config);
+            await this._folder_delete(params.full_path, fs_context);
         } catch (err) {
             throw this._translate_object_error_codes(err);
         }
     }
 
-    async check_access(fs_account_config, dir_path) {
+    async check_access(fs_context, dir_path) {
         try {
-            dbg.log0('check_access: dir_path', dir_path, 'fs_account_config', fs_account_config);
-            await this._check_path_in_bucket_boundaries(fs_account_config, dir_path);
-            await nb_native().fs.checkAccess(fs_account_config, dir_path);
+            dbg.log0('check_access: dir_path', dir_path, 'fs_context', fs_context);
+            await this._check_path_in_bucket_boundaries(fs_context, dir_path);
+            await nb_native().fs.checkAccess(fs_context, dir_path);
             return true;
         } catch (err) {
             dbg.error('check_access: error ', err.code, err, dir_path, this.bucket_path);
@@ -1457,7 +1458,7 @@ class NamespaceFS {
             }
             if (err.code === 'ENOENT' && !is_bucket_dir) {
                 // invalidate if dir
-                dir_cache.invalidate({ dir_path, fs_account_config });
+                dir_cache.invalidate({ dir_path, fs_context });
                 return false;
             }
             throw err;
@@ -1466,12 +1467,12 @@ class NamespaceFS {
 
     /**
      * Return false if the entry is outside of the bucket
-     * @param {*} fs_account_config 
+     * @param {*} fs_context 
      * @param {*} entry_path 
      * @returns 
      */
-    async _is_path_in_bucket_boundaries(fs_account_config, entry_path) {
-        dbg.log0('check_bucket_boundaries: fs_account_config', fs_account_config, 'file_path', entry_path);
+    async _is_path_in_bucket_boundaries(fs_context, entry_path) {
+        dbg.log0('check_bucket_boundaries: fs_context', fs_context, 'file_path', entry_path);
         if (!entry_path.startsWith(this.bucket_path)) {
             dbg.log0('check_bucket_boundaries: the path', entry_path, 'is not in the bucket', this.bucket_path, 'boundaries');
             return false;
@@ -1479,7 +1480,7 @@ class NamespaceFS {
         try {
             // Returns the real path of the entry.
             // The entry path may point to regular file or directory, but can have symbolic links  
-            let full_path = await nb_native().fs.realpath(fs_account_config, entry_path);
+            let full_path = await nb_native().fs.realpath(fs_context, entry_path);
             if (!full_path.startsWith(this.bucket_path)) {
                 dbg.log0('check_bucket_boundaries: the path', entry_path, 'is not in the bucket', this.bucket_path, 'boundaries');
                 return false;
@@ -1488,7 +1489,7 @@ class NamespaceFS {
             // Error: No such file or directory
             // In the upload use case, the destination file desn't exist yet, need to validate the parent dirs path.
             if (err.code === 'ENOENT') {
-                return this._is_path_in_bucket_boundaries(fs_account_config, path.dirname(entry_path));
+                return this._is_path_in_bucket_boundaries(fs_context, path.dirname(entry_path));
             }
             // Read or search permission was denied for a component of the path prefix.
             if (err.code === 'EACCES') {
@@ -1501,18 +1502,18 @@ class NamespaceFS {
 
     /**
      * throws AccessDenied, if the entry is outside of the bucket 
-     * @param {*} fs_account_config 
+     * @param {*} fs_context 
      * @param {*} entry_path 
      */
-    async _check_path_in_bucket_boundaries(fs_account_config, entry_path) {
-        if (!(await this._is_path_in_bucket_boundaries(fs_account_config, entry_path))) {
+    async _check_path_in_bucket_boundaries(fs_context, entry_path) {
+        if (!(await this._is_path_in_bucket_boundaries(fs_context, entry_path))) {
             throw Object.assign(new Error('Entry ' + entry_path + ' is not in bucket boundaries'), { code: 'EACCES' });
         }
     }
 
     // TODO: Return/Refactor check after handling of FSync
-    async _fail_if_archived_or_sparse_file(fs_account_config, file_path) {
-        // const stat = await nb_native().fs.stat(fs_account_config, file_path);
+    async _fail_if_archived_or_sparse_file(fs_context, file_path) {
+        // const stat = await nb_native().fs.stat(fs_context, file_path);
         // if (isDirectory(stat)) return;
         // // In order to verify if the file is stored in tape we compare sizes
         // // Multiple number of blocks by default block size and verify we get the size of the object

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -170,12 +170,12 @@ class NamespaceMonitor {
 
     async test_nsfs_resource(nsr) {
         try {
-            const fs_config_param = {
+            const fs_context = {
                 backend: nsr.nsfs_config.fs_backend || '',
                 warn_threshold_ms: config.NSFS_WARN_THRESHOLD_MS,
             };
-            await nb_native().fs.readdir(fs_config_param, nsr.nsfs_config.fs_root_path);
-            const stat = await nb_native().fs.stat(fs_config_param, nsr.nsfs_config.fs_root_path);
+            await nb_native().fs.readdir(fs_context, nsr.nsfs_config.fs_root_path);
+            const stat = await nb_native().fs.stat(fs_context, nsr.nsfs_config.fs_root_path);
             //In the event of deleting the nsr.nsfs_config.fs_root_path in the FS side, 
             // The number of link will be 0, then we will throw ENOENT which translate to STORAGE_NOT_EXIST
             if (stat.nlink === 0) {

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -5,7 +5,6 @@
  *
  */
 'use strict';
-
 const DEV_MODE = (process.env.DEV_MODE === 'true');
 const _ = require('lodash');
 const fs = require('fs');
@@ -51,6 +50,7 @@ const PARTIAL_STATS_REQUESTED_GRACE_TIME = 30 * 1000;
 let nsfs_io_counters = _new_nsfs_stats();
 // Will hold the op stats (op name, min/max/avg time, count, error count)
 let op_stats = {};
+let fs_workers_stats = {};
 
 /*
  * Stats Collction API
@@ -1240,8 +1240,9 @@ async function _perform_partial_cycle() {
 async function update_nsfs_stats(req) {
     dbg.log1(`update_nsfs_stats. nsfs_stats =`, req.rpc_params.nsfs_stats);
     const _nsfs_counters = req.rpc_params.nsfs_stats || {};
-    _update_io_stats(_nsfs_counters.io_stats);
-    _update_ops_stats(_nsfs_counters.op_stats);
+    if (_nsfs_counters.io_stats) _update_io_stats(_nsfs_counters.io_stats);
+    if (_nsfs_counters.op_stats) _update_ops_stats(_nsfs_counters.op_stats);
+    if (_nsfs_counters.fs_workers_stats) _update_fs_stats(_nsfs_counters.fs_workers_stats);
 }
 
 function _update_io_stats(io_stats) {
@@ -1269,6 +1270,48 @@ function _update_ops_stats(ops_stats) {
     for (const op_name of op_names) {
         if (op_name in ops_stats) {
             _set_op_stats(op_name, ops_stats[op_name]);
+        }
+    }
+}
+
+function _update_fs_stats(fs_stats) {
+    // Predefined fsworker_names
+    const fsworker_names = [
+        `stat`,
+        `lstat`,
+        `statfs`,
+        `checkaccess`,
+        `unlink`,
+        `unlinkat`,
+        `link`,
+        `linkat`,
+        `mkdir`,
+        `rmdir`,
+        `rename`,
+        `writefile`,
+        `readfile`,
+        `readdir`,
+        `fsync`,
+        `fileopen`,
+        `fileclose`,
+        `fileread`,
+        `filewrite`,
+        `filewritev`,
+        `filereplacexattr`,
+        `finkfileat`,
+        `filegetxattr`,
+        `filestat`,
+        `filefsync`,
+        `realpath`,
+        `getsinglexattr`,
+        `diropen`,
+        `dirclose`,
+        `dirreadentry`,
+    ];
+    //Go over the fs_stats
+    for (const fsworker_name of fsworker_names) {
+        if (fsworker_name in fs_stats) {
+            _set_fs_workers_stats(fsworker_name, fs_stats[fsworker_name]);
         }
     }
 }
@@ -1305,6 +1348,36 @@ function _set_op_stats(op_name, stats) {
     }
 }
 
+function _set_fs_workers_stats(fsworker_name, stats) {
+    if (fs_workers_stats[fsworker_name]) {
+        const count = fs_workers_stats[fsworker_name].count + stats.count;
+        const error_count = fs_workers_stats[fsworker_name].error_count + stats.error_count;
+        const old_sum_time = fs_workers_stats[fsworker_name].avg_time_microsec * fs_workers_stats[fsworker_name].count;
+        //Min time and Max time are not being counted in the namespace_fs if it was error
+        const min_time_microsec = Math.min(fs_workers_stats[fsworker_name].min_time_microsec, stats.min_time);
+        const max_time_microsec = Math.max(fs_workers_stats[fsworker_name].max_time_microsec, stats.max_time);
+        // At this point, as we populate only when there is at least one successful fsworker, there must be old_sum_time
+        const avg_time_microsec = Math.floor((old_sum_time + stats.sum_time) / (count - error_count));
+        fs_workers_stats[fsworker_name] = {
+            min_time_microsec,
+            max_time_microsec,
+            avg_time_microsec,
+            count,
+            error_count,
+        };
+        // When it is the first time we populate the fs_workers_stats with fsworker_name we do it 
+        // only if there are more successful ops than errors.
+    } else if (stats.count > stats.error_count) {
+        fs_workers_stats[fsworker_name] = {
+            min_time_microsec: stats.min_time,
+            max_time_microsec: stats.max_time,
+            avg_time_microsec: Math.floor(stats.sum_time / stats.count),
+            count: stats.count,
+            error_count: stats.error_count,
+        };
+    }
+}
+
 function _new_nsfs_stats() {
     return {
         read_count: 0,
@@ -1318,18 +1391,25 @@ function _new_nsfs_stats() {
     };
 }
 
-// Will return the current nsfs_counters and reset it.
+// Will return the current nsfs_io_counters and reset it.
 function get_nsfs_io_stats() {
     const nsfs_io_stats = nsfs_io_counters;
     nsfs_io_counters = _new_nsfs_stats();
     return nsfs_io_stats;
 }
 
-// Will return the current nsfs_counters and reset it.
+// Will return the current op_stats and reset it.
 function get_op_stats() {
     const nsfs_op_stats = op_stats;
     op_stats = {};
     return nsfs_op_stats;
+}
+
+// Will return the current fs_workers_stats and reset it.
+function get_fs_workers_stats() {
+    const nsfs_fs_workers_stats = fs_workers_stats;
+    fs_workers_stats = {};
+    return nsfs_fs_workers_stats;
 }
 
 // EXPORTS
@@ -1350,6 +1430,7 @@ exports.get_bucket_sizes_stats = get_bucket_sizes_stats;
 exports.get_object_usage_stats = get_object_usage_stats;
 exports.get_nsfs_io_stats = get_nsfs_io_stats;
 exports.get_op_stats = get_op_stats;
+exports.get_fs_workers_stats = get_fs_workers_stats;
 //OP stats collection
 exports.register_histogram = register_histogram;
 exports.add_sample_point = add_sample_point;

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -314,6 +314,16 @@ function _create_nsfs_report() {
         }
     }
 
+    const fs_workers_stats = stats_aggregator.get_fs_workers_stats();
+    // Building the report per fs worker name key and value
+    for (const [fs_worker_name, obj] of Object.entries(fs_workers_stats)) {
+        nsfs_report += `<br>`;
+        for (const [key, value] of Object.entries(obj)) {
+            const metric = `NooBaa_nsfs_${fs_worker_name}_${key}`.toLowerCase();
+            nsfs_report += `${metric}: ${value}<br>`;
+        }
+    }
+
     dbg.log1(`_create_nsfs_report: nsfs_report ${nsfs_report}`);
 
     return nsfs_report;

--- a/src/tools/chunk_fs_hashing.js
+++ b/src/tools/chunk_fs_hashing.js
@@ -40,7 +40,7 @@ const XATTR_MD5_KEY = XATTR_USER_PREFIX + 'content_md5';
 
 class TargetHash {
     constructor() {
-      this.hash = crypto.createHash('md5');
+        this.hash = crypto.createHash('md5');
     }
     digest() {
         return this.hash.digest('hex');
@@ -77,7 +77,7 @@ async function hash_target() {
         const target = new TargetHash();
         const chunk_fs = new ChunkFS({
             target_file: target,
-            fs_account_config: DEFAULT_FS_CONFIG,
+            fs_context: DEFAULT_FS_CONFIG,
             rpc_client: DUMMY_RPC,
             namespace_resource_id: 'MajesticSloth'
         });
@@ -115,7 +115,7 @@ async function file_target(chunk_size = CHUNK, parts = PARTS) {
             }());
             const chunk_fs = new ChunkFS({
                 target_file,
-                fs_account_config: DEFAULT_FS_CONFIG,
+                fs_context: DEFAULT_FS_CONFIG,
                 rpc_client: DUMMY_RPC,
                 namespace_resource_id: 'MajesticSloth'
             });

--- a/src/tools/fs_speed.js
+++ b/src/tools/fs_speed.js
@@ -152,26 +152,26 @@ async function write_nb_native(file_path) {
         highWaterMark: 2 * block_size,
         generator: argv.generator,
     });
-    const fs_account_config = {
+    const fs_context = {
         // uid: 666,
         // gid: 666,
         backend: 'GPFS',
         warn_threshold_ms: 1000,
     };
-    const file = await nb_native().fs.open(fs_account_config, file_path, 'w', 0x660);
+    const file = await nb_native().fs.open(fs_context, file_path, 'w', 0x660);
     for (let pos = 0; pos < file_size_aligned; pos += block_size) {
         const buf_start_time = Date.now();
         if (buf_start_time >= end_time) break;
         const buf = rand_stream.generator(block_size);
         if (argv.nvec > 1) {
-            await file.writev(fs_account_config, split_to_nvec(buf, argv.nvec));
+            await file.writev(fs_context, split_to_nvec(buf, argv.nvec));
         } else {
-            await file.write(fs_account_config, buf);
+            await file.write(fs_context, buf);
         }
         speedometer.update(block_size);
     }
-    if (argv.fsync) await file.fsync(fs_account_config);
-    await file.close(fs_account_config);
+    if (argv.fsync) await file.fsync(fs_context);
+    await file.close(fs_context);
 }
 
 async function write_node_fs(file_path) {

--- a/src/util/chunk_fs.js
+++ b/src/util/chunk_fs.js
@@ -15,13 +15,13 @@ const nb_native = require('./nb_native');
  */
 class ChunkFS extends stream.Transform {
 
-    constructor({ target_file, fs_account_config, rpc_client, namespace_resource_id }) {
+    constructor({ target_file, fs_context, rpc_client, namespace_resource_id }) {
         super();
         this.q_buffers = [];
         this.q_size = 0;
         this.MD5Async = config.NSFS_CALCULATE_MD5 ? new (nb_native().crypto.MD5Async)() : undefined;
         this.target_file = target_file;
-        this.fs_account_config = fs_account_config;
+        this.fs_context = fs_context;
         this.count = 1;
         this.rpc_client = rpc_client;
         this.namespace_resource_id = namespace_resource_id;
@@ -71,7 +71,7 @@ class ChunkFS extends stream.Transform {
                 const buffers_to_write = this.q_buffers;
                 this.q_buffers = [];
                 this.q_size = 0;
-                await this.target_file.writev(this.fs_account_config, buffers_to_write);
+                await this.target_file.writev(this.fs_context, buffers_to_write);
                 // Hold the ref on the buffers from the JS side
                 this._total_num_buffers += buffers_to_write.length;
             }


### PR DESCRIPTION
### Explain the changes
- Added fs_workers_stats to common_api and stats_api
- Renamed fs_config_param to fs_context to reflect this object nature better
- Added report_fs_stats function to be called in the fs_napi
- Add timing report of the fs Worker in the fs_napi
- Publishing the report of the fs Workers in the `/metrics/nsfs_stats` route

Signed-off-by: liranmauda <liran.mauda@gmail.com>
