### PR TITLE
NC | NSFS | HTTP Server not Starting, but logging mismatch

### DIFF
--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -316,8 +316,9 @@ async function main(argv = minimist(process.argv.slice(2))) {
                 req.object_sdk = new NsfsObjectSDK(fs_root, fs_config, account, versioning, nsfs_config_root);
             }
         });
-
-        console.log('nsfs: listening on', util.inspect(`http://localhost:${http_port}`));
+        if (await endpoint.is_http_allowed(nsfs_config_root)) {
+            dbg.log0('nsfs: listening on', util.inspect(`http://localhost:${http_port}`));
+        }
         console.log('nsfs: listening on', util.inspect(`https://localhost:${https_port}`));
 
     } catch (err) {


### PR DESCRIPTION
### Explain the changes
1. https://github.com/noobaa/noobaa-core/issues/7551
2. when `system.json` missing `allow_http` flag, the flow skips HTTP server creation

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7551

### Testing Instructions:
1. try to run nsfs with or without `allow_http` flag in system.json


- [ ] Doc added/updated
- [ ] Tests added
