### PR TITLE
S3select parquet fs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ ifdef testname
 endif
 
 BUILD_S3SELECT?=1
+BUILD_S3SELECT_PARQUET?=0
 
 ###############
 # BUILD LOCAL #
@@ -119,14 +120,14 @@ all: tester noobaa
 
 builder: assert-container-engine
 	@echo "\n##\033[1;32m Build image noobaa-builder ...\033[0m"
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-builder .
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-builder .
 	$(CONTAINER_ENGINE) tag noobaa-builder $(BUILDER_TAG)
 	@echo "##\033[1;32m Build image noobaa-builder done.\033[0m"
 .PHONY: builder
 
 base: builder
 	@echo "\n##\033[1;32m Build image noobaa-base ...\033[0m"
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
 	$(CONTAINER_ENGINE) tag noobaa-base $(NOOBAA_BASE_TAG)
 	@echo "##\033[1;32m Build image noobaa-base done.\033[0m"
 .PHONY: base
@@ -134,7 +135,7 @@ base: builder
 noobaa: base
 	@echo "\n##\033[1;32m Build image noobaa ...\033[0m"
 	@echo "$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG)"
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	$(CONTAINER_ENGINE) tag noobaa $(NOOBAA_TAG)
 	@echo "##\033[1;32m Build image noobaa done.\033[0m"
 .PHONY: noobaa

--- a/docs/design/s3select.md
+++ b/docs/design/s3select.md
@@ -43,7 +43,7 @@ There are two variations of files to consider:
     3. In the simple case of FS namespace buckets, if the required file resides in the endpoint host, the file path (rather than stream) can be sent to s3select for processing. This allows processing Parquet files stored in namespace buckets.
     4. Parquet requires Arrow, a library for processing Parquet files.
     5. Initial feature will not support Parquet.
-
+    6. Currently Parquet is only supported to NSFS, where seeking a file is easy.
 
 ### HTTP Response
 
@@ -82,7 +82,7 @@ The parser git repositories which are submodules of s3select repository.
 
 Boost is assumed by s3select make to be installed on the builder machine.
 
-
+For Parquet, Arrow (and its dependencies) are assumed to be installed.
 
 2. noobaa-core repository
 
@@ -96,13 +96,13 @@ It will have the s3select and boost repositories as submodules, and the two pars
 
 In docker build, these repositories are fetched and node-gyp uses the sources for compilation.
 
-Only necessary boost submodules are fetched.
+Only necessary Boost submodules are fetched.
 
 All repositories are checkout to a specific commit/tag so updates won’t affect us directly.
 
 When updates are needed, the checkout command needs to be updated to a new commit/tag.
 
-
+Parquet is not build by default.
 
 4. Native build
 

--- a/docs/dev_guide/s3select/S3Select_Build.md
+++ b/docs/dev_guide/s3select/S3Select_Build.md
@@ -34,10 +34,15 @@ Eg, on a Fedora-based linux:
 or, equivalently:
 `GYP_DEFINES=BUILD_S3SELECT=1 node-gyp rebuild`
 
+4. Parquet
+You will need to install Arrow lib and its depndencies.
+See https://arrow.apache.org/install/ and/or our adapted script ./src/deploy/NVA_build/install_arrow_run.sh.
+The relevant GYP param is BUILD_S3SELECT_PARQUET.
+
 ## Docker Build
 S3Select is enabled by defualt for docker build.  
-If you wish to explicitly enable/disable s3select in docker build, you can use BUILD_S3SELECT env parameter. Eg-  
-`BUILD_S3SELECT=0 make noobaa NOOBAA_TAG=noobaa-core:select`
+If you wish to explicitly enable/disable s3select in docker build, you can use BUILD_S3SELECT make parameter. Eg-
+`make noobaa NOOBAA_TAG=noobaa-core:select BUILD_S3SELECT=0`
 
 ## Test Native Code
 You can test native code with the provide s3select.js. Eg-  
@@ -45,4 +50,9 @@ You can test native code with the provide s3select.js. Eg-
 Which is equivalent to-
 `echo -e "1,2,3\n4,5,6" | node src/tools/s3select.js --query "SELECT sum(int(_2)) from stdin;" --input_format CSV --record_delimiter $'\n' --field_delimiter , --file_header_info IGNORE`
 
