### PR TITLE
NSFS | Merge NSFS standalone changes to master

### DIFF
--- a/docs/nsfs-multi-fs.md
+++ b/docs/nsfs-multi-fs.md
@@ -1,0 +1,124 @@
+# NSFS Multi FS Standalone
+
+Running noobaa-core standalone is useful for development, testing, or deploying in Linux without depending on Kubernetes, NSFS multi FS is different from the normal standalone in such a way that it doesn't depend on the Noobaa postgres db. All the Global configurations, Accounts, and Bucket related schemas are saved in FS. And it gives a more lightweight flavor to the Noobaa standalone version. Permissions are handled by uid and gid.
+
+Users can switch between Noobaa standalone and NSFS multi FS standalone by adding/removing the argument `multi_fs_config_dir`.
+
+```
+node src/cmd/nsfs ../standalon/nsfs_root --multi_fs_config_dir ../standalon/multi_fs_config
+
+```
+
+---
+
+## Compments
+
+### 1. Accounts
+
+- Account will have a directory and in that, it will map 1 file per account, and the file name will be {access_key}.json
+- Secrets will be saved either as plain text or Encrypted strings? [TBD]
+- JSON Schema - $ref: account_api#/definitions/account_info
+- new_buckets_path in the account schema will be used to populate the namespace store(read_resources, write_resource).
+- BucketSpace interface is updated with the new method `read_account_by_access_key()`
+    - Method will read multiple account config files referring to access_key and return the account to `account_cache`.
+
+```
+{
+	"name": "user1",
+	"email": "user1@noobaa.io",
+	"has_login": "false",
+	"has_s3_access": "true",
+    "allow_bucket_creation": "true",
+	"access_keys": [{
+		"access_key": "aa-abcdefghijklmn123456",
+		"secret_key": "ss-abcdefghijklmn123456"
+	}],
+	"nsfs_account_config": {
+		"uid": 10,
+		"gid": 10,
+		"new_buckets_path": "/",
+		"nsfs_only": "true"
+	}
+}
+```
+
+### 2. Bucket
+
+- Bucket will have a directory and in that, it will map 1 file per Bucket
+- bucket files name will be same as bucket name; eg: {bucket_name}.json
+- Bucket schema should have a name, account name/email, s3_policy, path, etc.
+- JSON Schema - $ref: 'bucket_api#/definitions/bucket_info'
+- BucketSpace interface is updated with the new method `read_bucket_sdk_info()`
+    - Method will read bucket schama referring to bucket name and return the bucket to `bucket_namespace_cache`.
+
+```
+{
+  "name": "mybucke-test1",
+  "tag": "",
+  "system_owner": "user1@noobaa.io",
+  "bucket_owner": "user1@noobaa.io",
+  "versioning": "DISABLED",
+  "path": "mybucke-test1",
+  "should_create_underlying_storage": true,
+  "s3_policy": {
+    "version": "2012-10-17",
+    "statement": [
+      {
+        "sid": "id-1222",
+        "effect": "allow",
+        "principal": [
+          "*"
+        ],
+        "action": [
+          "s3:*"
+        ],
+        "resource": [
+          "arn:aws:s3:::*"
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 3. Global config
+
+ - JSON Schema with Noobaa global properties
+
+## Operations
+
+### Accounts operations
+
+- S3 Authentication of account requests - lookup accounts by access key etc.
+- Create account - admin creates a file in the accounts dir, and Noobaa reloads on demand.
+- Delete account - admin deletes the file, we have a cache and will expire it after some time.
+- Regenerate credentials - update the file, and Noobaa will reload after up to 1 minute.
+- Update account details like uid, gid, email etc.
+
+### S3 Bucket operations
+
+- Create Bucket
+    - Set Bucket owner to the account, and path to new_buckets_path/bucket_name
+    - Mark the bucket as created from S3 (should_create_underlying_storage)
+- Delete Bucket
+    - We check the user has permission to do it using uid and gid
+    - Bucket owner and Admin can delete.
+    - If we created the bucket, we also cleaned up the bucket directory along with the .noobaa dir in it, but no data should be deleted. If there is still data we should fail the deletion
+- Update bucket
+    - Put bucket policy
+    - Put bucket website
+- List buckets
+    - Readdir the bucket config directory and filter based on the requesting account.
+    - Check uid/gid access to the bucket path
+
+## Code Structure
+To simplify the flow new SDK `BucketSpaceMultiFS` is added for the NSFS multi FS standalone by extending the `BucketSpaceFS`. `BucketSpaceMultiFS` will handle all the multi FS related functionalities on the other hand `BucketSpaceFS` keeps serving existing NSFS standalone functionalities.
+
+### BucketSpaceFS
+- simplified nsfs bucket manager - single root dir for all buckets under it, and a single account.
+- CLI: node nsfs /fsroot/
+
+### BucketSpaceMultiFS
+- Reuse the simple `BucketSpaceFS` code by extending it.
+- Implements the requirements from the top.
+- CLI: node nsfs --multi_fs_config_directory /fs-config-root/

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -36,6 +36,10 @@ api_schema.register_api(require('./replication_api'));
 
 api_schema.compile();
 
+function get_schema(name) {
+    return api_schema._ajv.getSchema(name);
+}
+
 function get_protocol_port(protocol) {
     switch (protocol.toLowerCase()) {
         case 'http:':
@@ -146,3 +150,4 @@ exports.new_rpc_from_routing = new_rpc_from_routing;
 exports.new_rpc_default_only = new_rpc_default_only;
 exports.new_router_from_address_list = new_router_from_address_list;
 exports.new_router_from_base_address = new_router_from_base_address;
+exports.get_schema = get_schema;

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -16,13 +16,18 @@ const minimist = require('minimist');
 
 require('../server/system_services/system_store').get_instance({ standalone: true });
 
+//const js_utils = require('../util/js_utils');
 const nb_native = require('../util/nb_native');
-const RpcError = require('../rpc/rpc_error');
+//const schema_utils = require('../util/schema_utils');
+//const RpcError = require('../rpc/rpc_error');
 const ObjectSDK = require('../sdk/object_sdk');
 const NamespaceFS = require('../sdk/namespace_fs');
 const BucketSpaceFS = require('../sdk/bucketspace_fs');
+const BucketSpaceMultiFS = require('../sdk/bucketspace_multi_fs');
 const SensitiveString = require('../util/sensitive_string');
 const endpoint_stats_collector = require('../sdk/endpoint_stats_collector');
+const { get_schema } = require('../api');
+//const { RPC_BUFFERS } = require('../rpc');
 
 const HELP = `
 Help:
