### PR TITLE
NSFS | NC | Use avj `compile` and Reuse `validate` Function

### DIFF
--- a/src/manage_nsfs/nsfs_schema_utils.js
+++ b/src/manage_nsfs/nsfs_schema_utils.js
@@ -36,6 +36,10 @@ schema_utils.strictify(account_schema, {
     additionalProperties: false
 });
 
+const validate_account = ajv.compile(account_schema);
+const validate_bucket = ajv.compile(bucket_schema);
+const validate_nsfs_config = ajv.compile(nsfs_config_schema);
+
 // NOTE - DO NOT strictify nsfs_config_schema
 // we might want to use it in the future for adding additional properties
 
@@ -44,9 +48,10 @@ schema_utils.strictify(account_schema, {
  * @param {object} account
  */
 function validate_account_schema(account) {
-    const valid = ajv.validate(account_schema, account);
+    const valid = validate_account(account);
     if (!valid) {
-        const err_msg = ajv.errors[0].message ? create_schema_err_msg(ajv.errors[0]) : undefined;
+        const first_err = validate_account.errors[0];
+        const err_msg = first_err.message ? create_schema_err_msg(first_err) : undefined;
         throw new RpcError('INVALID_SCHEMA', err_msg);
     }
 }
@@ -56,9 +61,10 @@ function validate_account_schema(account) {
  * @param {object} bucket
  */
 function validate_bucket_schema(bucket) {
-    const valid = ajv.validate(bucket_schema, bucket);
+    const valid = validate_bucket(bucket);
     if (!valid) {
-        const err_msg = ajv.errors[0].message ? create_schema_err_msg(ajv.errors[0]) : undefined;
+        const first_err = validate_bucket.errors[0];
+        const err_msg = first_err.message ? create_schema_err_msg(first_err) : undefined;
         throw new RpcError('INVALID_SCHEMA', err_msg);
     }
 }
@@ -68,9 +74,10 @@ function validate_bucket_schema(bucket) {
  * @param {object} config
  */
 function validate_nsfs_config_schema(config) {
-    const valid = ajv.validate(nsfs_config_schema, config);
+    const valid = validate_nsfs_config(config);
     if (!valid) {
-        const err_msg = ajv.errors[0].message ? create_schema_err_msg(ajv.errors[0]) : undefined;
+        const first_err = validate_nsfs_config.errors[0];
+        const err_msg = first_err.message ? create_schema_err_msg(first_err) : undefined;
         throw new RpcError('INVALID_SCHEMA', err_msg);
     }
 }


### PR DESCRIPTION
### Explain the changes
1. In NSFS schemas separate the `compile` (which is done once) from the `validate` (which is reuse).

### Issues:
1. Currently we use `ajv.validate(schema_name, object_to_validate)` and it doesn’t align with the avj documentation ([here](https://ajv.js.org/guide/getting-started.html#basic-data-validation)), please notice the comment “Best performance: compile and getSchema methods”:

> Best performance: compile and getSchema methods
> The best performance is achieved when using compiled functions returned by compile or getSchema methods.
> While execution of the compiled validation function is very fast, its compilation is relatively slow, so you need to make sure that you compile schemas only once and re-use compiled validation functions

Note: it is a partial fix to #7874

### Testing Instructions:
1. Run the schema unit tests:
`npx jest test_nc_nsfs_account_schema_validation.test.js`
`npx jest test_nc_nsfs_bucket_schema_validation.test.js`
`npx jest test_nc_nsfs_config_schema_validation.test.js`


- [ ] Doc added/updated
- [ ] Tests added
