### PR TITLE
block_store_fs enhanced to use xattrs and migrate blocks to tier2

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ var config = exports;
 
 const os = require('os');
 const fs = require('fs');
+const path = require('path');
 const assert = require('assert');
 const dbg = require('./src/util/debug_module')(__filename);
 
@@ -634,12 +635,29 @@ config.QUOTA_MAX_OBJECTS = Number.MAX_SAFE_INTEGER;
 //////////////////////////
 //      STS CONFIG      //
 //////////////////////////
+
 config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
 
 ///////////////////////////////////////////
 //      PostgreSQL client pool size      //
 ///////////////////////////////////////////
+
 config.POSTGRES_MAX_CLIENTS = (process.env.LOCAL_MD_SERVER === 'true') ? 80 : 10;
+
+/////////////////////////
+// BLOCK STORE FS      //
+/////////////////////////
+
+config.BLOCK_STORE_FS_TIER2_ENABLED = false;
+config.BLOCK_STORE_FS_MAPPING_INFO_ENABLED = false;
+
+config.BLOCK_STORE_FS_XATTR_BLOCK_MD = 'user.noobaa.block_md';
+config.BLOCK_STORE_FS_XATTR_QUERY_MIGSTAT = 'user._query.migstat';
+config.BLOCK_STORE_FS_XATTR_TRIGGER_RECALL = 'user._trigger.recall';
+config.BLOCK_STORE_FS_XATTR_TRIGGER_MIGRATE = 'user._trigger.migrate';
+config.BLOCK_STORE_FS_XATTR_TRIGGER_PREMIGRATE = 'user._trigger.premigrate';
+
+
 
 /////////////////////
 //                 //
