### PR TITLE
Replace revisions with current date

### DIFF
--- a/.github/workflows/manual-build-rpm.yaml
+++ b/.github/workflows/manual-build-rpm.yaml
@@ -36,10 +36,10 @@ jobs:
         run: |
           DATE=$(date +'%Y%m%d')
           VERSION=$(jq -r '.version' < ./package.json)
-          RPM_BASE_VERSION=noobaa-core-${VERSION}-1.el8.x86_64
-          RPM_FULL_PATH="${RPM_BASE_VERSION}_${{ github.event.inputs.branch }}_${DATE}${{ steps.suffix.outputs.suffix }}.rpm"
+          RPM_BASE_VERSION=noobaa-core-${VERSION}-${DATE}
+          RPM_FULL_PATH="${RPM_BASE_VERSION}-${{ github.event.inputs.branch }}_${{ steps.suffix.outputs.suffix }}.el8.x86_64.rpm"
           echo "RPM FULL PATH=${RPM_FULL_PATH}"
-          cp ./build/rpm/${RPM_BASE_VERSION}.rpm ${RPM_FULL_PATH}
+          cp ./build/rpm/${RPM_BASE_VERSION}.el8.x86_64.rpm ${RPM_FULL_PATH}
           echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact

--- a/.github/workflows/nightly-rpm-build.yml
+++ b/.github/workflows/nightly-rpm-build.yml
@@ -26,10 +26,8 @@ jobs:
         run: |
           DATE=$(date +'%Y%m%d')
           VERSION=$(jq -r '.version' < ./package.json)
-          RPM_BASE_VERSION=noobaa-core-${VERSION}-1.el8.x86_64
-          RPM_FULL_PATH="${RPM_BASE_VERSION}_${DATE}.rpm"
+          RPM_FULL_PATH=noobaa-core-${VERSION}-${DATE}.el8.x86_64
           echo "RPM FULL PATH=${RPM_FULL_PATH}"
-          cp ./build/rpm/${RPM_BASE_VERSION}.rpm ${RPM_FULL_PATH}
           echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact

--- a/src/deploy/RPM_build/packagerpm.sh
+++ b/src/deploy/RPM_build/packagerpm.sh
@@ -9,8 +9,8 @@ SKIP_NODE_INSTALL=1 source $dir/../install_nodejs.sh
 NODE_PATH="${NODE_PATH:-/usr/local/node}"
 
 noobaaver="$(npm pkg get version | tr -d '"')"
-revision="1"
 releasedate=$(date '+%a %b %d %Y')
+revision="$(date -u '+%Y%m%d')"
 nodever=$(node --version | tr -d 'v')
 changelogdata="Initial release of NooBaa ${noobaaver}"
 ARCHITECTURE=$(uname -m)


### PR DESCRIPTION
### Explain the changes
This PR replaces the fixed revision from `1` to current date.

### Testing Instructions:
1. Run `make rpm`
2. Check the generated RPM name, it should be of the format `noobaa-core-$(version)-$(date)`.


- [ ] Doc added/updated
- [ ] Tests added
