### PR TITLE
housekeeping: error_utils, tsc fixes, tools fixes

### DIFF
--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -201,11 +201,11 @@ class BucketSpaceNB {
     // DEFAULT OBJECT LOCK //
     /////////////////////////
 
-    async get_object_lock_configuration(params) {
+    async get_object_lock_configuration(params, object_sdk) {
         return this.rpc_client.bucket.get_object_lock_configuration(params);
     }
 
-    async put_object_lock_configuration(params) {
+    async put_object_lock_configuration(params, object_sdk) {
         return this.rpc_client.bucket.put_object_lock_configuration(params);
     }
 

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -57,10 +57,7 @@ class NamespaceBlob {
     }
 
     is_readonly_namespace() {
-        if (this.access_mode && this.access_mode === 'READ_ONLY') {
-            return true;
-        }
-        return false;
+        return this.access_mode === 'READ_ONLY';
     }
 
     /////////////////

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -41,10 +41,7 @@ class NamespaceCache {
     }
 
     is_readonly_namespace() {
-        if (this.namespace_hub.access_mode && this.namespace_hub.access_mode === 'READ_ONLY') {
-            return true;
-        }
-        return false;
+        return this.namespace_hub.is_readonly_namespace();
     }
 
     get_bucket() {

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -8,11 +8,12 @@ const path = require('path');
 const util = require('util');
 const mime = require('mime');
 const { v4: uuidv4 } = require('uuid');
-const dbg = require('../util/debug_module')(__filename);
-const P = require('../util/promise');
 
+const P = require('../util/promise');
+const dbg = require('../util/debug_module')(__filename);
 const config = require('../../config');
 const s3_utils = require('../endpoint/s3/s3_utils');
+const error_utils = require('../util/error_utils');
 const stream_utils = require('../util/stream_utils');
 const buffer_utils = require('../util/buffer_utils');
 const size_utils = require('../util/size_utils');
@@ -221,9 +222,7 @@ class NamespaceFS {
         const fs_context = object_sdk &&
             object_sdk.requesting_account && object_sdk.requesting_account.nsfs_account_config;
         if (!fs_context) {
-            const err = new Error('nsfs_account_config is missing');
-            err.rpc_code = 'UNAUTHORIZED';
-            throw err;
+            throw new RpcError('UNAUTHORIZED', 'nsfs_account_config is missing');
         }
 
         fs_context.backend = this.fs_backend || '';
@@ -274,10 +273,7 @@ class NamespaceFS {
     }
 
     is_readonly_namespace() {
-        if (this.access_mode && this.access_mode === 'READ_ONLY') {
-            return true;
-        }
-        return false;
+        return this.access_mode === 'READ_ONLY';
     }
 
     /////////////////
@@ -540,7 +536,7 @@ class NamespaceFS {
             await this._check_path_in_bucket_boundaries(fs_context, file_path);
             await this._load_bucket(params, fs_context);
             const stat = await nb_native().fs.stat(fs_context, file_path);
-            if (isDirectory(stat)) throw Object.assign(new Error('NoSuchKey'), { code: 'ENOENT' });
+            if (isDirectory(stat)) throw error_utils.new_error_code('ENOENT', 'NoSuchKey');
             this._throw_if_delete_marker(stat);
             return this._get_object_info(params.bucket, params.key, stat, params.version_id || 'null');
         } catch (err) {
@@ -1609,9 +1605,7 @@ class NamespaceFS {
             const list = await this.list_objects({ ...params, limit: 1 }, object_sdk);
 
             if (list && list.objects && list.objects.length > 0) {
-                const err = new Error('underlying directory has files in it');
-                err.rpc_code = 'NOT_EMPTY';
-                throw err;
+                throw new RpcError('NOT_EMPTY', 'underlying directory has files in it');
             }
 
             await this._folder_delete(params.full_path, fs_context);
@@ -1674,7 +1668,8 @@ class NamespaceFS {
             if (err.code === 'EACCES') {
                 return false;
             }
-            throw Object.assign(new Error('check_bucket_boundaries error ' + err.code + " " + entry_path + " " + err), { code: 'INTERNAL_ERROR' });
+            throw error_utils.new_error_code('INTERNAL_ERROR',
+                'check_bucket_boundaries error ' + err.code + ' ' + entry_path + ' ' + err, { cause: err });
         }
         return true;
     }
@@ -1686,7 +1681,7 @@ class NamespaceFS {
      */
     async _check_path_in_bucket_boundaries(fs_context, entry_path) {
         if (!(await this._is_path_in_bucket_boundaries(fs_context, entry_path))) {
-            throw Object.assign(new Error('Entry ' + entry_path + ' is not in bucket boundaries'), { code: 'EACCES' });
+            throw error_utils.new_error_code('EACCES', 'Entry ' + entry_path + ' is not in bucket boundaries');
         }
     }
 
@@ -1799,7 +1794,7 @@ class NamespaceFS {
         if (this.versioning === versioning_status_enum.VER_ENABLED || this.versioning === versioning_status_enum.VER_SUSPENDED) {
             const xattr_delete_marker = stat.xattr[XATTR_DELETE_MARKER];
             if (xattr_delete_marker) {
-                throw Object.assign(new Error('NoSuchKey'), { code: 'ENOENT' });
+                throw error_utils.new_error_code('ENOENT', 'Entry is a delete marker');
             }
         }
     }

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -53,10 +53,7 @@ class NamespaceGCP {
     }
 
     is_readonly_namespace() {
-        if (this.access_mode && this.access_mode === 'READ_ONLY') {
-            return true;
-        }
-        return false;
+        return this.access_mode === 'READ_ONLY';
     }
 
 
@@ -134,6 +131,9 @@ class NamespaceGCP {
     // OBJECT READ //
     /////////////////
 
+    /**
+     * @returns {Promise<nb.ObjectInfo>}
+     */
     async read_object_md(params, object_sdk) {
         dbg.log0('NamespaceGCP.read_object_md:', this.bucket, inspect(params));
         const file = this.gcs.bucket(this.bucket).file(params.key);
@@ -149,6 +149,9 @@ class NamespaceGCP {
         return this._get_gcp_object_info(metadata);
     }
 
+    /**
+     * @returns {Promise<import('stream').Readable>}
+     */
     async read_object_stream(params, object_sdk) {
         dbg.log0('NamespaceGCP.read_object_stream:', this.bucket, inspect(_.omit(params, 'object_md.ns')));
         throw new S3Error(S3Error.NotImplemented);
@@ -357,6 +360,20 @@ class NamespaceGCP {
         throw new Error('TODO');
     }
 
+    //////////////////////////
+    // AZURE BLOB MULTIPART //
+    //////////////////////////
+
+    async upload_blob_block(params, object_sdk) {
+        throw new Error('TODO');
+    }
+    async commit_blob_block_list(params, object_sdk) {
+        throw new Error('TODO');
+    }
+    async get_blob_block_lists(params, object_sdk) {
+        throw new Error('TODO');
+    }
+
     ///////////////
     // INTERNALS //
     ///////////////
@@ -382,7 +399,17 @@ class NamespaceGCP {
             last_modified_time: metadata.updated,
             content_type: metadata.contentType,
             md5_b64: metadata.md5Hash,
-            xattr
+            xattr,
+            is_latest: true,
+            delete_marker: false,
+            version_id: metadata.id,
+            tag_count: 0,
+            tagging: undefined,
+            num_parts: undefined,
+            sha256_b64: undefined,
+            lock_settings: undefined,
+            encryption: undefined,
+            stats: undefined,
         };
     }
 

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -55,10 +55,7 @@ class NamespaceS3 {
     }
 
     is_readonly_namespace() {
-        if (this.access_mode && this.access_mode === 'READ_ONLY') {
-            return true;
-        }
-        return false;
+        return this.access_mode === 'READ_ONLY';
     }
 
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -413,6 +413,7 @@ interface ObjectInfo {
     first_range_data?: Buffer;
     content_length?: number;
     content_range?: string;
+    ns?: Namespace;
 }
 
 
@@ -729,6 +730,7 @@ interface ObjectSDK {
 interface Namespace {
 
     is_server_side_copy(other: Namespace, params: object): boolean;
+    is_readonly_namespace(): boolean;
     get_write_resource(): Namespace;
     get_bucket(): string;
 
@@ -796,6 +798,6 @@ interface BucketSpace {
     delete_bucket_policy(params: object): Promise<any>;
     get_bucket_policy(params: object): Promise<any>;
 
-    get_object_lock_configuration(params: object): Promise<any>;
-    put_object_lock_configuration(params: object): Promise<any>;
+    get_object_lock_configuration(params: object, object_sdk: ObjectSDK): Promise<any>;
+    put_object_lock_configuration(params: object, object_sdk: ObjectSDK): Promise<any>;
 }

--- a/src/util/error_utils.js
+++ b/src/util/error_utils.js
@@ -1,0 +1,29 @@
+/* Copyright (C) 2023 NooBaa */
+'use strict';
+
+/** @typedef {Error & { code: string }} ErrorWithCode */
+
+/**
+ * Create a simple error with an error code.
+ * The code field is meant to be used for detecting the exact error type.
+ * @see https://nodejs.org/dist/latest-v18.x/docs/api/errors.html#errorcode
+ * @param {string} code a machine readable error code, e.g 'NOT_FOUND'.
+ * @param {string} [message] a human readable error message, e.g 'No such bucket'.
+ * @param {ErrorOptions} [options]
+ * @returns {ErrorWithCode}
+ */
+function new_error_code(code, message, options) {
+    return Object.assign(new Error(message ?? code, options), { code });
+}
+
+/**
+ * Remove the stack trace for errors that are too noisy with a stack.
+ * @param {Error} err 
+ */
+function stackless(err) {
+    err.stack = null;
+    return err;
+}
+
+exports.new_error_code = new_error_code;
+exports.stackless = stackless;

--- a/src/util/sensitive_string.js
+++ b/src/util/sensitive_string.js
@@ -5,6 +5,10 @@ const util = require('util');
 const crypto = require('crypto');
 
 class SensitiveString {
+
+    /**
+     * @param {SensitiveString | string} [val]
+     */
     constructor(val) {
         const type = typeof val;
         if (val instanceof SensitiveString) {


### PR DESCRIPTION
### Explain the changes
1. error_utils to unify how we throw errors with a code string (NOTE: it's not the same as rpc_code!)
2. typescript fixes - add more accurate type info.
3. s3cat - simplify the `--endpoint` option, presign fix, tsc fixes.
4. s3perf - simplify the `--endpoint` option, listing objects for `--get/head/delete` options.
5. fs_speed - add `--read` option.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. NA
