### PR TITLE
Move sanity tests to standalone deployment

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -12,13 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Deploy minikube
-        run: sudo bash ./.travis/deploy_minikube.sh
-
-      - name: Run make tester
-        run: make tester
-
       - name: Run Build & Sanity Tests
         run: |
-          cd ./src/test/framework/
-          sudo ./run_test_job.sh --name sanity --image noobaa --tester_image noobaa-tester --job_yaml ../../../.travis/travis_test_job.yaml --tests_list ./sanity_tests_list.js --wait
+          set -x
+          mkdir -p logs/sanity-test-logs
+          chmod 777 logs/sanity-test-logs
+          make test-sanity

--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,17 @@ test-cephs3: tester
 	@$(call remove_docker_network)
 .PHONY: test-cephs3
 
+test-sanity: tester
+	@echo "\033[1;34mRunning tests with Postgres.\033[0m"
+	@$(call create_docker_network)
+	@$(call run_postgres)
+	@echo "\033[1;34mRunning sanity tests\033[0m"
+	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" --env "POSTGRES_HOST=coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "POSTGRES_USER=noobaa" --env "DB_TYPE=postgres" --env "POSTGRES_DBNAME=coretest" -v $(PWD)/logs:/logs $(TESTER_TAG) "./src/test/system_tests/run_sanity_test_on_test_container.sh"
+	@$(call stop_noobaa)
+	@$(call stop_postgres)
+	@$(call remove_docker_network)
+.PHONY: test-sanity
+
 clean:
 	@echo Stopping and Deleting containers
 	@$(CONTAINER_ENGINE) ps -a | grep noobaa_ | awk '{print $1}' | xargs $(CONTAINER_ENGINE) stop &> /dev/null

--- a/src/deploy/NVA_build/Tests.Dockerfile
+++ b/src/deploy/NVA_build/Tests.Dockerfile
@@ -49,6 +49,7 @@ RUN npm install
 ##############################################################
 COPY ./src/deploy/NVA_build/standalone_deploy.sh ./src/deploy/NVA_build/standalone_deploy.sh
 COPY ./src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh ./src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh
+COPY ./src/test/system_tests/run_sanity_test_on_test_container.sh ./src/test/system_tests/run_sanity_test_on_test_container.sh
 
 COPY .eslintrc.js /root/node_modules/noobaa-core
 COPY .eslintignore /root/node_modules/noobaa-core

--- a/src/test/system_tests/run_sanity_test_on_test_container.sh
+++ b/src/test/system_tests/run_sanity_test_on_test_container.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} \e[0m'
+
+set -e
+
+# ====================================================================================
+# Set the environment variables
+export email='demo@noobaa.com'
+export password=DeMo1
+
+export PORT=8080
+export SSL_PORT=5443
+export ENDPOINT_PORT=80
+export ENDPOINT_SSL_PORT=443
+export NOOBAA_MGMT_SERVICE_HOST=localhost
+export NOOBAA_MGMT_SERVICE_PORT=${SSL_PORT}
+export NOOBAA_MGMT_SERVICE_PROTO=wss
+export S3_SERVICE_HOST=localhost
+
+export CREATE_SYS_NAME=demo
+export CREATE_SYS_EMAIL=${email}
+export CREATE_SYS_PASSWD=${password}
+export JWT_SECRET=123456789
+export NOOBAA_ROOT_SECRET='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+export LOCAL_MD_SERVER=true
+
+export POSTGRES_HOST=${POSTGRES_HOST:-localhost}
+export MGMT_ADDR=wss://${NOOBAA_MGMT_SERVICE_HOST:-localhost}:${NOOBAA_MGMT_SERVICE_PORT:-5443}
+export BG_ADDR=wss://localhost:5445
+export HOSTED_AGENTS_ADDR=wss://localhost:5446
+
+export CEPH_TEST_LOGS_DIR=/logs/sanity-test-logs
+
+# ====================================================================================
+
+# Create the logs directory
+mkdir -p ${CEPH_TEST_LOGS_DIR}
+
+# Deploy standalone NooBaa on the test container
+./src/deploy/NVA_build/standalone_deploy.sh
+
+# ====================================================================================
+
+# Run the tests
+node ./src/test/system_tests/sanity_build_test.js --mgmt_ip ${NOOBAA_MGMT_SERVICE_HOST} --mgmt_port ${PORT} --mgmt_port_https ${SSL_PORT} --s3_ip ${S3_SERVICE_HOST} --s3_port ${ENDPOINT_PORT} --s3_port_https ${ENDPOINT_SSL_PORT}
+
+# ====================================================================================

--- a/src/test/system_tests/sanity_build_test.js
+++ b/src/test/system_tests/sanity_build_test.js
@@ -95,7 +95,8 @@ async function init_test() {
     TEST_CTX.compatible_v2 = {
         name: 'compatible_V2',
         endpoint_type: 'S3_COMPATIBLE',
-        endpoint: 'http://noobaa-server-0:6001',
+        // here we are just using the same noobaa s3 endpoint
+        endpoint: TEST_CTX.s3_endpoint,
         identity: '123',
         secret: 'abc',
         auth_method: 'AWS_V2'
@@ -103,7 +104,9 @@ async function init_test() {
     TEST_CTX.compatible_v4 = {
         name: 'compatible_V4',
         endpoint_type: 'S3_COMPATIBLE',
-        endpoint: `http://127.0.0.1:6001`,
+        // doing the same as above but with https to have a different
+        // endpoint for testing
+        endpoint: TEST_CTX.s3_endpoint_https,
         identity: '123',
         secret: 'abc',
         auth_method: 'AWS_V4'


### PR DESCRIPTION
### Explain the changes
This PR moves the sanity tests to use standalone deployment instead of minikube based k8s deployment.

### Testing Instructions:
Just run `make test-sanity`


- [ ] Doc added/updated
- [ ] Tests added
