### PR TITLE
NSFS | NC | NC Coretests changes - PR 2/3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,14 @@ run-single-test: tester
 	@$(call remove_docker_network)
 .PHONY: run-single-test
 
+run-nc-tests: tester
+	@$(call create_docker_network)
+	@echo "\033[1;34mRunning nc tests\033[0m"
+	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --privileged --user root --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "NC_CORETEST=true" $(TESTER_TAG) ./src/test/unit_tests/run_npm_test_on_test_container.sh -s nc_index.js
+	@$(call stop_noobaa)
+	@$(call remove_docker_network)
+.PHONY: run-nc-tests
+
 run-single-test-postgres: tester
 	@echo "\033[1;34mRunning single test with Postgres.\033[0m"
 	@$(call create_docker_network)

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -1,0 +1,450 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const fs = require('fs');
+const p = require('path');
+const _ = require('lodash');
+const mocha = require('mocha');
+const { exec_manage_cli, nc_nsfs_manage_entity_types, nc_nsfs_manage_actions } = require('../system_tests/test_utils');
+const child_process = require('child_process');
+const argv = require('minimist')(process.argv);
+const SensitiveString = require('../../util/sensitive_string');
+
+// keep me first - this is setting envs that should be set before other modules are required.
+const NC_CORETEST = 'nc_coretest';
+process.env.DEBUG_MODE = 'true';
+process.env.ACCOUNTS_CACHE_EXPIRY = '1';
+process.env.NC_CORETEST = 'true';
+
+require('../../util/dotenv').load();
+require('../../util/panic');
+require('../../util/fips');
+
+const config = require('../../../config.js');
+config.test_mode = true;
+
+const new_umask = process.env.NOOBAA_ENDPOINT_UMASK || 0o000;
+const old_umask = process.umask(new_umask);
+console.log('test_nsfs_access: replacing old umask: ', old_umask.toString(8), 'with new umask: ', new_umask.toString(8));
+
+const dbg = require('../../util/debug_module')(__filename);
+const dbg_level =
+    (process.env.SUPPRESS_LOGS && -5) ||
+    (argv.verbose && 5) ||
+    0;
+dbg.set_module_level(dbg_level, 'core');
+
+const P = require('../../util/promise');
+let _setup = false;
+
+const SYSTEM = NC_CORETEST;
+const EMAIL = NC_CORETEST;
+const PASSWORD = NC_CORETEST;
+const http_port = 6001;
+const https_port = 6443;
+const http_address = `http://localhost:${http_port}`;
+const https_address = `https://localhost:${https_port}`;
+const MAC_PLATFORM = 'darwin';
+
+const TMP_PATH = get_tmp_path_by_os('/tmp/');
+const FIRST_BUCKET = 'first.bucket';
+const NC_CORETEST_CONFIG_DIR_PATH = p.join(TMP_PATH, 'nc_coretest_config_root_path/');
+const NC_CORETEST_REDIRECT_FILE_PATH = p.join(config.NSFS_NC_DEFAULT_CONF_DIR, '/config_dir_redirect');
+const NC_CORETEST_STORAGE_PATH = p.join(TMP_PATH, '/nc_coretest_storage_root_path/');
+const FIRST_BUCKET_PATH = p.join(NC_CORETEST_STORAGE_PATH, FIRST_BUCKET, '/');
+const CONFIG_FILE_PATH = p.join(NC_CORETEST_CONFIG_DIR_PATH, 'config.json');
+
+const nsrs_to_root_paths = {};
+let nsfs_process;
+
+/**
+ * setup will setup nc coretest
+ * @param {object} options
+ */
+function setup(options = {}) {
+    if (_setup) return;
+    _setup = true;
+
+    mocha.before('nc-coretest-before', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        const start = Date.now();
+        await announce('nc-coretest-before');
+
+        await config_dir_setup();
+        await admin_account_creation();
+        await first_bucket_creation();
+
+        await announce('start nsfs script');
+        const logStream = fs.createWriteStream('src/logfile.txt', { flags: 'a' });
+
+        nsfs_process = child_process.spawn('node', ['src/cmd/nsfs.js'], {
+            detached: true
+        });
+        nsfs_process.stdout.pipe(logStream);
+        nsfs_process.stderr.pipe(logStream);
+
+
+        nsfs_process.on('exit', (code, signal) => {
+            dbg.error(`nsfs.js exited code=${code}, signal=${signal}`);
+            logStream.end()
+        });
+
+        nsfs_process.on('error', err => {
+            dbg.error(`nsfs.js exited with error`, err);
+            logStream.end()
+        });
+
+        // TODO - run health
+        await announce(`nc coretest ready... (took ${((Date.now() - start) / 1000).toFixed(1)} sec)`);
+    });
+
+
+    mocha.after('nc-coretest-after', async function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        try {
+            await announce('stop nsfs script');
+            if (nsfs_process) nsfs_process.kill('SIGKILL');
+            await config_dir_teardown();
+            await announce('nc coretest done ...');
+        } catch (err) {
+            dbg.error('got error on mocha.after', err);
+        }
+    });
+}
+
+/**
+ * announce will pretty print msg
+ * @param {string} msg
+ * @returns {Promise<void>}
+ */
+async function announce(msg) {
+    if (process.env.SUPPRESS_LOGS) return;
+    const l = Math.max(80, msg.length + 4);
+    console.log('='.repeat(l));
+    console.log('=' + ' '.repeat(l - 2) + '=');
+    console.log('= ' + msg + ' '.repeat(l - msg.length - 3) + '=');
+    console.log('=' + ' '.repeat(l - 2) + '=');
+    console.log('='.repeat(l));
+    await P.delay(500);
+}
+
+/**
+ * config_dir_setup creates the config dir, storage dirs and other config files
+ * @returns {Promise<void>}
+ */
+async function config_dir_setup() {
+    await announce('config_dir_setup');
+    await fs.promises.mkdir(NC_CORETEST_STORAGE_PATH, { recursive: true });
+    await fs.promises.mkdir(config.NSFS_NC_DEFAULT_CONF_DIR, { recursive: true });
+    await fs.promises.mkdir(NC_CORETEST_CONFIG_DIR_PATH, { recursive: true });
+    await fs.promises.writeFile(NC_CORETEST_REDIRECT_FILE_PATH, NC_CORETEST_CONFIG_DIR_PATH);
+    await fs.promises.writeFile(CONFIG_FILE_PATH, JSON.stringify({ ALLOW_HTTP: true, OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS: 1 }));
+    await fs.promises.mkdir(FIRST_BUCKET_PATH, { recursive: true });
+
+}
+
+/**
+ * config_dir_teardown removes the config dir, storage dirs and other config files
+ * @returns {Promise<void>}
+ */
+async function config_dir_teardown() {
+    await announce('config_dir_teardown');
+    await fs.promises.rmdir(NC_CORETEST_STORAGE_PATH, { recursive: true });
+    await fs.promises.rm(NC_CORETEST_REDIRECT_FILE_PATH);
+    await fs.promises.rmdir(NC_CORETEST_CONFIG_DIR_PATH, { recursive: true, force: true });
+}
+
+/**
+ * admin_account_creation creates admin account
+ * @returns {Promise<void>}
+ */
+async function admin_account_creation() {
+    await announce('admin_account_creation');
+    const cli_account_options = {
+        name: NC_CORETEST,
+        email: NC_CORETEST,
+        new_buckets_path: NC_CORETEST_STORAGE_PATH,
+        uid: 200,
+        gid: 200
+    };
+    await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, nc_nsfs_manage_actions.ADD, cli_account_options);
+}
+
+/**
+ * first_bucket_creation creates first.bucket
+ * @returns {Promise<void>}
+ */
+async function first_bucket_creation() {
+    await announce('first_bucket_creation');
+    const cli_bucket_options = {
+        name: FIRST_BUCKET,
+        email: NC_CORETEST,
+        path: FIRST_BUCKET_PATH,
+    };
+    await exec_manage_cli(nc_nsfs_manage_entity_types.BUCKET, nc_nsfs_manage_actions.ADD, cli_bucket_options);
+}
+
+/**
+ * log prints args if process.env.SUPPRESS_LOGS=false
+ * @param {object} args
+ */
+function log(...args) {
+    if (process.env.SUPPRESS_LOGS) return;
+    console.log(...args);
+}
+
+/**
+ * get_dbg_level return nc coretest dbg_level variable
+ */
+function get_dbg_level() {
+    return dbg_level;
+}
+
+/**
+ * get_http_address return nc coretest http_address variable
+ */
+function get_http_address() {
+    return http_address;
+}
+
+/**
+ * get_https_address return nc coretest https_address variable
+ */
+function get_https_address() {
+    return https_address;
+}
+
+///////////////////////////////////
+///////// HELPER FUNCTIONS ////////
+///////////////////////////////////
+
+/**
+ * get_name_by_email returns name by email
+ * rpc account calls identified by email
+ * manage_nsfs account commands identified by name  
+ */
+const get_name_by_email = email => {
+    const name = email === NC_CORETEST ? NC_CORETEST : email.slice(0, email.indexOf('@'));
+    return name;
+};
+
+/**
+ * get_tmp_path_by_os returns the tmp path by the process platform
+ */
+function get_tmp_path_by_os(_path) {
+    return process.platform === MAC_PLATFORM ? '/private/' + _path : _path;
+}
+
+////////////////////////////////////
+//////// ACCOUNT MANAGE CMDS ///////
+////////////////////////////////////
+
+/**
+ * create_account_manage creates account using manage_nsfs and returns rpc-like result
+ * @param {object} options
+ * @return {Promise<object>}
+ */
+async function create_account_manage(options) {
+    const cli_options = {
+        name: options.name,
+        email: options.email,
+        new_buckets_path: options.default_resource ?
+            p.join(nsrs_to_root_paths[options.default_resource], options.nsfs_account_config.new_buckets_path) :
+            options.nsfs_account_config.new_buckets_path,
+        distinguished_name: options.nsfs_account_config.distinguished_name,
+        uid: options.nsfs_account_config.uid,
+        gid: options.nsfs_account_config.gid,
+        access_key: options.access_key,
+        secret_key: options.secret_key
+    };
+    const res = await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, nc_nsfs_manage_actions.ADD, cli_options);
+    const json_account = JSON.parse(res);
+    const account = json_account.response.reply;
+    account.access_keys[0] = {
+        access_key: new SensitiveString(account.access_keys[0].access_key),
+        secret_key: new SensitiveString(account.access_keys[0].secret_key)
+    };
+    return account;
+}
+
+/**
+ * read_account_manage reads an account using manage_nsfs and returns rpc-like result
+ * @param {object} options
+ * @return {Promise<object>}
+ */
+async function read_account_manage(options) {
+    const cli_options = { name: get_name_by_email(options.email), show_secrets: true };
+    const res = await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, nc_nsfs_manage_actions.STATUS, cli_options);
+    const json_account = JSON.parse(res);
+    const account = json_account.response.reply;
+    account.access_keys[0] = {
+        access_key: new SensitiveString(account.access_keys[0].access_key),
+        secret_key: new SensitiveString(account.access_keys[0].secret_key)
+    };
+    return account;
+}
+
+/**
+ * delete_account_manage deletes an account using manage_nsfs
+ * @param {object} options
+ * @returns {Promise<void>}
+ */
+async function delete_account_manage(options) {
+    const cli_options = { name: get_name_by_email(options.email) };
+    await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, nc_nsfs_manage_actions.DELETE, cli_options);
+}
+
+/**
+ * delete_account_by_property_manage lists accounts by property and deletes the result list using manage_nsfs
+ * @param {object} params
+ * @param {object} params.nsfs_account_config
+ * @returns {Promise<void>}
+ */
+async function delete_account_by_property_manage({ nsfs_account_config }) {
+    const list = await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, nc_nsfs_manage_actions.LIST, nsfs_account_config);
+    const accounts = JSON.parse(list).response.reply;
+    for (const account of accounts) {
+        const cli_options = { name: account.name };
+        await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, nc_nsfs_manage_actions.DELETE, cli_options);
+    }
+}
+
+/**
+ * list_accounts_manage lists accounts using manage_nsfs and returns rpc-like result
+ * @param {object} options
+ * @return {Promise<object>}
+ */
+async function list_accounts_manage(options) {
+    const list = await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, nc_nsfs_manage_actions.LIST, options);
+    return { accounts: JSON.parse(list).response.reply };
+}
+
+/**
+ * update_account_s3_access_manage updates an account using manage_nsfs
+ * @param {object} options
+ * @returns {Promise<void>}
+ */
+async function update_account_s3_access_manage(options) {
+    const cli_options = {
+        name: get_name_by_email(options.email),
+        new_buckets_path: options.default_resource ?
+            p.join(nsrs_to_root_paths[options.default_resource], options.nsfs_account_config.new_buckets_path) :
+            options.nsfs_account_config.new_buckets_path,
+        distinguished_name: options.nsfs_account_config.distinguished_name,
+        uid: options.nsfs_account_config.uid,
+        gid: options.nsfs_account_config.gid,
+    };
+    await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, nc_nsfs_manage_actions.UPDATE, cli_options);
+}
+
+////////////////////////////////////
+///// NAMESPACE RESOURCE MOCKS /////
+////////////////////////////////////
+
+/**
+ * read_namespace_resource_mock reads namespace_resource properties and returns rpc-like result
+ * @param {object} options
+ * @return {object}
+ * @throws {Error} throws if namespace resource not found
+ */
+function read_namespace_resource_mock(options) {
+    if (!nsrs_to_root_paths[options.name]) {
+        const err = new Error('Could not found namespace resource');
+        err.rpc_code = 'NO_SUCH_NAMESPACE_RESOURCE';
+        throw err;
+    }
+    return { name: options.name, fs_root_path: nsrs_to_root_paths[options.name] };
+}
+
+/**
+ * create_namespace_resource_mock sets namespace_resource properties
+ * @param {object} options
+ */
+function create_namespace_resource_mock(options) {
+    nsrs_to_root_paths[options.name] = options.nsfs_config && options.nsfs_config.fs_root_path;
+}
+
+////////////////////////////////////
+//////// BUCKET MANAGE CMDS ////////
+////////////////////////////////////
+
+/**
+ * create_bucket_manage creates a bucket using manage_nsfs
+ * TODO: return create result when needed
+ * @param {object} options
+ * @returns {Promise<void>}
+ */
+async function create_bucket_manage(options) {
+    const { resource, path } = options.namespace.write_resource;
+    const bucket_storage_path = p.join(nsrs_to_root_paths[resource], path);
+    const cli_options = { name: options.name, email: EMAIL, path: bucket_storage_path};
+    await exec_manage_cli(nc_nsfs_manage_entity_types.BUCKET, nc_nsfs_manage_actions.ADD, cli_options);
+}
+
+/**
+ * update_bucket_manage updates a bucket using manage_nsfs
+ * TODO: return update result when needed
+ * @param {object} options
+ * @returns {Promise<void>}
+ */
+async function update_bucket_manage(options) {
+    const { resource, path } = options.namespace.write_resource;
+    const bucket_storage_path = p.join(nsrs_to_root_paths[resource], path);
+    const cli_options = { name: options.name, path: bucket_storage_path };
+    await exec_manage_cli(nc_nsfs_manage_entity_types.BUCKET, nc_nsfs_manage_actions.UPDATE, cli_options);
+}
+
+/**
+ * put_bucket_policy_manage updates the bucket policy of a bucket using manage_nsfs
+ * @param {object} options
+ * @returns {Promise<void>}
+ */
+async function put_bucket_policy_manage(options) {
+    const cli_options = { name: options.name, bucket_policy: options.policy };
+    await exec_manage_cli(nc_nsfs_manage_entity_types.BUCKET, nc_nsfs_manage_actions.UPDATE, cli_options);
+}
+
+/**
+ * delete_bucket_manage deletes a bucket bucket using manage_nsfs
+ * @param {object} options
+ * @returns {Promise<void>}
+ */
+async function delete_bucket_manage(options) {
+    const cli_options = { name: options.name };
+    await exec_manage_cli(nc_nsfs_manage_entity_types.BUCKET, nc_nsfs_manage_actions.DELETE, cli_options);
+}
+
+// rpc_cli_funcs_to_manage_nsfs_cli_cmds contains override functions for nc coretest
+// containerized rpc calls mapped to managa_nsfs/mock functions
+const rpc_cli_funcs_to_manage_nsfs_cli_cmds = {
+    create_auth_token: () => _.noop,
+    account: {
+        create_account: async options => create_account_manage(options),
+        read_account: async options => read_account_manage(options),
+        delete_account: async options => delete_account_manage(options),
+        delete_account_by_property: async options => delete_account_by_property_manage(options),
+        list_accounts: async options => list_accounts_manage(options),
+        update_account_s3_access: async options => update_account_s3_access_manage(options)
+    },
+    pool: {
+        read_namespace_resource: options => read_namespace_resource_mock(options),
+        create_namespace_resource: options => create_namespace_resource_mock(options),
+    },
+    bucket: {
+        create_bucket: async options => create_bucket_manage(options),
+        update_bucket: async options => update_bucket_manage(options),
+        put_bucket_policy: async options => put_bucket_policy_manage(options),
+        delete_bucket: async options => delete_bucket_manage(options)
+    }
+};
+
+exports.setup = setup;
+exports.no_setup = _.noop;
+exports.log = log;
+exports.SYSTEM = SYSTEM;
+exports.EMAIL = EMAIL;
+exports.PASSWORD = PASSWORD;
+exports.get_dbg_level = get_dbg_level;
+exports.rpc_client = rpc_cli_funcs_to_manage_nsfs_cli_cmds;
+exports.get_http_address = get_http_address;
+exports.get_https_address = get_https_address;

