### PR TITLE
Fix Eslint Errors

### DIFF
--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -86,12 +86,12 @@ function setup(options = {}) {
 
         nsfs_process.on('exit', (code, signal) => {
             dbg.error(`nsfs.js exited code=${code}, signal=${signal}`);
-            logStream.end()
+            logStream.end();
         });
 
         nsfs_process.on('error', err => {
             dbg.error(`nsfs.js exited with error`, err);
-            logStream.end()
+            logStream.end();
         });
 
         // TODO - run health

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -754,7 +754,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
                 assert.fail(`found account: ${deleted_account_exist} - account should be deleted`);
             } catch (err) {
                 if (process.env.NC_CORETEST) {
-                    assert.equal(JSON.parse(err.stdout).error.code, ManageCLIError.NoSuchAccountName.code)
+                    assert.equal(JSON.parse(err.stdout).error.code, ManageCLIError.NoSuchAccountName.code);
                 } else {
                     assert.equal(err.rpc_code, 'NO_SUCH_ACCOUNT');
                 }
@@ -794,7 +794,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
                 assert.fail(`found account: ${deleted_account_exist} - account should be deleted`);
             } catch (err) {
                 if (process.env.NC_CORETEST) {
-                    assert.equal(JSON.parse(err.stdout).error.code, ManageCLIError.NoSuchAccountName.code)
+                    assert.equal(JSON.parse(err.stdout).error.code, ManageCLIError.NoSuchAccountName.code);
                 } else {
                     assert.equal(err.rpc_code, 'NO_SUCH_ACCOUNT');
                 }

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -196,7 +196,7 @@ mocha.describe('bucketspace_fs', function() {
             const res = await bucketspace_fs.read_account_by_access_key({ access_key });
             assert.strictEqual(res.email.unwrap(), account_user2.email);
             assert.strictEqual(res.access_keys[0].access_key.unwrap(), account_user2.access_keys[0].access_key);
-            const distinguished_name = res.nsfs_account_config.distinguished_name.unwrap();;
+            const distinguished_name = res.nsfs_account_config.distinguished_name.unwrap();
             assert.strictEqual(distinguished_name, 'root');
             const res2 = await native_fs_utils.get_user_by_distinguished_name({ distinguished_name });
             assert.strictEqual(res2.uid, 0);
@@ -207,7 +207,7 @@ mocha.describe('bucketspace_fs', function() {
             const res = await bucketspace_fs.read_account_by_access_key({ access_key });
             assert.strictEqual(res.email.unwrap(), account_user3.email);
             assert.strictEqual(res.access_keys[0].access_key.unwrap(), account_user3.access_keys[0].access_key);
-            const distinguished_name = res.nsfs_account_config.distinguished_name.unwrap();;
+            const distinguished_name = res.nsfs_account_config.distinguished_name.unwrap();
             assert.strictEqual(distinguished_name, os.userInfo().username);
             const res2 = await native_fs_utils.get_user_by_distinguished_name({ distinguished_name });
             assert.strictEqual(res2.uid, process.getuid());


### PR DESCRIPTION
### Explain the changes
1. Fix eslint errors by running `eslint src --fix`.

### Issues: Fixed #xxx / Gap #xxx
1. GAP - the CI should have returned an error on those cases (and the job should have stopped with failure).

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
