### PR TITLE
NSFS | NC | CLI | Change the `fs_context`

### DIFF
--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -449,10 +449,10 @@ function get_process_fs_context(backend = '', warn_threshold_ms = config.NSFS_WA
 
 /**
  * @param {Object} nsfs_account_config
- * @param {string} [config_root_backend]
+ * @param {string} [fs_backend]
  * @returns {Promise<nb.NativeFSContext>}
  */
-async function get_fs_context(nsfs_account_config, config_root_backend) {
+async function get_fs_context(nsfs_account_config, fs_backend) {
     let account_ids_by_dn;
     if (nsfs_account_config.distinguished_name) {
         account_ids_by_dn = await get_user_by_distinguished_name({ distinguished_name: nsfs_account_config.distinguished_name });
@@ -461,7 +461,7 @@ async function get_fs_context(nsfs_account_config, config_root_backend) {
         uid: (account_ids_by_dn && account_ids_by_dn.uid) ?? nsfs_account_config.uid,
         gid: (account_ids_by_dn && account_ids_by_dn.gid) ?? nsfs_account_config.gid,
         warn_threshold_ms: config.NSFS_WARN_THRESHOLD_MS,
-        backend: config_root_backend
+        backend: fs_backend
     };
 }
 


### PR DESCRIPTION
### Explain the changes
1. Change the `native_fs_utils.get_process_fs_context` argument according to the path that we use:
- `config_root_backend` for access that is related to the configuration.
- `fs_backend` for access that is related to the FS (for example `path` in a bucket, `new_buckets_path` in an account).
- no argument for other cases (`from_file` path).
2. Fix the arguemnt of `fs_context` in `native_fs_utils.get_fs_context` to the `fs_backend` instead of `config_root_backend` before using the `is_dir_rw_accessible`.
3. Rename the argument from `config_root_backend` to `fs_backend` in function `get_fs_context`.

### Issues: Fixed #7875
1. Currently, our code is not consistent with using the `native_fs_utils.get_process_fs_context` argument.
2. Fix the `fs_context` for `is_dir_rw_accessible` for `new_buckets_path`.
4. GAP - it was only changed in the file `manage_nsfs` (we might have it in `health` script).

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