-
+## Parquet
+Running select on Parquet object is supported only for file-system namespaces (NSFS).
+Parquet parsing implementation has relatively big dependencies (~500 MB).
+In order to save time, bandwidth and disk space, it is not enabled by default, in neither Docker nor native build.
+In order to compile with Parquet s3select support, add the BUILD_S3SELECT_PARQUET=1 flag.
+The BUILD_S3SELECT flag must also be enabled (explicitly in native build, by default in Docker).

--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -22,11 +22,12 @@ COPY ./src/native ./src/native/
 COPY ./src/deploy/NVA_build/clone_submodule.sh ./src/deploy/NVA_build/
 COPY ./src/deploy/NVA_build/clone_s3select_submodules.sh ./src/deploy/NVA_build/
 ARG BUILD_S3SELECT=1
+ARG BUILD_S3SELECT_PARQUET=0
 #Clone S3Select and its two submodules, but only if BUILD_S3SELECT=1.
 RUN ./src/deploy/NVA_build/clone_s3select_submodules.sh
 #Pass BUILD_S3SELECT down to GYP native build.
 #S3Select will be built only if this parameter is equal to "1".
-RUN GYP_DEFINES=BUILD_S3SELECT=$BUILD_S3SELECT npm run build
+RUN GYP_DEFINES="BUILD_S3SELECT=$BUILD_S3SELECT BUILD_S3SELECT_PARQUET=$BUILD_S3SELECT_PARQUET" npm run build
 
 ##############################################################
 # Layers:

--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -54,7 +54,7 @@ ENV ENDPOINT_NODE_OPTIONS ''
 ##############################################################
 # Layers:
 #   Title: Installing dependencies
-#   Size: ~ 379 MB
+#   Size: ~ 272 MB
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
 
@@ -75,6 +75,10 @@ RUN dnf install -y -q bash \
     jemalloc \
     xz && \
     dnf clean all
+
+COPY ./src/deploy/NVA_build/install_arrow_run.sh ./src/deploy/NVA_build/install_arrow_run.sh
+ARG BUILD_S3SELECT_PARQUET=0
+RUN ./src/deploy/NVA_build/install_arrow_run.sh $BUILD_S3SELECT_PARQUET
 
 RUN mkdir -p /usr/local/lib/python3.6/site-packages
 
@@ -149,6 +153,9 @@ EXPOSE 26050
 
 # Needs to be added only after installing jemalloc in dependencies section (our env section is before) - otherwise it will fail
 ENV LD_PRELOAD /usr/lib64/libjemalloc.so.2
+
+#RUN mkdir -p /nsfs/fs1/amitpb && chmod -R 777 /nsfs/
+#RUN mkdir -p /nsfsAA/fs1/amitpb && chmod -R 777 /nsfsAA/
 
 ###############
 # EXEC SETUP #

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -4,13 +4,16 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 ##############################################################
 # Layers:
 #   Title: Installing pre requirments
-#   Size: ~ 613 MB
+#   Size: ~ 613 MB (1324 MB with s3select for Parquet)
 #   Cache: Rebuild when we adding/removing requirments
 ##############################################################
 # RUN dnf --enablerepo=PowerTools install -y -q nasm && \
 #     dnf clean all
 RUN dnf update -y -q --nobest && \
     dnf clean all
+COPY ./src/deploy/NVA_build/install_arrow_build.sh ./src/deploy/NVA_build/install_arrow_build.sh
+ARG BUILD_S3SELECT_PARQUET=0
+RUN ./src/deploy/NVA_build/install_arrow_build.sh $BUILD_S3SELECT_PARQUET
 RUN dnf install -y -q wget unzip which vim python2 python3 boost-devel && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all

--- a/src/deploy/NVA_build/install_arrow_build.sh
+++ b/src/deploy/NVA_build/install_arrow_build.sh
@@ -1,0 +1,15 @@
+if [ -z "$1" ]; then
+	exit 0
+fi
+if [ $1 -ne 1 ]; then
+	exit 0
+fi
+
+dnf install -y epel-release
+dnf install -y https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm
+dnf config-manager --set-enabled epel
+dnf config-manager --set-enabled powertools || :
+#parquet-devel version must match the parquet-libs version in epel
+#otherwise node addon will fail to find the dependency
+dnf install -y parquet-devel-8.0.0-1.el8 # For Apache Parquet C++
+dnf clean all

