### PR TITLE
NSFS | NC | Manage NSFS | Remove `wide` Property from Fetch Data

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -136,7 +136,6 @@ async function fetch_bucket_data(action, user_input) {
         owner_account: undefined,
         system_owner: user_input.owner, // GAP - needs to be the system_owner (currently it is the account name)
         bucket_owner: user_input.owner,
-        wide: _.isUndefined(user_input.wide) ? undefined : get_boolean_or_string_value(user_input.wide),
         tag: undefined, // if we would add the option to tag a bucket using CLI, this should be changed
         versioning: action === ACTIONS.ADD ? 'DISABLED' : undefined,
         creation_date: action === ACTIONS.ADD ? new Date().toISOString() : undefined,
@@ -321,7 +320,8 @@ async function manage_bucket_operations(action, data, user_input) {
         await delete_bucket(data);
     } else if (action === ACTIONS.LIST) {
         const bucket_filters = _.pick(user_input, LIST_BUCKET_FILTERS);
-        const buckets = await list_config_files(TYPES.BUCKET, buckets_dir_path, data.wide, undefined, bucket_filters);
+        const wide = get_boolean_or_string_value(user_input.wide);
+        const buckets = await list_config_files(TYPES.BUCKET, buckets_dir_path, wide, undefined, bucket_filters);
         write_stdout_response(ManageCLIResponse.BucketList, buckets);
     } else {
         // we should not get here (we check it before)
@@ -365,7 +365,6 @@ async function fetch_account_data(action, user_input) {
         name: _.isUndefined(user_input.name) ? undefined : String(user_input.name),
         email: _.isUndefined(user_input.name) ? undefined : String(user_input.name), // temp, keep the email internally
         creation_date: action === ACTIONS.ADD ? new Date().toISOString() : undefined,
-        wide: _.isUndefined(user_input.wide) ? undefined : get_boolean_or_string_value(user_input.wide),
         new_name: _.isUndefined(user_input.new_name) ? undefined : String(user_input.new_name),
         new_access_key,
         access_keys,
@@ -572,7 +571,8 @@ async function manage_account_operations(action, data, show_secrets, user_input)
         await delete_account(data);
     } else if (action === ACTIONS.LIST) {
         const account_filters = _.pick(user_input, LIST_ACCOUNT_FILTERS);
-        const accounts = await list_config_files(TYPES.ACCOUNT, accounts_dir_path, data.wide, show_secrets, account_filters);
+        const wide = get_boolean_or_string_value(user_input.wide);
+        const accounts = await list_config_files(TYPES.ACCOUNT, accounts_dir_path, wide, show_secrets, account_filters);
         write_stdout_response(ManageCLIResponse.AccountList, accounts);
     } else {
         // we should not get here (we check it before)

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -647,6 +647,12 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['account3', 'account2', 'account1']));
+            // added additional properties that we can see with wide option (uid, new_buckets_path)
+            expect(JSON.parse(res).response.reply.map(item => item.nsfs_account_config.uid))
+                .toEqual(expect.arrayContaining([999, 888]));
+            expect(JSON.parse(res).response.reply.map(item => item.nsfs_account_config.new_buckets_path))
+                .toEqual(expect.arrayContaining([`${root_path}new_buckets_path_user1/`,
+                    `${root_path}new_buckets_path_user2/`, `${root_path}new_buckets_path_user3/`]));
         });
 
         it('cli list wide (use the flag with value "true"', async () => {


### PR DESCRIPTION
### Explain the changes
1. Remove wide property from ` fetch_bucket_data` `fetch_account_data`.
2. Edit test with list wide to make sure there is a difference between list and list with wide flag.

### Issues: Fixed #7871 
1. Currently, the `wide` property is fetched inside `fetch_bucket_data` and `fetch_account_data` while it is not a property of an account or bucket.

### Testing Instructions:
#### Manual Tests:
1. Create a couple of accounts and a couple of buckets (using Manage NSFS).
3. List accounts using wide flag: `sudo node src/cmd/manage_nsfs account list --wide`
4. List buckets using wide flag: `sudo node src/cmd/manage_nsfs bucket list --wide`

#### Unit Tests:
- `sudo npx jest test_nc_nsfs_account_cli.test.js` (for example: 'cli list wide').
- `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js` (for example: 'cli bucket list - wide')

- [ ] Doc added/updated
- [ ] Tests added
