### PR TITLE
[5.12] Hardcode orgs in releaser and bump version 5.12.1

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -32,11 +32,11 @@ jobs:
       - name: Release NooBaa Core Image
         env:
           GITHUB_TOKEN: ${{ secrets.GHACCESSTOKEN }}
-          DOCKERHUB_USERNAME: ${{ secrets.GHACTIONSDOCKERHUBNAME }}
+          DOCKERHUB_USERNAME: noobaa
           DOCKERHUB_TOKEN: ${{ secrets.GHACTIONSDOCKERHUB }}
-          QUAY_USERNAME: ${{ secrets.GHACTIONQUAYNAME }}
+          QUAY_USERNAME: noobaa
           QUAY_TOKEN: ${{ secrets.GHACTIONQUAYTOKEN }}
-          OCI_ORG: ${{ secrets.GHACTIONSDOCKERHUBNAME }}
+          OCI_ORG: noobaa
           BASE_BRANCH: "${{ github.event.inputs.base_branch }}"
         run: |
           git config --global user.email "github-action@noobaa.io"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",


### PR DESCRIPTION
### Explain the changes

This PR:
1. Hardcodes orgs in the releaser script in an attempt to fix it.
2. Bump NooBaa version to 5.12.1.