--- a/src/deploy/NVA_build/install_arrow_run.sh
+++ b/src/deploy/NVA_build/install_arrow_run.sh
@@ -1,0 +1,10 @@
+if [ -z "$1" ]; then
+        exit 0
+fi
+if [ $1 -ne 1 ]; then
+        exit 0
+fi
+
+dnf install -y epel-release
+dnf install -y parquet-libs # For Apache Parquet C++
+dnf clean all

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -521,6 +521,11 @@ S3Error.S3SelectNotCompiled = Object.freeze({
     message: 'This server was not compiled with S3 Select support. Recompile with BUILD_S3SELECT=1.',
     http_code: 501,
 });
+S3Error.S3SelectParquetNotCompiled = Object.freeze({
+    code: 'S3SelectParquetNotCompiled',
+    message: 'This server was not compiled with S3 Select for Parquet. Recompile with BUILD_S3SELECT=1 and BUILD_S3SELECT_PARQUET=1.',
+    http_code: 501,
+});
 S3Error.MissingInputSerialization = Object.freeze({
     code: 'MissingRequiredParameter',
     message: 'InputSerialization is required. Please check the service documentation and try again.',

--- a/src/native/nb_native.gyp
+++ b/src/native/nb_native.gyp
@@ -22,7 +22,8 @@
 
     'targets': [{
 	'variables': {
-            'BUILD_S3SELECT%':0
+            'BUILD_S3SELECT%':0,
+            'BUILD_S3SELECT_PARQUET%':0
         },
         'target_name': 'nb_native',
         'include_dirs': [

--- a/src/native/s3select/s3select.gyp
+++ b/src/native/s3select/s3select.gyp
@@ -14,6 +14,18 @@
         ],
 	'link_settings': {
 		'libraries': ['/lib64/libboost_thread.so.1.66.0']
-    }
+        },
+	'variables': {
+            'BUILD_S3SELECT_PARQUET%':0
+        },
+	'conditions': [
+            ['BUILD_S3SELECT_PARQUET==1', {
+                'link_settings': {
+			'libraries': ['/lib64/libarrow.so', '/lib64/libparquet.so']
+		},
+                'cflags' : ['-D_ARROW_EXIST']
+	    }]
+        ],
+
     }]
 }

--- a/src/native/s3select/s3select_napi.cpp
+++ b/src/native/s3select/s3select_napi.cpp
@@ -5,13 +5,14 @@
 #include "../util/common.h"
 #include "../util/napi.h"
 #include <arpa/inet.h>
+#include <condition_variable>
 
 namespace noobaa
 {
 
 const char *CSV_FORMAT = "CSV";
 const char *JSON_FORMAT = "JSON";
-const char *PARQUET_FORMAT = "PARQUET";
+const char *PARQUET_FORMAT = "Parquet";
 
 class S3SelectNapi;
 
@@ -23,6 +24,9 @@ public:
     Napi::ObjectWrap<S3SelectNapi>& _wrap;
     s3selectEngine::csv_object *_csv_object;
     s3selectEngine::json_object *_json_object;
+#ifdef _ARROW_EXIST
+    s3selectEngine::parquet_object *_parquet_object;
+#endif
     std::string _select;
     const char* _buffer;
     const unsigned int _buffer_len;
@@ -30,22 +34,41 @@ public:
     const std::string _input_format;
     const uint8_t* _headers_bytes;
     const uint32_t _headers_len;
+#ifdef _ARROW_EXIST
+    Napi::ThreadSafeFunction &_parquet_page;
+    Napi::ObjectReference &_s3select_js_ref;
+    uint32_t *_parquet_read_bytes;
+    std::mutex _mutex;
+    std::condition_variable _cond;
+#endif
 
     SelectWorker(const Napi::CallbackInfo& info,
         Napi::ObjectWrap<S3SelectNapi>& wrap,
         s3selectEngine::csv_object* csv_object,
         s3selectEngine::json_object* json_object,
+#ifdef _ARROW_EXIST
+        s3selectEngine::parquet_object * parquet_object,
+#endif
         const char* buffer,
         const unsigned int buffer_len,
         const bool is_flush,
         const std::string input_format,
         const uint8_t* headers_bytes,
-        const uint32_t headers_len)
+        const uint32_t headers_len
+#ifdef _ARROW_EXIST
+        ,Napi::ThreadSafeFunction &parquet_page,
+        Napi::ObjectReference &s3select_js_ref,
+        uint32_t *parquet_read_bytes
+#endif
+        )
         : AsyncWorker(info.Env())
         , _args_ref(Napi::Persistent(Napi::Object::New(info.Env())))
         , _wrap(wrap)
         , _csv_object(csv_object)
         , _json_object(json_object)
