### PR TITLE
NSFS | NC | CLI | fix nsfs cli uid/gid=0 issue

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -427,7 +427,9 @@ async function validate_account_add_args(data) {
         console.error('Error: Access key should not be empty');
         return false;
     }
-    if (!data.nsfs_account_config.uid || !data.nsfs_account_config.gid || !data.nsfs_account_config.new_buckets_path) {
+    if (data.nsfs_account_config.uid === undefined ||
+        data.nsfs_account_config.gid === undefined ||
+        !data.nsfs_account_config.new_buckets_path) {
         console.error('Error: Account config should not be empty');
         return false;
     }


### PR DESCRIPTION
### Explain the changes
1. when uid/gid = 0 we fail with 'Error: Account config should not be empty' because of the following condition evaluates to true - !data.nsfs_account_config.uid || !data.nsfs_account_config.gid so I changed the check

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
