### PR TITLE
Fix Log Replication Deletions

### DIFF
--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -22,6 +22,11 @@ type NodeType =
     'BLOCK_STORE_FS' |
     'ENDPOINT_S3';
 
+type ReplicationLogAction = 'copy' | 'delete' | 'conflict';
+type ReplicationLog = { key: string, action: ReplicationLogAction, time: Date };
+type ReplicationLogs = Array<ReplicationLog>;
+type ReplicationLogCandidates = Record<string, { action: ReplicationLogAction, time: Date }[]>;
+
 interface MapByID<T> {
     [id: string]: T;
 }


### PR DESCRIPTION
### Explain the changes
This PR ensures that even if multiple actions are performed on an object, we process all of the actions instead of processing only the last one. Processing only the last action causes issues in the scenario when the logs are not chronologically ordered, for example: `DELETE /cat.jpeg` then `PUT /cat.jpeg`, when these 2 entries are part of the same candidate batch, NooBaa would just process the last `PUT` which means that the `DELETE` will never be processed.

PS: Added JS Docs to have the static analysis "safety net".

### Issues: Fixed #xxx / Gap #xxx
This issue was discovered by Sagi (QE) during happy path testing. 

- [ ] Doc added/updated
- [ ] Tests added
