### PR TITLE
add semaphore state to noobaa endpoint metrics

### DIFF
--- a/config.js
+++ b/config.js
@@ -121,6 +121,11 @@ config.ENDPOINT_MONITOR_INTERVAL = 10 * 60 * 1000; // 10min
 // Keep connection on long requests
 config.S3_KEEP_ALIVE_WHITESPACE_INTERVAL = 15 * 1000;
 config.S3_MD_SIZE_LIMIT = 2 * 1024;
+// Semaphore monitoring execution interval
+config.SEMAPHORE_MONITOR_DELAY = 10 * 1000;
+// Semaphore metrics average calculation intervals in minutes, values need to be in ascending order
+config.SEMAPHORE_METRICS_AVERAGE_INTERVALS = Object.freeze(['1', '5', '10']);
+config.ENABLE_SEMAPHORE_MONITOR = true
 
 config.ENDPOINT_HTTP_SERVER_REQUEST_TIMEOUT = 300 * 1000;
 config.ENDPOINT_HTTP_SERVER_KEEPALIVE_TIMEOUT = 5 * 1000;

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1178,7 +1178,6 @@ class NamespaceFS {
 
         // when object is a dir, xattr are set on the folder itself and the content is in .folder file
         if (is_dir_content) await this._assign_dir_content_to_xattr(fs_context, fs_xattr, { ...params, size: stat.size });
-
         stat = await nb_native().fs.stat(fs_context, file_path);
         const upload_info = this._get_upload_info(stat, fs_xattr && fs_xattr[XATTR_VERSION_ID]);
         return upload_info;
@@ -1506,6 +1505,7 @@ class NamespaceFS {
                 fs_context,
                 path.join(params.mpu_path, 'create_object_upload')
             );
+
             upload_params.params.xattr = (JSON.parse(create_params_buffer.toString())).xattr;
             upload_params.digest = MD5Async && (((await MD5Async.digest()).toString('hex')) + '-' + multiparts.length);
             const upload_info = await this._finish_upload(upload_params);
@@ -2761,3 +2761,5 @@ class NamespaceFS {
 }
 
 module.exports = NamespaceFS;
+module.exports.buffers_pool = buffers_pool;
+

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -133,7 +133,6 @@ class ObjectIO {
             BUFFERS_MEM_LIMIT: config.BUFFERS_MEM_LIMIT,
             IO_SEMAPHORE_CAP: config.IO_SEMAPHORE_CAP,
         }));