+#ifdef _ARROW_EXIST
+        , _parquet_object(parquet_object)
+#endif
         , _buffer(buffer)
         , _buffer_len(buffer_len)
         , _is_flush(is_flush)
@@ -53,6 +76,11 @@ public:
         , _deferred(info.Env())
         , _headers_bytes(headers_bytes)
         , _headers_len(headers_len)
+#ifdef _ARROW_EXIST
+        , _parquet_page(parquet_page)
+        , _s3select_js_ref(s3select_js_ref)
+        , _parquet_read_bytes(parquet_read_bytes)
+#endif
     {
         //take a ref on args to make sure they are not GCed until worker is done
         uint32_t i;
@@ -69,6 +97,90 @@ public:
         _wrap.Unref();
     }
 
+    Napi::Object handle_result_str(Napi::Env env, std::string &result_str){
+        Napi::Object result_js = Napi::Object::New(env);
+        Napi::Value select_buf = Napi::Buffer<char>::/*New*/ Copy(env, result_str.data(), result_str.length());
+        result_js.Set("select", select_buf);
+
+        uint32_t prelude[3];
+        int32_t prelude_crc, message_crc, prelude_crc_BE;
+        prelude[0] = htonl(_select.length() + _headers_len + 16);
+        prelude[1] = htonl(_headers_len);
+        prelude_crc = crc32_gzip_refl_base(0, (uint8_t*)prelude, 8);
+        result_js.Set("prelude_crc", prelude_crc);
+        prelude_crc_BE = htonl(prelude_crc);
+        /*std::cout << "sz = " << sizeof(headers_bytes) << ", native prelude_crc = " << prelude_crc << ", prelude = " << std::hex << std::setfill('0') << std::setw(2) << prelude[0] << prelude[1];
+        std::cout << std::endl;
+        std::cout.flush();*/
+        message_crc = crc32_gzip_refl_base(prelude_crc, (uint8_t*)&prelude_crc_BE, 4);
+        message_crc = crc32_gzip_refl_base(message_crc, const_cast<uint8_t*>(_headers_bytes), _headers_len);
+        message_crc = crc32_gzip_refl_base(message_crc, (uint8_t*)_select.data(), _select.length());
+        result_js.Set("message_crc", message_crc);
+
+        return result_js;
+    }
+
+#ifdef _ARROW_EXIST
+    Napi::Value s3select_parquet_page_js_unlock_cb(const Napi::CallbackInfo &info)
+    {
+        _mutex.lock();
+        _cond.notify_one();
+        _mutex.unlock();
+
+        return info.Env().Null();
+    }
+
+    //call back into node to send the page down the pipe.
+    void s3select_parquet_page_js(Napi::Env env, Napi::Function handle_result, std::string *page)
+    {
+        Napi::Object result = handle_result_str(env, *page);
+        //tell the node object how many bytes we've read (for stats)
+        result.Set("parquet_read_bytes", Napi::Number::New(env, *_parquet_read_bytes));
+        *_parquet_read_bytes = 0;
+
+        napi_value s3select_js = _s3select_js_ref.Value();
+        Napi::Value res = handle_result.Call(s3select_js, {result});
+
+        //handle_result is an async node function
+        //it might, but not necessarily, return a promise
+        if (res.IsPromise()) {
+            Napi::Promise promise = res.As<Napi::Promise>();
+            Napi::Function then = promise.Get("then").As<Napi::Function>();
+            auto fp_s3select_parquet_page_js_unlock_cb =
+                std::bind(&SelectWorker::s3select_parquet_page_js_unlock_cb, this, std::placeholders::_1);
+            Napi::Function callback = Napi::Function::New(env, fp_s3select_parquet_page_js_unlock_cb, "unlock_cb");
+            then.Call(promise, {callback});
+        } else {
+            //sync (ie, no promise) return
+            _mutex.lock();
+            _cond.notify_one();
+            _mutex.unlock();
+        }
+    }
+
+    int s3select_parquet_page_cb(std::string& page)
+    {
+        //std::cout << "format res size in result_format = " << page.length() << std::endl;
+        std::function<void(Napi::Env, Napi::Function, std::string*)> fp_select_parquet_page_js = std::bind(
+            &SelectWorker::s3select_parquet_page_js,
+            this,
+            std::placeholders::_1,
+            std::placeholders::_2,
+            std::placeholders::_3);
+        _parquet_page.Acquire();
+        std::unique_lock ul(_mutex);
+        napi_status ns = _parquet_page.BlockingCall(&page, fp_select_parquet_page_js);
+
+        //wait until node is done with result.
+        _cond.wait(ul);
+        ul.unlock();
+
+        _parquet_page.Release();
+        page.clear();
+        return 0;
+    }
+#endif
+
     void Execute() override
     {
         int rc;
@@ -79,28 +191,43 @@ public:
             } else {
                 rc = _csv_object->run_s3select_on_stream(_select, _buffer, _buffer_len, SIZE_MAX);
             }
