### PR TITLE
NSFS | NC | CLI | add filter to list

### DIFF
--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -337,6 +337,7 @@ mocha.describe('manage_nsfs cli', function() {
             const update_options = {
                 config_root,
                 access_key: account_options.access_key,
+                secret_key: account_options.secret_key,
                 email: 'account2@noobaa.io',
                 uid: 222,
                 gid: 222
@@ -379,7 +380,8 @@ mocha.describe('manage_nsfs cli', function() {
             const update_options = {
                 config_root,
                 new_name: 'account1_new_name',
-                access_key: account_options.access_key
+                access_key: account_options.access_key,
+                secret_key: account_options.secret_key,
             };
             account_options.new_name = 'account1_new_name';
             const update_response = await exec_manage_cli(type, action, update_options);
@@ -544,7 +546,7 @@ mocha.describe('manage_nsfs cli', function() {
 
         mocha.it('cli account delete by access key', async function() {
             const action = nc_nsfs_manage_actions.DELETE;
-            const res = await exec_manage_cli(type, action, { config_root, access_key });
+            const res = await exec_manage_cli(type, action, { config_root, access_key, secret_key });
             assert_response(action, type, res);
             try {
                 await read_config_file(config_root, access_keys_schema_dir, access_key, true);


### PR DESCRIPTION
### Explain the changes
add a filter to lis: using the flags `--uid` or/and `--gid` we can filter the account list
If we would like to add more fields then we can add them to the `_.pick`

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: https://github.com/noobaa/noobaa-core/issues/7673
2. Fixes: https://github.com/noobaa/noobaa-core/issues/7585

### Testing Instructions:
1. run `sudo npx jest test_nc_nsfs_account_cli.test.js`
3. run `sudo node --allow-natives-syntax ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`

- [x] Tests added
