### PR TITLE
Migrating to AWS SDK V3 | Following PR on a Fix That Was Added

### DIFF
--- a/src/sdk/bucketspace_s3.js
+++ b/src/sdk/bucketspace_s3.js
@@ -35,6 +35,7 @@ class BucketSpaceS3 {
             const buckets_with_name_change = buckets.map(b => ({ name: new SensitiveString(b.Name) }));
             return { buckets_with_name_change };
         } catch (err) {
+            noobaa_s3_client.fix_error_object(err);
             this._translate_error_code(err);
             throw err;
         }
@@ -62,6 +63,7 @@ class BucketSpaceS3 {
                 undeletable: 'NOT_EMPTY',
             };
         } catch (err) {
+            noobaa_s3_client.fix_error_object(err);
             this._translate_error_code(err);
             throw err;
         }
@@ -73,6 +75,7 @@ class BucketSpaceS3 {
             console.log(`bss3: create_bucket ${name}`);
             await this.s3.createBucket({ Bucket: name });
         } catch (err) {
+            noobaa_s3_client.fix_error_object(err);
             this._translate_error_code(err);
             throw err;
         }
@@ -84,6 +87,7 @@ class BucketSpaceS3 {
             console.log(`bss3: delete_fs_bucket ${name}`);
             await this.s3.deleteBucket({ Bucket: name });
         } catch (err) {
+            noobaa_s3_client.fix_error_object(err);
             this._translate_error_code(err);
             throw err;
         }

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client.js
@@ -100,14 +100,9 @@ function get_requestHandler_with_suitable_agent(endpoint) {
     }
 }
 
-// v2: code, v3: Code
-function check_error_code(err, code) {
-    return err.code === code || err.Code === code;
-}
-
 /**
  * When using aws sdk v3 we get the error object with values that start with an uppercase instead of lowercase
- * we want to fix this value to be start with a lowercase.
+ * we want to fix this value to be start with a lowercase (example: v2: code, v3: Code).
  * 
  * @param {object} err
  */
@@ -134,6 +129,5 @@ function fix_error_object(err) {
 exports.get_s3_client_v3_params = get_s3_client_v3_params;
 exports.change_s3_client_params_to_v2_structure = change_s3_client_params_to_v2_structure;
 exports.get_sdk_class_str = get_sdk_class_str;
-exports.check_error_code = check_error_code;
 exports.fix_error_object = fix_error_object;
 exports.get_requestHandler_with_suitable_agent = get_requestHandler_with_suitable_agent;

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -141,12 +141,12 @@ class NamespaceMonitor {
                 Key: block_key
             });
         } catch (err) {
-            noobaa_s3_client.fix_error_object(err); //This makes the noobaa_s3_client.check_error_code redundant, we should consider removing it.
-            if (noobaa_s3_client.check_error_code(err, 'AccessDenied') && nsr.is_readonly_namespace()) {
+            noobaa_s3_client.fix_error_object(err);
+            if (err.code === 'AccessDenied' && nsr.is_readonly_namespace()) {
                 return;
             }
             dbg.log1('test_s3_resource: got error:', err);
-            if (!noobaa_s3_client.check_error_code(err, 'NoSuchKey')) throw err;
+            if (err.code !== 'NoSuchKey') throw err;
         }
 
     }

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1208,6 +1208,7 @@ async function get_cloud_buckets(req) {
             return buckets.map(bucket => _inject_usage_to_cloud_bucket(bucket.Name, connection.endpoint, used_cloud_buckets));
         }
     } catch (err) {
+        noobaa_s3_client.fix_error_object(err); // only relevant when using AWS SDK v3
         if (err instanceof P.TimeoutError) {
             dbg.log0('failed reading (t/o) external buckets list', req.rpc_params);
         } else {


### PR DESCRIPTION
### Explain the changes
#### Background:
In #7846 revealed a bug that we had in the code - when using the AWS SDK v3 the `error` properties were changed to uppercase, so instead of `err.code` it was `err.Code`. We had a function `check_error_code`, but if the catch is using `throw err` and the caller is looking for `err.code` - it will not find it. Hence whenever we use the `noobaa_s3_client` and in the catch clause we have `throw err` we need to add the function `fix_error_object` so we will have the `code` property.

The changes are:
1. Use `noobaa_s3_client.fix_error_object(err)` in catch clause whenever there is `throw err`.
2. Remove the function `check_error_code` and its usages.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