@@ -48,18 +53,33 @@ Arguments:
 const OPTIONS = `
 Options:
 
-    --http_port <port>                      (default 6001)           Set the S3 endpoint listening HTTP port to serve.
-    --https_port <port>                     (default 6443)           Set the S3 endpoint listening HTTPS port to serve.
-    --https_port_sts <port>                 (default -1)             Set the S3 endpoint listening HTTPS port for STS.
-    --metrics_port <port>                   (default -1)             Set the metrics listening port for prometheus.
-    --uid <uid>                             (default process uid)    Send requests to the Filesystem with uid.
-    --gid <gid>                             (default process gid)    Send requests to the Filesystem with gid.
-    --access_key <key>                      (default none)           Authenticate incoming requests from this access key only (default is no auth).
-    --secret_key <key>                      (default none)           Authenticate incoming requests with this secret key only (default is no auth).
-    --backend <fs>                          (default "")             Set default backend fs "".
-    --debug <level>                         (default 0)              Increase debug level
-    --versioning <ENABLED|SUSPENDED>        (default DISABLED)       Enable/suspend versioning
-    --forks <n>                             (default none)           Forks spread incoming requests (config.ENDPOINT_FORKS used if flag is not provided)
+    --http_port <port>         (default 6001)   Set the S3 endpoint listening HTTP port to serve.
+    --https_port <port>        (default 6443)   Set the S3 endpoint listening HTTPS port to serve.
+    --https_port_sts <port>    (default -1)     Set the S3 endpoint listening HTTPS port for STS.
+    --metrics_port <port>      (default -1)     Set the metrics listening port for prometheus.
+    --forks <n>                (default none)   Forks spread incoming requests (config.ENDPOINT_FORKS used if flag is not provided).
+    --debug <level>            (default 0)      Increase debug level.
+
+    ## single user mode
+
+    --uid <uid>          (default as process)   Send requests to the Filesystem with uid.
+    --gid <gid>          (default as process)   Send requests to the Filesystem with gid.
+    --access_key <key>      (default none)      Authenticate incoming requests for this access key only (default is no auth).
+    --secret_key <key>      (default none)      The secret key pair for the access key.
+
+    ## multi user mode
+
+    --iam_json_schema                           Print the json schema of the identity files in iam dir.
+    --iam_ttl <seconds>     (default 60)        Identities expire after this amount of time, and re-read from the FS.
+    --config_root <dir>     (default none)      Configuration files for Noobaa standalon NSFS. It includes config files for environment variables(<config-root>/.env), 
+                                                local configuration(<config-root>/config-local.js), authentication (<config-root>/accounts/<access-key>.json) and 
+                                                bucket schema (<config-root>/buckets/<bucket-name>.json).
+
+    ## features
+
+    --backend <fs>          (default none)      Use custom backend fs to CEPH_FS 'GPFS', 'NFSv4').
+    --versioning <mode>   (default DISABLED)    Set versioning mode to DISABLED | ENABLED | SUSPENDED.
+
 `;
 
 const ANONYMOUS_AUTH_WARNING = `
@@ -80,10 +100,29 @@ function print_usage() {
     process.exit(1);
 }
 
+const IAM_JSON_SCHEMA = get_schema('account_api#/definitions/account_info');
+
 class NsfsObjectSDK extends ObjectSDK {
 
-    constructor(fs_root, fs_config, account, versioning) {
-        const bucketspace = new BucketSpaceFS({ fs_root });
+    constructor(fs_root, fs_config, account, versioning, config_root) {
+
+        // const rpc_client_hooks = new_rpc_client_hooks();
+        // rpc_client_hooks.account.read_account_by_access_key = async ({ access_key }) => {
+        //     if (access_key) {
+        //         return { access_key };
+        //     }
+        // };
+        // rpc_client_hooks.bucket.read_bucket_sdk_info = async ({ name }) => {
+        //     if (name) {
+        //         return { name };
+        //     }
+        // };
+        let bucketspace;
+        if (config_root) {
+            bucketspace = new BucketSpaceMultiFS({ fs_root, config_root });
+        } else {
+            bucketspace = new BucketSpaceFS({ fs_root });
+        }
         super({
             rpc_client: null,
             internal_rpc_client: null,
@@ -115,40 +154,40 @@ class NsfsObjectSDK extends ObjectSDK {
         return ns_fs;
     }
 
-    async load_requesting_account(auth_req) {
-        const access_key = this.nsfs_account.access_keys?.[0]?.access_key;
-        if (access_key) {
-            const token = this.get_auth_token();
-            if (!token) {
-                throw new RpcError('UNAUTHORIZED', `Anonymous access to bucket no allowed`);
-            }
-            if (token.access_key !== access_key.unwrap()) {
-                throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not allowed`);
-            }
-        }
-        this.requesting_account = this.nsfs_account;
-    }
+    // async load_requesting_account(auth_req) {
+    //     const access_key = this.nsfs_account.access_keys?.[0]?.access_key;
+    //     if (access_key) {
+    //         const token = this.get_auth_token();
+    //         if (!token) {
+    //             throw new RpcError('UNAUTHORIZED', `Anonymous access to bucket not allowed`);
+    //         }
+    //         if (token.access_key !== access_key.unwrap()) {
+    //             throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
+    //         }
+    //     }
+    //     this.requesting_account = this.nsfs_account;
+    // }
 
