### PR TITLE
[Backport to 5.15] fixed signature calculations for cpp aws-sdk

### DIFF
--- a/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsumhdig_namewith=.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsumhdig_namewith=.sreq
@@ -1,0 +1,12 @@
+DELETE /first.bucket/delete=me HTTP/1.1
+Host: localhost:8080
+Accept: */*
+amz-sdk-invocation-id: EF88870A-D2F2-4869-8C7E-E8CBE7AB395E
+amz-sdk-request: attempt=1
+authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, Signature=13280d4f99f7a63ef393357a2326b22578c1bbac7de8ff6f7df0cfdc63d5905b
+content-type: application/xml
+user-agent: aws-sdk-cpp/1.11.265 ua/2.0 md/aws-crt#0.26.2 os/Darwin/23.1.0 md/arch#arm64 lang/c++#C++11 md/Clang#15.0.0 cfg/retry-mode#default api/S3
+x-amz-api-version: 2006-03-01
+x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20240220T171138Z
+

--- a/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsun15mj_namewith%253D.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsun15mj_namewith%253D.sreq
@@ -1,0 +1,12 @@
+DELETE /first.bucket/delete%253Dme HTTP/1.1
+Host: localhost:8080
+Accept: */*
+amz-sdk-invocation-id: EE0251F1-826D-4EBB-B159-378C14854857
+amz-sdk-request: attempt=1
+authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, Signature=fc002fbd73313210dadeac0bf9f80206a48da9246582169fe60392c0c31e8fe7
+content-type: application/xml
+user-agent: aws-sdk-cpp/1.11.265 ua/2.0 md/aws-crt#0.26.2 os/Darwin/23.1.0 md/arch#arm64 lang/c++#C++11 md/Clang#15.0.0 cfg/retry-mode#default api/S3
+x-amz-api-version: 2006-03-01
+x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20240220T172701Z
+

--- a/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsun46rc_namewith$.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsun46rc_namewith$.sreq
@@ -1,0 +1,12 @@
+DELETE /first.bucket/delete$me HTTP/1.1
+Host: localhost:8080
+Accept: */*
+amz-sdk-invocation-id: 831BAFD2-3E57-40CB-A9C9-876C43B2E7C0
+amz-sdk-request: attempt=1
+authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, Signature=8fd38603d2e5c6b61ec1c1ab8aa2fc7c1aaebcd5e1391dff92da466210200421
+content-type: application/xml
+user-agent: aws-sdk-cpp/1.11.265 ua/2.0 md/aws-crt#0.26.2 os/Darwin/23.1.0 md/arch#arm64 lang/c++#C++11 md/Clang#15.0.0 cfg/retry-mode#default api/S3
+x-amz-api-version: 2006-03-01
+x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20240220T172923Z
+

--- a/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsun7xep_namewith&.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsun7xep_namewith&.sreq
@@ -1,0 +1,12 @@
+DELETE /first.bucket/delete&me HTTP/1.1
+Host: localhost:8080
+Accept: */*
+amz-sdk-invocation-id: BFC38AFC-66CF-4F5A-8EAE-192296673B6E
+amz-sdk-request: attempt=1
+authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, Signature=1af41893baf86eaf8f8bd6763c1b2a99057ebdcfd7c4e847e12d77a38f5ff01b
+content-type: application/xml
+user-agent: aws-sdk-cpp/1.11.265 ua/2.0 md/aws-crt#0.26.2 os/Darwin/23.1.0 md/arch#arm64 lang/c++#C++11 md/Clang#15.0.0 cfg/retry-mode#default api/S3
+x-amz-api-version: 2006-03-01
+x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20240220T173217Z
+

