### PR TITLE
NSFS | NC | health giving trimmed output in pipe

### DIFF
--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -424,8 +424,9 @@ async function main(argv = minimist(process.argv.slice(2))) {
         if (deployment_type === 'nc') {
             const health = new NSFSHealth({ https_port, config_root, all_account_details, all_bucket_details, check_syslog_ng });
             const health_status = await health.nc_nsfs_health();
-            process.stdout.write(JSON.stringify(health_status) + '\n');
-            process.exit(0);
+            process.stdout.write(JSON.stringify(health_status) + '\n', () => {
+                process.exit(0);
+            });
         } else {
             dbg.log0('Health is not supported for simple nsfs deployment.');
         }

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -22,7 +22,7 @@ const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_response
 const tmp_fs_path = path.join(TMP_PATH, 'test_bucketspace_fs');
 const DEFAULT_FS_CONFIG = get_process_fs_context();
 
-const timeout = 10000;
+const timeout = 50000;
 
 // eslint-disable-next-line max-lines-per-function
 describe('manage nsfs cli account flow', () => {


### PR DESCRIPTION
### Explain the changes
1. if the size of health output is bucket/account details output getting trimmed when using with pipe 
usr/local/noobaa-core/bin/node /usr/local/noobaa-core/src/cmd/health --all_bucket_details | cat
2. Update timeout for test_nc_nsfs_account_cli.test.js
3. remove unused `iam_json_schema` and `iam_ttl`

with pipe `cat` or `tee` operation getting first batch of output and before flushing second set of data process is getting exited for health command. This change will remove the `process.exit()` from code and make sure complete output is printed/saved to terminal/file

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7894

### Testing Instructions:
1. run below command and make sure output size more than 64 bytes
usr/local/noobaa-core/bin/node /usr/local/noobaa-core/src/cmd/health --all_bucket_details | cat


- [ ] Doc added/updated
- [ ] Tests added
