### PR TITLE
Fix Eslint Errors

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -411,7 +411,7 @@ async function fetch_account_data(argv, from_file) {
     }
     if (action !== ACTIONS.LIST && action !== ACTIONS.STATUS) _validate_access_keys(argv);
     if (action === ACTIONS.ADD || action === ACTIONS.STATUS) {
-        const regenerate = action === ACTIONS.ADD
+        const regenerate = action === ACTIONS.ADD;
         access_keys = set_access_keys(argv, regenerate);
     } else if (action === ACTIONS.UPDATE) {
         access_keys = set_access_keys(argv, Boolean(argv.regenerate));

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -74,7 +74,7 @@ async function s3_rest(req, res) {
 
 async function handle_request(req, res) {
 
-    http_utils.validate_nsfs_whitelist(req)
+    http_utils.validate_nsfs_whitelist(req);
     http_utils.set_amz_headers(req, res);
     http_utils.set_cors_headers_s3(req, res);
 

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -388,7 +388,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                         name,
                         full_path: path.join(this.fs_root, namespace_bucket_config.write_resource.path) // includes write_resource.path + bucket name (s3 flow)
                     }, object_sdk);
-                } else if (namespace_bucket_config){
+                } else if (namespace_bucket_config) {
                     const list = await ns.list_objects({ ...params, limit: 1 }, object_sdk);
                     if (list && list.objects && list.objects.length > 0) {
                         throw new RpcError('NOT_EMPTY', 'underlying directory has files in it');

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -193,7 +193,7 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli account update name by name', async function() {
             const { type, name } = defaults;
-            const new_name = 'account1_new_name'
+            const new_name = 'account1_new_name';
             const account_options = { config_root, name, new_name };
             const action = nc_nsfs_manage_actions.UPDATE;
             account_options.new_name = 'account1_new_name';
@@ -209,7 +209,7 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli account update access key, secret_key & new_name by name', async function() {
             const { type, name } = defaults;
-            const new_name = 'account1_new_name'
+            const new_name = 'account1_new_name';
             const access_key = 'GIGiFAnjaaE7OKD5N7hB';
             const secret_key = 'U3AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
             const account_options = { config_root, name, new_name, access_key, secret_key };

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -161,7 +161,7 @@ function make_invalid_dummy_object_sdk() {
                 new_buckets_path: new_buckets_path,
             }
         },
-    }
+    };
 }
 
 mocha.describe('bucketspace_fs', function() {
@@ -262,7 +262,7 @@ mocha.describe('bucketspace_fs', function() {
             try {
                 const test_bucket_not_allowed = 'bucket4';
                 const param = { name: test_bucket_not_allowed};
-                const local_object_sdk = make_invalid_dummy_object_sdk()
+                const local_object_sdk = make_invalid_dummy_object_sdk();
                 await bucketspace_fs.create_bucket(param, local_object_sdk);
                 assert.fail('should have failed with UNAUTHORIZED bucket creation');
             } catch (err) {
@@ -326,7 +326,7 @@ mocha.describe('bucketspace_fs', function() {
                 });
             try {
                 await bucketspace_fs.delete_bucket(param, dummy_object_sdk);
-                assert.fail('should have failed with NOT EMPTY')
+                assert.fail('should have failed with NOT EMPTY');
             } catch (err) {
                 assert.strictEqual(err.rpc_code, 'NOT_EMPTY');
                 assert.equal(err.message, 'underlying directory has files in it');


### PR DESCRIPTION
### Explain the changes
1. Fix eslint errors by running `eslint src --fix`.

### Issues: Fixed #xxx / Gap #xxx
1. GAP - the CI should have returned an error on those cases (and the job should have stopped with failure).

### Testing Instructions:
1. none.


- [ ] Doc added/updated
- [ ] Tests added
