### PR TITLE
standalone backingstore agent

### DIFF
--- a/config.js
+++ b/config.js
@@ -84,6 +84,9 @@ config.NODE_ALLOCATOR_NUM_CLUSTERS = 2;
 // RPC CONFIG //
 ////////////////
 
+config.AGENT_RPC_PROTOCOL = 'n2n';
+config.AGENT_RPC_PORT = process.env.AGENT_PORT || '9999';
+
 config.RPC_CONNECT_TIMEOUT = 120 * 1000;
 config.RPC_SEND_TIMEOUT = 120 * 1000;
 

--- a/src/agent/backingstore.js
+++ b/src/agent/backingstore.js
@@ -1,0 +1,147 @@
+/* Copyright (C) 2020 NooBaa */
+'use strict';
+
+require('../util/dotenv').load();
+
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+
+const dbg = require('../util/debug_module')(__filename);
+dbg.set_process_name('backingstore');
+
+const system_store = require('../server/system_services/system_store');
+system_store.get_instance({ standalone: true });
+
+const Agent = require('./agent');
+const fs_utils = require('../util/fs_utils');
+const db_client = require('../util/db_client');
+const nb_native = require('../util/nb_native');
+const json_utils = require('../util/json_utils');
+const auth_server = require('../server/common_services/auth_server');
+
+const HELP = `
+Help:
+
+    "backingstore" is a noobaa-core command runs a local backingstore agent
+    For more information refer to the noobaa docs.
+`;
+
+const USAGE = `
+Usage:
+
+    node src/agent/backingstore <storage-path> [options...]
+`;
+
+const ARGUMENTS = `
+Arguments:
+
+    <storage-path>      Storage dir to use (e.g "data-dir/bucket-name")
+`;
+
+const OPTIONS = `
+Options:
+
+    --port <port>       (required!)                      Listening port for backingstore incoming requests
+    --address <url>     (default wss://localhost:5443)   The address of the base core server
+    --debug <level>     (default 0)                      Increase debug level
+`;
+
+const WARNINGS = `
+WARNING:
+
+    !!! This feature is WORK IN PROGRESS and can change without notice !!!
+`;
+
+function print_usage() {
+    console.warn(HELP);
+    console.warn(USAGE.trimStart());
+    console.warn(ARGUMENTS.trimStart());
+    console.warn(OPTIONS.trimStart());
+    console.warn(WARNINGS.trimStart());
+    process.exit(1);
+}
+
+async function main(argv = minimist(process.argv.slice(2))) {
+    try {
+        if (argv.help || argv.h) return print_usage();
+        if (argv.debug) {
+            const debug_level = Number(argv.debug) || 0;
+            dbg.set_module_level(debug_level, 'core');
+            nb_native().fs.set_debug_level(debug_level);
+        }
+        const port = String(argv.port || '');
+        const address = argv.address || 'wss://localhost:5443';
+        const storage_path = argv._[0];
+
+        if (!port) print_usage();
+        if (!storage_path) print_usage();
+
+        console.warn(WARNINGS);
+        console.log('backingstore: setting up ...', argv);
+
+        if (!fs.existsSync(storage_path)) {
+            console.error(`storage directory not found: ${storage_path}`);
+            print_usage();
+        }
+
+        await run_backingstore(storage_path, address, port);
+
+    } catch (err) {
+        console.error('backingstore: exit on error', err.stack || err);
+        process.exit(2);
+    }
+}
+
+async function run_backingstore(storage_path, address, port) {
+
+    await db_client.instance().connect();
+    await system_store.get_instance().load();
+    const get_system = () => system_store.get_instance().data.systems[0];
+
+    const conf_path = path.join(storage_path, 'agent_conf.json');
+    const token_path = path.join(storage_path, 'token');
+    const agent_conf = new json_utils.JsonFileWrapper(conf_path);
+
+    if (!fs.existsSync(token_path)) {
+        const system = get_system();
+        await fs_utils.replace_file(
+            token_path,
+            auth_server.make_auth_token({
+                system_id: String(system._id),
+                account_id: system.owner._id,
+                role: 'create_node',
+            })
+        );
+    }
+
+    const token_wrapper = {
+        read: () => fs.promises.readFile(token_path),
+        write: token => fs_utils.replace_file(token_path, token),
+    };
+    const create_node_token_wrapper = {
+        read: () => agent_conf.read().then(conf => conf.create_node_token),
+        write: new_token => agent_conf.update({ create_node_token: new_token }),
+    };
+
+    const agent = new Agent({
+        address,
+        rpc_port: port,
+        node_name: storage_path,
+        host_id: storage_path,
+        location_info: {
+            host_id: storage_path,
+        },
+        storage_path,
+        storage_limit: undefined,
+        agent_conf,
+        token_wrapper,
+        create_node_token_wrapper,
+    });
+
+    await agent.start();
+}
+
+exports.main = main;
+
+if (require.main === module) main();

