### PR TITLE
NSFS list_objects should only list latest objects

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -337,6 +337,9 @@ class NamespaceFS {
              * @returns {Promise<void>}
              */
             const process_dir = async dir_key => {
+                if (this._skip_version_dir(dir_key)) {
+                    return;
+                }
 
                 // /** @type {fs.Dir} */
                 let dir_handle;
@@ -2031,6 +2034,11 @@ class NamespaceFS {
         } catch (err) {
             dbg.warn('namespace_fs.find_max_version_past: .versions/ folder could not be found', err);
        }
+    }
+
+    _skip_version_dir(dir_key) {
+        const idx = dir_key.indexOf(HIDDEN_VERSIONS_PATH);
+        return ((idx === 0) || (idx > 0 && dir_key[idx - 1] === '/'));
     }
 }
 


### PR DESCRIPTION
### Explain the changes
list_objects, returns every object under the bucket. It should ignore objects under .versions where we
store the versions of the object.

### Issues: Fixed #7164 

### Testing Instructions:
1. Create a object and create versions of it
2. do list_objects(), that should not return objects under `.versions`


- [ ] Doc added/updated
- [ ] Tests added

Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>