### PR TITLE
Move block store cache size to config

### DIFF
--- a/config.js
+++ b/config.js
@@ -688,6 +688,8 @@ config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
 // BLOCK STORE FS      //
 /////////////////////////
 
+config.BLOCK_STORE_CACHE_SIZE = 256 * 1024 * 1024;
+
 config.BLOCK_STORE_FS_TMFS_ENABLED = false;
 config.BLOCK_STORE_FS_MAPPING_INFO_ENABLED = false;
 config.BLOCK_STORE_FS_TMFS_ALLOW_MIGRATED_READS = true;

--- a/src/agent/block_store_services/block_store_base.js
+++ b/src/agent/block_store_services/block_store_base.js
@@ -47,7 +47,7 @@ class BlockStoreBase {
         this.block_modify_lock = new KeysLock();
         this.block_cache = new LRUCache({
             name: 'BlockStoreCache',
-            max_usage: 100 * 1024 * 1024, // 100 MB
+            max_usage: config.BLOCK_STORE_CACHE_SIZE,
             item_usage: block => block.data.length,
             make_key: block_md => block_md.id,
             load: async block_md => this._read_block_and_verify(block_md),


### PR DESCRIPTION
### Explain the changes
1. Make the block store cache size configurable.
2. Increase the default from 100MB to 256MB.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. NA
