### PR TITLE
Bug Fix #7166 | Change message of error in PG client

### DIFF
--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -742,7 +742,7 @@ class SystemStore extends EventEmitter {
         for (const res of bulk_results) {
             if (res && !res.ok) {
                 dbg.error('got error on bulk execute', res.err);
-                // should we throw here? retry?
+                throw new Error(res.err);
             }
         }
 


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. Change the error message in case the query failed (command `query`).
2. Wrap the action `client.pool.connect` with an exception (i.e. - try... catch clause).
3.  Add a flag `should_rollback` to prevent rollback call in case the DB was not connected.

### Issues:
1. Although the issue was opened with a request to change the message to "Cannot connect to noobaa-db pod", this is still a fix to this issue ([link to the issue](https://github.com/noobaa/noobaa-core/issues/7166)).
_Note: this link was not added to the title of issues because we didn't want it to automatically close the issue - we changed the label of it._

### Testing Instructions:
1. Based on the instructions [here](https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76) - the steps of ‘Build images’ and ‘Deploy noobaa’.
3. use the watch to see all 5 pods running (and observe the changes that we will do).
`watch kubectl get pods`
4. kill `noobaa-db-pg` pod and create a new account
```
kubectl delete pod noobaa-db-pg-0 && nb api account_api create_account '{
  "email": "jenia5@noobaa.io",
  "name": "jenia5",
  "has_login": false,
  "s3_access": true,
  "default_resource": "noobaa-default-backing-store"
}'
```

### Attached Screenshots:
Previous message:
![Screenshot 2023-01-17 at 13 26 49](https://user-images.githubusercontent.com/57721533/212961178-c15917d9-17bd-4e51-9241-8339e549636e.png)

New message:
![Screenshot 2023-01-23 at 14 31 13](https://user-images.githubusercontent.com/57721533/214040312-366621c1-2be3-48fe-a999-c4799737ed14.png)


- [ ] Doc added/updated
- [ ] Tests added
