### PR TITLE
CI | Jest add `workflow_dispatch` (Manual Run on master)

### DIFF
--- a/.github/workflows/jest-unit-tests.yaml
+++ b/.github/workflows/jest-unit-tests.yaml
@@ -1,5 +1,5 @@
 name: Jest Unit Tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-unit-tests:


### PR DESCRIPTION
### Explain the changes
1. Add `workflow_dispatch` to CI for jest run.

### Issues: Fixed #xxx / Gap #xxx
1. none, I want to have the ability to run run jest test on master.

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
