### PR TITLE
Complete GCP namespace support

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -464,6 +464,9 @@ module.exports = {
                     },
                     endpoint_type: {
                         $ref: 'common_api#/definitions/endpoint_type'
+                    },
+                    gcp_hmac_key: {
+                        $ref: 'common_api#/definitions/gcp_hmac_key'
                     }
 
                 }

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -953,6 +953,17 @@ module.exports = {
             }
         },
 
+        gcp_access_id: { wrapper: SensitiveString },
+        gcp_secret_key: { wrapper: SensitiveString },
+
+        gcp_hmac_key: {
+            type: 'object',
+            properties: {
+                access_id: { $ref: '#/definitions/gcp_access_id' },
+                secret_key: { $ref: '#/definitions/gcp_secret_key' },
+            }
+        },
+
         ip_range: {
             type: 'object',
             required: ['start', 'end'],

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -644,6 +644,7 @@ module.exports = {
                 region: {
                     type: 'string'
                 },
+                gcp_hmac_key: { $ref: 'common_api#/definitions/gcp_hmac_key' },
             }
         },
 

--- a/src/endpoint/s3/ops/s3_put_object_tagging.js
+++ b/src/endpoint/s3/ops/s3_put_object_tagging.js
@@ -15,7 +15,7 @@ async function put_object_tagging(req, res) {
         tagging: tag_set,
         version_id
     });
