### PR TITLE
Log based replication | Add copy object flow for versioned objects

### DIFF
--- a/src/server/bg_services/log_replication_scanner.js
+++ b/src/server/bg_services/log_replication_scanner.js
@@ -12,6 +12,7 @@ const replication_store = require('../system_services/replication_store').instan
 const cloud_utils = require('../../util/cloud_utils');
 const log_parser = require('./replication_log_parser');
 const replication_utils = require('../utils/replication_utils');
+const { BucketDiff } = require('../../server/utils/bucket_diff');
 
 class LogReplicationScanner {
 
@@ -111,15 +112,66 @@ class LogReplicationScanner {
      * @param {boolean} sync_versions should we sync object versions
      */
     async process_candidates(src_bucket, dst_bucket, candidates, sync_versions) {
-        return sync_versions ? this.process_candidates_sync_version(src_bucket, dst_bucket, candidates) :
-            this.process_candidates_not_sync_version(src_bucket, dst_bucket, candidates);
+        let copy_keys;
+        let delete_keys;
+        if (sync_versions) {
+            ({ copy_keys, delete_keys } = await this.process_candidates_sync_version(src_bucket, dst_bucket, candidates));
+        } else {
+            ({ copy_keys, delete_keys } = await this.process_candidates_not_sync_version(src_bucket, dst_bucket, candidates));
+        }
+
+        dbg.log1('log_replication_scanner: process_candidates copy_keys: ', copy_keys);
+        dbg.log1('log_replication_scanner: process_candidates delete_keys: ', delete_keys);
+
+        // calling copy_objects and delete_objects by passing batch of keys
+        await Promise.all([
+            this.copy_objects(src_bucket.name, dst_bucket.name, copy_keys),
+            this.delete_objects(dst_bucket.name, delete_keys)
+        ]);
+
+        // Returning for testing purpose 
+        return { copy_keys, delete_keys };
     }
 
     async process_candidates_sync_version(src_bucket, dst_bucket, candidates) {
-        // process_candidates_sync_version will redirect to process_candidates_not_sync_version 
-        // till we implement sync_version for log-based replication
-        dbg.warn('process_candidates_sync_version is not yet supported, replicating without sync_version');
-        return this.process_candidates_not_sync_version(src_bucket, dst_bucket, candidates);
+        const bucketDiff = new BucketDiff({
+            first_bucket: src_bucket.name,
+            second_bucket: dst_bucket.name,
+            version: true,
+            connection: this.noobaa_connection,
+            for_replication: config.BUCKET_DIFF_FOR_REPLICATION
+        });
+
+        let copy_keys = {};
+        // TODO: support delete flow in object versions replication
+        // const delete_keys = [];
+
+        for (const candidate of Object.values(candidates)) {
+            const action = candidate.action;
+            if (action === 'skip') {
+                // Log skipped candidate key
+                dbg.log1('process_candidates: skipped_key: ', candidates.key);
+            } else {
+                // The action should not matter to get_buckets_diff, we will evaluate the action inside.
+                // This is because the order of the versions matter.  hance we just need the hint from the logs
+                // regarding which key was touched
+                const { keys_diff_map } = await bucketDiff.get_buckets_diff({
+                    prefix: candidates.key,
+                    max_keys: Number(process.env.REPLICATION_MAX_KEYS) || 1000, //max_keys refers her to the max number of versions (+deletes)
+                    current_first_bucket_cont_token: '',
+                    current_second_bucket_cont_token: '',
+                });
+                // Currently, as get_buckets_diff is not supporting deletions, we will just pass the keys_diff_map as copy
+                // This needs to be reevaluated once the delete is supported.
+                copy_keys = { ...copy_keys, ...keys_diff_map };
+            }
+        }
+
+        dbg.log1('process_candidates_sync_version:: copy_keys', copy_keys);
+        //TODO support delete flow and return also the delete
+        // returning copy_keys and delete_keys after processing candidates
+        // return { copy_keys, delete_keys };
+        return { copy_keys, delete_keys: [] };
     }
 
     async process_candidates_not_sync_version(src_bucket, dst_bucket, candidates) {
@@ -141,15 +193,6 @@ class LogReplicationScanner {
                 dbg.log1('process_candidates: skipped_key: ', candidates.key);
             }
         }
-
-        dbg.log1('log_replication_scanner: process_candidates copy_keys: ', copy_keys);
-        dbg.log1('log_replication_scanner: process_candidates delete_keys: ', delete_keys);
-
-        // calling copy_objects and delete_objects by passing batch of keys
-        await Promise.all([
-            this.copy_objects(src_bucket.name, dst_bucket.name, copy_keys),
-            this.delete_objects(dst_bucket.name, delete_keys)
-        ]);
 
         // returning copy_keys and delete_keys after processing candidates
         return { copy_keys, delete_keys };

--- a/src/server/bg_services/replication_log_parser.js
+++ b/src/server/bg_services/replication_log_parser.js
@@ -221,7 +221,7 @@ function create_candidates(logs) {
         }
     }
 
-    dbg.log1("ceate_candidates: candidates ", candidates);
+    dbg.log1("create_candidates: candidates ", candidates);
 
     return candidates;
 }
