### PR TITLE
Delete replication on delete bucket and objects flow

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -777,6 +777,11 @@ async function delete_bucket_and_objects(req) {
         }
     });
 
+    if (bucket.replication_policy_id) {
+        // delete replication from replication collection
+        await replication_store.instance().delete_replication_by_id(bucket.replication_policy_id);
+    }
+
     const req_account = req.account &&
         (req.account.email.unwrap() === config.OPERATOR_ACCOUNT_EMAIL ?
             'NooBaa operator' :


### PR DESCRIPTION
### Explain the changes
1. Currently we deleted an attached replication policy only on delete_bucket flow, Added deletion of the bucket's replication policy when deleted also using delete_bucket_and_objects flow.

### Issues: Fixed #xxx / Gap #xxx
1. Probably fixes https://bugzilla.redhat.com/show_bug.cgi?id=2168788, waiting for a response

### Testing Instructions:
1. install noobaa
2. create obc obc1
3. create replication config json and put obc1 bucket name as destination bucket
4. create obc obc2 with replication policy of step 3
5. upload objects to obc2
6. delete obc2
7. check in db that the replication config was deleted 
8. check in noobaa core logs that we stop replicating objects from obc2 to obc1



- [ ] Doc added/updated
- [ ] Tests added
