### PR TITLE
Adding support for SSL and connection string for Postgres client + SSL tests (2nd commit)

### DIFF
--- a/.github/workflows/sanity-ssl.yaml
+++ b/.github/workflows/sanity-ssl.yaml
@@ -1,0 +1,20 @@
+name: Build & Sanity SSL
+on: [push, pull_request]
+
+jobs:
+  run-sanity-ssl-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run Build & SSL Sanity Tests
+        run: |
+          set -x
+          mkdir -p logs/sanity-test-logs
+          chmod 777 logs/sanity-test-logs
+          make test-external-pg-sanity

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,17 @@ tester: noobaa
 	@echo "##\033[1;32m Build image noobaa-tester done.\033[0m"
 .PHONY: tester
 
+build-ssl-postgres: tester
+	@echo "\n##\033[1;32m Cretaing SSL CA for image ...\033[0m"
+	mkdir -p -m 755 certs
+	openssl ecparam -name prime256v1 -genkey -noout -out certs/ca.key
+	openssl req -new -x509 -sha256 -key certs/ca.key -out certs/ca.crt -subj "/CN=ca.noobaa.com"
+	@echo "\n##\033[1;32m Build image for SSL Postgres ...\033[0m"
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg HOST=ssl-pg-$(GIT_COMMIT)-$(NAME_POSTFIX) -f src/deploy/NVA_build/SSLPostgres.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t postgres:ssl . $(REDIRECT_STDOUT)
+	@echo "\033[1;32mBuild SSL Postgres done.\033[0m"
+	@echo "##\033[1;32m Build image postgres:ssl done.\033[0m"
+.PHONY: build-postgres
+
 test: tester
 	@echo "\033[1;34mRunning tests with Mongo.\033[0m"
 	@$(call create_docker_network)
@@ -244,6 +255,23 @@ test-postgres: tester
 	@$(call remove_docker_network)
 .PHONY: test-postgres
 
+test-external-postgres: build-ssl-postgres
+	@echo "\033[1;34mRunning tests with Postgres.\033[0m"
+	@$(call create_docker_network)
+	@$(call run_external_postgres)
+	@$(call run_blob_mock)
+	@$(call create_ssl_certs)
+	@echo "\033[1;34mRunning tests on SSL PG(15)\033[0m"
+	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" \
+	--env "POSTGRES_HOST=ssl-pg-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "POSTGRES_USER=postgres" --env "POSTGRES_DBNAME=coretest" \
+	--env "NODE_EXTRA_CA_CERTS=/tmp/ca.crt" --env "POSTGRES_SSL_REQUIRED=true" --env "DB_TYPE=postgres" --env "BLOB_HOST=blob-mock-$(GIT_COMMIT)-$(NAME_POSTFIX)" \
+	-v $(PWD)/logs:/logs -v $(PWD)/certs:/etc/external-db-secret -v $(PWD)/certs/ca.crt:/tmp/ca.crt $(TESTER_TAG)
+	@$(call stop_noobaa)
+	@$(call stop_external_postgres)
+	@$(call stop_blob_mock)
+	@$(call remove_docker_network)
+.PHONY: test-external-postgres
+
 tests: test #alias for test
 .PHONY: tests
 
@@ -268,6 +296,22 @@ test-sanity: tester
 	@$(call stop_postgres)
 	@$(call remove_docker_network)
 .PHONY: test-sanity
+
+test-external-pg-sanity: build-ssl-postgres
+	@echo "\033[1;34mRunning tests with External Postgres (v15).\033[0m"
+	@$(call create_docker_network)
+	@$(call run_external_postgres)
+	@$(call create_ssl_certs)
+	@echo "\033[1;34mRunning sanity tests on SSL PG(15)\033[0m"
+	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" \
+	--env "POSTGRES_HOST=ssl-pg-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "POSTGRES_USER=postgres" --env "POSTGRES_DBNAME=postgres" \
+	--env "NODE_EXTRA_CA_CERTS=/tmp/ca.crt" --env "POSTGRES_SSL_REQUIRED=true" --env "DB_TYPE=postgres" \
+	-v $(PWD)/logs:/logs -v $(PWD)/certs:/etc/external-db-secret -v $(PWD)/certs/ca.crt:/tmp/ca.crt $(TESTER_TAG) \
+	"./src/test/system_tests/run_sanity_test_on_test_container.sh"
+	@$(call stop_noobaa)
+	@$(call stop_external_postgres)
+	@$(call remove_docker_network)
+.PHONY: test-external-pg-sanity
 
 clean:
 	@echo Stopping and Deleting containers
@@ -344,6 +388,34 @@ define stop_postgres
 	$(CONTAINER_ENGINE) stop coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX)
 	$(CONTAINER_ENGINE) rm coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX)
 	@echo "\033[1;32mStop postgres done.\033[0m"
