### PR TITLE
NSFS | NC | S3 Flow | Fix list buckets creation date

### DIFF
--- a/src/endpoint/s3/ops/s3_get_service.js
+++ b/src/endpoint/s3/ops/s3_get_service.js
@@ -15,7 +15,7 @@ async function list_buckets(req) {
             Buckets: reply.buckets.map(bucket => ({
                 Bucket: {
                     Name: bucket.name.unwrap(),
-                    CreationDate: date,
+                    CreationDate: bucket.creation_date ? s3_utils.format_s3_xml_date(bucket.creation_date) : date,
                 }
             }))
         }

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 const P = require('../../util/promise');
 const config = require('../../../config');
 const fs_utils = require('../../util/fs_utils');
-const native_fs_utils = require('../../util/native_fs_utils');
+const { get_process_fs_context, read_config_file, get_user_by_distinguished_name} = require('../../util/native_fs_utils');
 const os_utils = require('../../util/os_utils');
 
 const BucketSpaceFS = require('../../sdk/bucketspace_fs');
@@ -24,7 +24,6 @@ const test_not_empty_bucket = 'notemptybucket';
 const test_bucket_temp_dir = 'buckettempdir';
 const test_bucket_invalid = 'bucket_invalid';
 let tmp_fs_path = '/tmp/test_bucketspace_fs';
-let bucket_temp_id;
 if (process.platform === MAC_PLATFORM) {
     tmp_fs_path = '/private/' + tmp_fs_path;
 }
@@ -50,6 +49,8 @@ const DEFAULT_FS_CONFIG = {
     backend: '',
     warn_threshold_ms: 100,
 };
+
+const process_fs_context = get_process_fs_context();
 
 // since the account in NS NSFS should be valid to the nsfs_account_schema
 // had to remove additional properties: has_s3_access: 'true' and nsfs_only: 'true'
@@ -156,10 +157,7 @@ function make_dummy_object_sdk() {
             return Boolean(fs_root_path || fs_root_path === '');
         },
         read_bucket_sdk_config_info(name) {
-            return {
-                _id: bucket_temp_id,
-                name: name
-            };
+            return bucketspace_fs.read_bucket_sdk_info({ name });
         }
     };
 }
@@ -216,7 +214,7 @@ mocha.describe('bucketspace_fs', function() {
             assert.strictEqual(res.access_keys[0].access_key.unwrap(), account_user2.access_keys[0].access_key);
             const distinguished_name = res.nsfs_account_config.distinguished_name.unwrap();
             assert.strictEqual(distinguished_name, 'root');
-            const res2 = await native_fs_utils.get_user_by_distinguished_name({ distinguished_name });
+            const res2 = await get_user_by_distinguished_name({ distinguished_name });
             assert.strictEqual(res2.uid, 0);
         });
 
@@ -227,7 +225,7 @@ mocha.describe('bucketspace_fs', function() {
             assert.strictEqual(res.access_keys[0].access_key.unwrap(), account_user3.access_keys[0].access_key);
             const distinguished_name = res.nsfs_account_config.distinguished_name.unwrap();
             assert.strictEqual(distinguished_name, os.userInfo().username);
-            const res2 = await native_fs_utils.get_user_by_distinguished_name({ distinguished_name });
+            const res2 = await get_user_by_distinguished_name({ distinguished_name });
             assert.strictEqual(res2.uid, process.getuid());
         });
 
@@ -290,7 +288,7 @@ mocha.describe('bucketspace_fs', function() {
         });
     });
 
