### PR TITLE
NSFS | NC | Changes in `nsfs_config_schema` Related to `strictify`

### DIFF
--- a/config.js
+++ b/config.js
@@ -1057,7 +1057,9 @@ function load_nsfs_nc_config() {
             }
             config[key] = merged_config[key];
         });
-        console.warn(`nsfs: config_dir_path=${config.NSFS_NC_CONF_DIR} config.json= ${util.inspect(merged_config)}`);
+        console.warn(`nsfs: config_dir_path=${config.NSFS_NC_CONF_DIR}`);
+        console.warn(`nsfs: config.json= ${util.inspect(config_data)}`);
+        console.warn(`nsfs: merged config.json= ${util.inspect(merged_config)}`);
         validate_nc_master_keys_config(config);
     } catch (err) {
         if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ENOENT') throw err;

--- a/src/manage_nsfs/nsfs_schema_utils.js
+++ b/src/manage_nsfs/nsfs_schema_utils.js
@@ -36,12 +36,11 @@ schema_utils.strictify(account_schema, {
     additionalProperties: false
 });
 
+schema_utils.strictify(nsfs_config_schema, {});
+
 const validate_account = ajv.compile(account_schema);
 const validate_bucket = ajv.compile(bucket_schema);
 const validate_nsfs_config = ajv.compile(nsfs_config_schema);
-
-// NOTE - DO NOT strictify nsfs_config_schema
-// we might want to use it in the future for adding additional properties
 
 /**
  * validate_account_schema validates an account object against the NC NSFS account schema

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -7,130 +7,112 @@ const nsfs_node_config_schema = {
     properties: {
         ENDPOINT_FORKS: {
             type: 'number',
-            default: 0,
-            description: 'number of concurrent endpoint forks allowed, suggested values are 2-64, service restart required'
+            doc: 'number of concurrent endpoint forks allowed, suggested values are 2-64, service restart required'
         },
         ENDPOINT_PORT: {
             type: 'number',
-            default: 6001,
-            description: 'http port number designated for s3 incoming requests, service restart required'
+            doc: 'http port number designated for s3 incoming requests, service restart required'
         },
         ENDPOINT_SSL_PORT: {
             type: 'number',
-            default: 6443,
-            description: 'https port number designated for s3 incoming requests, service restart required'
+            doc: 'https port number designated for s3 incoming requests, service restart required'
         },
         ENDPOINT_SSL_STS_PORT: {
             type: 'number',
-            default: 7443,
-            description: 'https port number designated for sts incoming requests, service restart required'
+            doc: 'https port number designated for sts incoming requests, service restart required'
         },
         EP_METRICS_SERVER_PORT: {
             type: 'number',
-            default: 7004,
-            description: 'http port number designated for metrics incoming requests, service restart required'
+            doc: 'http port number designated for metrics incoming requests, service restart required'
         },
         ALLOW_HTTP: {
             type: 'boolean',
-            default: false,
-            description: 'indicate whether s3 http requests are allowed, service restart required'
+            doc: 'indicate whether s3 http requests are allowed, service restart required'
         },
         NSFS_CALCULATE_MD5: {
             type: 'boolean',
-            default: false,
-            description: 'indicate whether MD5 will be calculated, hot reload'
+            doc: 'indicate whether MD5 will be calculated, hot reload'
         },
         NOOBAA_LOG_LEVEL: {
             type: 'string',
             enum: ['warn', 'default', 'nsfs', 'all'],
-            default: 'default',
-            description: 'logging verbosity level for the NooBaa system, service restart required'
+            doc: 'logging verbosity level for the NooBaa system, service restart required'
         },
         UV_THREADPOOL_SIZE: {
             type: 'number',
-            default: 4,
-            description: 'number of UV_THREADPOOL, suggested values are 4-1024, service restart required'
+            doc: 'number of UV_THREADPOOL, suggested values are 4-1024, service restart required'
         },
         GPFS_DL_PATH: {
             type: 'string',
-            default: '',
-            description: 'indicates the location of the gpfs library file, service restart required, usually should be set to /usr/lib64/libgpfs.so'
+            doc: 'indicates the location of the gpfs library file, service restart required, usually should be set to /usr/lib64/libgpfs.so'
         },
         NSFS_NC_STORAGE_BACKEND: {
             $ref: 'common_api#/definitions/fs_backend',
-            default: undefined,
-            description: 'indicates the global storage backend type, service restart required'
+            doc: 'indicates the global storage backend type, service restart required'
         },
         NSFS_NC_CONFIG_DIR_BACKEND: {
             $ref: 'common_api#/definitions/fs_backend',
-            default: undefined,
-            description: 'indicates the backend type of the config directory, service restart required'
+            doc: 'indicates the backend type of the config directory, service restart required'
         },
         NSFS_BUF_POOL_MEM_LIMIT: {
             type: 'number',
-            default: 32 * 1024 * 1024,
-            description: 'number of nsfs buffer pool memory limit, suggested values 1-4GB, service restart required'
+            doc: 'number of nsfs buffer pool memory limit, suggested values 1-4GB, service restart required'
         },
         NSFS_BUF_SIZE: {
             type: 'number',
-            default: 8 * 1024 * 1024,
-            description: 'number of nsfs buffer size, service restart required'
+            doc: 'number of nsfs buffer size, service restart required'
         },
         NSFS_OPEN_READ_MODE: {
             type: 'string',
-            default: 'r',
-            description: `describes the mode of open for read, use 'rd' for direct-io reads, hot reload`
+            doc: `describes the mode of open for read, use 'rd' for direct-io reads, hot reload`
         },
         NSFS_CHECK_BUCKET_BOUNDARIES: {
             type: 'boolean',
-            default: true,
-            description: `indicate whether bucket boundaries should be checked, hot reload`
+            doc: `indicate whether bucket boundaries should be checked, hot reload`
         },
         NSFS_TRIGGER_FSYNC: {
             type: 'boolean',
-            default: true,
-            description: 'indicate whether fsync should be triggered, changing value to false is unsafe for production envs, hot reload'
+            doc: 'indicate whether fsync should be triggered, changing value to false is unsafe for production envs, hot reload'
         },
         S3_SERVER_IP_WHITELIST: {
             type: 'array',
-            default: [],
-            description: 'Whitelist of server IPs for S3 access, Allow access to all the IPs if list is empty.'
+            items: {
+                type: 'string'
+            },
+            doc: 'Whitelist of server IPs for S3 access, Allow access to all the IPs if list is empty.'
         },
         NSFS_DIR_CACHE_MAX_DIR_SIZE: {
             type: 'number',
-            default: 64 * 1024 * 1024,
-            description: 'maximum directory size of the dir cache, suggested values 256MB, service restart required'
+            doc: 'maximum directory size of the dir cache, suggested values 256MB, service restart required'
         },
         NSFS_DIR_CACHE_MAX_TOTAL_SIZE: {
             type: 'number',
-            default: 4 * 64 * 1024 * 1024,
-            description: 'maximum size of the dir cache, suggested values 768MB, service restart required'
+            doc: 'maximum size of the dir cache, suggested values 768MB, service restart required'
         },
         ENABLE_DEV_RANDOM_SEED: {
             type: 'boolean',
-            default: false,
-            description: 'This flag will enable the random seeding for the application'
+            doc: 'This flag will enable the random seeding for the application'
         },
         NC_MASTER_KEYS_STORE_TYPE: {
             enum: ['file', 'executable'],
             type: 'string',
-            description: 'This flag will set the master keys store type'
+            doc: 'This flag will set the master keys store type'
         },
         NC_MASTER_KEYS_FILE_LOCATION: {
             type: 'string',
-            description: 'This flag will set the master keys file location'
+            doc: 'This flag will set the master keys file location'
         },
         NC_MASTER_KEYS_GET_EXECUTABLE: {
             type: 'string',
-            description: 'This flag will set the location of the executable script for reading the master keys file used by NooBa.'
+            doc: 'This flag will set the location of the executable script for reading the master keys file used by NooBa.'
         },
         NC_MASTER_KEYS_PUT_EXECUTABLE: {
             type: 'string',
-            description: 'This flag will set the location of the executable script for updating the master keys file used by NooBa.'
+            doc: 'This flag will set the location of the executable script for updating the master keys file used by NooBa.'
         },
         VIRTUAL_HOSTS: {
             type: 'string',
-            description: 'This flag will set the virtual hosts, service restart required, Set the virtual hosts as string of domains sepreated by spaces.'
+            doc: 'This flag will set the virtual hosts, service restart required, Set the virtual hosts as string of domains sepreated by spaces.'
         }
     }
 };
@@ -138,16 +120,13 @@ const nsfs_node_config_schema = {
 module.exports = {
     $id: 'nsfs_config_schema',
     type: 'object',
-    description: 'nsfs configuration shared across all hosts and host_customization nsfs configuration',
+    doc: 'nsfs configuration shared across all hosts and host_customization nsfs configuration',
     properties: {
         ...nsfs_node_config_schema.properties,
         host_customization: {
             type: 'object',
-            additionalProperties: { $ref: '#/definitions/nsfs_node_config_schema' },
-            description: 'nsfs configuration per host'
+            additionalProperties: nsfs_node_config_schema,
+            doc: 'nsfs configuration per host'
         }
-    },
-    definitions: {
-        nsfs_node_config_schema: nsfs_node_config_schema
     }
 };


### PR DESCRIPTION
### Explain the changes
1. Add `strictify` on `nsfs_config_schema`.
2. Change the structure of the schema `nsfs_config_schema`:
    - Replace the `description` with `doc`.
    - Remove `default`.
    - In `NSFS_WHITELIST` which is type `array` add `items` under it.
    - Remove the `definitions` in `nsfs_config_schema` and set the `additionalProperties` to `nsfs_node_config_schema`.
3. Edit the printings in `load_nsfs_nc_config`.

### Issues: Fixed #7874
1. Those changes are originally from after setting `strictify` on `nsfs_config_schema` and handling the errors.

#### GAPS:
1. GAP - I think we should add validations to some of the properties, for example: `NSFS_WHITELIST` is validated when the user passes the command `sudo node src/cmd/manage_nsfs whitelist  --ips <list-og-ips>` using `verify_whitelist_ips`:
https://github.com/noobaa/noobaa-core/blob/d1bf8c465af745dedbff9d3803ec13da344884ba/src/cmd/manage_nsfs.js#L993-L1000
2. GAP (suggestion) - We can translate our recommendations in the schema, for example: ports values 1-65535 using a definition that we have:
https://github.com/noobaa/noobaa-core/blob/d1bf8c465af745dedbff9d3803ec13da344884ba/src/api/common_api.js#L1204-L1208
In other cases, for example `ENDPOINT_FORKS` to be `minimum` 0 and `maximum` 64 and remove the suggestions from the `doc` part.

### Testing Instructions:
#### Unit Tests
1. Run the schema unit tests: `npx jest test_nc_nsfs_config_schema_validation.test.js`

#### Manual Tests
To see that the config is used when running the nsfs server.
1. Check your hostname, run: `hostname` in your terminal (this will be the `<hostname-output>` in the next step).
2. Add a config file: `sudo vi /etc/noobaa.conf.d/config.json` In this example we added 2 opposite values of `ALLOW_HTTP`
```json
 {
     "ALLOW_HTTP": false,
     "host_customization": {
         "<hostname-output>": {
             "ALLOW_HTTP": true
         }
     }
 }
```
3. Start the server: `sudo node src/cmd/nsfs --debug 5`
5. Notice the printings (`my-mac` is an example of a hostname):
```bash
nsfs: config_dir_path=/etc/noobaa.conf.d
nsfs: config.json= {
  ALLOW_HTTP: false,
  host_customization: { 'my-mac': { ALLOW_HTTP: true } }
}
nsfs: merged config.json= { ALLOW_HTTP: true }
```

```bash
[nsfs/75607]    [L0] core.endpoint.endpoint:: Starting S3 HTTP 6001
[nsfs/75607]    [L0] core.endpoint.endpoint:: Started S3 HTTP successfully
```

- [ ] Doc added/updated
- [ ] Tests added
