### PR TITLE
Fix docker and podman multi platform build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,19 @@ ifeq ($(CONTAINER_ENGINE),)
 	CONTAINER_ENGINE=$(shell lima nerdctl version >/dev/null 2>&1 && echo lima nerdctl)
 endif
 
+# If CONTAINER_PLATFORM is not set, then set automatically based on the host.
+ifeq ($(CONTAINER_PLATFORM),)
 # see https://github.com/containerd/nerdctl/blob/main/docs/multi-platform.md
 # e.g use CONTAINER_PLATFORM=amd64 for building x86_64 on arm.
-CONTAINER_PLATFORM?=$(shell [ "`arch`" = "arm64" ] || [ "`arch`" = "aarch64" ] && echo amd64)
+	CONTAINER_PLATFORM=$(shell [ "`arch`" = "arm64" ] || [ "`arch`" = "aarch64" ] && echo amd64)
+
+	ifneq ($(strip $(CONTAINER_PLATFORM)),)
+		ifeq ($(CONTAINER_ENGINE),$(filter $(CONTAINER_ENGINE), docker podman))
+			CONTAINER_PLATFORM:=linux/$(CONTAINER_PLATFORM)
+		endif
+	endif
+endif
+
 CONTAINER_PLATFORM_FLAG=
 ifneq ($(CONTAINER_PLATFORM),)
 	CONTAINER_PLATFORM_FLAG="--platform=$(CONTAINER_PLATFORM)"


### PR DESCRIPTION
### Explain the changes
This PR simply appends `linux/` to the architecture if no `CONTAINER_PLATFORM` was provided AND `CONTAINER_ENGINE` is either `docker` or `podman`.

Without this (unless `CONTAINER_PLATFORM` explicitly specified), we get the error
```
=> ERROR [internal] load metadata for [quay.io/centos/centos:stream8](http://quay.io/centos/centos:stream8)                                                                                                                                                                                                     2.8s
------
 > [internal] load metadata for [quay.io/centos/centos:stream8](http://quay.io/centos/centos:stream8):
------
builder.Dockerfile:1
--------------------
   1 | >>> FROM [quay.io/centos/centos:stream8](http://quay.io/centos/centos:stream8)
   2 |     LABEL maintainer=“Liran Mauda ([lmauda@redhat.com](mailto:lmauda@redhat.com))”
   3 |
--------------------
ERROR: failed to solve: [quay.io/centos/centos:stream8](http://quay.io/centos/centos:stream8): no match for platform in manifest sha256:59460e4360f0657a24ce56339b117f14ac236dd51e1cf33f30ed5725ba1b4429: not found
```

### Testing Instructions:
Should be able to run `make <recipe>` without explicitly providing `CONTAINER_PLATFORM` when using `docker`.


- [ ] Doc added/updated
- [ ] Tests added
