### PR TITLE
NSFS Fixes | handling too many forks exits + cleaning unwrap error in log

### DIFF
--- a/config.js
+++ b/config.js
@@ -722,6 +722,9 @@ config.NSFS_RENAME_RETRIES = 3;
 config.NSFS_VERSIONING_ENABLED = true;
 config.NSFS_UPDATE_ISSUES_REPORT_ENABLED = true;
 
+config.NSFS_EXIT_EVENTS_TIME_FRAME_MIN = 24 * 60; // per day
+config.NSFS_MAX_EXIT_EVENTS_PER_TIME_FRAME = 10; // allow max 10 failed forks per day
+
 config.NSFS_GLACIER_LOGS_DIR = '/var/run/noobaa-nsfs/wal';
 config.NSFS_GLACIER_LOGS_MAX_INTERVAL = 15 * 60 * 1000;
 

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -155,6 +155,7 @@ class NsfsObjectSDK extends ObjectSDK {
             this._get_bucket_namespace = bucket_name => this._simple_get_single_bucket_namespace(bucket_name);
             this.load_requesting_account = auth_req => this._simple_load_requesting_account(auth_req);
             this.read_bucket_sdk_policy_info = bucket_name => this._simple_read_bucket_sdk_policy_info(bucket_name);
+            this.read_bucket_sdk_config_info = () => undefined;
             this.read_bucket_usage_info = () => undefined;
             this.read_bucket_sdk_website_info = () => undefined;
             this.read_bucket_sdk_namespace_info = () => undefined;


### PR DESCRIPTION
### Explain the changes
1. adding special handling in case of getting too many forks exits in a given time frame
2. adding read_bucket_sdk_config_info to remove errors when running nsfs in simple mode

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
