### PR TITLE
NSFS | NC | CLI | add/update account | check account has rw permissions to new buckets path

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -803,6 +803,11 @@ async function validate_account_args(data, action) {
         if (!exists) {
             throw_cli_error(ManageCLIError.InvalidAccountNewBucketsPath, data.nsfs_account_config.new_buckets_path);
         }
+        const account_fs_context = await native_fs_utils.get_fs_context(data.nsfs_account_config, config_root_backend);
+        const accessible = await native_fs_utils.is_dir_rw_accessible(account_fs_context, data.nsfs_account_config.new_buckets_path);
+        if (!accessible) {
+            throw_cli_error(ManageCLIError.InaccessibleAccountNewBucketsPath, data.nsfs_account_config.new_buckets_path);
+        }
     }
 }
 

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -239,6 +239,17 @@ ManageCLIError.InvalidNewAccessKeyIdentifier = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.InaccessibleAccountNewBucketsPath = Object.freeze({
+    code: 'InaccessibleAccountNewBucketsPath',
+    message: 'Account should have read & write access to the specified new_buckets_path',
+    http_code: 400,
+});
+
+ManageCLIError.InvalidAccountDistinguishedName = Object.freeze({
+    code: 'InvalidAccountDistinguishedName',
+    message: 'Account distinguished name was not found',
+    http_code: 400,
+});
 
 ////////////////////////
 //// BUCKET ERRORS /////
@@ -343,6 +354,7 @@ ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
 
 ManageCLIError.RPC_ERROR_TO_MANAGE = Object.freeze({
     INVALID_SCHEMA: ManageCLIError.InvalidSchema,
+    NO_SUCH_USER: ManageCLIError.InvalidAccountDistinguishedName
 });
 
 exports.ManageCLIError = ManageCLIError;

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -1,9 +1,11 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const fs = require('fs');
 const _ = require('lodash');
 const P = require('../../util/promise');
 const os_utils = require('../../util/os_utils');
+const native_fs_utils = require('../../util/native_fs_utils');
 
 /**
  * 
@@ -311,6 +313,22 @@ async function delete_fs_user_by_platform(name) {
     }
 }
 
+/** 
+ * set_path_permissions_and_owner sets path permissions and owner and group
+ * @param {string} path
+ * @param {object} owner_options
+ * @param {number} permissions
+ */
+async function set_path_permissions_and_owner(path, owner_options, permissions = 0o700) {
+    if (owner_options.uid !== undefined && owner_options.gid !== undefined) {
+        await fs.promises.chown(path, owner_options.uid, owner_options.gid);
+    } else {
+        const { uid, gid } = await native_fs_utils.get_user_by_distinguished_name({ distinguished_name: owner_options.user });
+        await fs.promises.chown(owner_options.new_buckets_path, uid, gid);
+    }
+    await fs.promises.chmod(path, permissions);
+}
+
 exports.blocks_exist_on_cloud = blocks_exist_on_cloud;
 exports.create_hosts_pool = create_hosts_pool;
 exports.delete_hosts_pool = delete_hosts_pool;
@@ -324,3 +342,4 @@ exports.nc_nsfs_manage_entity_types = nc_nsfs_manage_entity_types;
 exports.nc_nsfs_manage_actions = nc_nsfs_manage_actions;
 exports.create_fs_user_by_platform = create_fs_user_by_platform;
 exports.delete_fs_user_by_platform = delete_fs_user_by_platform;
+exports.set_path_permissions_and_owner = set_path_permissions_and_owner;

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -12,8 +12,9 @@ const fs_utils = require('../../../util/fs_utils');
 const os_util = require('../../../util/os_utils');
 const config_module = require('../../../../config');
 const native_fs_utils = require('../../../util/native_fs_utils');
-const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const { set_path_permissions_and_owner } = require('../../system_tests/test_utils');
+const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 
 const MAC_PLATFORM = 'darwin';
 let tmp_fs_path = '/tmp/test_bucketspace_fs';
@@ -66,6 +67,7 @@ describe('manage nsfs cli bucket flow', () => {
             const account_options = { config_root, ...account_defaults };
             await fs_utils.create_fresh_path(account_path);
             await fs_utils.file_must_exist(account_path);
+            await set_path_permissions_and_owner(account_path, account_options, 0o700);
             await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
         });
 
