### PR TITLE
add support for RPM package builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ ifdef testname
 	endif
 endif
 
+BUILD_S3SELECT?=1
 
 ###############
 # BUILD LOCAL #
@@ -125,7 +126,7 @@ builder: assert-container-engine
 
 base: builder
 	@echo "\n##\033[1;32m Build image noobaa-base ...\033[0m"
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
 	$(CONTAINER_ENGINE) tag noobaa-base $(NOOBAA_BASE_TAG)
 	@echo "##\033[1;32m Build image noobaa-base done.\033[0m"
 .PHONY: base
@@ -156,6 +157,16 @@ nbdev:
 	@echo ""
 .PHONY: nbdev
 
+rpm: base
+	@PLATFORM=$(shell echo ${CONTAINER_PLATFORM} | tr '/' '-') && \
+	echo "\033[1;34mStarting RPM build for $${CONTAINER_PLATFORM}.\033[0m" && \
+	mkdir -p build/rpm && \
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/RPM_build/RPM.Dockerfile $(CACHE_FLAG) -t noobaa-rpm-build:$${PLATFORM} --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT) && \
+	echo "\033[1;32mImage 'noobaa-rpm-build' is ready.\033[0m" && \
+	echo "Generating RPM..." && \
+	$(CONTAINER_ENGINE) run --rm -v $(PWD)/build/rpm:/export -it noobaa-rpm-build:$${PLATFORM} && \
+	echo "\033[1;32mRPM for platform \"$${PLATFORM}\" is ready in build/rpm.\033[0m";
+.PHONY: rpm
 
 ###############
 # TEST IMAGES #

