### PR TITLE
Add experimental support for STS CLI usage

### DIFF
--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -265,6 +265,7 @@ function read_request_body(req, options) {
                 }
             } else {
                 req.content_sha256_buf = sha256_buf;
+                req.content_sha256_sig ||= sha256_buf.toString('hex');
             }
             return resolve();
         });


### PR DESCRIPTION
### Explain the changes
Currently, NooBaa overrides various AWS signing processes, which eventually leads to some authentication failures - e.g. when trying to use AWS CLI for STS operations.
I fixed the problem by repurposing an already-existing body checksum calculation, and assigning it to `content_sha256_sig` in case it wasn't yet assigned. Since the NooBaa signature process already utilizes it, no further changes were required.