### PR TITLE
 NSFS | NC | Fix Issue with Flags Separator

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -882,41 +882,21 @@ function validate_no_extra_options(type, action, input_options) {
 }
 /**
  * validate_options_type_by_value check the type of the value that match what we expect.
- * in case that type of value we have is boolean (and the option type is not boolean) -
- * we check if we have a value (non empty) with array of argument (without using minimist)
  * @param {string} type
  * @param {object} input_options_with_data object with flag (key) and value
  */
 function validate_options_type_by_value(type, input_options_with_data) {
-    const argv_arr = process.argv.slice(2); // we ignore argv[0] (path to node) and argv[1] (path to app)
-    let index_in_argv_arr; // we will iterate the argv array to find flags without value
-    if (type === TYPES.IP_WHITELIST) {
-        index_in_argv_arr = 1; // we ignore the type (there is no action)
-    } else {
-        index_in_argv_arr = 2; // we ignore the type and action
-    }
     for (const [option, value] of Object.entries(input_options_with_data)) {
         const type_of_option = OPTION_TYPE[option];
         const type_of_value = typeof value;
         if (type_of_value !== type_of_option) {
-            if ((type_of_value === 'boolean') &&
-                (argv_arr[index_in_argv_arr].slice(2) === option) && // we use slice(2) to remove the -- from string
-                ((index_in_argv_arr + 1 === argv_arr.length) ||
-                 (argv_arr[index_in_argv_arr + 1].startsWith('--')))) {
-                // in case the user sends --flag with no value there are 2 cases:
-                // (1) [--flag] there is no next element (index + 1 is out of array bound)
-                // (2) [--flag, --flag2] next element is a flag
-                throw_cli_error(ManageCLIError.InvalidArgumentType, `empty value in flag ${option}`);
-            }
             // special case for names, although the type is string we want to allow numbers as well
             if ((option === 'name' || option === 'new_name') && (type_of_value === 'number')) {
-                index_in_argv_arr += 2;
                 continue;
             }
             const err_msg = `type of flag ${option} should be ${type_of_option}`;
             throw_cli_error(ManageCLIError.InvalidArgumentType, err_msg);
         }
-        index_in_argv_arr += 2;
     }
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -174,6 +174,19 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
         });
 
+        it('should fail - cli create account invalid option type (path as boolean) use = in command as a flag separator', async () => {
+            const { type, name } = defaults;
+            const action = ACTIONS.ADD;
+            const command = `node src/cmd/manage_nsfs ${type} ${action} --config_root=${config_root} --name=${name} --new_buckets_path`;
+            let res;
+            try {
+                res = await os_util.exec(command, { return_stdout: true });
+            } catch (e) {
+                res = e;
+            }
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
+        });
+
         it('should fail - cli create account invalid option type (name as boolean)', async () => {
             const { type, email, new_buckets_path } = defaults;
             const account_options = { config_root, email, new_buckets_path};
@@ -454,6 +467,19 @@ describe('manage nsfs cli account flow', () => {
             const account_options = { config_root, wide: true };
             const action = ACTIONS.LIST;
             const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res).response.reply.map(item => item.name))
+                .toEqual(expect.arrayContaining(['account3', 'account2', 'account1']));
+        });
+
+        it('cli list wide (use = as flags separator)', async () => {
+            const action = ACTIONS.LIST;
+            const command = `node src/cmd/manage_nsfs ${type} ${action} --config_root=${config_root} --wide`;
+            let res;
+            try {
+                res = await os_util.exec(command, { return_stdout: true });
+            } catch (e) {
+                res = e;
+            }
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account3', 'account2', 'account1']));
         });


### PR DESCRIPTION
### Explain the changes
1. Fix the issue with the flag separator - remove the argv array manipulation.
2. Copy two existing tests and change their command line so they will be run with '=' separator instead of ' ' (space): one that passes and one that fails.

### Issues: none
1. In PR #7791 added argv manipulation for creating an error message of an empty flag, but working with that array cannot be directly used in case the separator between the flags is '=' (the flag and the argument will be the same element and not two elements) and it would result with `InternalError`.

### Testing Instructions:
1. Run any command that has an invalid argument with '=' separator, for example: `sudo node src/cmd/manage_nsfs account update --name=noobaa9 --new_buckets_path` (after name you can see the'=', the command invalid because `new_buckets_path` should be passed with <path>, a string value). 


- [ ] Doc added/updated
- [X] Tests added
