### PR TITLE
NSFS | NC | removing system store requirement from nsfs.js

### DIFF
--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -14,8 +14,9 @@ const fs = require('fs');
 const util = require('util');
 const minimist = require('minimist');
 
-require('../server/system_services/system_store').get_instance({ standalone: true });
-
+if (process.env.LOCAL_MD_SERVER === 'true') {
+    require('../server/system_services/system_store').get_instance({ standalone: true });
+}
 //const js_utils = require('../util/js_utils');
 const nb_native = require('../util/nb_native');
 //const schema_utils = require('../util/schema_utils');


### PR DESCRIPTION
### Explain the changes
1. System store requirement initiating the constructor of the system Store which defines the db collections. while defining db collection the vacumeAnalyzer is set to run once a day so the nsfs process panics when it happens.
currently, it's not being used so I suggest removing this requirement.

```Oct-25 18:13:17.778 [nsfs/90733] [ERROR] core.util.postgres_client:: vacuumAndAnalyze failed TypeError: Cannot read properties of undefined (reading 'query')
    at _do_query (/Users/romy/github/noobaa-core/src/util/postgres_client.js:250:37)
    at PostgresTable.single_query (/Users/romy/github/noobaa-core/src/util/postgres_client.js:679:16)
    at runNextTicks (node:internal/process/task_queues:60:5)
    at listOnTimeout (node:internal/timers:538:9)
    at process.processTimers (node:internal/timers:512:7)
    at async Timeout.vacuumAndAnalyze [as _onTimeout] (/Users/romy/github/noobaa-core/src/util/postgres_client.js:700:13)
/Users/romy/github/noobaa-core/src/util/postgres_client.js:250
        const res = await pg_client.query(q);
                                    ^

TypeError: Cannot read properties of undefined (reading 'query')
    at _do_query (/Users/romy/github/noobaa-core/src/util/postgres_client.js:250:37)
    at PostgresTable.single_query (/Users/romy/github/noobaa-core/src/util/postgres_client.js:679:16)
    at runNextTicks (node:internal/process/task_queues:60:5)
    at listOnTimeout (node:internal/timers:538:9)
    at process.processTimers (node:internal/timers:512:7)
    at async Timeout.vacuumAndAnalyze [as _onTimeout] (/Users/romy/github/noobaa-core/src/util/postgres_client.js:700:13)
```
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
