### PR TITLE
add encoding url to list objects

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_uploads.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_uploads.js
@@ -26,34 +26,36 @@ async function get_bucket_uploads(req) {
         limit: Math.min(max_keys_received, 1000),
     });
 
+    const field_encoder = s3_utils.get_response_field_encoder(req);
+
     return {
         ListMultipartUploadsResult: [{
-                'Bucket': req.params.bucket,
-                'Prefix': req.query.prefix,
-                'Delimiter': req.query.delimiter,
-                'MaxUploads': max_keys_received,
-                'KeyMarker': req.query['key-marker'],
-                'UploadIdMarker': req.query['upload-id-marker'],
-                'IsTruncated': reply.is_truncated,
-                'NextKeyMarker': reply.next_marker,
-                'NextUploadIdMarker': reply.next_upload_id_marker,
-                'Encoding-Type': req.query['encoding-type'],
-            },
-            _.map(reply.objects, obj => ({
-                Upload: {
-                    Key: obj.key,
-                    UploadId: obj.obj_id,
-                    Initiated: s3_utils.format_s3_xml_date(obj.upload_started),
-                    Initiator: s3_utils.DEFAULT_S3_USER,
-                    Owner: s3_utils.DEFAULT_S3_USER,
-                    StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
-                }
-            })),
-            _.map(reply.common_prefixes, prefix => ({
-                CommonPrefixes: {
-                    Prefix: prefix || ''
-                }
-            }))
+            Bucket: req.params.bucket,
+            Prefix: field_encoder(req.query.prefix),
+            Delimiter: field_encoder(req.query.delimiter),
+            MaxUploads: max_keys_received,
+            KeyMarker: field_encoder(req.query['key-marker']),
+            UploadIdMarker: req.query['upload-id-marker'],
+            IsTruncated: reply.is_truncated,
+            NextKeyMarker: field_encoder(reply.next_marker),
+            NextUploadIdMarker: reply.next_upload_id_marker,
+            EncodingType: req.query['encoding-type'],
+        },
+        _.map(reply.objects, obj => ({
+            Upload: {
+                Key: field_encoder(obj.key),
+                UploadId: obj.obj_id,
+                Initiated: s3_utils.format_s3_xml_date(obj.upload_started),
+                Initiator: s3_utils.DEFAULT_S3_USER,
+                Owner: s3_utils.DEFAULT_S3_USER,
+                StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+            }
+        })),
+        _.map(reply.common_prefixes, prefix => ({
+            CommonPrefixes: {
+                Prefix: field_encoder(prefix) || ''
+            }
+        }))
         ]
     };
 }

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -41,7 +41,9 @@ class S3Error extends Error {
 
 // See http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 
-
+//////////////////////////////////////////
+// Errors documented in AWS error pages //
+//////////////////////////////////////////
 S3Error.AccessDenied = Object.freeze({
     code: 'AccessDenied',
     message: 'Access Denied',
@@ -448,8 +450,6 @@ S3Error.NoSuchTagSet = Object.freeze({
     http_code: 404,
 });
 
-
-
 /////////////////////////////////////
 // Errors for generic HTTP replies //
 /////////////////////////////////////
@@ -506,6 +506,11 @@ S3Error.ObjectLockConfigurationNotFoundError = Object.freeze({
     message: 'Object Lock configuration does not exist for this bucket',
     http_code: 404,
 });
+S3Error.InvalidEncodingType = Object.freeze({
+    code: 'InvalidArgument',
+    message: 'Invalid Encoding Method specified in Request',
+    http_code: 400,
+});
 
 S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     UNAUTHORIZED: S3Error.AccessDenied,
@@ -543,6 +548,7 @@ S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     INTERNAL_ERROR: S3Error.InternalError,
     SERVER_SIDE_ENCRYPTION_CONFIGURATION_NOT_FOUND_ERROR: S3Error.ServerSideEncryptionConfigurationNotFoundError,
     NO_SUCH_TAG: S3Error.NoSuchTagSet,
+    INVALID_ENCODING_TYPE: S3Error.InvalidEncodingType,
 });
 
 exports.S3Error = S3Error;

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -648,6 +648,25 @@ function _is_statements_fit(statements, account, method, arn_path) {
     return false;
 }
 
+function get_response_field_encoder(req) {
+    const encoding_type = req.query['encoding-type'];
+    if ((typeof encoding_type === 'undefined') || (encoding_type === null)) return response_field_encoder_none;
+    if (encoding_type.toLowerCase() === 'url') return response_field_encoder_url;
+    dbg.warn('Invalid encoding-type', encoding_type);
+    throw new S3Error(S3Error.InvalidEncodingType);
+}
+
+function response_field_encoder_none(value) {
+    return value;
+}
+
+/** 
+* Using URLSearchParams to encode the string as x-www-form-urlencoded
+* with plus (+) instead of spaces (and not %20 as encodeURIComponent() does)
+*/
+function response_field_encoder_url(value) {
+    return new URLSearchParams({ 'a': value }).toString().slice(2); // slice the leading 'a='
+}
 
 exports.STORAGE_CLASS_STANDARD = STORAGE_CLASS_STANDARD;
 exports.DEFAULT_S3_USER = DEFAULT_S3_USER;
@@ -678,3 +697,4 @@ exports.get_http_response_from_resp = get_http_response_from_resp;
 exports.get_http_response_date = get_http_response_date;
 exports.has_bucket_policy_permission = has_bucket_policy_permission;
 exports.XATTR_SORT_SYMBOL = XATTR_SORT_SYMBOL;
+exports.get_response_field_encoder = get_response_field_encoder;


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
Today we do not encode any field in our response to list objects and list object v2. 
In this PR we add encoding to fields specified in the [documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html).

> [EncodingType](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseSyntax)
> Encoding type used by Amazon S3 to encode object key names in the XML response.
> If you specify the encoding-type request parameter, Amazon S3 includes this element in the response, and returns encoded key name values in the following response elements:
> Delimiter, Prefix, Key, and StartAfter.
> Type: String
> Valid Values: url

### Issues: Fixed #xxx / Gap #xxx
originally was found since the test `test_bucket_listv2_encoding_basic` and `test_bucket_list_encoding_basic` were failing.

### Testing Instructions:
see [here](https://gist.github.com/shirady/b3e6ce2af88ecccc484b179a57c4aa02)


- [ ] Doc added/updated
- [ ] Tests added
