### PR TITLE
Fix Bug #7151 | Change the Printing From NaN to 0 (In Average Calc)

### DIFF
--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -273,8 +273,8 @@ class BlockStoreBase {
         const old_stats = this.monitoring_stats;
         // zero all but the inflight
         this.monitoring_stats = _.defaults(_.pick(old_stats, ['inflight_reads', 'inflight_writes']), _new_monitring_stats());
-        old_stats.avg_read_latency = old_stats.total_read_latency / old_stats.read_count;
-        old_stats.avg_write_latency = old_stats.total_write_latency / old_stats.write_count;
+        old_stats.avg_read_latency = old_stats.read_count === 0 ? 0 : old_stats.total_read_latency / old_stats.read_count;
+        old_stats.avg_write_latency = old_stats.write_count === 0 ? 0 : old_stats.total_write_latency / old_stats.write_count;
         return old_stats;
     }
 


### PR DESCRIPTION
Signed-off-by: shirady <57721533+shirady@users.noreply.github.com>

### Explain the changes
1. If we didn't start reading/writing, change the printing from NaN to 0 (in average calc).

### Issues: Fixed #7151 
1. Today we print NaN when the average is actually 0 (and we can avoid it). 

### Testing Instructions:
1. 1. Based on the instructions [here](https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76) - the steps of ‘Build images’ and ‘Deploy noobaa’.
2. Then look at the logs of the backing store pod, for example:
` kubectl logs noobaa-default-backing-store-noobaa-pod-1148f18b -f`
3. See the printings of NaN in the values `avg_read_latency`, `avg_write_latency`.

![Screenshot 2023-02-12 at 13 21 09](https://user-images.githubusercontent.com/57721533/218308006-50e45244-4ee9-4b86-9c09-9f548756f21c.png)

- [ ] Doc added/updated
- [ ] Tests added