-        } else {
+        } else if (JSON_FORMAT == _input_format) {
             if (_is_flush) {
                 rc = _json_object->run_s3select_on_stream(_select, nullptr, 0, 0);
             } else {
                 rc = _json_object->run_s3select_on_stream(_select, _buffer, _buffer_len, SIZE_MAX);
             }
+#ifdef _ARROW_EXIST
+        } else {
+            std::function<int(std::string&)> fp_s3select_header_format = [](std::string& result){return 0;};
+            std::function<int(std::string&)> fp_s3select_result_format = std::bind(&SelectWorker::s3select_parquet_page_cb, this, std::placeholders::_1);
+            try {
+                rc = _parquet_object->run_s3select_on_object(_select, fp_s3select_result_format, fp_s3select_header_format);
+            }
+            catch(s3selectEngine::base_s3select_exception const &ex){
+                rc = -2; //this will cause us to go into SetError
+            }
+#endif
         }
         if (rc < 0) {
             if (CSV_FORMAT == _input_format) {
                 SetError(_csv_object->get_error_description());
-            } else {
+            } else if (JSON_FORMAT == _input_format) {
                 // SetError(json_object.get_error_description()); //TODO - they added a getter, use after submodule is updated
                 SetError("failed to select from json");
+#ifdef _ARROW_EXIST
+            } else {
+                if( rc != -1 ) { //-1 indicates EOF
+                    SetError(_parquet_object->get_error_description());    
+                }
+#endif
             }
         }
-
-        /*std::cout << "select res = " << this->select << std::endl;
-        std::cout.flush();*/
+        //std::cout << "select rc " << rc << ", str = " << this->_select << std::endl;
     }
 
     void OnOK() override
-    {
+    {   
         Napi::Env env = Env();
         // in case of empty select result (ie, no rows in current buffer matched sql condition), return null
         if (_select.empty()) {
@@ -108,26 +235,10 @@ public:
             return;
         }
 
-        Napi::Object result = Napi::Object::New(env);
-        Napi::Value select_buf = Napi::Buffer<char>::/*New*/ Copy(env, _select.data(), _select.length());
-        result.Set("select", select_buf);
-
-        uint32_t prelude[3];
-        int32_t prelude_crc, message_crc, prelude_crc_BE;
-        prelude[0] = htonl(_select.length() + _headers_len + 16);
-        prelude[1] = htonl(_headers_len);
-        prelude_crc = crc32_gzip_refl_base(0, (uint8_t*)prelude, 8);
-        result.Set("prelude_crc", prelude_crc);
-        prelude_crc_BE = htonl(prelude_crc);
-        /*std::cout << "sz = " << sizeof(headers_bytes) << ", native prelude_crc = " << prelude_crc << ", prelude = " << std::hex << std::setfill('0') << std::setw(2) << prelude[0] << prelude[1];
-        std::cout << std::endl;
-        std::cout.flush();*/
-        message_crc = crc32_gzip_refl_base(prelude_crc, (uint8_t*)&prelude_crc_BE, 4);
-        message_crc = crc32_gzip_refl_base(message_crc, const_cast<uint8_t*>(_headers_bytes), _headers_len);
-        message_crc = crc32_gzip_refl_base(message_crc, (uint8_t*)_select.data(), _select.length());
-        result.Set("message_crc", message_crc);
+        Napi::Object result = handle_result_str(env, _select);
 
         _deferred.Resolve(result);
+
     }
 
     void OnError(Napi::Error const& error) override
@@ -146,6 +257,10 @@ public:
     S3SelectNapi(const Napi::CallbackInfo& info);
     Napi::Value Write(const Napi::CallbackInfo& info);
     Napi::Value Flush(const Napi::CallbackInfo& info);
+#ifdef _ARROW_EXIST
+    Napi::Value SelectParquet(const Napi::CallbackInfo &info);
+    void Finalize(Napi::Env env) override;
+#endif
     ~S3SelectNapi();
 
 private:
@@ -153,8 +268,19 @@ private:
     Napi::ObjectReference _args_ref;
     std::string input_format;
     s3selectEngine::s3select s3select;
-    s3selectEngine::csv_object* csv_object = nullptr;
-    s3selectEngine::json_object* json_object = nullptr;
+    s3selectEngine::csv_object *csv_object = nullptr;
+    s3selectEngine::json_object *json_object = nullptr;
+#ifdef _ARROW_EXIST
+    s3selectEngine::parquet_object *parquet_object = nullptr;
+    s3selectEngine::rgw_s3select_api s3select_api;
+    uint32_t parquet_size_bytes, parquet_read_bytes = 0;
+    std::string parquet_file_path;
+    uid_t uid;
+    gid_t gid;
+    Napi::ThreadSafeFunction parquet_page;
+    Napi::ObjectReference s3select_js_ref;
+    FILE *parquet_file = nullptr;
+#endif
     const uint8_t* headers_buf;
     uint32_t headers_len;
 };
