### PR TITLE
bucket_logging: Bucket log processing in side car container

### DIFF
--- a/src/deploy/NVA_build/NooBaa.Dockerfile
+++ b/src/deploy/NVA_build/NooBaa.Dockerfile
@@ -74,7 +74,8 @@ RUN dnf install -y -q bash \
     python3-setuptools \
     jemalloc \
     xz \
-    python3-pip && \
+    python3-pip \
+    cronie && \
     dnf clean all
 
 COPY ./src/deploy/NVA_build/install_arrow_run.sh ./src/deploy/NVA_build/install_arrow_run.sh
@@ -113,7 +114,7 @@ COPY ./src/deploy/NVA_build/logrotate_noobaa.conf /etc/logrotate.d/noobaa/
 COPY ./src/deploy/NVA_build/noobaa_init.sh /noobaa_init_files/
 
 COPY ./src/deploy/NVA_build/setup_platform.sh /usr/bin/setup_platform.sh
-RUN /usr/bin/setup_platform.sh 
+RUN /usr/bin/setup_platform.sh
 
 RUN chmod 775 /noobaa_init_files && \
     chgrp -R 0 /noobaa_init_files/ && \
@@ -137,7 +138,7 @@ COPY --from=server_builder /noobaa/noobaa-NVA.tar.gz /tmp/
 RUN cd /root/node_modules && \
     tar -xzf /tmp/noobaa-NVA.tar.gz && \
     chgrp -R 0 /root/node_modules && \
-    chmod -R 775 /root/node_modules 
+    chmod -R 775 /root/node_modules
 
 ###############
 # PORTS SETUP #

--- a/src/deploy/NVA_build/logrotate.sh
+++ b/src/deploy/NVA_build/logrotate.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-# script to run logrotate every 15 minutes
+# Add a cron job to run script to segreagate bucket logs into individual bucket logs files.
+echo "*/5 * * * * /root/node_modules/noobaa-core/src/deploy/NVA_build/noobaa_log_segregate.sh" | crontab -
+
+# script to run logrotate every minute
 
 while true; do
-    echo "$(date): =================================== running logrotate ==================================="
-    /usr/sbin/logrotate -v /etc/logrotate.d/noobaa 2>&1
-    echo
-    sleep 900
+
+    echo "$(date): =================================== running logrotate ===================================" >/dev/stdout 2>&1
+    /usr/sbin/logrotate -v /etc/logrotate.d/noobaa/logrotate_noobaa.conf >/dev/stdout 2>&1
+    echo "$(date): =================================== logrotate Done ======================================" >/dev/stdout 2>&1
+
+    sleep 60
+
 done

--- a/src/deploy/NVA_build/logrotate_noobaa.conf
+++ b/src/deploy/NVA_build/logrotate_noobaa.conf
@@ -27,3 +27,17 @@
                 supervisorctl signal HUP rsyslog 2> /dev/null || true
         endscript
 }
+
+/var/log/bucket_logs.log
+{
+        daily
+        size 100k
+        start 1
+        missingok
+        rotate 100
+        create 666 noob root
+        dateext
+        dateformat %Y-%m-%d-%H-%M-%S
+        sharedscripts
+        olddir /var/log/noobaa_logs
+}

