### PR TITLE
NSFS | Fix lstat on mac

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -698,10 +698,13 @@ struct Stat : public FSWorker
     virtual void Work()
     {
         int flags = O_RDONLY; // This default will be used only for none-lstat cases
-        // using O_PATH (MAC - O_SYMLINK) with O_NOFOLLOW allow us to open the symlink itself
+        // LINUX - using O_PATH with O_NOFOLLOW allow us to open the symlink itself
         // instead of openning the file it links to https://man7.org/linux/man-pages/man7/symlink.7.html
+        // MAC - using O_SYMLINK (without O_NOFOLLOW!) allow us to open the symlink itself
+        // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/open.2.html
+        // If O_NOFOLLOW is used in the mask and the target file passed to open() is a symbolic link then the open() will fail.
 #ifdef __APPLE__
-        if (_use_lstat) flags = O_SYMLINK | O_NOFOLLOW;
+        if (_use_lstat) flags = O_SYMLINK;
 #else
         if (_use_lstat) flags = O_PATH | O_NOFOLLOW;
 #endif


### PR DESCRIPTION
### Explain the changes
1. Running stat(fs_context, path, { use_lstat: true }) on MAC, where path is a symbolic link threw ELOOP error. According to [mac docs of open()] ELOOP described as the following - 
```
[ELOOP]            Too many symbolic links
[ELOOP]            O_NOFOLLOW was specified and the target is a symbolic link.
```

2. According to [mac docs of open()](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/open.2.html) -
```
If O_NOFOLLOW is used in the mask and the target file passed to open() is
a symbolic link then the open() will fail.

If O_SYMLINK is used in the mask and the target file passed to open() is
a symbolic link then the open() will be for the symbolic link itself, not
what it links to.
```

Therefore, the O_NOFOLLOW flag should not be a part of the flags passed when calling open() of a symbolic link file and O_SYMLINK is enough.

3. Fixed the lstat test to run lstat on a symbolic link instead of a regular file.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #https://github.com/noobaa/noobaa-core/issues/7873

### Testing Instructions:
```
Automatic tests - 
On MAC, run the following tests and expect to pass - 
* sudo NC_CORETEST=true node  ./node_modules/mocha/bin/mocha noobaa-core/src/test/unit_tests/test_bucketspace.js
* sudo node ./node_modules/.bin/_mocha noobaa-core/src/test/unit_tests/test_nb_native_fs.js

Manual test using manage_nsfs.js - 
1. Create an account name=account1.
2. Create another account, name=account2, same access_key as of account1.
```
- [ ] Doc added/updated
- [x] Tests added
