### PR TITLE
NSFS | NC | Update Help `access_key` as Identifier of Account (Delete, Update)

### DIFF
--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -21,7 +21,7 @@ const GLOBAL_CONFIG_OPTIONS = new Set(['from_file', GLOBAL_CONFIG_ROOT, 'config_
 const VALID_OPTIONS_ACCOUNT = {
     'add': new Set(['name', 'email', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', ...GLOBAL_CONFIG_OPTIONS]),
     'update': new Set(['name', 'email', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
-    'delete': new Set(['name', 'access_key', GLOBAL_CONFIG_ROOT]),
+    'delete': new Set(['name', GLOBAL_CONFIG_ROOT]),
     'list': new Set(['wide', 'show_secrets', GLOBAL_CONFIG_ROOT, 'gid', 'uid', 'user', 'name', 'access_key']),
     'status': new Set(['name', 'access_key', 'show_secrets', GLOBAL_CONFIG_ROOT]),
 };

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -98,7 +98,7 @@ Flags:
 --new_buckets_path <string>                               (optional)                        Update the filesystem's root path where each subdirectory is a bucket
 --user <string>                                           (optional)                        Update the OS user name (instead of uid and gid)
 --regenerate                                              (optional)                        Update automatically generated access key and secret key
---access_key <string>                                     (optional)                        Update the access key. Can be used as identifier instead of --name
+--access_key <string>                                     (optional)                        Update the access key
 --secret_key <string>                                     (optional)                        Update the secret key
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>              (optional)                        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
 `;
@@ -109,7 +109,6 @@ account delete [flags]
 
 Flags:
 --name <string>                                                                             The name of the account
---access_key <string>                                     (optional)                        The access key of the account (identify the account instead of name)
 `;
 
 const ACCOUNT_FLAGS_STATUS = `

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -621,10 +621,19 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(config_path);
         });
 
-        it('should fail - cli delete account invalid option', async () => {
+        it('should fail - cli delete account invalid option (lala)', async () => {
             const action = ACTIONS.DELETE;
             const { type, name } = defaults;
-            const account_options = { config_root, name, lala: 'lala'}; // lala invalid option };
+            const account_options = { config_root, name, lala: 'lala'}; // lala invalid option
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
+        });
+
+        it('should fail - cli delete account invalid option (access_key)', async () => {
+            // access_key was identifier of account delete in the past, but not anymore
+            const action = ACTIONS.DELETE;
+            const { type, access_key } = defaults;
+            const account_options = { config_root, access_key};
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
         });


### PR DESCRIPTION
### Explain the changes
1. Update help printing of account update and delete.
2. Update the `VALID_OPTIONS_ACCOUNT` and remove the `access_key` from account delete.
3. Add a test to verify that we cannot use the flag `access_key` in account delete anymore.

### Issues:
1. Currently we see an unrelated error (`MissingAccountSecretKeyFlag`) when trying to delete an account using access_key` as the Identifier of the account.

### Testing Instructions:
1. For help updates run: `sudo node src/cmd/manage_nsfs account <action> --help 2>/dev/null` (replace `<action>` with update and then with delete).
2. For delete account:  (using an invalid option `--access_key` for account delete): `sudo node src/cmd/manage_nsfs account delete --access_key <access-key>`.


- [ ] Doc added/updated
- [X] Tests added
