### PR TITLE
NSFS | NC | NC coretest - bug fixes - PR 1/3

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -492,11 +492,14 @@ async function fetch_existing_account_data(target) {
         source = await get_config_data(account_path, true);
     } catch (err) {
         dbg.log1('NSFS Manage command: Could not find account', target, err);
-        if (is_undefined(target.name)) {
-            throw_cli_error(ManageCLIError.NoSuchAccountAccessKey, target.access_keys[0].access_key);
-        } else {
-            throw_cli_error(ManageCLIError.NoSuchAccountName, target.name);
+        if (err.code === 'ENOENT') {
+            if (is_undefined(target.name)) {
+                throw_cli_error(ManageCLIError.NoSuchAccountAccessKey, target.access_keys[0].access_key);
+            } else {
+                throw_cli_error(ManageCLIError.NoSuchAccountName, target.name);
+            }
         }
+        throw err;
     }
     const data = _.merge({}, source, target);
     return data;

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -196,8 +196,8 @@ mocha.describe('bucketspace_fs', function() {
             const res = await bucketspace_fs.read_account_by_access_key({ access_key });
             assert.strictEqual(res.email.unwrap(), account_user2.email);
             assert.strictEqual(res.access_keys[0].access_key.unwrap(), account_user2.access_keys[0].access_key);
-            const distinguished_name = res.nsfs_account_config.distinguished_name;
-            assert.strictEqual(res.nsfs_account_config.distinguished_name, 'root');
+            const distinguished_name = res.nsfs_account_config.distinguished_name.unwrap();;
+            assert.strictEqual(distinguished_name, 'root');
             const res2 = await native_fs_utils.get_user_by_distinguished_name({ distinguished_name });
             assert.strictEqual(res2.uid, 0);
         });
@@ -207,8 +207,8 @@ mocha.describe('bucketspace_fs', function() {
             const res = await bucketspace_fs.read_account_by_access_key({ access_key });
             assert.strictEqual(res.email.unwrap(), account_user3.email);
             assert.strictEqual(res.access_keys[0].access_key.unwrap(), account_user3.access_keys[0].access_key);
-            const distinguished_name = res.nsfs_account_config.distinguished_name;
-            assert.strictEqual(res.nsfs_account_config.distinguished_name, os.userInfo().username);
+            const distinguished_name = res.nsfs_account_config.distinguished_name.unwrap();;
+            assert.strictEqual(distinguished_name, os.userInfo().username);
             const res2 = await native_fs_utils.get_user_by_distinguished_name({ distinguished_name });
             assert.strictEqual(res2.uid, process.getuid());
         });

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -815,9 +815,13 @@ function assert_account(account, account_options, skip_secrets) {
     assert.equal(account.name, account_options.name);
     if (account_options.distinguished_name) {
         assert.equal(account.nsfs_account_config.distinguished_name, account_options.distinguished_name);
+        assert.equal(account.nsfs_account_config.uid, undefined);
+        assert.equal(account.nsfs_account_config.gid, undefined);
     } else {
         assert.equal(account.nsfs_account_config.uid, account_options.uid);
         assert.equal(account.nsfs_account_config.gid, account_options.gid);
+        assert.equal(account.nsfs_account_config.distinguished_name, undefined);
+
     }
     assert.equal(account.nsfs_account_config.new_buckets_path, account_options.new_buckets_path);
     assert.equal(account.nsfs_account_config.fs_backend, account_options.fs_backend === '' ? undefined : account_options.fs_backend);


### PR DESCRIPTION
### Explain the changes
1. manage_nsfs.js - throw NoSuchAccount only when err.code === ENOENT, and other errors on different error codes.
2. bucketspace_fs.js - 
    2.1. read_account_by_access_key() - distinguished_name should we wrapped as SensitiveString() & fixed the relevant 
           tests on test_bucketspace_fs.js.
    2.2. check_bucket_config() - nb_native().fs.stat() throws an error, wrapped with try and catch instead of the 
           (!bucket_dir_stat) condition.
    2.3. get_bucket_name() - replaced the nb_native().fs.readFile() to just return the suffix of the bucket config json file 
           (without the json).
    2.4. list_buckets() - moved try catch to wrap the readdir() only, removed the buckets.filter(bucket => 
           bucket.name.unwrap()) as it looks unnecessary.
3. test_nc_nsfs_cli.js - assert_account() - added check for uid,gid = undefined when distinguished_name defined and vice 
    versa.

### Testing Instructions:
1. Tests covering these cases are a part of the NC_CORETST effort - test_bucketspace.js,


- [ ] Doc added/updated
- [ ] Tests Edited
