### PR TITLE
bucket CORS move to config

### DIFF
--- a/config.js
+++ b/config.js
@@ -116,6 +116,38 @@ config.ENDPOINT_MONITOR_INTERVAL = 10 * 60 * 1000; // 10min
 config.S3_KEEP_ALIVE_WHITESPACE_INTERVAL = 15 * 1000;
 config.S3_MD_SIZE_LIMIT = 2 * 1024;
 
+// For now we enable fixed CORS for all buckets
+// but this should become a setting per bucket which is configurable
+// with the s3 put-bucket-cors api.
+// note that browsers do not really allow origin=* with credentials,
+// but we just allow both from our side for simplicity.
+config.S3_CORS_ENABLED = true;
+config.S3_CORS_ALLOW_ORIGIN = '*';
+config.S3_CORS_ALLOW_CREDENTIAL = 'true';
+config.S3_CORS_ALLOW_METHODS = [
+    'GET',
+    'POST',
+    'PUT',
+    'DELETE',
+    'OPTIONS'
+].join(',');
+config.S3_CORS_ALLOW_HEADERS = [
+    'Content-Type',
+    'Content-MD5',
+    'Authorization',
+    'X-Amz-User-Agent',
+    'X-Amz-Date',
+    'ETag',
+    'X-Amz-Content-Sha256',
+    'amz-sdk-invocation-id',
+    'amz-sdk-request',
+].join(',');
+config.S3_CORS_EXPOSE_HEADERS = [
+    'ETag',
+    'X-Amz-Version-Id'
+].join(',');
+config.STS_CORS_EXPOSE_HEADERS = 'ETag';
+
 /////////////////////
 // SECRETS CONFIG  //
 /////////////////////

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -2,14 +2,14 @@
 'use strict';
 
 const _ = require('lodash');
+const net = require('net');
 
 const dbg = require('../../util/debug_module')(__filename);
 const s3_ops = require('./ops');
 const S3Error = require('./s3_errors').S3Error;
+const s3_utils = require('./s3_utils');
 const time_utils = require('../../util/time_utils');
 const http_utils = require('../../util/http_utils');
-const s3_utils = require('./s3_utils');
-const net = require('net');
 const signature_utils = require('../../util/signature_utils');
 
 const S3_MAX_BODY_LEN = 4 * 1024 * 1024;
@@ -73,7 +73,8 @@ async function s3_rest(req, res) {
 
 async function handle_request(req, res) {
 
-    http_utils.set_response_headers(req, res, { expose_headers: 'ETag,X-Amz-Version-Id' });
+    http_utils.set_amz_headers(req, res);
+    http_utils.set_cors_headers_s3(req, res);
 
     if (req.method === 'OPTIONS') {
         dbg.log1('OPTIONS!');

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -45,7 +45,8 @@ async function sts_rest(req, res) {
 
 async function handle_request(req, res) {
 
-    http_utils.set_response_headers(req, res, { expose_headers: 'ETag' });
+    http_utils.set_amz_headers(req, res);
+    http_utils.set_cors_headers_sts(req, res);
 
     if (req.method === 'OPTIONS') {
         dbg.log1('OPTIONS!');


### PR DESCRIPTION
### Explain the changes
1. bucket cors was hardcoded
2. moved cors to config to allow modifying the behavior.
3. no change to default runtime functionality
4. next, we can consider moving it to be per bucket, and implement the s3 get/put_bucket_cors apis.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. NA

- [ ] Doc added/updated
- [ ] Tests added
