### PR TITLE
NSFS | NC | Update system.json structure + small redirect fix

### DIFF
--- a/docs/design/NonContainerizedNSFSDesign.md
+++ b/docs/design/NonContainerizedNSFSDesign.md
@@ -141,7 +141,9 @@ High level configuration -
 3.3. buckets/ - directory that contains buckets configurations, each bucket configuration file called {bucket_name}.json and fits the bucket schema.
 
 3.4. system.json - json file that contains information about the system deployed on the machine, the specified information has the following format: 
-`{"current_version":"5.15.0","upgrade_history":{"successful_upgrades":[]}}` 
+`{ [hostname1]: { "current_version":"5.15.0","upgrade_history":{"successful_upgrades":[]}},
+   [hostname2]: { "current_version":"5.15.0","upgrade_history":{"successful_upgrades":[]}}
+}` 
 
 3.5. config.json - json file that contains shared configurations of the node cluster, and machine specific configurations, the configuration has the following format: 
 {

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -101,35 +101,11 @@ mkdir -p /etc/noobaa.conf.d/access_keys/
 
 ```
 
-**3. Create env file under the configuration directory -**
-
-In order to apply env variables changes on the service, edit /etc/sysconfig/noobaa_nsfs env file as you wish before starting the service, notice that the env file format is key-value pair - 
-
-```sh
-vim  /etc/sysconfig/noobaa_nsfs
-```
-**Note** - If another /usr/local/noobaa-core/.env exists it should be merged into /etc/sysconfig/noobaa_nsfs carefully.
-
-In order to apply env changes after the service was started, edit the /etc/sysconfig/noobaa_nsfs env file and restart the service - 
-```sh
-vim  /etc/sysconfig/noobaa_nsfs
-systemctl restart noobaa_nsfs
-```
-
-
 ## Create FS -
 If it's not already existing, create the fs root path in which buckets (directories) and objects (files) will be created.
 
 ```sh
 mkdir -p /tmp/fs1/
-```
-
-
-## Run the nsfs service - 
-The systemd script runs noobaa non containerized, and requires config_root in order to find the location of the system/accounts/buckets configuration file.
-
-```sh
-systemctl start nsfs
 ```
 
 ## Developer customization of the nsfs service (OPTIONAL) - 
@@ -148,6 +124,13 @@ In order to create accounts and exported buckets see the management CLI instruct
 Design of Accounts and buckets configuration entities - [NonContainerizedNSFS](https://github.com/noobaa/noobaa-core/blob/master/docs/design/NonContainerizedNSFSDesign.md). <br />
 **Note** - All required paths on the configuration files (bucket - path, account - new_buckets_path) must be absolute paths.
 
+
+## Run the nsfs service - 
+The systemd script runs noobaa non containerized, and requires config_root in order to find the location of the system/accounts/buckets configuration file.
+Limitation - In a cluster each host should have a unique name.
+```sh
+systemctl start noobaa_nsfs
+```
 
 ## NSFS service logs -
 Run the following command in order to get the nsfs service logs - 
@@ -445,9 +428,7 @@ NSFS management CLI command will create both account and bucket dir if it's miss
 
 ## NSFS Certificate
 
-Non containerized NSFS certificate location is configured in system.json file under the property `nsfs_ssl_cert_dir` and the path should contain SSL files tls.key and tls.crt. System will use a cert from this dir to create a valid HTTPS connection. If cert is missing in this dir a self-signed SSL certificate will be generated. Make sure the path mentioned in `nsfs_ssl_cert_dir` is valid before running nsfs command, If the path is invalid then cert flow will fail.
-
-Non containerized NSFS allow nonsecure HTTP connection only when `allow_http` in system.json is true.
+Non containerized NSFS certificates/ directory location will be under the config_root path. The certificates/ directory should contain SSL files tls.key and tls.crt. System will use a cert from this dir to create a valid HTTPS connection. If cert is missing in this dir a self-signed SSL certificate will be generated. Make sure the path to certificates/ directory is valid before running nsfs command, If the path is invalid then cert flow will fail.
 
 ## Log and Logrotate
 Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running. 
@@ -465,4 +446,19 @@ Rotate the logs manually.
 
 ```
 logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf 
+```
+
+**Create env file under the configuration directory (OPTIONAL) -**
+
+In order to apply env variables changes on the service, edit /etc/sysconfig/noobaa_nsfs env file as you wish before starting the service, notice that the env file format is key-value pair - 
+
+```sh
+vim  /etc/sysconfig/noobaa_nsfs
+```
+**Note** - If another /usr/local/noobaa-core/.env exists it should be merged into /etc/sysconfig/noobaa_nsfs carefully.
+
+In order to apply env changes after the service was started, edit the /etc/sysconfig/noobaa_nsfs env file and restart the service - 
+```sh
+vim  /etc/sysconfig/noobaa_nsfs
+systemctl restart noobaa_nsfs
 ```

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -440,27 +440,6 @@ function get_root_fs_context(config_root_backend) {
     };
 }
 
-/**
- * @param {object} argv
- * @param {nb.NativeFSContext} fs_config
- * @returns {Promise<string>}
- */
-async function get_config_root(argv, fs_config) {
-    let config_root = config.NSFS_NC_DEFAULT_CONF_DIR;
-    if (argv.config_root) {
-        config_root = String(argv.config_root);
-    } else {
-        try {
-            const redirect_path = path.join(config.NSFS_NC_DEFAULT_CONF_DIR, config.NSFS_NC_CONF_DIR_REDIRECT_FILE);
-            const { data } = await nb_native().fs.readFile(fs_config, redirect_path);
-            config_root = data.toString().trim();
-        } catch (err) {
-            dbg.warn('native_fs_utils.get_config_root - could not find custom config_root, will use the default config_root ', config_root);
-        }
-    }
-    return config_root;
-}
-
 
 exports.get_umasked_mode = get_umasked_mode;
 exports._make_path_dirs = _make_path_dirs;
@@ -489,4 +468,3 @@ exports.delete_config_file = delete_config_file;
 exports.update_config_file = update_config_file;
 exports.isDirectory = isDirectory;
 exports.get_root_fs_context = get_root_fs_context;
-exports.get_config_root = get_config_root;


### PR DESCRIPTION
### Explain the changes
1. Since system.json might be shared between hosts we need to update the system.json structure to reflect the system per hostname.
The new structure is of the following format - 
```
{
  'hostname1': {
    current_version: '5.15.2',
    upgrade_history: { successful_upgrades: [ { timestamp: 1701619673797, completed_scripts: [], from_version: '5.15.1', to_version: '5.15.2' } ] }
  }, 
'hostname2': {
    current_version: '5.15.2',
    upgrade_history: { successful_upgrades: [ { timestamp: 1701619673797, completed_scripts: [], from_version: '5.15.1', to_version: '5.15.2' } ] }
  }
}
```
2. Added a small redirect fix

### Issues: Fixed #xxx / Gap #xxx
1. TODO: we need to handle concurrent upgrades of multiple hosts.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
