### PR TITLE
noobaa/core: Transaction related changes

### DIFF
--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -704,6 +704,7 @@ interface DBClient {
     check_entity_not_deleted(doc: object, entity: string): object;
     check_update_one(res: object, entity: string): void;
     make_object_diff(current: object, prev: object): object;
+    execute_multiple_bulks(bulk_per_collection: object): any[];
 }
 
 interface DBSequence {

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -746,9 +746,8 @@ class SystemStore extends EventEmitter {
             });
         });
 
-        const bulk_results = await Promise.all(Object.values(bulk_per_collection).map(
-            bulk => bulk.length && bulk.execute({ j: true })
-        ));
+
+        const bulk_results = await db_client.instance().execute_multiple_bulks(bulk_per_collection);
 
         for (const res of bulk_results) {
             if (res && !res.ok) {
@@ -756,6 +755,7 @@ class SystemStore extends EventEmitter {
                 throw new Error(res.err);
             }
         }
+
 
         return { any_news, last_update };
     }

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -361,6 +361,13 @@ class MongoClient extends EventEmitter {
         return diff;
     }
 
+    async execute_multiple_bulks(bulk_per_collection) {
+        const bulk_results = await Promise.all(Object.values(bulk_per_collection).map(
+            bulk => bulk.length && bulk.execute({ j: true })
+        ));
+        return bulk_results;
+    }
+
     async get_db_stats() {
         if (!this.promise) {
             throw new Error('get_db_stats: client is not connected');


### PR DESCRIPTION
This patch makes changes to send bulk queries for
multiple collections in one transaction for postgres DB. In case of failure of any query, all the bulk operations will be rollbacked.

unit test has not been added for this patch