### PR TITLE
Add system tuning hint in cases of DB query timeouts

### DIFF
--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -204,7 +204,11 @@ async function log_query(pg_client, query, tag, millitook, should_explain) {
     }
 
     if (millitook > config.LONG_DB_QUERY_THRESHOLD) {
-        dbg.warn(`QUERY_LOG: LONG QUERY (OVER ${config.LONG_DB_QUERY_THRESHOLD} ms `, JSON.stringify(log_obj));
+        dbg.warn(
+            `QUERY_LOG: LONG QUERY (OVER ${config.LONG_DB_QUERY_THRESHOLD} ms - 
+            please check whether the DB and core pods have sufficient CPU and memory `,
+            JSON.stringify(log_obj)
+        );
     } else {
         dbg.log0('QUERY_LOG:', JSON.stringify(log_obj));
     }

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -205,7 +205,7 @@ async function log_query(pg_client, query, tag, millitook, should_explain) {
 
     if (millitook > config.LONG_DB_QUERY_THRESHOLD) {
         dbg.warn(
-            `QUERY_LOG: LONG QUERY (OVER ${config.LONG_DB_QUERY_THRESHOLD} ms - 
+            `QUERY_LOG: LONG QUERY (OVER ${config.LONG_DB_QUERY_THRESHOLD} ms) - 
             please check whether the DB and core pods have sufficient CPU and memory `,
             JSON.stringify(log_obj)
         );


### PR DESCRIPTION
### Explain the changes
1. Added a hint pointing customers and support people to look at the system tuning in case DB queries run for longer than expected
