### PR TITLE
NSFS | S3 flow | BucketspaceFS - system/bucket_owner should be account name and wrap bucket name as Sensitive String

### DIFF
--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -149,6 +149,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 versioning: bucket.versioning
             };
 
+            bucket.name = new SensitiveString(bucket.name);
             bucket.system_owner = new SensitiveString(bucket.system_owner);
             bucket.bucket_owner = new SensitiveString(bucket.bucket_owner);
             if (bucket.s3_policy) {
@@ -318,8 +319,8 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             name,
             tag: js_utils.default_value(tag, undefined),
             owner_account: account._id,
-            system_owner: new SensitiveString(account.email),
-            bucket_owner: new SensitiveString(account.email),
+            system_owner: new SensitiveString(account.name),
+            bucket_owner: new SensitiveString(account.name),
             versioning: config.NSFS_VERSIONING_ENABLED && lock_enabled ? 'ENABLED' : 'DISABLED',
             object_lock_configuration: config.WORM_ENABLED ? {
                 object_lock_enabled: lock_enabled ? 'Enabled' : 'Disabled',

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -125,6 +125,7 @@ function make_dummy_object_sdk() {
         requesting_account: {
             _id: '65b3c68b59ab67b16f98c26e',
             force_md5_etag: false,
+            name: 'user2',
             email: 'user2@noobaa.io',
             allow_bucket_creation: true,
             nsfs_account_config: {


### PR DESCRIPTION
### Explain the changes
1. new_bucket_defaults() - bucket/system owner of a newly created bucket should be based on the requesting account name and not email -
This is a complement change of the change discussed on (https://github.com/noobaa/noobaa-core/pull/7801#discussion_r1485549529).
Principles of bucket policies on NC are names and not emails as opposed to containerized NooBaa in which the bucket policy principles are emails. After the merge of https://github.com/noobaa/noobaa-core/pull/7801 it doesn't matter because email is actually the name.
3. read_bucket_sdk_info() - bucket.name should be a sensitive string (a bug that was found on #7812)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
