### PR TITLE
Makefile add optional CONTAINER_PLATFORM flag to container builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,14 @@ ifeq ($(CONTAINER_ENGINE),)
 	CONTAINER_ENGINE=$(shell podman version >/dev/null 2>&1 && echo podman)
 endif
 
+# see https://github.com/containerd/nerdctl/blob/main/docs/multi-platform.md
+# e.g use CONTAINER_PLATFORM=amd64 for building x86_64 on arm.
+CONTAINER_PLATFORM_FLAG=
+ifdef CONTAINER_PLATFORM
+	CONTAINER_PLATFORM_FLAG="--platform=$(CONTAINER_PLATFORM)"
+endif
+
+
 GIT_COMMIT?="$(shell git rev-parse HEAD | head -c 7)"
 NAME_POSTFIX?="$(shell ${CONTAINER_ENGINE} ps -a | wc -l | xargs)"
 BUILDER_TAG?="noobaa-builder"
@@ -79,22 +87,22 @@ all: tester noobaa
 .PHONY: all
 
 builder: assert-container-engine
-	@echo "\033[1;34mStarting Builder $(CONTAINER_ENGINE) build.\033[0m"
-	$(CONTAINER_ENGINE) build $(CPUSET) -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-builder .
+	@echo "\033[1;34mStarting Builder $(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) \033[0m"
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-builder .
 	$(CONTAINER_ENGINE) tag noobaa-builder $(BUILDER_TAG)
 	@echo "\033[1;32mBuilder done.\033[0m"
 .PHONY: builder
 
 base: builder
-	@echo "\033[1;34mStarting Base $(CONTAINER_ENGINE) build.\033[0m"
-	$(CONTAINER_ENGINE) build $(CPUSET) --build-arg BUILD_S3SELECT -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
+	@echo "\033[1;34mStarting Base $(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) \033[0m"
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT -f src/deploy/NVA_build/Base.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-base . $(REDIRECT_STDOUT)
 	$(CONTAINER_ENGINE) tag noobaa-base $(NOOBAA_BASE_TAG)
 	@echo "\033[1;32mBase done.\033[0m"
 .PHONY: base
 
 tester: noobaa
-	@echo "\033[1;34mStarting Tester $(CONTAINER_ENGINE) build.\033[0m"
-	$(CONTAINER_ENGINE) build $(CPUSET) -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
+	@echo "\033[1;34mStarting Tester $(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) \033[0m"
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/NVA_build/Tests.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-tester . $(REDIRECT_STDOUT)
 	$(CONTAINER_ENGINE) tag noobaa-tester $(TESTER_TAG)
 	@echo "\033[1;32mTester done.\033[0m"
 .PHONY: tester
@@ -166,8 +174,8 @@ tests: test #alias for test
 .PHONY: tests
 
 noobaa: base
-	@echo "\033[1;34mStarting NooBaa $(CONTAINER_ENGINE) build.\033[0m"
-	$(CONTAINER_ENGINE) build $(CPUSET) -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	@echo "\033[1;34mStarting NooBaa $(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) \033[0m"
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	$(CONTAINER_ENGINE) tag noobaa $(NOOBAA_TAG)
 	@echo "\033[1;32mNooBaa done.\033[0m"
 .PHONY: noobaa
@@ -175,7 +183,7 @@ noobaa: base
 # This rule builds a container image that includes developer tools
 # which allows to build and debug the project.
 nbdev:
-	$(CONTAINER_ENGINE) build $(CPUSET) -f src/deploy/NVA_build/dev.Dockerfile $(CACHE_FLAG) -t nbdev --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/NVA_build/dev.Dockerfile $(CACHE_FLAG) -t nbdev --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	@echo "\033[1;32mImage 'nbdev' is ready.\033[0m"
 	@echo "Usage: docker run -it nbdev"
 .PHONY: nbdev


### PR DESCRIPTION
### Explain the changes
1. See https://lima-vm.io/?file=docs/multi-arch.md
2. See https://github.com/containerd/nerdctl/blob/main/docs/multi-platform.md
3. used `CONTAINER_PLATFORM=amd64` for building x86_64 images on Mac arm64.
4. In a lima shell:
```
make noobaa CONTAINER_ENGINE=nerdctl CONTAINER_PLATFORM=amd64
```

CC @utkarsh-pro 

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. NA


- [ ] Doc added/updated
- [ ] Tests added
