### PR TITLE
postgres client | upsert duplications fix

### DIFF
--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1207,17 +1207,23 @@ class PostgresTable {
         // eslint-disable-next-line no-constant-condition
         while (true) {
             let pg_client;
+            let locked;
             try {
                 pg_client = await this.client.pool.connect();
                 let update_res = await this._updateOneWithClient(pg_client, query, update, options);
                 if (update_res.rowCount === 0) {
-                    // try to lock the advisory_lock_key for this table and insert the first doc
-                    let locked = await this.try_lock_table(pg_client);
+                    // try to lock the advisory_lock_key for this table, try update and insert the first doc if 0 docs updated
+                    locked = await this.try_lock_table(pg_client);
                     if (locked) {
-                        const data = { _id: this.client.generate_id() };
-                        await this.insertOne(data);
-                        update_res = await this.updateOne(data, update, options);
+                        // try update again to avoid race conditions
+                        update_res = await this._updateOneWithClient(pg_client, query, update, options);
+                        if (update_res.rowCount === 0) {
+                            const data = { _id: this.client.generate_id() };
+                            await this.insertOne(data);
+                            update_res = await this.updateOne(data, update, options);
+                        }
                         await this.unlock_table(pg_client);
+                        locked = false;
                     } else {
                         // lock was already taken which means that another call to findOneAndUpdate should have inserted.
                         // throw and retry
@@ -1238,7 +1244,11 @@ class PostgresTable {
                     throw err;
                 }
             } finally {
-                pg_client.release();
+                if (locked) {
+                    await this.unlock_table(pg_client);
+                    locked = false;
+                }
+                if (pg_client) pg_client.release();
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. _Upsert() - added a call to _updateOneWithClient() after locking the table in order to avoid race conditions that cause duplications as we saw in io_stats & bucket_stats in some warp runs and in the past in a BZ.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed a symptom in #7076 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
