### PR TITLE
Fix issue with signature calculation

### DIFF
--- a/src/test/unit_tests/signature_test_suite/rgw/rgw_HEAD_BZ.sreq
+++ b/src/test/unit_tests/signature_test_suite/rgw/rgw_HEAD_BZ.sreq
@@ -1,0 +1,5 @@
+HEAD /awsnsbucket/bucket-head%2Flc-test-obj HTTP/1.1
+Host: 127.0.0.1
+X-Amz-Content-SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+Authorization: AWS4-HMAC-SHA256 Credential=123/20221206/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=10edb5e15be2934bae5bf19caceebedaedd0aba1184ffb600c151ec243866051
+X-Amz-Date: 20221206T084553Z

--- a/src/test/unit_tests/test_signature_utils.js
+++ b/src/test/unit_tests/test_signature_utils.js
@@ -49,6 +49,7 @@ mocha.describe('signature_utils', function() {
     add_tests_from(path.join(SIG_TEST_SUITE, 'cyberduck'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'postman'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'presigned'), '.sreq');
+    add_tests_from(path.join(SIG_TEST_SUITE, 'rgw'), '.sreq');
 
     function add_tests_from(fname, extension) {
 

--- a/src/util/signature_utils.js
+++ b/src/util/signature_utils.js
@@ -201,7 +201,7 @@ const HEADERS_MAP_FOR_AWS_SDK = {
 
 function _aws_request(req, region, service) {
     const v2_signature = _.isUndefined(region) && _.isUndefined(service);
-    const u = url.parse(req.originalUrl, true);
+    const u = url.parse(req.originalUrl.replace(/%2F/g, '/'), true);
     const pathname = service === 's3' ?
         u.pathname :
         path.normalize(decodeURI(u.pathname));


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. We have an issue when the url send us have %2F instead of '/' in the url like in the example below: /awsnsbucket/bucket-head%2Flc-test-obj. The problem is we do handle this for the url later in the code, but we don't for originalUrl that we are using for calculating the signature. This fix should resolve this as we are saving the correct format for both the url and orignalUrl.

```
[Endpoint/13] [ERROR] core.endpoint.s3.s3_rest:: S3 ERROR <?xml version="1.0" encoding="UTF-8"?><Error><Code>SignatureDoesNotMatch</Code>
<Message>The request signature we calculated does not match the signature you provided. Check your AWS secret access key and signing method. For more information, see REST Authentication and SOAP Authentication for details.</Message>
<Resource>/awsnsbucket/bucket-head%2Flc-test-obj?rgwx-prepend-metadata=true&amp;rgwx-stat=true&amp;rgwx-sync-manifest&amp;rgwx-skip-decrypt</Resource>
<RequestId>la85sqg3-8rmwhc-146o</RequestId>
</Error> HEAD /awsnsbucket/bucket-head%2Flc-test-obj?rgwx-prepend-metadata=true&rgwx-stat=true&rgwx-sync-manifest&rgwx-skip-decrypt {"accept":"*/*","authorization":"AWS4-HMAC-SHA256 Credential=Ieip6XK4IsHzgAdcBzhl/20221108/us-east-1/s3/aws4_request,SignedHeaders=date;host;x-amz-content-sha256;x-amz-date,Signature=41240a7240617b7c123b91af0af123802d3dd08dd5cc0e6cfb0a5d5d67173cc9","date":"Tue, 08 Nov 2022 11:58:57 +0000","x-amz-content-sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","x-amz-date":"20221108T115857Z","host":"[s3-openshift-storage.apps.ocp410.077dazopenshift.com](http://s3-openshift-storage.apps.ocp410.077dazopenshift.com/)","x-forwarded-host":"[s3-openshift-storage.apps.ocp410.077dazopenshift.com](http://s3-openshift-storage.apps.ocp410.077dazopenshift.com/)","x-forwarded-port":"80","x-forwarded-proto":"http","forwarded":"for=122.166.91.8;host=[s3-openshift-storage.apps.ocp410.077dazopenshift.com](http://s3-openshift-storage.apps.ocp410.077dazopenshift.com/);proto=http","x-forwarded-for":"122.166.91.8"} 
Error: Signature that was calculated did not match
```

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2142941

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
