### PR TITLE
Fix the replication scanner pagination support and add a fitting unittest

### DIFF
--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -85,8 +85,8 @@ class ReplicationScanner {
                 return;
             }
             const prefix = (rule.filter && rule.filter.prefix) || '';
-            const cur_src_cont_token = (rule.status && rule.status.src_cont_token) || '';
-            const cur_dst_cont_token = (rule.status && rule.status.dst_cont) || '';
+            const cur_src_cont_token = (rule.rule_status && rule.rule_status.src_cont_token) || '';
+            const cur_dst_cont_token = (rule.rule_status && rule.rule_status.dst_cont_token) || '';
 
             const { keys_sizes_map_to_copy, src_cont_token, dst_cont_token } = await this.list_buckets_and_compare(src_bucket.name,
                 dst_bucket.name, prefix, cur_src_cont_token, cur_dst_cont_token);


### PR DESCRIPTION
### Explain the changes
1. The replication scanner's pagination logic was bugged since it tried to access a rule's continuation token through the hierarchy `rule.status...` instead of `rule.rule_status...`. The PR changes the logic to use the correct hierarchy
2. Also corrected the name of the `dst_cont_token`
3. A new unittest verifies that the fix works and will also keep future regressions in check. The unittest works by writing 1100 objects to the bucket, and running the scanner twice.
4. `list_objects` was removed and replaced with `list_all_objs_in_bucket`. The original function had no pagination support, and would only list the first 1k objects. The new one supports pagination and provides an array holding data about *all* objects in a given bucket.

- [ ] Doc added/updated
- [x] Tests added
