### PR TITLE
NSFS | NC | Remove Email from NSFS Account and Bucket in manage_nsfs (CLI)

### DIFF
--- a/docs/design/NonContainerizedNSFSDesign.md
+++ b/docs/design/NonContainerizedNSFSDesign.md
@@ -27,7 +27,7 @@ node src/cmd/nsfs ../standalon/nsfs_root --config_dir ../standalon/fs_config
 ```json
 {
   "name": "user1",
-  "email": "user1@noobaa.io",
+  "email": "user1@noobaa.io", // this just an example - the email will be internally (the account name), email will not be set by user
   "creation_date": "2024-01-11T08:24:14.937Z",
   "access_keys": [
     {
@@ -98,7 +98,7 @@ node src/cmd/nsfs ../standalon/nsfs_root --config_dir ../standalon/fs_config
 - Create account - admin creates a file in the accounts dir, and Noobaa reloads on demand.
 - Delete account - admin deletes the file, we have a cache and will expire it after some time.
 - Regenerate credentials - update the file, and Noobaa will reload after up to 1 minute.
-- Update account details like uid, gid, email etc.
+- Update account details like uid, gid, fs_backend etc.
 
 ### S3 Bucket operations
 

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -441,9 +441,9 @@ NOTES -
 
 Bucket Commands
 ```
-sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com --path ../standalon/nsfs_root/1 --fs_backend GPFS 2>/dev/null
+sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --name bucket1 --owner noobaa --path ../standalon/nsfs_root/1 --fs_backend GPFS 2>/dev/null
 
-sudo node src/cmd/manage_nsfs bucket update --config_root ../standalon/config_root --name bucket1 --email noobaa@gmail.com --fs_backend GPFS 2>/dev/null
+sudo node src/cmd/manage_nsfs bucket update --config_root ../standalon/config_root --name bucket1 --owner noobaa --fs_backend GPFS 2>/dev/null
 
 sudo node src/cmd/manage_nsfs bucket list --config_root ../standalon/config_root 2>/dev/null
 
@@ -453,7 +453,7 @@ sudo node src/cmd/manage_nsfs bucket delete --config_root ../standalon/config_ro
 
 Account Commands
 ```
-sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --name noobaa --email noobaa@gmail.com --new_buckets_path ../standalon/nsfs_root/ --fs_backend GPFS 2>/dev/null
+sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --name noobaa --new_buckets_path ../standalon/nsfs_root/ --fs_backend GPFS 2>/dev/null
 
 sudo node src/cmd/manage_nsfs account update --config_root ../standalon/config_root --name noobaa --fs_backend GPFS 2>/dev/null
 

--- a/src/deploy/NVA_build/standalone_deploy_nsfs.sh
+++ b/src/deploy/NVA_build/standalone_deploy_nsfs.sh
@@ -11,8 +11,8 @@ function execute() {
 # Please note that the command we use here are without "sudo" because we are running from the container with Root permissions
 function main() {
     # Add accounts to run ceph tests
-    execute "node src/cmd/manage_nsfs account add --name cephalt --email ceph.alt@noobaa.com --new_buckets_path ${FS_ROOT_1} --uid 1000 --gid 1000" nsfs_cephalt.log
-    execute "node src/cmd/manage_nsfs account add --name cephtenant --email ceph.tenant@noobaa.com --new_buckets_path ${FS_ROOT_2} --uid 2000 --gid 2000" nsfs_cephtenant.log
+    execute "node src/cmd/manage_nsfs account add --name cephalt --new_buckets_path ${FS_ROOT_1} --uid 1000 --gid 1000" nsfs_cephalt.log
+    execute "node src/cmd/manage_nsfs account add --name cephtenant --new_buckets_path ${FS_ROOT_2} --uid 2000 --gid 2000" nsfs_cephtenant.log
 
     # Start nsfs server
     execute "node src/cmd/nsfs" nsfs.log

--- a/src/deploy/spectrum_archive/deployment_guide.md
+++ b/src/deploy/spectrum_archive/deployment_guide.md
@@ -25,12 +25,12 @@ Before proceeding, please ensure there are no stale items in `/etc/noobaa.conf.d
 In order to be able to access NooBaa, the user should create a account. This can be done in the following way.
 ```console
 $ cd /usr/local/noobaa-core
-$ bin/node src/cmd/manage_nsfs.js account add --email <email-address-of-user> --access_key <access-key> --secret_key <secret-key> --name <name-of-user> --new_buckets_path <path-to-store-bucket-data>
+$ bin/node src/cmd/manage_nsfs.js account add --access_key <access-key> --secret_key <secret-key> --name <name-of-user> --new_buckets_path <path-to-store-bucket-data>
 ```
 
 NOTE: `<path-to-store-bucket-data>` should already exist or else the above command will throw error.
 
-Following the above steps we will create a new user for NooBaa with the given name and email. The user will be able to access the NooBaa S3 endpoint with the access key and secret key pair.
+Following the above steps we will create a new user for NooBaa with the given name. The user will be able to access the NooBaa S3 endpoint with the access key and secret key pair.
 
 #### Example
 ```console
@@ -38,7 +38,7 @@ $ cd /usr/local/noobaa-core
 $ mkdir /ibm/gpfs/noobaadata #Bucket Data Path should already exist
 $ export AWS_ACCESS_KEY_ID=$(openssl rand -hex 20)
 $ export AWS_SECRET_ACCESS_KEY=$(openssl rand -hex 20)
-$ bin/node src/cmd/manage_nsfs.js account add --email noobaa@noobaa.io --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY --name noobaa --new_buckets_path /ibm/gpfs/noobaadata
+$ bin/node src/cmd/manage_nsfs.js account add --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY --name noobaa --new_buckets_path /ibm/gpfs/noobaadata
 ```
 
 ### Configure NooBaa

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -193,12 +193,6 @@ ManageCLIError.MissingAccountNameFlag = Object.freeze({
     http_code: 400,
 });
 
