### PR TITLE
Handle invalid Azure object metadata keys

### DIFF
--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -49,7 +49,8 @@ async function put_object(req, res) {
         tagging,
         tagging_copy: s3_utils.is_copy_tagging_directive(req),
         encryption,
-        lock_settings
+        lock_settings,
+        azure_invalid_md_header: req.headers['azure-metadata-handling'] || undefined
     });
 
     if (reply.version_id && reply.version_id !== 'null') {

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -525,6 +525,11 @@ function check_headers(req, options) {
         throw new options.ErrorClass(options.error_bad_request);
     }
 
+    if (req.headers['azure-metadata-handling'] && !_.includes(['ExcludeIfInvalid', 'FailIfInvalid', 'RenameIfInvalid'], req.headers['azure-metadata-handling'])) {
+        throw new options.ErrorClass(options.error_bad_request);
+    }
+
+
     if (req.method === 'POST' || req.method === 'PUT') parse_content_length(req, options);
 
     const content_md5_b64 = req.headers['content-md5'];


### PR DESCRIPTION
### Explain the changes
1. The new code should adhere to [azcopy's method](https://github.com/Azure/azure-storage-azcopy/blob/108dbddd5adba1ea133ad5ab391c122bd71bf731/common/fe-ste-models.go#L1235-L1244) of resolving invalid object metadata keys in Azure

The key of the newly added header is `azure-metadata-handling`, and its possible values are:
- `RenameIfInvalid` - which will rename the key in order to preserve it (which is the default behavior if the header is not supplied)
- `ExcludeIfInvalid` - which will exclude the invalid tag
- `FailIfInvalid` - which will fail the upload

We support the same naming and recovery methodologies as Microsoft, meaning we won't be able to discern between tags whose renamed form cannot be restored (e.g. -  `!@#` and `#$%` on the same object)

### Issues: Fixed #xxx / Gap #xxx
1. Fixes object IO when the object contains metadata keys that are invalid by Azure's standard

### Testing Instructions:
1. Upload an object with metadata keys containing non-alphanumeric characters (e.g. `!@#-`) to a bucket backed by an Azure namespacestore
2. Download the object from the bucket
3. Verify that the tags are the same as they were originally 
Bonus step:
4. After 1, download the object directly from Azure, and verify that it now contains two new metadata keys related to the invalid one, starting with `rename_` and `rename_key_`