--- a/src/test/unit_tests/nc_index.js
+++ b/src/test/unit_tests/nc_index.js
@@ -1,0 +1,26 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+
+const coretest = require('./nc_coretest');
+coretest.setup();
+
+require('./test_namespace_fs');
+require('./test_ns_list_objects');
+require('./test_chunk_fs');
+require('./test_namespace_fs_mpu');
+require('./test_nb_native_fs');
+require('./test_nc_nsfs_cli');
+require('./test_nc_nsfs_health');
+require('./test_nsfs_access');
+require('./test_bucketspace');
+require('./test_bucketspace_fs');
+
+// TODO: uncomment when supported
+//require('./test_s3_ops');
+//require('./test_s3_bucket_policy');
+//require('./test_s3_list_objects');
+//require('./test_s3_encryption');
+// require('./test_s3select');
+//require('./test_bucketspace_versioning');
+//require('./test_nsfs_versioning');

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -13,17 +13,17 @@ const { NodeHttpHandler } = require("@smithy/node-http-handler");
 const http = require('http');
 const assert = require('assert');
 const os = require('os');
-const coretest = require('./coretest');
+const test_utils = require('../system_tests/test_utils');
+const coretest = require(test_utils.get_coretest_path());
 const { rpc_client, EMAIL, PASSWORD, SYSTEM } = coretest;
