### PR TITLE
Fixes - GCP write not waiting for finish before resolve

### DIFF
--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -23,7 +23,7 @@ const block_store_info_cache = new LRUCache({
     max_usage: 1000,
     expiry_ms: 2 * 60 * 1000,
     make_key: params => params.options.address,
-    load: async ({ rpc_client, options }) => rpc_client.block_store.get_block_store_info(null, options),
+    load: async ({ rpc_client, options }) => rpc_client.block_store.get_block_store_info({}, options),
 });
 class BlockStoreClient {
 
@@ -98,8 +98,8 @@ class BlockStoreClient {
                         }
                     },
                 });
+                dbg.log3('writing block id to gcp: ', block_id);
                 await buffer_utils.write_to_stream(write_stream, data);
-                write_stream.end();
                 const data_length = data.length;
                 const usage = data_length ? {
                     size: (block_md.is_preallocated ? 0 : data_length) + encoded_md.length,

--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -165,7 +165,6 @@ class BlockStoreGoogle extends BlockStoreBase {
         dbg.log3('writing block id to cloud: ', key);
         try {
             await buffer_utils.write_to_stream(write_stream, data);
-            write_stream.end();
             const usage = {
                 size: data.length + encoded_md.length,
                 count: 1

--- a/src/tools/diagnostics/analyze_resource/analyze_resource_gcp.js
+++ b/src/tools/diagnostics/analyze_resource/analyze_resource_gcp.js
@@ -4,6 +4,7 @@
 const { inspect } = require('util');
 const { Storage } = require('@google-cloud/storage');
 const dbg = require('../../../util/debug_module')(__filename);
+const buffer_utils = require('../../../util/buffer_utils');
 dbg.set_process_name('analyze_resource');
 const CloudVendor = require('./analyze_resource_cloud_vendor_abstract');
 
@@ -58,8 +59,7 @@ class AnalyzeGcp extends CloudVendor {
             .bucket(bucket)
             .file(key)
             .createWriteStream();
-        stream.write(''); //write an empty file
-        stream.end();
+        await buffer_utils.write_to_stream(stream, ''); //write an empty file
         stream.on('response', resp => {
             dbg.log0(`Write of ${key} response: ${inspect(resp)}`);
         });

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -167,11 +167,12 @@ function count_length(buffers) {
 function write_to_stream(writable, buf) {
     return new Promise((resolve, reject) => {
         writable.once('error', reject);
+        writable.once('finish', resolve);
         writable.write(buf, err => {
             if (err) {
                 return reject(err);
             }
-            return resolve();
+            writable.end();
         });
     });
 }


### PR DESCRIPTION
### Explain the changes
1. main issue fix: GCP write not waiting for finish before resolving, we resolved the Promise after calling the write. we were supposed to wait for a finish event.
A few more minor fixes:
1. issue with get_block_store_info schema - null instead of object 
2. adapting analyze_resource_gcp to use the same code as block_store_google

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
