### PR TITLE
test_nsfs_cephs3: Add uid and gid to manage_nsfs cmd

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -456,7 +456,8 @@ async function add_account_config_file(data, accounts_path, access_keys_path, co
     data = JSON.stringify(data);
     await native_fs_utils.create_config_file(fs_context, accounts_path, full_account_config_path, data);
     await native_fs_utils._create_path(access_keys_path, fs_context);
-    await nb_native().fs.symlink(fs_context, full_account_config_path, full_account_config_access_key_path);
+    //await nb_native().fs.symlink(fs_context, full_account_config_path, full_account_config_access_key_path);
+    await copy_config_data_to_path(full_account_config_path, full_account_config_access_key_path);
 }
 
 async function update_account_config_file(data, accounts_path, access_keys_path, config_root_backend) {
@@ -592,6 +593,10 @@ async function get_config_data(config_file_path) {
     return resources;
 }
 
+async function copy_config_data_to_path(source, dest) {
+    const data = await fs.promises.readFile(source);
+    await fs.promises.writeFile(dest, data.toString());
+}
 /**
  * get_view_config_data will read a config file and return its content ready to be printed
  * @param {fs.PathLike} config_file_path

--- a/src/deploy/NVA_build/standalone_deploy_nsfs.sh
+++ b/src/deploy/NVA_build/standalone_deploy_nsfs.sh
@@ -10,8 +10,8 @@ function execute() {
 
 function main() {
     # Add accounts to run ceph tests
-    execute "node src/cmd/manage_nsfs account add --config_root ./standalone/config_root --name cephalt --email ceph.alt@noobaa.com --new_buckets_path ./standalone/nsfs_root --access_key abcd --secret_key abcd" nsfs_cephalt.log
-    execute "node src/cmd/manage_nsfs account add --config_root ./standalone/config_root --name cephtenant --email ceph.tenant@noobaa.com --new_buckets_path ./standalone/nsfs_root --access_key efgh --secret_key efgh" nsfs_cephtenant.log
+    execute "node src/cmd/manage_nsfs account add --config_root ./standalone/config_root --name cephalt --email ceph.alt@noobaa.com --new_buckets_path ./standalone/nsfs_root --access_key abcd --secret_key abcd --uid 10001 --gid 0" nsfs_cephalt.log
+    execute "node src/cmd/manage_nsfs account add --config_root ./standalone/config_root --name cephtenant --email ceph.tenant@noobaa.com --new_buckets_path ./standalone/nsfs_root --access_key efgh --secret_key efgh --uid 10001 --gid 0" nsfs_cephtenant.log
     # Start nsfs server
     execute "node src/cmd/nsfs --config_root ./standalone/config_root" nsfs.log
     # Wait for sometime to process to start


### PR DESCRIPTION
Testing Copy data instead of symlink.

1. Add uid and gid to manage_nsfs cmd in standalone_depoly_nsfs
2. copy data instead of symlink

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
