### PR TITLE
NSFS | Versioning | Suspended Mode Put Object

### DIFF
--- a/docs/design/NsfsVersioning.md
+++ b/docs/design/NsfsVersioning.md
@@ -3,7 +3,6 @@
 ## OVERVIEW
 NooBaa NSFS versioning feature is used for keeping multiple variants of an object in the same NSFS bucket. A user can use the NSFS Versioning feature to preserve, retrieve, and restore every version of every object stored in a versioning-enabled bucket. S3 WORM locking feature is based on versioned enabled buckets.
 
-
 ## GOALS
 * Maintain a directory tree of the NSFS bucket 
 * Support S3 versioning API for NSFS buckets -
@@ -22,49 +21,52 @@ NooBaa NSFS versioning feature is used for keeping multiple variants of an objec
 The Versioning implementation consists of lazy creation of a hidden sub-directory that will contain all versions of all objects under the parent directory except the latest version. 
 The latest version will be located in the parent directory itself.
 
-
 ### PROPOSED SOLUTION DIAGRAM
 The following diagram illustrates a directory tree of a versioning-enabled bucket
 
-<div id="top" />
-<img src="/docs/design/images/nsfs_versioning_dir_tree.png" />
+![Example of a directory '/' with versioning enabled bucket with one object 'Obj1' and one subdirectory 'folder1/' and inside it there's 'Obj2'. For each directory there are the previous versions inside '.versions/'](/docs/design/images/nsfs_versioning_dir_tree.png)
+
 In the figure, each original directory contains a hidden .versions/ sub- directory that stores past versions of objects located under the parent directory, while the latest version of each object can be found under the parent directory itself. For instance, the latest version of Obj1 can be found under the root directory (/), while the old versions of Obj1 reside under /.versions/.
 
-
-## CONCEPTS 
-
+## CONCEPTS
 * Objects that are stored in a bucket before you set the versioning state have a version ID of null. 
-* Objects that are stored in a bucket After you set the versioning state have a unique version ID. 
-* PUT, POST and COPY operations will create a new version of the object identified by a unique version id.
-* DELETE latest version will create a delete marker which is a dummy version identified by a  unique version id as well.
-* DELETE version id will delete the version completely.
+* Objects that are stored in a bucket after you set the versioning state have a unique version ID.
+* Objects that are stored in a bucket after you suspended the versioning state have a version ID of null.
 
+#### When versioning is enabled:
+* PUT, POST and COPY operations will create a new version of the object identified by a unique version ID.
+* DELETE latest version will create a delete marker which is a dummy version identified by a unique version ID as well.
+* DELETE version ID will delete the version completely.
+
+#### When versioning is suspended:
+* PUT, POST and COPY operations will create a version ID of null.
+* DELETE latest version will create a delete marker which is a dummy version with a version ID of null.
+* DELETE version ID will delete the version completely.
 
 ### Version ID 
-* Will be allocated to a version on PUT/POST request (or DELETE version id). 
+* Will be allocated to a version on PUT/POST request (or DELETE version ID). 
 * Consisted of the version mtimeMS + inode number.
 * The version ID will be attached as an xattr of the file.
 * When a latest version is moved to past versions directory, the file name will be changed from key to key_{version_id}.
 
-
 ### Delete marker
 * A dummy file that will be created under the hidden .versions/ sub-directory on DELETE latest request.
 * When A delete marker is the latest version of an object, it indicates that the object is deleted.
-* A unique version id will be allocated to the delete marker as for regular versions.
+* A unique version ID will be allocated to the delete marker as for regular versions.
 
 ### Posix safe rename
 
 #### In the following cases NooBaa will move files between a directory and its .versions/ directory:
 
-* Put object / Complete multipart upload - a new latest version will be created and the current latest version should move to .versions/.
+* Put object / Complete multipart upload - A new latest version will be created and the current latest version should move to .versions/.
 * Delete latest version - The latest version should move from the parent directory to .versions/ & a delete marker will be created in .versions as well.
-* Delete version id (latest version & regular version) - The current latest version should be removed and the second latest should move from .versions/ to the parent directory.
-* Delete version id (latest version & a delete marker) - The current latest version should be removed and if the second latest is not a delete marker it should move from .versions/ to the parent directory.
+* Delete version ID (latest version & regular version) - The current latest version should be removed and the second latest should move from .versions/ to the parent directory.
+* Delete version ID (latest version & a delete marker) - The current latest version should be removed and if the second latest is not a delete marker it should move from .versions/ to the parent directory.
 See - https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html
 
 In order to support best effort on scale of these scenarios, for POSIX file systems, we will use the following methods - 
 
-#### Safe link - 
+#### Safe link
 
 ```
 1. stat_res1 = stat path1
@@ -75,7 +77,7 @@ In order to support best effort on scale of these scenarios, for POSIX file syst
     4.2. retry
 ```
 
-#### safe unlink
+#### Safe unlink
 
 ```
 1. stat_res1 = stat path
@@ -88,7 +90,6 @@ In order to support best effort on scale of these scenarios, for POSIX file syst
 ```
 
 ## OUT OF SCOPE
-
 ### TODO
- * Handle Suspended versioning buckets.
- * Add GPFS design 
+* Add GPFS design.
+* Versioning on objects that their name ends with '/' (in the file system it looks like a directory).

--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -44,6 +44,15 @@ async function file_exists(file_path) {
     }
 }
 
