### PR TITLE
Ceph s3 Tests | Update Ceph S3 Tests Commit Number

### DIFF
--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -1,8 +1,5 @@
-name: ceph-s3-tests
-on: 
-  workflow_dispatch:
-  schedule:
-    - cron: "00 22,1 * * *" # Runs every day at 22:00 and 1:00 UTC
+name: Ceph S3 Tests
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   ceph-s3-tests:
@@ -48,7 +45,7 @@ jobs:
          ./build/_output/bin/noobaa-operator crd create
          ./build/_output/bin/noobaa-operator operator install
          ./build/_output/bin/noobaa-operator system create  \
-         --db-resources='{ "limits": {"cpu": "200m","memory": "1G"}, "requests": {"cpu": "200m","memory": "1G"}}' \
+         --db-resources='{ "limits": {"cpu": "200m","memory": "2G"}, "requests": {"cpu": "200m","memory": "2G"}}' \
          --core-resources='{ "limits": {"cpu": "200m","memory": "1G"}, "requests": {"cpu": "200m","memory": "1G"}}' \
          --endpoint-resources='{ "limits": {"cpu": "200m","memory": "1G"}, "requests": {"cpu": "200m","memory": "1G"}}' \
          --noobaa-image='noobaa-core:s3-tests'
@@ -66,6 +63,8 @@ jobs:
           kubectl apply -f ./src/test/system_tests/ceph_s3_tests/test_ceph_s3_job.yml
           kubectl wait --for=condition=complete job/noobaa-tests-s3 --timeout=30m || TIMEOUT=true
           kubectl logs job/noobaa-tests-s3 --tail 10000 -f
+          echo "K8S Events"
+          kubectl get events --sort-by='.metadata.creationTimestamp' -A
           if kubectl logs job/noobaa-tests-s3 | grep -q "Ceph Test Failed:"; then
             echo "At least one test failed!"
             exit 1

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3.js
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3.js
@@ -86,7 +86,9 @@ async function run_all_tests() {
     }
     tests_list = tests_list.split('\n');
     testing_status.total = tests_list.length;
-    await P.map(_.times(argv.concurrency || DEFAULT_NUMBER_OF_WORKERS), test_worker); //number of concurrent workers is set in the argument of times
+    const number_of_workers = argv.concurrency || DEFAULT_NUMBER_OF_WORKERS;
+    console.info('Number of workers (concurrency):', number_of_workers);
+    await P.map(_.times(number_of_workers), test_worker);
     console.log('Finished Running Ceph S3 Tests');
 }
 

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -17,7 +17,7 @@ DIRECTORY="s3-tests"
 CEPH_LINK="https://github.com/ceph/s3-tests.git"
 # using a fixed version (commit) of ceph tests to avoid sudden changes. 
 # we should retest and update the version once in a while
-CEPH_TESTS_VERSION=952beb9ebd986ae78c04f76705e557353e2030ed
+CEPH_TESTS_VERSION=114397c358c7e6b30e0ff2f5dd54607dad1ae8ce
 if [ ! -d $DIRECTORY ]; then
     echo "Downloading Ceph S3 Tests..."
     git clone $CEPH_LINK
@@ -30,7 +30,7 @@ commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}'
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
 
-max_days="500"
+max_days="180"
 if [ $((current_date-commit_date)) -gt $((3600*24*${max_days})) ]
 then
     echo "ceph tests were not updated for ${max_days} days, Exiting"


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. Update the commit number of the repo s3-tests by Ceph.
 As a result the number of the passed tests will be 387 instead of 386, the test `test_object_copy_16m` was [added](https://github.com/ceph/s3-tests/pull/473).
2. Add to the logs the printing of the number of workers. 
Note: Currently it is with 1
3. Change the action to run on push or pull request of code inside `src` directory on `master` branch (in addition to the option to run it manually).
4. Increase the memory of db pod.
5. Add printings of k8s events in the logs.
6. Change the max days from 500 to 180.

### Testing Instructions:
1. Based on the instructions [here](https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76) - the steps of ‘Build images’ and ‘Deploy noobaa’.
2. I’ve noticed that after installing noobaa we need to wait before running the job, otherwise all the tests will be failed.
`kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=3m`
wait a couple of minutes after this condition is met ~3m (it's just a bypass).
You can use this command to check when the default backing store is in mode OPTIMAL:
`nb api system read_system`
3. Deploy the tests job (run it from the noobaa-core repo):
` kubectl apply -f src/test/system_tests/ceph_s3_tests/test_ceph_s3_job.yml`
View the logs:
`kubectl logs job/noobaa-tests-s3 -f`


- [ ] Doc added/updated
- [ ] Tests added