+const ManageCLIError = require('../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 
 const fs_utils = require('../../util/fs_utils');
 coretest.setup({});
 const { stat } = require('../../util/nb_native')().fs;
 const path = require('path');
 const _ = require('lodash');
-const P = require('../../util/promise');
 const fs = require('fs');
-const test_utils = require('../system_tests/test_utils');
 const config = require('../../../config');
 const MAC_PLATFORM = 'darwin';
 
@@ -83,7 +83,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
             assert.ok(err.rpc_code === 'NO_SUCH_NAMESPACE_RESOURCE');
         }
     });
-    mocha.it('export dir as bucket', async function() {
+    mocha.it('export dir as a bucket', async function() {
         await rpc_client.pool.create_namespace_resource({
             name: nsr,
             nsfs_config: {
@@ -100,6 +100,8 @@ mocha.describe('bucket operations - namespace_fs', function() {
         });
     });
     mocha.it('export same dir as bucket - should fail', async function() {
+        // TODO: supporting it on NC is still on discussion
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         const obj_nsr = { resource: nsr, path: bucket_path };
         try {
             await rpc_client.bucket.create_bucket({
@@ -124,6 +126,8 @@ mocha.describe('bucket operations - namespace_fs', function() {
                 write_resource: other_obj_nsr
             }
         });
+        // TODO: supporting it on NC is still on discussion
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         try {
             await rpc_client.bucket.update_bucket({
                 name: bucket_name + '-other1',
@@ -134,7 +138,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
             });
             assert.fail(`can not update nsfs bucket for using path of existing exported bucket:`);
         } catch (err) {
-            assert.ok(err.rpc_code === 'BUCKET_ALREADY_EXISTS');
+            assert.equal(err.rpc_code, 'BUCKET_ALREADY_EXISTS');
         }
     });
 
@@ -204,16 +208,28 @@ mocha.describe('bucket operations - namespace_fs', function() {
         assert.ok(list_ok);
     });
     mocha.it('update account', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
         const email = 'account_wrong_uid0@noobaa.com';
         const account = await rpc_client.account.read_account({ email: email });
         const default_resource = account.default_resource;
         const arr = [{ nsfs_account_config: { uid: 26041993 }, default_resource, should_fail: false },
-            { nsfs_account_config: { new_buckets_path: 'dummy_dir1/' }, default_resource, should_fail: false },
-            { nsfs_account_config: {}, default_resource, should_fail: true },
+            {
+                nsfs_account_config: { new_buckets_path: 'dummy_dir1/' },
+                default_resource,
+                should_fail: process.env.NC_CORETEST,
+                error_code: ManageCLIError.InvalidAccountNewBucketsPath.code
+            },
+            {
+                nsfs_account_config: {},
+                default_resource,
+                should_fail: !process.env.NC_CORETEST,
+                error_code: 'FORBIDDEN'
+            },
             { nsfs_account_config: { uid: 26041992 }, default_resource, should_fail: false }
         ];
-        await P.all(_.map(arr, async item =>
-            update_account_nsfs_config(email, item.default_resource, item.nsfs_account_config, item.should_fail)));
+        for (const item of arr) {
+            await update_account_nsfs_config(email, item.default_resource, item.nsfs_account_config, item.should_fail, item.error_code);
+        }
     });
     mocha.it('list namespace resources after creation', async function() {
         await rpc_client.create_auth_token({
@@ -246,6 +262,8 @@ mocha.describe('bucket operations - namespace_fs', function() {
     });
     // s3 workflow 
     mocha.it('create account with namespace resource as default pool but without nsfs_account_config', async function() {
+        // not supported in NC
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         try {
             const res = await rpc_client.account.create_account({
                 ...new_account_params,
@@ -402,16 +420,18 @@ mocha.describe('bucket operations - namespace_fs', function() {
         await fs_utils.file_must_not_exist(path.join(tmp_fs_root, '/new_s3_buckets_dir', bucket_name + '-s3-should-fail'));
     });
     mocha.it('update account dn', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
         const email = 'account_wrong_dn0@noobaa.com';
         const account = await rpc_client.account.read_account({ email: email });
         const default_resource = account.default_resource;
         const arr = [{ nsfs_account_config: { distinguished_name: 'bla' }, default_resource, should_fail: false },
-            { nsfs_account_config: { new_buckets_path: 'dummy_dir1/' }, default_resource, should_fail: false },
-            { nsfs_account_config: {}, default_resource, should_fail: true },
+            { nsfs_account_config: { new_buckets_path: 'dummy_dir1/' }, default_resource, should_fail: process.env.NC_CORETEST, error_code: ManageCLIError.InvalidAccountNewBucketsPath.code},
+            { nsfs_account_config: {}, default_resource, should_fail: !process.env.NC_CORETEST, error_code: 'FORBIDDEN' },
             { nsfs_account_config: { distinguished_name: 'shaul101' }, default_resource, should_fail: false }
         ];
-        await P.all(_.map(arr, async item =>
-            update_account_nsfs_config(email, item.default_resource, item.nsfs_account_config, item.should_fail)));
+        for (const item of arr) {
+            await update_account_nsfs_config(email, item.default_resource, item.nsfs_account_config, item.should_fail, item.error_code);
+        }
     });
     mocha.it('list buckets with uid, gid', async function() {
         // Give s3_correct_uid access to the required buckets
@@ -472,18 +492,12 @@ mocha.describe('bucket operations - namespace_fs', function() {
     mocha.it('list parts with wrong uid gid', async function() {
         // eslint-disable-next-line no-invalid-this
         this.timeout(600000);
-
         // Give s3_correct_uid access to the required buckets
-        await Promise.all(
-            [bucket_name]
-            .map(bucket => test_utils.generate_s3_policy('*', bucket, ['s3:*']))
-            .map(generated =>
-                rpc_client.bucket.put_bucket_policy({
-                    name: generated.params.bucket,
-                    policy: generated.policy,
-                })
-            )
-        );
+        const generated = await test_utils.generate_s3_policy('*', bucket_name, ['s3:*']);
+        await rpc_client.bucket.put_bucket_policy({
+                name: bucket_name,
+                policy: generated.policy,
+        });
 
         const res1 = await s3_correct_uid.createMultipartUpload({
             Bucket: bucket_name,
@@ -521,6 +535,8 @@ mocha.describe('bucket operations - namespace_fs', function() {
         assert.ok(res && res.ETag);
     });
     mocha.it('delete bucket without uid, gid - bucket is not empty', async function() {
+        // account without uid and gid not supported in NC
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         try {
             const res = await s3_owner.deleteBucket({ Bucket: bucket_name + '-s3' });
             console.log(inspect(res));
@@ -662,6 +678,8 @@ mocha.describe('bucket operations - namespace_fs', function() {
 
     });
     mocha.it('delete bucket without uid, gid - bucket is empty', async function() {
+        // account without uid and gid is not supported in NC
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         try {
             const res = await s3_owner.deleteBucket({ Bucket: bucket_name + '-s3' });
             console.log(inspect(res));
@@ -671,6 +689,8 @@ mocha.describe('bucket operations - namespace_fs', function() {
         }
     });
     mocha.it('delete account by uid, gid - account has buckets - should fail', async function() {
+        // deletion of account that owns bucket currently allowd in NC - remove when supported
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         await s3_correct_uid_default_nsr.createBucket({ Bucket: 'bucket-to-delete123' });
         try {
             await rpc_client.account.delete_account({ email: 'account_s3_correct_uid@noobaa.com' });
@@ -704,6 +724,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
         await fs_utils.file_must_exist(path.join(tmp_fs_root, '/new_s3_buckets_dir'));
     });
     mocha.it('delete account by uid, gid', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
         const read_account_resp1 = await rpc_client.account.read_account({ email: 'account_wrong_uid0@noobaa.com' });
         assert.ok(read_account_resp1);
         // create another account with the same uid gid
@@ -732,13 +753,20 @@ mocha.describe('bucket operations - namespace_fs', function() {
                 const deleted_account_exist = await rpc_client.account.read_account({ email: `account_wrong_uid${i}@noobaa.com` });
                 assert.fail(`found account: ${deleted_account_exist} - account should be deleted`);
             } catch (err) {
-                assert.ok(err.rpc_code === 'NO_SUCH_ACCOUNT');
+                if (process.env.NC_CORETEST) {
+                    assert.equal(JSON.parse(err.stdout).error.code, ManageCLIError.NoSuchAccountName.code)
+                } else {
+                    assert.equal(err.rpc_code, 'NO_SUCH_ACCOUNT');
+                }
             }
         }
         const list_account_resp2 = (await rpc_client.account.list_accounts({})).accounts;
         assert.ok(list_account_resp2.length > 0);
     });
     mocha.it('delete account by dn', async function() {
+        // TODO: unskip when added list by distinguished name
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
+        this.timeout(600000); // eslint-disable-line no-invalid-this
         const read_account_resp1 = await rpc_client.account.read_account({ email: 'account_wrong_dn0@noobaa.com' });
         assert.ok(read_account_resp1);
         // create another account with the same uid gid
@@ -765,20 +793,26 @@ mocha.describe('bucket operations - namespace_fs', function() {
                 const deleted_account_exist = await rpc_client.account.read_account({ email: `account_wrong_dn${i}@noobaa.com` });
                 assert.fail(`found account: ${deleted_account_exist} - account should be deleted`);
             } catch (err) {
-                assert.ok(err.rpc_code === 'NO_SUCH_ACCOUNT');
+                if (process.env.NC_CORETEST) {
+                    assert.equal(JSON.parse(err.stdout).error.code, ManageCLIError.NoSuchAccountName.code)
+                } else {
+                    assert.equal(err.rpc_code, 'NO_SUCH_ACCOUNT');
+                }
             }
         }
         const list_account_resp2 = (await rpc_client.account.list_accounts({})).accounts;
         assert.ok(list_account_resp2.length > 0);
     });
     mocha.it('delete account by uid, gid - no such account', async function() {
+        // on NC - list will return empty, we won't run any delete
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         const list_account_resp1 = (await rpc_client.account.list_accounts({})).accounts;
         assert.ok(list_account_resp1.length > 0);
         try {
             await rpc_client.account.delete_account_by_property({ nsfs_account_config: { uid: 26041993, gid: 26041993 } });
             assert.fail(`delete account succeeded for none existing account`);
         } catch (err) {
-            assert.ok(err.rpc_code === 'NO_SUCH_ACCOUNT');
+            assert.equal(err.rpc_code, 'NO_SUCH_ACCOUNT');
         }
     });
     mocha.it('delete bucket with uid, gid - bucket is empty', async function() {
@@ -817,7 +851,7 @@ function object_in_list(res, key) {
     return false;
 }
 
-async function update_account_nsfs_config(email, default_resource, new_nsfs_account_config, should_fail) {
+async function update_account_nsfs_config(email, default_resource, new_nsfs_account_config, should_fail, error_code) {
     try {
         await rpc_client.account.update_account_s3_access({
             email,
@@ -830,7 +864,11 @@ async function update_account_nsfs_config(email, default_resource, new_nsfs_acco
         }
     } catch (err) {
         if (should_fail) {
-            assert.ok(err.rpc_code === 'FORBIDDEN');
+            if (process.env.NC_CORETEST) {
+                assert.equal(JSON.parse(err.stdout).error.code, error_code);
+            } else {
+                assert.equal(err.rpc_code, error_code || 'FORBIDDEN');
+            }
             return;
         }
         assert.fail(`update_account_nsfs_config failed ${err}, ${err.stack}`);
@@ -839,7 +877,7 @@ async function update_account_nsfs_config(email, default_resource, new_nsfs_acco
 
 
 
-mocha.describe('list objects - namespace_fs', function() {
+mocha.describe('list objects - namespace_fs', async function() {
     const namespace_resource_name = 'nsr1-list';
     const bucket_name = 'bucket-to-list1';
     const tmp_fs_root = get_tmp_path_by_os('/tmp/test_bucket_namespace_fs1');
@@ -859,6 +897,7 @@ mocha.describe('list objects - namespace_fs', function() {
     const full_path = path.join(tmp_fs_root, bucket_path);
 
     mocha.before(async function() {
+        this.timeout(30000); // eslint-disable-line no-invalid-this
         if (test_utils.invalid_nsfs_root_permissions()) this.skip(); // eslint-disable-line no-invalid-this
 
         await fs_utils.create_fresh_path(tmp_fs_root, permit_ugo);
@@ -890,7 +929,8 @@ mocha.describe('list objects - namespace_fs', function() {
             accounts[account_name].s3_client = s3_client;
         }
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
         await rpc_client.bucket.delete_bucket({ name: bucket_name });
         await rpc_client.bucket.delete_bucket({ name: s3_b_name });
         await rpc_client.bucket.delete_bucket({ name: s3_root_b_name });
@@ -950,7 +990,7 @@ mocha.describe('list objects - namespace_fs', function() {
         const { s3_client } = accounts.account1;
         const res = await s3_client.listBuckets({});
         assert.equal(res.Buckets.length, 2);
-        assert.deepStrictEqual(res.Buckets.map(bucket => bucket.Name), [s3_b_name, 'first.bucket']);
+        assert.equal(res.Buckets.filter(bucket => bucket.Name === s3_b_name || bucket.Name === 'first.bucket').length, 2);
     });
 
     mocha.it('list buckets - uid & gid mismatch - account2', async function() {
@@ -1095,11 +1135,14 @@ mocha.describe('nsfs account configurations', function() {
     };
     mocha.before(function() {
         if (test_utils.invalid_nsfs_root_permissions()) this.skip(); // eslint-disable-line no-invalid-this
+        // the following test suite tests account with/without nsfs_only and different nsfs/non nsfs buckets
+        // which is not relevant to NC
+        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
     });
 
     mocha.before(async () => fs_utils.create_fresh_path(tmp_fs_root1 + bucket_path, 0o770));
     mocha.after(async () => fs_utils.folder_delete(tmp_fs_root1));
-    mocha.it('export dir as bucket', async function() {
+    mocha.it('export dir as a bucket', async function() {
         await rpc_client.pool.create_namespace_resource({
             name: nsr1,
             nsfs_config: {


### PR DESCRIPTION
WIP - This PR is dependent on merging https://github.com/noobaa/noobaa-core/pull/7719
### Explain the changes
1. Makefile - added run-nc-tests makefile rule for running nc_index.js tests file.
2. test_utils.js - added a helper function for get_coretest_path() that chooses coretest/nc_coretest path by process.env.NC_CORETEST.
3. nc_coretest.js - config_dir, storage, and other setups and starting nsfs.js process, added mapping between rpc_client calls and manage_nsfs commands or other mocks.
4. nc_index.js - added NSFS relevant test files.
5. test_bucketspace.js - added skips by process.env.NC_CORETEST of non-relevant tests, and different error_codes.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - nc_index.js contains commented test files that needs to be added as well.
2. github action for running nc_index.js

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
