### PR TITLE
parameterize centos base image version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TESTER_TAG?="noobaa-tester"
 NOOBAA_RPM_TAG?="noobaa-rpm-build"
 POSTGRES_IMAGE?="centos/postgresql-12-centos7"
 MONGO_IMAGE?="centos/mongodb-36-centos7"
+CENTOS_VER?=9
 
 CONTAINER_ENGINE?=$(shell docker version >/dev/null 2>&1 && echo docker)
 ifeq ($(CONTAINER_ENGINE),)
@@ -126,7 +127,7 @@ all: tester noobaa
 
 builder: assert-container-engine
 	@echo "\n##\033[1;32m Build image noobaa-builder ...\033[0m"
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-builder .
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg CENTOS_VER=$(CENTOS_VER) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) -f src/deploy/NVA_build/builder.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa-builder .
 	$(CONTAINER_ENGINE) tag noobaa-builder $(BUILDER_TAG)
 	@echo "##\033[1;32m Build image noobaa-builder done.\033[0m"
 .PHONY: builder
@@ -141,7 +142,7 @@ base: builder
 noobaa: base
 	@echo "\n##\033[1;32m Build image noobaa ...\033[0m"
 	@echo "$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG)"
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) --build-arg CENTOS_VER=$(CENTOS_VER) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) -f src/deploy/NVA_build/NooBaa.Dockerfile $(CACHE_FLAG) $(NETWORK_FLAG) -t noobaa --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	$(CONTAINER_ENGINE) tag noobaa $(NOOBAA_TAG)
 	@echo "##\033[1;32m Build image noobaa done.\033[0m"
 .PHONY: noobaa
@@ -157,7 +158,7 @@ executable: base
 # which allows to build and debug the project.
 nbdev:
 	@echo "\n##\033[1;32m Build image nbdev ...\033[0m"
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/NVA_build/dev.Dockerfile $(CACHE_FLAG) -t nbdev --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/NVA_build/dev.Dockerfile $(CACHE_FLAG) -t nbdev --build-arg CENTOS_VER=$(CENTOS_VER) --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	@echo "##\033[1;32m Build image nbdev done.\033[0m"
 	@echo ""
 	@echo "Usage: docker run -it nbdev"

--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -27,6 +27,7 @@ ARG BUILD_S3SELECT=1
 ARG BUILD_S3SELECT_PARQUET=0
 #Clone S3Select and its two submodules, but only if BUILD_S3SELECT=1.
 RUN ./src/deploy/NVA_build/clone_s3select_submodules.sh
+RUN ln -s /lib64/libboost_thread.so.1.66.0 /lib64/libboost_thread.so.1.75.0 || true
 #Pass BUILD_S3SELECT down to GYP native build.
 #S3Select will be built only if this parameter is equal to "1".
 RUN GYP_DEFINES="BUILD_S3SELECT=$BUILD_S3SELECT BUILD_S3SELECT_PARQUET=$BUILD_S3SELECT_PARQUET" npm run build

--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -1,3 +1,4 @@
+ARG CENTOS_VER=9
 FROM noobaa-base as server_builder
 
 RUN mkdir -p /noobaa_init_files && \
@@ -38,7 +39,7 @@ RUN tar \
 #   Cache: Rebuild when any layer is changing
 ##############################################################
 
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream${CENTOS_VER}
 
 # The ports are overridden for Ceph Test later
 ENV container docker
@@ -73,7 +74,7 @@ RUN dnf install -y -q bash \
     python3-setuptools \
     jemalloc \
     xz \
-    pip && \
+    python3-pip && \
     dnf clean all
 
 COPY ./src/deploy/NVA_build/install_arrow_run.sh ./src/deploy/NVA_build/install_arrow_run.sh

--- a/src/deploy/NVA_build/Tests.Dockerfile
+++ b/src/deploy/NVA_build/Tests.Dockerfile
@@ -12,8 +12,10 @@ ENV TEST_CONTAINER true
 #   Cache: rebuild when we adding/removing requirments
 ##############################################################
 
+RUN dnf config-manager --enable crb || true
+
 RUN dnf group install -y -q "Development Tools" && \
-    dnf install -y -q --nogpgcheck --enablerepo=crb vim \
+    dnf install -y -q --nogpgcheck vim \
     which python3-virtualenv python3-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel \
     git  \
     tox && \

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/centos/centos:stream9
+ARG CENTOS_VER=9
+FROM quay.io/centos/centos:stream${CENTOS_VER}
 LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 
 ##############################################################

--- a/src/deploy/NVA_build/dev.Dockerfile
+++ b/src/deploy/NVA_build/dev.Dockerfile
@@ -1,5 +1,6 @@
 # dev.Dockerfile is meant to be used manually for developer testing
-FROM quay.io/centos/centos:stream9
+ARG CENTOS_VER=9
+FROM quay.io/centos/centos:stream${CENTOS_VER}
 
 ENV container docker
 

--- a/src/deploy/NVA_build/setup_platform.sh
+++ b/src/deploy/NVA_build/setup_platform.sh
@@ -21,7 +21,7 @@ function install_supervisor {
     if [ ${ID} == "centos" ] || [ ${ID} == "fedora" ]
     then
         deploy_log install_supervisor start
-        pip install supervisor
+        pip3 install supervisor
         deploy_log install_supervisor done
     fi
 


### PR DESCRIPTION
### Explain the changes
1. Make version of centos in base image of dockerfiles a parameter.

### Issues: Fixed #xxx / Gap #xxx
1. Build works for both centos 8 and 9

### Testing Instructions:
1.make noobaa CENTOS_VER=[8,9]
(default is 9) 


- [ ] Doc added/updated
- [ ] Tests added
