### PR TITLE
CI | Update Checkout Version

### DIFF
--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -15,7 +15,7 @@ jobs:
       GIT_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/build-ppc64le-image.yaml
+++ b/.github/workflows/build-ppc64le-image.yaml
@@ -15,7 +15,7 @@ jobs:
       GIT_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/ceph-nsfs-s3-tests.yaml
+++ b/.github/workflows/ceph-nsfs-s3-tests.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout noobaa-core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'

--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout noobaa-core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'

--- a/.github/workflows/jest-unit-tests.yaml
+++ b/.github/workflows/jest-unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Jest Unit Test
         run: |

--- a/.github/workflows/manual-build-rpm.yaml
+++ b/.github/workflows/manual-build-rpm.yaml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
      

--- a/.github/workflows/manual-full-build.yaml
+++ b/.github/workflows/manual-full-build.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/nc_unit.yml
+++ b/.github/workflows/nc_unit.yml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Non Containerized Test
         run: |

--- a/.github/workflows/nightly-rpm-build.yml
+++ b/.github/workflows/nightly-rpm-build.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
      

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Nightly Tests
         run: |

--- a/.github/workflows/postgres-unit-tests.yaml
+++ b/.github/workflows/postgres-unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Unit Tests with Postgres
         run: make test-postgres

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set branch
         run: echo "BRANCH=${{ github.event.inputs.base_branch }}" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH }}
       - name: Fetch all tags

--- a/.github/workflows/sanity-ssl.yaml
+++ b/.github/workflows/sanity-ssl.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Build & SSL Sanity Tests
         run: |

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Build & Sanity Tests
         run: |

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Test
         run: |


### PR DESCRIPTION
### Explain the changes
1. Update the checkout version from 3 to 4.

### Issues: Fixed #xxx / Gap #xxx
1. Currently we have a warning in our CI:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

### Testing Instructions:
1. none, will be tested in the CI.


- [ ] Doc added/updated
- [ ] Tests added
