### PR TITLE
Object Version Replication  - add the ability to replicate object versions.

### DIFF
--- a/config.js
+++ b/config.js
@@ -609,6 +609,7 @@ config.LOG_REPLICATION_ENABLED = true;
 config.AWS_LOG_CANDIDATES_LIMIT = 10;
 config.BUCKET_LOG_REPLICATOR_DELAY = 5 * 60 * 1000;
 config.AZURE_QUERY_TRUNCATION_MAX_SIZE_IN_BITS = 10 * 1024 * 1024;
+config.BUCKET_DIFF_FOR_REPLICATION = true;
 
 ///////////////////////////
 //      KEY ROTATOR      //

--- a/src/api/replication_api.js
+++ b/src/api/replication_api.js
@@ -18,7 +18,7 @@ module.exports = {
             method: 'POST',
             params: {
                 type: 'object',
-                required: ['src_bucket_name', 'dst_bucket_name', 'keys'],
+                required: ['src_bucket_name', 'dst_bucket_name', 'keys_diff_map'],
                 properties: {
                     copy_type: {
                         type: 'string',
@@ -26,19 +26,28 @@ module.exports = {
                     },
                     src_bucket_name: { $ref: 'common_api#/definitions/bucket_name' },
                     dst_bucket_name: { $ref: 'common_api#/definitions/bucket_name' },
-                    keys: {
-                        type: 'array',
-                        items: {
-                            type: 'string'
+                    keys_diff_map: {
+                        type: 'object',
+                        patternProperties: {
+                            '.*': {
+                                type: 'array',
+                                items: {
+                                    type: 'object',
+                                    additionalProperties: true,
+                                    properties: {}
+                                }
+                            }
                         }
                     },
                 }
             },
             reply: {
-                type: 'array',
-                items: {
-                    type: 'string'
-                }
+                type: 'object',
+                required: ['num_of_objects', 'size_of_objects'],
+                properties: {
+                    num_of_objects: { type: 'integer' },
+                    size_of_objects: { type: 'integer' }
+                },
             },
             auth: {
                 system: 'admin'

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -12,6 +12,8 @@ const replication_store = require('../system_services/replication_store').instan
 const cloud_utils = require('../../util/cloud_utils');
 const prom_reporting = require('../analytic_services/prometheus_reporting');
 const replication_utils = require('../utils/replication_utils');
+const { BucketDiff } = require('../../server/utils/bucket_diff');
+
 
 
 const PARTIAL_SINGLE_BUCKET_REPLICATION_DEFAULTS = {
@@ -88,35 +90,43 @@ class ReplicationScanner {
             const cur_src_cont_token = (rule.rule_status && rule.rule_status.src_cont_token) || '';
             const cur_dst_cont_token = (rule.rule_status && rule.rule_status.dst_cont_token) || '';
 
-            let src_cont_token;
-            let dst_cont_token;
-            let keys_sizes_map_to_copy;
+            const sync_versions = rule.sync_versions || false;
 
-            // eslint-disable-next-line no-constant-condition
-            if (false) { //rule.sync_versions) {
-                dbg.log0(`We have sync_versions :)`);
-                // TODO:
-                // ({ keys_sizes_map_to_copy, src_cont_token, dst_cont_token } = await this.list_versioned_buckets_and_compare(
-                //     src_bucket.name, dst_bucket.name, prefix, cur_src_cont_token, cur_dst_cont_token));
-            } else {
-                ({ keys_sizes_map_to_copy, src_cont_token, dst_cont_token } = await this.list_buckets_and_compare(
-                    src_bucket.name, dst_bucket.name, prefix, cur_src_cont_token, cur_dst_cont_token));
-            }
+            const bucketDiff = new BucketDiff({
+                first_bucket: src_bucket.name,
+                second_bucket: dst_bucket.name,
+                version: sync_versions,
+                connection: this.noobaa_connection,
+                for_replication: config.BUCKET_DIFF_FOR_REPLICATION
+            });
+            dbg.log1(`scan:: cur_src_cont_token: ${cur_src_cont_token},cur_dst_cont_token: ${cur_dst_cont_token}`);
+            const {
+                keys_diff_map,
+                first_bucket_cont_token: src_cont_token,
+                second_bucket_cont_token: dst_cont_token
+            } = await bucketDiff.get_buckets_diff({
+                prefix,
+                max_keys: Number(process.env.REPLICATION_MAX_KEYS) || 1000,
+                current_first_bucket_cont_token: cur_src_cont_token,
+                current_second_bucket_cont_token: cur_dst_cont_token,
+            });
 
-            dbg.log1('replication_scanner: keys_sizes_map_to_copy: ', keys_sizes_map_to_copy);
-            let move_res;
-            const keys_to_copy = Object.keys(keys_sizes_map_to_copy);
-            if (keys_to_copy.length) {
+            dbg.log1('scan:: keys_sizes_map_to_copy:', keys_diff_map, 'src_cont_token:', src_cont_token, 'dst_cont_token', dst_cont_token);
+            let copy_res = {
+                num_of_objects: 0,
+                size_of_objects: 0
+            };
+            if (Object.keys(keys_diff_map).length) {
                 const copy_type = replication_utils.get_copy_type();
-                move_res = await replication_utils.copy_objects(
+                copy_res = await replication_utils.copy_objects(
                     this.scanner_semaphore,
                     this.client,
                     copy_type,
                     src_bucket.name,
                     dst_bucket.name,
-                    keys_to_copy,
+                    keys_diff_map,
                 );
-                dbg.log0(`replication_scanner: scan move_res: ${move_res}`);
+                dbg.log0(`replication_scanner: scan copy_res: ${copy_res}`);
             }
 
             await replication_store.update_replication_status_by_id(replication_id,
@@ -128,147 +138,26 @@ class ReplicationScanner {
                     // always advance the src cont token, if failures happened - they will eventually will be copied
                 });
 
-            const replication_status = this._get_rule_status(rule.rule_id,
-                src_cont_token, keys_sizes_map_to_copy, move_res || []);
+            // update the prometheus metrics only if we have diff
+            if (Object.keys(keys_diff_map).length) {
+                const replication_status = this._get_rule_status(rule.rule_id, src_cont_token, keys_diff_map, copy_res);
 
-            this.update_replication_prom_report(src_bucket.name, replication_id, replication_status);
+                this.update_replication_prom_report(src_bucket.name, replication_id, replication_status);
+            }
         }));
     }
 
-    async list_buckets_and_compare(src_bucket, dst_bucket, prefix, cur_src_cont_token, cur_dst_cont_token) {
+    _get_rule_status(rule, src_cont_token, keys_diff_map, copy_res) {
+        const { num_keys_to_copy, num_bytes_to_copy } = Object.entries(keys_diff_map).reduce(
+            (acc, [key, value]) => {
+                acc.num_keys_to_copy += value.length;
+                acc.num_bytes_to_copy += value.reduce((key_bytes, obj) => key_bytes + obj.Size, 0);
+                return acc;
+            }, { num_keys_to_copy: 0, num_bytes_to_copy: 0 }
+        );
 
-        // list src_bucket
-        const src_list = await this.list_objects(src_bucket, prefix, cur_src_cont_token);
-        const ans = {
-            keys_sizes_map_to_copy: {},
-            src_cont_token: src_list.NextContinuationToken || '',
-            dst_cont_token: ''
-        };
-
-        // edge case 1: src list = [] , nothing to replicate
-        if (!src_list.Contents.length) return ans;
-
-        let src_contents_left = src_list.Contents;
-        let new_dst_cont_token = cur_dst_cont_token;
-        const last_src_key = src_list.Contents[src_list.Contents.length - 1].Key;
-
-        let keep_listing_dst = true;
-        while (keep_listing_dst) {
-            const dst_list = await this.list_objects(dst_bucket, prefix, new_dst_cont_token);
-
-            // edge case 2: dst list = [] , replicate all src_list
-            // edge case 3: all src_keys are lexicographic smaller than the first dst key, replicate all src_list
-            if (!dst_list.Contents.length || last_src_key < dst_list.Contents[0].Key) {
-                ans.keys_sizes_map_to_copy = src_contents_left.reduce(
-                    (acc, content1) => {
-                        acc[content1.Key] = content1.Size;
-                        return acc;
-                    }, { ...ans.keys_sizes_map_to_copy });
-                break;
-            }
-
-            // find keys to copy
-            const diff = await this.get_keys_diff(src_contents_left, dst_list.Contents, dst_list.NextContinuationToken,
-                src_bucket, dst_bucket);
-
-            keep_listing_dst = diff.keep_listing_dst;
-            src_contents_left = diff.src_contents_left;
-            ans.keys_sizes_map_to_copy = { ...ans.keys_sizes_map_to_copy, ...diff.to_replicate_map };
-
-            // advance dst token only when cur dst list could not contains next src list items
-            const last_dst_key = dst_list.Contents[dst_list.Contents.length - 1].Key;
-            if (last_src_key >= last_dst_key) {
-                new_dst_cont_token = dst_list.NextContinuationToken;
-            }
-        }
-        return {
-            ...ans,
-            // if src_list cont token is empty - dst_list cont token should be empty too
-            dst_cont_token: (src_list.NextContinuationToken && new_dst_cont_token) || ''
-        };
-    }
-
-    async list_objects(bucket_name, prefix, continuation_token) {
-        try {
-            dbg.log1('replication_server list_objects: params:', bucket_name, prefix, continuation_token);
-            const list = await this.noobaa_connection.listObjectsV2({
-                Bucket: bucket_name.unwrap(),
-                Prefix: prefix,
-                ContinuationToken: continuation_token,
-                MaxKeys: Number(process.env.REPLICATION_MAX_KEYS) || 1000
-            }).promise();
-
-            dbg.log1('replication_server.list_objects: finished successfully', list.Contents.map(c => c.Key));
-            return list;
-        } catch (err) {
-            dbg.error('replication_server.list_objects: error:', err);
-            throw err;
-        }
-    }
-
-    // get_keys_diff finds the object keys that src bucket contains but dst bucket doesn't
-    // iterate all src_keys and for each if:
-    // case 1: src_key is lexicographic bigger than last dst_key,
-    //         list dst from next cont token if exist, else - replicate all src keys
-    // case 2: src_key is lexicographic smaller than first dst_key
-    //         replicate src_key and continue the loop
-    // case 3: src_key in dst list keys range - 
-    // if src_key doesn't exist is dst_list or needs update - replicate, else do nothing; continue
-    async get_keys_diff(src_keys, dst_keys, dst_next_cont_token, src_bucket_name, dst_bucket_name) {
-        dbg.log1('replication_server.get_keys_diff: src contents', src_keys.map(c => c.Key), 'dst contents', dst_keys.map(c => c.Key));
-
-        const to_replicate_map = {};
-        const dst_map = _.keyBy(dst_keys, 'Key');
-
-        for (const [i, src_content] of src_keys.entries()) {
-            const cur_src_key = src_content.Key;
-            dbg.log1('replication_server.get_keys_diff, src_key: ', i, cur_src_key);
-
-            // case 1
-            if (cur_src_key > dst_keys[dst_keys.length - 1].Key) {
-
-                // in next iteration we shouldn't iterate again src keys we already passed
-                const src_contents_left = src_keys.slice(i);
-
-                const ans = dst_next_cont_token ? { to_replicate_map, keep_listing_dst: true, src_contents_left } : {
-                    to_replicate_map: src_contents_left.reduce((acc, cur_obj) => {
-                        acc[cur_obj.Key] = cur_obj.Size;
-                        return acc;
-                    }, { ...to_replicate_map })
-                };
-                dbg.log1('replication_server.get_keys_diff, case1: ', dst_next_cont_token, ans);
-                return ans;
-            }
-            // case 2
-            if (cur_src_key < dst_keys[0].Key) {
-                dbg.log1('replication_server.get_keys_diff, case2: ', cur_src_key);
-                to_replicate_map[cur_src_key] = src_content.Size;
-                continue;
-            }
-            // case 3: src_key is in range
-            const dst_content = dst_map[cur_src_key];
-            dbg.log1('replication_server.get_keys_diff, case3: src_content', src_content, 'dst_content:', dst_content);
-            if (dst_content) {
-                const src_md_info = await replication_utils.get_object_md(this.noobaa_connection, src_bucket_name, cur_src_key);
-                const dst_md_info = await replication_utils.get_object_md(this.noobaa_connection, dst_bucket_name, cur_src_key);
-
-                const should_copy = replication_utils.check_data_or_md_changed(src_md_info, dst_md_info);
-                if (should_copy) to_replicate_map[cur_src_key] = src_content.Size;
-            } else {
-                to_replicate_map[cur_src_key] = src_content.Size;
-            }
-        }
-        dbg.log1('replication_server.get_keys_diff result:', to_replicate_map);
-        return { to_replicate_map };
-    }
-
-    _get_rule_status(rule, src_cont_token, keys_sizes_map_to_copy, move_res) {
-        const keys_to_copy_sizes = Object.values(keys_sizes_map_to_copy);
-        const num_keys_to_copy = keys_to_copy_sizes.length || 0;
-        const num_bytes_to_copy = num_keys_to_copy > 0 ? _.sum(keys_to_copy_sizes) : 0;
-
-        const num_keys_moved = move_res.length || 0;
-        const num_bytes_moved = num_keys_moved > 0 ? _.sumBy(move_res, itm => keys_sizes_map_to_copy[itm]) : 0;
+        const num_keys_moved = copy_res.num_of_objects;
+        const num_bytes_moved = copy_res.size_of_objects;
 
         const status = {
             last_cycle_rule_id: rule,

--- a/src/server/bg_services/replication_server.js
+++ b/src/server/bg_services/replication_server.js
@@ -11,7 +11,7 @@ async function copy_objects(req) {
     switch (copy_type) {
         case 'MIX': {
             const res = await copy_objects_mixed_types(req);
-            console.log('move_objects_by_type: res', res);
+            dbg.log0('move_objects_by_type: res', res);
             return res;
         }
         default:
@@ -65,27 +65,50 @@ async function delete_objects(req) {
 }
 
 async function copy_objects_mixed_types(req) {
-    const { src_bucket_name, dst_bucket_name, keys } = req.rpc_params;
-    dbg.log1('replication_server copy_objects_mixed_types: params:', src_bucket_name, dst_bucket_name, keys);
-    const copy_done_list = [];
+    const { src_bucket_name, dst_bucket_name, keys_diff_map } = req.rpc_params;
+    dbg.log1('replication_server copy_objects_mixed_types: params:', src_bucket_name, dst_bucket_name, keys_diff_map);
+    const copy_res = {
+        num_of_objects: 0,
+        size_of_objects: 0
+    };
+    const keys = Object.keys(keys_diff_map);
 
     const noobaa_con = cloud_utils.set_noobaa_s3_connection(system_store.data.systems[0]);
     if (!noobaa_con) throw new Error('noobaa endpoint connection is not started yet...');
-    await P.map_with_concurrency(100, keys, async key => {
-        const params = {
-            Bucket: dst_bucket_name.unwrap(),
-            CopySource: `/${src_bucket_name.unwrap()}/${key}`, // encodeURI for special chars is needed
-            Key: key
-        };
-        try {
-            await noobaa_con.copyObject(params).promise();
-            copy_done_list.push(key);
-        } catch (err) {
-            dbg.error('replication_server copy_objects_mixed_types: got error:', err);
+    await P.map_with_concurrency(100, keys, async key => { //The concurrency can only be on the keys as the order of the versions matters
+        if (keys_diff_map[key].length === 1) {
+            const params = {
+                Bucket: dst_bucket_name.unwrap(),
+                CopySource: `/${src_bucket_name.unwrap()}/${key}`, // encodeURI for special chars is needed
+                Key: key
+            };
+            try {
+                await noobaa_con.copyObject(params).promise();
+                copy_res.num_of_objects += 1;
+                copy_res.size_of_objects += keys_diff_map[key][0].Size;
+            } catch (err) {
+                dbg.error('replication_server copy_objects_mixed_types: got error:', err);
+            }
+        } else {
+            for (let i = keys_diff_map[key].length - 1; i >= 0; i--) { // We need to replicate the oldest first
+                const version = keys_diff_map[key][i].VersionId;
+                const params = {
+                    Bucket: dst_bucket_name.unwrap(),
+                    CopySource: `/${src_bucket_name.unwrap()}/${key}?versionId=${version}`, // encodeURI for special chars is needed
+                    Key: key
+                };
+                try {
+                    await noobaa_con.copyObject(params).promise();
+                    copy_res.num_of_objects += 1;
+                    copy_res.size_of_objects += keys_diff_map[key][i].Size;
+                } catch (err) {
+                    dbg.error('replication_server copy_objects_mixed_types: got error:', err);
+                }
+            }
         }
     });
     dbg.log1('replication_server copy_objects_mixed_types: finished successfully');
-    return copy_done_list;
+    return copy_res;
 }
 
 ////////////////////////////////////////////


### PR DESCRIPTION
# Explain the changes

### Config.js: 
- Create config.BUCKET_DIFF_FOR_REPLICATION to determine if BucketDiff is in replication mode.

### Replication api:
- copy now get an object instead of keys and return an object instead of an array

### Replication Server:
 - copy_objects_mixed_types:
    - Will get objects instead of keys
    - Will return an object of num_of_objects and size_of_objects
    - if there is only one metadata per key, copy it as none version (even if there is a version) 
     - If there is more than one metadata, copy all from the older to the newest, considering the versionID

 ### Replication Utils:
 - copy_objects will get objects instead of keys
 - Cleaned unused `get_object_md` and `check_data_or_md_changed` functions

### Replication Scanner:
- Use BucketDiff for replication instead of the functions in the scanner, and remove the unused functions
- Support Object versions replication
- Fix the metrics to consume the new replay format. 

# Gap
1.  will not copy the last version if the latest is a delete marker, in order to do so we will need to be were if there is versioning enabled (maybe add to the replication_api sync_version flag)
2. need to add tests for replication of object versions
3. This will break:
https://github.com/noobaa/noobaa-core/blob/0db21bbf2e1b58a5b62f25525ef95622a020ee6d/src/server/bg_services/log_replication_scanner.js#L209-L220

# Testing Instructions:
1. Run `npx jest --testPathPattern="test_bucket_diff.test.js"`
4. Run unit tests `test_bucket_replication.js`

- [x] Tests added
