### PR TITLE
Bug Fix #7324 | Change Error Message of Put Bucket Versioning

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_versioning.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_versioning.js
@@ -11,7 +11,7 @@ async function put_bucket_versioning(req) {
         req.body.VersioningConfiguration.Status[0];
     if (!versioning) return;
     if (versioning !== 'Suspended' && versioning !== 'Enabled') {
-        throw new S3Error(S3Error.InvalidArgument);
+        throw new S3Error(S3Error.MalformedXML);
     }
     await req.object_sdk.set_bucket_versioning({
         name: req.params.bucket,


### PR DESCRIPTION
### Explain the changes
1. Change the error message of Put bucket versioning in case the versioning configuration status is not Enabled or Suspended.

### Issues: Fixed #7324 
1. Put bucket versioning error using NooBaa endpoint should be same as AWS (which is MalformedXML).

### Testing Instructions:
1. Are inside the issue mentioned above (#7324)

- [ ] Doc added/updated
- [ ] Tests added