-ManageCLIError.MissingAccountEmailFlag = Object.freeze({
-    code: 'MissingAccountEmailFlag',
-    message: 'Account email is mandatory, please use the --email flag',
-    http_code: 400,
-});
-
 ManageCLIError.MissingIdentifier = Object.freeze({
     code: 'MissingIdentifier',
     message: 'Account identifier is mandatory, please use the --access_key or --name flag',
@@ -305,9 +299,9 @@ ManageCLIError.MissingBucketNameFlag = Object.freeze({
     http_code: 400,
 });
 
-ManageCLIError.MissingBucketEmailFlag = Object.freeze({
-    code: 'MissingBucketEmailFlag',
-    message: 'Bucket email is mandatory, please use the --email flag',
+ManageCLIError.MissingBucketOwnerFlag = Object.freeze({
+    code: 'MissingBucketOwnerFlag',
+    message: 'Bucket owner (account name) is mandatory, please use the --owner flag',
     http_code: 400,
 });
 

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -19,16 +19,16 @@ const GLOBAL_CONFIG_ROOT = 'config_root';
 const GLOBAL_CONFIG_OPTIONS = new Set(['from_file', GLOBAL_CONFIG_ROOT, 'config_root_backend']);
 
 const VALID_OPTIONS_ACCOUNT = {
-    'add': new Set(['name', 'email', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'email', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
     'delete': new Set(['name', GLOBAL_CONFIG_ROOT]),
     'list': new Set(['wide', 'show_secrets', GLOBAL_CONFIG_ROOT, 'gid', 'uid', 'user', 'name', 'access_key']),
     'status': new Set(['name', 'access_key', 'show_secrets', GLOBAL_CONFIG_ROOT]),
 };
 
 const VALID_OPTIONS_BUCKET = {
-    'add': new Set(['name', 'email', 'path', 'bucket_policy', 'fs_backend', ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'email', 'path', 'bucket_policy', 'fs_backend', 'new_name', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'new_name', ...GLOBAL_CONFIG_OPTIONS]),
     'delete': new Set(['name', GLOBAL_CONFIG_ROOT]),
     'list': new Set(['wide', 'name', GLOBAL_CONFIG_ROOT]),
     'status': new Set(['name', GLOBAL_CONFIG_ROOT]),
@@ -44,7 +44,7 @@ const VALID_OPTIONS = {
 
 const OPTION_TYPE = {
     name: 'string',
-    email: 'string',
+    owner: 'string',
     uid: 'number',
     gid: 'number',
     new_buckets_path: 'string',

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -75,7 +75,6 @@ account add [flags]
 
 Flags:
 --name <string>                                                                             Set the name for the account
---email <string>                                                                            Set the email for the account (used as the identifier for buckets owner)
 --uid <number>                                                                              Set the User Identifier (UID) (UID and GID can be replaced by --user option)
 --gid <number>                                                                              Set the Group Identifier (GID) (UID and GID can be replaced by --user option)
 --new_buckets_path <string>                                                                 Set the filesystem's root path where each subdirectory is a bucket
@@ -92,7 +91,6 @@ account update [flags]
 Flags:
 --name <string>                                                                             The name of the account
 --new_name <string>                                       (optional)                        Update the account name
---email <string>                                          (optional)                        Update the email (used as the identifier for buckets owner)
 --uid <number>                                            (optional)                        Update the User Identifier (UID)
 --gid <number>                                            (optional)                        Update the Group Identifier (GID)
 --new_buckets_path <string>                               (optional)                        Update the filesystem's root path where each subdirectory is a bucket
@@ -141,7 +139,7 @@ bucket add [flags]
 
 Flags:
 --name <string>                                                                             Set the name for the bucket
---email <string>                                                                            Set the bucket owner email
+--owner <string>                                                                            Set the bucket owner name
 --path <string>                                                                             Set the bucket path
 --bucket_policy <string>                                  (optional)                        Set the bucket policy, type is a string of valid JSON policy
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>              (optional)                        Set the filesystem type (default config.NSFS_NC_STORAGE_BACKEND)
@@ -154,7 +152,7 @@ bucket update [flags]
 Flags:
 --name <string>                                                                             The name of the bucket
 --new_name <string>                                       (optional)                        Update the bucket name
---email <string>                                          (optional)                        Update the bucket owner email
+--owner <string>                                          (optional)                        Update the bucket owner name
 --path <string>                                           (optional)                        Update the bucket path
 --bucket_policy <string>                                  (optional)                        Update the bucket policy, type is a string of valid JSON policy (unset with '')
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>              (optional)                        Update the filesystem type (unset with '') (default config.NSFS_NC_STORAGE_BACKEND)

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -7,7 +7,7 @@ module.exports = {
     required: [
         '_id',
         'name',
-        'email',
+        'email', // temp, keep the email internally
         'access_keys',
         'nsfs_account_config',
         'creation_date',

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -29,6 +29,7 @@ module.exports = {
         system_owner: {
             type: 'string',
         },
+        // bucket_owner is the account name
         bucket_owner: {
             type: 'string',
         },

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -45,7 +45,6 @@ describe('manage nsfs cli account flow', () => {
             _id: 'account1',
             type: TYPES.ACCOUNT,
             name: 'account1',
-            email: 'account1@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user1/`,
             uid: 999,
             gid: 999,
@@ -66,8 +65,8 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli create account without access_keys', async () => {
             const action = ACTIONS.ADD;
-            const { type, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, name, email, new_buckets_path, uid, gid };
+            const { type, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, name, new_buckets_path, uid, gid };
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
@@ -84,8 +83,8 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli create account with access_key and without secret_key', async () => {
             const action = ACTIONS.ADD;
-            const { type, access_key, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, access_key, name, email, new_buckets_path, uid, gid };
+            const { type, access_key, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key, name, new_buckets_path, uid, gid };
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
@@ -95,8 +94,8 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli create account without access_key and with secret_key', async () => {
             const action = ACTIONS.ADD;
-            const { type, secret_key, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, secret_key, name, email, new_buckets_path, uid, gid };
+            const { type, secret_key, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, secret_key, name, new_buckets_path, uid, gid };
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
@@ -106,8 +105,8 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli create account with access_keys', async () => {
             const action = ACTIONS.ADD;
-            const { type, access_key, secret_key, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, access_key, secret_key, name, email, new_buckets_path, uid, gid };
+            const { type, access_key, secret_key, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key, secret_key, name, new_buckets_path, uid, gid };
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
@@ -119,16 +118,16 @@ describe('manage nsfs cli account flow', () => {
         });
 
         it('should fail - cli update account access_key wrong complexity', async () => {
-            const { type, secret_key, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, access_key: 'abc', secret_key, name, email, new_buckets_path, uid, gid };
+            const { type, secret_key, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key: 'abc', secret_key, name, new_buckets_path, uid, gid };
             const action = ACTIONS.UPDATE;
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.AccountAccessKeyFlagComplexity.message);
         });
 
         it('should fail - cli update account secret_key wrong complexity', async () => {
-            const { type, access_key, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, access_key, secret_key: 'abc', name, email, new_buckets_path, uid, gid };
+            const { type, access_key, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key, secret_key: 'abc', name, new_buckets_path, uid, gid };
             const action = ACTIONS.UPDATE;
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.AccountSecretKeyFlagComplexity.message);
@@ -136,8 +135,8 @@ describe('manage nsfs cli account flow', () => {
 
         it('should fail - cli create account integer uid and gid', async () => {
             const action = ACTIONS.ADD;
-            const { type, access_key, secret_key, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, access_key, secret_key, name, email, new_buckets_path, uid, gid };
+            const { type, access_key, secret_key, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, access_key, secret_key, name, new_buckets_path, uid, gid };
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
@@ -149,16 +148,16 @@ describe('manage nsfs cli account flow', () => {
         });
 
         it('should fail - cli create account invalid option', async () => {
-            const { type, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, name, email, new_buckets_path, uid, gid, lala: 'lala'}; // lala invalid option
+            const { type, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, name, new_buckets_path, uid, gid, lala: 'lala'}; // lala invalid option
             const action = ACTIONS.ADD;
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
         });
 
         it('should fail - cli create account invalid option type (user as boolean)', async () => {
-            const { type, name, email, new_buckets_path } = defaults;
-            const account_options = { config_root, name, email, new_buckets_path};
+            const { type, name, new_buckets_path } = defaults;
+            const account_options = { config_root, name, new_buckets_path};
             const action = ACTIONS.ADD;
             const command = create_command(type, action, account_options);
             const flag = 'user'; // we will add user flag without value
@@ -167,8 +166,8 @@ describe('manage nsfs cli account flow', () => {
         });
 
         it('should fail - cli create account invalid option type (user as number)', async () => {
-            const { type, name, email, new_buckets_path } = defaults;
-            const account_options = { config_root, name, email, new_buckets_path, user: 0};
+            const { type, name, new_buckets_path } = defaults;
+            const account_options = { config_root, name, new_buckets_path, user: 0};
             const action = ACTIONS.ADD;
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
@@ -188,8 +187,8 @@ describe('manage nsfs cli account flow', () => {
         });
 
         it('should fail - cli create account invalid option type (name as boolean)', async () => {
-            const { type, email, new_buckets_path } = defaults;
-            const account_options = { config_root, email, new_buckets_path};
+            const { type, new_buckets_path } = defaults;
+            const account_options = { config_root, new_buckets_path};
             const action = ACTIONS.ADD;
             const command = create_command(type, action, account_options);
             const flag = 'name'; // we will add name flag without value
@@ -197,37 +196,27 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
         });
 
-        it('should fail - cli create account invalid option type (email as boolean)', async () => {
-            const { type, name, new_buckets_path } = defaults;
-            const account_options = { config_root, name, new_buckets_path};
-            const action = ACTIONS.ADD;
-            const command = create_command(type, action, account_options);
-            const flag = 'email'; // we will add email flag without value
-            const res = await exec_manage_cli_add_empty_option(command, flag);
-            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
-        });
-
         it('should fail - cli create account invalid option type (new_buckets_path as number)', async () => {
             const action = ACTIONS.ADD;
-            const { type, name, email, uid, gid } = defaults;
+            const { type, name, uid, gid } = defaults;
             const new_buckets_path_invalid = 4e34; // invalid should be string represents a path
-            const account_options = { config_root, name, email, new_buckets_path: new_buckets_path_invalid, uid, gid };
+            const account_options = { config_root, name, new_buckets_path: new_buckets_path_invalid, uid, gid };
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
         });
 
         it('should fail - cli create account invalid option type (new_buckets_path as string)', async () => {
             const action = ACTIONS.ADD;
-            const { type, name, email, uid, gid } = defaults;
+            const { type, name, uid, gid } = defaults;
             const new_buckets_path_invalid = 'aaa'; // invalid should be string represents a path
-            const account_options = { config_root, name, email, new_buckets_path: new_buckets_path_invalid, uid, gid };
+            const account_options = { config_root, name, new_buckets_path: new_buckets_path_invalid, uid, gid };
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidAccountNewBucketsPath.message);
         });
 
         it('cli account add - name is a number', async function() {
             const account_name = '0';
-            const options = { name: account_name, email: `${account_name}@noobaa.com`, uid: 2001, gid: 2001 };
+            const options = { name: account_name, uid: 2001, gid: 2001 };
             const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...options });
             const account = JSON.parse(res).response.reply;
             assert_account(account, options, false);
@@ -237,7 +226,7 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli account add - uid is 0, gid is not 0', async function() {
             const account_name = 'uid_is_0';
-            const options = { name: account_name, email: `${account_name}@noobaa.com`, uid: 0, gid: 1001 };
+            const options = { name: account_name, uid: 0, gid: 1001 };
             const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...options });
             const account = JSON.parse(res).response.reply;
             assert_account(account, options, false);
@@ -246,7 +235,7 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli account add - uid is not 0, gid is 0', async function() {
             const account_name = 'gid_is_0';
-            const options = { name: account_name, email: `${account_name}@noobaa.com`, uid: 1001, gid: 0 };
+            const options = { name: account_name, uid: 1001, gid: 0 };
             const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...options });
             const account = JSON.parse(res).response.reply;
             assert_account(account, options, false);
@@ -255,7 +244,7 @@ describe('manage nsfs cli account flow', () => {
 
         it('cli account add - uid is 0, gid is 0', async function() {
             const account_name = 'uid_gid_are_0';
-            const options = { name: account_name, email: `${account_name}@noobaa.com`, uid: 0, gid: 0 };
+            const options = { name: account_name, uid: 0, gid: 0 };
             const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...options });
             const account = JSON.parse(res).response.reply;
             assert_account(account, options, false);
@@ -270,7 +259,6 @@ describe('manage nsfs cli account flow', () => {
         const type = TYPES.ACCOUNT;
         const defaults = {
             name: 'account1',
-            email: 'account1@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user1/`,
             uid: 999,
             gid: 999,
@@ -384,16 +372,6 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
         });
 
-        it('should fail - cli update account invalid option type (email as boolean)', async () => {
-            const { name } = defaults;
-            const account_options = { config_root, name};
-            const action = ACTIONS.UPDATE;
-            const command = create_command(type, action, account_options);
-            const flag = 'email'; // we will add email flag without value
-            const res = await exec_manage_cli_add_empty_option(command, flag);
-            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
-        });
-
     });
 
     describe('cli list account', () => {
@@ -402,7 +380,6 @@ describe('manage nsfs cli account flow', () => {
         const type = TYPES.ACCOUNT;
         const defaults = [{
             name: 'account1',
-            email: 'account1@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user1/`,
             uid: 999,
             gid: 999,
@@ -410,7 +387,6 @@ describe('manage nsfs cli account flow', () => {
             secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
         }, {
             name: 'account2',
-            email: 'account2@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user2/`,
             uid: 888,
             gid: 888,
@@ -418,7 +394,6 @@ describe('manage nsfs cli account flow', () => {
             secret_key: 'BIBYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
         }, {
             name: 'account3',
-            email: 'account3@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user2/`,
             uid: 999,
             gid: 888,
@@ -427,7 +402,6 @@ describe('manage nsfs cli account flow', () => {
             },
         {
             name: 'account4',
-            email: 'account4@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user2/`,
             user: 'root',
             access_key: 'DIBiFAnjaaE7OKD5N7hA',
@@ -577,7 +551,6 @@ describe('manage nsfs cli account flow', () => {
         const defaults = {
             type: TYPES.ACCOUNT,
             name: 'account11',
-            email: 'account11@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user11/`,
             uid: 1011,
             gid: 1011,
@@ -594,8 +567,8 @@ describe('manage nsfs cli account flow', () => {
         beforeEach(async () => {
             // cli create account
             const action = ACTIONS.ADD;
-            const { type, name, email, new_buckets_path, uid, gid } = defaults;
-            const account_options = { config_root, name, email, new_buckets_path, uid, gid };
+            const { type, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, name, new_buckets_path, uid, gid };
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(account_options.new_buckets_path, account_options, 0o700);
@@ -630,8 +603,9 @@ describe('manage nsfs cli account flow', () => {
             let type = TYPES.BUCKET;
             const bucket_name = 'bucket111';
             let action = ACTIONS.ADD;
-            const { email, new_buckets_path } = defaults;
-            const bucket_options = { config_root, path: new_buckets_path, name: bucket_name, email: email};
+            const { new_buckets_path } = defaults;
+            const account_name = defaults.name;
+            const bucket_options = { config_root, path: new_buckets_path, name: bucket_name, owner: account_name};
             await exec_manage_cli(type, action, bucket_options);
             let config_path = path.join(config_root, buckets_schema_dir, bucket_name + '.json');
             await fs_utils.file_must_exist(config_path);
@@ -672,7 +646,6 @@ describe('manage nsfs cli account flow', () => {
         const type = TYPES.ACCOUNT;
         const defaults = {
             name: 'account22',
-            email: 'account22@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user22/`,
             uid: 1022,
             gid: 1022,
@@ -726,7 +699,6 @@ describe('cli account flow distinguished_name - permissions', function() {
             cli_options: {
                 config_root,
                 name: 'rooti',
-                email: 'root@noobaa.io',
                 new_buckets_path,
                 user: 'root',
             }
@@ -735,7 +707,6 @@ describe('cli account flow distinguished_name - permissions', function() {
             cli_options: {
                 config_root,
                 name: 'account_dn1',
-                email: 'account_dn1@noobaa.io',
                 new_buckets_path,
                 user: 'moti1003'
             }
@@ -744,7 +715,6 @@ describe('cli account flow distinguished_name - permissions', function() {
             cli_options: {
                 config_root,
                 new_buckets_path,
-                email: 'accessible_user',
                 name: 'accessible_user',
                 user: 'accessible_user',
             },
@@ -759,7 +729,6 @@ describe('cli account flow distinguished_name - permissions', function() {
             cli_options: {
                 config_root,
                 new_buckets_path,
-                email: 'inaccessible_user',
                 name: 'inaccessible_user',
                 user: 'inaccessible_user',
             },
@@ -921,7 +890,6 @@ function assert_account(account, account_options, verify_access_keys) {
         expect(account.access_keys[0].access_key).toEqual(account_options.access_key);
         expect(account.access_keys[0].secret_key).toEqual(account_options.secret_key);
     }
-    expect(account.email).toEqual(account_options.email);
     expect(account.name).toEqual(account_options.name);
 
     if (account_options.distinguished_name) {

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -337,7 +337,7 @@ describe('schema validation NC NSFS account', () => {
 function get_account_data() {
     const account_name = 'account1';
     const id = '65a62e22ceae5e5f1a758aa9';
-    const account_email = 'account1@noobaa.io';
+    const account_email = account_name; // temp, keep the email internally
     const access_key = 'GIGiFAnjaaE7OKD5N7hA';
     const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
     const creation_date = new Date('December 17, 2023 09:00:00').toISOString();

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -42,7 +42,6 @@ describe('manage nsfs cli bucket flow', () => {
 
         const account_defaults = {
             name: 'account_test',
-            email: 'account1@noobaa.io',
             new_buckets_path: `${root_path}new_buckets_path_user1/`,
             uid: 1001,
             gid: 1001,
@@ -52,7 +51,7 @@ describe('manage nsfs cli bucket flow', () => {
 
         const bucket_defaults = {
             name: 'bucket1',
-            email: 'account1@noobaa.io',
+            owner: 'account1',
             path: bucket_storage_path,
         };
 
@@ -100,9 +99,9 @@ describe('manage nsfs cli bucket flow', () => {
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs2/');
         bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs2', 'bucket1');
 
+        const account_name = 'account_test';
         const account_defaults = {
-            name: 'account_test',
-            email: 'account1@noobaa.io',
+            name: account_name,
             new_buckets_path: `${root_path}new_buckets_path_user1/`,
             uid: 999,
             gid: 999,
@@ -112,7 +111,7 @@ describe('manage nsfs cli bucket flow', () => {
 
         const bucket_defaults = {
             name: 'bucket1',
-            email: 'account1@noobaa.io',
+            owner: account_name,
             path: bucket_storage_path,
         };
 
@@ -186,19 +185,19 @@ describe('manage nsfs cli bucket flow', () => {
  * @param {object} options
  */
 async function exec_manage_cli(type, action, options) {
-    let account_flags = ``;
+    let flags = ``;
     for (const key in options) {
         if (Object.hasOwn(options, key)) {
             if (typeof options[key] === 'boolean') {
-                account_flags += `--${key} `;
+                flags += `--${key} `;
             } else {
-                account_flags += `--${key} ${options[key]} `;
+                flags += `--${key} ${options[key]} `;
             }
         }
     }
-    account_flags = account_flags.trim();
+    flags = flags.trim();
+    const command = `node src/cmd/manage_nsfs ${type} ${action} ${flags}`;
 
-    const command = `node src/cmd/manage_nsfs ${type} ${action} ${account_flags}`;
     let res;
     try {
         res = await os_util.exec(command, { return_stdout: true });

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -400,8 +400,8 @@ describe('schema validation NC NSFS bucket', () => {
 function get_bucket_data() {
     const bucket_name = 'bucket1';
     const id = '65a62e22ceae5e5f1a758aa8';
-    const system_owner = 'account1@noobaa.io';
-    const bucket_owner = 'account1@noobaa.io';
+    const system_owner = 'account1'; // GAP - currently account name
+    const bucket_owner = 'account1'; // account name
     const owner_account = '65b3c68b59ab67b16f98c26e';
     const versioning_disabled = 'DISABLED';
     const creation_date = new Date('December 17, 2023 09:00:00').toISOString();

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -162,7 +162,6 @@ async function admin_account_creation() {
     await announce('admin_account_creation');
     const cli_account_options = {
         name: NC_CORETEST,
-        email: NC_CORETEST,
         new_buckets_path: NC_CORETEST_STORAGE_PATH,
         uid: 200,
         gid: 200
@@ -178,7 +177,7 @@ async function first_bucket_creation() {
     await announce('first_bucket_creation');
     const cli_bucket_options = {
         name: FIRST_BUCKET,
-        email: NC_CORETEST,
+        owner: NC_CORETEST,
         path: FIRST_BUCKET_PATH,
     };
     await exec_manage_cli(nc_nsfs_manage_entity_types.BUCKET, nc_nsfs_manage_actions.ADD, cli_bucket_options);
@@ -247,7 +246,6 @@ function get_tmp_path_by_os(_path) {
 async function create_account_manage(options) {
     const cli_options = {
         name: options.name,
-        email: options.email,
         new_buckets_path: options.default_resource ?
             p.join(nsrs_to_root_paths[options.default_resource], options.nsfs_account_config.new_buckets_path) :
             options.nsfs_account_config.new_buckets_path,
@@ -377,7 +375,7 @@ function create_namespace_resource_mock(options) {
 async function create_bucket_manage(options) {
     const { resource, path } = options.namespace.write_resource;
     const bucket_storage_path = p.join(nsrs_to_root_paths[resource], path);
-    const cli_options = { name: options.name, email: EMAIL, path: bucket_storage_path};
+    const cli_options = { name: options.name, owner: NC_CORETEST, path: bucket_storage_path};
     await exec_manage_cli(nc_nsfs_manage_entity_types.BUCKET, nc_nsfs_manage_actions.ADD, cli_options);
 }
 

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -54,7 +54,7 @@ mocha.describe('manage_nsfs cli', function() {
         const account_name = 'user1';
         const name = 'bucket1';
         const bucket_on_gpfs = 'bucketgpfs1';
-        const email = 'user1@noobaa.io';
+        const owner = account_name; // in a different variable for readability
         const bucket_path = `${root_path}${name}/`;
         const bucket_with_policy = 'bucket-with-policy';
         const bucket_policy = generate_s3_policy('*', bucket_with_policy, ['s3:*']).policy;
@@ -65,8 +65,8 @@ mocha.describe('manage_nsfs cli', function() {
 
         const schema_dir = 'buckets';
         const schema_dir_accounts = 'accounts';
-        let bucket_options = { config_root, name, email, path: bucket_path };
-        const gpfs_bucket_options = { config_root, name: bucket_on_gpfs, email, path: bucket_path, fs_backend: 'GPFS' };
+        let bucket_options = { config_root, name, owner, path: bucket_path };
+        const gpfs_bucket_options = { config_root, name: bucket_on_gpfs, owner, path: bucket_path, fs_backend: 'GPFS' };
         const bucket_with_policy_options = { ...bucket_options, bucket_policy: bucket_policy, name: bucket_with_policy };
 
         mocha.before(async () => {
@@ -93,8 +93,6 @@ mocha.describe('manage_nsfs cli', function() {
 
         mocha.it('cli create account for bucket (bucket create requirement to have a bucket owner)', async function() {
             const account_name2 = 'user2';
-            const owner_email = email;
-            const owner_email2 = 'user2@noobaa.io';
             const new_buckets_path1 = `${root_path}new_buckets_path_user1111/`;
             const new_buckets_path2 = `${root_path}new_buckets_path_user2222/`;
             const uid1 = 1111;
@@ -107,7 +105,6 @@ mocha.describe('manage_nsfs cli', function() {
             const account_options1 = {
                 config_root: config_root,
                 name: account_name,
-                email: owner_email,
                 new_buckets_path: new_buckets_path1,
                 uid: uid1,
                 gid: gid1,
@@ -120,7 +117,6 @@ mocha.describe('manage_nsfs cli', function() {
             const account_options2 = {
                 config_root: config_root,
                 name: account_name2,
-                email: owner_email2,
                 new_buckets_path: new_buckets_path2,
                 uid: uid2,
                 gid: gid2,
@@ -133,7 +129,6 @@ mocha.describe('manage_nsfs cli', function() {
 
         mocha.it('cli bucket create - should fail bucket owner\'s allow_bucket_creation is false', async function() {
             const account_name_for_account_cannot_create_bucket = 'user3';
-            const owner_email = 'user3@noobaa.io';
             const uid = 3333;
             const gid = 3333;
 
@@ -144,7 +139,6 @@ mocha.describe('manage_nsfs cli', function() {
             const account_options = {
                 config_root: config_root,
                 name: account_name_for_account_cannot_create_bucket,
-                email: owner_email,
                 uid: uid,
                 gid: gid,
             };
@@ -154,7 +148,7 @@ mocha.describe('manage_nsfs cli', function() {
                 const bucket_options_with_owner_of_account_cannot_create_bucket = {
                      config_root,
                      name,
-                     email: owner_email,
+                     owner: account_name_for_account_cannot_create_bucket,
                      path: bucket_path
                 };
                 await exec_manage_cli(type, action, { ...bucket_options_with_owner_of_account_cannot_create_bucket });
@@ -315,9 +309,9 @@ mocha.describe('manage_nsfs cli', function() {
             }
         });
 
-        mocha.it('cli bucket update owner email', async function() {
+        mocha.it('cli bucket update bucket owner', async function() {
             const action = nc_nsfs_manage_actions.UPDATE;
-            const update_options = { config_root, email: 'user2@noobaa.io', name };
+            const update_options = { config_root, owner: 'user2', name };
             const update_res = await exec_manage_cli(type, action, update_options);
             bucket_options = { ...bucket_options, ...update_options };
             const bucket = await read_config_file(config_root, schema_dir, name);
@@ -415,7 +409,7 @@ mocha.describe('manage_nsfs cli', function() {
 
         mocha.it('cli bucket update owner', async function() {
             const action = nc_nsfs_manage_actions.UPDATE;
-            gpfs_bucket_options.email = 'user2@noobaa.io';
+            gpfs_bucket_options.owner = 'user2';
             const bucket_status = await exec_manage_cli(type, action, gpfs_bucket_options);
             assert_response(action, type, bucket_status, gpfs_bucket_options);
             const bucket = await read_config_file(config_root, schema_dir, gpfs_bucket_options.name);
@@ -490,15 +484,14 @@ mocha.describe('manage_nsfs cli', function() {
     mocha.describe('cli account flow', async function() {
         const type = nc_nsfs_manage_entity_types.ACCOUNT;
         const name = 'account1';
-        const email = 'account1@noobaa.io';
         const gpfs_account = 'gpfs_account';
         const new_buckets_path = `${root_path}new_buckets_path_user1/`;
         const uid = 999;
         const gid = 999;
         const access_key = 'GIGiFAnjaaE7OKD5N7hA';
         const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFR';
-        let account_options = { config_root, name, email, new_buckets_path, uid, gid, access_key, secret_key };
-        const gpfs_account_options = { ...account_options, name: gpfs_account, email: gpfs_account, fs_backend: 'GPFS' };
+        let account_options = { config_root, name, new_buckets_path, uid, gid, access_key, secret_key };
+        const gpfs_account_options = { ...account_options, name: gpfs_account, fs_backend: 'GPFS' };
         let updating_options = account_options;
         let compare_details; // we will use it for update account and compare the results
         let add_res;
@@ -552,7 +545,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - no uid gid - should fail', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             try {
-                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla' });
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key });
                 assert.fail('should have failed with account config should not be empty');
             } catch (err) {
                 assert_error(err, ManageCLIError.InvalidAccountNSFSConfig);
@@ -562,7 +555,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - no uid - should fail', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             try {
-                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla', gid: 1001});
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, gid: 1001});
                 assert.fail('should have failed with account config should include UID');
             } catch (err) {
                 assert_error(err, ManageCLIError.MissingAccountNSFSConfigUID);
@@ -572,7 +565,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - no gid - should fail', async function() {
             const action = nc_nsfs_manage_actions.ADD;
             try {
-                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, email: 'bla', uid: 1001});
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, uid: 1001});
                 assert.fail('should have failed with account config should include GID');
             } catch (err) {
                 assert_error(err, ManageCLIError.MissingAccountNSFSConfigGID);
@@ -628,7 +621,6 @@ mocha.describe('manage_nsfs cli', function() {
             const update_options = {
                 config_root,
                 name,
-                email: 'account2@noobaa.io',
                 uid: 222,
                 gid: 222,
                 new_buckets_path: `${root_path}new_buckets_path_user2/`
@@ -679,25 +671,6 @@ mocha.describe('manage_nsfs cli', function() {
             await assert_config_file_permissions(config_root, accounts_schema_dir, gpfs_account_options.name);
         });
 
-        mocha.it('cli account update owner', async function() {
-            const action = nc_nsfs_manage_actions.UPDATE;
-            const account_options_for_update_owner = {
-                config_root: gpfs_account_options.config_root, // needed for exec_manage_cli function
-                name: gpfs_account_options.name,
-                fs_backend: gpfs_account_options.fs_backend, // added this not to mess up the comparison
-                email: 'blalal' //update the name
-            };
-            const account_status = await exec_manage_cli(type, action, account_options_for_update_owner);
-            compare_details = {
-                ...gpfs_account_options,
-                ...account_options_for_update_owner,
-            };
-            assert_response(action, type, account_status, compare_details);
-            const account = await read_config_file(config_root, accounts_schema_dir, gpfs_account_options.name);
-            assert_account(account, compare_details);
-            await assert_config_file_permissions(config_root, accounts_schema_dir, gpfs_account_options.name);
-        });
-
         mocha.it('cli account update to non GPFS', async function() {
             const action = nc_nsfs_manage_actions.UPDATE;
             const account_options_for_update_fs_backend = {
@@ -707,7 +680,7 @@ mocha.describe('manage_nsfs cli', function() {
             };
             const account_status = await exec_manage_cli(type, action, account_options_for_update_fs_backend);
             compare_details = {
-                ...compare_details,
+                ...gpfs_account_options,
                 ...account_options_for_update_fs_backend,
             };
             // in the CLI we use empty string to unset the fs_backend
@@ -737,15 +710,14 @@ mocha.describe('manage_nsfs cli', function() {
         const type = nc_nsfs_manage_entity_types.ACCOUNT;
         const name1 = 'account1';
         const name2 = 'account2';
-        const email = 'account1@noobaa.io';
         const new_buckets_path = `${root_path}new_buckets_path_user1/`;
         const uid = 999;
         const gid = 999;
         const access_key = 'GIGiFAnjaaE7OKD5N7hA';
         const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFR';
-        const account1_options = { config_root, name: name1, email, new_buckets_path, uid, gid, access_key, secret_key };
+        const account1_options = { config_root, name: name1, new_buckets_path, uid, gid, access_key, secret_key };
         const account1_options_for_delete = { config_root, name: name1 };
-        const account2_options = { config_root, name: 'account2', email, new_buckets_path, uid, gid, access_key: 'BISiDSnjaaE7OKD5N7hB', secret_key };
+        const account2_options = { config_root, name: 'account2', new_buckets_path, uid, gid, access_key: 'BISiDSnjaaE7OKD5N7hB', secret_key };
         const account2_options_for_delete = { config_root, name: name2 };
         mocha.before(async () => {
             await fs_utils.create_fresh_path(new_buckets_path);
@@ -789,13 +761,12 @@ mocha.describe('manage_nsfs cli', function() {
         this.timeout(50000); // eslint-disable-line no-invalid-this
         const type = nc_nsfs_manage_entity_types.ACCOUNT;
         const name = 'account2';
-        const email = 'account2@noobaa.io';
         const new_buckets_path = `${root_path}new_buckets_path_user2/`;
         const new_buckets_path_new_dn = `${root_path}new_buckets_path_new_dn/`;
         const distinguished_name = 'root';
         const access_key = 'GIGiFAnjaaE7OKD5N7hB';
         const secret_key = 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsDy3o+4h0oFr';
-        let account_options = { config_root, name, email, new_buckets_path, distinguished_name, access_key, secret_key };
+        let account_options = { config_root, name, new_buckets_path, distinguished_name, access_key, secret_key };
         const new_user = 'newuser';
 
         mocha.before(async () => {
@@ -1039,8 +1010,8 @@ function assert_response(action, type, actual_res, expected_res, show_secrets, w
 
 function assert_bucket(bucket, bucket_options) {
     assert.strictEqual(bucket.name, bucket_options.name);
-    assert.strictEqual(bucket.system_owner, bucket_options.email);
-    assert.strictEqual(bucket.bucket_owner, bucket_options.email);
+    assert.strictEqual(bucket.system_owner, bucket_options.owner);
+    assert.strictEqual(bucket.bucket_owner, bucket_options.owner);
     assert.strictEqual(bucket.path, bucket_options.path);
     assert.strictEqual(bucket.should_create_underlying_storage, false);
     assert.strictEqual(bucket.versioning, 'DISABLED');
@@ -1054,7 +1025,6 @@ function assert_account(account, account_options, skip_secrets) {
         assert.deepStrictEqual(account.access_keys[0].access_key, account_options.access_key);
         assert.deepStrictEqual(account.access_keys[0].secret_key, account_options.secret_key);
     }
-    assert.equal(account.email, account_options.email);
     assert.equal(account.name, account_options.name);
     if (account_options.distinguished_name) {
         assert.equal(account.nsfs_account_config.distinguished_name, account_options.distinguished_name);

--- a/src/test/unit_tests/test_s3_encryption.js
+++ b/src/test/unit_tests/test_s3_encryption.js
@@ -129,7 +129,7 @@ mocha.describe('Bucket Encryption Operations', async () => {
 
     mocha.it('should put encrypted object and copy with different encryption', async function() {
         const self = this; // eslint-disable-line no-invalid-this
-        self.timeout(60000);
+        self.timeout(100000);
         await copy(local_s3, BKT);
     });
 
@@ -238,7 +238,7 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
 
     mocha.it('should put encrypted object and copy with different encryption', async function() {
         const self = this; // eslint-disable-line no-invalid-this
-        self.timeout(60000);
+        self.timeout(100000);
         await copy(local_s3, BKT);
     });
 


### PR DESCRIPTION
### Explain the changes
1. Remove email from NSFS account and bucket mainly in manage CLI commands:
In account command - remove it
In bucket command replace it with the flag `--owner` and set the account name in it.
3. Remove tests related to email, and update existing tests.
4. Remove the email mentioned in the documentation related to manage NSFS.
5. Increase timeouts in `test_s3_encryption.js` (not related to this PR, but could not pass the CI).

### Issues: Fixed #7766 
1. Currently we use email as a flag in account add/update and bucket add/update, this code change is for fixing the issue (it is a temporary solution towards using only the account ID).

List of GAPs I'm aware of:
1. GAP - We would still have the email in the schema and it will be the output of json account (opened issue #7811).
2. GAP - After this change, we can improve the performance of `verify_bucket_owner` and lookup the `bucket_owner` has a config file (moved to use the account name).
3. GAP - in many places, I set the value of `system_owner` as the account name (there is open issue #7793).
4. GAP - in the documentation of NSFS NC we need to explain the account creation before bucket creation.

### Testing Instructions:
1. Manual test - now do not use `--flag` email, for example:
- First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
- account add: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /tmp/nsfs_root1 --uid <uid> --gid <gid>` (no `--email` flag).
- bucket add: `sudo node src/cmd/manage_nsfs bucket add --name <bucket-name> --owner <account-name> --path /tmp/nsfs_root1/my-bucket`
2. For running tests that were updated, please run:
- `sudo npx jest test_nc_nsfs_account_cli.test.js`
- `sudo npx jest test_nc_nsfs_bucket_cli.test.js`
- `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`
- `npx jest test_nc_nsfs_account_schema_validation.test.js`
- `npx jest test_nc_nsfs_bucket_schema_validation.test.js`
3. For checking the NSFS NC as it run in the CI: `make run-nc-tests CONTAINER_PLATFORM=linux/arm64` (the env `CONTAINER_PLATFORM=linux/arm64` is used because I have Mac). If you wish to run only specific tests, for example:
- `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace_fs.js`
Note: run it without the NSFS server working (ctrl + C to sudo node src/cmd/nsfs).
- `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace.js` 

- [X] Doc updated
- [ ] Tests added
