### PR TITLE
Migrating to AWS SDK V3 | Implementation In Analyze Resource and Namespace Monitor

### DIFF
--- a/config.js
+++ b/config.js
@@ -723,7 +723,7 @@ config.TIERING_TTL_MS = 30 * 60 * 1000; // 30 minutes
 // AWS SDK VERSION     //
 /////////////////////////
 
-config.AWS_SDK_VERSION_3_DISABLED = true;
+config.AWS_SDK_VERSION_3_ENABLED = true;
 config.DEFAULT_REGION = 'us-east-1';
 
 /////////////////////

--- a/src/test/unit_tests/jest_tests/test_noobaa_s3_client.test.js
+++ b/src/test/unit_tests/jest_tests/test_noobaa_s3_client.test.js
@@ -14,7 +14,7 @@ describe('noobaa_s3_client get_s3_client_v3_params', () => {
     describe('use AWS SDK V2', () => {
 
         it('should choose by signatureVersion v2', () => {
-            config.AWS_SDK_VERSION_3_DISABLED = false;
+            config.AWS_SDK_VERSION_3_ENABLED = true;
             const signature_version = 'v2';
             const params = {
                 signatureVersion: signature_version,
@@ -24,7 +24,7 @@ describe('noobaa_s3_client get_s3_client_v3_params', () => {
         });
 
         it('should choose by workaround config', () => {
-            config.AWS_SDK_VERSION_3_DISABLED = true;
+            config.AWS_SDK_VERSION_3_ENABLED = false;
             const signature_version = 'v4';
             const params = {
                 signatureVersion: signature_version,
@@ -37,14 +37,14 @@ describe('noobaa_s3_client get_s3_client_v3_params', () => {
     describe('use AWS SDK V3', () => {
 
         it('should choose by default', () => {
-            config.AWS_SDK_VERSION_3_DISABLED = false;
+            config.AWS_SDK_VERSION_3_ENABLED = true;
             const params = {};
             const s3 = noobaa_s3_client.get_s3_client_v3_params(params);
             expect(s3).toBeInstanceOf(S3ClientAutoRegion);
         });
 
         it('should choose by signatureVersion v4', () => {
-            config.AWS_SDK_VERSION_3_DISABLED = false;
+            config.AWS_SDK_VERSION_3_ENABLED = true;
             const signature_version = 'v4';
             const params = {
                 signatureVersion: signature_version,

--- a/src/tools/diagnostics/analyze_resource/analyze_resource.js
+++ b/src/tools/diagnostics/analyze_resource/analyze_resource.js
@@ -9,6 +9,7 @@ const get_cloud_vendor = require('./analyze_resource_cloud_vendor').get_cloud_ve
 const connection_basic_details = {
     bucket: process.env.BUCKET,
     endpoint: process.env.ENDPOINT,
+    region: process.env.REGION,
     signature_version: process.env.RESOURCE_TYPE === 'aws-s3' ? 'v4' : process.env.S3_SIGNATURE_VERSION,
 };
 
@@ -24,6 +25,7 @@ async function main() {
     try {
         const resource_type = process.env.RESOURCE_TYPE;
         check_supported_resource_type(resource_type);
+        console.info('connection_basic_details', connection_basic_details);
         const cloud_vendor = get_cloud_vendor(resource_type, connection_basic_details);
         await test_resource(cloud_vendor, connection_basic_details.bucket);
     } catch (err) {
@@ -46,7 +48,7 @@ function check_supported_resource_type(resource_type) {
 
 async function test_resource(cloud_vendor, bucket) {
     check_arguments(cloud_vendor, bucket);
-    console.info(`We will have several tests to check the status of the resource and permission of the bucket ${bucket}`);
+    console.info(`We will have several tests to check the status of the resource and permissions of the bucket ${bucket}`);
     let head_object_executed;
     let head_skip_reason;
     const key_to_head = await list_objects_and_get_one_key(cloud_vendor, bucket);

--- a/src/tools/diagnostics/analyze_resource/analyze_resource_aws.js
+++ b/src/tools/diagnostics/analyze_resource/analyze_resource_aws.js
@@ -1,14 +1,12 @@
 /* Copyright (C) 2023 NooBaa */
 'use strict';
 
-const AWS = require('aws-sdk');
 const dbg = require('../../../util/debug_module')(__filename);
 dbg.set_process_name('analyze_resource');
 const SensitiveString = require('../../../util/sensitive_string');
 const CloudVendor = require('./analyze_resource_cloud_vendor_abstract');
-// Next lines were needed since ts(2304) on the JSDoc of the class
-// Agent can be either from https or http (this is just a technical add)
-const { Agent } = require('https'); // eslint-disable-line no-unused-vars 
+const noobaa_s3_client = require('../../../sdk/noobaa_s3_client/noobaa_s3_client');
+const config = require('../../../../config');
 
 /**
  * @typedef {{
@@ -16,24 +14,25 @@ const { Agent } = require('https'); // eslint-disable-line no-unused-vars
  *      secret_access_key: SensitiveString | string, 
  *      endpoint: string,
  *      signature_version: string,
- *      agent: Agent,
+ *      region?: string,
  * }} AnalyzeAwsSpec
  */
 
 class AnalyzeAws extends CloudVendor {
-    constructor(access_key, secret_access_key, endpoint, signature_version, agent) {
+    constructor(access_key, secret_access_key, endpoint, signature_version, region) {
         super(); // Constructors for derived classes must contain a 'super' call.
         const s3_params = {
+            credentials: {
+                accessKeyId: access_key instanceof SensitiveString ? access_key.unwrap() : access_key,
+                secretAccessKey: secret_access_key instanceof SensitiveString ? secret_access_key.unwrap() : secret_access_key,
+            },
             endpoint: endpoint,
-            accessKeyId: access_key instanceof SensitiveString ? access_key.unwrap() : access_key,
-            secretAccessKey: secret_access_key instanceof SensitiveString ? secret_access_key.unwrap() : secret_access_key,
-            s3ForcePathStyle: true,
+            region: region || config.DEFAULT_REGION, // set config.DEFAULT_REGION to avoid missing region error in aws sdk v3
+            forcePathStyle: true,
             signatureVersion: signature_version,
-            httpOptions: {
-                agent,
-            }
+            requestHandler: noobaa_s3_client.get_requestHandler_with_suitable_agent(endpoint),
         };
-        this.s3 = new AWS.S3(s3_params);
+        this.s3 = noobaa_s3_client.get_s3_client_v3_params(s3_params);
     }
 
     async list_objects(bucket) {
@@ -42,7 +41,7 @@ class AnalyzeAws extends CloudVendor {
             MaxKeys: CloudVendor.MAX_KEYS,
         };
         dbg.log0('Calling AWS listObjectsV2');
-        const res = await this.s3.listObjectsV2(params).promise();
+        const res = await this.s3.listObjectsV2(params);
         dbg.log0(`List object response: ${JSON.stringify(res, null, 4)}`);
 
         this.key = '';
@@ -61,7 +60,7 @@ class AnalyzeAws extends CloudVendor {
             Key: key,
         };
         dbg.log0('Calling AWS headObject');
-        const res = await this.s3.headObject(params).promise();
+        const res = await this.s3.headObject(params);
         dbg.log0(`Head of ${key} response: ${JSON.stringify(res, null, 4)}`);
     }
 
@@ -71,7 +70,7 @@ class AnalyzeAws extends CloudVendor {
             Key: key,
         };
         dbg.log0('Calling AWS putObject');
-        const res = await this.s3.putObject(params).promise();
+        const res = await this.s3.putObject(params);
         dbg.log0(`Write of ${key} response: ${JSON.stringify(res, null, 4)}`);
     }
 
@@ -81,7 +80,7 @@ class AnalyzeAws extends CloudVendor {
             Key: key,
         };
         dbg.log0('Calling AWS deleteObject');
-        const res = await this.s3.deleteObject(params).promise();
+        const res = await this.s3.deleteObject(params);
         dbg.log0(`Delete of ${key} response: ${JSON.stringify(res, null, 4)}`); // getting empty response {}
     }
 }

--- a/src/tools/diagnostics/analyze_resource/analyze_resource_cloud_vendor.js
+++ b/src/tools/diagnostics/analyze_resource/analyze_resource_cloud_vendor.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const fs = require('fs');
-const http_utils = require('../../../util/http_utils');
 const SensitiveString = require('../../../util/sensitive_string');
 const AnalyzeAws = require('./analyze_resource_aws');
 const AnalyzeGcp = require('./analyze_resource_gcp');
@@ -18,17 +17,15 @@ function get_cloud_vendor(resource_type, connection_basic_details) {
         case 'aws-s3':
             cloud_vendor = new AnalyzeAws(credentials.access_key, credentials.secret_access_key,
                 connection_basic_details.endpoint, connection_basic_details.signature_version,
-                http_utils.get_default_agent(connection_basic_details.endpoint));
+                connection_basic_details.region);
             break;
         case 's3-compatible':
             cloud_vendor = new AnalyzeAws(credentials.access_key, credentials.secret_access_key,
-                connection_basic_details.endpoint, connection_basic_details.signature_version,
-                http_utils.get_unsecured_agent(connection_basic_details.endpoint));
+                connection_basic_details.endpoint, connection_basic_details.signature_version);
             break;
         case 'ibm-cos':
             cloud_vendor = new AnalyzeAws(credentials.access_key, credentials.secret_access_key,
-                connection_basic_details.endpoint, connection_basic_details.signature_version,
-                http_utils.get_unsecured_agent(connection_basic_details.endpoint));
+                connection_basic_details.endpoint, connection_basic_details.signature_version);
             break;
         case 'azure-blob':
             cloud_vendor = new AnalyzeAzure(credentials.access_key, credentials.secret_access_key, // Azure storage account name is stored as the access key


### PR DESCRIPTION
### Explain the changes
1. Implementation of AWS SDK V3 In Namespace Monitor.
2. Implementation of AWS SDK V3  In Analyze Resource (use passed region).
3. Omit endpoint parameter for AWS endpoint when using AWS SDK V3.
4. Change the default in the config file to use AWS SDK v3.

### Issues: Fixed #xxx / Gap #xxx
1. none.

### Testing Instructions:
**Analyze Resource**
1. Deploy noobaa on MInikube or Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. For backingstore, run:
`nb backingstore create aws-s3 <backing-store-name>` (optional: add the `--region` flag)
`nb backingstore create s3-compatible <backing-store-name>`
`nb diagnostics analyze backingstore <backing-store-name>`
3. For namespacestore, run:
`nb namespacestore create aws-s3 <namespace-store-name>`  (optional: add the `--region` flag)
`nb namespacestore create s3-compatible <namespace-store-name>`
`nb diagnostics analyze namespacestore <namespace-store-name>`
3. For all resources (backingstore and namespacestore), run:
`nb diagnostics analyze resources`
It creates the log files and then deletes the created job.
5. Check the logs of noobaa-core: `kubectl logs -f` look for `test_s3_resource` printings.

Cases:
1 - s3-compatible - Noobaa bucket (with noobaa system as a server, the endpoint was taken from the field `InternalDNS` under `S3 Addresses`).
2 - aws-s3 without flag region on a bucket in a region that is not 'us-east-1' (for example 'us-west-1') and aws-s3 with flag region.


- [ ] Doc added/updated
- [ ] Tests added
