### PR TITLE
CI | Update Ceph S3 Tests (Commit Hash Number and Pending Lists)

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
@@ -210,3 +210,5 @@ s3tests_boto3/functional/test_s3.py::test_object_raw_get_x_amz_expires_not_expir
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_get_object
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_get_object_tenant
 s3tests_boto3/functional/test_s3.py::test_encryption_sse_c_unaligned_multipart_upload
+s3tests_boto3/functional/test_s3.py::test_multipart_get_part
+s3tests_boto3/functional/test_s3.py::test_non_multipart_get_part

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -118,3 +118,5 @@ s3tests_boto3/functional/test_s3.py::test_object_raw_get_x_amz_expires_not_expir
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_x_amz_expires_not_expired_tenant
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_get_object
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_get_object_tenant
+s3tests_boto3/functional/test_s3.py::test_multipart_get_part
+s3tests_boto3/functional/test_s3.py::test_non_multipart_get_part

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -17,7 +17,7 @@ DIRECTORY="s3-tests"
 CEPH_LINK="https://github.com/ceph/s3-tests.git"
 # using a fixed version (commit) of ceph tests to avoid sudden changes. 
 # we should retest and update the version once in a while
-CEPH_TESTS_VERSION=e29d6246fc67668b4d9202c50076009c5ef0772e
+CEPH_TESTS_VERSION=6861c3d81081a6883fb90d66cb60392e1abdf3ca
 if [ ! -d $DIRECTORY ]; then
     echo "Downloading Ceph S3 Tests..."
     git clone $CEPH_LINK


### PR DESCRIPTION
### Explain the changes
1. Update Ceph S3 test commit hash number.
2. Added new and failed tests to the pending list of Ceph tests.

### Issues: Fixed #xxx / Gap #xxx
1. GAP - currently the Ceph test CI (not NSFS) passes although it might contain failed tests (currently all tests are passing).

### Testing Instructions:
1. none (tested through the CI).
2. If you wish to run it locally: 
`make test-cephs3 CONTAINER_PLATFORM=linux/arm64`
`make test-nsfs-cephs3 CONTAINER_PLATFORM=linux/arm64`
(I'm using the flag `CONTAINER_PLATFORM` because I have MacOS M1).


- [ ] Doc added/updated
- [ ] Tests added
