### PR TITLE
Remove python dependency explicitly from RPM package

### DIFF
--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -22,6 +22,8 @@ Recommends: jemalloc
 
 %global __os_install_post %{nil}
 
+%global __requires_exclude ^/usr/bin/python$
+
 %description
 NooBaa is a data service for cloud environments, providing S3 object-store interface with flexible tiering, mirroring, and spread placement policies, over any storage resource that allows GET/PUT including S3, GCS, Azure Blob, Filesystems, etc.
 


### PR DESCRIPTION
### Explain the changes
This PR removes the python dependency from the RPM package explicitly.

Why was this added in the first place?
RPM by default will detect the dependencies by looking at things like shebang, etc. We have certain python files for node-gyp config etc which are not required at runtime at all but RPM noticed the files and added the python dependencies.

### Testing Instructions:
1. Run `make rpm CONTAINER_PLATFORM=linux/arm64`
2. On a centos/RHEL system run `dnf install ./<name>`


- [ ] Doc added/updated
- [ ] Tests added
