### PR TITLE
Adding ROOT key rotate to core

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -725,6 +725,8 @@ module.exports = {
             }
         },
 
+        secret_enc_key: { wrapper: SensitiveString },
+
         ip_range: {
             type: 'object',
             required: ['start', 'end'],

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -115,6 +115,20 @@ module.exports = {
             }
         },
 
+        rotate_root_key: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: ['new_root_key'],
+                properties: {
+                    new_root_key: { $ref: 'common_api#/definitions/secret_enc_key' },
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
         rotate_master_key: {
             method: 'PUT',
             params: {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -1284,6 +1284,23 @@ async function _get_endpoint_groups() {
 
 /**
  *
+ * ROTATE ROOT KEY
+ *
+ */
+async function rotate_root_key(req) {
+    const new_root_key = req.rpc_params.new_root_key;
+    const mkm = system_store.master_key_manager;
+    await P.all(_.map(system_store.data.systems, async function(system) {
+        const reencrypted = mkm._reencrypt_master_key_by_root(system.master_key_id._id, new_root_key);
+        await upsert_master_key({
+            _id: system.master_key_id._id,
+            update: { cipher_key: reencrypted }
+        });
+    }));
+}
+
+/**
+ *
  * ROTATE MASTER KEY
  *
  */
@@ -1650,6 +1667,7 @@ exports.get_join_cluster_yaml = get_join_cluster_yaml;
 exports.update_endpoint_group = update_endpoint_group;
 exports.get_endpoints_history = get_endpoints_history;
 
+exports.rotate_root_key = rotate_root_key;
 exports.rotate_master_key = rotate_master_key;
 exports.disable_master_key = disable_master_key;
 exports.enable_master_key = enable_master_key;

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -409,7 +409,7 @@ class SystemStore extends EventEmitter {
                     this.last_update_time = since;
                 }
 
-                await this.master_key_manager.load_root_key();
+                this.master_key_manager.load_root_key();
                 let new_data = new SystemStoreData();
                 let millistamp = time_utils.millistamp();
                 await this._register_for_changes();


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. Adding rotate_root_key to system_api to allow key rotation of the ROOT_KEY for the system.
2. Admin that wants to rotate the ROOT_KEY needs to send the new ROOT_KEY as new_secret to this api, following with the changing the ROOT_KEY in the env variables
3. The function will decrypt all system master keys with the current ROOT_KEY and then re-encrypt it with the new secret
4. After that, the system will start re-encryption of all the other lower levels master keys in the system (like accounts for example)
5. Once finished the user will need to set the env variable ROOT_KEY to the new_secret so in the case of restart, keys will be able to decrypt.

Following this PR we will create a PR for NooBaa operator that will send this command every given time, so key periodic key rotation will be able to run automatically.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
