### PR TITLE
NC | NSFS | revoking `--new_access_key` and fixing access key update issues

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -158,12 +158,6 @@ ManageCLIError.AccountAccessKeyFlagComplexity = Object.freeze({
     http_code: 400,
 });
 
-ManageCLIError.NewAccountAccessKeyFlagComplexity = Object.freeze({
-    code: 'NewAccountAccessKeyFlagComplexity',
-    message: 'Account new access key length must be 20, and must contain uppercase and numbers',
-    http_code: 400,
-});
-
 ManageCLIError.MissingAccountNameFlag = Object.freeze({
     code: 'MissingAccountNameFlag',
     message: 'Account name is mandatory, please use the --name flag',
@@ -178,7 +172,7 @@ ManageCLIError.MissingAccountEmailFlag = Object.freeze({
 
 ManageCLIError.MissingIdentifier = Object.freeze({
     code: 'MissingIdentifier',
-    message: 'Account identifier is mandatory, please use the --acces_key or --name flag',
+    message: 'Account identifier is mandatory, please use the --access_key or --name flag',
     http_code: 400,
 });
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -190,29 +190,59 @@ describe('manage nsfs cli account flow', () => {
             assert_account(account_symlink, new_account_details);
         });
 
-        it('cli update account access_key', async () => {
+        it('cli account update name by name', async function() {
             const { type, name } = defaults;
-            const new_access_key = 'GIGiFAnjaaE7OKD5N7hB';
-            const account_options = { config_root, name, new_access_key: new_access_key };
-            const account_details = await read_config_file(config_root, accounts_schema_dir, name);
+            const new_name = 'account1_new_name'
+            const account_options = { config_root, name, new_name };
             const action = nc_nsfs_manage_actions.UPDATE;
+            account_options.new_name = 'account1_new_name';
             await exec_manage_cli(type, action, account_options);
-            let new_account_details = await read_config_file(config_root, accounts_schema_dir, name);
-            expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
-            expect(new_account_details.access_keys[0].access_key).toBe(new_access_key);
-            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, new_access_key, true);
+            let new_account_details = await read_config_file(config_root, accounts_schema_dir, new_name);
+            expect(new_account_details.name).toBe(new_name);
+            const access_key = new_account_details.access_keys[0].access_key;
+            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
             //fixing the new_account_details for compare. 
             new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
             assert_account(account_symlink, new_account_details);
         });
 
-        it('should fail - cli update account new access_key wrong complexity', async () => {
+        it('cli account update access key, secret_key & new_name by name', async function() {
             const { type, name } = defaults;
-            const new_access_key = 'new';
-            const account_options = { config_root, name, new_access_key: new_access_key };
+            const new_name = 'account1_new_name'
+            const access_key = 'GIGiFAnjaaE7OKD5N7hB';
+            const secret_key = 'U3AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
+            const account_options = { config_root, name, new_name, access_key, secret_key };
+            const account_details = await read_config_file(config_root, accounts_schema_dir, name);
             const action = nc_nsfs_manage_actions.UPDATE;
-            const res = await exec_manage_cli(type, action, account_options);
-            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.NewAccountAccessKeyFlagComplexity.message);
+            account_options.new_name = 'account1_new_name';
+            await exec_manage_cli(type, action, account_options);
+            let new_account_details = await read_config_file(config_root, accounts_schema_dir, new_name);
+            expect(new_account_details.name).toBe(new_name);
+            expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
+            expect(account_details.access_keys[0].secret_key).not.toBe(new_account_details.access_keys[0].secret_key);
+            expect(new_account_details.access_keys[0].access_key).toBe(access_key);
+            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
+            //fixing the new_account_details for compare. 
+            new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
+            assert_account(account_symlink, new_account_details);
+        });
+
+        it('cli update account access_key and secret_key using flags', async () => {
+            const { type, name } = defaults;
+            const access_key = 'GIGiFAnjaaE7OKD5N7hB';
+            const secret_key = 'U3AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
+            const account_options = { config_root, name, access_key, secret_key };
+            const account_details = await read_config_file(config_root, accounts_schema_dir, name);
+            const action = nc_nsfs_manage_actions.UPDATE;
+            await exec_manage_cli(type, action, account_options);
+            let new_account_details = await read_config_file(config_root, accounts_schema_dir, name);
+            expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
+            expect(account_details.access_keys[0].secret_key).not.toBe(new_account_details.access_keys[0].secret_key);
+            expect(new_account_details.access_keys[0].access_key).toBe(access_key);
+            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
+            //fixing the new_account_details for compare. 
+            new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
+            assert_account(account_symlink, new_account_details);
         });
 
     });

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -81,7 +81,7 @@ mocha.describe('manage_nsfs cli', function() {
             try {
                 await fs_utils.create_fresh_path(bucket_path);
                 await fs_utils.file_must_exist(bucket_path);
-                await exec_manage_cli(type, action, { ...bucket_options, bucket_policy: invalid_bucket_policy});
+                await exec_manage_cli(type, action, { ...bucket_options, bucket_policy: invalid_bucket_policy });
                 assert.fail('should have failed with invalid bucket policy');
             } catch (err) {
                 assert_error(err, ManageCLIError.MalformedPolicy);
@@ -432,27 +432,6 @@ mocha.describe('manage_nsfs cli', function() {
             assert_response(action, type, account_list, expected_list, undefined, true);
         });
 
-        mocha.it('cli account update uid by access key', async function() {
-            const action = nc_nsfs_manage_actions.UPDATE;
-            const update_options = {
-                config_root,
-                access_key: account_options.access_key,
-                secret_key: account_options.secret_key,
-                email: 'account2@noobaa.io',
-                uid: 222,
-                gid: 222
-            };
-            const update_response = await exec_manage_cli(type, action, update_options);
-            updating_options = { ...updating_options, ...update_options };
-            assert_response(action, type, update_response, updating_options);
-            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
-            account_options = { ...account_options, ...update_options };
-            assert_account(account_symlink, account_options);
-            const account = await read_config_file(config_root, accounts_schema_dir, name);
-            assert_account(account, account_options);
-            await assert_config_file_permissions(config_root, accounts_schema_dir, name);
-        });
-
         mocha.it('cli account update uid by name', async function() {
             const action = nc_nsfs_manage_actions.UPDATE;
             const update_options = {
@@ -472,64 +451,6 @@ mocha.describe('manage_nsfs cli', function() {
             const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
             assert_account(account_symlink, account_options);
             const account = await read_config_file(config_root, accounts_schema_dir, name);
-            assert_account(account, account_options);
-        });
-
-        mocha.it('cli account update name by access key', async function() {
-            const action = nc_nsfs_manage_actions.UPDATE;
-            const update_options = {
-                config_root,
-                new_name: 'account1_new_name',
-                access_key: account_options.access_key,
-                secret_key: account_options.secret_key,
-            };
-            account_options.new_name = 'account1_new_name';
-            const update_response = await exec_manage_cli(type, action, update_options);
-            updating_options = { ...updating_options, name: update_options.new_name };
-            assert_response(action, type, update_response, updating_options);
-            account_options = { ...account_options, new_name: undefined, name: update_options.new_name };
-            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
-            assert_account(account_symlink, account_options);
-            const account = await read_config_file(config_root, accounts_schema_dir, account_options.name);
-            assert_account(account, account_options);
-        });
-
-        mocha.it('cli account update access key by name', async function() {
-            const action = nc_nsfs_manage_actions.UPDATE;
-            const update_options = {
-                config_root,
-                new_access_key: 'BIGiFAnjaaE7OKD5N7hB',
-                name: account_options.name
-            };
-            const update_response = await exec_manage_cli(type, action, update_options);
-            updating_options = { ...updating_options, access_key: update_options.new_access_key };
-            assert_response(action, type, update_response, updating_options);
-            account_options = { ...account_options, new_access_key: undefined, access_key: update_options.new_access_key };
-            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, account_options.access_key, true);
-            assert_account(account_symlink, account_options);
-            const account = await read_config_file(config_root, accounts_schema_dir, account_options.name);
-            assert_account(account, account_options);
-        });
-
-        mocha.it('cli account update access key & new_name by name', async function() {
-            const action = nc_nsfs_manage_actions.UPDATE;
-            const update_options = {
-                config_root,
-                new_access_key: 'BIGiFAnjaaE6OGD5N7hB',
-                new_name: 'account2_new_name',
-                name: account_options.name
-            };
-            await exec_manage_cli(type, action, update_options);
-            account_options = {
-                ...account_options,
-                new_access_key: undefined,
-                new_name: undefined,
-                access_key: update_options.new_access_key,
-                name: update_options.new_name
-            };
-            const account_symlink = await read_config_file(config_root, access_keys_schema_dir, account_options.access_key, true);
-            assert_account(account_symlink, account_options);
-            const account = await read_config_file(config_root, accounts_schema_dir, account_options.name);
             assert_account(account, account_options);
         });
 
@@ -635,8 +556,10 @@ mocha.describe('manage_nsfs cli', function() {
 
         mocha.it('cli account2 update - new_access_key already exists', async function() {
             const action = nc_nsfs_manage_actions.UPDATE;
+            const options = { ...account2_options };
+            options.access_key = 'GIGiFAnjaaE7OKD5N7hA';
             try {
-                await exec_manage_cli(type, action, { ...account2_options, new_access_key: 'GIGiFAnjaaE7OKD5N7hA' });
+                await exec_manage_cli(type, action, options);
                 assert.fail('should have failed with account access key already exists');
             } catch (err) {
                 assert_error(err, ManageCLIError.AccountAccessKeyAlreadyExists);
@@ -685,32 +608,8 @@ mocha.describe('manage_nsfs cli', function() {
             assert_account(account, account_options);
         });
 
-        mocha.it('cli account delete by access key', async function() {
-            const action = nc_nsfs_manage_actions.DELETE;
-            const res = await exec_manage_cli(type, action, { config_root, access_key, secret_key });
-            assert_response(action, type, res);
-            try {
-                await read_config_file(config_root, access_keys_schema_dir, access_key, true);
-                throw new Error('cli account delete failed - account config file exists after deletion');
-            } catch (err) {
-                if (err.code !== 'ENOENT') {
-                    throw new Error('cli account delete failed - read file failed with the following error - ', err.code);
-                }
-            }
-            try {
-                await read_config_file(config_root, accounts_schema_dir, account_options.name);
-                throw new Error('cli account delete failed - account config file exists after deletion');
-            } catch (err) {
-                if (err.code !== 'ENOENT') {
-                    throw new Error('cli account delete failed - read file failed with the following error - ', err.code);
-                }
-            }
-        });
-
         mocha.it('cli account delete by name', async function() {
-            let action = nc_nsfs_manage_actions.ADD;
-            await exec_manage_cli(type, action, account_options);
-            action = nc_nsfs_manage_actions.DELETE;
+            const action = nc_nsfs_manage_actions.DELETE;
             const res = await exec_manage_cli(type, action, { config_root, name: account_options.name });
             assert_response(action, type, res);
             try {


### PR DESCRIPTION
### Explain the changes
1. revoking `--new_access_key`
2. fixing issue where `--regenerate` did not update the secret_key
3. fixing an issue where using `--access_key` without `--new_access_key` did not updated the symlink
4. updated the tests.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes: https://github.com/noobaa/noobaa-core/issues/7695
2. Fixes: https://github.com/noobaa/noobaa-core/issues/7683

### Testing Instructions:
1. run sudo npx jest test_nc_nsfs_account_cli.test.js
2. run sudo node --allow-natives-syntax ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js


- [x] Doc (help) added/updated
- [x] Tests added
