### PR TITLE
NSFS | NC | add manage_nsfs folder to RPM build

### DIFF
--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -25,6 +25,7 @@ COPY ./package*.json ./
 COPY ./src/deploy/standalone/noobaa_rsyslog.conf ./src/deploy/standalone/noobaa_rsyslog.conf
 COPY ./src/deploy/standalone/noobaa_syslog.conf ./src/deploy/standalone/noobaa_syslog.conf
 COPY ./src/deploy/standalone/logrotate_noobaa.conf ./src/deploy/standalone/logrotate_noobaa.conf
+COPY ./src/manage_nsfs ./src/manage_nsfs
 
 WORKDIR /build
 


### PR DESCRIPTION
### Explain the changes
1. Manage_nsfs folder was missing in rpm build

### Issues: Fixed #xxx / Gap #xxx
1. Manage_nsfs folder was missing in rpm build

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
