### PR TITLE
Replace minikube with standalone deployment for Ceph Tests

### DIFF
--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -15,89 +15,10 @@ jobs:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
-      - name: Deploy minikube
-        run: |
-         cd ./noobaa-core
-         sudo bash ./.travis/deploy_minikube.sh
-
-      - name: Build noobaa tester
-        run: |
-         cd ./noobaa-core
-         make tester TESTER_TAG=noobaa-tester:s3-tests
-         docker tag noobaa:latest noobaa-core:s3-tests
-
-      - name: Checkout noobaa-operator
-        uses: actions/checkout@v3
-        with:
-          repository: 'noobaa/noobaa-operator'
-          path: 'noobaa-operator'
-         # Freeze the version of operator
-         # to avoid a failed run due to code changes in the operator repo.
-         # Need to update the commit once in a while
-          ref: ca12ff9e360220bb50bb9a2b645846e4b241fa39
-
-      - name: Change settings for k8s and minikube
-        run: |
-          sudo mv /root/.kube /root/.minikube $HOME
-          sudo chown -R $USER $HOME/.kube $HOME/.minikube
-          sed "s/root/home\/$USER/g" $HOME/.kube/config > tmp; mv tmp $HOME/.kube/config
-
-      - name: Build operator
-        run: |
-         cd ./noobaa-operator
-         make all
-
-      - name: Install noobaa system
-        run: |
-         cd ./noobaa-operator
-         ./build/_output/bin/noobaa-operator crd create
-         ./build/_output/bin/noobaa-operator operator install
-         ./build/_output/bin/noobaa-operator system create  \
-         --db-resources='{ "limits": {"cpu": "200m","memory": "2G"}, "requests": {"cpu": "200m","memory": "2G"}}' \
-         --core-resources='{ "limits": {"cpu": "200m","memory": "1G"}, "requests": {"cpu": "200m","memory": "1G"}}' \
-         --endpoint-resources='{ "limits": {"cpu": "200m","memory": "1G"}, "requests": {"cpu": "200m","memory": "1G"}}' \
-         --noobaa-image='noobaa-core:s3-tests'
-         ./build/_output/bin/noobaa-operator status
-
-      - name: Wait for phase Ready in the backingstore pod
-        run: |
-          cd ./noobaa-operator
-          ./.travis/number_of_pods_in_system.sh --pods 5
-          kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=5m
-
       - name: Run Ceph s3-tests
         run: |
           set -x
           cd ./noobaa-core
-          kubectl apply -f ./src/test/system_tests/ceph_s3_tests/test_ceph_s3_job.yml
-          kubectl wait --for=condition=complete job/noobaa-tests-s3 --timeout=45m || TIMEOUT=true
-          kubectl logs job/noobaa-tests-s3 --tail 10000 -f
-          if kubectl logs job/noobaa-tests-s3 | grep -q "Ceph Test Failed:"; then
-            echo "At least one test failed!"
-            kubectl get pods
-            exit 1
-          fi
-          if [ ${TIMEOUT} ]; then
-            echo "Timed out waiting for the condition on jobs/noobaa-tests-s3"
-            exit 1
-          fi
-          if kubectl logs job/noobaa-tests-s3 | grep -q "ran 0 tests"; then
-            echo "The s3 tests did not run!"
-            exit 1
-          fi
-
-      - name: Collect logs
-        if: ${{ failure() }}         
-        run: |
-         set -x
-         echo "K8S Events"
-         kubectl get events --sort-by='.metadata.creationTimestamp' -A
-         cd ./noobaa-operator
-         ./build/_output/bin/noobaa-operator diagnose --db-dump --dir=ceph-s3-tests-logs
-
-      - name: Save logs
-        if: ${{ failure() }}    
-        uses: actions/upload-artifact@v3
-        with:
-          name: ceph-s3-tests-logs
-          path: noobaa-operator/ceph-s3-tests-logs
+          mkdir -p logs/ceph-test-logs
+          chmod 777 logs/ceph-test-logs
+          make test-cephs3

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,17 @@ test-postgres: tester
 tests: test #alias for test
 .PHONY: tests
 
