### PR TITLE
NSFS | NC | Avoid Updating Config When No Update Property Was Sent

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -874,6 +874,7 @@ async function validate_input_types(type, action, argv) {
     delete input_options_with_data._;
     validate_no_extra_options(type, action, input_options, false);
     validate_options_type_by_value(input_options_with_data);
+    if (action === ACTIONS.UPDATE) validate_min_flags_for_update(type, input_options_with_data);
 
     // currently we use from_file only in add action
     const path_to_json_options = argv.from_file ? String(argv.from_file) : '';
@@ -993,6 +994,28 @@ function validate_boolean_string_value(value) {
         return true;
     }
     return false;
+}
+
+/**
+ * validate_min_flags_for_update validates that we have at least one flag of a property to update
+ * @param {string} type
+ * @param {object} input_options_with_data
+ */
+function validate_min_flags_for_update(type, input_options_with_data) {
+    const input_options = Object.keys(input_options_with_data);
+    const config_and_identifier_options = ['config_root', 'config_root_backend', 'name'];
+
+    // GAP - mandatory flags check should be earlier in the calls in general
+    if (_.isUndefined(input_options_with_data.name)) {
+        if (type === TYPES.ACCOUNT) throw_cli_error(ManageCLIError.MissingAccountNameFlag);
+        if (type === TYPES.BUCKET) throw_cli_error(ManageCLIError.MissingBucketNameFlag);
+    }
+
+    const flags_for_update = input_options.filter(option => !config_and_identifier_options.includes(option));
+    if (flags_for_update.length === 0 ||
+        (flags_for_update.length === 1 && input_options_with_data.regenerate === 'false')) {
+            throw_cli_error(ManageCLIError.MissingUpdateProperty);
+        }
 }
 
 ///////////////////////////////

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -107,6 +107,12 @@ ManageCLIError.InvalidJSONFile = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.MissingUpdateProperty = Object.freeze({
+    code: 'MissingUpdateProperty',
+    message: 'Should have at least one property to update',
+    http_code: 400,
+});
+
 //////////////////////////////
 //// IP WHITE LIST ERRORS ////
 //////////////////////////////

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -654,6 +654,21 @@ describe('manage nsfs cli account flow', () => {
             expect(new_account_details.force_md5_etag).toBeUndefined();
         });
 
