### PR TITLE
[NSFS | NC] Simplify GLACIER xattr + minor fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -757,6 +757,12 @@ config.NSFS_GLACIER_RESTORE_INTERVAL = 15 * 60 * 1000;
 // of `manage_nsfs glacier expiry`
 config.NSFS_GLACIER_EXPIRY_INTERVAL = 12 * 60 * 60 * 1000;
 
+/** @type {'UTC' | 'LOCAL'} */
+config.NSFS_GLACIER_EXPIRY_TZ = 'LOCAL';
+
+// Format must be HH:MM:SS
+config.NSFS_GLACIER_EXPIRY_TIME_OF_DAY = '00:00:00';
+
 ////////////////////////////
 // NSFS NON CONTAINERIZED //
 ////////////////////////////

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -235,7 +235,6 @@ const static std::vector<std::string> USER_XATTRS{
     "user.noobaa.part_etag",
     "user.storage_class",
     "user.noobaa.restore.request",
-    "user.noobaa.restore.ongoing",
     "user.noobaa.restore.expiry",
 };
 
@@ -1346,7 +1345,7 @@ struct FileWrap : public Napi::ObjectWrap<FileWrap>
     }
     ~FileWrap()
     {
-        if (_fd) {
+        if (_fd >= 0) {
             LOG("FS::FileWrap::dtor: file not closed " << DVAL(_path) << DVAL(_fd));
             int r = ::close(_fd);
             if (r) LOG("FS::FileWrap::dtor: file close failed " << DVAL(_path) << DVAL(_fd) << DVAL(r));

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -1065,3 +1065,11 @@ interface S3Select {
 }
 
 type NodeCallback<T = void> = (err: Error | null, res?: T) => void;
+
+type RestoreState = 'CAN_RESTORE' | 'ONGOING' | 'RESTORED';
+
+interface RestoreStatus {
+  state: nb.RestoreState;
+  ongoing?: boolean;
+  expiry_time?: Date;
+}

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -561,12 +561,10 @@ mocha.describe('namespace_fs', function() {
 
                 // Don't leak the xattrs to the user
                 assert.strictEqual(restore_objectmd.xattr['user.noobaa.restore.request'], undefined);
-                assert.strictEqual(restore_objectmd.xattr['user.noobaa.restore.ongoing'], undefined);
                 assert.strictEqual(restore_objectmd.xattr['user.noobaa.restore.expiry'], undefined);
 
                 const xattr = await get_xattr(path.join(ns_tmp_bucket_path, temp_restore_key));
                 assert.strictEqual(xattr['user.noobaa.restore.request'], '1');
-                assert.strictEqual(xattr['user.noobaa.restore.ongoing'], undefined);
                 assert.strictEqual(xattr['user.noobaa.restore.expiry'], undefined);
 
                 // disallows duplicate restore requests


### PR DESCRIPTION
### Explain the changes
This PR:
1. Reduces the total number of `xattr` in GLACIER from 4 to 2.
    1. Removed `user.noobaa.restore.ongoing` attr.
    2. Removed `user.noobaa.restore.staged` attr.
    3. Refer `get_restore_status` function if interested in state resolution logic.
4. Fixes invalid fd check is `fs_napi.cpp`.
5. Adds logging to `tapecloud.js`.
6. Prevents `storage_class` being shown as part of metadata.
7. Handle the case where filtered persistent log is empty.

- [ ] Doc added/updated
- [ ] Tests added
