### PR TITLE
NSFS | Copy rsyslog config file as regular file

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -5,7 +5,7 @@ Running nsfs non containerized is useful for deploying in linux without dependin
 
 ## Build
 
-### Build options - 
+### Build options -
 1. noobaa-core S3 Select is enabled. This requires boost shared objects to be present on the machine where noobaa is supposed to be installed. This feature can be disabled if not required (due to additional dependency) by running make rpm BUILD_S3SELECT=0.
 2. In order to build RPM packages for other architectures simply run make rpm CONTAINER_PLATFORM=linux/amd64 or make rpm CONTAINER_PLATFORM=linux/ppc64le
 3. Building RPM packages is available on top of centos:9 / centos:8 base images, The default base image is centos:9.
@@ -19,14 +19,14 @@ make rpm
 
 ## Install
 
-### Pre-requisites (S3 select enabled) - 
-1. boost - 
+### Pre-requisites (S3 select enabled) -
+1. boost -
 ```sh
 yum install epel-release && yum install boost
 ```
 
 ### A workaround for machines that cannot install epel-release -
-Use the workaround below if `yum install epel-release` resulted in the following error - 
+Use the workaround below if `yum install epel-release` resulted in the following error -
 ```
 Updating Subscription Management repositories.
 Unable to read consumer identity
@@ -37,14 +37,14 @@ Last metadata expiration check: <SomeTimeStamp>
 No match for argument: epel-release
 Error: Unable to find a match: epel-release
 ```
-1. Install wget - 
+1. Install wget -
 
 ```sh
 yum install wget
 ```
 2. Download and install boost -
 
-RHEL8 / centos:stream8 - 
+RHEL8 / centos:stream8 -
 ```sh
 wget https://rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/boost-system-1.66.0-13.el8.x86_64.rpm
 wget https://rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/boost-thread-1.66.0-13.el8.x86_64.rpm
@@ -52,7 +52,7 @@ rpm -i boost-system-1.66.0-13.el8.x86_64.rpm
 rpm -i boost-thread-1.66.0-13.el8.x86_64.rpm
 ```
 
-RHEL9 / centos:stream9 - 
+RHEL9 / centos:stream9 -
 
 ```sh
 wget https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages/boost-system-1.75.0-8.el9.x86_64.rpm
@@ -61,8 +61,8 @@ rpm -i boost-system-1.75.0-8.el9.x86_64.rpm
 rpm -i boost-thread-1.75.0-8.el9.x86_64.rpm
 ```
 
-### Download NooBaa RPM - 
-Nightly RPM builds of the upstream master branch can be downloaded from a public S3 bucket by running the following command - 
+### Download NooBaa RPM -
+Nightly RPM builds of the upstream master branch can be downloaded from a public S3 bucket by running the following command -
 
 ```sh
 wget  noobaa-core-{VERSION}-{DATE}.el9.x86_64.rpm // Replace the VERSION and DATE
@@ -71,14 +71,14 @@ Example:
 wget https://noobaa-core-rpms.s3.amazonaws.com/noobaa-core-5.15.0-20231106.el9.x86_64.rpm
 ```
 
-### Install NooBaa RPM - 
-Install NooBaa RPM by running the following command - 
+### Install NooBaa RPM -
+Install NooBaa RPM by running the following command -
 
 ```sh
 rpm -i <rpm_file_name>.rpm
 ```
 
-After installing NooBaa RPM, it's expected to have noobaa-core source code under /usr/local/noobaa-core and an nsfs systemd example script under /etc/systemd/system/.
+After installing NooBaa RPM, it's expected to have noobaa-core source code under /usr/local/noobaa-core and an nsfs systemd example script under /usr/lib/systemd/system/.
 
 ## Create config dir redirect file -
 NooBaa will try locate a text file that contains a path to the configuration directory, the user should create the redirect file in the fixed location - /etc/noobaa.conf.d/config_dir_redirect
