### PR TITLE
NSFS | NC | health command exit

### DIFF
--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -335,6 +335,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
       const health = new NSFSHealth({https_port, config_root, all_account_details, all_bucket_details});
       const health_status = await health.nc_nsfs_health();
       process.stdout.write(JSON.stringify(health_status) + '\n');
+      process.exit(0);
     } else {
       dbg.log0('Health is not supported for simple nsfs deployment.');
     }


### PR DESCRIPTION
### Explain the changes
1. `process.exit(0)` added after the health script outputs the result.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7674

### Testing Instructions:
1. run the health script and verify the command exiting right after printing the output.


- [ ] Doc added/updated
- [ ] Tests added
