### PR TITLE
NSFS | NC | Add white list IP table support for S3

### DIFF
--- a/config.js
+++ b/config.js
@@ -702,6 +702,8 @@ config.NSFS_NC_ALLOW_HTTP = false;
 config.BASE_MODE_CONFIG_FILE = 0o600;
 config.BASE_MODE_CONFIG_DIR = 0o700;
 
+config.NSFS_WHITELIST = [];
+
 // NSFS_RESTORE_ENABLED can override internal autodetection and will force
 // the use of restore for all objects.
 config.NSFS_RESTORE_ENABLED = false;

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -233,8 +233,22 @@ Example:
 "NSFS_TRIGGER_FSYNC": false
 ```
 
+## 13. Whitelist IPs -
+**Description -** List of whitelist IPs. Access is restricted to these IPs only. If there are no IPs mentioned all IPs are allowed.
 
-## Config.json example - 
+**Configuration Key -** NSFS_WHITELIST
+
+**Type -** array
+
+**Default -** false
+
+**Steps -**
+```
+1. run CLI command
+node src/cmd/manage_nsfs whitelist --ips '["127.0.0.1", "192.000.10.000", "3002:0bd6:0000:0000:0000:ee00:0033:000"]'  2>/dev/null
+```
+
+## Config.json example 
 ```
 > cat /path/to/config_dir/config.json
 {
@@ -247,7 +261,8 @@ Example:
     "NSFS_BUF_SIZE": 16777216,
     "NSFS_OPEN_READ_MODE": "rd",
     "NSFS_CHECK_BUCKET_BOUNDARIES": false,
-    "ALLOW_HTTP": true
+    "ALLOW_HTTP": true,
+    "NSFS_WHITELIST":["127.0.0.1","192.000.10.000","3002:0bd6:0000:0000:0000:ee00:0033:000"]
 }
 
 ```

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -478,3 +478,11 @@ In order to apply env changes after the service was started, edit the /etc/sysco
 vim  /etc/sysconfig/noobaa_nsfs
 systemctl restart noobaa_nsfs
 ```
+
+## WhiteList IPs
+
+Access is restricted to these whitelist IPs. If there are no IPs mentioned all IPs are allowed. WhiteList IPs are added to cnfig.json.
+
+```
+node src/cmd/manage_nsfs whitelist --ips '["127.0.0.1", "192.000.10.000", "3002:0bd6:0000:0000:0000:ee00:0033:000"]'  2>/dev/null
+```

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -74,6 +74,7 @@ async function s3_rest(req, res) {
 
 async function handle_request(req, res) {
 
+    http_utils.validate_nsfs_whitelist(req)
     http_utils.set_amz_headers(req, res);
     http_utils.set_cors_headers_s3(req, res);
 

--- a/src/server/object_services/schemas/nsfs_config_schema.js
+++ b/src/server/object_services/schemas/nsfs_config_schema.js
@@ -80,6 +80,11 @@ const nsfs_node_config_schema = {
             type: 'boolean',
             default: true,
             description: 'indicate whether fsync should be triggered, changing value to false is unsafe for production envs, hot reload'
+        },
+        NSFS_WHITELIST: {
+            type: 'array',
+            default: [],
+            description: 'List of whitelisted IPs for S3 access, Allow access from all the IPs if list is empty.'
         }
     }
 };

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -452,6 +452,15 @@ function validate_bucket_creation(params) {
     }
 }
 
+async function config_file_exists(fs_context, config_path) {
+    try {
+        await nb_native().fs.stat(fs_context, config_path);
+    } catch (err) {
+        if (err.code === 'ENOENT') return false;
+    }
+    return true;
+}
+
 exports.get_umasked_mode = get_umasked_mode;
 exports._make_path_dirs = _make_path_dirs;
 exports._create_path = _create_path;
@@ -480,3 +489,4 @@ exports.update_config_file = update_config_file;
 exports.isDirectory = isDirectory;
 exports.get_process_fs_context = get_process_fs_context;
 exports.validate_bucket_creation = validate_bucket_creation;
+exports.config_file_exists = config_file_exists;


### PR DESCRIPTION
### Explain the changes
1. Noobaa should get the CES IP and have a white list in order to allow only incoming requests from a given list of IPs - not having it is a security issue from Spectrum scale perspective

doc : https://ibm.ent.box.com/file/1379004287366?s=bit6jatl19fbmfcov7ldyszoc4ttnbka

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/MCGI-209

### Testing Instructions:
1. 


- [X] Doc added/updated
- [X] Tests added
