### PR TITLE
Object Versions Replication - NamespaseS3 fix

### DIFF
--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -126,7 +126,7 @@ class ReplicationScanner {
                     dst_bucket.name,
                     keys_diff_map,
                 );
-                dbg.log0(`replication_scanner: scan copy_res: ${copy_res}`);
+                dbg.log0('replication_scanner: scan copy_res:', copy_res);
             }
 
             await replication_store.update_replication_status_by_id(replication_id,

--- a/src/server/utils/bucket_diff.js
+++ b/src/server/utils/bucket_diff.js
@@ -463,10 +463,13 @@ class BucketDiff {
         const params = {
             Bucket: bucket_name,
             Key: key,
+            VersionId: version_id,
         };
-        if (version_id) params.VersionId = version_id;
+
         try {
             const head = await this.s3.headObject(params).promise();
+            //for namespace s3 we are omitting the 'noobaa-namespace-s3-bucket' as it will be defer between buckets
+            if (head?.Metadata) head.Metadata = _.omit(head.Metadata, 'noobaa-namespace-s3-bucket');
             dbg.log1('BucketDiff _get_object_md: finished successfully', head);
             return head;
         } catch (err) {

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -170,7 +170,6 @@ function set_noobaa_s3_connection(sys) {
     const endpoint = system_address[0] && system_address[0].hostname;
     const access_key = sys.owner && sys.owner.access_keys && sys.owner.access_keys[0].access_key.unwrap();
     const secret_key = sys.owner && sys.owner.access_keys && sys.owner.access_keys[0].secret_key.unwrap();
-    dbg.log0('replication_server.set_noobaa_s3_connection: ', endpoint, access_key, secret_key);
     if (!endpoint || !access_key || !secret_key) {
         dbg.error('set_noobaa_s3_connection: temporary error: invalid noobaa s3 connection details');
         return;


### PR DESCRIPTION
### Explain the changes
As we are adding a field  `noobaa-namespace-s3-bucket` MetaData in the `Metadata` with the bucket name, we will always replicate it. in order to avoid this, we will omit this added field.

### Testing Instructions:
1. Enable versioning on 2 aws buckets
2. Write a few different versions for the same object on the first bucket
3. Create 2 namespace buckets pointing to those 2 aws buckets
4. Create a replication between those buckets with syc.versions flag on
5. See that the replication is working as expected

