### PR TITLE
Fixes Related To AWS STS (in `BlockStoreS3` And `add_external_connection`)

### DIFF
--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -255,6 +255,9 @@ class BlockStoreS3 extends BlockStoreBase {
         try {
             const endpoint = this.cloud_info.endpoint;
             if (cloud_utils.is_aws_endpoint(endpoint)) {
+                if (this.cloud_info.aws_sts_arn) {
+                    this.s3cloud = await cloud_utils.createSTSS3Client(this.cloud_info, this.additionalS3Params);
+                }
                 // in s3 there is no error for non-existing object
                 await this.s3cloud.deleteObjectTagging({
                     Bucket: this.cloud_info.target_bucket,
@@ -291,7 +294,8 @@ class BlockStoreS3 extends BlockStoreBase {
     }
 
     async _delete_past_versions(key) {
-        if (this.cloud_info.endpoint_type !== 'AWS') return;
+        if ((this.cloud_info.endpoint_type !== 'AWS') &&
+            (this.cloud_info.endpoint_type !== 'AWSSTS')) return;
         let is_truncated = true;
         let key_marker;
         let version_marker;

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -740,7 +740,7 @@ async function add_external_connection(req) {
     info.cp_code = req.rpc_params.cp_code || undefined;
     info.auth_method = req.rpc_params.auth_method || config.DEFAULT_S3_AUTH_METHOD[info.endpoint_type] || undefined;
     info = _.omitBy(info, _.isUndefined);
-    if ((info.endpoint_type === 'AWS' || info.endpoint_type === 'S3_COMPATIBLE') &&
+    if ((info.endpoint_type === 'AWS' || info.endpoint_type === 'AWSSTS' || info.endpoint_type === 'S3_COMPATIBLE') &&
         (!info.endpoint.startsWith('http://') && !info.endpoint.startsWith('https://'))) {
         info.endpoint = 'http://' + info.endpoint;
     }


### PR DESCRIPTION
### Explain the changes
1. In `test_store_validity` add the condition related to AWS STS as it appears in all other methods in the class.
2. In `_delete_past_versions` has a condition related to AWS so I added AWSSTS.
3. In `add_external_connection` add the type AWSSTS in a condition (which I thought was missing).

### Issues: Fixed #xxx / Gap #xxx
1. Without the change in `test_store_validity` you could see in noobaa-core logs:

> [WARN] core.agent.block_store_services.block_store_s3:: unexpected error (code=ExpiredToken) from deleteObject during test. ignoring..

Note: to see it live I changed the `defaultSTSCredsValidity` to 900 (minimum possible) and waited 15 minutes after the creation of the aws-sts backingstore.

### Testing Instructions:
1. Create AWS STS Setup on Minikube (the guide will be in the operator repo, meanwhile this is the PR #noobaa/noobaa-operator#1244.
2. Build the image and deploy noobaa on MInikube (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
4. Create backingstore:
`nb backingstore create aws-sts-s3 <backingstore-name> -n <your-namespace>`
5. Create bucket class:
`nb bucketclass create placement-bucketclass <bucketclass-name> --backingstores=<backingstore-name> -n <your-namespace>`
6. Create OBC:
`nb obc create <obc-name> --bucketclass=<bucket-class-name> -n <your-namespace>`
7. Using por-forward (due to using MacOS):
8. `kubectl port-forward -n <your-namespace> service/s3 12443:443`
9. Create the alias from the OBC creation output:
`alias s3-nb-user-1='AWS_SECRET_ACCESS_KEY=<paste-here> AWS_ACCESS_KEY_ID=<paste-here> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
10. Set higher debug level:
`nb system set-debug-level 3 -n <your-namespace>`
11. Put an object
`s3-nb-user-1 s3api put-object --bucket <obc-bucket-name> --key <key-name> --body <path-to-file>`
12. Get the object
`s3-nb-user-1 s3api get-object --bucket <obc-bucket-name> --key <key-name>`


- [ ] Doc added/updated
- [ ] Tests added
