### PR TITLE
Fix #7304 try to set TMFS trigger xattr but warn only on failure

### DIFF
--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -896,6 +896,7 @@ interface NativeFS {
     writeFile(fs_context: NativeFSContext, path: string, buffer: Buffer, options?: {
         mode?: number;
         xattr?: NativeFSXattr;
+        xattr_try?: NativeFSXattr;
         xattr_need_fsync?: boolean;
         xattr_clear_prefix?: string;
     }): Promise<void>;


### PR DESCRIPTION
### Explain the changes
1. Use optional xattr map for triggerring TMFS migration on block writes.

### Issues: Fixed #xxx / Gap #xxx
1. Fix #7304 

### Testing Instructions:
1. See above issue.

- [ ] Doc added/updated
- [ ] Tests added
