### PR TITLE
CI | NSFS Versioning | Increase Timeout for 7 Tests That Failed in the CI

### DIFF
--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -1604,7 +1604,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
 
         mocha.it('delete multiple objects - no version id', async function() {
             const self = this; // eslint-disable-line no-invalid-this
-            self.timeout(60000);
+            self.timeout(150000);
             const versions_type_arr = ['null'];
             for (let i = 0; i < 300; i++) {
                  versions_type_arr.push(i % 2 === 0 ? 'regular' : 'delete_marker');
@@ -1656,7 +1656,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
 
         mocha.it('delete multiple objects - delete only regular versions key1, delete delete markers key2', async function() {
             const self = this; // eslint-disable-line no-invalid-this
-            self.timeout(60000);
+            self.timeout(150000);
             const key2 = 'key2';
             const versions_type_arr = [];
             for (let i = 0; i < 300; i++) {
@@ -1696,7 +1696,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
 
         mocha.it('delete multiple objects - delete regular versions & delete markers - new latest is dm', async function() {
             const self = this; // eslint-disable-line no-invalid-this
-            self.timeout(60000);
+            self.timeout(150000);
             const versions_type_arr = [];
             for (let i = 0; i < 300; i++) {
                  versions_type_arr.push(i % 2 === 0 ? 'regular' : 'delete_marker');
@@ -1726,7 +1726,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
 
         mocha.it('delete multiple objects - delete regular versions & delete markers - new latest is regular version', async function() {
             const self = this; // eslint-disable-line no-invalid-this
-            self.timeout(60000);
+            self.timeout(150000);
             const versions_type_arr = [];
             for (let i = 0; i < 300; i++) {
                  versions_type_arr.push(i % 2 === 0 ? 'regular' : 'delete_marker');
@@ -1756,7 +1756,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
 
         mocha.it('delete multiple objects - delete keys & regular versions & delete markers ', async function() {
             const self = this; // eslint-disable-line no-invalid-this
-            self.timeout(60000);
+            self.timeout(150000);
             const versions_type_arr = [];
             for (let i = 0; i < 300; i++) {
                  versions_type_arr.push(i % 2 === 0 ? 'regular' : 'delete_marker');
@@ -1792,7 +1792,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
 
         mocha.it('delete multiple objects - delete regular versions & delete markers & latest & keys- ', async function() {
             const self = this; // eslint-disable-line no-invalid-this
-            self.timeout(60000);
+            self.timeout(150000);
             const versions_type_arr = [];
             for (let i = 0; i < 300; i++) {
                  versions_type_arr.push(i % 2 === 1 ? 'regular' : 'delete_marker');


### PR DESCRIPTION
### Explain the changes
1. Increase timeout for 7 tests that failed in the CI.
2. Those tests started to fail last week (inconsistency re-run the job solved it), for the first one the error is related to the timeout and I'm assuming the next failures are related.

>    1) bucketspace namespace_fs - versioning
>         delete multiple objects - versioning enabled
>           delete multiple objects - no version id:
>       Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/root/node_modules/noobaa-core/src/test/unit_tests/sudo_index.js)
>       at listOnTimeout (node:internal/timers:569:17)
>       at process.processTimers (node:internal/timers:512:7)

### Issues: Fixed #xxx / Gap #xxx
1. GAP - we will need to monitor that those tests pass consistently, in case this solution is not enough we would decrease the number of objects in the test (from hundreds to dozens).

### Testing Instructions:
Run Unit Tests on a local machine:
1. In file `src/test/unit_tests/sudo_index.js` leave only `require('./test_bucketspace_versioning');` (rest of test files  comment out).
2. From the core tab in the terminal run: `make root-perm-test` (You should see "144 passing" at the end of the output).

- [ ] Doc added/updated
- [ ] Tests added
