### PR TITLE
NSFS | NC | Fix Bucket Creation Verification

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -275,6 +275,12 @@ ManageCLIError.BucketSetForbiddenNoBucketOwner = Object.freeze({
     http_code: 403,
 });
 
+ManageCLIError.BucketCreationNotAllowed = Object.freeze({
+    code: 'BucketCreationNotAllowed',
+    message: 'Not allowed to create new buckets',
+    http_code: 403,
+});
+
 /////////////////////////////////
 //// BUCKET ARGUMENTS ERRORS ////
 /////////////////////////////////

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -124,6 +124,39 @@ mocha.describe('manage_nsfs cli', function() {
             await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, action, account_options2);
         });
 
+        mocha.it('cli bucket create - should fail bucket owner\'s allow_bucket_creation is false', async function() {
+            const account_name_for_account_cannot_create_bucket = 'user3';
+            const owner_email = 'user3@noobaa.io';
+            const uid = 3333;
+            const gid = 3333;
+
+            const action = nc_nsfs_manage_actions.ADD;
+            // create account 'user3'
+            // without new_buckets_path property 
+            // (currently this is the way to set allow_bucket_creation with false value)
+            const account_options = {
+                config_root: config_root,
+                name: account_name_for_account_cannot_create_bucket,
+                email: owner_email,
+                uid: uid,
+                gid: gid,
+            };
+            await exec_manage_cli(nc_nsfs_manage_entity_types.ACCOUNT, action, account_options);
+            // try to create a bucket
+            try {
+                const bucket_options_with_owner_of_account_cannot_create_bucket = {
+                     config_root,
+                     name,
+                     email: owner_email,
+                     path: bucket_path
+                };
+                await exec_manage_cli(type, action, { ...bucket_options_with_owner_of_account_cannot_create_bucket });
+                assert.fail('should have failed with not allowed to create new buckets');
+            } catch (err) {
+                assert_error(err, ManageCLIError.BucketCreationNotAllowed);
+            }
+        });
+
         mocha.it('cli bucket create with invalid bucket policy - should fail', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             try {


### PR DESCRIPTION
### Explain the changes
When an account not allowed to create a bucket (has `allow_bucket_creation` false) tries to create a bucket, it throws an error:
1. Add this check to the `verify_bucket_owner` function only when the action is to add a bucket.
2. Add a new error for this case.
3. Add a test for this case.

### Issues:
1. Currently we do not check if the account has the property `allow_bucket_creation` before creating a bucket using NSFS manage.
Note: We check it when the user tries to create a bucket using AWS CLI (inside `bucketspace_fs`).
2. GAP - need to add unit test for updating a bucket (see [this comment](https://github.com/noobaa/noobaa-core/pull/7785#discussion_r1477749730) with manual description).

### Testing Instructions:
#### Manual test:
1. Create an account without passing the flag `new-buckets-path`: 
`sudo node src/cmd/manage_nsfs account add --name <account-name> --email <account-email> --uid <uid> --<gid>`
2. Create the path for the bucket and give it permission, for example: `mkdir -p /tmp/nsfs_root1/my-bucket; chmod 777 /tmp/nsfs_root1/my-bucket`.
3. Create a bucket (should see the error): `sudo node src/cmd/manage_nsfs bucket add --name <bucket-name> --email <account-email> --path /tmp/nsfs_root1/my-bucket` (`path` with the example mentioned above).

#### Unit tests:
For running the unit test with a new test, please run:
`sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`

- [ ] Doc added/updated
- [X] Tests added
