### PR TITLE
nsfs support for direct io

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,7 +17,7 @@ BinPackParameters: false
 FixNamespaceComments: true
 NamespaceIndentation: Inner
 PointerAlignment: Left
-# IndentPPDirectives: AfterHash
+IndentPPDirectives: BeforeHash
 
 AlignOperands: DontAlign
 AlignAfterOpenBracket: DontAlign

--- a/config.js
+++ b/config.js
@@ -638,7 +638,7 @@ config.NSFS_DIR_CACHE_MAX_DIR_SIZE = 64 * 1024 * 1024;
 config.NSFS_DIR_CACHE_MIN_DIR_SIZE = 64;
 config.NSFS_DIR_CACHE_MAX_TOTAL_SIZE = 24 * config.NSFS_DIR_CACHE_MAX_DIR_SIZE;
 
-config.NSFS_OPEN_READ_MODE = 'r'; // use 'rd' for direct, or 'rs' for sync, or 'rds' for both
+config.NSFS_OPEN_READ_MODE = 'r'; // use 'rd' for direct io
 
 config.BASE_MODE_FILE = 0o666;
 config.BASE_MODE_DIR = 0o777;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -911,16 +911,19 @@ interface NativeFS {
     mkdir(fs_context: NativeFSContext, path: string, mode?: number): Promise<void>;
     rmdir(fs_context: NativeFSContext, path: string): Promise<void>;
 
+    dio_buffer_alloc(size: number): Buffer;
+    set_debug_level(level: number);
+
     S_IFMT: number;
     S_IFDIR: number;
     S_IFLNK: number;
     DT_DIR: number;
     DT_LNK: number;
     PLATFORM_IOV_MAX: number;
+    O_DIRECT?: number;
+    O_TMPFILE?: number;
 
     gpfs?: object;
-
-    set_debug_level(level: number);
 }
 
 interface NativeFile {

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -176,11 +176,20 @@ function write_to_stream(writable, buf) {
 
 class BuffersPool {
 
-    constructor({ buf_size, sem, warning_timeout }) {
+    /**
+     * @param {{
+     *      buf_size: number;
+     *      sem: import('./semaphore');
+     *      warning_timeout: number;
+     *      buffer_alloc?: (size: number) => Buffer;
+     * }} params
+     */
+    constructor({ buf_size, sem, warning_timeout, buffer_alloc }) {
         this.buf_size = buf_size;
         this.buffers = [];
         this.sem = sem;
         this.warning_timeout = warning_timeout;
+        this.buffer_alloc = buffer_alloc || Buffer.allocUnsafeSlow;
     }
 
     /**
@@ -200,7 +209,7 @@ class BuffersPool {
         if (this.buffers.length) {
             buffer = this.buffers.shift();
         } else {
-            buffer = Buffer.allocUnsafeSlow(this.buf_size);
+            buffer = this.buffer_alloc(this.buf_size);
         }
         if (this.warning_timeout) {
             const err = new Error('Warning stuck buffer_pool buffer');


### PR DESCRIPTION
### Explain the changes
1. direct io is useful in some cases to reduce data copies.
2. nsfs buffer pool allocates its buffers with memalign of 4K to allow direct io from the FS.
3. refactor parse_open_flags instead of the flags_to_case map, to allow direct/sync options no matter in which order.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. override in config-local to set `config.NSFS_OPEN_READ_FLAGS = 'rd'` or in .env with `CONFIG_JS_NSFS_OPEN_READ_FLAGS=rd`

- [ ] Doc added/updated
- [ ] Tests added
