### PR TITLE
NSFS | NC | Add Schema Validation to Bucket and Account Add and Update (NC NSFS CLI)

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -72,6 +72,11 @@ ManageCLIError.MissingConfigDirPath = Object.freeze({
     message: 'Config dir path should not be empty',
     http_code: 400,
 });
+ManageCLIError.InvalidSchema = Object.freeze({
+    code: 'InvalidSchema',
+    message: 'Schema invalid, please use required properties',
+    http_code: 400,
+});
 
 //////////////////////////////
 //// IP WHITE LIST ERRORS ////
@@ -299,6 +304,10 @@ ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
     NOT_EMPTY: ManageCLIError.BucketNotEmpty,
     MALFORMED_POLICY: ManageCLIError.MalformedPolicy,
     // EEXIST: ManageCLIError.BucketAlreadyExists,
+});
+
+ManageCLIError.RPC_ERROR_TO_MANAGE = Object.freeze({
+    INVALID_SCHEMA: ManageCLIError.InvalidSchema,
 });
 
 exports.ManageCLIError = ManageCLIError;

--- a/src/manage_nsfs/nsfs_schema_utils.js
+++ b/src/manage_nsfs/nsfs_schema_utils.js
@@ -1,0 +1,43 @@
+/* Copyright (C) 2023 NooBaa */
+'use strict';
+
+const RpcError = require('../rpc/rpc_error');
+const { default: Ajv } = require('ajv');
+const ajv = new Ajv({ verbose: true, allErrors: true });
+const { KEYWORDS } = require('../util/schema_keywords');
+const common_api = require('../api/common_api');
+const schema_utils = require('../util/schema_utils');
+
+ajv.addKeyword(KEYWORDS.methods);
+ajv.addKeyword(KEYWORDS.doc);
+ajv.addKeyword(KEYWORDS.date);
+ajv.addKeyword(KEYWORDS.idate);
+ajv.addKeyword(KEYWORDS.objectid);
+ajv.addKeyword(KEYWORDS.binary);
+ajv.addKeyword(KEYWORDS.wrapper);
+ajv.addSchema(common_api);
+
+const bucket_schema = require('../server/object_services/schemas/nsfs_bucket_schema');
+const account_schema = require('../server/object_services/schemas/nsfs_account_schema');
+
+schema_utils.strictify(bucket_schema, {
+    additionalProperties: false
+});
+
+schema_utils.strictify(account_schema, {
+    additionalProperties: false
+});
+
+function validate_account_schema(account) {
+    const valid = ajv.validate(account_schema, account);
+    if (!valid) throw new RpcError('INVALID_SCHEMA', ajv.errors[0]?.message);
+}
+
+function validate_bucket_schema(bucket) {
+    const valid = ajv.validate(bucket_schema, bucket);
+    if (!valid) throw new RpcError('INVALID_SCHEMA', ajv.errors[0]?.message);
+}
+
+//EXPORTS
+exports.validate_account_schema = validate_account_schema;
+exports.validate_bucket_schema = validate_bucket_schema;

