### PR TITLE
NSFS | NC | Actions | fix RHEL 9 rpm suffix

### DIFF
--- a/.github/workflows/manual-build-rpm.yaml
+++ b/.github/workflows/manual-build-rpm.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Prepare Suffix
         id: suffix
         if: ${{ github.event.inputs.tag != '' }}
-        run: echo suffix="_${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+        run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
       
       - name: Build RPM
         id: build_rpm
@@ -37,9 +37,9 @@ jobs:
           DATE=$(date +'%Y%m%d')
           VERSION=$(jq -r '.version' < ./package.json)
           RPM_BASE_VERSION=noobaa-core-${VERSION}-${DATE}
-          RPM_FULL_PATH="${RPM_BASE_VERSION}-${{ github.event.inputs.branch }}_${{ steps.suffix.outputs.suffix }}.el8.x86_64.rpm"
+          RPM_FULL_PATH="${RPM_BASE_VERSION}-${{ github.event.inputs.branch }}${{ steps.suffix.outputs.suffix }}.el9.x86_64.rpm"
           echo "RPM FULL PATH=${RPM_FULL_PATH}"
-          cp ./build/rpm/${RPM_BASE_VERSION}.el8.x86_64.rpm ${RPM_FULL_PATH}
+          cp ./build/rpm/${RPM_BASE_VERSION}.el9.x86_64.rpm ${RPM_FULL_PATH}
           echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact

--- a/.github/workflows/nightly-rpm-build.yml
+++ b/.github/workflows/nightly-rpm-build.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           DATE=$(date +'%Y%m%d')
           VERSION=$(jq -r '.version' < ./package.json)
-          RPM_FULL_PATH=noobaa-core-${VERSION}-${DATE}.el8.x86_64
+          RPM_FULL_PATH=noobaa-core-${VERSION}-${DATE}.el9.x86_64
           echo "RPM FULL PATH=${RPM_FULL_PATH}"
           echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Explain the changes
1. docker build was bumped base image to RHEL9 in https://github.com/noobaa/noobaa-core/pull/7571, so the rpm suffix should be updated as well.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
