### PR TITLE
Objects versions Replication - Step 1

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -717,9 +717,7 @@ module.exports = {
             method: 'PUT',
             params: {
                 type: 'object',
-                required: [
-                    'name', 'replication_policy'
-                ],
+                required: ['name', 'replication_policy'],
                 properties: {
                     name: { $ref: 'common_api#/definitions/bucket_name' },
                     replication_policy: { $ref: '#/definitions/replication_policy' },
@@ -734,9 +732,7 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
-                required: [
-                    'name'
-                ],
+                required: ['name'],
                 properties: {
                     name: { $ref: 'common_api#/definitions/bucket_name' },
                 },
@@ -753,9 +749,7 @@ module.exports = {
             method: 'DELETE',
             params: {
                 type: 'object',
-                required: [
-                    'name'
-                ],
+                required: ['name'],
                 properties: {
                     name: { $ref: 'common_api#/definitions/bucket_name' },
                 },
@@ -770,9 +764,7 @@ module.exports = {
             method: 'GET',
             params: {
                 type: 'object',
-                required: [
-                    'name', 'replication_policy'
-                ],
+                required: ['name', 'replication_policy'],
                 properties: {
                     name: { $ref: 'common_api#/definitions/bucket_name' },
                     replication_policy: { $ref: '#/definitions/replication_policy' },
@@ -874,7 +866,7 @@ module.exports = {
                 versioning: { $ref: '#/definitions/versioning' },
                 namespace: { $ref: '#/definitions/namespace_bucket_config' },
                 bucket_claim: { $ref: '#/definitions/bucket_claim' },
-                logging: {$ref: '#/definitions/logging'},
+                logging: { $ref: '#/definitions/logging' },
                 force_md5_etag: {
                     type: 'boolean'
                 },
@@ -1425,6 +1417,7 @@ module.exports = {
                                 }
                             },
                             sync_deletions: { type: 'boolean' },
+                            sync_versions: { type: 'boolean' },
                         }
                     }
                 },

--- a/src/server/system_services/schemas/replication_configuration_schema.js
+++ b/src/server/system_services/schemas/replication_configuration_schema.js
@@ -29,6 +29,7 @@ module.exports = {
                         }
                     },
                     sync_deletions: { type: 'boolean' },
+                    sync_versions: { type: 'boolean' },
                     rule_status: {
                         type: 'object',
                         required: ['src_cont_token', 'dst_cont_token', 'last_cycle_start', 'last_cycle_end'],

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -61,9 +61,9 @@ function get_copy_type() {
     return 'MIX';
 }
 
-async function move_objects(scanner_sem, client, copy_type, src_bucket_name, dst_bucket_name, keys) {
+async function move_objects(scanner_semaphore, client, copy_type, src_bucket_name, dst_bucket_name, keys) {
     try {
-        const res = await scanner_sem.surround_count(keys.length,
+        const res = await scanner_semaphore.surround_count(keys.length,
             async () => {
                 try {
                     const res1 = await client.replication.move_objects_by_type({
@@ -92,9 +92,9 @@ async function move_objects(scanner_sem, client, copy_type, src_bucket_name, dst
     }
 }
 
-async function delete_objects(scanner_sem, client, bucket_name, keys) {
+async function delete_objects(scanner_semaphore, client, bucket_name, keys) {
     try {
-        const res = await scanner_sem.surround_count(keys.length,
+        const res = await scanner_semaphore.surround_count(keys.length,
             async () => {
                 try {
                     const res1 = await client.replication.delete_objects({


### PR DESCRIPTION
### Explain the changes
- Adding sync_versions the bucket_api and to the replication_configuration_schema
- Adding list_versioned_buckets_and_compare which will currently only list the source
- Adding list_objects_versions
- Adding _object_grouped_by_key_and_omitted to group each key and its versions, and omit the last key if needed.
- Add a function (_get_next_key_marker) to get the desired next key marker.

*This PR is a prep, the code is not accessible. will add unit tests on a later PR, when we have the code ready*
*With this PR we should expect all the regular replication tests to work*
