### PR TITLE
NSFS | NC | Event syslog undefined -fix

### DIFF
--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -521,7 +521,9 @@ function log_event(event) {
         return;
     }
     event.pid = process.pid;
-    syslog(config.EVENT_LEVEL, JSON.stringify(event), config.EVENT_FACILITY);
+    if (syslog) {
+        syslog(config.EVENT_LEVEL, JSON.stringify(event), config.EVENT_FACILITY);
+    }
 }
 
 DebugLogger.prototype.error = log_syslog_builder('error');


### PR DESCRIPTION
### Explain the changes
1. Event syslog undefined, return error in system start if rsyslog is not installed

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. start NSFS, and verify application started


- [ ] Doc added/updated
- [ ] Tests added
