### PR TITLE
NSFS | NC |endpoint metrics should aggregated fork

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -436,6 +436,13 @@ NSFS management CLI command will create both account and bucket dir if it's miss
 
 Non containerized NSFS certificates/ directory location will be under the config_root path. The certificates/ directory should contain SSL files tls.key and tls.crt. System will use a cert from this dir to create a valid HTTPS connection. If cert is missing in this dir a self-signed SSL certificate will be generated. Make sure the path to certificates/ directory is valid before running nsfs command, If the path is invalid then cert flow will fail.
 
+Non containerized NSFS restrict insecure HTTP connections when `allow_http` is set to false in cofig.json. This is not the default behaviour.
+
+## Monitoring
+
+Prometheus metrics port can be passed through the argument `--metrics_port` while executing the nsfs command. 
+NSFS state and output metrics can be fetched from URL `http:{host}:{metrics_port}/metrics/nsfs_stats`.
+
 ## Log and Logrotate
 Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running. 
 

--- a/src/server/analytic_services/prometheus_reporting.js
+++ b/src/server/analytic_services/prometheus_reporting.js
@@ -10,6 +10,9 @@ const config = require('../../../config');
 const { NodeJsReport } = require('./prometheus_reports/nodejs_report');
 const { NooBaaCoreReport } = require('./prometheus_reports/noobaa_core_report');
 const { NooBaaEndpointReport } = require('./prometheus_reports/noobaa_endpoint_report');
