### PR TITLE
complete upload - skip db access for small object (for performance)

### DIFF
--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -467,7 +467,7 @@ class ObjectIO {
                     start: params.start,
                     end: params.start + chunk_info.size,
                     seq: params.seq,
-                    uncommitted: !params.complete_upload && (chunks.length > 1 || typeof params.multipart_id !== 'undefined'),
+                    uncommitted: typeof params.multipart_id === 'undefined' ? undefined : true,
                     // millistamp: time_utils.millistamp(),
                     // bucket: params.bucket,
                     // key: params.key,

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -454,6 +454,11 @@ class ObjectIO {
     async _upload_chunks(params, complete_params, chunks, callback) {
         try {
             const is_using_encryption = params.encryption || (params.copy_source && params.copy_source.encryption);
+            // on multipart upload we mark the parts as uncommitted
+            // because we still need to fix their offsets on complete upload.
+            // otherwise, we immediately mark the parts as committed
+            // because no further update is needed.
+            const uncommitted = Boolean(params.multipart_id);
             params.range = {
                 start: params.start,
                 end: params.start,
@@ -467,7 +472,7 @@ class ObjectIO {
                     start: params.start,
                     end: params.start + chunk_info.size,
                     seq: params.seq,
-                    uncommitted: typeof params.multipart_id === 'undefined' ? undefined : true,
+                    uncommitted: uncommitted,
                     // millistamp: time_utils.millistamp(),
                     // bucket: params.bucket,
                     // key: params.key,

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -467,7 +467,7 @@ class ObjectIO {
                     start: params.start,
                     end: params.start + chunk_info.size,
                     seq: params.seq,
-                    uncommitted: !params.complete_upload,
+                    uncommitted: !params.complete_upload && (chunks.length > 1 || typeof params.multipart_id !== 'undefined'),
                     // millistamp: time_utils.millistamp(),
                     // bucket: params.bucket,
                     // key: params.key,

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -280,6 +280,10 @@ class PutMapping {
                 this.add_new_chunk(chunk);
             }
         }
+        //commit single part
+        if (this.chunks.length === 1 && this.new_parts.length === 1) {
+            this.new_parts[0].uncommitted = undefined;
+        }
     }
 
     /**

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -280,10 +280,6 @@ class PutMapping {
                 this.add_new_chunk(chunk);
             }
         }
-        //commit single part
-        if (this.chunks.length === 1 && this.new_parts.length === 1) {
-            this.new_parts[0].uncommitted = undefined;
-        }
     }
 
     /**

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -406,17 +406,10 @@ async function complete_object_upload(req) {
         set_updates.sha256_b64 = req.rpc_params.sha256_b64;
     }
 
-    let map_res;
-
-    if (req.rpc_params.multiparts) {
-        map_res = await _complete_object_multiparts(obj, req.rpc_params.multiparts);
-    } else if (req?.params?.num_parts === 1) {
-        //skip db access for small objects
-        dbg.log1("skipped _complete_object_multiparts");
-        map_res = {size: req.rpc_params.size, num_parts: 1};
-    } else {
-        map_res = await _complete_object_parts(obj);
-    }
+    const map_res =
+        req.rpc_params.multiparts ?
+        await _complete_object_multiparts(obj, req.rpc_params.multiparts) :
+        await _complete_object_parts(obj, req?.params?.num_parts);
 
     if (req.rpc_params.size !== map_res.size) {
         if (req.rpc_params.size >= 0) {
@@ -1978,7 +1971,14 @@ async function update_endpoint_stats(req) {
 /**
  * @param {nb.ObjectMD} obj
  */
-async function _complete_object_parts(obj) {
+async function _complete_object_parts(obj, num_parts) {
+
+    if (num_parts === 1) {
+        //skip db access if only one part
+        //(this part is already ok in db, no need to fix it)
+        return {size: obj.size,
+                num_parts: 1};
+    }
     const context = {
         pos: 0,
         seq: 0,

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -409,7 +409,7 @@ async function complete_object_upload(req) {
     const map_res =
         req.rpc_params.multiparts ?
         await _complete_object_multiparts(obj, req.rpc_params.multiparts) :
-        await _complete_object_parts(obj, req?.params?.num_parts);
+        await _complete_object_parts(obj, req.rpc_params.num_parts);
 
     if (req.rpc_params.size !== map_res.size) {
         if (req.rpc_params.size >= 0) {
@@ -1976,8 +1976,7 @@ async function _complete_object_parts(obj, num_parts) {
     if (num_parts === 1) {
         //skip db access if only one part
         //(this part is already ok in db, no need to fix it)
-        return {size: obj.size,
-                num_parts: 1};
+        return {size: obj.size, num_parts: 1};
     }
     const context = {
         pos: 0,

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -406,8 +406,6 @@ async function complete_object_upload(req) {
         set_updates.sha256_b64 = req.rpc_params.sha256_b64;
     }
 
-    dbg.log0("req.rpc_params.num_parts = ", req.rpc_params.num_parts, ", req.params.num_parts = ", req.params.num_parts);
-
     let map_res;
     if (req.rpc_params.multiparts) {
         map_res = await _complete_object_multiparts(obj, req.rpc_params.multiparts);
@@ -1985,8 +1983,6 @@ async function _complete_object_parts(obj) {
 
     const parts = await MDStore.instance().find_all_parts_of_object(obj);
     _complete_next_parts(parts, context);
-
-    dbg.log0("_complete_object_parts num_parts = ", context.num_parts);
 
     return {
         size: context.pos,

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -685,7 +685,9 @@ async function copy_object_mapping(req) {
         part.obj = obj._id;
         part.bucket = req.bucket._id;
         part.multipart = multipart ? multipart._id : undefined;
-        part.uncommitted = true;
+        if (parts.length > 1) {
+            part.uncommitted = true;
+        }
     }
     await MDStore.instance().insert_parts(parts);
     return {


### PR DESCRIPTION
### Explain the changes
For small objects with one part, we know the start/end of object.
There's no need to fix values in db at the end of the put object.
(It's needed for multipart upload where each part doesn't know its start/end at single part upload).
Also, set part as committed when inserting the part (again, to skip db access for removing uncommitted at the end).

### Issues: Fixed #xxx / Gap #xxx
Redundant db access at the end of upload.

### Testing Instructions:

- [ ] Doc added/updated
- [ ] Tests added
