### PR TITLE
NSFS | get_single_user_xattr() shouldnt throw in case of missing attribute

### DIFF
--- a/src/test/unit_tests/test_nb_native_fs.js
+++ b/src/test/unit_tests/test_nb_native_fs.js
@@ -283,6 +283,17 @@ mocha.describe('nb_native fs', function() {
                 tmpfile.close(DEFAULT_FS_CONFIG);
             }
         });
+
+        mocha.it('stat -  not existing xattr', async function() {
+            const { open } = nb_native().fs;
+            const PATH = `/tmp/xattrtest${Date.now()}`;
+            const tmpfile = await open(DEFAULT_FS_CONFIG, PATH, 'w');
+            const xattr_obj = { 'user.key1': 'value1', 'user.key11': 'value11', 'user.key2': 'value2' };
+            await tmpfile.replacexattr(DEFAULT_FS_CONFIG, xattr_obj);
+            const res = await nb_native().fs.stat(DEFAULT_FS_CONFIG, PATH, { skip_user_xattr: true });
+            tmpfile.close(DEFAULT_FS_CONFIG);
+            console.log(res);
+        });
     });
 
     mocha.describe('Stat with xattr', function() {


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. By default we do not calculatie md5 on nsfs (config.NSFS_CALCULATE_MD5 = false)
While specifying skip_user_xattr flag on stat() we will check for a constant list of extended attributes.
currently, the list contains 'user.content_md5', but it's empty by default for every object because config.NSFS_CALCULATE_MD5 is false. 
This missing attribute caused stat() to fail on _is_same_inode() check which caused potential redundant links/uploads.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
