### PR TITLE
NSFS | NC | Allow unset 'new_buckets_path'

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -390,6 +390,10 @@ async function fetch_account_data(action, user_input) {
     // secret_key as SensitiveString
     data.access_keys[0].secret_key = _.isUndefined(data.access_keys[0].secret_key) ? undefined :
         new SensitiveString(String(data.access_keys[0].secret_key));
+    // fs_backend deletion specified with empty string '' (but it is not part of the schema)
+    data.nsfs_account_config.fs_backend = data.nsfs_account_config.fs_backend || undefined;
+    // new_buckets_path deletion specified with empty string ''
+    data.nsfs_account_config.new_buckets_path = data.nsfs_account_config.new_buckets_path || undefined;
     // allow_bucket_creation either set by user or infer from new_buckets_path
     if (_.isUndefined(user_input.allow_bucket_creation)) {
         data.allow_bucket_creation = !_.isUndefined(data.nsfs_account_config.new_buckets_path);
@@ -398,8 +402,6 @@ async function fetch_account_data(action, user_input) {
     } else { // string of true or false
         data.allow_bucket_creation = user_input.allow_bucket_creation.toLowerCase() === 'true';
     }
-    // fs_backend deletion specified with empty string '' (but it is not part of the schema)
-    data.nsfs_account_config.fs_backend = data.nsfs_account_config.fs_backend || undefined;
 
     return data;
 }

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -557,6 +557,25 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
         });
 
+        it('cli update account unset new_buckets_path', async () => {
+            const { name } = defaults;
+            //in exec_manage_cli an empty string is passed as no input. so operation fails on invalid type. use the string '' instead 
+            const empty_string = '\'\'';
+            const account_options = { config_root, name, new_buckets_path: empty_string};
+            const action = ACTIONS.UPDATE;
+            await exec_manage_cli(type, action, account_options);
+            let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            expect(new_account_details.nsfs_account_config.new_buckets_path).toBeUndefined();
+            expect(new_account_details.allow_bucket_creation).toBe(false);
+
+            //set new_buckets_path value back to its original value
+            account_options.new_buckets_path = defaults.new_buckets_path;
+            await exec_manage_cli(type, action, account_options);
+            new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            expect(new_account_details.nsfs_account_config.new_buckets_path).toBe(defaults.new_buckets_path);
+            expect(new_account_details.allow_bucket_creation).toBe(true);
+        });
+
     });
 
     describe('cli list account', () => {


### PR DESCRIPTION
### Explain the changes
1. Add a condition to set `new_buckets_path` to be undefined

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7828

### Testing Instructions:
1. Create an account with new_buckets_path (allow_bucket_creation inferred to be true): `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /tmp/nsfs_root1 --uid <uid> --gid <gid>`
2. update account to have empty new_buckets_path: `node src/cmd/manage_nsfs account update --name=<account-name> --new_buckets_path=''`
3. account json should not have `new_buckets_path` field and `allow_bucket_creation` should be set to false

Unit Tests:
`sudo npx jest test_nc_nsfs_account_cli.test.js`

- [ ] Doc added/updated
- [x] Tests added