-    async read_bucket_sdk_policy_info(bucket_name) {
-        return {
-            s3_policy: {
-                Version: '2012-10-17',
-                Statement: [{
-                    Effect: 'Allow',
-                    Action: ['*'],
-                    Resource: ['*'],
-                    Principal: new SensitiveString('*'),
-                }]
-            },
-            system_owner: new SensitiveString('nsfs'),
-            bucket_owner: new SensitiveString('nsfs'),
-        };
-    }
+    // async read_bucket_sdk_policy_info(bucket_name) {
+    //     return {
+    //         s3_policy: {
+    //             version: '2012-10-17',
+    //             statement: [{
+    //                 effect: 'allow',
+    //                 action: ['*'],
+    //                 resource: ['*'],
+    //                 principal: [new SensitiveString('*')],
+    //             }]
+    //         },
+    //         system_owner: new SensitiveString('nsfs'),
+    //         bucket_owner: new SensitiveString('nsfs'),
+    //     };
+    // }
 
-    async read_bucket_usage_info() { return undefined; }
-    async read_bucket_sdk_website_info() { return undefined; }
-    async read_bucket_sdk_namespace_info() { return undefined; }
-    async read_bucket_sdk_caching_info() { return undefined; }
+    // async read_bucket_usage_info() { return undefined; }
+    // async read_bucket_sdk_website_info() { return undefined; }
+    // async read_bucket_sdk_namespace_info() { return undefined; }
+    // async read_bucket_sdk_caching_info() { return undefined; }
 
 }
 
@@ -163,21 +202,31 @@ async function main(argv = minimist(process.argv.slice(2))) {
             dbg.set_module_level(debug_level, 'core');
             nb_native().fs.set_debug_level(debug_level);
         }
+        if (argv.iam_json_schema) {
+            console.log(JSON.stringify(IAM_JSON_SCHEMA.schema, null, 2));
+            return;
+        }
+
         const http_port = Number(argv.http_port) || 6001;
         const https_port = Number(argv.https_port) || 6443;
         const https_port_sts = Number(argv.https_port_sts) || -1;
         const metrics_port = Number(argv.metrics_port) || -1;
+        const forks = Number(argv.forks) || 0;
+        const uid = Number(argv.uid) || process.getuid();
+        const gid = Number(argv.gid) || process.getgid();
         const access_key = argv.access_key && new SensitiveString(String(argv.access_key));
         const secret_key = argv.secret_key && new SensitiveString(String(argv.secret_key));
+        const config_root = argv.config_root ? String(argv.config_root) : '';
+        const iam_ttl = Number(argv.iam_ttl ?? 60);
         const backend = argv.backend || (process.env.GPFS_DL_PATH ? 'GPFS' : '');
-        const forks = Number(argv.forks) || 0;
-        const fs_root = argv._[0];
-        if (!fs_root) return print_usage();
         const versioning = argv.versioning || 'DISABLED';
 
+        const fs_root = argv._[0];
+        if (!fs_root) return print_usage();
+
         const fs_config = {
-            uid: Number(argv.uid) || process.getuid(),
-            gid: Number(argv.gid) || process.getgid(),
+            uid,
+            gid,
             backend,
             warn_threshold_ms: config.NSFS_WARN_THRESHOLD_MS,
         };
