### PR TITLE
namespace_monitor.js | Fixing the error object values to start with a lowercase

### DIFF
--- a/src/sdk/noobaa_s3_client/noobaa_s3_client.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client.js
@@ -105,9 +105,35 @@ function check_error_code(err, code) {
     return err.code === code || err.Code === code;
 }
 
+/**
+ * When using aws sdk v3 we get the error object with values that start with an uppercase instead of lowercase
+ * we want to fix this value to be start with a lowercase.
+ * 
+ * @param {object} err
+ */
+function fix_error_object(err) {
+    for (const key in err) {
+        if (Object.hasOwn(err, key)) {
+            // Currently we want to fix only the value "Code",
+            // if we will want to fix all the values we can remove this "if" statement
+            if (key === "Code") {
+                const lowercaseKey = key.toLowerCase();
+                // If we remove the "if" statement above (key === "Code") then we need to check also key !== lowercaseKey
+                // to avoid running over a valid value.
+                // remove the next comment and delete the if 2 lines below. 
+                // if (key !== lowercaseKey && !Object.hasOwn(err, lowercaseKey)) {
+                if (!Object.hasOwn(err, lowercaseKey)) {
+                    err[lowercaseKey] = err[key];
+                }
+            }
+        }
+    }
+}
+
 // EXPORTS
 exports.get_s3_client_v3_params = get_s3_client_v3_params;
 exports.change_s3_client_params_to_v2_structure = change_s3_client_params_to_v2_structure;
 exports.get_sdk_class_str = get_sdk_class_str;
 exports.check_error_code = check_error_code;
+exports.fix_error_object = fix_error_object;
 exports.get_requestHandler_with_suitable_agent = get_requestHandler_with_suitable_agent;

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -141,6 +141,7 @@ class NamespaceMonitor {
                 Key: block_key
             });
         } catch (err) {
+            noobaa_s3_client.fix_error_object(err); //This makes the noobaa_s3_client.check_error_code redundant, we should consider removing it.
             if (noobaa_s3_client.check_error_code(err, 'AccessDenied') && nsr.is_readonly_namespace()) {
                 return;
             }


### PR DESCRIPTION
### Explain the changes
When using aws sdk v3  we get the error object with values that start with an uppercase instead of lowercase we want to fix this value to start with a lowercase.

### BUGS:
1. Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2265109
