### PR TITLE
NSFS | NC | CLI | Update config root default of manage_nsfs and health

### DIFF
--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -324,7 +324,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
   try {
 
     if (argv.help || argv.h) return print_usage();
-    const config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_DEFAULT_CONF_DIR;
+    const config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
     // disable console log to avoid unwanted logs in console.
     await disable_console_log();
     const https_port = Number(argv.https_port) || 6443;

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -148,7 +148,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
                 return;
             }
         }
-        const config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_DEFAULT_CONF_DIR;
+        const config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
         if (!config_root) {
             console.error('Error: Config dir should not be empty');
             print_account_usage();


### PR DESCRIPTION
### Explain the changes
1. update config root default to be evaluated from config.js instead of directly default value (can take path from config_dir_redirect file or config.NSFS_NC_DEFAULT_CONF_DIR. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
