### PR TITLE
NSFS | NC | fix bucket policy issue

### DIFF
--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -309,6 +309,48 @@ mocha.describe('bucketspace_fs', function() {
             const output_web = await bucketspace_fs.get_bucket_policy(param);
             assert.ok(output_web.policy === undefined);
         });
+
+        mocha.it('put_bucket_policy other account object', async function() {
+            const policy = {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: 'id-22',
+                        Effect: 'Allow',
+                        Principal: { AWS: 'noobaa@noobaa.io' },
+                        Action: ['s3:*'],
+                        Resource: ['arn:aws:s3:::*']
+                        }
+                    ]
+                };
+            const param = {name: test_bucket, policy: policy};
+            await bucketspace_fs.put_bucket_policy(param);
+            const bucket_policy = await bucketspace_fs.get_bucket_policy(param);
+            assert.deepEqual(bucket_policy.policy, policy);
+        });
+
+        mocha.it('put_bucket_policy other account array', async function() {
+            const policy = {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: 'id-22',
+                        Effect: 'Allow',
+                        Principal: { AWS: ['noobaa@noobaa.io', 'noobaa1@noobaa.io'] },
+                        Action: ['s3:*'],
+                        Resource: ['arn:aws:s3:::*']
+                        }
+                    ]
+                };
+            const param = {name: test_bucket, policy: policy};
+            await bucketspace_fs.put_bucket_policy(param);
+            const bucket_policy = await bucketspace_fs.get_bucket_policy(param);
+            assert.deepEqual(bucket_policy.policy, policy);
+        });
+        mocha.it('delete_bucket_policy ', async function() {
+            const param = {name: test_bucket};
+            await bucketspace_fs.delete_bucket_policy(param);
+            const bucket_policy = await bucketspace_fs.get_bucket_policy(param);
+            assert.ok(bucket_policy.policy === undefined);
+        });
     });
 });
 


### PR DESCRIPTION
### Explain the changes
1. bucketspace_fs.read_bucket_sdk_info() added iteration on existing bucket policies in order to convert plain principals  (email/"*") string to sensitive strings.
2.  bucketspace_fs.put_bucket_policy() - added validate_s3_policy() call.
3. moved validate_s3_policy() func from bucket_server to bucket_policy_utils so it can be re-used by bucketspace_fs.
since we don't have a system store in NC env, we currently won't check existence of accounts mentioned in bucket policies (see Gaps).
4. Added unit tests

### Issues: Fixed #xxx / Gap #xxx
1. Currently we won't check for existence of the accounts provided in the bucket policy as it requires a new account_by_email cache or a different solution.
2. Fixed #7527 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
