### PR TITLE
passing log candidates as batch for and copy and delete

### DIFF
--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -34,7 +34,7 @@ type S3Request = IncomingMessage & {
 type ReplicationLogAction = 'copy' | 'delete' | 'conflict';
 type ReplicationLog = { key: string, action: ReplicationLogAction, time: Date };
 type ReplicationLogs = Array<ReplicationLog>;
-type ReplicationLogCandidates = Record<string, { action: ReplicationLogAction, time: Date }[]>;
+type ReplicationLogCandidates = Record<string, { action: ReplicationLogAction, time: Date }>;
 
 interface MapByID<T> { [id: string]: T }
 

--- a/src/test/unit_tests/test_bucket_replication.js
+++ b/src/test/unit_tests/test_bucket_replication.js
@@ -964,8 +964,8 @@ mocha.describe('AWS S3 server log parsing tests', function() {
         `};
         log_parser.aws_parse_log_object(logs, example_log, true);
         const candidates = log_parser.create_candidates(logs);
-        assert.equal(candidates.test[0].action, 'copy');
-        assert.equal(candidates.test[1].action, 'delete');
+        // DELETE log should be the latest log present inside the candidate, as candidate storing only latest log per key
+        assert.equal(candidates.test.action, 'delete');
     });
 });
 


### PR DESCRIPTION
### Explain the changes
1. Currently one log object at a time is passed for copy and delete. In this PR we are trying to pass a batch of objects for both copy and delete individually.
