### PR TITLE
Parse seq as int

### DIFF
--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -522,7 +522,7 @@ class PostgresSequence {
     // - return the init value to be used for native sequence
     // If no table is found, return 1 - clean install
     async migrateFromMongoSequence(name, pool) {
-        const res = await _do_query(pool, {text: `SELECT count(*) FROM pg_tables WHERE tablename  = '${name}';`}, 0);
+        const res = await _do_query(pool, { text: `SELECT count(*) FROM pg_tables WHERE tablename  = '${name}';` }, 0);
         const count = Number(res.rows[0].count);
         if (count === 0) {
             dbg.log0(`Table ${name} not found, skipping sequence migration`);
@@ -542,9 +542,9 @@ class PostgresSequence {
     async _create(pool) {
         try {
             const start = await this.migrateFromMongoSequence(this.name, pool);
-            await _do_query(pool, {text: `CREATE SEQUENCE IF NOT EXISTS ${this.seqname()} AS BIGINT START ${start};`}, 0);
+            await _do_query(pool, { text: `CREATE SEQUENCE IF NOT EXISTS ${this.seqname()} AS BIGINT START ${start};` }, 0);
             if (start !== 1) {
-                await _do_query(pool, {text: `DROP table IF EXISTS ${this.name};`}, 0);
+                await _do_query(pool, { text: `DROP table IF EXISTS ${this.name};` }, 0);
                 dbg.log0(`✅ Table ${this.name} is dropped, migration to native sequence is completed`);
             }
         } catch (err) {
@@ -557,7 +557,7 @@ class PostgresSequence {
         if (this.init_promise) await this.init_promise;
         const q = { text: `SELECT nextval('${this.seqname()}')` };
         const res = await _do_query(this.client.pool, q, 0);
-        return res.rows[0].nextval;
+        return Number.parseInt(res.rows[0].nextval, 10);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. In these changes https://github.com/noobaa/noobaa-core/pull/7025 version seq was changed to string accidentally because of the fact that as default bigint type returned as string, 
in node-postgres repo it's suggested to do the following:
```
var pg = require('pg');
pg.types.setTypeParser(20, BigInt); // Type Id 20 = BIGINT | BIGSERIAL
```
this won't work because on complete_object_upload we call mongo-query-to-postgres-jsonb update() which calls to JSON.stringify() and it throws `TypeError: Do not know how to serialize a BigInt`. 
JSON doesn't support bigint see - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify

We decided to parse it as int for this moment since max safe integer in node.js is large enough for this purpose (and it was int before the seq changed).

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
