### PR TITLE
NSFS | handle content type

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -217,7 +217,14 @@ parse_open_flags(std::string flags)
 }
 
 const static std::vector<std::string> GPFS_XATTRS{ GPFS_ENCRYPTION_XATTR_NAME };
-const static std::vector<std::string> USER_XATTRS{ "user.content_md5", "user.version_id", "user.prev_version_id", "user.delete_marker", "user.dir_content" };
+const static std::vector<std::string> USER_XATTRS{
+    "user.content_type",
+    "user.content_md5",
+    "user.version_id",
+    "user.prev_version_id",
+    "user.delete_marker",
+    "user.dir_content",
+};
 
 struct Entry
 {


### PR DESCRIPTION
### Explain the changes
1. nsfs now stores and retrieves the content type as xattr

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. `npm run nsfs .`
2. `aws --endpoint http://localhost:6001 s3 cp --content-type x-my-type package.json s3://logs/my-file`
3. `aws --endpoint http://localhost:6001 s3api head-object --bucket logs --key my-file`
