### PR TITLE
[TMFS] Address minors from #7313 & support auto second tier creation & assignment if configured

### DIFF
--- a/config.js
+++ b/config.js
@@ -176,6 +176,7 @@ config.DEFAULT_BUCKET_NAME = 'first.bucket';
 config.INTERNAL_STORAGE_POOL_NAME = 'system-internal-storage-pool';
 // config.SPILLOVER_TIER_NAME = 'bucket-spillover-tier';
 config.ALLOW_BUCKET_CREATE_ON_INTERNAL = true;
+config.BUCKET_AUTOCONF_TIER2_ENABLED = false;
 
 //////////////////////////
 // MD AGGREGATOR CONFIG //

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -167,6 +167,9 @@ config.REBUILD_NODE_ENABLED = false;
 config.AWS_METERING_ENABLED = false;
 config.AGENT_BLOCKS_VERIFIER_ENABLED = false;
 config.TIERING_TTL_WORKER_ENABLED = true;
+
+// Enable auto tier2 for TMFS buckets
+config.BUCKET_AUTOCONF_TIER2_ENABLED = true;
 EOF
 ```
 
@@ -252,21 +255,6 @@ export AWS_SECRET_ACCESS_KEY=$(npm -- run api account read_account '{}' --json |
 
 ```sh
 aws --endpoint http://localhost:6001 s3 mb s3://testbucket