@@ -652,8 +670,11 @@ config.POSTGRES_MAX_CLIENTS = (process.env.LOCAL_MD_SERVER === 'true') ? 80 : 10
 // load a local config file that overwrites some of the config
 function load_config_local() {
     try {
+        // looking up config-local module using process.cwd() to allow pkg to find it
+        // outside the binary package - see https://github.com/vercel/pkg#snapshot-filesystem
+        // @ts-ignore
         // eslint-disable-next-line global-require
-        const local_config = require('./config-local');
+        const local_config = require(path.join(process.cwd(), 'config-local'));
         if (!local_config) return;
         console.log('load_config_local: LOADED', local_config);
         if (typeof local_config === 'function') {

--- a/src/agent/block_store_services/block_store_fs.js
+++ b/src/agent/block_store_services/block_store_fs.js
@@ -7,9 +7,10 @@ const path = require('path');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config.js');
 const fs_utils = require('../../util/fs_utils');
 const os_utils = require('../../util/os_utils');
-const config = require('../../../config.js');
+const nb_native = require('../../util/nb_native');
 const string_utils = require('../../util/string_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
 const get_block_internal_dir = require('./block_store_base').get_block_internal_dir;
@@ -24,9 +25,10 @@ class BlockStoreFs extends BlockStoreBase {
         this.old_blocks_path = path.join(this.root_path, 'blocks');
         this.config_path = path.join(this.root_path, 'config');
         this.usage_path = path.join(this.root_path, 'usage');
+        this.fs_context = {};
     }
 
-    init() {
+    async init() {
         // create internal directories to hold blocks by their last 3 hex digits
         // this is done to reduce the number of files in one directory which leads
         // to bad performance
@@ -58,171 +60,181 @@ class BlockStoreFs extends BlockStoreBase {
             });
     }
 
-    get_storage_info() {
-        return Promise.all([
+    async get_storage_info() {
+        try {
+            const [usage, drive] = await Promise.all([
                 this._get_usage(),
-                os_utils.get_drive_of_path(this.root_path)
-                .catch(err => {
-                    dbg.error('got error from get_drive_of_path. checking if root_path exists', err.message);
-                    this._test_root_path_exists();
-                    throw err;
-                })
-            ])
-            .then(([usage, drive]) => {
-                const storage = drive.storage;
-                storage.used = usage.size;
-                const total_unreserved = Math.max(storage.total - config.NODES_FREE_SPACE_RESERVE, 0);
-                this.usage_limit = Math.min(total_unreserved, this.storage_limit || Infinity);
-                return storage;
-            });
-    }
-
-    _test_root_path_exists() {
-        if (!fs.existsSync(this.root_path)) {
-            throw new RpcError('STORAGE_NOT_EXIST', `could not find the root path ${this.root_path}`);
+                os_utils.get_drive_of_path(this.root_path),
+            ]);
+            const storage = drive.storage;
+            storage.used = usage.size;
+            const total_unreserved = Math.max(storage.total - config.NODES_FREE_SPACE_RESERVE, 0);
+            this.usage_limit = Math.min(total_unreserved, this.storage_limit || Infinity);
+            return storage;
+        } catch (err) {
+            this._test_root_path_exists(err);
         }
     }
 
-    _read_block(block_md) {
+
+    /**
+     * @param {nb.BlockMD} block_md
+     * @returns {Promise<{ block_md: nb.BlockMD, data: Buffer }>}
+     */
+    async _read_block(block_md) {
+        const fs_context = this.fs_context;
         const block_path = this._get_block_data_path(block_md.id);
-        const meta_path = this._get_block_meta_path(block_md.id);
-        dbg.log1('fs read block', block_path);
-        return Promise.all([
-                fs.promises.readFile(block_path),
-                fs.promises.readFile(meta_path),
-            ])
-            .then(([data_file, meta_file]) => ({
-                block_md: block_md,
-                data: data_file,
-            }))
-            .catch(err => {
-                if (err.code === 'ENOENT') {
-                    dbg.error('got error when reading', block_md, '. checking if root_path exists', err.message);
-                    this._test_root_path_exists();
+
+        try {
+            const { data, stat } = await nb_native().fs.readFile(fs_context, block_path, { read_xattr: true });
+
+            // read md from xattr
+            let block_md_from_fs = try_parse_block_md(stat.xattr[config.BLOCK_STORE_FS_XATTR_BLOCK_MD]);
+
+            // if not able to parse md from xattr, fallback to reading .meta file content which was the old model.
+            if (!block_md_from_fs) {
+                try {
+                    const meta_path = this._get_block_meta_path(block_md.id);
+                    const { data: meta_data } = await nb_native().fs.readFile(fs_context, meta_path);
+                    block_md_from_fs = try_parse_block_md(meta_data);
+                } catch (err) {
+                    // noop
                 }
-                throw err;
-            });
+            }
+
+            return { block_md: block_md_from_fs || block_md, data };
+
+        } catch (err) {
+            this._test_root_path_exists(err);
+        }
     }
 
-    _write_block(block_md, data) {
-        let overwrite_stat;
-        let md_overwrite_stat;
+    /**
+     * @param {nb.BlockMD} block_md
+     * @param {Buffer} data
+     * @param {{ ignore_usage?: boolean }} [options]
+     * @returns {Promise<void>}
+     */
+    async _write_block(block_md, data, options) {
+        const fs_context = this.fs_context;
         const block_path = this._get_block_data_path(block_md.id);
-        const meta_path = this._get_block_meta_path(block_md.id);
-        const block_md_to_store = _.pick(block_md, 'id', 'digest_type', 'digest_b64');
+        const is_test_block = Boolean(options?.ignore_usage);
+
+        const usage = {
+            size: block_md.is_preallocated ? 0 : data.length,
+            count: block_md.is_preallocated ? 0 : 1,
+         };
+
+        /** @type {nb.NativeFSXattr} */
+        const xattr = {};
+
+        // fsync is needed before actually setting the migrate trigger
+        let xattr_need_fsync = false;
+
+        // set the block md xattr
+        const block_md_to_store = _.pick(block_md, 'id', 'digest_type', 'digest_b64', 'mapping_info');
         const block_md_data = JSON.stringify(block_md_to_store);
+        xattr[config.BLOCK_STORE_FS_XATTR_BLOCK_MD] = block_md_data;
 
-        return Promise.resolve()
-            .then(() => fs.promises.stat(block_path))
-            .catch(ignore_not_found)
-            .then(stat => {
-                overwrite_stat = stat;
-                dbg.log1('_write_block', block_path, data.length, overwrite_stat);
-                // create/replace the block on fs
-                return Promise.all([
-                    fs.promises.writeFile(block_path, data),
-                    fs.promises.writeFile(meta_path, block_md_data),
-                ]);
-            })
-            .catch(err => {
-                if (err.code === 'ENOENT') {
-                    dbg.error('got error when writing', block_md, '. checking if root_path exists', err.message);
-                    this._test_root_path_exists();
+        if (!is_test_block) {
+
+            // set xattr to trigger migration of file to underlying tier
+            if (config.BLOCK_STORE_FS_TIER2_ENABLED) {
+                xattr[config.BLOCK_STORE_FS_XATTR_TRIGGER_MIGRATE] = 'now';
+                xattr_need_fsync = true;
+            }
+
+            // check for existing file and get its size
+            const overwrite_stat = await nb_native().fs.stat(fs_context, block_path).catch(ignore_not_found);
+            if (overwrite_stat) {
+                usage.size -= overwrite_stat.size;
+                usage.count -= 1;
+
+                // also make sure we do not leave old .meta files on overwrite
+                const meta_path = this._get_block_meta_path(block_md.id);
+                const overwrite_meta_stat = await nb_native().fs.stat(fs_context, meta_path).catch(ignore_not_found);
+                if (overwrite_meta_stat) {
+                    usage.size -= overwrite_meta_stat.size;
+                    await nb_native().fs.unlink(fs_context, meta_path).catch(ignore_not_found);
                 }
-                throw err;
-            })
-            .then(() => {
-                if (overwrite_stat) {
-                    return fs.promises.stat(meta_path).catch(ignore_not_found)
-                        .then(md_stat => {
-                            md_overwrite_stat = md_stat;
-                        });
-                }
-            })
-            .then(() => {
-                let overwrite_size = 0;
-                let overwrite_count = 0;
-                if (overwrite_stat) {
-                    overwrite_size = overwrite_stat.size + (md_overwrite_stat ?
-                        md_overwrite_stat.size : 0);
-                    overwrite_count = 1;
-                }
-                const size = (block_md.is_preallocated ? 0 : data.length) + block_md_data.length - overwrite_size;
-                const count = (block_md.is_preallocated ? 0 : 1) - overwrite_count;
-                if (size || count) this._update_usage({ size, count });
+            }
+        }
+
+        try {
+            await nb_native().fs.writeFile(fs_context, block_path, data, {
+                xattr,
+                xattr_need_fsync,
             });
+        } catch (err) {
+            this._test_root_path_exists(err);
+        }
+
+        if (!is_test_block && (usage.size || usage.count)) {
+            this._update_usage(usage);
+        }
     }
 
-    _write_usage_internal() {
-        return fs_utils.replace_file(this.usage_path, JSON.stringify(this._usage));
+    async _delete_blocks(block_ids) {
+        const succeeded_block_ids = [];
+        const failed_block_ids = [];
+        await P.map_with_concurrency(10, block_ids, async block_id => {
+            try {
+                await this._delete_block(block_id);
+                succeeded_block_ids.push(block_id);
+            } catch (err) {
+                // treat ENOENT as success - 
+                // this check is already performed inside _delete_block by calling ignore_not_found
+                // but just in case something changes we perform it once again here explicitly
+                if (err.code === 'ENOENT') {
+                    succeeded_block_ids.push(block_id);
+                } else {
+                    failed_block_ids.push(block_id);
+                }
+                dbg.warn(`delete block ${block_id} failed due to`, err);
+            }
+        });
+        return { failed_block_ids, succeeded_block_ids };
     }
 
-
-    _delete_blocks(block_ids) {
-        const failed_to_delete_block_ids = [];
-        return P.map_with_concurrency(10, block_ids, block_id =>
-                this._delete_block(block_id)
-                .catch(err => {
-                    // This check is already performed inside _delete_block by calling ignore_not_found
-                    // but just in case something changes we perform it once again here explicitly
-                    if (err.code !== 'ENOENT') {
-                        failed_to_delete_block_ids.push(block_id);
-                    }
-                    // TODO handle failed deletions - report to server and reclaim later
-                    dbg.warn('delete block failed due to', err);
-                })
-            )
-            .then(() => ({
-                failed_block_ids: failed_to_delete_block_ids,
-                succeeded_block_ids: _.difference(block_ids, failed_to_delete_block_ids)
-            }));
-    }
-
-    _delete_block(block_id) {
+    async _delete_block(block_id) {
+        const fs_context = this.fs_context;
         const block_path = this._get_block_data_path(block_id);
         const meta_path = this._get_block_meta_path(block_id);
-        let del_stat;
-        let md_del_stat;
         dbg.log1("delete block", block_id);
-        return Promise.all([
-                fs.promises.stat(block_path)
-                .catch(ignore_not_found)
-                .then(stat => {
-                    del_stat = stat;
-                    return fs.promises.unlink(block_path).catch(ignore_not_found);
-                }),
-                fs.promises.stat(meta_path)
-                .catch(ignore_not_found)
-                .then(stat => {
-                    md_del_stat = stat;
-                    return fs.promises.unlink(meta_path).catch(ignore_not_found);
-                })
-            ])
-            .then(() => {
-                if (this._usage && del_stat) {
-                    const usage = {
-                        size: -(del_stat.size + ((md_del_stat && md_del_stat.size) ? md_del_stat.size : 0)),
-                        count: -1
-                    };
-                    return this._update_usage(usage);
-                }
-            });
+
+        const [block_stat, meta_stat] = await Promise.all([
+            nb_native().fs.stat(fs_context, block_path).catch(ignore_not_found),
+            nb_native().fs.stat(fs_context, meta_path).catch(ignore_not_found),
+        ]);
+
+        await Promise.all([
+            block_stat && nb_native().fs.unlink(fs_context, block_path).catch(ignore_not_found),
+            meta_stat && nb_native().fs.unlink(fs_context, meta_path).catch(ignore_not_found),
+        ]);
+
+        if (this._usage && block_stat) {
+            const usage = {
+                size: -(block_stat.size + ((meta_stat && meta_stat.size) ? meta_stat.size : 0)),
+                count: -1
+            };
+            this._update_usage(usage);
+        }
     }
 
     _get_usage() {
         return this._usage || this._count_usage();
     }
 
-    _count_usage() {
-        return fs_utils.disk_usage(this.blocks_path_root)
-            .then(usage => {
-                dbg.log0('counted disk usage', usage);
-                this._usage = usage; // object with properties size and count
-                // update usage file
-                const usage_data = JSON.stringify(this._usage);
-                return fs.promises.writeFile(this.usage_path, usage_data)
-                    .then(() => usage);
-            });
+    async _count_usage() {
+        const usage = await fs_utils.disk_usage(this.blocks_path_root);
+        dbg.log0('counted disk usage', usage);
+        this._usage = usage; // object with properties size and count
+        await this._write_usage_internal(); // update the usage file
+        return usage;
+    }
+
+    _write_usage_internal() {
+        return fs_utils.replace_file(this.usage_path, JSON.stringify(this._usage));
     }
 
     _read_config() {
@@ -265,11 +277,31 @@ class BlockStoreFs extends BlockStoreBase {
         return path.join(this.blocks_path_root, block_dir, file);
     }
 
+    _test_root_path_exists(err) {
+        if (err.code === 'ENOENT') {
+            dbg.error('got ENOENT, checking if root_path exists', err.message);
+            if (!fs.existsSync(this.root_path)) {
+                throw new RpcError('STORAGE_NOT_EXIST', `could not find the root path ${this.root_path}`);
+            }
+        }
+        throw err;
+    }
+
 }
 
 function ignore_not_found(err) {
     if (err.code === 'ENOENT') return;
     throw err;
+}
+
+function try_parse_block_md(str) {
+    if (str) {
+        try {
+            return JSON.parse(str);
+        } catch (err) {
+            // continue...
+        }
+    }
 }
 
 // EXPORTS

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -621,6 +621,24 @@ module.exports = {
                 digest_b64: { type: 'string' },
                 node_type: { $ref: '#/definitions/node_type' },
                 is_preallocated: { type: 'boolean' },
+                mapping_info: {
+                    type: 'object',
+                    properties: {
+                        obj_id: { type: 'string' },
+                        multipart_id: { type: 'string' },
+                        part_id: { type: 'string' },
+                        chunk_id: { type: 'string' },
+                        frag_id: { type: 'string' },
+                        bucket: { type: 'string' },
+                        key: { type: 'string' },
+                        part_start: { type: 'integer' },
+                        part_end: { type: 'integer' },
+                        part_seq: { type: 'integer' },
+                        data_index: { type: 'integer' },
+                        parity_index: { type: 'integer' },
+                        lrc_index: { type: 'integer' },
+                    }
+                },
             }
         },
 

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -374,6 +374,46 @@ get_fd_gpfs_xattr(int fd, XattrMap& xattr, int& gpfs_error)
     return 0;
 }
 
+static void
+get_xattr_from_object(XattrMap& xattr, Napi::Object obj)
+{
+    auto keys = obj.GetPropertyNames();
+    for (uint32_t i = 0; i < keys.Length(); ++i) {
+        auto key = keys.Get(i).ToString().Utf8Value();
+        auto value = obj.Get(key).ToString().Utf8Value();
+        xattr[key] = value;
+    }
+}
+
+/**
+ * TODO: Not atomic and might cause partial updates of MD
+ * need to be tested
+ */
+static int
+clear_xattr(int fd, std::string _prefix)
+{
+    ssize_t buf_len = flistxattr(fd, NULL, 0);
+    // No xattr, nothing to do
+    if (buf_len == 0) return 0;
+    if (buf_len == -1) return -1;
+    Buf buf(buf_len);
+    buf_len = flistxattr(fd, buf.cdata(), buf_len);
+    // No xattr, nothing to do
+    if (buf_len == 0) return 0;
+    if (buf_len == -1) return -1;
+    while (buf.length()) {
+        std::string key(buf.cdata());
+        // remove xattr only if its key starts with prefix
+        if (key.rfind(_prefix, 0) == 0) {
+            ssize_t value_len = fremovexattr(fd, key.c_str());
+            if (value_len == -1) return -1;
+        }
+        buf.slice(key.size() + 1, buf.length());
+    }
+    return 0;
+}
+
+
 /**
  * FSWorker is a general async worker for our fs operations
  */
@@ -858,11 +898,16 @@ struct Rename : public FSWorker
 struct Writefile : public FSWorker
 {
     std::string _path;
+    XattrMap _xattr;
+    bool _set_xattr;
+    bool _xattr_need_fsync;
+    std::string _xattr_clear_prefix;
     const uint8_t* _data;
     size_t _len;
     mode_t _mode;
     Writefile(const Napi::CallbackInfo& info)
         : FSWorker(info)
+        , _set_xattr(false)
         , _mode(0666)
     {
         _path = info[1].As<Napi::String>();
@@ -870,7 +915,14 @@ struct Writefile : public FSWorker
         _data = buf.Data();
         _len = buf.Length();
         if (info.Length() > 3 && !info[3].IsUndefined()) {
-            _mode = info[3].As<Napi::Number>().Uint32Value();
+            Napi::Object options = info[3].As<Napi::Object>();
+            if (options.Has("mode")) _mode = options.Get("mode").As<Napi::Number>().Uint32Value();
+            if (options.Has("xattr_need_fsync")) _xattr_need_fsync = options.Get("xattr_need_fsync").ToBoolean();
+            if (options.Has("xattr_clear_prefix")) _xattr_clear_prefix = options.Get("xattr_clear_prefix").As<Napi::String>();
+            if (options.Has("xattr")) {
+                _set_xattr = true;
+                get_xattr_from_object(_xattr, options.Get("xattr").As<Napi::Object>());
+            }
         }
         Begin(XSTR() << "Writefile " << DVAL(_path) << DVAL(_len) << DVAL(_mode));
     }
@@ -885,6 +937,18 @@ struct Writefile : public FSWorker
         } else if ((size_t)len != _len) {
             SetError(XSTR() << "Writefile: partial write error " << DVAL(len) << DVAL(_len));
         }
+
+        if (_set_xattr) {
+            if (_xattr_need_fsync) {
+                SYSCALL_OR_RETURN(fsync(fd));
+            }
+            if (_xattr_clear_prefix != "") {
+                SYSCALL_OR_RETURN(clear_xattr(fd, _xattr_clear_prefix));
+            }
+            for (auto it = _xattr.begin(); it != _xattr.end(); ++it) {
+                SYSCALL_OR_RETURN(fsetxattr(fd, it->first.c_str(), it->second.c_str(), it->second.length(), 0));
+            }
+        }
     }
 };
 
@@ -894,14 +958,24 @@ struct Writefile : public FSWorker
 struct Readfile : public FSWorker
 {
     std::string _path;
+    bool _read_xattr;
+    bool _skip_user_xattr;
+    struct stat _stat_res;
+    XattrMap _xattr;
     uint8_t* _data;
     int _len;
     Readfile(const Napi::CallbackInfo& info)
         : FSWorker(info)
+        , _read_xattr(false)
         , _data(0)
         , _len(0)
     {
         _path = info[1].As<Napi::String>();
+        if ((int)info.Length() == 3) {
+            Napi::Object options = info[2].As<Napi::Object>();
+            if (options.Has("read_xattr")) _read_xattr = options.Get("read_xattr").ToBoolean();
+            if (options.Has("skip_user_xattr")) _skip_user_xattr = options.Get("skip_user_xattr").ToBoolean();
+        }
         Begin(XSTR() << "Readfile " << DVAL(_path));
     }
     virtual ~Readfile()
@@ -915,11 +989,15 @@ struct Readfile : public FSWorker
     {
         int fd = open(_path.c_str(), O_RDONLY);
         CHECK_OPEN_FD(fd);
+        SYSCALL_OR_RETURN(fstat(fd, &_stat_res));
+        if (_read_xattr) {
+            SYSCALL_OR_RETURN(get_fd_xattr(fd, _xattr, _skip_user_xattr));
+            if (_backend == GPFS_BACKEND) {
+                GPFS_FCNTL_OR_RETURN(get_fd_gpfs_xattr(fd, _xattr, gpfs_error));
+            }
+        }
 
-        struct stat stat_res;
-        SYSCALL_OR_RETURN(fstat(fd, &stat_res));
-
-        _len = stat_res.st_size;
+        _len = _stat_res.st_size;
         _data = new uint8_t[_len];
 
         uint8_t* p = _data;
@@ -933,13 +1011,25 @@ struct Readfile : public FSWorker
             remain -= len;
             p += len;
         }
+
+        CHECK_CTIME_CHANGE(fd, _stat_res, _path);
     }
     virtual void OnOK()
     {
         DBG1("FS::FSWorker::OnOK: Readfile " << DVAL(_path));
         Napi::Env env = Env();
-        auto buf = Napi::Buffer<uint8_t>::Copy(env, _data, _len);
-        _deferred.Resolve(buf);
+
+        auto res_stat = Napi::Object::New(env);
+        set_stat_res(res_stat, env, _stat_res, _xattr);
+
+        auto data = _data;
+        _data = 0;
+        auto buf = Napi::Buffer<uint8_t>::New(env, data, _len);
+
+        auto res = Napi::Object::New(env);
+        res["stat"] = res_stat;
+        res["data"] = buf;
+        _deferred.Resolve(res);
         ReportWorkerStats(0);
     }
 };
@@ -1248,34 +1338,6 @@ struct FileWritev : public FSWrapWorker<FileWrap>
 
 /**
  * TODO: Not atomic and might cause partial updates of MD
- * need to be tested
- */
-static int
-clear_xattr(int fd, std::string _prefix)
-{
-    ssize_t buf_len = flistxattr(fd, NULL, 0);
-    // No xattr, nothing to do
-    if (buf_len == 0) return 0;
-    if (buf_len == -1) return -1;
-    Buf buf(buf_len);
-    buf_len = flistxattr(fd, buf.cdata(), buf_len);
-    // No xattr, nothing to do
-    if (buf_len == 0) return 0;
-    if (buf_len == -1) return -1;
-    while (buf.length()) {
-        std::string key(buf.cdata());
-        // remove xattr only if its key starts with prefix
-        if (key.rfind(_prefix, 0) == 0) {
-            ssize_t value_len = fremovexattr(fd, key.c_str());
-            if (value_len == -1) return -1;
-        }
-        buf.slice(key.size() + 1, buf.length());
-    }
-    return 0;
-}
-
-/**
- * TODO: Not atomic and might cause partial updates of MD
  */
 struct FileReplacexattr : public FSWrapWorker<FileWrap>
 {
@@ -1286,13 +1348,7 @@ struct FileReplacexattr : public FSWrapWorker<FileWrap>
         , _prefix("")
     {
         if (info.Length() > 1 && !info[1].IsUndefined()) {
-            auto md = info[1].As<Napi::Object>();
-            auto keys = md.GetPropertyNames();
-            for (uint32_t i = 0; i < keys.Length(); ++i) {
-                auto key = keys.Get(i).ToString().Utf8Value();
-                auto value = md.Get(key).ToString().Utf8Value();
-                _xattr[key] = value;
-            }
+            get_xattr_from_object(_xattr, info[1].As<Napi::Object>());
         }
         if (info.Length() > 2 && !info[2].IsUndefined()) {
             _prefix = info[2].As<Napi::String>();

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -129,9 +129,11 @@ const static std::map<std::string, int> flags_to_case = {
     { "r", O_RDONLY },
     { "rs", O_RDONLY | O_SYNC },
     { "sr", O_RDONLY | O_SYNC },
+#ifdef O_DIRECT
     { "rd", O_RDONLY | O_DIRECT },
     { "dr", O_RDONLY | O_DIRECT },
     { "rds", O_RDONLY | O_DIRECT | O_SYNC },
+#endif
     { "r+", O_RDWR },
     { "rs+", O_RDWR | O_SYNC },
     { "sr+", O_RDWR | O_SYNC },

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -494,7 +494,20 @@ class ObjectIO {
 
                 return chunk;
             });
+
+            /** 
+             * passing partial object info we have in this context which will be sent to block_stores
+             * as block_md.mapping_info so it can be used for recovery in case the db is not available.
+             * @type {Partial<nb.ObjectInfo>}
+             */
+            const object_md = {
+                obj_id: params.obj_id,
+                bucket: params.bucket,
+                key: params.key,
+            };
+
             const mc = new MapClient({
+                object_md,
                 chunks: map_chunks,
                 location_info: params.location_info,
                 check_dups: !is_using_encryption,

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -59,7 +59,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
         httpOptions: { agent: new http.Agent({ keepAlive: false }) },
     };
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         if (test_utils.invalid_nsfs_root_permissions()) this.skip(); // eslint-disable-line no-invalid-this
         await fs_utils.create_fresh_path(tmp_fs_root + '/new_s3_buckets_dir', 0o770);
         await fs_utils.create_fresh_path(tmp_fs_root + bucket_path, 0o770);

--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -14,6 +14,9 @@ const async_delay = util.promisify(setTimeout);
 
 let nb_native_napi;
 
+/**
+ * @returns {nb.Native}
+ */
 function nb_native() {
 
     if (nb_native_napi) return nb_native_napi;


### PR DESCRIPTION
### Explain the changes
1. Enhance backing_store_fs to use xattr to store block_md json instead of in separate .meta files.
2. This allows reducing the number of files needed on the file system by half.
3. Add new config option (false by default) - `config.BLOCK_STORE_FS_TIER2_ENABLED` - enable to set custom xattr trigger to signal the filesystem to migrate the data to archive tier (for filesystems that support that).
4. Added new config option (false by default) - `config.BLOCK_STORE_FS_MAPPING_INFO_ENABLED ` - enable to pass on extra recovery information (which bucket, object, offset, etc) to be added in block_md xattr, for cases when recovery without the db is needed.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. Regression of backing_store_fs (PV pools from the operator).
2. Enable the new configs to test the new options and check the xattr of the blocks (e.g `xattr -l <filename>` on mac).
