### PR TITLE
Fix #7314: Use mtime instead of ctime when tier2 FS is enabled.

### DIFF
--- a/src/agent/block_store_services/block_store_fs.js
+++ b/src/agent/block_store_services/block_store_fs.js
@@ -25,7 +25,10 @@ class BlockStoreFs extends BlockStoreBase {
         this.old_blocks_path = path.join(this.root_path, 'blocks');
         this.config_path = path.join(this.root_path, 'config');
         this.usage_path = path.join(this.root_path, 'usage');
-        this.fs_context = {};
+
+        this.fs_context = {
+            disable_ctime_check: config.BLOCK_STORE_FS_TIER2_ENABLED
+        };
     }
 
     async init() {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -947,6 +947,7 @@ interface NativeFSContext {
     backend?: 'GPFS';
     warn_threshold_ms?: number;
     report_fs_stats?: Function;
+    disable_ctime_check?: boolean;
 }
 
 type NativeFSXattr = { [key: string]: string };


### PR DESCRIPTION
### Explain the changes
This PR adds a simple flag in `fs_napi` which forces using `mtime` instead of `ctime` wherever appropriate. At some places use of mtime is not appropriate so in that place the check is completely skipped.

### Fixes: #7314

- [ ] Doc added/updated
- [ ] Tests added