@@ -241,7 +241,7 @@ async function aws_get_next_log_entry(s3, logs_bucket, logs_prefix, continuation
     };
 
     try {
-        dbg.log1('log_parser aws_get_next_log_entry: params:', params);
+        dbg.log2('log_parser aws_get_next_log_entry: params:', params);
         const res = await s3.listObjectsV2(params).promise();
         dbg.log1('log_parser aws_get_next_log_entry: finished successfully ', res);
         return res;
@@ -296,6 +296,7 @@ function aws_parse_log_object(logs, log_object, sync_deletions) {
                         action: 'copy',
                         time: log.time,
                     });
+                    dbg.log2('aws_parse_log_object:: key', log.key, 'contain copy (PUT or POST) entry');
                 }
                 if (log.operation.includes('DELETE.OBJECT') && sync_deletions && log.http_status === 204) {
                     logs.push({
@@ -303,6 +304,7 @@ function aws_parse_log_object(logs, log_object, sync_deletions) {
                         action: 'delete',
                         time: log.time,
                     });
+                    dbg.log2('aws_parse_log_object:: key', log.key, 'contain delete (DELETE) entry');
                 }
             }
         }
@@ -530,6 +532,7 @@ function parse_potentially_empty_log_value(log_value, custom_parser) {
 }
 
 function _get_log_object_continuation_token_for_rule(rule_id, replication_config) {
+    dbg.log1('_get_log_object_continuation_token_for_rule:: rule_id', rule_id, 'replication_config', replication_config);
     const replication_rule = replication_config.rules.find(rule => rule.rule_id === rule_id);
     return replication_rule?.rule_log_status?.log_marker?.continuation_token;
 }

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -76,6 +76,7 @@ function get_copy_type() {
 async function copy_objects(scanner_semaphore, client, copy_type, src_bucket_name, dst_bucket_name, keys_diff_map) {
     try {
         const keys_length = Object.keys(keys_diff_map);
+        if (!keys_length.length) return;
         const res = await scanner_semaphore.surround_count(keys_length, //We will do key by key even when a key have more then one version
             async () => {
                 try {
@@ -109,6 +110,7 @@ async function copy_objects(scanner_semaphore, client, copy_type, src_bucket_nam
 //TODO: probably need to handle it also, getting an objects and not keys array
 //      as delete_objects is not being called in the replication scanner, we will handle it later.
 async function delete_objects(scanner_semaphore, client, bucket_name, keys) {
+    if (!keys.length) return;
     try {
         const res = await scanner_semaphore.surround_count(keys.length,
             async () => {


### PR DESCRIPTION
### Explain the changes
- Add copy object flow for versioned objects 

### Note: 
in the case of a few objects with the same prefix, all these objects up to a maximum of REPLICATION_MAX_KEYS (or 1000) will be processed and replicated.
e.g. 
if we have an object name `test.text` and it have 3 versions 
and if we also have  `test1.text` and `test2.text` which also have few versions,
and the log hints that `test.text` was written, all of those objects and their versions (up to 1000 as default)  will be processed and replicated. 

### Note 2:
in the case of sync-version, there will be no difference between copy and delete operations process.
This is because we still need to be aware of the version's history and may even do a copy before we do a delete (which should only be if the delete marker is the latest.) 

### Testing Instructions:
1.  Disable scanner replication in the config.js: `config.REPLICATION_ENABLED = false;`
2. Create a replication with log-based and sync_version
3. See that all the objects are getting replicated 

