### PR TITLE
Remove `s3_access` As Required From `update_account_s3_access`

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -266,7 +266,7 @@ module.exports = {
             method: 'PUT',
             params: {
                 type: 'object',
-                required: ['email', 's3_access'],
+                required: ['email'],
                 properties: {
                     email: { $ref: 'common_api#/definitions/email' },
                     s3_access: {


### PR DESCRIPTION
### Explain the changes
1. Remove `s3_access` as required from `update_account_s3_access`. The use of `s3_access` was historical: before the UI was deprecated we had two types of accounts: 
(1) account access S3
(2) account UI - account UI was for using the UI and it didn't have `s3_access`.
Today all accounts have `s3_access`.

### Issues: Fixed #7204 
1. In the opened issue this is a fix to the [comment](https://github.com/noobaa/noobaa-core/issues/7204#issuecomment-1427477227).

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
