### PR TITLE
Fix Backingstore AWS STS - Pass the Role ARN

### DIFF
--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -297,14 +297,16 @@ class BlockStoreClient {
                 s3_params.httpOptions = {
                     agent: http_utils.get_unsecured_agent(s3_params.endpoint)
                 };
-                if (bs_info.aws_sts_arn) {
+                if (bs_info.connection_params.aws_sts_arn) {
                     const creds = await cloud_utils.generate_aws_sts_creds(s3_params, "_delegate_write_block_s3_session");
                     s3_params.accessKeyId = creds.accessKeyId;
                     s3_params.secretAccessKey = creds.secretAccessKey;
                     s3_params.sessionToken = creds.sessionToken;
                 }
-                dbg.log1('got s3_params from block_store. writing using S3 sdk. s3_params =',
-                    _.omit(s3_params, 'secretAccessKey'));
+                dbg.log1('_delegate_write_block_s3:',
+                    'got s3_params from block_store. writing using S3 sdk. s3_params =',
+                    _.omit(s3_params, 'secretAccessKey'),
+                    'aws_sts_arn', bs_info.connection_params.aws_sts_arn);
                 const s3 = new AWS.S3(s3_params);
                 write_params.Body = data;
                 await s3.putObject(write_params).promise();
@@ -348,14 +350,16 @@ class BlockStoreClient {
                 s3_params.httpOptions = {
                     agent: http_utils.get_unsecured_agent(s3_params.endpoint)
                 };
-                if (bs_info.aws_sts_arn) {
+                if (bs_info.connection_params.aws_sts_arn) {
                     const creds = await cloud_utils.generate_aws_sts_creds(s3_params, "_delegate_read_block_s3_session");
                     s3_params.accessKeyId = creds.accessKeyId;
                     s3_params.secretAccessKey = creds.secretAccessKey;
                     s3_params.sessionToken = creds.sessionToken;
                 }
-                dbg.log1('got s3_params from block_store. writing using S3 sdk. s3_params =',
-                    _.omit(s3_params, 'secretAccessKey'));
+                dbg.log1('_delegate_read_block_s3:',
+                    'got s3_params from block_store. writing using S3 sdk. s3_params =',
+                    _.omit(s3_params, 'secretAccessKey'),
+                    'aws_sts_arn', bs_info.connection_params.aws_sts_arn);
                 const s3 = new AWS.S3(s3_params);
                 const data = await s3.getObject(read_params).promise();
                 const noobaablockmd = data.Metadata.noobaablockmd || data.Metadata.noobaa_block_md;


### PR DESCRIPTION
### Explain the changes
1. In AWS STS backingstore inside `block_store_client.js` we use `bs_info.connection_params.aws_sts_arn` to pass the role ARN (instead of `bs_info.aws_sts_arn` which is undefined).
2. Add logs related to role ARN since it will not appear in the current log that prints s3_param (because we use it to get the credentials).

### Issues: Fixed #xxx / Gap #xxx
Currently, we are not able to write and read using backingstore AWS STS. When using the backingstore its mode changes from `OPTIMAL` to `IO_ERRORS` and the phase from `Ready` to `Rejected`.

Added logs (can be seen in the endpoint pod):
> Nov-7 12:35:51.256 [Endpoint/12]   [LOG] CONSOLE:: SDSD bs_info.aws_sts_arn undefined

### Testing Instructions:
1. Create AWS STS Setup on Minikube (the guide will be in the operator repo, meanwhile this is the PR #noobaa/noobaa-operator#1244.
2. Build the image and deploy noobaa on MInikube (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
3. Create backingstore:
`nb backingstore create aws-sts-s3 <backingstore-name> -n <your-namespace>`
4. Create bucket class:
`nb bucketclass create placement-bucketclass <bucketclass-name> --backingstores=<backingstore-name> -n <your-namespace>`
5. Create OBC:
`nb obc create <obc-name> --bucketclass=<bucket-class-name> -n <your-namespace>`
6. Using por-forward (due to using MacOS):
7. `kubectl port-forward -n <your-namespace> service/s3 12443:443`
8. Create the alias from the OBC creation output:
`alias s3-nb-user-1='AWS_SECRET_ACCESS_KEY=<paste-here> AWS_ACCESS_KEY_ID=<paste-here> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
9. Set higher debug level (to see the `dbg.log1` printing that was added):
`nb system set-debug-level 3 -n <your-namespace>`
10. Put an object
`s3-nb-user-1 s3api put-object --bucket <obc-bucket-name> --key <key-name> --body <path-to-file>`
11. Get the object
`s3-nb-user-1 s3api get-object --bucket <obc-bucket-name> --key <key-name>`

- [ ] Doc added/updated
- [ ] Tests added
