### PR TITLE
Add Logs In http_utils.js

### DIFF
--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -375,8 +375,10 @@ function send_reply(req, res, reply, options) {
  */
 function should_proxy(hostname) {
     const isIp = ip.isV4Format(hostname) || ip.isV6Format(hostname);
+    dbg.log2(`should_proxy: hostname ${hostname} isIp ${isIp}`);
 
     for (const { kind, addr } of no_proxy_list) {
+        dbg.log3(`should_proxy: an item from no_proxy_list: kind ${kind} addr ${addr}`);
         if (isIp) {
             if (kind === 'IP' && ip.isEqual(addr, hostname)) {
                 return false;
@@ -417,9 +419,14 @@ function get_unsecured_agent(endpoint) {
 
 function _get_http_agent(endpoint, request_unsecured) {
     const { protocol, hostname } = url.parse(endpoint);
+    const should_proxy_by_hostname = should_proxy(hostname);
+    dbg.log2(`_get_http_agent: ` +
+     `endpoint ${endpoint} request_unsecured ${request_unsecured} ` +
+     `protocol ${protocol} hostname ${hostname} should_proxy(hostname) ${should_proxy_by_hostname} ` +
+     `Boolean(HTTPS_PROXY) ${Boolean(HTTPS_PROXY)} Boolean(HTTP_PROXY) ${Boolean(HTTP_PROXY)}`);
 
     if (protocol === "https:" || protocol === "wss:") {
-        if (HTTPS_PROXY && should_proxy(hostname)) {
+        if (HTTPS_PROXY && should_proxy_by_hostname) {
             if (request_unsecured) {
                 return unsecured_https_proxy_agent;
             } else {
@@ -430,7 +437,7 @@ function _get_http_agent(endpoint, request_unsecured) {
         } else {
             return https_agent;
         }
-    } else if (HTTP_PROXY && should_proxy(hostname)) {
+    } else if (HTTP_PROXY && should_proxy_by_hostname) {
         return http_proxy_agent;
     } else {
         return http_agent;


### PR DESCRIPTION
### Explain the changes
1. Add logs in levels 2 and 3 to help support and developers understand the parameters that we have in the functions `_get_http_agent` and `should_proxy`. It was not set in debug level 0 or 1 because every creation of S3 Client with an agent would call those functions.

### Issues: Fixed #xxx / Gap #xxx
1. none, I had a BZ [2238334](https://bugzilla.redhat.com/show_bug.cgi?id=2238334) where I had to assume the values and do a dry-run to understand what happens. It could be easier for support and developers to find those values in the logs in such cases.

### Testing Instructions:
1. Deploy noobaa on MInikube or Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Set debug level of 3 by running: `nb system set-debug-level 3`
3. Create a new backingstore: `nb backingstore create aws-s3 <backing-store-name>` (optional: add the `--region` flag).
4. Check the logs of noobaa-core: `k logs noobaa-core-0 -f` look for ` should_proxy:` and `_get_http_agent:` printings.

- [ ] Doc added/updated
- [ ] Tests added
