### PR TITLE
Build RPM - some fixes

### DIFF
--- a/src/deploy/NVA_build/install_nodejs.sh
+++ b/src/deploy/NVA_build/install_nodejs.sh
@@ -46,16 +46,18 @@ function install_node() {
     local node_version="v${NODEJS_VERSION}"
     local filename="node-${node_version}-linux-${arch}.tar.xz"
 
-    mkdir -p ${NODE_PATH}
-    cd ${NODE_PATH}
-    download_node
-    tar -xf ${filename}
+    if [ ! -f ${NODE_PATH}/${filename} ]
+    then
+        mkdir -p ${NODE_PATH}
+        cd ${NODE_PATH}
+        download_node
+        tar -xf ${filename}
 
-    ln -s ${NODE_PATH}/node-${node_version}-linux-${arch}/bin/node /usr/local/bin/node
-    ln -s ${NODE_PATH}/node-${node_version}-linux-${arch}/bin/npm /usr/local/bin/npm
-    ln -s ${NODE_PATH}/node-${node_version}-linux-${arch}/bin/npm /usr/local/bin/npx
+        ln -s ${NODE_PATH}/node-${node_version}-linux-${arch}/bin/node /usr/local/bin/node
+        ln -s ${NODE_PATH}/node-${node_version}-linux-${arch}/bin/npm /usr/local/bin/npm
+        ln -s ${NODE_PATH}/node-${node_version}-linux-${arch}/bin/npm /usr/local/bin/npx
+    fi
 
-    rm ${filename}
 }
 
 if [ -z "${SKIP_NODE_INSTALL}" ]

--- a/src/deploy/RPM_build/packagerpm.sh
+++ b/src/deploy/RPM_build/packagerpm.sh
@@ -6,6 +6,7 @@ set -x
 dir=$(dirname "$0")
 
 SKIP_NODE_INSTALL=1 source $dir/../install_nodejs.sh
+NODE_PATH="${NODE_PATH:-/usr/local/node}"
 
 noobaaver="$(npm pkg get version | tr -d '"')"
 revision="1"
@@ -33,9 +34,17 @@ function move_builds() {
 }
 
 function get_node_tar() {
+    local arch=$(get_arch)
+    local filename="node-v${nodever}-linux-${arch}.tar.xz"
+
     pushd ~/rpmbuild/SOURCES/
-    local path=$(NODEJS_VERSION=${nodever} download_node)
-    mv ${path} node-${nodever}.tar.xz
+    if [ -f ${NODE_PATH}/${filename} ]
+    then
+        mv ${NODE_PATH}/${filename} node-${nodever}.tar.xz
+    else 
+        local path=$(NODEJS_VERSION=${nodever} download_node)
+        mv ${path} node-${nodever}.tar.xz
+    fi
     popd
 }
 


### PR DESCRIPTION
### Explain the changes
- Removed redundant downloading for nodejs
- Fix an issue when building the rpm target failed when PLATFORM was not set
- Added the ability to provide the rep build image tag externally
