### PR TITLE
bucket_logging: Change bucket API's and functions as per schema

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -827,9 +827,6 @@ module.exports = {
             reply: {
                 type: 'object',
                 properties: {
-                    name: {
-                        $ref: 'common_api#/definitions/bucket_name'
-                    },
                     log_bucket: {
                         $ref: 'common_api#/definitions/bucket_name'
                     },

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -393,7 +393,6 @@ async function put_bucket_logging(req) {
     dbg.log0('put_bucket_logging:', req.rpc_params);
     const bucket = find_bucket(req);
     const logging = {
-                        "name": bucket.name,
                         "log_bucket": req.rpc_params.log_bucket,
                         "log_prefix": req.rpc_params.log_prefix
                     };
@@ -414,9 +413,8 @@ async function get_bucket_logging(req) {
     const bucket = find_bucket(req);
 
     const logging = {
-        "name": bucket.name,
-        "log_bucket": bucket.logging.log_bucket,
-        "log_prefix": bucket.logging.log_prefix
+        "log_bucket": bucket.logging?.log_bucket || "Not Configured",
+        "log_prefix": bucket.logging?.log_prefix || "Not Configured"
     };
     return logging;
 }


### PR DESCRIPTION
We do not store name of the bucket, on which we are setting bucket logging, in bucket schema.
There is no need to return that name as part of get_bucket_logging and store it as part of put_bucket_logging

Also, made changed to return a correct value in case of bucket logging is configured for a bucket.
