### PR TITLE
CI | GAP | Ceph S3 Tests

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_config_and_run_s3_tests.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_config_and_run_s3_tests.sh
@@ -14,4 +14,4 @@ NUMBER_OF_WORKERS=1
 
 cd /root/node_modules/noobaa-core/
 node ./${CEPH_S3_TESTS_CONFIG}
-node ./${CEPH_S3_RUN_TESTS} --ignore_lists ${S3_CEPH_TEST_BLACKLIST},${S3_CEPH_TEST_PENDING_LIST} --concurrency ${NUMBER_OF_WORKERS} || true
+node ./${CEPH_S3_RUN_TESTS} --ignore_lists ${S3_CEPH_TEST_BLACKLIST},${S3_CEPH_TEST_PENDING_LIST} --concurrency ${NUMBER_OF_WORKERS}


### PR DESCRIPTION
### Explain the changes
1. In the NC Ceph tests (not NSFS) we had a “|| true” part after the run that was leftover from running it in the k8s job that we always wanted to complete successfully, in the new platform it is not relevant.

### Issues:
1. none, it closes a Gap I found during working on PR #7589

### Testing Instructions:
1. none (tested through the CI).
2. If you wish to run it locally: 
`make test-cephs3 CONTAINER_PLATFORM=linux/arm64`
`make test-nsfs-cephs3 CONTAINER_PLATFORM=linux/arm64`
(I'm using the flag `CONTAINER_PLATFORM` because I have MacOS M1).


- [ ] Doc added/updated
- [ ] Tests added
