### PR TITLE
Exclude `storage_class` from `new_tier_defaults` when it's not provided

### DIFF
--- a/src/server/system_services/tier_server.js
+++ b/src/server/system_services/tier_server.js
@@ -19,7 +19,7 @@ const chunk_config_utils = require('../utils/chunk_config_utils');
 const SensitiveString = require('../../util/sensitive_string');
 
 function new_tier_defaults(name, system_id, chunk_config, mirrors, storage_class) {
-    return {
+    return _.omitBy({
         _id: system_store.new_system_store_id(),
         name: name,
         system: system_id,
@@ -27,7 +27,7 @@ function new_tier_defaults(name, system_id, chunk_config, mirrors, storage_class
         data_placement: 'SPREAD',
         mirrors,
         storage_class: storage_class,
-    };
+    }, _.isUndefined);
 }
 
 function new_policy_defaults(name, system_id, chunk_split_config, tiers_orders) {


### PR DESCRIPTION
### Explain the changes
1. The inclusion of `storage_class: undefined` in `new_tier_defaults` caused an exception in certain scenarios (e.g. - when patching a replication policy to a bucketclass with existing OBCs) -

```
Nov-14 16:30:34.252 [WebServer/40] [ERROR] core.util.postgres_client:: postgres_client: T00000032|Q00000888: failed with error: error: invalid input syntax for type json
    at /root/node_modules/noobaa-core/node_modules/pg/lib/client.js:526:17
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async _do_query (/root/node_modules/noobaa-core/src/util/postgres_client.js:250:21)
    at async UnorderedBulkOp.execute (/root/node_modules/noobaa-core/src/util/postgres_client.js:411:27)
    at async Promise.all (index 0)
    at async SystemStore._make_changes_internal (/root/node_modules/noobaa-core/src/server/system_services/system_store.js:751:30)
    at async Semaphore.surround (/root/node_modules/noobaa-core/src/util/semaphore.js:71:84)
    at async SystemStore.make_changes (/root/node_modules/noobaa-core/src/server/system_services/system_store.js:605:43)
    at async Object.update_bucket_class (/root/node_modules/noobaa-core/src/server/system_services/tier_server.js:413:24)
    at async /root/node_modules/noobaa-core/src/rpc/rpc.js:340:32 {
  length: 164,
  severity: 'ERROR',
  code: '22P02',
  detail: 'Token "undefined" is invalid.',
  hint: undefined,
  position: '408',
  internalPosition: undefined,
  internalQuery: undefined,
  where: 'JSON data, line 1: undefined',
  schema: undefined,
  table: undefined,
```
This PR fixes the problem by changing the return value of `new_tier_defaults` to exclude `storage_class` when it's `undefined`