### PR TITLE
Pass Region For Namespace S3 

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1171,6 +1171,7 @@ function get_namespace_resource_extended_info(namespace_resource) {
         cp_code: namespace_resource.connection.cp_code || undefined,
         azure_log_access_keys: namespace_resource.connection.azure_log_access_keys,
         target_bucket: namespace_resource.connection.target_bucket,
+        region: namespace_resource.connection.region,
         access_key: namespace_resource.connection.access_key,
         secret_key: namespace_resource.connection.secret_key,
         access_mode: namespace_resource.access_mode,


### PR DESCRIPTION
### Explain the changes
1. Pass region for namespace s3 (not using it yet).
Note: It's something I missed in PR #7433 - here we check that it passed to namespace s3.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. Deploy noobaa on MInikube or Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create namespacestore and pass the region explicitly:
`nb namespacestore create aws-s3  <namespace-store-name> --region=<target-bucket-region>`.
3. Create bucket class:
`nb bucketclass create namespace-bucketclass single <bucket-class-name>  --resource=<namespace-store-name> `
4. Create OBC:
`nb obc create <obc-name> --bucketclass=<bucket-class-name>`
6. Use the alias from previous step and run s3 operation, for example:
`kubectl port-forward -n default service/s3 12443:443`
`alias s3-user-1='AWS_SECRET_ACCESS_KEY=<paste-here> AWS_ACCESS_KEY_ID=<paste-here> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
`s3-user-1 s3api head-object --bucket <bucket-name> --key <key-name>`
7. After adding printings to `_setup_single_namespace` (print `r.region`) see that the region passed.

- [ ] Doc added/updated
- [ ] Tests added