--- a/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsundqfu_namewith,.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsundqfu_namewith,.sreq
@@ -1,0 +1,12 @@
+DELETE /first.bucket/delete,me HTTP/1.1
+Host: localhost:8080
+Accept: */*
+amz-sdk-invocation-id: 3AD05F0E-D931-44EA-A656-DE518B0F85A9
+amz-sdk-request: attempt=1
+authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, Signature=d3a39b0d940a512607d800e36017c9092a99b72b83e12553f770a21d0d7f9445
+content-type: application/xml
+user-agent: aws-sdk-cpp/1.11.265 ua/2.0 md/aws-crt#0.26.2 os/Darwin/23.1.0 md/arch#arm64 lang/c++#C++11 md/Clang#15.0.0 cfg/retry-mode#default api/S3
+x-amz-api-version: 2006-03-01
+x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20240220T173648Z
+

--- a/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsunew5a_namewith:.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsunew5a_namewith:.sreq
@@ -1,0 +1,12 @@
+DELETE /first.bucket/delete:me HTTP/1.1
+Host: localhost:8080
+Accept: */*
+amz-sdk-invocation-id: ED8C1574-32D6-4EF1-9CB8-33D6783CD626
+amz-sdk-request: attempt=1
+authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, Signature=ef4f57b1e3a205d0d0642dc917e84509ae14940032a5864d2db4ec5da5487166
+content-type: application/xml
+user-agent: aws-sdk-cpp/1.11.265 ua/2.0 md/aws-crt#0.26.2 os/Darwin/23.1.0 md/arch#arm64 lang/c++#C++11 md/Clang#15.0.0 cfg/retry-mode#default api/S3
+x-amz-api-version: 2006-03-01
+x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20240220T173742Z
+

