### PR TITLE
Migrating to AWS SDK V3 | Implementation In Account Server and Bucket Server

### DIFF
--- a/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv2.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv2.js
@@ -58,6 +58,10 @@ class S3ClientSDKV2 {
         return this.s3.headObject(params).promise();
     }
 
+    listBuckets(params) {
+        return this.s3.listBuckets(params).promise();
+    }
+
     listMultipartUploads(params) {
         return this.s3.listMultipartUploads(params).promise();
     }

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -362,9 +362,9 @@ exports.resolve = val => Promise.resolve(val);
 exports.reject = err => Promise.reject(err);
 exports.all = arr => Promise.all(arr);
 // deprecated
-exports.fromCallback = fromCallback; // 96 occurences
-exports.fcall = fcall; // 64 occurences
-exports.ninvoke = ninvoke; // 32 occurences
-exports.wait_until = wait_until; // 21 occurences
-exports.Defer = Defer; // 18 occurences
-exports.pwhile = pwhile; // 17 occurences
+exports.fromCallback = fromCallback; // 50 occurrences
+exports.fcall = fcall; // 60 occurrences
+exports.ninvoke = ninvoke; // 31 occurrences
+exports.wait_until = wait_until; // 21 occurrences
+exports.Defer = Defer; // 18 occurrences
+exports.pwhile = pwhile; // 16 occurrences


### PR DESCRIPTION
### Explain the changes
1. Implementation of AWS SDK V3 in account server - check connection.
2. Implementation of AWS SDK V3 in bucket server - check get cloud buckets.
3. Add missing action in AWS SDK V2 of `listBuckets`.
4. In the bucket server inside `get_cloud_buckets` changing deprecated `P.fcall` with promise chain to async-await with try-catch.
5. Update occurrences of deprecated functions in promise.js.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. Deploy noobaa on MInikube or Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create namespacestores:
`nb namespacestore create aws-s3  <namespace-store-name> --region=<target-bucket-region>`.
`nb namespacestore create aws-s3  <namespace-store-name>`
`nb namespacestore create s3-compatible <namespace-store-name>`
3. Check in the logs of noobaa core: `kubectl logs pod/noobaa-core-0` the printings of `check_external_connection`, `get cloud buckets` (easiest way is to search by the namespacestore name).

- [ ] Doc added/updated
- [ ] Tests added