--- a/src/server/object_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/object_services/schemas/nsfs_bucket_schema.js
@@ -28,6 +28,9 @@ module.exports = {
         },
         versioning: {
             type: 'string',
+            enum: ['DISABLED', 'SUSPENDED', 'ENABLED']
+            // GAP would like to use $ref: 'bucket_api#/definitions/versioning'
+            // but currently it creates an error Error: reference "bucket_api" resolves to more than one schema
         },
         path: {
             type: 'string',

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_schema_validation.test.js
@@ -1,0 +1,1260 @@
+/* Copyright (C) 2024 NooBaa */
+/* eslint-disable no-undef */
+/*eslint max-lines-per-function: ["error", 800]*/
+
+'use strict';
+
+const nsfs_schema_utils = require('../../../manage_nsfs/nsfs_schema_utils');
+const RpcError = require('../../../rpc/rpc_error');
+const test_utils = require('../../system_tests/test_utils');
+
+// function that we use to make sure that we are in the catch clause
+// it would fail the test
+function throw_error_in_case_error_was_not_thrown() {
+    throw new Error('Test passed instead of failed');
+}
+
+describe('schema validation NC NSFS account', () => {
+    const account_name = 'account1';
+    const account_email = 'account1@noobaa.io';
+    const access_key = 'GIGiFAnjaaE7OKD5N7hA';
+    const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
+    const creation_date = new Date('December 17, 2023 09:00:00').toISOString();
+    const nsfs_account_config_uid_gid = {
+        uid: 1001,
+        gid: 1001,
+    };
+    const nsfs_account_config_distinguished_name = {
+        distinguished_name: 'moti-1003',
+    };
+    const new_bucket_path = '/tmp/nsfs_root1';
+
+    describe('account with all needed properties', () => {
+
+        it('nsfs_account_config with uid, gid', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+        it('nsfs_account_config with distinguished_name', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_distinguished_name
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+        it('nsfs_account_config with fs_backend', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                    fs_backend: 'GPFS' // added
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+        it('nsfs_account_config with new_bucket_path', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                    new_buckets_path: new_bucket_path //added
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+    });
+
+    describe('account with additional properties', () => {
+
+        it('nsfs_account_config with distinguished_name AND uid gid', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    // here we use both uid gid and distinguished_name
+                    ...nsfs_account_config_uid_gid,
+                    ...nsfs_account_config_distinguished_name
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must NOT have additional properties');
+            }
+        });
+
+        it('account with new_name', () => {
+            const account_data = {
+                name: account_name,
+                new_name: 'account2', // this is not part of the schema
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must NOT have additional properties');
+            }
+        });
+
+        // note: it is new_access_key (and not new_access_keys in the code)
+        it('account with new_access_key', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                // this is not part of the schema
+                new_access_key: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must NOT have additional properties');
+            }
+        });
+
+        it('account with duration_seconds inside access_keys', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key,
+                        duration_seconds: 3600, // this is not part of the schema
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must NOT have additional properties');
+            }
+        });
+
+        it('account with my_id inside nsfs_account_config', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key,
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                    my_id: 123, // this is not part of the schema
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must NOT have additional properties');
+            }
+        });
+
+    });
+
+    // note: had to use " " (double quotes) instead of ' ' (single quotes) to match the message
+    describe('account without required properties', () => {
+
+        it('account without name', () => {
+            const account_data = {
+                // name: account_name, // hide it on purpose
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'name'");
+            }
+        });
+
+        it('account with undefined name', () => {
+            const account_data = {
+                name: undefined, // on purpose
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'name'");
+            }
+        });
+
+        it('account without email', () => {
+            const account_data = {
+                name: account_name,
+                // email: account_email, // hide it on purpose
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'email'");
+            }
+        });
+
+        it('account with undefined email', () => {
+            const account_data = {
+                name: account_name,
+                email: undefined, // on purpose
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'email'");
+            }
+        });
+
+        it('account without access_keys', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                // access_keys: [ // hide it on purpose
+                //     {
+                //         access_key: access_key,
+                //         secret_key: secret_key
+                //     },
+                // ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'access_keys'");
+            }
+        });
+
+        it('account with undefined access_keys', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: undefined, // on purpose
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'access_keys'");
+            }
+        });
+
+        it('account without access_keys details (access_key and secret_key)', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                    // hide it on purpose
+                //         access_key: access_key,
+                //         secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'access_key'");
+            }
+        });
+
+        it('account without access_key', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                //         access_key: access_key, // hide it on purpose
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'access_key'");
+            }
+        });
+
+        it('account with undefined access_key', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: undefined, // on purpose
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'access_key'");
+            }
+        });
+
+        it('account without secret_key', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        // secret_key: secret_key // hide it on purpose
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'secret_key'");
+            }
+        });
+
+        it('account with undefined secret_key', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: undefined // on purpose
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'secret_key'");
+            }
+        });
+
+        it('account without nsfs_account_config', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                // nsfs_account_config: { // hide it on purpose
+                //     ...nsfs_account_config_uid_gid,
+                // },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message',
+                    "must have required property 'nsfs_account_config'");
+            }
+        });
+
+        it('account with undefined nsfs_account_config', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: undefined, // on purpose
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message',
+                    "must have required property 'nsfs_account_config'");
+            }
+        });
+
+        it('account without nsfs_account_config details (uid gid or distinguished_name)', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                //     ...nsfs_account_config_uid_gid, // hide it on purpose
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'uid'");
+            }
+        });
+
+        it('account without creation_date', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                // creation_date: creation_date, // hide it on purpose
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message',
+                    "must have required property 'creation_date'");
+            }
+        });
+
+        it('account with undefined creation_date', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: undefined, // on purpose
+                allow_bucket_creation: false,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message',
+                    "must have required property 'creation_date'");
+            }
+        });
+
+        it('account without allow_bucket_creation', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                // allow_bucket_creation: false, // hide it on purpose
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message',
+                    "must have required property 'allow_bucket_creation'");
+            }
+        });
+
+        it('account with undefined allow_bucket_creation', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: undefined, // on purpose
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message',
+                    "must have required property 'allow_bucket_creation'");
+            }
+        });
+
+    });
+
+    describe('account with wrong types', () => {
+
+        it('nsfs_account_config with uid, gid as boolean (instead of number)', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    // boolean instead of number
+                    uid: false,
+                    gid: false,
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must be number');
+            }
+        });
+
+        it('nsfs_account_config with creation_date as Date (instead of string)', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                },
+                creation_date: Date.now(), // Date instead of string
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must be string');
+            }
+        });
+
+        it('nsfs_account_config with fs_backend not part of enum', () => {
+            const account_data = {
+                name: account_name,
+                email: account_email,
+                access_keys: [
+                    {
+                        access_key: access_key,
+                        secret_key: secret_key
+                    },
+                ],
+                nsfs_account_config: {
+                    ...nsfs_account_config_uid_gid,
+                    fs_backend: '' // not part of definition of fs_backend
+                },
+                creation_date: creation_date,
+                allow_bucket_creation: true,
+            };
+            try {
+                nsfs_schema_utils.validate_account_schema(account_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must be equal to one of the allowed values');
+            }
+        });
+
+    });
+
+});
+
+describe('schema validation NC NSFS bucket', () => {
+    const bucket_name = 'bucket1';
+    const system_owner = 'account1@noobaa.io';
+    const bucket_owner = 'account1@noobaa.io';
+    const versioning_disabled = 'DISABLED';
+    const versioning_enabled = 'ENABLED';
+    const creation_date = new Date('December 17, 2023 09:00:00').toISOString();
+    const path = '/tmp/nsfs_root1';
+    const bucket_policy = test_utils.generate_s3_policy('*', bucket_name, ['s3:*']).policy;
+
+    describe('account with all needed properties', () => {
+
+        it('nsfs_bucket', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: true,
+            };
+            nsfs_schema_utils.validate_bucket_schema(bucket_data);
+        });
+
+        it('nsfs_bucket with tag', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_enabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: true,
+                tag: 'myTag', // added
+            };
+            nsfs_schema_utils.validate_bucket_schema(bucket_data);
+        });
+
+        it('nsfs_bucket with fs_backend', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: true,
+                fs_backend: 'CEPH_FS', // added
+            };
+            nsfs_schema_utils.validate_bucket_schema(bucket_data);
+        });
+
+        it('nsfs_bucket with s3_policy (bucket policy)', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+                s3_policy: bucket_policy, // added
+            };
+            nsfs_schema_utils.validate_bucket_schema(bucket_data);
+        });
+
+    });
+
+    describe('bucket with additional properties', () => {
+
+        it('bucket with new_name', () => {
+            const bucket_data = {
+                name: bucket_name,
+                new_name: 'bucket', // this is not part of the schema
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must NOT have additional properties');
+            }
+        });
+
+    });
+
+    // note: had to use " " (double quotes) instead of ' ' (single quotes) to match the message
+    describe('bucket without required properties', () => {
+
+        it('bucket without name', () => {
+            const bucket_data = {
+                // name: bucket_name, // hide it on purpose
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'name'");
+            }
+        });
+
+        it('bucket with undefined name', () => {
+            const bucket_data = {
+                name: undefined, // on purpose
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'name'");
+            }
+        });
+
+        it('bucket without system_owner', () => {
+            const bucket_data = {
+                name: bucket_name,
+                // system_owner: system_owner, // hide it on purpose
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'system_owner'");
+            }
+        });
+
+        it('bucket with undefined system_owner', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: undefined, // on purpose
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'system_owner'");
+            }
+        });
+
+        it('bucket without bucket_owner', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                // bucket_owner: bucket_owner, // hide it on purpose
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'bucket_owner'");
+            }
+        });
+
+        it('bucket with undefined bucket_owner', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: undefined, // on purpose
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'bucket_owner'");
+            }
+        });
+
+        it('bucket without versioning', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                // versioning: versioning, // hide it on purpose
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'versioning'");
+            }
+        });
+
+        it('bucket with undefined versioning', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: undefined, // on purpose
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'versioning'");
+            }
+        });
+
+        it('bucket without creation_date', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                // creation_date: creation_date, // hide it on purpose
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'creation_date'");
+            }
+        });
+
+        it('bucket with undefined creation_date', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: undefined, // on purpose
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'creation_date'");
+            }
+        });
+
+        it('bucket without path', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                // path: path, // hide it on purpose
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'path'");
+            }
+        });
+
+        it('bucket with undefined path', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: undefined, // on purpose
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'path'");
+            }
+        });
+
+        it('bucket without should_create_underlying_storage', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                // should_create_underlying_storage: false, // hide it on purpose
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'should_create_underlying_storage'");
+            }
+        });
+
+        it('bucket with undefined should_create_underlying_storage', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: undefined, // on purpose
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', "must have required property 'should_create_underlying_storage'");
+            }
+        });
+
+    });
+
+    describe('bucket with wrong types', () => {
+
+        it('bucket with creation_date as Date (instead of string)', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: Date.now(), // Date instead of string
+                path: path,
+                should_create_underlying_storage: true,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must be string');
+            }
+        });
+
+        it('bucket with s3_policy as string (instead of object)', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_disabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: true,
+                s3_policy: '', // string instead of object
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must be object');
+            }
+        });
+
+        it('bucket with should_create_underlying_storage as string (instead of boolean)', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_enabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: 'yes', // string instead of boolean
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must be boolean');
+            }
+        });
+
+        it('bucket with versioning as string (instead of enum)', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: 'lala', // not part of definition of versioning
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must be equal to one of the allowed values');
+            }
+        });
+
+        it('bucket with fs_backend as string (instead of enum)', () => {
+            const bucket_data = {
+                name: bucket_name,
+                system_owner: system_owner,
+                bucket_owner: bucket_owner,
+                versioning: versioning_enabled,
+                creation_date: creation_date,
+                path: path,
+                should_create_underlying_storage: false,
+                fs_backend: '' // not part of definition of fs_backend
+            };
+            try {
+                nsfs_schema_utils.validate_bucket_schema(bucket_data);
+                throw_error_in_case_error_was_not_thrown();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err).toHaveProperty('message', 'must be equal to one of the allowed values');
+            }
+        });
+
+    });
+
+});

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -48,10 +48,11 @@ const DEFAULT_FS_CONFIG = {
     warn_threshold_ms: 100,
 };
 
