### PR TITLE
NSFS | NC | CLI | Account add/update when uid = 0 and gid != 0 bug fix

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -176,6 +176,33 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidAccountNewBucketsPath.message);
         });
 
+        it('cli account add - uid is 0, gid is not 0', async function() {
+            const account_name = 'uid_is_0';
+            const options = { name: account_name, email: `${account_name}@noobaa.com`, uid: 0, gid: 1001 };
+            const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...options });
+            const account = JSON.parse(res).response.reply;
+            assert_account(account, options, false);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, { config_root, name: account_name });
+        });
+
+        it('cli account add - uid is not 0, gid is 0', async function() {
+            const account_name = 'gid_is_0';
+            const options = { name: account_name, email: `${account_name}@noobaa.com`, uid: 1001, gid: 0 };
+            const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...options });
+            const account = JSON.parse(res).response.reply;
+            assert_account(account, options, false);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, { config_root, name: account_name });
+        });
+
+        it('cli account add - uid is 0, gid is 0', async function() {
+            const account_name = 'uid_gid_are_0';
+            const options = { name: account_name, email: `${account_name}@noobaa.com`, uid: 0, gid: 0 };
+            const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...options });
+            const account = JSON.parse(res).response.reply;
+            assert_account(account, options, false);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, { config_root, name: account_name });
+        });
+
     });
 
     describe('cli update account', () => {


### PR DESCRIPTION
### Explain the changes
1. is_undefined() checks using if (!value), which return true when uid/gid is 0, causing the account add/update to fail.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/7787

### Testing Instructions:
1. `manage_nsfs.js account add --name foo --email foo@example.com --uid 0 --gid 10 2>/dev/null`


- [ ] Doc added/updated
- [x] Tests added
