### PR TITLE
Add a description and files for logging in the stand alone environment

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -28,10 +28,44 @@ cd noobaa-core
 npm install
 npm run build
 # optional package everything into a single-executable at build/noobaa-core
-npm run pkg 
+npm run pkg
 ```
 
-### 3. Quick test
+### 3. Various system setting (optional)
+
+You can use the configuration for `rsyslog` and `logrotate` for RHEL8. The logs of the NooBaa shall be stored into `/var/log/noobaa.log` if you make the instruction below. And the log file shall be rotated automatically by the `logrotate`.
+
+```
+sudo cp src/deploy/standalone/noobaa_syslog.conf /etc/rsyslog.d/
+sudo cp src/deploy/standalone/logrotate_noobaa.conf /etc/logrotate.d/
+sudo systemctl restart systemd-journald rsyslog
+```
+
+#### 3.1 Additional syslog configuration for RHEL8
+
+Additionally, it would be helpful if you configure to disable the rate limit of the log system.
+
+1. Add the 2 lines below into `/etc/systemd/journald.conf`
+
+```
+RateLimitInterva]lSec=0s
+RateLimitBurst=0
+```
+
+2. Add teh 2 lines below into `/etc/rsyslog.conf` (Just after the comment line `#### GLOBAL DIRECTIVES ####`)
+
+```
+$imjournalRatelimitInterval 0
+$imjournalRatelimitBurst 0
+```
+
+3. Restart log system
+
+```
+sudo systemctl restart systemd-journald rsyslog
+```
+
+### 4. Quick test
 
 This tool invokes key functions (e.g erasure coding), and should be able to run to completion without failures:
 
@@ -244,7 +278,7 @@ aws --endpoint http://localhost:6001 s3 rm s3://testbucket/testobject
 ## Multipart uploads
 
 ```sh
-node src/tools/s3cat --endpoint http://localhost:6001 --sig s3 --bucket testbucket --upload testobject --size 4096 --part_size 1024 --concur 4 
+node src/tools/s3cat --endpoint http://localhost:6001 --sig s3 --bucket testbucket --upload testobject --size 4096 --part_size 1024 --concur 4
 ```
 
 ### Perf tools

--- a/src/deploy/standalone/logrotate_noobaa.conf
+++ b/src/deploy/standalone/logrotate_noobaa.conf
@@ -1,0 +1,31 @@
+/var/log/noobaa.log
+{
+    daily
+    size 100M
+    start 1
+    missingok
+    rotate 100
+    compress
+    create 644 root root
+    sharedscripts
+    postrotate
+        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}
+
+/var/log/client_noobaa.log
+{
+    daily
+    size 100M
+    start 1
+    missingok
+    rotate 10
+    compress
+    create 644 root root
+    sharedscripts
+    postrotate
+        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}

--- a/src/deploy/standalone/noobaa_syslog.conf
+++ b/src/deploy/standalone/noobaa_syslog.conf
@@ -1,0 +1,18 @@
+# NooBaa syslog setting
+
+$umask 0000
+$FileCreateMode 0644
+$EscapeControlCharactersOnReceive off
+
+# Provides UDP/TCP forwarding. The IP/DNS is the server's IP/DNS address
+# This is an example of sending everything except NooBaa logs using UDP
+# When changing this format make sure to change the relevant functions in os_utils
+#if $syslogfacility-text != 'local0' then @192.168.1.108:514
+
+# For servers
+local0.*        /var/log/noobaa.log;RSYSLOG_FileFormat
+&stop
+
+# For clients
+local1.*        /var/log/client_noobaa.log;RSYSLOG_FileFormat
+&stop


### PR DESCRIPTION
### Explain the changes

1. Adding the configuration file of `rsyslog` for the standalone environment
2. Adding the configuration file of `logrotate` for the standalone environment
3. Updating the document how to build the stand alone environment to configure `rsyslog` and `logrotate` (Main target is RHEL8)

### Issues:

No issues to be linked at this time. This is an additional improvement of PR #7296.

### Testing Instructions:

Just adding the configuration file for stand alone environment and update the document for stand alone environment.

The configuration file is verified on my test bench.  

- [X] Doc added/updated
