### PR TITLE
Move Versioning Definition From `bucket_api` to `common_api` for Reuse

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -867,7 +867,7 @@ module.exports = {
                         id: { objectid: true }
                     }
                 },
-                versioning: { $ref: '#/definitions/versioning' },
+                versioning: { $ref: 'common_api#/definitions/versioning' },
                 namespace: { $ref: '#/definitions/namespace_bucket_config' },
                 bucket_claim: { $ref: '#/definitions/bucket_claim' },
                 logging: { $ref: '#/definitions/logging' },
@@ -1194,7 +1194,7 @@ module.exports = {
                 //     }]
                 // },
                 namespace: { $ref: '#/definitions/namespace_bucket_config' },
-                versioning: { $ref: '#/definitions/versioning' },
+                versioning: { $ref: 'common_api#/definitions/versioning' },
             }
         },
         policy_modes: {
@@ -1287,11 +1287,6 @@ module.exports = {
                     type: 'integer'
                 },
             }
-        },
-
-        versioning: {
-            type: 'string',
-            enum: ['DISABLED', 'SUSPENDED', 'ENABLED']
         },
 
         lambda_trigger_info: {

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -109,6 +109,11 @@ module.exports = {
             }
         },
 
+        versioning: {
+            type: 'string',
+            enum: ['DISABLED', 'SUSPENDED', 'ENABLED']
+        },
+
         assume_role_policy: {
             type: 'object',
             required: ['statement'],

--- a/src/server/object_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/object_services/schemas/nsfs_bucket_schema.js
@@ -27,10 +27,7 @@ module.exports = {
             type: 'string',
         },
         versioning: {
-            type: 'string',
-            enum: ['DISABLED', 'SUSPENDED', 'ENABLED']
-            // GAP would like to use $ref: 'bucket_api#/definitions/versioning'
-            // but currently it creates an error Error: reference "bucket_api" resolves to more than one schema
+            $ref: 'common_api#/definitions/versioning',
         },
         path: {
             type: 'string',


### PR DESCRIPTION
### Explain the changes
1. Move the versioning definition from `bucket_api` to `common_api` for reuse.

### Issues: Fixed #xxx / Gap #xxx
1. When I worked on PR #7702 I noticed that I could not reuse the versioning definition, and added this as a GAP.

### Testing Instructions:
1. none.


- [ ] Doc added/updated
- [ ] Tests added