@@ -108,10 +108,10 @@ If it's not already existing, create the fs root path in which buckets (director
 mkdir -p /tmp/fs1/
 ```
 
-## Developer customization of the nsfs service (OPTIONAL) - 
+## Developer customization of the nsfs service (OPTIONAL) -
 One can customize noobaa nsfs service by creation of config.json file under the config_dir/ directory (/path/to/config_dir/config.json).
 The following are some of the properties that can be customized -
-1. Number of forks 
+1. Number of forks
 2. Log debug level
 3. Ports
 4. Allow http
@@ -127,15 +127,16 @@ Design of Accounts and buckets configuration entities - [NonContainerizedNSFS](h
 **Note** - All required paths on the configuration files (bucket - path, account - new_buckets_path) must be absolute paths.
 
 
-## Run the nsfs service - 
+## Run the nsfs service -
 The systemd script runs noobaa non containerized, and requires config_root in order to find the location of the system/accounts/buckets configuration file.
 Limitation - In a cluster each host should have a unique name.
 ```sh
-systemctl start noobaa_nsfs
+systemctl enable noobaa_nsfs.service
+systemctl start noobaa_nsfs.service
 ```
 
 ## NSFS service logs -
-Run the following command in order to get the nsfs service logs - 
+Run the following command in order to get the nsfs service logs -
 
 ```sh
 journalctl -u noobaa_nsfs.service
@@ -159,11 +160,11 @@ alias s3-account1='AWS_ACCESS_KEY_ID=abc AWS_SECRET_ACCESS_KEY=123 aws --endpoin
 
 #### 4. S3 Create bucket -
 
-4.1. Create  a bucket called s3bucket using account1 - 
+4.1. Create  a bucket called s3bucket using account1 -
 ```sh
 s3-account1 mb s3://s3bucket
 
-Output - 
+Output -
 make_bucket: s3bucket
 ```
 
@@ -171,7 +172,7 @@ make_bucket: s3bucket
 ```sh
 cat /tmp/noobaa_config_dir/buckets/s3bucket.json
 
-Output - 
+Output -
 {"_id":"65cb1efcbec92b33220112d7","name":"s3bucket","owner_account":"65cb1e7c9e6ae40d499c0ae4","system_owner":"account1","bucket_owner":"account1","versioning":"DISABLED","creation_date":"2023-09-26T05:56:16.252Z","path":"/tmp/fs1/s3bucket","should_create_underlying_storage":true}
 ```
 
@@ -180,7 +181,7 @@ Output -
 ```sh
 ls -l /tmp/fs1/s3bucket/
 
-Output - 
+Output -
 total 0
 ```
 
@@ -188,25 +189,25 @@ total 0
 ```sh
 s3-account1 ls
 
-Output - 
+Output -
 2023-09-21 11:50:26 s3bucket
 ```
 
 
 #### 6. S3 Upload objects -
 
-6.1. Copy an object to the S3 bucket - 
+6.1. Copy an object to the S3 bucket -
 
 ```sh
 echo  "This is the content of object1" | s3-account1 cp - s3://s3bucket/object1.txt
 ```
 
-6.2. Check the object was created on the file system - 
+6.2. Check the object was created on the file system -
 
 ```sh
 sudo cat /tmp/fs1/s3bucket/object1.txt
 
-Output - 
+Output -
 This is the content of object1
 ```
 
@@ -216,12 +217,12 @@ This is the content of object1
 ```sh
 s3-account1 ls s3://s3bucket
 
-Output - 
+Output -
 2023-09-21 11:55:01         31 object1.txt
 ```
 
 ## Health script
-NSFS Health status can be fetched using the command line. Run `--help` to get all the available options. 
+NSFS Health status can be fetched using the command line. Run `--help` to get all the available options.
 
 NOTE - health script execution requires root permissions.
 
