### PR TITLE
Add storage_class for objects, use GLACIER_IR for TMFS

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -119,6 +119,16 @@ CREATE_SYS_PASSWD=123456789
 JWT_SECRET=123456789
 NOOBAA_ROOT_SECRET='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
 LOCAL_MD_SERVER=true
+
+ENDPOINT_FORKS=4
+UV_THREADPOOL_SIZE=64
+
+# replace localhost with the hostname where postgres,web,bg,ha are running
+POSTGRES_HOST=localhost
+MGMT_ADDR=wss://localhost:5443
+BG_ADDR=wss://localhost:5445
+HOSTED_AGENTS_ADDR=wss://localhost:5446
+
 EOF
 ```
 
@@ -131,10 +141,11 @@ cat >config-local.js <<EOF
 const config = exports;
 
 config.DEFAULT_POOL_TYPE = 'HOSTS';
-
 config.AGENT_RPC_PORT = '9999';
 config.AGENT_RPC_PROTOCOL = 'tcp';
 
+// Enable auto tier2 for TMFS buckets
+config.BUCKET_AUTOCONF_TIER2_ENABLED = true;
 config.BLOCK_STORE_FS_TMFS_ENABLED = true;
 config.BLOCK_STORE_FS_MAPPING_INFO_ENABLED = true;
 
@@ -143,7 +154,7 @@ config.IO_CALC_MD5_ENABLED = false;
 config.IO_CALC_SHA256_ENABLED = false;
 
 config.MAX_OBJECT_PART_SIZE = 1024 * 1024 * 1024;
-config.IO_CHUNK_READ_CACHE_SIZE = 4 * 1024 * 1024 * 1024;
+config.IO_CHUNK_READ_CACHE_SIZE = 1024 * 1024 * 1024;
 config.IO_READ_BLOCK_TIMEOUT = 5 * 60 * 1000;
 
 config.CHUNK_SPLIT_AVG_CHUNK = 256 * 1024 * 1024;
@@ -167,9 +178,6 @@ config.REBUILD_NODE_ENABLED = false;
 config.AWS_METERING_ENABLED = false;
 config.AGENT_BLOCKS_VERIFIER_ENABLED = false;
 config.TIERING_TTL_WORKER_ENABLED = true;
-
-// Enable auto tier2 for TMFS buckets
-config.BUCKET_AUTOCONF_TIER2_ENABLED = true;
 EOF
 ```
 
@@ -194,22 +202,6 @@ Running a local endpoint alongside the database and other services is simple:
 
 ```sh
 npm run s3
-```
-
-In order to enable multiple forks of the endpoint serving on the same port use:
-
-```sh
-ENDPOINT_FORKS=4 npm run s3
-```
-
-For remote hosts, need to specify the addresses:
-
-```sh
-POSTGRES_HOST=ip \
-  MGMT_ADDR=wss://ip:5443 \
-  BG_ADDR=wss://ip:5445 \
-  HOSTED_AGENTS_ADDR=wss://ip:5446 \
-  npm run s3
 ```
 
 ---

