### PR TITLE
Omit dummy access key and secret key from agent logs

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -359,7 +359,7 @@ class AgentCLI {
     create_node_helper(current_node_path_info) {
         const self = this;
         return P.fcall(function() {
-            dbg.log0('create_node_helper called with self.params', self.params);
+            dbg.log0('create_node_helper called with self.params', _.omit(self.params, ['access_key', 'secret_key']));
             const current_node_path = current_node_path_info.mount;
             let node_name = self.params.hostname;
             const noobaa_storage_dir_name = self.params.test_hostname ? 'noobaa_storage_' + self.params.test_hostname : 'noobaa_storage';


### PR DESCRIPTION
### Explain the changes
1. omit dummy access key and secret key from agent logs

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2189866 

### Testing Instructions:
1. create pv-pool bucketstore.
2. take logs of the bucketstore
3. check that on trace "create_node_helper called with self.params: <params>" access_key and secret_key are omitted


- [ ] Doc added/updated
- [ ] Tests added
