### PR TITLE
CI | Change Deprecating `set-output`

### DIFF
--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -34,12 +34,12 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       
       - name: Prepare Suffix
         id: suffix
         if: ${{ github.event.inputs.tag != '' }}
-        run: echo ::set-output name=suffix::"-${{ github.event.inputs.tag }}"
+        run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
 
       - name: Prepare Tags
         id: prep
@@ -54,10 +54,10 @@ jobs:
           CORE_TAGS="${DOCKER_CORE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
           CORE_OCS_DEV_TAG="ocs-dev/noobaa-core:${{ github.event.inputs.branch }}-latest"
           echo "::warning ${CORE_TAGS}"
-          echo ::set-output name=basetags::${BASE_TAGS}
-          echo ::set-output name=buildertags::${BUILDER_TAGS}
-          echo ::set-output name=coretags::${CORE_TAGS}
-          echo ::set-output name=ocsdevlatest::${CORE_OCS_DEV_TAG}
+          echo "basetags=${BASE_TAGS}" >> $GITHUB_OUTPUT
+          echo "buildertags=${BUILDER_TAGS}" >> $GITHUB_OUTPUT
+          echo "coretags=${CORE_TAGS}" >> $GITHUB_OUTPUT
+          echo "ocsdevlatest=${CORE_OCS_DEV_TAG}" >> $GITHUB_OUTPUT
 
       - name: Build Builder Images
         run: |

--- a/.github/workflows/build-ppc64le-image.yaml
+++ b/.github/workflows/build-ppc64le-image.yaml
@@ -34,12 +34,12 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       
       - name: Prepare Suffix
         id: suffix
         if: ${{ github.event.inputs.tag != '' }}
-        run: echo ::set-output name=suffix::"-${{ github.event.inputs.tag }}"
+        run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
 
       - name: Prepare Tags
         id: prep
@@ -54,10 +54,10 @@ jobs:
           CORE_TAGS="${DOCKER_CORE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
           CORE_OCS_DEV_TAG="ocs-dev/noobaa-core:${{ github.event.inputs.branch }}-latest"
           echo "::warning ${CORE_TAGS}"
-          echo ::set-output name=basetags::${BASE_TAGS}
-          echo ::set-output name=buildertags::${BUILDER_TAGS}
-          echo ::set-output name=coretags::${CORE_TAGS}
-          echo ::set-output name=ocsdevlatest::${CORE_OCS_DEV_TAG}
+          echo "basetags=${BASE_TAGS}" >> $GITHUB_OUTPUT
+          echo "buildertags=${BUILDER_TAGS}" >> $GITHUB_OUTPUT
+          echo "coretags=${CORE_TAGS}" >> $GITHUB_OUTPUT
+          echo "ocsdevlatest=${CORE_OCS_DEV_TAG}" >> $GITHUB_OUTPUT
 
       - name: Build Builder Images
         run: |

--- a/.github/workflows/manual-full-build.yaml
+++ b/.github/workflows/manual-full-build.yaml
@@ -21,12 +21,12 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       
       - name: Prepare Suffix
         id: suffix
         if: ${{ github.event.inputs.tag != '' }}
-        run: echo ::set-output name=suffix::"-${{ github.event.inputs.tag }}"
+        run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
 
       - name: Prepare Tags
         id: prep
@@ -41,10 +41,10 @@ jobs:
           CORE_TAGS="${DOCKER_CORE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
           CORE_OCS_DEV_TAG="ocs-dev/noobaa-core:${{ github.event.inputs.branch }}-latest"
           echo "::warning ${CORE_TAGS}"
-          echo ::set-output name=basetags::${BASE_TAGS}
-          echo ::set-output name=buildertags::${BUILDER_TAGS}
-          echo ::set-output name=coretags::${CORE_TAGS}
-          echo ::set-output name=ocsdevlatest::${CORE_OCS_DEV_TAG}
+          echo "basetags=${BASE_TAGS}" >> $GITHUB_OUTPUT
+          echo "buildertags=${BUILDER_TAGS}" >> $GITHUB_OUTPUT
+          echo "coretags=${CORE_TAGS}" >> $GITHUB_OUTPUT
+          echo "ocsdevlatest=${CORE_OCS_DEV_TAG}" >> $GITHUB_OUTPUT
 
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.GHACTIONSDOCKERHUB }} | docker login -u ${{ secrets.GHACTIONSDOCKERHUBNAME }} --password-stdin


### PR DESCRIPTION
### Explain the changes
1. Change deprecating set-output (instead we use `GITHUB_OUTPUT`), more information [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none

- [ ] Doc added/updated
- [ ] Tests added
