### PR TITLE
Add workflow for automated NooBaa releases

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,45 @@
+name: Releaser
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'The base branch to release from'
+        required: true 
+      sync_operator_repository:
+        description: "Sync operator repository"
+        required: false
+        default: "noobaa-operator"
+
+permissions:
+  contents: write
+
+jobs:
+  releaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set branch
+        run: echo "BRANCH=${{ github.event.inputs.base_branch }}" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BRANCH }}
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+      - name: Release NooBaa Core Image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHACTION_GH_PAT }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          OCI_ORG: ${{ secrets.OCI_ORG }}
+          BASE_BRANCH: "${{ github.event.inputs.base_branch }}"
+        run: |
+          git config --global user.email "github-action@noobaa.io"
+          git config --global user.name "NooBaa GitHub Action"
+
+          bash tools/releaser.sh --oci-org $OCI_ORG --sync-operator-repository ${{ github.event.inputs.sync_operator_repository }} --gh-org noobaa 

--- a/tools/releaser.sh
+++ b/tools/releaser.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+export PS4='\e[36m+ ${FUNCNAME:-main}@${BASH_SOURCE}:${LINENO} \e[0m'
+
+dir=$(dirname "$0")
+
+# Default values for the arguments.
+GH_ORG="noobaa"
+GH_REPO="noobaa-core"
+OCI_ORG="noobaa"
+DRY_RUN="false"
+SYNC_OPERATOR_REPOSITORY=""
+
+# Default values for the environment variables.
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-}
+DOCKERHUB_TOKEN=${DOCKERHUB_TOKEN:-}
+QUAY_USERNAME=${QUAY_USERNAME:-}
+QUAY_TOKEN=${QUAY_TOKEN:-}
+BASE_BRANCH=${BASE_BRANCH:-master}
+
+function check_environment_variables() {
+  if [[ -z "${GITHUB_TOKEN}" ]]; then
+    echo "GITHUB_TOKEN environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${DOCKERHUB_USERNAME}" ]]; then
+    echo "DOCKERHUB_USERNAME environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${DOCKERHUB_TOKEN}" ]]; then
+    echo "DOCKERHUB_TOKEN environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${QUAY_USERNAME}" ]]; then
+    echo "QUAY_USERNAME environment variable is not set."
+    exit 1
+  fi
+  if [[ -z "${QUAY_TOKEN}" ]]; then
+    echo "QUAY_TOKEN environment variable is not set."
+    exit 1
+  fi
+}
+
+function usage() {
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  --help - Print this help message."
+  echo "  --oci-org <org> - The organization of the OCI images."
+  echo "  --gh-org <org> - The organization of the GitHub repository."
+  echo "  --gh-repo <repo> - The GitHub repository name."
+  echo "  --dry-run - Do not create the release."
+  echo "  --sync-operator-repository <repository> - The operator repository to sync."
+}
+
+function parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --gh-org)
+      GH_ORG="$2"
+      shift
+      ;;
+    --gh-repo)
+      GH_REPO="$2"
+      shift
+      ;;
+    --oci-org)
+      OCI_ORG="$2"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      ;;
+    --sync-operator-repository)
+      SYNC_OPERATOR_REPOSITORY="$2"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+    esac
+    shift
+  done
+}
+
+function strip_prefix() {
+  local str="$1"
+  local prefix="$2"
+
+  echo ${str#"$prefix"}
+}
+
+function version_without_v() {
+  strip_prefix "$1" v
+}
+
+function version_with_v() {
+  local without_v=$(version_without_v "$1")
+
+  echo "v$without_v"
+}
+
+# get_noobaa_version returns the NooBaa version by reading the `cmd/version/main.go`
+#
+# The function can be called without any arguments in which case it will return
+# noobaa version without "v" prefixed to the version however if ANY second
+# argument is provided to the function then it will prefix "v" to the version.
+#
+# Example: get_noobaa_version # returns version without "v" prefix
+# Example: get_noobaa_version 1 # returns version with "v" prefix
+function get_noobaa_version() {
+  local version=$(go run cmd/version/main.go)
+  if [[ $# -gte 1 ]]; then
+    version_with_v "$version"
+  else
+    version_without_v "$version"
+  fi
+}
+
+# bump_semver_patch takes in a semver and bumps the patch version
+function bump_semver_patch() {
+  local version=$(version_without_v "$1")
+  version=$(echo ${version} | awk -F. -v OFS=. '{$NF = $NF+1 ; print}')
+  echo "$version"
+}
+
+function create_noobaa_image() {
+  echo "Creating noobaa image"
+  make noobaa
+
+  echo "Tagging noobaa image"
+  docker tag noobaa ${OCI_ORG}/noobaa-core:$(get_noobaa_version)
+}
+
+function create_oci_release() {
+  # Release OCI images to docker and quay.io
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY_RUN is set, skipping OCI release creation."
+    return
+  fi
+
+  local quay_image="quay.io/$QUAY_USERNAME/noobaa-core:$(get_noobaa_version)"
+  local docker_image="$DOCKERHUB_USERNAME/noobaa-core:$(get_noobaa_version)"
+
+  echo "Tagging the images..."
+  docker tag "$OCI_ORG/noobaa-core:$(get_noobaa_version)" $quay_image
+  docker tag "$OCI_ORG/noobaa-core:$(get_noobaa_version)" $docker_image
+
+  echo "Logging in to docker.io..."
+  echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+
+  echo "Pushing the images to docker.io..."
+  docker push $docker_image
+
+  echo "Logging in to quay.io..."
+  echo "$QUAY_TOKEN" | docker login -u "$QUAY_USERNAME" --password-stdin quay.io
+
+  echo "Pushing the images to quay.io..."
+  docker push $quay_image
+}
+
+function sync_operator() {
+  if [[ -z "$SYNC_OPERATOR_REPOSITORY" ]]; then
+    echo "Skip Syncing operator, no repository was provided."
+    return
+  fi
+
+  gh workflow run releaser.yaml -R "$GH_ORG/$SYNC_OPERATOR_REPOSITORY" -f base_branch="$BASE_BRANCH"
+}
+
+function update_package_json() {
+  local version=$(bump_semver_patch $(get_noobaa_version))
+  npm version ${version} --no-git-tag-version
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY_RUN is set, skipping version bump."
+    return
+  fi
+
+  git add .
+  git commit -m "Automated commit to update README for version: ${version}"
+  git push
+}
+
+function init() {
+  check_environment_variables
+  parse_args "$@"
+}
+
+function main() {
+  create_noobaa_image
+  create_oci_release
+  sync_operator
+  update_package_json
+}
+
+init "$@"
+main


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

### Explain the changes
This PR attempts to add a Github workflow to automate releases of **both** NooBaa core and NooBaa operator. The PR changes does the following:
1. Release NooBaa core OCI images to dockerhub and quay registries.
2. Dispatch a release in the NooBaa operator repository by triggering workflow in PR: https://github.com/noobaa/noobaa-operator/pull/998.
3. Update the version in the `package.json` and `package-lock.json`.

![image](https://user-images.githubusercontent.com/45818886/207250671-192570a8-b196-4d75-a270-018c4468181a.png)

Flow:
1. Read the version to be released from `package.json`.
2. Build OCI images for the version read.
3. Push the OCI images to Quay and Dockerhub.
4. Dispatch workflow in the `sync_operator_repository` (format: `repo`).
5. Increment version in `package.json` and `package-lock.json`.
6. Commit the changes in the tree to the base branch.

Caveats:
- The entire workflow assumes that the version in the `package.json` is correct. It does not have additional logic to ensure that. Whatever the version would be in that file, it will be released.
- Rollbacks are manual for now. That is,  rollback sync operator changes, delete OCI images and revert the commits. Can be automated in the future though.
- Whenever a new version branch is created, we need to ensure that `package.json` reflects that. So when we move to 5.14 branch, `package.json` needs to be set to "5.14.0". This can be automated as well but not sure if its worth doing so.

The scripts/workflow will require a few secrets in place like:
1. `GHACTION_GH_PAT` - A github token which has write access to the repositories. This is needed because the workflow attempts to synchronize a release in the operator repository as well by dispatching the release workflow there.
8. `DOCKERHUB_USERNAME` - Username in dockerhub where the OCI image is supposed to be pushed.
9. `DOCKERHUB_TOKEN` - Dockerhub token is used to login to the registry and push the image.
10. `QUAY_USERNAME` - Username in quay where the OCI image is supposed to be pushed.
11. `QUAY_TOKEN` - Quay token is used to login to the registry and push the image.
12. `OCI_ORG` - This is used internally hence this can be anything. It can be same as `DOCKERHUB_USERNAME` or `QUAY_USERNAME` or a random string.
