### PR TITLE
NSFS | NC | Remove SensitiveStrings in manage_nsfs

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -315,6 +315,43 @@ describe('manage nsfs cli account flow', () => {
             assert_account(account_symlink, new_account_details);
         });
 
+        it('cli account update name undefined (and back to original name)', async function() {
+            // set the name as undefined
+            let name = defaults.name;
+            let new_name = 'undefined'; // it is string on purpose
+            let account_options = { config_root, name, new_name };
+            const action = ACTIONS.UPDATE;
+            await exec_manage_cli(type, action, account_options);
+            let new_account_details = await read_config_file(config_root, accounts_schema_dir, new_name);
+            expect(new_account_details.name).toBe(new_name);
+
+            // set the name as back as it was
+            let temp = name; // we swap between name and new_name
+            name = new_name;
+            new_name = temp;
+            account_options = { config_root, name, new_name };
+            await exec_manage_cli(type, action, account_options);
+            new_account_details = await read_config_file(config_root, accounts_schema_dir, new_name);
+            expect(new_account_details.name).toBe(new_name);
+
+            // set the name as undefined (not string)
+            name = defaults.name;
+            new_name = undefined;
+            account_options = { config_root, name, new_name };
+            await exec_manage_cli(type, action, account_options);
+            new_account_details = await read_config_file(config_root, accounts_schema_dir, new_name);
+            expect(new_account_details.name).toBe(String(new_name));
+
+            // set the name as back as it was
+            temp = name; // we swap between name and new_name
+            name = String(new_name);
+            new_name = temp;
+            account_options = { config_root, name, new_name };
+            await exec_manage_cli(type, action, account_options);
+            new_account_details = await read_config_file(config_root, accounts_schema_dir, new_name);
+            expect(new_account_details.name).toBe(new_name);
+        });
+
         it('cli account update access key, secret_key & new_name by name', async function() {
             const { name } = defaults;
             const new_name = 'account1_new_name';

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -10,7 +10,6 @@ const { v4: uuidv4 } = require('uuid');
 const config = require('../../config');
 const RpcError = require('../rpc/rpc_error');
 const nb_native = require('../util/nb_native');
-const SensitiveString = require('../util/sensitive_string');
 
 const gpfs_link_unlink_retry_err = 'EEXIST';
 const gpfs_unlink_retry_catch = 'GPFS_UNLINK_RETRY';
@@ -453,10 +452,7 @@ function get_process_fs_context(config_root_backend) {
 async function get_fs_context(nsfs_account_config, config_root_backend) {
     let account_ids_by_dn;
     if (nsfs_account_config.distinguished_name) {
-        const dn = (nsfs_account_config.distinguished_name instanceof SensitiveString) ?
-            nsfs_account_config.distinguished_name.unwrap() :
-            nsfs_account_config.distinguished_name;
-        account_ids_by_dn = await get_user_by_distinguished_name({ distinguished_name: dn });
+        account_ids_by_dn = await get_user_by_distinguished_name({ distinguished_name: nsfs_account_config.distinguished_name });
     }
     return {
         uid: (account_ids_by_dn && account_ids_by_dn.uid) ?? nsfs_account_config.uid,


### PR DESCRIPTION
### Explain the changes
1. Remove SensitiveStrings from all properties except `secret_access_key` and `access_key` in manage_nsfs.
2. Remove SensitiveString from `nsfs_account_config.distinguished_name` inside `get_fs_context` (`native_fs_utils`).

### Issues: Fixed #7792 
1. Currently we have SensitiveStrings on properties, such as email, name, etc.
2. We have a minor issue with account name as undefined - when updating an account with name `undefined` (the string 'undefined'), we get an error (`MissingAccountNameFlag`).

### Testing Instructions:
Manual test:
1. First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
- `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
- `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
2. Create an account, example: `sudo node src/cmd/manage_nsfs account add --name shira-1009 --email shira-1009@noobaa.com --new_buckets_path /tmp/nsfs_root1 --uid 1009 --gid 1009`
3. Update account name to 'undefined', example: `sudo node src/cmd/manage_nsfs account update --name=shira-1009 --new_name=undefined`
4. Update the account name to the original name: `sudo node src/cmd/manage_nsfs account update --name=undefined --new_name=shira-1009`

Unit test:
1. `sudo npx jest test_nc_nsfs_account_cli.test.js`

- [ ] Doc added/updated
- [X] Tests added