+test-cephs3: tester
+	@echo "\033[1;34mRunning tests with Postgres.\033[0m"
+	@$(call create_docker_network)
+	@$(call run_postgres)
+	@echo "\033[1;34mRunning tests\033[0m"
+	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" --env "POSTGRES_HOST=coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "POSTGRES_USER=noobaa" --env "DB_TYPE=postgres" --env "POSTGRES_DBNAME=coretest" -v $(PWD)/logs:/logs $(TESTER_TAG) "./src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh"
+	@$(call stop_noobaa)
+	@$(call stop_postgres)
+	@$(call remove_docker_network)
+.PHONY: test-cephs3
+
 clean:
 	@echo Stopping and Deleting containers
 	@$(CONTAINER_ENGINE) ps -a | grep noobaa_ | awk '{print $1}' | xargs $(CONTAINER_ENGINE) stop &> /dev/null

--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -40,6 +40,7 @@ RUN tar \
 
 FROM quay.io/centos/centos:stream8
 
+# The ports are overridden for Ceph Test later
 ENV container docker
 ENV PORT 8080
 ENV SSL_PORT 8443

--- a/src/deploy/NVA_build/Tests.Dockerfile
+++ b/src/deploy/NVA_build/Tests.Dockerfile
@@ -41,6 +41,15 @@ RUN cd ./src/test/system_tests/ceph_s3_tests/ && \
 ##############################################################
 RUN npm install
 
+##############################################################
+# Layers:
+#   Title: Copy standalone deployment script to be used in the ceph tests
+#   Size: ~ 1 KB
+#
+##############################################################
+COPY ./src/deploy/NVA_build/standalone_deploy.sh ./src/deploy/NVA_build/standalone_deploy.sh
+COPY ./src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh ./src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh
+
 COPY .eslintrc.js /root/node_modules/noobaa-core
 COPY .eslintignore /root/node_modules/noobaa-core
 

