### PR TITLE
endpoint forks revamped

### DIFF
--- a/config.js
+++ b/config.js
@@ -106,6 +106,7 @@ config.N2N_OFFER_INTERNAL = false;
 // ENDPOINT CONFIG //
 /////////////////////
 
+config.ENDPOINT_FORKS = Number(process.env.ENDPOINT_FORKS) || 0;
 config.AMZ_DATE_MAX_TIME_SKEW_MILLIS = 15 * 60 * 1000;
 config.ENDPOINT_MONITOR_INTERVAL = 10 * 60 * 1000; // 10min
 // Keep connection on long requests

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -31,6 +31,7 @@ const xml_utils = require('../util/xml_utils');
 const ssl_utils = require('../util/ssl_utils');
 const net_utils = require('../util/net_utils');
 const addr_utils = require('../util/addr_utils');
+const fork_utils = require('../util/fork_utils');
 const md_server = require('../server/md_server');
 const server_rpc = require('../server/server_rpc');
 const debug_config = require('../util/debug_config');
@@ -71,6 +72,7 @@ dbg.log0('endpoint: replacing old umask: ', old_umask.toString(8), 'with new uma
  *  https_port?: number;
  *  https_port_sts?: number;
  *  init_request_sdk?: EndpointHandler;
+ *  forks?: number;
  * }} EndpointOptions
  */
 
@@ -79,6 +81,8 @@ dbg.log0('endpoint: replacing old umask: ', old_umask.toString(8), 'with new uma
  */
 async function start_endpoint(options = {}) {
     try {
+        fork_utils.start_workers(options.forks ?? config.ENDPOINT_FORKS);
+
         const http_port = options.http_port || Number(process.env.ENDPOINT_PORT) || 6001;
         const https_port = options.https_port || Number(process.env.ENDPOINT_SSL_PORT) || 6443;
         const https_port_sts = options.https_port_sts || Number(process.env.ENDPOINT_SSL_PORT_STS) || 7443;

--- a/src/util/fork_utils.js
+++ b/src/util/fork_utils.js
@@ -1,0 +1,42 @@
+/* Copyright (C) 2023 NooBaa */
+'use strict';
+
+// these type hacks are needed because the type info from require('node:cluster') is incorrect
+const cluster = /** @type {import('node:cluster').Cluster} */ (
+    /** @type {unknown} */ (require('node:cluster'))
+);
+
+/**
+ * The cluster module allows easy creation of child processes that all share server ports.
+ * When count > 0 the primary process will fork worker processes to process incoming http requests.
+ * In case of any worker exit, also the entire process group will exit.
+ * @see https://nodejs.org/api/cluster.html
+ * 
+ * @param {number?} count number of workers to start.
+ * @returns {boolean} true if workers were started.
+ */
+function start_workers(count = 0) {
+
+    if (cluster.isPrimary && count > 0) {
+        for (let i = 0; i < count; ++i) {
+            const worker = cluster.fork();
+            console.warn('WORKER started', { id: worker.id, pid: worker.process.pid });
+        }
+
+        // We don't want to leave the process with a partial set of workers,
+        // so if any worker exits, we exit the primary process and the entire group will be killed.
+        // We prefer to rely on the controller that executed this process to recover from such a crash.
+        cluster.on('exit', (worker, code, signal) => {
+            console.warn('WORKER exit', { id: worker.id, pid: worker.process.pid, code, signal });
+            console.error('EXIT ON WORKER ERROR');
+            process.exit(1);
+        });
+
+        return true;
+    }
+
+    return false;
+}
+
+exports.cluster = cluster;
+exports.start_workers = start_workers;


### PR DESCRIPTION
### Explain the changes
1. Allow running endpoints with multiple workers (forks) that share the same ports and respond to incoming http request as a "cluster".
2. This is needed when running endpoints in standalone mode for performance. 
3. This is limited to a single host.
4. Currently this is off by default.
5. When on kubernetes, this is done by starting multiple endpoint pods with a service on top, which is also a multi-host service, but for standalone this is the simplest way to get good performance from a host.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. NA

- [ ] Doc added/updated
- [ ] Tests added
