### PR TITLE
Bucket Logging : Log delivery changes

### DIFF
--- a/src/deploy/NVA_build/rsyslog.conf
+++ b/src/deploy/NVA_build/rsyslog.conf
@@ -19,6 +19,11 @@ $ModLoad imuxsock # provides support for local system logging (e.g. via logger c
 #$ModLoad imtcp
 #$InputTCPServerRun 514
 
+# module(load="imtcp")
+# input(type="imtcp" port="514")
+
+module(load="imudp")
+input(type="imudp" port="514")
 
 #### GLOBAL DIRECTIVES ####
 
@@ -52,6 +57,8 @@ $OmitLocalLogging off
 # Log anything (except mail) of level info or higher.
 # Don't log private authentication messages!
 *.info;mail.none;authpriv.none;cron.none                /var/log/messages
+
+*.*                                                /var/log/noobaa-logging
 
 # The authpriv file has restricted access.
 authpriv.*                                              /var/log/secure

--- a/src/endpoint/s3/s3_bucket_logging.js
+++ b/src/endpoint/s3/s3_bucket_logging.js
@@ -3,7 +3,11 @@
 
 const dbg = require('../../util/debug_module')(__filename);
 const http_utils = require('../../util/http_utils');
+const { pino } = require('pino');
+const pinoUdp = require('pino-udp');
 
+// const dgram = require('dgram');
+// const net = require('net');
 
 async function send_bucket_op_logs(req, res) {
     if (req.params && req.params.bucket) {
@@ -12,7 +16,7 @@ async function send_bucket_op_logs(req, res) {
 
         if (is_bucket_logging_enabled(bucket_info)) {
             dbg.log2("Bucket logging is enabled for Bucket : ", req.params.bucket);
-            endpoint_bucket_op_logs(req.op_name, req, res, bucket_info);
+            await endpoint_bucket_op_logs(req.op_name, req, res, bucket_info);
         }
     }
 }
@@ -26,13 +30,14 @@ function is_bucket_logging_enabled(source_bucket) {
     return true;
 }
 
-function endpoint_bucket_op_logs(op_name, req, res, source_bucket) {
+async function endpoint_bucket_op_logs(op_name, req, res, source_bucket) {
 
     dbg.log2("Sending op logs for op name = ", op_name);
     // 1 - Get all the information to be logged in a log message.
     // 2 - Format it and send it to log bucket/syslog.
     const s3_log = get_bucket_log_record(op_name, source_bucket, req, res);
     dbg.log1("Bucket operation logs = ", s3_log);
+    await send_rsyslog();
 
 }
 
@@ -58,9 +63,66 @@ function get_bucket_log_record(op_name, source_bucket, req, res) {
     return log;
 }
 
+async function send_rsyslog() {
+
+    const logMessage = '********** This is a test log message : log-collector-service.default.svc.cluster.local';
+    const remoteHost = 'log-collector-service.default.svc.cluster.local';
+    const port = 514;
+    // await send_rsyslog_UDP(logMessage, remoteHost, port);
+    // await send_rsyslog_TCP(logMessage, remoteHost, port);
+    await send_pino_logs(logMessage, remoteHost, port);
+}
+
+async function send_pino_logs(message, remoteHost, port) {
+    const logger = pino({
+        level: 'info',
+        transport: {
+            target: pinoUdp,
+            options: {
+                host: remoteHost,
+                port: port,
+            },
+        },
+        });
+        logger.info('This is a Pino log message');
+}
+
+// async function send_rsyslog_TCP(message, remoteHost, port) {
+//     const client = new net.Socket();
+//     client.connect(port, remoteHost, () => {
+//         dbg.log('Connected to rsyslog server.');
+
+//         const logMessage = message + '\n';
+
+//         client.write(logMessage, () => {
+//             dbg.log('Log message sent successfully!');
+//             client.end();
+//         });
+//     });
+
+//     client.on('error', err => {
+//         dbg.error('Error connecting to rsyslog server:', err);
+//         client.destroy();
+//     });
+// }
+
+
+// async function send_rsyslog_UDP(message, remoteHost, port) {
+//     const client = dgram.createSocket('udp4');
+//     const messageBuffer = Buffer.from(message);
+
+//     client.send(messageBuffer, 0, messageBuffer.length, port, remoteHost, err => {
+//         if (err) {
+//             dbg.log0('***************Error sending log message:', err);
+//         } else {
+//             dbg.log0('*************Log message sent successfully!');
+//         }
+//         client.close();
+//     });
+// }
+
 
 exports.is_bucket_logging_enabled = is_bucket_logging_enabled;
 exports.endpoint_bucket_op_logs = endpoint_bucket_op_logs;
 exports.get_bucket_log_record = get_bucket_log_record;
 exports.send_bucket_op_logs = send_bucket_op_logs;
-


### PR DESCRIPTION
For now, whenever an operation happens on an object, we record that log and send it to endpoint logs.
This change is responsible for sending these logs to noobaa core rsyslogs.

### Explain the changes


