### PR TITLE
NSFS | NC | Add global storage backend type

### DIFF
--- a/config.js
+++ b/config.js
@@ -699,6 +699,7 @@ config.NSFS_NC_DEFAULT_CONF_DIR = '/etc/noobaa.conf.d';
 config.NSFS_NC_CONF_DIR = process.env.NSFS_NC_CONF_DIR || '';
 config.NSFS_TEMP_CONF_DIR_NAME = '.noobaa-config-nsfs';
 config.NSFS_NC_CONFIG_DIR_BACKEND = '';
+config.NSFS_NC_STORAGE_BACKEND = '';
 config.ENDPOINT_PORT = Number(process.env.ENDPOINT_PORT) || 6001;
 config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
 config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || -1;

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -248,8 +248,8 @@ Example:
 node src/cmd/manage_nsfs whitelist --ips '["127.0.0.1", "192.000.10.000", "3002:0bd6:0000:0000:0000:ee00:0033:000"]'  2>/dev/null
 ```
 
-## 13. Config directory backend -
-**Description -** Set custom config directory backend. Set to GPFS in order to increase performance of creation/deletion of config files under the config directory.
+## 14. Config directory backend -
+**Description -** Set custom file system backend type of the config directory. Set to GPFS in order to increase performance of creation/deletion of config files under the config directory.
 
 **Configuration Key -** NSFS_NC_CONFIG_DIR_BACKEND
 
@@ -265,9 +265,23 @@ Example:
 "NSFS_NC_CONFIG_DIR_BACKEND": "GPFS"
 ```
 
+## 15. Storage Backend -
+**Description -** Set custom file system backend type of the storage file system. Set to GPFS in order to increase performance of creation/deletion of objects stored in the underlying file system.
 
+**Configuration Key -** NSFS_NC_STORAGE_BACKEND
 
+**Type -** string
 
+**Default -** ''
+
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"NSFS_NC_STORAGE_BACKEND": "GPFS"
+3. systemctl restart noobaa_nsfs
+```
 
 ## Config.json example 
 ```

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -868,7 +868,7 @@ function assert_bucket(bucket, bucket_options) {
     assert.strictEqual(bucket.path, bucket_options.bucket_path);
     assert.strictEqual(bucket.should_create_underlying_storage, false);
     assert.strictEqual(bucket.versioning, 'DISABLED');
-    assert.strictEqual(bucket.fs_backend, bucket_options.fs_backend);
+    assert.strictEqual(bucket.fs_backend, bucket_options.fs_backend === '' ? undefined : bucket_options.fs_backend);
     assert.deepStrictEqual(bucket.s3_policy, bucket_options.bucket_policy);
     return true;
 }
@@ -887,7 +887,7 @@ function assert_account(account, account_options, skip_secrets) {
         assert.equal(account.nsfs_account_config.gid, account_options.gid);
     }
     assert.equal(account.nsfs_account_config.new_buckets_path, account_options.new_buckets_path);
-    assert.equal(account.nsfs_account_config.fs_backend, account_options.fs_backend);
+    assert.equal(account.nsfs_account_config.fs_backend, account_options.fs_backend === '' ? undefined : account_options.fs_backend);
     return true;
 }
 


### PR DESCRIPTION
### Explain the changes
1. As discussed in an internal meeting, we want to allow the user to set a global storage file system backend instead of specifying it on every bucket/account creation (which is still needed in some cases).

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [x] Doc added/updated
- [ ] Tests added