+// since the account in NS NSFS should be valid to the nsfs_account_schema
+// had to remove additional properties: has_s3_access: 'true' and nsfs_only: 'true'
 const account_user1 = {
     name: 'user1',
     email: 'user1@noobaa.io',
-    has_s3_access: 'true',
     allow_bucket_creation: true,
     access_keys: [{
         access_key: 'a-abcdefghijklmn123456',
@@ -61,7 +62,6 @@ const account_user1 = {
         uid: 0,
         gid: 0,
         new_buckets_path: new_buckets_path_user1,
-        nsfs_only: 'true'
     },
     creation_date: '2023-10-30T04:46:33.815Z',
 };
@@ -69,7 +69,6 @@ const account_user1 = {
 const account_user2 = {
     name: 'user2',
     email: 'user2@noobaa.io',
-    has_s3_access: 'true',
     allow_bucket_creation: true,
     access_keys: [{
         access_key: 'a-abcdefghijklmn123457',
@@ -78,7 +77,6 @@ const account_user2 = {
     nsfs_account_config: {
         distinguished_name: "root",
         new_buckets_path: new_buckets_path_user2,
-        nsfs_only: 'true'
     },
     creation_date: '2023-10-30T04:46:33.815Z',
 };
@@ -86,7 +84,6 @@ const account_user2 = {
 const account_user3 = {
     name: 'user3',
     email: 'user3@noobaa.io',
-    has_s3_access: 'true',
     allow_bucket_creation: true,
     access_keys: [{
         access_key: 'a-abcdefghijklmn123458',
@@ -95,7 +92,6 @@ const account_user3 = {
     nsfs_account_config: {
         distinguished_name: os.userInfo().username,
         new_buckets_path: new_buckets_path_user2,
-        nsfs_only: 'true'
     },
     creation_date: '2023-10-30T04:46:33.815Z',
 };


### PR DESCRIPTION
### Explain the changes
1. Move the NC NSFS schema validation that we had in file `src/sdk/bucketspace_fs.js` (from PR #7544) to a separate file (`src/manage_nsfs/nsfs_schema_utils.js`) to reuse it.
2. Edit the values of `s3_policy` and `fs_backend` to be undefined (and not empty `''`, as it passed as an argument).
3. Validate the data using schema and return an error in case it doesn't match (details would be passed according to the original message), using a mapping `ManageCLIError.RPC_ERROR_TO_MANAGE`.
4. Update the unit tests for the cases of `s3_policy` and `fs_backend` deletions (separate the argument that we pass as `''` to the actual property that would be `undefined`).
5. Change the `uid` and `gid` extract in function `fetch_account_data` to be `undefined` when the argument user was passed (and not `false`).
6. Use `schema_utils.strictify` with option  `additionalProperties: false` in the `nsfs_account_schema` and `nsfs_bucket_schema`.
7. Add the `versioning` enum to the bucket schema.
8. Add tests for the schema validation of nsfs_account_schema and nsfs_bucket_schema.

### Issues: Fixed #7694  
1. Add schema validation to bucket and account add and update - using NC NSFS CLI (fs_backend changes in a separate PR).
2. GAP - I couldn't ref bucket_api schema and had to duplicate the values, else got the error: `Error: reference "bucket_api" resolves to more than one schema` in the CI in job `run-unit-tests`.

### Testing Instructions:
1. For tests that were edited, please run:
`sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`
`sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_bucketspace_fs.js`
3. For new tests, please run: 
`npx jest test_nc_nsfs_schema_validation.test.js`
(no need for sudo permission, can see results live also with jest extension in VSCode).

- [ ] Doc added/updated
- [X] Tests added
- [X] Tests edited (see comment above)
