### PR TITLE
[5.12] Update K8s version to 1.23.12

### DIFF
--- a/.travis/deploy_minikube.sh
+++ b/.travis/deploy_minikube.sh
@@ -15,7 +15,7 @@ set -x
 # https://github.com/jaegertracing/jaeger-operator/blob/master/.travis/setupMinikube.sh
 
 export MINIKUBE_VERSION=v1.8.2
-export KUBERNETES_VERSION=v1.17.3
+export KUBERNETES_VERSION=v1.23.12
 
 source /etc/os-release
 


### PR DESCRIPTION
### Explain the changes
This PR attempts to fix broken minikube deployment in our sanity tests by updating k8s version to what we have in master.

- [ ] Doc added/updated
- [ ] Tests added
