### PR TITLE
NSFS | NC | Verify That Account Doesn’t Own Buckets before Deletion

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -134,6 +134,13 @@ ManageCLIError.AccountNameAlreadyExists = Object.freeze({
     http_code: 409,
 });
 
+ManageCLIError.AccountDeleteForbiddenHasBuckets = Object.freeze({
+    code: 'AccountDeleteForbiddenHasBuckets',
+    message: 'Cannot delete account that is owner of buckets. ' +
+        'You must delete all buckets before deleting the account',
+    http_code: 403,
+});
+
 
 //////////////////////////////////
 //// ACCOUNT ARGUMENTS ERRORS ////


### PR DESCRIPTION
### Explain the changes
1. Verify that an account doesn't own buckets before deletion.

### Issues: Fixed #7707
1. Currently we allow the deletion of an account that owns a bucket.
2. GAP optimization to function `list_config_file` (see [comment](https://github.com/noobaa/noobaa-core/pull/7723#discussion_r1453118484)).

### Testing Instructions:
1. Create an account: `sudo node src/cmd/manage_nsfs account add --name <account-name> --email <account-email> --new_buckets_path <new-bucket-path> --uid <number-uid> --gid <number-gid>`.
3. Create a bucket for the account: `sudo node src/cmd/manage_nsfs bucket add --name <bucket-name> --email <account-email-above> --path <path>`.
4. Delete the account: `sudo node src/cmd/manage_nsfs account delete --name <account-name>` (should throw an error). 

For running the unit test with the new test, please run: `sudo npx jest test_nc_nsfs_account_cli.test.js`.


- [ ] Doc added/updated
- [X] Tests added
