### PR TITLE
NSFS | Fix broken nsfs tool

### DIFF
--- a/src/core/nsfs.js
+++ b/src/core/nsfs.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const util = require('util');
 const minimist = require('minimist');
+const SensitiveString = require('../util/sensitive_string');
 
 const dbg = require('../util/debug_module')(__filename);
 if (!dbg.get_process_name()) dbg.set_process_name('nsfs');
@@ -141,7 +142,20 @@ function init_request_sdk(req, res, fs_root, fs_config) {
     object_sdk.read_bucket_sdk_website_info = noop;
     object_sdk.read_bucket_sdk_namespace_info = noop;
     object_sdk.read_bucket_sdk_caching_info = noop;
-    object_sdk.read_bucket_sdk_policy_info = noop;
+    object_sdk.read_bucket_sdk_policy_info = async bucket_name => ({
+        s3_policy: {
+                version: '2012-10-17',
+                statement: [
+                {
+                    effect: 'allow',
+                    action: [ 's3:*' ],
+                    principal: [ new SensitiveString('*')],
+                    resource: [ `arn:aws:s3:::${bucket_name}/*` ]
+                }]
+        },
+        system_owner: undefined,
+        bucket_owner: undefined,
+    });
     object_sdk.read_bucket_usage_info = noop;
     object_sdk.requesting_account = {
         nsfs_account_config: fs_config


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. return bucket_policy (that allows everything on the bucket) from read_bucket_sdk_policy_info() since after https://github.com/noobaa/noobaa-core/pull/6998 changes were merged, authorization of anonymous requests includes bucket policy permission check as well.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. run nsfs tool
2. cp obj to a bucket


- [ ] Doc added/updated
- [ ] Tests added
