### PR TITLE
Fix for HTTP Agent no longer working with unsecure S3 backend

### DIFF
--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -411,7 +411,7 @@ function get_unsecured_agent(endpoint) {
     const is_aws_address = cloud_utils.is_aws_endpoint(endpoint);
     const hostname = url.parse(endpoint) ? url.parse(endpoint).hostname : endpoint;
     const is_localhost = _.isString(hostname) && hostname.toLowerCase() === 'localhost';
-    return _get_http_agent(endpoint, is_localhost || (!is_aws_address && _.isEmpty(NODE_EXTRA_CA_CERTS)));
+    return _get_http_agent(endpoint, is_localhost || !is_aws_address);
 }
 
 function _get_http_agent(endpoint, request_unsecured) {


### PR DESCRIPTION
### Explain the changes
1. remove checking if NODE_EXTRA_CA_CERTS is empty

### Issues: Fixed #xxx / Gap #xxx
1. fixes getting an HTTP Client when requesting an unsecure HTTP Agent
2. broken by https://github.com/noobaa/noobaa-core/commit/621a634abba9ec0f4fd6774fa1b2f0e22d5f8a7f#diff-edc32a1c01ddf9d0c80b785573ad7de7443829016b1260eee65c5f1e92961406R398

### Testing Instructions:
1. connect noobaa to unsecure S3 backend e.g. Minio
2. get and put requests fail


