### PR TITLE
NSFS | NC | Fix owner_account runtime object

### DIFF
--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -151,6 +151,10 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             bucket.name = new SensitiveString(bucket.name);
             bucket.system_owner = new SensitiveString(bucket.system_owner);
             bucket.bucket_owner = new SensitiveString(bucket.bucket_owner);
+            bucket.owner_account = {
+                id: bucket.owner_account,
+                email: bucket.bucket_owner
+            };
             if (bucket.s3_policy) {
                 for (const [s_index, statement] of bucket.s3_policy.Statement.entries()) {
                     const statement_principal = statement.Principal || statement.NotPrincipal;

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -258,6 +258,23 @@ async function create_account_manage(options) {
     return account;
 }
 
+
+/**
+ * read_bucket_manage reads a bucket using manage_nsfs and returns rpc-like result
+ * @param {object} options
+ * @return {Promise<object>}
+ */
+async function read_bucket_manage(options) {
+    const res = await exec_manage_cli(TYPES.BUCKET, ACTIONS.STATUS, options);
+    const json_bucket = JSON.parse(res);
+    const bucket = json_bucket.response.reply;
+    bucket.owner_account = {
+        email: bucket.bucket_owner,
+        id: bucket.owner_account
+    };
+    return bucket;
+}
+
 /**
  * read_account_manage reads an account using manage_nsfs and returns rpc-like result
  * @param {object} options
@@ -425,7 +442,8 @@ const rpc_cli_funcs_to_manage_nsfs_cli_cmds = {
         create_bucket: async options => create_bucket_manage(options),
         update_bucket: async options => update_bucket_manage(options),
         put_bucket_policy: async options => put_bucket_policy_manage(options),
-        delete_bucket: async options => delete_bucket_manage(options)
+        delete_bucket: async options => delete_bucket_manage(options),
+        read_bucket: async options => read_bucket_manage(options),
     }
 };
 


### PR DESCRIPTION
### Explain the changes
1. runtime object of owner_account should be an object of the following form - { id: owner_account_id, email: owner_account_email }

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #https://github.com/noobaa/noobaa-core/issues/7853

### Testing Instructions:
1. Manual testing as mentioned in the issue - 
```
$ aws  --endpoint http://localhost:6001/ s3api get-bucket-acl --bucket test1
An error occurred (InternalError) when calling the GetBucketAcl operation (reached max retries: 4): We encountered an internal error. Please try again.
```
2. new get-bucket-acl tests - 
```
sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha noobaa-core/src/test/unit_tests/test_bucketspace.js
```

- [ ] Doc added/updated
- [x] Tests added
