### PR TITLE
NSFS | NC | Health | add account uid gid can access new_buckets_path check

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -270,14 +270,17 @@ NOTE - health script execution requires root permissions.
     "accounts_status": {
       "invalid_accounts": [
         {
-          "name": "naveen",
+          "name": "account_invalid",
           "storage_path": "/tmp/nsfs_root_invalid/",
           "code": "STORAGE_NOT_EXIST"
-        }
+        },
+        { "name": "account_inaccessible",
+          "storage_path": "/tmp/account_inaccessible",
+          "code": "ACCESS_DENIED" } 
       ],
       "valid_accounts": [
         {
-          "name": "naveen",
+          "name": "account2",
           "storage_path": "/tmp/nsfs_root"
         }
       ],
@@ -401,11 +404,23 @@ These error codes will get attached with a specific Bucket or Account schema ins
 - Make sure the path mentioned in Bucket/Account schema is a valid directory path.
 - User has sufficient access.
 
-#### . `INVALID_CONFIG`
+#### 2. `INVALID_CONFIG`
 #### Reasons
 - Bucket/Account Schema JSON is not valid or not in JSON format.
 #### Resolutions
 - Check for any JSON syntax error in the schema structure for Bucket/Account.
+
+#### 3. `ACCESS_DENIED`
+#### Reasons
+- Account `new_buckets_path` is not accessible with account uid and gid.
+#### Resolutions
+- Check access restriction in the path mentioned in `new_buckets_path` and compare it with account uid and gid
+
+#### 4. `MISSING_CONFIG`
+#### Reasons
+- Account/Bucket schema config file is missing for config root.
+#### Resolutions
+- Check for schema config file in respective Accounts or Buckets dir.
 
 ## Bucket and Account Manage CLI
 Users can create, update, delete, and list buckets and accounts using CLI. If the config directory is missing CLI will create one and also create accounts and buckets sub-directories in it and default config directory is `${config.NSFS_NC_DEFAULT_CONF_DIR}`. 

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -385,7 +385,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                     if (list && list.objects && list.objects.length > 0) {
                         throw new RpcError('NOT_EMPTY', 'underlying directory has files in it');
                     }
-                    const bucket = await object_sdk.read_bucket_sdk_config_info(params.name)
+                    const bucket = await object_sdk.read_bucket_sdk_config_info(params.name);
                     const bucket_temp_dir_path = path.join(namespace_bucket_config.write_resource.path,
                             config.NSFS_TEMP_DIR_NAME + "_" + bucket._id);
                     await native_fs_utils.folder_delete(bucket_temp_dir_path, this.fs_context, true);

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -155,9 +155,9 @@ function make_dummy_object_sdk() {
         },
         read_bucket_sdk_config_info(name) {
             return {
-                _id : bucket_temp_id,
+                _id: bucket_temp_id,
                 name: name
-            }
+            };
         }
     };
 }

--- a/src/util/mongo_utils.js
+++ b/src/util/mongo_utils.js
@@ -169,7 +169,7 @@ function mongoObjectId() {
         // eslint-disable-next-line no-bitwise
         return (Math.random() * 16 | 0).toString(16);
     }).toLowerCase();
-};
+}
 
 // function is_err_duplicate_key(err) {
 //     return err && err.code === 11000;
@@ -249,4 +249,4 @@ exports.is_object_id = is_object_id;
 // exports.check_update_one = check_update_one;
 // exports.make_object_diff = make_object_diff;
 // exports.get_db_stats = get_db_stats;
-exports.mongoObjectId = mongoObjectId
+exports.mongoObjectId = mongoObjectId;

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -458,7 +458,7 @@ function validate_bucket_creation(params) {
  * @param {string} config_path
  * @param {boolean} use_lstat
  */
-async function is_path_exists(fs_context, config_path, use_lstat=false) {
+async function is_path_exists(fs_context, config_path, use_lstat = false) {
     try {
         await nb_native().fs.stat(fs_context, config_path, { use_lstat });
     } catch (err) {


### PR DESCRIPTION
### Explain the changes
1. Add check if an account can access its new_buckets_path during the run of the health script.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7715

### Testing Instructions:
1. Create a path that only root can access - for example - sudo mkdir /tmp/root_dir ; chmod 700 /tmp/root_dir/
2. Add an account having uid=200, gid=200, new_buckets_path = /tmp/root_dir/
3. Run health script - currently you won't see an error, after this bug is resolved - expect to see this issue reported.

- [X] Doc added/updated
- [X] Tests added