--- a/src/deploy/NVA_build/standalone_deploy.sh
+++ b/src/deploy/NVA_build/standalone_deploy.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Assumes that a postgresql is already running
+
+# This deployment script just automates the steps in the doc/standalone.md file
+
+# Create a basic config file for standalone
+cat >config-local.js <<EOF
+/* Copyright (C) 2023 NooBaa */
+'use strict';
+
+/** @type {import('./config')} */
+const config = exports;
+
+config.DEFAULT_POOL_TYPE = 'HOSTS';
+config.AGENT_RPC_PORT = '9999';
+config.AGENT_RPC_PROTOCOL = 'tcp';
+config.POSTGRES_MAX_CLIENTS = 10;
+EOF
+
+# setup_env is not needed when running inside a container because the container
+# environment would already be setup (in case of ceph test for example)
+function setup_env() {
+    cat >.env <<EOF
+    CREATE_SYS_NAME=${CREATE_SYS_NAME:-noobaa}
+    CREATE_SYS_EMAIL=${CREATE_SYS_EMAIL:-admin@noobaa.io}
+    CREATE_SYS_PASSWD=${CREATE_SYS_PASSWD:-123456789}
+    JWT_SECRET=${JWT_SECRET:-123456789}
+    NOOBAA_ROOT_SECRET=${NOOBAA_ROOT_SECRET:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}
+    LOCAL_MD_SERVER=${LOCAL_MD_SERVER:-true}
+
+    POSTGRES_HOST=${POSTGRES_HOST:-localhost}
+    MGMT_ADDR=${MGMT_ADDR:-wss://localhost:5443}
+    BG_ADDR=${BG_ADDR:-wss://localhost:5445}
+    HOSTED_AGENTS_ADDR=${HOSTED_AGENTS_ADDR:-wss://localhost:5446}
+EOF
+}
+
+function execute() {
+    if [[ -z "${CEPH_TEST_LOGS_DIR}" ]]; then
+        $1 &
+    else
+        $1 2>&1 | tee "${CEPH_TEST_LOGS_DIR}/${2}" &
+    fi
+}
+
+function main() {
+    if [ "${STANDALONE_SETUP_ENV}" = "true" ]; then
+        setup_env
+    fi
+
+    # Start NooBaa processes
+    execute "npm run web" web.log
+    sleep 10
+
+    execute "npm run bg" bg.log
+    sleep 10
+
+    execute "npm run hosted_agents" hosted_agents.log
+    sleep 10
+
+    execute "npm run s3" s3.log
+    sleep 10
+
+    mkdir -p storage/backingstores/drive1
+    execute "npm -- run backingstore storage/backingstores/drive1 --port 9991" backingstore1.log
+    sleep 30
+}
+
+main

--- a/src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh
+++ b/src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} \e[0m'
+
+set -e
+
+# ====================================================================================
+# Set the environment variables
+export email='admin@noobaa.io'
+export password=123456789
+
+export PORT=8080
+export SSL_PORT=5443
+export ENDPOINT_PORT=80 # This is the port that is set in the ceph tests config file
+export ENDPOINT_SSL_PORT=443
+export NOOBAA_MGMT_SERVICE_HOST=localhost
+export NOOBAA_MGMT_SERVICE_PORT=${SSL_PORT}
+export NOOBAA_MGMT_SERVICE_PROTO=wss
+export S3_SERVICE_HOST=localhost
+
+export CREATE_SYS_NAME=noobaa
+export CREATE_SYS_EMAIL=${email}
+export CREATE_SYS_PASSWD=${password}
+export JWT_SECRET=123456789
+export NOOBAA_ROOT_SECRET='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+export LOCAL_MD_SERVER=true
+
+export POSTGRES_HOST=${POSTGRES_HOST:-localhost}
+export MGMT_ADDR=wss://${NOOBAA_MGMT_SERVICE_HOST:-localhost}:${NOOBAA_MGMT_SERVICE_PORT:-5443}
+export BG_ADDR=wss://localhost:5445
+export HOSTED_AGENTS_ADDR=wss://localhost:5446
+
+export CEPH_TEST_LOGS_DIR=/logs/ceph-test-logs
+
+# ====================================================================================
+
+# Create the logs directory
+mkdir -p ${CEPH_TEST_LOGS_DIR}
+
+# Deploy standalone NooBaa on the test container
+./src/deploy/NVA_build/standalone_deploy.sh
+
+# ====================================================================================
+
+# Run the tests
+./src/test/system_tests/ceph_s3_tests/test_ceph_s3_config_and_run_s3_tests.sh
+
+# ====================================================================================

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_config_setup.js
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_config_setup.js
@@ -19,7 +19,7 @@ const { CEPH_TEST } = require('./test_ceph_s3_constants.js');
 // the client is used to perform setup operations on noobaa system
 const rpc = api.new_rpc();
 const client = rpc.new_client({
-    address: `ws://${process.env.NOOBAA_MGMT_SERVICE_HOST}:${process.env.NOOBAA_MGMT_SERVICE_PORT}`
+    address: `${process.env.NOOBAA_MGMT_SERVICE_PROTO || 'ws'}://${process.env.NOOBAA_MGMT_SERVICE_HOST}:${process.env.NOOBAA_MGMT_SERVICE_PORT}`
 });
 
 async function main() {


### PR DESCRIPTION
### Explain the changes
This PR replaces minikube with standalone deployment (inside a container). The expectations are:
1. Have more reliable runs.
2. Runs should take lesser time.

This is done by creating a `standalone_deploy.sh` script which can be used locally as well to spin up a fully functioning NooBaa.

### Testing Instructions:
1. Run `make test-cephs3` or `CONTAINER_PLATFORM=linux/arm64 make test-cephs3` if on mac.


- [ ] Doc added/updated
- [ ] Tests added
