### PR TITLE
S3 Select Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "s3select"]
+	path = submodules/s3select
+	url = https://github.com/ceph/s3select

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ builder: assert-container-engine
 
 base: builder
 	@echo "\033[1;34mStarting Base $(CONTAINER_ENGINE) build.\033[0m"
-	$(DOCKER_BUILDKIT) $(CONTAINER_ENGINE) build $(CPUSET) -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
+	$(DOCKER_BUILDKIT) $(CONTAINER_ENGINE) build $(CPUSET) --build-arg BUILD_S3SELECT -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
 	$(CONTAINER_ENGINE) tag noobaa-base $(NOOBAA_BASE_TAG)
 	@echo "\033[1;32mBase done.\033[0m"
 .PHONY: base

--- a/docs/design/s3select.md
+++ b/docs/design/s3select.md
@@ -1,0 +1,123 @@
+
+# S3 Select
+
+
+## Goal
+
+Provide a feature to run S3 Select queries as close as possible to AWS feature.
+
+
+## Scenarios
+
+A client sends an S3 Select request according to AWS specification (see [SelectObjectContent - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/API/API_SelectObjectContent.html)).
+
+The endpoint will retrieve the relevant file (AKA key), process the query, and reply according to specification (see [Appendix: SelectObjectContent Response - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html)).
+
+
+## Technical Details
+
+
+### Query Processing Implementation
+
+Use external implementation, as implementing in-house is not a valid option.
+
+
+
+* S3Select ([https://github.com/ceph/s3select](https://github.com/ceph/s3select)) implements running SQL on character stream in C++. This requires napi, git and build changes. This is the chosen implementation.
+* Partiql ([https://partiql.org/](https://partiql.org/)) is available only in Kotlin implementation. This requires starting a JVM in the endpoint to process SQL, which is cumbersome.
+    * [https://github.com/partiql/partiql-lang-rust](https://github.com/partiql/partiql-lang-rust) can be considered in the future, but for now it doesn’t have a full implementation yet.
+
+
+### New S3 OP
+
+A new s3 op, post_object_select will be added.
+
+There are two variations of files to consider:
+
+
+
+1. csv, json - These are “stream-friendly”, they are read once from start to finish. So we can get their stream like standard get_object s3 op, pipe the stream to s3select to process, and pipe the result to http res object.
+2. Parquet
+    1. Processing a parquet file requires random seeking. In other words, at any time during the processing of the SQL, s3select can require to read any address of the file. So the stream-piping is not suitable.
+    2. A general, currently undesigned, solution is to channel the request upwards, back to a callback in post_object_select, which will ask object_sdk for the required address and send it back to s3select.
+    3. In the simple case of FS namespace buckets, if the required file resides in the endpoint host, the file path (rather than stream) can be sent to s3select for processing. This allows processing Parquet files stored in namespace buckets.
+    4. Parquet requires Arrow, a library for processing Parquet files.
+    5. Initial feature will not support Parquet.
+
+
+### HTTP Response
+
+Response should conform to specification (see [Appendix: SelectObjectContent Response - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html)).
+
+We can adapt S3Select example code that already has implementation to add crc and headers for each chunk.
+
+
+### Napi
+
+New native code that will implement a transform stream (similar to coder/chunker). This stream will have these functions:
+
+
+
+* write(byte array) - that will reply with rows matching the query.
+* flush() - that will reply with SQL-aggregate (eg count, sum) result.
+
+Preferably, stream will not encode/decode bytes into/from strings and will not copy buffers.
+
+
+### Git and Build
+
+
+
+1. S3Select source
+
+S3Select is a git repository. It has 3 dependencies:
+
+
+
+* Fast Cpp Csv Parser ([https://github.com/ben-strasser/fast-cpp-csv-parser](https://github.com/ben-strasser/fast-cpp-csv-parser))
+* RapidJson parser ([https://github.com/Tencent/rapidjson](https://github.com/Tencent/rapidjson))
+* Boost
+
+The parser git repositories which are submodules of s3select repository.
+
+Boost is assumed by s3select make to be installed on the builder machine.
+
+
+
+2. noobaa-core repository
+
+In noobaa-core repository, a new submodules directory and .gitmodules file are added.
+
+It will have the s3select and boost repositories as submodules, and the two parsers recursively, inside the s3select submodule.
+
+
+
+3. Docker build
+
+In docker build, these repositories are fetched and node-gyp uses the sources for compilation.
+
+Only necessary boost submodules are fetched.
+
+All repositories are checkout to a specific commit/tag so updates won’t affect us directly.
+
+When updates are needed, the checkout command needs to be updated to a new commit/tag.
+
+
+
+4. Native build
+
+Running native build should still be possible.
+
+Git submodules are needed to be fetched manually (once).
+
+
+### Tests
+
+
+
+* S3 ceph tests
+* ..
+
+
+### Upstream Docs
+

--- a/docs/dev_guide/S3Select_Build.md
+++ b/docs/dev_guide/S3Select_Build.md
@@ -1,0 +1,48 @@
+# How to build S3 Select
+
+S3 Select is a native library integrated into noobaa-core.  
+In noobaa-core git repository, it is present under as git submodule in /submodules/s3select (as defined in .gitmodules file).
+
+## Local Native Build
+
+By default, S3 Select is not build in local native default.  
+This is to streamline builds of developers who don't need S3 Select feature.  
+In other words, running "npm run build" and executing S3 Select code will fail.  
+In order to build native locally with S3 Select, you need to:  
+
+1. Init and clone submodule.
+
+These git commands will fetch necessary code into your git reporosity:  
+-`git submodule init (needed only once)`  
+-`git submodule update (needed each update of submodule)`  
+These two commands can be combined:  
+`git submodule update --init`
+
+Since S3Select has two submodules of its own, you need to repeat above commands.
+
+All of the above can be done with:  
+`git submodule update --init --recursive`
+
+2. Install "boost-devel" package.
+The "boost-devel" package is assumed to be installed by local native build.
+It is a relatively widespread package, available in general package repository.
+Eg, on a Fedora-based linux:
+`yum install boost-devel`
+
+3. Run build command with BUILD_S3SELECT enabled in GYP:  
+`GYP_DEFINES=BUILD_S3SELECT=1 npm run build`
+or, equivalently:
+`GYP_DEFINES=BUILD_S3SELECT=1 node-gyp rebuild`
+
+## Docker Build
+S3Select is enabled by defualt for docker build.  
+If you wish to explicitly enable/disable s3select in docker build, you can use BUILD_S3SELECT env parameter. Eg-  
+`BUILD_S3SELECT=0 make noobaa NOOBAA_TAG=noobaa-core:select`
+
+## Test Native Code
+You can test native code with the provide s3select.js. Eg-  
+`echo -e "1,2,3\n4,5,6" | node noobaa-core/src/tools/s3select.js --query "SELECT sum(int(_2)) from stdin;"`
+Which is equivalent to-
+`echo -e "1,2,3\n4,5,6" | node src/tools/s3select.js --query "SELECT sum(int(_2)) from stdin;" --input_format CSV --record_delimiter $'\n' --field_delimiter , --file_header_info IGNORE`
+
+

--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -19,7 +19,14 @@ RUN npm install --production && \
 ##############################################################
 COPY ./binding.gyp .
 COPY ./src/native ./src/native/
-RUN npm run build:native
+COPY ./src/deploy/NVA_build/clone_submodule.sh ./src/deploy/NVA_build/
+COPY ./src/deploy/NVA_build/clone_s3select_submodules.sh ./src/deploy/NVA_build/
+ARG BUILD_S3SELECT=1
+#Clone S3Select and its two submodules, but only if BUILD_S3SELECT=1.
+RUN ./src/deploy/NVA_build/clone_s3select_submodules.sh
+#Pass BUILD_S3SELECT down to GYP native build.
+#S3Select will be built only if this parameter is equal to "1".
+RUN GYP_DEFINES=BUILD_S3SELECT=$BUILD_S3SELECT npm run build:native
 
 ##############################################################
 # Layers:

--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -59,6 +59,7 @@ ENV ENDPOINT_NODE_OPTIONS ''
 
 RUN dnf install -y epel-release
 RUN dnf install -y -q bash \
+    boost \
     lsof \
     procps \
     openssl \

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 #     dnf clean all
 RUN dnf update -y -q --nobest && \
     dnf clean all
-RUN dnf install -y -q wget unzip which vim python2 python3 && \
+RUN dnf install -y -q wget unzip which vim python2 python3 boost-devel && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
 RUN alternatives --set python /usr/bin/python3

--- a/src/deploy/NVA_build/clone_s3select_submodules.sh
+++ b/src/deploy/NVA_build/clone_s3select_submodules.sh
@@ -1,0 +1,5 @@
+#Clone S3Select and its two submodules, but only if BUILD_S3SELECT=1.
+./src/deploy/NVA_build/clone_submodule.sh submodules/s3select https://github.com/ceph/s3select 58875a5ee76261cc0a3d943bb168f9f9292c34a4 BUILD_S3SELECT
+./src/deploy/NVA_build/clone_submodule.sh submodules/s3select/rapidjson https://github.com/Tencent/rapidjson fcb23c2dbf561ec0798529be4f66394d3e4996d8 BUILD_S3SELECT
+./src/deploy/NVA_build/clone_submodule.sh submodules/s3select/include/csvparser https://github.com/ben-strasser/fast-cpp-csv-parser 5a417973b4cea674a5e4a3b88a23098a2ab75479 BUILD_S3SELECT
+

--- a/src/deploy/NVA_build/clone_submodule.sh
+++ b/src/deploy/NVA_build/clone_submodule.sh
@@ -1,0 +1,18 @@
+enabled=`printf '%s\n' "${!4}"`
+echo $enabled
+if [ -z "$enabled" ]; then
+	echo "not en"
+	exit 0
+fi
+if [ $enabled -ne 1 ]; then
+	echo "exit"
+	exit 0
+fi
+echo "done"
+mkdir -p $1 
+cd $1 
+git init
+git remote add origin $2
+git fetch origin $3 --depth=1
+git reset --hard FETCH_HEAD
+rm -rf .git

--- a/src/endpoint/s3/ops/s3_post_object_select.js
+++ b/src/endpoint/s3/ops/s3_post_object_select.js
@@ -1,0 +1,118 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const S3Error = require('../s3_errors').S3Error;
+const s3_utils = require('../s3_utils');
+const { S3SelectStream } = require('../../../util/s3select');
+const nb_native = require('../../../util/nb_native');
+const stream_utils = require('../../../util/stream_utils');
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_SelectObjectContent.html
+ */
+async function post_object_select(req, res) {
+
+    if (!nb_native().S3Select) {
+        throw new S3Error(S3Error.S3SelectNotCompiled);
+    }
+
+    req.object_sdk.setup_abort_controller(req, res);
+    const agent_header = req.headers['user-agent'];
+    const noobaa_trigger_agent = agent_header && agent_header.includes('exec-env/NOOBAA_FUNCTION');
+    const encryption = s3_utils.parse_encryption(req);
+    const http_req_select_params = req.body.SelectObjectContentRequest;
+
+    const md_params = {
+        bucket: req.params.bucket,
+        key: req.params.key,
+        version_id: req.query.versionId,
+        encryption,
+    };
+    const object_md = await req.object_sdk.read_object_md(md_params);
+
+    const params = {
+        object_md,
+        obj_id: object_md.obj_id,
+        bucket: req.params.bucket,
+        key: req.params.key,
+        content_type: object_md.content_type,
+        noobaa_trigger_agent,
+        encryption,
+    };
+
+    //handle ScanRange
+    if (Array.isArray(http_req_select_params.ScanRange)) {
+        const scan_range = http_req_select_params.ScanRange[0];
+        if (scan_range.Start) {
+            params.start = Number(scan_range.Start);
+        }
+        if (scan_range.End) {
+            if (scan_range.Start) {
+                params.end = Number(scan_range.End);
+            } else {
+                //if only End is specified, start from {End} bytes from the end.
+                params.start = object_md.size - (Number(scan_range.End));
+            }
+        }
+    }
+
+    //prepare s3select stream
+    const input_serialization = http_req_select_params.InputSerialization[0];
+    let input_format = null;
+    if (input_serialization.CSV) {
+        input_format = 'CSV';
+    } else if (input_serialization.JSON) {
+        input_format = 'JSON';
+    } else {
+        throw new S3Error(S3Error.MissingInputSerialization);
+    }
+
+    //currently s3select can only output in the same format as input format
+    if (Array.isArray(http_req_select_params.OutputSerialization)) {
+        const output_serialization = http_req_select_params.OutputSerialization[0];
+        if ((output_serialization.CSV && input_format !== 'CSV') ||
+            (output_serialization.JSON && input_format !== 'JSON')) {
+                throw new S3Error(S3Error.OutputInputFormatMismatch);
+            }
+    }
+
+    const select_args = {
+        query: http_req_select_params.Expression[0],
+        input_format: input_format,
+        input_serialization_format: http_req_select_params.InputSerialization[0][input_format][0],
+        records_header_buf: S3SelectStream.records_message_headers
+    };
+    const s3select = new S3SelectStream(select_args);
+    dbg.log3("select_args = ", select_args);
+
+    //pipe s3select result into http result
+    stream_utils.pipeline([s3select, res], true /*res is a write stream, no need for resume*/);
+
+    //send s3select pipe to read_object_stream.
+    //in some cases (currently nsfs) it will pipe object stream into our pipe (s3select)
+    const read_stream = await req.object_sdk.read_object_stream(params, s3select);
+    if (read_stream) {
+        // if read_stream supports closing, then we handle abort cases such as http disconnection
+        // by calling the close method to stop it from buffering more data which will go to waste.
+        if (read_stream.close) {
+            req.object_sdk.add_abort_handler(() => read_stream.close());
+        }
+        read_stream.on('error', err => {
+            dbg.error('read stream error:', err, req.path);
+            res.destroy(err);
+        });
+        //in other cases, we need to pipe the read stream ourselves
+        stream_utils.pipeline([read_stream, s3select], true /*no need to resume s3select*/);
+    }
+}
+
+module.exports = {
+    handler: post_object_select,
+    body: {
+        type: 'xml',
+    },
+    reply: {
+        type: 'raw',
+    },
+};

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -512,6 +512,26 @@ S3Error.InvalidEncodingType = Object.freeze({
     http_code: 400,
 });
 
+////////////////////////////////////////////////////////////////
+// S3 Select                                                  //
+////////////////////////////////////////////////////////////////
+
+S3Error.S3SelectNotCompiled = Object.freeze({
+    code: 'S3SelectNotCompiled',
+    message: 'This server was not compiled with S3 Select support. Recompile with BUILD_S3SELECT=1.',
+    http_code: 501,
+});
+S3Error.MissingInputSerialization = Object.freeze({
+    code: 'MissingRequiredParameter',
+    message: 'InputSerialization is required. Please check the service documentation and try again.',
+    http_code: 400,
+});
+S3Error.OutputInputFormatMismatch = Object.freeze({
+    code: 'OutputInputFormatMismatch',
+    message: 'OutputSerialization format must match InputSerializatoin format.',
+    http_code: 501,
+});
+
 S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     UNAUTHORIZED: S3Error.AccessDenied,
     BAD_REQUEST: S3Error.BadRequest,

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -52,7 +52,8 @@ const OBJECT_SUB_RESOURCES = Object.freeze({
     'uploads': 'uploads',
     'uploadId': 'uploadId',
     'legal-hold': 'legal_hold',
-    'retention': 'retention'
+    'retention': 'retention',
+    'select': 'select',
 });
 
 const S3_OPS = load_ops();
@@ -581,6 +582,7 @@ function load_ops() {
         post_bucket_delete: require('./ops/s3_post_bucket_delete'),
         post_object_uploadId: require('./ops/s3_post_object_uploadId'),
         post_object_uploads: require('./ops/s3_post_object_uploads'),
+        post_object_select: require('./ops/s3_post_object_select'),
         put_bucket: require('./ops/s3_put_bucket'),
         put_bucket_accelerate: require('./ops/s3_put_bucket_accelerate'),
         put_bucket_acl: require('./ops/s3_put_bucket_acl'),

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -80,6 +80,7 @@ const OP_NAME_TO_ACTION = Object.freeze({
     post_object: { regular: "s3:putobject" },
     post_object_uploadId: { regular: "s3:putobject" },
     post_object_uploads: { regular: "s3:putobject" },
+    post_object_select: { regular: "s3:selectobjectcontent" },
 
     put_bucket_accelerate: { regular: "s3:putaccelerateconfiguration" },
     put_bucket_acl: { regular: "s3:putbucketacl" },

--- a/src/native/nb_native.cpp
+++ b/src/native/nb_native.cpp
@@ -11,6 +11,9 @@ void splitter_napi(Napi::Env env, Napi::Object exports);
 void chunk_coder_napi(napi_env env, napi_value exports);
 void fs_napi(Napi::Env env, Napi::Object exports);
 void crypto_napi(Napi::Env env, Napi::Object exports);
+#ifdef BUILD_S3SELECT
+void s3select_napi(Napi::Env env, Napi::Object exports);
+#endif
 
 Napi::Object
 nb_native_napi(Napi::Env env, Napi::Object exports)
@@ -22,6 +25,9 @@ nb_native_napi(Napi::Env env, Napi::Object exports)
     chunk_coder_napi(env, exports);
     fs_napi(env, exports);
     crypto_napi(env, exports);
+#ifdef BUILD_S3SELECT
+    s3select_napi(env, exports);
+#endif
     return exports;
 }
 

--- a/src/native/nb_native.gyp
+++ b/src/native/nb_native.gyp
@@ -16,15 +16,24 @@
             }],
             [ 'node_arch=="arm64"', {
                 'cflags': ['-DUSE_NEON']
-            }],
+            }]
         ],
     },
 
     'targets': [{
+	'variables': {
+            'BUILD_S3SELECT%':0
+        },
         'target_name': 'nb_native',
         'include_dirs': [
             '<@(napi_include_dirs)',
         ],
+	'conditions': [
+	    ['BUILD_S3SELECT==1', {
+		'dependencies': ['s3select/s3select.gyp:s3select'],
+		'cflags': ['-DBUILD_S3SELECT=1']
+	    }]
+	],
         'dependencies': [
             '<@(napi_dependencies)',
             'third_party/cm256.gyp:cm256',
@@ -32,6 +41,7 @@
             'third_party/isa-l.gyp:isa-l-ec',
             'third_party/isa-l.gyp:isa-l-md5',
             'third_party/isa-l.gyp:isa-l-sha1',
+            'third_party/isa-l.gyp:isa-l-crc'
         ],
         'sources': [
             # module

--- a/src/native/s3select/s3select.gyp
+++ b/src/native/s3select/s3select.gyp
@@ -1,0 +1,19 @@
+{
+    'includes': ['../third_party/common_third_party.gypi'],
+    'targets': [{
+        'target_name': 's3select',
+        'type': 'static_library',
+        'cflags_cc!': ['-fno-rtti'],
+        'include_dirs': [
+            '<@(napi_include_dirs)',
+            '../../../submodules/s3select/include',
+            '../../../submodules/s3select/rapidjson/include/'
+        ],
+        'sources': [
+            's3select_napi.cpp'
+        ],
+	'link_settings': {
+		'libraries': ['/lib64/libboost_thread.so.1.66.0']
+    }
+    }]
+}

--- a/src/native/s3select/s3select_napi.cpp
+++ b/src/native/s3select/s3select_napi.cpp
@@ -1,0 +1,279 @@
+/* Copyright (C) 2016 NooBaa */
+
+#include "../../../src/native/third_party/isa-l/include/crc.h"
+#include "../../../submodules/s3select/include/s3select.h"
+#include "../util/common.h"
+#include "../util/napi.h"
+#include <arpa/inet.h>
+
+namespace noobaa
+{
+
+const char *CSV_FORMAT = "CSV";
+const char *JSON_FORMAT = "JSON";
+const char *PARQUET_FORMAT = "PARQUET";
+
+class S3SelectNapi;
+
+class SelectWorker : public Napi::AsyncWorker
+{
+public:
+    Napi::ObjectReference _args_ref;
+    Napi::Promise::Deferred _deferred;
+    Napi::ObjectWrap<S3SelectNapi>& _wrap;
+    s3selectEngine::csv_object *_csv_object;
+    s3selectEngine::json_object *_json_object;
+    std::string _select;
+    const char* _buffer;
+    const unsigned int _buffer_len;
+    const bool _is_flush;
+    const std::string _input_format;
+    const uint8_t* _headers_bytes;
+    const uint32_t _headers_len;
+
+    SelectWorker(const Napi::CallbackInfo& info,
+        Napi::ObjectWrap<S3SelectNapi>& wrap,
+        s3selectEngine::csv_object* csv_object,
+        s3selectEngine::json_object* json_object,
+        const char* buffer,
+        const unsigned int buffer_len,
+        const bool is_flush,
+        const std::string input_format,
+        const uint8_t* headers_bytes,
+        const uint32_t headers_len)
+        : AsyncWorker(info.Env())
+        , _args_ref(Napi::Persistent(Napi::Object::New(info.Env())))
+        , _wrap(wrap)
+        , _csv_object(csv_object)
+        , _json_object(json_object)
+        , _buffer(buffer)
+        , _buffer_len(buffer_len)
+        , _is_flush(is_flush)
+        , _input_format(input_format)
+        , _deferred(info.Env())
+        , _headers_bytes(headers_bytes)
+        , _headers_len(headers_len)
+    {
+        //take a ref on args to make sure they are not GCed until worker is done
+        uint32_t i;
+        for (i = 0; i < info.Length(); ++i) {
+            _args_ref.Set(i, info[i]);
+        }
+        //prevent GC of S3SelectNapi object by JS until worker is done
+        _wrap.Ref();
+    }
+
+    ~SelectWorker()
+    {
+        //Worker is done, unref the ref we took in ctor
+        _wrap.Unref();
+    }
+
+    void Execute() override
+    {
+        int rc;
+        // TODO - if we get total size on beginning, i think we can remove the is_flush if
+        if (CSV_FORMAT == _input_format) {
+            if (_is_flush) {
+                rc = _csv_object->run_s3select_on_stream(_select, nullptr, 0, 0);
+            } else {
+                rc = _csv_object->run_s3select_on_stream(_select, _buffer, _buffer_len, SIZE_MAX);
+            }
+        } else {
+            if (_is_flush) {
+                rc = _json_object->run_s3select_on_stream(_select, nullptr, 0, 0);
+            } else {
+                rc = _json_object->run_s3select_on_stream(_select, _buffer, _buffer_len, SIZE_MAX);
+            }
+        }
+        if (rc < 0) {
+            if (CSV_FORMAT == _input_format) {
+                SetError(_csv_object->get_error_description());
+            } else {
+                // SetError(json_object.get_error_description()); //TODO - they added a getter, use after submodule is updated
+                SetError("failed to select from json");
+            }
+        }
+
+        /*std::cout << "select res = " << this->select << std::endl;
+        std::cout.flush();*/
+    }
+
+    void OnOK() override
+    {
+        Napi::Env env = Env();
+        // in case of empty select result (ie, no rows in current buffer matched sql condition), return null
+        if (_select.empty()) {
+            _deferred.Resolve(env.Null());
+            return;
+        }
+
+        Napi::Object result = Napi::Object::New(env);
+        Napi::Value select_buf = Napi::Buffer<char>::/*New*/ Copy(env, _select.data(), _select.length());
+        result.Set("select", select_buf);
+
+        uint32_t prelude[3];
+        int32_t prelude_crc, message_crc, prelude_crc_BE;
+        prelude[0] = htonl(_select.length() + _headers_len + 16);
+        prelude[1] = htonl(_headers_len);
+        prelude_crc = crc32_gzip_refl_base(0, (uint8_t*)prelude, 8);
+        result.Set("prelude_crc", prelude_crc);
+        prelude_crc_BE = htonl(prelude_crc);
+        /*std::cout << "sz = " << sizeof(headers_bytes) << ", native prelude_crc = " << prelude_crc << ", prelude = " << std::hex << std::setfill('0') << std::setw(2) << prelude[0] << prelude[1];
+        std::cout << std::endl;
+        std::cout.flush();*/
+        message_crc = crc32_gzip_refl_base(prelude_crc, (uint8_t*)&prelude_crc_BE, 4);
+        message_crc = crc32_gzip_refl_base(message_crc, const_cast<uint8_t*>(_headers_bytes), _headers_len);
+        message_crc = crc32_gzip_refl_base(message_crc, (uint8_t*)_select.data(), _select.length());
+        result.Set("message_crc", message_crc);
+
+        _deferred.Resolve(result);
+    }
+
+    void OnError(Napi::Error const& error) override
+    {
+        Napi::Env env = Env();
+        auto obj = error.Value();
+        _deferred.Reject(obj);
+    }
+};
+
+class S3SelectNapi : public Napi::ObjectWrap<S3SelectNapi>
+{
+
+public:
+    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+    S3SelectNapi(const Napi::CallbackInfo& info);
+    Napi::Value Write(const Napi::CallbackInfo& info);
+    Napi::Value Flush(const Napi::CallbackInfo& info);
+    ~S3SelectNapi();
+
+private:
+    static Napi::FunctionReference constructor;
+    Napi::ObjectReference _args_ref;
+    std::string input_format;
+    s3selectEngine::s3select s3select;
+    s3selectEngine::csv_object* csv_object = nullptr;
+    s3selectEngine::json_object* json_object = nullptr;
+    const uint8_t* headers_buf;
+    uint32_t headers_len;
+};
+
+Napi::Value
+S3SelectNapi::Write(const Napi::CallbackInfo& info)
+{
+    Napi::Buffer<char> buffer = info[0].As<Napi::Buffer<char>>();
+    SelectWorker* worker = new SelectWorker(
+        info,
+        *this,
+        csv_object,
+        json_object,
+        buffer.Data(),
+        buffer.Length(),
+        false,
+        input_format,
+        headers_buf,
+        headers_len);
+    worker->Queue();
+    return worker->_deferred.Promise();
+}
+
+Napi::Value
+S3SelectNapi::Flush(const Napi::CallbackInfo& info)
+{
+    SelectWorker* worker = new SelectWorker(
+        info,
+        *this,
+        csv_object,
+        json_object,
+        nullptr, /*No buffer for flush*/
+        0,
+        true,
+        input_format,
+        headers_buf,
+        headers_len);
+    worker->Queue();
+    return worker->_deferred.Promise();
+}
+
+Napi::FunctionReference S3SelectNapi::constructor;
+
+Napi::Object
+S3SelectNapi::Init(Napi::Env env, Napi::Object exports)
+{
+    Napi::HandleScope scope(env);
+
+    Napi::Function func = DefineClass(
+        env,
+        "S3SelectNapi",
+        {
+            InstanceMethod("write", &S3SelectNapi::Write),
+            InstanceMethod("flush", &S3SelectNapi::Flush)
+        }
+    ); //end of DefineClass
+
+    constructor = Napi::Persistent(func);
+    constructor.SuppressDestruct();
+
+    exports.Set("S3Select", func);
+    return exports;
+}
+
+void
+s3select_napi(Napi::Env env, Napi::Object exports)
+{
+    S3SelectNapi::Init(env, exports);
+}
+
+std::string
+GetStringWithDefault(Napi::Object obj, std::string name, std::string dfault)
+{
+    if (obj.Has(name)) {
+        return obj.Get(name).ToString().Utf8Value();
+    }
+    return dfault;
+}
+
+S3SelectNapi::S3SelectNapi(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<S3SelectNapi>(info)
+    , _args_ref(Napi::Persistent(Napi::Object::New(info.Env())))
+{
+    Napi::Object context = info[0].As<Napi::Object>();
+    Napi::Object input_serialization_format = context.Get("input_serialization_format").As<Napi::Object>();
+    Napi::Buffer headers_buf_obj = context.Get("records_header_buf").As<Napi::Buffer<uint8_t>>();
+    _args_ref.Set("headers_buf", headers_buf_obj);
+    headers_buf = headers_buf_obj.Data();
+    headers_len = headers_buf_obj.Length();
+    std::string query = context.Get("query").ToString();
+    input_format = context.Get("input_format").ToString();
+
+    s3select.parse_query(query.c_str());
+    if (!s3select.get_error_description().empty()) {
+        throw Napi::Error::New(info.Env(), XSTR() << "s3select: parse_query failed " << s3select.get_error_description());
+    }
+
+    if (input_format == JSON_FORMAT) {
+        json_object = new s3selectEngine::json_object(&s3select);
+    } else if (input_format == CSV_FORMAT) {
+        s3selectEngine::csv_object::csv_defintions csv_defs;
+        csv_defs.row_delimiter = GetStringWithDefault(input_serialization_format, "RecordDelimiter", "\n").c_str()[0];
+        csv_defs.column_delimiter = GetStringWithDefault(input_serialization_format, "FieldDelimiter", ",").c_str()[0];
+        csv_defs.use_header_info = (0 == GetStringWithDefault(input_serialization_format, "FileHeaderInfo", "IGNORE").compare("USE"));
+        csv_defs.quote_fields_always = false;
+        csv_object = new s3selectEngine::csv_object(&s3select, csv_defs);
+    } else {
+        throw Napi::Error::New(info.Env(), XSTR() << "input_format is neither csv nor json");
+    }
+}
+
+S3SelectNapi::~S3SelectNapi()
+{
+    if (nullptr != csv_object) {
+        delete csv_object;
+    }
+    if (nullptr != json_object) {
+        delete json_object;
+    }
+}
+
+} // namespace noobaa

--- a/src/tools/s3select.js
+++ b/src/tools/s3select.js
@@ -1,0 +1,59 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const { S3Select } = require('../util/nb_native')();
+const { Transform } = require('readable-stream');
+const minimist = require('minimist');
+
+const argv = minimist(process.argv, {
+    default: {
+        input_format: 'CSV',
+        field_delimiter: ',',
+        record_delimiter: '\n',
+        file_header_info: 'IGNORE'
+    }
+});
+
+class S3SelectStream extends Transform {
+
+    constructor(opts = {}) {
+        super(opts);
+        const context = {
+            query: argv.query,
+            input_format: argv.input_format,
+            input_serialization_format: {
+                FieldDelimiter: argv.field_delimiter,
+                RecordDelimiter: argv.record_delimiter,
+                FileHeaderInfo: argv.file_header_info
+            },
+            records_header_buf: Buffer.from("don't care") /*Used for CRC, ignored here.*/
+        };
+        if (S3Select) {
+            this.s3select = new S3Select(context);
+        } else {
+            console.log("ERROR - nb_native doesn't have S3Select. Did you build with GYP_DEFINES=BUILD_S3SELECT=1?");
+            process.exit(1);
+        }
+    }
+
+    async _transform(chunk, encoding, cb) {
+        //console.log("got chunk ", chunk.length);
+        let res = await this.s3select.write(chunk);
+        if (res) {
+            this.push(res.select);
+        }
+        return cb();
+    }
+
+    async _flush(cb) {
+        //console.log("in flush");
+        let res = await this.s3select.flush();
+        if (res) {
+            this.push(res.select);
+        }
+        return cb();
+    }
+}
+
+const s3select = new S3SelectStream();
+process.stdin.pipe(s3select).pipe(process.stdout);

--- a/src/util/s3select.js
+++ b/src/util/s3select.js
@@ -1,0 +1,127 @@
+/* Copyright (C) 2023 NooBaa */
+'use strict';
+
+const dbg = require('./debug_module')(__filename);
+const { Transform } = require('stream');
+const nb_native = require('./nb_native');
+const assert = require('assert');
+
+/*Encodes an s3select response according to AWS format. See
+https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html*/
+
+class S3SelectStream extends Transform {
+
+    static prelude_length_bytes = 12;
+    static crc_length_bytes = 4;
+    static string_type = 7;
+    static header_max_len = 256;
+
+    static header_to_buffer(key, val) {
+        assert(key.length < S3SelectStream.header_max_len);
+        assert(val.length < S3SelectStream.header_max_len);
+        return Buffer.concat([
+            Buffer.from([key.length]),
+            Buffer.from(key),
+            Buffer.from([S3SelectStream.string_type, 0, val.length]),
+            Buffer.from(val)
+        ]);
+    }
+
+    //end message is always the same, so we allocate and init it once.
+    static end_message = Buffer.concat([
+        Buffer.from([0, 0, 0, 56]), //PRELUDE begins: total byte length
+        Buffer.from([0, 0, 0, 40]), //headers byte length
+        Buffer.from([0xc1, 0xc6, 0x84, 0xd4]), //crc of above (end of PRELUDE)
+        //DATA begins, HEADERS begin
+        S3SelectStream.header_to_buffer(':event-type', 'End'),
+        S3SelectStream.header_to_buffer(':message-type', 'event'),
+        //no PAYLOAD (DATA ends)
+        Buffer.from([0xfe, 0x2c, 0xee, 0x99]) //MESSAGE CRC (crc of above)
+    ]);
+
+    //same for headers of records message
+    static records_message_headers = Buffer.concat([
+        S3SelectStream.header_to_buffer(':event-type', 'Records'),
+        S3SelectStream.header_to_buffer(':content-type', 'application/octet-stream'),
+        S3SelectStream.header_to_buffer(':message-type', 'event'),
+    ]);
+
+    /**
+         * @param {{
+    *     query: string;
+    *     input_format: 'CSV' | 'JSON';
+    *     input_serialization_format: {
+    *        FieldDelimiter: string;
+    *        RecordDelimiter: string;
+    *        FileHeaderInfo: string;
+    *     };
+    *     records_header_buf: Buffer;
+    *  }} opts
+    */
+    constructor(opts) {
+        super(opts);
+        this.s3select = new (nb_native().S3Select)(opts);
+    }
+
+    encode_chunk(select_result) {
+        dbg.log2("select res = ", select_result.select.toString());
+
+        const total_length_bytes =
+            select_result.select.length +
+            S3SelectStream.records_message_headers.length +
+            S3SelectStream.prelude_length_bytes +
+            S3SelectStream.crc_length_bytes;
+        const buffer = Buffer.alloc(S3SelectStream.prelude_length_bytes);
+        let index = 0;
+
+        //prelude:
+        index = buffer.writeUInt32BE(total_length_bytes);
+        index = buffer.writeUInt32BE(S3SelectStream.records_message_headers.length, index);
+        buffer.writeInt32BE(select_result.prelude_crc, index);
+        this.push(buffer);
+        //headers:
+        this.push(S3SelectStream.records_message_headers);
+        //body:
+        this.push(select_result.select);
+        //message crc:
+        const buffer2 = Buffer.alloc(S3SelectStream.crc_length_bytes);
+        buffer2.writeInt32BE(select_result.message_crc);
+        this.push(buffer2);
+
+        //this transforms the buffer into a human-readable string.
+        //it is not at any debug level because it is cpu-intensive and will be useful only in specific debug scenarios
+        //dbg.log2("select content response = ", buffer.toString('hex').match(/../g).join(' '));
+    }
+
+    handle_result(result) {
+        if (result) {
+            this.encode_chunk(result);
+        }
+    }
+
+    async _transform(chunk, encoding, cb) {
+        try {
+            const select_result = await this.s3select.write(chunk);
+            this.handle_result(select_result);
+            return cb();
+        } catch (err) {
+            dbg.error(err);
+            return cb(err);
+        }
+    }
+
+    async _flush(cb) {
+        try {
+            const select_result = await this.s3select.flush();
+            this.handle_result(select_result);
+            this.push(S3SelectStream.end_message);
+            this.push(null); //ends http res
+            return cb();
+        } catch (err) {
+            dbg.error(err);
+            return cb(err);
+        }
+    }
+}
+
+exports.S3SelectStream = S3SelectStream;


### PR DESCRIPTION
### Explain the changes
1. Incorporate s3select (https://github.com/ceph/s3select) to implement a "select object content"-like feature.
Feature is ideally as close as possible to s3, but it is excpeted that s3select will somewhat diverge.
If and when s3select will introduce new features which don't change its api, we can take them by changing our commit in the submodule (if api changes we also need to adapt native code accordingly).

### Issues: Fixed #xxx / Gap #xxx
1. None

### Testing Instructions:
1. Consider enabling ceph s3 tests related to "select object content"


- [ ] Doc added/updated
/docs/desgin/s3select.md
/docs/dev_guide/S3Select_Build.md
- [ ] Tests added
TODO