### PR TITLE
NC | NSFS | new_buckets_path should be optional

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -436,6 +436,7 @@ async function fetch_account_data(argv, config_root, from_file) {
             new_buckets_path: data.nsfs_account_config.new_buckets_path,
             fs_backend: data.nsfs_account_config.fs_backend
         },
+        allow_bucket_creation: !is_undefined(data.nsfs_account_config.new_buckets_path),
         // updates of account identifiers
         new_name: data.new_name && new SensitiveString(String(data.new_name)),
         new_access_key: data.new_access_key && new SensitiveString(String(data.new_access_key))
@@ -697,8 +698,7 @@ async function validate_account_args(data, action) {
         if (is_undefined(data.access_keys[0].secret_key)) throw_cli_error(ManageCLIError.MissingAccountSecretKeyFlag);
         if (is_undefined(data.access_keys[0].access_key)) throw_cli_error(ManageCLIError.MissingAccountAccessKeyFlag);
         if ((is_undefined(data.nsfs_account_config.distinguished_name) &&
-                (data.nsfs_account_config.uid === undefined || data.nsfs_account_config.gid === undefined)) ||
-            !data.nsfs_account_config.new_buckets_path) {
+                (data.nsfs_account_config.uid === undefined || data.nsfs_account_config.gid === undefined))) {
             throw_cli_error(ManageCLIError.InvalidAccountNSFSConfig, data.nsfs_account_config);
         }
         // fs_backend='' used for deletion of the fs_backend property
@@ -708,6 +708,9 @@ async function validate_account_args(data, action) {
         if (data.nsfs_account_config.uid && typeof data.nsfs_account_config.uid !== 'number') throw_cli_error(ManageCLIError.InvalidAccountUID);
         if (data.nsfs_account_config.gid && typeof data.nsfs_account_config.gid !== 'number') throw_cli_error(ManageCLIError.InvalidAccountGID);
 
+        if (is_undefined(data.nsfs_account_config.new_buckets_path)) {
+            return;
+        }
         const fs_context = native_fs_utils.get_process_fs_context();
         const exists = await native_fs_utils.config_file_exists(fs_context, data.nsfs_account_config.new_buckets_path);
         if (!exists) {

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -252,8 +252,6 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             _.isUndefined(account.nsfs_account_config.gid)) return false;
         try {
             dbg.log0('_has_access_to_nsfs_dir: checking access:', ns.write_resource, account.nsfs_account_config.uid, account.nsfs_account_config.gid);
-            //TODO:  Operation not permitted error on change_user() with non root user, and 
-            //proccess exit with error
             await nb_native().fs.checkAccess({
                 uid: account.nsfs_account_config.uid,
                 gid: account.nsfs_account_config.gid,
@@ -283,6 +281,9 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
 
     async create_bucket(params, sdk) {
         return bucket_semaphore.surround_key(String(params.name), async () => {
+            if (!sdk.requesting_account.allow_bucket_creation) {
+                throw new RpcError('UNAUTHORIZED', 'Not allowed to create new buckets')
+            }
             if (!sdk.requesting_account.nsfs_account_config || !sdk.requesting_account.nsfs_account_config.new_buckets_path) {
                 throw new RpcError('MISSING_NSFS_ACCOUNT_CONFIGURATION');
             }

--- a/src/server/object_services/schemas/nsfs_account_schema.js
+++ b/src/server/object_services/schemas/nsfs_account_schema.js
@@ -10,6 +10,7 @@ module.exports = {
         'access_keys',
         'nsfs_account_config',
         'creation_date',
+        'allow_bucket_creation',
     ],
     properties: {
         name: {
@@ -20,6 +21,9 @@ module.exports = {
         },
         creation_date: {
             type: 'string',
+        },
+        allow_bucket_creation: {
+            type: 'boolean',
         },
         access_keys: {
             type: 'array',
@@ -39,7 +43,7 @@ module.exports = {
         nsfs_account_config: {
             oneOf: [{
                 type: 'object',
-                required: ['uid', 'gid', 'new_buckets_path'],
+                required: ['uid', 'gid'],
                 properties: {
                     uid: { type: 'number' },
                     gid: { type: 'number' },
@@ -50,7 +54,7 @@ module.exports = {
                 }
             }, {
                 type: 'object',
-                required: [ 'distinguished_name', 'new_buckets_path'],
+                required: [ 'distinguished_name'],
                 properties: {
                     distinguished_name: { type: 'string' },
                     new_buckets_path: { type: 'string' },


### PR DESCRIPTION
### Explain the changes
1. new_buckets_path should be optional and set allow_bucket_creation to false if missing.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7625

### Testing Instructions:
1. run account add without specifying new_buckets_path and try to create bucket using that account and verify the error


- [ ] Doc added/updated
- [ ] Tests added
