### PR TITLE
Ceph s3 Tests | Collect logs in case of failure

### DIFF
--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -4,6 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   ceph-s3-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Checkout noobaa-core
         uses: actions/checkout@v3
@@ -27,6 +28,10 @@ jobs:
         with:
           repository: 'noobaa/noobaa-operator'
           path: 'noobaa-operator'
+         # Freeze the version of operator
+         # to avoid a failed run due to code changes in the operator repo.
+         # Need to update the commit once in a while
+          ref: 28960d4dbbba612d1a3e53245791076c11632b60
 
       - name: Change settings for k8s and minikube
         run: |
@@ -63,8 +68,6 @@ jobs:
           kubectl apply -f ./src/test/system_tests/ceph_s3_tests/test_ceph_s3_job.yml
           kubectl wait --for=condition=complete job/noobaa-tests-s3 --timeout=30m || TIMEOUT=true
           kubectl logs job/noobaa-tests-s3 --tail 10000 -f
-          echo "K8S Events"
-          kubectl get events --sort-by='.metadata.creationTimestamp' -A
           if kubectl logs job/noobaa-tests-s3 | grep -q "Ceph Test Failed:"; then
             echo "At least one test failed!"
             exit 1
@@ -77,3 +80,18 @@ jobs:
             echo "The s3 tests did not run!"
             exit 1
           fi
+
+      - name: Collect logs
+        if: ${{ failure() }}         
+        run: |
+         set -x
+         echo "K8S Events"
+         kubectl get events --sort-by='.metadata.creationTimestamp' -A
+         cd ./noobaa-operator
+         ./build/_output/bin/noobaa-operator diagnose --db-dump --dir=ceph-s3-tests-logs
+      - name: Save logs
+        if: ${{ failure() }}    
+        uses: actions/upload-artifact@v3
+        with:
+          name: ceph-s3-tests-logs
+          path: noobaa-operator/ceph-s3-tests-logs


### PR DESCRIPTION
### Explain the changes
1. Move the command to print the k8s events to run only in case of failure.
2. Create a new step to collect logs in case of failure and collect noobaa diagnostics and db dump.

### Issues: Gap
1. Today we print the k8s events on every run, although we need it only if the runner failed.
2. We saw runs that after noobaa install the backing store pod is not created yet ([example1](https://github.com/noobaa/noobaa-core/actions/runs/3939866458/jobs/6740234105), [example2](https://github.com/noobaa/noobaa-core/actions/runs/3952806933/jobs/6768330683)).
Today we don't have the tools to investigate it, and we would like to check this case specifically and use the logs in general as needed.
3. Freeze the version of operator to the latest current commit, to avoid a failed run due to code changes in the operator repo.
4. Add a timeout of 90 minutes according to the CI/CD discussion today.

### Testing Instructions:
1. GH Action changes on the workflow in this push, tests will happen in every push.

- [ ] Doc added/updated
- [ ] Tests added
