### PR TITLE
NSFS | NC | CLI | read and write permissions of config subdirs and file fix and other small fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -698,6 +698,9 @@ config.ENDPOINT_PORT = Number(process.env.ENDPOINT_PORT) || 6001;
 config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
 config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || -1;
 config.NSFS_NC_ALLOW_HTTP = false;
+// config files should allow access to the owner of the files 
+config.BASE_MODE_CONFIG_FILE = 0o600;
+config.BASE_MODE_CONFIG_DIR = 0o700;
 
 // NSFS_RESTORE_ENABLED can override internal autodetection and will force
 // the use of restore for all objects.

--- a/docs/design/NonContainerizedNSFSDesign.md
+++ b/docs/design/NonContainerizedNSFSDesign.md
@@ -1,6 +1,6 @@
-# NSFS FS Standalone
+# NSFS Non Containerized
 
-Running noobaa-core standalone is useful for development, testing, or deploying in Linux without depending on Kubernetes, NSFS FS is different from the simple standalone in such a way that it doesn't depend on the Noobaa postgres db. All the Global configurations, Accounts, and Bucket related schemas are saved in FS. And it gives a more lightweight flavor to the Noobaa standalone version. Permissions are handled by uid and gid, or by providing a distinguished name (LDAP/AD) that will be resolved to uid/gid by the operating system.
+Running noobaa-core non containerized is useful for development, testing, or deploying in Linux without depending on Kubernetes, NSFS FS is different from the simple standalone in such a way that it doesn't depend on the Noobaa postgres db. All the Global configurations, Accounts, and Bucket related schemas are saved in FS. And it gives a more lightweight flavor to the Noobaa standalone version. Permissions are handled by uid and gid, or by providing a distinguished name (LDAP/AD) that will be resolved to uid/gid by the operating system.
 
 Users can switch between Noobaa standalone and NSFS FS standalone by adding/removing the argument `config_dir`.
 
@@ -160,3 +160,7 @@ High level configuration -
 #### config.json schema - 
 See [NSFS config.json schema](https://github.com/noobaa/noobaa-core/src/server/object_services/schemas/nsfs_config_schema.js)
 config.json will be reloaded every 10 seconds automatically, please notice that some config.json properties require restart of the service, for more details check the schema.
+
+### Configuration files (accounts/buckets) permissions
+- Configuration files created under accounts/ or buckets/ will have 600 permissions (read, write, execute) for the owner of the config file only. 
+- config_file created by manage_nsfs.js CLI tool will be owned by the user who ran the command. 

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -1,5 +1,8 @@
 # Non Containerized NSFS - Developer customization (OPTIONAL)
 
+One can customize noobaa nsfs service by creation of config.json file under the config_dir/ directory.
+In this file you will find the available customizable properties and a [config.json example file](#configjson-example).
+
 The following list consists of supported optional developer customization  -
 
 ## 1. Number of forks - 
@@ -228,4 +231,23 @@ Example:
 2. Set the config key -
 Example:
 "NSFS_TRIGGER_FSYNC": false
+```
+
+
+## Config.json example - 
+```
+> cat /path/to/config_dir/config.json
+{
+    "ENDPOINT_PORT": 80,
+    "ENDPOINT_SSL_PORT": 443,
+    "ENDPOINT_FORKS": 16,
+    "UV_THREADPOOL_SIZE": 256,
+    "GPFS_DL_PATH": "/usr/lpp/mmfs/lib/libgpfs.so",
+    "NSFS_BUF_POOL_MEM_LIMIT": 4294967296,
+    "NSFS_BUF_SIZE": 16777216,
+    "NSFS_OPEN_READ_MODE": "rd",
+    "NSFS_CHECK_BUCKET_BOUNDARIES": false,
+    "ALLOW_HTTP": true
+}
+
 ```

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -109,14 +109,16 @@ mkdir -p /tmp/fs1/
 ```
 
 ## Developer customization of the nsfs service (OPTIONAL) - 
-The following list consists of supported optional developer customization -
+One can customize noobaa nsfs service by creation of config.json file under the config_dir/ directory (/path/to/config_dir/config.json).
+The following are some of the properties that can be customized -
 1. Number of forks 
 2. Log debug level
 3. Ports
 4. Allow http
+5. GPFS library path
 etc...
 
-For more details see - [Non Containerized NSFS Developer Customization](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/NonContainerizedDeveloperCustomizations.md)
+For more details about the available properties and an example see - [Non Containerized NSFS Developer Customization](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/NonContainerizedDeveloperCustomizations.md)
 
 ## Create accounts and exported buckets configuration files - ##
 

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -347,7 +347,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
     }
 }
 
-async function verify_gpfslib() {
+function verify_gpfslib() {
     if (!nb_native().fs.gpfs) {
         dbg.event({
             code: "noobaa_gpfslib_missing",


### PR DESCRIPTION
### Explain the changes
1. CLI + Bucketspace_fs.js - Set 0o600 and 0o700 to config dirs or files on creation and update.
2. CLI - validate bucket names on creation and update
3. CLI - throw error on invalid type (not account/bucket) and on invalid action ( not add,list,update,status,delete)
4. CLI - replace old non native().fs readdir / read
5. Added CLI unit tests
### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/MCGI-213
2. Fixed #https://github.com/noobaa/noobaa-core/issues/7612
### Testing Instructions:
1. 


- [x] Doc added/updated
- [x] Tests added
