### PR TITLE
NSFS | NC | Health | Account without new_buckets_path

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -338,6 +338,8 @@ NOTE - health script execution requires root permissions.
 
 In this health output, `bucket2`'s storage path is invalid and the directory mentioned in `new_buckets_path` for `user1` is missing or not accessible. Endpoint curl command returns an error response(`"endpoint_response":404`) if one or more buckets point to an invalid bucket storage path.
 
+Account without `new_buckets_path` and `allow_bucket_creation` value is `false` then it's considered a valid account, But if the `allow_bucket_creation` is true, in that case account is invalid. 
+ 
 ### Health Error Codes
 These are the error codes populated in the health output if the system is facing some issues. If any of these error codes are present in health status then the overall status will be in `NOTOK` state.
 #### 1. `NOOBAA_NSFS_SERVICE_FAILED`

--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -186,7 +186,7 @@ class NSFSHealth {
           }
         }
       });
-    } catch (err) {
+    } catch(err) {
       console.log('Error while pinging endpoint host :' + HOSTNAME + ', port ' + this.https_port, err);
       return {
         response: fork_response_code.NOT_RUNNING.response_code,
@@ -363,36 +363,14 @@ async get_storage_status(config_root, type, all_details) {
           code: health_errors.INVALID_CONFIG.error_code,
         };
       }
-      invalid_storages.push(invalid_storage);
-      continue;
     }
     let storage_path;
     try {
       storage_path = type === 'bucket' ? config_data.path : config_data.nsfs_account_config.new_buckets_path;
+      // check for access in account new_buckets_path dir
       if (type === 'account') {
-        // account is invalid when allow_bucket_creation is true and new_buckets_path is missing, 
-        // else account is considered a valid account that can not create a bucket.
-        if (!storage_path) {
-          if (config_data.allow_bucket_creation) {
-            invalid_storage = {
-              name: config_data.name,
-              storage_path: storage_path,
-              code: health_errors.STORAGE_NOT_EXIST.error_code,
-            };
-            invalid_storages.push(invalid_storage);
-            continue;
-          } else {
-            const valid_storage = {
-              name: config_data.name,
-              storage_path: storage_path,
-            };
-            valid_storages.push(valid_storage);
-            continue;
-          }
-        }
-        // check for access in account new_buckets_path dir
-        await nb_native().fs.checkAccess(this.get_account_fs_context(config_data.nsfs_account_config.uid,
-          config_data.nsfs_account_config.gid), storage_path);
+          await nb_native().fs.checkAccess(this.get_account_fs_context(config_data.nsfs_account_config.uid,
+            config_data.nsfs_account_config.gid), storage_path);
       }
       const dir_stat = await nb_native().fs.stat(fs_context, storage_path);
       if (dir_stat && all_details) {

--- a/src/test/unit_tests/test_nc_nsfs_health.js
+++ b/src/test/unit_tests/test_nc_nsfs_health.js
@@ -276,6 +276,45 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].code, "ACCESS_DENIED");
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].name, account_inaccessible.name);
         });
+
+        mocha.it('Account with new_buckets_path missing and allow_bucket_creation false, valid accoount', async function() {
+            const account_valid = { name: 'account_valid', nsfs_account_config: { uid: 999, gid: 999 }, allow_bucket_creation: false };
+            await write_config_file(config_root, accounts_schema_dir, account_valid.name, account_valid);
+            Health.get_service_state.restore();
+            Health.get_endpoint_response.restore();
+            Health.all_account_details = true;
+            Health.all_bucket_details = false;
+            const get_service_state = sinon.stub(Health, "get_service_state");
+            get_service_state.onFirstCall().returns(Promise.resolve({ service_status: 'active', pid: 1000 }))
+                .onSecondCall().returns(Promise.resolve({ service_status: 'active', pid: 2000 }));
+            const get_endpoint_response = sinon.stub(Health, "get_endpoint_response");
+            get_endpoint_response.onFirstCall().returns(Promise.resolve({response: {response_code: 'RUNNING', total_fork_count: 0}}));
+            const health_status = await Health.nc_nsfs_health();
+            assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 2);
+            assert.strictEqual(health_status.checks.accounts_status.valid_accounts[1].name, 'account_valid');
+            assert.strictEqual(health_status.checks.accounts_status.valid_accounts[1].storage_path, undefined);
+            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 1);
+        });
+
+        mocha.it('Account with new_buckets_path missing and allow_bucket_creation true, invalid accoount', async function() {
+            const account_invalid = { name: 'account_invalid', nsfs_account_config: { uid: 999, gid: 999 }, allow_bucket_creation: true };
+            await write_config_file(config_root, accounts_schema_dir, account_invalid.name, account_invalid);
+            Health.get_service_state.restore();
+            Health.get_endpoint_response.restore();
+            Health.all_account_details = true;
+            Health.all_bucket_details = false;
+            const get_service_state = sinon.stub(Health, "get_service_state");
+            get_service_state.onFirstCall().returns(Promise.resolve({ service_status: 'active', pid: 1000 }))
+                .onSecondCall().returns(Promise.resolve({ service_status: 'active', pid: 2000 }));
+            const get_endpoint_response = sinon.stub(Health, "get_endpoint_response");
+            get_endpoint_response.onFirstCall().returns(Promise.resolve({response: {response_code: 'RUNNING', total_fork_count: 0}}));
+            const health_status = await Health.nc_nsfs_health();
+            assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 2);
+            assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 2);
+            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[1].name, 'account_invalid');
+            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[1].storage_path, undefined);
+            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 2);
+        });
     });
 });
 

