### PR TITLE
Fixing ESlint issues and returning some missing rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -174,6 +174,11 @@ module.exports = {
             "ignoreReadBeforeAssign": false
         }],
 
+        // These were deprecated out of eslint-all and moved to @stylistic plugin.
+        // will be changed once we will start using the plugin as well
+        'no-multi-spaces': ['error', {}],
+        'semi': ['error', 'always'],
+
         //////////////////////////////////////////////////////////////////////
         //                                                                  //
         // WARN                                                             //

--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -100,7 +100,7 @@ const fork_response_code = {
 const health_errors_tyes = {
   PERSISTENT: 'PERSISTENT',
   TEMPORARY: 'TEMPORARY',
-}
+};
 
 //suppress aws sdk related commands.
 process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
@@ -132,8 +132,8 @@ class NSFSHealth {
       service_health = "NOTOK";
     }
     const error_code = await this.get_error_code(service_status, pid, rsyslog.service_status, response_code);
-    if (this.all_bucket_details)  bucket_details = await this.get_bucket_status(this.config_root);
-    if (this.all_account_details)  account_details = await this.get_account_status(this.config_root);
+    if (this.all_bucket_details) bucket_details = await this.get_bucket_status(this.config_root);
+    if (this.all_account_details) account_details = await this.get_account_status(this.config_root);
     const health = {
       service_name: NSFS_SERVICE,
       status: service_health,
@@ -157,7 +157,7 @@ class NSFSHealth {
             error_type: health_errors_tyes.TEMPORARY,
           },
           accounts_status: {
-            invalid_accounts: account_details === undefined ?  undefined: account_details.invalid_storages,
+            invalid_accounts: account_details === undefined ? undefined: account_details.invalid_storages,
             valid_accounts: account_details === undefined ? undefined : account_details.valid_storages,
             error_type: health_errors_tyes.PERSISTENT,
           },
@@ -168,8 +168,8 @@ class NSFSHealth {
           }
       }
     };
-    if (!this.all_account_details)  delete health.checks.accounts_status;
-    if (!this.all_bucket_details)  delete health.checks.buckets_status;
+    if (!this.all_account_details) delete health.checks.accounts_status;
+    if (!this.all_bucket_details) delete health.checks.buckets_status;
     return health;
   }
 

--- a/src/test/unit_tests/test_nc_nsfs_health.js
+++ b/src/test/unit_tests/test_nc_nsfs_health.js
@@ -255,7 +255,7 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 0);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 0);
             //revert to config root
-            Health.config_root =  config_root;
+            Health.config_root = config_root;
         });
 
         mocha.it('Account with inaccessible path', async function() {

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -231,7 +231,7 @@ class BuffersPool {
     [util.inspect.custom]() {
         return 'BufferPool.get_buffer: sem value: ' + this.sem._value +
             ' waiting_value: ' + this.sem._waiting_value +
-            ' buffers length: ' +  this.buffers.length;
+            ' buffers length: ' + this.buffers.length;
     }
 }
 


### PR DESCRIPTION
### Explain the changes
1. When we moved to a newer version of eslint, we moved to one that deprecated the rules for semicolons and spaces
https://eslint.org/docs/latest/rules/
2. We need to move eventually to the replacement of these rules and to start using the stylistic plugin:
https://eslint.style/

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
