### PR TITLE
Noobaa/Bucket Logging : Log delivery to noobaa core

### DIFF
--- a/src/deploy/NVA_build/rsyslog.conf
+++ b/src/deploy/NVA_build/rsyslog.conf
@@ -12,8 +12,8 @@ $ModLoad imuxsock # provides support for local system logging (e.g. via logger c
 #$ModLoad immark  # provides --MARK-- message capability
 
 # Provides UDP syslog reception
-#$ModLoad imudp
-#$UDPServerRun 514
+$ModLoad imudp
+$UDPServerRun 514
 
 # Provides TCP syslog reception
 #$ModLoad imtcp
@@ -48,6 +48,11 @@ $OmitLocalLogging off
 # Log all kernel messages to the console.
 # Logging much else clutters up the screen.
 #kern.*                                                 /dev/console
+
+if $msg contains '{"noobaa_bucket_logging":"true"' then {
+    action(type="omfile" file="/var/log/bucket_logs.log")
+    stop
+}
 
 # Log anything (except mail) of level info or higher.
 # Don't log private authentication messages!

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -328,6 +328,7 @@ function get_rpc_router(env) {
         bg: env.BG_ADDR || addr_utils.format_base_address(hostname, ports.bg),
         hosted_agents: env.HOSTED_AGENTS_ADDR || addr_utils.format_base_address(hostname, ports.hosted_agents),
         master: env.MGMT_ADDR || addr_utils.format_base_address(hostname, ports.mgmt),
+        syslog: env.SYSLOG_ADDR || "udp://localhost:514",
     };
 }
 

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -78,7 +78,7 @@ module.exports = {
                 properties: {
                     service: {
                         type: 'string',
-                        enum: ['noobaa-mgmt', 's3', 'sts', 'noobaa-db', 'noobaa-db-pg']
+                        enum: ['noobaa-mgmt', 's3', 'sts', 'noobaa-db', 'noobaa-db-pg', 'noobaa-syslog']
                     },
                     kind: {
                         type: 'string',
@@ -88,7 +88,7 @@ module.exports = {
                     port: { $ref: 'common_api#/definitions/port' },
                     api: {
                         type: 'string',
-                        enum: ['mgmt', 's3', 'sts', 'md', 'bg', 'hosted_agents', 'mongodb', 'metrics', 'postgres']
+                        enum: ['mgmt', 's3', 'sts', 'md', 'bg', 'hosted_agents', 'mongodb', 'metrics', 'postgres', 'syslog']
                     },
                     secure: { type: 'boolean' },
                     weight: { type: 'integer' }


### PR DESCRIPTION
Whenever an object operation comes to endpoint, handle_request function process it and logs it to its /var/log/messages.

We need these logs to be sent on noobaa core so that we can process it further and accordingly write it to log bucket as log objects.

In this code change we are sending logs to noobaa core via noobaa-syslog service.

Credit goes to aprinzse@redhat.com for the code contribution.
