### PR TITLE
NSFS | NC | github action for manual & nightly rpm build and upload it as artifact / s3

### DIFF
--- a/.github/workflows/manual-build-rpm.yaml
+++ b/.github/workflows/manual-build-rpm.yaml
@@ -1,0 +1,49 @@
+name: Manual RPM Build Dispatch
+on: 
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to RPM Build From'
+        required: true
+      tag:
+        description: 'Additional tag for the build (such as alpha, beta, etc.) - Optional'
+        default: ''
+
+jobs:
+  manual-rpm-build-and-upload-artifact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+     
+      - name: Prepare Suffix
+        id: suffix
+        if: ${{ github.event.inputs.tag != '' }}
+        run: echo suffix="_${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+      
+      - name: Build RPM
+        id: build_rpm
+        run: |
+          echo "Starting make rpm"
+          make rpm
+          echo "Make rpm completed"
+
+      - name: Finalize RPM
+        id: finalize_full_rpm_path
+        run: |
+          DATE=$(date +'%Y%m%d')
+          VERSION=$(jq -r '.version' < ./package.json)
+          RPM_BASE_VERSION=noobaa-core-${VERSION}-1.el8.x86_64
+          RPM_FULL_PATH="${RPM_BASE_VERSION}_${{ github.event.inputs.branch }}_${DATE}${{ steps.suffix.outputs.suffix }}.rpm"
+          echo "RPM FULL PATH=${RPM_FULL_PATH}"
+          cp ./build/rpm/${RPM_BASE_VERSION}.rpm ${RPM_FULL_PATH}
+          echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: noobaa_rpm
+          path: ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }}

--- a/.github/workflows/nightly-rpm-build.yml
+++ b/.github/workflows/nightly-rpm-build.yml
@@ -1,0 +1,49 @@
+name: Nightly RPM Build Dispatch
+on: 
+  schedule:
+    - cron: "0 23 * * *"
+
+
+jobs:
+  nightly-rpm-build-and-upload-artifact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: master
+     
+      - name: Build RPM
+        id: build_rpm
+        run: |
+          echo "Starting make rpm"
+          make rpm
+          echo "Make rpm completed"
+
+      - name: Finalize RPM
+        id: finalize_full_rpm_path
+        run: |
+          DATE=$(date +'%Y%m%d')
+          VERSION=$(jq -r '.version' < ./package.json)
+          RPM_BASE_VERSION=noobaa-core-${VERSION}-1.el8.x86_64
+          RPM_FULL_PATH="${RPM_BASE_VERSION}_${{ github.event.inputs.branch }}_${DATE}${{ steps.suffix.outputs.suffix }}.rpm"
+          echo "RPM FULL PATH=${RPM_FULL_PATH}"
+          cp ./build/rpm/${RPM_BASE_VERSION}.rpm ${RPM_FULL_PATH}
+          echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: noobaa_rpm
+          path: ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }}
+
+      - name: Setup AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.NEWAWSPROJKEY }}
+          aws-secret-access-key: ${{ secrets.NEWAWSPROJSECRET }}
+          aws-region: us-east-1
+
+      - name: Copy RPM to S3 bucket
+        run: aws s3 cp ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }} s3://noobaa-core-rpms/

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ rpm: base
 	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/RPM_build/RPM.Dockerfile $(CACHE_FLAG) -t $(NOOBAA_RPM_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	echo "\033[1;32mImage \"$(NOOBAA_RPM_TAG)\" is ready.\033[0m"
 	echo "Generating RPM..."
-	$(CONTAINER_ENGINE) run --rm -v $(PWD)/build/rpm:/export:z -it $(NOOBAA_RPM_TAG)
+	$(CONTAINER_ENGINE) run --rm -v $(PWD)/build/rpm:/export:z -t $(NOOBAA_RPM_TAG)
 	echo "\033[1;32mRPM for platform \"$(NOOBAA_RPM_TAG)\" is ready in build/rpm.\033[0m";
 .PHONY: rpm
 


### PR DESCRIPTION
### Explain the changes
1. Added manual RPM build
2. Added nightly RPM build.
3. uploaded the created RPM as artifact, nightly build will upload it to s3 as well.
4. makefile - replaced -it with -t in order to get TTY env on the github action. 
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
