### PR TITLE
NSFS | NC | Directories cache max total usage reduction and configuration addition to nsfs_config_schema

### DIFF
--- a/config.js
+++ b/config.js
@@ -697,7 +697,7 @@ config.NSFS_FOLDER_OBJECT_NAME = '.folder';
 
 config.NSFS_DIR_CACHE_MAX_DIR_SIZE = 64 * 1024 * 1024;
 config.NSFS_DIR_CACHE_MIN_DIR_SIZE = 64;
-config.NSFS_DIR_CACHE_MAX_TOTAL_SIZE = 24 * config.NSFS_DIR_CACHE_MAX_DIR_SIZE;
+config.NSFS_DIR_CACHE_MAX_TOTAL_SIZE = 4 * config.NSFS_DIR_CACHE_MAX_DIR_SIZE;
 
 config.NSFS_OPEN_READ_MODE = 'r'; // use 'rd' for direct io
 

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -283,6 +283,43 @@ Example:
 3. systemctl restart noobaa_nsfs
 ```
 
+## 16. Directories cache max directory size -
+**Description -** Establish a custom maximum directory size configuration to enhance the performance of listing objects, particularly in scenarios where a bucket comprises a substantial number of directories.
+
+**Configuration Key -** NSFS_DIR_CACHE_MAX_DIR_SIZE
+
+**Type -** number
+
+**Default -** 67108864 // 64MB = 64 * 1024 * 1024
+
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"NSFS_DIR_CACHE_MAX_DIR_SIZE": 268435456
+3. systemctl restart noobaa_nsfs
+```
+
+## 17. Directories cache max total usage size -
+**Description -** Establish a custom maximum total cache usage size configuration to enhance the performance of listing objects, particularly in scenarios where a bucket comprises a substantial number of directories.
+
+**Configuration Key -** NSFS_DIR_CACHE_MAX_TOTAL_SIZE
+
+**Type -** number
+
+**Default -**  268435456 // 256MB = 4 * config.NSFS_DIR_CACHE_MAX_DIR_SIZE = 4 * 1024 * 1024
+
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"NSFS_DIR_CACHE_MAX_TOTAL_SIZE": 805306368
+3. systemctl restart noobaa_nsfs
+```
+
+
 ## Config.json example 
 ```
 > cat /path/to/config_dir/config.json

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -95,6 +95,16 @@ const nsfs_node_config_schema = {
             type: 'array',
             default: [],
             description: 'List of whitelisted IPs for S3 access, Allow access from all the IPs if list is empty.'
+        },
+        NSFS_DIR_CACHE_MAX_DIR_SIZE: {
+            type: 'number',
+            default: 64 * 1024 * 1024,
+            description: 'maximum directory size of the dir cache, suggested values 256MB, service restart required'
+        },
+        NSFS_DIR_CACHE_MAX_TOTAL_SIZE: {
+            type: 'number',
+            default: 4 * 64 * 1024 * 1024,
+            description: 'maximum size of the dir cache, suggested values 768MB, service restart required'
         }
     }
 };

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -10,17 +10,19 @@ describe('schema validation NC NSFS config', () => {
 
     describe('config with all needed properties', () => {
 
-        it('nsfs_account_config - valid simple', () => {
+        it('nsfs_config - valid simple', () => {
             const config_data = {
                 ALLOW_HTTP: true,
                 NSFS_NC_STORAGE_BACKEND: 'GPFS',
                 NSFS_NC_CONFIG_DIR_BACKEND: 'CEPH_FS',
-                FORKS: 20
+                FORKS: 20,
+                NSFS_DIR_CACHE_MAX_DIR_SIZE: 67108864,
+                NSFS_DIR_CACHE_MAX_TOTAL_SIZE: 268435456,
             };
             nsfs_schema_utils.validate_nsfs_config_schema(config_data);
         });
 
-        it('nsfs_account_config - recommendation', () => {
+        it('nsfs_config - recommendation', () => {
             const config_data = {
                 ENDPOINT_PORT: 80,
                 ENDPOINT_SSL_PORT: 443,
@@ -39,6 +41,8 @@ describe('schema validation NC NSFS config', () => {
                     '0000:0000:0000:0000:0000:ffff:7f00:0002',
                     '::ffff:7f00:3'
                 ],
+                NSFS_DIR_CACHE_MAX_DIR_SIZE: 268435456,
+                NSFS_DIR_CACHE_MAX_TOTAL_SIZE: 805306368,
             };
             nsfs_schema_utils.validate_nsfs_config_schema(config_data);
         });
@@ -46,7 +50,7 @@ describe('schema validation NC NSFS config', () => {
 
     describe('config with wrong types', () => {
 
-        it('nsfs_account_config invalid ALLOW_HTTP', () => {
+        it('nsfs_config invalid ALLOW_HTTP', () => {
             const config_data = {
                 ALLOW_HTTP: 123, // number instead of boolean
             };
@@ -56,7 +60,7 @@ describe('schema validation NC NSFS config', () => {
             assert_validation(config_data, reason, message);
         });
 
-        it('nsfs_account_config invalid forks', () => {
+        it('nsfs_config invalid forks', () => {
             const config_data = {
                 ENDPOINT_FORKS: true, // boolean instead of number
             };
@@ -66,7 +70,7 @@ describe('schema validation NC NSFS config', () => {
             assert_validation(config_data, reason, message);
         });
 
-        it('nsfs_account_config invalid storage fs_backend', () => {
+        it('nsfs_config invalid storage fs_backend', () => {
             const config_data = {
                 NSFS_NC_STORAGE_BACKEND: 'INVALID_FS_BACKEND', // not part of definition of fs_backend
             };
@@ -76,13 +80,33 @@ describe('schema validation NC NSFS config', () => {
             assert_validation(config_data, reason, message);
         });
 
-        it('nsfs_account_config invalid config dir fs_backend', () => {
+        it('nsfs_config invalid config dir fs_backend', () => {
             const config_data = {
                 NSFS_NC_CONFIG_DIR_BACKEND: 123, // number instead of string
             };
             const reason = 'Test should have failed because of wrong type ' +
                 'NSFS_NC_CONFIG_DIR_BACKEND with number (instead of string)';
             const message = 'must be string';
+            assert_validation(config_data, reason, message);
+        });
+
+        it('nsfs_config invalid config dir dir cache max dir size', () => {
+            const config_data = {
+                NSFS_DIR_CACHE_MAX_DIR_SIZE: 'not a number', // string instead of number
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+                'NSFS_DIR_CACHE_MAX_DIR_SIZE with number (instead of string)';
+            const message = 'must be number';
+            assert_validation(config_data, reason, message);
+        });
+
+        it('nsfs_config invalid config dir dir cache max total size', () => {
+            const config_data = {
+                NSFS_DIR_CACHE_MAX_TOTAL_SIZE: 'not a number', // string instead of number
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+                'NSFS_DIR_CACHE_MAX_TOTAL_SIZE with number (instead of string)';
+            const message = 'must be number';
             assert_validation(config_data, reason, message);
         });
     });


### PR DESCRIPTION
### Explain the changes
1. NSFS_DIR_CACHE_MAX_TOTAL_SIZE default reduced to 4 *  config.NSFS_DIR_CACHE_MAX_DIR_SIZE (256MB)
2. The previous value was 24 full size directories = 24 *  config.NSFS_DIR_CACHE_MAX_DIR_SIZE = 24*64*1024*1024 = 1.6 GB)
3. Added NSFS_DIR_CACHE_MAX_TOTAL_SIZE and NSFS_DIR_CACHE_MAX_DIR_SIZE to nsfs_config_schema to avoid type issues.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. sudo jest --testRegex=jest_tests/test_nc_nsfs_config_schema


- [x] Doc added/updated
- [x] Tests added
