### PR TITLE
NSFS | Content-type / directory object fixes

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -40,8 +40,8 @@ const buffers_pool = new buffer_utils.BuffersPool({
 const XATTR_USER_PREFIX = 'user.';
 const XATTR_NOOBAA_INTERNAL_PREFIX = XATTR_USER_PREFIX + 'noobaa.';
 // TODO: In order to verify validity add content_md5_mtime as well
-const XATTR_CONTENT_TYPE = XATTR_USER_PREFIX + 'content_type';
 const XATTR_MD5_KEY = XATTR_USER_PREFIX + 'content_md5';
+const XATTR_CONTENT_TYPE = XATTR_NOOBAA_INTERNAL_PREFIX + 'content_type';
 const XATTR_PART_OFFSET = XATTR_NOOBAA_INTERNAL_PREFIX + 'part_offset';
 const XATTR_PART_SIZE = XATTR_NOOBAA_INTERNAL_PREFIX + 'part_size';
 const XATTR_PART_ETAG = XATTR_NOOBAA_INTERNAL_PREFIX + 'part_etag';
@@ -835,7 +835,7 @@ class NamespaceFS {
                 if (r.common_prefix) {
                     res.common_prefixes.push(r.key);
                 } else {
-                    obj_info = this._get_object_info(bucket, r.key, r.stat, 'null', true);
+                    obj_info = this._get_object_info(bucket, r.key, r.stat, 'null', false, true);
                     if (!list_versions && obj_info.delete_marker) {
                         continue;
                     }
@@ -871,9 +871,23 @@ class NamespaceFS {
             const file_path = await this._find_version_path(fs_context, params, true);
             await this._check_path_in_bucket_boundaries(fs_context, file_path);
             await this._load_bucket(params, fs_context);
-            const stat = await nb_native().fs.stat(fs_context, file_path);
+            let stat = await nb_native().fs.stat(fs_context, file_path);
+            const isDir = isDirectory(stat);
+            if (isDir) {
+                if (!stat.xattr?.[XATTR_DIR_CONTENT]) {
+                    throw error_utils.new_error_code('ENOENT', 'NoSuchKey');
+                } else if (stat.xattr?.[XATTR_DIR_CONTENT] === '0') {
+                    stat.size = 0;
+                } else {
+                    // find dir object content file path  and return its stat + xattr of its parent directory
+                    const dir_content_path = await this._find_version_path(fs_context, params);
+                    const dir_content_path_stat = await nb_native().fs.stat(fs_context, dir_content_path);
+                    const xattr = stat.xattr;
+                    stat = { ...dir_content_path_stat, xattr };
+                }
+            }
             this._throw_if_delete_marker(stat);
-            return this._get_object_info(params.bucket, params.key, stat, params.version_id || 'null');
+            return this._get_object_info(params.bucket, params.key, stat, params.version_id || 'null', isDir);
         } catch (err) {
             this.run_update_issues_report(object_sdk, err);
             throw this._translate_object_error_codes(err);
@@ -1174,41 +1188,40 @@ class NamespaceFS {
         const part_upload = file_path === upload_path;
         const same_inode = params.copy_source && copy_res === copy_status_enum.SAME_INODE;
         const is_dir_content = this._is_directory_content(file_path, params.key);
-
         let stat = await target_file.stat(fs_context);
         this._verify_encryption(params.encryption, this._get_encryption_info(stat));
 
-        let fs_xattr;
         // handle xattr
-        if (!params.copy_source || !params.xattr_copy) {
-            fs_xattr = to_fs_xattr(params.xattr);
-            if (params.content_type) {
-                fs_xattr = fs_xattr || {};
-                fs_xattr[XATTR_CONTENT_TYPE] = params.content_type;
-            }
-            if (digest) {
-                const { md5_b64, key, bucket, upload_id } = params;
-                if (md5_b64) {
-                    const md5_hex = Buffer.from(md5_b64, 'base64').toString('hex');
-                    if (md5_hex !== digest) throw new Error('_upload_stream mismatch etag: ' + util.inspect({ key, bucket, upload_id, md5_hex, digest }));
-                }
-                fs_xattr = this._assign_md5_to_fs_xattr(digest, fs_xattr);
-            }
-            if (part_upload) {
-                fs_xattr = await this._assign_part_props_to_fs_xattr(fs_context, params.size, digest, offset, fs_xattr);
-            }
-            if (!part_upload && (this._is_versioning_enabled() || this._is_versioning_suspended())) {
-                const cur_ver_info = await this._get_version_info(fs_context, file_path);
-                fs_xattr = await this._assign_versions_to_fs_xattr(fs_context, cur_ver_info, stat, params.key, fs_xattr);
-            }
-            if (!part_upload && params.storage_class) {
-                fs_xattr = Object.assign(fs_xattr || {}, {
-                    [XATTR_STORAGE_CLASS_KEY]: params.storage_class
-                });
-            }
+        // assign user xattr on non copy / copy with xattr_copy header provided
+        const copy_xattr = params.copy_source && params.xattr_copy;
+        let fs_xattr = copy_xattr ? undefined : to_fs_xattr(params.xattr);
 
-            if (fs_xattr && !is_dir_content) await target_file.replacexattr(fs_context, fs_xattr);
+        // assign noobaa internal xattr - content type, md5, versioning xattr
+        if (params.content_type) {
+            fs_xattr = fs_xattr || {};
+            fs_xattr[XATTR_CONTENT_TYPE] = params.content_type;
         }
+        if (digest) {
+            const { md5_b64, key, bucket, upload_id } = params;
+            if (md5_b64) {
+                const md5_hex = Buffer.from(md5_b64, 'base64').toString('hex');
+                if (md5_hex !== digest) throw new Error('_upload_stream mismatch etag: ' + util.inspect({ key, bucket, upload_id, md5_hex, digest }));
+            }
+            fs_xattr = this._assign_md5_to_fs_xattr(digest, fs_xattr);
+        }
+        if (part_upload) {
+            fs_xattr = await this._assign_part_props_to_fs_xattr(fs_context, params.size, digest, offset, fs_xattr);
+        }
+        if (!part_upload && (this._is_versioning_enabled() || this._is_versioning_suspended())) {
+            const cur_ver_info = await this._get_version_info(fs_context, file_path);
+            fs_xattr = await this._assign_versions_to_fs_xattr(fs_context, cur_ver_info, stat, params.key, fs_xattr);
+        }
+        if (!part_upload && params.storage_class) {
+            fs_xattr = Object.assign(fs_xattr || {}, {
+                [XATTR_STORAGE_CLASS_KEY]: params.storage_class
+            });
+        }
+        if (fs_xattr && !is_dir_content) await target_file.replacexattr(fs_context, fs_xattr);
         // fsync
         if (config.NSFS_TRIGGER_FSYNC) await target_file.fsync(fs_context);
         dbg.log1('NamespaceFS._finish_upload:', open_mode, file_path, upload_path, fs_xattr);
@@ -1219,7 +1232,10 @@ class NamespaceFS {
         }
 
         // when object is a dir, xattr are set on the folder itself and the content is in .folder file
-        if (is_dir_content) await this._assign_dir_content_to_xattr(fs_context, fs_xattr, { ...params, size: stat.size });
+        if (is_dir_content) {
+            if (params.copy_source) fs_xattr = await this._get_copy_source_xattr(params, fs_context, fs_xattr);
+            await this._assign_dir_content_to_xattr(fs_context, fs_xattr, { ...params, size: stat.size }, copy_xattr);
+        }
         stat = await nb_native().fs.stat(fs_context, file_path);
         const upload_info = this._get_upload_info(stat, fs_xattr && fs_xattr[XATTR_VERSION_ID]);
         return upload_info;
@@ -1227,22 +1243,35 @@ class NamespaceFS {
 
     async _create_empty_dir_content(fs_context, params, file_path) {
         await this._make_path_dirs(file_path, fs_context);
+        const copy_xattr = params.copy_source && params.xattr_copy;
 
-        const fs_xattr = to_fs_xattr(params.xattr);
-        await this._assign_dir_content_to_xattr(fs_context, fs_xattr, params);
+        let fs_xattr = copy_xattr ? {} : to_fs_xattr(params.xattr) || {};
+        if (params.content_type) {
+            fs_xattr = fs_xattr || {};
+            fs_xattr[XATTR_CONTENT_TYPE] = params.content_type;
+        }
+        if (params.copy_source) fs_xattr = await this._get_copy_source_xattr(params, fs_context, fs_xattr);
+
+        await this._assign_dir_content_to_xattr(fs_context, fs_xattr, params, copy_xattr);
         // when .folder exist and it's no upload flow - .folder should be deleted if it exists
         try {
-           await nb_native().fs.unlink(fs_context, file_path);
+            await nb_native().fs.unlink(fs_context, file_path);
         } catch (err) {
             if (err.code !== 'ENOENT') throw err;
             dbg.log0(`namespace_fs._create_empty_dir_content: dir object file ${config.NSFS_FOLDER_OBJECT_NAME} was already deleted`);
         }
         const dir_path = this._get_file_md_path(params);
         const stat = await nb_native().fs.stat(fs_context, dir_path);
-        const upload_info = this._get_upload_info(stat, fs_xattr && fs_xattr[XATTR_VERSION_ID]);
+        const upload_info = this._get_upload_info(stat, fs_xattr[XATTR_VERSION_ID]);
         return upload_info;
     }
 
+    async _get_copy_source_xattr(params, fs_context, fs_xattr) {
+        const is_source_dir = params.copy_source.key.endsWith('/');
+        const source_file_md_path = await this._find_version_path(fs_context, params.copy_source, is_source_dir);
+        const source_stat = await nb_native().fs.stat(fs_context, source_file_md_path);
+        return { ...source_stat.xattr, ...fs_xattr };
+    }
 
     // move to dest GPFS (wt) / POSIX (w / undefined) - non part upload
     async _move_to_dest(fs_context, source_path, dest_path, target_file, open_mode, key) {
@@ -2020,12 +2049,14 @@ class NamespaceFS {
      * assigns XATTR_DIR_CONTENT xattr to the fs_xattr object of the file and set to the directory
      * existing xattr starting with XATTR_USER_PREFIX will be cleared
     */
-    async _assign_dir_content_to_xattr(fs_context, fs_xattr, params) {
+    async _assign_dir_content_to_xattr(fs_context, fs_xattr, params, copy_xattr) {
         const dir_path = this._get_file_md_path(params);
         fs_xattr = Object.assign(fs_xattr || {}, {
             [XATTR_DIR_CONTENT]: params.size || 0
         });
-        await this.set_fs_xattr_op(fs_context, dir_path, fs_xattr, XATTR_USER_PREFIX);
+        // when copying xattr we shouldn't clear user xattr
+        const clear_xattr = copy_xattr ? '' : XATTR_USER_PREFIX;
+        await this.set_fs_xattr_op(fs_context, dir_path, fs_xattr, clear_xattr);
     }
 
     /**
@@ -2090,15 +2121,18 @@ class NamespaceFS {
      * @param {nb.NativeFSStats} stat 
      * @returns {nb.ObjectInfo}
      */
-     _get_object_info(bucket, key, stat, return_version_id, is_latest = true) {
+     _get_object_info(bucket, key, stat, return_version_id, isDir, is_latest = true) {
         const etag = this._get_etag(stat);
         const create_time = stat.mtime.getTime();
         const encryption = this._get_encryption_info(stat);
         const version_id = return_version_id && this._is_versioning_enabled() && this._get_version_id_by_xattr(stat);
         const delete_marker = stat.xattr[XATTR_DELETE_MARKER] === 'true';
-        const content_type = stat.xattr[XATTR_CONTENT_TYPE] || mime.getType(key) || 'application/octet-stream';
-        const storage_class = s3_utils.parse_storage_class(stat.xattr[XATTR_STORAGE_CLASS_KEY]);
+        const dir_content_type = stat.xattr[XATTR_DIR_CONTENT] && ((Number(stat.xattr[XATTR_DIR_CONTENT]) > 0 && 'application/octet-stream') || 'application/x-directory');
+        const content_type = stat.xattr[XATTR_CONTENT_TYPE] ||
+            (isDir && dir_content_type) ||
+            mime.getType(key) || 'application/octet-stream';
 
+        const storage_class = s3_utils.parse_storage_class(stat.xattr[XATTR_STORAGE_CLASS_KEY]);
         let restore_status;
         if (storage_class === s3_utils.STORAGE_CLASS_GLACIER) {
             const restore_request = stat.xattr[XATTR_RESTORE_REQUEST] ? parseInt(stat.xattr[XATTR_RESTORE_REQUEST], 10) : null;

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -26,8 +26,11 @@ const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null,
 // TODO: In order to verify validity add content_md5_mtime as well
 const XATTR_MD5_KEY = 'content_md5';
 const XATTR_DIR_CONTENT = 'user.noobaa.dir_content';
+const XATTR_CONTENT_TYPE = 'user.noobaa.content_type';
 
 const MAC_PLATFORM = 'darwin';
+const dir_content_type = 'application/x-directory';
+const stream_content_type = 'application/octet-stream';
 
 const DEFAULT_FS_CONFIG = {
     uid: process.getuid(),
@@ -156,12 +159,17 @@ mocha.describe('namespace_fs', function() {
         console.log(inspect(res));
     });
 
-    mocha.it('read_object_md succeed on directory head', async function() {
-        const res = await ns_src.read_object_md({
-            bucket: src_bkt,
-            key: src_key.substr(0, src_key.lastIndexOf('/')),
-        }, dummy_object_sdk);
-        console.log(inspect(res));
+    mocha.it('read_object_md succeed on directory head - not directory object - should fail', async function() {
+        try {
+            const res = await ns_src.read_object_md({
+                bucket: src_bkt,
+                key: src_key.substr(0, src_key.lastIndexOf('/')),
+            }, dummy_object_sdk);
+            console.log(inspect(res));
+            assert.fail('head should have failed with no such key');
+        } catch (err) {
+            assert.equal(err.code, 'ENOENT');
+        }
     });
 
     mocha.describe('read_object_stream', function() {
@@ -597,6 +605,7 @@ mocha.describe('namespace_fs', function() {
     });
 });
 
+const add_user_prefix = user_xattr => _.mapKeys(user_xattr, (val, key) => 'user.' + key);
 
 
 mocha.describe('namespace_fs folders tests', function() {
@@ -798,7 +807,6 @@ mocha.describe('namespace_fs folders tests', function() {
             }, dummy_object_sdk, read_res);
             assert.equal(read_res.buffers.length, 1);
             assert.equal(read_res.total_length, 100);
-
             if (Object.keys(not_user_xattr).length) await set_xattr(DEFAULT_FS_CONFIG, ns_tmp_bucket_path + '/' + upload_key_2, not_user_xattr);
 
             const new_size = 0;
@@ -877,15 +885,27 @@ mocha.describe('namespace_fs folders tests', function() {
             await fs_utils.file_must_not_exist(p);
         });
 
+        mocha.it(`get folder object md - should fail, not a directory object`, async function() {
+            try {
+                await ns_tmp.read_object_md({
+                    bucket: upload_bkt,
+                    key: dir_1,
+                }, dummy_object_sdk);
+                assert.fail('get object should have failed with no such key');
+            } catch (err) {
+                assert.equal(err.code, 'ENOENT');
+            }
+        });
+
         mocha.it(`read folder object md missing md`, async function() {
-            const dir_path = ns_tmp_bucket_path + '/' + dir_1;
+            const dir_path = ns_tmp_bucket_path + '/' + upload_key_1;
             const get_md_res = await ns_tmp.read_object_md({
                 bucket: upload_bkt,
-                key: dir_1,
+                key: upload_key_1,
             }, dummy_object_sdk);
-            assert.equal(Object.keys(get_md_res.xattr).length, 0);
+            assert.deepEqual(get_md_res.xattr, md);
             const full_xattr = await get_xattr(dir_path);
-            assert.equal(Object.keys(full_xattr).length, 0);
+            assert.deepEqual(full_xattr, { ...user_md_and_dir_content_xattr, [XATTR_DIR_CONTENT]: obj_sizes_map[upload_key_1] });
         });
 
         mocha.it(`put /a/b/c folder object md exists`, async function() {
@@ -1044,6 +1064,7 @@ mocha.describe('namespace_fs folders tests', function() {
 //     }, dummy_object_sdk);
 //     console.log('delete_object with trailing / (key 2) response', inspect(delete_res));
 // });
+
 
 async function get_xattr(file_path) {
     const stat = await nb_native().fs.stat(DEFAULT_FS_CONFIG, file_path);
@@ -1215,6 +1236,8 @@ mocha.describe('namespace_fs copy object', function() {
     if (process.platform === MAC_PLATFORM) {
         tmp_fs_path = '/private/' + tmp_fs_path;
     }
+    const md1 = { key123: 'val123', key234: 'val234' };
+
     const dummy_object_sdk = make_dummy_object_sdk();
 
     const ns_tmp_bucket_path = `${tmp_fs_path}/${src_bkt}`;
@@ -1236,6 +1259,7 @@ mocha.describe('namespace_fs copy object', function() {
         const copy_xattr = {};
         const copy_key_1 = 'copy_key_1';
         const data = crypto.randomBytes(100);
+        const empty_data = crypto.randomBytes(0);
 
         mocha.before(async function() {
             const upload_res = await ns_tmp.upload_object({
@@ -1303,6 +1327,262 @@ mocha.describe('namespace_fs copy object', function() {
                 key: copy_key_1,
             }, dummy_object_sdk);
             console.log('delete_object: copy twice to the same file name response', inspect(delete_copy_res));
+        });
+
+
+        mocha.it(`copy directory object to same dir - size 100`, async function() {
+            const key = 'dir_to_copy_to_itself0/';
+            const res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: key,
+                xattr: md1,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+                size: 100
+            }, dummy_object_sdk);
+            const file_path = ns_tmp_bucket_path + '/' + key;
+            let xattr = await get_xattr(file_path);
+            let read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: key
+            }, dummy_object_sdk);
+            assert.equal(stream_content_type, read_md_res.content_type);
+            assert.equal(res.etag, read_md_res.etag);
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(read_md_res.xattr), [XATTR_DIR_CONTENT]: `${read_md_res.size}` });
+            md1[s3_utils.XATTR_SORT_SYMBOL] = true;
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+
+            const new_content_type = 'application/x-directory1';
+            const copy_res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key,
+                copy_source: { bucket: upload_bkt, key},
+                size: 100,
+                content_type: new_content_type,
+                xattr_copy: true
+            }, dummy_object_sdk);
+            xattr = await get_xattr(file_path);
+            read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: key
+            }, dummy_object_sdk);
+            assert.equal(new_content_type, read_md_res.content_type);
+            assert.equal(copy_res.etag, read_md_res.etag);
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+            assert.deepStrictEqual(xattr, {
+                ...add_user_prefix(read_md_res.xattr),
+                [XATTR_DIR_CONTENT]: `${read_md_res.size}`,
+                [XATTR_CONTENT_TYPE]: new_content_type
+            });
+        });
+
+        mocha.it(`override directory object - size 100 -> size 0`, async function() {
+            const key = 'dir_to_override0/';
+            let res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: key,
+                xattr: md1,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+                size: 100
+            }, dummy_object_sdk);
+            const file_path = ns_tmp_bucket_path + '/' + key;
+            let xattr = await get_xattr(file_path);
+            let read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: key
+            }, dummy_object_sdk);
+            assert.equal(stream_content_type, read_md_res.content_type);
+            assert.equal(res.etag, read_md_res.etag);
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(read_md_res.xattr), [XATTR_DIR_CONTENT]: `${read_md_res.size}` });
+            md1[s3_utils.XATTR_SORT_SYMBOL] = true;
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+
+            res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key,
+                source_stream: buffer_utils.buffer_to_read_stream(empty_data),
+                size: 0,
+            }, dummy_object_sdk);
+            xattr = await get_xattr(file_path);
+            read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: key
+            }, dummy_object_sdk);
+            assert.equal(read_md_res.size, 0);
+            assert.equal(dir_content_type, read_md_res.content_type);
+            assert.equal(res.etag, read_md_res.etag);
+            assert.deepStrictEqual(0, Object.keys(read_md_res.xattr).length);
+            assert.deepStrictEqual(xattr, {
+                ...add_user_prefix(read_md_res.xattr),
+                [XATTR_DIR_CONTENT]: `${read_md_res.size}`
+            });
+        });
+
+
+        mocha.it(`copy directory object to same dir - size 0`, async function() {
+            const key = 'dir_to_copy_to_itself1/';
+            const new_content_type = 'application/x-directory2';
+
+            const res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: key,
+                xattr: md1,
+                source_stream: buffer_utils.buffer_to_read_stream(empty_data),
+                size: 0
+            }, dummy_object_sdk);
+            const file_path = ns_tmp_bucket_path + '/' + key;
+            let xattr = await get_xattr(file_path);
+            let read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: key
+            }, dummy_object_sdk);
+            assert.equal(dir_content_type, read_md_res.content_type);
+            assert.equal(res.etag, read_md_res.etag);
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(read_md_res.xattr), [XATTR_DIR_CONTENT]: `${read_md_res.size}` });
+            md1[s3_utils.XATTR_SORT_SYMBOL] = true;
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+
+            const copy_res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key,
+                copy_source: { bucket: upload_bkt, key},
+                size: 0,
+                xattr: { k1: 'v1', k2: 'v2', k3: 'v3' },
+                content_type: new_content_type,
+            }, dummy_object_sdk);
+            xattr = await get_xattr(file_path);
+            read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key
+            }, dummy_object_sdk);
+            assert.equal(new_content_type, read_md_res.content_type);
+            assert.equal(copy_res.etag, read_md_res.etag);
+            assert.deepStrictEqual(xattr, {
+                ...add_user_prefix(read_md_res.xattr),
+                [XATTR_DIR_CONTENT]: `${read_md_res.size}`,
+                [XATTR_CONTENT_TYPE]: new_content_type
+            });
+        });
+
+        mocha.it(`copy directory object to another dir`, async function() {
+            const key1 = 'dir_to_copy_to_itself2/';
+            const key2 = 'dir_to_copy_to_itself3/';
+
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: key1,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+                size: 100,
+                xattr: md1
+            }, dummy_object_sdk);
+            const file_path1 = ns_tmp_bucket_path + '/' + key1;
+            let xattr = await get_xattr(file_path1);
+            let read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: key1
+            }, dummy_object_sdk);
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(read_md_res.xattr), [XATTR_DIR_CONTENT]: `${read_md_res.size}` });
+            assert.equal(stream_content_type, read_md_res.content_type);
+
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: key2,
+                copy_source: { bucket: upload_bkt, key: key1 },
+                size: 100,
+                xattr_copy: true
+            }, dummy_object_sdk);
+            const file_path2 = ns_tmp_bucket_path + '/' + key2;
+            xattr = await get_xattr(file_path2);
+            read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: key2
+            }, dummy_object_sdk);
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(read_md_res.xattr), [XATTR_DIR_CONTENT]: `${read_md_res.size}` });
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+            assert.equal(stream_content_type, read_md_res.content_type);
+
+        });
+
+        mocha.it(`copy object to a directory dir - size 100`, async function() {
+            const src_key = 'obj_to_copy1';
+            const dst_key = 'dir_obj_dst1/';
+
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: src_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+                size: 100,
+                xattr: md1
+            }, dummy_object_sdk);
+            const file_path1 = ns_tmp_bucket_path + '/' + src_key;
+            let xattr = await get_xattr(file_path1);
+            let read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: src_key
+            }, dummy_object_sdk);
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(read_md_res.xattr) });
+            assert.equal(stream_content_type, read_md_res.content_type);
+
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: dst_key,
+                copy_source: { bucket: upload_bkt, key: src_key },
+                size: 100,
+                xattr_copy: true,
+            }, dummy_object_sdk);
+            const file_path2 = ns_tmp_bucket_path + '/' + dst_key;
+            xattr = await get_xattr(file_path2);
+            read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: dst_key
+            }, dummy_object_sdk);
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(read_md_res.xattr), [XATTR_DIR_CONTENT]: `${read_md_res.size}` });
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+            assert.equal(stream_content_type, read_md_res.content_type);
+
+        });
+
+        mocha.it(`copy object to a directory dir - size 0`, async function() {
+            const src_key = 'obj_to_copy2';
+            const dst_key = 'dir_obj_dst2/';
+
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: src_key,
+                source_stream: buffer_utils.buffer_to_read_stream(empty_data),
+                size: 0,
+                xattr: md1
+            }, dummy_object_sdk);
+            const file_path1 = ns_tmp_bucket_path + '/' + src_key;
+            let xattr = await get_xattr(file_path1);
+            const read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: src_key
+            }, dummy_object_sdk);
+
+            assert.deepStrictEqual(md1, read_md_res.xattr);
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(read_md_res.xattr) });
+            assert.equal(stream_content_type, read_md_res.content_type);
+
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: dst_key,
+                copy_source: { bucket: upload_bkt, key: src_key },
+                size: 0,
+                xattr_copy: true
+            }, dummy_object_sdk);
+            const file_path2 = ns_tmp_bucket_path + '/' + dst_key;
+            xattr = await get_xattr(file_path2);
+            const copy_read_md_res = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: dst_key
+            }, dummy_object_sdk);
+
+            assert.deepStrictEqual(xattr, { ...add_user_prefix(copy_read_md_res.xattr), [XATTR_DIR_CONTENT]: `${copy_read_md_res.size}` });
+            assert.deepStrictEqual(md1, copy_read_md_res.xattr);
+            assert.equal(dir_content_type, copy_read_md_res.content_type);
+
         });
 
         mocha.after(async function() {


### PR DESCRIPTION
### Explain the changes

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #7430 
2. Fixed issue raised on slack - https://noobaa.slack.com/archives/C0NSK9ZNE/p1694374090079059
3. Fixed #7421
4. Today on some flows like override/copy we clean the user. xattr but we shouldn't clean internal xattrs like MD5, we need to merge and have a complete fix for it in - https://github.com/noobaa/noobaa-core/pull/7463 which contains the initial implementation of user.noobaa. xattr prefix in order to differentiate between user xattr and noobaa internal xattr

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added