### PR TITLE
Support role config deletion

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -206,6 +206,9 @@ module.exports = {
                     role_config: {
                         $ref: 'common_api#/definitions/role_config'
                     },
+                    remove_role_config: {
+                        type: 'boolean'
+                    },
                 }
             },
             auth: {

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -464,7 +464,8 @@ function update_account(req) {
 
     const removals = {
         next_password_change: params.must_change_password === false ? true : undefined,
-        allowed_ips: params.ips === null ? true : undefined
+        allowed_ips: params.ips === null ? true : undefined,
+        role_config: params.remove_role_config,
     };
 
     //Create the event description according to the changes performed


### PR DESCRIPTION
### Explain the changes
This PR adds support for a role config deletion flag that can be set to `true` if a user wishes to delete an account's role config

### Issues: Fixed #xxx / Gap #xxx
This PR is necessary for [operator PR 1238](https://github.com/noobaa/noobaa-operator/pull/1238)
