### PR TITLE
use service certificate for rpc_http_server

### DIFF
--- a/src/rpc/rpc_http_server.js
+++ b/src/rpc/rpc_http_server.js
@@ -42,14 +42,15 @@ class RpcHttpServer extends events.EventEmitter {
     /**
      * start_server
      */
-    start_server(options) {
+    async start_server(options) {
         const port = parseInt(options.port, 10);
         const secure = options.protocol === 'https:' || options.protocol === 'wss:';
         const logging = options.logging;
         dbg.log0('HTTP SERVER:', 'port', port, 'secure', secure, 'logging', logging);
 
+        const ssl_cert = await ssl_utils.get_ssl_certificate('MGMT');
         const server = secure ?
-            https.createServer({ ...ssl_utils.generate_ssl_certificate(), honorCipherOrder: true }) :
+            https.createServer({ ...ssl_cert, honorCipherOrder: true }) :
             http.createServer();
         this.install_on_server(server, options.default_handler);
         return P.fromCallback(callback => server.listen(port, callback))


### PR DESCRIPTION
Signed-off-by: jackyalbo <jacky.albo@gmail.com>

### Explain the changes
1. We were using our own certificate instead of the service one for all the rpc servers (bg_workers and hosted_agents)
2. Every attempt to reach this servers in openshift caused error of self sign certificate - now suppose to be fixed

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2168867

### Testing Instructions:
1.  use curl from endpoint/core:
 curl --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt https://noobaa-mgmt.openshift-storage.svc:8445/.    *** or 8446 for hosted_agents

See that you don't get this result:
curl: (60) SSL certificate problem: self signed certificate ===> fails

instead you should get an empty response

- [ ] Doc added/updated
- [ ] Tests added