--- a/src/agent/block_store_services/block_store_fs.js
+++ b/src/agent/block_store_services/block_store_fs.js
@@ -15,7 +15,11 @@ const string_utils = require('../../util/string_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
 const get_block_internal_dir = require('./block_store_base').get_block_internal_dir;
 const { RpcError } = require('../../rpc');
-const { STORAGE_CLASS_GLACIER, STORAGE_CLASS_STANDARD } = require('../../endpoint/s3/s3_utils');
+const {
+    STORAGE_CLASS_STANDARD,
+    STORAGE_CLASS_GLACIER,
+    STORAGE_CLASS_GLACIER_IR,
+} = require('../../endpoint/s3/s3_utils');
 
 const TMFS_STATE_MIGRATED = 'MIGRATED';
 const TMFS_STATE_PREMIGRATED = 'PREMIGRATED';
@@ -272,7 +276,8 @@ class BlockStoreFs extends BlockStoreBase {
      * @returns {Promise<{ moved_block_ids: string[] }>}
      */
     async _move_blocks_to_storage_class(block_ids, storage_class) {
-        if (storage_class === STORAGE_CLASS_GLACIER) {
+        if (storage_class === STORAGE_CLASS_GLACIER ||
+            storage_class === STORAGE_CLASS_GLACIER_IR) {
             if (config.BLOCK_STORE_FS_TMFS_ENABLED) {
                 return this._move_blocks_to_tmfs(block_ids);
             }

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1162,10 +1162,6 @@ module.exports = {
             }
         },
 
-        storage_class_enum: {
-            enum: ['STANDARD_IA', 'GLACIER'],
-            type: 'string'
-        },
         update_bucket_params: {
             type: 'object',
             required: ['name'],

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1191,7 +1191,7 @@ module.exports = {
 
         storage_class_enum: {
             type: 'string',
-            enum: ['STANDARD', 'GLACIER']
+            enum: ['STANDARD', 'GLACIER', 'GLACIER_IR']
         },
     }
 };

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -60,6 +60,7 @@ module.exports = {
                     last_modified_time: {
                         idate: true
                     },
+                    storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
                 }
             },
             reply: {
@@ -1442,6 +1443,7 @@ module.exports = {
                 capacity_size: { type: 'integer' },
                 s3_signed_url: { type: 'string' },
                 lock_settings: { $ref: 'common_api#/definitions/lock_settings' },
+                storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
             }
         },
 
@@ -1495,6 +1497,7 @@ module.exports = {
                 is_accessible: { type: 'boolean' },
                 is_building_blocks: { type: 'boolean' },
                 is_building_frags: { type: 'boolean' },
+                storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
             }
         },
 

--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -72,7 +72,7 @@ async function get_bucket(req) {
                 ETag: `"${obj.etag}"`,
                 Size: obj.size,
                 Owner: (!list_type || req.query['fetch-owner']) && s3_utils.DEFAULT_S3_USER,
-                StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+                StorageClass: s3_utils.parse_storage_class(obj.storage_class),
             }
         })),
         _.map(reply.common_prefixes, prefix => ({

--- a/src/endpoint/s3/ops/s3_get_bucket_uploads.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_uploads.js
@@ -48,7 +48,7 @@ async function get_bucket_uploads(req) {
                 Initiated: s3_utils.format_s3_xml_date(obj.upload_started),
                 Initiator: s3_utils.DEFAULT_S3_USER,
                 Owner: s3_utils.DEFAULT_S3_USER,
-                StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+                StorageClass: s3_utils.parse_storage_class(obj.storage_class),
             }
         })),
         _.map(reply.common_prefixes, prefix => ({

--- a/src/endpoint/s3/ops/s3_get_bucket_versions.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_versions.js
@@ -63,7 +63,7 @@ async function get_bucket_versions(req) {
                 ETag: `"${obj.etag}"`,
                 Size: obj.size,
                 Owner: s3_utils.DEFAULT_S3_USER,
-                StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+                StorageClass: s3_utils.parse_storage_class(obj.storage_class),
             }
         }))),
         _.map(reply.common_prefixes, prefix => ({

--- a/src/endpoint/s3/ops/s3_post_object_uploads.js
+++ b/src/endpoint/s3/ops/s3_post_object_uploads.js
@@ -11,12 +11,14 @@ const mime = require('mime');
 async function post_object_uploads(req, res) {
     const tagging = s3_utils.parse_tagging_header(req);
     const encryption = s3_utils.parse_encryption(req);
+    const storage_class = s3_utils.parse_storage_class_header(req);
     const reply = await req.object_sdk.create_object_upload({
         bucket: req.params.bucket,
         key: req.params.key,
         content_type: req.headers['content-type'] || mime.getType(req.params.key) || 'application/octet-stream',
         content_encoding: req.headers['content-encoding'],
         xattr: s3_utils.get_request_xattr(req),
+        storage_class,
         tagging,
         encryption
     });

--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -20,6 +20,7 @@ async function put_object(req, res) {
     const encryption = s3_utils.parse_encryption(req);
     const copy_source = s3_utils.parse_copy_source(req);
     const tagging = s3_utils.parse_tagging_header(req);
+    const storage_class = s3_utils.parse_storage_class_header(req);
     const lock_settings = config.WORM_ENABLED ? s3_utils.parse_lock_header(req) : undefined;
     // Copy request sends empty content and not relevant to the object data
     const { size, md5_b64, sha256_b64 } = copy_source ? {} : {
@@ -50,6 +51,7 @@ async function put_object(req, res) {
         tagging_copy: s3_utils.is_copy_tagging_directive(req),
         encryption,
         lock_settings,
+        storage_class,
         azure_invalid_md_header: req.headers['azure-metadata-handling'] || undefined
     });
 

--- a/src/sdk/map_api_types.js
+++ b/src/sdk/map_api_types.js
@@ -55,6 +55,7 @@ class ChunkAPI {
     get cipher_iv_b64() { return this.chunk_info.cipher_iv_b64; }
     get cipher_auth_tag_b64() { return this.chunk_info.cipher_auth_tag_b64; }
     get chunk_coder_config() { return this.chunk_info.chunk_coder_config; }
+    get storage_class() { return this.tier.storage_class; }
 
     get data() { return this.chunk_info.data; }
     set data(buf) { this.chunk_info.data = buf; }
@@ -145,6 +146,7 @@ class ChunkAPI {
             cipher_iv_b64: this.chunk_info.cipher_iv_b64,
             cipher_auth_tag_b64: this.chunk_info.cipher_auth_tag_b64,
             dup_chunk: this.chunk_info.dup_chunk,
+            storage_class: this.storage_class,
             is_accessible: this.chunk_info.is_accessible,
             is_building_blocks: this.chunk_info.is_building_blocks,
             is_building_frags: this.chunk_info.is_building_frags,

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1808,6 +1808,8 @@ class NamespaceFS {
             size: stat.size,
             create_time: stat.mtime.getTime(),
             content_type: mime.getType(key) || 'application/octet-stream',
+            // storage_class: stat.xattr[...TODO...]
+
             // temp:
             version_id: version_id,
             is_latest: is_latest,

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -291,6 +291,7 @@ class NamespaceS3 {
                 Key: params.key,
                 CopySource: copy_source,
                 ContentType: params.content_type,
+                StorageClass: params.storage_class,
                 Metadata: params.xattr,
                 MetadataDirective: params.xattr_copy ? 'COPY' : 'REPLACE',
                 Tagging,
@@ -373,6 +374,7 @@ class NamespaceS3 {
             Bucket: this.bucket,
             Key: params.key,
             ContentType: params.content_type,
+            StorageClass: params.storage_class,
             Metadata: params.xattr,
             Tagging
         };
@@ -752,6 +754,7 @@ class NamespaceS3 {
             is_latest: res.IsLatest,
             delete_marker: res.DeleteMarker,
             content_type: res.ContentType,
+            storage_class: s3_utils.parse_storage_class(res.StorageClass),
             xattr,
             tag_count: res.TagCount,
             first_range_data: Buffer.isBuffer(res.Body) ? res.Body : undefined,

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -14,6 +14,7 @@ const buffer_utils = require('../util/buffer_utils');
 const stream_utils = require('../util/stream_utils');
 const ChunkSplitter = require('../util/chunk_splitter');
 const CoalesceStream = require('../util/coalesce_stream');
+const system_store = require('../server/system_services/system_store').get_instance();
 
 const { MapClient } = require('./map_client');
 const { ChunkAPI } = require('./map_api_types');
@@ -202,6 +203,7 @@ class ObjectIO {
             'tagging',
             'encryption',
             'lock_settings',
+            'storage_class',
             'last_modified_time',
         );
         const complete_params = _.pick(params,
@@ -479,7 +481,7 @@ class ObjectIO {
                 chunk_info.parts = [part];
                 chunk_info.master_key_id = params.bucket_master_key_id;
                 for (const frag of chunk_info.frags) frag.blocks = [];
-                const chunk = new ChunkAPI(chunk_info);
+                const chunk = new ChunkAPI(chunk_info, system_store);
                 params.seq += 1;
                 params.start += chunk.size;
                 params.range.end = params.start;

--- a/src/server/bg_services/tier_ttf_worker.js
+++ b/src/server/bg_services/tier_ttf_worker.js
@@ -155,7 +155,8 @@ class TieringTTFWorker {
             await this._build_chunks(
                 chunk_ids,
                 next_tier_id,
-                cache_evict
+                cache_evict,
+                chunk_ids.map(() => previous_tier._id),
             );
         }
         this.last_run = undefined;
@@ -166,8 +167,13 @@ class TieringTTFWorker {
         return bucket.tiering.tiers.find(t => String(t.tier._id) === String(tier._id)).order;
     }
 
-    async _build_chunks(chunk_ids, next_tier, cache_evict) {
-        return this.client.scrubber.build_chunks({ chunk_ids, tier: next_tier, evict: cache_evict }, {
+    async _build_chunks(chunk_ids, next_tier, cache_evict, current_tiers) {
+        return this.client.scrubber.build_chunks({
+            chunk_ids,
+            tier: next_tier,
+            evict: cache_evict,
+            current_tiers,
+        }, {
             auth_token: auth_server.make_auth_token({
                 system_id: system_store.data.systems[0]._id,
                 role: 'admin'

--- a/src/server/node_services/nodes_aggregator.js
+++ b/src/server/node_services/nodes_aggregator.js
@@ -7,7 +7,7 @@ const mapper = require('../object_services/mapper');
 const size_utils = require('../../util/size_utils');
 const server_rpc = require('../server_rpc');
 const system_store = require('../system_services/system_store').get_instance();
-const { STORAGE_CLASS_GLACIER } = require('../../endpoint/s3/s3_utils');
+const { STORAGE_CLASS_GLACIER, STORAGE_CLASS_GLACIER_IR } = require('../../endpoint/s3/s3_utils');
 
 const { BigInteger } = size_utils;
 
@@ -56,7 +56,8 @@ function _aggregate_data_free_for_tier(tier, nodes_by_pool) {
     const num_blocks_per_chunk = mapper.get_num_blocks_per_chunk(tier);
     return tier.mirrors.map(({ spread_pools }) => {
         // If the tier is glacier, we don't want to calculate the free space - Assume it's 1PB
-        if (tier.storage_class === STORAGE_CLASS_GLACIER) {
+        if (tier.storage_class === STORAGE_CLASS_GLACIER ||
+            tier.storage_class === STORAGE_CLASS_GLACIER_IR) {
             return {
                 free: size_utils.bigint_to_json(BigInteger.PETABYTE),
                 redundant_free: size_utils.bigint_to_json(BigInteger.zero),

--- a/src/server/object_services/map_db_types.js
+++ b/src/server/object_services/map_db_types.js
@@ -60,6 +60,7 @@ class ChunkDB {
     get cipher_iv_b64() { return to_b64(this.chunk_db.cipher_iv); }
     get cipher_auth_tag_b64() { return to_b64(this.chunk_db.cipher_auth_tag); }
     get chunk_coder_config() { return this.chunk_config.chunk_coder_config; }
+    get storage_class() { return this.tier.storage_class; }
 
     /** @returns {nb.Bucket} */
     get bucket() { return system_store.data.get_by_id(this.chunk_db.bucket); }
@@ -139,6 +140,7 @@ class ChunkDB {
             is_building_frags: this.is_building_frags,
             frags: this.frags.map(frag => frag.to_api(adminfo)),
             parts: this.parts.map(part => part.to_api()),
+            storage_class: this.storage_class,
         };
     }
 
@@ -369,7 +371,7 @@ class BlockDB {
 
 
 /**
- * @implements {nb.Frag}
+ * @implements {nb.Part}
  */
 class PartDB {
 

--- a/src/server/object_services/map_reader.js
+++ b/src/server/object_services/map_reader.js
@@ -139,11 +139,13 @@ async function update_chunks_on_read(chunks, location_info) {
             }
         }
         if (chunks_to_scrub.length) {
-            const chunk_ids = _.map(chunks_to_scrub, '_id');
+            const chunk_ids = chunks_to_scrub.map(chunk => chunk._id);
+            const current_tiers = chunks_to_scrub.map(chunk => chunk.tier._id);
             dbg.log1('Chunks wasn\'t found in local pool/upper tier - the following will be rebuilt:', util.inspect(chunks_to_scrub));
             await server_rpc.client.scrubber.build_chunks({
                 chunk_ids,
                 tier: selected_tier._id,
+                current_tiers,
             }, {
                 auth_token: auth_server.make_auth_token({
                     system_id: bucket.system._id,

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -428,6 +428,7 @@ async function make_room_in_tier(tier_id, bucket_id) {
         await server_rpc.client.scrubber.build_chunks({
             chunk_ids,
             tier: next_tier._id,
+            current_tiers: chunk_ids.map(() => tier._id),
         }, {
             auth_token: auth_server.make_auth_token({
                 system_id: bucket.system._id,

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -71,6 +71,7 @@ async function create_object_upload(req) {
             mime.getType(req.rpc_params.key) ||
             'application/octet-stream',
         tagging: req.rpc_params.tagging,
+        storage_class: req.rpc_params.storage_class,
         encryption
     };
 
@@ -1415,6 +1416,7 @@ function get_object_info(md, options = {}) {
         etag: get_etag(md),
         md5_b64: md.md5_b64 || undefined,
         sha256_b64: md.sha256_b64 || undefined,
+        storage_class: md.storage_class,
         content_type: md.content_type || 'application/octet-stream',
         content_encoding: md.content_encoding,
         create_time: md.create_time ? md.create_time.getTime() : md._id.getTimestamp().getTime(),

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -95,6 +95,8 @@ module.exports = {
         md5_b64: { type: 'string' },
         sha256_b64: { type: 'string' },
 
+        storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
+
         // xattr saved as free form object
         xattr: {
             type: 'object',

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -40,7 +40,7 @@ const path = require('path');
 const KeysSemaphore = require('../../util/keys_semaphore');
 const bucket_semaphore = new KeysSemaphore(1);
 const Quota = require('../system_services/objects/quota');
-const { STORAGE_CLASS_GLACIER } = require('../../endpoint/s3/s3_utils');
+const { STORAGE_CLASS_GLACIER_IR } = require('../../endpoint/s3/s3_utils');
 
 const VALID_BUCKET_NAME_REGEXP =
     /^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$/;
@@ -138,7 +138,7 @@ function auto_setup_tier2(req, initial_tier, tiering_policy, changes, skip_check
         system_id,
         initial_tier.chunk_config,
         tier2_mirrors,
-        STORAGE_CLASS_GLACIER,
+        STORAGE_CLASS_GLACIER_IR,
     );
 
     changes.insert.tiers.push(tier2);

--- a/src/server/system_services/tier_server.js
+++ b/src/server/system_services/tier_server.js
@@ -747,6 +747,7 @@ function get_tier_info(tier, nodes_aggregate_pool, tiering_tier_status) {
         name: tier.name,
         chunk_coder_config: tier.chunk_config.chunk_coder_config,
         data_placement: tier.data_placement,
+        storage_class: tier.storage_class,
         attached_pools,
         mirror_groups,
         storage,

--- a/src/test/unit_tests/test_map_builder.js
+++ b/src/test/unit_tests/test_map_builder.js
@@ -24,7 +24,7 @@ const map_deleter = require('../../server/object_services/map_deleter');
 const map_reader = require('../../server/object_services/map_reader');
 const SliceReader = require('../../util/slice_reader');
 const system_store = require('../../server/system_services/system_store').get_instance();
-const { STORAGE_CLASS_GLACIER } = require('../../endpoint/s3/s3_utils');
+const { STORAGE_CLASS_GLACIER_IR } = require('../../endpoint/s3/s3_utils');
 
 const { rpc_client } = coretest;
 const object_io = new ObjectIO();
@@ -313,7 +313,7 @@ mocha.describe('map_builder', function() {
                 attached_pools: [current_tier.mirrors[0].spread_pools[0].name],
                 order: 1,
                 data_placement: 'SPREAD',
-                storage_class: STORAGE_CLASS_GLACIER,
+                storage_class: STORAGE_CLASS_GLACIER_IR,
             }
         });
 

--- a/src/test/unit_tests/test_map_client.js
+++ b/src/test/unit_tests/test_map_client.js
@@ -360,7 +360,7 @@ coretest.describe_mapper_test_case({
             };
 
             const temporary_tier = generate_mock_tier({
-                storage_class: 'MOCKED',
+                storage_class: 'GLACIER_IR',
                 mirrors: [
                     {
                         spread_pools: bucket.tiering.tiers[0].tier.mirrors[0].spread_pools,


### PR DESCRIPTION
### Explain the changes
1. Maintain an optional storage class field per object
2. Update the object storage class when chunks are moving to tier.
3. Use GLACIER_IR for TMFS because GLACIER is not allowing transparent reads.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. use standalone.md

2. upload an object and check its storage class
```
$ aws s3 cp README.md s3://testbucket/
$ aws s3api head-object --bucket testbucket --key README.md
{
    "AcceptRanges": "bytes",
    "LastModified": "2023-06-28T07:16:02+00:00",
    "ContentLength": 2387,
    "ETag": "\"a00e1a5fb5c7ad1fc1a215825d1ce03a\"",
    "ContentType": "text/markdown",
    "Metadata": {},
    "StorageClass": "GLACIER_IR"
}
$ aws s3api list-objects --bucket testbucket
{
    "Contents": [
        {
            "Key": "README.md",
            "LastModified": "2023-06-28T07:16:02+00:00",
            "ETag": "\"a00e1a5fb5c7ad1fc1a215825d1ce03a\"",
            "Size": 2387,
            "StorageClass": "GLACIER_IR",
            "Owner": {
                "DisplayName": "NooBaa",
                "ID": "123"
            }
        }
    ]
}
```

3. find the block on the FS and for local mock its migstat (not needed on TMFS, only for local FS tests):
```
$ xattr -l user._trigger.migrate storage/backingstores/drive1/blocks_tree/c69.blocks/649bde32e1fa4e14f58b5c69.data
user._trigger.migrate: now
user.noobaa.block_md: {"id":"649bde32e1fa4e14f58b5c69","mapping_info":{"obj_id":"649bde31e1fa4e14f58b5c68","bucket":"testbucket","key":"README.md","part_start":0,"part_end":2387,"part_seq":0,"data_index":0}}
$ xattr -d user._trigger.migrate storage/backingstores/drive1/blocks_tree/c69.blocks/649bde32e1fa4e14f58b5c69.data
$ xattr -w user._query.migstat '{ "State":"PREMIGRATED", "TargetState":"" }' storage/backingstores/drive1/blocks_tree/c69.blocks/649bde32e1fa4e14f58b5c69.data
```

4. read the object:
```
$ aws s3 cp s3://testbucket/README.md - | wc
```

5. check the storage class changed to STANDARD (on no header in HEAD)
```
s3api list-objects --bucket testbucket
{
    "Contents": [
        {
            "Key": "README.md",
            "LastModified": "2023-06-28T07:16:02+00:00",
            "ETag": "\"a00e1a5fb5c7ad1fc1a215825d1ce03a\"",
            "Size": 2387,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "NooBaa",
                "ID": "123"
            }
        }
    ]
}
```

6. Wait until the TTL expires (config.TIERING_TTL_MS) and check that the storage_class was changed back to GLACIER_IR on the object:
```
$ aws s3api list-objects --bucket testbucket
{
    "Contents": [
        {
            "Key": "README.md",
            "LastModified": "2023-06-28T07:16:02+00:00",
            "ETag": "\"a00e1a5fb5c7ad1fc1a215825d1ce03a\"",
            "Size": 2387,
            "StorageClass": "GLACIER_IR",
            "Owner": {
                "DisplayName": "NooBaa",
                "ID": "123"
            }
        }
    ]
}
```

7. Check that the block on the FS has the new xattr set:
```
$ xattr -l storage/backingstores/drive1/blocks_tree/c69.blocks/649bde32e1fa4e14f58b5c69.data
user._query.migstat: { "State":"PREMIGRATED", "TargetState":"" }
user._trigger.migrate: now
user.noobaa.block_md: {"id":"649bde32e1fa4e14f58b5c69","mapping_info":{"obj_id":"649bde31e1fa4e14f58b5c68","bucket":"testbucket","key":"README.md","part_start":0,"part_end":2387,"part_seq":0,"data_index":0}}
```