### PR TITLE
Fix cross platform RPM builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,10 @@ nbdev:
 	@echo ""
 .PHONY: nbdev
 
-rpm: base
+rpm: builder
 	echo "\033[1;34mStarting RPM build for $${CONTAINER_PLATFORM}.\033[0m"
 	mkdir -p build/rpm
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/RPM_build/RPM.Dockerfile $(CACHE_FLAG) -t $(NOOBAA_RPM_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/RPM_build/RPM.Dockerfile $(CACHE_FLAG) -t $(NOOBAA_RPM_TAG) --build-arg CENTOS_VER=$(CENTOS_VER) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) --build-arg SRPM_ONLY=$(SRPM_ONLY) --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	echo "\033[1;32mImage \"$(NOOBAA_RPM_TAG)\" is ready.\033[0m"
 	echo "Generating RPM..."
 	$(CONTAINER_ENGINE) run --rm -v $(PWD)/build/rpm:/export:z -t $(NOOBAA_RPM_TAG)

--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -1,6 +1,9 @@
-FROM noobaa-base
+FROM noobaa-builder
 ARG TARGETARCH
+
+ARG CENTOS_VER=9
 ARG BUILD_S3SELECT=0
+ARG BUILD_S3SELECT_PARQUET=0
 
 RUN mkdir -p /etc/logrotate.d/noobaa/
 RUN mkdir -p /etc/noobaa.conf.d/
@@ -9,8 +12,14 @@ COPY ./src/agent ./src/agent
 COPY ./src/api ./src/api
 COPY ./src/cmd ./src/cmd
 COPY ./src/deploy/spectrum_archive ./src/deploy/spectrum_archive
+COPY ./src/deploy/noobaa_nsfs.service ./src/deploy/
+COPY ./src/deploy/nsfs_env.env ./src/deploy/
+COPY ./src/deploy/NVA_build/clone_submodule.sh ./src/deploy/NVA_build/
+COPY ./src/deploy/NVA_build/clone_s3select_submodules.sh ./src/deploy/NVA_build/
+COPY ./src/deploy/NVA_build/install_nodejs.sh ./src/deploy/NVA_build/
 COPY ./src/endpoint ./src/endpoint
 COPY ./src/hosted_agents ./src/hosted_agents
+COPY ./src/native ./src/native/
 COPY ./src/rpc ./src/rpc
 COPY ./src/s3 ./src/s3
 COPY ./src/sdk ./src/sdk
@@ -22,6 +31,7 @@ COPY ./config.js ./
 COPY ./platform_restrictions.json ./
 COPY ./Makefile ./
 COPY ./package*.json ./
+COPY ./binding.gyp .
 COPY ./src/deploy/standalone/noobaa_rsyslog.conf ./src/deploy/standalone/noobaa_rsyslog.conf
 COPY ./src/deploy/standalone/noobaa_syslog.conf ./src/deploy/standalone/noobaa_syslog.conf
 COPY ./src/deploy/standalone/logrotate_noobaa.conf ./src/deploy/standalone/logrotate_noobaa.conf
@@ -29,10 +39,17 @@ COPY ./src/manage_nsfs ./src/manage_nsfs
 
 WORKDIR /build
 
