### PR TITLE
Optimize NooBaa deletion paths

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1160,6 +1160,30 @@ module.exports = {
             },
             auth: { system: 'admin' }
         },
+
+        delete_multiple_objects_unordered: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['bucket'],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    limit: {
+                        type: 'integer'
+                    }
+                }
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    is_empty: {
+                        type: 'boolean'
+                    }
+                }
+            },
+            auth: { system: 'admin' }
+        },
+
         put_object_legal_hold: {
             method: 'PUT',
             params: {

--- a/src/server/bg_services/buckets_reclaimer.js
+++ b/src/server/bg_services/buckets_reclaimer.js
@@ -32,9 +32,8 @@ class BucketsReclaimer {
         await P.all(deleting_buckets.map(async bucket => {
             try {
                 dbg.log0(`emptying bucket ${bucket.name}. deleting next ${config.BUCKET_RECLAIMER_BATCH_SIZE} objects`);
-                const { is_empty } = await this.client.object.delete_multiple_objects_by_filter({
+                const { is_empty } = await this.client.object.delete_multiple_objects_unordered({
                     bucket: bucket.name,
-                    prefix: "",
                     limit: config.BUCKET_RECLAIMER_BATCH_SIZE
                 }, {
                     auth_token: auth_server.make_auth_token({

--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -51,7 +51,7 @@ async function background_worker() {
 }
 
 async function clean_md_store(last_date_to_remove) {
-    const total_objects_count = await MDStore.instance().count_total_objects();
+    const total_objects_count = await MDStore.instance().estimated_total_objects();
     if (total_objects_count < config.DB_CLEANER.MAX_TOTAL_DOCS) {
         dbg.log0(`DB_CLEANER: found less than ${config.DB_CLEANER.MAX_TOTAL_DOCS} objects in MD-STORE 
         ${total_objects_count} objects - Skipping...`);

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -71,7 +71,7 @@ async function background_worker() {
         dbg.log0('LIFECYCLE READ BUCKETS configuration buckets:', system_store.data.buckets.map(e => e.name));
         for (const bucket of system_store.data.buckets) {
             dbg.log0('LIFECYCLE READ BUCKETS configuration bucket name:', bucket.name, "rules", bucket.lifecycle_configuration_rules);
-            if (!bucket.lifecycle_configuration_rules || bucket.deleting) return;
+            if (!bucket.lifecycle_configuration_rules || bucket.deleting) continue;
 
             await P.all(_.map(bucket.lifecycle_configuration_rules,
                 async (lifecycle_rule, j) => {

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -245,6 +245,24 @@ class MDStore {
         db_client.instance().check_update_one(res, 'object');
     }
 
+    async remove_objects_and_unset_latest(objs) {
+        if (!objs || !objs.length) return;
+
+        await this._objects.updateMany(
+            {
+                _id: {
+                    $in: objs.map(obj => obj._id),
+                }
+            },
+            {
+                $set: {
+                    deleted: new Date(),
+                    version_past: true,
+                },
+            }
+        );
+    }
+
     // 2, 3, 4
     async remove_object_move_latest(old_latest_obj, new_latest_obj) {
         const bulk = this._objects.initializeOrderedBulkOp();
@@ -849,7 +867,10 @@ class MDStore {
 
     async find_deleted_objects(max_delete_time, limit) {
         const objects = await this._objects.find({
-            deleted: { $lt: new Date(max_delete_time) },
+            deleted: {
+                $lt: new Date(max_delete_time),
+                $exists: true // This forces the index to be used
+            },
         }, {
             limit: Math.min(limit, 1000),
             projection: {
@@ -1736,7 +1757,8 @@ class MDStore {
     find_deleted_blocks(max_delete_time, limit) {
         const query = {
             deleted: {
-                $lt: new Date(max_delete_time)
+                $lt: new Date(max_delete_time),
+                $exists: true // Force index usage
             },
         };
         return this._blocks.find(query, {
@@ -1762,6 +1784,10 @@ class MDStore {
 
     count_total_objects() {
         return this._objects.countDocuments({}); // maybe estimatedDocumentCount()
+    }
+
+    estimated_total_objects() {
+        return this._objects.estimatedDocumentCount();
     }
 }
 

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -14,7 +14,7 @@ const glob_to_regexp = require('glob-to-regexp');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
-const { MDStore } = require('./md_store');
+const { MDStore, make_md_id } = require('./md_store');
 const LRUCache = require('../../util/lru_cache');
 const size_utils = require('../../util/size_utils');
 const time_utils = require('../../util/time_utils');
@@ -979,6 +979,39 @@ async function delete_multiple_objects_by_filter(req) {
             }))
         }
     }));
+    const bucket_has_objects = await MDStore.instance().has_any_objects_for_bucket(bucket_id);
+    return { is_empty: !bucket_has_objects };
+}
+
+/**
+ * delete_multiple_objects_unordered is an internal function which
+ * takes a number `limit` and a `bucket_id` and will delete the `limit`
+ * objects from the bucket in NO PARTICULAR ORDER.
+ * 
+ * This function is inteded to use in the case of a bucket deletion
+ * where we want to delete all the objects in the bucket but we don't
+ * care about the order in which they are deleted or the versioning, etc.
+ * @param {*} req 
+ */
+async function delete_multiple_objects_unordered(req) {
+    load_bucket(req, { include_deleting: true });
+    const bucket_id = req.bucket._id;
+    const limit = req.rpc_params.limit;
+    dbg.log0(`delete_multiple_objects_unordered: bucket=${req.bucket.name} limit=${limit}`);
+
+    // find the objects - no need to paginate explicitly because
+    // find_objects will ensure that it does not return any object
+    // which is already marked for deletion and that's all we care
+    // about here.
+    const { objects } = await MDStore.instance().find_objects({
+        bucket_id: make_md_id(bucket_id),
+        limit,
+        key: undefined,
+    });
+
+    // delete the objects
+    await MDStore.instance().remove_objects_and_unset_latest(objects);
+
     const bucket_has_objects = await MDStore.instance().has_any_objects_for_bucket(bucket_id);
     return { is_empty: !bucket_has_objects };
 }
@@ -2092,6 +2125,7 @@ exports.update_object_md = update_object_md;
 exports.delete_object = delete_object;
 exports.delete_multiple_objects = delete_multiple_objects;
 exports.delete_multiple_objects_by_filter = delete_multiple_objects_by_filter;
+exports.delete_multiple_objects_unordered = delete_multiple_objects_unordered;
 // listing
 exports.list_objects = list_objects;
 exports.list_uploads = list_uploads;

--- a/src/server/object_services/schemas/object_multipart_indexes.js
+++ b/src/server/object_services/schemas/object_multipart_indexes.js
@@ -1,16 +1,30 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-module.exports = [{
-    fields: {
-        obj: 1,
-        num: 1,
+module.exports = [
+    {
+        fields: {
+            obj: 1,
+            num: 1,
+        },
+        options: {
+            unique: false,
+            partialFilterExpression: {
+                obj: { $exists: true },
+                deleted: null,
+            }
+        }
     },
-    options: {
-        unique: false,
-        partialFilterExpression: {
-            obj: { $exists: true },
-            deleted: null,
+    {
+        fields: {
+            obj: 1,
+        },
+        options: {
+            unique: false,
+            partialFilterExpression: {
+                obj: { $exists: true },
+                deleted: { $exists: true },
+            }
         }
     }
-}];
+];

--- a/src/server/object_services/schemas/object_part_indexes.js
+++ b/src/server/object_services/schemas/object_part_indexes.js
@@ -1,7 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-module.exports = [{
+module.exports = [
+    {
         fields: {
             // this index is used for index prefix for queries on the object without start offset
             obj: 1,
@@ -31,4 +32,18 @@ module.exports = [{
             }
         }
     },
+    {
+        // This index is used for queries where we want to find all the chunks of a specific object
+        // which are already marked deleted.
+        fields: {
+            obj: 1,
+        },
+        options: {
+            unique: false,
+            partialFilterExpression: {
+                obj: { $exists: true },
+                deleted: { $exists: true },
+            }
+        }
+    }
 ];


### PR DESCRIPTION
### Explain the changes
This PR attempts to improve performance NooBaa delete paths by doing the following:
1. Change bucket_reclaimer approach to object deletion - instead of deleting objects 1 by 1, 1k objects are marked deleted at once, this significantly reduces DB calls.
2. Add index for objectparts table which significantly speed up the queries which DB cleaner uses to identify the object parts that needs to be deleted.
3. Add index for objectmultiparts table which significantly speed up the queries which DB cleaner uses to identify the object parts that needs to be deleted.
4. Forces use of indexes by altering selections in DB calls.

#### Analysis
[analysis.md](https://github.com/noobaa/noobaa-core/files/11262724/analysis.md)

### Issues: Fixed #xxx / Gap #xxx
This was a customer issue where they noticed serious NooBaa degradation when a bucket with 3M objects was deleted.

- [ ] Doc added/updated
- [ ] Tests added
