### PR TITLE
Migrating to AWS SDK V3 | Use AWS SDK V3 In Unit Tests (upgrade_script, dedup, lifecycle)

### DIFF
--- a/src/test/lifecycle/common.js
+++ b/src/test/lifecycle/common.js
@@ -51,7 +51,7 @@ function date_lifecycle_configuration(Bucket, Key) {
         LifecycleConfiguration: {
             Rules: [{
                 Expiration: {
-                    Date: midnight.toISOString(),
+                    Date: midnight,
                 },
                 Filter: {
                     Prefix: Key,
@@ -73,7 +73,7 @@ function date_lifecycle_configuration_and_tags(Bucket, Prefix, tagging) {
         LifecycleConfiguration: {
             Rules: [{
                 Expiration: {
-                    Date: midnight.toISOString(),
+                    Date: midnight,
                 },
                 Filter: {
                     And: {
@@ -97,7 +97,7 @@ function size_less_lifecycle_configuration(Bucket, ObjectSizeLessThan) {
         LifecycleConfiguration: {
             Rules: [{
                 Expiration: {
-                    Date: midnight.toISOString(),
+                    Date: midnight,
                 },
                 Filter: {
                     ObjectSizeLessThan,
@@ -157,7 +157,7 @@ function size_gt_lt_lifecycle_configuration(Bucket, gt, lt) {
         LifecycleConfiguration: {
             Rules: [{
                 Expiration: {
-                    Date: midnight.toISOString(),
+                    Date: midnight,
                 },
                 Filter: {
                     ObjectSizeLessThan: lt,
@@ -230,23 +230,6 @@ function and_tags_lifecycle_configuration(Bucket, Key1, Value1, Key2, Value2) {
                         ]
                     }
                 },
-                Status: 'Enabled',
-            }, ],
-        },
-    };
-}
-
-function empty_filter_lifecycle_configuration(Bucket) {
-    const ID = 'rule_id';
-    return {
-        Bucket,
-        LifecycleConfiguration: {
-            Rules: [{
-                ID,
-                Expiration: {
-                    Days: 17,
-                },
-                Filter: {},
                 Status: 'Enabled',
             }, ],
         },
@@ -343,7 +326,7 @@ function rules_length_lifecycle_configuration(Bucket, Key) {
                 {
                     ID: 'rule2',
                     Expiration: {
-                        Date: midnight.toISOString(),
+                        Date: midnight,
                     },
                     Filter: {
                         Prefix: Key,
@@ -376,7 +359,7 @@ function id_lifecycle_configuration(Bucket, Key) {
 }
 
 async function put_get_lifecycle_configuration(Bucket, putLifecycleParams, s3) {
-    const putLifecycleResult = await s3.putBucketLifecycleConfiguration(putLifecycleParams).promise();
+    const putLifecycleResult = await s3.putBucketLifecycleConfiguration(putLifecycleParams);
     console.log('put lifecycle params:', putLifecycleParams, 'result', putLifecycleResult);
     for (const rule of putLifecycleParams.LifecycleConfiguration.Rules) {
         console.log("put lifecycle ID", rule.ID, "expiration", rule.Expiration, "filter", rule.Filter);
@@ -384,12 +367,12 @@ async function put_get_lifecycle_configuration(Bucket, putLifecycleParams, s3) {
     const lifecycleParams = {
         Bucket,
     };
-    const getLifecycleResult = await s3.getBucketLifecycleConfiguration(lifecycleParams).promise();
+    const getLifecycleResult = await s3.getBucketLifecycleConfiguration(lifecycleParams);
     console.log('get lifecycle params:', lifecycleParams, 'result', getLifecycleResult);
     for (const rule of getLifecycleResult.Rules) {
         console.log("get lifecycle ID", rule.ID, "expiration", rule.Expiration, "filter", rule.Filter);
     }
-    const deleteLifecycleResult = await s3.deleteBucketLifecycle(lifecycleParams).promise();
+    const deleteLifecycleResult = await s3.deleteBucketLifecycle(lifecycleParams);
     console.log('delete lifecycle params:', lifecycleParams, 'result', deleteLifecycleResult);
 
     return getLifecycleResult;
@@ -503,17 +486,6 @@ exports.test_rule_id = async function(Bucket, Key, s3) {
     console.log('get rule id:', actualId, ' expected:', expectedId);
 
     assert.deepEqual(actualId, expectedId, 'rule id');
-};
-
-exports.test_empty_filter = async function(Bucket, s3) {
-    const putLifecycleParams = empty_filter_lifecycle_configuration(Bucket);
-    const getLifecycleResult = await put_get_lifecycle_configuration(Bucket, putLifecycleParams, s3);
-
-    const actualFilter = getLifecycleResult.Rules[0].Filter;
-    const expectedFilter = putLifecycleParams.LifecycleConfiguration.Rules[0].Filter;
-    console.log('get empty filter:', actualFilter, ' expected:', expectedFilter);
-
-    assert.deepEqual(actualFilter, expectedFilter, 'empty filter');
 };
 
 exports.test_filter_size = async function(Bucket, s3) {

--- a/src/test/system_tests/test_lifecycle.js
+++ b/src/test/system_tests/test_lifecycle.js
@@ -52,7 +52,6 @@ async function main() {
     await commonTests.test_and_tag(Bucket, TagName, TagValue, TagName2, TagValue2, s3);
     await commonTests.test_and_tag_prefix(Bucket, Key, TagName, TagValue, TagName2, TagValue2, s3);
     await commonTests.test_rule_id(Bucket, Key, s3);
-    await commonTests.test_empty_filter(Bucket, s3);
     await commonTests.test_filter_size(Bucket, s3);
     await commonTests.test_and_prefix_size(Bucket, Key, s3);
 

--- a/src/test/unit_tests/test_upgrade_scripts.js
+++ b/src/test/unit_tests/test_upgrade_scripts.js
@@ -5,14 +5,15 @@
 const coretest = require('./coretest');
 const { rpc_client, EMAIL } = coretest;
 coretest.setup({ pools_to_create: [coretest.POOL_LIST[1]] });
-
-const AWS = require('aws-sdk');
+const { S3 } = require('@aws-sdk/client-s3');
+const { NodeHttpHandler } = require("@smithy/node-http-handler");
 const http = require('http');
 const system_store = require('../../server/system_services/system_store').get_instance();
 const upgrade_bucket_policy = require('../../upgrade/upgrade_scripts/5.14.0/upgrade_bucket_policy');
 const dbg = require('../../util/debug_module')(__filename);
 const assert = require('assert');
 const mocha = require('mocha');
+const config = require('../../../config');
 
 const BKT = 'test-bucket';
 let s3;
@@ -20,7 +21,7 @@ let s3;
 async function _clean_all_bucket_policies() {
     for (const bucket of system_store.data.buckets) {
         if (bucket.s3_policy) {
-            await s3.deleteBucketPolicy({Bucket: bucket.name.unwrap()}).promise();
+            await s3.deleteBucketPolicy({Bucket: bucket.name.unwrap()});
         }
     }
 }
@@ -31,18 +32,19 @@ mocha.describe('test upgrade scripts', async function() {
         await system_store.load();
 
         const account_info = await rpc_client.account.read_account({ email: EMAIL, });
-        s3 = new AWS.S3({
+        s3 = new S3({
             endpoint: coretest.get_http_address(),
-            accessKeyId: account_info.access_keys[0].access_key.unwrap(),
-            secretAccessKey: account_info.access_keys[0].secret_key.unwrap(),
-            s3ForcePathStyle: true,
-            signatureVersion: 'v4',
-            computeChecksums: true,
-            s3DisableBodySigning: false,
-            region: 'us-east-1',
-            httpOptions: { agent: new http.Agent({ keepAlive: false }) },
+            credentials: {
+                accessKeyId: account_info.access_keys[0].access_key.unwrap(),
+                secretAccessKey: account_info.access_keys[0].secret_key.unwrap(),
+            },
+            forcePathStyle: true,
+            region: config.DEFAULT_REGION,
+            requestHandler: new NodeHttpHandler({
+                httpAgent: new http.Agent({ keepAlive: false })
+            }),
         });
-        await s3.createBucket({ Bucket: BKT }).promise();
+        await s3.createBucket({ Bucket: BKT });
     });
 
     mocha.it('test upgrade bucket policy to version 5.14.0', async function() {
@@ -80,7 +82,7 @@ mocha.describe('test upgrade scripts', async function() {
         await upgrade_bucket_policy.run({dbg, system_store, system_server: null});
         const res = await s3.getBucketPolicy({ // should work - bucket policy should fit current schema
             Bucket: BKT,
-        }).promise();
+        });
         const new_policy = JSON.parse(res.Policy);
 
         assert.strictEqual(new_policy.Statement.length, old_policy.statement.length);
@@ -93,6 +95,6 @@ mocha.describe('test upgrade scripts', async function() {
     });
 
     mocha.after(async function() {
-        await s3.deleteBucket({ Bucket: BKT }).promise();
+        await s3.deleteBucket({ Bucket: BKT });
     });
 });


### PR DESCRIPTION
### Explain the changes
Implementation of AWS SDK V3 (without wrapper) in unit tests:
1. upgrade_script
2. dedup
3. lifecycle:
- pass Date as Date (not string)
- remove test of Filter {} (empty Filter) since it is not allowed (Filter must have exactly one of Prefix, Tag, or And specified)

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. `make test` (upgrade_script and lifecycle run as a part of the CI).

- [ ] Doc added/updated
- [ ] Tests added
