### PR TITLE
Root key rotate - core side

### DIFF
--- a/config.js
+++ b/config.js
@@ -123,6 +123,8 @@ config.JWT_SECRET = process.env.JWT_SECRET || _get_data_from_file(`/etc/noobaa-s
 config.SERVER_SECRET = process.env.SERVER_SECRET || _get_data_from_file(`/etc/noobaa-server/server_secret`);
 config.NOOBAA_AUTH_TOKEN = process.env.NOOBAA_AUTH_TOKEN || _get_data_from_file(`/etc/noobaa-auth-token/auth_token`);
 
+config.ROOT_KEY_MOUNT = '/etc/noobaa-server/root_keys';
+
 ///////////////
 // MD CONFIG //
 ///////////////
@@ -348,6 +350,7 @@ config.DEFAULT_S3_AUTH_METHOD = {
 //////////////////////
 
 config.LIFECYCLE_INTERVAL = 8 * 60 * 60 * 1000; // 8h
+config.LIFECYCLE_ENABLED = true;
 
 //////////////////////////
 // STATISTICS_COLLECTOR //
@@ -553,6 +556,14 @@ config.REPLICATION_ENABLED = true;
 config.LOG_REPLICATION_ENABLED = true;
 config.AWS_LOG_CANDIDATES_LIMIT = 10;
 config.BUCKET_LOG_REPLICATOR_DELAY = 5 * 60 * 1000;
+
+///////////////////////////
+//      KEY ROTATOR      //
+///////////////////////////
+
+config.KEY_ROTATOR_ENABLED = true;
+config.KEY_ROTATOR_RUN_INTERVAL = 24 * 60 * 60 * 1000; // Once a day,
+config.KEY_ROTATOR_ERROR_DELAY = 10 * 60 * 1000; // Run again in 10 minutes
 
 ///////////////////////
 // NAMESPACE CACHING //

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -115,20 +115,6 @@ module.exports = {
             }
         },
 
-        rotate_root_key: {
-            method: 'PUT',
-            params: {
-                type: 'object',
-                required: ['new_root_key'],
-                properties: {
-                    new_root_key: { $ref: 'common_api#/definitions/secret_enc_key' },
-                }
-            },
-            auth: {
-                system: 'admin'
-            }
-        },
-
         rotate_master_key: {
             method: 'PUT',
             params: {

--- a/src/deploy/NVA_build/Tests.Dockerfile
+++ b/src/deploy/NVA_build/Tests.Dockerfile
@@ -12,18 +12,8 @@ ENV TEST_CONTAINER true
 #   Cache: rebuild when we adding/removing requirments
 ##############################################################
 
-# RUN dnf install -y ntpdate vim && \
-COPY ./src/deploy/NVA_build/set_mongo_repo.sh /tmp/
-RUN chmod +x /tmp/set_mongo_repo.sh && \
-    /bin/bash -xc "/tmp/set_mongo_repo.sh"
-
 RUN dnf group install -y -q "Development Tools" && \
     dnf install -y -q --nogpgcheck vim \
-    mongodb-org-3.6.3 \
-    mongodb-org-server-3.6.3 \
-    mongodb-org-shell-3.6.3 \
-    mongodb-org-mongos-3.6.3 \
-    mongodb-org-tools-3.6.3 \
     which python3-virtualenv python36-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel \ 
     git && \
     dnf clean all

--- a/src/server/bg_services/key_rotator.js
+++ b/src/server/bg_services/key_rotator.js
@@ -1,0 +1,68 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+
+const dbg = require('../../util/debug_module')(__filename);
+const system_store = require('../system_services/system_store').get_instance();
+const system_utils = require('../utils/system_utils');
+const config = require('../../../config');
+
+class KeyRotator {
+
+    constructor({ name }) {
+        this.name = name;
+    }
+
+    async run_batch() {
+        if (!this._can_run()) return config.KEY_ROTATOR_ERROR_DELAY;
+        const mkm = system_store.master_key_manager;
+        await mkm.load_root_keys_from_mount();
+
+        dbg.log0('KeyRotator: new rotate cycle has started');
+        const system = system_store.data.systems[0];
+        // if the system root_key_id exist and enabled - nothing to do 
+        if (system.master_key_id.root_key_id && !mkm.is_m_key_disabled(system.master_key_id.root_key_id)) {
+            return config.KEY_ROTATOR_RUN_INTERVAL;
+        }
+        try {
+            const active_root_key_id = mkm.get_root_key_id();
+            const reencrypted = mkm._reencrypt_master_key_by_current_root(
+                system.master_key_id._id,
+                active_root_key_id
+            );
+            const unset = system.master_key_id.master_key_id && { master_key_id: 1 };
+            await system_store.make_changes({
+                update: {
+                    master_keys: [_.omitBy({
+                        _id: system.master_key_id._id,
+                        $set: {
+                            root_key_id: active_root_key_id,
+                            cipher_key: reencrypted
+                        },
+                        $unset: unset,
+                    }, _.isUndefined)]
+                }
+            });
+        } catch (err) {
+            dbg.error(`KeyRotator: got error when trying to rotate system ${system._id} root key:`, err);
+            return config.KEY_ROTATOR_ERROR_DELAY;
+        }
+        dbg.log0(`KeyRotator: root key for system ${system._id} was rotated succesfully`);
+        return config.KEY_ROTATOR_RUN_INTERVAL;
+    }
+
+    _can_run() {
+        if (!system_store.is_finished_initial_load) {
+            dbg.log0('KeyRotator: system_store did not finish initial load');
+            return false;
+        }
+        const system = system_store.data.systems[0];
+        if (!system || system_utils.system_in_maintenance(system._id)) return false;
+
+        return true;
+    }
+}
+
+// EXPORTS
+exports.KeyRotator = KeyRotator;

--- a/src/server/system_services/schemas/master_key_schema.js
+++ b/src/server/system_services/schemas/master_key_schema.js
@@ -10,10 +10,10 @@ module.exports = {
     properties: {
         _id: { objectid: true },
         description: { type: 'string' },
-        // If missing - encrypted with root key
-        // 1. ENV - Mounted key from Kubernetes secret
-        // 2. HSM configuration TBD - Get key from Vault
+        // If missing - encrypted with a root key (external to DB)
         master_key_id: { objectid: true },
+        // Exists only for system keys - holding the external key identifier
+        root_key_id: { type: 'string' },
         // cipher used to provide confidentiality - computed on the compressed data
         cipher_type: { $ref: 'common_api#/definitions/cipher_type' },
         cipher_key: { binary: true },

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -157,8 +157,6 @@ function setup(options = {}) {
         await fs.promises.writeFile(config.ROOT_KEY_MOUNT + '/active_root_key', 'key1');
         await fs.promises.writeFile(config.ROOT_KEY_MOUNT + '/key1', root_secret);
 
-        await announce('db_client dropDatabase()');
-        await db_client.instance().dropDatabase();
         await announce('db_client createDatabase()');
         await db_client.instance().createDatabase();
         await announce('db_client reconnect()');

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -7,13 +7,14 @@ const argv = require('minimist')(process.argv);
 const mocha = require('mocha');
 const assert = require('assert');
 const crypto = require('crypto');
+const fs = require('fs');
 
 // keep me first - this is setting envs that should be set before other modules are required.
 const CORETEST = 'coretest';
 process.env.DEBUG_MODE = 'true';
 process.env.CORETEST = CORETEST;
 process.env.JWT_SECRET = CORETEST;
-process.env.NOOBAA_ROOT_SECRET = crypto.randomBytes(32).toString('base64');
+const root_secret = crypto.randomBytes(32).toString('base64');
 process.env.ACCOUNTS_CACHE_EXPIRY = '1';
 
 console.log('loading .env file');
@@ -25,6 +26,8 @@ const config = require('../../../config.js');
 config.test_mode = true;
 config.NODES_FREE_SPACE_RESERVE = 10 * 1024 * 1024;
 config.NSFS_VERSIONING_ENABLED = true;
+
+config.ROOT_KEY_MOUNT = '/tmp/noobaa-server/root_keys';
 
 const dbg = require('../../util/debug_module')(__filename);
 const dbg_level =
@@ -149,6 +152,10 @@ function setup(options = {}) {
     mocha.before('coretest-before', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         const start = Date.now();
+
+        await fs.promises.mkdir(config.ROOT_KEY_MOUNT, { recursive: true});
+        await fs.promises.writeFile(config.ROOT_KEY_MOUNT + '/active_root_key', 'key1');
+        await fs.promises.writeFile(config.ROOT_KEY_MOUNT + '/key1', root_secret);
 
         await announce('db_client dropDatabase()');
         await db_client.instance().dropDatabase();

--- a/src/test/unit_tests/run_npm_test_on_test_container.sh
+++ b/src/test/unit_tests/run_npm_test_on_test_container.sh
@@ -11,17 +11,8 @@ function cleanup() {
     else
         rc=$2
     fi
-    echo "$(date) exiting mongod"
-    kill -2 ${pid}
     echo "$(date) return code was: ${rc}"
     exit ${rc}
-}
-
-function start_mongo() {
-    mkdir -p /data/db
-    echo "$(date) starting mongod"
-    mongod --logpath /dev/null &
-    PID=$!
 }
 
 PATH=$PATH:/noobaa-core/node_modules/.bin
@@ -56,7 +47,6 @@ done
 
 trap cleanup 1 2
 
-start_mongo
 echo "$(date) running ${command}"
 ${command}
-cleanup ${PID} ${?}
+cleanup ${?}

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -540,7 +540,9 @@ class MongoClient extends EventEmitter {
 
     set_db_name(name) {
         if (this.is_connected()) throw new Error('Cannot set DB name to connected DB');
-        this.url = `mongodb://localhost/${name}`;
+        const u = new URL(this.url);
+        u.pathname = '/' + name;
+        this.url = u.href;
     }
 
     get_db_name(name) {


### PR DESCRIPTION
### Explain the changes
1. We decided to move key rotation part in core to a daily running process checking if anything is changed with the external root keys file and if so, to re-encrypt the system/systems keys accordingly.
2. the key files will be under directory /etc/noobaa-server/root_keys. the active root key id will be under /etc/noobaa-server/active_root_key
3. As trying to support both old format (env-variable) and the new one(a directory mount with no env variable) checks were added to system_server load and also in case of running in the new format and seeing the old format leftovers - those leftovers will get cleaned

in 2nd commit:
- moving mongodb outside of noobaa tester container (due to issues with the image in M1)
- like in postgres, mongo will run in its own container and tester will connect to it for DB access.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Fixed #7179 


- [ ] Doc added/updated
- [x] Tests added
