### PR TITLE
Add a step  to cancel previous runs in GH Action

### DIFF
--- a/.github/workflows/postgres-unit-tests.yaml
+++ b/.github/workflows/postgres-unit-tests.yaml
@@ -7,8 +7,11 @@ jobs:
   run-unit-tests-postgres:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Run Unit Tests with Postgres
         id: run-test-postgres


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. Add a step to cancel previous runs in `run-unit-tests-postgres` workflow (as a pilot test).
2. Update the version of checkout to the latest.

### Issues: Gap
1. Waste of computing resources when we use successive pushes, [for more information](https://github.com/marketplace/actions/cancel-workflow-action)

### Testing Instructions:
1. none, this is the pilot test.


- [ ] Doc added/updated
- [ ] Tests added
