### PR TITLE
NSFS | NC | Avoid vacuumAndAnalyze on nc nsfs without db

### DIFF
--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -9,6 +9,13 @@ const dbg = require('../util/debug_module')(__filename);
 if (!dbg.get_process_name()) dbg.set_process_name('nsfs');
 dbg.original_console();
 
+// NC nsfs deployments specifying process.env.LOCAL_MD_SERVER=true deployed together with a db
+// when a system_store object is initialized VaccumAnalyzer is being called once a day.
+// when NC nsfs deployed without db we would like to avoid running VaccumAnalyzer in any flow there is
+// because running it will cause a panic.
+if (process.env.LOCAL_MD_SERVER !== 'true') {
+    process.env.NC_NSFS_NO_DB_ENV = 'true';
+}
 const config = require('../../config');
 
 const os = require('os');
@@ -19,6 +26,7 @@ const minimist = require('minimist');
 if (process.env.LOCAL_MD_SERVER === 'true') {
     require('../server/system_services/system_store').get_instance({ standalone: true });
 }
+
 //const js_utils = require('../util/js_utils');
 const nb_native = require('../util/nb_native');
 //const schema_utils = require('../util/schema_utils');

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -187,7 +187,8 @@ async function main(options = {}) {
             await prom_reporting.start_server(metrics_port, false);
             dbg.log0('Started metrics server successfully');
         }
-
+        // TODO: currently NC NSFS deployments don't have internal_rpc_client nor db, 
+        // there for namespace monitor won't be registered
         if (internal_rpc_client && config.NAMESPACE_MONITOR_ENABLED) {
             endpoint_stats_collector.instance().set_rpc_client(internal_rpc_client);
 

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -603,7 +603,7 @@ class PostgresTable {
             this.client._ajv.addSchema(schema, name);
         }
 
-        if (!process.env.CORETEST) {
+        if (!process.env.CORETEST && !process.env.NC_NSFS_NO_DB_ENV) {
             // Run once a day
             // TODO: Configure from PostgreSQL
             setInterval(this.vacuumAndAnalyze, 86400000, this).unref();


### PR DESCRIPTION
### Explain the changes
1. Avoid vacuumAndAnalyze call on nc nsfs without db environment. (more places like sts_rest and namespace_montior calling system_store)

### Issues: Fixed #xxx / Gap #xxx
1. will fix https://github.com/noobaa/noobaa-core/issues/7735
2. make sts_rest and namespace_monitor work on nc nsfs without db.

### Testing Instructions:
1. manually change postgres_client.PostgresTable.constructor `setInterval(this.vacuumAndAnalyze, 86400000, this).unref();` to `setInterval(this.vacuumAndAnalyze, 1, this).unref();`
2. sudo  node src/cmd/nsfs.js


- [ ] Doc added/updated
- [ ] Tests added
