### PR TITLE
[NC | NSFS] Fix WAL processing failure

### DIFF
--- a/src/manage_nsfs/manage_nsfs_glacier.js
+++ b/src/manage_nsfs/manage_nsfs_glacier.js
@@ -12,10 +12,6 @@ const native_fs_utils = require('../util/native_fs_utils');
 const CLUSTER_LOCK = 'cluster.lock';
 const SCAN_LOCK = 'scan.lock';
 
-const RESTORE_TIMESTAMP_FILE = 'restore.timestamp';
-const MIGRATE_TIMESTAMP_FILE = 'migrate.timestamp';
-const EXPIRY_TIMESTAMP_FILE = 'expiry.timestamp';
-
 async function process_migrations() {
     const fs_context = native_fs_utils.get_process_fs_context();
 
@@ -24,10 +20,10 @@ async function process_migrations() {
 
         if (
             await backend.low_free_space() ||
-            await time_exceeded(fs_context, config.NSFS_GLACIER_MIGRATE_INTERVAL, MIGRATE_TIMESTAMP_FILE)
+            await time_exceeded(fs_context, config.NSFS_GLACIER_MIGRATE_INTERVAL, GlacierBackend.MIGRATE_TIMESTAMP_FILE)
         ) {
             await run_glacier_migrations(fs_context, backend);
-            await record_current_time(fs_context, MIGRATE_TIMESTAMP_FILE);
+            await record_current_time(fs_context, GlacierBackend.MIGRATE_TIMESTAMP_FILE);
         }
     });
 }
@@ -57,12 +53,12 @@ async function process_restores() {
 
         if (
             await backend.low_free_space() ||
-            !(await time_exceeded(fs_context, config.NSFS_GLACIER_RESTORE_INTERVAL, RESTORE_TIMESTAMP_FILE))
+            !(await time_exceeded(fs_context, config.NSFS_GLACIER_RESTORE_INTERVAL, GlacierBackend.RESTORE_TIMESTAMP_FILE))
         ) return;
 
 
         await run_glacier_restore(fs_context, backend);
-        await record_current_time(fs_context, RESTORE_TIMESTAMP_FILE);
+        await record_current_time(fs_context, GlacierBackend.RESTORE_TIMESTAMP_FILE);
     });
 }
 
@@ -87,11 +83,11 @@ async function process_expiry() {
     const fs_context = native_fs_utils.get_process_fs_context();
 
     await lock_and_run(fs_context, SCAN_LOCK, async () => {
-        if (!(await time_exceeded(fs_context, config.NSFS_GLACIER_EXPIRY_INTERVAL, EXPIRY_TIMESTAMP_FILE))) return;
+        if (!(await time_exceeded(fs_context, config.NSFS_GLACIER_EXPIRY_INTERVAL, GlacierBackend.EXPIRY_TIMESTAMP_FILE))) return;
 
 
         await getGlacierBackend().expiry(fs_context);
-        await record_current_time(fs_context, EXPIRY_TIMESTAMP_FILE);
+        await record_current_time(fs_context, GlacierBackend.EXPIRY_TIMESTAMP_FILE);
     });
 }
 

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -184,23 +184,19 @@ Flags:
 
 const GLACIER_OPTIONS = `
 Usage:
-    manage_nsfs glacier <migrate | restore | expiry> [options]
+glacier <action> [flags]
+
+List of actions supported:
+migrate
+restore
+expiry
 `;
 
-const GLACIER_MIGRATE_OPTIONS = `
-Glacier Migrate Options:
-    --interval <interval>                         (default none)            Run the operation if "interval" milliseconds have passed since last run
-`;
+const GLACIER_MIGRATE_OPTIONS = ``;
 
-const GLACIER_RESTORE_OPTIONS = `
-Glacier Restore Options:
-    --interval <interval>                         (default none)            Run the operation if "interval" milliseconds have passed since last run
-`;
+const GLACIER_RESTORE_OPTIONS = ``;
 
