### PR TITLE
NSFS | NC | Fail nsfs.js completely on system.json failure

### DIFF
--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -233,7 +233,10 @@ async function init_nsfs_system(config_root) {
         });
         console.log('created NSFS system data with version: ', pkg.version);
     } catch (err) {
-        console.error('failed to create NSFS system data', err);
+        const msg = 'failed to create NSFS system data due to - ' + err.message;
+        const error = new Error(msg);
+        console.error(msg, err);
+        throw error;
     }
 }
 


### PR DESCRIPTION
### Explain the changes
1. Currently on nsfs.js system.json update issues we fail silently and keep running the endpoint even if got an error, we need to fail the whole NSFS service in this case.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/7857
2. we might need to think about more cases this could happen.

### Testing Instructions:
1. start nsfs service before the config dir mounting is available.
2. (This can also easily be mocked by throwing an error from init_nsfs_system() try scope).


- [ ] Doc added/updated
- [ ] Tests added
