### PR TITLE
Small object buffer fix

### DIFF
--- a/src/sdk/endpoint_stats_collector.js
+++ b/src/sdk/endpoint_stats_collector.js
@@ -90,7 +90,10 @@ class EndpointStatsCollector {
         this.prom_metrics_report = prom_report.get_endpoint_report();
         this.semaphore_reports = {
             object_io: [],
-            nsfs: [],
+            nsfs_l: [],
+            nsfs_m: [],
+            nsfs_s: [],
+            nsfs_xs: [],
         };
     }
 

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -20,20 +20,30 @@ const size_utils = require('../util/size_utils');
 const native_fs_utils = require('../util/native_fs_utils');
 const ChunkFS = require('../util/chunk_fs');
 const LRUCache = require('../util/lru_cache');
-const Semaphore = require('../util/semaphore');
 const nb_native = require('../util/nb_native');
 const RpcError = require('../rpc/rpc_error');
 const { S3Error } = require('../endpoint/s3/s3_errors');
 
-const buffers_pool_sem = new Semaphore(config.NSFS_BUF_POOL_MEM_LIMIT, {
-    timeout: config.IO_STREAM_SEMAPHORE_TIMEOUT,
-    timeout_error_code: 'IO_STREAM_ITEM_TIMEOUT',
-    warning_timeout: config.NSFS_SEM_WARNING_TIMEOUT,
-});
-const buffers_pool = new buffer_utils.BuffersPool({
-    buf_size: config.NSFS_BUF_SIZE,
-    sem: buffers_pool_sem,
+const multi_buffer_pool = new buffer_utils.MultiSizeBuffersPool({
+    sorted_buf_sizes: [
+        {
+            size: config.NSFS_BUF_SIZE_XS,
+            sem_size: config.NSFS_BUF_POOL_MEM_LIMIT_XS,
+        }, {
+            size: config.NSFS_BUF_SIZE_S,
+            sem_size: config.NSFS_BUF_POOL_MEM_LIMIT_S,
+        }, {
+            size: config.NSFS_BUF_SIZE_M,
+            sem_size: config.NSFS_BUF_POOL_MEM_LIMIT_M,
+        }, {
+            size: config.NSFS_BUF_SIZE_L,
+            sem_size: config.NSFS_BUF_POOL_MEM_LIMIT_L,
+        },
+    ],
     warning_timeout: config.NSFS_BUF_POOL_WARNING_TIMEOUT,
+    sem_timeout: config.IO_STREAM_SEMAPHORE_TIMEOUT,
+    sem_timeout_error_code: 'IO_STREAM_ITEM_TIMEOUT',
+    sem_warning_timeout: config.NSFS_SEM_WARNING_TIMEOUT,
     buffer_alloc: size => nb_native().fs.dio_buffer_alloc(size),
 });
 
@@ -446,8 +456,8 @@ class NamespaceFS {
         stats,
         force_md5_etag,
     }) {
-        dbg.log1('NamespaceFS: buffers_pool length',
-            buffers_pool.buffers.length, buffers_pool.sem);
+        dbg.log0('NamespaceFS: buffers_pool ',
+            multi_buffer_pool.pools);
         this.bucket_path = path.resolve(bucket_path);
         this.fs_backend = fs_backend;
         this.bucket_id = bucket_id;
@@ -957,17 +967,17 @@ class NamespaceFS {
                     await file.read(fs_context, this.warmup_buffer, 0, 1, pos);
                 }
 
+                const remain_size = Math.min(Math.max(0, end - pos), stat.size);
+
                 // allocate or reuse buffer
                 // TODO buffers_pool and the underlying semaphore should support abort signal
                 // to avoid sleeping inside the semaphore until the timeout while the request is already aborted.
-                const { buffer, callback } = await buffers_pool.get_buffer();
+                const { buffer, callback } = await multi_buffer_pool.get_buffers_pool(remain_size).get_buffer();
                 buffer_pool_cleanup = callback; // must be called ***IMMEDIATELY*** after get_buffer
                 object_sdk.throw_if_aborted();
 
                 // read from file
-                const remain_size = Math.max(0, end - pos);
                 const read_size = Math.min(buffer.length, remain_size);
-
                 const bytesRead = await file.read(fs_context, buffer, 0, read_size, pos);
                 if (!bytesRead) {
                     buffer_pool_cleanup = null;
@@ -1111,10 +1121,10 @@ class NamespaceFS {
             upload_params = await this._start_upload(fs_context, object_sdk, file_path, params, open_mode);
 
             if (!params.copy_source || upload_params.copy_res === copy_status_enum.FALLBACK) {
-            // TODO: Take up only as much as we need (requires fine-tune of the semaphore inside the _upload_stream)
-            // Currently we are taking config.NSFS_BUF_SIZE for any sized upload (1KB upload will take a full buffer from semaphore)
-                const upload_res = await buffers_pool_sem.surround_count(
-                    config.NSFS_BUF_SIZE, async () => this._upload_stream(upload_params));
+                // We are taking the buffer size closest to the sized upload
+                const bp = multi_buffer_pool.get_buffers_pool(params.size);
+                const upload_res = await bp.sem.surround_count(
+                    bp.buf_size, async () => this._upload_stream(upload_params));
                 upload_params.digest = upload_res.digest;
             }
 
@@ -1420,7 +1430,7 @@ class NamespaceFS {
         }
     }
 
-    // Allocated config.NSFS_BUF_SIZE in Semaphore but in fact we can take up more inside
+    // Allocated the largest semaphore size config.NSFS_BUF_SIZE_L in Semaphore but in fact we can take up more inside
     // This is due to MD5 calculation and data buffers
     // Can be finetuned further on if needed and inserting the Semaphore logic inside
     // Instead of wrapping the whole _upload_stream function (q_buffers lives outside of the data scope of the stream)
@@ -1437,7 +1447,8 @@ class NamespaceFS {
                 namespace_resource_id: this.namespace_resource_id,
                 md5_enabled,
                 offset,
-                bucket: params.bucket
+                bucket: params.bucket,
+                large_buf_size: multi_buffer_pool.get_buffers_pool(undefined).buf_size
             });
             chunk_fs.on('error', err1 => dbg.error('namespace_fs._upload_stream: error occured on stream ChunkFS: ', err1));
             await stream_utils.pipeline([source_stream, chunk_fs]);
@@ -1527,7 +1538,9 @@ class NamespaceFS {
             const pre_known_size = (params.size >= 0);
             if (!pre_known_size) {
                 // 2.1
-                upload_res = await buffers_pool_sem.surround_count(config.NSFS_BUF_SIZE, async () => this._upload_stream(md_upload_params));
+                const bp = multi_buffer_pool.get_buffers_pool(undefined);
+                upload_res = await bp.sem.surround_count(bp.buf_size,
+                    async () => this._upload_stream(md_upload_params));
                 params.size = upload_res.total_bytes;
             }
             const offset = params.size * (params.num - 1);
@@ -1541,11 +1554,12 @@ class NamespaceFS {
             };
 
             if (pre_known_size) {
-                upload_res = await buffers_pool_sem.surround_count(config.NSFS_BUF_SIZE,
+                const bp = multi_buffer_pool.get_buffers_pool(params.size);
+                upload_res = await bp.sem.surround_count(bp.buf_size,
                     async () => this._upload_stream(data_upload_params));
             } else {
                 // 2.3 if size was not pre known, copy data from part_md_file to by_size file
-                await native_fs_utils.copy_bytes(buffers_pool, fs_context, part_md_file, target_file, params.size, offset, 0);
+                await native_fs_utils.copy_bytes(multi_buffer_pool, fs_context, part_md_file, target_file, params.size, offset, 0);
             }
 
             md_upload_params = { ...md_upload_params, offset, digest: upload_res.digest };
@@ -1661,13 +1675,13 @@ class NamespaceFS {
                         }
                         // copy (num - 1) parts, all the same size of the prev part
                         const copy_size = prev_part_size * (num - 1);
-                        await native_fs_utils.copy_bytes(buffers_pool, fs_context, prev_read_file, target_file, copy_size, 0, 0);
+                        await native_fs_utils.copy_bytes(multi_buffer_pool, fs_context, prev_read_file, target_file, copy_size, 0, 0);
                     }
                     should_copy_file_prefix = false;
                 }
                 // 3
                 if (!target_file) target_file = await native_fs_utils.open_file(fs_context, this.bucket_path, upload_path, open_mode);
-                await native_fs_utils.copy_bytes(buffers_pool, fs_context, read_file, target_file, part_size, total_size, part_offset);
+                await native_fs_utils.copy_bytes(multi_buffer_pool, fs_context, read_file, target_file, part_size, total_size, part_offset);
                 prev_part_size = part_size;
                 total_size += part_size;
             }
@@ -3027,5 +3041,5 @@ class NamespaceFS {
 }
 
 module.exports = NamespaceFS;
-module.exports.buffers_pool = buffers_pool;
+module.exports.multi_buffer_pool = multi_buffer_pool;
 

--- a/src/server/analytic_services/prometheus_reports/noobaa_endpoint_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_endpoint_report.js
@@ -10,7 +10,7 @@ const js_utils = require('../../../util/js_utils');
 // come next to add endpoint metrics reporting.
 // -----------------------------------------
 
-const nsfs_suffix = "_nsfs";
+const nsfs_suffixes = ["_nsfs_xs", "_nsfs_s", "_nsfs_m", "_nsfs_l"];
 const NOOBAA_ENDPOINT_METRICS = js_utils.deep_freeze([{
         type: 'Counter',
         name: 'hub_read_bytes',
@@ -258,9 +258,11 @@ class NooBaaEndpointReport extends BasePrometheusReport {
                                     if (this[average_interval]) {
                                         m.collect(this, this[average_interval].labels, this[average_interval].value);
                                     }
-                                    if (this[average_interval + nsfs_suffix]) {
-                                        m.collect(this, this[average_interval + nsfs_suffix].labels,
-                                            this[average_interval + nsfs_suffix].value);
+                                    for (const suffix of nsfs_suffixes) {
+                                        if (this[average_interval + suffix]) {
+                                            m.collect(this, this[average_interval + suffix].labels,
+                                                this[average_interval + suffix].value);
+                                        }
                                     }
                                 }
                             }
@@ -289,8 +291,8 @@ class NooBaaEndpointReport extends BasePrometheusReport {
         if (labels.type === 'object_io') {
             metric.prom_instance[labels.average_interval] = { labels, value };
         } else {
-            // Adding suffix to distinguish between object_io and nsfs semaphore
-            metric.prom_instance[labels.average_interval + nsfs_suffix] = { labels, value };
+            // Adding suffix to distinguish between object_io and nsfs semaphores
+            metric.prom_instance[labels.average_interval + '_' + labels.type] = { labels, value };
         }
         metric.prom_instance.average_intervals = average_intervals;
     }

--- a/src/test/unit_tests/test_buffer_pool.js
+++ b/src/test/unit_tests/test_buffer_pool.js
@@ -44,4 +44,59 @@ mocha.describe('Test buffers pool', function() {
         assert(buffers_pool.sem.value === SEM_LIMIT, 'Smepahore did not deallocate after buffers release');
     });
 
+    mocha.it('Work parallel with buffers with different sizes and different semaphores', async function() {
+        const BUF_LIMIT1 = 4 * 1024;
+        const SEM_LIMIT1 = 1024 * BUF_LIMIT1;
+        const BUF_LIMIT2 = 64 * 1024;
+        const SEM_LIMIT2 = 256 * BUF_LIMIT2;
+        const BUF_LIMIT3 = 1 * 1024 * 1024;
+        const SEM_LIMIT3 = 128 * BUF_LIMIT3;
+        const MAX_POOL_ALLOWED1 = SEM_LIMIT1 / BUF_LIMIT1;
+        const SLEEP_BEFORE_RELEASE = 264;
+        const multi_buffer_pool = new buffer_utils.MultiSizeBuffersPool({
+            sorted_buf_sizes: [
+                {
+                    size: BUF_LIMIT1,
+                    sem_size: SEM_LIMIT1,
+                }, {
+                    size: BUF_LIMIT2,
+                    sem_size: SEM_LIMIT2,
+                }, {
+                    size: BUF_LIMIT3,
+                    sem_size: SEM_LIMIT3,
+                },
+            ],
+            warning_timeout: 0,
+        });
+        const lazy_fill = new Array(MAX_POOL_ALLOWED1 + 2).fill(0);
+        const from_pool_allocation = lazy_fill.map(async () => {
+            const { buffer, callback } = await multi_buffer_pool.get_buffers_pool(BUF_LIMIT1 - 500).get_buffer();
+            await new Promise((resolve, reject) => setTimeout(resolve, SLEEP_BEFORE_RELEASE));
+            console.log('From pool allocations', buffer.length,
+                multi_buffer_pool.pools[0].buffers.length, multi_buffer_pool.pools[0].sem.value);
+            assert(buffer.length === BUF_LIMIT1, 'Allocated different buffer size than expected');
+            callback();
+        });
+        let buf = await multi_buffer_pool.get_buffers_pool(BUF_LIMIT1 + 500).get_buffer();
+        console.log('From pool allocations', buf.buffer.length,
+                multi_buffer_pool.pools[1].buffers.length, multi_buffer_pool.pools[1].sem.value);
+        buf.callback();
+        assert(buf.buffer.length === BUF_LIMIT2, 'Allocated different buffer size than expected');
+        const from_pool_buffers = await Promise.all(from_pool_allocation);
+        assert(from_pool_buffers.length === MAX_POOL_ALLOWED1 + 2, 'Allocated more buffers than requested');
+        assert(multi_buffer_pool.pools[0].buffers.length === MAX_POOL_ALLOWED1,
+            `Buffer pool allocated more than semaphore allows: ${multi_buffer_pool.pools[0].buffers.length}`);
+        assert(multi_buffer_pool.pools[0].sem.value === SEM_LIMIT1, 'Sempahore did not deallocate after buffers release');
+        buf = await multi_buffer_pool.get_buffers_pool(BUF_LIMIT2 + 500).get_buffer();
+        console.log('From pool allocations', buf.buffer.length,
+                multi_buffer_pool.pools[2].buffers.length, multi_buffer_pool.pools[2].sem.value);
+        buf.callback();
+        assert(buf.buffer.length === BUF_LIMIT3, 'Allocated different buffer size than expected');
+        buf = await multi_buffer_pool.get_buffers_pool(0).get_buffer();
+        assert(buf.buffer.length === BUF_LIMIT1, 'Allocated different buffer size than expected for 0 size');
+        buf = await multi_buffer_pool.get_buffers_pool(undefined).get_buffer();
+        assert(buf.buffer.length === BUF_LIMIT3, 'Allocated different buffer size than expected for undefined');
+        buf = await multi_buffer_pool.get_buffers_pool(-1).get_buffer();
+        assert(buf.buffer.length === BUF_LIMIT3, 'Allocated different buffer size than expected for negative');
+    });
 });

--- a/src/test/unit_tests/test_chunk_fs.js
+++ b/src/test/unit_tests/test_chunk_fs.js
@@ -20,13 +20,13 @@ mocha.describe('ChunkFS', function() {
         await chunk_fs_hashing.file_target();
     });
 
-    mocha.it('Concurrent ChunkFS with file target - produce num_chunks > 1024 && total_chunks_size < config.NSFS_BUF_SIZE', async function() {
+    mocha.it('Concurrent ChunkFS with file target - produce num_chunks > 1024 && total_chunks_size < config.NSFS_BUF_SIZE_L', async function() {
         const self = this;
         self.timeout(RUN_TIMEOUT);
-        // The goal of this test is to produce num_chunks > 1024 && total_chunks_size < config.NSFS_BUF_SIZE
+        // The goal of this test is to produce num_chunks > 1024 && total_chunks_size < config.NSFS_BUF_SIZE_L
         // so we will flush buffers because of reaching max num of buffers and not because we reached the max NSFS buf size
         // chunk size = 100, num_chunks = (10 * 1024 * 1024)/100 < 104587, 104587 = num_chunks > 1024 
-        // chunk size = 100, total_chunks_size after having 1024 chunks is = 100 * 1024 < config.NSFS_BUF_SIZE
+        // chunk size = 100, total_chunks_size after having 1024 chunks is = 100 * 1024 < config.NSFS_BUF_SIZE_L
         const chunk_size = 100;
         const parts_s = 50;
         await chunk_fs_hashing.file_target(chunk_size, parts_s);


### PR DESCRIPTION
### Explain the changes
1. Adding multi_buffer_pool - a pool consisting of 4 different buffer pools with different sizes as was proposed in https://github.com/noobaa/noobaa-core/issues/7449

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. I ran this in order to see if we get improvement 

```warp get --host=127.0.0.1:6001 --access-key=jVK45OKEXls2GeEpz67G --secret-key=VRXfwvxwKfpnRb4koqsCHDW1YnQHJNPZoeqxcOt3 --disable-multipart  --noclear --duration 1m --concurrent=20 --objects=1000 --obj.size 80K --list-existing```

MASTER results
```
----------------------------------------
Operation: GET. Concurrency: 20
* Average: 99.35 MiB/s, 1302.17 obj/s

Throughput, split into 59 x 1s:
 * Fastest: 106.9MiB/s, 1400.98 obj/s
 * 50% Median: 104.7MiB/s, 1372.23 obj/s
 * Slowest: 39.0MiB/s, 510.91 obj/s
```
PR results: (20% better)
```
----------------------------------------
Operation: GET. Concurrency: 20
* Average: 120.07 MiB/s, 1573.84 obj/s

Throughput, split into 59 x 1s:
 * Fastest: 129.4MiB/s, 1695.97 obj/s
 * 50% Median: 126.3MiB/s, 1655.10 obj/s
 * Slowest: 40.5MiB/s, 530.49 obj/s
```


- [ ] Doc added/updated
- [x] Tests added


warp suggestions:
```
WARP_GET="warp get --host=127.0.0.1:6001 --access-key=jVK45OKEXls2GeEpz67G --secret-key=VRXfwvxwKfpnRb4koqsCHDW1YnQHJNPZoeqxcOt3 --disable-multipart  --noclear --duration 5m"

# step 1 - create dataset and bench get right after
$WARP_GET --concurrent=20 --objects=300 --obj.size 8M

# step 2 - bench get and read existing dataset
$WARP_GET --concurrent=20 --objects=300 --obj.size 8M --list-existing


$WARP_GET --concurrent=100 --objects=1000 --obj.size 1M
$WARP_GET --concurrent=100 --objects=1000 --obj.size 1M --list-existing


$WARP_GET --concurrent=100 --objects=1000 --obj.size 4K
$WARP_GET --concurrent=100 --objects=1000 --obj.size 4K --list-existing

```