--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -1,0 +1,30 @@
+FROM noobaa-base
+ARG TARGETARCH
+ARG BUILD_S3SELECT=0
+
+COPY ./src/agent ./src/agent
+COPY ./src/api ./src/api
+COPY ./src/cmd ./src/cmd
+COPY ./src/endpoint ./src/endpoint
+COPY ./src/hosted_agents ./src/hosted_agents
+COPY ./src/rpc ./src/rpc
+COPY ./src/s3 ./src/s3
+COPY ./src/sdk ./src/sdk
+COPY ./src/server ./src/server
+COPY ./src/tools ./src/tools
+COPY ./src/upgrade ./src/upgrade
+COPY ./src/util ./src/util
+COPY ./config.js ./
+COPY ./platform_restrictions.json ./
+COPY ./Makefile ./
+COPY ./package*.json ./
+
+WORKDIR /build
+
+RUN tar -czvf noobaa-core.tar.gz /noobaa
+
+COPY ./src/deploy/RPM_build/* ./
+COPY ./package.json ./
+RUN chmod +x ./packagerpm.sh
+
+CMD ./packagerpm.sh /export /build

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -1,0 +1,74 @@
+%define revision null
+%define noobaaver null
+%define nodever null
+%define releasedate null
+%define changelogdata null
+
+%define noobaatar %{name}-%{version}-%{revision}.tar.gz
+%define nodetar node-%{nodever}.tar.xz
+%define buildroot %{_tmppath}/%{name}-%{version}-%{release}
+
+Name:		noobaa-core
+Version:	%{noobaaver}
+Release:	%{revision}%{?dist}
+Summary:	NooBaa RPM
+
+License:	Apache-2.0
+URL:        https://www.noobaa.io/
+Source0:	%{noobaatar}
+Source1:    %{nodetar}
+
+Recommends: jemalloc
+
+%global __os_install_post %{nil}
+
+%description
+NooBaa is a data service for cloud environments, providing S3 object-store interface with flexible tiering, mirroring, and spread placement policies, over any storage resource that allows GET/PUT including S3, GCS, Azure Blob, Filesystems, etc.
+
+%prep
+mkdir noobaa-core-%{version}-%{revision}
+mkdir node-%{nodever}
+tar -xzf %{SOURCE0} -C noobaa-core-%{version}-%{revision}/
+tar -xJf %{SOURCE1} -C node-%{nodever}/
+
+%clean
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/usr/local/
+
+cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa $RPM_BUILD_ROOT/usr/local/noobaa-core
+cp -R %{_builddir}/node-%{nodever}/* $RPM_BUILD_ROOT/usr/local/node
+
+mkdir -p $RPM_BUILD_ROOT/usr/bin/
+ln -s /usr/local/node/bin/node $RPM_BUILD_ROOT/usr/bin/node
+ln -s /usr/local/node/bin/npm $RPM_BUILD_ROOT/usr/bin/npm
+ln -s /usr/local/node/bin/npx $RPM_BUILD_ROOT/usr/bin/npx
+
+%files
+/usr/local/noobaa-core
+/usr/local/node
+/usr/bin/node
+/usr/bin/npm
+/usr/bin/npx
+%doc
+
+%post
+if [ $1 -gt 1 ]; then
+  NOOBAA_RPM_BASE_PATH="$RPM_BUILD_ROOT/usr/local/noobaa-core"
+  pushd $NOOBAA_RPM_BASE_PATH
+
+  UPGRADE_SCRIPTS_DIR=/root/node_modules/noobaa-core/src/upgrade/upgrade_scripts
+  echo "Running /usr/local/node/bin/node src/upgrade/upgrade_manager.js --upgrade_scripts_dir ${UPGRADE_SCRIPTS_DIR}"
+  /usr/local/node/bin/node src/upgrade/upgrade_manager.js --upgrade_scripts_dir ${UPGRADE_SCRIPTS_DIR}
+  rc=$?
+  if [ ${rc} -ne 0 ]; then
+    echo "upgrade_manager failed with exit code ${rc}"
+    exit ${rc}
+  fi
+fi
+
+%changelog
+* %{releasedate} NooBaa Team <noobaa@noobaa.io>
+%{changelogdata}

--- a/src/deploy/RPM_build/packagerpm.sh
+++ b/src/deploy/RPM_build/packagerpm.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -eou pipefail
+set -x
+
+dir=$(dirname "$0")
+
+SKIP_NODE_INSTALL=1 source $dir/../install_nodejs.sh
+
+noobaaver="$(npm pkg get version | tr -d '"')"
+revision="1"
+releasedate=$(date '+%a %b %d %Y')
+nodever=$(node --version | tr -d 'v')
+changelogdata="Initial release of NooBaa ${noobaaver}"
+ARCHITECTURE=$(uname -m)
+
+TEMPLATE_FILE="${dir}/noobaa.spec"
+OUTPUT_FILE="${dir}/noobaa.final.spec"
+
+TARGET_DIR="$1"
+TAR_DIR="$2"
+
+function set_changelog() {
+    if [ -f $dir/changelog.txt ]; then
+        local path=$(realpath $dir/changelog.txt)
+        changelogdata="%{lua: print(io.open(\"$path\"):read(\"*a\"))}"
+    fi
+}
+
+function move_builds() {
+    mv ${TAR_DIR}/noobaa-core.tar.gz ${TAR_DIR}/noobaa-core-${noobaaver}-${revision}.tar.gz
+    cp ${TAR_DIR}/noobaa-core-${noobaaver}-${revision}.tar.gz ~/rpmbuild/SOURCES/
+}
+
+function get_node_tar() {
+    pushd ~/rpmbuild/SOURCES/
+    local path=$(NODEJS_VERSION=${nodever} download_node)
+    mv ${path} node-${nodever}.tar.xz
+    popd
+}
+
+function generate_spec_from_template() {
+    while IFS= read -r line; do
+        # Check if the line starts with '%define' and contains 'null'
+        if [[ $line =~ ^%define[[:space:]]+([^[:space:]]+)[[:space:]]+null$ ]]; then
+            # Extract the variable name
+            VAR_NAME="${BASH_REMATCH[1]}"
+
+            # Get the value of the variable
+            VAR_VALUE=$(eval echo "\${${VAR_NAME}}")
+
+            # Replace 'null' with the variable value
+            line="${line/null/$VAR_VALUE}"
+        fi
+
+        # Write the updated line to the output file
+        echo "$line" >>"${OUTPUT_FILE}"
+    done <"${TEMPLATE_FILE}"
+}
+
+# Create the necessary directories
+mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+# Move the binary into the SOURCES directory
+move_builds
+
+# Download nodejs tarball to SOURCES directory
+get_node_tar
+
+# Set the changelog
+set_changelog
+
+# Generate spec file from template
+generate_spec_from_template
+
+# Print the generated spec file if NRPM_DEBUG is set to true
+[[ "${NRPM_DEBUG:-false}" == "true" ]] && cat ${OUTPUT_FILE}
+
+# Move the spec file to the SPECS directory
+mv ${OUTPUT_FILE} ~/rpmbuild/SPECS/
+
+# Build the RPM package
+rpmbuild -ba ~/rpmbuild/SPECS/noobaa.final.spec
+
+# Move the RPM package to the current directory
+mv ~/rpmbuild/RPMS/${ARCHITECTURE}/noobaa-core-${noobaaver}-${revision}.*.rpm ${TARGET_DIR}


### PR DESCRIPTION
### Explain the changes
This PR:
1. Adds support for building RPM packages for noobaa-core.

#### How to use?
Prerequisites: 
1. Docker (If on macos then docker in a qemu based VM).
2. Run `docker run --privileged --rm tonistiigi/binfmt --install all`

Build:
1. Checkout this PR (or master if and when merged).
2. From the root of the project run, `make rpm`. This will create an RPM package and will dump it inside `./build/rpm/<name>`.
    1. The RPM packages entire noobaa-core as well as nodejs (version from `.nvmrc`).
    2. noobaa-core S3 Select is enabled. This requires `boost` shared objects to be present on the machine where noobaa is supposed to be installed. This feature can be disabled if not required (due to additional dependency) by running `make rpm BUILD_S3SELECT=0`.
    3. In order to build RPM packages for other architectures simply run `make rpm CONTAINER_PLATFORM=linux/amd64` or `make rpm CONTAINER_PLATFORM=linux/ppc64le`.

Post install expectations:
1. `node`, `npm`, `npx` should be installed.
2. `noobaa-core` files should be present in `/usr/local/noobaa-core`.
3. If this was an upgrade run then NooBaa's upgrade manager should perform the necessary upgrade scripts (require database to reachable).

NOTE:
NooBaa uses `jemalloc` as its allocator optionally. `jemalloc` is not bundled with noobaa-core RPM and needs to be installed manually. If `epel-release` repository is available and `dnf` package manager is being used in that case it will try to install `jemalloc` automatically but can be ignored by passing `--setopt=install_weak_deps=False` to `dnf`.

### Testing
Follow the above `Build` and `Post install expectations` guide.

Previously tested build process on arm64, amd64, ppc64le.
Recent build tested on arm64 and amd64 only.

- [ ] Doc added/updated
- [ ] Tests added
