### PR TITLE
Migrating to AWS SDK V3 | Implementation In BucketSpaceS3 (And nscache)

### DIFF
--- a/src/cmd/nscache.js
+++ b/src/cmd/nscache.js
@@ -14,6 +14,7 @@ const NamespaceS3 = require('../sdk/namespace_s3');
 const BucketSpaceS3 = require('../sdk/bucketspace_s3');
 const NamespaceNB = require('../sdk/namespace_nb');
 const endpoint_stats_collector = require('../sdk/endpoint_stats_collector');
+const config = require('../../config');
 
 const HELP = `
 Help:
@@ -40,6 +41,7 @@ Options:
 
     --access_key <key>
     --secret_key <key>
+    --region <region>      (default us-east-1) Set the S3 region of the bucket in case it is AWS endpoint.
     --http_port <port>     (default 6001)   Set the S3 endpoint listening HTTP port to serve.
     --https_port <port>    (default 6443)   Set the S3 endpoint listening HTTPS port to serve.
 `;
@@ -79,8 +81,11 @@ async function main(argv = minimist(process.argv.slice(2))) {
         const s3_params = {
             // TODO
             endpoint: hub_endpoint,
-            accessKeyId: argv.access_key,
-            secretAccessKey: argv.secret_key,
+            region: argv.region || config.DEFAULT_REGION, // notice: we don't validate the region input
+            credentials: {
+                accessKeyId: argv.access_key,
+                secretAccessKey: argv.secret_key,
+            },
         };
         const bs = new BucketSpaceS3({ s3_params });
         const ns_nb = new NamespaceNB(); // TODO need to setup rpc_client

--- a/src/sdk/bucketspace_s3.js
+++ b/src/sdk/bucketspace_s3.js
@@ -1,9 +1,9 @@
 /* Copyright (C) 2020 NooBaa */
 'use strict';
 
-const AWS = require('aws-sdk');
 const SensitiveString = require('../util/sensitive_string');
 // const { S3Error } = require('../endpoint/s3/s3_errors');
+const noobaa_s3_client = require('../sdk/noobaa_s3_client/noobaa_s3_client');
 
 /**
  * @implements {nb.BucketSpace}
@@ -11,7 +11,7 @@ const SensitiveString = require('../util/sensitive_string');
 class BucketSpaceS3 {
 
     constructor({ s3_params }) {
-        this.s3 = new AWS.S3(s3_params);
+        this.s3 = noobaa_s3_client.get_s3_client_v3_params(s3_params);
     }
 
     async read_account_by_access_key({ access_key }) {
@@ -30,9 +30,10 @@ class BucketSpaceS3 {
     async list_buckets() {
         try {
             console.log(`bss3: list_buckets`);
-            const res = await this.s3.listBuckets().promise();
-            const buckets = res.Buckets.map(b => ({ name: new SensitiveString(b.Name) }));
-            return { buckets };
+            const res = await this.s3.listBuckets({});
+            const buckets = res.Buckets ?? [];
+            const buckets_with_name_change = buckets.map(b => ({ name: new SensitiveString(b.Name) }));
+            return { buckets_with_name_change };
         } catch (err) {
             this._translate_error_code(err);
             throw err;
@@ -43,7 +44,7 @@ class BucketSpaceS3 {
         try {
             const { name } = params;
             console.log(`bss3: read_bucket ${name}`);
-            await this.s3.headBucket({ Bucket: name }).promise();
+            await this.s3.headBucket({ Bucket: name });
             return {
                 name,
                 bucket_type: 'NAMESPACE',
@@ -70,7 +71,7 @@ class BucketSpaceS3 {
         try {
             const { name } = params;
             console.log(`bss3: create_bucket ${name}`);
-            await this.s3.createBucket({ Bucket: name }).promise();
+            await this.s3.createBucket({ Bucket: name });
         } catch (err) {
             this._translate_error_code(err);
             throw err;
@@ -81,7 +82,7 @@ class BucketSpaceS3 {
         try {
             const { name } = params;
             console.log(`bss3: delete_fs_bucket ${name}`);
-            await this.s3.deleteBucket({ Bucket: name }).promise();
+            await this.s3.deleteBucket({ Bucket: name });
         } catch (err) {
             this._translate_error_code(err);
             throw err;

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv2.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv2.js
@@ -30,6 +30,14 @@ class S3ClientSDKV2 {
         return this.s3.createMultipartUpload(params).promise();
     }
 
+    createBucket(params) {
+        return this.s3.createBucket(params).promise();
+    }
+
+    deleteBucket(params) {
+        return this.s3.deleteBucket(params).promise();
+    }
+
     deleteObject(params) {
         return this.s3.deleteObject(params).promise();
     }
@@ -52,6 +60,10 @@ class S3ClientSDKV2 {
 
     getObjectTagging(params) {
         return this.s3.getObjectTagging(params).promise();
+    }
+
+    headBucket(params) {
+        return this.s3.headBucket(params).promise();
     }
 
     headObject(params) {


### PR DESCRIPTION
### Explain the changes
1. Implementation of AWS SDK V3 in `BucketSpaceS3`.
2. Add the needed parameters of AWS SDK V3 in `nscache` script (the only use of `BucketSpaceS3` today).
3. Add missing actions in AWS SDK V2 of `createBucket`, `deleteBucket`, and `headBucket`.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none - `nscache` is not working today, I didn't test it.


- [ ] Doc added/updated
- [ ] Tests added
