### PR TITLE
NSFS | NC | CLI | account missing name in error message

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -458,7 +458,7 @@ async function add_account(data) {
     const event_arg = data.name ? data.name : access_key;
     if (name_exists || access_key_exists) {
         const err_code = name_exists ? ManageCLIError.AccountNameAlreadyExists : ManageCLIError.AccountAccessKeyAlreadyExists;
-        throw_cli_error(err_code, '', {account: event_arg});
+        throw_cli_error(err_code, event_arg, {account: event_arg});
     }
     data._id = mongo_utils.mongoObjectId();
     data = JSON.stringify(data);


### PR DESCRIPTION
### Explain the changes
1. account missing name in error message for already existing account name

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. try to add same account again and error message should have account name 


- [ ] Doc added/updated
- [ ] Tests added
