### PR TITLE
Add Region to Connection Schemas + Use Region in Check Connection

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -445,6 +445,9 @@ module.exports = {
                     identity: { $ref: 'common_api#/definitions/access_key' },
                     secret: { $ref: 'common_api#/definitions/secret_key' },
                     azure_log_access_keys: { $ref: 'common_api#/definitions/azure_log_access_keys' },
+                    region: {
+                        type: 'string'
+                    }
                 }
             },
             auth: {
@@ -652,6 +655,9 @@ module.exports = {
                                         type: 'string'
                                     },
                                     endpoint: {
+                                        type: 'string'
+                                    },
+                                    region: {
                                         type: 'string'
                                     },
                                     identity: { $ref: 'common_api#/definitions/access_key' },

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -621,6 +621,9 @@ module.exports = {
                 aws_sts_arn: {
                     type: 'string'
                 },
+                region: {
+                    type: 'string'
+                },
             }
         },
 

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -164,6 +164,7 @@ class HostedAgents {
                 secret_key: pool.cloud_pool_info.access_keys.secret_key
             },
             aws_sts_arn: pool.cloud_pool_info.aws_sts_arn,
+            region: pool.cloud_pool_info.region,
             pool_name: pool.name
         } : {
             pool_name: pool.name

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -286,6 +286,7 @@ async function create_namespace_resource(req) {
             cp_code: connection.cp_code || undefined,
             secret_key,
             endpoint_type: connection.endpoint_type || 'AWS',
+            region: connection.region,
             azure_log_access_keys,
         }, _.isUndefined), undefined, req.rpc_params.access_mode);
 
@@ -345,6 +346,7 @@ async function create_cloud_pool(req) {
             account_id: req.account._id
         },
         aws_sts_arn: connection.aws_sts_arn,
+        region: connection.region,
         endpoint_type: connection.endpoint_type || 'AWS',
         backingstore: req.rpc_params.backingstore,
         available_capacity: req.rpc_params.available_capacity,

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -78,6 +78,7 @@ module.exports = {
                         enum: ['AWS_V2', 'AWS_V4']
                     },
                     endpoint: { type: 'string' },
+                    region: { type: 'string' },
                     cp_code: { type: 'string' },
                     endpoint_type: {
                         type: 'string',

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -44,6 +44,9 @@ module.exports = {
                 endpoint: {
                     type: 'string'
                 },
+                region: {
+                    type: 'string'
+                },
                 target_bucket: {
                     type: 'string'
                 },

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -94,6 +94,9 @@ module.exports = {
                 target_bucket: {
                     type: 'string'
                 },
+                region: {
+                    type: 'string'
+                },
                 auth_method: {
                     type: 'string',
                     enum: ['AWS_V2', 'AWS_V4']


### PR DESCRIPTION
### Explain the changes
1. Add region to connection schemas.
2. Use region in `check_aws_connection`.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
Need to build with operator change noobaa/noobaa-operator#1188.
1. Deploy noobaa on MInikube or Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create namespacestore/backingstore and pass the region explicitly:
`nb namespacestore create aws-s3  <namespace-store-name> --region=<target-bucket-region>`.
`nb backingstore create aws-s3  <backingstore-store-name> --region=<target-bucket-region>`.
3. Add printings to `check_external_connection`, `check_aws_connection` and see that the region passed.
Note: test on buckets in the regions 'us-east-1' and 'us-west-1'.

- [ ] Doc added/updated
- [ ] Tests added
