### PR TITLE
change bucket policy schema to fit AWS json

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -252,41 +252,65 @@ module.exports = {
             }
         },
 
+        bucket_policy_principal: {
+            anyOf: [{
+                    wrapper: SensitiveString,
+                }, {
+                    type: 'object',
+                    required: ['AWS'],
+                    properties: {
+                        AWS: {
+                            anyOf: [{
+                                    wrapper: SensitiveString
+                                }, {
+                                    type: 'array',
+                                    items: {
+                                        wrapper: SensitiveString
+                                    }
+                                }]
+                        }
+                    }
+                }
+            ]},
+        string_or_string_array: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    }
+                }
+              ]
+        },
         bucket_policy: {
             type: 'object',
-            required: ['statement'],
+            required: ['Statement'],
             properties: {
-                version: { type: 'string' },
-                statement: {
+                Version: { type: 'string' },
+                Statement: {
                     type: 'array',
                     items: {
                         type: 'object',
-                        required: ['effect', 'action', 'principal', 'resource'],
+                        required: ['Effect', 'Action', 'Principal', 'Resource'],
                         properties: {
-                            sid: {
+                            Sid: {
                                 type: 'string'
                             },
-                            effect: {
-                                enum: ['allow', 'deny'],
+                            Effect: {
+                                enum: ['Allow', 'Deny'],
                                 type: 'string'
                             },
-                            action: {
-                                type: 'array',
-                                items: {
-                                    type: 'string'
-                                }
+                            Action: {
+                                $ref: '#/definitions/string_or_string_array'
                             },
-                            principal: {
-                                type: 'array',
-                                items: {
-                                    wrapper: SensitiveString,
-                                }
+                            Principal: {
+                                $ref: '#/definitions/bucket_policy_principal'
                             },
-                            resource: {
-                                type: 'array',
-                                items: {
-                                    type: 'string'
-                                }
+                            Resource: {
+                                $ref: '#/definitions/string_or_string_array'
                             }
                         }
                     }

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -132,12 +132,12 @@ class NsfsObjectSDK extends ObjectSDK {
     async read_bucket_sdk_policy_info(bucket_name) {
         return {
             s3_policy: {
-                version: '2012-10-17',
-                statement: [{
-                    effect: 'allow',
-                    action: ['*'],
-                    resource: ['*'],
-                    principal: [new SensitiveString('*')],
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['*'],
+                    Resource: ['*'],
+                    Principal: new SensitiveString('*'),
                 }]
             },
             system_owner: new SensitiveString('nsfs'),

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -364,7 +364,7 @@ function handle_error(req, res, err) {
         ((err instanceof S3Error) && err) ||
         new S3Error(S3Error.RPC_ERRORS_TO_S3[err.rpc_code] || S3Error.InternalError);
 
-    if (s3err.code === 'MalformedPolicy') {
+    if (!(err instanceof S3Error) && s3err.code === 'MalformedPolicy') {
         s3err.message = err.message;
         s3err.detail = err.rpc_data.detail;
     }

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -37,84 +37,84 @@ const XATTR_SORT_SYMBOL = Symbol('XATTR_SORT_SYMBOL');
 const base64_regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 const OP_NAME_TO_ACTION = Object.freeze({
-    delete_bucket_analytics: { regular: "s3:putanalyticsconfiguration" },
-    delete_bucket_cors: { regular: "s3:putbucketcors" },
-    delete_bucket_encryption: { regular: "s3:putencryptionconfiguration" },
-    delete_bucket_inventory: { regular: "s3:putinventoryconfiguration" },
-    delete_bucket_lifecycle: { regular: "s3:putlifecycleconfiguration" },
-    delete_bucket_metrics: { regular: "s3:putmetricsconfiguration" },
-    delete_bucket_policy: { regular: "s3:deletebucketpolicy" },
-    delete_bucket_replication: { regular: "s3:putreplicationconfiguration" },
-    delete_bucket_tagging: { regular: "s3:putbuckettagging" },
-    delete_bucket_website: { regular: "s3:deletebucketwebsite" },
-    delete_bucket: { regular: "s3:deletebucket" },
-    delete_object_tagging: { regular: "s3:deleteobjecttagging", versioned: "s3:deleteobjectversiontagging" },
-    delete_object_uploadId: { regular: "s3:abortmultipartupload" },
-    delete_object: { regular: "s3:deleteobject", versioned: "s3:deleteobjectversion" },
+    delete_bucket_analytics: { regular: "s3:PutAnalyticsConfiguration" },
+    delete_bucket_cors: { regular: "s3:PutBucketCORS" },
+    delete_bucket_encryption: { regular: "s3:PutEncryptionConfiguration" },
+    delete_bucket_inventory: { regular: "s3:PutInventoryConfiguration" },
+    delete_bucket_lifecycle: { regular: "s3:PutLifecycleConfiguration" },
+    delete_bucket_metrics: { regular: "s3:PutMetricsConfiguration" },
+    delete_bucket_policy: { regular: "s3:DeleteBucketPolicy" },
+    delete_bucket_replication: { regular: "s3:PutReplicationConfiguration" },
+    delete_bucket_tagging: { regular: "s3:PutBucketTagging" },
+    delete_bucket_website: { regular: "s3:DeleteBucketWebsite" },
+    delete_bucket: { regular: "s3:DeleteBucket" },
+    delete_object_tagging: { regular: "s3:DeleteObjectTagging", versioned: "s3:DeleteObjectVersionTagging" },
+    delete_object_uploadId: { regular: "s3:AbortMultipartUpload" },
+    delete_object: { regular: "s3:DeleteObject", versioned: "s3:DeleteObjectVersion" },
 
-    get_bucket_accelerate: { regular: "s3:getaccelerateconfiguration" },
-    get_bucket_acl: { regular: "s3:getbucketacl" },
-    get_bucket_analytics: { regular: "s3:getanalyticsconfiguration" },
-    get_bucket_cors: { regular: "s3:getbucketcors" },
-    get_bucket_encryption: { regular: "s3:getencryptionconfiguration" },
-    get_bucket_inventory: { regular: "s3:getinventoryconfiguration" },
-    get_bucket_lifecycle: { regular: "s3:getlifecycleconfiguration" },
-    get_bucket_location: { regular: "s3:getbucketlocation" },
-    get_bucket_logging: { regular: "s3:getbucketlogging" },
-    get_bucket_metrics: { regular: "s3:getmetricsconfiguration" },
-    get_bucket_notification: { regular: "s3:getbucketnotification" },
-    get_bucket_policy: { regular: "s3:getbucketpolicy" },
-    get_bucket_policy_status: { regular: "s3:getbucketpolicystatus" },
-    get_bucket_replication: { regular: "s3:getreplicationconfiguration" },
-    get_bucket_requestpayment: { regular: "s3:getbucketrequestpayment" },
-    get_bucket_tagging: { regular: "s3:getbuckettagging" },
-    get_bucket_uploads: { regular: "s3:listbucketmultipartuploads" },
-    get_bucket_versioning: { regular: "s3:getbucketversioning" },
-    get_bucket_versions: { regular: "s3:listbucketversions" },
-    get_bucket_website: { regular: "s3:getbucketwebsite" },
-    get_bucket_object_lock: { regular: "s3:getbucketobjectlockconfiguration" },
-    get_bucket: { regular: "s3:listbucket" },
-    get_object_acl: { regular: "s3:getobjectacl" },
-    get_object_tagging: { regular: "s3:getobjecttagging", versioned: "s3:getobjectversiontagging" },
-    get_object_uploadId: { regular: "s3:listmultipartuploadparts" },
-    get_object_retention: { regular: "s3:getobjectretention"},
-    get_object_legal_hold: { regular: "s3:getobjectlegalhold" },
-    get_object: { regular: "s3:getobject", versioned: "s3:getobjectversion" },
-    get_service: { regular: "s3:listallmybuckets" },
+    get_bucket_accelerate: { regular: "s3:GetAccelerateConfiguration" },
+    get_bucket_acl: { regular: "s3:GetBucketAcl" },
+    get_bucket_analytics: { regular: "s3:GetAnalyticsConfiguration" },
+    get_bucket_cors: { regular: "s3:GetBucketCORS" },
+    get_bucket_encryption: { regular: "s3:GetEncryptionConfiguration" },
+    get_bucket_inventory: { regular: "s3:GetInventoryConfiguration" },
+    get_bucket_lifecycle: { regular: "s3:GetLifecycleConfiguration" },
+    get_bucket_location: { regular: "s3:GetBucketLocation" },
+    get_bucket_logging: { regular: "s3:GetBucketLogging" },
+    get_bucket_metrics: { regular: "s3:GetMetricsConfiguration" },
+    get_bucket_notification: { regular: "s3:GetBucketNotification" },
+    get_bucket_policy: { regular: "s3:GetBucketPolicy" },
+    get_bucket_policy_status: { regular: "s3:GetBucketPolicyStatus" },
+    get_bucket_replication: { regular: "s3:GetReplicationConfiguration" },
+    get_bucket_requestpayment: { regular: "s3:GetBucketRequestPayment" },
+    get_bucket_tagging: { regular: "s3:GetBucketTagging" },
+    get_bucket_uploads: { regular: "s3:ListBucketMultipartUploads" },
+    get_bucket_versioning: { regular: "s3:GetBucketVersioning" },
+    get_bucket_versions: { regular: "s3:ListBucketVersions" },
+    get_bucket_website: { regular: "s3:GetBucketWebsite" },
+    get_bucket_object_lock: { regular: "s3:GetBucketObjectLockConfiguration" },
+    get_bucket: { regular: "s3:ListBucket" },
+    get_object_acl: { regular: "s3:GetObjectAcl" },
+    get_object_tagging: { regular: "s3:GetObjectTagging", versioned: "s3:GetObjectVersionTagging" },
+    get_object_uploadId: { regular: "s3:ListMultipartUploadParts" },
+    get_object_retention: { regular: "s3:GetObjectRetention"},
+    get_object_legal_hold: { regular: "s3:GetObjectLegalHold" },
+    get_object: { regular: "s3:GetObject", versioned: "s3:GetObjectVersion" },
+    get_service: { regular: "s3:ListAllMyBuckets" },
 
-    head_bucket: { regular: "s3:listbucket" },
-    head_object: { regular: "s3:getobject", versioned: "s3:getobjectversion" },
+    head_bucket: { regular: "s3:ListBucket" },
+    head_object: { regular: "s3:GetObject", versioned: "s3:GetObjectVersion" },
 
-    post_bucket_delete: { regular: "s3:deleteobject" },
-    post_object: { regular: "s3:putobject" },
-    post_object_uploadId: { regular: "s3:putobject" },
-    post_object_uploads: { regular: "s3:putobject" },
-    post_object_select: { regular: "s3:selectobjectcontent" },
+    post_bucket_delete: { regular: "s3:DeleteObject" },
+    post_object: { regular: "s3:PutObject" },
+    post_object_uploadId: { regular: "s3:PutObject" },
+    post_object_uploads: { regular: "s3:PutObject" },
+    post_object_select: { regular: "s3:GetObject" },
 
-    put_bucket_accelerate: { regular: "s3:putaccelerateconfiguration" },
-    put_bucket_acl: { regular: "s3:putbucketacl" },
-    put_bucket_analytics: { regular: "s3:putanalyticsconfiguration" },
-    put_bucket_cors: { regular: "s3:putbucketcors" },
-    put_bucket_encryption: { regular: "s3:putencryptionconfiguration" },
-    put_bucket_inventory: { regular: "s3:putinventoryconfiguration" },
-    put_bucket_lifecycle: { regular: "s3:putlifecycleconfiguration" },
-    put_bucket_logging: { regular: "s3:putbucketlogging" },
-    put_bucket_metrics: { regular: "s3:putmetricsconfiguration" },
-    put_bucket_notification: { regular: "s3:putbucketnotification" },
-    put_bucket_policy: { regular: "s3:putbucketpolicy" },
-    put_bucket_replication: { regular: "s3:putreplicationconfiguration" },
-    put_bucket_requestpayment: { regular: "s3:putbucketrequestpayment" },
-    put_bucket_tagging: { regular: "s3:putbuckettagging" },
-    put_bucket_versioning: { regular: "s3:putbucketversioning" },
-    put_bucket_website: { regular: "s3:putbucketwebsite" },
-    put_bucket_object_lock: { regular: "s3:putbucketobjectlockconfiguration" },
-    put_bucket: { regular: "s3:createbucket" },
-    put_object_acl: { regular: "s3:putobjectacl" },
-    put_object_tagging: { regular: "s3:putobjecttagging", versioned: "s3:putobjectversiontagging" },
-    put_object_uploadId: { regular: "s3:putobject" },
-    put_object_retention: { regular: "s3:putobjectretention" },
-    put_object_legal_hold: { regular: "s3:getobjectlegalhold"},
-    put_object: { regular: "s3:putobject" },
+    put_bucket_accelerate: { regular: "s3:PutAccelerateConfiguration" },
+    put_bucket_acl: { regular: "s3:PutBucketAcl" },
+    put_bucket_analytics: { regular: "s3:PutAnalyticsConfiguration" },
+    put_bucket_cors: { regular: "s3:PutBucketCORS" },
+    put_bucket_encryption: { regular: "s3:PutEncryptionConfiguration" },
+    put_bucket_inventory: { regular: "s3:PutInventoryConfiguration" },
+    put_bucket_lifecycle: { regular: "s3:PutLifecycleConfiguration" },
+    put_bucket_logging: { regular: "s3:PutBucketLogging" },
+    put_bucket_metrics: { regular: "s3:PutMetricsConfiguration" },
+    put_bucket_notification: { regular: "s3:PutBucketNotification" },
+    put_bucket_policy: { regular: "s3:PutBucketPolicy" },
+    put_bucket_replication: { regular: "s3:PutReplicationConfiguration" },
+    put_bucket_requestpayment: { regular: "s3:PutBucketRequestPayment" },
+    put_bucket_tagging: { regular: "s3:PutBucketTagging" },
+    put_bucket_versioning: { regular: "s3:PutBucketVersioning" },
+    put_bucket_website: { regular: "s3:PutBucketWebsite" },
+    put_bucket_object_lock: { regular: "s3:PutBucketObjectLockConfiguration" },
+    put_bucket: { regular: "s3:CreateBucket" },
+    put_object_acl: { regular: "s3:PutObjectAcl" },
+    put_object_tagging: { regular: "s3:PutObjectTagging", versioned: "s3:PutObjectVersionTagging" },
+    put_object_uploadId: { regular: "s3:PutObject" },
+    put_object_retention: { regular: "s3:PutObjectRetention" },
+    put_object_legal_hold: { regular: "s3:GetObjectLegalHold"},
+    put_object: { regular: "s3:PutObject" },
 });
 
 function decode_chunked_upload(source_stream) {
@@ -652,7 +652,7 @@ function get_http_response_from_resp(res) {
 }
 
 function has_bucket_policy_permission(policy, account, method, arn_path) {
-    const [allow_statements, deny_statements] = _.partition(policy.statement, statement => statement.effect === 'allow');
+    const [allow_statements, deny_statements] = _.partition(policy.Statement, statement => statement.Effect === 'Allow');
 
     // look for explicit denies
     if (_is_statements_fit(deny_statements, account, method, arn_path)) return 'DENY';
@@ -671,19 +671,20 @@ function _is_statements_fit(statements, account, method, arn_path) {
         let action_fit = false;
         let principal_fit = false;
         let resource_fit = false;
-        for (const action of statement.action) {
+        for (const action of _.flatten([statement.Action])) {
             dbg.log1('bucket_policy: action fit?', action, method);
             if ((action === '*') || (action === 's3:*') || (action === method)) {
                 action_fit = true;
             }
         }
-        for (const principal of statement.principal) {
+        const statement_principal = statement.Principal.AWS || statement.Principal;
+        for (const principal of _.flatten([statement_principal])) {
             dbg.log1('bucket_policy: principal fit?', principal, account);
             if ((principal.unwrap() === '*') || (principal.unwrap() === account)) {
                 principal_fit = true;
             }
         }
-        for (const resource of statement.resource) {
+        for (const resource of _.flatten([statement.Resource])) {
             const resource_regex = RegExp(`^${resource.replace(qm_regex, '.?').replace(ar_regex, '.*')}$`);
             dbg.log1('bucket_policy: resource fit?', resource_regex, arn_path);
             if (resource_regex.test(arn_path)) {

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -703,7 +703,7 @@ async function read_object_mapping(req) {
     const obj = await find_object_md(req);
 
     // Check if the requesting account is authorized to read the object
-    if (!req.has_s3_bucket_permission(req.bucket, 's3:getobject', '/' + obj.key)) {
+    if (!req.has_s3_bucket_permission(req.bucket, 's3:GetObject', '/' + obj.key)) {
         throw new RpcError('UNAUTHORIZED', 'requesting account is not authorized to read the object');
     }
 
@@ -791,7 +791,7 @@ async function read_object_md(req) {
     const obj = await find_object_md(req);
 
     // Check if the requesting account is authorized to read the object
-    if (!req.has_s3_bucket_permission(req.bucket, 's3:getobject', '/' + obj.key)) {
+    if (!req.has_s3_bucket_permission(req.bucket, 's3:GetObject', '/' + obj.key)) {
         throw new RpcError('UNAUTHORIZED', 'requesting account is not authorized to read the object');
     }
 
@@ -1060,7 +1060,7 @@ async function list_objects(req) {
     dbg.log1('object_server.list_objects', req.rpc_params);
     load_bucket(req);
 
-    if (!req.has_s3_bucket_permission(req.bucket, "s3:listbucket")) {
+    if (!req.has_s3_bucket_permission(req.bucket, "s3:ListBucket")) {
         throw new RpcError('UNAUTHORIZED', 'requesting account is not authorized to list objects');
     }
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -488,23 +488,27 @@ async function put_bucket_policy(req) {
 
 function _validate_s3_policy(policy, bucket_name) {
     const all_op_names = _.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned]));
-    for (const statement of policy.statement) {
-        for (const principal of statement.principal) {
-            if (principal.unwrap() !== '*') {
-                const account = system_store.get_account_by_email(principal);
-                if (!account) {
-                    throw new RpcError('MALFORMED_POLICY', 'Invalid principal in policy', { detail: principal });
+    for (const statement of policy.Statement) {
+        if (statement.Principal.AWS) {
+            for (const principal of _.flatten([statement.Principal.AWS])) {
+                if (principal.unwrap() !== '*') {
+                    const account = system_store.get_account_by_email(principal);
+                    if (!account) {
+                        throw new RpcError('MALFORMED_POLICY', 'Invalid principal in policy', { detail: principal });
+                    }
                 }
             }
+        } else if (statement.Principal.unwrap() !== '*') {
+            throw new RpcError('MALFORMED_POLICY', 'Invalid principal in policy', { detail: statement.Principal });
         }
-        for (const resource of statement.resource) {
+        for (const resource of _.flatten([statement.Resource])) {
             const resource_bucket_part = resource.split('/')[0];
             const resource_regex = RegExp(`^${resource_bucket_part.replace(qm_regex, '.?').replace(ar_regex, '.*')}$`);
             if (!resource_regex.test('arn:aws:s3:::' + bucket_name)) {
                 throw new RpcError('MALFORMED_POLICY', 'Policy has invalid resource', { detail: resource });
             }
         }
-        for (const action of statement.action) {
+        for (const action of _.flatten([statement.Action])) {
             if (action !== 's3:*' && !all_op_names.includes(action)) {
                 throw new RpcError('MALFORMED_POLICY', 'Policy has invalid action', { detail: action });
             }
@@ -987,7 +991,7 @@ async function delete_bucket_lifecycle(req) {
 async function list_buckets(req) {
     const buckets_by_name = _.filter(
         req.system.buckets_by_name,
-        bucket => req.has_s3_bucket_permission(bucket, "s3:listbucket") && !bucket.deleting
+        bucket => req.has_s3_bucket_permission(bucket, "s3:ListBucket") && !bucket.deleting
     );
     return {
         buckets: _.map(buckets_by_name, function(bucket) {

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -176,13 +176,13 @@ async function disable_accounts_s3_access(rpc_client, accounts_emails) {
 function generate_s3_policy(principal, bucket, action) {
     return {
         policy: {
-            version: '2012-10-17',
-            statement: [
+            Version: '2012-10-17',
+            Statement: [
                 {
-                    effect: 'allow',
-                    principal: [principal],
-                    action: action,
-                    resource: [
+                    Effect: 'Allow',
+                    Principal: { AWS: [principal] },
+                    Action: action,
+                    Resource: [
                         `arn:aws:s3:::${bucket}/*`,
                         `arn:aws:s3:::${bucket}`
                     ]

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -91,6 +91,7 @@ require('./test_encryption');
 require('./test_bucket_replication');
 require('./test_sts');
 require('./test_cloud_utils');
+require('./test_upgrade_scripts.js');
 // require('./test_tiering_upload');
 //require('./test_s3_worm');
 

--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -372,7 +372,7 @@ mocha.describe('s3_bucket_policy', function() {
                 Sid: 'id-1',
                 Effect: 'Allow',
                 Principal: { AWS: user_a },
-                Action: ['s3:PutObject', 's3:deleteObjectVersion'],
+                Action: ['s3:PutObject', 's3:DeleteObjectVersion'],
                 Resource: [`arn:aws:s3:::${BKT}/*`]
             }, {
                 Sid: 'id-2',
@@ -384,7 +384,7 @@ mocha.describe('s3_bucket_policy', function() {
                 Sid: 'id-3',
                 Effect: 'Deny',
                 Principal: { AWS: user_a },
-                Action: ['s3:deleteObject'],
+                Action: ['s3:DeleteObject'],
                 Resource: [`arn:aws:s3:::${BKT}/*`]
             }]
         };
@@ -502,7 +502,7 @@ mocha.describe('s3_bucket_policy', function() {
             Version: '2012-10-17',
             Statement: [
                 {
-                    Effect: 'DENY',
+                    Effect: 'Deny',
                     Principal: { AWS: "*" },
                     Action: ['s3:GetObject', 's3:ListBucket'],
                     Resource: [`arn:aws:s3:::*`]
@@ -539,7 +539,7 @@ mocha.describe('s3_bucket_policy', function() {
             Statement: [
                 {
                     Effect: 'Allow',
-                    Principal: { AWS: "*" },
+                    Principal: "*",
                     Action: ['s3:GetObject'],
                     Resource: [`arn:aws:s3:::*`]
                 },

--- a/src/test/unit_tests/test_sts.js
+++ b/src/test/unit_tests/test_sts.js
@@ -110,12 +110,12 @@ mocha.describe('STS tests', function() {
             }]
         };
         const s3accesspolicy = {
-            version: '2012-10-17',
-            statement: [{
-                effect: 'allow',
-                principal: [user_a, user_b, user_c],
-                action: ['s3:*'],
-                resource: ['arn:aws:s3:::first.bucket/*', 'arn:aws:s3:::first.bucket'],
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: {AWS: [user_a, user_b, user_c]},
+                Action: ['s3:*'],
+                Resource: ['arn:aws:s3:::first.bucket/*', 'arn:aws:s3:::first.bucket'],
             }]
         };
         const user_a_keys = (await rpc_client.account.create_account(account)).access_keys;
@@ -505,12 +505,12 @@ mocha.describe('Session token tests', function() {
         }));
 
         const s3accesspolicy = {
-            version: '2012-10-17',
-            statement: [{
-                effect: 'allow',
-                principal: [alice2],
-                action: ['s3:*'],
-                resource: [
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: { AWS: alice2 },
+                Action: ['s3:*'],
+                Resource: [
                     'arn:aws:s3:::first.bucket/*',
                     'arn:aws:s3:::first.bucket',
                 ]

--- a/src/test/unit_tests/test_upgrade_scripts.js
+++ b/src/test/unit_tests/test_upgrade_scripts.js
@@ -1,0 +1,98 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('./coretest');
+const { rpc_client, EMAIL } = coretest;
+coretest.setup({ pools_to_create: [coretest.POOL_LIST[1]] });
+
+const AWS = require('aws-sdk');
+const http = require('http');
+const system_store = require('../../server/system_services/system_store').get_instance();
+const upgrade_bucket_policy = require('../../upgrade/upgrade_scripts/5.14.0/upgrade_bucket_policy');
+const dbg = require('../../util/debug_module')(__filename);
+const assert = require('assert');
+const mocha = require('mocha');
+
+const BKT = 'test-bucket';
+let s3;
+
+async function _clean_all_bucket_policies() {
+    for (const bucket of system_store.data.buckets) {
+        if (bucket.s3_policy) {
+            await s3.deleteBucketPolicy({Bucket: bucket.name.unwrap()}).promise();
+        }
+    }
+}
+
+mocha.describe('test upgrade scripts', async function() {
+    mocha.before(async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        await system_store.load();
+
+        const account_info = await rpc_client.account.read_account({ email: EMAIL, });
+        s3 = new AWS.S3({
+            endpoint: coretest.get_http_address(),
+            accessKeyId: account_info.access_keys[0].access_key.unwrap(),
+            secretAccessKey: account_info.access_keys[0].secret_key.unwrap(),
+            s3ForcePathStyle: true,
+            signatureVersion: 'v4',
+            computeChecksums: true,
+            s3DisableBodySigning: false,
+            region: 'us-east-1',
+            httpOptions: { agent: new http.Agent({ keepAlive: false }) },
+        });
+        await s3.createBucket({ Bucket: BKT }).promise();
+    });
+
+    mocha.it('test upgrade bucket policy to version 5.14.0', async function() {
+        const old_policy = {
+            version: '2012-10-17',
+            statement: [
+                {
+                    sid: 'id-1',
+                    effect: 'allow',
+                    principal: ["*"],
+                    action: ['s3:getobject', 's3:*'],
+                    resource: [`arn:aws:s3:::*`]
+                },
+                {
+                    effect: 'deny',
+                    principal: ["*"],
+                    action: ['s3:putobject'],
+                    resource: [`arn:aws:s3:::*`]
+                },
+            ]
+        };
+        // clean all leftover bucket policies as upgrade script doesn't work on updated policies 
+        await _clean_all_bucket_policies();
+
+        const bucket = system_store.data.buckets.find(bucket_obj => bucket_obj.name.unwrap() === BKT);
+        await system_store.make_changes({
+            update: {
+                buckets: [{
+                    _id: bucket._id,
+                    s3_policy: old_policy
+                }]
+            }
+        });
+
+        await upgrade_bucket_policy.run({dbg, system_store, system_server: null});
+        const res = await s3.getBucketPolicy({ // should work - bucket policy should fit current schema
+            Bucket: BKT,
+        }).promise();
+        const new_policy = JSON.parse(res.Policy);
+
+        assert.strictEqual(new_policy.Statement.length, old_policy.statement.length);
+        assert.strictEqual(new_policy.Version, old_policy.version);
+        assert.strictEqual(new_policy.Statement[0].Sid, old_policy.statement[0].sid);
+        assert.strictEqual(new_policy.Statement[0].Effect, 'Allow');
+        assert.strictEqual(new_policy.Statement[0].Action[0], 's3:GetObject');
+        assert.strictEqual(new_policy.Statement[0].Action[1], 's3:*');
+        assert.strictEqual(new_policy.Statement[0].Resource[0], old_policy.statement[0].resource[0]);
+    });
+
+    mocha.after(async function() {
+        await s3.deleteBucket({ Bucket: BKT }).promise();
+    });
+});

--- a/src/upgrade/upgrade_scripts/5.14.0/upgrade_bucket_policy.js
+++ b/src/upgrade/upgrade_scripts/5.14.0/upgrade_bucket_policy.js
@@ -1,0 +1,62 @@
+/* Copyright (C) 2023 NooBaa */
+"use strict";
+
+const util = require('util');
+const { OP_NAME_TO_ACTION } = require('../../../endpoint/s3/s3_utils');
+
+function _create_actions_map() {
+    const actions_map = new Map();
+    for (const action of Object.values(OP_NAME_TO_ACTION)) {
+        actions_map.set(action.regular.toLowerCase(), action.regular);
+        if (action.versioned) {
+            actions_map.set(action.versioned.toLowerCase(), action.versioned);
+        }
+    }
+    actions_map.set('s3:*', 's3:*');
+    return actions_map;
+}
+
+async function run({ dbg, system_store, system_server }) {
+
+    try {
+        dbg.log0('Starting bucket policy upgrade...');
+        const buckets = [];
+        const actions_map = _create_actions_map();
+        for (const bucket of system_store.data.buckets) {
+            //Do not update if there are no bucket policy.
+            if (!bucket.s3_policy) continue;
+
+            const new_policy = {};
+            if (bucket.s3_policy.version) new_policy.Version = bucket.s3_policy.version;
+
+            new_policy.Statement = bucket.s3_policy.statement.map(statement => ({
+                Effect: statement.effect === 'allow' ? 'Allow' : 'Deny',
+                Action: statement.action.map(action => actions_map.get(action)),
+                Principal: { AWS: statement.principal },
+                Resource: statement.resource,
+                Sid: statement.sid
+            }));
+            buckets.push({
+                _id: bucket._id,
+                s3_policy: new_policy,
+            });
+        }
+
+        if (buckets.length > 0) {
+            dbg.log0(`Replacing bucket policy rules to the new API structure for buckets: ${buckets.map(bucket => util.inspect(bucket)).join(', ')}`);
+            await system_store.make_changes({ update: { buckets } });
+        } else {
+            dbg.log0('Upgrading buckets policy: no upgrade needed...');
+        }
+
+    } catch (err) {
+        dbg.error('Got error while upgrading buckets policy:', err);
+        throw err;
+    }
+}
+
+
+module.exports = {
+    run,
+    description: 'Update bucket policy to new API format'
+};


### PR DESCRIPTION
### Explain the changes
1. change bucket policy schema to match AWS schema, according to what we currently support. passing the json as is from the request
3. change all calling functions to use correct arguments.
4. add an upgrade script for the bucket policy
5. add unit tests for upgrade script 

### Issues: Fixed #xxx / Gap #xxx
1. gap - anyOf schema changes aren't dealt by decode_json / encode_json functions. since we only use string and sensitiveString in our case it works fine. issue: https://github.com/noobaa/noobaa-core/issues/7448

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
