### PR TITLE
NSFS | NC | Health | Account without new_buckets_path

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -338,6 +338,8 @@ NOTE - health script execution requires root permissions.
 
 In this health output, `bucket2`'s storage path is invalid and the directory mentioned in `new_buckets_path` for `user1` is missing or not accessible. Endpoint curl command returns an error response(`"endpoint_response":404`) if one or more buckets point to an invalid bucket storage path.
 
+Account without `new_buckets_path` and `allow_bucket_creation` value is `false` then it's considered a valid account, But if the `allow_bucket_creation` is true `new_buckets_path` is empty, in that case account is invalid. 
+
 ### Health Error Codes
 These are the error codes populated in the health output if the system is facing some issues. If any of these error codes are present in health status then the overall status will be in `NOTOK` state.
 #### 1. `NOOBAA_NSFS_SERVICE_FAILED`


### PR DESCRIPTION
### Explain the changes
1. the new_buckets_path is optional for account creation even though such an account shows invalid account list
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
First case:-
1. Create an account without `new_buckets_path`
2. run health script, this bucket should not be listed in invalid bucket list, should be valid bucket list
Second case:-
1. update the `allow_bucket_creation` from false to true, 
2. run health script, this bucket should be listed in the invalid bucket list


- [X] Doc added/updated
- [X] Tests added
