### PR TITLE
put_object_acl - continue even without canned acl which some clients require

### DIFF
--- a/src/endpoint/s3/ops/s3_put_object_acl.js
+++ b/src/endpoint/s3/ops/s3_put_object_acl.js
@@ -1,21 +1,18 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const S3Error = require('../s3_errors').S3Error;
-
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html
  */
 async function put_object_acl(req) {
-    if (!req.headers['x-amz-acl']) {
-        throw new S3Error(S3Error.AccessDenied);
-    }
-
+    // we only handle canned acl, the rest is deprecated in favor of bucket policy.
+    // however we do not fail the request because there are still clients that call it.
+    // we should still check that the object exists or else return the proper error.
     await req.object_sdk.put_object_acl({
         bucket: req.params.bucket,
         key: req.params.key,
         version_id: req.query.versionId,
-        acl: req.headers['x-amz-acl']
+        acl: req.headers['x-amz-acl'],
     });
 }
 


### PR DESCRIPTION
### Explain the changes
1. The current put_object_acl code assumed that it should fail if a non canned acl was provided.
2. However this caused clients to fail and not be able to continue.
3. Instead we prefer to pass the info to the next layer of the namespaces and let it decide how to handle.
4. Most namespaces will ignore if they do not support setting acl, which at least allows clients to continue.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. `npm run nsfs .`
2. `aws --endpoint http://localhost:6001 s3 cp package.json s3://logs/package.json`
3. `aws --endpoint http://localhost:6001 s3api put-object-acl --bucket logs --key package.json --grant-read joe.shmoe`
