### PR TITLE
Bucket API Scehma: Remove "name" field from logging

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1065,11 +1065,8 @@ module.exports = {
 
         logging: {
             type: 'object',
-            required: ['name', 'log_bucket', 'log_prefix'],
+            required: ['log_bucket', 'log_prefix'],
             properties: {
-                name: {
-                    $ref: 'common_api#/definitions/bucket_name',
-                },
                 log_bucket: {
                     $ref: 'common_api#/definitions/bucket_name',
                 },


### PR DESCRIPTION
We do not need name field of the source bucket to be present in logging.


