### PR TITLE
DRAFT ssl cert reload - run in endpoint bg (bz 2237903)

### DIFF
--- a/src/endpoint/cert_worker.js
+++ b/src/endpoint/cert_worker.js
@@ -1,0 +1,44 @@
+/* Copyright (C) 2023 NooBaa */
+'use strict';
+
+const dbg = require('../util/debug_module')(__filename);
+const config = require('../../config.js');
+const ssl_utils = require('../util/ssl_utils');
+
+/**
+ * Updates s3 https server(s) when certificate files are updated.
+ * Note ODF rotates certificates every 13 months.
+ * Some more details in operator's doc/ssl-dns-routing.md -
+ * https://github.com/noobaa/noobaa-operator/blob/master/doc/ssl-dns-routing.md
+ */
+class CertWorker {
+
+    /**
+     * @param {{
+     *   name: string;
+     *   https_server: https.Server;
+     *   sts_server: https.Server;
+     * }} params
+     */
+    constructor({ name, https_server, sts_server }) {
+        this.name = name;
+        this.https_server = https_server;
+        this.sts_server = sts_server;
+    }
+
+    async run_batch() {
+        dbg.log2('certificate bg worker: running check for certificate update');
+        if (await ssl_utils.update_certs_from_disk()) {
+            //certificate were updated. give new cert to https servers.
+            dbg.log0('certificate bg worker: updating certs');
+            const ssl_cert = await ssl_utils.get_ssl_certificate('S3');
+            const ssl_options = { ...ssl_cert, honorCipherOrder: true };
+            this.https_server.setSecureContext(ssl_options);
+            this.sts_server.setSecureContext(ssl_options);
+        }
+        //use same delay as core
+        return config.CLUSTER_HB_INTERVAL;
+    }
+}
+
+exports.CertWorker = CertWorker;

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -41,6 +41,8 @@ const background_scheduler = require('../util/background_scheduler').get_instanc
 const endpoint_stats_collector = require('../sdk/endpoint_stats_collector');
 const { NamespaceMonitor } = require('../server/bg_services/namespace_monitor');
 const { SemaphoreMonitor } = require('../server/bg_services/semaphore_monitor');
+const { CertWorker } = require('./cert_worker');
+
 
 if (process.env.NOOBAA_LOG_LEVEL) {
     const dbg_conf = debug_config.get_debug_config(process.env.NOOBAA_LOG_LEVEL);
@@ -81,6 +83,7 @@ dbg.log0('endpoint: replacing old umask: ', old_umask.toString(8), 'with new uma
 /**
  * @param {EndpointOptions} options
  */
+/* eslint-disable max-statements */
 async function main(options = {}) {
     try {
         // the primary just forks and returns, workers will continue to serve
@@ -189,6 +192,12 @@ async function main(options = {}) {
                 object_io: object_io,
             }));
         }
+
+        background_scheduler.register_bg_worker(new CertWorker({
+            name: 'certificate_worker',
+            https_server: https_server,
+            sts_server: https_server_sts,
+        }));
 
         // Start a monitor to send periodic endpoint reports about endpoint usage.
         start_monitor(internal_rpc_client, endpoint_group_id);

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -41,7 +41,7 @@ const background_scheduler = require('../util/background_scheduler').get_instanc
 const endpoint_stats_collector = require('../sdk/endpoint_stats_collector');
 const { NamespaceMonitor } = require('../server/bg_services/namespace_monitor');
 const { SemaphoreMonitor } = require('../server/bg_services/semaphore_monitor');
-const { CertWorker } = require('./cert_worker');
+const { CertWorker } = require('../server/bg_services/cert_worker');
 
 
 if (process.env.NOOBAA_LOG_LEVEL) {
@@ -194,7 +194,7 @@ async function main(options = {}) {
         }
 
         background_scheduler.register_bg_worker(new CertWorker({
-            name: 'certificate_worker',
+            name: 'cert_worker',
             https_server: https_server,
             sts_server: https_server_sts,
         }));

--- a/src/server/bg_services/cert_worker.js
+++ b/src/server/bg_services/cert_worker.js
@@ -1,9 +1,9 @@
 /* Copyright (C) 2023 NooBaa */
 'use strict';
 
-const dbg = require('../util/debug_module')(__filename);
-const config = require('../../config.js');
-const ssl_utils = require('../util/ssl_utils');
+const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config.js');
+const ssl_utils = require('../../util/ssl_utils');
 
 /**
  * Updates s3 https server(s) when certificate files are updated.
@@ -27,10 +27,10 @@ class CertWorker {
     }
 
     async run_batch() {
-        dbg.log2('certificate bg worker: running check for certificate update');
+        dbg.log2('cert_worker: running check for certificate update');
         if (await ssl_utils.update_certs_from_disk()) {
             //certificate were updated. give new cert to https servers.
-            dbg.log0('certificate bg worker: updating certs');
+            dbg.log0('cert_worker: updating certs');
             const ssl_cert = await ssl_utils.get_ssl_certificate('S3');
             const ssl_options = { ...ssl_cert, honorCipherOrder: true };
             this.https_server.setSecureContext(ssl_options);


### PR DESCRIPTION
### Explain the changes
The certificate for S3 endpoint can change.
Endpoint now periodically checks whether certificate file has changed.
If so, the https servers are updated with new certificate.
(Endpoint pod doesn't need to be restarted).

### Issues: Fixed #xxx / Gap #xxx
https://bugzilla.redhat.com/show_bug.cgi?id=2237903

### Testing Instructions:
Note currently used certificate, eg-
openssl s_client -connect localhost:10443 -showcerts 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | openssl x509 -text -noout

Create a new certificate, eg-
openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname"

From here, follow instructions in https://github.com/noobaa/noobaa-operator/blob/master/doc/ssl-dns-routing.md:
Delete current secret (if exists), eg-
kubectl delete secret noobaa-s3-serving-cert
Create a new secret from the new certificate. Note filenames must be tls.crt and tls.key-
kubectl create secret generic  noobaa-s3-serving-cert --from-file=tls.crt --from-file=tls.key
Wait until new files are created in endpoint's pod /etc/s3-secret.
Wait until background worker runs.
Running openssl -showcerts now should have the new certificate.

- [ ] Doc added/updated
- [ ] Tests added
