### PR TITLE
Changes to all GitHub workflows - timeout, checkout v3, concurrency, general cleanup

### DIFF
--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -4,6 +4,10 @@ on: [ push, pull_request ]
 jobs:
   build-arm64-image:
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     env:
       # For multiplatform use list like:
       # "linux/amd64,linux/arm64"
@@ -11,7 +15,7 @@ jobs:
       GIT_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/build-ppc64le-image.yaml
+++ b/.github/workflows/build-ppc64le-image.yaml
@@ -4,6 +4,10 @@ on: [ push, pull_request ]
 jobs:
   build-ppc64le-image:
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     env:
       # For multiplatform use list like:
       # "linux/amd64,linux/arm64"
@@ -11,7 +15,7 @@ jobs:
       GIT_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -5,6 +5,9 @@ jobs:
   ceph-s3-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout noobaa-core
         uses: actions/checkout@v3

--- a/.github/workflows/current-ver-build.yaml
+++ b/.github/workflows/current-ver-build.yaml
@@ -1,5 +1,4 @@
 name: Current Version Build on Changes
-
 # Run on Backports
 on: 
   push:
@@ -9,6 +8,7 @@ on:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Invoke Build on Operator Repo
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/manual-full-build.yaml
+++ b/.github/workflows/manual-full-build.yaml
@@ -12,9 +12,10 @@ on:
 jobs:
   manual-build-and-publish-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/next-ver-build.yaml
+++ b/.github/workflows/next-ver-build.yaml
@@ -1,6 +1,4 @@
 name: Next Version Build
-
-# Run the Weekly on Monday 8 AM UTC
 on: 
   schedule:
     - cron: "0 12 * * 1"
@@ -13,6 +11,7 @@ on:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Invoke Build on Operator Repo
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -1,5 +1,4 @@
 name: Nightly Tests
-
 on: workflow_dispatch
 
 jobs:
@@ -7,14 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Nightly Tests
-        id: run-nightly-tests
         run: |
-          make test || exit 1
+          make test
           docker run --rm -e NEWAWSPROJKEY=${{ secrets.NEWAWSPROJKEY }} \
           -e NEWAWSPROJSECRET=${{ secrets.NEWAWSPROJSECRET }} \
           -e NEWAZUREPROJKEY=${{ secrets.NEWAZUREPROJKEY }} \
           -e NEWAZUREPROJSECRET=${{ secrets.NEWAZUREPROJSECRET }} \
-          --name test1 noobaa-tester ./src/test/unit_tests/run_npm_test_on_test_container.sh -s test_s3_ops.js || exit 1
+          --name test1 noobaa-tester ./src/test/unit_tests/run_npm_test_on_test_container.sh -s test_s3_ops.js

--- a/.github/workflows/postgres-unit-tests.yaml
+++ b/.github/workflows/postgres-unit-tests.yaml
@@ -1,18 +1,16 @@
 name: Unit Tests with Postgres
-
-# Run on each new PR and each new push to existing PR
 on: [push, pull_request]
 
 jobs:
   run-unit-tests-postgres:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Run Unit Tests with Postgres
-        id: run-test-postgres
-        run: make test-postgres || exit 1
+        run: make test-postgres

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   releaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Set branch
         run: echo "BRANCH=${{ github.event.inputs.base_branch }}" >> $GITHUB_ENV

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,25 +1,24 @@
 name: Build & Sanity
-
-# Run on each new PR and each new push to existing PR
 on: [push, pull_request]
 
 jobs:
   run-sanity-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Deploy minikube
-        id: deploy
         run: sudo bash ./.travis/deploy_minikube.sh
 
       - name: Run make tester
-        id: run-make-tester
-        run: make tester || exit 1
+        run: make tester
 
       - name: Run Build & Sanity Tests
-        id: run-sanity
         run: |
           cd ./src/test/framework/
-          sudo ./run_test_job.sh --name sanity --image noobaa --tester_image noobaa-tester --job_yaml ../../../.travis/travis_test_job.yaml --tests_list ./sanity_tests_list.js --wait || exit 1
+          sudo ./run_test_job.sh --name sanity --image noobaa --tester_image noobaa-tester --job_yaml ../../../.travis/travis_test_job.yaml --tests_list ./sanity_tests_list.js --wait

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,17 +1,18 @@
 name: Unit Tests
-
-# Run on each new PR and each new push to existing PR
 on: [push, pull_request]
 
 jobs:
   run-unit-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Test
-        id: run-test
         run: |
-          make test || exit 1
-          docker run --privileged --rm --name test1 noobaa-tester ./src/test/unit_tests/run_npm_test_on_test_container.sh -s sudo_index.js || exit 1
+          make test
+          docker run --privileged --rm --name test1 noobaa-tester ./src/test/unit_tests/run_npm_test_on_test_container.sh -s sudo_index.js

--- a/.github/workflows/weekly-build.yaml
+++ b/.github/workflows/weekly-build.yaml
@@ -1,6 +1,4 @@
 name: Weekly Build
-
-# Run every day at 23:00 UTC
 on: 
   schedule:
     - cron: "0 23 * * *"
@@ -8,6 +6,7 @@ on:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Invoke Build on Operator Repo
         uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
According to _CI next steps_ meeting:
1. Change default timeouts for our tests to 1.5h (90 minutes).
2. Change all checkout to v3 (v2 is using node version 12).
3. Use GH Concurrency to cancel the previous run.
This was a pilot in #7159 , but after we started using it, we [discovered](https://github.com/styfle/cancel-workflow-action/issues/200) that there is a builtin option from GitHub (concurrency).

General cleanup (was not in the meeting): 
1. Remove `exit 1` since the default behavior is when a step is failing to fail the whole job.
2. Remove extra newlines.
3. Remove comments that explain the code itself.
4. Remove unused `id` fields in the steps.

### Issues: Gap
The main gap is that the default timeout of jobs is 6 hours and it is a waste of computing resources since all of our jobs run in a sixth of the time.  Another waste of computing resources is when we use successive pushes, and we would like to reduce it.

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
