### PR TITLE
Reload certs 2237903 watch

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -81,6 +81,7 @@ dbg.log0('endpoint: replacing old umask: ', old_umask.toString(8), 'with new uma
 /**
  * @param {EndpointOptions} options
  */
+/* eslint-disable max-statements */
 async function main(options = {}) {
     try {
         // the primary just forks and returns, workers will continue to serve
@@ -145,11 +146,17 @@ async function main(options = {}) {
         const endpoint_request_handler = create_endpoint_handler(init_request_sdk, virtual_hosts);
         const endpoint_request_handler_sts = create_endpoint_handler(init_request_sdk, virtual_hosts, true);
 
-        const ssl_cert = await ssl_utils.get_ssl_certificate('S3');
-        const ssl_options = { ...ssl_cert, honorCipherOrder: true };
+        const ssl_cert_info = await ssl_utils.get_ssl_cert_info('S3');
+        const ssl_options = { ...ssl_cert_info.cert, honorCipherOrder: true };
         const http_server = http.createServer(endpoint_request_handler);
         const https_server = https.createServer(ssl_options, endpoint_request_handler);
         const https_server_sts = https.createServer(ssl_options, endpoint_request_handler_sts);
+        ssl_cert_info.on('update', updated_ssl_cert_info => {
+            dbg.log0("Setting updated S3 ssl certs for endpoint.");
+            const updated_ssl_options = { ...updated_ssl_cert_info.cert, honorCipherOrder: true };
+            https_server.setSecureContext(updated_ssl_options);
+            https_server_sts.setSecureContext(updated_ssl_options);
+        });
 
         if (http_port > 0) {
             dbg.log0('Starting S3 HTTP', http_port);

--- a/src/server/bg_services/server_monitor.js
+++ b/src/server/bg_services/server_monitor.js
@@ -9,7 +9,6 @@ const os_utils = require('../../util/os_utils');
 const Dispatcher = require('../notifications/dispatcher');
 const server_rpc = require('../server_rpc');
 const system_store = require('../system_services/system_store').get_instance();
-const ssl_utils = require('../../util/ssl_utils');
 const db_client = require('../../util/db_client');
 
 
@@ -53,7 +52,6 @@ async function run_monitors() {
 
     _check_dns_and_phonehome();
     await _check_internal_ips();
-    await _verify_ssl_certs();
     await _check_db_disk_usage();
     await _check_address_changes(CONTAINER_PLATFORM);
 }
@@ -78,17 +76,6 @@ function _check_internal_ips() {
             monitoring_status.cluster_status = "UNKNOWN";
             dbg.warn(`Error when trying to check cluster servers' status.`, err.stack || err);
         });
-}
-
-async function _verify_ssl_certs() {
-    dbg.log2('_verify_ssl_certs');
-    const updated = await ssl_utils.update_certs_from_disk();
-    if (updated) {
-        dbg.log0('_verify_ssl_certs: SSL certificates changed, restarting relevant services');
-        await os_utils.restart_services([
-            'webserver'
-        ]);
-    }
 }
 
 async function _check_db_disk_usage() {

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -90,8 +90,12 @@ async function main() {
         server_rpc.rpc.register_ws_transport(http_server);
         await P.ninvoke(http_server, 'listen', http_port);
 
-        const ssl_cert = await ssl_utils.get_ssl_certificate('MGMT');
-        const https_server = https.createServer({ ...ssl_cert, honorCipherOrder: true }, app);
+        const ssl_cert_info = await ssl_utils.get_ssl_cert_info('MGMT');
+        const https_server = https.createServer({ ...ssl_cert_info.cert, honorCipherOrder: true }, app);
+        ssl_cert_info.on('update', updated_cert_info => {
+            dbg.log0("Setting updated MGMT ssl certs for web server.");
+            https_server.setSecureContext({...updated_cert_info.cert, honorCipherOrder: true });
+        });
         server_rpc.rpc.register_ws_transport(https_server);
         await P.ninvoke(https_server, 'listen', https_port);
 

--- a/src/util/ssl_utils.js
+++ b/src/util/ssl_utils.js
@@ -8,19 +8,42 @@ const https = require('https');
 const Semaphore = require('../util/semaphore');
 const dbg = require('./debug_module')(__filename);
 const nb_native = require('./nb_native');
+const { EventEmitter } = require('events');
 
-const init_cert_info = dir => ({
-    dir,
-    cert: null,
-    is_loaded: false,
-    is_generated: false,
-    sem: new Semaphore(1)
-});
+class CertInfo extends EventEmitter {
+
+    constructor(dir) {
+        super();
+        this.dir = dir;
+        this.cert = null;
+        this.is_loaded = false;
+        this.is_generated = false;
+        this.sem = new Semaphore(1);
+    }
+
+    async file_notification(event, filename) {
+        try {
+            const cert_on_disk = await _read_ssl_certificate(this.dir);
+            if (this.cert.key === cert_on_disk.key) {
+                return;
+            }
+
+            this.cert = cert_on_disk;
+            this.is_generated = false;
+
+            this.emit('update', this);
+        } catch (err) {
+            if (err.code !== 'ENOENT') {
+                dbg.warn(`SSL certificate failed to update from dir ${this.dir}:`, err.message);
+            }
+        }
+    }
+}
 
 const certs = {
-    MGMT: init_cert_info('/etc/mgmt-secret'),
-    S3: init_cert_info('/etc/s3-secret'),
-    EXTERNAL_DB: init_cert_info('/etc/external-db-secret'),
+    MGMT: new CertInfo('/etc/mgmt-secret'),
+    S3: new CertInfo('/etc/s3-secret'),
+    EXTERNAL_DB: new CertInfo('/etc/external-db-secret'),
 };
 
 function generate_ssl_certificate() {
@@ -37,19 +60,19 @@ function verify_ssl_certificate(certificate) {
 }
 
 // Get SSL certificate (load once then serve from cache)
-function get_ssl_certificate(service) {
+function get_ssl_cert_info(service) {
     const cert_info = certs[service];
     if (!cert_info) {
         throw new Error(`Invalid service name, got: ${service}`);
     }
 
     if (cert_info.is_loaded) {
-        return cert_info.cert;
+        return cert_info;
     }
 
     return cert_info.sem.surround(async () => {
         if (cert_info.is_loaded) {
-            return cert_info.cert;
+            return cert_info;
         }
 
         try {
@@ -71,40 +94,19 @@ function get_ssl_certificate(service) {
         }
 
         cert_info.is_loaded = true;
-        return cert_info.cert;
+
+        try {
+            fs.watch(cert_info.dir, {}, cert_info.file_notification.bind(cert_info));
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                dbg.warn("Certificate folder ", cert_info.dir, " does not exist. New certificate won't be loaded.");
+            } else {
+                dbg.error("Failed to watch certificate dir ", cert_info.dir, ". err = ", err);
+            }
+        }
+
+        return cert_info;
     });
-}
-
-// For each cert that was loaded into memory we check if the cert was changed on disk.
-// If so we update it. If any of the certs was updated we return true else we return false.
-async function update_certs_from_disk() {
-    const promiseList = Object.values(certs).map(cert_info =>
-        cert_info.sem.surround(async () => {
-            if (!cert_info.is_loaded) {
-                return false;
-            }
-
-            try {
-                const cert_on_disk = await _read_ssl_certificate(cert_info.dir);
-                if (cert_info.cert.key === cert_on_disk.key) {
-                    return false;
-                }
-
-                cert_info.cert = cert_on_disk;
-                cert_info.is_generated = false;
-                return true;
-
-            } catch (err) {
-                if (err.code !== 'ENOENT') {
-                    dbg.warn(`SSL certificate failed to update from dir ${cert_info.dir}:`, err.message);
-                }
-                return false;
-            }
-        })
-    );
-
-    const updatedList = await Promise.all(promiseList);
-    return updatedList.some(Boolean);
 }
 
 // Read SSL certificate form disk
@@ -128,6 +130,15 @@ function is_using_generated_certs() {
     );
 }
 
+function get_cert_dir(service) {
+    const cert_info = certs[service];
+    if (!cert_info) {
+        throw new Error(`Invalid service name, got: ${service}`);
+    }
+
+    return cert_info.dir;
+}
+
 // create a default certificate and start an https server to test it in the browser
 function run_https_test_server() {
     const server = https.createServer(generate_ssl_certificate());
@@ -147,8 +158,8 @@ function run_https_test_server() {
 
 exports.generate_ssl_certificate = generate_ssl_certificate;
 exports.verify_ssl_certificate = verify_ssl_certificate;
-exports.get_ssl_certificate = get_ssl_certificate;
+exports.get_ssl_cert_info = get_ssl_cert_info;
 exports.is_using_generated_certs = is_using_generated_certs;
-exports.update_certs_from_disk = update_certs_from_disk;
+exports.get_cert_dir = get_cert_dir;
 
 if (require.main === module) run_https_test_server();


### PR DESCRIPTION
### Explain the changes
The certificate for S3 endpoint can change.
Endpoint now watches for changes in certificate file.
If so, the https servers are updated with new certificate.
(Endpoint pod doesn't need to be restarted).

### Issues: Fixed #xxx / Gap #xxx
(https://bugzilla.redhat.com/show_bug.cgi?id=2237903)

### Testing Instructions:
Note currently used certificate, eg-
openssl s_client -connect localhost:10443 -showcerts 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | openssl x509 -text -noout

Create a new certificate, eg-
openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname"

From here, follow instructions in https://github.com/noobaa/noobaa-operator/blob/master/doc/ssl-dns-routing.md:
Delete current secret (if exists), eg-
kubectl delete secret noobaa-s3-serving-cert
Create a new secret from the new certificate. Note filenames must be tls.crt and tls.key-
kubectl create secret generic noobaa-s3-serving-cert --from-file=tls.crt --from-file=tls.key
Wait until new files are created in endpoint's pod /etc/s3-secret.
Wait until background worker runs.
Running openssl -showcerts now should have the new certificate.


- [ ] Doc added/updated
- [ ] Tests added
