### PR TITLE
NSFS | NC | add root permission requirement for health and manage scripts

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -222,8 +222,11 @@ Output -
 
 ## Health script
 NSFS Health status can be fetched using the command line. Run `--help` to get all the available options. 
+
+NOTE - health script execution requires root permissions.
+
  ```
- node usr/local/noobaa-core/src/cmd/health [--https_port,--all_account_details,  --all_bucket_details]
+ sudo node usr/local/noobaa-core/src/cmd/health [--https_port,--all_account_details,  --all_bucket_details]
  ```
 
  output:
@@ -396,29 +399,29 @@ Users can create, update, delete, and list buckets and accounts using CLI. If th
 
 CLI will never create or delete a bucket directory for the user if a bucket directory is missing CLI will return with error.
 
-
+NOTE - manage_nsfs execution requires root permissions.
  
- Bucket Commands
- ```
- node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com --path ../standalon/nsfs_root/1 2>/dev/null
+Bucket Commands
+```
+sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com --path ../standalon/nsfs_root/1 2>/dev/null
 
-node src/cmd/manage_nsfs bucket update --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com 2>/dev/null
+sudo node src/cmd/manage_nsfs bucket update --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com 2>/dev/null
 
-node src/cmd/manage_nsfs bucket list --config_root ../standalon/config_root 2>/dev/null
+sudo node src/cmd/manage_nsfs bucket list --config_root ../standalon/config_root 2>/dev/null
 
-node src/cmd/manage_nsfs bucket delete --config_root ../standalon/config_root --name bucket1 2>/dev/null
+sudo node src/cmd/manage_nsfs bucket delete --config_root ../standalon/config_root --name bucket1 2>/dev/null
 
 ```
 
- Account Commands
- ```
-node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --name noobaa --email noobaa@gmail.com --new_buckets_path ../standalon/nsfs_root/ --access_key abc --secret_key abc 2>/dev/null
+Account Commands
+```
+sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --name noobaa --email noobaa@gmail.com --new_buckets_path ../standalon/nsfs_root/ --access_key abc --secret_key abc 2>/dev/null
 
-node src/cmd/manage_nsfs account update --config_root ../standalon/config_root --name noobaa --access_key abc --secret_key abc123 2>/dev/null
+sudo node src/cmd/manage_nsfs account update --config_root ../standalon/config_root --name noobaa --access_key abc --secret_key abc123 2>/dev/null
 
-node src/cmd/manage_nsfs account delete --config_root ../standalon/config_root --access_key abc 2>/dev/null
+sudo node src/cmd/manage_nsfs account delete --config_root ../standalon/config_root --access_key abc 2>/dev/null
 
-node src/cmd/manage_nsfs account list --config_root ../standalon/config_root 2>/dev/null
+sudo node src/cmd/manage_nsfs account list --config_root ../standalon/config_root 2>/dev/null
 
  ```
 
@@ -428,7 +431,7 @@ Users can also pass account and bucket/account values in JSON file instead of pa
 
 
 ```
-node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --from_file /json_file/path
+sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --from_file /json_file/path
 ```
 NSFS management CLI command will create both account and bucket dir if it's missing in the config_root path.
 

--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -322,7 +322,9 @@ class NSFSHealth {
 
 async function main(argv = minimist(process.argv.slice(2))) {
   try {
-
+    if (process.getuid() !== 0 || process.getgid() !== 0) {
+        throw new Error('Root permissions required for NSFS Health execution.');
+    }
     if (argv.help || argv.h) return print_usage();
     const config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
     const https_port = Number(argv.https_port) || 6443;

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -132,6 +132,9 @@ async function check_and_create_config_dirs(config_root) {
 
 async function main(argv = minimist(process.argv.slice(2))) {
     try {
+        if (process.getuid() !== 0 || process.getgid() !== 0) {
+            throw new Error('Root permissions required for Manage NSFS execution.');
+        }
         const resources_type = argv._[0] || '';
         if (argv.help || argv.h) {
             if (resources_type === 'account') {

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -61,8 +61,6 @@ require('./test_chunk_fs');
 require('./test_namespace_fs_mpu');
 require('./test_nb_native_fs');
 require('./test_s3select');
-require('./test_nc_nsfs_cli');
-require('./test_nc_nsfs_health');
 
 // // SERVERS
 require('./test_agent');

--- a/src/test/unit_tests/sudo_index.js
+++ b/src/test/unit_tests/sudo_index.js
@@ -20,4 +20,6 @@ require('./test_bucketspace');
 require('./test_bucketspace_versioning');
 require('./test_bucketspace_fs');
 require('./test_nsfs_versioning');
+require('./test_nc_nsfs_cli');
+require('./test_nc_nsfs_health');
 


### PR DESCRIPTION
### Explain the changes
1. As discussed at the latest HPO meeting, we should require root permissions for manage_nsfs execution, also sounds like we won't be able to run health without it as well.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
