### PR TITLE
Fix get_tags for copy from namespace-s3

### DIFF
--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -247,6 +247,8 @@ class NamespaceS3 {
                     req.removeListener('httpData', AWS.EventListeners.Core.HTTP_DATA);
                     req.removeListener('httpError', AWS.EventListeners.Core.HTTP_ERROR);
                     let count = 1;
+                    // on s3 read_object_md might not return x-amz-tagging-count header, so we get it here
+                    params.tag_count = headers['x-amz-tagging-count'];
                     const count_stream = stream_utils.get_tap_stream(data => {
                         this.stats?.update_namespace_read_stats({
                             namespace_resource_id: this.namespace_resource_id,


### PR DESCRIPTION
### Explain the changes
1. Get tag_count from read_object_stream on s3 since this value is not always returned in read_object_md
2. moved _populate_source_object_tagging to only run when copying on different servers. (when copying from the same server tagging is copied already)

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/5341

### Testing Instructions:
1. create s3 namespace bucket, and noobaa bucket
2. create object with tags on the s3 bucket
3. copy object from s3 bucket to noobaa bucket with COPY tagging_dierctive
4. run get_object_tagging on the new object. check that the tags were copied


- [ ] Doc added/updated
- [x] Tests added
