### PR TITLE
NSFS | NC | Fix Check Flag Type From Manage NSFS CLI

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -19,7 +19,7 @@ const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').Ma
 const bucket_policy_utils = require('../endpoint/s3/s3_bucket_policy_utils');
 const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
 const { print_usage } = require('../manage_nsfs/manage_nsfs_help_utils');
-const { TYPES, ACTIONS, VALID_OPTIONS, OPTION_TYPE, TYPE_STRING_OR_NUMBER,
+const { TYPES, ACTIONS, VALID_OPTIONS, OPTION_TYPE,
     LIST_ACCOUNT_FILTERS, LIST_BUCKET_FILTERS} = require('../manage_nsfs/manage_nsfs_constants');
 
 function throw_cli_error(error_code, detail) {
@@ -77,7 +77,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         if (argv.help || argv.h) {
             return print_usage(type, action);
         }
-        validate_options(type, action, argv);
+        validate_flags_arguments(type, action, argv);
         config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
         if (!config_root) throw_cli_error(ManageCLIError.MissingConfigDirPath);
 
@@ -121,7 +121,7 @@ async function fetch_bucket_data(argv, from_file) {
         const fs_context = native_fs_utils.get_process_fs_context();
         const raw_data = (await nb_native().fs.readFile(fs_context, from_file)).data;
         data = JSON.parse(raw_data.toString());
-        validate_options_type(data);
+        // GAP - from-file is not validated
     }
     if (!data) {
         // added undefined values to keep the order the properties when printing the data object
@@ -372,7 +372,7 @@ async function fetch_account_data(argv, from_file) {
         const fs_context = native_fs_utils.get_process_fs_context();
         const raw_data = (await nb_native().fs.readFile(fs_context, from_file)).data;
         data = JSON.parse(raw_data.toString());
-        validate_options_type(data);
+        // GAP - from-file is not validated
     }
     if (action !== ACTIONS.LIST && action !== ACTIONS.STATUS) _validate_access_keys(argv);
     if (action === ACTIONS.ADD || action === ACTIONS.STATUS) {
@@ -811,36 +811,46 @@ async function validate_account_args(data, action) {
     }
 }
 
-/** validate_options checks if input option are valid.
+/** validate_flags_arguments checks if input option are valid.
  * @param {string} type
  * @param {string} action
  * @param {object} argv
  */
-function validate_options(type, action, argv) {
-    validate_no_extra_options(type, action, argv);
+function validate_flags_arguments(type, action, argv) {
+    validate_type_and_action(type, action);
+    // when we use validate_no_extra_options
+    // we don't care about the value, only the flags
+    const input_options = Object.keys(argv);
+    // the first element is _ with the type and action, so we remove it
+    input_options.shift();
+    validate_no_extra_options(type, action, input_options);
     const input_options_with_data = { ...argv };
     delete input_options_with_data._;
-    validate_options_type(input_options_with_data);
+    validate_options_type_by_value(type, input_options_with_data);
 }
 
 /**
- * validate_no_extra_options will check that input options are valid options - 
- * only required arguments, optional options and global configurations
+ * validate_type_and_action checks that the type and action are supported
  * @param {string} type
  * @param {string} action
- * @param {object} argv
  */
-function validate_no_extra_options(type, action, argv) {
+function validate_type_and_action(type, action) {
     if (!Object.values(TYPES).includes(type)) throw_cli_error(ManageCLIError.InvalidType);
     if (type === TYPES.ACCOUNT || type === TYPES.BUCKET) {
         if (!Object.values(ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidAction);
     } else if (type === TYPES.IP_WHITELIST) {
         if (action !== '') throw_cli_error(ManageCLIError.InvalidAction);
     }
+}
 
-    const input_options = Object.keys(argv); // we don't care about the value, only the flags
-    input_options.shift(); // the first element is _ with the type and action, so we remove it
-
+/**
+ * validate_no_extra_options will check that input flags are valid options - 
+ * only required arguments, optional flags and global configurations
+ * @param {string} type
+ * @param {string} action
+ * @param {string[]} input_options array with the names of the flags
+ */
+function validate_no_extra_options(type, action, input_options) {
     let valid_options; // for performance, we use Set as data structure
     if (type === TYPES.BUCKET) {
         valid_options = VALID_OPTIONS.bucket_options[action];
@@ -860,26 +870,43 @@ function validate_no_extra_options(type, action, argv) {
         throw_cli_error(ManageCLIError.InvalidArgument, err_msg);
     }
 }
-
 /**
- *  validate_options_type check the type of the value that match what we expect
- * @param {object} input_options_with_data
+ * validate_options_type_by_value check the type of the value that match what we expect.
+ * in case that type of value we have is boolean (and the option type is not boolean) -
+ * we check if we have a value (non empty) with array of argument (without using minimist)
+ * @param {string} type
+ * @param {object} input_options_with_data object with flag (key) and value
  */
-function validate_options_type(input_options_with_data) {
+function validate_options_type_by_value(type, input_options_with_data) {
+    const argv_arr = process.argv.slice(2); // we ignore argv[0] (path to node) and argv[1] (path to app)
+    let index_in_argv_arr; // we will iterate the argv array to find flags without value
+    if (type === TYPES.IP_WHITELIST) {
+        index_in_argv_arr = 1; // we ignore the type (there is no action)
+    } else {
+        index_in_argv_arr = 2; // we ignore the type and action
+    }
     for (const [option, value] of Object.entries(input_options_with_data)) {
         const type_of_option = OPTION_TYPE[option];
         const type_of_value = typeof value;
-        const err_msg = `type of option ${option} should be ${type_of_option}, ` +
-            `received: ${value} (type ${type_of_value})`;
-        if (type_of_option === TYPE_STRING_OR_NUMBER) {
-            if ((type_of_value === 'string') || (type_of_value === 'number')) {
-                continue;
-            } else {
-                throw_cli_error(ManageCLIError.InvalidArgumentType, err_msg);
+        if (type_of_value !== type_of_option) {
+            if ((type_of_value === 'boolean') &&
+                (argv_arr[index_in_argv_arr].slice(2) === option) && // we use slice(2) to remove the -- from string
+                ((index_in_argv_arr + 1 === argv_arr.length) ||
+                 (argv_arr[index_in_argv_arr + 1].startsWith('--')))) {
+                // in case the user sends --flag with no value there are 2 cases:
+                // (1) [--flag] there is no next element (index + 1 is out of array bound)
+                // (2) [--flag, --flag2] next element is a flag
+                throw_cli_error(ManageCLIError.InvalidArgumentType, `empty value in flag ${option}`);
             }
-        } else if (type_of_value !== type_of_option) {
+            // special case for names, although the type is string we want to allow numbers as well
+            if ((option === 'name' || option === 'new_name') && (type_of_value === 'number')) {
+                index_in_argv_arr += 2;
+                continue;
+            }
+            const err_msg = `type of flag ${option} should be ${type_of_option}`;
             throw_cli_error(ManageCLIError.InvalidArgumentType, err_msg);
         }
+        index_in_argv_arr += 2;
     }
 }
 

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -42,14 +42,13 @@ const VALID_OPTIONS = {
     whitelist_options: VALID_OPTIONS_WHITELIST,
 };
 
-const TYPE_STRING_OR_NUMBER = 'string, number'; // we allow the names to be numbers and strings
 const OPTION_TYPE = {
-    name: TYPE_STRING_OR_NUMBER,
+    name: 'string',
     email: 'string',
     uid: 'number',
     gid: 'number',
     new_buckets_path: 'string',
-    user: TYPE_STRING_OR_NUMBER,
+    user: 'string',
     access_key: 'string',
     secret_key: 'string',
     fs_backend: 'string',
@@ -58,7 +57,7 @@ const OPTION_TYPE = {
     config_root_backend: 'string',
     path: 'string',
     bucket_policy: 'string',
-    new_name: TYPE_STRING_OR_NUMBER,
+    new_name: 'string',
     regenerate: 'boolean',
     wide: 'boolean',
     show_secrets: 'boolean',
@@ -73,7 +72,6 @@ exports.TYPES = TYPES;
 exports.ACTIONS = ACTIONS;
 exports.VALID_OPTIONS = VALID_OPTIONS;
 exports.OPTION_TYPE = OPTION_TYPE;
-exports.TYPE_STRING_OR_NUMBER = TYPE_STRING_OR_NUMBER;
 
 exports.LIST_ACCOUNT_FILTERS = LIST_ACCOUNT_FILTERS;
 exports.LIST_BUCKET_FILTERS = LIST_BUCKET_FILTERS;

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -74,12 +74,12 @@ Usage:
 account add [flags]
 
 Flags:
---name <string or number>                                                                   Set the name for the account
+--name <string>                                                                             Set the name for the account
 --email <string>                                                                            Set the email for the account (used as the identifier for buckets owner)
 --uid <number>                                                                              Set the User Identifier (UID) (UID and GID can be replaced by --user option)
 --gid <number>                                                                              Set the Group Identifier (GID) (UID and GID can be replaced by --user option)
 --new_buckets_path <string>                                                                 Set the filesystem's root path where each subdirectory is a bucket
---user <string or number>                                 (optional)                        Set the OS user name (instead of UID and GID)
+--user <string>                                           (optional)                        Set the OS user name (instead of UID and GID)
 --access_key <string>                                     (optional)                        Set the access key for the account (default is generated)
 --secret_key <string>                                     (optional)                        Set the secret key for the account (default is generated)
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>              (optional)                        Set the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
@@ -90,13 +90,13 @@ Usage:
 account update [flags]
 
 Flags:
---name <string or number>                                                                   The name of the account
---new_name <string or number>                             (optional)                        Update the account name
+--name <string>                                                                             The name of the account
+--new_name <string>                                       (optional)                        Update the account name
 --email <string>                                          (optional)                        Update the email (used as the identifier for buckets owner)
 --uid <number>                                            (optional)                        Update the User Identifier (UID)
 --gid <number>                                            (optional)                        Update the Group Identifier (GID)
 --new_buckets_path <string>                               (optional)                        Update the filesystem's root path where each subdirectory is a bucket
---user <string or number>                                 (optional)                        Update the OS user name (instead of uid and gid)
+--user <string>                                           (optional)                        Update the OS user name (instead of uid and gid)
 --regenerate                                              (optional)                        Update automatically generated access key and secret key
 --access_key <string>                                     (optional)                        Update the access key. Can be used as identifier instead of --name
 --secret_key <string>                                     (optional)                        Update the secret key
@@ -108,7 +108,7 @@ Usage:
 account delete [flags]
 
 Flags:
---name <string or number>                                                                   The name of the account
+--name <string>                                                                             The name of the account
 --access_key <string>                                     (optional)                        The access key of the account (identify the account instead of name)
 `;
 
@@ -117,7 +117,7 @@ Usage:
 account status [flags]
 
 Flags:
---name <string or number>                                                                   The name of the account
+--name <string>                                                                             The name of the account
 --access_key <string>                                     (optional)                        The access key of the account (identify the account instead of name)
 --show_secrets                                            (optional)                        Print the access key and secret key of the account
 `;
@@ -131,8 +131,8 @@ Flags:
 --show_secrets                                            (optional)                        Print the access key and secret key of each account (only when using flag --wide)
 --uid <number>                                            (optional)                        Filter the list based on the provided account UID
 --gid <number>                                            (optional)                        Filter the list based on the provided account GID
---user <string or number>                                 (optional)                        Filter the list based on the provided account user
---name <string or number>                                 (optional)                        Filter the list based on the provided account name
+--user <string>                                           (optional)                        Filter the list based on the provided account user
+--name <string>                                           (optional)                        Filter the list based on the provided account name
 --access_key <string>                                     (optional)                        Filter the list based on the provided account access key
 `;
 
@@ -141,7 +141,7 @@ Usage:
 bucket add [flags]
 
 Flags:
---name <string or number>                                                                   Set the name for the bucket
+--name <string>                                                                             Set the name for the bucket
 --email <string>                                                                            Set the bucket owner email
 --path <string>                                                                             Set the bucket path
 --bucket_policy <string>                                  (optional)                        Set the bucket policy, type is a string of valid JSON policy
@@ -153,8 +153,8 @@ Usage:
 bucket update [flags]
 
 Flags:
---name <string or number>                                                                   The name of the bucket
---new_name <string or number>                             (optional)                        Update the bucket name
+--name <string>                                                                             The name of the bucket
+--new_name <string>                                       (optional)                        Update the bucket name
 --email <string>                                          (optional)                        Update the bucket owner email
 --path <string>                                           (optional)                        Update the bucket path
 --bucket_policy <string>                                  (optional)                        Update the bucket policy, type is a string of valid JSON policy (unset with '')
@@ -166,7 +166,7 @@ Usage:
 bucket delete [flags]
 
 Flags:
---name <string or number>                                                                   The name of the bucket
+--name <string>                                                                             The name of the bucket
 `;
 
 const BUCKET_FLAGS_STATUS = `
@@ -174,7 +174,7 @@ Usage:
 bucket status [flags]
 
 Flags:
---name <string or number>                                                                   The name of the bucket
+--name <string>                                                                             The name of the bucket
 `;
 
 const BUCKET_FLAGS_LIST = `
@@ -183,7 +183,7 @@ bucket list [flags]
 
 Flags:
 --wide                                                    (optional)                        Print the additional details for each bucket
---name                                                    (optional)                        Filter the list based on the provided bucket name
+--name <string>                                           (optional)                        Filter the list based on the provided bucket name
 `;
 
 /** 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -166,6 +166,34 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
         });
 
+        it('should fail - cli create account invalid option type (user as number)', async () => {
+            const { type, name, email, new_buckets_path } = defaults;
+            const account_options = { config_root, name, email, new_buckets_path, user: 0};
+            const action = ACTIONS.ADD;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
+        });
+
+        it('should fail - cli create account invalid option type (name as boolean)', async () => {
+            const { type, email, new_buckets_path } = defaults;
+            const account_options = { config_root, email, new_buckets_path};
+            const action = ACTIONS.ADD;
+            const command = create_command(type, action, account_options);
+            const flag = 'name'; // we will add name flag without value
+            const res = await exec_manage_cli_add_empty_option(command, flag);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
+        });
+
+        it('should fail - cli create account invalid option type (email as boolean)', async () => {
+            const { type, name, new_buckets_path } = defaults;
+            const account_options = { config_root, name, new_buckets_path};
+            const action = ACTIONS.ADD;
+            const command = create_command(type, action, account_options);
+            const flag = 'email'; // we will add email flag without value
+            const res = await exec_manage_cli_add_empty_option(command, flag);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
+        });
+
         it('should fail - cli create account invalid option type (new_buckets_path as number)', async () => {
             const action = ACTIONS.ADD;
             const { type, name, email, uid, gid } = defaults;
@@ -183,6 +211,16 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidAccountNewBucketsPath.message);
         });
+
+        it('cli account add - name is a number', async function() {
+            const account_name = '0';
+            const options = { name: account_name, email: `${account_name}@noobaa.com`, uid: 2001, gid: 2001 };
+            const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...options });
+            const account = JSON.parse(res).response.reply;
+            assert_account(account, options, false);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, { config_root, name: account_name });
+        });
+
 
         it('cli account add - uid is 0, gid is not 0', async function() {
             const account_name = 'uid_is_0';
@@ -323,12 +361,22 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
         });
 
-        it('should fail - cli update account invalid option type', async () => {
+        it('should fail - cli update account invalid option type (user as boolean)', async () => {
             const { name } = defaults;
             const account_options = { config_root, name};
             const action = ACTIONS.UPDATE;
             const command = create_command(type, action, account_options);
             const flag = 'user'; // we will add user flag without value
+            const res = await exec_manage_cli_add_empty_option(command, flag);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
+        });
+
+        it('should fail - cli update account invalid option type (email as boolean)', async () => {
+            const { name } = defaults;
+            const account_options = { config_root, name};
+            const action = ACTIONS.UPDATE;
+            const command = create_command(type, action, account_options);
+            const flag = 'email'; // we will add email flag without value
             const res = await exec_manage_cli_add_empty_option(command, flag);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
         });


### PR DESCRIPTION
### Explain the changes
1. Remove the string or number and only handle names and allow it to be a number (there were part of #7756).
2. Check that the argument is not empty directly with argv array (and not object my minimist).
3. Rename the function from "options' to "flags" to be aligned with customer terms when referring to the raw input from the user.
4. Remove option validation from from-file (will be a GAP).

### Issues: Fixed #7790
1. In the PR we will change the message when the user passes a flag that is not boolean without a value.
2. GAP - I removed the validation in the part of "from-file", which should be handled and tested specifically.

### Testing Instructions:
1. For manual tests add a valid flag without value (except boolean flags), for example:
`sudo node src/cmd/manage_nsfs account add --name` (`--name` with no value).
2. For running the unit test with the new tests, please run:
`sudo npx jest test_nc_nsfs_account_cli.test.js`.


- [ ] Doc added/updated
- [X] Tests added
