### PR TITLE
Migrating to AWS SDK V3 | Add AWS SDK V3 Wrapper

### DIFF
--- a/src/sdk/noobaa_s3_client/noobaa_s3_client.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client.js
@@ -6,7 +6,7 @@ const https = require('https');
 const { HttpProxyAgent } = require('http-proxy-agent');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { S3ClientSDKV2 } = require('./noobaa_s3_client_sdkv2');
-const { S3 } = require("@aws-sdk/client-s3");
+const { S3ClientAutoRegion } = require('./noobaa_s3_client_sdkv3');
 const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
 const config = require('../../../config');
 const http_utils = require('../../util/http_utils');
@@ -20,7 +20,7 @@ function get_s3_client_v3_params(params) {
         change_s3_client_params_to_v2_structure(params);
         s3_client = new S3ClientSDKV2(params);
     } else {
-        s3_client = new S3(params);
+        s3_client = new S3ClientAutoRegion(params);
     }
     return s3_client;
 }

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv3.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv3.js
@@ -1,0 +1,39 @@
+/* Copyright (C) 2023 NooBaa */
+'use strict';
+
+const { S3 } = require('@aws-sdk/client-s3');
+const dbg = require('../../util/debug_module')(__filename);
+
+/**
+ * Same as S3Client but wraps the send method to resubmit the request with the correct region
+ * if the server responds that another region should be used.
+ * 
+ * S3 Interface, S3 Class and operations in AWS SDK V3:
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/Interface/S3/
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/Class/S3/
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/
+ */
+class S3ClientAutoRegion extends S3 {
+
+    /**
+     * Overriding the send method by wrapping it and fixing the region if the error indicates it.
+     * All the methods of the base class call send() to submit an SDK command.
+     * @override
+     */
+    async send(...args) {
+        try {
+            const res = await super.send(...args);
+            return res;
+        } catch (err) {
+            const region = err.$response?.headers?.['x-amz-bucket-region'];
+            if (!region) throw err;
+            dbg.log0(`Updating region to new region ${region} in bucket ${args[0].input.Bucket}, will call ${args[0].constructor.name} again with the new region`);
+            this.config.region = region;
+            const res = await super.send(...args);
+            return res;
+        }
+    }
+}
+
+// EXPORTS
+exports.S3ClientAutoRegion = S3ClientAutoRegion;

--- a/src/test/unit_tests/jest_tests/test_noobaa_s3_client.test.js
+++ b/src/test/unit_tests/jest_tests/test_noobaa_s3_client.test.js
@@ -2,10 +2,10 @@
 /* eslint-disable no-undef */
 'use strict';
 
-const { S3 } = require("@aws-sdk/client-s3");
 const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
 const { Agent } = require("http");
 const { S3ClientSDKV2 } = require("../../../sdk/noobaa_s3_client/noobaa_s3_client_sdkv2");
+const { S3ClientAutoRegion } = require("../../../sdk/noobaa_s3_client/noobaa_s3_client_sdkv3");
 const noobaa_s3_client = require("../../../sdk/noobaa_s3_client/noobaa_s3_client");
 const config = require('../../../../config');
 
@@ -40,7 +40,7 @@ describe('noobaa_s3_client get_s3_client_v3_params', () => {
             config.AWS_SDK_VERSION_3_DISABLED = false;
             const params = {};
             const s3 = noobaa_s3_client.get_s3_client_v3_params(params);
-            expect(s3).toBeInstanceOf(S3);
+            expect(s3).toBeInstanceOf(S3ClientAutoRegion);
         });
 
         it('should choose by signatureVersion v4', () => {
@@ -50,7 +50,7 @@ describe('noobaa_s3_client get_s3_client_v3_params', () => {
                 signatureVersion: signature_version,
             };
             const s3 = noobaa_s3_client.get_s3_client_v3_params(params);
-            expect(s3).toBeInstanceOf(S3);
+            expect(s3).toBeInstanceOf(S3ClientAutoRegion);
         });
 
     });


### PR DESCRIPTION
### Explain the changes
1. add aws sdk v3 wrapper, in case we didn't receive the region (best practice is to get the region of the target bucket from the client).

### Issues: Fixed #xxx / Gap #xxx
1. none.

### Testing Instructions:
**Analyze resource**
We use analyze resource with a change - we set the region to be the `config.DEFAULT_REGION`, params as aws sdk v3 structure, and use `noobaa_s3_client.get_s3_client_v3_params` function.
1. Deploy noobaa on MInikube or Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create namespacestore:
`nb namespacestore create <aws-s3 or s3-compatible>  <namespace-store-name>`
3. Run analyze resource (It creates the log files and then deletes the created job):
`nb diagnostics analyze namespacestore <namespace-store-name>`
3. Cases:
1 - s3-compatible - Noobaa bucket (with noobaa system as a server, the endpoint was taken from the field `InternalDNS` under `S3 Addresses`).
2 - aws-s3 without flag region on a bucket in a region that is not 'us-east-1' (for example 'us-west-1').

**To run jest tests:**
`npx jest test_noobaa_s3_client.test.js`

- [ ] Doc added/updated
- [x] Tests added: edit existing tests in `test_noobaa_s3_client.test.js`.