-const GLACIER_EXPIRY_OPTIONS = `
-Glacier Expiry Options:
-    --interval <interval>                         (default none)            Run the operation if "interval" milliseconds have passed since last run
-`;
+const GLACIER_EXPIRY_OPTIONS = ``;
 
 /** 
  * print_usage would print the help according to the arguments that were passed

--- a/src/sdk/nsfs_glacier_backend/backend.js
+++ b/src/sdk/nsfs_glacier_backend/backend.js
@@ -4,8 +4,14 @@
 const nb_native = require('../../util/nb_native');
 
 class GlacierBackend {
-    static MIGRATE_TIMESTAMP_FILE = 'timestamp.migrate';
-    static RESTORE_TIMESTAMP_FILE = 'timestamp.restore';
+    // These names start with the word 'timestamp' so as to assure
+    // that it acts like a 'namespace' for the these kind of files.
+    //
+    // It also helps in making sure that the persistent logger does not
+    // confuses these files with the WAL files.
+    static MIGRATE_TIMESTAMP_FILE = 'migrate.timestamp';
+    static RESTORE_TIMESTAMP_FILE = 'restore.timestamp';
+    static EXPIRY_TIMESTAMP_FILE = 'expiry.timestamp';
 
     /**
      * XATTR_RESTORE_REQUEST is set to a NUMBER (expiry days) by `restore_object` when 
@@ -149,6 +155,12 @@ class GlacierBackend {
             stat.xattr[GlacierBackend.XATTR_RESTORE_REQUEST_STAGED]) {
             return false;
         }
+
+        // If there are no associated blocks with the file then skip
+        // the migration.
+        if (stat.blocks === 0) return false;
+
+        return true;
     }
 
     /**

--- a/src/sdk/nsfs_glacier_backend/tapecloud.js
+++ b/src/sdk/nsfs_glacier_backend/tapecloud.js
@@ -4,11 +4,11 @@
 const { PersistentLogger } = require("../../util/persistent_logger");
 const { NewlineReader } = require('../../util/file_reader');
 const { GlacierBackend } = require("./backend");
-const nb_native = require('../../util/nb_native');
 const config = require('../../../config');
 const path = require("path");
 const { parse_decimal_int } = require("../../endpoint/s3/s3_utils");
 const { exec } = require('../../util/os_utils');
+const dbg = require('../../util/debug_module')(__filename);
 
 const ERROR_DUPLICATE_TASK = "GLESM431E";
 
@@ -104,6 +104,8 @@ async function process_expired() {
 
 class TapeCloudGlacierBackend extends GlacierBackend {
     async migrate(fs_context, log_file) {
+        dbg.log2('TapeCloudGlacierBackend.migrate starting for', log_file);
+
         let filtered_log = null;
         let walreader = null;
         try {
@@ -115,10 +117,10 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
             walreader = new NewlineReader(fs_context, log_file, 'EXCLUSIVE');
 
-            const result = await walreader.forEach(async entry => {
+            const [processed, result] = await walreader.forEachFilePathEntry(async entry => {
                 let should_migrate = true;
                 try {
-                    should_migrate = await this.should_migrate(fs_context, entry);
+                    should_migrate = await this.should_migrate(fs_context, entry.path);
                 } catch (err) {
                     if (err.code === 'ENOENT') {
                         // Skip this file
@@ -127,13 +129,14 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
                     // Something else is wrong with this entry of this file
                     // should skip processing this WAL for now
+                    dbg.log1('skipping log entry', entry.path, 'due to error:', err);
                     return false;
                 }
 
                 // Skip the file if it shouldn't be migrated
                 if (!should_migrate) return true;
 
-                await filtered_log.append(entry);
+                await filtered_log.append(entry.path);
                 return true;
             });
 
@@ -141,13 +144,22 @@ class TapeCloudGlacierBackend extends GlacierBackend {
             // to exit early hence the file shouldn't be processed further, exit
             if (!result) return false;
 
+            // If we didn't read even one line then it most likely indicates that the WAL is
+            // empty - this case is unlikely given the mechanism of WAL but still needs to be
+            // handled.
+            // Return `true` to mark it for deletion.
+            if (processed === 0) {
+                dbg.warn('unexpected empty persistent log found:', log_file);
+                return true;
+            }
+
             await filtered_log.close();
-            const failed = await migrate(filtered_log.active_path);
+            const failed = await this._migrate(filtered_log.active_path);
 
             // Do not delete the WAL if migration failed - This allows easy retries
             return failed.length === 0;
         } catch (error) {
-            console.error('unexpected error occured while processing migrate WAL:', error);
+            dbg.error('unexpected error occured while processing migrate WAL:', error);
 
             // Preserve the WAL if we encounter exception here, possible failures
             // 1.eaedm command failure
@@ -165,6 +177,8 @@ class TapeCloudGlacierBackend extends GlacierBackend {
     }
 
     async restore(fs_context, log_file) {
+        dbg.log2('TapeCloudGlacierBackend.restore starting for', log_file);
+
         let tempwal = null;
         let walreader = null;
         let tempwalreader = null;
@@ -178,10 +192,10 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
             walreader = new NewlineReader(fs_context, log_file, 'EXCLUSIVE');
 
-            const [precount, preres] = await walreader.forEach(async entry => {
+            let [processed, result] = await walreader.forEachFilePathEntry(async entry => {
                 let fh = null;
                 try {
-                    fh = await nb_native().fs.open(fs_context, entry, 'rw');
+                    fh = await entry.open();
                     const stat = await fh.stat(
                         fs_context,
                         {
@@ -192,7 +206,7 @@ class TapeCloudGlacierBackend extends GlacierBackend {
                         }
                     );
 
-                    const should_restore = await this.should_restore(fs_context, entry, stat);
+                    const should_restore = await this.should_restore(fs_context, entry.path, stat);
                     if (!should_restore) {
                         // Skip this file
                         return true;
@@ -208,7 +222,7 @@ class TapeCloudGlacierBackend extends GlacierBackend {
                     );
 
                     // Add entry to the tempwal
-                    await tempwal.append(entry);
+                    await tempwal.append(entry.path);
 
                     return true;
                 } catch (error) {
@@ -226,27 +240,30 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
             // If the result of the above iteration was negative it indicates
             // an early exit hence no need to process further for now
-            if (!preres) return false;
+            if (!result) return false;
 
             // If we didn't read even one line then it most likely indicates that the WAL is
             // empty - this case is unlikely given the mechanism of WAL but still needs to be
             // handled.
-            // Still return `false` so as to not insist file deletion
-            if (precount === 0) return false;
+            // Return `true` so as clear this file
+            if (processed === 0) {
+                dbg.warn('unexpected empty persistent log found:', log_file);
+                return true;
+            }
 
             // If we didn't find any candidates despite complete read, exit and delete this WAL
             if (tempwal.local_size === 0) return true;
 
             await tempwal.close();
-            const failed = await recall(tempwal.active_path);
+            const failed = await this._recall(tempwal.active_path);
 
             tempwalreader = new NewlineReader(fs_context, tempwal.active_path, "EXCLUSIVE");
 
             // Start iteration over the WAL again
-            const post = await tempwalreader.forEach(async entry => {
+            [processed, result] = await tempwalreader.forEachFilePathEntry(async entry => {
                 let fh = null;
                 try {
-                    fh = await nb_native().fs.open(fs_context, entry, 'rw');
+                    fh = await entry.open();
 
                     const stat = await fh.stat(
                         fs_context,
@@ -260,7 +277,7 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
                     // We noticed that the file has failed earlier
                     // so mustn't have been part of the WAL, ignore
-                    if (failed.includes(entry)) {
+                    if (failed.includes(entry.path)) {
                         await fh.replacexattr(
                             fs_context,
                             {
@@ -284,7 +301,7 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
                     return true;
                 } catch (error) {
-                    console.error(`failed to process ${entry}`, error);
+                    dbg.error(`failed to process ${entry.path}`, error);
                     // It's OK if the file got deleted between the last check and this check
                     // but if there is any other error, retry restore
                     //
@@ -299,12 +316,12 @@ class TapeCloudGlacierBackend extends GlacierBackend {
                 }
             });
 
-            if (!post[1]) return false;
+            if (!result) return false;
 
             // Even if we failed to process one entry in log, preserve the WAL
             return failed.length === 0;
         } catch (error) {
-            console.error('unexpected error occured while processing restore WAL:', error);
+            dbg.error('unexpected error occured while processing restore WAL:', error);
 
             // Preserve the WAL, failure cases:
             // 1. tapecloud command exception
@@ -324,15 +341,46 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
     async expiry(fs_context) {
         try {
-            await process_expired();
+            await this._process_expired();
         } catch (error) {
-            console.error('Unexpected error occured while running tapecloud.expiry:', error);
+            dbg.error('unexpected error occured while running tapecloud.expiry:', error);
         }
     }
 
     async low_free_space() {
         const result = await exec(get_bin_path(LOW_FREE_SPACE_SCRIPT), { return_stdout: true });
         return result.toLowerCase() === 'true';
+    }
+
+    // ============= PRIVATE FUNCTIONS =============
+
+    /**
+     * _migrate should perform migration
+     * 
+     * NOTE: Must be overwritten for tests
+     * @param {string} file 
+     */
+    async _migrate(file) {
+        return migrate(file);
+    }
+
+    /**
+     * _recall should perform recall
+     * 
+     * NOTE: Must be overwritten for tests
+     * @param {string} file 
+     */
+    async _recall(file) {
+        return recall(file);
+    }
+
+    /**
+     * _process_expired should process expired objects
+     * 
+     * NOTE: Must be overwritten for tests
+     */
+    async _process_expired() {
+        return process_expired();
     }
 }
 

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -61,6 +61,7 @@ require('./test_chunk_fs');
 require('./test_namespace_fs_mpu');
 require('./test_nb_native_fs');
 require('./test_s3select');
