### PR TITLE
NSFS | NC | Validate Options in Manage NSFS (CLI)

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -62,16 +62,25 @@ ManageCLIError.InvalidAction = Object.freeze({
     message: 'Invalid action, available actions are add, status, update, delete, list',
     http_code: 400,
 });
-ManageCLIError.InvalidConfigType = Object.freeze({
-    code: 'InvalidConfigType',
-    message: 'Invalid config type, available config types are account, bucket or whitelist',
+
+ManageCLIError.InvalidArgument = Object.freeze({
+    code: 'InvalidArgument',
+    message: 'Invalid argument',
     http_code: 400,
 });
+
+ManageCLIError.InvalidType = Object.freeze({
+    code: 'InvalidType',
+    message: 'Invalid type, available types are account, bucket or whitelist',
+    http_code: 400,
+});
+
 ManageCLIError.MissingConfigDirPath = Object.freeze({
     code: 'MissingConfigDirPath',
     message: 'Config dir path should not be empty',
     http_code: 400,
 });
+
 ManageCLIError.InvalidSchema = Object.freeze({
     code: 'InvalidSchema',
     message: 'Schema invalid, please use required properties',

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -15,6 +15,34 @@ const ACTIONS = {
     STATUS: 'status'
 };
 
+const GLOBAL_CONFIG_ROOT = 'config_root';
+const GLOBAL_CONFIG_OPTIONS = new Set(['from_file', GLOBAL_CONFIG_ROOT, 'config_root_backend']);
+
+const VALID_OPTIONS_ACCOUNT = {
+    'add': new Set(['name', 'email', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'email', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
+    'delete': new Set(['name', 'access_key', GLOBAL_CONFIG_ROOT]),
+    'list': new Set(['wide', 'show_secrets', GLOBAL_CONFIG_ROOT, 'gid', 'uid', 'user']),
+    'status': new Set(['name', 'access_key', 'show_secrets', GLOBAL_CONFIG_ROOT]),
+};
+
+const VALID_OPTIONS_BUCKET = {
+    'add': new Set(['name', 'email', 'path', 'bucket_policy', 'fs_backend', ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'email', 'path', 'bucket_policy', 'fs_backend', 'new_name', ...GLOBAL_CONFIG_OPTIONS]),
+    'delete': new Set(['name', GLOBAL_CONFIG_ROOT]),
+    'list': new Set(['wide', GLOBAL_CONFIG_ROOT]),
+    'status': new Set(['name', GLOBAL_CONFIG_ROOT]),
+};
+
+const VALID_OPTIONS_WHITELIST = new Set(['ips', GLOBAL_CONFIG_ROOT]);
+
+const VALID_OPTIONS = {
+    account_options: VALID_OPTIONS_ACCOUNT,
+    bucket_options: VALID_OPTIONS_BUCKET,
+    whitelist_options: VALID_OPTIONS_WHITELIST,
+};
+
 // EXPORTS
 exports.TYPES = TYPES;
 exports.ACTIONS = ACTIONS;
+exports.VALID_OPTIONS = VALID_OPTIONS;

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -50,7 +50,12 @@ set the general configuration to allow only incoming requests from a given list 
     --ips <ips>                       (default none)          Set whitelist ips in format: '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]'.
 `;
 
-const OPTIONS_GLOBAL = `
+const GLOBAL_CONFIG_ROOT_ALL = `
+    # global configurations
+    --config_root <dir>                             (default config.NSFS_NC_DEFAULT_CONF_DIR)   Use Configuration files path.
+`;
+
+const GLOBAL_CONFIG_OPTIONS_ADD_UPDATE = `
     # global configurations
     --from_file <dir>                                         (default none)                                  Use details from the JSON file, there is no need to mention all the properties individually in the CLI.
     --config_root <dir>                                       (default config.NSFS_NC_DEFAULT_CONF_DIR)       Use Configuration files path.
@@ -82,7 +87,8 @@ account update [options...]:
     update an existing account
 
     # required
-    --name <name>                                                                               The name of the account.
+    --name <name>                                                                               The name of the account
+                                                                                                (can identify the account by --access_key option)
 
     # optional
     --new_name <name>                               (default none)                              Update the account name.
@@ -92,7 +98,7 @@ account update [options...]:
     --new_buckets_path <dir>                        (default none)                              Update the filesystem's root where each subdirectory is a bucket.
     --user <user-name>                              (default none)                              Update the OS user name (instead of uid and gid).
     --regenerate                                    (default none)                              Update automatically generated access key and secret key.
-    --access_key <key>                              (default none)                              Update the access key.
+    --access_key <key>                              (default none)                              Update the access key. Can be used as identifier instead of --name.
     --secret_key <key>                              (default none)                              Update the secret key.
     --fs_backend <none | GPFS | CEPH_FS | NFSv4>    (default config.NSFS_NC_STORAGE_BACKEND)    Update filesystem type of new_buckets_path.
 `;
@@ -104,6 +110,7 @@ account delete [options...]:
 
     # required
     --name <name>                                                                               The name of the account.
+                                                                                                (can identify the account by --access_key option)
 `;
 
 const ACCOUNT_OPTIONS_STATUS = `
@@ -114,6 +121,7 @@ account status [options...]:
 
     # required
     --name <name>                                                                               The name of the account.
+                                                                                                (can identify the account by --access_key option)
 
     # optional
     --show_secrets                                  (default false)                             Print the access key and secret key of the account.
@@ -217,22 +225,24 @@ function print_help_options(type, action) {
 function print_help_account(action) {
     switch (action) {
         case ACTIONS.ADD:
-            process.stdout.write(ACCOUNT_OPTIONS_ADD.trimStart() + OPTIONS_GLOBAL + '\n');
-            break;
+            process.stdout.write(ACCOUNT_OPTIONS_ADD.trimStart() +
+                GLOBAL_CONFIG_OPTIONS_ADD_UPDATE + '\n');
+        break;
         case ACTIONS.UPDATE:
-            process.stdout.write(ACCOUNT_OPTIONS_UPDATE.trimStart() + OPTIONS_GLOBAL + '\n');
-            break;
+            process.stdout.write(ACCOUNT_OPTIONS_UPDATE.trimStart() +
+                GLOBAL_CONFIG_OPTIONS_ADD_UPDATE + '\n');
+        break;
         case ACTIONS.DELETE:
-            process.stdout.write(ACCOUNT_OPTIONS_DELETE.trimStart() + '\n');
+            process.stdout.write(ACCOUNT_OPTIONS_DELETE.trimStart() + GLOBAL_CONFIG_ROOT_ALL + '\n');
             break;
         case ACTIONS.STATUS:
-            process.stdout.write(ACCOUNT_OPTIONS_STATUS.trimStart() + '\n');
+            process.stdout.write(ACCOUNT_OPTIONS_STATUS.trimStart() + GLOBAL_CONFIG_ROOT_ALL + '\n');
             break;
         case ACTIONS.LIST:
-            process.stdout.write(ACCOUNT_OPTIONS_LIST.trimStart() + '\n');
+            process.stdout.write(ACCOUNT_OPTIONS_LIST.trimStart() + GLOBAL_CONFIG_ROOT_ALL + '\n');
             break;
         default:
-            process.stdout.write(ARGUMENTS_ACCOUNT.trimStart() + '\n');
+            process.stdout.write(ARGUMENTS_ACCOUNT.trimStart() + GLOBAL_CONFIG_ROOT_ALL + '\n');
     }
     process.exit(0);
 }
@@ -243,22 +253,24 @@ function print_help_account(action) {
 function print_help_bucket(action) {
     switch (action) {
         case ACTIONS.ADD:
-            process.stdout.write(BUCKET_OPTIONS_ADD.trimStart() + OPTIONS_GLOBAL + '\n');
+            process.stdout.write(BUCKET_OPTIONS_ADD.trimStart() +
+                GLOBAL_CONFIG_OPTIONS_ADD_UPDATE + '\n');
             break;
         case ACTIONS.UPDATE:
-            process.stdout.write(BUCKET_OPTIONS_UPDATE.trimStart() + OPTIONS_GLOBAL + '\n');
+            process.stdout.write(BUCKET_OPTIONS_UPDATE.trimStart() +
+                GLOBAL_CONFIG_OPTIONS_ADD_UPDATE + '\n');
             break;
         case ACTIONS.DELETE:
-            process.stdout.write(BUCKET_OPTIONS_DELETE.trimStart() + '\n');
+            process.stdout.write(BUCKET_OPTIONS_DELETE.trimStart() + GLOBAL_CONFIG_ROOT_ALL + '\n');
             break;
         case ACTIONS.STATUS:
-            process.stdout.write(BUCKET_OPTIONS_STATUS.trimStart() + '\n');
+            process.stdout.write(BUCKET_OPTIONS_STATUS.trimStart() + GLOBAL_CONFIG_ROOT_ALL + '\n');
             break;
         case ACTIONS.LIST:
-            process.stdout.write(BUCKET_OPTIONS_LIST.trimStart() + '\n');
+            process.stdout.write(BUCKET_OPTIONS_LIST.trimStart() + GLOBAL_CONFIG_ROOT_ALL + '\n');
             break;
         default:
-            process.stdout.write(ARGUMENTS_BUCKET.trimStart() + '\n');
+            process.stdout.write(ARGUMENTS_BUCKET.trimStart() + GLOBAL_CONFIG_ROOT_ALL + '\n');
     }
     process.exit(0);
 }

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -146,14 +146,21 @@ describe('manage nsfs cli account flow', () => {
             assert_account(account_symlink, account_options);
         });
 
+        it('should fail - cli create account invalid option', async () => {
+            const { type, name, email, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, name, email, new_buckets_path, uid, gid, lala: 'lala'}; // lala invalid option
+            const action = nc_nsfs_manage_actions.ADD;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
+        });
+
     });
 
     describe('cli update account', () => {
         const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs1');
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs1/');
+        const type = 'account';
         const defaults = {
-            _id: 'account1',
-            type: 'account',
             name: 'account1',
             email: 'account1@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user1/`,
@@ -167,9 +174,8 @@ describe('manage nsfs cli account flow', () => {
             await P.all(_.map([accounts_schema_dir, access_keys_schema_dir], async dir =>
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
-            // Creating the account
             const action = nc_nsfs_manage_actions.ADD;
-            const { type, new_buckets_path } = defaults;
+            const { new_buckets_path } = defaults;
             const account_options = { config_root, ...defaults };
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
@@ -182,7 +188,7 @@ describe('manage nsfs cli account flow', () => {
         });
 
         it('cli regenerate account access_keys', async () => {
-            const { type, name } = defaults;
+            const { name } = defaults;
             const account_options = { config_root, name, regenerate: true };
             const account_details = await read_config_file(config_root, accounts_schema_dir, name);
             const action = nc_nsfs_manage_actions.UPDATE;
@@ -197,7 +203,7 @@ describe('manage nsfs cli account flow', () => {
         });
 
         it('cli account update name by name', async function() {
-            const { type, name } = defaults;
+            const { name } = defaults;
             const new_name = 'account1_new_name';
             const account_options = { config_root, name, new_name };
             const action = nc_nsfs_manage_actions.UPDATE;
@@ -213,7 +219,7 @@ describe('manage nsfs cli account flow', () => {
         });
 
         it('cli account update access key, secret_key & new_name by name', async function() {
-            const { type, name } = defaults;
+            const { name } = defaults;
             const new_name = 'account1_new_name';
             const access_key = 'GIGiFAnjaaE7OKD5N7hB';
             const secret_key = 'U3AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
@@ -234,7 +240,7 @@ describe('manage nsfs cli account flow', () => {
         });
 
         it('cli update account access_key and secret_key using flags', async () => {
-            const { type, name } = defaults;
+            const { name } = defaults;
             const access_key = 'GIGiFAnjaaE7OKD5N7hB';
             const secret_key = 'U3AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
             const account_options = { config_root, name, access_key, secret_key };
@@ -251,14 +257,21 @@ describe('manage nsfs cli account flow', () => {
             assert_account(account_symlink, new_account_details);
         });
 
+        it('should fail - cli update account invalid option', async () => {
+            const { name } = defaults;
+            const account_options = { config_root, name, lala: 'lala'}; // lala invalid option
+            const action = nc_nsfs_manage_actions.UPDATE;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
+        });
+
     });
 
     describe('cli list account', () => {
         const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs1');
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs1/');
+        const type = 'account';
         const defaults = [{
-            _id: 'account1',
-            type: 'account',
             name: 'account1',
             email: 'account1@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user1/`,
@@ -267,8 +280,6 @@ describe('manage nsfs cli account flow', () => {
             access_key: 'GIGiFAnjaaE7OKD5N7hA',
             secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
         }, {
-            _id: 'account1',
-            type: 'account',
             name: 'account2',
             email: 'account2@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user2/`,
@@ -277,8 +288,6 @@ describe('manage nsfs cli account flow', () => {
             access_key: 'BIBiFAnjaaE7OKD5N7hA',
             secret_key: 'BIBYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
         }, {
-            _id: 'account1',
-            type: 'account',
             name: 'account3',
             email: 'account3@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user2/`,
@@ -295,8 +304,8 @@ describe('manage nsfs cli account flow', () => {
             // Creating the account
             const action = nc_nsfs_manage_actions.ADD;
             for (const account_defaults of Object.values(defaults)) {
-                const { type, new_buckets_path } = account_defaults;
-                const account_options = { config_root, ...account_defaults };
+                const { new_buckets_path, name, email, uid, gid, access_key, secret_key } = account_defaults;
+                const account_options = { config_root, name, email, uid, gid, access_key, secret_key };
                 await fs_utils.create_fresh_path(new_buckets_path);
                 await fs_utils.file_must_exist(new_buckets_path);
                 await exec_manage_cli(type, action, account_options);
@@ -311,7 +320,7 @@ describe('manage nsfs cli account flow', () => {
         it('cli list', async () => {
             const account_options = { config_root };
             const action = nc_nsfs_manage_actions.LIST;
-            const res = await exec_manage_cli('account', action, account_options);
+            const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account3', 'account2', 'account1']));
         });
@@ -319,7 +328,7 @@ describe('manage nsfs cli account flow', () => {
         it('cli list wide', async () => {
             const account_options = { config_root, wide: true };
             const action = nc_nsfs_manage_actions.LIST;
-            const res = await exec_manage_cli('account', action, account_options);
+            const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account3', 'account2', 'account1']));
         });
@@ -327,7 +336,7 @@ describe('manage nsfs cli account flow', () => {
         it('cli list filter by UID', async () => {
             const account_options = { config_root, uid: 999 };
             const action = nc_nsfs_manage_actions.LIST;
-            const res = await exec_manage_cli('account', action, account_options);
+            const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account3', 'account1']));
         });
@@ -335,7 +344,7 @@ describe('manage nsfs cli account flow', () => {
         it('cli list filter by GID', async () => {
             const account_options = { config_root, gid: 999 };
             const action = nc_nsfs_manage_actions.LIST;
-            const res = await exec_manage_cli('account', action, account_options);
+            const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account1']));
         });
@@ -343,7 +352,7 @@ describe('manage nsfs cli account flow', () => {
         it('cli list filter by UID and GID (account 1)', async () => {
             const account_options = { config_root, uid: 999, gid: 999 };
             const action = nc_nsfs_manage_actions.LIST;
-            const res = await exec_manage_cli('account', action, account_options);
+            const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account1']));
         });
@@ -351,16 +360,18 @@ describe('manage nsfs cli account flow', () => {
         it('cli list filter by UID and GID (account 3)', async () => {
             const account_options = { config_root, uid: 999, gid: 888 };
             const action = nc_nsfs_manage_actions.LIST;
-            const res = await exec_manage_cli('account', action, account_options);
+            const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account3']));
         });
 
-        it('cli account status without name and access_key', async function() {
-            const action = nc_nsfs_manage_actions.STATUS;
-                const res = await exec_manage_cli('account', action, { config_root });
-                expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingIdentifier.code);
+        it('should fail - cli list account invalid option', async () => {
+            const account_options = { config_root, lala: 'lala'}; // lala invalid option
+            const action = nc_nsfs_manage_actions.LIST;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
         });
+
     });
 
     describe('cli delete account', () => {
@@ -405,7 +416,6 @@ describe('manage nsfs cli account flow', () => {
 
             // cli delete account
             const action = nc_nsfs_manage_actions.DELETE;
-            // @ts-ignore
             const { type, name } = defaults;
             const account_options = { config_root, name };
             const res = await exec_manage_cli(type, action, account_options);
@@ -431,13 +441,67 @@ describe('manage nsfs cli account flow', () => {
             // cli delete account
             type = 'account';
             action = nc_nsfs_manage_actions.DELETE;
-            // @ts-ignore
             const { name } = defaults;
             const account_options = { config_root, name };
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.AccountDeleteForbiddenHasBuckets.code);
             config_path = path.join(config_root, accounts_schema_dir, name + '.json');
             await fs_utils.file_must_exist(config_path);
+        });
+
+        it('should fail - cli delete account invalid option', async () => {
+            const action = nc_nsfs_manage_actions.DELETE;
+            const { type, name } = defaults;
+            const account_options = { config_root, name, lala: 'lala'}; // lala invalid option };
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
+        });
+
+    });
+
+    describe('cli status account', () => {
+        const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs22');
+        const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs22/');
+        const type = 'account';
+        const defaults = {
+            name: 'account22',
+            email: 'account22@noobaa.io',
+            new_buckets_path: `${root_path}new_buckets_path_user22/`,
+            uid: 1022,
+            gid: 1022,
+            access_key: 'GIGiFAnjaaE7OKD5N722',
+            secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+22EXAMPLE',
+        };
+
+        beforeEach(async () => {
+            await P.all(_.map([accounts_schema_dir, access_keys_schema_dir], async dir =>
+                fs_utils.create_fresh_path(`${config_root}/${dir}`)));
+            await fs_utils.create_fresh_path(root_path);
+            const action = nc_nsfs_manage_actions.ADD;
+            const { new_buckets_path } = defaults;
+            const account_options = { config_root, ...defaults };
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            await exec_manage_cli(type, action, account_options);
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('cli account status without name and access_key', async function() {
+            const action = nc_nsfs_manage_actions.STATUS;
+            const res = await exec_manage_cli(type, action, { config_root });
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingIdentifier.code);
+        });
+
+        it('should fail - cli status account invalid option', async () => {
+            const action = nc_nsfs_manage_actions.STATUS;
+            const { name } = defaults;
+            const account_options = { config_root, name, lala: 'lala'}; // lala invalid option };
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
         });
 
     });

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -37,7 +37,7 @@ const nc_nsfs_manage_actions = {
 };
 
 // eslint-disable-next-line max-lines-per-function
-describe('manage nsfs cli account flow', () => {
+describe('manage nsfs cli bucket flow', () => {
     const buckets_schema_dir = 'buckets';
 
     describe('cli delete bucket', () => {
@@ -46,8 +46,6 @@ describe('manage nsfs cli account flow', () => {
         bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs2', 'bucket1');
 
         const account_defaults = {
-            _id: '65a9fbe7ab49fd2fe430bc3f',
-            type: 'account',
             name: 'account_test',
             email: 'account1@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user1/`,
@@ -55,20 +53,12 @@ describe('manage nsfs cli account flow', () => {
             gid: 999,
             access_key: 'GIGiFAnjaaE7OKD5N7hX',
             secret_key: 'G2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
-            creation_date: '2024-01-19T04:34:47.273Z',
         };
 
         const bucket_defaults = {
-            type: 'bucket',
             name: 'bucket1',
-            tag:'',
-            owner_account: 'account_test',
-            system_owner: 'account1@noobaa.io',
-            bucket_owner: 'account1@noobaa.io',
             email: 'account1@noobaa.io',
             path: bucket_storage_path,
-            should_create_underlying_storage: true,
-            creation_date: '2024-01-19T04:34:47.273Z',
         };
 
         beforeEach(async () => {
@@ -78,18 +68,18 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.create_fresh_path(bucket_storage_path);
             const action = nc_nsfs_manage_actions.ADD;
             // Account add
-            const { type: account_type, new_buckets_path: account_path } = account_defaults;
+            const { new_buckets_path: account_path } = account_defaults;
             const account_options = { config_root, ...account_defaults };
             await fs_utils.create_fresh_path(account_path);
             await fs_utils.file_must_exist(account_path);
-            await exec_manage_cli(account_type, action, account_options);
+            await exec_manage_cli('account', action, account_options);
 
             //bucket add
-            const { type: bucket_type, path: bucket_path } = bucket_defaults;
+            const { path: bucket_path } = bucket_defaults;
             const bucket_options = { config_root, ...bucket_defaults };
             await fs_utils.create_fresh_path(bucket_path);
             await fs_utils.file_must_exist(bucket_path);
-            const resp = await exec_manage_cli(bucket_type, action, bucket_options);
+            const resp = await exec_manage_cli('bucket', action, bucket_options);
             const bucket_resp = JSON.parse(resp);
             expect(bucket_resp.response.reply._id).not.toBeNull();
             //create temp dir
@@ -107,14 +97,14 @@ describe('manage nsfs cli account flow', () => {
         it('cli delete bucket and delete temp dir', async () => {
             let is_path_exists = await native_fs_utils.is_path_exists(DEFAULT_FS_CONFIG, bucket_temp_dir_path);
             expect(is_path_exists).toBe(true);
-            const account_options = { config_root, name: 'bucket1'};
+            const bucket_options = { config_root, name: 'bucket1'};
             const action = nc_nsfs_manage_actions.DELETE;
-            await exec_manage_cli('bucket', action, account_options);
+            await exec_manage_cli('bucket', action, bucket_options);
             is_path_exists = await native_fs_utils.is_path_exists(DEFAULT_FS_CONFIG, bucket_temp_dir_path);
             expect(is_path_exists).toBe(false);
         });
     });
-})
+});
 
 /**
  * exec_manage_cli will get the flags for the cli and runs the cli with it's flags

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -152,12 +152,34 @@ mocha.describe('manage_nsfs cli', function() {
             await assert_config_file_permissions(config_root, schema_dir, name);
         });
 
+        mocha.it('cli bucket create - should fail invalid option', async function() {
+            const action = nc_nsfs_manage_actions.ADD;
+            const bucket_options_with_invalid_option = {...bucket_options, lala: 'lala'}; // lala invalid option
+            try {
+                add_res = await exec_manage_cli(type, action, bucket_options_with_invalid_option);
+                assert.fail('should have failed with invalid option');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidArgument);
+            }
+        });
+
         mocha.it('cli bucket status', async function() {
             const action = nc_nsfs_manage_actions.STATUS;
             const bucket_status = await exec_manage_cli(type, action, { config_root, name });
             assert_response(action, type, bucket_status, bucket_options);
             const bucket = await read_config_file(config_root, schema_dir, name);
             assert_bucket(bucket, bucket_options);
+        });
+
+        mocha.it('cli bucket status - should fail invalid option', async function() {
+            const action = nc_nsfs_manage_actions.STATUS;
+            const bucket_options_with_invalid_option = {...bucket_options, lala: 'lala'}; // lala invalid option
+            try {
+                add_res = await exec_manage_cli(type, action, bucket_options_with_invalid_option);
+                assert.fail('should have failed with invalid option');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidArgument);
+            }
         });
 
         mocha.it('cli bucket status - bucket does not exist - should fail', async function() {
@@ -182,6 +204,17 @@ mocha.describe('manage_nsfs cli', function() {
             const bucket_list = await exec_manage_cli(type, action, { config_root, wide: true });
             const expected_list = [bucket_options, bucket_with_policy_options];
             assert_response(action, type, bucket_list, expected_list, undefined, true);
+        });
+
+        mocha.it('cli bucket list - should fail invalid option', async function() {
+            const action = nc_nsfs_manage_actions.LIST;
+            const bucket_options_with_invalid_option = {config_root, lala: 'lala'}; // lala invalid option
+            try {
+                add_res = await exec_manage_cli(type, action, bucket_options_with_invalid_option);
+                assert.fail('should have failed with invalid option');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidArgument);
+            }
         });
 
         mocha.it('cli bucket create - should fail on already exists', async function() {
@@ -211,6 +244,17 @@ mocha.describe('manage_nsfs cli', function() {
                 assert.fail('should have failed with invalid bucket name');
             } catch (err) {
                 assert_error(err, ManageCLIError.InvalidBucketName);
+            }
+        });
+
+        mocha.it('cli bucket update - should fail invalid option', async function() {
+            const action = nc_nsfs_manage_actions.UPDATE;
+            const bucket_options_with_invalid_option = { config_root, name, lala: 'lala'}; // lala invalid option
+            try {
+                add_res = await exec_manage_cli(type, action, bucket_options_with_invalid_option);
+                assert.fail('should have failed with invalid option');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidArgument);
             }
         });
 
@@ -292,6 +336,17 @@ mocha.describe('manage_nsfs cli', function() {
             }
         });
 
+        mocha.it('cli bucket delete - should fail invalid option', async function() {
+            const action = nc_nsfs_manage_actions.UPDATE;
+            const bucket_options_with_invalid_option = { config_root, name, lala: 'lala'}; // lala invalid option
+            try {
+                add_res = await exec_manage_cli(type, action, bucket_options_with_invalid_option);
+                assert.fail('should have failed with invalid option');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidArgument);
+            }
+        });
+
         mocha.it('cli bucket create on GPFS', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             const bucket_status = await exec_manage_cli(type, action, gpfs_bucket_options);
@@ -303,7 +358,7 @@ mocha.describe('manage_nsfs cli', function() {
 
         mocha.it('cli bucket update owner', async function() {
             const action = nc_nsfs_manage_actions.UPDATE;
-            gpfs_bucket_options.owner_email = 'user2@noobaa.io';
+            gpfs_bucket_options.email = 'user2@noobaa.io';
             const bucket_status = await exec_manage_cli(type, action, gpfs_bucket_options);
             assert_response(action, type, bucket_status, gpfs_bucket_options);
             const bucket = await read_config_file(config_root, schema_dir, gpfs_bucket_options.name);
@@ -369,7 +424,7 @@ mocha.describe('manage_nsfs cli', function() {
                 await exec_manage_cli(type, action, { config_root });
                 assert.fail('should have failed with invalid type');
             } catch (err) {
-                assert_error(err, ManageCLIError.InvalidConfigType);
+                assert_error(err, ManageCLIError.InvalidType);
             }
         });
 
@@ -451,7 +506,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - no uid - should fail', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             try {
-                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla' ,gid: 1001});
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla', gid: 1001});
                 assert.fail('should have failed with account config should include UID');
             } catch (err) {
                 assert_error(err, ManageCLIError.MissingAccountNSFSConfigUID);
@@ -461,7 +516,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - no gid - should fail', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             try {
-                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla' ,uid: 1001});
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla', uid: 1001});
                 assert.fail('should have failed with account config should include GID');
             } catch (err) {
                 assert_error(err, ManageCLIError.MissingAccountNSFSConfigGID);
@@ -622,15 +677,18 @@ mocha.describe('manage_nsfs cli', function() {
     mocha.describe('cli account flow - updates', async function() {
         this.timeout(50000); // eslint-disable-line no-invalid-this
         const type = nc_nsfs_manage_entity_types.ACCOUNT;
-        const name = 'account1';
+        const name1 = 'account1';
+        const name2 = 'account2';
         const email = 'account1@noobaa.io';
         const new_buckets_path = `${root_path}new_buckets_path_user1/`;
         const uid = 999;
         const gid = 999;
         const access_key = 'GIGiFAnjaaE7OKD5N7hA';
         const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFR';
-        const account1_options = { config_root, name, email, new_buckets_path, uid, gid, access_key, secret_key };
+        const account1_options = { config_root, name: name1, email, new_buckets_path, uid, gid, access_key, secret_key };
+        const account1_options_for_delete = { config_root, name: name1 };
         const account2_options = { config_root, name: 'account2', email, new_buckets_path, uid, gid, access_key: 'BISiDSnjaaE7OKD5N7hB', secret_key };
+        const account2_options_for_delete = { config_root, name: name2 };
         mocha.before(async () => {
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
@@ -641,8 +699,8 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.after(async () => {
             await fs_utils.folder_delete(new_buckets_path);
             const action = nc_nsfs_manage_actions.DELETE;
-            await exec_manage_cli(type, action, account1_options);
-            await exec_manage_cli(type, action, account2_options);
+            await exec_manage_cli(type, action, account1_options_for_delete);
+            await exec_manage_cli(type, action, account2_options_for_delete);
         });
 
         mocha.it('cli account2 update - new_name already exists', async function() {
@@ -809,6 +867,20 @@ mocha.describe('manage_nsfs cli', function() {
                 assert.fail('should have failed with whitelist ips with invalid ip address');
             } catch (err) {
                 assert_error(err, ManageCLIError.InvalidWhiteListIPFormat);
+            }
+        });
+
+        mocha.it('cli whitelist with invalid option', async function() {
+            const ips = ['127.0.0.1']; // IPV4 format
+            try {
+                await exec_manage_cli(type, '', {
+                    config_root,
+                    ips: JSON.stringify(ips),
+                    lala: 'lala', // lala invalid option
+                });
+                assert.fail('should have failed with invalid option');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidArgument);
             }
         });
     });


### PR DESCRIPTION
### Explain the changes
1. Validate options in manage NSFS (CLI).
2. Rename `InvalidConfigType` to `InvalidType`.
3. Update the help menu to print the `root_config` global config for every action in bucket and account, and add a clarification that an account can be identified by `access_key` (in addition to `name`).
4. Update the tests that would not pass irrelevant options.

### Issues: Fixed #7647
1. Currently we don't check if the user passed options that we don't use (we ignored them), with this fix, we would return an error.

### Testing Instructions:
1. For manual tests add an invalid option, for example `--lala lala` for each command, examples:
- `sudo node src/cmd/manage_nsfs account add --name <account-name> --email <email> --new_buckets_path <path>  --uid <uid> --gid <gid> --lala lala`
- `sudo node src/cmd/manage_nsfs bucket add --name <bucket-name> --email <email> --path <path> --lala lala`
- `sudo node src/cmd/manage_nsfs bucket status --name <bucket-name> --lala lala`
- `sudo node src/cmd/manage_nsfs whitelist  --ips '["127.0.0.1"]' --lala lala`
2. For running the unit tests with the new test, please run:
- `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`.
- `sudo npx jest test_nc_nsfs_account_cli.test.js`.

- [ ] Doc added/updated
- [X] Tests added
