### PR TITLE
NSFS | NC | Allow one or more buckets to use the same dir path

### DIFF
--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -92,7 +92,7 @@ const fork_response_code = {
 const health_errors_tyes = {
   PERSISTENT: 'PERSISTENT',
   TEMPORARY: 'TEMPORARY',
-}
+};
 
 //suppress aws sdk related commands.
 process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
@@ -180,7 +180,7 @@ class NSFSHealth {
           }
         }
       });
-    } catch(err) {
+    } catch (err) {
       console.log('Error while pinging endpoint host :' + HOSTNAME + ', port ' + this.https_port, err);
       return {
         response: fork_response_code.NOT_RUNNING.response_code,

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -5,6 +5,7 @@ module.exports = {
     $id: 'account_schema',
     type: 'object',
     required: [
+        '_id',
         'name',
         'email',
         'access_keys',
@@ -13,6 +14,9 @@ module.exports = {
         'allow_bucket_creation',
     ],
     properties: {
+        _id: {
+            type: 'string',
+        },
         name: {
             type: 'string'
         },

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -5,6 +5,7 @@ module.exports = {
     $id: 'bucket_schema',
     type: 'object',
     required: [
+        '_id',
         'name',
         'system_owner',
         'bucket_owner',
@@ -14,6 +15,12 @@ module.exports = {
         'creation_date',
     ],
     properties: {
+        _id: {
+            type: 'string',
+        },
+        owner_account: {
+            type: 'string',
+        },
         name: {
             type: 'string',
         },

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -45,6 +45,7 @@ describe('manage nsfs cli account flow', () => {
         const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs');
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs/');
         const defaults = {
+            _id: 'account1',
             type: 'account',
             name: 'account1',
             email: 'account1@noobaa.io',
@@ -151,6 +152,7 @@ describe('manage nsfs cli account flow', () => {
         const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs1');
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs1/');
         const defaults = {
+            _id: 'account1',
             type: 'account',
             name: 'account1',
             email: 'account1@noobaa.io',
@@ -255,6 +257,7 @@ describe('manage nsfs cli account flow', () => {
         const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs1');
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs1/');
         const defaults = [{
+            _id: 'account1',
             type: 'account',
             name: 'account1',
             email: 'account1@noobaa.io',
@@ -264,6 +267,7 @@ describe('manage nsfs cli account flow', () => {
             access_key: 'GIGiFAnjaaE7OKD5N7hA',
             secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
         }, {
+            _id: 'account1',
             type: 'account',
             name: 'account2',
             email: 'account2@noobaa.io',
@@ -273,6 +277,7 @@ describe('manage nsfs cli account flow', () => {
             access_key: 'BIBiFAnjaaE7OKD5N7hA',
             secret_key: 'BIBYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
         }, {
+            _id: 'account1',
             type: 'account',
             name: 'account3',
             email: 'account3@noobaa.io',

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -273,6 +273,23 @@ describe('schema validation NC NSFS account', () => {
             assert_validation(account_data, reason, message);
         });
 
+        it('account without _id', () => {
+            const account_data = get_account_data();
+            delete account_data._id;
+            const reason = 'Test should have failed because of missing required property ' +
+                '_id';
+            const message = "must have required property '_id'";
+            assert_validation(account_data, reason, message);
+        });
+
+        it('account with undefined _id', () => {
+            const account_data = get_account_data();
+            account_data._id = undefined;
+            const reason = 'Test should have failed because of missing required property ' +
+                '_id';
+            const message = "must have required property '_id'";
+            assert_validation(account_data, reason, message);
+        });
     });
 
     describe('account with wrong types', () => {
@@ -312,7 +329,6 @@ describe('schema validation NC NSFS account', () => {
             const message = 'must be equal to one of the allowed values';
             assert_validation(account_data, reason, message);
         });
-
     });
 
 });
@@ -320,6 +336,7 @@ describe('schema validation NC NSFS account', () => {
 
 function get_account_data() {
     const account_name = 'account1';
+    const id = '65a62e22ceae5e5f1a758aa9';
     const account_email = 'account1@noobaa.io';
     const access_key = 'GIGiFAnjaaE7OKD5N7hA';
     const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
@@ -330,6 +347,7 @@ function get_account_data() {
     };
 
     const account_data = {
+        _id: id,
         name: account_name,
         email: account_email,
         access_keys: [{

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -1,0 +1,146 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-disable no-undef */
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = "true";
+
+const _ = require('lodash');
+const path = require('path');
+const P = require('../../../util/promise');
+const fs_utils = require('../../../util/fs_utils');
+const os_util = require('../../../util/os_utils');
+const config_module = require('../../../../config');
+const native_fs_utils = require('../../../util/native_fs_utils');
+
+const MAC_PLATFORM = 'darwin';
+let tmp_fs_path = '/tmp/test_bucketspace_fs';
+if (process.platform === MAC_PLATFORM) {
+    tmp_fs_path = '/private/' + tmp_fs_path;
+}
+let bucket_storage_path;
+let bucket_temp_dir_path;
+
+const DEFAULT_FS_CONFIG = {
+    uid: process.getuid(),
+    gid: process.getgid(),
+    backend: '',
+    warn_threshold_ms: 100,
+};
+
+const nc_nsfs_manage_actions = {
+    ADD: 'add',
+    UPDATE: 'update',
+    LIST: 'list',
+    DELETE: 'delete',
+    STATUS: 'status',
+};
+
+// eslint-disable-next-line max-lines-per-function
+describe('manage nsfs cli account flow', () => {
+    const buckets_schema_dir = 'buckets';
+
+    describe('cli delete bucket', () => {
+        const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs2');
+        const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs2/');
+        bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs2', 'bucket1');
+
+        const account_defaults = {
+            _id: '65a9fbe7ab49fd2fe430bc3f',
+            type: 'account',
+            name: 'account_test',
+            email: 'account1@noobaa.io',
+            new_buckets_path: `${root_path}new_buckets_path_user1/`,
+            uid: 999,
+            gid: 999,
+            access_key: 'GIGiFAnjaaE7OKD5N7hX',
+            secret_key: 'G2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
+            creation_date: '2024-01-19T04:34:47.273Z',
+        };
+
+        const bucket_defaults = {
+            type: 'bucket',
+            name: 'bucket1',
+            tag:'',
+            owner_account: 'account_test',
+            system_owner: 'account1@noobaa.io',
+            bucket_owner: 'account1@noobaa.io',
+            email: 'account1@noobaa.io',
+            path: bucket_storage_path,
+            should_create_underlying_storage: true,
+            creation_date: '2024-01-19T04:34:47.273Z',
+        };
+
+        beforeEach(async () => {
+            await P.all(_.map([buckets_schema_dir], async dir =>
+                fs_utils.create_fresh_path(`${config_root}/${dir}`)));
+            await fs_utils.create_fresh_path(root_path);
+            await fs_utils.create_fresh_path(bucket_storage_path);
+            const action = nc_nsfs_manage_actions.ADD;
+            // Account add
+            const { type: account_type, new_buckets_path: account_path } = account_defaults;
+            const account_options = { config_root, ...account_defaults };
+            await fs_utils.create_fresh_path(account_path);
+            await fs_utils.file_must_exist(account_path);
+            await exec_manage_cli(account_type, action, account_options);
+
+            //bucket add
+            const { type: bucket_type, path: bucket_path } = bucket_defaults;
+            const bucket_options = { config_root, ...bucket_defaults };
+            await fs_utils.create_fresh_path(bucket_path);
+            await fs_utils.file_must_exist(bucket_path);
+            const resp = await exec_manage_cli(bucket_type, action, bucket_options);
+            const bucket_resp = JSON.parse(resp);
+            expect(bucket_resp.response.reply._id).not.toBeNull();
+            //create temp dir
+            bucket_temp_dir_path = path.join(bucket_storage_path,
+                config_module.NSFS_TEMP_DIR_NAME + "_" + bucket_resp.response.reply._id);
+            await fs_utils.create_fresh_path(bucket_temp_dir_path);
+            await fs_utils.file_must_exist(bucket_temp_dir_path);
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('cli delete bucket and delete temp dir', async () => {
+            let is_path_exists = await native_fs_utils.is_path_exists(DEFAULT_FS_CONFIG, bucket_temp_dir_path);
+            expect(is_path_exists).toBe(true);
+            const account_options = { config_root, name: 'bucket1'};
+            const action = nc_nsfs_manage_actions.DELETE;
+            await exec_manage_cli('bucket', action, account_options);
+            is_path_exists = await native_fs_utils.is_path_exists(DEFAULT_FS_CONFIG, bucket_temp_dir_path);
+            expect(is_path_exists).toBe(false);
+        });
+    });
+})
+
+/**
+ * exec_manage_cli will get the flags for the cli and runs the cli with it's flags
+ * @param {string} type
+ * @param {string} action
+ * @param {object} options
+ */
+async function exec_manage_cli(type, action, options) {
+    let account_flags = ``;
+    for (const key in options) {
+        if (Object.hasOwn(options, key)) {
+            if (typeof options[key] === 'boolean') {
+                account_flags += `--${key} `;
+            } else {
+                account_flags += `--${key} ${options[key]} `;
+            }
+        }
+    }
+    account_flags = account_flags.trim();
+
+    const command = `node src/cmd/manage_nsfs ${type} ${action} ${account_flags}`;
+    let res;
+    try {
+        res = await os_util.exec(command, { return_stdout: true });
+    } catch (e) {
+        res = e;
+    }
+    return res;
+}

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -263,6 +263,24 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
+        it('bucket with undefined _id', () => {
+            const bucket_data = get_bucket_data();
+            bucket_data._id = undefined;
+            const reason = 'Test should have failed because of missing required property ' +
+                '_id';
+            const message = "must have required property '_id'";
+            assert_validation(bucket_data, reason, message);
+        });
+
+        it('bucket without _id', () => {
+            const bucket_data = get_bucket_data();
+            delete bucket_data._id;
+            const reason = 'Test should have failed because of missing required property ' +
+                '_id';
+            const message = "must have required property '_id'";
+            assert_validation(bucket_data, reason, message);
+        });
+
     });
 
     describe('bucket with wrong types', () => {
@@ -343,6 +361,7 @@ describe('schema validation NC NSFS bucket', () => {
 
 function get_bucket_data() {
     const bucket_name = 'bucket1';
+    const id = '65a62e22ceae5e5f1a758aa8';
     const system_owner = 'account1@noobaa.io';
     const bucket_owner = 'account1@noobaa.io';
     const versioning_disabled = 'DISABLED';
@@ -350,6 +369,7 @@ function get_bucket_data() {
     const path = '/tmp/nsfs_root1';
 
     const bucket_data = {
+        _id: id,
         name: bucket_name,
         system_owner: system_owner,
         bucket_owner: bucket_owner,

--- a/src/test/unit_tests/test_nc_nsfs_health.js
+++ b/src/test/unit_tests/test_nc_nsfs_health.js
@@ -237,7 +237,7 @@ mocha.describe('nsfs nc health', function() {
             Health.get_endpoint_response.restore();
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            Health.config_root =  config_root_invalid;
+            Health.config_root = config_root_invalid;
             const get_service_state = sinon.stub(Health, "get_service_state");
             get_service_state.onFirstCall().returns(Promise.resolve({ service_status: 'active', pid: 100 }))
                 .onSecondCall().returns(Promise.resolve({ service_status: 'active', pid: 200 }));

--- a/src/util/mongo_utils.js
+++ b/src/util/mongo_utils.js
@@ -162,6 +162,15 @@ function is_object_id(id) {
     return (id instanceof mongodb.ObjectId);
 }
 
+function mongoObjectId() {
+    // eslint-disable-next-line no-bitwise
+    const timestamp = (new Date().getTime() / 1000 | 0).toString(16);
+    return timestamp + 'xxxxxxxxxxxxxxxx'.replace(/[x]/g, function() {
+        // eslint-disable-next-line no-bitwise
+        return (Math.random() * 16 | 0).toString(16);
+    }).toLowerCase();
+};
+
 // function is_err_duplicate_key(err) {
 //     return err && err.code === 11000;
 // }
@@ -240,3 +249,4 @@ exports.is_object_id = is_object_id;
 // exports.check_update_one = check_update_one;
 // exports.make_object_diff = make_object_diff;
 // exports.get_db_stats = get_db_stats;
+exports.mongoObjectId = mongoObjectId


### PR DESCRIPTION
### Explain the changes
1. Allow one or more buckets to use the same dir path for the storage
2. Clean after bucket delete
-   delete temp dir from bucket dir, 
    eg: `config.NSFS_TEMP_DIR_NAME_<bucket._id>` folder

3. new property `_id` added to bucket and account
4. `config_file_exists()` renamed to `is_path_exists()`.
5. Jest test added for bucket delete
### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7717

### Testing Instructions:
1. Create two or more buckets with the same storage path and start a multipart upload
verify the temp folder name

- [ ] Doc added/updated
- [X] Tests added