@@ -276,7 +277,7 @@ NOTE - health script execution requires root permissions.
         },
         { "name": "account_inaccessible",
           "storage_path": "/tmp/account_inaccessible",
-          "code": "ACCESS_DENIED" } 
+          "code": "ACCESS_DENIED" }
       ],
       "valid_accounts": [
         {
@@ -338,7 +339,7 @@ NOTE - health script execution requires root permissions.
 
 In this health output, `bucket2`'s storage path is invalid and the directory mentioned in `new_buckets_path` for `user1` is missing or not accessible. Endpoint curl command returns an error response(`"endpoint_response":404`) if one or more buckets point to an invalid bucket storage path.
 
-Account without `new_buckets_path` and `allow_bucket_creation` value is `false` then it's considered a valid account, But if the `allow_bucket_creation` is true `new_buckets_path` is empty, in that case account is invalid. 
+Account without `new_buckets_path` and `allow_bucket_creation` value is `false` then it's considered a valid account, But if the `allow_bucket_creation` is true `new_buckets_path` is empty, in that case account is invalid.
 
 ### Optional status checks
 
@@ -356,13 +357,13 @@ These are the error codes populated in the health output if the system is facing
 #### Resolutions
 - Verify the NSFS service is running by checking the status and logs command.
 ```
-systemctl status nsfs
-journalctl -xeu nsfs.service
+systemctl status noobaa_nsfs.service
+journalctl -xeu noobaa_nsfs.service
 ```
 If the NSFS is not started, start the service
 ```
-systemctl enable nsfs
-systemctl start nsfs
+systemctl enable noobaa_nsfs.service
+systemctl start noobaa_nsfs.service
 ```
 #### 2. `RSYSLOG_SERVICE_FAILED`
 #### Reasons
@@ -372,13 +373,13 @@ systemctl start nsfs
 #### Resolutions
 - Verify the Rsyslog service is running by checking the status and logs command.
 ```
-systemctl status rsyslog
+systemctl status rsyslog.service
 journalctl -xeu rsyslog.service
 ```
 If the rsyslog is not started, start the service
 ```
-systemctl enable rsyslog
-systemctl start rsyslog
+systemctl enable rsyslog.service
+systemctl start rsyslog.service
 ```
 
 #### 3. `NSFS_ENDPOINT_FORK_MISSING`
@@ -389,7 +390,7 @@ systemctl start rsyslog
 #### Resolutions
 - Restart the NSFS service and also verify NSFS fork/s is exited with error in logs.
 ```
-systemctl status rsyslog
+systemctl status rsyslog.service
 journalctl -xeu rsyslog.service
 ```
 
@@ -431,11 +432,11 @@ These error codes will get attached with a specific Bucket or Account schema ins
 - Check for schema config file in respective Accounts or Buckets dir.
 
 ## Bucket and Account Manage CLI
-Users can create, get status, update, delete, and list buckets and accounts using CLI. If the config directory is missing CLI will create one and also create accounts and buckets sub-directories in it and default config directory is `${config.NSFS_NC_DEFAULT_CONF_DIR}`. 
+Users can create, get status, update, delete, and list buckets and accounts using CLI. If the config directory is missing CLI will create one and also create accounts and buckets sub-directories in it and default config directory is `${config.NSFS_NC_DEFAULT_CONF_DIR}`.
 
 CLI will never create or delete a bucket directory for the user if a bucket directory is missing CLI will return with error.
 
-NOTES - 
+NOTES -
 1. manage_nsfs execution requires root permissions.
 2. While path specifies a GPFS path, it's recommended to add fs_backend=GPFS in order to increase performance by ordering NooBaa to use GPFS library.
 
@@ -478,12 +479,12 @@ NSFS management CLI command will create both account and bucket dir if it's miss
 ## NSFS Certificate
 
 Non containerized NSFS certificates/ directory location will be under the config_root path. <br />
-The certificates/ directory should contain SSL files tls.key and tls.crt. <br /> 
+The certificates/ directory should contain SSL files tls.key and tls.crt. <br />
 System will use a cert from this dir to create a valid HTTPS connection. If cert is missing in this dir a self-signed SSL certificate will be generated. Make sure the path to certificates/ directory is valid before running nsfs command, If the path is invalid then cert flow will fail.
 
 Non containerized NSFS restrict insecure HTTP connections when `ALLOW_HTTP` is set to false in cofig.json. This is the default behaviour.
 
-### Setting Up Self signed SSL/TLS Certificates for Secure Communication Between S3 Client and NooBaa NSFS Service - 
+### Setting Up Self signed SSL/TLS Certificates for Secure Communication Between S3 Client and NooBaa NSFS Service -
 
 #### 1. Creating a SAN (Subject Alternative Name) Config File -
 **Important**: This step is needed only if S3 Client and NooBaa Service Running on different nodes.
@@ -519,7 +520,7 @@ subjectAltName = DNS:localhost,DNS:nsfs-domain-name-example.com,IP:<nsfs-server-
 
 #### 2. Generating TLS Key, CSR, and CRT Files via OpenSSL -
  The following process will generate the necessary TLS key (tls.key), certificate signing request (tls.csr), and SSL certificate (tls.crt) files for secure communication between the S3 client and the NooBaa service.
- 
+
 * If S3 Client and NooBaa Service Running on the Same Node, run -
 
 ```bash
@@ -541,28 +542,28 @@ Note - The default config_dir is /etc/noobaa.conf.d/.
 sudo mv tls.key {config_dir_path}/certificates/
 sudo mv tls.csr {config_dir_path}/certificates/
 ```
-#### 4. Restart the NooBaa NSFS service - 
+#### 4. Restart the NooBaa NSFS service -
 ```bash
 sudo systemctl restart noobaa_nsfs
 ```
-#### 5. Create S3 CLI alias while including tls.crt at the s3 commands via AWS_CA_BUNDLE=/path/to/tls.crt - 
+#### 5. Create S3 CLI alias while including tls.crt at the s3 commands via AWS_CA_BUNDLE=/path/to/tls.crt -
 * Make sure to replace credentials placeholders with their respective values, and the <endpoint> placeholder either with `localhost` or the domain name or IP of the node which is running the NSFS service.
 ```bash
 alias s3_ssl='AWS_CA_BUNDLE=/path/to/tls.crt AWS_ACCESS_KEY_ID=add_your_access_key AWS_SECRET_ACCESS_KEY=add_your_secret_key aws --endpoint https://<endpoint>:6443 s3'
 ```
 
-#### 6. Try running an s3 list buckets using the s3 alias - 
+#### 6. Try running an s3 list buckets using the s3 alias -
 ```bash
 s3_ssl ls
 ```
 
 ## Monitoring
 
-Prometheus metrics port can be passed through the argument `--metrics_port` while executing the nsfs command. 
+Prometheus metrics port can be passed through the argument `--metrics_port` while executing the nsfs command.
 NSFS state and output metrics can be fetched from URL `http:{host}:{metrics_port}/metrics/nsfs_stats`.
 
 ## Log and Logrotate
-Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running. 
+Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running.
 
 Rsyslog status check
 ```
@@ -571,24 +572,24 @@ systemctl status rsyslog
 
 Noobaa logs are pushed to `var/log/noobaa.log` and the log is rotated and compressed daily.
 
-Verify the rsyslog and logrotate rpm configuration is complete by checking the files `etc/rsyslog.d/noobaa_syslog.conf` and `etc/rsyslog.d/noobaa_rsyslog.conf` for rsyslog and `etc/logrotate.d/noobaa/logrotate_noobaa.conf` for logrotate.These files contain the noobaa specific configuration for rsyslog and logrotate.
+Verify the rsyslog and logrotate rpm configuration is complete by checking the files `etc/rsyslog.d/noobaa_syslog.conf` for rsyslog and `etc/logrotate.d/noobaa/logrotate_noobaa.conf` for logrotate.These files contain the noobaa specific configuration for rsyslog and logrotate.
 
 Rotate the logs manually.
 
 ```
-logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf 
+logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf
 ```
 
 **Create env file under the configuration directory (OPTIONAL) -**
 
-In order to apply env variables changes on the service, edit /etc/sysconfig/noobaa_nsfs env file as you wish before starting the service, notice that the env file format is key-value pair - 
+In order to apply env variables changes on the service, edit /etc/sysconfig/noobaa_nsfs env file as you wish before starting the service, notice that the env file format is key-value pair -
 
 ```sh
 vim  /etc/sysconfig/noobaa_nsfs
 ```
 **Note** - If another /usr/local/noobaa-core/.env exists it should be merged into /etc/sysconfig/noobaa_nsfs carefully.
 
-In order to apply env changes after the service was started, edit the /etc/sysconfig/noobaa_nsfs env file and restart the service - 
+In order to apply env changes after the service was started, edit the /etc/sysconfig/noobaa_nsfs env file and restart the service -
 ```sh
 vim  /etc/sysconfig/noobaa_nsfs
 systemctl restart noobaa_nsfs

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -18,6 +18,8 @@ URL:        https://www.noobaa.io/
 Source0:	%{noobaatar}
 Source1:    %{nodetar}
 
+BuildRequires: systemd
+
 Recommends: jemalloc
 
 %global __os_install_post %{nil}
@@ -48,23 +50,21 @@ ln -s /usr/local/noobaa-core/node/bin/node $RPM_BUILD_ROOT/usr/local/noobaa-core
 ln -s /usr/local/noobaa-core/node/bin/npm $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npm
 ln -s /usr/local/noobaa-core/node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npx
 
-mkdir -p $RPM_BUILD_ROOT/etc/systemd/system/
-cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/noobaa_nsfs.service
+mkdir -p $RPM_BUILD_ROOT%{_unitdir}/
+cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT%{_unitdir}/noobaa_nsfs.service
 ln -s /usr/local/noobaa-core/src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
 mkdir -p $RPM_BUILD_ROOT/etc/noobaa.conf.d/
 
 mkdir -p $RPM_BUILD_ROOT/etc/rsyslog.d/
-ln -s /usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
-ln -s /usr/local/noobaa-core/src/deploy/standalone/noobaa_rsyslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_rsyslog.conf
+cp -R $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
 
 mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d/noobaa
 ln -s /usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.conf $RPM_BUILD_ROOT/etc/logrotate.d/noobaa/logrotate_noobaa.conf
 
 %files
 /usr/local/noobaa-core
-/etc/systemd/system/noobaa_nsfs.service
+%{_unitdir}/noobaa_nsfs.service
 /etc/logrotate.d/noobaa/logrotate_noobaa.conf
-/etc/rsyslog.d/noobaa_rsyslog.conf
 /etc/rsyslog.d/noobaa_syslog.conf
 /etc/noobaa.conf.d/
 %doc

--- a/src/deploy/spectrum_archive/deployment_guide.md
+++ b/src/deploy/spectrum_archive/deployment_guide.md
@@ -13,7 +13,7 @@ NooBaa is packaged as a RPM which needs to be installed in order to be able to u
 1. Install by using `dnf`, `yum` or `rpm`.
    - Example: `rpm -i noobaa-core-5.15.0-1.el8.x86_64.20231009`.
 2. NooBaa RPM installation should provide the following things
-	1. `noobaa_nsfs.service` file located (soft link) at `/etc/systemd/systemd/noobaa_nsfs.service`.
+	1. `noobaa_nsfs.service` file located at `/usr/lib/systemd/system/noobaa_nsfs.service`.
 	2. NooBaa source available at `/usr/local/noobaa-core`.
 
 ## NooBaa Configuration
@@ -76,7 +76,7 @@ Here,
 - `device-or-directory-name` is the name of the GPFS device or directory name. You may be able to find this by running `mount | grep gpfs`.
 - `noobaa-bucket-data-path` is the path on GPFS where NooBaa is storing the data. This path should be the same as we passed in the [Configure NooBaa User](#configure-noobaa-user)'s `<path-to-store-bucket-data>`.
 - `tape-pool-name` should be a valid tape pool name. You can find this by running `eeadm pool list`.
- 
+
 #### Example
 ```console
 $ cd /usr/local/noobaa-core
@@ -148,7 +148,7 @@ download: s3://first.bucket/somefile to ./somefile.cp
 ```
 
 ## Log and Logrotate
-Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running. 
+Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running.
 
 Rsyslog status check
 ```
@@ -162,7 +162,7 @@ Verify the rsyslog and logrotate rpm configuration is complete by checking the f
 Rotate the logs manually.
 
 ```
-logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf 
+logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf
 ```
 
 # FAQ

--- a/src/deploy/standalone/noobaa_rsyslog.conf
+++ b/src/deploy/standalone/noobaa_rsyslog.conf
@@ -6,7 +6,7 @@
 #### MODULES ####
 
 # The imjournal module bellow is now used as a message source instead of imuxsock.
-# $ModLoad imuxsock  # Turn off message reception via local log socket; 
+# $ModLoad imuxsock  # Turn off message reception via local log socket;
 #$ModLoad imjournal # provides access to the systemd journal
 #$ModLoad imklog # reads kernel messages (the same are read from journald)
 #$ModLoad immark  # provides --MARK-- message capability
@@ -41,25 +41,6 @@ $WorkDirectory /var/lib/rsyslog
 
 # File to store the position in the journal
 #$IMJournalStateFile imjournal.state
-
-template(name="LogseneFormat" type="list" option.json="on") {
-  constant(value="{")
-  constant(value="\"timestamp\":\"")
-  property(name="timereported" dateFormat="rfc3339")
-  constant(value="\",\"message\":\"")
-  property(name="msg")
-  constant(value="\",\"host\":\"")
-  property(name="hostname")
-  constant(value="\",\"severity\":\"")
-  property(name="syslogseverity-text")
-  constant(value="\",\"facility\":\"")
-  property(name="syslogfacility-text")
-  constant(value="\",\"syslog-tag\":\"")
-  property(name="syslogtag")
-  constant(value="\",\"source\":\"")
-  property(name="programname")
-  constant(value="\"}\n")
-}
 
 #### RULES ####
 

--- a/src/deploy/standalone/noobaa_syslog.conf
+++ b/src/deploy/standalone/noobaa_syslog.conf
@@ -9,6 +9,25 @@ $EscapeControlCharactersOnReceive off
 # When changing this format make sure to change the relevant functions in os_utils
 #if $syslogfacility-text != 'local0' then @192.168.1.108:514
 
+template(name="LogseneFormat" type="list" option.json="on") {
+  constant(value="{")
+  constant(value="\"timestamp\":\"")
+  property(name="timereported" dateFormat="rfc3339")
+  constant(value="\",\"message\":\"")
+  property(name="msg")
+  constant(value="\",\"host\":\"")
+  property(name="hostname")
+  constant(value="\",\"severity\":\"")
+  property(name="syslogseverity-text")
+  constant(value="\",\"facility\":\"")
+  property(name="syslogfacility-text")
+  constant(value="\",\"syslog-tag\":\"")
+  property(name="syslogtag")
+  constant(value="\",\"source\":\"")
+  property(name="programname")
+  constant(value="\"}\n")
+}
+
 # For servers
 local0.*        /var/log/noobaa.log;RSYSLOG_FileFormat
 &stop


### PR DESCRIPTION
### Explain the changes

This is the new PR of fix which is tried in #7781.

Current rsyslog log configuration, `noobaa_syslog.conf`, is done by symlink. But this implementation makes a problem in some systems like stand alone installed RHEL8. So need to install the config file as a regular file.

`noobaa_rsyslog.conf` has many conflict configuration in stand alone installed RHEL8. So it is removed from installation under `/etc/rsyslog.conf.d` and only time stamp config is moved to `noobaa_syslog.conf`.

In addition to this, move the unit file for systemd from `/etc/systemd/system` to `/usr/lib/systemd/system`. Because `/usr/lib/systemd/system` is the directory for additional systemd unit files. Symlinks under `/etc/systemd/system` shall be managed by `systemctl` command after install.

 1. Copy noobaa_syslog.conf as a regular file instead of a symlink
 2. Do not copy noobaa_rsyslog.conf at the rpm install
 3. Move tilestamp format definition from noobaa_rsyslog.conf to noobaa_syslog.conf
 4. Copy the unit file of systemd to /usr/lib/systemd/system

### UT Log

Confirmed the rpm can be created correctly by `make rpm CENTOS_VER=8`.

```
...
= 4.0-1
Requires(post): /bin/sh
Requires: /bin/bash /bin/sh /usr/bin/env ld-linux-x86-64.so.2()(64bit) ld-linux-x86-64.so.2(GLIBC_2.2.5)(64bit) libboost_thread.so.1.66.0()(64bit) libc.so.6()(64bit) libc.so.6(GLIBC_2.10)(64bit) libc.so.6(GLIBC_2.12)(64bit) libc.so.6(GLIBC_2.14)(64bit) libc.so.6(GLIBC_2.16)(64bit) libc.so.6(GLIBC_2.17)(64bit) libc.so.6(GLIBC_2.2.5)(64bit) libc.so.6(GLIBC_2.25)(64bit) libc.so.6(GLIBC_2.28)(64bit) libc.so.6(GLIBC_2.3)(64bit) libc.so.6(GLIBC_2.3.2)(64bit) libc.so.6(GLIBC_2.3.4)(64bit) libc.so.6(GLIBC_2.4)(64bit) libc.so.6(GLIBC_2.6)(64bit) libc.so.6(GLIBC_2.7)(64bit) libc.so.6(GLIBC_2.9)(64bit) libdl.so.2()(64bit) libdl.so.2(GLIBC_2.2.5)(64bit) libgcc_s.so.1()(64bit) libgcc_s.so.1(GCC_3.0)(64bit) libgcc_s.so.1(GCC_3.4)(64bit) libm.so.6()(64bit) libm.so.6(GLIBC_2.2.5)(64bit) libm.so.6(GLIBC_2.27)(64bit) libpthread.so.0()(64bit) libpthread.so.0(GLIBC_2.2.5)(64bit) libpthread.so.0(GLIBC_2.3.2)(64bit) libpthread.so.0(GLIBC_2.3.3)(64bit) libpthread.so.0(GLIBC_2.3.4)(64bit) librt.so.1()(64bit) libstdc++.so.6()(64bit) libstdc++.so.6(CXXABI_1.3)(64bit) libstdc++.so.6(CXXABI_1.3.11)(64bit) libstdc++.so.6(CXXABI_1.3.5)(64bit) libstdc++.so.6(CXXABI_1.3.7)(64bit) libstdc++.so.6(CXXABI_1.3.8)(64bit) libstdc++.so.6(CXXABI_1.3.9)(64bit) libstdc++.so.6(GLIBCXX_3.4)(64bit) libstdc++.so.6(GLIBCXX_3.4.11)(64bit) libstdc++.so.6(GLIBCXX_3.4.14)(64bit) libstdc++.so.6(GLIBCXX_3.4.15)(64bit) libstdc++.so.6(GLIBCXX_3.4.18)(64bit) libstdc++.so.6(GLIBCXX_3.4.19)(64bit) libstdc++.so.6(GLIBCXX_3.4.20)(64bit) libstdc++.so.6(GLIBCXX_3.4.21)(64bit) libstdc++.so.6(GLIBCXX_3.4.9)(64bit) rtld(GNU_HASH)
Recommends: jemalloc
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/noobaa-core-5.15.0-20240205.el8.x86_64
Wrote: /root/rpmbuild/SRPMS/noobaa-core-5.15.0-20240205.el8.src.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/noobaa-core-5.15.0-20240205.el8.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.bAI9FM
+ umask 022
+ cd /root/rpmbuild/BUILD
+ '[' /root/rpmbuild/BUILDROOT/noobaa-core-5.15.0-20240205.el8.x86_64 '!=' / ']'
+ rm -rf /root/rpmbuild/BUILDROOT/noobaa-core-5.15.0-20240205.el8.x86_64
+ exit 0
+ main@./packagerpm.sh:95 mv /root/rpmbuild/RPMS/x86_64/noobaa-core-5.15.0-20240205.el8.x86_64.rpm /export
+ main@./packagerpm.sh:96 mv /root/rpmbuild/SRPMS/noobaa-core-5.15.0-20240205.el8.src.rpm /export
echo "\033[1;32mRPM for platform \""noobaa-rpm-build"\" is ready in build/rpm.\033[0m";
RPM for platform "noobaa-rpm-build" is ready in build/rpm.
```