### PR TITLE
NSFS | NC | Change Debug Level of a Message HTTP Not Enabled

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -163,7 +163,7 @@ async function main(options = {}) {
             https_server_sts.setSecureContext(updated_ssl_options);
         });
         if (options.nsfs_config_root && !config.ALLOW_HTTP) {
-            dbg.log0('HTTP is not allowed for NC NSFS.');
+            dbg.warn('HTTP is not allowed for NC NSFS.');
         } else {
             const http_server = http.createServer(endpoint_request_handler);
             if (http_port > 0) {


### PR DESCRIPTION
### Explain the changes
1. Change the debug level of a message HTTP not enabled from `log0` to `warn`.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
