### PR TITLE
Fix folder creation on namespaced Azure blob backend

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -268,7 +268,7 @@ class NamespaceBlob {
 
                 obj = await blob_client.uploadStream(
                     new_stream.pipe(count_stream),
-                    params.size,
+                    params.size === 0 ? 1 : params.size,
                     undefined, {
                         metadata: params.xattr,
                         blobHTTPHeaders: headers


### PR DESCRIPTION
### Explain the changes
1. on object upload set uploadStream size to 1 if object size is 0 (= empty directory)

### Issues: Fixed #xxx / Gap #xxx
1. fixes folder creation on namespace Azure blob backend. For some reason the blob client throws an error when size of the uploaded object is 0.
2. maybe there is a better solution however this is the most simple at the moment


### Testing Instructions:
1. start noobaa with a namespaced azure blob backend
2. create directory
