### PR TITLE
NSFS | GPFS | PUT OBJECT | Fix for upload object of nested key - temp file flow

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -770,13 +770,14 @@ class NamespaceFS {
 
     // opens open_path on POSIX, and on GPFS it will open open_path parent folder
     async _open_file(fs_context, open_path, open_mode) {
-        if (open_mode === 'wt') {
-            open_path = path.dirname(open_path);
-            dbg.log1('NamespaceFS._open_file: wt creating dirs', open_path, this.bucket_path);
-            if (open_path !== this.bucket_path) await this._make_path_dirs(open_path, fs_context);
+        const dir_path = path.dirname(open_path);
+        if ((open_mode === 'wt' || open_mode === 'w') && dir_path !== this.bucket_path) {
+            dbg.log1(`NamespaceFS._open_file: mode=${open_mode} creating dirs`, open_path, this.bucket_path);
+            await this._make_path_dirs(open_path, fs_context);
         }
-        dbg.log0('NamespaceFS._open_file:', open_path);
-        return nb_native().fs.open(fs_context, open_path, open_mode, get_umasked_mode(config.BASE_MODE_FILE));
+        dbg.log0(`NamespaceFS._open_file: mode=${open_mode || 'r'}`, open_path);
+        const actual_open_path = open_mode === 'wt' ? dir_path : open_path;
+        return nb_native().fs.open(fs_context, actual_open_path, open_mode, get_umasked_mode(config.BASE_MODE_FILE));
     }
 
     // on server side copy - 


### PR DESCRIPTION
### Explain the changes
On PUT OBJECT of nested key (a/b) on GPFS namespace resource - the directory a/ was not created due to setting open_path = dirname(open_path), According to https://nodejs.org/api/path.html#pathdirnamepath - dirname(path) returns directory name of a path, similar to the Unix dirname command. **Trailing directory separators are ignored.**
Removing the last '/' caused make_path_dirs() to not create a/ because it's searching for the last index of '/' of the path. 
**Example -** 
open_path = 'a/b';
open_path = dirname(open_path); // = 'a'
make_path_dirs -> no '/' - nothing to create

Took Guy's code to fix this issue - 
1. By not changing open_path, and setting dir_path = path.dirname(open_path) to a new variable, make_path_dirs created the nested object correctly.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Install NooBaa
2. Create GPFS namespace resource
3. put object key = a/b and check it was created correctly


- [ ] Doc added/updated
- [ ] Tests added
