### PR TITLE
Copy rsyslog config file as regular file

### DIFF
--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -48,23 +48,21 @@ ln -s /usr/local/noobaa-core/node/bin/node $RPM_BUILD_ROOT/usr/local/noobaa-core
 ln -s /usr/local/noobaa-core/node/bin/npm $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npm
 ln -s /usr/local/noobaa-core/node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npx
 
-mkdir -p $RPM_BUILD_ROOT/etc/systemd/system/
-cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/noobaa_nsfs.service
+mkdir -p $RPM_BUILD_ROOT/usr/lib/systemd/system/
+cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT/usr/lib/systemd/system/noobaa_nsfs.service
 ln -s /usr/local/noobaa-core/src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
 mkdir -p $RPM_BUILD_ROOT/etc/noobaa.conf.d/
 
 mkdir -p $RPM_BUILD_ROOT/etc/rsyslog.d/
-ln -s /usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
-ln -s /usr/local/noobaa-core/src/deploy/standalone/noobaa_rsyslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_rsyslog.conf
+cp -R /usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
 
 mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d/noobaa
 ln -s /usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.conf $RPM_BUILD_ROOT/etc/logrotate.d/noobaa/logrotate_noobaa.conf
 
 %files
 /usr/local/noobaa-core
-/etc/systemd/system/noobaa_nsfs.service
+/usr/lib/systemd/system/noobaa_nsfs.service
 /etc/logrotate.d/noobaa/logrotate_noobaa.conf
-/etc/rsyslog.d/noobaa_rsyslog.conf
 /etc/rsyslog.d/noobaa_syslog.conf
 /etc/noobaa.conf.d/
 %doc
@@ -73,6 +71,41 @@ ln -s /usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.conf $RPM_BU
 state=$(systemctl show -p ActiveState --value rsyslog)
 if [ "${state}" == "active" ]; then
   service rsyslog restart
+fi
+
+if [ $1 -gt 1 ]; then
+  UPGRADE_SCRIPTS_DIR=/root/node_modules/noobaa-core/src/upgrade/upgrade_scripts
+  NSFS_UPGRADE_SCRIPTS_DIR=/root/node_modules/noobaa-core/src/upgrade/nsfs_upgrade_scripts
+
+  NOOBAA_RPM_BASE_PATH="$RPM_BUILD_ROOT/usr/local/noobaa-core"
+  pushd $NOOBAA_RPM_BASE_PATH
+
+  echo "Checking deployment type"
+  echo "Looking for NSFS deployment"
+  pgrep -f "cmd/nsfs" > /dev/null
+  rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    echo "Found NSFS deployment"
+    /usr/local/noobaa-core/bin/node src/upgrade/upgrade_manager.js --nsfs true --upgrade_scripts_dir ${NSFS_UPGRADE_SCRIPTS_DIR}
+    rccmd=$?
+  else
+    echo "Looking for non-NSFS deployment"
+    pgrep -f "server/web_server" > /dev/null
+    rc=$?
+    if [ "${rc}" -eq 0 ]; then
+      echo "Found non-NSFS deployment"
+      /usr/local/noobaa-core/bin/node src/upgrade/upgrade_manager.js --upgrade_scripts_dir ${UPGRADE_SCRIPTS_DIR}
+      rccmd=$?
+    else
+      echo "No deployments found, skipping upgrade"
+      exit 0
+    fi
+  fi
+
+  if [ ${rccmd} -ne 0 ]; then
+    echo "upgrade_manager failed with exit code ${rccmd}"
+    exit ${rccmd}
+  fi
 fi
 
 %changelog

--- a/src/deploy/standalone/noobaa_rsyslog.conf
+++ b/src/deploy/standalone/noobaa_rsyslog.conf
@@ -6,7 +6,7 @@
 #### MODULES ####
 
 # The imjournal module bellow is now used as a message source instead of imuxsock.
-# $ModLoad imuxsock  # Turn off message reception via local log socket; 
+# $ModLoad imuxsock  # Turn off message reception via local log socket;
 #$ModLoad imjournal # provides access to the systemd journal
 #$ModLoad imklog # reads kernel messages (the same are read from journald)
 #$ModLoad immark  # provides --MARK-- message capability
@@ -41,25 +41,6 @@ $WorkDirectory /var/lib/rsyslog
 
 # File to store the position in the journal
 #$IMJournalStateFile imjournal.state
-
-template(name="LogseneFormat" type="list" option.json="on") {
-  constant(value="{")
-  constant(value="\"timestamp\":\"")
-  property(name="timereported" dateFormat="rfc3339")
-  constant(value="\",\"message\":\"")
-  property(name="msg")
-  constant(value="\",\"host\":\"")
-  property(name="hostname")
-  constant(value="\",\"severity\":\"")
-  property(name="syslogseverity-text")
-  constant(value="\",\"facility\":\"")
-  property(name="syslogfacility-text")
-  constant(value="\",\"syslog-tag\":\"")
-  property(name="syslogtag")
-  constant(value="\",\"source\":\"")
-  property(name="programname")
-  constant(value="\"}\n")
-}
 
 #### RULES ####
 

--- a/src/deploy/standalone/noobaa_syslog.conf
+++ b/src/deploy/standalone/noobaa_syslog.conf
@@ -9,6 +9,25 @@ $EscapeControlCharactersOnReceive off
 # When changing this format make sure to change the relevant functions in os_utils
 #if $syslogfacility-text != 'local0' then @192.168.1.108:514
 
+template(name="LogseneFormat" type="list" option.json="on") {
+  constant(value="{")
+  constant(value="\"timestamp\":\"")
+  property(name="timereported" dateFormat="rfc3339")
+  constant(value="\",\"message\":\"")
+  property(name="msg")
+  constant(value="\",\"host\":\"")
+  property(name="hostname")
+  constant(value="\",\"severity\":\"")
+  property(name="syslogseverity-text")
+  constant(value="\",\"facility\":\"")
+  property(name="syslogfacility-text")
+  constant(value="\",\"syslog-tag\":\"")
+  property(name="syslogtag")
+  constant(value="\",\"source\":\"")
+  property(name="programname")
+  constant(value="\"}\n")
+}
+
 # For servers
 local0.*        /var/log/noobaa.log;RSYSLOG_FileFormat
 &stop


### PR DESCRIPTION
### Explain the changes

Current rsyslog log configuration, `noobaa_syslog.conf`, is done by symlink. But this implementation makes a problem in some systems like stand alone installed RHEL8. So need to install the config file as a regular file.

`noobaa_rsyslog.conf` has many conflict configuration in stand alone installed RHEL8. So it is removed from installation under `/etc/rsyslog.conf.d` and only time stamp config is moved to `noobaa_syslog.conf`.

In addition to this, move the unit file for systemd from `/etc/systemd/system` to `/usr/lib/systemd/system`. Because `/usr/lib/systemd/system` is the directory for additional systemd unit files. Symlinks under `/etc/systemd/system` shall be managed by `systemctl` command after install.

 1. Copy noobaa_syslog.conf as a regular file instead of a symlink
 2. Do not copy noobaa_rsyslog.conf at the rpm install
 3. Move tilestamp format definition from noobaa_rsyslog.conf to noobaa_syslog.conf
 4. Copy the unit file of systemd to /usr/lib/systemd/system
