### PR TITLE
NSFS | NC | Add Details to Error Message When Invalid Schema

### DIFF
--- a/src/manage_nsfs/nsfs_schema_utils.js
+++ b/src/manage_nsfs/nsfs_schema_utils.js
@@ -32,19 +32,53 @@ schema_utils.strictify(account_schema, {
 // NOTE - DO NOT strictify nsfs_config_schema
 // we might want to use it in the future for adding additional properties
 
+/**
+ * validate_account_schema validates an account object against the NC NSFS account schema
+ * @param {object} account
+ */
 function validate_account_schema(account) {
     const valid = ajv.validate(account_schema, account);
-    if (!valid) throw new RpcError('INVALID_SCHEMA', ajv.errors[0]?.message);
+    if (!valid) {
+        const err_msg = ajv.errors[0].message ? create_schema_err_msg(ajv.errors[0]) : undefined;
+        throw new RpcError('INVALID_SCHEMA', err_msg);
+    }
 }
 
+/**
+ * validate_bucket_schema validates a bucket object against the NC NSFS bucket schema
+ * @param {object} bucket
+ */
 function validate_bucket_schema(bucket) {
     const valid = ajv.validate(bucket_schema, bucket);
-    if (!valid) throw new RpcError('INVALID_SCHEMA', ajv.errors[0]?.message);
+    if (!valid) {
+        const err_msg = ajv.errors[0].message ? create_schema_err_msg(ajv.errors[0]) : undefined;
+        throw new RpcError('INVALID_SCHEMA', err_msg);
+    }
 }
 
+/**
+ * validate_nsfs_config_schema validates a config object against the NC NSFS config schema
+ * @param {object} config
+ */
 function validate_nsfs_config_schema(config) {
     const valid = ajv.validate(nsfs_config_schema, config);
-    if (!valid) throw new RpcError('INVALID_SCHEMA', ajv.errors[0]?.message);
+    if (!valid) {
+        const err_msg = ajv.errors[0].message ? create_schema_err_msg(ajv.errors[0]) : undefined;
+        throw new RpcError('INVALID_SCHEMA', err_msg);
+    }
+}
+
+/**
+ * create_schema_err_msg would use the original error message we got from avj
+ * and adds additional info in case we have it
+ * @param {object} err
+ */
+function create_schema_err_msg(err) {
+    if (!err || !err.message) return;
+    const err_msg = [err.message];
+    if (err.params) err_msg.push(JSON.stringify(err.params));
+    if (err.instancePath) err_msg.push(JSON.stringify(err.instancePath));
+    return err_msg.join(' | ');
 }
 
 //EXPORTS

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -364,13 +364,14 @@ function get_account_data() {
     return account_data;
 }
 
-function assert_validation(account_to_validate, reason, message) {
+function assert_validation(account_to_validate, reason, basic_message) {
     try {
         nsfs_schema_utils.validate_account_schema(account_to_validate);
         fail(reason);
     } catch (err) {
         expect(err).toBeInstanceOf(RpcError);
-        expect(err).toHaveProperty('message', message);
+        expect(err).toHaveProperty('message');
+        expect((err.message).includes(basic_message)).toBeTruthy();
     }
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -382,13 +382,14 @@ function get_bucket_data() {
     return bucket_data;
 }
 
-function assert_validation(bucket_to_validate, reason, message) {
+function assert_validation(bucket_to_validate, reason, basic_message) {
     try {
         nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
         fail(reason);
     } catch (err) {
         expect(err).toBeInstanceOf(RpcError);
-        expect(err).toHaveProperty('message', message);
+        expect(err).toHaveProperty('message');
+        expect((err.message).includes(basic_message)).toBeTruthy();
     }
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -88,13 +88,14 @@ describe('schema validation NC NSFS config', () => {
     });
 });
 
-function assert_validation(config_to_validate, reason, message) {
+function assert_validation(config_to_validate, reason, basic_message) {
     try {
         nsfs_schema_utils.validate_nsfs_config_schema(config_to_validate);
         fail(reason);
     } catch (err) {
         expect(err).toBeInstanceOf(RpcError);
-        expect(err).toHaveProperty('message', message);
+        expect(err).toHaveProperty('message');
+        expect((err.message).includes(basic_message)).toBeTruthy();
     }
 }
 


### PR DESCRIPTION
### Explain the changes
1. Add details to the error message when invalid schema.
2. Update the tests to check the basic message (without the additional info).
3. Add JSDoc on the functions in the file `nsfs_schema_utils`.

### Issues: Fixed #7752
1. Today we send the error message of `ajv.errors[0]?.message`, there are cases where we would like to have more details in the message - for example: if there is an additional property it is "must NOT have additional properties" without the property name.

### Testing Instructions:
1. Create an account: `sudo node src/cmd/manage_nsfs account add --name <account-name> --email <email> --new_buckets_path <path> --uid <uid> --gid <gid>`.
4. Create a bucket: `sudo node src/cmd/manage_nsfs bucket add --name <bucket-name> --email <account-email> --path <path>`.
5. Change the details insides the config: `sudo vi /etc/noobaa.conf.d/buckets/<bucket-name>.json` to invalid, examples:
(1) add additional property `"lala": "lala"`, (2) remove required property `creation_date`, (3) change type `"should_create_underlying_storage":123`
6. Update the bucket (for example unset `fs_backend`): `sudo node src/cmd/manage_nsfs bucket update --name <bucket-name> --fs_backend ''`


- [ ] Doc added/updated
- [ ] Tests added
