### PR TITLE
Bucket_logging: Reset rsyslogd after logrotation

### DIFF
--- a/src/deploy/NVA_build/logrotate_noobaa.conf
+++ b/src/deploy/NVA_build/logrotate_noobaa.conf
@@ -9,7 +9,7 @@
         create 660 noob root
         sharedscripts
         postrotate
-                supervisorctl signal HUP rsyslog 2> /dev/null || true
+                kill -HUP $(pidof rsyslogd) >/dev/null 2>&1 || true
         endscript
 }
 
@@ -24,7 +24,7 @@
         create 640 root root
         sharedscripts
         postrotate
-                supervisorctl signal HUP rsyslog 2> /dev/null || true
+                kill -HUP $(pidof rsyslogd) >/dev/null 2>&1 || true
         endscript
 }
 
@@ -40,4 +40,7 @@
         dateformat %Y-%m-%d-%H-%M-%S
         sharedscripts
         olddir /var/log/noobaa_logs
+        postrotate
+                kill -HUP $(pidof rsyslogd) >/dev/null 2>&1 || true
+        endscript
 }


### PR DESCRIPTION
When logrotate rotates bucket_logs.log file after
it reaches a given size, rsyslogd could not send logs to bucket_logs.log file as it still has old fd opened for this file.

To fix this we need to send HUP signal after every rotation of logs.
