### PR TITLE
manage_nsfs | Generate access keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ts": "tsc",
     "lint": "eslint src --quiet",
     "mocha": "node --allow-natives-syntax ./node_modules/.bin/_mocha src/test/unit_tests/index.js",
-    "jest": "npx jest",
+    "jest": "sudo npx jest",
     "----": "-----------------------------------------------------------------",
     "start": "node --unhandled-rejections=warn src/cmd",
     "cmd": "node --unhandled-rejections=warn src/cmd",

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -134,15 +134,33 @@ ManageCLIError.AccountNameAlreadyExists = Object.freeze({
 //// ACCOUNT ARGUMENTS ERRORS ////
 //////////////////////////////////
 
- ManageCLIError.MissingAccountSecretKeyFlag = Object.freeze({
+ManageCLIError.MissingAccountSecretKeyFlag = Object.freeze({
     code: 'MissingAccountSecretKeyFlag',
-    message: 'Account secret key is mandatory, please use the --secret_key flag',
+    message: 'Account secret key is mandatory, please use the --secret_key flag or --regenerate on update',
     http_code: 400,
 });
 
 ManageCLIError.MissingAccountAccessKeyFlag = Object.freeze({
     code: 'MissingAccountAccessKeyFlag',
-    message: 'Account access key is mandatory, please use the --access_key flag',
+    message: 'Account access key is mandatory, please use the --access_key flag or --regenerate on update on update',
+    http_code: 400,
+});
+
+ManageCLIError.AccountSecretKeyFlagComplexity = Object.freeze({
+    code: 'AccountSecretKeyFlagComplexity',
+    message: 'Account secret length must be 40, and must contain uppercase, lowercase, numbers and symbols',
+    http_code: 400,
+});
+
+ManageCLIError.AccountAccessKeyFlagComplexity = Object.freeze({
+    code: 'AccountAccessKeyFlagComplexity',
+    message: 'Account access key length must be 20, and must contain uppercase and numbers',
+    http_code: 400,
+});
+
+ManageCLIError.NewAccountAccessKeyFlagComplexity = Object.freeze({
+    code: 'NewAccountAccessKeyFlagComplexity',
+    message: 'Account new access key length must be 20, and must contain uppercase and numbers',
     http_code: 400,
 });
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1,0 +1,285 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-disable no-undef */
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = "true";
+
+const _ = require('lodash');
+const path = require('path');
+const P = require('../../../util/promise');
+const fs_utils = require('../../../util/fs_utils');
+const os_util = require('../../../util/os_utils');
+const nb_native = require('../../../util/nb_native');
+const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
+
+const MAC_PLATFORM = 'darwin';
+let tmp_fs_path = '/tmp/test_bucketspace_fs';
+if (process.platform === MAC_PLATFORM) {
+    tmp_fs_path = '/private/' + tmp_fs_path;
+}
+
+const DEFAULT_FS_CONFIG = {
+    uid: process.getuid(),
+    gid: process.getgid(),
+    backend: '',
+    warn_threshold_ms: 100,
+};
+
+const nc_nsfs_manage_actions = {
+    ADD: 'add',
+    UPDATE: 'update',
+    DELETE: 'delete'
+};
+
+describe('manage nsfs cli account flow', () => {
+    const accounts_schema_dir = 'accounts';
+    const access_keys_schema_dir = 'access_keys';
+
+    describe('cli create account', () => {
+        const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs');
+        const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs/');
+        const defaults = {
+            type: 'account',
+            name: 'account1',
+            email: 'account1@noobaa.io',
+            new_buckets_path: `${root_path}new_buckets_path_user1/`,
+            uid: 999,
+            gid: 999,
+            access_key: 'GIGiFAnjaaE7OKD5N7hA',
+            secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFR',
+        };
+
+        beforeEach(async () => {
+            await P.all(_.map([accounts_schema_dir, access_keys_schema_dir], async dir =>
+                fs_utils.create_fresh_path(`${config_root}/${dir}`)));
+            await fs_utils.create_fresh_path(root_path);
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('cli create account without access_keys', async () => {
+            const action = nc_nsfs_manage_actions.ADD;
+            const { type, name, email, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, name, email, new_buckets_path, uid, gid };
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            await exec_manage_cli(type, action, account_options);
+            const account = await read_config_file(config_root, accounts_schema_dir, name);
+            assert_account(account, account_options, false);
+            const access_key = account.access_keys[0].access_key;
+            const secret_key = account.access_keys[0].secret_key;
+            expect(access_key).toBeDefined();
+            expect(secret_key).toBeDefined();
+            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
+            assert_account(account_symlink, account_options);
+        });
+
+        // it('cli create account with access_key and without secret_key', async () => {
+        //     const action = nc_nsfs_manage_actions.ADD;
+        //     const { type, access_key, name, email, new_buckets_path, uid, gid } = defaults;
+        //     const account_options = { config_root, access_key, name, email, new_buckets_path, uid, gid };
+        //     await fs_utils.create_fresh_path(new_buckets_path);
+        //     await fs_utils.file_must_exist(new_buckets_path);
+        //     const res = await exec_manage_cli(type, action, account_options);
+        //     expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.MissingAccountSecretKeyFlag.message);
+        // });
+
+        it('cli create account without access_key and with secret_key', async () => {
+            const action = nc_nsfs_manage_actions.ADD;
+            const { type, secret_key, name, email, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, secret_key, name, email, new_buckets_path, uid, gid };
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.MissingAccountAccessKeyFlag.message);
+        });
+
+        it('cli create account with access_keys', async () => {
+            const action = nc_nsfs_manage_actions.ADD;
+            const { type, access_key, secret_key, name, email, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key, secret_key, name, email, new_buckets_path, uid, gid };
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            await exec_manage_cli(type, action, account_options);
+            const account = await read_config_file(config_root, accounts_schema_dir, name);
+            assert_account(account, account_options, true);
+            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
+            assert_account(account_symlink, account_options);
+        });
+
+        it('should fail - cli update account access_key wrong complexity', async () => {
+            const { type, secret_key, name, email, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key: 'abc', secret_key, name, email, new_buckets_path, uid, gid };
+            const action = nc_nsfs_manage_actions.UPDATE;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.AccountAccessKeyFlagComplexity.message);
+        });
+
+        it('should fail - cli update account secret_key wrong complexity', async () => {
+            const { type, access_key, name, email, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key, secret_key: 'abc', name, email, new_buckets_path, uid, gid };
+            const action = nc_nsfs_manage_actions.UPDATE;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.AccountSecretKeyFlagComplexity.message);
+        });
+
+        it('should fail - cli create account integer uid and gid', async () => {
+            const action = nc_nsfs_manage_actions.ADD;
+            const { type, access_key, secret_key, name, email, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key, secret_key, name, email, new_buckets_path, uid, gid };
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            await exec_manage_cli(type, action, account_options);
+            const account = await read_config_file(config_root, accounts_schema_dir, name);
+            assert_account(account, account_options, false);
+            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
+            assert_account(account_symlink, account_options);
+        });
+
+    });
+
+    describe('cli update account', () => {
+        const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs1');
+        const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs1/');
+        const defaults = {
+            type: 'account',
+            name: 'account1',
+            email: 'account1@noobaa.io',
+            new_buckets_path: `${root_path}new_buckets_path_user1/`,
+            uid: 999,
+            gid: 999,
+            access_key: 'GIGiFAnjaaE7OKD5N7hA',
+            secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFR',
+        };
+
+        beforeEach(async () => {
+            await P.all(_.map([accounts_schema_dir, access_keys_schema_dir], async dir =>
+                fs_utils.create_fresh_path(`${config_root}/${dir}`)));
+            await fs_utils.create_fresh_path(root_path);
+            // Creating the account
+            const action = nc_nsfs_manage_actions.ADD;
+            const { type, new_buckets_path } = defaults;
+            const account_options = { config_root, ...defaults };
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            await exec_manage_cli(type, action, account_options);
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('cli regenerate account access_keys', async () => {
+            const { type, name } = defaults;
+            const account_options = { config_root, name, regenerate: true };
+            const account_details = await read_config_file(config_root, accounts_schema_dir, name);
+            const action = nc_nsfs_manage_actions.UPDATE;
+            await exec_manage_cli(type, action, account_options);
+            let new_account_details = await read_config_file(config_root, accounts_schema_dir, name);
+            expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
+            const new_access_key = new_account_details.access_keys[0].access_key;
+            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, new_access_key, true);
+            //fixing the new_account_details for compare. 
+            new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
+            assert_account(account_symlink, new_account_details);
+        });
+
+        it('cli update account access_key', async () => {
+            const { type, name } = defaults;
+            const new_access_key = 'GIGiFAnjaaE7OKD5N7hB';
+            const account_options = { config_root, name, new_access_key: new_access_key };
+            const account_details = await read_config_file(config_root, accounts_schema_dir, name);
+            const action = nc_nsfs_manage_actions.UPDATE;
+            await exec_manage_cli(type, action, account_options);
+            let new_account_details = await read_config_file(config_root, accounts_schema_dir, name);
+            expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
+            expect(new_account_details.access_keys[0].access_key).toBe(new_access_key);
+            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, new_access_key, true);
+            //fixing the new_account_details for compare. 
+            new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
+            assert_account(account_symlink, new_account_details);
+        });
+
+        it('should fail - cli update account new access_key wrong complexity', async () => {
+            const { type, name } = defaults;
+            const new_access_key = 'new';
+            const account_options = { config_root, name, new_access_key: new_access_key };
+            const action = nc_nsfs_manage_actions.UPDATE;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.NewAccountAccessKeyFlagComplexity.message);
+        });
+
+    });
+});
+
+/**
+ * read_config_file will read the config files 
+ * @param {string} config_root
+ * @param {string} schema_dir 
+ * @param {string} config_file_name the name of the config file
+ * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
+ */
+async function read_config_file(config_root, schema_dir, config_file_name, is_symlink) {
+    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
+    const config = JSON.parse(data.toString());
+    return config;
+}
+
+/**
+ * assert_account will verify the fields of the accounts 
+ * @param {object} account
+ * @param {object} account_options
+ * @param {boolean} [verify_access_keys] a flag to skip verifying the access_keys 
+ */
+function assert_account(account, account_options, verify_access_keys) {
+    if (verify_access_keys) {
+        expect(account.access_keys[0].access_key).toEqual(account_options.access_key);
+        expect(account.access_keys[0].secret_key).toEqual(account_options.secret_key);
+    }
+    expect(account.email).toEqual(account_options.email);
+    expect(account.name).toEqual(account_options.name);
+
+    if (account_options.distinguished_name) {
+        expect(account.nsfs_account_config.distinguished_name).toEqual(account_options.distinguished_name);
+    } else {
+        expect(account.nsfs_account_config.uid).toEqual(account_options.uid);
+        expect(account.nsfs_account_config.gid).toEqual(account_options.gid);
+    }
+
+    expect(account.nsfs_account_config.new_buckets_path).toEqual(account_options.new_buckets_path);
+}
+
+/**
+ * exec_manage_cli will get the flags for the cli and runs the cli with it's flags
+ * @param {string} type
+ * @param {string} action
+ * @param {object} options
+ */
+async function exec_manage_cli(type, action, options) {
+    let account_flags = ``;
+    for (const key in options) {
+        if (Object.hasOwn(options, key)) {
+            if (typeof options[key] === 'boolean') {
+                account_flags += `--${key} `;
+            } else {
+                account_flags += `--${key} ${options[key]} `;
+            }
+        }
+    }
+    account_flags = account_flags.trim();
+
+    const command = `node src/cmd/manage_nsfs ${type} ${action} ${account_flags}`;
+    let res;
+    try {
+        res = await os_util.exec(command, { return_stdout: true });
+    } catch (e) {
+        res = e;
+    }
+    return res;
+}

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -143,7 +143,7 @@ mocha.describe('manage_nsfs cli', function() {
             const action = nc_nsfs_manage_actions.UPDATE;
             const update_options = { config_root, owner_email: 'user2@noobaa.io', name };
             await exec_manage_cli(type, action, update_options);
-            bucket_options = { ...bucket_options, ...update_options};
+            bucket_options = { ...bucket_options, ...update_options };
             const bucket = await read_config_file(config_root, schema_dir, name);
             assert_bucket(bucket, bucket_options);
             await assert_config_file_permissions(config_root, schema_dir, name);
@@ -162,7 +162,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli bucket2 update - new_name already exists', async function() {
             let action = nc_nsfs_manage_actions.ADD;
             const bucket_name3 = 'bucket3';
-            await exec_manage_cli(type, action, { ...bucket_options, name: bucket_name3});
+            await exec_manage_cli(type, action, { ...bucket_options, name: bucket_name3 });
             action = nc_nsfs_manage_actions.UPDATE;
             try {
                 await exec_manage_cli(type, action, { ...bucket_options, name: bucket_name3, new_name: 'bucket2' });
@@ -228,8 +228,8 @@ mocha.describe('manage_nsfs cli', function() {
         const new_buckets_path = `${root_path}new_buckets_path_user1/`;
         const uid = 999;
         const gid = 999;
-        const access_key = 'abc';
-        const secret_key = '123';
+        const access_key = 'GIGiFAnjaaE7OKD5N7hA';
+        const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFR';
         let account_options = { config_root, name, email, new_buckets_path, uid, gid, access_key, secret_key };
         const accounts_schema_dir = 'accounts';
         const access_keys_schema_dir = 'access_keys';
@@ -396,7 +396,7 @@ mocha.describe('manage_nsfs cli', function() {
             const action = nc_nsfs_manage_actions.UPDATE;
             const update_options = {
                 config_root,
-                new_access_key: 'abcd',
+                new_access_key: 'BIGiFAnjaaE7OKD5N7hB',
                 name: account_options.name
             };
             const update_response = await exec_manage_cli(type, action, update_options);
@@ -413,7 +413,7 @@ mocha.describe('manage_nsfs cli', function() {
             const action = nc_nsfs_manage_actions.UPDATE;
             const update_options = {
                 config_root,
-                new_access_key: 'abcde',
+                new_access_key: 'BIGiFAnjaaE6OGD5N7hB',
                 new_name: 'account2_new_name',
                 name: account_options.name
             };
@@ -462,10 +462,10 @@ mocha.describe('manage_nsfs cli', function() {
         const new_buckets_path = `${root_path}new_buckets_path_user1/`;
         const uid = 999;
         const gid = 999;
-        const access_key = 'abc';
-        const secret_key = '123';
+        const access_key = 'GIGiFAnjaaE7OKD5N7hA';
+        const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFR';
         const account1_options = { config_root, name, email, new_buckets_path, uid, gid, access_key, secret_key };
-        const account2_options = { config_root, name: 'account2', email, new_buckets_path, uid, gid, access_key: 'abcd', secret_key };
+        const account2_options = { config_root, name: 'account2', email, new_buckets_path, uid, gid, access_key: 'BISiDSnjaaE7OKD5N7hB', secret_key };
         mocha.before(async () => {
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
@@ -493,7 +493,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account2 update - new_access_key already exists', async function() {
             const action = nc_nsfs_manage_actions.UPDATE;
             try {
-                await exec_manage_cli(type, action, { ...account2_options, new_access_key: 'abc' });
+                await exec_manage_cli(type, action, { ...account2_options, new_access_key: 'GIGiFAnjaaE7OKD5N7hA' });
                 assert.fail('should have failed with account access key already exists');
             } catch (err) {
                 assert_error(err, ManageCLIError.AccountAccessKeyAlreadyExists);
@@ -508,8 +508,8 @@ mocha.describe('manage_nsfs cli', function() {
         const email = 'account2@noobaa.io';
         const new_buckets_path = `${root_path}new_buckets_path_user2/`;
         const distinguished_name = 'moti1003';
-        const access_key = 'bcd';
-        const secret_key = '234';
+        const access_key = 'GIGiFAnjaaE7OKD5N7hB';
+        const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFr';
         let account_options = { config_root, name, email, new_buckets_path, distinguished_name, access_key, secret_key };
         const accounts_schema_dir = 'accounts';
         const access_keys_schema_dir = 'access_keys';
@@ -592,7 +592,7 @@ mocha.describe('manage_nsfs cli', function() {
     mocha.describe('cli whitelist flow', async function() {
         this.timeout(50000); // eslint-disable-line no-invalid-this
         const type = nc_nsfs_manage_entity_types.IPWHITELIST;
-        const config_options = { ENDPOINT_FORKS: 1, UV_THREADPOOL_SIZE: 4};
+        const config_options = { ENDPOINT_FORKS: 1, UV_THREADPOOL_SIZE: 4 };
         const ips = ['127.0.0.1', '192.000.10.000', '3002:0bd6:0000:0000:0000:ee00:0033:999'];
         mocha.before(async () => {
             await write_config_file(config_root, '', 'config', config_options);
@@ -602,11 +602,11 @@ mocha.describe('manage_nsfs cli', function() {
         });
 
         mocha.it('cli add whitelist ips first time', async function() {
-                const res = await exec_manage_cli(type, '', { config_root, ips: JSON.stringify(ips) });
-                config_options.NSFS_WHITELIST = ips;
-                const config_data = await read_config_file(config_root, '', 'config');
-                assert_response('', type, res, ips);
-                assert_whitelist(config_data, config_options);
+            const res = await exec_manage_cli(type, '', { config_root, ips: JSON.stringify(ips) });
+            config_options.NSFS_WHITELIST = ips;
+            const config_data = await read_config_file(config_root, '', 'config');
+            assert_response('', type, res, ips);
+            assert_whitelist(config_data, config_options);
         });
 
         mocha.it('cli update whitelist ips', async function() {

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -263,7 +263,7 @@ async function create_config_file(fs_context, schema_dir, config_path, config_da
         } catch (err) {
             if (err.code !== 'ENOENT') throw err;
         }
-        dbg.log1('native_fs_utils: create_config_file config_path:', config_path, 'config_data:', config_data, 'is_gpfs:', open_mode);
+        dbg.log1('create_config_file:: config_path:', config_path, 'config_data:', config_data, 'is_gpfs:', open_mode);
         // create config dir if it does not exist
         await _create_path(schema_dir, fs_context, config.BASE_MODE_CONFIG_DIR);
         // when using GPFS open dst file as soon as possible for later linkat validation
@@ -287,13 +287,13 @@ async function create_config_file(fs_context, schema_dir, config_path, config_da
         } else {
             src_stat = await nb_native().fs.stat(fs_context, open_path);
         }
-        dbg.log1('native_fs_utils: create_config_file moving from:', open_path, 'to:', config_path, 'is_gpfs=', is_gpfs);
+        dbg.log1('create_config_file:: moving from:', open_path, 'to:', config_path, 'is_gpfs=', is_gpfs);
 
         await safe_move(fs_context, open_path, config_path, src_stat, gpfs_options, tmp_dir_path);
 
-        dbg.log1('native_fs_utils: create_config_file done', config_path);
+        dbg.log1('create_config_file:: done', config_path);
     } catch (err) {
-        dbg.error('native_fs_utils: create_config_file error', err);
+        dbg.error('create_config_file:: error', err);
         throw err;
     } finally {
         await finally_close_files(fs_context, [upload_tmp_file, gpfs_dst_file]);

--- a/src/util/string_utils.js
+++ b/src/util/string_utils.js
@@ -8,6 +8,10 @@ const crypto = require('crypto');
 const ALPHA_NUMERIC_CHARSET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 const email_regexp = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
 const escape_regexp = /[\\^$.*+?()[\]{}|]/g;
+const uppercase_regexp = /[A-Z]/;
+const lowercase_regexp = /[a-z]/;
+const numbers_regexp = /\d/;
+const symbols_regexp = /[!@#$%^&*(),.?":+-{}|<>]/;
 
 function crypto_random_string(len, charset = ALPHA_NUMERIC_CHARSET) {
     // In order to not favor any specific chars over others we limit the maximum random value
@@ -144,6 +148,99 @@ function escape_reg_exp(str) {
     return str.replace(escape_regexp, '\\$&');
 }
 
+/**
+ * 
+ * @param {string} string
+ * @param {number} require_length
+ */
+function validate_length(string, require_length) {
+    if (string.length !== require_length) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @param {string} string
+ * @param {boolean} check_uppercase
+ */
+function validate_uppercase(string, check_uppercase) {
+    const uppercase_test = uppercase_regexp.test(string);
+    if (check_uppercase && !uppercase_test) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @param {string} string
+ * @param {boolean} check_lowercase
+ */
+function validate_lowercase(string, check_lowercase) {
+    const lowercase_test = lowercase_regexp.test(string);
+    if (check_lowercase && !lowercase_test) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @param {string} string
+ * @param {boolean} check_numbers
+ */
+function validate_numbers(string, check_numbers) {
+    const numbers_test = numbers_regexp.test(string);
+    if (check_numbers && !numbers_test) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @param {string} string
+ * @param {boolean} check_symbols
+ */
+function validate_symbols(string, check_symbols) {
+    const symbols_test = symbols_regexp.test(string);
+    if (check_symbols && !symbols_test) {
+        return false;
+    }
+    return true;
+}
+
+
+/**
+ * validate_complexity will validate the complexity of a string
+ * 
+ * @param {string} string
+ * @param {{
+ *   require_length?: number,
+ *   check_uppercase?: boolean,
+ *   check_lowercase?: boolean,
+ *   check_numbers?: boolean,
+ *   check_symbols?: boolean,
+ * }} options - Options for complexity validation.
+ *
+ * @returns {boolean}
+ */
+function validate_complexity(string, options = {}) {
+    const {
+        require_length = 20,
+            check_uppercase = true,
+            check_lowercase = true,
+            check_numbers = true,
+            check_symbols = true,
+    } = options;
+
+    return (
+        validate_length(string, require_length) &&
+        validate_uppercase(string, check_uppercase) &&
+        validate_lowercase(string, check_lowercase) &&
+        validate_numbers(string, check_numbers) &&
+        validate_symbols(string, check_symbols)
+    );
+}
+
 exports.ALPHA_NUMERIC_CHARSET = ALPHA_NUMERIC_CHARSET;
 exports.crypto_random_string = crypto_random_string;
 exports.left_pad_zeros = left_pad_zeros;
@@ -152,3 +249,9 @@ exports.rolling_hash = rolling_hash;
 exports.equal_case_insensitive = equal_case_insensitive;
 exports.is_email_address = is_email_address;
 exports.escape_reg_exp = escape_reg_exp;
+exports.validate_length = validate_length;
+exports.validate_uppercase = validate_uppercase;
+exports.validate_lowercase = validate_lowercase;
+exports.validate_numbers = validate_numbers;
+exports.validate_symbols = validate_symbols;
+exports.validate_complexity = validate_complexity;


### PR DESCRIPTION
### Explain the changes
- Generate access keys if not provided by the flags
- Added --regenerate flag to regenerate the access keys automatically on update
- Add test complexity for the access and secret keys
### BUG
Fixes: https://github.com/noobaa/noobaa-core/issues/7580

### Test instruction 
 1. Run `sudo npx jest test_nc_nsfs_account_cli.test.js`

- [x] Tests added