### PR TITLE
[NSFS] Add support for restore-object

### DIFF
--- a/config.js
+++ b/config.js
@@ -683,6 +683,9 @@ config.NSFS_VERSIONING_ENABLED = true;
 
 config.NSFS_NC_DEFAULT_CONF_DIR = '/etc/noobaa.conf.d';
 
+// NSFS_RESTORE_ENABLED can override internal autodetection and will force
+// the use of restore for all objects.
+config.NSFS_RESTORE_ENABLED = false;
 
 //Quota
 config.QUOTA_LOW_THRESHOLD = 80;

--- a/src/endpoint/s3/ops/s3_post_object_restore.js
+++ b/src/endpoint/s3/ops/s3_post_object_restore.js
@@ -1,32 +1,47 @@
 /* Copyright (C) 2023 NooBaa */
 'use strict';
 
+const { S3Error } = require('../s3_errors');
 const s3_utils = require('../s3_utils');
+const dbg = require('../../../util/debug_module')(__filename);
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html
  */
 async function post_object_restore(req, res) {
     const encryption = s3_utils.parse_encryption(req);
-    const days = req.body?.RestoreRequest?.Days ? parseInt(req.body.RestoreRequest.Days?.[0], 10) : undefined;
+
+    if (!req.body?.RestoreRequest?.Days?.[0]) {
+        dbg.warn('post_object_restore: missing Days in body');
+        throw new S3Error(S3Error.MalformedXML);
+    }
+
+    const days = s3_utils.parse_decimal_int(req.body.RestoreRequest.Days[0]);
+    if (days < 1) {
+        dbg.warn('post_object_restore: days cannot be less than 1');
+        throw new S3Error(S3Error.InvalidArgument);
+    }
+
     const params = {
         bucket: req.params.bucket,
         key: req.params.key,
         version_id: req.query.versionId,
-        days: days,
+        days,
         encryption,
     };
 
-
-    await req.object_sdk.restore_object(params);
-    res.statusCode = 200;
+    const accepted = await req.object_sdk.restore_object(params);
+    if (accepted) {
+        res.statusCode = 202;
+    } else {
+        res.statusCode = 200;
+    }
 }
 
 module.exports = {
     handler: post_object_restore,
     body: {
         type: 'xml',
-        optional: true
     },
     reply: {
         type: 'empty',

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -537,6 +537,21 @@ S3Error.OutputInputFormatMismatch = Object.freeze({
     http_code: 501,
 });
 
+////////////////////////////////////////////////////////////////
+// S3 Restore Object
+////////////////////////////////////////////////////////////////
+
+S3Error.InvalidObjectStorageClass = Object.freeze({
+    code: 'InvalidObjectState',
+    message: 'Restore is not allowed for the object\'s current storage class.',
+    http_code: 403,
+});
+S3Error.StorageClassNotImplemented = Object.freeze({
+    code: 'NotImplemented',
+    message: 'This storage class is not implemented.',
+    http_code: 501,
+});
+
 S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     UNAUTHORIZED: S3Error.AccessDenied,
     BAD_REQUEST: S3Error.BadRequest,

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -224,6 +224,10 @@ const static std::vector<std::string> USER_XATTRS{
     "user.prev_version_id",
     "user.delete_marker",
     "user.dir_content",
+    "user.storage_class",
+    "user.noobaa.restore.request",
+    "user.noobaa.restore.ongoing",
+    "user.noobaa.restore.expiry",
 };
 
 struct Entry

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -432,6 +432,7 @@ interface ObjectInfo {
     content_range?: string;
     ns?: Namespace;
     storage_class?: StorageClass;
+    restore_status?: { ongoing?: boolean; expiry_time?: Date; };
 }
 
 


### PR DESCRIPTION
### Explain the changes
This PR adds
1. Primitive support for `restore-object` API in NSFS.
2. Support for `storage-class` in `head/get-object`.

- [ ] Doc added/updated
- [ ] Tests added
