### PR TITLE
NSFS | NC | CLI | CLI commands responses & errors refactor, --show_secrets and lstat linux fix 

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -1,0 +1,274 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+/**
+ * @typedef {{
+ *      code?: string, 
+ *      message: string, 
+ *      http_code: number,
+ * }} ManageCLIErrorSpec
+ */
+
+class ManageCLIError extends Error {
+
+    /**
+     * @param {ManageCLIErrorSpec} error_spec 
+     */
+    constructor({ code, message, http_code }) {
+        super(message); // sets this.message
+        this.code = code;
+        this.http_code = http_code;
+    }
+
+    to_string(detail) {
+        const json = {
+            error: {
+                code: this.code,
+                message: this.message,
+                detail: detail
+            }
+        };
+        return JSON.stringify(json, null, 2);
+    }
+}
+
+// See Manage NSFS CLI error codes docs - TODO: add docs
+
+////////////////////////
+//// GENERAL ERRORS ////
+////////////////////////
+
+
+ManageCLIError.InternalError = Object.freeze({
+    code: 'InternalError',
+    message: 'The server encountered an internal error. Please retry the request',
+    http_code: 500,
+});
+
+ManageCLIError.InvalidRequest = Object.freeze({
+    code: 'InvalidRequest',
+    message: 'The request is invalid',
+    http_code: 400,
+});
+
+ManageCLIError.NotImplemented = Object.freeze({
+    code: 'NotImplemented',
+    message: 'functionality is not implemented.',
+    http_code: 501,
+});
+
+ManageCLIError.InvalidAction = Object.freeze({
+    code: 'InvalidAction',
+    message: 'Invalid action, available actions are add, status, update, delete, list',
+    http_code: 400,
+});
+ManageCLIError.InvalidConfigType = Object.freeze({
+    code: 'InvalidConfigType',
+    message: 'Invalid config type, available config types are account, bucket or whitelist',
+    http_code: 400,
+});
+ManageCLIError.MissingConfigDirPath = Object.freeze({
+    code: 'MissingConfigDirPath',
+    message: 'Config dir path should not be empty',
+    http_code: 400,
+});
+
+//////////////////////////////
+//// IP WHITE LIST ERRORS ////
+//////////////////////////////
+
+ManageCLIError.MissingWhiteListIPFlag = Object.freeze({
+    code: 'MissingWhiteListIPFlag',
+    message: 'Whitelist ips are mandatory, please use the --ips flag',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidWhiteListIPFormat = Object.freeze({
+    code: 'InvalidWhiteListIPFormat',
+    message: 'Whitelist IP body format is invalid',
+    http_code: 400,
+});
+
+ManageCLIError.WhiteListIPUpdateFailed = Object.freeze({
+    code: 'WhiteListIPUpdateFailed',
+    message: 'Whitelist ip update failed',
+    http_code: 500,
+});
+
+////////////////////////
+//// ACCOUNT ERRORS ////
+////////////////////////
+
+ManageCLIError.AccessDenied = Object.freeze({
+    code: 'AccessDenied',
+    message: 'Account has no permissions to access the bucket',
+    http_code: 403,
+});
+
+ManageCLIError.NoSuchAccountAccessKey = Object.freeze({
+    code: 'NoSuchAccountAccessKey',
+    message: 'Account does not exist - access key',
+    http_code: 404,
+});
+
+ManageCLIError.NoSuchAccountName = Object.freeze({
+    code: 'NoSuchAccountName',
+    message: 'Account does not exist - access key',
+    http_code: 404,
+});
+
+ManageCLIError.AccountAccessKeyAlreadyExists = Object.freeze({
+    code: 'AccountAccessKeyAlreadyExists',
+    message: 'Account already exists - access_key',
+    http_code: 409,
+});
+
+ManageCLIError.AccountNameAlreadyExists = Object.freeze({
+    code: 'AccountNameAlreadyExists',
+    message: 'Account already exists - name',
+    http_code: 409,
+});
+
+
+//////////////////////////////////
+//// ACCOUNT ARGUMENTS ERRORS ////
+//////////////////////////////////
+
+ ManageCLIError.MissingAccountSecretKeyFlag = Object.freeze({
+    code: 'MissingAccountSecretKeyFlag',
+    message: 'Account secret key is mandatory, please use the --secret_key flag',
+    http_code: 400,
+});
+
+ManageCLIError.MissingAccountAccessKeyFlag = Object.freeze({
+    code: 'MissingAccountAccessKeyFlag',
+    message: 'Account access key is mandatory, please use the --access_key flag',
+    http_code: 400,
+});
+
+ManageCLIError.MissingAccountNameFlag = Object.freeze({
+    code: 'MissingAccountNameFlag',
+    message: 'Account name is mandatory, please use the --name flag',
+    http_code: 400,
+});
+
+ManageCLIError.MissingAccountEmailFlag = Object.freeze({
+    code: 'MissingAccountEmailFlag',
+    message: 'Account email is mandatory, please use the --email flag',
+    http_code: 400,
+});
+
+ManageCLIError.MissingIdentifier = Object.freeze({
+    code: 'MissingIdentifier',
+    message: 'Account identifier is mandatory, please use the --acces_key or --name flag',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidAccountNSFSConfig = Object.freeze({
+    code: 'InvalidAccountNSFSConfig',
+    message: 'Account config should not be empty',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidAccountNewBucketsPath = Object.freeze({
+    code: 'InvalidAccountNewBucketsPath',
+    message: 'Account\'s new_buckets_path should be a valid and existing directory path',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidAccountUID = Object.freeze({
+    code: 'InvalidAccountUID',
+    message: 'Account UID must be a number',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidAccountGID = Object.freeze({
+    code: 'InvalidAccountGID',
+    message: 'Account GID must be a number',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidNewNameAccountIdentifier = Object.freeze({
+    code: 'InvalidNewNameAccountIdentifier',
+    message: 'Account new_name can not be used on add command, please remove the --new_name flag',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidNewAccessKeyIdentifier = Object.freeze({
+    code: 'InvalidNewAccessKeyIdentifier',
+    message: 'Account new_access_key can not be used on add command, please remove the --new_access_key flag',
+    http_code: 400,
+});
+
+
+////////////////////////
+//// BUCKET ERRORS /////
+////////////////////////
+
+ManageCLIError.NoSuchBucket = Object.freeze({
+    code: 'NoSuchBucket',
+    message: 'Bucket does not exist',
+    http_code: 404,
+});
+
+ManageCLIError.InvalidBucketName = Object.freeze({
+    code: 'InvalidBucketName',
+    message: 'The specified bucket name is not valid.',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidStoragePath = Object.freeze({
+    code: 'InvalidStoragePath',
+    message: 'The specified bucket storage path is not valid.',
+    http_code: 400,
+});
+
+ManageCLIError.BucketAlreadyExists = Object.freeze({
+    code: 'BucketAlreadyExists',
+    message: 'The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.',
+    http_code: 409,
+});
+
+/////////////////////////////////
+//// BUCKET ARGUMENTS ERRORS ////
+/////////////////////////////////
+
+
+ManageCLIError.MissingBucketNameFlag = Object.freeze({
+    code: 'MissingBucketNameFlag',
+    message: 'Bucket name is mandatory, please use the --name flag',
+    http_code: 400,
+});
+
+ManageCLIError.MissingBucketEmailFlag = Object.freeze({
+    code: 'MissingBucketEmailFlag',
+    message: 'Bucket email is mandatory, please use the --email flag',
+    http_code: 400,
+});
+
+ManageCLIError.MissingBucketPathFlag = Object.freeze({
+    code: 'MissingBucketPathFlag',
+    message: 'Bucket path is mandatory, please use the --path flag',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidNewNameBucketIdentifier = Object.freeze({
+    code: 'InvalidNewNameBucketIdentifier',
+    message: 'Bucket new_name can not be used on add command, please remove the --new_name flag',
+    http_code: 400,
+});
+
+
+ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
+    EACCES: ManageCLIError.AccessDenied,
+    EPERM: ManageCLIError.AccessDenied,
+    EINVAL: ManageCLIError.InvalidRequest,
+    NOT_IMPLEMENTED: ManageCLIError.NotImplemented,
+    INTERNAL_ERROR: ManageCLIError.InternalError,
+    // ENOENT: ManageCLIError.NoSuchBucket,
+    // NOT_EMPTY: ManageCLIError.BucketNotEmpty,
+    // MALFORMED_POLICY: ManageCLIError.MalformedPolicy,
+    // EEXIST: ManageCLIError.BucketAlreadyExists,
+});
+
+exports.ManageCLIError = ManageCLIError;

--- a/src/manage_nsfs/manage_nsfs_cli_responses.js
+++ b/src/manage_nsfs/manage_nsfs_cli_responses.js
@@ -1,0 +1,103 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// TODO : define list & status types
+/**
+ * @typedef {{
+ *      code?: string, 
+ *      http_code: number,
+ *      list?: object,
+ *      status?: object,  
+ * }} ManageCLIResponseSpec
+ */
+
+class ManageCLIResponse {
+
+    /**
+     * @param {ManageCLIResponseSpec} response_spec 
+     */
+    constructor({ code, status, list }) {
+        this.code = code;
+        this.http_code = 200;
+        this.status = status;
+        this.list = list;
+    }
+
+    to_string(detail) {
+        const json = {
+            response: {
+                code: this.code,
+            }
+        };
+        if (this.list || this.status) json.response.reply = typeof detail === 'string' ? JSON.parse(detail) : detail;
+        return JSON.stringify(json, null, 2);
+    }
+}
+
+// See Manage NSFS CLI error codes docs - TODO: add docs
+
+///////////////////////////////
+// IPS WHITE LIST RESPONSES ///
+///////////////////////////////
+ManageCLIResponse.WhiteListIPUpdated = Object.freeze({
+    code: 'WhiteListIPUpdated',
+    status: {}
+});
+
+////////////////////////
+// ACCOUNT RESPONSES ///
+////////////////////////
+
+ManageCLIResponse.AccountCreated = Object.freeze({
+    code: 'AccountCreated',
+    status: {}
+});
+
+ManageCLIResponse.AccountDeleted = Object.freeze({
+    code: 'AccountDeleted',
+});
+
+ManageCLIResponse.AccountUpdated = Object.freeze({
+    code: 'AccountUpdated',
+    status: {}
+});
+
+ManageCLIResponse.AccountStatus = Object.freeze({
+    code: 'AccountStatus',
+    status: {}
+});
+
+ManageCLIResponse.AccountList = Object.freeze({
+    code: 'AccountList',
+    list: {}
+});
+
+////////////////////////
+/// BUCKET RESPONSES ///
+////////////////////////
+
+ManageCLIResponse.BucketCreated = Object.freeze({
+    code: 'BucketCreated',
+    status: {}
+});
+
+ManageCLIResponse.BucketDeleted = Object.freeze({
+    code: 'BucketDeleted',
+});
+
+ManageCLIResponse.BucketUpdated = Object.freeze({
+    code: 'BucketUpdated',
+    status: {}
+});
+
+ManageCLIResponse.BucketStatus = Object.freeze({
+    code: 'BucketStatus',
+    status: {}
+});
+
+ManageCLIResponse.BucketList = Object.freeze({
+    code: 'BucketList',
+    list: {}
+});
+
+exports.ManageCLIResponse = ManageCLIResponse;

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -452,11 +452,12 @@ function validate_bucket_creation(params) {
     }
 }
 
-async function config_file_exists(fs_context, config_path) {
+async function config_file_exists(fs_context, config_path, use_lstat) {
     try {
-        await nb_native().fs.stat(fs_context, config_path);
+        await nb_native().fs.stat(fs_context, config_path, { use_lstat });
     } catch (err) {
         if (err.code === 'ENOENT') return false;
+        throw err;
     }
     return true;
 }


### PR DESCRIPTION
### Explain the changes

This PR suggests changing all cli responses / errors written to stdout to be of json format. notice that help will be printed only by help command, and no longer be available after printing errors.
create/update/status commands will result a json containing Status of the manipulated entity.
list command will result a json containing List of the listed entities.: 
```
Example 1:
  "response": {
    "code": "AccountCreated",
    "reply": {
      "name": "account2",
      "email": "account2@noobaa.io",
      "creation_date": "2023-12-11T15:07:31.886Z",
      "access_keys": [
        {
          "access_key": "bcd",
          "secret_key": "234"
        }
      ],
      "nsfs_account_config": {
        "uid": 222,
        "gid": 222,
        "new_buckets_path": "/private/tmp/test_bucketspace_fs/root_path_manage_nsfs/new_buckets_path_user2/"
      }
    }
  }

EXAMPLE 2: 
node src/cmd/manage_nsfs account add --name project1 --email project1@gmail.com --access_key pr1 --secret_key pr1 --new_buckets_path /root/project1-data --uid "1602" --gid "1996" 2> /dev/null
{
  "error": {
    "code": "InvalidAccountNewBucketsPath",
    "message": "Account's new_buckets_path should be a valid and existing directory path",
    "detail": "/root/project1-data"
  }
}

```
1. Added manage_nsfs_cli_errors.js and manage_nsfs_cli_responsed.js in order to have a well defined errors and responses of the manage cli commands.
2. manage_nsfs.js - 
    2.1. added write_stdout_response() and throw_cli_error() functions in order to have a single place where we write to stdout. 
    2.2. replaced all stdout.write() calls to call the new functions while specifying the new error/response type. 
   2.3. some refactoring of is_undefined(value), the validation functions.
   2.4. added --show-secrets flag.
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
