### PR TITLE
Use async-await in `test_agent_blocks_reclaimer`

### DIFF
--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -362,9 +362,9 @@ exports.resolve = val => Promise.resolve(val);
 exports.reject = err => Promise.reject(err);
 exports.all = arr => Promise.all(arr);
 // deprecated
-exports.fromCallback = fromCallback; // 50 occurrences
-exports.fcall = fcall; // 60 occurrences
-exports.ninvoke = ninvoke; // 31 occurrences
-exports.wait_until = wait_until; // 21 occurrences
-exports.Defer = Defer; // 18 occurrences
-exports.pwhile = pwhile; // 16 occurrences
+exports.fromCallback = fromCallback; // 44 occurrences
+exports.fcall = fcall; // 59 occurrences
+exports.ninvoke = ninvoke; // 30 occurrences
+exports.wait_until = wait_until; // 20 occurrences
+exports.Defer = Defer; // 13 occurrences
+exports.pwhile = pwhile; // 15 occurrences


### PR DESCRIPTION
### Explain the changes
1. Use async-await in `test_agent_blocks_reclaimer`(started in commit a81231b part of PR #5835 ).
2. Update occurrences of deprecated functions in promise.js.

### Issues: Fixed #xxx / Gap #xxx
1. none.

### Testing Instructions:
`make run-single-test testname=test_agent_blocks_reclaimer.js CONTAINER_PLATFORM=linux/arm64` (I'm using the flag `CONTAINER_PLATFORM` because I have MacOS M1). See:

> 5 passing (1m)  return code was: 0


- [ ] Doc added/updated
- [ ] Tests added
