### PR TITLE
NSFS | NC | fix type of ports in nsfs config schema

### DIFF
--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -49,7 +49,7 @@ ln -s /usr/local/noobaa-core/node/bin/npm $RPM_BUILD_ROOT/usr/local/noobaa-core/
 ln -s /usr/local/noobaa-core/node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npx
 
 mkdir -p $RPM_BUILD_ROOT/etc/systemd/system/
-ln -s /usr/local/noobaa-core/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/noobaa_nsfs.service
+cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/noobaa_nsfs.service
 ln -s /usr/local/noobaa-core/src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
 mkdir -p $RPM_BUILD_ROOT/etc/noobaa.conf.d/
 

--- a/src/server/object_services/schemas/nsfs_config_schema.js
+++ b/src/server/object_services/schemas/nsfs_config_schema.js
@@ -11,22 +11,22 @@ const nsfs_node_config_schema = {
             description: 'number of concurrent endpoint forks allowed, suggested values are 2-64, service restart required'
         },
         ENDPOINT_PORT: {
-            type: 'string',
+            type: 'number',
             default: 6001,
             description: 'http port number designated for s3 incoming requests, service restart required'
         },
         ENDPOINT_SSL_PORT: {
-            type: 'string',
+            type: 'number',
             default: 6443,
             description: 'https port number designated for s3 incoming requests, service restart required'
         },
         ENDPOINT_SSL_STS_PORT: {
-            type: 'string',
+            type: 'number',
             default: 7443,
             description: 'https port number designated for sts incoming requests, service restart required'
         },
         EP_METRICS_SERVER_PORT: {
-            type: 'string',
+            type: 'number',
             default: -1,
             description: 'http port number designated for metrics incoming requests, service restart required'
         },


### PR DESCRIPTION
### Explain the changes
1. fix type of ports in nsfs config schema
2. change on rpm install the systemd noobaa_nsfs.service from symbolic link to hard link so it won't be deleted on systemctl disable noobaa_nsfs

### Issues: Fixed #xxx / Gap #xxx
1. should fix https://github.com/noobaa/noobaa-core/issues/7621

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
