### PR TITLE
NSFS | NC | nsfs health check

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -77,3 +77,9 @@ The following is an expected valid response -
 ```xml
 <?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>123</ID><DisplayName>NooBaa</DisplayName></Owner><Buckets><Bucket><Name>bucket1</Name><CreationDate>2023-08-30T17:12:29.000Z</CreationDate></Bucket></Buckets></ListAllMyBucketsResult>
 ```
+
+## health
+Health status of the NSFS can be fetched using the command line.
+ ```
+ node usr/local/noobaa-core/src/cmd/health
+ ```

--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -1,0 +1,130 @@
+/* Copyright (C) 2020 NooBaa */
+'use strict';
+
+const os_util = require('../util/os_utils');
+const { make_https_request } = require('../util/http_utils');
+const minimist = require('minimist');
+
+
+
+const HELP = `
+Help:
+
+    "nsfs" is a noobaa-core command runs a local S3 endpoint on top of a filesystem.
+    Each sub directory of the root filesystem represents an S3 bucket.
+    Health command will return the health status of deployed nsfs.
+`;
+
+const USAGE = `
+Usage:
+
+    node src/cmd/health [options...]
+`;
+
+
+const OPTIONS = `
+Options:
+
+    --deployment_type <type>         (default nc)   Set the nsfs type for heath check.
+
+`;
+
+function print_usage() {
+    console.warn(HELP);
+    console.warn(USAGE.trimStart());
+    console.warn(OPTIONS.trimStart());
+    process.exit(1);
+}
+
+const HOSTNAME = "localhost";
+const PORT = 6443;
+const SERVICE = "nsfs";
+
+async function nc_nsfs_health() {
+
+    const {service_status, pid} = await get_service_state();
+    const status_code = await get_endpoint_response();
+    const memory = await get_service_memory_usage();
+    let service_health = "OK";
+    if (service_status !== "active" || pid === "0" || status_code !== 200) {
+      service_health = "NOTOK";
+    }
+    const helath = {
+      service_name: 'nsfs',
+      status: service_health,
+      memory: memory,
+      checks: {
+          service: {
+              service_status: service_status,
+              pid: pid,
+          },
+          endpoint: {
+              endpoint_response: status_code,
+          },
+      }
+  };
+  console.log(helath);
+}
+
+async function get_service_state() {
+  const service_status = await os_util.exec('systemctl show -p ActiveState --value ' + SERVICE, {
+    ignore_rc: true,
+    return_stdout: true,
+    trim_stdout: true,
+  });
+  const pid = await os_util.exec('systemctl show --property MainPID --value ' + SERVICE, {
+    ignore_rc: true,
+    return_stdout: true,
+    trim_stdout: true,
+  });
+  return { service_status: service_status, pid: pid };
+}
+
+async function get_endpoint_response() {
+  const path = '';
+    try {
+        const response = await make_https_request({ HOSTNAME, port: PORT, path, method: 'GET',
+                              rejectUnauthorized: false });
+        if (response) {
+          const status_code = response.statusCode;
+          return status_code;
+        }
+    } catch (err) {
+      console.debug('Error while pinging endpoint host :' + HOSTNAME + ', port ' + PORT);
+    }
+    return 0;
+}
+
+async function get_service_memory_usage() {
+  const memory_status = await os_util.exec('systemctl status ' + SERVICE + ' | grep Memory ', {
+    ignore_rc: true,
+    return_stdout: true,
+    trim_stdout: true,
+  });
+  if (memory_status) {
+    const memory = memory_status.split("Memory: ")[1].trim();
+    return memory;
+  }
+}
+
+
+async function main(argv = minimist(process.argv.slice(2))) {
+  try {
+
+    if (argv.help || argv.h) return print_usage();
+
+    const deployment_type = argv.deployment_type || 'nc';
+    if (deployment_type === 'nc') {
+      return nc_nsfs_health();
+    } else {
+      console.log('Health is not supported for simple nsfs deployment.');
+    }
+  } catch (err) {
+    console.error('Helath: exit on error', err.stack || err);
+    process.exit(2);
+  }
+}
+
+exports.main = main;
+
+if (require.main === module) main();

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -16,6 +16,7 @@ const CORE_COMMANDS = Object.freeze({
     s3: () => require('../endpoint/endpoint'),
     bg: () => require('../server/bg_workers'),
     s3cat: () => require('../tools/s3cat'),
+    health: () => require('./health'),
 });
 
 const HELP = `

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -71,9 +71,9 @@ Options:
 
     --iam_json_schema                           Print the json schema of the identity files in iam dir.
     --iam_ttl <seconds>     (default 60)        Identities expire after this amount of time, and re-read from the FS.
-    --config_root <dir>     (default none)      Configuration files for Noobaa standalon NSFS. It includes config files for environment variables(<config-root>/.env), 
-                                                local configuration(<config-root>/config-local.js), authentication (<config-root>/accounts/<access-key>.json) and 
-                                                bucket schema (<config-root>/buckets/<bucket-name>.json).
+    --config_root <dir>     (default none)      Configuration files for Noobaa standalon NSFS. It includes config files for environment variables(<config_root>/.env), 
+                                                local configuration(<config_root>/config-local.js), authentication (<config_root>/accounts/<access-key>.json) and 
+                                                bucket schema (<config_root>/buckets/<bucket-name>.json).
 
     ## features
 

--- a/src/deploy/nsfs.service
+++ b/src/deploy/nsfs.service
@@ -7,9 +7,10 @@ RestartSec=2
 User=root
 Group=root
 Environment=
-ExecStart=/usr/local/node/bin/node /usr/local/noobaa-core/src/cmd/nsfs.js /tmp/test/
-ExecStop=/bin/kill QUIT $MAINPID
+ExecStart=/usr/local/node/bin/node /usr/local/noobaa-core/src/cmd/nsfs.js --config_root /tmp/config
+ExecStop=/bin/kill $MAINPID
 WorkingDirectory=/usr/local/noobaa-core/
 LimitNOFILE=65536
 
 [Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### Explain the changes
1. This PR will add a script to validate the nc nsfs health, 
eg:
bash ./nc_nsfs_health.sh
`{
  "service_name": "nsfs",
  "status": "NOTOK",
  "memory": "",
  "checks": {
    "service": {
      "service_status": "activating",
      "pid": "0"
    },
    "endpoint": {
      "endpoint_response": "000"
    },
  }
} `

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/MCGI-170

### Testing Instructions:
1. run the bash command `bash ./nc_nsfs_health.sh`


- [ ] Doc added/updated
- [ ] Tests added