+require('./test_nsfs_glacier_backend');
 
 // // SERVERS
 require('./test_agent');

--- a/src/test/unit_tests/nc_index.js
+++ b/src/test/unit_tests/nc_index.js
@@ -15,6 +15,7 @@ require('./test_nc_nsfs_health');
 require('./test_nsfs_access');
 require('./test_bucketspace');
 require('./test_bucketspace_fs');
+require('./test_nsfs_glacier_backend');
 
 // TODO: uncomment when supported
 //require('./test_s3_ops');

--- a/src/test/unit_tests/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/test_nsfs_glacier_backend.js
@@ -1,0 +1,155 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const fs = require('fs');
+const util = require('util');
+const path = require('path');
+const mocha = require('mocha');
+const crypto = require('crypto');
+const assert = require('assert');
+const os = require('os');
+const config = require('../../../config');
+const NamespaceFS = require('../../sdk/namespace_fs');
+const s3_utils = require('../../endpoint/s3/s3_utils');
+const buffer_utils = require('../../util/buffer_utils');
+const endpoint_stats_collector = require('../../sdk/endpoint_stats_collector');
+const { NewlineReader } = require('../../util/file_reader');
+const { TapeCloudGlacierBackend } = require('../../sdk/nsfs_glacier_backend/tapecloud');
+
+const mkdtemp = util.promisify(fs.mkdtemp);
+const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null, maxArrayLength: max_arr });
+
+function make_dummy_object_sdk() {
+    return {
+        requesting_account: {
+            force_md5_etag: false,
+            nsfs_account_config: {
+                uid: process.getuid(),
+                gid: process.getgid(),
+            }
+        },
+        abort_controller: new AbortController(),
+        throw_if_aborted() {
+            if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        }
+    };
+}
+
+mocha.describe('nsfs_glacier', async () => {
+	const src_bkt = 'src';
+
+	const dummy_object_sdk = make_dummy_object_sdk();
+    const upload_bkt = 'test_ns_uploads_object';
+	const ns_src_bucket_path = `./${src_bkt}`;
+
+	const glacier_ns = new NamespaceFS({
+		bucket_path: ns_src_bucket_path,
+		bucket_id: '1',
+		namespace_resource_id: undefined,
+		access_mode: undefined,
+		versioning: undefined,
+		force_md5_etag: false,
+		stats: endpoint_stats_collector.instance(),
+	});
+
+	glacier_ns._is_storage_class_supported = async () => true;
+
+	mocha.before(async () => {
+		config.NSFS_GLACIER_LOGS_DIR = await mkdtemp(path.join(os.tmpdir(), 'nsfs-wal-'));
+	});
+
+	mocha.describe('nsfs_glacier_tapecloud', async () => {
+        const upload_key = 'upload_key_1';
+        const restore_key = 'restore_key_1';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+
+		const backend = new TapeCloudGlacierBackend();
+
+		// Patch backend for test
+		backend._migrate = async () => [];
+		backend._recall = async () => [];
+		backend._process_expired = async () => { /**noop*/ };
+
+		mocha.it('upload to GLACIER should work', async () => {
+            const data = crypto.randomBytes(100);
+            const upload_res = await glacier_ns.upload_object({
+                bucket: upload_bkt,
+                key: upload_key,
+				storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+                xattr,
+                source_stream: buffer_utils.buffer_to_read_stream(data)
+            }, dummy_object_sdk);
+
+            console.log('upload_object response', inspect(upload_res));
+
+			// Force a swap, 3 cases are possible:
+			// 1. The file was already swapped - Unlikely but whatever
+			// 2. The file was empty (bug) - swap returns without doing anything
+			// 3. The file is swapped successfully
+			await NamespaceFS.migrate_wal._swap();
+
+			// Check if the log contains the entry
+			let found = false;
+			await NamespaceFS.migrate_wal.process_inactive(async file => {
+				const fs_context = glacier_ns.prepare_fs_context(dummy_object_sdk);
+				const reader = new NewlineReader(fs_context, file, 'EXCLUSIVE');
+
+				await reader.forEachFilePathEntry(async entry => {
+					if (entry.path.endsWith(`${upload_key}`)) {
+						found = true;
+
+						// Not only should the file exist, it should be ready for
+						// migration as well
+						assert(backend.should_migrate(fs_context, entry.path));
+					}
+
+					return true;
+				});
+
+				// Don't delete the file
+				return false;
+			});
+
+			assert(found);
+		});
+
+		mocha.it('restore-object should successfully restore', async () => {
+            const data = crypto.randomBytes(100);
+			const params = {
+                bucket: upload_bkt,
+                key: restore_key,
+				storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+                xattr,
+				days: 1,
+                source_stream: buffer_utils.buffer_to_read_stream(data)
+            };
+
+            const upload_res = await glacier_ns.upload_object(params, dummy_object_sdk);
+            console.log('upload_object response', inspect(upload_res));
+
+			const restore_res = await glacier_ns.restore_object(params, dummy_object_sdk);
+			assert(restore_res);
+
+			// Force a swap, 3 cases are possible:
+			// 1. The file was already swapped - Unlikely but whatever
+			// 2. The file was empty (bug) - swap returns without doing anything
+			// 3. The file is swapped successfully
+			await NamespaceFS.restore_wal._swap();
+
+			// Issue restore
+			await NamespaceFS.restore_wal.process_inactive(async file => {
+				const fs_context = glacier_ns.prepare_fs_context(dummy_object_sdk);
+				await backend.restore(fs_context, file);
+
+				// Don't delete the file
+				return false;
+			});
+
+			// Ensure object is restored
+			const md = await glacier_ns.read_object_md(params, dummy_object_sdk);
+			assert(!md.restore_status.ongoing);
+			assert(new Date(new Date().setDate(md.restore_status.expiry_time.getDate() - params.days)).getDate() === new Date().getDate());
+		});
+	});
+});


### PR DESCRIPTION
### Explain the changes
This PR attempts to fix WAL processing. This issue was identified with the help of Abe-san. It was noticed that PersistentLogger's processor was trying to consume the timestamp file as well because of sharing the same prefix. This PR puts the `timestamp` files into the `timestamp` "namespace" such that the processor will not confuse that file with a WAL.


- [ ] Doc added/updated
- [x] Tests added