--- a/src/deploy/NVA_build/noobaa_log_segregate.sh
+++ b/src/deploy/NVA_build/noobaa_log_segregate.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# /var/log/noobaa_logs will have all the rotated bucket_logs.log files.
+# Each log file will be having a timestamp appended to it based on the
+# time it was rotated by logrotate. These log files will be holding logs
+# from all the endpoints for all the buckets.
+# We need to segregate these logs based on the log bucket name and put it
+# into respective log files. These files will be moved to the final location
+# /log/noobaa_bucket_logs/ which will be scanned by the background worker.
+
+
+log_dir="/var/log/noobaa_logs"
+# Lock file to make sure that the script is not running multiple times.
+lock_file="/var/log/noobaa_bucket_logs/noobaa_log_segregate.lock"
+
+if [ -e "$lock_file" ]; then
+    echo "Script is already running. Exiting."
+    exit
+fi
+
+remove_lock_file() {
+    if [ -e "$lock_file" ]; then
+        rm "$lock_file"
+    fi
+    exit
+}
+
+#make sure clean up of the lock file in case it gets killed.
+trap 'remove_lock_file; exit' SIGINT SIGTERM
+
+touch "$lock_file"
+
+# Delimiter for the file name. To separate the file name from the timestamp.
+# S3 Bucket name are not allowed to have "_" in its name.
+File_Name_Del="_"
+
+# Get the oldest log file in the /var/log/noobaa_logs directory
+# by iterating over all the files in the directory that start with
+# bucket_logs.log and finding the one with the earliest modification
+# time.
+oldest_log_file() {
+    cd "$log_dir" || remove_lock_file
+    earliest_filename=""
+    for file in bucket_logs.log*; do
+        if [ -z "$earliest_filename" ] || [ "$file" \< "$earliest_filename" ]; then
+            earliest_filename="$file"
+        fi
+    done
+    echo "$earliest_filename"
+}
+
+if [ ! -d "$log_dir" ] || [ -z "$(ls -A "$log_dir")" ]; then
+    echo "log_dir $log_dir does not exist or is empty."
+    remove_lock_file
+fi
+
+while [ -n "$(ls -A "$log_dir")" ]; do
+    log_file=$(oldest_log_file)
+    echo "processing $log_file"
+    mv "$log_dir/$log_file" "$log_dir/$log_file.processing"
+    log_file="$log_dir/$log_file.processing"
+    # Iterate over each log records in the log file and do the following -
+    # - Fetch the log bucket name from the log entry.
+    # - Create a file based on this log bucket name if the file is not there.
+    # - Append the log entry to this file.
+    # - Check the size of this file, if it is 50KB, then rename the file by
+    # - appending the current timestamp to the file name.
+    # - Remove the log file once all log entries are processed.
+    while read -r log; do
+        IFS=, read -r -a log_fields <<< "$log"
+        for log_field in "${log_fields[@]}"; do
+            if [[ "$log_field" =~ "log_bucket" ]]; then
+                IFS=: read -r -a log_values <<< "$log_field"
+                log_bucket_name=$(echo "${log_values[1]}" | tr -d '"' | sed 's/^[ \t]*//; s/[ \t]*$//')
+                echo "$log" >> "/var/log/noobaa_bucket_logs/$log_bucket_name.log"
+                                file_size=$(stat -c "%s" "/var/log/noobaa_bucket_logs/$log_bucket_name.log")
+                if [[ $file_size -gt 50000 ]]; then
+                    time_string=$(date +"%Y-%m-%d-%H-%M-%S.%N")
+                    mv "/var/log/noobaa_bucket_logs/$log_bucket_name.log" "/log/noobaa_bucket_logs/$log_bucket_name$File_Name_Del$time_string.log"
+                fi
+
+            fi
+        done
+    done < "$log_file"
+    rm "$log_file"
+done
+
+remove_lock_file

--- a/src/deploy/NVA_build/noobaa_logs.sh
+++ b/src/deploy/NVA_build/noobaa_logs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# File where rsyslog is going to redirect bucket logs from all endpoints.
+touch /var/log/bucket_logs.log
+chmod 777 /var/log/bucket_logs.log
+
+# Directory used by logrotate to store rotated bucket_logs.log files
+mkdir -p /var/log/noobaa_logs
+chmod 777 /var/log/noobaa_logs
+
+# Directory used by noobaa_log_segreagate.sh to keep temporarily segregated bucket logs.
+# Maximum size of the bucket log files would be 50K. After that it will be moved to
+# /log/noobaa_bucket_logs and a timestamp will be added to the file name.
+mkdir -p /var/log/noobaa_bucket_logs
+chmod 777 /var/log/noobaa_bucket_logs
+
+# Directory on a mounted volume to keep bucket logs from /var/log/noobaa_bucket_logs.
+# This location is shared between core and side card containers.
+# These are logs which will be finally uploaded to log bucket.
+mkdir -p /log/noobaa_bucket_logs
+chmod 777 /log/noobaa_bucket_logs
+
+
+/usr/sbin/crond  &
+/usr/sbin/rsyslogd  &
+/root/node_modules/noobaa-core/src/deploy/NVA_build/logrotate.sh &
+
+wait

