### PR TITLE
Update s3_rest error message on unsupported op

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -263,7 +263,7 @@ async function authorize_anonymous_access(s3_policy, method, arn_path, req) {
 function _get_method_from_req(req) {
     const s3_op = s3_bucket_policy_utils.OP_NAME_TO_ACTION[req.op_name];
     if (!s3_op) {
-        dbg.error(`Got a not supported S3 op ${req.op_name} - doesn't suppose to happen`);
+        dbg.error(`ERROR: ${req.op_name} - unsupported s3 operation`);
         throw new S3Error(S3Error.InternalError);
     }
     if (req.query && req.query.versionId && s3_op.versioned) {


### PR DESCRIPTION
### Explain the changes
1. Changed line 258 to include a smaller, more informative error message when dealing with unsupported s3 operations.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
