### PR TITLE
logrotate : logrotate.sh is running but not rotating the logs

### DIFF
--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -161,6 +161,7 @@ ENV LD_PRELOAD /usr/lib64/libjemalloc.so.2
 # EXEC SETUP #
 ###############
 # Run as non root user that belongs to root 
+RUN useradd -u 10001 -g 0 -m -d /home/noob -s /bin/bash noob
 USER 10001:0
 
 # We are using CMD and not ENDPOINT so 


### PR DESCRIPTION
While core container startsd, it also starts following script- /root/node_modules/noobaa-core/src/deploy/NVA_build/logrotate.sh which loop around every 15 min and tries to rotate the /log/client.log and /log/noobaa.log files as per configuration in
logrotate_noobaa.conf file.

Problem: Logrotate is throwing an error message whenever it is started as part of loop.

Wed Feb  7 07:00:31 UTC 2024: =========== running logrotate =============== error: Cannot find logrotate UID (10001) in passwd file: Success error: found error in file logrotate_noobaa.conf, skipping Reading state from file: /var/lib/logrotate/logrotate.status Allocating hash table for state file, size 64 entries

Handling 0 logs

It is happening because there is no user in /etc/passwd file with UID of 10001.

Solution:
This patch is solving the this issue by adding a user noob using Dockerfile, NooBaa.Dockerfile - RUN useradd -u 10001 -g 0 -m -d /home/noob -s /bin/bash noob

