### PR TITLE
[backport to 5.14] object io semaphore deadlock on copy fix

### DIFF
--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -340,7 +340,7 @@ class ObjectIO {
                     object_md
                 });
             }
-            return this._upload_stream(params, complete_params);
+            return this._upload_stream(params, complete_params, true);
         }
     }
 
@@ -354,10 +354,11 @@ class ObjectIO {
      * @param {UploadParams} params
      * @param {Object} complete_params
      */
-    async _upload_stream(params, complete_params) {
+    async _upload_stream(params, complete_params, is_copy) {
         try {
+            // on non server side copy the buffer will be taken when called to read_object_stream
             const res = await this._io_buffers_sem.surround_count(
-                _get_io_semaphore_size(params.size),
+                _get_io_semaphore_size(is_copy ? 0 : params.size),
                 () => this._upload_stream_internal(params, complete_params)
             );
             return res;
@@ -635,6 +636,9 @@ class ObjectIO {
                     dbg.error('READ reader error', err.stack || err);
                     reader.emit('error', err || 'reader error');
                 }
+            }).catch(err => {
+                dbg.error('Semaphore reader error', (err && err.stack) || err);
+                reader.emit('error', err || 'Semaphore reader error');
             });
 
             // when starting to stream also prefrech the last part of the file


### PR DESCRIPTION
Signed-off-by: Romy <35330373+romayalon@users.noreply.github.com>
(cherry picked from commit 4f7f94d22de2e8b284b77f340592e9c71a52b1c2)

### Explain the changes
1.  backported PR #7443 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
