### PR TITLE
NSFS | NC | CLI |  Add force_md5_etag option to account and bucket

### DIFF
--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -33,16 +33,16 @@ const GLOBAL_CONFIG_OPTIONS = new Set([GLOBAL_CONFIG_ROOT, 'config_root_backend'
 const FROM_FILE = 'from_file';
 
 const VALID_OPTIONS_ACCOUNT = {
-    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
     'delete': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
     'list': new Set(['wide', 'show_secrets', 'gid', 'uid', 'user', 'name', 'access_key', ...GLOBAL_CONFIG_OPTIONS]),
     'status': new Set(['name', 'access_key', 'show_secrets', ...GLOBAL_CONFIG_OPTIONS]),
 };
 
 const VALID_OPTIONS_BUCKET = {
-    'add': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'new_name', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'force_md5_etag', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'new_name', 'force_md5_etag', ...GLOBAL_CONFIG_OPTIONS]),
     'delete': new Set(['name', 'force', ...GLOBAL_CONFIG_OPTIONS]),
     'list': new Set(['wide', 'name', ...GLOBAL_CONFIG_OPTIONS]),
     'status': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
@@ -77,6 +77,7 @@ const OPTION_TYPE = {
     secret_key: 'string',
     fs_backend: 'string',
     allow_bucket_creation: 'boolean',
+    force_md5_etag: 'boolean',
     config_root: 'string',
     from_file: 'string',
     config_root_backend: 'string',
@@ -92,6 +93,9 @@ const OPTION_TYPE = {
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];
 
+//options that can be unset using ''
+const LIST_UNSETABLE_OPTIONS = ['fs_backend', 's3_policy', 'force_md5_etag'];
+
 const LIST_ACCOUNT_FILTERS = ['uid', 'gid', 'user', 'name', 'access_key'];
 const LIST_BUCKET_FILTERS = ['name'];
 
@@ -104,6 +108,7 @@ exports.VALID_OPTIONS = VALID_OPTIONS;
 exports.OPTION_TYPE = OPTION_TYPE;
 exports.FROM_FILE = FROM_FILE;
 exports.BOOLEAN_STRING_VALUES = BOOLEAN_STRING_VALUES;
+exports.LIST_UNSETABLE_OPTIONS = LIST_UNSETABLE_OPTIONS;
 
 exports.LIST_ACCOUNT_FILTERS = LIST_ACCOUNT_FILTERS;
 exports.LIST_BUCKET_FILTERS = LIST_BUCKET_FILTERS;

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -78,6 +78,7 @@ Flags:
 --secret_key <string>                                 (optional)        Set the secret key for the account (default is generated)
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
 --allow_bucket_creation <true | false>                (optional)        Set the account to explicitly allow or block bucket creation
+--force_md5_etag <true | false>                       (optional)        Set the account to force md5 etag calculation. (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
 --from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
 `;
 
@@ -97,6 +98,7 @@ Flags:
 --secret_key <string>                                 (optional)        Update the secret key
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
 --allow_bucket_creation <true | false>                (optional)        Update the account to explicitly allow or block bucket creation
+--force_md5_etag <true | false>                       (optional)        Update the account to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
 `;
 
 const ACCOUNT_FLAGS_DELETE = `
@@ -141,6 +143,7 @@ Flags:
 --path <string>                                                         Set the bucket path
 --bucket_policy <string>                              (optional)        Set the bucket policy, type is a string of valid JSON policy
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type (default config.NSFS_NC_STORAGE_BACKEND)
+--force_md5_etag <true | false>                       (optional)        Set the bucket to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
 --from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
 `;
 
@@ -155,6 +158,7 @@ Flags:
 --path <string>                                       (optional)        Update the bucket path
 --bucket_policy <string>                              (optional)        Update the bucket policy, type is a string of valid JSON policy (unset with '')
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type (unset with '') (default config.NSFS_NC_STORAGE_BACKEND)
+--force_md5_etag <true | false>                       (optional)        Update the bucket to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
 `;
 
 const BUCKET_FLAGS_DELETE = `

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -29,6 +29,9 @@ module.exports = {
         allow_bucket_creation: {
             type: 'boolean',
         },
+        force_md5_etag: {
+            type: 'boolean',
+        },
         access_keys: {
             type: 'array',
             items: {

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -59,6 +59,9 @@ module.exports = {
         },
         website: {
             $ref: 'common_api#/definitions/bucket_website',
+        },
+        force_md5_etag: {
+            type: 'boolean',
         }
     }
 };

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -44,6 +44,13 @@ describe('schema validation NC NSFS account', () => {
             nsfs_schema_utils.validate_account_schema(account_data);
         });
 
+        it('nsfs_account_config with force_md5_etag', () => {
+            const account_data = get_account_data();
+            // @ts-ignore
+            account_data.force_md5_etag = true; // added
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
     });
 
     describe('account with additional properties', () => {
@@ -327,6 +334,16 @@ describe('schema validation NC NSFS account', () => {
             const reason = 'Test should have failed because of wrong type ' +
                 'fs_backend with string (instead of enum)';
             const message = 'must be equal to one of the allowed values';
+            assert_validation(account_data, reason, message);
+        });
+
+        it('nsfs_account_config with force_md5_etag as a string (instead of boolean)', () => {
+            const account_data = get_account_data();
+            // @ts-ignore
+            account_data.force_md5_etag = ""; // added
+            const reason = 'Test should have failed because of wrong type for' +
+                'force_md5_etag (string instead of boolean)';
+            const message = 'must be boolean';
             assert_validation(account_data, reason, message);
         });
     });

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -83,6 +83,12 @@ describe('schema validation NC NSFS bucket', () => {
             nsfs_schema_utils.validate_bucket_schema(bucket_data);
         });
 
+        it('nsfs_bucket with force_md5_etag', () => {
+            const bucket_data = get_bucket_data();
+            bucket_data.force_md5_etag = true; // added
+            nsfs_schema_utils.validate_bucket_schema(bucket_data);
+        });
+
     });
 
     describe('bucket with additional properties', () => {
@@ -384,6 +390,16 @@ describe('schema validation NC NSFS bucket', () => {
             const reason = 'Test should have failed because of wrong type ' +
                 'owner_account with number (instead of string)';
             const message = 'must be string';
+            assert_validation(bucket_data, reason, message);
+        });
+
+        it('bucket with force_md5_etag as string (instead of boolean)', () => {
+            const bucket_data = get_bucket_data();
+            // @ts-ignore
+            bucket_data.force_md5_etag = "aaa"; // number instead of string
+            const reason = 'Test should have failed because of wrong type ' +
+                'force_md5_etag with boolean (instead of string)';
+            const message = 'must be boolean';
             assert_validation(bucket_data, reason, message);
         });
 


### PR DESCRIPTION
### Explain the changes
1. add an option to set force_md5_etag to both account bucket add and update in the nsfs manager cli. add this option to the account and bucket schema
2. change force_md5_etag logic to first check if it is defined for the bucket, if not check if it is defined for the account, and if it isn't defined for both of them use default config.NSFS_CALCULATE_MD5.
3. add an option to unset the force_md5_etag flag to both the account and bucket

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7616

### Testing Instructions:
1. for bucket tests run: `sudo npx jest test_nc_nsfs_bucket_cli.test.js`
4. for account tests run `sudo npx jest test_nc_nsfs_account_cli.test.js`
5. for schema tests run ` sudo npx jest test_nc_nsfs_bucket_schema_validation.test.js`


- [ ] Doc added/updated
- [x] Tests added
