### PR TITLE
[NC | NSFS] RPM Upgrades

### DIFF
--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -1,17 +1,14 @@
 /* Copyright (C) 2016 NooBaa */
 "use strict";
 
-
 const argv = require('minimist')(process.argv);
 const _ = require('lodash');
 const pkg = require('../../package.json');
 const fs = require('fs');
 const path = require('path');
+const json_utils = require('../util/json_utils');
 
-const system_store = require('../server/system_services/system_store').get_instance({ standalone: true });
-const system_server = require('../server/system_services/system_server');
 const dbg = require('../util/debug_module')('UPGRADE');
-const db_client = require('../util/db_client');
 dbg.set_process_name('Upgrade');
 
 function parse_ver(ver) {
@@ -19,8 +16,7 @@ function parse_ver(ver) {
     return stripped_ver.split('.').map(i => Number.parseInt(i, 10));
 }
 
-const { upgrade_scripts_dir } = argv;
-
+const { upgrade_scripts_dir, nsfs_config_root } = argv;
 
 // compares 2 versions. returns positive if ver1 is larger, negative if ver2, 0 if equal
 function version_compare(ver1, ver2) {
@@ -37,9 +33,7 @@ function version_compare(ver1, ver2) {
     return 0;
 }
 
-
-
-async function init() {
+async function init_db_upgrade(db_client, system_store) {
     try {
         dbg.log0('waiting for system_store to load');
         await db_client.instance().connect();
@@ -51,75 +45,13 @@ async function init() {
     }
 }
 
+async function upgrade_db() {
+    const system_store = require('../server/system_services/system_store').get_instance({ standalone: true });
+    const system_server = require('../server/system_services/system_server');
+    const db_client = require('../util/db_client');
 
-function should_upgrade(server_version, container_version) {
-    if (!server_version) {
-        dbg.log('system does not exist. no need for an upgrade');
-        return false;
-    }
-    const ver_comparison = version_compare(container_version, server_version);
-    if (ver_comparison === 0) {
-        if (server_version !== container_version) {
-            dbg.warn(`the container and server appear to be the same version but different builds. (container: ${container_version}), (server: ${server_version})`);
-            dbg.warn(`upgrade is not supported for different builds of the same version!!`);
-        }
-        dbg.log0('the versions of the container and the server match. no need to upgrade');
-        return false;
-    } else if (ver_comparison < 0) {
-        // container version is older than the server version - can't downgrade
-        dbg.error(`the container version (${container_version}) appear to be older than the current server version (${server_version}). cannot downgrade`);
-        throw new Error('attempt to run old container version with newer server version');
-    } else {
-        dbg.log0(`container version is ${container_version} and server version is ${server_version}. will upgrade`);
-        return true;
-    }
-}
-
-
-// load all scripts that should be run according to the given versions
-async function load_required_scripts(server_version, container_version) {
-    // expecting scripts directories to be in a semver format. e.g. ./upgrade_scripts/5.0.1
-    let upgrade_dir_content = [];
     try {
-        upgrade_dir_content = fs.readdirSync(upgrade_scripts_dir);
-    } catch (err) {
-        if (err.code === 'ENOENT') {
-            dbg.warn(`upgrade scripts directory "${upgrade_scripts_dir}" was not found. treating it as empty`);
-        } else {
-            throw err;
-        }
-    }
-    // get all dirs for versions newer than server_version
-    const newer_versions = upgrade_dir_content.filter(ver =>
-            version_compare(ver, server_version) > 0 &&
-            version_compare(ver, container_version) <= 0)
-        .sort(version_compare);
-    dbg.log0(`found the following versions with upgrade scripts which are newer than server version (${server_version}):`, newer_versions);
-    // get all scripts under new_versions
-    const upgrade_scripts = _.flatMap(newer_versions, ver => {
-        const full_path = path.join(upgrade_scripts_dir, ver);
-        const scripts = fs.readdirSync(full_path);
-        return scripts.map(script => path.join(full_path, script));
-    });
-
-    // TODO: we might want to filter out scripts that have run in a previous run of upgrade(e.g. in case of a crash)
-    // for now assume that any upgrade script can be rerun safely
-
-    // for each script load the js file. expecting the export to return an object in the format
-    // {
-    //      description: 'what this upgrade script does'
-    //      run: run_func,
-    // }
-    return upgrade_scripts.map(script => ({
-        ...require(script), // eslint-disable-line global-require
-        file: script
-    }));
-}
-
-
-async function run_upgrade() {
-    try {
-        await init();
+        await init_db_upgrade(db_client, system_store);
     } catch (error) {
         dbg.error('failed to init upgrade process!!');
         process.exit(1);
@@ -175,7 +107,138 @@ async function run_upgrade() {
             exit_code = 1;
         }
     }
+
     return exit_code;
+}
+
+function should_upgrade(server_version, container_version) {
+    if (!server_version) {
+        dbg.log('system does not exist. no need for an upgrade');
+        return false;
+    }
+    const ver_comparison = version_compare(container_version, server_version);
+    if (ver_comparison === 0) {
+        if (server_version !== container_version) {
+            dbg.warn(`the container and server appear to be the same version but different builds. (container: ${container_version}), (server: ${server_version})`);
+            dbg.warn(`upgrade is not supported for different builds of the same version!!`);
+        }
+        dbg.log0('the versions of the container and the server match. no need to upgrade');
+        return false;
+    } else if (ver_comparison < 0) {
+        // container version is older than the server version - can't downgrade
+        dbg.error(`the container version (${container_version}) appear to be older than the current server version (${server_version}). cannot downgrade`);
+        throw new Error('attempt to run old container version with newer server version');
+    } else {
+        dbg.log0(`container version is ${container_version} and server version is ${server_version}. will upgrade`);
+        return true;
+    }
+}
+
+// load all scripts that should be run according to the given versions
+async function load_required_scripts(server_version, container_version) {
+    // expecting scripts directories to be in a semver format. e.g. ./upgrade_scripts/5.0.1
+    let upgrade_dir_content = [];
+    try {
+        upgrade_dir_content = fs.readdirSync(upgrade_scripts_dir);
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            dbg.warn(`upgrade scripts directory "${upgrade_scripts_dir}" was not found. treating it as empty`);
+        } else {
+            throw err;
+        }
+    }
+    // get all dirs for versions newer than server_version
+    const newer_versions = upgrade_dir_content.filter(ver =>
+            version_compare(ver, server_version) > 0 &&
+            version_compare(ver, container_version) <= 0)
+        .sort(version_compare);
+    dbg.log0(`found the following versions with upgrade scripts which are newer than server version (${server_version}):`, newer_versions);
+    // get all scripts under new_versions
+    const upgrade_scripts = _.flatMap(newer_versions, ver => {
+        const full_path = path.join(upgrade_scripts_dir, ver);
+        const scripts = fs.readdirSync(full_path);
+        return scripts.map(script => path.join(full_path, script));
+    });
+
+    // TODO: we might want to filter out scripts that have run in a previous run of upgrade(e.g. in case of a crash)
+    // for now assume that any upgrade script can be rerun safely
+
+    // for each script load the js file. expecting the export to return an object in the format
+    // {
+    //      description: 'what this upgrade script does'
+    //      run: run_func,
+    // }
+    return upgrade_scripts.map(script => ({
+        ...require(script), // eslint-disable-line global-require
+        file: script
+    }));
+}
+
+async function upgrade_nsfs() {
+    const system_data_path = path.join(nsfs_config_root, 'system.json');
+    const system_data = new json_utils.JsonFileWrapper(system_data_path);
+
+    const system = await system_data.read();
+    const upgrade_history = system.upgrade_history;
+    let current_version = system.current_version;
+
+    const new_version = pkg.version;
+
+    let exit_code = 0;
+
+    if (!should_upgrade(current_version, new_version)) return exit_code;
+
+    const this_upgrade = {
+        timestamp: Date.now(),
+        completed_scripts: [],
+        from_version: current_version,
+        to_version: new_version
+    };
+
+    try {
+        const upgrade_scripts = await load_required_scripts(current_version, new_version);
+        for (const script of upgrade_scripts) {
+            dbg.log0(`running upgrade script ${script.file}: ${script.description}`);
+            try {
+                await script.run({ dbg, db_client: null, system_store: null, system_server: null });
+                this_upgrade.completed_scripts.push(script.file);
+            } catch (err) {
+                dbg.error(`failed running upgrade script ${script.file}`, err);
+                this_upgrade.error = err.stack;
+                throw err;
+            }
+        }
+
+        upgrade_history.successful_upgrades = [this_upgrade, ...upgrade_history.successful_upgrades];
+        current_version = new_version;
+    } catch (err) {
+        dbg.error('upgrade manager failed!!!', err);
+        exit_code = 1;
+        if (upgrade_history) {
+            upgrade_history.last_failure = this_upgrade;
+            upgrade_history.last_failure.error = err.stack;
+        }
+    }
+    // update upgrade_history
+    try {
+        await system_data.update({
+            current_version,
+            upgrade_history
+        });
+    } catch (error) {
+        dbg.error('failed to update system_store with upgrade information');
+        exit_code = 1;
+    }
+
+    return exit_code;
+}
+
+async function run_upgrade() {
+    if (nsfs_config_root) {
+        return upgrade_nsfs();
+    }
+
+    return upgrade_db();
 }
 
 async function main() {


### PR DESCRIPTION
### Explain the changes
This PR updates the RPM upgrades to add support for:
1. Auto upgrade trigger for both nsfs and non-nsfs deployments (determines the deployment type based on the processes running).
2. Enhances the upgrade_manager to support NSFS deployments where it does not rely on the presence of a DB.
3. Adds the construct `system.json` under `/etc/noobaa.conf.d` which holds the following data right now `{ "current_version": "...", "upgrade_history": "[ ... ]" }` which is created by the `nsfs.js` during its first boot.

### Testing Instructions:
1. Build and install the RPM.
2. Update the version in package.json and build the RPM again.
3. Upgrade the RPM by running `rpm -U <name>` and you should see additional logs flowing in, ultimately the upgrade_manager should exit with zero exit code.

- [ ] Doc added/updated
- [ ] Tests added
