### PR TITLE
RPM build updates for downstream builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ rpm: base
 	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/RPM_build/RPM.Dockerfile $(CACHE_FLAG) -t $(NOOBAA_RPM_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	echo "\033[1;32mImage \"$(NOOBAA_RPM_TAG)\" is ready.\033[0m"
 	echo "Generating RPM..."
-	$(CONTAINER_ENGINE) run --rm -v $(PWD)/build/rpm:/export -it $(NOOBAA_RPM_TAG)
+	$(CONTAINER_ENGINE) run --rm -v $(PWD)/build/rpm:/export:z -it $(NOOBAA_RPM_TAG)
 	echo "\033[1;32mRPM for platform \"$(NOOBAA_RPM_TAG)\" is ready in build/rpm.\033[0m";
 .PHONY: rpm
 

--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -21,10 +21,9 @@ COPY ./config.js ./
 COPY ./platform_restrictions.json ./
 COPY ./Makefile ./
 COPY ./package*.json ./
-
-COPY ./src/deploy/standalone/noobaa_rsyslog.conf /etc/rsyslog.d/
-COPY ./src/deploy/standalone/noobaa_syslog.conf /etc/rsyslog.d/
-COPY ./src/deploy/standalone/logrotate_noobaa.conf /etc/logrotate.d/noobaa/
+COPY ./src/deploy/standalone/noobaa_rsyslog.conf ./src/deploy/standalone/noobaa_rsyslog.conf
+COPY ./src/deploy/standalone/noobaa_syslog.conf ./src/deploy/standalone/noobaa_syslog.conf
+COPY ./src/deploy/standalone/logrotate_noobaa.conf ./src/deploy/standalone/logrotate_noobaa.conf
 
 WORKDIR /build
 

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -39,7 +39,6 @@ tar -xJf %{SOURCE1} -C node-%{nodever}/
 %install
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/usr/local/
-mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d/noobaa
 
 cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa $RPM_BUILD_ROOT/usr/local/noobaa-core
 cp -R %{_builddir}/node-%{nodever}/* $RPM_BUILD_ROOT/usr/local/noobaa-core/node
@@ -50,12 +49,15 @@ ln -s /usr/local/noobaa-core/node/bin/npm $RPM_BUILD_ROOT/usr/local/noobaa-core/
 ln -s /usr/local/noobaa-core/node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npx
 
 mkdir -p $RPM_BUILD_ROOT/etc/systemd/system/
-ln %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/nsfs.service
-ln %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
+ln -s /usr/local/noobaa-core/src/deploy/nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/nsfs.service
+ln -s /usr/local/noobaa-core/src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
 
-cp -R /etc/rsyslog.d $RPM_BUILD_ROOT/etc/rsyslog.d
-cp -R /etc/logrotate.d/noobaa $RPM_BUILD_ROOT/etc/logrotate.d/
+mkdir -p $RPM_BUILD_ROOT/etc/rsyslog.d/
+ln -s /usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
+ln -s /usr/local/noobaa-core/src/deploy/standalone/noobaa_rsyslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_rsyslog.conf
 
+mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d/noobaa
+ln -s /usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.conf $RPM_BUILD_ROOT/etc/logrotate.d/noobaa/logrotate_noobaa.conf
 
 %files
 /usr/local/noobaa-core

--- a/src/deploy/RPM_build/packagerpm.sh
+++ b/src/deploy/RPM_build/packagerpm.sh
@@ -91,5 +91,6 @@ mv ${OUTPUT_FILE} ~/rpmbuild/SPECS/
 # Build the RPM package
 rpmbuild -ba ~/rpmbuild/SPECS/noobaa.final.spec
 
-# Move the RPM package to the current directory
+# Move the RPM and SRPM package to the target directory
 mv ~/rpmbuild/RPMS/${ARCHITECTURE}/noobaa-core-${noobaaver}-${revision}.*.rpm ${TARGET_DIR}
+mv ~/rpmbuild/SRPMS/noobaa-core-${noobaaver}-${revision}.*.rpm ${TARGET_DIR}


### PR DESCRIPTION
### Explain the changes
1.  This adds SELinux support to the RPM generation
2.  It stores src.rpm on the system as well
3.  It fixes the syslog and logrotate file locations during the build
4.  It unifies the treatment of the files inside the RPM (via symlinks)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1.  Run make rpm on a Fedora host


- [ ] Doc added/updated
- [ ] Tests added
