### PR TITLE
Makefile target to build linux executable in build container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "jest": "29.6.1",
         "mocha": "10.2.0",
         "pkg": "5.8.1",
-        "prebuild-install": "7.1.1",
+        "pkg-fetch": "3.4.2",
         "sinon": "15.2.0",
         "wtfnode": "0.9.1"
       }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "jest": "29.6.1",
     "mocha": "10.2.0",
     "pkg": "5.8.1",
-    "prebuild-install": "7.1.1",
+    "pkg-fetch": "3.4.2",
     "sinon": "15.2.0",
     "wtfnode": "0.9.1"
   }

--- a/src/deploy/standalone/executable.Dockerfile
+++ b/src/deploy/standalone/executable.Dockerfile
@@ -1,0 +1,17 @@
+# This dockerfile starts from the base image which contains all the node-js code
+# and native libraries already build, and then it builds a single executable using pkg.
+FROM noobaa-base
+
+RUN npm install --include=dev && ./node_modules/.bin/pkg-fetch -n node18
+
+ARG GIT_COMMIT 
+RUN if [ "${GIT_COMMIT}" != "" ]; then \
+        sed -i 's/^  "version": "\(.*\)",$/  "version": "\1-'${GIT_COMMIT:0:7}'",/' package.json; \
+    fi
+
+COPY src ./src
+COPY config.js ./config.js
+COPY platform_restrictions.json ./platform_restrictions.json
+RUN npm run pkg
+
+ENTRYPOINT [ "/noobaa/build/noobaa-core" ]

--- a/src/deploy/standalone/export.Dockerfile
+++ b/src/deploy/standalone/export.Dockerfile
@@ -1,0 +1,11 @@
+# This dockerfile exports just the single file executable from the built image.
+# It uses a multi-stage to pick just one file which would then be exported with:
+#   docker build --output ...
+# see https://docs.docker.com/engine/reference/commandline/build/#output
+# or https://docs.podman.io/en/latest/markdown/podman-build.1.html#output-o-output-opts
+FROM noobaa-core-executable as noobaa-core-executable
+FROM scratch AS export-stage
+ARG OS=linux
+ARG PLATFORM=x86_64
+ARG GIT_COMMIT
+COPY --from=noobaa-core-executable /noobaa/build/noobaa-core ./noobaa-core-${OS}-${PLATFORM}-${GIT_COMMIT}


### PR DESCRIPTION
### Explain the changes
1. Added a `make executable` target to build the noobaa-core single-executable (with pkg for now) for linux x86_64 inside a build container.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. See standalone.md - tldr - `make executable`

- [x] Doc added/updated