--- a/src/test/unit_tests/test_nc_nsfs_health.js
+++ b/src/test/unit_tests/test_nc_nsfs_health.js
@@ -276,45 +276,6 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].code, "ACCESS_DENIED");
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].name, account_inaccessible.name);
         });
-
-        mocha.it('Account with new_buckets_path missing and allow_bucket_creation false, valid accoount', async function() {
-            const account_valid = { name: 'account_valid', nsfs_account_config: { uid: 999, gid: 999 }, allow_bucket_creation: false };
-            await write_config_file(config_root, accounts_schema_dir, account_valid.name, account_valid);
-            Health.get_service_state.restore();
-            Health.get_endpoint_response.restore();
-            Health.all_account_details = true;
-            Health.all_bucket_details = false;
-            const get_service_state = sinon.stub(Health, "get_service_state");
-            get_service_state.onFirstCall().returns(Promise.resolve({ service_status: 'active', pid: 1000 }))
-                .onSecondCall().returns(Promise.resolve({ service_status: 'active', pid: 2000 }));
-            const get_endpoint_response = sinon.stub(Health, "get_endpoint_response");
-            get_endpoint_response.onFirstCall().returns(Promise.resolve({response: {response_code: 'RUNNING', total_fork_count: 0}}));
-            const health_status = await Health.nc_nsfs_health();
-            assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 2);
-            assert.strictEqual(health_status.checks.accounts_status.valid_accounts[1].name, 'account_valid');
-            assert.strictEqual(health_status.checks.accounts_status.valid_accounts[1].storage_path, undefined);
-            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 1);
-        });
-
-        mocha.it('Account with new_buckets_path missing and allow_bucket_creation true, invalid accoount', async function() {
-            const account_invalid = { name: 'account_invalid', nsfs_account_config: { uid: 999, gid: 999 }, allow_bucket_creation: true };
-            await write_config_file(config_root, accounts_schema_dir, account_invalid.name, account_invalid);
-            Health.get_service_state.restore();
-            Health.get_endpoint_response.restore();
-            Health.all_account_details = true;
-            Health.all_bucket_details = false;
-            const get_service_state = sinon.stub(Health, "get_service_state");
-            get_service_state.onFirstCall().returns(Promise.resolve({ service_status: 'active', pid: 1000 }))
-                .onSecondCall().returns(Promise.resolve({ service_status: 'active', pid: 2000 }));
-            const get_endpoint_response = sinon.stub(Health, "get_endpoint_response");
-            get_endpoint_response.onFirstCall().returns(Promise.resolve({response: {response_code: 'RUNNING', total_fork_count: 0}}));
-            const health_status = await Health.nc_nsfs_health();
-            assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 2);
-            assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 2);
-            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[1].name, 'account_invalid');
-            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[1].storage_path, undefined);
-            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 2);
-        });
     });
 });
 


### PR DESCRIPTION
### Explain the changes
1. the new_buckets_path is optional for account creation even though such an account shows invalid account list
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
First case:-
1. Create an account without `new_buckets_path`
2. run health script, this bucket should not be listed in invalid bucket list, should be valid bucket list
Second case:-
1. update the `allow_bucket_creation` from false to true, 
2. run health script, this bucket should be listed in the invalid bucket list


- [X] Doc added/updated
- [X] Tests added