-    if (reply.version_id) res.setHeader('x-amz-version-id', reply.version_id);
+    if (reply?.version_id) res.setHeader('x-amz-version-id', reply.version_id);
 }
 
 module.exports = {

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -47,6 +47,13 @@ class NamespaceGCP {
         this.project_id = project_id;
         this.client_email = client_email;
         this.private_key = private_key;
+        this.gcs = new GoogleCloudStorage({
+            projectId: this.project_id,
+            credentials: {
+                client_email: this.client_email,
+                private_key: this.private_key,
+            }
+        });
         this.s3_client = new AWS.S3({
             endpoint: 'https://storage.googleapis.com',
             accessKeyId: hmac_key.access_id,

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -11,7 +11,7 @@ const s3_utils = require('../endpoint/s3/s3_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 // we use this wrapper to set a custom user agent
 const GoogleCloudStorage = require('../util/google_storage_wrap');
-const aws_sdk = require('aws-sdk');
+const AWS = require('aws-sdk');
 
 /**
  * @implements {nb.Namespace}
@@ -53,7 +53,7 @@ class NamespaceGCP {
             this.hmac_key = res[0];
             this.hmac_secret = res[1];
         });
-        this.s3_client = new aws_sdk.S3({
+        this.s3_client = new AWS.S3({
             endpoint: 'https://storage.googleapis.com',
             accessKeyId: this.hmac_key,
             secretAccessKey: this.hmac_secret

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -27,6 +27,10 @@ class NamespaceGCP {
     *      private_key: string,
     *      access_mode: string,
     *      stats: import('./endpoint_stats_collector').EndpointStatsCollector,
+    *      hmac_key: {
+    *         access_id: string,
+    *         secret_key: string,
+    *      }
     * }} params
     */
     constructor({
@@ -37,26 +41,16 @@ class NamespaceGCP {
         private_key,
         access_mode,
         stats,
+        hmac_key,
     }) {
         this.namespace_resource_id = namespace_resource_id;
         this.project_id = project_id;
         this.client_email = client_email;
         this.private_key = private_key;
-        this.gcs = new GoogleCloudStorage({
-            projectId: this.project_id,
-            credentials: {
-                client_email: this.client_email,
-                private_key: this.private_key,
-            }
-        });
-        this.gcs.createHmacKey(client_email).then(res => {
-            this.hmac_key = res[0];
-            this.hmac_secret = res[1];
-        });
         this.s3_client = new AWS.S3({
             endpoint: 'https://storage.googleapis.com',
-            accessKeyId: this.hmac_key,
-            secretAccessKey: this.hmac_secret
+            accessKeyId: hmac_key.access_id,
+            secretAccessKey: hmac_key.secret_key
         });
 
         this.bucket = target_bucket;

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -64,7 +64,7 @@ class NamespaceGCP {
                 private_key: this.private_key,
             }
         });
-        /* An S3 client is needed for multipart upload since GCP only supports multipart i[;pads] via the S3-compatible XML API
+        /* An S3 client is needed for multipart upload since GCP only supports multipart uploads via the S3-compatible XML API
         *  https://cloud.google.com/storage/docs/multipart-uploads
         *  This is also the reason an HMAC key is generated as part of `add_external_connection` - since the standard GCP credentials
         *  cannot be used in conjunction with the S3 client.

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -7,9 +7,11 @@ const util = require('util');
 const P = require('../util/promise');
 const stream_utils = require('../util/stream_utils');
 const dbg = require('../util/debug_module')(__filename);
+const s3_utils = require('../endpoint/s3/s3_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 // we use this wrapper to set a custom user agent
 const GoogleCloudStorage = require('../util/google_storage_wrap');
+const aws_sdk = require('aws-sdk');
 
 /**
  * @implements {nb.Namespace}
@@ -47,6 +49,16 @@ class NamespaceGCP {
                 private_key: this.private_key,
             }
         });
+        this.gcs.createHmacKey(client_email).then((res) => {
+            this.hmac_key = res[0];
+            this.hmac_secret = res[1];
+        });
+        this.s3_client = new aws_sdk.S3({
+            endpoint: 'https://storage.googleapis.com',
+            accessKeyId: this.hmac_key,
+            secretAccessKey: this.hmac_secret
+        });
+
         this.bucket = target_bucket;
         this.access_mode = access_mode;
         this.stats = stats;
@@ -297,27 +309,129 @@ class NamespaceGCP {
 
     async create_object_upload(params, object_sdk) {
         dbg.log0('NamespaceGCP.create_object_upload:', this.bucket, inspect(params));
-        throw new S3Error(S3Error.NotImplemented);
+        const Tagging = params.tagging && params.tagging.map(tag => tag.key + '=' + tag.value).join('&');
+        /** @type {AWS.S3.CreateMultipartUploadRequest} */
+        const request = {
+            Bucket: this.bucket,
+            Key: params.key,
+            ContentType: params.content_type,
+            StorageClass: params.storage_class,
+            Metadata: params.xattr,
+            Tagging
+        };
+        const res = await this.s3_client.createMultipartUpload(request).promise();
+
+        dbg.log0('NamespaceGCP.create_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
+        return { obj_id: res.UploadId };
     }
 
     async upload_multipart(params, object_sdk) {
         dbg.log0('NamespaceGCP.upload_multipart:', this.bucket, inspect(params));
-        throw new S3Error(S3Error.NotImplemented);
+        let res;
+        if (params.copy_source) {
+            const { copy_source, copy_source_range } = s3_utils.format_copy_source(params.copy_source);
+
+            /** @type {AWS.S3.UploadPartCopyRequest} */
+            const request = {
+                Bucket: this.bucket,
+                Key: params.key,
+                UploadId: params.obj_id,
+                PartNumber: params.num,
+                CopySource: copy_source,
+                CopySourceRange: copy_source_range,
+            };
+
+            res = await this.s3_client.uploadPartCopy(request).promise();
+        } else {
+            let count = 1;
+            const count_stream = stream_utils.get_tap_stream(data => {
+                this.stats?.update_namespace_write_stats({
+                    namespace_resource_id: this.namespace_resource_id,
+                    size: data.length,
+                    count
+                });
+                // clear count for next updates
+                count = 0;
+            });
+            /** @type {AWS.S3.UploadPartRequest} */
+            const request = {
+                Bucket: this.bucket,
+                Key: params.key,
+                UploadId: params.obj_id,
+                PartNumber: params.num,
+                Body: params.source_stream.pipe(count_stream),
+                ContentMD5: params.md5_b64,
+                ContentLength: params.size,
+            };
+            try {
+                res = await this.s3_client.uploadPart(request).promise();
+            } catch (err) {
+                object_sdk.rpc_client.pool.update_issues_report({
+                    namespace_resource_id: this.namespace_resource_id,
+                    error_code: String(err.code),
+                    time: Date.now(),
+                });
+                throw err;
+            }
+        }
+        dbg.log0('NamespaceGCP.upload_multipart:', this.bucket, inspect(params), 'res', inspect(res));
+        const etag = s3_utils.parse_etag(res.ETag);
+        return { etag };
     }
 
     async list_multiparts(params, object_sdk) {
         dbg.log0('NamespaceGCP.list_multiparts:', this.bucket, inspect(params));
-        throw new S3Error(S3Error.NotImplemented);
+
+        const res = await this.s3_client.listParts({
+            Bucket: this.bucket,
+            Key: params.key,
+            UploadId: params.obj_id,
+            MaxParts: params.max,
+            PartNumberMarker: params.num_marker,
+        }).promise();
+
+        dbg.log0('NamespaceGCP.list_multiparts:', this.bucket, inspect(params), 'res', inspect(res));
+        return {
+            is_truncated: res.IsTruncated,
+            next_num_marker: res.NextPartNumberMarker,
+            multiparts: _.map(res.Parts, p => ({
+                num: p.PartNumber,
+                size: p.Size,
+                etag: s3_utils.parse_etag(p.ETag),
+                last_modified: p.LastModified,
+            }))
+        };
     }
 
     async complete_object_upload(params, object_sdk) {
         dbg.log0('NamespaceGCP.complete_object_upload:', this.bucket, inspect(params));
-        throw new S3Error(S3Error.NotImplemented);
+
+        const res = await this.s3_client.completeMultipartUpload({
+            Bucket: this.bucket,
+            Key: params.key,
+            UploadId: params.obj_id,
+            MultipartUpload: {
+                Parts: _.map(params.multiparts, p => ({
+                    PartNumber: p.num,
+                    ETag: `"${p.etag}"`,
+                }))
+            }
+        }).promise();
+
+        dbg.log0('NamespaceGCP.complete_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
+        const etag = s3_utils.parse_etag(res.ETag);
+        return { etag, version_id: res.VersionId };
     }
 
     async abort_object_upload(params, object_sdk) {
         dbg.log0('NamespaceGCP.abort_object_upload:', this.bucket, inspect(params));
-        throw new S3Error(S3Error.NotImplemented);
+        const res = await this.s3_client.abortMultipartUpload({
+            Bucket: this.bucket,
+            Key: params.key,
+            UploadId: params.obj_id,
+        }).promise();
+
+        dbg.log0('NamespaceGCP.abort_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
     }
 
     //////////
@@ -378,13 +492,35 @@ class NamespaceGCP {
     ////////////////////
 
     async get_object_tagging(params, object_sdk) {
-        throw new Error('TODO');
+        dbg.log0('NamespaceGCP.get_object_tagging:', this.bucket, inspect(params));
+        const obj_tags = (await this.read_object_md(params, object_sdk)).xattr
+        // Converting tag dictionary to array of key-value object pairs
+        const tags = Object.entries(obj_tags).map(([key, value]) => ({ key, value }));
+        return {
+            tagging: tags
+        };
     }
     async delete_object_tagging(params, object_sdk) {
-        throw new Error('TODO');
+        dbg.log0('NamespaceGCP.delete_object_tagging:', this.bucket, inspect(params));
+        try {
+            // Set an empty metadata object to remove all tags
+            const res = await this.gcs.bucket(this.bucket).file(params.key).setMetadata({});
+            dbg.log0('NamespaceGCP.delete_object_tagging:', this.bucket, inspect(params), 'res', inspect(res));
+          } catch (err) {
+            dbg.error('NamespaceGCP.delete_object_tagging error:', err);
+          }
     }
     async put_object_tagging(params, object_sdk) {
-        throw new Error('TODO');
+        dbg.log0('NamespaceGCP.put_object_tagging:', this.bucket, inspect(params));
+        try {
+            // Convert the array of key-value object pairs to a dictionary
+            const tags_to_put = Object.fromEntries(params.tagging.map(tag => ([tag.key, tag.value])));
+            const res = await this.gcs.bucket(this.bucket).file(params.key).setMetadata({ metadata: tags_to_put });
+            dbg.log0('NamespaceGCP.put_object_tagging:', this.bucket, inspect(params), 'res', inspect(res));
+        } catch (err) {
+            dbg.error('NamespaceGCP.put_object_tagging error:', err);
+        }
+
     }
 
     ///////////////////

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -49,7 +49,7 @@ class NamespaceGCP {
                 private_key: this.private_key,
             }
         });
-        this.gcs.createHmacKey(client_email).then((res) => {
+        this.gcs.createHmacKey(client_email).then(res => {
             this.hmac_key = res[0];
             this.hmac_secret = res[1];
         });
@@ -493,7 +493,7 @@ class NamespaceGCP {
 
     async get_object_tagging(params, object_sdk) {
         dbg.log0('NamespaceGCP.get_object_tagging:', this.bucket, inspect(params));
-        const obj_tags = (await this.read_object_md(params, object_sdk)).xattr
+        const obj_tags = (await this.read_object_md(params, object_sdk)).xattr;
         // Converting tag dictionary to array of key-value object pairs
         const tags = Object.entries(obj_tags).map(([key, value]) => ({ key, value }));
         return {

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -11,7 +11,15 @@ const s3_utils = require('../endpoint/s3/s3_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 // we use this wrapper to set a custom user agent
 const GoogleCloudStorage = require('../util/google_storage_wrap');
-const AWS = require('aws-sdk');
+const {
+    AbortMultipartUploadCommand,
+    CompleteMultipartUploadCommand,
+    CreateMultipartUploadCommand,
+    ListPartsCommand,
+    S3Client,
+    UploadPartCommand,
+    UploadPartCopyCommand,
+} = require('@aws-sdk/client-s3');
 
 /**
  * @implements {nb.Namespace}
@@ -54,10 +62,13 @@ class NamespaceGCP {
                 private_key: this.private_key,
             }
         });
-        this.s3_client = new AWS.S3({
+        this.s3_client = new S3Client({
             endpoint: 'https://storage.googleapis.com',
-            accessKeyId: hmac_key.access_id,
-            secretAccessKey: hmac_key.secret_key
+            region: 'auto', //https://cloud.google.com/storage/docs/aws-simple-migration#storage-list-buckets-s3-python
+            credentials: {
+                accessKeyId: hmac_key.access_id,
+                secretAccessKey: hmac_key.secret_key,
+            },
         });
 
         this.bucket = target_bucket;
@@ -204,7 +215,7 @@ class NamespaceGCP {
             read_stream.on('response', () => {
                 let count = 1;
                 const count_stream = stream_utils.get_tap_stream(data => {
-                    this.stats_collector.update_namespace_write_stats({
+                    this.stats.update_namespace_write_stats({
                         namespace_resource_id: this.namespace_resource_id,
                         bucket_name: params.bucket,
                         size: data.length,
@@ -311,8 +322,9 @@ class NamespaceGCP {
     async create_object_upload(params, object_sdk) {
         dbg.log0('NamespaceGCP.create_object_upload:', this.bucket, inspect(params));
         const Tagging = params.tagging && params.tagging.map(tag => tag.key + '=' + tag.value).join('&');
-        /** @type {AWS.S3.CreateMultipartUploadRequest} */
-        const request = {
+
+        /** @type {import('@aws-sdk/client-s3').CreateMultipartUploadRequest} */
+        const mp_upload_input = {
             Bucket: this.bucket,
             Key: params.key,
             ContentType: params.content_type,
@@ -320,7 +332,8 @@ class NamespaceGCP {
             Metadata: params.xattr,
             Tagging
         };
-        const res = await this.s3_client.createMultipartUpload(request).promise();
+        const mp_upload_cmd = new CreateMultipartUploadCommand(mp_upload_input);
+        const res = await this.s3_client.send(mp_upload_cmd);
 
         dbg.log0('NamespaceGCP.create_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
         return { obj_id: res.UploadId };
@@ -328,11 +341,11 @@ class NamespaceGCP {
 
     async upload_multipart(params, object_sdk) {
         dbg.log0('NamespaceGCP.upload_multipart:', this.bucket, inspect(params));
+        let etag;
         let res;
         if (params.copy_source) {
             const { copy_source, copy_source_range } = s3_utils.format_copy_source(params.copy_source);
-
-            /** @type {AWS.S3.UploadPartCopyRequest} */
+            /** @type {import('@aws-sdk/client-s3').UploadPartCopyRequest} */
             const request = {
                 Bucket: this.bucket,
                 Key: params.key,
@@ -342,7 +355,9 @@ class NamespaceGCP {
                 CopySourceRange: copy_source_range,
             };
 
-            res = await this.s3_client.uploadPartCopy(request).promise();
+            const command = new UploadPartCopyCommand(request);
+            res = await this.s3_client.send(command);
+            etag = s3_utils.parse_etag(res.CopyPartResult.ETag);
         } else {
             let count = 1;
             const count_stream = stream_utils.get_tap_stream(data => {
@@ -354,7 +369,7 @@ class NamespaceGCP {
                 // clear count for next updates
                 count = 0;
             });
-            /** @type {AWS.S3.UploadPartRequest} */
+            /** @type {import('@aws-sdk/client-s3').UploadPartRequest} */
             const request = {
                 Bucket: this.bucket,
                 Key: params.key,
@@ -365,7 +380,8 @@ class NamespaceGCP {
                 ContentLength: params.size,
             };
             try {
-                res = await this.s3_client.uploadPart(request).promise();
+                const command = new UploadPartCommand(request);
+                res = await this.s3_client.send(command);
             } catch (err) {
                 object_sdk.rpc_client.pool.update_issues_report({
                     namespace_resource_id: this.namespace_resource_id,
@@ -374,22 +390,25 @@ class NamespaceGCP {
                 });
                 throw err;
             }
+            etag = s3_utils.parse_etag(res.ETag);
         }
         dbg.log0('NamespaceGCP.upload_multipart:', this.bucket, inspect(params), 'res', inspect(res));
-        const etag = s3_utils.parse_etag(res.ETag);
         return { etag };
     }
 
     async list_multiparts(params, object_sdk) {
         dbg.log0('NamespaceGCP.list_multiparts:', this.bucket, inspect(params));
 
-        const res = await this.s3_client.listParts({
+        /** @type {import('@aws-sdk/client-s3').ListPartsRequest} */
+        const request = {
             Bucket: this.bucket,
             Key: params.key,
             UploadId: params.obj_id,
             MaxParts: params.max,
             PartNumberMarker: params.num_marker,
-        }).promise();
+        };
+        const command = new ListPartsCommand(request);
+        const res = await this.s3_client.send(command);
 
         dbg.log0('NamespaceGCP.list_multiparts:', this.bucket, inspect(params), 'res', inspect(res));
         return {
@@ -407,7 +426,8 @@ class NamespaceGCP {
     async complete_object_upload(params, object_sdk) {
         dbg.log0('NamespaceGCP.complete_object_upload:', this.bucket, inspect(params));
 
-        const res = await this.s3_client.completeMultipartUpload({
+        /** @type {import('@aws-sdk/client-s3').CompleteMultipartUploadRequest} */
+        const request = {
             Bucket: this.bucket,
             Key: params.key,
             UploadId: params.obj_id,
@@ -417,7 +437,9 @@ class NamespaceGCP {
                     ETag: `"${p.etag}"`,
                 }))
             }
-        }).promise();
+        };
+        const command = new CompleteMultipartUploadCommand(request);
+        const res = await this.s3_client.send(command);
 
         dbg.log0('NamespaceGCP.complete_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
         const etag = s3_utils.parse_etag(res.ETag);
@@ -426,11 +448,14 @@ class NamespaceGCP {
 
     async abort_object_upload(params, object_sdk) {
         dbg.log0('NamespaceGCP.abort_object_upload:', this.bucket, inspect(params));
-        const res = await this.s3_client.abortMultipartUpload({
+        /** @type {import('@aws-sdk/client-s3').AbortMultipartUploadRequest} */
+        const request = {
             Bucket: this.bucket,
             Key: params.key,
             UploadId: params.obj_id,
-        }).promise();
+        };
+        const command = new AbortMultipartUploadCommand(request);
+        const res = await this.s3_client.send(command);
 
         dbg.log0('NamespaceGCP.abort_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
     }
@@ -479,8 +504,8 @@ class NamespaceGCP {
 
         const res = await P.map_with_concurrency(10, params.objects, obj =>
             this.gcs.bucket(this.bucket).file(obj.key).delete()
-            .then(() => ({}))
-            .catch(err => ({ err_code: err.code, err_message: err.errors[0].reason || 'InternalError' })));
+                .then(() => ({}))
+                .catch(err => ({ err_code: err.code, err_message: err.errors[0].reason || 'InternalError' })));
 
         dbg.log1('NamespaceGCP.delete_multiple_objects:', this.bucket, inspect(params), 'res', inspect(res));
 
@@ -508,9 +533,9 @@ class NamespaceGCP {
             // Set an empty metadata object to remove all tags
             const res = await this.gcs.bucket(this.bucket).file(params.key).setMetadata({});
             dbg.log0('NamespaceGCP.delete_object_tagging:', this.bucket, inspect(params), 'res', inspect(res));
-          } catch (err) {
+        } catch (err) {
             dbg.error('NamespaceGCP.delete_object_tagging error:', err);
-          }
+        }
     }
     async put_object_tagging(params, object_sdk) {
         dbg.log0('NamespaceGCP.put_object_tagging:', this.bucket, inspect(params));

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -21,6 +21,8 @@ const {
     UploadPartCopyCommand,
 } = require('@aws-sdk/client-s3');
 
+const { fix_error_object } = require('./noobaa_s3_client/noobaa_s3_client');
+
 /**
  * @implements {nb.Namespace}
  */
@@ -62,6 +64,11 @@ class NamespaceGCP {
                 private_key: this.private_key,
             }
         });
+        /* An S3 client is needed for multipart upload since GCP only supports multipart i[;pads] via the S3-compatible XML API
+        *  https://cloud.google.com/storage/docs/multipart-uploads
+        *  This is also the reason an HMAC key is generated as part of `add_external_connection` - since the standard GCP credentials
+        *  cannot be used in conjunction with the S3 client.
+        */
         this.s3_client = new S3Client({
             endpoint: 'https://storage.googleapis.com',
             region: 'auto', //https://cloud.google.com/storage/docs/aws-simple-migration#storage-list-buckets-s3-python
@@ -383,6 +390,7 @@ class NamespaceGCP {
                 const command = new UploadPartCommand(request);
                 res = await this.s3_client.send(command);
             } catch (err) {
+                fix_error_object(err);
                 object_sdk.rpc_client.pool.update_issues_report({
                     namespace_resource_id: this.namespace_resource_id,
                     error_code: String(err.code),

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -330,17 +330,15 @@ class NamespaceGCP {
         dbg.log0('NamespaceGCP.create_object_upload:', this.bucket, inspect(params));
         const Tagging = params.tagging && params.tagging.map(tag => tag.key + '=' + tag.value).join('&');
 
-        /** @type {import('@aws-sdk/client-s3').CreateMultipartUploadRequest} */
-        const mp_upload_input = {
-            Bucket: this.bucket,
-            Key: params.key,
-            ContentType: params.content_type,
-            StorageClass: params.storage_class,
-            Metadata: params.xattr,
-            Tagging
-        };
-        const mp_upload_cmd = new CreateMultipartUploadCommand(mp_upload_input);
-        const res = await this.s3_client.send(mp_upload_cmd);
+        const res = await this.s3_client.send(
+            new CreateMultipartUploadCommand({
+                Bucket: this.bucket,
+                Key: params.key,
+                ContentType: params.content_type,
+                StorageClass: params.storage_class,
+                Metadata: params.xattr,
+                Tagging
+        }));
 
         dbg.log0('NamespaceGCP.create_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
         return { obj_id: res.UploadId };
@@ -352,18 +350,16 @@ class NamespaceGCP {
         let res;
         if (params.copy_source) {
             const { copy_source, copy_source_range } = s3_utils.format_copy_source(params.copy_source);
-            /** @type {import('@aws-sdk/client-s3').UploadPartCopyRequest} */
-            const request = {
-                Bucket: this.bucket,
-                Key: params.key,
-                UploadId: params.obj_id,
-                PartNumber: params.num,
-                CopySource: copy_source,
-                CopySourceRange: copy_source_range,
-            };
 
-            const command = new UploadPartCopyCommand(request);
-            res = await this.s3_client.send(command);
+            res = await this.s3_client.send(
+                new UploadPartCopyCommand({
+                    Bucket: this.bucket,
+                    Key: params.key,
+                    UploadId: params.obj_id,
+                    PartNumber: params.num,
+                    CopySource: copy_source,
+                    CopySourceRange: copy_source_range,
+            }));
             etag = s3_utils.parse_etag(res.CopyPartResult.ETag);
         } else {
             let count = 1;
@@ -376,19 +372,17 @@ class NamespaceGCP {
                 // clear count for next updates
                 count = 0;
             });
-            /** @type {import('@aws-sdk/client-s3').UploadPartRequest} */
-            const request = {
-                Bucket: this.bucket,
-                Key: params.key,
-                UploadId: params.obj_id,
-                PartNumber: params.num,
-                Body: params.source_stream.pipe(count_stream),
-                ContentMD5: params.md5_b64,
-                ContentLength: params.size,
-            };
             try {
-                const command = new UploadPartCommand(request);
-                res = await this.s3_client.send(command);
+                res = await this.s3_client.send(
+                    new UploadPartCommand({
+                        Bucket: this.bucket,
+                        Key: params.key,
+                        UploadId: params.obj_id,
+                        PartNumber: params.num,
+                        Body: params.source_stream.pipe(count_stream),
+                        ContentMD5: params.md5_b64,
+                        ContentLength: params.size,
+                }));
             } catch (err) {
                 fix_error_object(err);
                 object_sdk.rpc_client.pool.update_issues_report({
@@ -407,16 +401,14 @@ class NamespaceGCP {
     async list_multiparts(params, object_sdk) {
         dbg.log0('NamespaceGCP.list_multiparts:', this.bucket, inspect(params));
 
-        /** @type {import('@aws-sdk/client-s3').ListPartsRequest} */
-        const request = {
-            Bucket: this.bucket,
-            Key: params.key,
-            UploadId: params.obj_id,
-            MaxParts: params.max,
-            PartNumberMarker: params.num_marker,
-        };
-        const command = new ListPartsCommand(request);
-        const res = await this.s3_client.send(command);
+        const res = await this.s3_client.send(
+            new ListPartsCommand({
+                Bucket: this.bucket,
+                Key: params.key,
+                UploadId: params.obj_id,
+                MaxParts: params.max,
+                PartNumberMarker: params.num_marker,
+        }));
 
         dbg.log0('NamespaceGCP.list_multiparts:', this.bucket, inspect(params), 'res', inspect(res));
         return {
@@ -434,20 +426,18 @@ class NamespaceGCP {
     async complete_object_upload(params, object_sdk) {
         dbg.log0('NamespaceGCP.complete_object_upload:', this.bucket, inspect(params));
 
-        /** @type {import('@aws-sdk/client-s3').CompleteMultipartUploadRequest} */
-        const request = {
-            Bucket: this.bucket,
-            Key: params.key,
-            UploadId: params.obj_id,
-            MultipartUpload: {
-                Parts: _.map(params.multiparts, p => ({
-                    PartNumber: p.num,
-                    ETag: `"${p.etag}"`,
-                }))
-            }
-        };
-        const command = new CompleteMultipartUploadCommand(request);
-        const res = await this.s3_client.send(command);
+        const res = await this.s3_client.send(
+            new CompleteMultipartUploadCommand({
+                Bucket: this.bucket,
+                Key: params.key,
+                UploadId: params.obj_id,
+                MultipartUpload: {
+                    Parts: _.map(params.multiparts, p => ({
+                        PartNumber: p.num,
+                        ETag: `"${p.etag}"`,
+                    }))
+                }
+        }));
 
         dbg.log0('NamespaceGCP.complete_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
         const etag = s3_utils.parse_etag(res.ETag);
@@ -456,14 +446,13 @@ class NamespaceGCP {
 
     async abort_object_upload(params, object_sdk) {
         dbg.log0('NamespaceGCP.abort_object_upload:', this.bucket, inspect(params));
-        /** @type {import('@aws-sdk/client-s3').AbortMultipartUploadRequest} */
-        const request = {
-            Bucket: this.bucket,
-            Key: params.key,
-            UploadId: params.obj_id,
-        };
-        const command = new AbortMultipartUploadCommand(request);
-        const res = await this.s3_client.send(command);
+
+        const res = await this.s3_client.send(
+            new AbortMultipartUploadCommand({
+                Bucket: this.bucket,
+                Key: params.key,
+                UploadId: params.obj_id,
+        }));
 
         dbg.log0('NamespaceGCP.abort_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
     }

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -446,12 +446,13 @@ class NamespaceGCP {
     */
     async get_object_acl(params, object_sdk) {
         dbg.log0('NamespaceGCP.get_object_acl:', this.bucket, inspect(params));
-        throw new S3Error(S3Error.NotImplemented);
+        await this.read_object_md(params, object_sdk);
+        return s3_utils.DEFAULT_OBJECT_ACL;
     }
 
     async put_object_acl(params, object_sdk) {
         dbg.log0('NamespaceGCP.put_object_acl:', this.bucket, inspect(params));
-        throw new S3Error(S3Error.NotImplemented);
+        await this.read_object_md(params, object_sdk);
     }
 
     ///////////////////

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -443,6 +443,7 @@ class ObjectSDK {
     /**
      * @returns {nb.Namespace}
      */
+    // resource is a namespace_resource
     _setup_single_namespace({ resource: r, path: p }, bucket_id, options) {
 
         if (r.endpoint_type === 'NOOBAA') {
@@ -502,6 +503,7 @@ class ObjectSDK {
                 private_key,
                 access_mode: r.access_mode,
                 stats: this.stats,
+                hmac_key: r.gcp_hmac_key,
             });
         }
         if (r.fs_root_path || r.fs_root_path === '') {

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -443,7 +443,7 @@ class ObjectSDK {
     /**
      * @returns {nb.Namespace}
      */
-    // resource is a namespace_resource
+    // resource contains the values of namespace_resource_extended_info
     _setup_single_namespace({ resource: r, path: p }, bucket_id, options) {
 
         if (r.endpoint_type === 'NOOBAA') {
@@ -503,7 +503,8 @@ class ObjectSDK {
                 private_key,
                 access_mode: r.access_mode,
                 stats: this.stats,
-                hmac_key: r.gcp_hmac_key,
+                hmac_key: { access_id : r.gcp_hmac_key.access_id.unwrap(),
+                            secret_key : r.gcp_hmac_key.secret_key.unwrap() }
             });
         }
         if (r.fs_root_path || r.fs_root_path === '') {

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -503,8 +503,8 @@ class ObjectSDK {
                 private_key,
                 access_mode: r.access_mode,
                 stats: this.stats,
-                hmac_key: { access_id : r.gcp_hmac_key.access_id.unwrap(),
-                            secret_key : r.gcp_hmac_key.secret_key.unwrap() }
+                hmac_key: { access_id: r.gcp_hmac_key.access_id.unwrap(),
+                            secret_key: r.gcp_hmac_key.secret_key.unwrap() }
             });
         }
         if (r.fs_root_path || r.fs_root_path === '') {

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -786,7 +786,7 @@ async function add_external_connection(req) {
 
     // If the connection is for Google, generate an HMAC key for S3-compatible actions (e.g. multipart uploads)
     if (info.endpoint_type === 'GOOGLE') {
-        dbg.log0('add_external_connection: creating HMAC key for Google connection')
+        dbg.log0('add_external_connection: creating HMAC key for Google connection');
         const key_file = JSON.parse(req.rpc_params.secret.unwrap());
         const credentials = _.pick(key_file, 'client_email', 'private_key');
         const gs_client = new GoogleStorage({ credentials, projectId: key_file.project_id });

--- a/src/server/system_services/master_key_manager.js
+++ b/src/server/system_services/master_key_manager.js
@@ -378,6 +378,13 @@ class MasterKeysManager {
                             master_key_id: ns_resource.account.master_key_id._id
                         }, undefined);
                     }
+                    if (ns_resource.connection.gcp_hmac_key?.secret_key) {
+                        ns_resource.connection.gcp_hmac_key.secret_key = await this.secret_keys_cache.get_with_cache({
+                            encrypted_value: ns_resource.connection.gcp_hmac_key.secret_key.unwrap(),
+                            undefined,
+                            master_key_id: ns_resource.account.master_key_id._id
+                        }, undefined);
+                    }
                 }
             }
         }

--- a/src/server/system_services/master_key_manager.js
+++ b/src/server/system_services/master_key_manager.js
@@ -339,6 +339,13 @@ class MasterKeysManager {
                                 decipher: crypto.createDecipheriv(m_key.cipher_type, m_key.cipher_key, m_key.cipher_iv)
                             }, undefined);
                         }
+                        if (keys.gcp_hmac_key?.secret_key) {
+                            keys.gcp_hmac_key.secret_key = await this.secret_keys_cache.get_with_cache({
+                                encrypted_value: keys.gcp_hmac_key.secret_key,
+                                decipher: crypto.createDecipheriv(m_key.cipher_type, m_key.cipher_key, m_key.cipher_iv)
+                            }, undefined);
+                        
+                        }
                     }
                 }
             }

--- a/src/server/system_services/master_key_manager.js
+++ b/src/server/system_services/master_key_manager.js
@@ -344,7 +344,7 @@ class MasterKeysManager {
                                 encrypted_value: keys.gcp_hmac_key.secret_key,
                                 decipher: crypto.createDecipheriv(m_key.cipher_type, m_key.cipher_key, m_key.cipher_iv)
                             }, undefined);
-                        
+
                         }
                     }
                 }

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -301,7 +301,7 @@ async function create_namespace_resource(req) {
         }
 
         let gcp_hmac_key;
-        if (connection?.gcp_hmac_key?.secret_key) {
+        if (connection.gcp_hmac_key?.secret_key) {
             gcp_hmac_key = {
                 access_id: connection.gcp_hmac_key.access_id,
                 secret_key: system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -300,6 +300,16 @@ async function create_namespace_resource(req) {
             };
         }
 
+        let gcp_hmac_key;
+        if (connection?.gcp_hmac_key?.secret_key) {
+            gcp_hmac_key = {
+                access_id: connection.gcp_hmac_key.access_id,
+                secret_key: system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
+                    connection.gcp_hmac_key.secret_key, req.account.master_key_id._id
+                )
+            };
+        }
+
         namespace_resource = new_namespace_resource_defaults(name, req.system._id, req.account._id, _.omitBy({
             aws_sts_arn: connection.aws_sts_arn,
             endpoint: connection.endpoint,
@@ -311,6 +321,7 @@ async function create_namespace_resource(req) {
             endpoint_type: connection.endpoint_type || 'AWS',
             region: connection.region,
             azure_log_access_keys,
+            gcp_hmac_key,
         }, _.isUndefined), undefined, req.rpc_params.access_mode);
 
         const cloud_buckets = await server_rpc.client.bucket.get_cloud_buckets({
@@ -1210,6 +1221,7 @@ function get_namespace_resource_extended_info(namespace_resource) {
         secret_key: namespace_resource.connection.secret_key,
         access_mode: namespace_resource.access_mode,
         aws_sts_arn: namespace_resource.connection.aws_sts_arn || undefined,
+        gcp_hmac_key: namespace_resource.connection.gcp_hmac_key,
     };
     const nsfs_info = namespace_resource.nsfs_config && {
         fs_root_path: namespace_resource.nsfs_config.fs_root_path,

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -70,6 +70,7 @@ module.exports = {
                     access_key: { $ref: 'common_api#/definitions/access_key' },
                     secret_key: { $ref: 'common_api#/definitions/secret_key' },
                     azure_log_access_keys: { $ref: 'common_api#/definitions/azure_log_access_keys' },
+                    gcp_hmac_key: { $ref: 'common_api#/definitions/gcp_hmac_key' },
                     aws_sts_arn: {
                         type: 'string'
                     },

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -53,6 +53,7 @@ module.exports = {
                 access_key: { $ref: 'common_api#/definitions/access_key' },
                 secret_key: { $ref: 'common_api#/definitions/secret_key' },
                 azure_log_access_keys: { $ref: 'common_api#/definitions/azure_log_access_keys' },
+                gcp_hmac_key: { $ref: 'common_api#/definitions/gcp_hmac_key' },
                 cp_code: {
                     type: 'string'
                 }


### PR DESCRIPTION
### Explain the changes
1. This PR implements several functions (namely multipart uploads and tag support) required for proper namespace support over Google Cloud Storage.
I opted to use AWS SDK v3 for posterity, and went with barebones commands to speed things up a bit,
2. Since GCP only supports multipart uploads via the S3-compatible XML API, it is necessary to generate an HMAC key to use an S3 client with GCP. The PR also takes care of generating the HMAC key, as well as storing it in our DB.

### Issues: Fixed #xxx / Gap #xxx
1.  Up until now, our GCP interface supported resumable uploads but not multipart uploads - this PR addresses that gap

### Testing Instructions:
1. Use multipart upload to upload an object with tags to a GCP namespace bucket
3. Read the uploaded object and compare checksums to verify both write and read were successful
4. Read the object's tags and compare them to the ones from before the upload
5. Add additional tags to the object
6. Make sure the additional tags are present as well

I tested the PR locally with multipart uploads, as well as addition and removal of object metadata

- [ ] Doc added/updated
- [ ] Tests added
