### PR TITLE
[NSFS | NC] fix NooBaa NSFS RPM Upgrade

### DIFF
--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -75,41 +75,6 @@ if [ "${state}" == "active" ]; then
   service rsyslog restart
 fi
 
-if [ $1 -gt 1 ]; then
-  UPGRADE_SCRIPTS_DIR=/root/node_modules/noobaa-core/src/upgrade/upgrade_scripts
-  NSFS_UPGRADE_SCRIPTS_DIR=/root/node_modules/noobaa-core/src/upgrade/nsfs_upgrade_scripts
-
-  NOOBAA_RPM_BASE_PATH="$RPM_BUILD_ROOT/usr/local/noobaa-core"
-  pushd $NOOBAA_RPM_BASE_PATH
-
-  echo "Checking deployment type"
-  echo "Looking for NSFS deployment"
-  pgrep -f "cmd/nsfs" > /dev/null
-  rc=$?
-  if [ "${rc}" -eq 0 ]; then
-    echo "Found NSFS deployment"
-    /usr/local/noobaa-core/bin/node src/upgrade/upgrade_manager.js --nsfs true --upgrade_scripts_dir ${NSFS_UPGRADE_SCRIPTS_DIR}
-    rccmd=$?
-  else
-    echo "Looking for non-NSFS deployment"
-    pgrep -f "server/web_server" > /dev/null
-    rc=$?
-    if [ "${rc}" -eq 0 ]; then
-      echo "Found non-NSFS deployment"
-      /usr/local/noobaa-core/bin/node src/upgrade/upgrade_manager.js --upgrade_scripts_dir ${UPGRADE_SCRIPTS_DIR}
-      rccmd=$?
-    else
-      echo "No deployments found, skipping upgrade"
-      exit 0
-    fi
-  fi
-
-  if [ ${rccmd} -ne 0 ]; then
-    echo "upgrade_manager failed with exit code ${rccmd}"
-    exit ${rccmd}
-  fi
-fi
-
 %changelog
 * %{releasedate} NooBaa Team <noobaa@noobaa.io>
 %{changelogdata}

--- a/src/deploy/noobaa_nsfs.service
+++ b/src/deploy/noobaa_nsfs.service
@@ -7,6 +7,7 @@ Restart=always
 RestartSec=2
 User=root
 Group=root
+ExecStartPre=/usr/local/noobaa-core/bin/node /usr/local/noobaa-core/src/upgrade/upgrade_manager.js --nsfs true --upgrade_scripts_dir /usr/local/noobaa-core/src/upgrade/nsfs_upgrade_scripts
 ExecStart=/usr/local/noobaa-core/bin/node /usr/local/noobaa-core/src/cmd/nsfs.js
 EnvironmentFile=-/etc/sysconfig/noobaa_nsfs
 ExecStop=/bin/kill $MAINPID


### PR DESCRIPTION
### Explain the changes
This PR attempts to fix NSFS NooBaa upgrade. The idea is to separate the source file upgrade from the upgrade scripts execution. Instead of running the upgrade script during upgrade process, we will run it before starting the NSFS service. This helps us to remove the ambiguity of service running or not running and also relieves us of detecting a deployment type. 

### Testing Instructions:
1. Build a NooBaa RPM.
2. Install the RPM. Start the noobaa nsfs service.
3. Update the NooBaa version in package.json and add an upgrade script.
4. Stop the nsfs service.
5. Update the RPM.
6. Start the NSFS service again.
7. You **should** be able to see that the upgrade manager was run in the output of `systemctl status noobaa_nsfs`. The logs generated by the upgrade manager should also be available in `journalctl`.

- [ ] Doc added/updated
- [ ] Tests added
