### PR TITLE
# BZ 2168010 | Bytes used by Noobaa Bucket in Prometheus metrics

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -758,7 +758,7 @@ module.exports = {
                     type: 'array',
                     items: {
                         type: 'object',
-                        required: ['bucket_name', 'quota_size_precent', 'quota_quantity_percent', 'capacity_precent', 'is_healthy', 'tagging'],
+                        required: ['bucket_name', 'quota_size_precent', 'quota_quantity_percent', 'capacity_precent', 'is_healthy', 'tagging', 'bucket_used_bytes'],
                         properties: {
                             bucket_name: {
                                 type: 'string'
@@ -774,6 +774,9 @@ module.exports = {
                             },
                             is_healthy: {
                                 type: 'boolean'
+                            },
+                            bucket_used_bytes: {
+                                type: 'number'
                             },
                             tagging: {
                                 $ref: 'common_api#/definitions/tagging',

--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -382,6 +382,13 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
             help: 'Number of error objects replication_id in last replication cycle',
             labelNames: ['replication_id']
         }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_used_bytes',
+        configuration: {
+            help: 'Object Bucket Used Bytes',
+            labelNames: ['bucket_name']
+        }
     }
 ]);
 
@@ -534,6 +541,7 @@ class NooBaaCoreReport extends BasePrometheusReport {
         this._metrics.bucket_quantity_quota.reset();
         this._metrics.bucket_capacity.reset();
         this._metrics.bucket_tagging.reset();
+        this._metrics.bucket_used_bytes.reset();
         buckets_info.forEach(bucket_info => {
             const bucket_labels = { bucket_name: bucket_info.bucket_name };
             if (bucket_info.tagging && bucket_info.tagging.length) {
@@ -544,7 +552,7 @@ class NooBaaCoreReport extends BasePrometheusReport {
             this._metrics.bucket_size_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_size_precent);
             this._metrics.bucket_quantity_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_quantity_percent);
             this._metrics.bucket_capacity.set({ bucket_name: bucket_info.bucket_name }, bucket_info.capacity_precent);
-
+            this._metrics.bucket_used_bytes.set({ bucket_name: bucket_info.bucket_name }, bucket_info.bucket_used_bytes);
         });
     }
 

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -518,7 +518,8 @@ async function _partial_buckets_info(req) {
                 capacity_precent: (is_capacity_relevant && bucket_total > 0) ? size_utils.bigint_to_json(bucket_used.multiply(100)
                     .divide(bucket_total)) : 0,
                 is_healthy: _.includes(OPTIMAL_MODES, bucket_info.mode),
-                tagging: bucket_info.tagging || []
+                tagging: bucket_info.tagging || [],
+                bucket_used_bytes: bucket_used.valueOf()
             });
         }
 


### PR DESCRIPTION
### Explain the changes
1.  showing the number of bytes used by Noobaa Bucket in Prometheus metrics



### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2168010#

### Testing Instructions:
1. add one or more buckets to noobaa
3. upload data to that bucket and check for `NooBaa_objectbucket_used_bytes` in Prometheus it should return all the buckets with bytes used by each bucket


- [ ] Doc added/updated
- [ ] Tests added

Signed-off-by: Naveen Paul @naveenpaul1 