@@ -125,6 +127,7 @@ describe('manage nsfs cli bucket flow', () => {
             const account_options = { config_root, ...account_defaults };
             await fs_utils.create_fresh_path(account_path);
             await fs_utils.file_must_exist(account_path);
+            await set_path_permissions_and_owner(account_path, account_options, 0o700);
             await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
 
             //bucket add

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -12,7 +12,9 @@ const nb_native = require('../../util/nb_native');
 const config_module = require('../../../config');
 const { ManageCLIError } = require('../../manage_nsfs/manage_nsfs_cli_errors');
 const { ManageCLIResponse } = require('../../manage_nsfs/manage_nsfs_cli_responses');
-const { exec_manage_cli, generate_s3_policy, nc_nsfs_manage_actions, nc_nsfs_manage_entity_types } = require('../system_tests/test_utils');
+const { exec_manage_cli, generate_s3_policy, create_fs_user_by_platform, delete_fs_user_by_platform,
+    nc_nsfs_manage_actions, nc_nsfs_manage_entity_types, set_path_permissions_and_owner
+} = require('../system_tests/test_utils');
 
 const MAC_PLATFORM = 'darwin';
 let tmp_fs_path = '/tmp/test_bucketspace_fs';
@@ -25,6 +27,9 @@ const DEFAULT_FS_CONFIG = {
     backend: '',
     warn_threshold_ms: 100,
 };
+
+const accounts_schema_dir = 'accounts';
+const access_keys_schema_dir = 'access_keys';
 
 mocha.describe('manage_nsfs cli', function() {
 
@@ -109,6 +114,7 @@ mocha.describe('manage_nsfs cli', function() {
             };
             await fs_utils.create_fresh_path(new_buckets_path1);
             await fs_utils.file_must_exist(new_buckets_path1);
+            await set_path_permissions_and_owner(new_buckets_path1, { uid: uid1, gid: gid1 }, 0o700);
             await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, action, account_options1);
             // create account 'user2' 'user2@noobaa.io'
             const account_options2 = {
@@ -121,6 +127,7 @@ mocha.describe('manage_nsfs cli', function() {
             };
             await fs_utils.create_fresh_path(new_buckets_path2);
             await fs_utils.file_must_exist(new_buckets_path2);
+            await set_path_permissions_and_owner(new_buckets_path2, { uid: uid2, gid: gid2 }, 0o700);
             await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, action, account_options2);
         });
 
@@ -492,8 +499,6 @@ mocha.describe('manage_nsfs cli', function() {
         const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFR';
         let account_options = { config_root, name, email, new_buckets_path, uid, gid, access_key, secret_key };
         const gpfs_account_options = { ...account_options, name: gpfs_account, email: gpfs_account, fs_backend: 'GPFS' };
-        const accounts_schema_dir = 'accounts';
-        const access_keys_schema_dir = 'access_keys';
         let updating_options = account_options;
         let compare_details; // we will use it for update account and compare the results
         let add_res;
@@ -502,6 +507,7 @@ mocha.describe('manage_nsfs cli', function() {
             const action = nc_nsfs_manage_actions.ADD;
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
+            await set_path_permissions_and_owner(new_buckets_path, { uid, gid }, 0o700);
             add_res = await exec_manage_cli(type, action, account_options);
             assert_response(action, type, add_res, account_options);
             const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
@@ -629,7 +635,9 @@ mocha.describe('manage_nsfs cli', function() {
             };
             await fs_utils.create_fresh_path(update_options.new_buckets_path);
             await fs_utils.file_must_exist(update_options.new_buckets_path);
+            await set_path_permissions_and_owner(update_options.new_buckets_path, update_options, 0o700);
             const update_response = await exec_manage_cli(type, action, update_options);
+
             updating_options = { ...updating_options, ...update_options };
             assert_response(action, type, update_response, updating_options);
             account_options = { ...account_options, ...update_options };
@@ -742,6 +750,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.before(async () => {
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
+            await set_path_permissions_and_owner(new_buckets_path, { uid, gid }, 0o700);
             const action = nc_nsfs_manage_actions.ADD;
             await exec_manage_cli(type, action, account1_options);
             await exec_manage_cli(type, action, account2_options);
@@ -782,17 +791,30 @@ mocha.describe('manage_nsfs cli', function() {
         const name = 'account2';
         const email = 'account2@noobaa.io';
         const new_buckets_path = `${root_path}new_buckets_path_user2/`;
-        const distinguished_name = 'moti1003';
+        const new_buckets_path_new_dn = `${root_path}new_buckets_path_new_dn/`;
+        const distinguished_name = 'root';
         const access_key = 'GIGiFAnjaaE7OKD5N7hB';
         const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFr';
         let account_options = { config_root, name, email, new_buckets_path, distinguished_name, access_key, secret_key };
-        const accounts_schema_dir = 'accounts';
-        const access_keys_schema_dir = 'access_keys';
+        const new_user = 'newuser';
+
+        mocha.before(async () => {
+            this.timeout(50000); // eslint-disable-line no-invalid-this
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            await fs_utils.create_fresh_path(new_buckets_path_new_dn);
+            await fs_utils.file_must_exist(new_buckets_path_new_dn);
+            await create_fs_user_by_platform(new_user, 'newpass', 2222, 2222);
+            await set_path_permissions_and_owner(new_buckets_path_new_dn, { uid: 2222, gid: 2222 }, 0o700);
+        });
+
+        mocha.after(async () => {
+            this.timeout(50000); // eslint-disable-line no-invalid-this
+            await delete_fs_user_by_platform(new_user);
+        });
 
         mocha.it('cli account create', async function() {
             const action = nc_nsfs_manage_actions.ADD;
-            await fs_utils.create_fresh_path(new_buckets_path);
-            await fs_utils.file_must_exist(new_buckets_path);
             const res = await exec_manage_cli(type, action, account_options);
             assert_response(action, type, res, account_options);
             const account_symlink = await read_config_file(config_root, access_keys_schema_dir, access_key, true);
@@ -806,7 +828,8 @@ mocha.describe('manage_nsfs cli', function() {
             const update_options = {
                 config_root,
                 name,
-                distinguished_name: 'moti1004',
+                new_buckets_path: new_buckets_path_new_dn,
+                distinguished_name: new_user,
             };
             const res = await exec_manage_cli(type, action, update_options);
             account_options = { ...account_options, ...update_options };
@@ -1054,4 +1077,3 @@ function assert_whitelist(config_data, config_options) {
     assert.strictEqual(config_data.NSFS_WHITELIST.length, config_options.NSFS_WHITELIST.length);
     return true;
 }
-

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -2,14 +2,15 @@
 'use strict';
 
 const dbg = require('../util/debug_module')(__filename);
-const P = require('../util/promise');
+const fs = require('fs');
+const net = require('net');
 const path = require('path');
-const nb_native = require('../util/nb_native');
+const P = require('../util/promise');
 const { v4: uuidv4 } = require('uuid');
 const config = require('../../config');
 const RpcError = require('../rpc/rpc_error');
-const net = require('net');
-const fs = require('fs');
+const nb_native = require('../util/nb_native');
+const SensitiveString = require('../util/sensitive_string');
 
 const gpfs_link_unlink_retry_err = 'EEXIST';
 const gpfs_unlink_retry_catch = 'GPFS_UNLINK_RETRY';
@@ -452,10 +453,10 @@ function get_process_fs_context(config_root_backend) {
 async function get_fs_context(nsfs_account_config, config_root_backend) {
     let account_ids_by_dn;
     if (nsfs_account_config.distinguished_name) {
-        account_ids_by_dn = await get_user_by_distinguished_name(nsfs_account_config);
-        //{
-        //    distinguished_name: nsfs_account_config.distinguished_name // TODO add it for manage_nsfs .unwrap()
-        //});
+        const dn = (nsfs_account_config.distinguished_name instanceof SensitiveString) ?
+            nsfs_account_config.distinguished_name.unwrap() :
+            nsfs_account_config.distinguished_name;
+        account_ids_by_dn = await get_user_by_distinguished_name({ distinguished_name: dn });
     }
     return {
         uid: (account_ids_by_dn && account_ids_by_dn.uid) ?? nsfs_account_config.uid,


### PR DESCRIPTION
### Explain the changes
1. manage_nsfs - validate_account_args() - added a is_dir_rw_accessible() call for checking a the added/updated account (user/uid/gid) can access its new_buckets_path (if it exists).
2. ManageCLIError - added 2 new types of errors -
    2.1. InaccessibleAccountNewBucketsPath
    2.2. InvalidAccountDistinguishedName.
3. native_fs_utils - get_fs_context() - changed the implementation to accept String and SensitiveString as the distinguished_name 
4. test_nc_nsfs_account_cli - added new tests.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/7783

### Testing Instructions:
1. sudo jest --testRegex=jest_tests/test_nc_nsfs_account_cli.test.js
2. Manually - 
    Create a fs user 'my_user' having uid 1111, gid 1111
    mkdir my_dir 
    chmod my_dir 000  (0o000 or any permutation of no rw/r/w permissions to uid 1111 gid 1111 )
    1. manage_nsfs account add --name account1  --email account1  --new_buckets_path my_dir --uid 1111 --gid 1111
    2. manage_nsfs account add --name account1 --email account1 --new_buckets_path my_dir --user my_user
    3. manage_nsfs account add --name account1 --email account1 --new_buckets_path my_dir --user non_existing_user
    Expect failures on these 3 tests

- [ ] Doc added/updated
- [x] Tests added
