### PR TITLE
Migrating to AWS SDK V3 | noobaa_s3_client without region + implement It in analyze resource

### DIFF
--- a/config.js
+++ b/config.js
@@ -710,7 +710,7 @@ config.TIERING_TTL_MS = 30 * 60 * 1000; // 30 minutes
 // AWS SDK VERSION     //
 /////////////////////////
 
-config.AWS_SDK_VERSION_3_DISABLED = true;
+config.AWS_SDK_VERSION_3_DISABLED = false;
 config.DEFAULT_REGION = 'us-east-1';
 
 /////////////////////

--- a/src/test/unit_tests/jest_tests/test_noobaa_s3_client.test.js
+++ b/src/test/unit_tests/jest_tests/test_noobaa_s3_client.test.js
@@ -2,11 +2,11 @@
 /* eslint-disable no-undef */
 'use strict';
 
-const { S3 } = require("@aws-sdk/client-s3");
-const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
-const { Agent } = require("http");
-const { S3ClientSDKV2 } = require("../../../sdk/noobaa_s3_client/noobaa_s3_client_sdkv2");
-const noobaa_s3_client = require("../../../sdk/noobaa_s3_client/noobaa_s3_client");
+const { S3 } = require('@aws-sdk/client-s3');
+const { NodeHttpHandler } = require('@aws-sdk/node-http-handler');
+const { Agent } = require('http');
+const { S3ClientSDKV2 } = require('../../../sdk/noobaa_s3_client/noobaa_s3_client_sdkv2');
+const noobaa_s3_client = require('../../../sdk/noobaa_s3_client/noobaa_s3_client');
 const config = require('../../../../config');
 
 describe('noobaa_s3_client get_s3_client_v3_params', () => {
@@ -99,5 +99,51 @@ describe('noobaa_s3_client change_s3_client_params_to_v2_structure', () => {
             expect(params).toHaveProperty('httpOptions');
             expect(params.requestHandler).toBeUndefined();
         });
+
+});
+
+describe('noobaa_s3_client get_region', () => {
+    // global endpoint is 's3.amazonaws.com'
+    it('aws non-global endpoint without region', async () => {
+        const params = {
+            endpoint: 'https://s3.us-west-1.amazonaws.com',
+        };
+        const region = await noobaa_s3_client.get_region(params);
+        expect(region).toBe('us-west-1');
+    });
+
+    it('aws global endpoint with region', async () => {
+        const params = {
+            endpoint: 'https://s3.amazonaws.com',
+            region: 'us-west-1'
+        };
+        const region = await noobaa_s3_client.get_region(params);
+        expect(region).toBe('us-west-1');
+    });
+
+});
+
+describe('noobaa_s3_client edit_global_aws_endpoint', () => {
+    // global endpoint is 's3.amazonaws.com'
+    it('aws non-global endpoint', () => {
+        const endpoint = 'https://s3.us-west-1.amazonaws.com';
+        const region = 'us-west-1';
+        const endpoint_non_global = noobaa_s3_client.get_non_global_aws_endpoint(endpoint, region);
+        expect(endpoint_non_global).toBe('https://s3.us-west-1.amazonaws.com');
+    });
+
+    it('aws non-global endpoint (https)', () => {
+        const endpoint = 'https://s3.amazonaws.com';
+        const region = 'us-west-1';
+        const endpoint_non_global = noobaa_s3_client.get_non_global_aws_endpoint(endpoint, region);
+        expect(endpoint_non_global).toBe('https://s3.us-west-1.amazonaws.com');
+    });
+
+    it('aws non-global endpoint (http)', () => {
+        const endpoint = 'http://s3.amazonaws.com';
+        const region = 'us-west-1';
+        const endpoint_non_global = noobaa_s3_client.get_non_global_aws_endpoint(endpoint, region);
+        expect(endpoint_non_global).toBe('http://s3.us-west-1.amazonaws.com');
+    });
 
 });

--- a/src/test/unit_tests/jest_tests/test_string_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_string_utils.test.js
@@ -1,0 +1,22 @@
+/* Copyright (C) 2023 NooBaa */
+/* eslint-disable no-undef */
+'use strict';
+
+const string_utils = require('../../../util/string_utils');
+
+describe('string_utils index_of_end', () => {
+    it('non existing string', () => {
+        const original_string = 'hello world';
+        const string_to_search = 'good';
+        const res = string_utils.index_of_end(original_string, string_to_search);
+        expect(res).toBe(-1); //string_to_search doesn't exist in original_string
+    });
+
+    it('existing string', () => {
+        const original_string = 'hello world';
+        const string_to_search = 'hello';
+        const res = string_utils.index_of_end(original_string, string_to_search);
+        expect(res).toBe(5); // string_to_search is at the beginning of original_string (indices 0 to 4)
+    });
+
+});

