### PR TITLE
Add a comment with gitleaks:allow

### DIFF
--- a/src/test/framework/report.js
+++ b/src/test/framework/report.js
@@ -10,7 +10,7 @@ const P = require('../../util/promise');
 //const report_schema = require('./report_schema'); //NBNB TODO add schema verification
 require('../../util/dotenv').load();
 
-const REMOTE_MONGO_URL = 'mongodb://reporter:4*pRw3-vZb@ds139841.mlab.com:39841/test_reports';
+const REMOTE_MONGO_URL = 'mongodb://reporter:4*pRw3-vZb@ds139841.mlab.com:39841/test_reports'; // gitleaks:allow
 const REMOTE_MONGO_CONFIG = {
     promiseLibrary: P,
     reconnectTries: -1,

--- a/src/test/qa/tests_report_summary.js
+++ b/src/test/qa/tests_report_summary.js
@@ -50,7 +50,7 @@ class ReportsSummarizer {
 
     constructor(params) {
         this.init_params(params);
-        this.connection_string = 'mongodb://summarizer:T3st1ng1sFun!@ds139841.mlab.com:39841/test_reports';
+        this.connection_string = 'mongodb://summarizer:T3st1ng1sFun!@ds139841.mlab.com:39841/test_reports'; // gitleaks:allow
     }
 
     async init() {

--- a/src/tools/tcp_tunnel.js
+++ b/src/tools/tcp_tunnel.js
@@ -182,8 +182,8 @@ function human_addr(addr) {
 }
 
 function ssl_key() {
-    return `-----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAx1dRbX6F9q7V56EmMGlhuksnqXPcQM4cL/FfwQG/15CPG8Mp
+    return `-----BEGIN RSA PRIVATE KEY-----\n` + // gitleaks:allow
+`MIIEpAIBAAKCAQEAx1dRbX6F9q7V56EmMGlhuksnqXPcQM4cL/FfwQG/15CPG8Mp
 3bEPIOSGvbhaDiTgisAJ5sKhIfI7Ac5BQpps8Y9YJQDhIr4hXkFFjZ7nu2t/KxbC
 g4S/9+p+USySt9zsr+ER0W3k69G7pHcngLbiuUkJMz9ku4Zq2iDBmZLvO+H98Wwk
 u5udx0yuAq0rvM24JE4dBRTk57bOmBp9L6R6AhZKh9q8YigXwtoB2JKy5pCxu8Jj


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. Add a comment with `gitleaks:allow` for the lines the infoSec found in its alerts that were false-positive alerts

### Issues: Gap
1. When I worked on the GH Action on a copy of noobaa-core repository I got false-positive alerts from infoSec.
2. One of the ways to turn it off is to add the comment `gitleaks:allow`, which is the simplest way.

Note: There are two optional solutions - adding the comment `gitleaks:allow` or adding a file `.gitleaks.toml`, usually `.gitleaks.toml` is preferred over adding the comment, @bplaxco:
> If you commit something that looks like a secret and then in a different commit add a `gitleaks:allow` the scanner will probably still find the original commit where it was uncommented and alert on that. With the .gitleaks.toml config file you can tell the scanner, "I don't care which commit it's on---ignore this pattern or path"

Since those alerts were sent when copying the repo (as a new commit) adding the comment should be a sufficient solution.

### Testing Instructions:
none, this change adds comments that should not change any flow.


- [ ] Doc added/updated
- [ ] Tests added