@@ -191,13 +240,17 @@ async function main(argv = minimist(process.argv.slice(2))) {
             console.error('Error: Root path not found', fs_root);
             return print_usage();
         }
-
+        if (config_root && access_key) {
+            console.error('Error: Access key and IAM dir cannot be used together');
+            return print_usage();
+        }
         if (Boolean(access_key) !== Boolean(secret_key)) {
             console.error('Error: Access and secret keys should be either both set or else both unset');
             return print_usage();
         }
-
-        if (!access_key) console.log(ANONYMOUS_AUTH_WARNING);
+        if (!access_key && !config_root) {
+            console.log(ANONYMOUS_AUTH_WARNING);
+        }
 
         console.log('nsfs: setting up ...', {
             fs_root,
@@ -205,10 +258,14 @@ async function main(argv = minimist(process.argv.slice(2))) {
             https_port,
             https_port_sts,
             metrics_port,
-            access_key,
-            secret_key,
             backend,
             forks,
+            access_key,
+            secret_key,
+            uid,
+            gid,
+            config_root,
+            iam_ttl,
         });
 
         const endpoint = require('../endpoint/endpoint');
@@ -219,7 +276,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
             metrics_port,
             forks,
             init_request_sdk: (req, res) => {
-                req.object_sdk = new NsfsObjectSDK(fs_root, fs_config, account, versioning);
+                req.object_sdk = new NsfsObjectSDK(fs_root, fs_config, account, versioning, config_root);
             }
         });
 
@@ -231,6 +288,51 @@ async function main(argv = minimist(process.argv.slice(2))) {
         process.exit(2);
     }
 }
