### PR TITLE
Fix test signature utils CRLF

### DIFF
--- a/src/test/unit_tests/test_signature_utils.js
+++ b/src/test/unit_tests/test_signature_utils.js
@@ -31,9 +31,9 @@ mocha.describe('signature_utils', function() {
     mocha.before(function() {
         return new Promise((resolve, reject) =>
             http_server
-            .once('listening', resolve)
-            .once('error', reject)
-            .listen());
+                .once('listening', resolve)
+                .once('error', reject)
+                .listen());
     });
 
     mocha.after(function() {
@@ -88,42 +88,60 @@ mocha.describe('signature_utils', function() {
         });
     }
 
+    const LF = '\n';
+    const LF2 = '\n\n';
+    const CRLF = '\r\n';
+    const CRLF2 = '\r\n\r\n';
+
+    /**
+     * Fixing the buffer from file in git to include CRLF line endings for the http headers section.
+     * @param {Buffer} buf
+     * @returns {Buffer}
+     */
+    function fix_http_crlf(buf) {
+        const index_lf2 = buf.indexOf(LF2);
+        const index_crlf2 = buf.indexOf(CRLF2);
+        const end_lf2 = index_lf2 >= 0 ? index_lf2 + LF2.length : buf.length;
+        const end_crlf2 = index_crlf2 >= 0 ? index_crlf2 + CRLF2.length : buf.length;
+        const end = Math.min(end_lf2, end_crlf2);
+        const header = buf.slice(0, end)
+            .toString()
+            .replaceAll(CRLF, LF)
+            .replaceAll(LF, CRLF)
+            .trimEnd();
+        const body = buf.slice(end);
+        return Buffer.concat([Buffer.from(header), Buffer.from(CRLF2), body]);
+    }
+
     /**
      * send_signed_request is the client function
      * that takes a raw http request dump of a signed http request,
      * and sends it to the http server for verification.
+     * @param {Buffer} signed_req_buf
      */
-    function send_signed_request(signed_req_buf) {
-        const socket = net.connect({
-            port: http_server.address().port
-        }, () => {
-            socket.write(signed_req_buf);
-            if (!signed_req_buf.includes('\r\n\r\n')) {
-                socket.write('\r\n\r\n');
-            }
-        });
+    async function send_signed_request(signed_req_buf) {
+        const server_addr = /** @type {net.AddressInfo} */ (http_server.address());
+        const socket = net.connect({ port: server_addr.port });
+        const http_req_buf = fix_http_crlf(signed_req_buf);
+        socket.write(http_req_buf);
         let reply = '';
-        return new Promise((resolve, reject) => socket
-                .setEncoding('utf8')
-                .on('data', data => {
-                    reply += data;
-                })
-                .once('error', reject)
-                .once('end', resolve)
-            )
-            .then(() => {
-                socket.destroy();
-                reply = reply.trim();
-                log('REPLY:', reply);
-                const CONT = 'HTTP/1.1 100 Continue';
-                if (reply.startsWith(CONT)) {
-                    reply = reply.slice(CONT.length).trim();
-                }
-                if (reply.startsWith('HTTP/1.1 200 OK')) {
-                    return;
-                }
-                throw new Error('BAD REPLY: ' + reply);
-            });
+        await new Promise((resolve, reject) => socket
+            .setEncoding('utf8')
+            .on('data', data => { reply += data; })
+            .once('error', reject)
+            .once('end', resolve)
+        );
+        socket.destroy();
+        reply = reply.trim();
+        log('REPLY:', reply);
+        const CONT = 'HTTP/1.1 100 Continue';
+        if (reply.startsWith(CONT)) {
+            reply = reply.slice(CONT.length).trim();
+        }
+        if (reply.startsWith('HTTP/1.1 200 OK')) {
+            return;
+        }
+        throw new Error('BAD REPLY: ' + reply);
     }
 
     /**
@@ -131,72 +149,70 @@ mocha.describe('signature_utils', function() {
      * that receives the signed http request, calculates signature
      * and checks if the signature is correct
      */
-    function accept_signed_request(req, res) {
-        let body_len = 0;
-        req.originalUrl = req.url;
-        const parsed_url = url.parse(req.originalUrl, true);
-        req.url = parsed_url.pathname;
-        req.query = parsed_url.query;
-        const virtual_hosted_bucket = req.headers.host.split('.', 1)[0];
-        if ((/[a-zA-Z][a-zA-Z0-9]*/).test(virtual_hosted_bucket)) {
-            req.virtual_hosted_bucket = virtual_hosted_bucket;
+    async function accept_signed_request(req, res) {
+        try {
+            let body_len = 0;
+            req.originalUrl = req.url;
+            const parsed_url = url.parse(req.originalUrl, true);
+            req.url = parsed_url.pathname;
+            req.query = parsed_url.query;
+            const virtual_hosted_bucket = req.headers.host.split('.', 1)[0];
+            if ((/[a-zA-Z][a-zA-Z0-9]*/).test(virtual_hosted_bucket)) {
+                req.virtual_hosted_bucket = virtual_hosted_bucket;
+            }
+            res.setHeader('Connection', 'close');
+            if (req.method === 'OPTIONS') return res.end();
+            log(
+                'Handle:', req.method, req.originalUrl,
+                'query', req.query,
+                'headers', req.headers);
+            const hasher = crypto.createHash('sha256');
+            await new Promise((resolve, reject) => req
+                .on('data', data => {
+                    hasher.update(data);
+                    body_len += data.length;
+                    log(`Request body length so far ${body_len}`);
+                })
+                .once('end', resolve)
+                .once('error', reject)
+            );
+            const sha256_buf = hasher.digest();
+            log(`Request body ended body length ${body_len} sha256 ${sha256_buf.toString('hex')}`);
+            const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
+            const STREAMING_PAYLOAD = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';
+            const content_sha256_hdr = req.headers['x-amz-content-sha256'];
+            req.content_sha256_sig = req.query['X-Amz-Signature'] ?
+                UNSIGNED_PAYLOAD :
+                content_sha256_hdr;
+            if (typeof content_sha256_hdr === 'string' &&
+                content_sha256_hdr !== UNSIGNED_PAYLOAD &&
+                content_sha256_hdr !== STREAMING_PAYLOAD) {
+                req.content_sha256_buf = Buffer.from(content_sha256_hdr, 'hex');
+                if (req.content_sha256_buf.length !== 32) {
+                    throw new Error('InvalidDigest');
+                }
+            }
+            if (req.content_sha256_buf) {
+                if (Buffer.compare(req.content_sha256_buf, sha256_buf)) {
+                    throw new Error('XAmzContentSHA256Mismatch');
+                }
+            } else {
+                req.content_sha256_buf = sha256_buf;
+                if (!req.content_sha256_sig) req.content_sha256_sig = req.content_sha256_buf.toString('hex');
+            }
+            const auth_token = signature_utils.make_auth_token_from_request(req);
+            const signature = signature_utils.get_signature_from_auth_token(auth_token, SECRETS[auth_token.access_key]);
+            log('auth_token', auth_token, 'signature', signature);
+            if (signature !== auth_token.signature) {
+                throw new Error('Signature mismatch');
+            }
+            res.end(JSON.stringify(auth_token));
+
+        } catch (err) {
+            console.error('SIGNATURE ERROR', err.stack);
+            res.statusCode = 500;
+            res.end();
         }
-        res.setHeader('Connection', 'close');
-        if (req.method === 'OPTIONS') return res.end();
-        log(
-            'Handle:', req.method, req.originalUrl,
-            'query', req.query,
-            'headers', req.headers);
-        return new Promise((resolve, reject) => {
-                const hasher = crypto.createHash('sha256');
-                req.on('data', data => {
-                        hasher.update(data);
-                        body_len += data.length;
-                        log(`Request body length so far ${body_len}`);
-                    })
-                    .once('end', () => {
-                        const sha256 = hasher.digest();
-                        log(`Request body ended body length ${body_len} sha256 ${sha256.toString('hex')}`);
-                        return resolve(sha256);
-                    })
-                    .once('error', reject);
-            })
-            .then(sha256_buf => {
-                const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
-                const STREAMING_PAYLOAD = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';
-                const content_sha256_hdr = req.headers['x-amz-content-sha256'];
-                req.content_sha256_sig = req.query['X-Amz-Signature'] ?
-                    UNSIGNED_PAYLOAD :
-                    content_sha256_hdr;
-                if (typeof content_sha256_hdr === 'string' &&
-                    content_sha256_hdr !== UNSIGNED_PAYLOAD &&
-                    content_sha256_hdr !== STREAMING_PAYLOAD) {
-                    req.content_sha256_buf = Buffer.from(content_sha256_hdr, 'hex');
-                    if (req.content_sha256_buf.length !== 32) {
-                        throw new Error('InvalidDigest');
-                    }
-                }
-                if (req.content_sha256_buf) {
-                    if (Buffer.compare(req.content_sha256_buf, sha256_buf)) {
-                        throw new Error('XAmzContentSHA256Mismatch');
-                    }
-                } else {
-                    req.content_sha256_buf = sha256_buf;
-                    if (!req.content_sha256_sig) req.content_sha256_sig = req.content_sha256_buf.toString('hex');
-                }
-                const auth_token = signature_utils.make_auth_token_from_request(req);
-                const signature = signature_utils.get_signature_from_auth_token(auth_token, SECRETS[auth_token.access_key]);
-                log('auth_token', auth_token, 'signature', signature);
-                if (signature !== auth_token.signature) {
-                    throw new Error('Signature mismatch');
-                }
-                res.end(JSON.stringify(auth_token));
-            })
-            .catch(err => {
-                console.error('SIGNATURE ERROR', err.stack);
-                res.statusCode = 500;
-                res.end();
-            });
     }
 
 });


### PR DESCRIPTION
Signed-off-by: Guy Margalit <guymguym@gmail.com>

### Explain the changes
1. Our signature test files are stored in git and their line endings is inconsistent - sometimes LF and sometimes CRLF.
2. Added code to fix the line endings to CRLF in the http headers section so that http server will not fail.
3. These errors started since node 18.5.0 fixed a related CVE which now does not accept LF endings, see https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2022-07-07-version-1850-current-rafaelgss and this description:

> HTTP Request Smuggling - Improper Delimiting of Header Fields (Medium)([CVE-2022-32214](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32214)): The llhttp parser in the http module does not strictly use the CRLF sequence to delimit HTTP requests. This can lead to HTTP Request Smuggling.
Note: This can be considered a breaking change due to disabling LF header delimiting. To enable LF header delimiting you can specify the --insecure-http-parser command-line flag, but note that this will additionally enable other insecure behaviours.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. mocha src/test/unit_tests/test_signature_utils.js

