### PR TITLE
NSFS | NC | fix allow http property on config

### DIFF
--- a/config.js
+++ b/config.js
@@ -701,7 +701,7 @@ config.NSFS_TEMP_CONF_DIR_NAME = '.noobaa-config-nsfs';
 config.ENDPOINT_PORT = Number(process.env.ENDPOINT_PORT) || 6001;
 config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
 config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || -1;
-config.NSFS_NC_ALLOW_HTTP = false;
+config.ALLOW_HTTP = false;
 // config files should allow access to the owner of the files 
 config.BASE_MODE_CONFIG_FILE = 0o600;
 config.BASE_MODE_CONFIG_DIR = 0o700;

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -90,7 +90,7 @@ Example:
 1. Open /path/to/config_dir/config.json file.
 2. Set the config key -
 Example:
-"ALLOW_HTTP": false
+"ALLOW_HTTP": true
 3. systemctl restart noobaa_nsfs
 ```
 

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -439,7 +439,7 @@ NSFS management CLI command will create both account and bucket dir if it's miss
 
 Non containerized NSFS certificates/ directory location will be under the config_root path. The certificates/ directory should contain SSL files tls.key and tls.crt. System will use a cert from this dir to create a valid HTTPS connection. If cert is missing in this dir a self-signed SSL certificate will be generated. Make sure the path to certificates/ directory is valid before running nsfs command, If the path is invalid then cert flow will fail.
 
-Non containerized NSFS restrict insecure HTTP connections when `allow_http` is set to false in cofig.json. This is not the default behaviour.
+Non containerized NSFS restrict insecure HTTP connections when `ALLOW_HTTP` is set to false in cofig.json. This is the default behaviour.
 
 ## Monitoring
 

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -326,7 +326,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
                 req.object_sdk = new NsfsObjectSDK(fs_root, fs_config, account, versioning, nsfs_config_root);
             }
         });
-        if (config.NSFS_NC_ALLOW_HTTP) {
+        if (config.ALLOW_HTTP) {
             console.log('nsfs: listening on', util.inspect(`http://localhost:${http_port}`));
         }
         console.log('nsfs: listening on', util.inspect(`https://localhost:${https_port}`));

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -162,7 +162,7 @@ async function main(options = {}) {
             https_server.setSecureContext(updated_ssl_options);
             https_server_sts.setSecureContext(updated_ssl_options);
         });
-        if (options.nsfs_config_root && !config.NSFS_NC_ALLOW_HTTP) {
+        if (options.nsfs_config_root && !config.ALLOW_HTTP) {
             dbg.log0('HTTP is not allowed for NC NSFS.');
         } else {
             const http_server = http.createServer(endpoint_request_handler);


### PR DESCRIPTION
### Explain the changes
1. ALLOW_HTTP was having NSFS_NC prefix which is an old version of this property before the config reload change

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
