### PR TITLE
NSFS | NC | Add `owner_account` to the bucket schema as a required property

### DIFF
--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -9,6 +9,7 @@ module.exports = {
         'name',
         'system_owner',
         'bucket_owner',
+        'owner_account',
         'versioning',
         'path',
         'should_create_underlying_storage',
@@ -18,6 +19,7 @@ module.exports = {
         _id: {
             type: 'string',
         },
+        // owner_account is the account _id
         owner_account: {
             type: 'string',
         },

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -281,6 +281,24 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
+        it('bucket without owner_account', () => {
+            const bucket_data = get_bucket_data();
+            delete bucket_data.owner_account;
+            const reason = 'Test should have failed because of missing required property ' +
+                'owner_account';
+            const message = "must have required property 'owner_account'";
+            assert_validation(bucket_data, reason, message);
+        });
+
+        it('bucket with undefined owner_account', () => {
+            const bucket_data = get_bucket_data();
+            bucket_data.owner_account = undefined;
+            const reason = 'Test should have failed because of missing required property ' +
+                'owner_account';
+            const message = "must have required property 'owner_account'";
+            assert_validation(bucket_data, reason, message);
+        });
+
     });
 
     describe('bucket with wrong types', () => {
@@ -355,6 +373,26 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
+        it('bucket with _id as number (instead of string)', () => {
+            const bucket_data = get_bucket_data();
+            // @ts-ignore
+            bucket_data._id = 123; // number instead of string
+            const reason = 'Test should have failed because of wrong type ' +
+                '_id with number (instead of string)';
+            const message = 'must be string';
+            assert_validation(bucket_data, reason, message);
+        });
+
+        it('bucket with owner_account as number (instead of string)', () => {
+            const bucket_data = get_bucket_data();
+            // @ts-ignore
+            bucket_data.owner_account = 123; // number instead of string
+            const reason = 'Test should have failed because of wrong type ' +
+                'owner_account with number (instead of string)';
+            const message = 'must be string';
+            assert_validation(bucket_data, reason, message);
+        });
+
     });
 
 });
@@ -364,6 +402,7 @@ function get_bucket_data() {
     const id = '65a62e22ceae5e5f1a758aa8';
     const system_owner = 'account1@noobaa.io';
     const bucket_owner = 'account1@noobaa.io';
+    const owner_account = '65b3c68b59ab67b16f98c26e';
     const versioning_disabled = 'DISABLED';
     const creation_date = new Date('December 17, 2023 09:00:00').toISOString();
     const path = '/tmp/nsfs_root1';
@@ -373,6 +412,7 @@ function get_bucket_data() {
         name: bucket_name,
         system_owner: system_owner,
         bucket_owner: bucket_owner,
+        owner_account: owner_account,
         versioning: versioning_disabled,
         creation_date: creation_date,
         path: path,

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -11,6 +11,7 @@ const P = require('../../util/promise');
 const config = require('../../../config');
 const fs_utils = require('../../util/fs_utils');
 const native_fs_utils = require('../../util/native_fs_utils');
+const os_utils = require('../../util/os_utils');
 
 const BucketSpaceFS = require('../../sdk/bucketspace_fs');
 const NamespaceFS = require('../../sdk/namespace_fs');
@@ -121,6 +122,7 @@ const dummy_ns = {
 function make_dummy_object_sdk() {
     return {
         requesting_account: {
+            _id: '65b3c68b59ab67b16f98c26e',
             force_md5_etag: false,
             email: 'user2@noobaa.io',
             allow_bucket_creation: true,
@@ -367,7 +369,9 @@ mocha.describe('bucketspace_fs', function() {
                 await fs.promises.stat(bucket_config_path);
             } catch (err) {
                 assert.strictEqual(err.code, 'ENOENT');
-                assert.equal(err.message, "ENOENT: no such file or directory, stat '/tmp/test_bucketspace_fs/config_root/buckets/buckettempdir.json'");
+                let path_for_err_msg = '/tmp/test_bucketspace_fs/config_root/buckets/buckettempdir.json';
+                if (os_utils.IS_MAC) path_for_err_msg = '/private' + path_for_err_msg;
+                assert.equal(err.message, `ENOENT: no such file or directory, stat '${path_for_err_msg}'`);
             }
             await fs.promises.stat(path.join(new_buckets_path, param.name));
         });

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -46,6 +46,7 @@ mocha.describe('manage_nsfs cli', function() {
 
     mocha.describe('cli bucket flow ', async function() {
         const type = nc_nsfs_manage_entity_types.BUCKET;
+        const account_name = 'user1';
         const name = 'bucket1';
         const bucket_on_gpfs = 'bucketgpfs1';
         const email = 'user1@noobaa.io';
@@ -58,6 +59,7 @@ mocha.describe('manage_nsfs cli', function() {
         let add_res;
 
         const schema_dir = 'buckets';
+        const schema_dir_accounts = 'accounts';
         let bucket_options = { config_root, name, email, path: bucket_path };
         const gpfs_bucket_options = { config_root, name: bucket_on_gpfs, email, path: bucket_path, fs_backend: 'GPFS' };
         const bucket_with_policy_options = { ...bucket_options, bucket_policy: bucket_policy, name: bucket_with_policy };
@@ -85,7 +87,6 @@ mocha.describe('manage_nsfs cli', function() {
         });
 
         mocha.it('cli create account for bucket (bucket create requirement to have a bucket owner)', async function() {
-            const account_name = 'user1';
             const account_name2 = 'user2';
             const owner_email = email;
             const owner_email2 = 'user2@noobaa.io';
@@ -148,6 +149,10 @@ mocha.describe('manage_nsfs cli', function() {
             add_res = await exec_manage_cli(type, action, bucket_options);
             assert_response(action, type, add_res, bucket_options);
             const bucket = await read_config_file(config_root, schema_dir, name);
+            // make sure that the config file includes id and owner_account (account id)
+            assert(!_.isUndefined(bucket._id));
+            const account = await read_config_file(config_root, schema_dir_accounts, account_name);
+            assert(bucket.owner_account === account._id);
             assert_bucket(bucket, bucket_options);
             await assert_config_file_permissions(config_root, schema_dir, name);
         });


### PR DESCRIPTION
### Explain the changes
1. Add `owner_account` to the bucket schema as a required property (it was already added as property in PR #7718.
2. Add `undefined` values in `_id` and `owner_account` to keep the order the properties when printing the data object, and change the position of `creation_date`.
3. Change the function `verify_bucket_owner` to return the `account_id` (`owner_account` is the account id).
4. Added tests for the schema addition of required value (and adding additional test of `_id`).
5. Update `test_bucketspace_fs` by adding `_id` to the account (that will be used as `owner_account` when creating a bucket) and edit one of the test paths to allow it to pass on Mac when running the test locally.

### Issues: Fixed #7768 
1. Currently the output of `sudo node src/cmd/manage_nsfs bucket status --name <bucke-name>` is different if the bucket was created in the manage_nsfs or by s3 command - in the first option we don't have the property `owner_account`.

### Testing Instructions:
Manual test:
1. Create a bucket with s3
2. Create a bucket with manage nsfs
3. compare the details of the created buckets

Unit tests:
For running the unit test with the new tests (or updated tests), please run:
- `sudo npx jest test_nc_nsfs_bucket_cli.test.js`
- `npx jest test_nc_nsfs_bucket_schema_validation.test.js`
- `sudo node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_bucketspace_fs.js`

- [ ] Doc added/updated
- [X] Tests added
