### PR TITLE
NSFS | NC | Check Option Type from CLI

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -69,6 +69,12 @@ ManageCLIError.InvalidArgument = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.InvalidArgumentType = Object.freeze({
+    code: 'InvalidArgumentType',
+    message: 'Invalid argument type',
+    http_code: 400,
+});
+
 ManageCLIError.InvalidType = Object.freeze({
     code: 'InvalidType',
     message: 'Invalid type, available types are account, bucket or whitelist',
@@ -218,18 +224,6 @@ ManageCLIError.MissingAccountNSFSConfigGID = Object.freeze({
 ManageCLIError.InvalidAccountNewBucketsPath = Object.freeze({
     code: 'InvalidAccountNewBucketsPath',
     message: 'Account\'s new_buckets_path should be a valid and existing directory path',
-    http_code: 400,
-});
-
-ManageCLIError.InvalidAccountUID = Object.freeze({
-    code: 'InvalidAccountUID',
-    message: 'Account UID must be a number',
-    http_code: 400,
-});
-
-ManageCLIError.InvalidAccountGID = Object.freeze({
-    code: 'InvalidAccountGID',
-    message: 'Account GID must be a number',
     http_code: 400,
 });
 

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -42,7 +42,33 @@ const VALID_OPTIONS = {
     whitelist_options: VALID_OPTIONS_WHITELIST,
 };
 
+const TYPE_STRING_OR_NUMBER = 'string, number'; // we allow the names to be numbers and strings
+const OPTION_TYPE = {
+    name: TYPE_STRING_OR_NUMBER,
+    email: 'string',
+    uid: 'number',
+    gid: 'number',
+    new_buckets_path: 'string',
+    user: TYPE_STRING_OR_NUMBER,
+    access_key: 'string',
+    secret_key: 'string',
+    fs_backend: 'string',
+    config_root: 'string',
+    from_file: 'string',
+    config_root_backend: 'string',
+    path: 'string',
+    bucket_policy: 'string',
+    new_name: TYPE_STRING_OR_NUMBER,
+    regenerate: 'boolean',
+    wide: 'boolean',
+    show_secrets: 'boolean',
+    ips: 'string',
+};
+
 // EXPORTS
 exports.TYPES = TYPES;
 exports.ACTIONS = ACTIONS;
 exports.VALID_OPTIONS = VALID_OPTIONS;
+exports.OPTION_TYPE = OPTION_TYPE;
+exports.TYPE_STRING_OR_NUMBER = TYPE_STRING_OR_NUMBER;
+

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -217,6 +217,18 @@ mocha.describe('manage_nsfs cli', function() {
             }
         });
 
+        mocha.it('cli bucket list - should fail invalid option type', async function() {
+            const action = nc_nsfs_manage_actions.LIST;
+            const invalid_wide = 'not-boolean';
+            const bucket_options_with_invalid_option = {config_root, wide: invalid_wide};
+            try {
+                add_res = await exec_manage_cli(type, action, bucket_options_with_invalid_option);
+                assert.fail('should have failed with invalid option type');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidArgumentType);
+            }
+        });
+
         mocha.it('cli bucket create - should fail on already exists', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             try {


### PR DESCRIPTION
### Explain the changes
Check the option type from CLI
1. Added a structure with the types of each option.
2. Removed `InvalidAccountUID` and `InvalidAccountGID` since they will be checked when the values are passed.
3. In the file `test_nc_nsfs_cli.js` separate the function `exec_manage_cli` to allow passing flags without value.

### Issues: Fixed #7750, #7764 
1. Currently we only checked that the type from the CLI is number for gid and uid options:
- We had an issue for a flag user that an empty flag added `true` user.
- We had an issue with the path - in case the path input is a number user encountered `InternalError`.
2. Changing the error message for invalid options should fix #7651 (see [comment](https://github.com/noobaa/noobaa-core/issues/7651#issuecomment-1909653541)), continuing #7743.

### Testing Instructions:
1. For manual tests add a valid flag without value (except boolean flags), for example:
`sudo node src/cmd/manage_nsfs account add --name <name> --email <email> --new_buckets_path <path> --user` (`--user` with no value).
2. For manual tests with invalid options (to check the error message), you can run:
- `sudo node src/cmd/manage_nsfs account add --name <account-name> --email <email> --new_buckets_path <path> --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid> --lala lala` (`--lala` is one invalid option).
-  `sudo node src/cmd/manage_nsfs account add --name <account-name> --email <email> --new_buckets_path <path> --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid> --lala lala --lala2 lala2` (`--lala` and `--lala2` are  two invalid options).
3. For manual tests with an invalid option type (to check the error message), you can run:
- `sudo node src/cmd/manage_nsfs account add --name <name> --email <email> --new_buckets_path 4e34 --uid <uid> --gid <gid>` (`--new_buckets_path` should be a string that represents an existing path).
- `sudo node src/cmd/manage_nsfs account add --name <name> --email <email> --new_buckets_path aaa --uid <uid> --gid <gid>` (`--new_buckets_path` should be a string that represents an existing path).
4. For running the unit test with the new tests, please run:
- `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`.
- `sudo npx jest test_nc_nsfs_account_cli.test.js`.
- `sudo npx jest test_nc_nsfs_bucket_cli.test.js`.

- [ ] Doc added/updated
- [X] Tests added
