### PR TITLE
Fix CVE-2019-15597 - Implement new DF command instead of library function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "ncp": "2.0.0",
         "net-ping": "1.2.3",
         "node-addon-api": "7.0.0",
-        "node-df": "0.1.4",
         "node-gyp": "9.4.0",
         "performance-now": "2.1.0",
         "pg": "8.11.0",
@@ -7383,14 +7382,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
       "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
-    },
-    "node_modules/node-df": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-df/-/node-df-0.1.4.tgz",
-      "integrity": "sha512-9DJSSoyaimvfyGUU5UMEI/uzVBS0N+xkki9B38Usn/N1KldKAbRoAMwTf6hdyqNLwHYYpa2MrOeLt/xYJFcFWw==",
-      "dependencies": {
-        "underscore": "^1.6.0"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.11",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "ncp": "2.0.0",
     "net-ping": "1.2.3",
     "node-addon-api": "7.0.0",
-    "node-df": "0.1.4",
     "node-gyp": "9.4.0",
     "performance-now": "2.1.0",
     "pg": "8.11.0",

--- a/src/test/unit_tests/jest_tests/test_os_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_os_utils.test.js
@@ -1,0 +1,60 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-disable no-undef */
+'use strict';
+
+const child_process = require('child_process');
+const util = require('util');
+const os_utils = require('../../../util/os_utils');
+
+describe('os_utils', () => {
+
+  describe('disk free', () => {
+
+    it('should work with flag', async () => {
+      const execFile = util.promisify(child_process.execFile);
+      const { stdout } = await execFile('/bin/df', ['-kPl']);
+      const expected_drives = stdout.trim().split(/\r\n|\r|\n/).slice(1);
+
+      const actual_drives = await os_utils._df(null, 'l');
+      expect(actual_drives.length).toBe(expected_drives.length);
+    });
+
+    it('should work with file', async () => {
+      const actual_drives = await os_utils._df('src/server');
+      expect(actual_drives.length).toBe(1);
+    });
+
+    it('should return error with invalid input', async () => {
+      try {
+        await os_utils._df(null, 'wqe');
+        fail('Test was supposed to fail');
+      } catch (err) {
+        if (!err.message.includes('invalid option')) {
+          throw err;
+        }
+      }
+    });
+
+    it('should work with no input', async () => {
+      const execFile = util.promisify(child_process.execFile);
+      const { stdout } = await execFile('/bin/df', []);
+      const expected_drives = stdout.trim().split(/\r\n|\r|\n/).slice(1);
+
+      const actual_drives = await os_utils._df();
+      expect(actual_drives.length).toBe(expected_drives.length);
+    });
+
+    it('should parse correctly', async () => {
+      const drives = await os_utils._df();
+      drives.forEach(drive => {
+        expect(typeof(drive.filesystem)).toBe('string');
+        expect(typeof(drive.size)).toBe('number');
+        expect(typeof(drive.used)).toBe('number');
+        expect(typeof(drive.available)).toBe('number');
+        expect(typeof(drive.capacity)).toBe('number');
+        expect(typeof(drive.mount)).toBe('string');
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
### Explain the changes
1. implemented a local function to replace the unmaintained node-df library. this function is based on the node-df implementation with changes to fit our code better (https://github.com/adriano-di-giovanni/node-df).
2. add '\' before all special characters in the file name so bash will read them as part of the file name itself. this is to prevent the code injection suggested in  CVE-2019-15597

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2124534

### Testing Instructions:
1. df is used mainly during node creation, so create a new backing store and validate that it was created successfully


- [ ] Doc added/updated
- [x] Tests added