@@ -163,17 +289,26 @@ Napi::Value
 S3SelectNapi::Write(const Napi::CallbackInfo& info)
 {
     Napi::Buffer<char> buffer = info[0].As<Napi::Buffer<char>>();
-    SelectWorker* worker = new SelectWorker(
+    SelectWorker *worker = new SelectWorker(
         info,
         *this,
         csv_object,
         json_object,
+#ifdef _ARROW_EXIST
+        parquet_object,
+#endif
         buffer.Data(),
         buffer.Length(),
         false,
         input_format,
         headers_buf,
-        headers_len);
+        headers_len
+#ifdef _ARROW_EXIST
+        ,parquet_page,
+        s3select_js_ref,
+        &parquet_read_bytes
+#endif
+        );
     worker->Queue();
     return worker->_deferred.Promise();
 }
@@ -181,20 +316,53 @@ S3SelectNapi::Write(const Napi::CallbackInfo& info)
 Napi::Value
 S3SelectNapi::Flush(const Napi::CallbackInfo& info)
 {
-    SelectWorker* worker = new SelectWorker(
+    SelectWorker *worker = new SelectWorker(
         info,
         *this,
         csv_object,
         json_object,
+#ifdef _ARROW_EXIST
+        parquet_object,
+#endif
         nullptr, /*No buffer for flush*/
         0,
-        true,
+        true, //is_flush
         input_format,
         headers_buf,
-        headers_len);
+        headers_len
+#ifdef _ARROW_EXIST
+        ,parquet_page,
+        s3select_js_ref,
+        nullptr
+#endif
+        );
     worker->Queue();
     return worker->_deferred.Promise();
 }
+
+#ifdef _ARROW_EXIST
+Napi::Value
+S3SelectNapi::SelectParquet(const Napi::CallbackInfo& info)
+{
+    SelectWorker *worker = new SelectWorker(
+        info,
+        *this,
+        nullptr, //csv object
+        nullptr, //json object
+        parquet_object,
+        nullptr, //no buffer parquet
+        0, //buffer len
+        false, //is_flush
+        PARQUET_FORMAT, //format
+        headers_buf,
+        headers_len,
+        parquet_page,
+        s3select_js_ref,
+        &parquet_read_bytes);
+    worker->Queue();
+    return worker->_deferred.Promise();
+}
+#endif
 
 Napi::FunctionReference S3SelectNapi::constructor;
 
@@ -208,7 +376,10 @@ S3SelectNapi::Init(Napi::Env env, Napi::Object exports)
         "S3SelectNapi",
         {
             InstanceMethod("write", &S3SelectNapi::Write),
-            InstanceMethod("flush", &S3SelectNapi::Flush)
+            InstanceMethod("flush", &S3SelectNapi::Flush),
+#ifdef _ARROW_EXIST
+            InstanceMethod("select_parquet",  &S3SelectNapi::SelectParquet)
+#endif
         }
     ); //end of DefineClass
 
