### PR TITLE
bugfix - LRUCache.invalidate should use item.d, not item.val.

### DIFF
--- a/src/util/lru_cache.js
+++ b/src/util/lru_cache.js
@@ -153,8 +153,8 @@ class LRUCache {
      */
     invalidate_key(key) {
         const item = this.lru.remove_item(key);
-        if (item && item.val) {
-            return item.val;
+        if (item && item.d) {
+            return item.d;
         }
     }
 


### PR DESCRIPTION
### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
LRUCache.invalidate() uses wrong field item.val.
Should be item.d.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
