### PR TITLE
[Backport to 5.10] Fixed map_common_prefixes queries

### DIFF
--- a/.travis/deploy_minikube.sh
+++ b/.travis/deploy_minikube.sh
@@ -15,7 +15,7 @@ set -x
 # https://github.com/jaegertracing/jaeger-operator/blob/master/.travis/setupMinikube.sh
 
 export MINIKUBE_VERSION=v1.8.2
-export KUBERNETES_VERSION=v1.17.3
+export KUBERNETES_VERSION=v1.23.12
 
 source /etc/os-release
 

--- a/src/util/sql_functions/map_common_prefixes.sql
+++ b/src/util/sql_functions/map_common_prefixes.sql
@@ -1,35 +1,45 @@
-CREATE OR REPLACE FUNCTION map_common_prefixes(TEXT, TEXT, TEXT) RETURNS TABLE(_id TEXT[], value JSON) AS $$
+CREATE OR REPLACE FUNCTION map_common_prefixes(prefix TEXT, delimiter TEXT, query_filter TEXT, sort TEXT, max_keys INTEGER) RETURNS TABLE(_id TEXT[], value JSON) AS $$
 DECLARE
-    prefix ALIAS FOR $1;
-    delimiter ALIAS FOR $2;
-    cur_query ALIAS FOR $3;
+    total_count INTEGER := 0;
     suffix TEXT;
     pos INTEGER;
     cut_prefix TEXT;
     rec_key TEXT;
     rec_id TEXT;
+    cur_query TEXT;
+    next_marker_query TEXT;
+    next_marker TEXT;
     rec RECORD;
     cur REFCURSOR;
 BEGIN
+  cur_query := 'SELECT * FROM objectmds WHERE ' || query_filter || ' ORDER BY ' || sort;
   OPEN cur FOR EXECUTE cur_query; 
   FETCH NEXT FROM cur INTO rec;
-  WHILE FOUND 
-  LOOP
-    rec_key := rec.data->>'key';
-    suffix := substring(rec_key from length(prefix) + 1);
-    pos := position(delimiter in suffix);
-    IF pos > 0 THEN
-        cut_prefix := substring(suffix from 1 for pos);
-        _id := ARRAY [cut_prefix, 'common_prefix'];
-        value := null;
-    ELSE
-        rec_id := rec.data->>'_id';
-        _id := ARRAY [suffix, rec_id];
-        value := rec.data;
-    END IF;
-    RETURN NEXT;
-    FETCH NEXT FROM cur INTO rec; 
-  END LOOP;
+  WHILE FOUND AND total_count < max_keys
+    LOOP
+      rec_key := rec.data->>'key';
+      suffix := substring(rec_key from length(prefix) + 1);
+      pos := position(delimiter in suffix);
+
+      IF pos > 0 THEN
+          cut_prefix := substring(suffix from 1 for pos);
+          _id := ARRAY [cut_prefix, 'common_prefix'];
+          value := null;
+          -- a common prefix is found, so we can skip the rest of the keys with the same prefix
+          -- as the next_marker, use the common prefix "incremented" by 1 (inc the last char)
+          next_marker := prefix || substring(cut_prefix from 1 for length(cut_prefix) - 1) || chr(ascii(delimiter) + 1);
+          cur_query:= 'SELECT * FROM objectmds WHERE ' || query_filter || ' AND data->>' || quote_literal('key') || ' >= ' || quote_literal(next_marker) || ' ORDER BY ' || sort;
+          CLOSE cur;
+          OPEN cur FOR EXECUTE cur_query;
+      ELSE
+          rec_id := rec.data->>'_id';
+          _id := ARRAY [suffix, rec_id];
+          value := rec.data;
+      END IF;
+      total_count := total_count + 1;
+      RETURN NEXT;
+      FETCH NEXT FROM cur INTO rec; 
+    END LOOP;
   CLOSE cur; 
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
* changed pl/sql function map_common_prefixes to fetch all required entries in one call.
* instead of querying for 1000 keys and then extracting the common prefixes from it (can be very few common prefixes if there are a lot of objects in that "dir"), it iterates over the objectmds untils reaching to the max keys or the end.
* To avoid unnecessary scanning of objects - if we find a common prefix, we set the marker to be the next possible value for a common prefix (by incrementing the last charecter by 1)
* These changes rely on the DB having collation of LC_COLLATE = 'C'. it will not work on DBs with utf8 collation

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 78f0ff813979371c90e7f33ac93fdbc6d928e80d)

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