+const stats_aggregator = require('../system_services/stats_aggregator');
+const AggregatorRegistry = require('prom-client').AggregatorRegistry;
+const aggregatorRegistry = new AggregatorRegistry();
 
 // Currenty supported reprots
 const reports = Object.seal({
@@ -17,6 +20,9 @@ const reports = Object.seal({
     core: null, // optional
     endpoint: null // optional
 });
+
+let io_stats_complete = {};
+let ops_stats_complete = {};
 
 function get_nodejs_report() {
     return reports.nodejs;
@@ -43,6 +49,7 @@ async function export_all_metrics() {
 
 async function start_server(
     port,
+    fork_enabled,
     retry_count = config.PROMETHEUS_SERVER_RETRY_COUNT,
     delay = config.PROMETHEUS_SERVER_RETRY_DELAY
 ) {
@@ -51,20 +58,50 @@ async function start_server(
     }
 
     const server = http.createServer(async (req, res) => {
-        // Serve all metrics on the root path.
-        if (req.url === '' || req.url === '/') {
-            res.writeHead(200, { 'Content-Type': 'text/plain' });
-            res.end(await export_all_metrics());
-            return;
-        }
-
-        // Serve report's metrics on the report name path
-        const report_name = req.url.substr(1);
-        const report = reports[report_name];
-        if (report) {
-            res.writeHead(200, { 'Content-Type': 'text/plain' });
-            res.end(await report.export_metrics(report_name));
-            return;
+        // Serve all metrics on the root path for system that do have one or more fork running.
+        if (fork_enabled) {
+            const metrics = await aggregatorRegistry.clusterMetrics();
+            if (req.url === '' || req.url === '/') {
+                res.writeHead(200, { 'Content-Type': aggregatorRegistry.contentType });
+                res.end(metrics);
+                return;
+            }
+            if (req.url === '/metrics/nsfs_stats') {
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                const nsfs_report = {
+                    nsfs_counters: io_stats_complete,
+                    op_stats_counters: ops_stats_complete,
+                };
+                res.end(JSON.stringify(nsfs_report));
+                return;
+            }
+            // Serve report's metrics on the report name path
+            const report_name = req.url.substr(1);
+            const single_metrics = export_single_metrics(metrics, report_name);
+            if (single_metrics !== "") {
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.end(single_metrics);
+                return;
+            }
+        } else {
+            // Serve all metrics on the root path for system that do not have any fork running.
+            if (req.url === '' || req.url === '/') {
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.end(await export_all_metrics());
+                return;
+            }
+            if (req.url === '/metrics/nsfs_stats') {
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.end(await metrics_nsfs_stats_handler());
+                return;
+            }
+            const report_name = req.url.substr(1);
+            const report = reports[report_name];
+            if (report) {
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.end(await report.export_metrics(report_name));
+                return;
+            }
         }
 
         res.writeHead(404, { 'Content-Type': 'text/plain' });
@@ -94,6 +131,62 @@ async function start_server(
     }
 }
 
+async function metrics_nsfs_stats_handler() {
+    const nsfs_io_stats = {};
+    const nsfs_counters = stats_aggregator.get_nsfs_io_stats(false);
+    // Building the report per io and value
+    for (const [key, value] of Object.entries(nsfs_counters)) {
+        nsfs_io_stats[`noobaa_nsfs_io_${key}`.toLowerCase()] = value;
+    }
+
+    const op_stats_counters = {};
+    const op_stats = stats_aggregator.get_op_stats(false);
+    // Building the report per op name key and value
+    for (const [op_name, obj] of Object.entries(op_stats)) {
+        for (const [key, value] of Object.entries(obj)) {
+            op_stats_counters[`noobaa_nsfs_op_${op_name}_${key}`.toLowerCase()] = value;
+        }
+    }
+
+    const nsfs_report = {
+        nsfs_counters: nsfs_io_stats,
+        op_stats_counters: op_stats_counters,
+    };
+    dbg.log1(`_create_nsfs_report: nsfs_report ${nsfs_report}`);
+    return JSON.stringify(nsfs_report);
+}
+
+function export_single_metrics(all_metrics, report_name) {
+    let single_metrics = "";
+    const metrics_arr = all_metrics.split('\n');
+    for (const metrics_line of metrics_arr) {
+        if (metrics_line.includes(report_name)) {
+            single_metrics = single_metrics + metrics_line + "\n";
+        }
+    }
+    return single_metrics;
+
+}
+
+function set_io_stats(io_stats) {
+    const nsfs_io_stats = {};
+    for (const [key, value] of Object.entries(io_stats)) {
+        nsfs_io_stats[`noobaa_nsfs_io_${key}`.toLowerCase()] = value;
+    }
+    io_stats_complete = nsfs_io_stats;
+}
+
+function set_ops_stats(ops_stats) {
+    const op_stats_counters = {};
+    // Building the report per op name key and value
+    for (const [op_name, obj] of Object.entries(ops_stats)) {
+        for (const [key, value] of Object.entries(obj)) {
+            op_stats_counters[`noobaa_nsfs_op_${op_name}_${key}`.toLowerCase()] = value;
+        }
+    }
+    ops_stats_complete = op_stats_counters;
+}
+
 // -----------------------------------------
 // exports
 // -----------------------------------------
@@ -102,3 +195,5 @@ exports.get_core_report = get_core_report;
 exports.get_endpoint_report = get_endpoint_report;
 exports.export_all_metrics = export_all_metrics;
 exports.start_server = start_server;
+exports.set_io_stats = set_io_stats;
+exports.set_ops_stats = set_ops_stats;

--- a/src/server/analytic_services/prometheus_reports/base_prometheus_report.js
+++ b/src/server/analytic_services/prometheus_reports/base_prometheus_report.js
@@ -6,15 +6,15 @@ const config = require('../../../../config.js');
 
 class BasePrometheusReport {
     constructor() {
-        this._registry = new this.prom_client.Registry();
+        this._register = this.prom_client.register;
     }
 
     get prom_client() {
         return prom_client;
     }
 
-    get registry() {
-        return this._registry;
+    get register() {
+        return this._register;
     }
 
     get metric_prefix() {
@@ -30,7 +30,7 @@ class BasePrometheusReport {
     }
 
     export_metrics() {
-        return this.registry.metrics();
+        return this.register.metrics();
     }
 }
 

--- a/src/server/analytic_services/prometheus_reports/nodejs_report.js
+++ b/src/server/analytic_services/prometheus_reports/nodejs_report.js
@@ -14,7 +14,7 @@ class NodeJsReport extends BasePrometheusReport {
 
         if (this.enabled) {
             this.prom_client.collectDefaultMetrics({
-                register: this.registry,
+                register: this.register,
                 prefix: this.metric_prefix
             });
         }

--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -407,7 +407,7 @@ class NooBaaCoreReport extends BasePrometheusReport {
                 }
                 this._metrics[m.name] = new this.prom_client[m.type]({
                     name: this.get_prefixed_name(m.name),
-                    registers: [this.registry],
+                    registers: [this.register],
                     ...m.configuration,
                 });
             }

--- a/src/server/analytic_services/prometheus_reports/noobaa_endpoint_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_endpoint_report.js
@@ -227,6 +227,15 @@ const NOOBAA_ENDPOINT_METRICS = js_utils.deep_freeze([{
             total_values = 0;
         },
     },
+    {
+        type: 'Counter',
+        name: 'fork_counter',
+        configuration: {
+            help: 'Counter on number of fork hit',
+            labelNames: ['code']
+        },
+        aggregator: 'average',
+    }
 ]);
 
 class NooBaaEndpointReport extends BasePrometheusReport {
@@ -241,7 +250,7 @@ class NooBaaEndpointReport extends BasePrometheusReport {
                     collect: m.collect,
                     prom_instance: new this.prom_client[m.type]({
                         name: this.get_prefixed_name(m.name),
-                        registers: [this.registry],
+                        registers: [this.register],
                         ...m.configuration,
                         collect() {
                             if (m.collect && this.average_intervals) {

--- a/src/test/utils/metrics.js
+++ b/src/test/utils/metrics.js
@@ -4,12 +4,12 @@
 // Get metric from prometheus collector
 function get_metric(stat_collector, name) {
     const metric_name = stat_collector.get_prefixed_name(name);
-    return stat_collector.registry.getSingleMetric(metric_name);
+    return stat_collector.register.getSingleMetric(metric_name);
 }
 
 // Reset all metrics in prometheus collector
 function reset_metrics(stat_collector) {
-    return stat_collector.registry.resetMetrics();
+    return stat_collector.register.resetMetrics();
 }
 
 exports.get_metric = get_metric;

--- a/src/util/fork_utils.js
+++ b/src/util/fork_utils.js
@@ -5,7 +5,18 @@
 const cluster = /** @type {import('node:cluster').Cluster} */ (
     /** @type {unknown} */ (require('node:cluster'))
 );
+const dbg = require('../util/debug_module')(__filename);
+const prom_reporting = require('../server/analytic_services/prometheus_reporting');
 
+
+const io_stats = {
+    read_count: 0,
+    write_count: 0,
+    read_bytes: 0,
+    write_bytes: 0,
+};
+
+const op_stats = {};
 /**
  * The cluster module allows easy creation of child processes that all share server ports.
  * When count > 0 the primary process will fork worker processes to process incoming http requests.
@@ -13,10 +24,10 @@ const cluster = /** @type {import('node:cluster').Cluster} */ (
  * @see https://nodejs.org/api/cluster.html
  * 
  * @param {number?} count number of workers to start.
+ * @param {number?} metrics_port prometheus metris port.
  * @returns {boolean} true if workers were started.
  */
-function start_workers(count = 0) {
-
+function start_workers(metrics_port, count = 0) {
     if (cluster.isPrimary && count > 0) {
         for (let i = 0; i < count; ++i) {
             const worker = cluster.fork();
@@ -31,12 +42,74 @@ function start_workers(count = 0) {
             console.error('EXIT ON WORKER ERROR');
             process.exit(1);
         });
-
+        for (const id in cluster.workers) {
+            if (id) {
+                cluster.workers[id].on('message', nsfs_io_state_handler);
+            }
+        }
+        if (metrics_port > 0) {
+            dbg.log0('Starting metrics server', metrics_port);
+            prom_reporting.start_server(metrics_port, true);
+            dbg.log0('Started metrics server successfully');
+        }
         return true;
     }
 
     return false;
 }
 
-exports.cluster = cluster;
+function nsfs_io_state_handler(msg) {
+    if (msg.io_stats) {
+        for (const [key, value] of Object.entries(msg.io_stats)) {
+            io_stats[key] += value;
+        }
+        prom_reporting.set_io_stats(io_stats);
+    }
+    if (msg.op_stats) {
+        _update_ops_stats(msg.op_stats);
+        prom_reporting.set_ops_stats(op_stats);
+    }
+}
+
+function _update_ops_stats(ops_stats) {
+    // Predefined op_names
+    const op_names = [
+        `upload_object`,
+        `delete_object`,
+        `create_bucket`,
+        `list_buckets`,
+        `delete_bucket`,
+        `list_objects`,
+        `head_object`,
+        `read_object`,
+        `initiate_multipart`,
+        `upload_part`,
+        `complete_object_upload`,
+    ];
+    //Go over the op_stats
+    for (const op_name of op_names) {
+        if (op_name in ops_stats) {
+            _set_op_stats(op_name, ops_stats[op_name]);
+        }
+    }
+}
+
+function _set_op_stats(op_name, stats) {
+    //In the event of all of the same ops are failing (count = error_count) we will not masseur the op times
+    // As this is intended as a timing masseur and not a counter. 
+    if (op_stats[op_name]) {
+        const count = op_stats[op_name].count + stats.count;
+        const error_count = op_stats[op_name].error_count + stats.error_count;
+        op_stats[op_name] = {
+            count,
+            error_count,
+        };
+    } else if (stats.count > stats.error_count) {
+        op_stats[op_name] = {
+            count: stats.count,
+            error_count: stats.error_count,
+        };
+    }
+}
+
 exports.start_workers = start_workers;


### PR DESCRIPTION
### Explain the changes
1. Currently the endpoint_stats_collector just prints the metrics to log in standalone mode (no rpc_client).
2. In addition, when combined with --forks, the metrics port does not work as expected and will just load balance each request to a different fork.
3. NSFS Certificate doc updated

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7482

### Testing Instructions:

1. start nsfs with multiple forks and Prometheus port
2. Hit Prometheus url and verify the values



- [ ] Doc added/updated
- [ ] Tests added
