### PR TITLE
Fix NooBaa usagereports and endpointgroupreports collections

### DIFF
--- a/src/server/analytic_services/endpoint_group_report_indexes.js
+++ b/src/server/analytic_services/endpoint_group_report_indexes.js
@@ -4,10 +4,10 @@
 module.exports = [{
     fields: {
         start_time: 1,
-        aggregated_time: -1,
-        aggregated_time_range: 1,
+        end_time: 1,
+        group_name: 1,
     },
     options: {
         unique: false,
     }
-}, ];
+}];

--- a/src/server/analytic_services/endpoint_stats_store.js
+++ b/src/server/analytic_services/endpoint_stats_store.js
@@ -167,17 +167,17 @@ class EndpointStatsStore {
 
     async get_endpoint_group_reports(params) {
         dbg.log1('get_endpoint_group_reports', params);
-        const query = this._format_endpoint_gorup_report_query(params);
+        const query = this._format_endpoint_group_report_query(params);
         return this._endpoint_group_reports.find(query);
     }
 
     async clean_endpoint_group_reports(params) {
         dbg.log1('clean_endpoint_group_reports', params);
-        const query = this._format_endpoint_gorup_report_query(params);
+        const query = this._format_endpoint_group_report_query(params);
         return this._endpoint_group_reports.deleteMany(query);
     }
 
-    _format_endpoint_gorup_report_query(params) {
+    _format_endpoint_group_report_query(params) {
         const { groups, since, till } = params;
         const query = {};
         if (groups) _.set(query, ['group_name', '$in'], _.castArray(groups));
@@ -196,6 +196,7 @@ class EndpointStatsStore {
             group_name: report.endpoint_group,
         };
         const update = {
+            $set: selector,
             $push: {
                 endpoints: _.pick(report, [
                     'hostname',

--- a/src/server/analytic_services/usage_report_indexes.js
+++ b/src/server/analytic_services/usage_report_indexes.js
@@ -1,13 +1,17 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-module.exports = [{
-    fields: {
-        start_time: 1,
-        aggregated_time: -1,
-        aggregated_time_range: 1,
-    },
-    options: {
-        unique: false,
+module.exports = [
+    // There are many other fields in the table but this is a common denominator
+    // and the hot query uses only these fields.
+    {
+        fields: {
+            start_time: 1,
+            end_time: 1,
+            bucket: 1,
+        },
+        options: {
+            unique: false,
+        }
     }
-}, ];
+];

--- a/src/server/bg_services/usage_aggregator.js
+++ b/src/server/bg_services/usage_aggregator.js
@@ -112,6 +112,9 @@ async function background_worker() {
     const till = moment().subtract(8, 'weeks').valueOf();
     dbg.log0('Deleting reports older than', new Date(till));
     await EndpointStatsStore.instance.clean_bandwidth_reports({ till });
+
+    // Clean endpoint group reports here as well?
+    await EndpointStatsStore.instance.clean_endpoint_group_reports({ till });
 }
 
 function _accumulate_bandwidth(acc, update) {


### PR DESCRIPTION
### Explain the changes
This PR:
1. Adds cleanup for endpointgroupreports.
2. Fixes invalid endpointgroupreports data being stored in the tables which was slowing down the queries.
3. Fixes the outdated indexes. NOTE: Even after trying quite a bit, I cannot get PG to reliably use the index. Sometimes it does, sometime it does not.


- [ ] Doc added/updated
- [ ] Tests added
