### PR TITLE
NSFS | NC | fix ENDPOINT_FORKS usage

### DIFF
--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -1,5 +1,6 @@
 /* Copyright (C) 2020 NooBaa */
 'use strict';
+/* eslint-disable complexity */
 
 require('../util/dotenv').load();
 require('aws-sdk/lib/maintenance_mode_message').suppress = true;
@@ -243,7 +244,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         const https_port = Number(argv.https_port) || Number(process.env.ENDPOINT_SSL_PORT) || 6443;
         const https_port_sts = Number(argv.https_port_sts) || -1;
         const metrics_port = Number(argv.metrics_port) || -1;
-        const forks = Number(argv.forks);
+        const forks = Number(argv.forks) || config.ENDPOINT_FORKS;
         const uid = Number(argv.uid) || process.getuid();
         const gid = Number(argv.gid) || process.getgid();
         const access_key = argv.access_key && new SensitiveString(String(argv.access_key));


### PR DESCRIPTION
### Explain the changes
1. line 89 in endpoint.js does the following - if (fork_utils.start_workers((options.forks ?? config.ENDPOINT_FORKS))) return;
2. without passing forks, options.forks is NaN, and the evaluation of (Nan ?? config.ENDPOINT_FORKS) equals Nan. changing the default of options.forks to config.ENDPOINT_FORKS will solve this issue.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. set ENDPOINT_FORKS=4 in /etc/noobaa.conf.d/.env
2. run systemctl restart nsfs
3. run ps auxf and check that all forks created 


- [ ] Doc added/updated
- [ ] Tests added
