### PR TITLE
[5.12] Bumping "azure-storage" from 2.10.5 to 2.10.7 to avoid CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noobaa-core",
-  "version": "5.12.1",
+  "version": "5.12.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "noobaa-core",
-      "version": "5.12.1",
+      "version": "5.12.10",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -14,7 +14,7 @@
         "@google-cloud/storage": "5.18.3",
         "ajv": "8.11.2",
         "aws-sdk": "2.1127.0",
-        "azure-storage": "2.10.5",
+        "azure-storage": "2.10.7",
         "bcrypt": "5.0.1",
         "big-integer": "1.6.51",
         "bindings": "1.5.0",
@@ -1774,21 +1774,22 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "node_modules/azure-storage": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.5.tgz",
-      "integrity": "sha512-kLCbiW1lvwwJwB/iOX7ic7xw/RIcSReF1sUFetEyFSiE+HDdv/wpSlsQx0F0khkXrPtJmBJRH0y9s/CRuRBWLQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.7.tgz",
+      "integrity": "sha512-4oeFGtn3Ziw/fGs/zkoIpKKtygnCVIcZwzJ7UQzKTxhkGQqVCByOFbYqMGYR3L+wOsunX9lNfD0jc51SQuKSSA==",
       "deprecated": "Please note: newer packages @azure/storage-blob, @azure/storage-queue and @azure/storage-file are available as of November 2019 and @azure/data-tables is available as of June 2021. While the legacy azure-storage package will continue to receive critical bug fixes, we strongly encourage you to upgrade. Migration guide can be found: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/MigrationGuide.md",
       "dependencies": {
-        "browserify-mime": "~1.2.9",
+        "browserify-mime": "^1.2.9",
         "extend": "^3.0.2",
-        "json-edm-parser": "0.1.2",
-        "md5.js": "1.3.4",
-        "readable-stream": "~2.0.0",
+        "json-edm-parser": "~0.1.2",
+        "json-schema": "~0.4.0",
+        "md5.js": "^1.3.4",
+        "readable-stream": "^2.0.0",
         "request": "^2.86.0",
         "underscore": "^1.12.1",
         "uuid": "^3.0.0",
-        "validator": "~13.6.0",
-        "xml2js": "0.2.8",
+        "validator": "^13.7.0",
+        "xml2js": "~0.2.8",
         "xmlbuilder": "^9.0.7"
       },
       "engines": {
@@ -4862,6 +4863,11 @@
         "jsonparse": "~1.2.0"
       }
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4952,11 +4958,6 @@
       "engines": {
         "node": ">=0.6.0"
       }
-    },
-    "node_modules/jsprim/node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -8723,9 +8724,9 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/validator": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -10517,20 +10518,21 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "azure-storage": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.5.tgz",
-      "integrity": "sha512-kLCbiW1lvwwJwB/iOX7ic7xw/RIcSReF1sUFetEyFSiE+HDdv/wpSlsQx0F0khkXrPtJmBJRH0y9s/CRuRBWLQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.7.tgz",
+      "integrity": "sha512-4oeFGtn3Ziw/fGs/zkoIpKKtygnCVIcZwzJ7UQzKTxhkGQqVCByOFbYqMGYR3L+wOsunX9lNfD0jc51SQuKSSA==",
       "requires": {
-        "browserify-mime": "~1.2.9",
+        "browserify-mime": "^1.2.9",
         "extend": "^3.0.2",
-        "json-edm-parser": "0.1.2",
-        "md5.js": "1.3.4",
-        "readable-stream": "~2.0.0",
+        "json-edm-parser": "~0.1.2",
+        "json-schema": "~0.4.0",
+        "md5.js": "^1.3.4",
+        "readable-stream": "^2.0.0",
         "request": "^2.86.0",
         "underscore": "^1.12.1",
         "uuid": "^3.0.0",
-        "validator": "~13.6.0",
-        "xml2js": "0.2.8",
+        "validator": "^13.7.0",
+        "xml2js": "~0.2.8",
         "xmlbuilder": "^9.0.7"
       },
       "dependencies": {
@@ -12863,6 +12865,11 @@
         "jsonparse": "~1.2.0"
       }
     },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -12930,13 +12937,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "json-schema": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        }
       }
     },
     "just-extend": {
@@ -15752,9 +15752,9 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "validator": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "5.12.1",
+  "version": "5.12.10",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "",
@@ -73,7 +73,7 @@
     "@google-cloud/storage": "5.18.3",
     "ajv": "8.11.2",
     "aws-sdk": "2.1127.0",
-    "azure-storage": "2.10.5",
+    "azure-storage": "2.10.7",
     "bcrypt": "5.0.1",
     "big-integer": "1.6.51",
     "bindings": "1.5.0",

--- a/src/test/system_tests/ceph_s3_tests_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests_deploy.sh
@@ -28,10 +28,3 @@ fi
 commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}')
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
-
-max_days="500"
-if [ $((current_date-commit_date)) -gt $((3600*24*${max_days})) ]
-then
-    echo "ceph tests were not updated for ${max_days} days, Exiting"
-    exit 1
-fi


### PR DESCRIPTION
### Explain the changes
[5.12] Bumping "azure-storage" from 2.10.5 to 2.10.7

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2126305
