### PR TITLE
change in KeyCount field in s3 reply

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -46,7 +46,7 @@ async function get_bucket(req) {
                 ...(list_type === '2' ? {
                     ContinuationToken: cont_tok,
                     StartAfter: start_after,
-                    KeyCount: reply.objects.length,
+                    KeyCount: reply.objects.length + reply.common_prefixes.length,
                     NextContinuationToken: key_marker_to_cont_tok(
                         reply.next_marker, reply.objects, reply.is_truncated),
                 } : { // list_type v1


### PR DESCRIPTION
change in KeyCount field in s3 reply (is used in list object command). 

Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. add the number of prefixes to the KeyCount field

### Issues: Fixed #xxx / Gap #xxx
1.  test_bucket_listv2_delimiter_basic was failing (1 != 3).

### Testing Instructions:
1. https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76


- [ ] Doc added/updated
- [ ] Tests added
