### PR TITLE
Added a check for bidirectional replication for matching prefix

### DIFF
--- a/src/server/system_services/replication_store.js
+++ b/src/server/system_services/replication_store.js
@@ -54,6 +54,11 @@ class ReplicationStore {
         return parsed_id;
     }
 
+    async get_replication_rules() {
+        const repl = await this._replicationconfigs.find({ deleted: null });
+        return repl;
+    }
+
     async get_replication_by_id(replication_id) {
         dbg.log1('get_replication_by_id: ', replication_id);
         const repl = await this._replicationconfigs.findOne({ _id: db_client.instance().parse_object_id(replication_id), deleted: null });

--- a/src/test/unit_tests/test_bucket_replication.js
+++ b/src/test/unit_tests/test_bucket_replication.js
@@ -78,6 +78,26 @@ mocha.describe('replication configuration validity tests', function() {
         ], true);
     });
 
+    mocha.it('_put_replication - bidirectional replication for matching prefix - should fail', async function() {
+        await _put_replication(bucket1, [{ rule_id: 'rule-1', destination_bucket: first_bucket, sync_versions: false, filter: { prefix: 'ab' }}], false);
+        await _put_replication(first_bucket, [{ rule_id: 'rule-1', destination_bucket: bucket1, sync_versions: false, filter: { prefix: 'ab' } }], true);
+    });
+
+    mocha.it('_put_replication - bidirectional replication for matching prefix subset 1 - should fail', async function() {
+        await _put_replication(bucket1, [{ rule_id: 'rule-1', destination_bucket: first_bucket, sync_versions: false, filter: { prefix: 'ab' }}], false);
+        await _put_replication(first_bucket, [{ rule_id: 'rule-1', destination_bucket: bucket1, sync_versions: false, filter: { prefix: 'a' } }], true);
+    });
+
+    mocha.it('_put_replication - bidirectional replication for matching prefix subset 2 - should fail', async function() {
+        await _put_replication(bucket1, [{ rule_id: 'rule-1', destination_bucket: first_bucket, sync_versions: false, filter: { prefix: 'a' }}], false);
+        await _put_replication(first_bucket, [{ rule_id: 'rule-1', destination_bucket: bucket1, sync_versions: false, filter: { prefix: 'ab' } }], true);
+    });
+
+    mocha.it('_put_replication - bidirectional replication for no prefix - should fail', async function() {
+        await _put_replication(bucket1, [{ rule_id: 'rule-1', destination_bucket: first_bucket, sync_versions: false, filter: { prefix: 'ab' }}], false);
+        await _put_replication(first_bucket, [{ rule_id: 'rule-1', destination_bucket: bucket1, sync_versions: false }], true);
+    });
+
     mocha.it('_put_replication 2 - valid', async function() {
         await _put_replication(bucket2, [
             { rule_id: 'rule-1', destination_bucket: first_bucket, sync_versions: false, filter: { prefix: 'a' } },


### PR DESCRIPTION
### Explain the changes
1. Replication Validation - Block bi-directional replication for matching prefixes
