### PR TITLE
[Backport to 5.12] remove sorting by version_past for postgres

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -525,7 +525,12 @@ class MDStore {
         limit
     }) {
         const hint = 'latest_version_index';
-        const sort = { bucket: 1, key: 1, version_past: 1 };
+        const sort = { bucket: 1, key: 1 };
+
+        // for mongodb add version_past to the sort
+        if (process.env.DB_TYPE === 'mongodb') {
+            sort.version_past = 1;
+        }
 
         const { key_query } = this._build_list_key_query_from_markers(prefix, delimiter, key_marker);
 


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit c86d6f621d03e1daee4b173c0271cc382e2a325b)

### Explain the changes
* backport of #7099 
* when listing objects we expect to hit Postgres latest_version_index which only contains objectmds with version_past=null.
* when sorting by version_past, Postgres performs a sort of all objectmds before scanning the index. This eventually have a great effect on performance

* for mongo, leaving the old implementation as is, since the index still contains version_past as a field

### Issues: Fixed #xxx / Gap #xxx
1. Fix for https://bugzilla.redhat.com/show_bug.cgi?id=2135782

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
