### PR TITLE
remove sorting by version_past for Postgres

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -525,7 +525,12 @@ class MDStore {
         limit
     }) {
         const hint = 'latest_version_index';
-        const sort = { bucket: 1, key: 1, version_past: 1 };
+        const sort = { bucket: 1, key: 1 };
+
+        // for mongodb add version_past to the sort
+        if (process.env.DB_TYPE === 'mongodb') {
+            sort.version_past = 1;
+        }
 
         const { key_query } = this._build_list_key_query_from_markers(prefix, delimiter, key_marker);
 


### PR DESCRIPTION
### Explain the changes
* when listing objects we expect to hit Postgres latest_version_index which only contains objectmds with version_past=null.
* due to the index changes in #7044 - when sorting by version_past, Postgres performs a sort of all objectmds before scanning the index. This  eventually has a great effect on performance
* for mongo, leaving the old implementation as is, since the index still contains version_past as a field


### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2135782#c13

### Testing Instructions:
1. this affects listing when there is a large number of objects. in the BZ case, it was ~3,000,000 objects


- [ ] Doc added/updated
- [ ] Tests added
