### PR TITLE
[NC | NSFS] Improve time bounds for glacier operations

### DIFF
--- a/config.js
+++ b/config.js
@@ -734,7 +734,7 @@ config.NSFS_EXIT_EVENTS_TIME_FRAME_MIN = 24 * 60; // per day
 config.NSFS_MAX_EXIT_EVENTS_PER_TIME_FRAME = 10; // allow max 10 failed forks per day
 
 config.NSFS_GLACIER_LOGS_DIR = '/var/run/noobaa-nsfs/wal';
-config.NSFS_GLACIER_LOGS_MAX_INTERVAL = 15 * 60 * 1000;
+config.NSFS_GLACIER_LOGS_POLL_INTERVAL = 10 * 1000;
 
 // NSFS_GLACIER_ENABLED can override internal autodetection and will force
 // the use of restore for all objects.

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -3011,7 +3011,7 @@ class NamespaceFS {
     static get migrate_wal() {
         if (!NamespaceFS._migrate_wal) {
             NamespaceFS._migrate_wal = new PersistentLogger(config.NSFS_GLACIER_LOGS_DIR, GlacierBackend.MIGRATE_WAL_NAME, {
-                max_interval: config.NSFS_GLACIER_LOGS_MAX_INTERVAL,
+                poll_interval: config.NSFS_GLACIER_LOGS_POLL_INTERVAL,
                 locking: 'SHARED',
             });
         }
@@ -3022,7 +3022,7 @@ class NamespaceFS {
     static get restore_wal() {
         if (!NamespaceFS._restore_wal) {
             NamespaceFS._restore_wal = new PersistentLogger(config.NSFS_GLACIER_LOGS_DIR, GlacierBackend.RESTORE_WAL_NAME, {
-                max_interval: config.NSFS_GLACIER_LOGS_MAX_INTERVAL,
+                poll_interval: config.NSFS_GLACIER_LOGS_POLL_INTERVAL,
                 locking: 'SHARED',
             });
         }

--- a/src/sdk/nsfs_glacier_backend/backend.js
+++ b/src/sdk/nsfs_glacier_backend/backend.js
@@ -60,9 +60,10 @@ class GlacierBackend {
      * NOTE: This needs to be implemented by each backend.
      * @param {nb.NativeFSContext} fs_context
      * @param {string} log_file log filename
+     * @param {(entry: string) => Promise<void>} failure_recorder
      * @returns {Promise<boolean>}
      */
-    async migrate(fs_context, log_file) {
+    async migrate(fs_context, log_file, failure_recorder) {
         throw new Error('Unimplementented');
     }
 
@@ -77,9 +78,10 @@ class GlacierBackend {
      * NOTE: This needs to be implemented by each backend.
      * @param {nb.NativeFSContext} fs_context
      * @param {string} log_file log filename
+     * @param {(entry: string) => Promise<void>} failure_recorder
      * @returns {Promise<boolean>}
      */
-    async restore(fs_context, log_file) {
+    async restore(fs_context, log_file, failure_recorder) {
         throw new Error('Unimplementented');
     }
 

--- a/src/sdk/nsfs_glacier_backend/tapecloud.js
+++ b/src/sdk/nsfs_glacier_backend/tapecloud.js
@@ -1,12 +1,17 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
+const { spawn } = require("child_process");
+const events = require('events');
+const os = require("os");
+const path = require("path");
 const { PersistentLogger } = require("../../util/persistent_logger");
 const { NewlineReader } = require('../../util/file_reader');
 const { GlacierBackend } = require("./backend");
 const config = require('../../../config');
-const path = require("path");
 const { exec } = require('../../util/os_utils');
+const nb_native = require("../../util/nb_native");
+const { get_process_fs_context } = require("../../util/native_fs_utils");
 const dbg = require('../../util/debug_module')(__filename);
 
 const ERROR_DUPLICATE_TASK = "GLESM431E";
@@ -21,11 +26,63 @@ function get_bin_path(bin_name) {
     return path.join(config.NSFS_GLACIER_TAPECLOUD_BIN_DIR, bin_name);
 }
 
-async function get_task(task_id) {
-    return await exec(`${get_bin_path(TASK_SHOW_SCRIPT)} ${task_id}`, { return_stdout: true });
+/**
+ * @param {*} task_id 
+ * @param {(entry: string) => Promise<void>} recorder 
+ */
+async function record_failed_tasks(task_id, recorder) {
+    const fs_context = get_process_fs_context();
+    const tmp = path.join(os.tmpdir(), `eeadm_task_out_${Date.now()}`);
+
+    let temp_fh = null;
+    let reader = null;
+    try {
+        temp_fh = await nb_native().fs.open(fs_context, tmp, 'rw');
+
+        const proc = spawn(get_bin_path(TASK_SHOW_SCRIPT), [task_id], {
+            stdio: ['pipe', temp_fh.fd, temp_fh.fd],
+        });
+
+        const [errcode] = await events.once(proc, 'exit');
+        if (errcode) {
+            throw new Error('process exited with non-zero exit code:', errcode);
+        }
+
+        reader = new NewlineReader(fs_context, tmp);
+        await reader.forEach(async line => {
+            if (!line.startsWith("Fail")) return;
+
+            const parsed = line.split(/\s+/);
+            if (parsed.length !== 6) {
+                throw new Error('failed to parse task show');
+            }
+
+            if (parsed[1] !== ERROR_DUPLICATE_TASK) {
+                // Column 5 is the filename (refer tapecloud [eeadm] manual)
+                await recorder(parsed[5]);
+            }
+
+            return true;
+        });
+    } finally {
+        if (temp_fh) {
+            await temp_fh.close(fs_context);
+            await nb_native().fs.unlink(fs_context, tmp);
+        }
+
+        if (reader) {
+            await reader.close();
+        }
+    }
 }
 
-async function tapecloud_failure_handler(error) {
+/**
+ * tapecloud_failure_handler takes the error and runs task_show on the task
+ * ID to identify the failed entries and record them to the recorder
+ * @param {*} error 
+ * @param {(entry: string) => Promise<void>} recorder 
+ */
+async function tapecloud_failure_handler(error, recorder) {
     const { stdout } = error;
 
     // Find the line in the stdout which has the line 'task ID is, <id>' and extract id
@@ -37,24 +94,7 @@ async function tapecloud_failure_handler(error) {
     const task_id = match[1];
 
     // Fetch task status and see what failed
-    const taskshowstdout = await get_task(task_id);
-    return taskshowstdout
-        .split('\n')
-        .filter(line => line.startsWith("Fail"))
-        .map(line => {
-            const parsed = line.split(/\s+/);
-            if (parsed.length !== 6) {
-                throw Error('failed to parse task show');
-            }
-
-            if (parsed[1] === ERROR_DUPLICATE_TASK) {
-                return null;
-            }
-
-            // Column 5 is the filename (refer tapecloud [eeadm] manual)
-            return parsed[5];
-        })
-        .filter(Boolean);
+    await record_failed_tasks(task_id, recorder);
 }
 
 /**
@@ -66,17 +106,16 @@ async function tapecloud_failure_handler(error) {
  * The function returns the names of the files which failed
  * to migrate.
  * @param {string} file filename
- * @returns {Promise<string[]>} failedfiles
+ * @param {(entry: string) => Promise<void>} recorder 
  */
-async function migrate(file) {
+async function migrate(file, recorder) {
     try {
         dbg.log1("Starting migration for file", file);
         const out = await exec(`${get_bin_path(MIGRATE_SCRIPT)} ${file}`, { return_stdout: true });
         dbg.log4("migrate finished with:", out);
         dbg.log1("Finished migration for file", file);
-        return [];
     } catch (error) {
-        return tapecloud_failure_handler(error);
+        await tapecloud_failure_handler(error, recorder);
     }
 }
 
@@ -89,17 +128,16 @@ async function migrate(file) {
  * The function returns the names of the files which failed
  * to recall.
  * @param {string} file filename
- * @returns {Promise<string[]>} failed files
+ * @param {(entry: string) => Promise<void>} recorder 
  */
-async function recall(file) {
+async function recall(file, recorder) {
     try {
         dbg.log1("Starting recall for file", file);
         const out = await exec(`${get_bin_path(RECALL_SCRIPT)} ${file}`, { return_stdout: true });
         dbg.log4("recall finished with:", out);
         dbg.log1("Finished recall for file", file);
-        return [];
     } catch (error) {
-        return tapecloud_failure_handler(error);
+        await tapecloud_failure_handler(error, recorder);
     }
 }
 
@@ -111,7 +149,7 @@ async function process_expired() {
 }
 
 class TapeCloudGlacierBackend extends GlacierBackend {
-    async migrate(fs_context, log_file) {
+    async migrate(fs_context, log_file, failure_recorder) {
         dbg.log2('TapeCloudGlacierBackend.migrate starting for', log_file);
 
         let filtered_log = null;
@@ -120,7 +158,7 @@ class TapeCloudGlacierBackend extends GlacierBackend {
             filtered_log = new PersistentLogger(
                 config.NSFS_GLACIER_LOGS_DIR,
                 `tapecloud_migrate_run_${Date.now().toString()}`,
-                { disable_rotate: true, locking: 'EXCLUSIVE' },
+                { locking: 'EXCLUSIVE' },
             );
 
             walreader = new NewlineReader(fs_context, log_file, 'EXCLUSIVE');
@@ -135,10 +173,13 @@ class TapeCloudGlacierBackend extends GlacierBackend {
                         return true;
                     }
 
-                    // Something else is wrong with this entry of this file
-                    // should skip processing this WAL for now
-                    dbg.log1('skipping log entry', entry.path, 'due to error:', err);
-                    return false;
+                    dbg.log0(
+                        'adding log entry', entry.path,
+                        'to failure recorder due to error', err,
+                    );
+                    await failure_recorder(entry.path);
+
+                    return true;
                 }
 
                 // Skip the file if it shouldn't be migrated
@@ -150,6 +191,8 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
             // If the result of the above is false then it indicates that we concluded
             // to exit early hence the file shouldn't be processed further, exit
+            //
+            // NOTE: Should not hit this case anymore
             if (!result) return false;
 
             // If we didn't read even one line then it most likely indicates that the WAL is
@@ -164,17 +207,18 @@ class TapeCloudGlacierBackend extends GlacierBackend {
             if (filtered_log.local_size === 0) return true;
 
             await filtered_log.close();
-            const failed = await this._migrate(filtered_log.active_path);
+            await this._migrate(filtered_log.active_path, failure_recorder);
 
-            // Do not delete the WAL if migration failed - This allows easy retries
-            return failed.length === 0;
+            // Delete the log if the above write succeeds or else keep it
+            return true;
         } catch (error) {
             dbg.error('unexpected error occured while processing migrate WAL:', error);
 
             // Preserve the WAL if we encounter exception here, possible failures
-            // 1.eaedm command failure
+            // 1. eeadm command failure
             // 2. tempwal failure
             // 3. newline reader failure
+            // 4. failure log failure
             return false;
         } finally {
             if (filtered_log) {
@@ -186,18 +230,18 @@ class TapeCloudGlacierBackend extends GlacierBackend {
         }
     }
 
-    async restore(fs_context, log_file) {
+    async restore(fs_context, log_file, failure_recorder) {
         dbg.log2('TapeCloudGlacierBackend.restore starting for', log_file);
 
-        let tempwal = null;
+        let filtered_log = null;
         let walreader = null;
-        let tempwalreader = null;
+        let filtered_log_reader = null;
         try {
             // tempwal will store all the files of interest and will be handed over to tapecloud script
-            tempwal = new PersistentLogger(
+            filtered_log = new PersistentLogger(
                 config.NSFS_GLACIER_LOGS_DIR,
                 `tapecloud_restore_run_${Date.now().toString()}`,
-                { disable_rotate: true, locking: 'EXCLUSIVE' },
+                { locking: 'EXCLUSIVE' },
             );
 
             walreader = new NewlineReader(fs_context, log_file, 'EXCLUSIVE');
@@ -211,7 +255,7 @@ class TapeCloudGlacierBackend extends GlacierBackend {
                     }
 
                     // Add entry to the tempwal
-                    await tempwal.append(entry.path);
+                    await filtered_log.append(entry.path);
 
                     return true;
                 } catch (error) {
@@ -220,8 +264,13 @@ class TapeCloudGlacierBackend extends GlacierBackend {
                         return true;
                     }
 
-                    // Something else is wrong so skip processing the file for now
-                    return false;
+                    dbg.log0(
+                        'adding log entry', entry.path,
+                        'to failure recorder due to error', error,
+                    );
+                    await failure_recorder(entry.path);
+
+                    return true;
                 }
             });
 
@@ -239,15 +288,14 @@ class TapeCloudGlacierBackend extends GlacierBackend {
             }
 
             // If we didn't find any candidates despite complete read, exit and delete this WAL
-            if (tempwal.local_size === 0) return true;
+            if (filtered_log.local_size === 0) return true;
 
-            await tempwal.close();
-            const failed = await this._recall(tempwal.active_path);
+            await filtered_log.close();
+            await this._recall(filtered_log.active_path, failure_recorder);
 
-            tempwalreader = new NewlineReader(fs_context, tempwal.active_path, "EXCLUSIVE");
+            filtered_log_reader = new NewlineReader(fs_context, filtered_log.active_path, "EXCLUSIVE");
 
-            // Start iteration over the WAL again
-            [processed, result] = await tempwalreader.forEachFilePathEntry(async entry => {
+            [processed, result] = await filtered_log_reader.forEachFilePathEntry(async entry => {
                 let fh = null;
                 try {
                     fh = await entry.open();
@@ -257,12 +305,6 @@ class TapeCloudGlacierBackend extends GlacierBackend {
                             GlacierBackend.XATTR_RESTORE_REQUEST,
                         ]
                     });
-
-                    // We noticed that the file has failed earlier
-                    // so mustn't have been part of the WAL, ignore
-                    if (failed.includes(entry.path)) {
-                        return true;
-                    }
 
                     const days = Number(stat.xattr[GlacierBackend.XATTR_RESTORE_REQUEST]);
                     const expires_on = GlacierBackend.generate_expiry(
@@ -295,8 +337,7 @@ class TapeCloudGlacierBackend extends GlacierBackend {
 
             if (!result) return false;
 
-            // Even if we failed to process one entry in log, preserve the WAL
-            return failed.length === 0;
+            return true;
         } catch (error) {
             dbg.error('unexpected error occured while processing restore WAL:', error);
 
@@ -307,11 +348,11 @@ class TapeCloudGlacierBackend extends GlacierBackend {
             return false;
         } finally {
             if (walreader) await walreader.close();
-            if (tempwalreader) await tempwalreader.close();
+            if (filtered_log_reader) await filtered_log_reader.close();
 
-            if (tempwal) {
-                await tempwal.close();
-                await tempwal.remove();
+            if (filtered_log) {
+                await filtered_log.close();
+                await filtered_log.remove();
             }
         }
     }
@@ -336,9 +377,10 @@ class TapeCloudGlacierBackend extends GlacierBackend {
      * 
      * NOTE: Must be overwritten for tests
      * @param {string} file 
+     * @param {(entry: string) => Promise<void>} recorder 
      */
-    async _migrate(file) {
-        return migrate(file);
+    async _migrate(file, recorder) {
+        return migrate(file, recorder);
     }
 
     /**
@@ -346,9 +388,10 @@ class TapeCloudGlacierBackend extends GlacierBackend {
      * 
      * NOTE: Must be overwritten for tests
      * @param {string} file 
+     * @param {(entry: string) => Promise<void>} recorder 
      */
-    async _recall(file) {
-        return recall(file);
+    async _recall(file, recorder) {
+        return recall(file, recorder);
     }
 
     /**

--- a/src/test/unit_tests/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/test_nsfs_glacier_backend.js
@@ -108,7 +108,7 @@ mocha.describe('nsfs_glacier', async () => {
 
 			// Check if the log contains the entry
 			let found = false;
-			await NamespaceFS.migrate_wal.process_inactive(async file => {
+			await NamespaceFS.migrate_wal._process(async file => {
 				const fs_context = glacier_ns.prepare_fs_context(dummy_object_sdk);
 				const reader = new NewlineReader(fs_context, file, 'EXCLUSIVE');
 
@@ -149,7 +149,7 @@ mocha.describe('nsfs_glacier', async () => {
 			assert(restore_res);
 
 			// Issue restore
-			await NamespaceFS.restore_wal.process_inactive(async file => {
+			await NamespaceFS.restore_wal._process(async file => {
 				const fs_context = glacier_ns.prepare_fs_context(dummy_object_sdk);
 				await backend.restore(fs_context, file);
 

--- a/src/util/file_reader.js
+++ b/src/util/file_reader.js
@@ -21,7 +21,7 @@ class NewlineReader {
      * in memory.
      * @param {nb.NativeFSContext} fs_context 
      * @param {string} filepath 
-     * @param {'EXCLUSIVE' | 'SHARED' | undefined} lock 
+     * @param {'EXCLUSIVE' | 'SHARED'} [lock]
      */
     constructor(fs_context, filepath, lock) {
         this.path = filepath;
@@ -83,7 +83,7 @@ class NewlineReader {
         let count = 0;
         while (entry !== null) {
             count += 1;
-            if (!await cb(entry)) return [count, false];
+            if ((await cb(entry)) === false) return [count, false];
 
             entry = await this.nextline();
         }


### PR DESCRIPTION
### Explain the changes
This PR attempts to:
1. Improve time bounds for glacier operations by delegating the responsibility of log rotation on the log consumer (manage_nsfs.js).
2. Add the concept of failure logging. This helps in recording the previously failed entries in a separate log whose size will be always be at most the size of the processing log. This allows for more efficient retires and at the same time provides more visibility into the functioning as the failed entries are stored in `migrate.failure.[...].log` and `restore.failure.[...].log` files.
3. Improves CLI logging

- [ ] Doc added/updated
- [ ] Tests added
