### PR TITLE
NSFS | NC | Fix Return `Accountaccesskeyalreadyexists` Error (for MacOS)

### DIFF
--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -485,6 +485,7 @@ async function is_path_exists(fs_context, config_path, use_lstat = false) {
         await nb_native().fs.stat(fs_context, config_path, { use_lstat });
     } catch (err) {
         if (err.code === 'ENOENT') return false;
+        if (err.code === 'ELOOP') return true; // for MacOS 
         throw err;
     }
     return true;


### PR DESCRIPTION
### Explain the changes
1. Add a case inside `is_path_exists` the MacOS user encounter.

### Issues: Fixed #7873
1. Currently when using the NSFS NC and running it on MacOS when creating an account with an existing access key returns `InternalError` instead of `Accountaccesskeyalreadyexists`.

### Testing Instructions:
1. Manual test:
- Create an account using `access_key` and `secret_key` flags: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path <path> --access_key <access_key> --secret_key <secret_key> --uid <uid> --gid <gid>`.
- Create another account and use the same values for `access_key` and `secret_key` flags: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path <path> --access_key <same_access_key> --secret_key <same_secret_key> --uid <uid> --gid <gid>`. (See `AccountAccessKeyAlreadyExists` and not `InternalError`).

2. Before this change when MacOS users run the: `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js` they encountered a couple of failed tests (for example: `cli account create - access_key exists - should fail`, `cli account2 update - new_access_key already exists`, and `cli account2 update - new_access_key already exists`).


- [ ] Doc added/updated
- [ ] Tests added
