### PR TITLE
NSFS | Native xattr api additions

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -846,7 +846,7 @@ class NamespaceFS {
                 fs_xattr = this._assign_md5_to_fs_xattr((await MD5Async.digest()).toString('hex'), fs_xattr);
             }
             if (fs_xattr) {
-                await target_file.setxattr(fs_account_config, fs_xattr);
+                await target_file.replacexattr(fs_account_config, fs_xattr);
             }
             //Closing the source_file and target files
             await source_file.close(fs_account_config);
@@ -915,7 +915,7 @@ class NamespaceFS {
                 fs_xattr = this._assign_md5_to_fs_xattr(chunk_fs.digest, fs_xattr);
             }
             if (fs_xattr) {
-                await target_file.setxattr(fs_account_config, fs_xattr);
+                await target_file.replacexattr(fs_account_config, fs_xattr);
             }
             if (config.NSFS_TRIGGER_FSYNC) await target_file.fsync(fs_account_config);
             dbg.log1('NamespaceFS.upload_stream:', open_mode, file_path, upload_path);
@@ -1078,7 +1078,7 @@ class NamespaceFS {
             const { xattr } = JSON.parse(create_params_buffer);
             let fs_xattr = to_fs_xattr(xattr);
             if (MD5Async) fs_xattr = this._assign_md5_to_fs_xattr(((await MD5Async.digest()).toString('hex')) + '-' + multiparts.length, fs_xattr);
-            if (fs_xattr) await write_file.setxattr(fs_account_config, fs_xattr);
+            if (fs_xattr) await write_file.replacexattr(fs_account_config, fs_xattr);
             if (config.NSFS_TRIGGER_FSYNC) await write_file.fsync(fs_account_config);
             const stat = await write_file.stat(fs_account_config);
             await write_file.close(fs_account_config);

--- a/src/test/unit_tests/sudo_index.js
+++ b/src/test/unit_tests/sudo_index.js
@@ -12,8 +12,7 @@ coretest.setup({ incomplete_rpc_coverage: 'show' });
 
 
 // // CORE
-// TODO: fix stat native timestamps - should be checked on Linux
-//require('./test_nb_native_fs');
+require('./test_nb_native_fs');
 require('./test_namespace_fs');
 require('./test_ns_list_objects');
 require('./test_bucketspace');

--- a/src/tools/chunk_fs_hashing.js
+++ b/src/tools/chunk_fs_hashing.js
@@ -122,7 +122,7 @@ async function file_target(chunk_size = CHUNK, parts = PARTS) {
             await stream_utils.pipeline([source_stream, chunk_fs]);
             await stream_utils.wait_finished(chunk_fs);
             if (XATTR) {
-                await target_file.setxattr(
+                await target_file.replacexattr(
                     DEFAULT_FS_CONFIG,
                     assign_md5_to_fs_xattr(chunk_fs.digest, {})
                 );


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. moved out xattr changes from https://github.com/noobaa/noobaa-core/pull/7020 so it can be used by @jackyalbo for the encryption feature.
2. get_single_xattr() added.
3. setXattr(xattr) was changed to replaceXattr(xattr, prefix_of_xattrs_to_clear)
4. Added unit tests

### Issues: Fixed #xxx / Gap #xxx
1. GAP - ENODATA error (No data available) is thrown when getsinglexattr() is called but the corresponding attr doesn't exist, in fs_napi - err.code is set by calling uv_translate_sys_error, but ENODATA is not translated by this function and we get an unknown system error instead, opened the following to track it https://github.com/libuv/libuv/issues/3795
In the meantime, I used error.message in tests instead err.code.
### Testing Instructions:
1. 


- [ ] Doc added/updated
- [X] Tests added
