### PR TITLE
NSFS | NC | `nc_coretest` use `rm` instead of `rmdir`

### DIFF
--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -148,9 +148,9 @@ async function config_dir_setup() {
  */
 async function config_dir_teardown() {
     await announce('config_dir_teardown');
-    await fs.promises.rmdir(NC_CORETEST_STORAGE_PATH, { recursive: true });
+    await fs.promises.rm(NC_CORETEST_STORAGE_PATH, { recursive: true });
     await fs.promises.rm(NC_CORETEST_REDIRECT_FILE_PATH);
-    await fs.promises.rmdir(NC_CORETEST_CONFIG_DIR_PATH, { recursive: true, force: true });
+    await fs.promises.rm(NC_CORETEST_CONFIG_DIR_PATH, { recursive: true, force: true });
 }
 
 /**


### PR DESCRIPTION
### Explain the changes
1. `nc_coretest` use `rm` instead of `rmdir` (to avoid Node `DeprecationWarning`).

### Issues: Fixed #7890
1. Currently when running the `nc_coretest` (locally or in the CI) there is a warning:

> (node:8) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead

### Testing Instructions:
1. run the `nc_coretest` - locally `make run-nc-tests CONTAINER_PLATFORM=linux/arm64` (I'm using `CONTAINER_PLATFORM=linux/arm64` because I have MacOS), it also runs in the CI in the workflow `Non Containerized Unit Tests`.
2. Search for the warning above (should not appear with this change).


- [ ] Doc added/updated
- [ ] Tests added
