### PR TITLE
NSFS | NC | Split The Error "Account config should not be empty"

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -719,6 +719,12 @@ async function validate_account_args(data, action) {
 
         if (is_undefined(data.access_keys[0].secret_key)) throw_cli_error(ManageCLIError.MissingAccountSecretKeyFlag);
         if (is_undefined(data.access_keys[0].access_key)) throw_cli_error(ManageCLIError.MissingAccountAccessKeyFlag);
+        if (data.nsfs_account_config.gid && (is_undefined(data.nsfs_account_config.uid))) {
+            throw_cli_error(ManageCLIError.MissingAccountNSFSConfigUID, data.nsfs_account_config);
+        }
+        if (data.nsfs_account_config.uid && (is_undefined(data.nsfs_account_config.gid))) {
+            throw_cli_error(ManageCLIError.MissingAccountNSFSConfigGID, data.nsfs_account_config);
+        }
         if ((is_undefined(data.nsfs_account_config.distinguished_name) &&
                 (data.nsfs_account_config.uid === undefined || data.nsfs_account_config.gid === undefined))) {
             throw_cli_error(ManageCLIError.InvalidAccountNSFSConfig, data.nsfs_account_config);

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -190,7 +190,19 @@ ManageCLIError.MissingIdentifier = Object.freeze({
 
 ManageCLIError.InvalidAccountNSFSConfig = Object.freeze({
     code: 'InvalidAccountNSFSConfig',
-    message: 'Account config should not be empty',
+    message: 'Account config should not be empty, should contain UID, GID or user',
+    http_code: 400,
+});
+
+ManageCLIError.MissingAccountNSFSConfigUID = Object.freeze({
+    code: 'MissingAccountNSFSConfigUID',
+    message: 'Account config should include UID',
+    http_code: 400,
+});
+
+ManageCLIError.MissingAccountNSFSConfigGID = Object.freeze({
+    code: 'MissingAccountNSFSConfigGID',
+    message: 'Account config should include GID',
     http_code: 400,
 });
 

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -448,6 +448,26 @@ mocha.describe('manage_nsfs cli', function() {
             }
         });
 
+        mocha.it('cli account create - no uid - should fail', async function() {
+            const action = nc_nsfs_manage_actions.ADD;
+            try {
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla' ,gid: 1001});
+                assert.fail('should have failed with account config should include UID');
+            } catch (err) {
+                assert_error(err, ManageCLIError.MissingAccountNSFSConfigUID);
+            }
+        });
+
+        mocha.it('cli account create - no gid - should fail', async function() {
+            const action = nc_nsfs_manage_actions.ADD;
+            try {
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla' ,uid: 1001});
+                assert.fail('should have failed with account config should include GID');
+            } catch (err) {
+                assert_error(err, ManageCLIError.MissingAccountNSFSConfigGID);
+            }
+        });
+
         mocha.it('cli account create - new_buckets_path does not exist - should fail', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             try {


### PR DESCRIPTION
### Explain the changes
1. Split the error `Account config should not be empty`.

### Issues: Fixed #7651
1. Currently the error `Account config should not be empty` is not indicative enough.

### Testing Instructions:
1. Manual tests: create account without gid, uid, user, examples:
- `sudo node src/cmd/manage_nsfs account add --name <account-name> --email <email> --new_buckets_path <path>` (without any configurations)
- `sudo node src/cmd/manage_nsfs account add --name <account-name> --email <email> --new_buckets_path <path> --uid <uid>` (without gid)
- `sudo node src/cmd/manage_nsfs account add --name <account-name> --email <email> --new_buckets_path <path> --gid <gid>` (without uid)
2. For running the unit test with the new test, please run: `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`.

- [ ] Doc added/updated
- [X] Tests added
