### PR TITLE
[NC | NSFS] Add mm policy migration rule to kick in every 15 mins

### DIFF
--- a/src/deploy/spectrum_archive/process_restore_candidates.sh
+++ b/src/deploy/spectrum_archive/process_restore_candidates.sh
@@ -13,9 +13,10 @@ function get_expiry() {
 		exit 1
 	fi
 
-	# This ugly piece of code converts the ISO 8601 date to a format that is similar
-	# to NodeJS's Date.toISOString() output
-	local expiry=$(date -u -Ins -d "+$requested_days days" | sed s/+00:00/Z/ | sed s/,/./)
+	# Take the current date and add "requested_days" to it and strip away the time
+	# bits just like AWS does
+	# This format is ISO 8601
+	local expiry=$(date -u -d "+${requested_days} days" +"%Y-%m-%dT00:00:00.000Z")
 
 	echo "$expiry"
 }

--- a/src/deploy/spectrum_archive/setup_policies.sh
+++ b/src/deploy/spectrum_archive/setup_policies.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-currdir="`pwd`"
+currdir="$(pwd)"
 
 function help_msg() {
 	echo "Usage: $0 <device-or-directory> <bucket-data-path> <pool-name>"
 }
 
-if [ $# -ne 3 ]; then
+if [[ $# -ne 3 ]]; then
 	help_msg
 	exit 1
 fi
@@ -15,8 +15,12 @@ DEVICE_DIRECTORY="$1"
 BUCKET_DATA_PATH="$2"
 POOL_NAME="$3"
 
-if [ ! -d "$BUCKET_DATA_PATH" ]; then
-	echo "Invalid bucket data path: $BUCKET_DATA_PATH"
+POLICY_DIR="${currdir}/src/deploy/spectrum_archive/policies"
+RESTORE_AND_MIGRATE_POLICY="${POLICY_DIR}/restore_and_migrate.policy"
+MIGRATE_PREMIGRATED_POLICY="${POLICY_DIR}/migrate_premigrated.policy"
+
+if [[ ! -d "${BUCKET_DATA_PATH}" ]]; then
+	echo "Invalid bucket data path: ${BUCKET_DATA_PATH}"
 	exit 1
 fi
 
@@ -33,20 +37,19 @@ function sanity_checks() {
 		exit 1
 	fi
 
-	if [ ! -d "$currdir/src/deploy/spectrum_archive/policies" ]
+	if [[ ! -d "${POLICY_DIR}" ]]
 	then
 		echo "policies directory could not be found"
 		echo "Creating"
-		mkdir -p "$currdir/src/deploy/spectrum_archive/policies"
+		mkdir -p "${POLICY_DIR}"
 	fi
 }
 
-function migrate_policy() {
+function migrate_premigrated_policy() {
 	local eeadmpath=`which eeadm`
-	cat > $currdir/src/deploy/spectrum_archive/policies/migrate.policy <<EOF
+	cat > "${MIGRATE_PREMIGRATED_POLICY}" <<EOF
 define(user_exclude_list,(PATH_NAME LIKE '/ibm/gpfs/.ltfsee/%' OR PATH_NAME LIKE '/ibm/gpfs/.SpaceMan/%'))
 define(is_premigrated,(MISC_ATTRIBUTES LIKE '%M%' AND MISC_ATTRIBUTES NOT LIKE '%V%'))
-define(is_resident,(NOT MISC_ATTRIBUTES LIKE '%M%'))
 
 RULE 'SYSTEM_POOL_PLACEMENT_RULE' SET POOL 'system'
 
@@ -61,26 +64,23 @@ WHERE
     AND PATH_NAME LIKE '${BUCKET_DATA_PATH}/%'
     AND xattr('user.storage_class') = 'GLACIER'
     AND (
-            (is_resident)
-            OR
-            (
-                    is_premigrated
-                    AND
-                    CURRENT_TIMESTAMP - TIMESTAMP(SUBSTR(xattr('user.noobaa.restore.expiry'), 0, 10)) >= INTERVAL '0' DAYS
-            )
+            is_premigrated
+            AND
+            CURRENT_TIMESTAMP - TIMESTAMP(SUBSTR(xattr('user.noobaa.restore.expiry'), 0, 10)) >= INTERVAL '0' DAYS
     )
     AND NOT user_exclude_list
 EOF
 }
 
-function restore_policy() {
+function restore_and_migrate_policy() {
 	local eeadmpath=`which eeadm`
-	cat > $currdir/src/deploy/spectrum_archive/policies/restore.policy <<EOF
+	cat > "${RESTORE_AND_MIGRATE_POLICY}" <<EOF
 define(user_exclude_list,(PATH_NAME LIKE '/ibm/gpfs/.ltfsee/%' OR PATH_NAME LIKE '/ibm/gpfs/.SpaceMan/%'))
 define(is_migrated,(MISC_ATTRIBUTES LIKE '%V%'))
+define(is_resident,(NOT MISC_ATTRIBUTES LIKE '%M%'))
 
 RULE EXTERNAL LIST 'CANDIDATES_LIST'
-EXEC '$currdir/src/deploy/spectrum_archive/process_restore_candidates.sh'
+EXEC '${currdir}/src/deploy/spectrum_archive/process_restore_candidates.sh'
 
 RULE 'LTFSEE_FILES_RULE' LIST 'CANDIDATES_LIST'
 WHERE 
@@ -91,30 +91,45 @@ WHERE
     AND xattr('user.storage_class') = 'GLACIER'
     AND xattr('user.noobaa.restore.request') is NOT NULL
     AND xattr('user.noobaa.restore._request') IS NULL
+
+RULE 'SYSTEM_POOL_PLACEMENT_RULE' SET POOL 'system'
+
+RULE EXTERNAL POOL 'ltfs'
+EXEC '${eeadmpath}'
+OPTS '-p ${POOL_NAME}'
+
+RULE 'LTFS_EE_FILES' MIGRATE FROM POOL 'system'
+TO POOL 'ltfs'
+WHERE
+    FILE_SIZE > 0
+    AND PATH_NAME LIKE '${BUCKET_DATA_PATH}/%'
+    AND xattr('user.storage_class') = 'GLACIER'
+    AND is_resident
+    AND NOT user_exclude_list
 EOF
 }
 
 function setup_policy_files_if_absent() {
-	if [ ! -f "$currdir/src/deploy/spectrum_archive/policies/restore.policy" ]; then
-		migrate_policy
+	if [[ ! -f "${MIGRATE_PREMIGRATED_POLICY}" ]]; then
+		migrate_premigrated_policy
 	fi
 
-	if [ ! -f "$currdir/src/deploy/spectrum_archive/policies/migrate.policy" ]; then
-		restore_policy
+	if [[ ! -f "${RESTORE_AND_MIGRATE_POLICY}" ]]; then
+		restore_and_migrate_policy
 	fi
 }
 
 function setup_cron_triggers() {
-	local migcmd="`which mmapplypolicy` ${DEVICE_DIRECTORY} -P \"$currdir/src/deploy/spectrum_archive/policies/migrate.policy\""
+	local migcmd="`which mmapplypolicy` ${DEVICE_DIRECTORY} -P \"${MIGRATE_PREMIGRATED_POLICY}\""
 	# Run everyday at 00:00
-	local migjob="0 0 * * * $migcmd"
+	local migjob="0 0 * * * ${migcmd}"
 
-	local rescmd="`which mmapplypolicy` ${DEVICE_DIRECTORY} -P \"$currdir/src/deploy/spectrum_archive/policies/restore.policy\""
+	local res_mig_cmd="`which mmapplypolicy` ${DEVICE_DIRECTORY} -P \"${RESTORE_AND_MIGRATE_POLICY}\""
 	# Run every 15 minutes
-	local resjob="*/15 * * * * $rescmd"
+	local res_mig_job="*/15 * * * * ${res_mig_cmd}"
 
-	crontab -l | fgrep -i -v "$migcmd" | { cat; echo "$migjob"; } | crontab -
-	crontab -l | fgrep -i -v "$rescmd" | { cat; echo "$resjob"; } | crontab -
+	crontab -l | fgrep -i -v "${migcmd}" | { cat; echo "${migjob}"; } | crontab -
+	crontab -l | fgrep -i -v "${res_mig_cmd}" | { cat; echo "${res_mig_job}"; } | crontab -
 }
 
 function main() {


### PR DESCRIPTION
### Explain the changes
This PR adds a new rule to the spectrum scale policies which migrates **resident** data from disk to tape **every** 15 minutes along with the restore trigger that happens every 15 minutes.

**Why?**
Previously, if a user would upload an object to `GLACIER` storage class and then will issue a recall, they will have to wait at least till `00:15 UTC` to be able to get their object back. That is acceptable from S3 protocol perspective IMO as restores can take upto days but in this case we are simply taking more time to restore because the **resident** files are migrated to the tape at `00:00 UTC` and only once migrated we bring them back to the tape (every 15 mins) hence the user will have to wait till `00:15 UTC`.

**What?**
With this PR, we have 3 different flows, one for migrating restored data (aka _premigrated_ data), one for data that was freshly uploaded hence not on tape (aka _resident_ data) and one for restoring data to the disk from tape.
We trigger migration of premigrated data every day at `00:00 UTC` as the granularity for restore request is in days and there is no point in issuing it more often.
We trigger the restoration every 15 mins.
We trigger migration of resident data (freshly uploaded data) every 15 mins.

With this PR if a user uploads an object and immediately requests a refresh then at max the restore will take 30 mins (15 mins to first move that data to tape and then 15 to move that data back to disk).

**Can there be race between data moving to tape and back to disk in the same flow?**
I don't think so. The flows identify the candidates based on their state on the filesystem. If the file is `resident`, it will be handed over to migration flow while if the file is `migrated` it will be handed over to the restore flow.

Tested this in the tape simulation environment.

- [ ] Doc added/updated
- [ ] Tests added
