### PR TITLE
NSFS | NC | fs_backend support on bucket and account config files and as config.json configuration for config dirs

### DIFF
--- a/config.js
+++ b/config.js
@@ -698,6 +698,7 @@ config.NSFS_NC_CONF_DIR_REDIRECT_FILE = 'config_dir_redirect';
 config.NSFS_NC_DEFAULT_CONF_DIR = '/etc/noobaa.conf.d';
 config.NSFS_NC_CONF_DIR = process.env.NSFS_NC_CONF_DIR || '';
 config.NSFS_TEMP_CONF_DIR_NAME = '.noobaa-config-nsfs';
+config.NSFS_NC_CONFIG_DIR_BACKEND = '';
 config.ENDPOINT_PORT = Number(process.env.ENDPOINT_PORT) || 6001;
 config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
 config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || -1;

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -248,6 +248,27 @@ Example:
 node src/cmd/manage_nsfs whitelist --ips '["127.0.0.1", "192.000.10.000", "3002:0bd6:0000:0000:0000:ee00:0033:000"]'  2>/dev/null
 ```
 
+## 13. Config directory backend -
+**Description -** Set custom config directory backend. Set to GPFS in order to increase performance of creation/deletion of config files under the config directory.
+
+**Configuration Key -** NSFS_NC_CONFIG_DIR_BACKEND
+
+**Type -** string
+
+**Default -** ''
+
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"NSFS_NC_CONFIG_DIR_BACKEND": "GPFS"
+```
+
+
+
+
+
 ## Config.json example 
 ```
 > cat /path/to/config_dir/config.json

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -399,13 +399,15 @@ Users can create, update, delete, and list buckets and accounts using CLI. If th
 
 CLI will never create or delete a bucket directory for the user if a bucket directory is missing CLI will return with error.
 
-NOTE - manage_nsfs execution requires root permissions.
- 
+NOTES - 
+1. manage_nsfs execution requires root permissions.
+2. While path specifies a GPFS path, it's recommended to add fs_backend=GPFS in order to increase performance by ordering NooBaa to use GPFS library.
+
 Bucket Commands
 ```
-sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com --path ../standalon/nsfs_root/1 2>/dev/null
+sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com --path ../standalon/nsfs_root/1 --fs_backend GPFS 2>/dev/null
 
-sudo node src/cmd/manage_nsfs bucket update --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com 2>/dev/null
+sudo node src/cmd/manage_nsfs bucket update --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com --fs_backend GPFS 2>/dev/null
 
 sudo node src/cmd/manage_nsfs bucket list --config_root ../standalon/config_root 2>/dev/null
 
@@ -415,9 +417,9 @@ sudo node src/cmd/manage_nsfs bucket delete --config_root ../standalon/config_ro
 
 Account Commands
 ```
-sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --name noobaa --email noobaa@gmail.com --new_buckets_path ../standalon/nsfs_root/ --access_key abc --secret_key abc 2>/dev/null
+sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --name noobaa --email noobaa@gmail.com --new_buckets_path ../standalon/nsfs_root/ --fs_backend GPFS 2>/dev/null
 
-sudo node src/cmd/manage_nsfs account update --config_root ../standalon/config_root --name noobaa --access_key abc --secret_key abc123 2>/dev/null
+sudo node src/cmd/manage_nsfs account update --config_root ../standalon/config_root --name noobaa --fs_backend GPFS 2>/dev/null
 
 sudo node src/cmd/manage_nsfs account delete --config_root ../standalon/config_root --access_key abc 2>/dev/null
 

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -276,6 +276,11 @@ ManageCLIError.InvalidNewNameBucketIdentifier = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.InvalidFSBackend = Object.freeze({
+    code: 'InvalidFSBackend',
+    message: 'FS backend supported types is GPFS, default is POSIX',
+    http_code: 400,
+});
 
 ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
     EACCES: ManageCLIError.AccessDenied,

--- a/src/server/object_services/schemas/nsfs_account_schema.js
+++ b/src/server/object_services/schemas/nsfs_account_schema.js
@@ -44,6 +44,9 @@ module.exports = {
                     uid: { type: 'number' },
                     gid: { type: 'number' },
                     new_buckets_path: { type: 'string' },
+                    fs_backend: {
+                        $ref: 'common_api#/definitions/fs_backend'
+                    }
                 }
             }, {
                 type: 'object',
@@ -51,6 +54,9 @@ module.exports = {
                 properties: {
                     distinguished_name: { type: 'string' },
                     new_buckets_path: { type: 'string' },
+                    fs_backend: {
+                        $ref: 'common_api#/definitions/fs_backend'
+                    }
                 }
             }]
         },

--- a/src/server/object_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/object_services/schemas/nsfs_bucket_schema.js
@@ -38,5 +38,8 @@ module.exports = {
         creation_date: {
             type: 'string',
         },
+        fs_backend: {
+            $ref: 'common_api#/definitions/fs_backend'
+        },
     }
 };


### PR DESCRIPTION
### Explain the changes
1. This PR handles the missing fs_backend of namespace_fs and bucketspace_fs - 
2. bucketspace_fs - there are 2 fs_backends
    2.1. config files fs_backend - can be configured by config. NSFS_NC_CONFIG_DIR_BACKEND
    2.2. s3 bucket ops - fs_backen is taken from the creating/deleting account nsfs_account_config
3. namespace_fs - in order to pass fs_backend to NamespaceFs, read_bucket_sdk_info() loads fs_backend to its runtime nsr.
4. manage_nsfs - added fs_backend to add/update bucket - fs_backend is the backend of the bucket's storage_path (under lying directory)
5. manage_nsfs - added fs_backend to add/update account - fs_backend is the backend of the account's new_bucket_path. this is needed for buckets creation by S3.

### Issues: Fixed #xxx / Gap #xxx
1. Add tests

### Testing Instructions:
1. 


- [x] Doc added/updated
- [x] Tests added