--- a/src/tools/diagnostics/analyze_resource/analyze_resource.js
+++ b/src/tools/diagnostics/analyze_resource/analyze_resource.js
@@ -24,7 +24,7 @@ async function main() {
     try {
         const resource_type = process.env.RESOURCE_TYPE;
         check_supported_resource_type(resource_type);
-        const cloud_vendor = get_cloud_vendor(resource_type, connection_basic_details);
+        const cloud_vendor = await get_cloud_vendor(resource_type, connection_basic_details);
         await test_resource(cloud_vendor, connection_basic_details.bucket);
     } catch (err) {
         // we use this string as a summary in the file (in the operator repo)
@@ -46,7 +46,7 @@ function check_supported_resource_type(resource_type) {
 
 async function test_resource(cloud_vendor, bucket) {
     check_arguments(cloud_vendor, bucket);
-    console.info(`We will have several tests to check the status of the resource and permission of the bucket ${bucket}`);
+    console.info(`We will have several tests to check the status of the resource and permissions of the bucket ${bucket}`);
     let head_object_executed;
     let head_skip_reason;
     const key_to_head = await list_objects_and_get_one_key(cloud_vendor, bucket);

--- a/src/tools/diagnostics/analyze_resource/analyze_resource_aws.js
+++ b/src/tools/diagnostics/analyze_resource/analyze_resource_aws.js
@@ -1,14 +1,12 @@
 /* Copyright (C) 2023 NooBaa */
 'use strict';
 
-const AWS = require('aws-sdk');
 const dbg = require('../../../util/debug_module')(__filename);
 dbg.set_process_name('analyze_resource');
 const SensitiveString = require('../../../util/sensitive_string');
 const CloudVendor = require('./analyze_resource_cloud_vendor_abstract');
-// Next lines were needed since ts(2304) on the JSDoc of the class
-// Agent can be either from https or http (this is just a technical add)
-const { Agent } = require('https'); // eslint-disable-line no-unused-vars 
+const noobaa_s3_client = require('../../../sdk/noobaa_s3_client/noobaa_s3_client');
+const config = require('../../../../config');
 
 /**
  * @typedef {{
@@ -16,24 +14,25 @@ const { Agent } = require('https'); // eslint-disable-line no-unused-vars
  *      secret_access_key: SensitiveString | string, 
  *      endpoint: string,
  *      signature_version: string,
- *      agent: Agent,
+ *      region?: string,
  * }} AnalyzeAwsSpec
  */
 
 class AnalyzeAws extends CloudVendor {
-    constructor(access_key, secret_access_key, endpoint, signature_version, agent) {
+    constructor(access_key, secret_access_key, endpoint, signature_version, region) {
         super(); // Constructors for derived classes must contain a 'super' call.
         const s3_params = {
-            endpoint: endpoint,
-            accessKeyId: access_key instanceof SensitiveString ? access_key.unwrap() : access_key,
-            secretAccessKey: secret_access_key instanceof SensitiveString ? secret_access_key.unwrap() : secret_access_key,
-            s3ForcePathStyle: true,
+            credentials: {
+                accessKeyId: access_key instanceof SensitiveString ? access_key.unwrap() : access_key,
+                secretAccessKey: secret_access_key instanceof SensitiveString ? secret_access_key.unwrap() : secret_access_key,
+            },
+            region: region || config.DEFAULT_REGION, // set config.DEFAULT_REGION to avoid missing region error in aws sdk v3 for s3-compatible
+            endpoint: region ? noobaa_s3_client.get_non_global_aws_endpoint(endpoint, region) : endpoint,
+            forcePathStyle: true,
             signatureVersion: signature_version,
-            httpOptions: {
-                agent,
-            }
+            requestHandler: noobaa_s3_client.get_requestHandler_with_suitable_agent(endpoint),
         };
-        this.s3 = new AWS.S3(s3_params);
+        this.s3 = noobaa_s3_client.get_s3_client_v3_params(s3_params);
     }
 
     async list_objects(bucket) {
@@ -42,7 +41,7 @@ class AnalyzeAws extends CloudVendor {
             MaxKeys: CloudVendor.MAX_KEYS,
         };
         dbg.log0('Calling AWS listObjectsV2');
-        const res = await this.s3.listObjectsV2(params).promise();
+        const res = await this.s3.listObjectsV2(params);
         dbg.log0(`List object response: ${JSON.stringify(res, null, 4)}`);
 
         this.key = '';
@@ -61,7 +60,7 @@ class AnalyzeAws extends CloudVendor {
             Key: key,
         };
         dbg.log0('Calling AWS headObject');
-        const res = await this.s3.headObject(params).promise();
+        const res = await this.s3.headObject(params);
         dbg.log0(`Head of ${key} response: ${JSON.stringify(res, null, 4)}`);
     }
 
@@ -71,7 +70,7 @@ class AnalyzeAws extends CloudVendor {
             Key: key,
         };
         dbg.log0('Calling AWS putObject');
-        const res = await this.s3.putObject(params).promise();
+        const res = await this.s3.putObject(params);
         dbg.log0(`Write of ${key} response: ${JSON.stringify(res, null, 4)}`);
     }
 
@@ -81,7 +80,7 @@ class AnalyzeAws extends CloudVendor {
             Key: key,
         };
         dbg.log0('Calling AWS deleteObject');
-        const res = await this.s3.deleteObject(params).promise();
+        const res = await this.s3.deleteObject(params);
         dbg.log0(`Delete of ${key} response: ${JSON.stringify(res, null, 4)}`); // getting empty response {}
     }
 }

--- a/src/util/string_utils.js
+++ b/src/util/string_utils.js
@@ -144,6 +144,14 @@ function escape_reg_exp(str) {
     return str.replace(escape_regexp, '\\$&');
 }
 
+// indexOfEnd is the index of of string_to_search including it
+// Based on this: https://stackoverflow.com/a/18893403
+// Didn't use it as is since it creates eslint error: no-extend-native error
+function index_of_end(original_string, string_to_search) {
+    const index = original_string.indexOf(string_to_search);
+    return index === -1 ? -1 : index + string_to_search.length;
+}
+
 exports.ALPHA_NUMERIC_CHARSET = ALPHA_NUMERIC_CHARSET;
 exports.crypto_random_string = crypto_random_string;
 exports.left_pad_zeros = left_pad_zeros;
@@ -152,3 +160,5 @@ exports.rolling_hash = rolling_hash;
 exports.equal_case_insensitive = equal_case_insensitive;
 exports.is_email_address = is_email_address;
 exports.escape_reg_exp = escape_reg_exp;
+exports.index_of_end = index_of_end;
+


### PR DESCRIPTION
### Explain the changes
1. Change the default and use AWS SDK V3 (config file).
2. Add get region and edit endpoint address (for AWS only).
3. Implement the use of AWS SDK V3: s3 params, region, and edited endpoint in analyze resource.
4. Style and typo fixes.

#### Background:
In AWS SDK v3 S3 client and bucket must have the same region, the concept of a global client doesn't exist anymore [(here)](https://github.com/aws/aws-sdk-js-v3/issues/1807). Without region, you'll get an error message `Region is missing` [(here)](https://github.com/aws/aws-sdk-js-v3/issues/1845), even if the endpoint address is not AWS.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - we don't enforce AWS endpoint address to include the region today (`region` is not required).

### Testing Instructions:
**Analyze resource**
1. Based on the instructions [here](https://gist.github.com/dannyzaken/c85f0006e5d6582c8d8666cafce6ab76) - the steps of _‘Build images’_ and _‘Deploy noobaa’._
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. For namespacestore, Run:
`nb namespacestore create <aws-s3 or s3-compatible>  <namespace-store-name>`
`nb diagnostics analyze namespacestore <namespace-store-name>`
* It creates the log files and then deletes the created job.
3. Cases:
* s3-compatible - Noobaa bucket (with noobaa system as a server, the endpoint was taken from the field `InternalDNS` under `S3 Addresses`).
* aws-s3 with flag region in  region that is not 'us-east-1'.
* aws-s3 without flag region on bucket in region that is not 'us-east-1'.

**To run jest tests:**
`npx jest test_noobaa_s3_client.test.js`
`npx jest test_string_utils.test.js`

- [ ] Doc added/updated
- [ X] Tests added: basic tests for new functions (`get_region`, `edit_global_aws_endpoint`, `index_of_end`)