+        it('should fail - cli update account without a property to update', async () => {
+            const action = ACTIONS.UPDATE;
+            const { name } = defaults;
+            const account_options = { config_root, name };
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.MissingUpdateProperty.message);
+        });
+
+        it('should fail - cli update account without a property to update (regenerate false)', async () => {
+            const action = ACTIONS.UPDATE;
+            const { name } = defaults;
+            const account_options = { config_root, name, regenerate: 'false' };
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.MissingUpdateProperty.message);
+        });
     });
 
     describe('cli list account', () => {

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -453,6 +453,13 @@ describe('cli update bucket', () => {
         bucket_config = await read_config_file(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name);
         expect(bucket_config.force_md5_etag).toBeUndefined();
     });
+
+    it('should fail - cli update bucket without a property to update', async () => {
+        const action = ACTIONS.UPDATE;
+        const account_options = { config_root, name: bucket_defaults.name };
+        const res = await exec_manage_cli(TYPES.BUCKET, action, account_options);
+        expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.MissingUpdateProperty.message);
+    });
 });
 
 /**

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -213,6 +213,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
         const email = 'account_wrong_uid0@noobaa.com';
         const account = await rpc_client.account.read_account({ email: email });
         const default_resource = account.default_resource;
+        const is_nc_coretest = process.env.NC_CORETEST === 'true';
         const arr = [{ nsfs_account_config: { uid: 26041993 }, default_resource, should_fail: false },
             {
                 nsfs_account_config: { new_buckets_path: 'dummy_dir1/' },
@@ -223,8 +224,8 @@ mocha.describe('bucket operations - namespace_fs', function() {
             {
                 nsfs_account_config: {},
                 default_resource,
-                should_fail: !process.env.NC_CORETEST,
-                error_code: 'FORBIDDEN'
+                should_fail: true,
+                error_code: is_nc_coretest ? ManageCLIError.MissingUpdateProperty.code : 'FORBIDDEN'
             },
             { nsfs_account_config: { uid: 26041992 }, default_resource, should_fail: false }
         ];
@@ -443,9 +444,11 @@ mocha.describe('bucket operations - namespace_fs', function() {
         const email = `${no_permissions_dn}@noobaa.io`;
         const account = await rpc_client.account.read_account({ email: email });
         const default_resource = account.default_resource;
+        const is_nc_coretest = process.env.NC_CORETEST === 'true';
         const arr = [
-            { nsfs_account_config: { distinguished_name: 'bla' }, default_resource, should_fail: process.env.NC_CORETEST, error_code: ManageCLIError.InvalidAccountDistinguishedName.code }, { nsfs_account_config: { new_buckets_path: 'dummy_dir1/' }, default_resource, should_fail: process.env.NC_CORETEST, error_code: ManageCLIError.InvalidAccountNewBucketsPath.code },
-            { nsfs_account_config: {}, default_resource, should_fail: !process.env.NC_CORETEST, error_code: 'FORBIDDEN' },
+            { nsfs_account_config: { distinguished_name: 'bla' }, default_resource, should_fail: process.env.NC_CORETEST, error_code: ManageCLIError.InvalidAccountDistinguishedName.code },
+            { nsfs_account_config: { new_buckets_path: 'dummy_dir1/' }, default_resource, should_fail: process.env.NC_CORETEST, error_code: ManageCLIError.InvalidAccountNewBucketsPath.code },
+            { nsfs_account_config: {}, default_resource, should_fail: true, error_code: is_nc_coretest ? ManageCLIError.MissingUpdateProperty.code : 'FORBIDDEN' },
             { nsfs_account_config: { distinguished_name: 'root' }, default_resource, should_fail: false },
             {
                 nsfs_account_config: { distinguished_name: no_permissions_dn, new_buckets_path: public_new_buckets_dir, },


### PR DESCRIPTION
### Explain the changes
1. Add function `validate_min_flags_for_update` to validate that we have at least one flag of a property to update (for bucket and account).
2. Add new error `MissingUpdateProperty`.
3. Changes in `test_bucketspace.js` (in item `arr[2]`) due to this change we had a couple of tests failing and adding a newline in the arr between 2 items.

### Issues: Fixed #7872 
1. Currently, when running an account update only with the flag `name` (without actual change) the response is `AccountUpdated`, although nothing was updated (same for bucket).
2. GAP - mandatory flags check should be earlier in the calls in general, specially identifiers for the commands.

### Testing Instructions:
#### Manual Tests:
1. First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/` `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
2. Create an account: `sudo node src/cmd/manage_nsfs account add --name <account-name> --uid <uid> --gid <gid> --new_buckets_path <new_buckets_path>`
3. Update the account using the `name` flag only: `sudo node src/cmd/manage_nsfs account update --name <account-name>`
4. Create a bucket: `sudo node src/cmd/manage_nsfs bucket add --name <bucket-name> --owner <account-name> --path <path>` (use the `--owner` from the previous account add command).
5. Update the bucket using the `name` flag only: `sudo node src/cmd/manage_nsfs bucket update --name <bucket-name>`

#### Unit Tests:
Please run:
- `sudo npx jest test_nc_nsfs_account_cli.test.js`
- `sudo npx jest test_nc_nsfs_bucket_cli.test.js`
- `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace.js`
- `make root-perm-test CONTAINER_PLATFORM=linux/arm64` (since I have MacOS I need to add the `CONTAINER_PLATFORM=linux/arm64`) to make sure the tests also passes in the container run of NSFS.

- [ ] Doc added/updated
- [X] Tests added