+
+// TODO: uncomment
+// /**
+//  * @returns {nb.APIClient}
+//  */
+// function new_rpc_client_hooks() {
+//     return {
+//         account: {},
+//         bucket: {},
+//         auth: {},
+//         system: {},
+//         tier: {},
+//         node: {},
+//         host: {},
+//         object: {},
+//         events: {},
+//         agent: {},
+//         block_store: {},
+//         stats: {},
+//         scrubber: {},
+//         debug: {},
+//         redirector: {},
+//         tiering_policy: {},
+//         pool: {},
+//         cluster_server: {},
+//         cluster_internal: {},
+//         server_inter_process: {},
+//         hosted_agents: {},
+//         func: {},
+//         func_node: {},
+//         replication: {},
+//         options: {},
+//         RPC_BUFFERS,
+//         async create_auth_token(params) {
+//             return {};
+//         },
+//         async create_access_key_auth(params) {
+//             return {};
+//         },
+//         async create_k8s_auth(params) {
+//             return {};
+//         },
+//     };
+// }
+// 
 
 exports.main = main;
 

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -131,6 +131,7 @@ function authenticate_request(req) {
 // authorize_request_policy checks that the requester is allowed to assume a role 
 // by the role's assume role policy permissions
 async function authorize_request(req) {
+    await req.sts_sdk.load_requesting_account(req);
     await req.sts_sdk.authorize_request_account(req);
     await authorize_request_policy(req);
 }

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -25,15 +25,24 @@ function isDirectory(ent) {
  */
 class BucketSpaceFS {
 
-    constructor({ fs_root }) {
+    constructor({fs_root}) {
         this.fs_root = fs_root;
         this.fs_context = {
             uid: process.getuid(),
             gid: process.getgid(),
-            backend: '',
             warn_threshold_ms: config.NSFS_WARN_THRESHOLD_MS,
+            //backend: '',
         };
     }
+
+    async read_account_by_access_key({ access_key }) {
+        return {};
+    }
+
+    async read_bucket_sdk_info({ name }) {
+        return {};
+    }
+
 
     ////////////
     // BUCKET //

--- a/src/sdk/bucketspace_multi_fs.js
+++ b/src/sdk/bucketspace_multi_fs.js
@@ -1,0 +1,415 @@
+/* Copyright (C) 2020 NooBaa */
+'use strict';
+
+const path = require('path');
+const config = require('../../config');
+const nb_native = require('../util/nb_native');
+const SensitiveString = require('../util/sensitive_string');
+const { S3Error } = require('../endpoint/s3/s3_errors');
+const RpcError = require('../rpc/rpc_error');
+const net = require('net');
+const js_utils = require('../util/js_utils');
+const P = require('../util/promise');
+const BucketSpaceFS = require('./bucketspace_fs');
+const _ = require('lodash');
+const dbg = require('../util/debug_module')(__filename);
+
+const VALID_BUCKET_NAME_REGEXP =
+    /^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$/;
+const ACCOUNT_PATH = 'accounts';
+const BUCKET_PATH = 'buckets';
+
+//TODO:  dup from namespace_fs - need to handle and not dup code
+function isDirectory(ent) {
+    if (!ent) throw new Error('isDirectory: ent is empty');
+    if (ent.mode) {
+        // eslint-disable-next-line no-bitwise
+        return (((ent.mode) & nb_native().fs.S_IFMT) === nb_native().fs.S_IFDIR);
+    } else if (ent.type) {
+        return ent.type === nb_native().fs.DT_DIR;
+    } else {
+        throw new Error(`isDirectory: ent ${ent} is not supported`);
+    }
+}
+
+
+class BucketSpaceMultiFS extends BucketSpaceFS {
+    constructor({fs_root, config_root}) {
+        super({fs_root});
+        this.fs_root = fs_root;
+        this.iam_dir = path.join(config_root, ACCOUNT_PATH);
+        this.bucket_schema_dir = path.join(config_root, BUCKET_PATH);
+        this.config_root = config_root;
+        this.fs_context = {
+            uid: process.getuid(),
+            gid: process.getgid(),
+            warn_threshold_ms: config.NSFS_WARN_THRESHOLD_MS,
+        };
+    }
+
+    async read_account_by_access_key({ access_key }) {
+        try {
+            if (!access_key) throw new Error('no access key');
+            const iam_path = path.join(this.iam_dir, access_key);
+            const { data } = await nb_native().fs.readFile(this.fs_context, iam_path + ".json");
+            const account = JSON.parse(data.toString());
+            account.name = new SensitiveString(account.name);
+            account.email = new SensitiveString(account.email);
+            for (const k of account.access_keys) {
+                k.access_key = new SensitiveString(k.access_key);
+                k.secret_key = new SensitiveString(k.secret_key);
+            }
+            return account;
+        } catch (err) {
+            throw new RpcError('NO_SUCH_ACCOUNT', `Account with access_key not found`, err);
+        }
+    }
+
+    async read_bucket_sdk_info({ name }) {
+        const bucket_path = path.join(this.bucket_schema_dir, name);
+        const { data } = await nb_native().fs.readFile(this.fs_context, bucket_path + ".json");
+        const bucket = JSON.parse(data.toString());
+        const is_valid = await this.check_bucket_config(bucket);
+        if (!is_valid) {
+            console.warn('BucketSpaceMultiFS: one or more bucket config check is failed for bucket : ', name);
+        }
+        const nsr = {
+            resource: {
+                fs_root_path: this.fs_root,
+            },
+            path: bucket.path
+        };
+        bucket.namespace = {
+            read_resources: [nsr],
+            write_resource: nsr,
+        };
+
+        bucket.system_owner = new SensitiveString(bucket.system_owner);
+        bucket.bucket_owner = new SensitiveString(bucket.bucket_owner);
+        return bucket;
+    }
+
+    async check_bucket_config(bucket) {
+        const bucket_dir_stat = await nb_native().fs.stat(this.fs_context, path.join(this.fs_root, bucket.path || ''));
+        if (!bucket_dir_stat) {
+            return false;
+        }
+        //TODO: Bucket owner check
+        return true;
+    }
+
+
+    ////////////
+    // BUCKET //
+    ////////////
+
+    async list_buckets(object_sdk) {
+        try {
+            const entries = await nb_native().fs.readdir(this.fs_context, this.bucket_schema_dir);
+            const bucket_config_files = entries.filter(entree => !isDirectory(entree));
+            //TODO : we need to add pagination support to list buckets for more than 1000 buckets.
+            let buckets = await P.map(bucket_config_files, bucket_config_file => this.get_bucket_name(bucket_config_file.name));
+            buckets = buckets.filter(bucket => bucket.name.unwrap());
+            return this.validate_bucket_access(buckets, object_sdk);
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                console.error('BucketSpaceMultiFS: root dir not found', err);
+                throw new S3Error(S3Error.NoSuchBucket);
+            }
+            throw err;
+        }
+    }
+    async validate_bucket_access(buckets, object_sdk) {
+        const has_access_buckets = (await P.all(_.map(
+            buckets,
+            async bucket => {
+                const ns = await object_sdk.read_bucket_sdk_namespace_info(bucket.name.unwrap());
+                const has_access_to_bucket = object_sdk.is_nsfs_bucket(ns) ?
+                    await this._has_access_to_nsfs_dir(ns, object_sdk) : false;
+                return has_access_to_bucket && bucket;
+            }))).filter(bucket => bucket);
+            return { buckets: has_access_buckets };
+    }
+
+    async _has_access_to_nsfs_dir(ns, object_sdk) {
+        const account = object_sdk.requesting_account;
+        dbg.log0('_has_access_to_nsfs_dir: nsr: ', ns, 'account.nsfs_account_config: ', account.nsfs_account_config);
+        // nsfs bucket
+        if (!account.nsfs_account_config || _.isUndefined(account.nsfs_account_config.uid) ||
+            _.isUndefined(account.nsfs_account_config.gid)) return false;
+        try {
+            dbg.log0('_has_access_to_nsfs_dir: checking access:', ns.write_resource, account.nsfs_account_config.uid, account.nsfs_account_config.gid);
+            await nb_native().fs.checkAccess({
+                uid: account.nsfs_account_config.uid,
+                gid: account.nsfs_account_config.gid,
+                backend: ns.write_resource.resource.fs_backend,
+                warn_threshold_ms: config.NSFS_WARN_THRESHOLD_MS,
+            }, path.join(ns.write_resource.resource.fs_root_path, ns.write_resource.path || ''));
+
+            return true;
+        } catch (err) {
+            dbg.log0('_has_access_to_nsfs_dir: failed', err);
+            if (err.code === 'ENOENT' || err.code === 'EACCES' || (err.code === 'EPERM' && err.message === 'Operation not permitted')) return false;
+            throw err;
+        }
+    }
+
+    async get_bucket_name(bucket_config_file_name) {
+        const bucket_path = path.join(this.bucket_schema_dir, bucket_config_file_name);
+        const { data } = await nb_native().fs.readFile(this.fs_context, bucket_path);
+        const bucket = JSON.parse(data.toString());
+        return { name: new SensitiveString(bucket.name) };
+    }
+
+    async read_bucket(params) {
+        try {
+            const { name } = params;
+            //TODO : use this.config_root to resolve the bucket json localtion
+            const bucket_path = path.join(this.fs_root, name);
+            console.log(`BucketSpaceMultiFS: read_bucket ${bucket_path}`);
+            const bucket_dir_stat = await nb_native().fs.stat(this.fs_context, bucket_path);
+            if (!isDirectory(bucket_dir_stat)) {
+                throw new S3Error(S3Error.NoSuchBucket);
+            }
+            const owner_account = {
+                email: new SensitiveString('nsfs@noobaa.io'),
+                id: '12345678',
+            };
+            const nsr = {
+                resource: 'nsfs',
+                path: '',
+            };
+            return {
+                name,
+                owner_account,
+                namespace: {
+                    read_resources: [nsr],
+                    write_resource: nsr,
+                    should_create_underlying_storage: true,
+                },
+                tiering: { name, tiers: [] },
+                usage_by_pool: { last_update: 0, pools: [] },
+                num_objects: { last_update: 0, value: 0 },
+                storage: { last_update: 0, values: {} },
+                data: { last_update: 0 },
+                host_tolerance: undefined,
+                node_tolerance: undefined,
+                writable: true,
+                tag: '',
+                bucket_type: 'NAMESPACE',
+                versioning: 'DISABLED',
+                mode: 'OPTIMAL',
+                undeletable: 'NOT_EMPTY',
+            };
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                console.error('BucketSpaceMultiFS: bucket dir not found', err);
+                throw new S3Error(S3Error.NoSuchBucket);
+            }
+            throw err;
+        }
+    }
+
+    async create_bucket(params, sdk) {
+        try {
+            if (!sdk.requesting_account.nsfs_account_config || !sdk.requesting_account.nsfs_account_config.new_buckets_path) {
+                throw new RpcError('MISSING_NSFS_ACCOUNT_CONFIGURATION');
+            }
+            this.validate_bucket_creation(params);
+            const { name } = params;
+            const bucket_path = path.join(this.fs_root, name);
+            console.log(`BucketSpaceMultiFS: create_bucket ${bucket_path}`);
+            // eslint-disable-next-line no-bitwise
+            const unmask_mode = config.BASE_MODE_DIR & ~config.NSFS_UMASK;
+            await nb_native().fs.mkdir(this.fs_context, bucket_path, unmask_mode);
+
+            // bucket configuration file start
+            console.log('creating bucket on default namespace resource', sdk.requesting_account.nsfs_account_config);
+            if (!sdk.requesting_account.nsfs_account_config || !sdk.requesting_account.nsfs_account_config.new_buckets_path) {
+                throw new RpcError('MISSING_NSFS_ACCOUNT_CONFIGURATION');
+            }
+            const bucket = this.new_bucket_defaults(params.name, sdk.requesting_account.email,
+                sdk.requesting_account._id, params.tag, params.lock_enabled);
+            bucket.path = path.join(params.name);
+            bucket.should_create_underlying_storage = true;
+            bucket.force_md5_etag = params.force_md5_etag;
+            const create_bucket = JSON.stringify(bucket);
+            const bucket_schema_path = path.join(this.bucket_schema_dir, name);
+            await nb_native().fs.writeFile(
+                this.fs_context,
+                bucket_schema_path + ".json",
+                Buffer.from(create_bucket), {
+                    mode: this.get_umasked_mode(config.BASE_MODE_FILE)
+                }
+            );
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                console.error('BucketSpaceMultiFS: root dir not found', err);
+                throw new S3Error(S3Error.NoSuchBucket);
+            }
+            throw err;
+        }
+    }
+
+    get_umasked_mode(mode) {
+        // eslint-disable-next-line no-bitwise
+        return mode & ~config.NSFS_UMASK;
+    }
+
+
+    new_bucket_defaults(name, email, owner_account_id, tag, lock_enabled) {
+        return {
+            name: name,
+            tag: js_utils.default_value(tag, ''),
+            owner_account: owner_account_id,
+            system_owner: new SensitiveString(email),
+            bucket_owner: new SensitiveString(email),
+            versioning: config.WORM_ENABLED && lock_enabled ? 'ENABLED' : 'DISABLED',
+            object_lock_configuration: config.WORM_ENABLED ? {
+                object_lock_enabled: lock_enabled ? 'Enabled' : 'Disabled',
+            } : undefined,
+        };
+    }
+
+    async delete_bucket(params) {
+        try {
+            const { name } = params;
+            const bucket_path = path.join(this.fs_root, name);
+            console.log(`BucketSpaceMultiFS: delete_fs_bucket ${bucket_path}`);
+            // TODO we want to have the logic from bucketspace_nb to separate between two cases:
+            // - either we should_create_underlying_storage (uls) and then we delete the bucket itself
+            // - or we just remove the bucket.json and keep the bucket files as is.
+            await nb_native().fs.rmdir(this.fs_context, bucket_path);
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                console.error('BucketSpaceMultiFS: root dir not found', err);
+                throw new S3Error(S3Error.NoSuchBucket);
+            }
+            throw err;
+        }
+    }
+
+    validate_bucket_creation(params) {
+        if (params.name.length < 3 ||
+            params.name.length > 63 ||
+            net.isIP(params.name) ||
+            !VALID_BUCKET_NAME_REGEXP.test(params.name)) {
+            throw new RpcError('INVALID_BUCKET_NAME');
+        }
+    }
+
+    //////////////////////
+    // BUCKET LIFECYCLE //
+    //////////////////////
+
+    async get_bucket_lifecycle_configuration_rules(params) {
+        // TODO
+    }
+
+    async set_bucket_lifecycle_configuration_rules(params) {
+        // TODO
+    }
+
+    async delete_bucket_lifecycle(params) {
+        // TODO
+    }
+
+    ///////////////////////
+    // BUCKET VERSIONING //
+    ///////////////////////
+
+    async set_bucket_versioning(params) {
+        // TODO
+    }
+
+    ////////////////////
+    // BUCKET TAGGING //
+    ////////////////////
+
+    async put_bucket_tagging(params) {
+        // TODO
+    }
+
+    async delete_bucket_tagging(params) {
+        // TODO
+    }
+
+    async get_bucket_tagging(params) {
+        // TODO
+    }
+
+    ///////////////////////
+    // BUCKET ENCRYPTION //
+    ///////////////////////
+
+    async put_bucket_encryption(params) {
+        // TODO
+    }
+
+    async get_bucket_encryption(params) {
+        // TODO
+    }
+
+    async delete_bucket_encryption(params) {
+        // TODO
+    }
+
+    ////////////////////
+    // BUCKET WEBSITE //
+    ////////////////////
+
+    async put_bucket_website(params) {
+        // TODO
+    }
+
+    async delete_bucket_website(params) {
+        // TODO
+    }
+
+    async get_bucket_website(params) {
+        // TODO
+    }
+
+    ////////////////////
+    // BUCKET POLICY  //
+    ////////////////////
+
+    async put_bucket_policy(params) {
+        const { name, policy } = params;
+        console.log("BucketSpaceMultiFS: Bucket name, policy", name, policy);
+        const bucket_path = path.join(this.bucket_schema_dir, name);
+        const { data } = await nb_native().fs.readFile(this.fs_context, bucket_path + ".json");
+        const bucket = JSON.parse(data.toString());
+        bucket.s3_policy = policy;
+        const update_bucket = JSON.stringify(bucket);
+        await nb_native().fs.writeFile(
+            this.fs_context,
+            bucket_path + ".json",
+            Buffer.from(update_bucket), {
+                mode: this.get_umasked_mode(config.BASE_MODE_FILE)
+            }
+        );
+    }
+
+    async delete_bucket_policy(params) {
+        // TODO
+    }
+
+    async get_bucket_policy(params) {
+        // TODO
+    }
+
+    /////////////////////////
+    // DEFAULT OBJECT LOCK //
+    /////////////////////////
+
+    async get_object_lock_configuration(params, object_sdk) {
+        // TODO
+    }
+
+    async put_object_lock_configuration(params, object_sdk) {
+        // TODO
+    }
+}
+
+module.exports = BucketSpaceMultiFS;

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -16,7 +16,17 @@ class BucketSpaceNB {
 
     constructor(options) {
         this.rpc_client = options.rpc_client;
+        this.internal_rpc_client = options.internal_rpc_client;
     }
+
+    async read_account_by_access_key({ access_key }) {
+        return this.internal_rpc_client.account.read_account_by_access_key({ access_key });
+    }
+
+    async read_bucket_sdk_info({ name }) {
+        return this.internal_rpc_client.bucket.read_bucket_sdk_info({ name });
+    }
+
 
     ////////////
     // BUCKET //

--- a/src/sdk/bucketspace_s3.js
+++ b/src/sdk/bucketspace_s3.js
@@ -14,6 +14,15 @@ class BucketSpaceS3 {
         this.s3 = new AWS.S3(s3_params);
     }
 
+    async read_account_by_access_key({ access_key }) {
+        return {};
+    }
+
+    async read_bucket_sdk_info({ name }) {
+        return {};
+    }
+
+
     ////////////
     // BUCKET //
     ////////////

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -621,7 +621,11 @@ interface PartSchemaDB {
  *
  **********************************************************/
 
-type APIMethod = (params?: object, options?: object) => Promise<any>;
+interface APIParams {
+    [key: string]: any;
+}
+
+type APIMethod = (params?: APIParams, options?: object) => Promise<any>;
 
 interface APIGroup {
     [key: string]: APIMethod;
@@ -662,9 +666,9 @@ interface APIClient {
 
     RPC_BUFFERS: symbol;
 
-    create_auth_token(params: object): Promise<object>;
-    create_access_key_auth(params: object): Promise<object>;
-    create_k8s_auth(params: object): Promise<object>;
+    create_auth_token(params: APIParams): Promise<object>;
+    create_access_key_auth(params: APIParams): Promise<object>;
+    create_k8s_auth(params: APIParams): Promise<object>;
 }
 
 
@@ -805,6 +809,9 @@ interface Namespace {
 }
 
 interface BucketSpace {
+
+    read_account_by_access_key({ access_key: string }): Promise<any>;
+    read_bucket_sdk_info({ name: string }): Promise<any>;
 
     list_buckets(object_sdk: ObjectSDK): Promise<any>;
     read_bucket(params: object): Promise<any>;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -51,11 +51,11 @@ const account_cache = new LRUCache({
      * Set type for the generic template
      * @param {{
      *      access_key: string;
-     *      rpc_client: nb.APIClient;
+     *      bucketspace: nb.BucketSpace;
      * }} params
      */
     make_key: ({ access_key }) => access_key,
-    load: async ({ rpc_client, access_key }) => rpc_client.account.read_account_by_access_key({ access_key }),
+    load: async ({ bucketspace, access_key }) => bucketspace.read_account_by_access_key({ access_key }),
 });
 
 const MULTIPART_NAMESPACES = [
@@ -81,7 +81,7 @@ class ObjectSDK {
         this.internal_rpc_client = internal_rpc_client;
         this.object_io = object_io;
         this.stats = stats;
-        this.bucketspace = bucketspace || new BucketSpaceNB({ rpc_client });
+        this.bucketspace = bucketspace || new BucketSpaceNB({ rpc_client, internal_rpc_client });
         this.abort_controller = new AbortController();
     }
 
@@ -189,11 +189,11 @@ class ObjectSDK {
             const token = this.get_auth_token();
             if (!token) return;
             this.requesting_account = await account_cache.get_with_cache({
-                rpc_client: this.internal_rpc_client,
+                bucketspace: this._get_bucketspace(),
                 access_key: token.access_key,
             });
         } catch (error) {
-            dbg.error('authorize_request_account error:', error);
+            dbg.error('load_requesting_account error:', error);
             if (error.rpc_code && error.rpc_code === 'NO_SUCH_ACCOUNT') {
                 throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
             } else {
@@ -249,14 +249,14 @@ class ObjectSDK {
 
     async _load_bucket_namespace(params) {
         // params.bucket might be added by _validate_bucket_namespace
-        const bucket = params.bucket || await this.internal_rpc_client.bucket.read_bucket_sdk_info({ name: params.name });
+        const bucket = params.bucket || await this._get_bucketspace().read_bucket_sdk_info({ name: params.name });
         return this._setup_bucket_namespace(bucket);
     }
 
     async _validate_bucket_namespace(data, params) {
         const time = Date.now();
         if (time <= data.valid_until) return true;
-        const bucket = await this.internal_rpc_client.bucket.read_bucket_sdk_info({ name: params.name });
+        const bucket = await this._get_bucketspace().read_bucket_sdk_info({ name: params.name });
         if (_.isEqual(bucket, data.bucket)) {
             // namespace unchanged - extend validity for another period
             data.valid_until = time + config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS;
@@ -304,7 +304,7 @@ class ObjectSDK {
                             bucket.namespace.read_resources[0],
                             bucket._id,
                             {
-                                versioning: bucket.bucket_info.versioning,
+                                versioning: bucket.bucket_info && bucket.bucket_info.versioning,
                                 force_md5_etag: bucket.force_md5_etag
                             },
                         ),

--- a/src/test/unit_tests/test_sts.js
+++ b/src/test/unit_tests/test_sts.js
@@ -3,7 +3,7 @@
 
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
-coretest.setup({ pools_to_create: coretest.POOL_LIST });
+coretest.setup({ pools_to_create: coretest.POOL_LIST[1] });
 const AWS = require('aws-sdk');
 const https = require('https');
 const mocha = require('mocha');


### PR DESCRIPTION
### Explain the changes
Merge multi-account NSFS standalone change to master
NSFS multi FS is different from the normal standalone in such a way that it doesn't depend on the Noobaa postgres db. All bucket and account-related configs are saved to the filesystem

### Issues: Fixed #xxx / Gap #xxx
1. Implementation for read_bucket_sdk_info() and create_bucket() and put_bucket_policy(), List_bucket() methods
2. New SDK BucketSpaceMultiFS added extending BucketSpaceFS
3. Added new callbacks for read_account_by_access_key and read_bucket_sdk_info
4. Initial doc


### Testing Instructions:
1. Test NSFS
2. Test standalone NSFS changes `node src/cmd/nsfs ../standalon/nsfs_root --config_root ../standalon/noobaa/`


- [x] Doc added/updated
- [ ] Tests added
