### PR TITLE
fix rpc on web server over http/s

### DIFF
--- a/src/rpc/rpc_http.js
+++ b/src/rpc/rpc_http.js
@@ -63,12 +63,9 @@ class RpcHttpConnection extends RpcBaseConnection {
      */
     _close() {
         // try to abort the connetion's running request
-        if (this.req) {
-            if (this.req.abort) {
-                dbg.warn('HTTP ABORT REQ', this.reqid);
-                this.req.abort();
-            }
-            this.req = null;
+        if (this.res) {
+            dbg.warn('HTTP CLOSE CONN', this.connid);
+            this.res?.destroy();
         }
     }
 

--- a/src/rpc/rpc_message.js
+++ b/src/rpc/rpc_message.js
@@ -103,7 +103,7 @@ class RpcMessage {
             throw new Error('RPC VERSION MISMATCH');
         }
         const body_length = meta_buffer.readUInt32BE(4);
-        const body = JSON.parse(buffer_utils.extract_join(msg_buffers, body_length));
+        const body = JSON.parse(buffer_utils.extract_join(msg_buffers, body_length).toString());
 
         return new RpcMessage(body, msg_buffers);
     }


### PR DESCRIPTION
### Explain the changes
1. web server express app initialization was wrong as it installed the rpc route at the end after the last error handler route, which hides everything after it.
2. This was not a problem for ws/wss access to the rpc, but did not allow http/https access.
3. Fixed by moving the initialization to be called only from inside main.
4. Also fixed the error handling for rpc http to destroy the response connection.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. `npm run db:init`
2. `npm run db`  (keeps running)
3. `npm run db:create`
4. `npm run web` (keeps running)
5. make an http rpc call:
```
> curl http://127.0.0.1:5001/rpc/ -sd '{ "api":"system_api", "method":"get_system_status" }' | jq
{
  "op": "res",
  "reqid": "1@http://::ffff:127.0.0.1:54324(1lwr449y.z92)",
  "took": 0.9169590473175049,
  "reply": {
    "state": "READY",
    "last_state_change": 1688549106495
  }
}
```
