### PR TITLE
[Backport into 5.12] Consume secret variables from a file  and use service certificate for rpc_http_server

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,7 +7,9 @@
 var config = exports;
 
 const os = require('os');
+const fs = require('fs');
 const assert = require('assert');
+const dbg = require('./src/util/debug_module')(__filename);
 
 /////////////////////////
 // CONTAINER RESOURCES //
@@ -109,6 +111,14 @@ config.ENDPOINT_MONITOR_INTERVAL = 10 * 60 * 1000; // 10min
 // Keep connection on long requests
 config.S3_KEEP_ALIVE_WHITESPACE_INTERVAL = 15 * 1000;
 config.S3_MD_SIZE_LIMIT = 2 * 1024;
+
+/////////////////////
+// SECRETS CONFIG  //
+/////////////////////
+
+config.JWT_SECRET = process.env.JWT_SECRET || _get_data_from_file(`/etc/noobaa-server/jwt`);
+config.SERVER_SECRET = process.env.SERVER_SECRET || _get_data_from_file(`/etc/noobaa-server/server_secret`);
+config.NOOBAA_AUTH_TOKEN = process.env.NOOBAA_AUTH_TOKEN || _get_data_from_file(`/etc/noobaa-auth-token/auth_token`);
 
 ///////////////
 // MD CONFIG //
@@ -674,6 +684,17 @@ function load_config_env_overrides() {
             console.warn(`load_config_env_overrides: failed to load ${key}`, err);
         }
     }
+}
+
+function _get_data_from_file(file_name) {
+    let data;
+    try {
+        data = fs.readFileSync(file_name).toString();
+    } catch (e) {
+        dbg.log1(`Error accrued while getting the data from ${file_name}: ${e}`);
+        return;
+    }
+    return data;
 }
 
 load_config_local();

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -237,9 +237,9 @@ function get_rpc_router(env) {
 }
 
 async function get_auth_token(env) {
-    if (env.NOOBAA_AUTH_TOKEN) return env.NOOBAA_AUTH_TOKEN;
+    if (config.NOOBAA_AUTH_TOKEN) return config.NOOBAA_AUTH_TOKEN;
 
-    if (env.JWT_SECRET && env.LOCAL_MD_SERVER === 'true') {
+    if (config.JWT_SECRET && env.LOCAL_MD_SERVER === 'true') {
         const system_store_inst = system_store.get_instance();
         await P.wait_until(() =>
             system_store_inst.is_finished_initial_load

--- a/src/rpc/rpc_http_server.js
+++ b/src/rpc/rpc_http_server.js
@@ -42,14 +42,15 @@ class RpcHttpServer extends events.EventEmitter {
     /**
      * start_server
      */
-    start_server(options) {
+    async start_server(options) {
         const port = parseInt(options.port, 10);
         const secure = options.protocol === 'https:' || options.protocol === 'wss:';
         const logging = options.logging;
         dbg.log0('HTTP SERVER:', 'port', port, 'secure', secure, 'logging', logging);
 
+        const ssl_cert = await ssl_utils.get_ssl_certificate('MGMT');
         const server = secure ?
-            https.createServer({ ...ssl_utils.generate_ssl_certificate(), honorCipherOrder: true }) :
+            https.createServer({ ...ssl_cert, honorCipherOrder: true }) :
             http.createServer();
         this.install_on_server(server, options.default_handler);
         return P.fromCallback(callback => server.listen(port, callback))

--- a/src/util/jwt_utils.js
+++ b/src/util/jwt_utils.js
@@ -4,27 +4,23 @@
 /* eslint-disable global-require */
 
 const jwt = require('jsonwebtoken');
+const config = require('../../config');
 const dbg = require('./debug_module')(__filename);
 const JWT_SECRET = get_jwt_secret();
 
 function get_jwt_secret() {
-    if (process.env.JWT_SECRET) {
-        return process.env.JWT_SECRET;
-    } else {
-        // in kubernetes we must have JWT_SECRET loaded from a kubernetes secret
-        if (process.env.CONTAINER_PLATFORM === 'KUBERNETES') {
-            throw new Error('JWT_SECRET env variable not found. it must exist when running in kuberentes');
-        }
-        // for all non kubernetes platforms (docker, local, etc.) return a dummy secret
-        return 'abcdefgh';
+    if (config.JWT_SECRET) return config.JWT_SECRET;
+    // in kubernetes we must have JWT_SECRET loaded from a kubernetes secret
+    if (process.env.CONTAINER_PLATFORM === 'KUBERNETES') {
+        throw new Error('jwt_secret mounted to a file was not found. it must exist when running in kubernetes');
     }
+    // for all non kubernetes platforms (docker, local, etc.) return a dummy secret
+    return 'abcdefgh';
 }
 
 function make_auth_token(object = {}, jwt_options = {}) {
     // Remote services/endpoints should not sign tokens
-    if (process.env.NOOBAA_AUTH_TOKEN) {
-        return process.env.NOOBAA_AUTH_TOKEN;
-    }
+    if (config.NOOBAA_AUTH_TOKEN) return config.NOOBAA_AUTH_TOKEN;
     // create and return the signed token
     return jwt.sign(object, JWT_SECRET, jwt_options);
 }

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -591,16 +591,13 @@ function is_folder_permissions_set(current_path) {
 }
 
 function read_server_secret() {
-    if (process.env.SERVER_SECRET) {
-        return process.env.SERVER_SECRET;
-    } else {
-        // in kubernetes we must have SERVER_SECRET loaded from a kubernetes secret
-        if (process.env.CONTAINER_PLATFORM === 'KUBERNETES') {
-            throw new Error('SERVER_SECRET env variable not found. it must exist when running in kubernetes');
-        }
-        // for all non kubernetes platforms (docker, local, etc.) return a dummy secret
-        return '12345678';
+    if (config.SERVER_SECRET) return config.SERVER_SECRET;
+    // in kubernetes we must have SERVER_SECRET loaded from a kubernetes secret
+    if (process.env.CONTAINER_PLATFORM === 'KUBERNETES') {
+        throw new Error('server_secret mounted to a file was not found. it must exist when running in kubernetes');
     }
+    // for all non kubernetes platforms (docker, local, etc.) return a dummy secret
+    return '12345678';
 }
 
 function is_supervised_env() {


### PR DESCRIPTION
### Explain the changes
- Add a util to get data from a file. will use that to fetch kubernetes secret mounted to a file.
- Replaced env.NOOBAA_AUTH_TOKEN with config.NOOBAA_AUTH_TOKEN
- Replaced env.JWT_SECRET wite config.JWT_SECRET
- Replaced env.SECRET_SERVER with config.SECRET_SERVER
- Keeping the default behavior of using env variables for overriding if needed or testing.

and
- use service certificate for rpc_http_server

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit 5d19b5570ac5a485e75a8e0fee0ccb2c5e6dbf35)
(cherry picked from commit 9f64ad7a6c394898c33180c486cf7a193752f068)

### Issues: Fixed #xxx / Gap #xxx
1.  https://bugzilla.redhat.com/show_bug.cgi?id=2171968
2. https://bugzilla.redhat.com/show_bug.cgi?id=2168867