-    mocha.describe('list_buckets', function() {
+    mocha.describe('list_buckets', async function() {
         mocha.before(async function() {
             await create_bucket(test_bucket);
         });
@@ -308,6 +306,15 @@ mocha.describe('bucketspace_fs', function() {
             await fs_utils.folder_delete(`${new_buckets_path}/${test_bucket}`);
             const file_path = get_config_file_path(buckets, test_bucket);
             await fs_utils.file_delete(file_path);
+        });
+        mocha.it('list buckets - validate creation_date', async function() {
+            const expected_bucket_name = 'bucket1';
+            const objects = await bucketspace_fs.list_buckets(dummy_object_sdk);
+            assert.equal(objects.buckets.length, 1);
+            assert.equal(objects.buckets[0].name.unwrap(), expected_bucket_name);
+            const bucket_config_path = get_config_file_path(buckets, expected_bucket_name);
+            const bucket_data = await read_config_file(process_fs_context, bucket_config_path);
+            assert.equal(objects.buckets[0].creation_date, bucket_data.creation_date);
         });
     });
     mocha.describe('delete_bucket', function() {
@@ -354,7 +361,6 @@ mocha.describe('bucketspace_fs', function() {
             const bucket_config_path = get_config_file_path(buckets, param.name);
             const data = await fs.promises.readFile(bucket_config_path);
             const bucket = await JSON.parse(data.toString());
-            bucket_temp_id = bucket._id;
             const bucket_temp_dir_path = path.join(new_buckets_path, param.name, config.NSFS_TEMP_DIR_NAME + "_" + bucket._id);
             await nb_native().fs.mkdir(ACCOUNT_FS_CONFIG, bucket_temp_dir_path);
             await fs.promises.stat(bucket_temp_dir_path);
@@ -384,8 +390,7 @@ mocha.describe('bucketspace_fs', function() {
             const param = {name: test_bucket, versioning: 'ENABLED'};
             await bucketspace_fs.set_bucket_versioning(param, dummy_object_sdk);
             const bucket_config_path = get_config_file_path(buckets, param.name);
-            const data = await fs.promises.readFile(bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await read_config_file(process_fs_context, bucket_config_path);
             assert.equal(bucket.versioning, 'ENABLED');
 
         });

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -551,6 +551,18 @@ async function folder_delete(dir, fs_context, is_temp = false) {
     await nb_native().fs.rmdir(fs_context, dir);
 }
 
+/**
+ * read_config_file reads and returns the parsed config file data
+ * @param {nb.NativeFSContext} fs_context
+ * @param {string} config_path 
+ * @return {Promise<object>} 
+ */
+async function read_config_file(fs_context, config_path) {
+    const { data } = await nb_native().fs.readFile(fs_context, config_path);
+    const config_data = JSON.parse(data.toString());
+    return config_data;
+}
+
 exports.get_umasked_mode = get_umasked_mode;
 exports._make_path_dirs = _make_path_dirs;
 exports._create_path = _create_path;
@@ -576,6 +588,7 @@ exports.gpfs_unlink_retry_catch = gpfs_unlink_retry_catch;
 exports.create_config_file = create_config_file;
 exports.delete_config_file = delete_config_file;
 exports.update_config_file = update_config_file;
+exports.read_config_file = read_config_file;
 exports.isDirectory = isDirectory;
 exports.get_process_fs_context = get_process_fs_context;
 exports.get_fs_context = get_fs_context;


### PR DESCRIPTION
### Explain the changes
1. BucketspaceFS.list_buckets() - Called read_bucket_sdk_config_info() instead of read_bucket_sdk_namespace_info() to get creation_date of the bucket. If the requesting account can access the bucket, return it together with the bucket name.
2. s3_get_service() - Returned bucket.creation_date in the correct date format if it exists, else return the fixed date.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/7795
2. Gaps - 
3. BucketspaceFs - 2 places where we can use concurrency for performance improvement - will add it in a follow-up PR.
4. Added read_config_file() helper function that can be re-used at many places in our code, will add it in a follow-up refactoring PR.
5. Refactor delete bucket 
### Testing Instructions:
1.  sudo node mocha src/test/unit_tests/test_bucketspace_fs.js
2. Manually - create a few buckets and list buckets and check their creation_date.

- [ ] Doc added/updated
- [x] Tests added
