### PR TITLE
Adding distinguished_name to nsfs_account_config

### DIFF
--- a/docs/nsfs-standalone.md
+++ b/docs/nsfs-standalone.md
@@ -1,6 +1,6 @@
 # NSFS FS Standalone
 
-Running noobaa-core standalone is useful for development, testing, or deploying in Linux without depending on Kubernetes, NSFS FS is different from the simple standalone in such a way that it doesn't depend on the Noobaa postgres db. All the Global configurations, Accounts, and Bucket related schemas are saved in FS. And it gives a more lightweight flavor to the Noobaa standalone version. Permissions are handled by uid and gid.
+Running noobaa-core standalone is useful for development, testing, or deploying in Linux without depending on Kubernetes, NSFS FS is different from the simple standalone in such a way that it doesn't depend on the Noobaa postgres db. All the Global configurations, Accounts, and Bucket related schemas are saved in FS. And it gives a more lightweight flavor to the Noobaa standalone version. Permissions are handled by uid and gid, or by providing a distinguished name (LDAP/AD) that will be resolved to uid/gid by the operating system.
 
 Users can switch between Noobaa standalone and NSFS FS standalone by adding/removing the argument `config_dir`.
 
@@ -34,9 +34,9 @@ node src/cmd/nsfs ../standalon/nsfs_root --config_dir ../standalon/fs_config
 		"secret_key": "ss-abcdefghijklmn123456"
 	}],
 	"nsfs_account_config": {
-		"uid": 10,
-		"gid": 10,
-		"new_buckets_path": "/",
+		"uid": 10,   // Both can also be replaced with "distingished_name": "unique_user1_name",
+		"gid": 10,   // 
+ 		"new_buckets_path": "/",
 		"nsfs_only": "true"
 	}
 }

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -1,6 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const SensitiveString = require('../util/sensitive_string');
+
 /**
  *
  * ACCOUNT API
@@ -287,6 +289,7 @@ module.exports = {
                     nsfs_account_config: {
                         type: 'object',
                         properties: {
+                            distinguished_name: { wrapper: SensitiveString },
                             uid: { type: 'number' },
                             gid: { type: 'number' },
                             new_buckets_path: { type: 'string' },
@@ -323,12 +326,20 @@ module.exports = {
                 required: ['nsfs_account_config'],
                 properties: {
                     nsfs_account_config: {
-                        type: 'object',
-                        required: ['uid', 'gid'],
-                        properties: {
-                            uid: { type: 'number' },
-                            gid: { type: 'number' },
-                        }
+                        oneOf: [{
+                            type: 'object',
+                            required: ['uid', 'gid'],
+                            properties: {
+                                uid: { type: 'number' },
+                                gid: { type: 'number' },
+                            }
+                        }, {
+                            type: 'object',
+                            required: ['distinguished_name'],
+                            properties: {
+                                distinguished_name: { wrapper: SensitiveString },
+                            }
+                        }]
                     }
                 }
             },
@@ -347,12 +358,20 @@ module.exports = {
                         type: 'object',
                         properties: {
                             fs_identity: {
-                                type: 'object',
-                                required: ['uid', 'gid'],
-                                properties: {
-                                    uid: { type: 'number' },
-                                    gid: { type: 'number' },
-                                }
+                                oneOf: [{
+                                    type: 'object',
+                                    required: ['uid', 'gid'],
+                                    properties: {
+                                        uid: { type: 'number' },
+                                        gid: { type: 'number' },
+                                    }
+                                }, {
+                                    type: 'object',
+                                    required: ['distinguished_name'],
+                                    properties: {
+                                        distinguished_name: { wrapper: SensitiveString },
+                                    }
+                                }]
                             }
                         }
                     }

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1285,14 +1285,24 @@ module.exports = {
             }
         },
         nsfs_account_config: {
-            type: 'object',
-            required: ['uid', 'gid', 'new_buckets_path', 'nsfs_only'],
-            properties: {
-                uid: { type: 'number' },
-                gid: { type: 'number' },
-                new_buckets_path: { type: 'string' },
-                nsfs_only: { type: 'boolean' }
-            }
+            oneOf: [{
+                type: 'object',
+                required: ['uid', 'gid', 'new_buckets_path', 'nsfs_only'],
+                properties: {
+                    uid: { type: 'number' },
+                    gid: { type: 'number' },
+                    new_buckets_path: { type: 'string' },
+                    nsfs_only: { type: 'boolean' }
+                }
+            }, {
+                type: 'object',
+                required: [ 'distinguished_name', 'new_buckets_path', 'nsfs_only'],
+                properties: {
+                    distinguished_name: { wrapper: SensitiveString },
+                    new_buckets_path: { type: 'string' },
+                    nsfs_only: { type: 'boolean' }
+                }
+            }]
         },
         quota_config: {
             type: 'object',

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -125,6 +125,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         const valid = ajv.validate(bucket_schema, bucket);
         if (!valid) throw new RpcError('INVALID_SCHEMA', ajv.errors[0]?.message);
     }
+
     async read_bucket_sdk_info({ name }) {
         try {
             const bucket_config_path = this._get_bucket_config_path(name);

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -904,6 +904,7 @@ interface NativeFS {
     realpath(fs_context: NativeFSContext, path: string): Promise<string>;
     checkAccess(fs_context: NativeFSContext, path: string): Promise<void>;
     getsinglexattr(fs_context: NativeFSContext, path: string, key: string): Promise<string>;
+    getpwname(fs_context: NativeFSContext, user: string): Promise<object>;
 
     readFile(
         fs_context: NativeFSContext,

--- a/src/server/object_services/schemas/nsfs_account_schema.js
+++ b/src/server/object_services/schemas/nsfs_account_schema.js
@@ -37,19 +37,22 @@ module.exports = {
             }
         },
         nsfs_account_config: {
-            type: 'object',
-            required: ['uid', 'gid', 'new_buckets_path'],
-            properties: {
-                uid: {
-                    type: 'number'
-                },
-                gid: {
-                    type: 'number'
-                },
-                new_buckets_path: {
-                    type: 'string'
+            oneOf: [{
+                type: 'object',
+                required: ['uid', 'gid', 'new_buckets_path'],
+                properties: {
+                    uid: { type: 'number' },
+                    gid: { type: 'number' },
+                    new_buckets_path: { type: 'string' },
                 }
-            }
-        }
+            }, {
+                type: 'object',
+                required: [ 'distinguished_name', 'new_buckets_path'],
+                properties: {
+                    distinguished_name: { type: 'string' },
+                    new_buckets_path: { type: 'string' },
+                }
+            }]
+        },
     }
 };

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -355,7 +355,8 @@ function update_account_s3_access(req) {
         }
 
         if (req.rpc_params.nsfs_account_config) {
-            if (_.isUndefined(req.rpc_params.nsfs_account_config.uid) &&
+            if (_.isUndefined(req.rpc_params.nsfs_account_config.distinguished_name) &&
+                _.isUndefined(req.rpc_params.nsfs_account_config.uid) &&
                 _.isUndefined(req.rpc_params.nsfs_account_config.gid) && !req.rpc_params.nsfs_account_config.new_buckets_path &&
                 _.isUndefined(req.rpc_params.nsfs_account_config.nsfs_only)) {
                 throw new RpcError('FORBIDDEN', 'Invalid nsfs_account_config');
@@ -674,6 +675,8 @@ function list_accounts(req) {
         .filter(account => !req.rpc_params.filter ||
             (req.rpc_params.filter &&
                 req.rpc_params.filter.fs_identity &&
+                _.isEqual(req.rpc_params.filter.fs_identity.distinguished_name,
+                    account.nsfs_account_config && account.nsfs_account_config.distinguished_name) &&
                 req.rpc_params.filter.fs_identity.uid === (account.nsfs_account_config && account.nsfs_account_config.uid) &&
                 req.rpc_params.filter.fs_identity.gid === (account.nsfs_account_config && account.nsfs_account_config.gid))
         )

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -807,8 +807,9 @@ class SystemStore extends EventEmitter {
     get_accounts_by_nsfs_account_config(nsfs_account_config) {
         if (this.data && !_.isEmpty(this.data.accounts)) {
             return this.data.accounts.filter(account => account.nsfs_account_config &&
-                account.nsfs_account_config.uid === nsfs_account_config.uid &&
-                account.nsfs_account_config.gid === nsfs_account_config.gid);
+                    _.isEqual(account.nsfs_account_config.distinguished_name, nsfs_account_config.distinguished_name) &&
+                    account.nsfs_account_config.uid === nsfs_account_config.uid &&
+                    account.nsfs_account_config.gid === nsfs_account_config.gid);
         }
     }
 

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -31,6 +31,7 @@ mocha.describe('system_servers', function() {
     const EMAIL1 = `${PREFIX}-${EMAIL}`;
     const EMAIL2 = `${PREFIX}-${EMAIL}2`;
     const EMAIL3 = `${PREFIX}-${EMAIL}3`;
+    const EMAIL4 = `${PREFIX}-${EMAIL}4`;
     const NAMESPACE_RESOURCE_CONNECTION = 'Majestic Namespace Sloth';
     const NAMESPACE_RESOURCE_NAME = `${PREFIX}-namespace-resource`;
     const NAMESPACE_RESOURCE_NAME_2 = `${PREFIX}-namespace-resource-2`;
@@ -148,6 +149,18 @@ mocha.describe('system_servers', function() {
                 nsfs_only: false
             }
         });
+        await rpc_client.account.create_account({
+            name: EMAIL4,
+            email: EMAIL4,
+            has_login: false,
+            s3_access: true,
+            default_resource: DEFAULT_POOL_NAME,
+            nsfs_account_config: {
+                distinguished_name: 'rami11',
+                new_buckets_path: '/test1',
+                nsfs_only: false
+            }
+        });
         const account_params = {
             name: EMAIL3,
             email: EMAIL3,
@@ -177,7 +190,7 @@ mocha.describe('system_servers', function() {
         }
         await rpc_client.system.read_system();
         const accountlistnofilter = await rpc_client.account.list_accounts({});
-        await assert(accountlistnofilter.accounts.length === 5, 'should return 5 accounts');
+        await assert(accountlistnofilter.accounts.length === 6, 'should return 6 accounts');
         const accountlistfilter = await rpc_client.account.list_accounts({
             filter: {
                 fs_identity: {
@@ -187,9 +200,18 @@ mocha.describe('system_servers', function() {
             }
         });
         await assert(accountlistfilter.accounts.length === 1, 'should return 1 account');
+        const accountlistfilter2 = await rpc_client.account.list_accounts({
+            filter: {
+                fs_identity: {
+                    distinguished_name: 'rami11',
+                }
+            }
+        });
+        await assert(accountlistfilter2.accounts.length === 1, 'should return 1 account');
         await rpc_client.account.delete_account({ email: EMAIL1 });
         await rpc_client.account.delete_account({ email: EMAIL2 });
         await rpc_client.account.delete_account({ email: EMAIL3 });
+        await rpc_client.account.delete_account({ email: EMAIL4 });
         await rpc_client.events.read_activity_log({ limit: 2016 });
     });
 


### PR DESCRIPTION
### Explain the changes
1. In order to work with external users, we will support adding to the account instead of uid/gid an option to provide the user's distinguished name. this will be resolved into uid/gid using the os call getpwnam.
2. We will use a default 1 minute cache in order to not running this fs call for every s3 operation.
3. update Api's to support adding account with distinguished_name instead of uid/gid
4. Updated the tests for bucketspace and bucketspace_fs to support using distinguished_name 

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #7467 

### Testing Instructions:
1.


- [ ] Doc added/updated
- [x] Tests added