+async function file_not_exists(file_path) {
+    try {
+        await file_must_not_exist(file_path);
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
+
 /**
  * options.on_entry - function({path, stat})
  *      returning false from on_entry will stop recursing to entry
@@ -302,3 +311,4 @@ exports.ignore_eexist = ignore_eexist;
 exports.ignore_enoent = ignore_enoent;
 exports.PRIVATE_DIR_PERMISSIONS = PRIVATE_DIR_PERMISSIONS;
 exports.file_exists = file_exists;
+exports.file_not_exists = file_not_exists;


### PR DESCRIPTION
### Explain the changes
1. Add NSFS Versioning Suspended mode to support put-object operation.
 
### Issues: Gaps
1. In suspended mode changes we used only "safe" filesystem functions (safe_move, safe_unlink), later we might change it according to the specific case (we also don't have concurrency tests).
2. GPFS was not tested yet with these changes.
3. We currently don't keep `XATTR_PREV_VERSION_ID` updated in case there is a deletion of a specific version id or in case we delete an old null version from the `.versions/` directory.
4. Test cases that combine delete-object and put-object will be added after the delete-object in suspended mode will be implemented.
 
### Testing Instructions:
#### Manual Tests:
1. Change the configuration of NSFS Versioning to be Enabled in file `config.js` and change `config.NSFS_VERSIONING_ENABLED` to `true`.
2. Deploy noobaa system on minikube (Based on the instructions [here](https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76) - the steps of _‘Build images’_ and _‘Deploy noobaa’_).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
4. Deploy NSFS on minikube (Based on the instructions [here](https://github.com/noobaa/noobaa-core/wiki/NSFS-on-Kubernetes/8fa95c3b827c40f2435a63f60fae5f7285e6b221)).
5. Use AWS CLI and use the put-object command (here is a link to their [doc](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/put-object.html)).
6. Set the bucket to versioning Enabled and put-object of another key (here is a link to their [doc](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/put-bucket-versioning.html)).
7. Set versioning to suspended and put versions of the same object that were uploaded before (steps 4 and 5).
 
While you add objects to the bucket you can view the changes
1. Connect to the endpoint pod: `kubectl exec -it [endpont-pod-name] -- bash`.
2. Move to the bucket path (if you did it as written in the wiki it would be ' cd /nsfs/fs1/bucket-path/').
3. Use Linux commands to list the files (including hidden files), for example: `ls -al`.
 
#### Run Unit Tests: 
1. In file `src/test/unit_tests/sudo_index.js` leave only `require('./test_bucketspace_versioning');` (rest of test files  comment out).
2. From the core tab in the terminal run: `make root-perm-test` (You should see "110 passing" at the end of the output).
 
- [X] Doc added/updated: updated.
- [X] Tests added: NSFS Versioning Suspended mode: put-object, copy-object, and upload multipart (based on existing tests that we have in NSFS Versioning Enabled mode).