### PR TITLE
NSFS | NC | Fix Ceph S3 Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ test-cephs3: tester
 
 test-nsfs-cephs3: tester
 	@echo "\033[1;34mRunning Ceph S3 tests on NSFS Standalone platform\033[0m"
-	$(CONTAINER_ENGINE) run $(CPUSET) --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" -v $(PWD)/logs:/logs $(TESTER_TAG) "./src/test/system_tests/ceph_s3_tests/run_ceph_nsfs_test_on_test_container.sh"
+	$(CONTAINER_ENGINE) run $(CPUSET) --privileged --user root --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" -v $(PWD)/logs:/logs $(TESTER_TAG) "./src/test/system_tests/ceph_s3_tests/run_ceph_nsfs_test_on_test_container.sh"
 .PHONY: test-nsfs-cephs3
 
 test-sanity: tester

--- a/src/deploy/NVA_build/standalone_deploy_nsfs.sh
+++ b/src/deploy/NVA_build/standalone_deploy_nsfs.sh
@@ -8,12 +8,15 @@ function execute() {
     fi
 }
 
+# Please note that the command we use here are without "sudo" because we are running from the container with Root permissions
 function main() {
     # Add accounts to run ceph tests
-    execute "node src/cmd/manage_nsfs account add --config_root ./standalone/config_root --name cephalt --email ceph.alt@noobaa.com --new_buckets_path ./standalone/nsfs_root --access_key abcd --secret_key abcd --uid 100 --gid 100" nsfs_cephalt.log
-    execute "node src/cmd/manage_nsfs account add --config_root ./standalone/config_root --name cephtenant --email ceph.tenant@noobaa.com --new_buckets_path ./standalone/nsfs_root --access_key efgh --secret_key efgh --uid 200 --gid 200" nsfs_cephtenant.log
+    execute "node src/cmd/manage_nsfs account add --name cephalt --email ceph.alt@noobaa.com --new_buckets_path ${FS_ROOT_1} --uid 1000 --gid 1000" nsfs_cephalt.log
+    execute "node src/cmd/manage_nsfs account add --name cephtenant --email ceph.tenant@noobaa.com --new_buckets_path ${FS_ROOT_2} --uid 2000 --gid 2000" nsfs_cephtenant.log
+
     # Start nsfs server
-    execute "node src/cmd/nsfs --config_root ./standalone/config_root" nsfs.log
+    execute "node src/cmd/nsfs" nsfs.log
+
     # Wait for sometime to process to start
     sleep 10
 }

--- a/src/test/system_tests/ceph_s3_tests/run_ceph_nsfs_test_on_test_container.sh
+++ b/src/test/system_tests/ceph_s3_tests/run_ceph_nsfs_test_on_test_container.sh
@@ -3,6 +3,8 @@
 export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} \e[0m'
 
 set -e
+# It will add to the logs every line that we run
+set -x
 
 # ====================================================================================
 # Set the environment variables
@@ -19,14 +21,34 @@ export NOOBAA_MGMT_SERVICE_PROTO=wss
 export S3_SERVICE_HOST=localhost
 
 export CEPH_TEST_LOGS_DIR=/logs/ceph-nsfs-test-logs
+export FS_ROOT_1=/tmp/nsfs_root1
+export FS_ROOT_2=/tmp/nsfs_root2
+export CONFIG_DIR=/etc/noobaa.conf.d/
 
 # ====================================================================================
 
 # Create the logs directory
 mkdir -p ${CEPH_TEST_LOGS_DIR}
+
+# Create configuration directory
+mkdir -p ${CONFIG_DIR}
+
 # Create root directory for bucket creation
-mkdir -p ./standalone/nsfs_root
+mkdir -p ${FS_ROOT_1}
+mkdir -p ${FS_ROOT_2}
+
+# Add permission to all users
+# this will allow the new accounts to create directories (buckets),
+# else we would see [Error: Permission denied] { code: 'EACCES' }
+chmod 777 ${FS_ROOT_1}
+chmod 777 ${FS_ROOT_2}
+
+# Create config.json file
+config='{"ALLOW_HTTP":true}'
+echo "$config" > ${CONFIG_DIR}/config.json
+
 # Deploy standalone NooBaa on the test container
+# And create the accounts needed for the Ceph tests
 ./src/deploy/NVA_build/standalone_deploy_nsfs.sh
 
 # ====================================================================================

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_constants.js
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_constants.js
@@ -20,6 +20,10 @@ const CEPH_TEST = {
     },
 };
 
+// For NSFS NC path (using default values)
+const account_path = '/etc/noobaa.conf.d/accounts/cephalt.json';
+const account_tenant_path = '/etc/noobaa.conf.d/accounts/cephtenant.json';
+
 const DEFAULT_NUMBER_OF_WORKERS = 5; //5 was the number of workers in the previous CI/CD process
 
 const TOX_ARGS = `-c ${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir}${CEPH_TEST.tox_config}`;
@@ -27,6 +31,8 @@ const TOX_ARGS = `-c ${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir}${CEPH_TEST.to
 const AWS4_TEST_SUFFIX = '_aws4';
 
 exports.CEPH_TEST = CEPH_TEST;
+exports.account_path = account_path;
+exports.account_tenant_path = account_tenant_path;
 exports.DEFAULT_NUMBER_OF_WORKERS = DEFAULT_NUMBER_OF_WORKERS;
 exports.TOX_ARGS = TOX_ARGS;
 exports.AWS4_TEST_SUFFIX = AWS4_TEST_SUFFIX;


### PR DESCRIPTION
### Explain the changes
1. Use root permission on the container (without it we cannot create accounts).
2. Use the configuration `ALLOW_HTTP` `true` (without it we won't listen to port 80 as configured).
3. Remove access keys flags and use defaults that were created (else we would have an error on the length of these properties).
4. Create the directories for the bucket path and add permission for everyone (otherwise we would not be able to create new buckets). 
Note: we don't use the path "/standalone" and instead use "/tmp" since it creates issues with permissions.
5. Update the configuration of access keys to read from the config file (instead of hard-coded). 
Note: I removed a line that I suspect caused bugs (it was overriding the access keys of the cephalt with the tenant access keys). 

### Issues: Fixed #xxx / Gap #xxx
1. Our CI tests used to fail because of configuration changes.
2. Gap - documentation for running the tests and debugging locally (all tests, a single test).

### Testing Instructions:
1. It is running in the CI.
2. If you want to run locally: `make test-nsfs-cephs3 CONTAINER_PLATFORM=linux/arm64` (I'm using the flag `CONTAINER_PLATFORM` because I have MacOS M1).

- [ ] Doc added/updated
- [X] Tests ~~added~~ fixed