@@ -216,8 +387,22 @@ S3SelectNapi::Init(Napi::Env env, Napi::Object exports)
     constructor.SuppressDestruct();
 
     exports.Set("S3Select", func);
+#ifdef _ARROW_EXIST
+    exports.Set("select_parquet", Napi::Boolean::New(env, true));
+#else
+    exports.Set("select_parquet", Napi::Boolean::New(env, false));
+#endif
     return exports;
 }
+
+#ifdef _ARROW_EXIST
+void S3SelectNapi::Finalize(Napi::Env env)
+{
+    if (PARQUET_FORMAT == input_format) {
+        s3select_js_ref.Unref();
+    }
+}
+#endif
 
 void
 s3select_napi(Napi::Env env, Napi::Object exports)
@@ -238,7 +423,9 @@ S3SelectNapi::S3SelectNapi(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<S3SelectNapi>(info)
     , _args_ref(Napi::Persistent(Napi::Object::New(info.Env())))
 {
+    Napi::Env env = info.Env();
     Napi::Object context = info[0].As<Napi::Object>();
+    _args_ref.Set("context", context);
     Napi::Object input_serialization_format = context.Get("input_serialization_format").As<Napi::Object>();
     Napi::Buffer headers_buf_obj = context.Get("records_header_buf").As<Napi::Buffer<uint8_t>>();
     _args_ref.Set("headers_buf", headers_buf_obj);
@@ -246,12 +433,10 @@ S3SelectNapi::S3SelectNapi(const Napi::CallbackInfo& info)
     headers_len = headers_buf_obj.Length();
     std::string query = context.Get("query").ToString();
     input_format = context.Get("input_format").ToString();
-
     s3select.parse_query(query.c_str());
     if (!s3select.get_error_description().empty()) {
-        throw Napi::Error::New(info.Env(), XSTR() << "s3select: parse_query failed " << s3select.get_error_description());
+        throw Napi::Error::New(env, XSTR() << "s3select: parse_query failed " << s3select.get_error_description());
     }
-
     if (input_format == JSON_FORMAT) {
         json_object = new s3selectEngine::json_object(&s3select);
     } else if (input_format == CSV_FORMAT) {
@@ -262,8 +447,75 @@ S3SelectNapi::S3SelectNapi(const Napi::CallbackInfo& info)
         csv_defs.use_header_info = (0 == GetStringWithDefault(input_serialization_format, "FileHeaderInfo", "").compare("USE"));
         csv_defs.quote_fields_always = false;
         csv_object = new s3selectEngine::csv_object(&s3select, csv_defs);
+#ifdef _ARROW_EXIST
+    } else if (input_format == PARQUET_FORMAT) {
+        Napi::Function handle_result = context.Get("handle_result").As<Napi::Function>();
+        Napi::Object s3select_js_obj = context.Get("s3select_js").As<Napi::Object>();
+        s3select_js_ref = Napi::Persistent(s3select_js_obj);
+        parquet_page = Napi::ThreadSafeFunction::New(
+            info.Env(),
+            handle_result,
+            "Handle Parquet Page",
+            0,
+            1,
+            []( Napi::Env ) {} //empty finalizer
+        );
+        parquet_size_bytes = context.Get("size_bytes").As<Napi::Number>().Uint32Value();
+        std::function<int(void)> fp_get_size=[&](){
+            //std::cout << "returning size_bytes = " << parquet_size_bytes << std::endl;
+            return parquet_size_bytes;
+        };
+        s3select_api.set_get_size_api(fp_get_size);
+
+        parquet_file_path = context.Get("filepath").As<Napi::String>();
+        Napi::Object fs_context = context.Get("fs_context").As<Napi::Object>();
+        uid = fs_context.Get("uid").ToNumber();
+        gid = fs_context.Get("gid").ToNumber();
+        //std::cout << "parquet path = " << parquet_file_path << ", gid = " << gid << ", uid = " << uid << std::endl;
+        ThreadScope tx;
+        tx.set_user(uid, gid);
+
+        parquet_file = fopen(parquet_file_path.c_str(), "r");
+        if (nullptr == parquet_file) {
+            throw std::runtime_error(XSTR() << "Failed to open " << parquet_file_path << ", errno = " << errno);
+        }
+
+
+        std::function<size_t(int64_t, int64_t, void *, optional_yield *)> fp_range_request =
+        [&](int64_t start, int64_t length, void *buff, optional_yield *y) {
+            //std::cout << "range req start = " << start << " ,length = " << length << std::endl;
+            //std::cout << "range req path = " << parquet_file_path << " ,FILE = " << file << std::endl;
+
+            int res = fseek(parquet_file, start, SEEK_SET);
+            if (res) {
+                throw std::runtime_error(XSTR() << "Failed to open " << parquet_file_path << ", errno = " << errno);
+            }
+            //std::cout << "range req fseek res = " << res << std::endl;
+            size_t read_bytes = fread(buff, 1, length, parquet_file);
+            if (read_bytes < length) {
+                res = ferror(parquet_file);
+                if(res){
+                    throw std::runtime_error(XSTR() << "Failed to read " << parquet_file_path << ", res = " << res);
+                }
+            }
+            //std::cout << "range req read = " << read_bytes << " bytes" << std::endl;
+            parquet_read_bytes += read_bytes; //keep track of number of read bytes
+
+            return read_bytes;
+        };
+        s3select_api.set_range_req_api(fp_range_request);
+        try {
+            parquet_object = new s3selectEngine::parquet_object(parquet_file_path, &s3select, &s3select_api);
+        }
+        catch(s3selectEngine::base_s3select_exception const &ex) {
+            throw Napi::Error::New(env, XSTR() << "parquet error - " << ex.what());
+        }
     } else {
-        throw Napi::Error::New(info.Env(), XSTR() << "input_format is neither csv nor json");
+        throw Napi::Error::New(env, XSTR() << "input_format must be either CSV, JSON or Parquet.");
+#else
+    } else {
+        throw Napi::Error::New(env, XSTR() << "input_format must be either CSV or JSON.");
+#endif
     }
 }
 
@@ -275,6 +527,15 @@ S3SelectNapi::~S3SelectNapi()
     if (nullptr != json_object) {
         delete json_object;
     }
+#ifdef _ARROW_EXIST
+    if (nullptr != parquet_object) {
+        delete parquet_object;
+        //parquet_page was started with 1 thread,
+        //release it now we're done
+        parquet_page.Release();
+        fclose(parquet_file);
+    }
+#endif
 }
 
 } // namespace noobaa

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -869,6 +869,7 @@ interface Native {
     fs: NativeFS;
 
     S3Select: { new(options: S3SelectOptions): S3Select };
+    select_parquet: boolean;
 }
 
 interface NativeFS {
@@ -1024,20 +1025,25 @@ interface X509Name {
     O: string;
 }
 
+type select_input_format =  'CSV' | 'JSON' | 'Parquet';
 interface S3SelectOptions {
     query: string;
-    input_format: 'CSV' | 'JSON';
+    input_format: select_input_format;
     input_serialization_format: {
         FieldDelimiter: string;
         RecordDelimiter: string;
         FileHeaderInfo: string;
     };
     records_header_buf: Buffer;
+    size_bytes: number;
+    fs_context: NativeFSContext;
+    filepath: string;
 }
 
 interface S3Select {
     write(data: Buffer): Promise<Buffer>;
     flush(): Promise<Buffer>;
+    select_parquet(): Promise<Buffer>;
 }
 
 type NodeCallback<T = void> = (err: Error | null, res?: T) => void;


### PR DESCRIPTION
### Explain the changes
1. Implement s3select for parquet in nsfs.


### Issues: Fixed #xxx / Gap #xxx
1. No support for other namespaces nor noobaa.
2. build issues TBD (specifically downstream, but upstream build changes are also not final yet)

### Testing Instructions:
1. Get a parquet file in nsfs. A simple way is with
-node src/core/nsfs.js /home/aprinzse/work/nsfs/
-alias s3-user1='AWS_ACCESS_KEY_ID=dc1 AWS_SECRET_ACCESS_KEY=dc2 aws --endpoint https://127.0.0.1:6443 --no-verify-ssl s3'
-s3-user1 mb s3://<bucket name>
-s3-user1 cp <parquet_file> s3://<bucket name>

-AWS_ACCESS_KEY_ID=dc1 AWS_SECRET_ACCESS_KEY=dc2 aws --endpoint https://127.0.0.1:6443 --no-verify-ssl s3api select-object-content --bucket <bucket name> --key <filename> --expression "select * from stdin;" --expression-type 'SQL' --input-serialization '{"Parquet": {}}' --output-serialization '{"CSV": {}}' "output.csv"

- [ ] Doc added/updated
- [ ] Tests added
