### PR TITLE
Support Azure log credentials in `update_external_connection`

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -444,6 +444,7 @@ module.exports = {
                     },
                     identity: { $ref: 'common_api#/definitions/access_key' },
                     secret: { $ref: 'common_api#/definitions/secret_key' },
+                    azure_log_access_keys: { $ref: 'common_api#/definitions/azure_log_access_keys' },
                 }
             },
             auth: {


### PR DESCRIPTION
### Explain the changes
1. Added support for the optional Azure log credentials in `update_external_connection`
2. Fixed a bug in the Azure log iterator