### PR TITLE
Add configuration to deny upload to "STANDARD" storage class

### DIFF
--- a/config.js
+++ b/config.js
@@ -172,6 +172,8 @@ config.S3_CORS_EXPOSE_HEADERS = [
 ].join(',');
 config.STS_CORS_EXPOSE_HEADERS = 'ETag';
 
+config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD = false;
+
 /////////////////////
 // SECRETS CONFIG  //
 /////////////////////

--- a/src/endpoint/s3/ops/s3_post_object_uploads.js
+++ b/src/endpoint/s3/ops/s3_post_object_uploads.js
@@ -3,6 +3,8 @@
 
 const s3_utils = require('../s3_utils');
 const mime = require('mime');
+const config = require('../../../../config');
+const S3Error = require('../s3_errors').S3Error;
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html
@@ -12,6 +14,10 @@ async function post_object_uploads(req, res) {
     const tagging = s3_utils.parse_tagging_header(req);
     const encryption = s3_utils.parse_encryption(req);
     const storage_class = s3_utils.parse_storage_class_header(req);
+    if (config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD && storage_class === s3_utils.STORAGE_CLASS_STANDARD) {
+        throw new S3Error(S3Error.InvalidStorageClass);
+    }
+
     const reply = await req.object_sdk.create_object_upload({
         bucket: req.params.bucket,
         key: req.params.key,

--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -21,6 +21,9 @@ async function put_object(req, res) {
     const copy_source = s3_utils.parse_copy_source(req);
     const tagging = s3_utils.parse_tagging_header(req);
     const storage_class = s3_utils.parse_storage_class_header(req);
+    if (config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD && storage_class === s3_utils.STORAGE_CLASS_STANDARD) {
+        throw new S3Error(S3Error.InvalidStorageClass);
+    }
     const lock_settings = config.WORM_ENABLED ? s3_utils.parse_lock_header(req) : undefined;
     // Copy request sends empty content and not relevant to the object data
     const { size, md5_b64, sha256_b64 } = copy_source ? {} : {


### PR DESCRIPTION
### Explain the changes
This PR adds a simple configuration which denies uploads to `STANDARD` storage class. The default value is `false` which can be overridden by `config-local.js`.

### Testing Instructions:
1. Set `config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD = true` in `config-local.js`
2. Try uploading a file either without specifying the storage class or after specifying `STANDARD` storage class.
3. The upload should fail. Replace the storage class with `GLACIER` and the upload should succeed (given `config.NSFS_RESTORE_ENABLED = true`).


- [ ] Doc added/updated
- [ ] Tests added
