### PR TITLE
NSFS | NC |  Account Add `new_buckets_path` As Optional in Help

### DIFF
--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -72,7 +72,7 @@ Flags:
 --name <string>                                                         Set the name for the account
 --uid <number>                                                          Set the User Identifier (UID) (UID and GID can be replaced by --user option)
 --gid <number>                                                          Set the Group Identifier (GID) (UID and GID can be replaced by --user option)
---new_buckets_path <string>                                             Set the filesystem's root path where each subdirectory is a bucket
+--new_buckets_path <string>                           (optional)        Set the filesystem's root path where each subdirectory is a bucket
 --user <string>                                       (optional)        Set the OS user name (instead of UID and GID)
 --access_key <string>                                 (optional)        Set the access key for the account (default is generated)
 --secret_key <string>                                 (optional)        Set the secret key for the account (default is generated)


### PR DESCRIPTION
### Explain the changes
1. In the help of the account add change `new_buckets_path` to optional.

### Issues: Fixed #xxx / Gap #xxx
1. Currently, the property `new_buckets_path` is optional, which means that account can be created without it (but it was not reflected in the help).
Note: it is optional in account update help.

### Testing Instructions:
1. `sudo node src/cmd/manage_nsfs account add --help 2>/dev/null`


- [ ] Doc added/updated
- [ ] Tests added
