### PR TITLE
NSFS | NC | github actions rpm build fix for both centos8 and centos9

### DIFF
--- a/.github/workflows/manual-build-rpm.yaml
+++ b/.github/workflows/manual-build-rpm.yaml
@@ -8,6 +8,13 @@ on:
       tag:
         description: 'Additional tag for the build (such as alpha, beta, etc.) - Optional'
         default: ''
+      centos_ver:
+        type: choice
+        description: 'Centos Base image (options: 8/9) - Optional, default is 9'
+        default: '9'
+        options: 
+          - '8'
+          - '9'
 
 jobs:
   manual-rpm-build-and-upload-artifact:
@@ -24,11 +31,15 @@ jobs:
         if: ${{ github.event.inputs.tag != '' }}
         run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
       
+      - name: Prepare CENTOS base image version
+        id: centos_ver
+        run: echo "centos_ver=${{ github.event.inputs.centos_ver }}" >> $GITHUB_OUTPUT
+      
       - name: Build RPM
         id: build_rpm
         run: |
           echo "Starting make rpm"
-          make rpm
+          make rpm CENTOS_VER=${{ steps.centos_ver.outputs.centos_ver }}
           echo "Make rpm completed"
 
       - name: Finalize RPM
@@ -36,10 +47,12 @@ jobs:
         run: |
           DATE=$(date +'%Y%m%d')
           VERSION=$(jq -r '.version' < ./package.json)
+          CENTOS_VER=${{ steps.centos_ver.outputs.centos_ver }}
+          RPM_SUFFIX=el${CENTOS_VER}.x86_64.rpm
           RPM_BASE_VERSION=noobaa-core-${VERSION}-${DATE}
-          RPM_FULL_PATH="${RPM_BASE_VERSION}-${{ github.event.inputs.branch }}${{ steps.suffix.outputs.suffix }}.el9.x86_64.rpm"
-          echo "RPM FULL PATH=${RPM_FULL_PATH}"
-          cp ./build/rpm/${RPM_BASE_VERSION}.el9.x86_64.rpm ${RPM_FULL_PATH}
+          RPM_FULL_PATH=${RPM_BASE_VERSION}-${{ github.event.inputs.branch }}${{ steps.suffix.outputs.suffix }}.${RPM_SUFFIX}
+          echo "rpm_full_path=${RPM_FULL_PATH}"
+          cp ./build/rpm/${RPM_BASE_VERSION}.${RPM_SUFFIX} ${RPM_FULL_PATH}
           echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact

--- a/.github/workflows/nightly-rpm-build.yml
+++ b/.github/workflows/nightly-rpm-build.yml
@@ -14,27 +14,40 @@ jobs:
         with:
           ref: master
      
-      - name: Build RPM
-        id: build_rpm
+      - name: Build RPM CENTOS8
+        id: build_rpm_centos8
         run: |
-          echo "Starting make rpm"
-          make rpm
-          echo "Make rpm completed"
+          echo "Starting make rpm - CENTOS8"
+          make rpm CENTOS_VER=8
+          echo "Make rpm completed - CENTOS8"
 
-      - name: Finalize RPM
-        id: finalize_full_rpm_path
+      - name: Build RPM CENTOS9
+        id: build_rpm_centos9
+        run: |
+          echo "Starting make rpm - CENTOS9"
+          make rpm CENTOS_VER=9
+          echo "Make rpm completed - CENTOS9"
+
+      - name: Finalize RPM full paths
+        id: finalize_rpm
         run: |
           DATE=$(date +'%Y%m%d')
           VERSION=$(jq -r '.version' < ./package.json)
-          RPM_FULL_PATH=noobaa-core-${VERSION}-${DATE}.el9.x86_64
-          echo "RPM FULL PATH=${RPM_FULL_PATH}"
-          echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
+          RPM_BASE_VERSION_CENTOS8=noobaa-core-${VERSION}-${DATE}.el8.x86_64.rpm
+          RPM_BASE_VERSION_CENTOS9=noobaa-core-${VERSION}-${DATE}.el9.x86_64.rpm
+          echo "RPM_BASE_VERSION_CENTOS8=${RPM_BASE_VERSION_CENTOS8} RPM_BASE_VERSION_CENTOS9=${RPM_BASE_VERSION_CENTOS9}"
+          cp ./build/rpm/${RPM_BASE_VERSION_CENTOS8} ${RPM_BASE_VERSION_CENTOS8}
+          cp ./build/rpm/${RPM_BASE_VERSION_CENTOS9} ${RPM_BASE_VERSION_CENTOS9}
+          echo "rpm_full_path_centos8=${RPM_BASE_VERSION_CENTOS8}" >> $GITHUB_OUTPUT
+          echo "rpm_full_path_centos9=${RPM_BASE_VERSION_CENTOS9}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v3
         with:
           name: noobaa_rpm
-          path: ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }}
+          path: |
+            ${{ steps.finalize_rpm.outputs.rpm_full_path_centos8 }}
+            ${{ steps.finalize_rpm.outputs.rpm_full_path_centos9 }}
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@v1
@@ -44,4 +57,6 @@ jobs:
           aws-region: us-east-1
 
       - name: Copy RPM to S3 bucket
-        run: aws s3 cp ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }} s3://noobaa-core-rpms/
+        run: |
+          aws s3 cp ${{ steps.finalize_rpm.outputs.rpm_full_path_centos8 }} s3://noobaa-core-rpms/
+          aws s3 cp ${{ steps.finalize_rpm.outputs.rpm_full_path_centos9 }} s3://noobaa-core-rpms/

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -8,6 +8,8 @@ Running nsfs non containerized is useful for deploying in linux without dependin
 ### Build options - 
 1. noobaa-core S3 Select is enabled. This requires boost shared objects to be present on the machine where noobaa is supposed to be installed. This feature can be disabled if not required (due to additional dependency) by running make rpm BUILD_S3SELECT=0.
 2. In order to build RPM packages for other architectures simply run make rpm CONTAINER_PLATFORM=linux/amd64 or make rpm CONTAINER_PLATFORM=linux/ppc64le
+3. Building RPM packages is available on top of centos:9 / centos:8 base images, The default base image is centos:9.
+In order to build RPM packages for centos:8 simply run `make rpm CENTOS_VER=8`.
 
 Running the following command will result with an RPM file -
 ```sh


### PR DESCRIPTION
### Explain the changes
1. This PR is a follow-up PR of https://github.com/noobaa/noobaa-core/pull/7611 
2. nightly builds uploads both centos8 and centos9 
3. manual build can build centos8/centos9

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
