### PR TITLE
NSFS | NC | Add disable dev random seed flag

### DIFF
--- a/config.js
+++ b/config.js
@@ -96,6 +96,7 @@ config.AGENT_TEST_CONNECTION_TIMEOUT = 1 * 60 * 1000;
 config.STORE_PERF_TEST_INTERVAL = 60 * 60 * 1000; // perform test_store_perf every 1 hour
 config.CLOUD_MAX_ALLOWED_IO_TEST_ERRORS = 3;
 
+config.ENABLE_DEV_RANDOM_SEED = process.env.DISABLE_DEV_RANDOM_SEED === 'false' || false;
 
 ////////////////
 // RPC CONFIG //

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -320,6 +320,23 @@ Example:
 ```
 
 
+## 18. Disable random seeding -
+**Description -** This flag will enable the random seeding for the application.
+
+**Configuration Key -** ENABLE_DEV_RANDOM_SEED
+
+**Type -** boolean
+
+**Default -**  false
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"ENABLE_DEV_RANDOM_SEED": false
+3. systemctl restart noobaa_nsfs
+```
+
 ## Config.json example 
 ```
 > cat /path/to/config_dir/config.json

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -105,6 +105,11 @@ const nsfs_node_config_schema = {
             type: 'number',
             default: 4 * 64 * 1024 * 1024,
             description: 'maximum size of the dir cache, suggested values 768MB, service restart required'
+        },
+        ENABLE_DEV_RANDOM_SEED: {
+            type: 'boolean',
+            default: false,
+            description: 'This flag will enable the random seeding for the application'
         }
     }
 };

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -109,6 +109,16 @@ describe('schema validation NC NSFS config', () => {
             const message = 'must be number';
             assert_validation(config_data, reason, message);
         });
+
+        it('nsfs_config invalid config disable random seed', () => {
+            const config_data = {
+                ENABLE_DEV_RANDOM_SEED: 'not boolean', // string instead of boolean
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+                'ENABLE_DEV_RANDOM_SEED with string (instead of boolean)';
+            const message = 'must be boolean';
+            assert_validation(config_data, reason, message);
+        });
     });
 });
 

--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -8,6 +8,7 @@ const events = require('events');
 const chance = require('chance')();
 const bindings = require('bindings');
 const child_process = require('child_process');
+const config = require('../../config');
 
 const async_exec = util.promisify(child_process.exec);
 const async_delay = util.promisify(setTimeout);
@@ -82,7 +83,7 @@ async function read_rand_seed(seed_bytes) {
     while (offset < buf.length) {
         try {
             const count = buf.length - offset;
-            const random_dev = process.env.DISABLE_DEV_RANDOM_SEED ? '/dev/urandom' : '/dev/random';
+            const random_dev = config.ENABLE_DEV_RANDOM_SEED ? '/dev/random' : '/dev/urandom';
             if (!fh) {
                 if (process.env.LOCAL_MD_SERVER) {
                     console.log(`read_rand_seed: opening ${random_dev} ...`);


### PR DESCRIPTION
### Explain the changes
1. add configuration for disabling random seed for CLI, the default value is `true`, new flag added `DISABLE_CLI_RANDOM_SEED`
2. `DISABLE_DEV_RANDOM_SEED` flag value will be fetched from config if no value is set on `process.env.DISABLE_DEV_RANDOM_SEED`. And the default value would be `false`

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7701

### Testing Instructions:
1. update `DISABLE_CLI_RANDOM_SEED` and `DISABLE_DEV_RANDOM_SEED` to check whether random seed is enabled or not.

- [X] Doc added/updated
- [ ] Tests added
