### PR TITLE
[NC | NSFS] Fix NSFS prometheus write bytes

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1443,7 +1443,8 @@ class NamespaceFS {
                 stats: this.stats,
                 namespace_resource_id: this.namespace_resource_id,
                 md5_enabled,
-                offset
+                offset,
+                bucket: params.bucket
             });
             chunk_fs.on('error', err1 => dbg.error('namespace_fs._upload_stream: error occured on stream ChunkFS: ', err1));
             await stream_utils.pipeline([source_stream, chunk_fs]);

--- a/src/util/chunk_fs.js
+++ b/src/util/chunk_fs.js
@@ -23,9 +23,10 @@ class ChunkFS extends stream.Transform {
      *      md5_enabled: boolean,
      *      stats: import('../sdk/endpoint_stats_collector').EndpointStatsCollector,
      *      offset?: number,
+     *      bucket?: string,
      * }} params
      */
-    constructor({ target_file, fs_context, namespace_resource_id, md5_enabled, stats, offset }) {
+    constructor({ target_file, fs_context, namespace_resource_id, md5_enabled, stats, offset, bucket }) {
         super();
         this.q_buffers = [];
         this.q_size = 0;
@@ -40,6 +41,7 @@ class ChunkFS extends stream.Transform {
         this._total_num_buffers = 0;
         const platform_iov_max = nb_native().fs.PLATFORM_IOV_MAX;
         this.iov_max = platform_iov_max ? Math.min(platform_iov_max, config.NSFS_DEFAULT_IOV_MAX) : config.NSFS_DEFAULT_IOV_MAX;
+        this.bucket = bucket;
     }
 
     async _transform(chunk, encoding, callback) {
@@ -48,7 +50,8 @@ class ChunkFS extends stream.Transform {
             this.stats?.update_nsfs_write_stats({
                 namespace_resource_id: this.namespace_resource_id,
                 size: chunk.length,
-                count: this.count
+                count: this.count,
+                bucket_name: this.bucket,
             });
             this.count = 0;
             while (chunk && chunk.length) {


### PR DESCRIPTION
### Explain the changes
This PR fixes missing write bytes from the prometheus metrics

Example
```
# HELP NooBaa_Endpoint_hub_read_bytes hub read bytes in namespace cache bucket
# TYPE NooBaa_Endpoint_hub_read_bytes counter
NooBaa_Endpoint_hub_read_bytes{bucket_name="first.bucket"} 899606

# HELP NooBaa_Endpoint_hub_write_bytes hub write bytes in namespace cache bucket
# TYPE NooBaa_Endpoint_hub_write_bytes counter
NooBaa_Endpoint_hub_write_bytes{bucket_name="first.bucket"} 1349409
```

NOTE: This PR was tested with #7562 as well.

### Issues: Fixed #xxx / Gap #xxx
Previously, prometheus metrics lacked write bytes related info.

### Testing Instructions:
1. Start NooBaa (NSFS) with metrics server
2. Open the webpage and find the write bytes as mentioned in the above example.


- [ ] Doc added/updated
- [ ] Tests added
