### PR TITLE
NSFS | NC | Prevent Adding Additional Properties (Bucket Schema)

### DIFF
--- a/src/manage_nsfs/nsfs_schema_utils.js
+++ b/src/manage_nsfs/nsfs_schema_utils.js
@@ -1,6 +1,7 @@
 /* Copyright (C) 2023 NooBaa */
 'use strict';
 
+const _ = require('lodash');
 const RpcError = require('../rpc/rpc_error');
 const { default: Ajv } = require('ajv');
 const ajv = new Ajv({ verbose: true, allErrors: true });
@@ -20,6 +21,12 @@ ajv.addSchema(common_api);
 const bucket_schema = require('../server/system_services/schemas/nsfs_bucket_schema');
 const account_schema = require('../server/system_services/schemas/nsfs_account_schema');
 const nsfs_config_schema = require('../server/system_services/schemas/nsfs_config_schema');
+
+_.each(common_api.definitions, schema => {
+    schema_utils.strictify(schema, {
+        additionalProperties: false
+    });
+});
 
 schema_utils.strictify(bucket_schema, {
     additionalProperties: false

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -96,9 +96,7 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
-        // GAP - this test should have passing
-        // currently we can properties to s3_policy which are not part of the schema
-        it.skip('bucket with my_id inside s3_policy', () => {
+        it('bucket with my_id inside s3_policy', () => {
             const bucket_data = get_bucket_data();
             bucket_data.s3_policy = bucket_policy1; // added
             bucket_data.s3_policy.my_id = '123'; // this is not part of the schema
@@ -108,9 +106,7 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
-        // GAP - this test should have passing
-        // currently we can properties to encryption which are not part of the schema
-        it.skip('bucket with my_id inside encryption', () => {
+        it('bucket with my_id inside encryption', () => {
             const bucket_data = get_bucket_data();
             bucket_data.encryption = encryption1; // added
             bucket_data.encryption.my_id = '123'; // this is not part of the schema
@@ -120,9 +116,7 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
-        // GAP - this test should have passing
-        // currently we can properties to website which are not part of the schema
-        it.skip('bucket with my_id inside website', () => {
+        it('bucket with my_id inside website', () => {
             const bucket_data = get_bucket_data();
             bucket_data.website = website1; // added
             bucket_data.website.my_id = '123'; // this is not part of the schema


### PR DESCRIPTION
### Explain the changes
1. Prevent adding additional properties (bucket schema) - by using strictly on objects under schema that use ref (with an object underneath).

### Issues: Fixed #7757 
1. Currently a user can add additional properties to the JSON of `s3_policy`, `website`, and `encryption` objects.

### Testing Instructions:
1. Using unit tests, please run: `npx jest test_nc_nsfs_bucket_schema_validation.test.js`.


- [ ] Doc added/updated
- [X] Tests added (we had tests that were `it.skip` and in this PR we removed the skip part.
