### PR TITLE
storage class set to tier2 on uploads

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -357,7 +357,7 @@ function parse_storage_class_header(req) {
 }
 
 /**
- * @param {string} storage_class
+ * @param {string} [storage_class]
  * @returns {nb.StorageClass}
  */
 function parse_storage_class(storage_class) {

--- a/src/server/object_services/map_reader.js
+++ b/src/server/object_services/map_reader.js
@@ -122,7 +122,7 @@ async function update_chunks_on_read(chunks, location_info) {
     const chunks_to_scrub = [];
     try {
         const bucket = chunks[0].bucket;
-        const selected_tier = await map_server.select_tier_for_write(bucket);
+        const selected_tier = await map_server.select_tier_for_read(bucket);
         for (const chunk of chunks) {
             if ((!chunk.tier._id || !_.isEqual(chunk.tier._id, selected_tier._id)) &&
                 map_server.enough_room_in_tier(selected_tier, bucket)) {

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -36,6 +36,7 @@ const { IoStatsStore } = require('../analytic_services/io_stats_store');
 const { ChunkAPI } = require('../../sdk/map_api_types');
 const config = require('../../../config');
 const Quota = require('../system_services/objects/quota');
+const { STORAGE_CLASS_STANDARD } = require('../../endpoint/s3/s3_utils');
 
 // short living cache for objects
 // the purpose is to reduce hitting the DB many many times per second during upload/download.
@@ -114,6 +115,10 @@ async function create_object_upload(req) {
     }
 
     const tier = req.bucket.tiering && await map_server.select_tier_for_write(req.bucket);
+    if (tier && tier.storage_class && tier.storage_class !== STORAGE_CLASS_STANDARD) {
+        info.storage_class = tier.storage_class;
+    }
+
     await MDStore.instance().insert_object(info);
     object_md_cache.put_in_cache(String(info._id), info);
 


### PR DESCRIPTION
### Explain the changes
1. Previously uploads to TMFS would set the blocks to migrate immediately, but the first tier was used and the object storage class did not represent the correct tier.
2. Now the selected tier on upload will take into account the configuration and set the proper tier right when the object creates.
3. This is probably not the last iteration on this, because we also want to postpone the update to the second tier only once the blocks are actually migrated, instead of upon triggering the migration, but for now this is an improvement of the storage class reporting.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
```
> alias s3='aws --endpoint http://localhost:6001 s3'
> alias s3api='aws --endpoint http://localhost:6001 s3api'
> s3 cp README.md s3://first.bucket
> s3api head-object --bucket first.bucket --key README.md
{
    "AcceptRanges": "bytes",
    "LastModified": "2023-07-06T08:00:00+00:00",
    "ContentLength": 2387,
    "ETag": "\"a00e1a5fb5c7ad1fc1a215825d1ce03a\"",
    "ContentType": "text/markdown",
    "Metadata": {},
    "StorageClass": "GLACIER_IR"
}
```
