### PR TITLE
node18 fixes for openssl3

### DIFF
--- a/src/native/tools/ssl_napi.cpp
+++ b/src/native/tools/ssl_napi.cpp
@@ -452,9 +452,9 @@ _nb_x509_verify(napi_env env, napi_callback_info info)
     switch (EVP_PKEY_base_id(issuer_private_key)) {
     case EVP_PKEY_RSA:
     case EVP_PKEY_RSA2: {
-        RSA* rsa = EVP_PKEY_get1_RSA(issuer_private_key);
-        int rc = RSA_check_key(rsa);
-        RSA_free(rsa);
+        EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new(issuer_private_key, NULL);
+        int rc = EVP_PKEY_check(ctx);
+        EVP_PKEY_CTX_free(ctx);
         if (rc != 1) {
             napi_throw_error(env, 0, "RSA check key failed");
             return 0;

--- a/src/test/unit_tests/test_ssl_utils.js
+++ b/src/test/unit_tests/test_ssl_utils.js
@@ -86,7 +86,10 @@ mocha.describe('ssl_utils', function() {
             x.key = x.key.slice(0, 500) + '!' + x.key.slice(501);
 
             assert.throws(() => ssl_utils.verify_ssl_certificate(x),
-                /^Error: error:09091064:PEM routines:PEM_read_bio_ex:bad base64 decode$/);
+                process.version.startsWith('v16') ?
+                    /^Error: error:09091064:PEM routines:PEM_read_bio_ex:bad base64 decode$/ :
+                    /^Error: error:1E08010C:DECODER routines::unsupported$/
+            );
             assert.throws(() => x509_verify(x),
                 /^Error: Private key PEM decode failed$/);
         });
@@ -100,7 +103,10 @@ mocha.describe('ssl_utils', function() {
             x.cert = x.cert.slice(0, 500) + '!' + x.cert.slice(501);
 
             assert.throws(() => ssl_utils.verify_ssl_certificate(x),
-                /^Error: error:09091064:PEM routines:PEM_read_bio_ex:bad base64 decode$/);
+                process.version.startsWith('v16') ?
+                    /^Error: error:09091064:PEM routines:PEM_read_bio_ex:bad base64 decode$/ :
+                    /^Error: error:04800064:PEM routines::bad base64 decode$/
+            );
             assert.throws(() => x509_verify(x),
                 /^Error: X509 PEM decode failed$/);
         });
@@ -116,8 +122,12 @@ mocha.describe('ssl_utils', function() {
             // replace the key with another valid key
             x.key = other.key;
 
-            assert.throws(() => ssl_utils.verify_ssl_certificate(x),
-                /^Error: error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch$/);
+            assert.throws(
+                () => ssl_utils.verify_ssl_certificate(x),
+                process.version.startsWith('v16') ?
+                    /^Error: error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch$/ :
+                    /^Error: error:05800074:x509 certificate routines::key values mismatch$/
+            );
             assert.throws(() => x509_verify(x),
                 /^Error: X509 verify failed$/);
         });


### PR DESCRIPTION
Signed-off-by: Guy Margalit <guymguym@gmail.com>

### Explain the changes
1. Node v18 upgraded to openssl v3 - see migration guide - https://www.openssl.org/docs/man3.0/man7/migration_guide.html
2. Fixing a code and tests.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. NA


- [ ] Doc added/updated
- [ ] Tests added
