### PR TITLE
NSFS | NC | Manage NSFS | Create bucket - Add Check If Bucket Owner Has `rw_access` to Underlying Path

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -199,13 +199,11 @@ function get_symlink_config_file_path(config_type_path, file_name) {
 
 async function add_bucket(data) {
     await validate_bucket_args(data, ACTIONS.ADD);
-    const account_id = await verify_bucket_owner(data.bucket_owner, ACTIONS.ADD);
     const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
     const bucket_conf_path = get_config_file_path(buckets_dir_path, data.name);
     const exists = await native_fs_utils.is_path_exists(fs_context, bucket_conf_path);
     if (exists) throw_cli_error(ManageCLIError.BucketAlreadyExists, data.name, { bucket: data.name });
     data._id = mongo_utils.mongoObjectId();
-    data.owner_account = account_id;
     const data_json = JSON.stringify(data);
     // We take an object that was stringify
     // (it unwraps ths sensitive strings, creation_date to string and removes undefined parameters)
@@ -215,19 +213,16 @@ async function add_bucket(data) {
     write_stdout_response(ManageCLIResponse.BucketCreated, data_json, { bucket: data.name });
 }
 
-/** verify_bucket_owner will check if the bucket_owner has an account
- * bucket_owner is the account name in the account schema
- * after it finds one, it returns the account id, otherwise it would throw an error
- * (in case the action is add bucket it also checks that the owner has allow_bucket_creation)
+/**
+ * get_bucket_owner_account will return the account of the bucket_owner
+ * otherwise it would throw an error
  * @param {string} bucket_owner
- * @param {string} action
  */
-async function verify_bucket_owner(bucket_owner, action) {
-    // check if bucket owner exists
+async function get_bucket_owner_account(bucket_owner) {
     const account_config_path = get_config_file_path(accounts_dir_path, bucket_owner);
-    let account;
     try {
-        account = await get_config_data(account_config_path);
+        const account = await get_config_data(account_config_path);
+        return account;
     } catch (err) {
         if (err.code === 'ENOENT') {
             const detail_msg = `bucket owner ${bucket_owner} does not exists`;
@@ -235,13 +230,6 @@ async function verify_bucket_owner(bucket_owner, action) {
         }
         throw err;
     }
-    // check if bucket owner has the permission to create bucket (for bucket add only)
-    if (action === ACTIONS.ADD && !account.allow_bucket_creation) {
-            const detail_msg = `${bucket_owner} account not allowed to create new buckets. ` +
-            `Please make sure to have a valid new_buckets_path and enable the flag allow_bucket_creation`;
-            throw_cli_error(ManageCLIError.BucketCreationNotAllowed, detail_msg);
-    }
-    return account._id;
 }
 
 async function get_bucket_status(data) {
@@ -259,7 +247,6 @@ async function get_bucket_status(data) {
 
 async function update_bucket(data) {
     await validate_bucket_args(data, ACTIONS.UPDATE);
-    await verify_bucket_owner(data.bucket_owner, ACTIONS.UPDATE);
 
     const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
 
@@ -761,7 +748,7 @@ function get_access_keys(action, user_input) {
 async function validate_bucket_args(data, action) {
     if (action === ACTIONS.DELETE || action === ACTIONS.STATUS) {
         if (_.isUndefined(data.name)) throw_cli_error(ManageCLIError.MissingBucketNameFlag);
-    } else {
+    } else { // action === ACTIONS.ADD || action === ACTIONS.UPDATE
         if (_.isUndefined(data.name)) throw_cli_error(ManageCLIError.MissingBucketNameFlag);
         try {
             native_fs_utils.validate_bucket_creation({ name: data.name });
@@ -787,6 +774,20 @@ async function validate_bucket_args(data, action) {
         const exists = await native_fs_utils.is_path_exists(fs_context_fs_backend, data.path);
         if (!exists) {
             throw_cli_error(ManageCLIError.InvalidStoragePath, data.path);
+        }
+        const account = await get_bucket_owner_account(data.bucket_owner);
+        const account_fs_context = await native_fs_utils.get_fs_context(account.nsfs_account_config, data.fs_backend);
+        const accessible = await native_fs_utils.is_dir_rw_accessible(account_fs_context, data.path);
+        if (!accessible) {
+            throw_cli_error(ManageCLIError.InaccessibleStoragePath, data.path);
+        }
+        if (action === ACTIONS.ADD) {
+            if (!account.allow_bucket_creation) {
+                const detail_msg = `${data.bucket_owner} account not allowed to create new buckets. ` +
+                `Please make sure to have a valid new_buckets_path and enable the flag allow_bucket_creation`;
+                throw_cli_error(ManageCLIError.BucketCreationNotAllowed, detail_msg);
+        }
+            data.owner_account = account._id; // TODO move this assignment to better place
         }
         if (data.s3_policy) {
             try {

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -366,6 +366,11 @@ ManageCLIError.MalformedPolicy = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.InaccessibleStoragePath = Object.freeze({
+    code: 'InaccessibleStoragePath',
+    message: 'Bucket owner should have read & write access to the specified bucket storage path',
+    http_code: 400,
+});
 
 ManageCLIError.BucketNotEmpty = Object.freeze({
     code: 'BucketNotEmpty',

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -62,7 +62,7 @@ describe('manage nsfs cli bucket flow', () => {
             await fs_utils.folder_delete(`${root_path}`);
         });
 
-        it('cli create bucket invalid option type (path as number)', async () => {
+        it('should fail - cli create bucket - invalid option type (path as number)', async () => {
             const action = ACTIONS.ADD;
             const path_invalid = 4e34; // invalid should be string represents a path
             const bucket_options = { config_root, ...bucket_defaults, path: path_invalid };
@@ -70,7 +70,7 @@ describe('manage nsfs cli bucket flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgumentType.message);
         });
 
-        it('cli create bucket invalid option type (path as string)', async () => {
+        it('should fail - cli create bucket - invalid option type (path as string)', async () => {
             const action = ACTIONS.ADD;
             const path_invalid = 'aaa'; // invalid should be string represents a path
             const bucket_options = { config_root, ...bucket_defaults, path: path_invalid };
@@ -82,9 +82,53 @@ describe('manage nsfs cli bucket flow', () => {
             const action = ACTIONS.ADD;
             const force_md5_etag = 'true';
             const bucket_options = { config_root, ...bucket_defaults, force_md5_etag };
+            await fs_utils.create_fresh_path(bucket_options.path);
+            await fs_utils.file_must_exist(bucket_options.path);
+            await set_path_permissions_and_owner(bucket_options.path, account_defaults, 0o700);
             await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             const bucket = await read_config_file(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name);
             expect(bucket.force_md5_etag).toBe(true);
+        });
+
+        it('should fail - cli create bucket - owner does not have any permission to path', async () => {
+            const action = ACTIONS.ADD;
+            const bucket_options = { config_root, ...bucket_defaults};
+            await fs_utils.create_fresh_path(bucket_options.path);
+            await fs_utils.file_must_exist(bucket_options.path);
+            await set_path_permissions_and_owner(bucket_options.path, account_defaults, 0o077);
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InaccessibleStoragePath.code);
+        });
+
+        it('should fail - cli create bucket - owner does not have write permission to path', async () => {
+            const action = ACTIONS.ADD;
+            const bucket_options = { config_root, ...bucket_defaults};
+            await fs_utils.create_fresh_path(bucket_options.path);
+            await fs_utils.file_must_exist(bucket_options.path);
+            await set_path_permissions_and_owner(bucket_options.path, account_defaults, 0o477);
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InaccessibleStoragePath.code);
+        });
+
+        it('should fail - cli create bucket - owner does not have read permission to path', async () => {
+            const action = ACTIONS.ADD;
+            const bucket_options = { config_root, ...bucket_defaults};
+            await fs_utils.create_fresh_path(bucket_options.path);
+            await fs_utils.file_must_exist(bucket_options.path);
+            await set_path_permissions_and_owner(bucket_options.path, account_defaults, 0o277);
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InaccessibleStoragePath.code);
+        });
+
+        it('cli create bucket - account can access path', async () => {
+            const action = ACTIONS.ADD;
+            const bucket_options = { config_root, ...bucket_defaults};
+            await fs_utils.create_fresh_path(bucket_options.path);
+            await fs_utils.file_must_exist(bucket_options.path);
+            await set_path_permissions_and_owner(bucket_options.path, account_defaults, 0o700);
+            await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            const bucket = await read_config_file(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name);
+            assert_bucket(bucket, bucket_options);
         });
 
     });
@@ -130,6 +174,7 @@ describe('manage nsfs cli bucket flow', () => {
             const bucket_options = { config_root, ...bucket_defaults };
             await fs_utils.create_fresh_path(bucket_path);
             await fs_utils.file_must_exist(bucket_path);
+            await set_path_permissions_and_owner(bucket_path, account_options, 0o700);
             const resp = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             const bucket_resp = JSON.parse(resp);
             expect(bucket_resp.response.reply._id).not.toBeNull();
@@ -245,6 +290,11 @@ describe('cli create bucket using from_file', () => {
         await fs_utils.file_must_exist(account_path);
         await set_path_permissions_and_owner(account_path, account_options, 0o700);
         await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
+        // give permission on bucket path to bucket owner 
+        const { path: bucket_path } = bucket_defaults;
+        await fs_utils.create_fresh_path(bucket_path);
+        await fs_utils.file_must_exist(bucket_path);
+        await set_path_permissions_and_owner(bucket_path, account_options, 0o700);
     });
 
     afterEach(async () => {
@@ -382,11 +432,20 @@ describe('cli update bucket', () => {
     const bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs3', 'bucket1');
 
     const account_name = 'account_test';
+    const account_name2 = 'account_test_update2';
+
     const account_defaults = {
         name: account_name,
         new_buckets_path: `${root_path}new_buckets_path_4/`,
         uid: 1001,
         gid: 1001,
+    };
+
+    const account_defaults2 = {
+        name: account_name2,
+        new_buckets_path: `${root_path}new_buckets_path_user41/`,
+        uid: 1002,
+        gid: 1002,
     };
 
     const bucket_defaults = {
@@ -400,19 +459,28 @@ describe('cli update bucket', () => {
         await fs_utils.create_fresh_path(root_path);
         await fs_utils.create_fresh_path(bucket_storage_path);
         const action = ACTIONS.ADD;
-        // Account add
-        const { new_buckets_path: account_path } = account_defaults;
-        const account_options = { config_root, ...account_defaults };
+        // account add 1
+        let { new_buckets_path: account_path } = account_defaults;
+        let account_options = { config_root, ...account_defaults };
         await fs_utils.create_fresh_path(account_path);
         await fs_utils.file_must_exist(account_path);
         await set_path_permissions_and_owner(account_path, account_options, 0o700);
         await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
 
-        //bucket add
+        // account add 2
+        account_path = account_defaults2.new_buckets_path;
+        account_options = { config_root, ...account_defaults2 };
+        await fs_utils.create_fresh_path(account_path);
+        await fs_utils.file_must_exist(account_path);
+        await set_path_permissions_and_owner(account_path, account_options, 0o700);
+        await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
+
+        // bucket add
         const { path: bucket_path } = bucket_defaults;
         const bucket_options = { config_root, ...bucket_defaults };
         await fs_utils.create_fresh_path(bucket_path);
         await fs_utils.file_must_exist(bucket_path);
+        await set_path_permissions_and_owner(bucket_path, account_defaults, 0o700);
         const resp = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
         const bucket_resp = JSON.parse(resp);
         expect(bucket_resp.response.reply._id).not.toBeNull();
@@ -459,6 +527,47 @@ describe('cli update bucket', () => {
         const account_options = { config_root, name: bucket_defaults.name };
         const res = await exec_manage_cli(TYPES.BUCKET, action, account_options);
         expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.MissingUpdateProperty.message);
+    });
+
+    it('should fail - cli update bucket owner - owner does not have any permission to path', async () => {
+        const action = ACTIONS.UPDATE;
+        const bucket_options = { config_root, name: bucket_defaults.name, owner: account_defaults2.name};
+        await fs_utils.create_fresh_path(bucket_defaults.path);
+        await fs_utils.file_must_exist(bucket_defaults.path);
+        await set_path_permissions_and_owner(bucket_defaults.path, account_defaults2, 0o077);
+        const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InaccessibleStoragePath.code);
+    });
+
+    it('should fail - cli update bucket owner - owner does not have write permission to path', async () => {
+        const action = ACTIONS.UPDATE;
+        const bucket_options = { config_root, name: bucket_defaults.name, owner: account_defaults2.name};
+        await fs_utils.create_fresh_path(bucket_defaults.path);
+        await fs_utils.file_must_exist(bucket_defaults.path);
+        await set_path_permissions_and_owner(bucket_defaults.path, account_defaults2, 0o477);
+        const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InaccessibleStoragePath.code);
+    });
+
+    it('should fail - cli update bucket owner - owner does not have read permission to path', async () => {
+        const action = ACTIONS.UPDATE;
+        const bucket_options = { config_root, name: bucket_defaults.name, owner: account_defaults2.name};
+        await fs_utils.create_fresh_path(bucket_defaults.path);
+        await fs_utils.file_must_exist(bucket_defaults.path);
+        await set_path_permissions_and_owner(bucket_defaults.path, account_defaults2, 0o277);
+        const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InaccessibleStoragePath.code);
+    });
+
+    it('cli update bucket owner - account can access path', async () => {
+        const action = ACTIONS.UPDATE;
+        const bucket_options = { config_root, name: bucket_defaults.name, owner: account_defaults2.name};
+        await fs_utils.create_fresh_path(bucket_defaults.path);
+        await fs_utils.file_must_exist(bucket_defaults.path);
+        await set_path_permissions_and_owner(bucket_defaults.path, account_defaults2, 0o700);
+        await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+        const bucket = await read_config_file(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name);
+        expect(bucket.bucket_owner).toBe(account_defaults2.name);
     });
 });
 

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -161,12 +161,7 @@ async function config_dir_teardown() {
  */
 async function admin_account_creation() {
     await announce('admin_account_creation');
-    const cli_account_options = {
-        name: NC_CORETEST,
-        new_buckets_path: NC_CORETEST_STORAGE_PATH,
-        uid: 200,
-        gid: 200
-    };
+    const cli_account_options = get_admin_account_details();
     await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, cli_account_options);
 }
 
@@ -228,6 +223,18 @@ const get_name_by_email = email => {
     return name;
 };
 
+/**
+ * get_admin_account_details returns the account details that we use in NC core tests
+ */
+function get_admin_account_details() {
+    const cli_account_options = {
+        name: NC_CORETEST,
+        new_buckets_path: NC_CORETEST_STORAGE_PATH,
+        uid: 200,
+        gid: 200
+    };
+    return cli_account_options;
+}
 
 ////////////////////////////////////
 //////// ACCOUNT MANAGE CMDS ///////
@@ -459,3 +466,4 @@ exports.get_dbg_level = get_dbg_level;
 exports.rpc_client = rpc_cli_funcs_to_manage_nsfs_cli_cmds;
 exports.get_http_address = get_http_address;
 exports.get_https_address = get_https_address;
+exports.get_admin_account_details = get_admin_account_details;


### PR DESCRIPTION
### Explain the changes
1. Add a check if the owner of the bucket has `rw_access` to the underlying path when creating or updating a bucket.
2. Move the functionality of `verify_bucket_owner` to `validate_bucket_args`  before we check the access of the underlying path (so we will have the account's details - to reduce fetching the config file again).
3. Add a new error: `InaccessibleStoragePath`.
4. Edit the existing tests to permit read and write access to the bucket owner.
5. Minor style changes and renaming in `test_nc_nsfs_bucket_cli.test.js`.

### Issues: Fixed #7883 
1. Currently, one can create a bucket that his owner can not access the underlying path of the bucket.
2. GAP - currently, we use `verify_bucket_owner` on every bucket update. It needs to be only when the owner is updated.
3. inside `validate_bucket_args` we have `data.owner_account = account._id`, we need to move it to better place.

### Testing Instructions:
#### Manual Tests:
1. Create the directories:
   - `path` for the bucket: `mkdir /tmp/p1`
   - `new_buckets_path` for the account: `mkdir /tmp/p2`
4. Change file owner and group of `path` directory to uid 7171 and gid 7171: `sudo chown 7171:7171  /tmp/p1`
5. Give permission: 
   - `path` for the bucket: `sudo chmod 770 /tmp/p1`
   - `new_buckets_path`  for the account: `chmod 770 /tmp/p2`
6. Create an account: `sudo node src/cmd/manage_nsfs account add --name=account1 --uid=7272 --gid=7272 --new_buckets_path=/tmp/p2`
7. Create a bucket: `sudo node src/cmd/manage_nsfs bucket add --name=account1-bucket1 --owner=account1 --path=/tmp/p1`.

#### Unit Tests:
Please run:
- `sudo npx jest test_nc_nsfs_bucket_cli.test.js` (new tests)
- `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js` (edited tests)

- [ ] Doc added/updated
- [X] Tests added
