### PR TITLE
NSFS | NC | Verify That Bucket Owner Exists

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -253,6 +253,13 @@ ManageCLIError.BucketAlreadyExists = Object.freeze({
     http_code: 409,
 });
 
+ManageCLIError.BucketSetForbiddenNoBucketOwner = Object.freeze({
+    code: 'BucketSetForbiddenNoBucketOwner',
+    message: 'The bucket owner you set for the bucket does not exist. ' +
+        'Please set the bucket owner from existing account',
+    http_code: 403,
+});
+
 /////////////////////////////////
 //// BUCKET ARGUMENTS ERRORS ////
 /////////////////////////////////


### PR DESCRIPTION
### Explain the changes
1. Verify that the bucket owner exists when using `bucket add` and `bucket update` options from the NC NSFS CLI.
2. Change the variable names in the test `cli account list` to match the test.

### Issues: Fixed #7724
1. Currently we can create and update a bucket with a bucket owner that doesn't exist.
2. GAP - should improve performance of the implementation, iterate with concurrency, and the ability to stop the iteration once we find that the bucket owner account exists (more details, [here](https://github.com/noobaa/noobaa-core/pull/7728#discussion_r1457403937)).

### Testing Instructions:
1. Manual tests are described in the issue mentioned above.
3. For running the unit test with the new tests, please run: `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`.


- [ ] Doc added/updated
- [X] Tests added
