### PR TITLE
NSFS | NC | CLI |bucket delete leaving objects

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -411,7 +411,8 @@ async function fetch_account_data(argv, from_file) {
     }
     if (action !== ACTIONS.LIST && action !== ACTIONS.STATUS) _validate_access_keys(argv);
     if (action === ACTIONS.ADD || action === ACTIONS.STATUS) {
-        access_keys = set_access_keys(argv, true);
+        const regenerate = action === ACTIONS.ADD
+        access_keys = set_access_keys(argv, regenerate);
     } else if (action === ACTIONS.UPDATE) {
         access_keys = set_access_keys(argv, Boolean(argv.regenerate));
         new_access_key = access_keys[0].access_key;
@@ -577,9 +578,9 @@ async function get_account_status(data, show_secrets) {
         write_stdout_response(ManageCLIResponse.AccountStatus, config_data);
     } catch (err) {
         if (is_undefined(data.name)) {
-            throw_cli_error(ManageCLIError.AccountAccessKeyAlreadyExists, data.access_keys[0].access_key.unwrap());
+            throw_cli_error(ManageCLIError.NoSuchAccountAccessKey, data.access_keys[0].access_key.unwrap());
         } else {
-            throw_cli_error(ManageCLIError.AccountNameAlreadyExists, data.name.unwrap());
+            throw_cli_error(ManageCLIError.NoSuchAccountName, data.name.unwrap());
         }
     }
 }

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -113,7 +113,7 @@ ManageCLIError.NoSuchAccountAccessKey = Object.freeze({
 
 ManageCLIError.NoSuchAccountName = Object.freeze({
     code: 'NoSuchAccountName',
-    message: 'Account does not exist - access key',
+    message: 'Account does not exist - name',
     http_code: 404,
 });
 
@@ -283,6 +283,12 @@ ManageCLIError.MalformedPolicy = Object.freeze({
 });
 
 
+ManageCLIError.BucketNotEmpty = Object.freeze({
+    code: 'BucketNotEmpty',
+    message: 'The bucket you tried to delete is not empty. You must delete all versions in the bucket',
+    http_code: 400,
+});
+
 ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
     EACCES: ManageCLIError.AccessDenied,
     EPERM: ManageCLIError.AccessDenied,
@@ -290,8 +296,8 @@ ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
     NOT_IMPLEMENTED: ManageCLIError.NotImplemented,
     INTERNAL_ERROR: ManageCLIError.InternalError,
     // ENOENT: ManageCLIError.NoSuchBucket,
-    // NOT_EMPTY: ManageCLIError.BucketNotEmpty,
-    // MALFORMED_POLICY: ManageCLIError.MalformedPolicy,
+    NOT_EMPTY: ManageCLIError.BucketNotEmpty,
+    MALFORMED_POLICY: ManageCLIError.MalformedPolicy,
     // EEXIST: ManageCLIError.BucketAlreadyExists,
 });
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -30,7 +30,8 @@ const nc_nsfs_manage_actions = {
     ADD: 'add',
     UPDATE: 'update',
     LIST: 'list',
-    DELETE: 'delete'
+    DELETE: 'delete',
+    STATUS: 'status',
 };
 
 describe('manage nsfs cli account flow', () => {
@@ -345,6 +346,12 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli('account', action, account_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account3']));
+        });
+
+        it('cli account status without name and access_key', async function() {
+            const action = nc_nsfs_manage_actions.STATUS;
+                const res = await exec_manage_cli('account', action, { config_root });
+                expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingIdentifier.code);
         });
     });
 });


### PR DESCRIPTION
### Explain the changes
1. S3 bucket delete is possible only for empty buckets.
2. Falied unit test cases after changing the `assert_error` condition to `equal`
3. https://github.com/noobaa/noobaa-core/issues/7699

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7699

### Testing Instructions:
1. create a bucket and copy one or more items to it and try to delete.
2. test steps mentioned issue [7699](https://github.com/noobaa/noobaa-core/issues/7699)


- [ ] Doc added/updated
- [X] Tests added