-```
-
-Add additional second tier to the bucket so that TTL worker can do the cache eviction.Note that here:
-1. The `bucket_name` is the same as the name of the bucket we created in the previous step.
-2. The `attached_pools` is the same as the name of the pool we created in the [above](#create-a-pool) section.
-```sh
-node src/cmd/api.js tiering_policy add_tier_to_bucket '{
-  "bucket_name": "testbucket", 
-  "tier":{
-    "attached_pools": ["backingstores"],
-    "order": 1, 
-    "data_placement":"SPREAD",
-    "storage_class": "GLACIER"
-  }
-}'
 ```
 
 ### Listing

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -14,6 +14,7 @@ const ChunkedContentDecoder = require('../../util/chunked_content_decoder');
 const stream_utils = require('../../util/stream_utils');
 
 const STORAGE_CLASS_STANDARD = 'STANDARD';
+const STORAGE_CLASS_GLACIER = 'GLACIER';
 
 const DEFAULT_S3_USER = Object.freeze({
     ID: '123',
@@ -677,6 +678,7 @@ function response_field_encoder_url(value) {
 }
 
 exports.STORAGE_CLASS_STANDARD = STORAGE_CLASS_STANDARD;
+exports.STORAGE_CLASS_GLACIER = STORAGE_CLASS_GLACIER;
 exports.DEFAULT_S3_USER = DEFAULT_S3_USER;
 exports.DEFAULT_OBJECT_ACL = DEFAULT_OBJECT_ACL;
 exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;

--- a/src/sdk/map_client.js
+++ b/src/sdk/map_client.js
@@ -17,7 +17,6 @@ const Semaphore = require('../util/semaphore');
 const KeysSemaphore = require('../util/keys_semaphore');
 const block_store_client = require('../agent/block_store_services/block_store_client').instance();
 const system_store = require('../server/system_services/system_store').get_instance();
-const js_utils = require('../util/js_utils');
 
 const { ChunkAPI } = require('./map_api_types');
 const { RpcError, RPC_BUFFERS } = require('../rpc');
@@ -578,7 +577,7 @@ class MapClient {
             const current_attached_pools = tier_before_move.mirrors.map(mirror => mirror.spread_pools.map(pool => String(pool._id))).flat();
 
             if (
-                !js_utils.compare_unordered(target_attached_pools, current_attached_pools, true) ||
+                _.xor(target_attached_pools, current_attached_pools).length ||
                 tier_before_move.storage_class === target_storage_class
             ) continue;
 

--- a/src/server/bg_services/agent_blocks_reclaimer.js
+++ b/src/server/bg_services/agent_blocks_reclaimer.js
@@ -45,7 +45,7 @@ class AgentBlocksReclaimer {
             const blocks_to_reclaim = await this.populate_agent_blocks_reclaimer_blocks(blocks);
             if (!blocks_to_reclaim || !blocks_to_reclaim.length) return;
             dbg.log0('AGENT_BLOCKS_RECLAIMER:',
-                'DELETING:', blocks_to_reclaim);
+                'DELETING:', blocks_to_reclaim.length);
             await this.delete_blocks_from_nodes(blocks_to_reclaim);
             // return the delay before next batch
             if (this.marker) {

--- a/src/server/node_services/nodes_aggregator.js
+++ b/src/server/node_services/nodes_aggregator.js
@@ -7,6 +7,7 @@ const mapper = require('../object_services/mapper');
 const size_utils = require('../../util/size_utils');
 const server_rpc = require('../server_rpc');
 const system_store = require('../system_services/system_store').get_instance();
+const { STORAGE_CLASS_GLACIER } = require('../../endpoint/s3/s3_utils');
 
 const { BigInteger } = size_utils;
 
@@ -55,7 +56,7 @@ function _aggregate_data_free_for_tier(tier, nodes_by_pool) {
     const num_blocks_per_chunk = mapper.get_num_blocks_per_chunk(tier);
     return tier.mirrors.map(({ spread_pools }) => {
         // If the tier is glacier, we don't want to calculate the free space - Assume it's 1PB
-        if (tier.storage_class === 'GLACIER') {
+        if (tier.storage_class === STORAGE_CLASS_GLACIER) {
             return {
                 free: size_utils.bigint_to_json(BigInteger.PETABYTE),
                 redundant_free: size_utils.bigint_to_json(BigInteger.zero),

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -38,6 +38,7 @@ const path = require('path');
 const KeysSemaphore = require('../../util/keys_semaphore');
 const bucket_semaphore = new KeysSemaphore(1);
 const Quota = require('../system_services/objects/quota');
+const { STORAGE_CLASS_GLACIER } = require('../../endpoint/s3/s3_utils');
 
 const VALID_BUCKET_NAME_REGEXP =
     /^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$/;
@@ -74,6 +75,66 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, owner_account_i
             object_lock_enabled: lock_enabled ? 'Enabled' : 'Disabled',
         } : undefined,
     };
+}
+
+function auto_setup_tier2(req, changes, skip_check = false) {
+    if (!config.BUCKET_AUTOCONF_TIER2_ENABLED) return;
+    if (!changes.insert) return;
+
+    const tiering_policies = changes.insert.tieringpolicies;
+    if (!tiering_policies) return;
+
+    const initial_tier = changes.insert.tiers?.[0];
+    if (!initial_tier) return;
+
+    // Assume that chunk_config_id will always be present.
+    const chunk_config_id = initial_tier?.chunk_config;
+
+    // Assume default pool to be assigned to the initial tier.
+    const default_pool_id = initial_tier.mirrors?.[0]?.spread_pools?.[0];
+
+    // Tiers must have name => that initial tier will always have a name.
+    const initial_tier_name = initial_tier.name;
+
+    const tier2_name = `${initial_tier_name}_auto_tier2`;
+
+    const system_id = initial_tier.system;
+    if (!system_id) return;
+
+    const tier2_mirrors = [{
+        _id: system_store.new_system_store_id(),
+        spread_pools: [default_pool_id]
+    }];
+
+    // skip_check can be set to true in the cases where there is no system
+    // consequently, chances of tier2 name collision are -> 0 as well in such cases.
+    if (!skip_check) {
+        tier_server.check_tier_exists(req, tier2_name);
+    }
+
+    const init_tiering_policy = tiering_policies?.[0];
+    if (!init_tiering_policy) return;
+
+    const init_tier_order = init_tiering_policy.tiers?.[0]?.order;
+    if (_.isUndefined(init_tier_order)) return;
+
+    // No conditionals beyond this, failing is better than creating a broken
+    // bucket.
+    const tier2 = tier_server.new_tier_defaults(
+        tier2_name,
+        system_id,
+        chunk_config_id,
+        tier2_mirrors,
+        STORAGE_CLASS_GLACIER,
+    );
+
+    changes.insert.tiers.push(tier2);
+    init_tiering_policy.tiers.push({
+        tier: tier2._id,
+        order: init_tier_order + 1,
+        spillover: false,
+        disabled: false
+    });
 }
 
 /**
@@ -142,7 +203,8 @@ async function create_bucket(req) {
             tiering_policy = tier_server.new_policy_defaults(
                 bucket_with_suffix,
                 req.system._id,
-                req.rpc_params.chunk_split_config, [{
+                req.rpc_params.chunk_split_config,
+                [{
                     tier: tier._id,
                     order: 0,
                     spillover: false,
@@ -151,6 +213,12 @@ async function create_bucket(req) {
             );
             changes.insert.tieringpolicies = [tiering_policy];
             changes.insert.tiers = [tier];
+
+            // Attach a `GLACIER` tier to the bucket if it is not namespace.caching
+            // and appropriate configuration is set
+            if (!req.rpc_params.namespace?.caching) {
+                auto_setup_tier2(req, changes);
+            }
         }
 
         validate_non_nsfs_bucket_creation(req);
@@ -1911,6 +1979,7 @@ function normalize_replication(req) {
 // EXPORTS
 exports.new_bucket_defaults = new_bucket_defaults;
 exports.get_bucket_info = get_bucket_info;
+exports.auto_setup_tier2 = auto_setup_tier2;
 //Bucket Management
 exports.create_bucket = create_bucket;
 exports.read_bucket = read_bucket;

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -339,6 +339,8 @@ async function create_system(req) {
     try {
         const account_id = system_store.new_system_store_id();
         const changes = new_system_changes(name, account_id);
+        bucket_server.auto_setup_tier2(req, changes, true);
+
         system_id = changes.insert.systems[0]._id;
         const cluster_info = await _get_cluster_info();
         if (cluster_info) {

--- a/src/test/unit_tests/test_map_builder.js
+++ b/src/test/unit_tests/test_map_builder.js
@@ -24,6 +24,7 @@ const map_deleter = require('../../server/object_services/map_deleter');
 const map_reader = require('../../server/object_services/map_reader');
 const SliceReader = require('../../util/slice_reader');
 const system_store = require('../../server/system_services/system_store').get_instance();
+const { STORAGE_CLASS_GLACIER } = require('../../endpoint/s3/s3_utils');
 
 const { rpc_client } = coretest;
 const object_io = new ObjectIO();
@@ -312,7 +313,7 @@ mocha.describe('map_builder', function() {
                 attached_pools: [current_tier.mirrors[0].spread_pools[0].name],
                 order: 1,
                 data_placement: 'SPREAD',
-                storage_class: 'GLACIER'
+                storage_class: STORAGE_CLASS_GLACIER,
             }
         });
 

--- a/src/util/js_utils.js
+++ b/src/util/js_utils.js
@@ -237,29 +237,6 @@ function omit_symbol(maybe_obj, sym) {
     return _.omit(obj, sym);
 }
 
-/**
- * compare_unordered takes two arrays and returns true 
- * if they contain the same elements, regardless of order.
- * @param {Array<any>} arr1 
- * @param {Array<any>} arr2 
- * @param {boolean} ignore_frequency
- */
-function compare_unordered(arr1, arr2, ignore_frequency = false) {
-    if (!ignore_frequency && (arr1.length !== arr2.length)) return false;
-
-    const fc = arr1.reduce((acc, val) => {
-        acc[val] = (acc[val] || 0) + 1;
-        return acc;
-    }, {});
-
-    for (const val of arr2) {
-        if (!fc[val]) return false;
-        if (!ignore_frequency) fc[val] -= 1;
-    }
-
-    return true;
-}
-
 exports.self_bind = self_bind;
 exports.array_push_all = array_push_all;
 exports.array_push_keep_latest = array_push_keep_latest;
@@ -273,4 +250,3 @@ exports.inspect_lazy = inspect_lazy;
 exports.make_array = make_array;
 exports.map_get_or_create = map_get_or_create;
 exports.omit_symbol = omit_symbol;
-exports.compare_unordered = compare_unordered;


### PR DESCRIPTION
### Explain the changes

This PR:
1. Adds support for auto tier 2 creation and assignment to backingstore buckets if `TMFS_BUCKET_TIER2_AUTOCONF` and `BLOCK_STORE_FS_TMFS_ENABLED` are enabled. Created another config parameter instead of linking it to `BLOCK_STORE_FS_TMFS_ENABLED` to provide slightly more control over behaviour hopefully helpful while debugging.
2. Addresses minors from #7313 by removing the js_utils function and renaming the functions.

PS: 2nd change was introduced accidentally as a result of creating a branch off my previous branch (which had the changes). I can split the PR into 2 different PRs or merge the 2 commits, I have no preference here.


- [ ] Doc added/updated
- [ ] Tests added