-
     }
 
     set_verification_mode() {
@@ -337,7 +336,7 @@ class ObjectIO {
             } else {
                 params.source_stream = this.read_object_stream({
                     client: params.client,
-                    object_md
+                    object_md,
                 });
             }
             return this._upload_stream(params, complete_params);

--- a/src/server/analytic_services/prometheus_reports/noobaa_endpoint_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_endpoint_report.js
@@ -10,6 +10,7 @@ const js_utils = require('../../../util/js_utils');
 // come next to add endpoint metrics reporting.
 // -----------------------------------------
 
+const nsfs_suffix = "_nsfs";
 const NOOBAA_ENDPOINT_METRICS = js_utils.deep_freeze([{
         type: 'Counter',
         name: 'hub_read_bytes',
@@ -161,7 +162,71 @@ const NOOBAA_ENDPOINT_METRICS = js_utils.deep_freeze([{
                 10000, 20000, 50000,
             ],
         }
-    }
+    },
+    {
+        type: 'Gauge',
+        name: 'semaphore_waiting_value',
+        configuration: {
+            help: 'Namespace semaphore waiting value',
+            labelNames: ['type', 'average_interval']
+        },
+        collect: function(prom_instance, labels, values) {
+            let total_values = 0;
+            for (const value of values) {
+                total_values += value.semaphore_state.waiting_value;
+            }
+            prom_instance.set(labels, total_values / values.length);
+            total_values = 0;
+        },
+    },
+    {
+        type: 'Gauge',
+        name: 'semaphore_waiting_time',
+        configuration: {
+            help: 'Namespace semaphore waiting time',
+            labelNames: ['type', 'average_interval']
+        },
+        collect: function(prom_instance, labels, values) {
+            let total_values = 0;
+            for (const value of values) {
+                total_values += value.semaphore_state.waiting_time;
+            }
+            prom_instance.set(labels, total_values / values.length);
+            total_values = 0;
+        },
+    },
+    {
+        type: 'Gauge',
+        name: 'semaphore_waiting_queue',
+        configuration: {
+            help: 'Namespace semaphore waiting queue size',
+            labelNames: ['type', 'average_interval']
+        },
+        collect: function(prom_instance, labels, values) {
+            let total_values = 0;
+            for (const value of values) {
+                total_values += value.semaphore_state.waiting_queue;
+            }
+            prom_instance.set(labels, total_values / values.length);
+            total_values = 0;
+        },
+    },
+    {
+        type: 'Gauge',
+        name: 'semaphore_value',
+        configuration: {
+            help: 'Namespace semaphore value',
+            labelNames: ['type', 'average_interval']
+        },
+        collect(prom_instance, labels, values) {
+            let total_values = 0;
+            for (const value of values) {
+                total_values += value.semaphore_state.value;
+            }
+            prom_instance.set(labels, total_values / values.length);
+            total_values = 0;
+        },
+    },
 ]);
 
 class NooBaaEndpointReport extends BasePrometheusReport {
@@ -173,10 +238,24 @@ class NooBaaEndpointReport extends BasePrometheusReport {
             for (const m of NOOBAA_ENDPOINT_METRICS) {
                 this._metrics[m.name] = {
                     type: m.type,
+                    collect: m.collect,
                     prom_instance: new this.prom_client[m.type]({
                         name: this.get_prefixed_name(m.name),
                         registers: [this.registry],
                         ...m.configuration,
+                        collect() {
+                            if (m.collect && this.average_intervals) {
+                                for (const average_interval of this.average_intervals) {
+                                    if (this[average_interval]) {
+                                        m.collect(this, this[average_interval].labels, this[average_interval].value);
+                                    }
+                                    if (this[average_interval + nsfs_suffix]) {
+                                        m.collect(this, this[average_interval + nsfs_suffix].labels,
+                                            this[average_interval + nsfs_suffix].value);
+                                    }
+                                }
+                            }
+                        }
                     }),
                 };
             }
@@ -190,6 +269,21 @@ class NooBaaEndpointReport extends BasePrometheusReport {
         if (!metric) throw new Error(`Unknown metric ${name}`);
         if (metric.type !== 'Counter') throw new Error(`Metric ${name} is not Counter`);
         metric.prom_instance.inc(labels, value);
+    }
+
+    // Set value metric
+    set(name, labels, value, average_intervals) {
+        if (!this._metrics) return;
+        const metric = this._metrics[name];
+        if (!metric) throw new Error(`Unknown metric ${name}`);
+        if (metric.type !== 'Gauge') throw new Error(`Metric ${name} is not Gauge`);
+        if (labels.type === 'object_io') {
+            metric.prom_instance[labels.average_interval] = { labels, value };
+        } else {
+            // Adding suffix to distinguish between object_io and nsfs semaphore
+            metric.prom_instance[labels.average_interval + nsfs_suffix] = { labels, value };
+        }
+        metric.prom_instance.average_intervals = average_intervals;
     }
 
     // Update histogram metric

--- a/src/server/bg_services/semaphore_monitor.js
+++ b/src/server/bg_services/semaphore_monitor.js
@@ -1,0 +1,115 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config');
+const endpoint_stats_collector = require('../../sdk/endpoint_stats_collector').instance();
+const { buffers_pool } = require('../../sdk/namespace_fs');
+
+class SemaphoreMonitor {
+
+    /**
+     * @param {{
+     *   name: string;
+     *   object_io: import('../../sdk/object_io'),
+     *   report_sample_sizes?: Array<Object>,
+     * }} params
+     */
+    constructor({ name, object_io, report_sample_sizes }) {
+        this.name = name;
+        this.object_io = object_io;
+        this.report_sample_sizes = report_sample_sizes || semaphore_report_sample_sizes();
+    }
+
+    async run_batch() {
+        dbg.log1("semaphore_monitor: START");
+        if (!this._can_run()) return;
+        try {
+            this.run_semaphore_monitor();
+        } catch (err) {
+            dbg.error('semaphore_monitor:', err, err.stack);
+        }
+        return config.SEMAPHORE_MONITOR_DELAY;
+    }
+
+    run_semaphore_monitor() {
+        try {
+            this.sample_object_io_semaphore();
+            this.sample_nsfs_semaphore();
+        } catch (err) {
+            dbg.error('semaphore_monitor:', err, err.stack);
+        }
+    }
+
+    _can_run() {
+        if (!this.report_sample_sizes || this.report_sample_sizes.length === 0) {
+            dbg.log0('semaphore_monitor: report_sample_sizes do not have valid size', this.report_sample_sizes);
+            return false;
+        }
+
+        return true;
+    }
+
+    sample_object_io_semaphore() {
+        if (!this.object_io) {
+            dbg.log0('semaphore_monitor: object_io is invalid', this.object_io);
+            return;
+        }
+        try {
+            const semaphore_report = {
+                timestamp: Date.now(),
+                semaphore_state: {
+                    semaphore_cap: config.IO_SEMAPHORE_CAP,
+                    value: this.object_io._io_buffers_sem.value,
+                    waiting_value: this.object_io._io_buffers_sem.waiting_value,
+                    waiting_time: this.object_io._io_buffers_sem.waiting_time,
+                    waiting_queue: this.object_io._io_buffers_sem._wq.length,
+                }
+            };
+            endpoint_stats_collector.update_semaphore_state(semaphore_report, "object_io", this.report_sample_sizes);
+        } catch (err) {
+            dbg.error('Could not submit endpoint monitor report, got:', err);
+        }
+    }
+
+    sample_nsfs_semaphore() {
+        const buffers_pool_sem = buffers_pool.sem;
+        if (!buffers_pool_sem) {
+            dbg.log0('semaphore_monitor: buffers_pool_sem is invalid', this.object_io);
+            return;
+        }
+        try {
+            const semaphore_report = {
+                timestamp: Date.now(),
+                semaphore_state: {
+                    semaphore_cap: config.NSFS_BUF_POOL_MEM_LIMIT,
+                    value: buffers_pool_sem.value,
+                    waiting_value: buffers_pool_sem.waiting_value,
+                    waiting_time: buffers_pool_sem.waiting_time,
+                    waiting_queue: buffers_pool_sem._wq.length,
+                }
+            };
+           endpoint_stats_collector.update_semaphore_state(semaphore_report, "nsfs", this.report_sample_sizes);
+        } catch (err) {
+            dbg.error('Could not submit nsfs endpoint monitor report, got:', err);
+        }
+    }
+
+}
+
+
+// Method will return the sampling size for each interval, That means if the interval is 1 minute and the 
+// semaphore monitoring delay is 10 seconds then that interval will have 6 samples. And this sample size 
+// along with the complete sample array is used to calculate average semaphore values for each interval.
+function semaphore_report_sample_sizes() {
+    const report_sample_sizes = [];
+    for (const interval of config.SEMAPHORE_METRICS_AVERAGE_INTERVALS) {
+        const interval_num = parseInt(interval, 10);
+        // Convert the interval minute to seconds and divide it with semaphore delay seconds to get the sample size.
+        const sample_size = interval_num * 60 * 1000 / config.SEMAPHORE_MONITOR_DELAY;
+        report_sample_sizes.push(sample_size);
+    }
+    return report_sample_sizes;
+}
+
+exports.SemaphoreMonitor = SemaphoreMonitor;


### PR DESCRIPTION
### Explain the changes
1. This code change will add both namespace store and NSFS semaphore state to noobaa endpoint metrics `s3-service-monitor`


### Issues: Fixed #xxx / Gap #xxx
1. semaphore metrics will give more understanding of semaphore related issues

### Testing Instructions:
1. read/write data to either namespace store or NSFS S3 bucket.
2. verify Prometheus metrics, noobaa endpoint metrics should have the following metrics 
`semaphore_value,
semaphore_waiting_value,
semaphore_waiting_time,
semaphore_waiting_queue`
![image](https://github.com/noobaa/noobaa-core/assets/79908956/6ac4d5b0-979d-4073-a02e-8e58cb61a7ac)


- [ ] Doc added/updated
- [ ] Tests added
