### PR TITLE
NSFS | NC | Add a Flag to Change the Value of  `allow_bucket_creation`

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -223,6 +223,12 @@ ManageCLIError.InvalidAccountNewBucketsPath = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.InvalidBooleanValue = Object.freeze({
+    code: 'InvalidBooleanValue',
+    message: 'supported values are true and false',
+    http_code: 400,
+});
+
 ManageCLIError.InvalidNewNameAccountIdentifier = Object.freeze({
     code: 'InvalidNewNameAccountIdentifier',
     message: 'Account new_name can not be used on add command, please remove the --new_name flag',

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -32,8 +32,8 @@ const GLOBAL_CONFIG_ROOT = 'config_root';
 const GLOBAL_CONFIG_OPTIONS = new Set(['from_file', GLOBAL_CONFIG_ROOT, 'config_root_backend']);
 
 const VALID_OPTIONS_ACCOUNT = {
-    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
     'delete': new Set(['name', GLOBAL_CONFIG_ROOT]),
     'list': new Set(['wide', 'show_secrets', GLOBAL_CONFIG_ROOT, 'gid', 'uid', 'user', 'name', 'access_key']),
     'status': new Set(['name', 'access_key', 'show_secrets', GLOBAL_CONFIG_ROOT]),
@@ -72,6 +72,7 @@ const OPTION_TYPE = {
     access_key: 'string',
     secret_key: 'string',
     fs_backend: 'string',
+    allow_bucket_creation: 'boolean',
     config_root: 'string',
     from_file: 'string',
     config_root_backend: 'string',
@@ -84,6 +85,8 @@ const OPTION_TYPE = {
     ips: 'string',
 };
 
+const BOOLEAN_STRING_VALUES = ['true', 'false'];
+
 const LIST_ACCOUNT_FILTERS = ['uid', 'gid', 'user', 'name', 'access_key'];
 const LIST_BUCKET_FILTERS = ['name'];
 
@@ -94,6 +97,7 @@ exports.GLACIER_ACTIONS = GLACIER_ACTIONS;
 exports.CONFIG_SUBDIRS = CONFIG_SUBDIRS;
 exports.VALID_OPTIONS = VALID_OPTIONS;
 exports.OPTION_TYPE = OPTION_TYPE;
+exports.BOOLEAN_STRING_VALUES = BOOLEAN_STRING_VALUES;
 
 exports.LIST_ACCOUNT_FILTERS = LIST_ACCOUNT_FILTERS;
 exports.LIST_BUCKET_FILTERS = LIST_BUCKET_FILTERS;

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -55,18 +55,18 @@ const WHITELIST_FLAGS = `
 whitelist [flags]
 
 Flags:
---ips <string>                                                                              Set the general configuration to allow only incoming requests from a given list of IP addresses
-                                                                                            in format: '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]'
+--ips <string>                                                          Set the general configuration to allow only incoming requests from a given list of IP addresses
+                                                                        in format: '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]'
 `;
 
 const GLOBAL_CONFIG_ROOT_ALL_FLAG = `
---config_root <string>                                    (optional)                        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
+--config_root <string>                                (optional)        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
 `;
 
 const GLOBAL_CONFIG_FLAGS_ADD_UPDATE_FLAGS = `
---from_file <string>                                      (optional)                        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
---config_root <string>                                    (optional)                        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
---config_root_backend <none | GPFS | CEPH_FS | NFSv4>     (optional)                        Use the filesystem type in the configuration (default config.NSFS_NC_CONFIG_DIR_BACKEND)
+--from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
+--config_root <string>                                (optional)        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
+--config_root_backend <none | GPFS | CEPH_FS | NFSv4> (optional)        Use the filesystem type in the configuration (default config.NSFS_NC_CONFIG_DIR_BACKEND)
 `;
 
 const ACCOUNT_FLAGS_ADD = `
@@ -74,14 +74,15 @@ Usage:
 account add [flags]
 
 Flags:
---name <string>                                                                             Set the name for the account
---uid <number>                                                                              Set the User Identifier (UID) (UID and GID can be replaced by --user option)
---gid <number>                                                                              Set the Group Identifier (GID) (UID and GID can be replaced by --user option)
---new_buckets_path <string>                                                                 Set the filesystem's root path where each subdirectory is a bucket
---user <string>                                           (optional)                        Set the OS user name (instead of UID and GID)
---access_key <string>                                     (optional)                        Set the access key for the account (default is generated)
---secret_key <string>                                     (optional)                        Set the secret key for the account (default is generated)
---fs_backend <none | GPFS | CEPH_FS | NFSv4>              (optional)                        Set the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
+--name <string>                                                         Set the name for the account
+--uid <number>                                                          Set the User Identifier (UID) (UID and GID can be replaced by --user option)
+--gid <number>                                                          Set the Group Identifier (GID) (UID and GID can be replaced by --user option)
+--new_buckets_path <string>                                             Set the filesystem's root path where each subdirectory is a bucket
+--user <string>                                       (optional)        Set the OS user name (instead of UID and GID)
+--access_key <string>                                 (optional)        Set the access key for the account (default is generated)
+--secret_key <string>                                 (optional)        Set the secret key for the account (default is generated)
+--fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
+--allow_bucket_creation <true | false>                (optional)        Set the account to explicitly allow or block bucket creation
 `;
 
 const ACCOUNT_FLAGS_UPDATE = `
@@ -89,16 +90,17 @@ Usage:
 account update [flags]
 
 Flags:
---name <string>                                                                             The name of the account
---new_name <string>                                       (optional)                        Update the account name
---uid <number>                                            (optional)                        Update the User Identifier (UID)
---gid <number>                                            (optional)                        Update the Group Identifier (GID)
---new_buckets_path <string>                               (optional)                        Update the filesystem's root path where each subdirectory is a bucket
---user <string>                                           (optional)                        Update the OS user name (instead of uid and gid)
---regenerate                                              (optional)                        Update automatically generated access key and secret key
---access_key <string>                                     (optional)                        Update the access key
---secret_key <string>                                     (optional)                        Update the secret key
---fs_backend <none | GPFS | CEPH_FS | NFSv4>              (optional)                        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
+--name <string>                                                         The name of the account
+--new_name <string>                                   (optional)        Update the account name
+--uid <number>                                        (optional)        Update the User Identifier (UID)
+--gid <number>                                        (optional)        Update the Group Identifier (GID)
+--new_buckets_path <string>                           (optional)        Update the filesystem's root path where each subdirectory is a bucket
+--user <string>                                       (optional)        Update the OS user name (instead of uid and gid)
+--regenerate                                          (optional)        Update automatically generated access key and secret key
+--access_key <string>                                 (optional)        Update the access key
+--secret_key <string>                                 (optional)        Update the secret key
+--fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
+--allow_bucket_creation <true | false>                (optional)        Update the account to explicitly allow or block bucket creation
 `;
 
 const ACCOUNT_FLAGS_DELETE = `
@@ -106,7 +108,7 @@ Usage:
 account delete [flags]
 
 Flags:
---name <string>                                                                             The name of the account
+--name <string>                                                         The name of the account
 `;
 
 const ACCOUNT_FLAGS_STATUS = `
@@ -114,9 +116,9 @@ Usage:
 account status [flags]
 
 Flags:
---name <string>                                                                             The name of the account
---access_key <string>                                     (optional)                        The access key of the account (identify the account instead of name)
---show_secrets                                            (optional)                        Print the access key and secret key of the account
+--name <string>                                                         The name of the account
+--access_key <string>                                 (optional)        The access key of the account (identify the account instead of name)
+--show_secrets                                        (optional)        Print the access key and secret key of the account
 `;
 
 const ACCOUNT_FLAGS_LIST = `
@@ -124,13 +126,13 @@ Usage:
 account list [flags]
 
 Flags:
---wide                                                    (optional)                        Print the additional details for each account
---show_secrets                                            (optional)                        Print the access key and secret key of each account (only when using flag --wide)
---uid <number>                                            (optional)                        Filter the list based on the provided account UID
---gid <number>                                            (optional)                        Filter the list based on the provided account GID
---user <string>                                           (optional)                        Filter the list based on the provided account user
---name <string>                                           (optional)                        Filter the list based on the provided account name
---access_key <string>                                     (optional)                        Filter the list based on the provided account access key
+--wide                                                (optional)        Print the additional details for each account
+--show_secrets                                        (optional)        Print the access key and secret key of each account (only when using flag --wide)
+--uid <number>                                        (optional)        Filter the list based on the provided account UID
+--gid <number>                                        (optional)        Filter the list based on the provided account GID
+--user <string>                                       (optional)        Filter the list based on the provided account user
+--name <string>                                       (optional)        Filter the list based on the provided account name
+--access_key <string>                                 (optional)        Filter the list based on the provided account access key
 `;
 
 const BUCKET_FLAGS_ADD = `
@@ -138,11 +140,11 @@ Usage:
 bucket add [flags]
 
 Flags:
---name <string>                                                                             Set the name for the bucket
---owner <string>                                                                            Set the bucket owner name
---path <string>                                                                             Set the bucket path
---bucket_policy <string>                                  (optional)                        Set the bucket policy, type is a string of valid JSON policy
---fs_backend <none | GPFS | CEPH_FS | NFSv4>              (optional)                        Set the filesystem type (default config.NSFS_NC_STORAGE_BACKEND)
+--name <string>                                                         Set the name for the bucket
+--owner <string>                                                        Set the bucket owner name
+--path <string>                                                         Set the bucket path
+--bucket_policy <string>                              (optional)        Set the bucket policy, type is a string of valid JSON policy
+--fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type (default config.NSFS_NC_STORAGE_BACKEND)
 `;
 
 const BUCKET_FLAGS_UPDATE = `
@@ -150,12 +152,12 @@ Usage:
 bucket update [flags]
 
 Flags:
---name <string>                                                                             The name of the bucket
---new_name <string>                                       (optional)                        Update the bucket name
---owner <string>                                          (optional)                        Update the bucket owner name
---path <string>                                           (optional)                        Update the bucket path
---bucket_policy <string>                                  (optional)                        Update the bucket policy, type is a string of valid JSON policy (unset with '')
---fs_backend <none | GPFS | CEPH_FS | NFSv4>              (optional)                        Update the filesystem type (unset with '') (default config.NSFS_NC_STORAGE_BACKEND)
+--name <string>                                                         The name of the bucket
+--new_name <string>                                   (optional)        Update the bucket name
+--owner <string>                                      (optional)        Update the bucket owner name
+--path <string>                                       (optional)        Update the bucket path
+--bucket_policy <string>                              (optional)        Update the bucket policy, type is a string of valid JSON policy (unset with '')
+--fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type (unset with '') (default config.NSFS_NC_STORAGE_BACKEND)
 `;
 
 const BUCKET_FLAGS_DELETE = `
@@ -163,7 +165,7 @@ Usage:
 bucket delete [flags]
 
 Flags:
---name <string>                                                                             The name of the bucket
+--name <string>                                                         The name of the bucket
 `;
 
 const BUCKET_FLAGS_STATUS = `
@@ -171,7 +173,7 @@ Usage:
 bucket status [flags]
 
 Flags:
---name <string>                                                                             The name of the bucket
+--name <string>                                                         The name of the bucket
 `;
 
 const BUCKET_FLAGS_LIST = `
@@ -179,8 +181,8 @@ Usage:
 bucket list [flags]
 
 Flags:
---wide                                                    (optional)                        Print the additional details for each bucket
---name <string>                                           (optional)                        Filter the list based on the provided bucket name
+--wide                                                (optional)        Print the additional details for each bucket
+--name <string>                                       (optional)        Filter the list based on the provided bucket name
 `;
 
 const GLACIER_OPTIONS = `

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -229,6 +229,34 @@ mocha.describe('manage_nsfs cli', function() {
             assert_response(action, type, bucket_list, expected_list, undefined, true);
         });
 
+        mocha.it('cli bucket list - wide "true"', async function() {
+            const action = ACTIONS.LIST;
+            const bucket_list = await exec_manage_cli(type, action, { config_root, wide: 'true' });
+            const expected_list = [bucket_options, bucket_with_policy_options];
+            assert_response(action, type, bucket_list, expected_list, undefined, true);
+        });
+
+        mocha.it('cli bucket list - wide "TRUE" (case insensitive)', async function() {
+            const action = ACTIONS.LIST;
+            const bucket_list = await exec_manage_cli(type, action, { config_root, wide: 'TRUE' });
+            const expected_list = [bucket_options, bucket_with_policy_options];
+            assert_response(action, type, bucket_list, expected_list, undefined, true);
+        });
+
+        mocha.it('cli bucket list - wide "false"', async function() {
+            const action = ACTIONS.LIST;
+            const bucket_list = await exec_manage_cli(type, action, { config_root, wide: 'false' });
+            const expected_list = [{ name }, { name: bucket_with_policy }];
+            assert_response(action, type, bucket_list, expected_list);
+        });
+
+        mocha.it('cli bucket list - wide "FALSE" (case insensitive)', async function() {
+            const action = ACTIONS.LIST;
+            const bucket_list = await exec_manage_cli(type, action, { config_root, wide: 'FALSE' });
+            const expected_list = [{ name }, { name: bucket_with_policy }];
+            assert_response(action, type, bucket_list, expected_list);
+        });
+
         mocha.it('cli bucket list - should fail invalid option', async function() {
             const action = ACTIONS.LIST;
             const bucket_options_with_invalid_option = {config_root, lala: 'lala'}; // lala invalid option
@@ -240,9 +268,21 @@ mocha.describe('manage_nsfs cli', function() {
             }
         });
 
-        mocha.it('cli bucket list - should fail invalid option type', async function() {
+        mocha.it('cli bucket list wide - should fail invalid string value', async function() {
             const action = ACTIONS.LIST;
-            const invalid_wide = 'not-boolean';
+            const invalid_wide = 'not-boolean'; // we accept true and false strings
+            const bucket_options_with_invalid_option = {config_root, wide: invalid_wide};
+            try {
+                add_res = await exec_manage_cli(type, action, bucket_options_with_invalid_option);
+                assert.fail('should have failed with invalid boolean value');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidBooleanValue);
+            }
+        });
+
+        mocha.it('cli bucket list wide - should fail invalid type', async function() {
+            const action = ACTIONS.LIST;
+            const invalid_wide = 1234;
             const bucket_options_with_invalid_option = {config_root, wide: invalid_wide};
             try {
                 add_res = await exec_manage_cli(type, action, bucket_options_with_invalid_option);
@@ -524,6 +564,60 @@ mocha.describe('manage_nsfs cli', function() {
             assert_account(account_symlink, account_options);
             const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
             assert_account(account, account_options);
+        });
+
+        mocha.it('cli account status show_secrets "true"', async function() {
+            const action = ACTIONS.STATUS;
+            const account_status = await exec_manage_cli(type, action, { config_root, name: account_options.name, show_secrets: 'true' });
+            assert_response(action, type, account_status, account_options, true);
+            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+            assert_account(account_symlink, account_options);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            assert_account(account, account_options);
+        });
+
+        mocha.it('cli account status show_secrets "TRUE" (case insensitive)', async function() {
+            const action = ACTIONS.STATUS;
+            const account_status = await exec_manage_cli(type, action, { config_root, name: account_options.name, show_secrets: 'TRUE' });
+            assert_response(action, type, account_status, account_options, true);
+            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+            assert_account(account_symlink, account_options);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            assert_account(account, account_options);
+        });
+
+        mocha.it('cli account status show_secrets "false"', async function() {
+            const action = ACTIONS.STATUS;
+            const account_status = await exec_manage_cli(type, action, { config_root, name: account_options.name, show_secrets: 'false' });
+            // when there is no show_secrets, the access_keys property doesn't exists in the reply
+            assert.equal(JSON.parse(account_status).response.reply.access_keys, undefined);
+        });
+
+        mocha.it('cli account status show_secrets "FALSE" (case insensitive)', async function() {
+            const action = ACTIONS.STATUS;
+            const account_status = await exec_manage_cli(type, action, { config_root, name: account_options.name, show_secrets: 'FALSE' });
+            // when there is no show_secrets, the access_keys property doesn't exists in the reply
+            assert.equal(JSON.parse(account_status).response.reply.access_keys, undefined);
+        });
+
+        mocha.it('list wide with invalid string value - should fail', async function() {
+            const action = ACTIONS.STATUS;
+            try {
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, show_secrets: 'blabla' });
+                assert.fail('should have failed with invalid boolean value');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidBooleanValue);
+            }
+        });
+
+        mocha.it('list wide with invalid type - should fail', async function() {
+            const action = ACTIONS.STATUS;
+            try {
+                await exec_manage_cli(type, action, { config_root, name: account_options.name, show_secrets: 1234 });
+                assert.fail('should have failed with invalid option type');
+            } catch (err) {
+                assert_error(err, ManageCLIError.InvalidArgumentType);
+            }
         });
 
         mocha.it('cli account create - no uid gid - should fail', async function() {


### PR DESCRIPTION
### Explain the changes
1. Add a flag to change the value of  `allow_bucket_creation`.
2. Edit details message when `BucketCreationNotAllowed` is thrown.
3. Add the option for boolean flags to pass 'true' and 'false' (`wide`, `show_secrets`, `regenerate`).
4. Add a new error `InvalidBooleanValue`.
5. Reduce the number of spaces in the help menu (without glacier changes to match the existing style, since it changes in PR #7848).

### Issues: Fixed [BZ 2262992](https://bugzilla.redhat.com/show_bug.cgi?id=2262992) #7786
1. Currently, the `allow_bucket_creation` value is inferred from the `new_buckets_path`: if the user passes a value to `new_buckets_path` then it is true, otherwise, it is false.
2. The fix is partial for the BZ 2262992, because the automated tests are using `from_file` flag, after this PR is merged we need to merge also PR #7779 as a fix.
3. GAP - I think we need to extract `wide` not part of the fetch data or extract and remove it before writing the config file (opened issue #7871).

### Testing Instructions:
#### Manual Tests:
1. Use the new flag `bucket_creation` and see the value of `allow_bucket_creation` changes, for example:
- First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/` `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
- Create an account with `new_buckets_path` (`allow_bucket_creation` inferred to be true): `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /tmp/nsfs_root1 --uid <uid> --gid <gid>`
- Update the account (so `allow_bucket_creation` will be false): `sudo node src/cmd/manage_nsfs account update --name <account-name> --allow_bucket_creation false`.

4. Use the boolean flags with true/false values, for example: `sudo node src/cmd/manage_nsfs account status --name <account-name> --show_secrets=true`

#### Unit Tests:
please run:
- `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`.
- `sudo npx jest test_nc_nsfs_account_cli.test.js`.


- [ ] Doc added/updated
- [X] Tests added