+endef
+
+#########################
+# SSL EXTERNAL POSTGRES #
+#########################
+
+define run_external_postgres
+	@echo "\033[1;34mRunning Postgres container\033[0m"
+	$(CONTAINER_ENGINE) run -d $(CPUSET) --network noobaa-net --name ssl-pg-$(GIT_COMMIT)-$(NAME_POSTFIX) --env "POSTGRES_PASSWORD=noobaa" --env "LC_COLLATE=C" -v $(PWD)/certs/ca.crt:/etc/ssl/certs/ca.crt postgres:ssl
+	@echo "\033[1;34mWaiting for postgres to start..\033[0m"
+	sleep 20
+	@echo "\033[1;32mRun postgres done.\033[0m"
+endef
+
+define stop_external_postgres
+	@echo "\033[1;34mStopping/removing Postgres container\033[0m"
+	$(CONTAINER_ENGINE) network disconnect noobaa-net ssl-pg-$(GIT_COMMIT)-$(NAME_POSTFIX)
+	$(CONTAINER_ENGINE) stop ssl-pg-$(GIT_COMMIT)-$(NAME_POSTFIX)
+	$(CONTAINER_ENGINE) rm ssl-pg-$(GIT_COMMIT)-$(NAME_POSTFIX)
+	@echo "\033[1;32mStop postgres done.\033[0m"
+endef
+
+define create_ssl_certs
+	@echo "\033[1;34mCreating ssl client certificates for NooBaa container\033[0m"
+	openssl ecparam -name prime256v1 -genkey -noout -out certs/tls.key
+	openssl req -new -sha256 -key certs/tls.key -out certs/tls.csr -subj "/CN=postgres"
+	openssl x509 -req -in certs/tls.csr -CA certs/ca.crt -CAkey certs/ca.key -CAcreateserial -out certs/tls.crt -days 365 -sha256
+	chmod +r certs/tls.key
 endef
 
 #############

--- a/src/deploy/NVA_build/SSLPostgres.Dockerfile
+++ b/src/deploy/NVA_build/SSLPostgres.Dockerfile
@@ -1,0 +1,20 @@
+# This Dockerfile contains the image specification of our database
+FROM postgres:15
+
+ARG HOST=localhost
+COPY ./certs/ca.crt  /etc/ssl/certs/ca.crt
+COPY ./certs/ca.key  /etc/ssl/certs/ca.key
+COPY ./src/deploy/NVA_build/ssl_conf.sh /docker-entrypoint-initdb.d/ssl_conf.sh
+
+RUN openssl genrsa -out /etc/ssl/private/server.key 2048
+RUN openssl req -new -sha256 -key /etc/ssl/private/server.key -out /etc/ssl/private/server.csr -subj "/CN=${HOST}"
+RUN openssl x509 -req -in /etc/ssl/private/server.csr -CA /etc/ssl/certs/ca.crt -CAkey  /etc/ssl/certs/ca.key -CAcreateserial -out /etc/ssl/private/server.crt -days 365 -sha256
+
+RUN chmod 640 /etc/ssl/private/server.key
+RUN chown root:ssl-cert /etc/ssl/private/server.key
+
+ENTRYPOINT ["docker-entrypoint.sh"] 
+
+CMD [ "-c", "ssl=on" , "-c", "ssl_cert_file=/etc/ssl/private/server.crt", "-c",\
+    "ssl_key_file=/etc/ssl/private/server.key", "-c", \
+    "ssl_ca_file=/etc/ssl/certs/ca.crt"]

--- a/src/deploy/NVA_build/ssl_conf.sh
+++ b/src/deploy/NVA_build/ssl_conf.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# echo ssl setting into pg_hba.conf configuration file
+echo 'local all all trust' > /var/lib/postgresql/data/pg_hba.conf
+echo 'hostssl all all all cert clientcert=verify-full' >> /var/lib/postgresql/data/pg_hba.conf

--- a/src/util/ssl_utils.js
+++ b/src/util/ssl_utils.js
@@ -20,6 +20,7 @@ const init_cert_info = dir => ({
 const certs = {
     MGMT: init_cert_info('/etc/mgmt-secret'),
     S3: init_cert_info('/etc/s3-secret'),
+    EXTERNAL_DB: init_cert_info('/etc/external-db-secret'),
 };
 
 function generate_ssl_certificate() {


### PR DESCRIPTION
### Explain the changes
1. Adding support for SSL/TLS for working with an external Postgres DB. in case of adding env variable POSTGRES_SSL_REQUIRED
2. Adding support for supporting self-signed server certificate, by using env variable POSTGRES_SSL_UNAUTHORIZED
3. Adding support to work with client certificate - when located in /etc/external-db-secret (like for MGMT and S3)
4. Adding support to work with a unified connection string (instead of providing host, dbname, port, and creds) with POSTGRES_CONNETION_STRING env variable

Testing:
5. Added docker builder to create an SSL-supported version for external PG (v15)
6. Added Makefile actions for building this docker image: build_ssl_postgres
7. Added Makefile for running sanity and unit test on top of the docker image for SSL Postgres
8. Added actions to run both sanity and unit test for SSL Postgres

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