--- a/src/api/agent_api.js
+++ b/src/api/agent_api.js
@@ -57,6 +57,9 @@ module.exports = {
                     base_address: {
                         type: 'string'
                     },
+                    rpc_port: {
+                        type: 'string'
+                    },
                     rpc_address: {
                         type: 'string'
                     },

--- a/src/rpc/ice.js
+++ b/src/rpc/ice.js
@@ -629,8 +629,14 @@ Ice.prototype._connect_tcp_active_passive_pair = function(session) {
         }
         session.tcp = net.connect(session.remote.port, session.remote.address);
         session.tcp.on('error', function(err) {
-            dbg.log0('Got error', err);
+            dbg.log0('Got error', err.message);
             session.tcp.destroy();
+            if (err.code === 'EHOSTUNREACH') {
+                // no reason to believe that retries will help to find a route to an address,
+                // so better just stop immediately with this candidate
+                session.close(new Error('ICE TCP AP EHOSTUNREACH'));
+                return;
+            }
             setTimeout(try_ap, delay);
             attempts += 1;
         });
@@ -677,8 +683,14 @@ Ice.prototype._connect_tcp_simultaneous_open_pair = function(session) {
         }
         session.tcp = net.connect(so_connect_conf);
         session.tcp.on('error', function(err) {
-            dbg.log0('Got error', err);
+            dbg.log0('Got error', err.message);
             session.tcp.destroy();
+            if (err.code === 'EHOSTUNREACH') {
+                // no reason to believe that retries will help to find a route to an address,
+                // so better just stop immediately with this candidate
+                session.close(new Error('ICE TCP AP EHOSTUNREACH'));
+                return;
+            }
             setTimeout(try_so, delay);
             attempts += 1;
             if (delay > 10) {

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -874,9 +874,15 @@ class RPC extends EventEmitter {
      */
     async register_tcp_transport(port, tls_options) {
         dbg.log0('RPC register_tcp_transport');
+        const tcp_server = this.create_tcp_server(port, tls_options);
+        await tcp_server.listen(port);
+        return tcp_server;
+    }
+
+    create_tcp_server(port, tls_options) {
+        dbg.log0('RPC create_tcp_server');
         const tcp_server = new RpcTcpServer(tls_options);
         tcp_server.on('connection', conn => this._accept_new_connection(conn));
-        await tcp_server.listen(port);
         return tcp_server;
     }
 

--- a/src/rpc/rpc_n2n_agent.js
+++ b/src/rpc/rpc_n2n_agent.js
@@ -16,6 +16,7 @@ const nb_native = require('../util/nb_native');
 const EventEmitter = require('events').EventEmitter;
 const RpcN2NConnection = require('./rpc_n2n');
 
+const N2N_STAR = 'n2n://*';
 const N2N_CONFIG_PORT_PICK = ['min', 'max', 'port'];
 const N2N_CONFIG_FIELDS_PICK = [
     'offer_ipv4',
@@ -134,7 +135,7 @@ class RpcN2NAgent extends EventEmitter {
     }
 
     set_any_rpc_address() {
-        this.set_rpc_address('*');
+        this.set_rpc_address(N2N_STAR);
     }
 
     set_ssl_context(secure_context_params) {
@@ -196,11 +197,11 @@ class RpcN2NAgent extends EventEmitter {
         dbg.log1('N2N AGENT accept_signal:', params, 'my rpc_address', this.rpc_address);
 
         // target address is me, source is you.
-        // the special case if rpc_address='*' allows testing code to accept for any target
+        // the special case if rpc_address='n2n://*' allows testing code to accept for any target
         let source = url_utils.quick_parse(params.source);
         let target = url_utils.quick_parse(params.target);
         if (!this.rpc_address || !target ||
-            (this.rpc_address !== '*' && this.rpc_address !== target.href)) {
+            (this.rpc_address !== N2N_STAR && this.rpc_address !== target.href)) {
             throw new Error('N2N MISMATCHING PEER ID ' + params.target +
                 ' my rpc_address ' + this.rpc_address);
         }

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -214,6 +214,7 @@ class NodesMonitor extends EventEmitter {
         this._started = true;
         this.n2n_rpc.set_disconnected_state(false);
         await this._load_from_store();
+        await system_store.refresh();
 
         // initialize nodes stats in prometheus
         if (config.PROMETHEUS_ENABLED && system_store.data.systems[0]) {
@@ -1308,10 +1309,11 @@ class NodesMonitor extends EventEmitter {
 
         try {
             const system = system_store.data.get_by_id(item.node.system);
-            const rpc_proto = process.env.AGENTS_PROTOCOL || 'n2n';
+            const rpc_proto = config.AGENT_RPC_PROTOCOL;
+            const rpc_port = item.agent_info.rpc_port || config.AGENT_RPC_PORT;
             const rpc_address = rpc_proto === 'n2n' ?
-                'n2n://' + item.node.peer_id :
-                rpc_proto + '://' + item.node.ip + ':' + (process.env.AGENT_PORT || 9999);
+                `n2n://${item.node.peer_id}` :
+                `${rpc_proto}://${item.node.ip}:${rpc_port}`;
             const rpc_config = {};
             if (rpc_address !== item.agent_info.rpc_address) {
                 rpc_config.rpc_address = rpc_address;
@@ -1467,14 +1469,14 @@ class NodesMonitor extends EventEmitter {
     }
 
 
-    _test_network_to_server(item) {
+    async _test_network_to_server(item) {
         if (!item.connection) return;
         if (!item.node.rpc_address) return;
 
-        const start = Date.now();
-
-        dbg.log1('_test_network_to_server::', item.node.name);
-        return P.timeout(AGENT_TEST_CONNECTION_TIMEOUT,
+        try {
+            const start = Date.now();
+            dbg.log1('_test_network_to_server::', item.node.name);
+            const req = await P.timeout(AGENT_TEST_CONNECTION_TIMEOUT,
                 this.n2n_client.agent.test_network_perf({
                     source: this.n2n_agent.rpc_address,
                     target: item.node.rpc_address,
@@ -1483,27 +1485,26 @@ class NodesMonitor extends EventEmitter {
                     address: item.node.rpc_address,
                     return_rpc_req: true // we want to check req.connection
                 })
-            )
-            .then(req => {
-                var took = Date.now() - start;
-                this._set_need_update.add(item);
-                item.node.latency_to_server = js_utils.array_push_keep_latest(
-                    item.node.latency_to_server, [took], MAX_NUM_LATENCIES);
-                dbg.log1('_test_network_to_server:: Succeeded in sending n2n rpc to ',
-                    item.node.name, 'took', took);
-                req.connection.close();
+            );
 
-                if (item.gateway_errors &&
-                    Date.now() - item.gateway_errors > config.NODE_IO_DETENTION_THRESHOLD) {
-                    item.gateway_errors = 0;
-                }
-            })
-            .catch(err => {
-                if (!item.gateway_errors) {
-                    dbg.error('_test_network_to_server:: node has gateway_errors', item.node.name, err);
-                    item.gateway_errors = Date.now();
-                }
-            });
+            const took = Date.now() - start;
+            this._set_need_update.add(item);
+            item.node.latency_to_server = js_utils.array_push_keep_latest(
+                item.node.latency_to_server, [took], MAX_NUM_LATENCIES);
+            dbg.log1('_test_network_to_server:: Succeeded in sending n2n rpc to ',
+                item.node.name, 'took', took);
+            req.connection.close();
+
+            if (item.gateway_errors &&
+                Date.now() - item.gateway_errors > config.NODE_IO_DETENTION_THRESHOLD) {
+                item.gateway_errors = 0;
+            }
+        } catch (err) {
+            if (!item.gateway_errors) {
+                dbg.error('_test_network_to_server:: node has gateway_errors', item.node.name, err);
+                item.gateway_errors = Date.now();
+            }
+        }
     }
 
 

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const _ = require('lodash');
+const os = require('os');
 const url = require('url');
 const net = require('net');
 const dns = require('dns');
@@ -121,7 +122,20 @@ function is_ip(address) {
     return ip_module.isV4Format(address) || ip_module.isV6Format(address);
 }
 
-
+function find_ifc_containing_address(address) {
+    const family =
+        (ip_module.isV4Format(address) && 'IPv4') ||
+        (ip_module.isV6Format(address) && 'IPv6') ||
+        '';
+    if (!family) return;
+    for (const [ifc, arr] of Object.entries(os.networkInterfaces())) {
+        for (const info of arr) {
+            if (info.family === family && ip_module.cidrSubnet(info.cidr).contains(address)) {
+                return { ifc, info };
+            }
+        }
+    }
+}
 
 exports.ping = ping;
 exports.dns_resolve = dns_resolve;
@@ -132,3 +146,4 @@ exports.is_localhost = is_localhost;
 exports.unwrap_ipv6 = unwrap_ipv6;
 exports.ip_to_long = ip_to_long;
 exports.retrieve_public_ip = retrieve_public_ip;
+exports.find_ifc_containing_address = find_ifc_containing_address;


### PR DESCRIPTION
### Explain the changes
1. add a standalone backingstore program.
2. specify a port and a path on command line args for each backingstore.
3. choose the agent ip based on the server address for easy cluster networks.
4. allow agent request auth when protocol is not only n2n to support direct tcp connect.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. NA
