### PR TITLE
add bucket authentication for server side encryption algorithm

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -254,7 +254,7 @@ module.exports = {
 
         bucket_policy_principal: {
             anyOf: [{
-                    wrapper: SensitiveString,
+                    wrapper: SensitiveString
                 }, {
                     type: 'object',
                     required: ['AWS'],
@@ -285,6 +285,22 @@ module.exports = {
                 }
               ]
         },
+
+        bucket_policy_string_condition: {
+            type: 'object',
+            additionalProperties: {
+                type: 'string'
+            }
+        },
+
+        bucket_policy_null_condition: {
+            type: 'object',
+            additionalProperties: {
+                enum: ['true', 'false'],
+                type: 'string'
+            }
+        },
+
         bucket_policy: {
             type: 'object',
             required: ['Statement'],
@@ -311,6 +327,32 @@ module.exports = {
                             },
                             Resource: {
                                 $ref: '#/definitions/string_or_string_array'
+                            },
+                            Condition: {
+                                type: 'object',
+                                properties: {
+                                    StringEquals: {
+                                        $ref: '#/definitions/bucket_policy_string_condition'
+                                    },
+                                    StringNotEquals: {
+                                        $ref: '#/definitions/bucket_policy_string_condition'
+                                    },
+                                    StringEqualsIgnoreCase: {
+                                        $ref: '#/definitions/bucket_policy_string_condition'
+                                    },
+                                    StringNotEqualsIgnoreCase: {
+                                        $ref: '#/definitions/bucket_policy_string_condition'
+                                    },
+                                    StringLike: {
+                                        $ref: '#/definitions/bucket_policy_string_condition'
+                                    },
+                                    StringNotLike: {
+                                        $ref: '#/definitions/bucket_policy_string_condition'
+                                    },
+                                    Null: {
+                                        $ref: '#/definitions/bucket_policy_null_condition'
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/endpoint/s3/s3_bucket_policy_utils.js
+++ b/src/endpoint/s3/s3_bucket_policy_utils.js
@@ -1,0 +1,219 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+const dbg = require('../../util/debug_module')(__filename);
+const s3_utils = require('./s3_utils');
+
+const OP_NAME_TO_ACTION = Object.freeze({
+    delete_bucket_analytics: { regular: "s3:PutAnalyticsConfiguration" },
+    delete_bucket_cors: { regular: "s3:PutBucketCORS" },
+    delete_bucket_encryption: { regular: "s3:PutEncryptionConfiguration" },
+    delete_bucket_inventory: { regular: "s3:PutInventoryConfiguration" },
+    delete_bucket_lifecycle: { regular: "s3:PutLifecycleConfiguration" },
+    delete_bucket_metrics: { regular: "s3:PutMetricsConfiguration" },
+    delete_bucket_policy: { regular: "s3:DeleteBucketPolicy" },
+    delete_bucket_replication: { regular: "s3:PutReplicationConfiguration" },
+    delete_bucket_tagging: { regular: "s3:PutBucketTagging" },
+    delete_bucket_website: { regular: "s3:DeleteBucketWebsite" },
+    delete_bucket: { regular: "s3:DeleteBucket" },
+    delete_object_tagging: { regular: "s3:DeleteObjectTagging", versioned: "s3:DeleteObjectVersionTagging" },
+    delete_object_uploadId: { regular: "s3:AbortMultipartUpload" },
+    delete_object: { regular: "s3:DeleteObject", versioned: "s3:DeleteObjectVersion" },
+
+    get_bucket_accelerate: { regular: "s3:GetAccelerateConfiguration" },
+    get_bucket_acl: { regular: "s3:GetBucketAcl" },
+    get_bucket_analytics: { regular: "s3:GetAnalyticsConfiguration" },
+    get_bucket_cors: { regular: "s3:GetBucketCORS" },
+    get_bucket_encryption: { regular: "s3:GetEncryptionConfiguration" },
+    get_bucket_inventory: { regular: "s3:GetInventoryConfiguration" },
+    get_bucket_lifecycle: { regular: "s3:GetLifecycleConfiguration" },
+    get_bucket_location: { regular: "s3:GetBucketLocation" },
+    get_bucket_logging: { regular: "s3:GetBucketLogging" },
+    get_bucket_metrics: { regular: "s3:GetMetricsConfiguration" },
+    get_bucket_notification: { regular: "s3:GetBucketNotification" },
+    get_bucket_policy: { regular: "s3:GetBucketPolicy" },
+    get_bucket_policy_status: { regular: "s3:GetBucketPolicyStatus" },
+    get_bucket_replication: { regular: "s3:GetReplicationConfiguration" },
+    get_bucket_requestpayment: { regular: "s3:GetBucketRequestPayment" },
+    get_bucket_tagging: { regular: "s3:GetBucketTagging" },
+    get_bucket_uploads: { regular: "s3:ListBucketMultipartUploads" },
+    get_bucket_versioning: { regular: "s3:GetBucketVersioning" },
+    get_bucket_versions: { regular: "s3:ListBucketVersions" },
+    get_bucket_website: { regular: "s3:GetBucketWebsite" },
+    get_bucket_object_lock: { regular: "s3:GetBucketObjectLockConfiguration" },
+    get_bucket: { regular: "s3:ListBucket" },
+    get_object_acl: { regular: "s3:GetObjectAcl" },
+    get_object_tagging: { regular: "s3:GetObjectTagging", versioned: "s3:GetObjectVersionTagging" },
+    get_object_uploadId: { regular: "s3:ListMultipartUploadParts" },
+    get_object_retention: { regular: "s3:GetObjectRetention"},
+    get_object_legal_hold: { regular: "s3:GetObjectLegalHold" },
+    get_object: { regular: "s3:GetObject", versioned: "s3:GetObjectVersion" },
+    get_service: { regular: "s3:ListAllMyBuckets" },
+
+    head_bucket: { regular: "s3:ListBucket" },
+    head_object: { regular: "s3:GetObject", versioned: "s3:GetObjectVersion" },
+
+    post_bucket_delete: { regular: "s3:DeleteObject" },
+    post_object: { regular: "s3:PutObject" },
+    post_object_uploadId: { regular: "s3:PutObject" },
+    post_object_uploads: { regular: "s3:PutObject" },
+    post_object_select: { regular: "s3:GetObject" },
+
+    put_bucket_accelerate: { regular: "s3:PutAccelerateConfiguration" },
+    put_bucket_acl: { regular: "s3:PutBucketAcl" },
+    put_bucket_analytics: { regular: "s3:PutAnalyticsConfiguration" },
+    put_bucket_cors: { regular: "s3:PutBucketCORS" },
+    put_bucket_encryption: { regular: "s3:PutEncryptionConfiguration" },
+    put_bucket_inventory: { regular: "s3:PutInventoryConfiguration" },
+    put_bucket_lifecycle: { regular: "s3:PutLifecycleConfiguration" },
+    put_bucket_logging: { regular: "s3:PutBucketLogging" },
+    put_bucket_metrics: { regular: "s3:PutMetricsConfiguration" },
+    put_bucket_notification: { regular: "s3:PutBucketNotification" },
+    put_bucket_policy: { regular: "s3:PutBucketPolicy" },
+    put_bucket_replication: { regular: "s3:PutReplicationConfiguration" },
+    put_bucket_requestpayment: { regular: "s3:PutBucketRequestPayment" },
+    put_bucket_tagging: { regular: "s3:PutBucketTagging" },
+    put_bucket_versioning: { regular: "s3:PutBucketVersioning" },
+    put_bucket_website: { regular: "s3:PutBucketWebsite" },
+    put_bucket_object_lock: { regular: "s3:PutBucketObjectLockConfiguration" },
+    put_bucket: { regular: "s3:CreateBucket" },
+    put_object_acl: { regular: "s3:PutObjectAcl" },
+    put_object_tagging: { regular: "s3:PutObjectTagging", versioned: "s3:PutObjectVersionTagging" },
+    put_object_uploadId: { regular: "s3:PutObject" },
+    put_object_retention: { regular: "s3:PutObjectRetention" },
+    put_object_legal_hold: { regular: "s3:GetObjectLegalHold"},
+    put_object: { regular: "s3:PutObject" },
+});
+
+const qm_regex = /\?/g;
+const ar_regex = /\*/g;
+
+const predicate_map = {
+    'StringEquals': (request_value, policy_value) => request_value === policy_value,
+    'StringNotEquals': (request_value, policy_value) => request_value !== policy_value,
+    'StringEqualsIgnoreCase': (request_value, policy_value) => request_value.toLowerCase() === policy_value.toLowerCase(),
+    'StringNotEqualsIgnoreCase': (request_value, policy_value) => request_value.toLowerCase() !== policy_value.toLowerCase(),
+    'StringLike': function(request_value, policy_value) {
+        const value_regex = RegExp(`^${policy_value.replace(qm_regex, '.?').replace(ar_regex, '.*')}$`);
+        return value_regex.test(request_value);
+    },
+    'StringNotLike': function(request_value, policy_value) {
+        const value_regex = RegExp(`^${policy_value.replace(qm_regex, '.?').replace(ar_regex, '.*')}$`);
+        return !value_regex.test(request_value);
+    },
+    'Null': function(request_value, policy_value) { return policy_value === 'true' ? request_value === null : request_value !== null; },
+};
+
+const condition_fit_functions = {
+    's3:ExistingObjectTag': _is_object_tag_fit,
+    's3:x-amz-server-side-encryption': _is_server_side_encryption_fit
+};
+
+const supported_actions = {
+    's3:ExistingObjectTag': ['s3:DeleteObjectTagging', 's3:DeleteObjectVersionTagging', 's3:GetObject', 's3:GetObjectAcl', 's3:GetObjectTagging', 's3:GetObjectVersion', 's3:GetObjectVersionTagging', 's3:PutObjectAcl', 's3:PutObjectTagging', 's3:PutObjectVersionTagging'],
+    's3:x-amz-server-side-encryption': ['s3:PutObject']
+};
+
+async function _is_server_side_encryption_fit(req, predicate, value) {
+    const encryption = s3_utils.parse_encryption(req);
+    const algorithm = encryption ? encryption.algorithm : null;
+    const res = predicate(algorithm, value);
+    dbg.log1('bucket_policy: encrytpion fit?', value, algorithm, res);
+    return res;
+}
+
+async function _is_object_tag_fit(req, predicate, value) {
+    const reply = await req.object_sdk.get_object_tagging(req.params);
+    const tag = reply?.tagging?.find(element => (element.key === value.key));
+    const tag_value = tag ? tag.value : null;
+    const res = predicate(tag_value, value.value);
+    dbg.log1('bucket_policy: object tag fit?', value, tag, res);
+    return res;
+}
+
+async function has_bucket_policy_permission(policy, account, method, arn_path, req) {
+    const [allow_statements, deny_statements] = _.partition(policy.Statement, statement => statement.Effect === 'Allow');
+
+    // look for explicit denies
+    if (await _is_statements_fit(deny_statements, account, method, arn_path, req)) return 'DENY';
+
+    // look for explicit allows
+    if (await _is_statements_fit(allow_statements, account, method, arn_path, req)) return 'ALLOW';
+
+    // implicit deny
+    return 'IMPLICIT_DENY';
+}
+
+async function _is_statements_fit(statements, account, method, arn_path, req) {
+    for (const statement of statements) {
+        let action_fit = false;
+        let principal_fit = false;
+        let resource_fit = false;
+        let condition_fit = true;
+        for (const action of _.flatten([statement.Action])) {
+            dbg.log1('bucket_policy: action fit?', action, method);
+            if ((action === '*') || (action === 's3:*') || (action === method)) {
+                action_fit = true;
+            }
+        }
+        const statement_principal = statement.Principal.AWS ? statement.Principal.AWS : statement.Principal;
+        for (const principal of _.flatten([statement_principal])) {
+            dbg.log1('bucket_policy: principal fit?', principal, account);
+            if ((principal.unwrap() === '*') || (principal.unwrap() === account)) {
+                principal_fit = true;
+            }
+        }
+        for (const resource of _.flatten([statement.Resource])) {
+            const resource_regex = RegExp(`^${resource.replace(qm_regex, '.?').replace(ar_regex, '.*')}$`);
+            dbg.log1('bucket_policy: resource fit?', resource_regex, arn_path);
+            if (resource_regex.test(arn_path)) {
+                resource_fit = true;
+            }
+        }
+        condition_fit = await _is_condition_fit(statement, req, method);
+
+        dbg.log1('bucket_policy: is_statements_fit', action_fit, principal_fit, resource_fit, condition_fit);
+        if (action_fit && principal_fit && resource_fit && condition_fit) return true;
+    }
+    return false;
+}
+
+async function _is_condition_fit(policy_statement, req, method) {
+    if (!policy_statement.Condition || !req) {
+        return true;
+    }
+    _parse_condition_keys(policy_statement.Condition);
+    for (const [condition, condition_statements] of Object.entries(policy_statement.Condition)) {
+        const predicate = predicate_map[condition];
+        for (const [condition_key, value] of Object.entries(condition_statements)) {
+            if (!supported_actions[condition_key].includes(method)) {
+                continue;
+            }
+            if (await condition_fit_functions[condition_key](req, predicate, value) === false) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+function _parse_condition_keys(condition_statement) {
+    // condition key might include two parts: the condition itself and the key it uses.
+    // for example s3:ExistingObjectTag/<key>: ExistingObjectTag is the condition, and <key> 
+    // is the tag key it refers
+    for (const condition of Object.values(condition_statement)) {
+        for (const [condition_key, value] of Object.entries(condition)) {
+            const key_parts = condition_key.split("/");
+            if (key_parts[1]) {
+                condition[key_parts[0]] = {key: key_parts[1], value: value};
+                delete condition[condition_key];
+            }
+        }
+    }
+}
+
+
+exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;
+exports.SUPPORTED_BUCKET_POLICY_CONDITIONS = Object.keys(supported_actions);
+exports.has_bucket_policy_permission = has_bucket_policy_permission;

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -7,7 +7,7 @@ const net = require('net');
 const dbg = require('../../util/debug_module')(__filename);
 const s3_ops = require('./ops');
 const S3Error = require('./s3_errors').S3Error;
-const s3_utils = require('./s3_utils');
+const s3_bucket_policy_utils = require('./s3_bucket_policy_utils');
 const time_utils = require('../../util/time_utils');
 const http_utils = require('../../util/http_utils');
 const signature_utils = require('../../util/signature_utils');
@@ -213,7 +213,7 @@ async function authorize_request_policy(req) {
 
     const is_anon = !(auth_token && auth_token.access_key);
     if (is_anon) {
-        authorize_anonymous_access(s3_policy, method, arn_path);
+        authorize_anonymous_access(s3_policy, method, arn_path, req);
         return;
     }
 
@@ -234,24 +234,26 @@ async function authorize_request_policy(req) {
         throw new S3Error(S3Error.AccessDenied);
     }
 
-    const permission = s3_utils.has_bucket_policy_permission(s3_policy, account.email.unwrap(), method, arn_path);
+    const permission = await s3_bucket_policy_utils.has_bucket_policy_permission(
+        s3_policy, account.email.unwrap(), method, arn_path, req);
     if (permission === "DENY") throw new S3Error(S3Error.AccessDenied);
     if (permission === "ALLOW" || is_owner) return;
 
     throw new S3Error(S3Error.AccessDenied);
 }
 
-function authorize_anonymous_access(s3_policy, method, arn_path) {
+async function authorize_anonymous_access(s3_policy, method, arn_path, req) {
     if (!s3_policy) throw new S3Error(S3Error.AccessDenied);
 
-    const permission = s3_utils.has_bucket_policy_permission(s3_policy, undefined, method, arn_path);
+    const permission = await s3_bucket_policy_utils.has_bucket_policy_permission(
+        s3_policy, undefined, method, arn_path, req);
     if (permission === "ALLOW") return;
 
     throw new S3Error(S3Error.AccessDenied);
 }
 
 function _get_method_from_req(req) {
-    const s3_op = s3_utils.OP_NAME_TO_ACTION[req.op_name];
+    const s3_op = s3_bucket_policy_utils.OP_NAME_TO_ACTION[req.op_name];
     if (!s3_op) {
         dbg.error(`Got a not supported S3 op ${req.op_name} - doesn't suppose to happen`);
         throw new S3Error(S3Error.InternalError);

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -36,87 +36,6 @@ const DEFAULT_OBJECT_ACL = Object.freeze({
 const XATTR_SORT_SYMBOL = Symbol('XATTR_SORT_SYMBOL');
 const base64_regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
-const OP_NAME_TO_ACTION = Object.freeze({
-    delete_bucket_analytics: { regular: "s3:PutAnalyticsConfiguration" },
-    delete_bucket_cors: { regular: "s3:PutBucketCORS" },
-    delete_bucket_encryption: { regular: "s3:PutEncryptionConfiguration" },
-    delete_bucket_inventory: { regular: "s3:PutInventoryConfiguration" },
-    delete_bucket_lifecycle: { regular: "s3:PutLifecycleConfiguration" },
-    delete_bucket_metrics: { regular: "s3:PutMetricsConfiguration" },
-    delete_bucket_policy: { regular: "s3:DeleteBucketPolicy" },
-    delete_bucket_replication: { regular: "s3:PutReplicationConfiguration" },
-    delete_bucket_tagging: { regular: "s3:PutBucketTagging" },
-    delete_bucket_website: { regular: "s3:DeleteBucketWebsite" },
-    delete_bucket: { regular: "s3:DeleteBucket" },
-    delete_object_tagging: { regular: "s3:DeleteObjectTagging", versioned: "s3:DeleteObjectVersionTagging" },
-    delete_object_uploadId: { regular: "s3:AbortMultipartUpload" },
-    delete_object: { regular: "s3:DeleteObject", versioned: "s3:DeleteObjectVersion" },
-
-    get_bucket_accelerate: { regular: "s3:GetAccelerateConfiguration" },
-    get_bucket_acl: { regular: "s3:GetBucketAcl" },
-    get_bucket_analytics: { regular: "s3:GetAnalyticsConfiguration" },
-    get_bucket_cors: { regular: "s3:GetBucketCORS" },
-    get_bucket_encryption: { regular: "s3:GetEncryptionConfiguration" },
-    get_bucket_inventory: { regular: "s3:GetInventoryConfiguration" },
-    get_bucket_lifecycle: { regular: "s3:GetLifecycleConfiguration" },
-    get_bucket_location: { regular: "s3:GetBucketLocation" },
-    get_bucket_logging: { regular: "s3:GetBucketLogging" },
-    get_bucket_metrics: { regular: "s3:GetMetricsConfiguration" },
-    get_bucket_notification: { regular: "s3:GetBucketNotification" },
-    get_bucket_policy: { regular: "s3:GetBucketPolicy" },
-    get_bucket_policy_status: { regular: "s3:GetBucketPolicyStatus" },
-    get_bucket_replication: { regular: "s3:GetReplicationConfiguration" },
-    get_bucket_requestpayment: { regular: "s3:GetBucketRequestPayment" },
-    get_bucket_tagging: { regular: "s3:GetBucketTagging" },
-    get_bucket_uploads: { regular: "s3:ListBucketMultipartUploads" },
-    get_bucket_versioning: { regular: "s3:GetBucketVersioning" },
-    get_bucket_versions: { regular: "s3:ListBucketVersions" },
-    get_bucket_website: { regular: "s3:GetBucketWebsite" },
-    get_bucket_object_lock: { regular: "s3:GetBucketObjectLockConfiguration" },
-    get_bucket: { regular: "s3:ListBucket" },
-    get_object_acl: { regular: "s3:GetObjectAcl" },
-    get_object_tagging: { regular: "s3:GetObjectTagging", versioned: "s3:GetObjectVersionTagging" },
-    get_object_uploadId: { regular: "s3:ListMultipartUploadParts" },
-    get_object_retention: { regular: "s3:GetObjectRetention"},
-    get_object_legal_hold: { regular: "s3:GetObjectLegalHold" },
-    get_object: { regular: "s3:GetObject", versioned: "s3:GetObjectVersion" },
-    get_service: { regular: "s3:ListAllMyBuckets" },
-
-    head_bucket: { regular: "s3:ListBucket" },
-    head_object: { regular: "s3:GetObject", versioned: "s3:GetObjectVersion" },
-
-    post_bucket_delete: { regular: "s3:DeleteObject" },
-    post_object: { regular: "s3:PutObject" },
-    post_object_uploadId: { regular: "s3:PutObject" },
-    post_object_uploads: { regular: "s3:PutObject" },
-    post_object_select: { regular: "s3:GetObject" },
-
-    put_bucket_accelerate: { regular: "s3:PutAccelerateConfiguration" },
-    put_bucket_acl: { regular: "s3:PutBucketAcl" },
-    put_bucket_analytics: { regular: "s3:PutAnalyticsConfiguration" },
-    put_bucket_cors: { regular: "s3:PutBucketCORS" },
-    put_bucket_encryption: { regular: "s3:PutEncryptionConfiguration" },
-    put_bucket_inventory: { regular: "s3:PutInventoryConfiguration" },
-    put_bucket_lifecycle: { regular: "s3:PutLifecycleConfiguration" },
-    put_bucket_logging: { regular: "s3:PutBucketLogging" },
-    put_bucket_metrics: { regular: "s3:PutMetricsConfiguration" },
-    put_bucket_notification: { regular: "s3:PutBucketNotification" },
-    put_bucket_policy: { regular: "s3:PutBucketPolicy" },
-    put_bucket_replication: { regular: "s3:PutReplicationConfiguration" },
-    put_bucket_requestpayment: { regular: "s3:PutBucketRequestPayment" },
-    put_bucket_tagging: { regular: "s3:PutBucketTagging" },
-    put_bucket_versioning: { regular: "s3:PutBucketVersioning" },
-    put_bucket_website: { regular: "s3:PutBucketWebsite" },
-    put_bucket_object_lock: { regular: "s3:PutBucketObjectLockConfiguration" },
-    put_bucket: { regular: "s3:CreateBucket" },
-    put_object_acl: { regular: "s3:PutObjectAcl" },
-    put_object_tagging: { regular: "s3:PutObjectTagging", versioned: "s3:PutObjectVersionTagging" },
-    put_object_uploadId: { regular: "s3:PutObject" },
-    put_object_retention: { regular: "s3:PutObjectRetention" },
-    put_object_legal_hold: { regular: "s3:GetObjectLegalHold"},
-    put_object: { regular: "s3:PutObject" },
-});
-
 function decode_chunked_upload(source_stream) {
     const decoder = new ChunkedContentDecoder();
     // pipeline will back-propagate errors from the decoder to stop streaming from the source,
@@ -651,52 +570,6 @@ function get_http_response_from_resp(res) {
     return r;
 }
 
-function has_bucket_policy_permission(policy, account, method, arn_path) {
-    const [allow_statements, deny_statements] = _.partition(policy.Statement, statement => statement.Effect === 'Allow');
-
-    // look for explicit denies
-    if (_is_statements_fit(deny_statements, account, method, arn_path)) return 'DENY';
-
-    // look for explicit allows
-    if (_is_statements_fit(allow_statements, account, method, arn_path)) return 'ALLOW';
-
-    // implicit deny
-    return 'IMPLICIT_DENY';
-}
-
-const qm_regex = /\?/g;
-const ar_regex = /\*/g;
-function _is_statements_fit(statements, account, method, arn_path) {
-    for (const statement of statements) {
-        let action_fit = false;
-        let principal_fit = false;
-        let resource_fit = false;
-        for (const action of _.flatten([statement.Action])) {
-            dbg.log1('bucket_policy: action fit?', action, method);
-            if ((action === '*') || (action === 's3:*') || (action === method)) {
-                action_fit = true;
-            }
-        }
-        const statement_principal = statement.Principal.AWS || statement.Principal;
-        for (const principal of _.flatten([statement_principal])) {
-            dbg.log1('bucket_policy: principal fit?', principal, account);
-            if ((principal.unwrap() === '*') || (principal.unwrap() === account)) {
-                principal_fit = true;
-            }
-        }
-        for (const resource of _.flatten([statement.Resource])) {
-            const resource_regex = RegExp(`^${resource.replace(qm_regex, '.?').replace(ar_regex, '.*')}$`);
-            dbg.log1('bucket_policy: resource fit?', resource_regex, arn_path);
-            if (resource_regex.test(arn_path)) {
-                resource_fit = true;
-            }
-        }
-        dbg.log1('bucket_policy: is_statements_fit', action_fit, principal_fit, resource_fit);
-        if (action_fit && principal_fit && resource_fit) return true;
-    }
-    return false;
-}
-
 function get_response_field_encoder(req) {
     const encoding_type = req.query['encoding-type'];
     if ((typeof encoding_type === 'undefined') || (encoding_type === null)) return response_field_encoder_none;
@@ -722,7 +595,6 @@ exports.STORAGE_CLASS_GLACIER = STORAGE_CLASS_GLACIER;
 exports.STORAGE_CLASS_GLACIER_IR = STORAGE_CLASS_GLACIER_IR;
 exports.DEFAULT_S3_USER = DEFAULT_S3_USER;
 exports.DEFAULT_OBJECT_ACL = DEFAULT_OBJECT_ACL;
-exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;
 exports.decode_chunked_upload = decode_chunked_upload;
 exports.format_s3_xml_date = format_s3_xml_date;
 exports.get_request_xattr = get_request_xattr;
@@ -748,6 +620,5 @@ exports.parse_to_camel_case = parse_to_camel_case;
 exports._is_valid_retention = _is_valid_retention;
 exports.get_http_response_from_resp = get_http_response_from_resp;
 exports.get_http_response_date = get_http_response_date;
-exports.has_bucket_policy_permission = has_bucket_policy_permission;
 exports.XATTR_SORT_SYMBOL = XATTR_SORT_SYMBOL;
 exports.get_response_field_encoder = get_response_field_encoder;

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -18,7 +18,7 @@ const addr_utils = require('../../util/addr_utils');
 const kube_utils = require('../../util/kube_utils');
 const jwt_utils = require('../../util/jwt_utils');
 const config = require('../../../config');
-const s3_utils = require('../../endpoint/s3/s3_utils');
+const s3_bucket_policy_utils = require('../../endpoint/s3/s3_bucket_policy_utils');
 
 
 /**
@@ -600,7 +600,7 @@ function _prepare_auth_request(req) {
         return has_bucket_anonymous_permission(bucket, action, bucket_path);
     };
 
-    req.has_s3_bucket_permission = function(bucket, action, bucket_path) {
+    req.has_s3_bucket_permission = async function(bucket, action, bucket_path) {
         // Since this method can be called both authorized and unauthorized
         // We need to check the anonymous permission only when the bucket is configured to server anonymous requests
         // In case of anonymous function but with authentication flow we roll back to previous code and not return here
@@ -621,13 +621,13 @@ function _prepare_auth_request(req) {
         return false;
     };
 
-    req.check_bucket_action_permission = function(bucket, action, bucket_path) {
-        if (!has_bucket_action_permission(bucket, req.account, action, bucket_path)) {
+    req.check_bucket_action_permission = async function(bucket, action, bucket_path) {
+        if (!await has_bucket_action_permission(bucket, req.account, action, bucket_path)) {
             throw new RpcError('UNAUTHORIZED', 'No permission to access bucket');
         }
     };
 
-    req.has_bucket_action_permission = function(bucket, action, bucket_path) {
+    req.has_bucket_action_permission = async function(bucket, action, bucket_path) {
         return has_bucket_action_permission(bucket, req.account, action, bucket_path);
     };
 }
@@ -670,7 +670,7 @@ function _get_auth_info(account, system, authorized_by, role, extra) {
  * @param {string} bucket_path s3 bucket path (must start from "/")
  * @returns {boolean} true if the account has permission to perform the action on the bucket
  */
-function has_bucket_action_permission(bucket, account, action, bucket_path = "") {
+async function has_bucket_action_permission(bucket, account, action, bucket_path = "") {
     dbg.log1('has_bucket_action_permission:', bucket.name, account.email, bucket.owner_account.email);
 
     // If the system owner account wants to access the bucket, allow it
@@ -685,11 +685,12 @@ function has_bucket_action_permission(bucket, account, action, bucket_path = "")
         throw new Error('has_bucket_action_permission: action is required');
     }
 
-    const result = s3_utils.has_bucket_policy_permission(
+    const result = await s3_bucket_policy_utils.has_bucket_policy_permission(
         bucket_policy,
         account.email.unwrap(),
         action,
         `arn:aws:s3:::${bucket.name.unwrap()}${bucket_path}`,
+        undefined
     );
 
     if (result === 'DENY') return false;
@@ -704,15 +705,16 @@ function has_bucket_action_permission(bucket, account, action, bucket_path = "")
  * @param {string} bucket_path bucket path
  * @returns {boolean} true if the bucket is configured to serve anonymous requests
  */
-function has_bucket_anonymous_permission(bucket, action, bucket_path = "") {
+async function has_bucket_anonymous_permission(bucket, action, bucket_path = "") {
     const bucket_policy = bucket.s3_policy;
     if (!bucket_policy) return false;
-    return s3_utils.has_bucket_policy_permission(
+    return await s3_bucket_policy_utils.has_bucket_policy_permission(
         bucket_policy,
         // Account is anonymous
         undefined,
-        action || `s3:getobject`,
+        action || `s3:GetObject`,
         `arn:aws:s3:::${bucket.name.unwrap()}${bucket_path}`,
+        undefined
     ) === 'ALLOW';
 }
 

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -703,7 +703,7 @@ async function read_object_mapping(req) {
     const obj = await find_object_md(req);
 
     // Check if the requesting account is authorized to read the object
-    if (!req.has_s3_bucket_permission(req.bucket, 's3:GetObject', '/' + obj.key)) {
+    if (!await req.has_s3_bucket_permission(req.bucket, 's3:GetObject', '/' + obj.key)) {
         throw new RpcError('UNAUTHORIZED', 'requesting account is not authorized to read the object');
     }
 
@@ -791,7 +791,7 @@ async function read_object_md(req) {
     const obj = await find_object_md(req);
 
     // Check if the requesting account is authorized to read the object
-    if (!req.has_s3_bucket_permission(req.bucket, 's3:GetObject', '/' + obj.key)) {
+    if (!await req.has_s3_bucket_permission(req.bucket, 's3:GetObject', '/' + obj.key)) {
         throw new RpcError('UNAUTHORIZED', 'requesting account is not authorized to read the object');
     }
 
@@ -1060,7 +1060,7 @@ async function list_objects(req) {
     dbg.log1('object_server.list_objects', req.rpc_params);
     load_bucket(req);
 
-    if (!req.has_s3_bucket_permission(req.bucket, "s3:ListBucket")) {
+    if (!await req.has_s3_bucket_permission(req.bucket, "s3:ListBucket")) {
         throw new RpcError('UNAUTHORIZED', 'requesting account is not authorized to list objects');
     }
 

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -41,7 +41,6 @@ s3tests_boto3/functional/test_s3.py::test_lifecycle_transition_set_invalid_date
 s3tests_boto3/functional/test_s3.py::test_put_obj_enc_conflict_c_s3
 s3tests_boto3/functional/test_s3.py::test_put_obj_enc_conflict_c_kms
 s3tests_boto3/functional/test_s3.py::test_put_obj_enc_conflict_s3_kms
-s3tests_boto3/functional/test_s3.py::test_bucket_policy_put_obj_s3_noenc
 s3tests_boto3/functional/test_s3.py::test_bucket_policy_put_obj_s3_kms
 s3tests_boto3/functional/test_s3.py::test_bucket_policy_put_obj_kms_noenc
 s3tests_boto3/functional/test_s3.py::test_bucket_policy_put_obj_kms_s3

--- a/src/upgrade/upgrade_scripts/5.14.0/upgrade_bucket_policy.js
+++ b/src/upgrade/upgrade_scripts/5.14.0/upgrade_bucket_policy.js
@@ -2,7 +2,7 @@
 "use strict";
 
 const util = require('util');
-const { OP_NAME_TO_ACTION } = require('../../../endpoint/s3/s3_utils');
+const { OP_NAME_TO_ACTION } = require('../../../endpoint/s3/s3_bucket_policy_utils');
 
 function _create_actions_map() {
     const actions_map = new Map();


### PR DESCRIPTION
### Explain the changes
expend bucket policy to enable statements containing conditions for authenticating based on server side encryption algorithm. providing base for farther adding other condition statements. enabling deny, accept bucket policies for stringEquals StringNotEquals and null conditions for server side encryptions

### Testing Instructions:
1. ceph s3 test: s3tests_boto3.functional.test_s3:test_bucket_policy_put_obj_s3_noenc
