### PR TITLE
NSFS | NC | Add syslog configuration on RPM

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,7 +10,6 @@ const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
-const dbg = require('./src/util/debug_module')(__filename);
 
 /////////////////////////
 // CONTAINER RESOURCES //
@@ -433,6 +432,7 @@ config.BLOCK_STORE_USAGE_INTERVAL = 1 * 60 * 1000; // 1 minute
 config.DEBUG_MODE_PERIOD = 10 * 60 * 1000; // 10 minutes for increased debug level
 
 config.dbg_log_level = 0;
+config.DEBUG_FACILITY = 'LOG_LOCAL0';
 
 // TEST Mode
 config.test_mode = false;
@@ -811,7 +811,7 @@ function _get_data_from_file(file_name) {
     try {
         data = fs.readFileSync(file_name).toString();
     } catch (e) {
-        dbg.log1(`Error accrued while getting the data from ${file_name}: ${e}`);
+        console.warn(`Error accrued while getting the data from ${file_name}: ${e}`);
         return;
     }
     return data;

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -254,3 +254,21 @@ Users can also pass account and bucket/account values in JSON file instead of pa
 node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --from_file /json_file/path
 ```
 NSFS management CLI command will create both account and bucket dir if it's missing in the config_root path.
+
+## Log and Logrotate
+Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running. 
+
+Rsyslog status check
+```
+systemctl status rsyslog
+```
+
+Noobaa logs are pushed to `var/log/noobaa.log` and the log is rotated and compressed daily.
+
+Verify the rsyslog and logrotate rpm configuration is complete by checking the files `etc/rsyslog.d/noobaa_syslog.conf` and `etc/rsyslog.d/noobaa_rsyslog.conf` for rsyslog and `etc/logrotate.d/noobaa/logrotate_noobaa.conf` for logrotate.These files contain the noobaa specific configuration for rsyslog and logrotate.
+
+Rotate the logs manually.
+
+```
+logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf 
+```

--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -2,6 +2,8 @@ FROM noobaa-base
 ARG TARGETARCH
 ARG BUILD_S3SELECT=0
 
+RUN mkdir -p /etc/logrotate.d/noobaa/
+
 COPY ./src/agent ./src/agent
 COPY ./src/api ./src/api
 COPY ./src/cmd ./src/cmd
@@ -19,6 +21,10 @@ COPY ./config.js ./
 COPY ./platform_restrictions.json ./
 COPY ./Makefile ./
 COPY ./package*.json ./
+
+COPY ./src/deploy/standalone/noobaa_rsyslog.conf /etc/rsyslog.d/
+COPY ./src/deploy/standalone/noobaa_syslog.conf /etc/rsyslog.d/
+COPY ./src/deploy/standalone/logrotate_noobaa.conf /etc/logrotate.d/noobaa/
 
 WORKDIR /build
 

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -39,6 +39,7 @@ tar -xJf %{SOURCE1} -C node-%{nodever}/
 %install
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/usr/local/
+mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d/noobaa
 
 cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa $RPM_BUILD_ROOT/usr/local/noobaa-core
 cp -R %{_builddir}/node-%{nodever}/* $RPM_BUILD_ROOT/usr/local/noobaa-core/node
@@ -51,13 +52,24 @@ ln -s /usr/local/noobaa-core/node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/
 mkdir -p $RPM_BUILD_ROOT/etc/systemd/system/
 ln %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/nsfs.service
 
+cp -R /etc/rsyslog.d $RPM_BUILD_ROOT/etc/rsyslog.d
+cp -R /etc/logrotate.d/noobaa $RPM_BUILD_ROOT/etc/logrotate.d/
+
 
 %files
 /usr/local/noobaa-core
 /etc/systemd/system/nsfs.service
+/etc/logrotate.d/noobaa/logrotate_noobaa.conf
+/etc/rsyslog.d/noobaa_rsyslog.conf
+/etc/rsyslog.d/noobaa_syslog.conf
 %doc
 
 %post
+state=$(systemctl show -p ActiveState --value rsyslog)
+if [ "${state}" == "active" ]; then
+  service rsyslog restart
+fi
+
 if [ $1 -gt 1 ]; then
   UPGRADE_SCRIPTS_DIR=/root/node_modules/noobaa-core/src/upgrade/upgrade_scripts
   NSFS_UPGRADE_SCRIPTS_DIR=/root/node_modules/noobaa-core/src/upgrade/nsfs_upgrade_scripts

--- a/src/deploy/spectrum_archive/deployment_guide.md
+++ b/src/deploy/spectrum_archive/deployment_guide.md
@@ -100,6 +100,24 @@ $ aws s3 --endpoint https://localhost:443 --no-verify-ssl ls # List all of the b
 2023-10-05 21:18:45 first.bucket
 ```
 
+## Log and Logrotate
+Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running. 
+
+Rsyslog status check
+```
+systemctl status rsyslog
+```
+
+Noobaa logs are pushed to `var/log/noobaa.log` and the log is rotated and compressed daily.
+
+Verify the rsyslog and logrotate rpm configuration is complete by checking the files `etc/rsyslog.d/noobaa_syslog.conf` and `etc/rsyslog.d/noobaa_rsyslog.conf` for rsyslog and `etc/logrotate.d/noobaa/logrotate_noobaa.conf` for logrotate.These files contain the noobaa specific configuration for rsyslog and logrotate.
+
+Rotate the logs manually.
+
+```
+logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf 
+```
+
 # FAQ
 - What happens if I forget the credentials used to generate NooBaa User?
   - You can find all of the NooBaa accounts details here: `/etc/noobaa.conf.d/accounts`.

--- a/src/deploy/standalone/noobaa_rsyslog.conf
+++ b/src/deploy/standalone/noobaa_rsyslog.conf
@@ -1,0 +1,92 @@
+# rsyslog configuration file
+
+# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+
+#### MODULES ####
+
+# The imjournal module bellow is now used as a message source instead of imuxsock.
+module(load="imuxsock" 	  # provides support for local system logging (e.g. via logger command)
+    SysSock.Use="off") # Turn off message reception via local log socket; 
+#$ModLoad imjournal # provides access to the systemd journal
+#$ModLoad imklog # reads kernel messages (the same are read from journald)
+#$ModLoad immark  # provides --MARK-- message capability
+
+# Provides UDP syslog reception
+#$ModLoad imudp
+#$UDPServerRun 514
+
+# Provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+
+#### GLOBAL DIRECTIVES ####
+
+# Where to place auxiliary files
+global(workDirectory="/var/lib/rsyslog")
+
+# Use default timestamp format
+module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+
+# File syncing capability is disabled by default. This feature is usually not required,
+# not useful and an extreme performance hit
+#$ActionFileEnableSync on
+
+# Include all config files in /etc/rsyslog.d/
+include(file="/etc/rsyslog.d/*.conf" mode="optional")
+
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+#$OmitLocalLogging off
+
+# File to store the position in the journal
+#$IMJournalStateFile imjournal.state
+
+
+#### RULES ####
+
+# Log all kernel messages to the console.
+# Logging much else clutters up the screen.
+#kern.*                                                 /dev/console
+
+# Log anything (except mail) of level info or higher.
+# Don't log private authentication messages!
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+
+# The authpriv file has restricted access.
+authpriv.*                                              /var/log/secure
+
+# Log all the mail messages in one place.
+mail.*                                                  -/var/log/maillog
+
+
+# Log cron stuff
+cron.*                                                  /var/log/cron
+
+# Everybody gets emergency messages
+*.emerg                                                 :omusrmsg:*
+
+# Save news errors of level crit and higher in a special file.
+uucp,news.crit                                          /var/log/spooler
+
+# Save boot messages also to boot.log
+local7.*                                                /var/log/boot.log
+
+
+# ### begin forwarding rule ###
+# The statement between the begin ... end define a SINGLE forwarding
+# rule. They belong together, do NOT split them. If you create multiple
+# forwarding rules, duplicate the whole block!
+# Remote Logging (we use TCP for reliable delivery)
+#
+# An on-disk queue is created for this action. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+#$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+#$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+#$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+#$ActionQueueType LinkedList   # run asynchronously
+#$ActionResumeRetryCount -1    # infinite retries if host is down
+# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+#*.* @@remote-host:514
+# ### end of the forwarding rule ###

--- a/src/native/tools/syslog_napi.cpp
+++ b/src/native/tools/syslog_napi.cpp
@@ -31,7 +31,7 @@ _syslog(const Napi::CallbackInfo& info)
 #ifndef WIN32
     int priority = info[0].As<Napi::Number>();
     std::string message = info[1].As<Napi::String>().Utf8Value();
-    int facility = 0;
+    int facility = LOG_LOCAL0;
     if (info.Length() == 3) {
         std::string facility_str = info[2].As<Napi::String>().Utf8Value();
         if (facility_str == "LOG_LOCAL0") {

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -21,6 +21,7 @@ const path = require('path');
 const util = require('util');
 const os = require('os');
 const debug_config = require('./debug_config');
+const config = require('../../config.js');
 
 const nb_native = require('./nb_native');
 const LRU = require('./lru');
@@ -32,16 +33,6 @@ if (process.env.NOOBAA_LOG_LEVEL) {
     if (process.env.NOOBAA_LOG_LEVEL !== 'nsfs') {
         LOG_LEVEL = dbg_conf.level;
     }
-}
-
-let config = {
-    dbg_log_level: 0,
-};
-
-try {
-    config = require('../../config.js');
-} catch (err) {
-    // ignore
 }
 
 function _should_log_to_file() {
@@ -407,7 +398,7 @@ class InternalDebugLogger {
     log_internal(msg_info) {
         if (syslog) {
             // syslog path
-            syslog(this._levels_to_syslog[msg_info.level], msg_info.message_syslog, 'LOG_LOCAL0');
+            syslog(this._levels_to_syslog[msg_info.level], msg_info.message_syslog, config.DEBUG_FACILITY);
         } else if (this._log_file) {
             // rotating file steam path (non browser)
             this._log_file.write(msg_info.message_file + os.EOL);


### PR DESCRIPTION
### Explain the changes
1. Add syslog configuration on RPM deployment/service enablement

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/MCGI-196

### Testing Instructions:
1. install RPM
2. check for log file `var/log/noobaa.log`
3. verify logrotate by running.
`logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf` and check for `var/log/noobaa.log.1.gz`



- [X] Doc added/updated
- [ ] Tests added
