### PR TITLE
NSFS | versioning | Implement list-object-versions

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_versions.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_versions.js
@@ -17,6 +17,11 @@ async function get_bucket_versions(req) {
         throw new S3Error(S3Error.InvalidArgument);
     }
 
+    if (req.query['version-id-marker'] && !req.query['key-marker']) {
+        dbg.warn('A version-id marker cannot be specified without a key marker');
+        throw new S3Error(S3Error.InvalidArgument);
+    }
+
     const reply = await req.object_sdk.list_object_versions({
         bucket: req.params.bucket,
         prefix: req.query.prefix,

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1,5 +1,6 @@
 /* Copyright (C) 2020 NooBaa */
-/*eslint max-lines: ["error", 2500]*/
+/*eslint max-lines: ["error", 3000]*/
+/*eslint max-statements: ["error", 80, { "ignoreTopLevelFunctions": true }]*/
 'use strict';
 
 const _ = require('lodash');
@@ -8,7 +9,6 @@ const path = require('path');
 const util = require('util');
 const mime = require('mime');
 const { v4: uuidv4 } = require('uuid');
-
 const P = require('../util/promise');
 const dbg = require('../util/debug_module')(__filename);
 const config = require('../../config');
@@ -77,6 +77,47 @@ function sort_entries_by_name(a, b) {
     if (a.name < b.name) return -1;
     if (a.name > b.name) return 1;
     return 0;
+}
+
+function _get_mtime_from_filename(filename) {
+    if (!filename.includes('_mtime-')) {
+        // Latest file wont have time suffix which will push the latest
+        // object last in the list. So to keep the order maintained,
+        // returning the latest time. Multiplying with 1e6 to provide
+        // nano second precision
+        return BigInt(Date.now() * 1e6);
+    }
+    const file_parts = filename.split('-');
+    return size_utils.string_to_bigint(file_parts[file_parts.length - 3], 36);
+}
+
+function _get_filename(file_name) {
+    if (file_name.includes('_mtime-')) {
+        return file_name.substring(0, file_name.indexOf('_mtime-'));
+    }
+    return file_name;
+}
+/**
+ * @param {fs.Dirent} first_entry
+ * @param {fs.Dirent} second_entry
+ * @returns {Number}
+ */
+function sort_entries_by_name_and_time(first_entry, second_entry) {
+    const first_entry_name = _get_filename(first_entry.name);
+    const second_entry_name = _get_filename(second_entry.name);
+    if (first_entry_name === second_entry_name) {
+        const first_entry_mtime = _get_mtime_from_filename(first_entry.name);
+        const second_entry_mtime = _get_mtime_from_filename(second_entry.name);
+        // To sort the versions in the latest first order,
+        // below logic is followed
+        if (second_entry_mtime < first_entry_mtime) return -1;
+        if (second_entry_mtime > first_entry_mtime) return 1;
+        return 0;
+    } else {
+        if (first_entry_name < second_entry_name) return -1;
+        if (first_entry_name > second_entry_name) return 1;
+        return 0;
+    }
 }
 
 function isDirectory(ent) {
@@ -185,6 +226,62 @@ const dir_cache = new LRUCache({
         if (stat.size <= config.NSFS_DIR_CACHE_MAX_DIR_SIZE) {
             sorted_entries = await nb_native().fs.readdir(fs_context, dir_path);
             sorted_entries.sort(sort_entries_by_name);
+            for (const ent of sorted_entries) {
+                usage += ent.name.length + 4;
+            }
+        }
+        return { time, stat, sorted_entries, usage };
+    },
+    validate: async ({ stat }, { dir_path, fs_context }) => {
+        const new_stat = await nb_native().fs.stat(fs_context, dir_path);
+        return (new_stat.ino === stat.ino && new_stat.mtimeNsBigint === stat.mtimeNsBigint);
+    },
+    item_usage: ({ usage }, dir_path) => usage,
+    max_usage: config.NSFS_DIR_CACHE_MAX_TOTAL_SIZE,
+});
+
+/**
+ * @typedef {{
+ *  time: number,
+ *  stat: nb.NativeFSStats,
+ *  usage: number,
+ *  sorted_entries?: fs.Dirent[],
+ * }} ReaddirVersionsCacheItem
+ * @type {LRUCache<object, string, ReaddirCacheItem>}
+ */
+const versions_dir_cache = new LRUCache({
+    name: 'nsfs-versions-dir-cache',
+    make_key: ({ dir_path }) => dir_path,
+    load: async ({ dir_path, fs_context }) => {
+        const time = Date.now();
+        const stat = await nb_native().fs.stat(fs_context, dir_path);
+        const version_path = dir_path + "/" + HIDDEN_VERSIONS_PATH;
+        let ver_dir_stat_size;
+        let is_version_path_exists = false;
+        try {
+            const ver_dir_stat = await nb_native().fs.stat(fs_context, version_path);
+            ver_dir_stat_size = ver_dir_stat.size;
+            is_version_path_exists = true;
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                dbg.log0('NamespaceFS: Version dir not found, ', version_path);
+            } else {
+                throw err;
+            }
+            ver_dir_stat_size = 0;
+        }
+        let sorted_entries;
+        let usage = config.NSFS_DIR_CACHE_MIN_DIR_SIZE;
+        if (stat.size + ver_dir_stat_size <= config.NSFS_DIR_CACHE_MAX_DIR_SIZE) {
+            const latest_versions = await nb_native().fs.readdir(fs_context, dir_path);
+            if (is_version_path_exists) {
+                const old_versions = await nb_native().fs.readdir(fs_context, version_path);
+                const entries = latest_versions.concat(old_versions);
+                sorted_entries = entries.sort(sort_entries_by_name_and_time);
+            } else {
+                sorted_entries = latest_versions.sort(sort_entries_by_name);
+            }
+            /*eslint no-unused-expressions: ["error", { "allowTernary": true }]*/
             for (const ent of sorted_entries) {
                 usage += ent.name.length + 4;
             }
@@ -315,6 +412,27 @@ class NamespaceFS {
      * @param {ListParams} params
      */
     async list_objects(params, object_sdk) {
+        return this._list_objects(params, object_sdk, false);
+    }
+
+    /**
+     * @typedef {{
+     *  bucket: string,
+     *  prefix?: string,
+     *  delimiter?: string,
+     *  key_marker?: string,
+     *  version_id_marker?: string,
+     *  limit?: number,
+     * }} ListVersionsParams
+     */
+    /**
+     * @param {ListVersionsParams} params
+     */
+    async list_object_versions(params, object_sdk) {
+        return this._list_objects(params, object_sdk, true);
+    }
+
+    async _list_objects(params, object_sdk, list_versions) {
         try {
             const fs_context = this.prepare_fs_context(object_sdk);
             await this._load_bucket(params, fs_context);
@@ -323,13 +441,13 @@ class NamespaceFS {
                 bucket,
                 delimiter = '',
                 prefix = '',
+                version_id_marker = '',
                 key_marker = '',
             } = params;
 
             if (delimiter && delimiter !== '/') {
                 throw new Error('NamespaceFS: Invalid delimiter ' + delimiter);
             }
-
             const limit = Math.min(1000, _.isUndefined(params.limit) ? 1000 : params.limit);
             if (limit < 0) throw new Error('Limit must be a positive Integer');
             // In case that we've received max-keys 0, we should return an empty reply without is_truncated
@@ -354,25 +472,20 @@ class NamespaceFS {
              * @returns {Promise<void>}
              */
             const process_dir = async dir_key => {
-                if (this._skip_version_dir(dir_key)) {
+                if (this._is_hidden_version_path(dir_key)) {
                     return;
                 }
-
                 // /** @type {fs.Dir} */
                 let dir_handle;
-
                 /** @type {ReaddirCacheItem} */
                 let cached_dir;
-
                 const dir_path = path.join(this.bucket_path, dir_key);
-
                 const prefix_dir = prefix.slice(0, dir_key.length);
                 const prefix_ent = prefix.slice(dir_key.length);
                 if (!dir_key.startsWith(prefix_dir)) {
                     // dbg.log0(`prefix dir does not match so no keys in this dir can apply: dir_key=${dir_key} prefix_dir=${prefix_dir}`);
                     return;
                 }
-
                 const marker_dir = key_marker.slice(0, dir_key.length);
                 const marker_ent = key_marker.slice(dir_key.length);
                 // marker is after dir so no keys in this dir can apply
@@ -383,7 +496,6 @@ class NamespaceFS {
                 // when the dir portion of the marker is completely below the current dir
                 // then every key in this dir satisfies the marker and marker_ent should not be used.
                 const marker_curr = (marker_dir < dir_key) ? '' : marker_ent;
-
                 // dbg.log0(`process_dir: dir_key=${dir_key} prefix_ent=${prefix_ent} marker_curr=${marker_curr}`);
                 /**
                  * @typedef {{
@@ -393,7 +505,11 @@ class NamespaceFS {
                  */
                 const insert_entry_to_results_arr = async r => {
                     let pos;
-                    if (results.length && r.key < results[results.length - 1].key) {
+                    // Since versions are arranged next to latest object in the latest first order,
+                    // no need to find the sorted last index. Push the ".versions/#VERSION_OBJECT" as
+                    // they are in order
+                    if (results.length && r.key < results[results.length - 1].key &&
+                        !this._is_hidden_version_path(r.key)) {
                         pos = _.sortedLastIndexBy(results, r, a => a.key);
                     } else {
                         pos = results.length;
@@ -403,7 +519,6 @@ class NamespaceFS {
                         is_truncated = true;
                         return; // not added
                     }
-
                     if (!delimiter && r.common_prefix) {
                         await process_dir(r.key);
                     } else {
@@ -424,26 +539,37 @@ class NamespaceFS {
                  */
                 const process_entry = async ent => {
                     // dbg.log0('process_entry', dir_key, ent.name);
-                    if (!ent.name.startsWith(prefix_ent) ||
+                    if ((!ent.name.startsWith(prefix_ent) ||
                         ent.name < marker_curr ||
                         ent.name === this.get_bucket_tmpdir() ||
-                        ent.name === config.NSFS_FOLDER_OBJECT_NAME) {
+                        ent.name === config.NSFS_FOLDER_OBJECT_NAME) &&
+                        !this._is_hidden_version_path(ent.name)) {
                         return;
                     }
-
                     const isDir = await is_directory_or_symlink_to_directory(ent, fs_context, path.join(dir_path, ent.name));
 
-                    const r = {
-                        key: this._get_entry_key(dir_key, ent, isDir),
-                        common_prefix: isDir,
-                    };
+                    let r;
+                    if (list_versions && ent.name.includes('_mtime-')) {
+                        r = {
+                            key: this._get_version_entry_key(dir_key, ent),
+                            common_prefix: isDir,
+                        };
+                    } else {
+                        r = {
+                            key: this._get_entry_key(dir_key, ent, isDir),
+                            common_prefix: isDir,
+                        };
+                    }
                     await insert_entry_to_results_arr(r);
                 };
 
                 if (!(await this.check_access(fs_context, dir_path))) return;
-
                 try {
-                    cached_dir = await dir_cache.get_with_cache({ dir_path, fs_context });
+                    if (list_versions) {
+                        cached_dir = await versions_dir_cache.get_with_cache({ dir_path, fs_context });
+                    } else {
+                        cached_dir = await dir_cache.get_with_cache({ dir_path, fs_context });
+                    }
                 } catch (err) {
                     if (err.code === 'ENOENT') {
                         dbg.log0('NamespaceFS: no keys for non existing dir', dir_path);
@@ -462,11 +588,27 @@ class NamespaceFS {
 
                 if (cached_dir.sorted_entries) {
                     const sorted_entries = cached_dir.sorted_entries;
-                    const marker_index = _.sortedLastIndexBy(
-                        sorted_entries,
-                        make_named_dirent(marker_curr),
-                        get_entry_name
-                    );
+                    let marker_index;
+                    // Two ways followed here to find the index.
+                    // 1. When inside marker_dir: Here the entries are sorted based on time. Here
+                    //    FindIndex() is called since sortedLastIndexBy() expects sorted order by name
+                    // 2. When marker_dir above dir_path: sortedLastIndexBy() is called since entries are
+                    //     sorted by name
+                    if (list_versions && marker_curr && !marker_curr.includes('/')) {
+                        let start_marker = marker_curr;
+                        if (version_id_marker) start_marker = version_id_marker;
+                        marker_index = _.findIndex(
+                            sorted_entries,
+                            {name: start_marker}
+                        ) + 1;
+                    } else {
+                        marker_index = _.sortedLastIndexBy(
+                            sorted_entries,
+                            make_named_dirent(marker_curr),
+                            get_entry_name
+                        );
+                    }
+
                     // handling a scenario in which key_marker points to an object inside a directory
                     // since there can be entries inside the directory that will need to be pushed
                     // to results array
@@ -485,6 +627,10 @@ class NamespaceFS {
                     }
                     for (let i = marker_index; i < sorted_entries.length; ++i) {
                         const ent = sorted_entries[i];
+                        if (list_versions && marker_curr) {
+                            const ent_name = ent.name.substring(0, ent.name.indexOf('_mtime-'));
+                            if (ent_name !== marker_curr) break;
+                        }
                         // when entry is NSFS_FOLDER_OBJECT_NAME=.folder file,
                         // and the dir key marker is the name of the curr directory - skip on adding it
                         if (ent.name === config.NSFS_FOLDER_OBJECT_NAME && dir_key === marker_dir) {
@@ -497,7 +643,6 @@ class NamespaceFS {
                     }
                     return;
                 }
-
                 // for large dirs we cannot keep all entries in memory
                 // so we have to stream the entries one by one while filtering only the needed ones.
                 try {
@@ -539,26 +684,37 @@ class NamespaceFS {
                 common_prefixes: [],
                 is_truncated,
                 next_marker: undefined,
+                next_version_id_marker: undefined,
             };
             for (const r of results) {
+                let obj_info;
                 if (r.common_prefix) {
                     res.common_prefixes.push(r.key);
                 } else {
-                    res.objects.push(this._get_object_info(bucket, r.key, r.stat, 'null'));
+                    obj_info = this._get_object_info(bucket, r.key, r.stat, 'null', true);
+                    if (!list_versions && obj_info.delete_marker) {
+                        continue;
+                    }
+                    if (this._is_hidden_version_path(obj_info.key)) {
+                        obj_info.key = path.normalize(obj_info.key.replace(HIDDEN_VERSIONS_PATH + '/', ''));
+                        obj_info.key = obj_info.key.substring(0, obj_info.key.indexOf('_mtime-'));
+                    }
+                    res.objects.push(obj_info);
                 }
                 if (res.is_truncated) {
-                    res.next_marker = r.key;
+                    if (list_versions && r.key.includes('_mtime-')) {
+                        const next_version_id_marker = r.key.substring(r.key.lastIndexOf('/') + 1);
+                        res.next_version_id_marker = next_version_id_marker;
+                        res.next_marker = next_version_id_marker.substring(0, next_version_id_marker.indexOf('_mtime'));
+                    } else {
+                        res.next_marker = r.key;
+                    }
                 }
             }
             return res;
         } catch (err) {
             throw this._translate_object_error_codes(err);
         }
-    }
-
-    async list_object_versions(params, object_sdk) {
-        // for now we do not support versioning, so returning the same as list objects
-        return this.list_objects(params, object_sdk);
     }
 
     /////////////////
@@ -1547,6 +1703,16 @@ class NamespaceFS {
         return dir_key + ent.name + (isDir ? '/' : '');
     }
 
+    /**
+     * @param {string} dir_key
+     * @param {fs.Dirent} ent
+     * @returns {string}
+     */
+     _get_version_entry_key(dir_key, ent) {
+        if (ent.name === config.NSFS_FOLDER_OBJECT_NAME) return dir_key;
+        return dir_key + HIDDEN_VERSIONS_PATH + '/' + ent.name;
+    }
+
     async _make_path_dirs(file_path, fs_context) {
         const last_dir_pos = file_path.lastIndexOf('/');
         if (last_dir_pos > 0) return this._create_path(file_path.slice(0, last_dir_pos), fs_context);
@@ -1579,10 +1745,11 @@ class NamespaceFS {
      * @param {nb.NativeFSStats} stat 
      * @returns {nb.ObjectInfo}
      */
-    _get_object_info(bucket, key, stat, return_version_id) {
+     _get_object_info(bucket, key, stat, return_version_id, is_latest = true) {
         const etag = this._get_etag(stat);
         const encryption = this._get_encryption_info(stat);
         const version_id = return_version_id && this._is_versioning_enabled() && this._get_version_id_by_xattr(stat);
+
         return {
             obj_id: etag,
             bucket,
@@ -1593,8 +1760,8 @@ class NamespaceFS {
             content_type: mime.getType(key) || 'application/octet-stream',
             // temp:
             version_id: version_id,
-            is_latest: true,
-            delete_marker: false,
+            is_latest: is_latest,
+            delete_marker: stat.xattr[XATTR_DELETE_MARKER] === 'true',
             tag_count: 0,
             encryption,
             xattr: to_xattr(stat.xattr),
@@ -2216,7 +2383,7 @@ class NamespaceFS {
        }
     }
 
-    _skip_version_dir(dir_key) {
+    _is_hidden_version_path(dir_key) {
         const idx = dir_key.indexOf(HIDDEN_VERSIONS_PATH);
         return ((idx === 0) || (idx > 0 && dir_key[idx - 1] === '/'));
     }

--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -1642,6 +1642,211 @@ async function generate_nsfs_account(options = {}) {
     };
 }
 
+mocha.describe('List-objects', function() {
+    const nsr = 'noobaa-nsr-object-vesions';
+    const bucket_name = 'noobaa-bucket-object-vesions';
+    let tmp_fs_root = '/tmp/test_bucketspace_list_object_versions';
+    if (process.platform === MAC_PLATFORM) {
+        tmp_fs_root = '/private/' + tmp_fs_root;
+    }
+    const bucket_path = '/bucket';
+    const full_path = tmp_fs_root + bucket_path;
+    const version_dir = '/.versions';
+    const full_path_version_dir = full_path + `${version_dir}`;
+    const dir1 = full_path + '/dir1';
+    const dir1_version_dir = dir1 + `${version_dir}`;
+
+    let s3_client;
+    let s3_admin;
+    const accounts = [];
+    const key = 'search_key';
+    const body = 'AAAA';
+    const version_key_1 = 'search_key_mtime-crh3783sxk3k-ino-guty';
+    const version_key_2 = 'search_key_mtime-crkfjum9883k-ino-guu7';
+    const version_key_3 = 'search_key_mtime-crkfjx1hui2o-ino-guu9';
+
+    const dir_key = 'dir1/delete_marker_key';
+    const dir_version_key_1 = 'delete_marker_key_mtime-crkfjknr7xmo-ino-guu4';
+    const dir_version_key_2 = 'delete_marker_key_mtime-crkfjr98uiv4-ino-guu6';
+    const version_body = 'A1A1A1A';
+
+    let file_pointer;
+
+    mocha.before(async function() {
+        if (process.getgid() !== 0 || process.getuid() !== 0) {
+            console.log('No Root permissions found in env. Skipping test');
+            this.skip(); // eslint-disable-line no-invalid-this
+        }
+        // create paths
+        await fs_utils.create_fresh_path(tmp_fs_root, 0o777);
+        await fs_utils.create_fresh_path(full_path, 0o770);
+        await fs_utils.file_must_exist(full_path);
+        await fs_utils.create_fresh_path(full_path_version_dir, 0o770);
+        await fs_utils.file_must_exist(full_path_version_dir);
+        await fs_utils.create_fresh_path(dir1, 0o770);
+        await fs_utils.file_must_exist(dir1);
+        await fs_utils.create_fresh_path(dir1_version_dir, 0o770);
+        await fs_utils.file_must_exist(dir1_version_dir);
+
+        // export dir as a bucket
+        await rpc_client.pool.create_namespace_resource({
+            name: nsr,
+            nsfs_config: {
+                fs_root_path: tmp_fs_root,
+            }
+        });
+        const obj_nsr = { resource: nsr, path: bucket_path };
+        await rpc_client.bucket.create_bucket({
+            name: bucket_name,
+            namespace: {
+                read_resources: [obj_nsr],
+                write_resource: obj_nsr
+            }
+        });
+        const policy = {
+            Version: '2012-10-17',
+            Statement: [{
+                Sid: 'id-1',
+                Effect: 'Allow',
+                Principal: { AWS: "*" },
+                Action: ['s3:*'],
+                Resource: [`arn:aws:s3:::*`]
+            },
+        ]
+        };
+        // create accounts
+        let res = await generate_nsfs_account({ admin: true });
+        s3_admin = generate_s3_client(res.access_key, res.secret_key);
+        await s3_admin.putBucketPolicy({
+            Bucket: bucket_name,
+            Policy: JSON.stringify(policy)
+        }).promise();
+        // create nsfs account
+        res = await generate_nsfs_account();
+        s3_client = generate_s3_client(res.access_key, res.secret_key);
+        accounts.push(res.email);
+        await s3_client.putBucketVersioning({ Bucket: bucket_name, VersioningConfiguration: { MFADelete: 'Disabled', Status: 'Enabled' } }).promise();
+        const bucket_ver = await s3_client.getBucketVersioning({ Bucket: bucket_name }).promise();
+        assert.equal(bucket_ver.Status, 'Enabled');
+        await create_object(`${full_path}/${key}`, body, 'null');
+        await create_object(`${full_path_version_dir}/${version_key_1}`, version_body, 'null');
+        await create_object(`${full_path_version_dir}/${version_key_2}`, version_body, 'null');
+        await create_object(`${full_path_version_dir}/${version_key_3}`, version_body, 'null');
+        file_pointer = await create_object(`${full_path}/${dir_key}`, version_body, 'null', true);
+        await create_object(`${dir1_version_dir}/${dir_version_key_1}`, version_body, 'null');
+        await create_object(`${dir1_version_dir}/${dir_version_key_2}`, version_body, 'null');
+    });
+
+    mocha.after(async () => {
+        await file_pointer.close(DEFAULT_FS_CONFIG);
+        fs_utils.folder_delete(tmp_fs_root);
+        for (const email of accounts) {
+            await rpc_client.account.delete_account({ email });
+        }
+    });
+
+    mocha.it('list objects - should return only latest object', async function() {
+        const res = await s3_client.listObjects({Bucket: bucket_name}).promise();
+        let count = 0;
+        res.Contents.forEach(val => {
+            if (val.Key === key) {
+                count += 1;
+            }
+        });
+        assert.equal(count, 1);
+    });
+
+    mocha.it('list object versions - should return all versions of all the object', async function() {
+        const res = await s3_client.listObjectVersions({Bucket: bucket_name}).promise();
+        let count = 0;
+        res.Versions.forEach(val => {
+           count += 1;
+        });
+        assert.equal(count, 7);
+    });
+
+    mocha.it('list object versions - should return all the versions of the requested object', async function() {
+        const res = await s3_client.listObjectVersions({Bucket: bucket_name, KeyMarker: key}).promise();
+        let count = 0;
+        res.Versions.forEach(val => {
+            count += 1;
+        });
+        assert.equal(count, 3);
+    });
+
+    mocha.it('list object versions - should return only max_key number of elements', async function() {
+        const res = await s3_client.listObjectVersions({Bucket: bucket_name, MaxKeys: 2}).promise();
+        let count = 0;
+        res.Versions.forEach(val => {
+           count += 1;
+        });
+        assert.equal(count, 2);
+    });
+
+    mocha.it('list object versions - should return only max keys of the versions of the requested object and nextKeyMarker should point to the next version', async function() {
+        const res = await s3_client.listObjectVersions({Bucket: bucket_name, KeyMarker: key, MaxKeys: 2}).promise();
+        let count = 0;
+        assert(res.KeyMarker, key);
+        assert(res.NextKeyMarker, key);
+        assert(res.NextVersionIdMarker, version_key_2);
+        res.Versions.forEach(val => {
+            count += 1;
+        });
+        assert.equal(count, 2);
+    });
+
+    mocha.it('list object versions - should return only max keys of the versions of the requested object from the version id marker', async function() {
+        const res = await s3_client.listObjectVersions({Bucket: bucket_name,
+                                                        KeyMarker: key, MaxKeys: 2,
+                                                        VersionIdMarker: version_key_3}).promise();
+        let count = 0;
+        res.Versions.forEach(val => {
+            count += 1;
+        });
+        assert.equal(count, 2);
+    });
+
+    mocha.it('list objects - deleted object should not be listed', async function() {
+        const xattr_delete_marker = { 'user.delete_marker': 'true' };
+        file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
+        const res = await s3_client.listObjects({Bucket: bucket_name}).promise();
+        let count = 0;
+        res.Contents.forEach(val => {
+            if (val.Key === dir_key) {
+                count += 1;
+            }
+        });
+        assert.equal(count, 0);
+    });
+
+    mocha.it('list object versions - All versions of the object should be listed', async function() {
+        const xattr_delete_marker = { 'user.delete_marker': 'true' };
+        file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
+        const res = await s3_client.listObjectVersions({Bucket: bucket_name}).promise();
+        let count = 0;
+        res.Versions.forEach(val => {
+            if (val.Key === dir_key) {
+                count += 1;
+            }
+        });
+        assert.equal(count, 2);
+    });
+
+    mocha.it('list object versions - Check whether the deleted object is the latest and should be present under delete markers as well', async function() {
+        const xattr_delete_marker = { 'user.delete_marker': 'true' };
+        file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
+        const res = await s3_client.listObjectVersions({Bucket: bucket_name}).promise();
+
+        res.Versions.forEach(val => {
+            if (val.Key === dir_key) {
+                assert.equal(val.IsLatest, true);
+                assert.equal(res.DeleteMarkers[0].IsLatest, true);
+                assert.equal(res.DeleteMarkers[0].Key, dir_key);
+            }
+        });
+    });
+});
+
 async function create_object(object_path, data, version_id, return_fd) {
     const target_file = await nb_native().fs.open(DEFAULT_FS_CONFIG, object_path, 'w+');
     await fs.promises.writeFile(object_path, data);
@@ -1653,3 +1858,5 @@ async function create_object(object_path, data, version_id, return_fd) {
     await target_file.close(DEFAULT_FS_CONFIG);
 }
 
+exports.generate_nsfs_account = generate_nsfs_account;
+exports.generate_s3_client = generate_s3_client;

--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -1806,6 +1806,16 @@ mocha.describe('List-objects', function() {
         assert.equal(count, 2);
     });
 
+    mocha.it('list object versions - should fail because of missing key_marker', async function() {
+        try {
+            await s3_client.listObjectVersions({Bucket: bucket_name,
+                                                MaxKeys: 2, VersionIdMarker: version_key_3}).promise();
+            assert.fail(`list object versions passed though key marker is missing`);
+        } catch (err) {
+            assert.equal(err.code, 'InvalidArgument');
+        }
+    });
+
     mocha.it('list objects - deleted object should not be listed', async function() {
         const xattr_delete_marker = { 'user.delete_marker': 'true' };
         file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);


### PR DESCRIPTION
### Explain the changes
list-object-versions returns metadata about all versions of the objects in a bucket. You can also use request parameters as selection criteria to return metadata about a subset of all the object versions.

Moved object sorting under .versions to dir_cache
    
    1. Kept 2 seperate cache for list-objects and list_object_versions
    2. Sorting of the all entries done in version_dir_cache
    3. handled keymarker and versions id marker
    4. Added test cases for list object versions
    
Issues: Fixed #7169

### Testing Instructions:
1.  Create few objects and append the same to create versions of the original object
2. Delete few object
3. Performat `list-object_versions` operation. This should returns the metadata of all objects including `versions` and `delete_markers`


- [ ] Doc added/updated
- [x] Tests added

Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>