### PR TITLE
Fix for ceph tests failing, increased count to 240 days

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -38,7 +38,7 @@ commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}'
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
 
-max_days="180"
+max_days="240"
 if [ $((current_date-commit_date)) -gt $((3600*24*${max_days})) ]
 then
     echo "ceph tests were not updated for ${max_days} days, Exiting"


### PR DESCRIPTION
### Explain the changes
1.  Increased the count to 240 days for ceph tests updation.

### Issues: Fixed #xxx / Gap #xxx
1.  Ceph tests are failing as were not updated within the limit of 180days.