### PR TITLE
NSFS | NC | Fix nightly rpm build final path

### DIFF
--- a/.github/workflows/nightly-rpm-build.yml
+++ b/.github/workflows/nightly-rpm-build.yml
@@ -27,7 +27,7 @@ jobs:
           DATE=$(date +'%Y%m%d')
           VERSION=$(jq -r '.version' < ./package.json)
           RPM_BASE_VERSION=noobaa-core-${VERSION}-1.el8.x86_64
-          RPM_FULL_PATH="${RPM_BASE_VERSION}_${{ github.event.inputs.branch }}_${DATE}${{ steps.suffix.outputs.suffix }}.rpm"
+          RPM_FULL_PATH="${RPM_BASE_VERSION}_${DATE}.rpm"
           echo "RPM FULL PATH=${RPM_FULL_PATH}"
           cp ./build/rpm/${RPM_BASE_VERSION}.rpm ${RPM_FULL_PATH}
           echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Explain the changes
1.  removed redundant _branch from the nightly rpm build final path of the rpm - 
noobaa-core-5.15.0-1.el8.x86_64__20231106.rpm -> noobaa-core-5.15.0-1.el8.x86_64_20231106.rpm

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
