### PR TITLE
NSFS | Versioning | Safe unlink - on error link back and not rename

### DIFF
--- a/docs/design/NsfsVersioning.md
+++ b/docs/design/NsfsVersioning.md
@@ -78,12 +78,13 @@ In order to support best effort on scale of these scenarios, for POSIX file syst
 #### safe unlink
 
 ```
-1. mv path unique_tmp_path
-2. stat_res_tmp = stat unique_tmp_path
-3. if stat_res1.inode_number != stat_res2.inode_number OR stat_res1.mtimeMs != stat_res2.mtimeMs - 
-    3.1. mv unique_tmp_path path
-    3.2. retry
-4. else - unlink unique_tmp_path
+1. stat_res1 = stat path
+2. mv path unique_tmp_path
+3. stat_res2 = stat unique_tmp_path
+4. if stat_res1.inode_number != stat_res2.inode_number OR stat_res1.mtimeMs != stat_res2.mtimeMs - 
+    4.1. link unique_tmp_path path
+    4.2. retry
+5. else - unlink unique_tmp_path
 ```
 
 ## OUT OF SCOPE

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -816,7 +816,7 @@ struct SafeUnlink : public FSWorker
             SYSCALL_OR_RETURN(unlink(_mv_to.c_str()));
             return;
         }
-        SYSCALL_OR_RETURN(rename(_mv_to.c_str(), _to_unlink.c_str()));
+        SYSCALL_OR_RETURN(link(_mv_to.c_str(), _to_unlink.c_str()));
         DBG0("FS::SafeUnlink::Execute: ERROR unlink target doesn't match the expected inode + mtime, retry" <<  DVAL(_to_unlink) 
             << DVAL(_unlink_expected_mtime) << DVAL(_unlink_expected_inode));
         SetError(XSTR() << "FS::SafeUnlink ERROR unlink target doesn't match expected inode and mtime");

--- a/src/test/unit_tests/test_nb_native_fs.js
+++ b/src/test/unit_tests/test_nb_native_fs.js
@@ -366,7 +366,8 @@ mocha.describe('nb_native fs', function() {
                 assert.fail('should have failed');
             } catch (err) {
                 const actual_err_msg = err.message;
-                assert.ok(actual_err_msg === 'FS::SafeLink ERROR link target doesn\'t match expected inode and mtime');
+                assert.equal(actual_err_msg, 'FS::SafeLink ERROR link target doesn\'t match expected inode and mtime');
+                await fs_utils.file_must_exist(PATH1);
             }
             await fs_utils.file_delete(PATH1);
         });
@@ -378,14 +379,8 @@ mocha.describe('nb_native fs', function() {
             await create_file(PATH1);
             const res1 = await nb_native().fs.stat(DEFAULT_FS_CONFIG, PATH1);
             await safe_unlink(DEFAULT_FS_CONFIG, PATH1, tmp_mv_path, res1.mtimeNsBigint, res1.ino);
-            try {
-                await nb_native().fs.stat(DEFAULT_FS_CONFIG, PATH1);
-                await fs_utils.file_delete(PATH1);
-                assert.fail('file should be deleted');
-            } catch (err) {
-                await fs_utils.file_must_not_exist(PATH1);
-                assert.equal(err.code, 'ENOENT');
-            }
+            await fs_utils.file_must_not_exist(PATH1);
+            await fs_utils.file_delete(PATH1);
         });
 
         mocha.it('safe unlink - failure', async function() {
@@ -401,10 +396,12 @@ mocha.describe('nb_native fs', function() {
             } catch (err) {
                 assert.equal(err.message, 'FS::SafeUnlink ERROR unlink target doesn\'t match expected inode and mtime');
                 const res2 = await nb_native().fs.stat(DEFAULT_FS_CONFIG, PATH1);
-                // file should still exist
+                // source file & target file should still exist
                 assert.equal(res1.ino.toString(), res2.ino.toString());
                 await fs_utils.file_must_exist(PATH1);
+                await fs_utils.file_must_exist(tmp_mv_path);
                 await fs_utils.file_delete(PATH1);
+                await fs_utils.file_delete(tmp_mv_path);
             }
         });
     });


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

### Explain the changes
1. According to NSFS versioning downstream design docs  - when got error of inode/mtime verification of safe unlink we should link back and not rename.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
