### PR TITLE
NSFS | CLI | Delete the bucket only if the bucket is empty or with --force flag

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -312,6 +312,13 @@ ManageCLIError.BucketCreationNotAllowed = Object.freeze({
     http_code: 403,
 });
 
+ManageCLIError.BucketDeleteForbiddenHasObjects = Object.freeze({
+    code: 'BucketDeleteForbiddenHasObjects',
+    message: 'Cannot delete non-empty bucket. ' +
+    'You must delete all object before deleting the bucket or use --force flag',
+    http_code: 403,
+});
+
 /////////////////////////////////
 //// BUCKET ARGUMENTS ERRORS ////
 /////////////////////////////////

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -43,7 +43,7 @@ const VALID_OPTIONS_ACCOUNT = {
 const VALID_OPTIONS_BUCKET = {
     'add': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
     'update': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'new_name', ...GLOBAL_CONFIG_OPTIONS]),
-    'delete': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
+    'delete': new Set(['name', 'force', ...GLOBAL_CONFIG_OPTIONS]),
     'list': new Set(['wide', 'name', ...GLOBAL_CONFIG_OPTIONS]),
     'status': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
 };
@@ -87,6 +87,7 @@ const OPTION_TYPE = {
     wide: 'boolean',
     show_secrets: 'boolean',
     ips: 'string',
+    force: 'boolean'
 };
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -163,6 +163,7 @@ bucket delete [flags]
 
 Flags:
 --name <string>                                                         The name of the bucket
+--force                                               (optional)        Forcefully delete bucket if the bucket is not empty
 `;
 
 const BUCKET_FLAGS_STATUS = `

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -418,7 +418,7 @@ async function put_bucket_policy_manage(options) {
  * @returns {Promise<void>}
  */
 async function delete_bucket_manage(options) {
-    const cli_options = { name: options.name };
+    const cli_options = { name: options.name, force: true };
     await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, cli_options);
 }
 


### PR DESCRIPTION
### Explain the changes
1. Deletes the bucket with out checking if there is an object inside the bucket. This change will check whether the bucket is empty or not
2. check for temp folder and do not consider temp folder for empty condition
3. add --force flag to delete bucket even if its not empty

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7902

### Testing Instructions:
1. create a bucket add objects to it and try to delete with bucket CLI command, should throw error `BucketDeleteForbiddenHasObjects`
2. create a bucket add objects to it and try to delete with --force flag, bucket should get delete.


- [ ] Doc added/updated
- [X] Tests added