--- a/src/deploy/NVA_build/noobaa_logs_create.sh
+++ b/src/deploy/NVA_build/noobaa_logs_create.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+help_message="Usage: $0 <log_bucket_range>
+This script can be used to test log parsing. It takes number of buckets,
+which you want to have logs from. Logs will be sent to /var/log/bucket_logs.log,
+which is actually the path where rsyslogd will save the logs. Log buckets will be
+having name like log.bucket-1, log.bucket-2, etc. So, to test if the BG worker is
+uploading the logs correctly, you need to create buckets with similar names.
+Example: $0 10"
+
+if [[ "$1" == "-h" ]]; then
+  echo "$help_message"
+  exit 0
+fi
+
+if [ -z "$1" ]; then
+  echo "$help_message"
+  exit 1
+fi
+
+if [[ ! "$1" =~ ^[0-9]+$ ]]; then
+  echo "$help_message"
+  exit 1
+fi
+
+log_bucket_range=$1
+
+# Initialize log message parts. Trying to emulate the actual logs.
+log_time=$(date +"%b %d %H:%M:%S")
+log1=' _gateway�| {"noobaa_bucket_logging":"true","op":"PUT","bucket_owner":"admin@noobaa.io","source_bucket":'
+log2=',"object_key":"/first.bucket/test.file","log_bucket":'
+log3=',"remote_ip":"::ffff:127.0.0.1","request_uri":"/first.bucket/test.file","request_id":"'
+
+log4="first.bucket-"
+log5="log.bucket-"
+
+# Just to have some different between log messages, a random request id is being attached.
+generate_request_id() {
+  head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1
+}
+request_id=""
+create_log_message() {
+  local log_bucket_num=$((RANDOM % $log_bucket_range + 1))
+  local source_bucket_num=$log_bucket_num
+  request_id="xxxxxxxxx"
+  echo "$log_time " "$log_time" "$log1" "$log4$source_bucket_num" "$log2" "$log5$log_bucket_num" "$log3" "$request_id"
+}
+# These logs will be keep generating in infinite loop.use CTRL + C to stop the script.
+
+while true ; do
+  log_message=$(create_log_message)
+  echo "$log_message" >>/var/log/bucket_logs.log
+done

--- a/src/deploy/NVA_build/noobaa_supervisor.conf
+++ b/src/deploy/NVA_build/noobaa_supervisor.conf
@@ -36,29 +36,3 @@ stderr_logfile=/dev/fd/1
 stderr_logfile_maxbytes=0
 command=/usr/local/bin/node %(ENV_HOSTED_AGENTS_NODE_OPTIONS)s --unhandled-rejections=warn src/hosted_agents/hosted_agents_starter.js
 #endprogram
-
-[program:rsyslog]
-stopsignal=KILL
-killasgroup=true
-stopasgroup=true
-autostart=true
-directory=/usr/sbin
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/fd/1
-stderr_logfile_maxbytes=0
-command=/usr/sbin/rsyslogd -n
-#endprogram
-
-[program:logrotate]
-stopsignal=KILL
-killasgroup=true
-stopasgroup=true
-autostart=true
-directory=/root/node_modules/noobaa-core
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/fd/1
-stderr_logfile_maxbytes=0
-command=/root/node_modules/noobaa-core/src/deploy/NVA_build/logrotate.sh
-#endprogram

--- a/src/deploy/NVA_build/rsyslog.conf
+++ b/src/deploy/NVA_build/rsyslog.conf
@@ -13,7 +13,8 @@ $ModLoad imuxsock # provides support for local system logging (e.g. via logger c
 
 # Provides UDP syslog reception
 $ModLoad imudp
-$UDPServerRun 514
+# $UDPServerRun 514
+$UDPServerRun 5140
 
 # Provides TCP syslog reception
 #$ModLoad imtcp

--- a/src/deploy/NVA_build/setup_platform.sh
+++ b/src/deploy/NVA_build/setup_platform.sh
@@ -120,6 +120,9 @@ function setup_non_root_user() {
     # setuid for rsyslog so it can run as root
     chmod u+s /sbin/rsyslogd
 
+    # setuid for crond so it can run as root
+    chmod u+s /sbin/crond
+
 }
 
 deploy_log "Starting setup platform"


### PR DESCRIPTION
Firstly,
rsyslogd and logrotate.sh script has been moved to side car container. Now, these two processes will be started by "command" rather than superviserd

Secondly,
we have added following bash script and changes in logrotate_noobaa.conf 1 - Added an entry in conf file to rotate /var/log/bucket_logs.log

2 - Rotated files will be moved to /var/log/noobaa_logs/ and each rotated file will have dat and time attached to its name. Example: bucket_logs.log2024-02-19-10-09-16

3 - These files will have logs for all the buckets from all the endpoints.

4 - Added a bash script noobaa_log_segregate.sh, which will keep reading rotated files in /var/log/noobaa_logs/ and segregate the bucket logs in its respective log file names. These will be kept at /log/noobaa_bucket_logs/

For example:
log.bucket-1-2024-02-19-10-05-58.341870679.log
log.bucket-2-2024-02-19-09-49-37.242243366.log

5 - These are the final log objects which will be sent to respective bucket logs.


### Testing Instructions:

./noobaa_logs_create.sh <log_bucket_range>
This script can be used to test log parsing. It takes number of buckets,
which you want to have logs from. Logs will be sent to /var/log/bucket_logs.log,
which is actually the path where rsyslogd will save the logs. Log buckets will be
having name like log.bucket-1, log.bucket-2, etc. So, to test if the BG worker is
uploading the logs correctly, you need to create buckets with similar names.
Example: ./noobaa_logs_create.sh 10
