### PR TITLE
NC | NSFS |Account update script change access_key

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -458,6 +458,10 @@ async function fetch_existing_account_data(config_root, target) {
             throw_cli_error(ManageCLIError.NoSuchAccountName, target.name);
         }
     }
+    if (source.access_keys[0].access_key && target.access_keys[0].access_key &&
+            source.access_keys[0].access_key !== target.access_keys[0].access_key) {
+        throw_cli_error(ManageCLIError.AccountAccessKeyAndNameMismatch, target.access_keys[0].access_key);
+    }
     const data = _.merge({}, source, target);
     return data;
 }

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -113,7 +113,7 @@ ManageCLIError.NoSuchAccountAccessKey = Object.freeze({
 
 ManageCLIError.NoSuchAccountName = Object.freeze({
     code: 'NoSuchAccountName',
-    message: 'Account does not exist - access key',
+    message: 'Account does not exist - name',
     http_code: 404,
 });
 
@@ -129,6 +129,11 @@ ManageCLIError.AccountNameAlreadyExists = Object.freeze({
     http_code: 409,
 });
 
+ManageCLIError.AccountAccessKeyAndNameMismatch = Object.freeze({
+    code: 'AccountAccessKeyAndNameMismatch',
+    message: 'Account access key and name mismatch',
+    http_code: 403,
+});
 
 //////////////////////////////////
 //// ACCOUNT ARGUMENTS ERRORS ////

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -477,6 +477,21 @@ mocha.describe('manage_nsfs cli', function() {
             const account = await read_config_file(config_root, accounts_schema_dir, account_options.name);
             assert_account(account, account_options);
         });
+        mocha.it('cli account update with invalid set of name & access key', async function() {
+            const action = nc_nsfs_manage_actions.UPDATE;
+            const update_options = {
+                config_root,
+                new_access_key: 'BIGiFAnjaaE6OGD5N7hB_Invalid',
+                new_name: 'account2_new_name',
+                name: account_options.name
+            };
+            try {
+                await exec_manage_cli(type, action, update_options);
+                assert.fail('should have failed with account access and name mismatch');
+            } catch (err) {
+                assert_error(err, ManageCLIError.AccountAccessKeyAndNameMismatch);
+            }
+        });
 
         mocha.it('cli account delete by name', async function() {
             const action = nc_nsfs_manage_actions.DELETE;
@@ -856,12 +871,12 @@ async function exec_manage_cli(type, action, options) {
         (options.show_secrets ? ` --show_secrets ${options.show_secrets}` : ``);
 
 
-    const whiteist_flags = (options.ips ? ` --ips '${options.ips}'` : ``);
+    const whitelist_flags = (options.ips ? ` --ips '${options.ips}'` : ``);
 
     const update_identity_flags = (options.new_name ? ` --new_name ${options.new_name}` : ``) +
         (options.new_access_key ? ` --new_access_key ${options.new_access_key}` : ``);
     let flags = (type === nc_nsfs_manage_entity_types.BUCKET ? bucket_flags : account_flags) + update_identity_flags;
-    flags = (type === nc_nsfs_manage_entity_types.IPWHITELIST ? whiteist_flags : flags);
+    flags = (type === nc_nsfs_manage_entity_types.IPWHITELIST ? whitelist_flags : flags);
     const wide_list = (options.wide ? ` --wide ${options.wide}` : ``);
     const cmd = `node src/cmd/manage_nsfs ${type} ${action} --config_root ${options.config_root} ${flags} ${wide_list}`;
     const res = await os_util.exec(cmd, { return_stdout: true });


### PR DESCRIPTION
### Explain the changes
1. Account is updating with the wrong access_key. access_key in the config file got updated with the new access-key but the symlink file name remains the old name and it making the account corrupted.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7683

### Testing Instructions:
1.  ``` sudo node src/cmd/manage_nsfs account add --config_root /standalon/noobaa --name account1 --email z1@noobaa.com --new_buckets_path ../../standalon/nsfs_root/ --access_key Dwertyuiopasdfg12345 --secret_key Qwertyuiopasdfg12345Qwertyuiopasdfg12345 --uid 1000 --gid 1000```
2. ``` sudo node src/cmd/manage_nsfs account update --config_root /standalon/noobaa --name account1 --email z111ddddd@noobaa.com --access_key Hwertyuiopasdfg1234 ```


- [ ] Doc added/updated
- [X] Tests added