--- a/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsung2nb_namewith@.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdkcpp/awssdkcpp_lsung2nb_namewith@.sreq
@@ -1,0 +1,12 @@
+DELETE /first.bucket/delete@me HTTP/1.1
+Host: localhost:8080
+Accept: */*
+amz-sdk-invocation-id: 38361583-8810-4C35-8DF0-B8EFEDA78780
+amz-sdk-request: attempt=1
+authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, Signature=7139b924dabf8f09c4d913d98c01d3620767cb3c3e07bb80977e780f564e79b6
+content-type: application/xml
+user-agent: aws-sdk-cpp/1.11.265 ua/2.0 md/aws-crt#0.26.2 os/Darwin/23.1.0 md/arch#arm64 lang/c++#C++11 md/Clang#15.0.0 cfg/retry-mode#default api/S3
+x-amz-api-version: 2006-03-01
+x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20240220T173837Z
+

--- a/src/test/unit_tests/signature_test_suite/awssdknodejs/awssdknodejs_lsunnm4a_namewith%3D.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdknodejs/awssdknodejs_lsunnm4a_namewith%3D.sreq
@@ -1,0 +1,10 @@
+DELETE /first.bucket/delete%3Dme HTTP/1.1
+User-Agent: aws-sdk-nodejs/2.1550.0 darwin/v20.9.0 promise
+Content-Type: application/octet-stream
+X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+Content-Length: 0
+Host: 127.0.0.1:8080
+X-Amz-Date: 20240220T174429Z
+Authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=e8320f51d20857850f9194ed3878447b3c3cdb9f3924c4a7564751bee37646c8
+Connection: close
+

--- a/src/test/unit_tests/signature_test_suite/awssdknodejs/awssdknodejs_lsunp5sx_namewith%40.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdknodejs/awssdknodejs_lsunp5sx_namewith%40.sreq
@@ -1,0 +1,10 @@
+DELETE /first.bucket/delete%40me HTTP/1.1
+User-Agent: aws-sdk-nodejs/2.1550.0 darwin/v20.9.0 promise
+Content-Type: application/octet-stream
+X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+Content-Length: 0
+Host: 127.0.0.1:8080
+X-Amz-Date: 20240220T174541Z
+Authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=83c3f9484aeeff7fb1ff0e6cd7634471a6128bd4c1b0fa9433f8c3b7bd7d4f67
+Connection: close
+

--- a/src/test/unit_tests/signature_test_suite/awssdknodejs/awssdknodejs_lsunppst_namewith%24.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdknodejs/awssdknodejs_lsunppst_namewith%24.sreq
@@ -1,0 +1,10 @@
+DELETE /first.bucket/delete%24me HTTP/1.1
+User-Agent: aws-sdk-nodejs/2.1550.0 darwin/v20.9.0 promise
+Content-Type: application/octet-stream
+X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+Content-Length: 0
+Host: 127.0.0.1:8080
+X-Amz-Date: 20240220T174607Z
+Authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=c4963b728534483bebb29ba487511a93a39695d1f5786aca32482753631fc281
+Connection: close
+

--- a/src/test/unit_tests/signature_test_suite/awssdknodejs/awssdknodejs_lsunqlri_namewith%253D.sreq
+++ b/src/test/unit_tests/signature_test_suite/awssdknodejs/awssdknodejs_lsunqlri_namewith%253D.sreq
@@ -1,0 +1,10 @@
+DELETE /first.bucket/delete%253Dme HTTP/1.1
+User-Agent: aws-sdk-nodejs/2.1550.0 darwin/v20.9.0 promise
+Content-Type: application/octet-stream
+X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+Content-Length: 0
+Host: 127.0.0.1:8080
+X-Amz-Date: 20240220T174649Z
+Authorization: AWS4-HMAC-SHA256 Credential=QlBdp923Pnpu2qxn9Qpj/20240220/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=928ca61d630f826daf8c8f59ade2af4f7bd7b0876204c2673650970c25f435ef
+Connection: close
+

--- a/src/test/unit_tests/test_signature_utils.js
+++ b/src/test/unit_tests/test_signature_utils.js
@@ -24,6 +24,7 @@ mocha.describe('signature_utils', function() {
     const SECRETS = {
         'AKIDEXAMPLE': 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
         '123': 'abc',
+        'QlBdp923Pnpu2qxn9Qpj': 'YLIkByxr/V5LiBJIpZS+TpQvuFSYqDAD3bG5ePaY'
     };
 
     const http_server = http.createServer(accept_signed_request);
@@ -31,9 +32,9 @@ mocha.describe('signature_utils', function() {
     mocha.before(function() {
         return new Promise((resolve, reject) =>
             http_server
-                .once('listening', resolve)
-                .once('error', reject)
-                .listen());
+            .once('listening', resolve)
+            .once('error', reject)
+            .listen());
     });
 
     mocha.after(function() {
@@ -46,6 +47,7 @@ mocha.describe('signature_utils', function() {
     add_tests_from(path.join(SIG_TEST_SUITE, 'awssdknodejs'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'awssdkjava'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'awssdkruby2'), '.sreq');
+    add_tests_from(path.join(SIG_TEST_SUITE, 'awssdkcpp'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'cyberduck'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'postman'), '.sreq');
     add_tests_from(path.join(SIG_TEST_SUITE, 'presigned'), '.sreq');

--- a/src/util/signature_utils.js
+++ b/src/util/signature_utils.js
@@ -202,8 +202,11 @@ const HEADERS_MAP_FOR_AWS_SDK = {
 function _aws_request(req, region, service) {
     const v2_signature = _.isUndefined(region) && _.isUndefined(service);
     const u = url.parse(req.originalUrl.replace(/%2F/g, '/'), true);
+    // for S3 we decode and escape the URI components to handle cpp sdk behaior, which for a few charecters (e.g. =,?$@) 
+    // it does not escape it in the request but escapes it for the signature calculations.
+    // see https://github.com/noobaa/noobaa-core/issues/7784 
     const pathname = service === 's3' ?
-        u.pathname :
+        u.pathname.split('/').map(c => AWS.util.uriEscape(decodeURIComponent(c))).join('/') :
         path.normalize(decodeURI(u.pathname));
     const query = _.omit(
         req.query,


### PR DESCRIPTION
(cherry picked from commit ccf16e3d9bbc38add306c9a16d348ed36fa966d6)

### Explain the changes
1. Backport of https://github.com/noobaa/noobaa-core/pull/7829

* AWS SDK for C++ sends the '=' character unencoded when it is in the "key" string but calculates the signature for the encoded '%3D' value.
* fixed `function _aws_request` to first decode the pathname (to avoid reencoding of '%' characters) and then encode the path again.
* added signature tests

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2265288

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
