### PR TITLE
NSFS | NC | Missing Space Removal in Help

### DIFF
--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -60,8 +60,8 @@ Flags:
 `;
 
 const GLOBAL_CONFIG_ROOT_ALL_FLAG = `
---config_root <string>                                    (optional)                        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
---config_root_backend <none | GPFS | CEPH_FS | NFSv4>     (optional)                        Use the filesystem type in the configuration (default config.NSFS_NC_CONFIG_DIR_BACKEND)
+--config_root <string>                                (optional)        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
+--config_root_backend <none | GPFS | CEPH_FS | NFSv4> (optional)        Use the filesystem type in the configuration (default config.NSFS_NC_CONFIG_DIR_BACKEND)
 `;
 
 const ACCOUNT_FLAGS_ADD = `


### PR DESCRIPTION
### Explain the changes
1. In PR #7827 I reduce the number of spaces in the help menu, but in PR #7779 I accidentally (in the conflict resolving) override this.

### Issues: Fixed #xxx / Gap #xxx
1. none

### Testing Instructions:
1. For help updates run: `sudo node src/cmd/manage_nsfs account <action> --help 2>/dev/null` (replace `<action>` with update and then with delete).


- [ ] Doc added/updated
- [ ] Tests added