-RUN tar -czvf noobaa-core.tar.gz /noobaa
-
 COPY ./src/deploy/RPM_build/* ./
 COPY ./package.json ./
+RUN bash ./preparesrc.sh /noobaa
 RUN chmod +x ./packagerpm.sh
 
+# These envs are used by the packagerpm.sh either directly or by
+# performing subsitutions in the noobaa.spec file
+ARG SRPM_ONLY=false
+
+ENV BUILD_S3SELECT=${BUILD_S3SELECT}
+ENV BUILD_S3SELECT_PARQUET=${BUILD_S3SELECT_PARQUET}
+ENV CENTOS_VER=${CENTOS_VER}
+ENV SRPM_ONLY=${SRPM_ONLY}
 CMD ./packagerpm.sh /export /build

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -1,3 +1,8 @@
+# Disable debuginfo -- it does not work well with nodejs apps
+%global debug_package %{nil}
+# This speeds up the build a lot and it is not really required
+%global __os_install_post %{nil}
+
 %define revision null
 %define noobaaver null
 %define nodever null
@@ -6,9 +11,9 @@
 %define BUILD_S3SELECT null
 %define BUILD_S3SELECT_PARQUET null
 %define CENTOS_VER null
+%define _build_id_links none
 
 %define noobaatar %{name}-%{version}-%{revision}.tar.gz
-%define buildroot %{_tmppath}/%{name}-%{version}-%{release}
 
 Name: noobaa-core
 Version:  %{noobaaver}
@@ -19,76 +24,67 @@ License:  Apache-2.0
 URL:  https://www.noobaa.io/
 Source0:  %{noobaatar}
 
-Recommends: jemalloc
+BuildRequires:  python3
+BuildRequires:  make
+BuildRequires:  gcc-c++
+BuildRequires:  nasm
+BuildRequires:  boost-devel
+%if 0%{?rhel} >= 9
+BuildRequires:  python-unversioned-command
+%endif
 
-%global __os_install_post %{nil}
-
-%global __requires_exclude ^/usr/bin/python$
+Recommends:     jemalloc
 
 %description
 NooBaa is a data service for cloud environments, providing S3 object-store interface with flexible tiering, mirroring, and spread placement policies, over any storage resource that allows GET/PUT including S3, GCS, Azure Blob, Filesystems, etc.
 
 %prep
-mkdir noobaa-core-%{version}-%{revision}
-mkdir node-%{nodever}
-tar -xzf %{SOURCE0} -C noobaa-core-%{version}-%{revision}/
-
-%clean
-[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+%setup -n noobaa -q
 
 %build
-#!/bin/bash
-NOOBAA_DIR="noobaa-core-%{version}-%{revision}"
 NODEJS_VERSION="%{nodever}"
-SKIP_NODE_INSTALL=1 source $NOOBAA_DIR/noobaa/src/deploy/NVA_build/install_nodejs.sh $NODEJS_VERSION
+SKIP_NODE_INSTALL=1 source src/deploy/NVA_build/install_nodejs.sh $NODEJS_VERSION
 
-pushd %{_sourcedir}
+mkdir -p ../node/
+
 nodepath=$(download_node)
-tar -xJf ${nodepath} -C %{_builddir}/node-%{nodever}/
-popd
+tar -xJf ${nodepath} -C ../node/
 
-PATH=$PATH:%{_builddir}/node-%{nodever}/node-v$NODEJS_VERSION-linux-$(get_arch)/bin
+PATH=$PATH:%{_builddir}/node/node-v$NODEJS_VERSION-linux-$(get_arch)/bin
 
-pushd $NOOBAA_DIR/noobaa
 npm install --omit=dev && npm cache clean --force
 ./src/deploy/NVA_build/clone_s3select_submodules.sh
+# Update the boost version on CentOS/RHEL 8
 if [[ "%{CENTOS_VER}" = "8" ]]
 then
   sed -i 's/\/lib64\/libboost_thread.so.1.75.0/\/lib64\/libboost_thread.so.1.66.0/g' ./src/native/s3select/s3select.gyp
   echo "Using libboost 1.66 for S3 Select"
-elif [[ "%{CENTOS_VER}" = "9" ]]
-then
-  echo "Using libboost 1.75 for S3 Select"
-else
-  echo "Unexpected CENTOS_VER: %{CENTOS_VER}"
-  exit 1
 fi
 GYP_DEFINES="BUILD_S3SELECT=%{BUILD_S3SELECT} BUILD_S3SELECT_PARQUET=%{BUILD_S3SELECT_PARQUET}" npm run build
-popd
 
 %install
 rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT/usr/local/
-
-cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa $RPM_BUILD_ROOT/usr/local/noobaa-core
-cp -R %{_builddir}/node-%{nodever}/* $RPM_BUILD_ROOT/usr/local/noobaa-core/node
-
-mkdir -p $RPM_BUILD_ROOT/usr/local/noobaa-core/bin
-ln -s /usr/local/noobaa-core/node/bin/node $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/node
-ln -s /usr/local/noobaa-core/node/bin/npm $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npm
-ln -s /usr/local/noobaa-core/node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npx
 
 mkdir -p $RPM_BUILD_ROOT/etc/systemd/system/
-cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/noobaa_nsfs.service
-ln -s /usr/local/noobaa-core/src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
+mv %{_builddir}/noobaa/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT/etc/systemd/system/noobaa_nsfs.service
 mkdir -p $RPM_BUILD_ROOT/etc/noobaa.conf.d/
 
 mkdir -p $RPM_BUILD_ROOT/etc/rsyslog.d/
-ln -s /usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
-ln -s /usr/local/noobaa-core/src/deploy/standalone/noobaa_rsyslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_rsyslog.conf
+mv %{_builddir}/noobaa/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
+mv %{_builddir}/noobaa/src/deploy/standalone/noobaa_rsyslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_rsyslog.conf
 
 mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d/noobaa
-ln -s /usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.conf $RPM_BUILD_ROOT/etc/logrotate.d/noobaa/logrotate_noobaa.conf
+mv %{_builddir}/noobaa/src/deploy/standalone/logrotate_noobaa.conf $RPM_BUILD_ROOT/etc/logrotate.d/noobaa/logrotate_noobaa.conf
+
+mkdir -p $RPM_BUILD_ROOT/usr/local/
+mv %{_builddir}/noobaa $RPM_BUILD_ROOT/usr/local/noobaa-core
+mv src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
+mv %{_builddir}/node/* $RPM_BUILD_ROOT/usr/local/noobaa-core/node/
+
+mkdir -p $RPM_BUILD_ROOT/usr/local/noobaa-core/bin
+ln -s ../node/bin/node $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/node
+ln -s ../node/bin/npm $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npm
+ln -s ../node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npx
 
 %files
 /usr/local/noobaa-core

--- a/src/deploy/RPM_build/preparesrc.sh
+++ b/src/deploy/RPM_build/preparesrc.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eou pipefail
+set -x
+
+TARGET="noobaa-core.tar.gz"
+
+SRC_DIR=$(realpath "${1:-$(pwd)}")
+
+function prepare_excludes() {
+	local exclude_flag_gitignore="$(grep -v '^#' $SRC_DIR/.gitignore | grep '[^[:blank:]]' | xargs -I{} printf '%s=%s ' '--exclude' '{}')"
+	local exclude_flag_local="--exclude ./build --exclude ./images --exclude ./tools --exclude ./submodules --exclude .github --exclude .travis --exclude .jenkins"
+
+	echo "${exclude_flag_gitignore} ${exclude_flag_local}"
+}
+
+function archive() {
+	local tar="$1"
+	local exclude_flag="$(prepare_excludes)"
+
+	# No quotes here is intentional
+	tar $exclude_flag --exclude-vcs -czvf "$tar" "$SRC_DIR"
+}
+
+echo "Using source: $SRC_DIR"
+if [ "$SRC_DIR" = "$(pwd)" ]; then
+	pushd ..
+	tpath="$TMPDIR$TARGET"
+	archive "$tpath"
+	popd
+
+	mv "$tpath" .
+else
+	tpath="./$TARGET"
+	archive "$tpath"
+fi


### PR DESCRIPTION
### Explain the changes
1. This PR restructures how we do the RPM builds today.

What changed?

 *  Instead of fetching NooBaa runtime dependencies in the Dockerfile, we fetch them in the RPM build process.
 * We make sure the environment has all the dependencies that NooBaa requires for the build process

Why changed?

 *  This approach allows generating a true architecture independent SRPM, hence a SRPM can be generated once (per RHEL version) and then rpmbuild --rebuild <rpm> can be used to generate RPMS for different architectures.
 * This approach allows us to use `mock` to build the RPMs

**Note**: Usage remains same, that is use, make rpm. This will generate a SRPM and a RPM. Use the SRPM to generate the RPMs for other architectures. The command also supports make rpm SRPM_ONLY=true which is significantly faster and jsut generates SRPMs.

- [ ] Doc added/updated
- [ ] Tests added
