### PR TITLE
[5.15.2] Backport to 5.15.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,10 @@ nbdev:
 	@echo ""
 .PHONY: nbdev
 
-rpm: base
+rpm: builder
 	echo "\033[1;34mStarting RPM build for $${CONTAINER_PLATFORM}.\033[0m"
 	mkdir -p build/rpm
-	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/RPM_build/RPM.Dockerfile $(CACHE_FLAG) -t $(NOOBAA_RPM_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
+	$(CONTAINER_ENGINE) build $(CONTAINER_PLATFORM_FLAG) $(CPUSET) -f src/deploy/RPM_build/RPM.Dockerfile $(CACHE_FLAG) -t $(NOOBAA_RPM_TAG) --build-arg CENTOS_VER=$(CENTOS_VER) --build-arg BUILD_S3SELECT=$(BUILD_S3SELECT) --build-arg BUILD_S3SELECT_PARQUET=$(BUILD_S3SELECT_PARQUET) --build-arg SRPM_ONLY=$(SRPM_ONLY) --build-arg GIT_COMMIT=$(GIT_COMMIT) . $(REDIRECT_STDOUT)
 	echo "\033[1;32mImage \"$(NOOBAA_RPM_TAG)\" is ready.\033[0m"
 	echo "Generating RPM..."
 	$(CONTAINER_ENGINE) run --rm -v $(PWD)/build/rpm:/export:z -t $(NOOBAA_RPM_TAG)

--- a/config.js
+++ b/config.js
@@ -750,6 +750,12 @@ config.NSFS_GLACIER_RESTORE_INTERVAL = 15 * 60 * 1000;
 // of `manage_nsfs glacier expiry`
 config.NSFS_GLACIER_EXPIRY_INTERVAL = 12 * 60 * 60 * 1000;
 
+/** @type {'UTC' | 'LOCAL'} */
+config.NSFS_GLACIER_EXPIRY_TZ = 'LOCAL';
+
+// Format must be HH:MM:SS
+config.NSFS_GLACIER_EXPIRY_TIME_OF_DAY = '00:00:00';
+
 ////////////////////////////
 // NSFS NON CONTAINERIZED //
 ////////////////////////////

--- a/docs/design/NonContainerizedNSFSDesign.md
+++ b/docs/design/NonContainerizedNSFSDesign.md
@@ -145,7 +145,7 @@ High level configuration -
 
 3.1. accounts/ - directory that contains accounts configurations, each account configuration file is called {account_name}.json and fits to the account schema.
 
-3.2. access_keys/ - directory that contains symlinks to accounts configurations, each symlink called {access_key}.symlink and links to an account under accounts/ directory.
+3.2. access_keys/ - directory that contains symlinks to accounts configurations, each symlink called {access_key}.symlink and links to an account under accounts/ directory. Access key symlink is targeted to relative account path not absolute path. eg: `../accounts/acc_symlink1.json`
 
 3.3. buckets/ - directory that contains buckets configurations, each bucket configuration file called {bucket_name}.json and fits the bucket schema.
 

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -474,24 +474,43 @@ NSFS management CLI run will create both accounts, access_keys, and buckets dire
 Using `from_file` flag:
 - For account and bucket creation users can also pass account or bucket values in JSON file (hereinafter referred to as "options JSON file") instead of passing them in CLI as arguments using flags.
 - General use:
-```
+
+```bash
 sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --from_file <options_JSON_file_path>
 sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --from_file <options_JSON_file_path>
 ```
-- The options are key-value, where the key is the same as suggested flags. For example:
-create JSON file for account:
+
+- The options are key-value, where the key is the same as suggested flags, for example:
+
+(1) Create JSON file for account
+
 ```json
-// JSON file of key-value options for creating an account
 {
     "name": "account-1001",
     "uid": 1001,
     "gid": 1001,
-    "new_buckets_path": "/tmp/nsfs_root1/my-bucket"
+    "new_buckets_path": "/tmp/nsfs_root1"
 }
 ```
+
+```bash
+sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --from_file <options_account_JSON_file_path>
 ```
-sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --from_file <options_JSON_file_path>
+
+(2) Create JSON file for bucket:
+
+```json
+{
+    "name": "account-1001-bucket-1",
+    "owner": "account-1001",
+    "path": "/tmp/nsfs_root1/account-1001-bucket-1"
+}
 ```
+
+```
+sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --from_file <options_bucket_JSON_file_path>
+```
+
 - When using `from_file` flag the details about the account/bucket should be only inside the options JSON file.
 - The JSON config file and JSON options file of account are different! 
 

--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -424,8 +424,9 @@ async function main(argv = minimist(process.argv.slice(2))) {
         if (deployment_type === 'nc') {
             const health = new NSFSHealth({ https_port, config_root, all_account_details, all_bucket_details, check_syslog_ng });
             const health_status = await health.nc_nsfs_health();
-            process.stdout.write(JSON.stringify(health_status) + '\n');
-            process.exit(0);
+            process.stdout.write(JSON.stringify(health_status) + '\n', () => {
+                process.exit(0);
+            });
         } else {
             dbg.log0('Health is not supported for simple nsfs deployment.');
         }

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -65,7 +65,7 @@ async function check_and_create_config_dirs() {
     ];
     for (const dir_path of pre_req_dirs) {
         try {
-            const fs_context = native_fs_utils.get_process_fs_context();
+            const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
             const dir_exists = await native_fs_utils.is_path_exists(fs_context, dir_path);
             if (dir_exists) {
                 dbg.log1('nsfs.check_and_create_config_dirs: config dir exists:', dir_path);
@@ -295,12 +295,14 @@ async function update_bucket(data) {
 
 async function delete_bucket(data) {
     await validate_bucket_args(data, ACTIONS.DELETE);
-    const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
+    // we have fs_contexts: (1) fs_backend for bucket temp dir (2) config_root_backend for config files
+    const fs_context_config_root_backend = native_fs_utils.get_process_fs_context(config_root_backend);
+    const fs_context_fs_backend = native_fs_utils.get_process_fs_context(data.fs_backend);
     const bucket_config_path = get_config_file_path(buckets_dir_path, data.name);
     try {
         const bucket_temp_dir_path = path.join(data.path, config.NSFS_TEMP_DIR_NAME + "_" + data._id);
-        await native_fs_utils.folder_delete(bucket_temp_dir_path, fs_context, true);
-        await native_fs_utils.delete_config_file(fs_context, buckets_dir_path, bucket_config_path);
+        await native_fs_utils.folder_delete(bucket_temp_dir_path, fs_context_fs_backend, true);
+        await native_fs_utils.delete_config_file(fs_context_config_root_backend, buckets_dir_path, bucket_config_path);
     } catch (err) {
         if (err.code === 'ENOENT') throw_cli_error(ManageCLIError.NoSuchBucket, data.name);
         throw err;
@@ -526,7 +528,7 @@ async function delete_account(data) {
  */
 async function verify_delete_account(account_name) {
     const show_secrets = false; // in buckets we don't save secrets in coofig file
-    const fs_context = native_fs_utils.get_process_fs_context();
+    const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
     const entries = await nb_native().fs.readdir(fs_context, buckets_dir_path);
     await P.map_with_concurrency(10, entries, async entry => {
         if (entry.name.endsWith('.json')) {
@@ -635,7 +637,7 @@ function filter_bucket(bucket, filters) {
  * @param {object} [filters]
  */
 async function list_config_files(type, config_path, wide, show_secrets, filters) {
-    const fs_context = native_fs_utils.get_process_fs_context();
+    const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
     const entries = await nb_native().fs.readdir(fs_context, config_path);
     const should_filter = Object.keys(filters).length > 0;
 
@@ -665,7 +667,7 @@ async function list_config_files(type, config_path, wide, show_secrets, filters)
  * @param {boolean} [show_secrets]
  */
 async function get_config_data(config_file_path, show_secrets = false) {
-    const fs_context = native_fs_utils.get_process_fs_context();
+    const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
     const { data } = await nb_native().fs.readFile(fs_context, config_file_path);
     const config_data = _.omit(JSON.parse(data.toString()), show_secrets ? [] : ['access_keys']);
     return config_data;
@@ -677,6 +679,7 @@ async function get_config_data(config_file_path, show_secrets = false) {
  * @param {string} file_path
  */
 async function get_options_from_file(file_path) {
+    // we don't pass neither config_root_backend nor fs_backend
     const fs_context = native_fs_utils.get_process_fs_context();
     try {
         const input_options_with_data = await native_fs_utils.read_file(fs_context, file_path);
@@ -744,14 +747,15 @@ async function validate_bucket_args(data, action) {
         }
         if (_.isUndefined(data.system_owner)) throw_cli_error(ManageCLIError.MissingBucketOwnerFlag);
         if (!data.path) throw_cli_error(ManageCLIError.MissingBucketPathFlag);
-        const fs_context = native_fs_utils.get_process_fs_context();
-        const exists = await native_fs_utils.is_path_exists(fs_context, data.path);
-        if (!exists) {
-            throw_cli_error(ManageCLIError.InvalidStoragePath, data.path);
-        }
         // fs_backend='' used for deletion of the fs_backend property
         if (data.fs_backend !== undefined && !['GPFS', 'CEPH_FS', 'NFSv4'].includes(data.fs_backend)) {
             throw_cli_error(ManageCLIError.InvalidFSBackend);
+        }
+        // in case we have the fs_backend it changes the fs_context that we use for the path
+        const fs_context_fs_backend = native_fs_utils.get_process_fs_context(data.fs_backend);
+        const exists = await native_fs_utils.is_path_exists(fs_context_fs_backend, data.path);
+        if (!exists) {
+            throw_cli_error(ManageCLIError.InvalidStoragePath, data.path);
         }
         if (data.s3_policy) {
             try {
@@ -759,7 +763,8 @@ async function validate_bucket_args(data, action) {
                     async principal => {
                         const account_config_path = get_config_file_path(accounts_dir_path, principal);
                         try {
-                            await nb_native().fs.stat(native_fs_utils.get_process_fs_context(), account_config_path);
+                            const fs_context_config_root_backend = native_fs_utils.get_process_fs_context(config_root_backend);
+                            await nb_native().fs.stat(fs_context_config_root_backend, account_config_path);
                             return true;
                         } catch (err) {
                             return false;
@@ -807,12 +812,13 @@ async function validate_account_args(data, action) {
         if (_.isUndefined(data.nsfs_account_config.new_buckets_path)) {
             return;
         }
-        const fs_context = native_fs_utils.get_process_fs_context();
-        const exists = await native_fs_utils.is_path_exists(fs_context, data.nsfs_account_config.new_buckets_path);
+        // in case we have the fs_backend it changes the fs_context that we use for the new_buckets_path
+        const fs_context_fs_backend = native_fs_utils.get_process_fs_context(data.fs_backend);
+        const exists = await native_fs_utils.is_path_exists(fs_context_fs_backend, data.nsfs_account_config.new_buckets_path);
         if (!exists) {
             throw_cli_error(ManageCLIError.InvalidAccountNewBucketsPath, data.nsfs_account_config.new_buckets_path);
         }
-        const account_fs_context = await native_fs_utils.get_fs_context(data.nsfs_account_config, config_root_backend);
+        const account_fs_context = await native_fs_utils.get_fs_context(data.nsfs_account_config, data.fs_backend);
         const accessible = await native_fs_utils.is_dir_rw_accessible(account_fs_context, data.nsfs_account_config.new_buckets_path);
         if (!accessible) {
             throw_cli_error(ManageCLIError.InaccessibleAccountNewBucketsPath, data.nsfs_account_config.new_buckets_path);
@@ -968,7 +974,7 @@ async function whitelist_ips_management(args) {
     try {
         const config_data = require(config_path);
         config_data.NSFS_WHITELIST = whitelist_ips;
-        const fs_context = native_fs_utils.get_process_fs_context();
+        const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
         const data = JSON.stringify(config_data);
         await native_fs_utils.update_config_file(fs_context, config_root, config_path, data);
     } catch (err) {

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -293,21 +293,27 @@ async function update_bucket(data) {
     write_stdout_response(ManageCLIResponse.BucketUpdated, data);
 }
 
-async function delete_bucket(data) {
+async function delete_bucket(data, force) {
     await validate_bucket_args(data, ACTIONS.DELETE);
     // we have fs_contexts: (1) fs_backend for bucket temp dir (2) config_root_backend for config files
     const fs_context_config_root_backend = native_fs_utils.get_process_fs_context(config_root_backend);
     const fs_context_fs_backend = native_fs_utils.get_process_fs_context(data.fs_backend);
     const bucket_config_path = get_config_file_path(buckets_dir_path, data.name);
     try {
-        const bucket_temp_dir_path = path.join(data.path, config.NSFS_TEMP_DIR_NAME + "_" + data._id);
-        await native_fs_utils.folder_delete(bucket_temp_dir_path, fs_context_fs_backend, true);
-        await native_fs_utils.delete_config_file(fs_context_config_root_backend, buckets_dir_path, bucket_config_path);
+        const temp_dir_name = config.NSFS_TEMP_DIR_NAME + "_" + data._id;
+        const bucket_temp_dir_path = path.join(data.path, temp_dir_name);
+        const entries = await nb_native().fs.readdir(fs_context_fs_backend, data.path);
+        const object_entries = entries.filter(element => !element.name.endsWith(temp_dir_name));
+        if (object_entries.length === 0 || force) {
+            await native_fs_utils.folder_delete(bucket_temp_dir_path, fs_context_fs_backend, true);
+            await native_fs_utils.delete_config_file(fs_context_config_root_backend, buckets_dir_path, bucket_config_path);
+            write_stdout_response(ManageCLIResponse.BucketDeleted, '', {bucket: data.name});
+        }
+        throw_cli_error(ManageCLIError.BucketDeleteForbiddenHasObjects, data.name);
     } catch (err) {
         if (err.code === 'ENOENT') throw_cli_error(ManageCLIError.NoSuchBucket, data.name);
         throw err;
     }
-    write_stdout_response(ManageCLIResponse.BucketDeleted, '', {bucket: data.name});
 }
 
 async function manage_bucket_operations(action, data, user_input) {
@@ -318,7 +324,8 @@ async function manage_bucket_operations(action, data, user_input) {
     } else if (action === ACTIONS.UPDATE) {
         await update_bucket(data);
     } else if (action === ACTIONS.DELETE) {
-        await delete_bucket(data);
+        const force = get_boolean_or_string_value(user_input.force);
+        await delete_bucket(data, force);
     } else if (action === ACTIONS.LIST) {
         const bucket_filters = _.pick(user_input, LIST_BUCKET_FILTERS);
         const buckets = await list_config_files(TYPES.BUCKET, buckets_dir_path, data.wide, undefined, bucket_filters);
@@ -931,7 +938,7 @@ function validate_options_type_by_value(input_options_with_data) {
                 continue;
             }
             // special case for boolean values
-            if (['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets'].includes(option) && validate_boolean_string_value(value)) {
+            if (['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force'].includes(option) && validate_boolean_string_value(value)) {
                 continue;
             }
             // special case for bucket_policy (from_file)

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -49,6 +49,7 @@ function write_stdout_response(response_code, detail, event_arg) {
 const buckets_dir_name = '/buckets';
 const accounts_dir_name = '/accounts';
 const access_keys_dir_name = '/access_keys';
+const acounts_dir_relative_path = '../accounts/';
 
 let config_root;
 let accounts_dir_path;
@@ -439,6 +440,7 @@ async function add_account(data) {
     const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
     const access_key = data.access_keys[0].access_key;
     const account_config_path = get_config_file_path(accounts_dir_path, data.name);
+    const account_config_relative_path = get_config_file_path(acounts_dir_relative_path, data.name);
     const account_config_access_key_path = get_symlink_config_file_path(access_keys_dir_path, access_key);
 
     const name_exists = await native_fs_utils.is_path_exists(fs_context, account_config_path);
@@ -457,7 +459,7 @@ async function add_account(data) {
     nsfs_schema_utils.validate_account_schema(JSON.parse(data));
     await native_fs_utils.create_config_file(fs_context, accounts_dir_path, account_config_path, data);
     await native_fs_utils._create_path(access_keys_dir_path, fs_context, config.BASE_MODE_CONFIG_DIR);
-    await nb_native().fs.symlink(fs_context, account_config_path, account_config_access_key_path);
+    await nb_native().fs.symlink(fs_context, account_config_relative_path, account_config_access_key_path);
     write_stdout_response(ManageCLIResponse.AccountCreated, data, {account: event_arg});
 }
 
@@ -488,6 +490,7 @@ async function update_account(data) {
     data.access_keys[0].access_key = data.new_access_key || cur_access_key;
     const cur_account_config_path = get_config_file_path(accounts_dir_path, cur_name);
     const new_account_config_path = get_config_file_path(accounts_dir_path, data.name);
+    const new_account_relative_config_path = get_config_file_path(acounts_dir_relative_path, data.name);
     const cur_access_key_config_path = get_symlink_config_file_path(access_keys_dir_path, cur_access_key);
     const new_access_key_config_path = get_symlink_config_file_path(access_keys_dir_path, data.access_keys[0].access_key);
     const name_exists = update_name && await native_fs_utils.is_path_exists(fs_context, new_account_config_path);
@@ -511,7 +514,7 @@ async function update_account(data) {
     // need to find a better way for atomic unlinking of symbolic links
     // handle atomicity for symlinks
     await nb_native().fs.unlink(fs_context, cur_access_key_config_path);
-    await nb_native().fs.symlink(fs_context, new_account_config_path, new_access_key_config_path);
+    await nb_native().fs.symlink(fs_context, new_account_relative_config_path, new_access_key_config_path);
     write_stdout_response(ManageCLIResponse.AccountUpdated, data);
 }
 

--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -1,6 +1,9 @@
-FROM noobaa-base
+FROM noobaa-builder
 ARG TARGETARCH
+
+ARG CENTOS_VER=9
 ARG BUILD_S3SELECT=0
+ARG BUILD_S3SELECT_PARQUET=0
 
 RUN mkdir -p /etc/logrotate.d/noobaa/
 RUN mkdir -p /etc/noobaa.conf.d/
@@ -9,8 +12,14 @@ COPY ./src/agent ./src/agent
 COPY ./src/api ./src/api
 COPY ./src/cmd ./src/cmd
 COPY ./src/deploy/spectrum_archive ./src/deploy/spectrum_archive
+COPY ./src/deploy/noobaa_nsfs.service ./src/deploy/
+COPY ./src/deploy/nsfs_env.env ./src/deploy/
+COPY ./src/deploy/NVA_build/clone_submodule.sh ./src/deploy/NVA_build/
+COPY ./src/deploy/NVA_build/clone_s3select_submodules.sh ./src/deploy/NVA_build/
+COPY ./src/deploy/NVA_build/install_nodejs.sh ./src/deploy/NVA_build/
 COPY ./src/endpoint ./src/endpoint
 COPY ./src/hosted_agents ./src/hosted_agents
+COPY ./src/native ./src/native/
 COPY ./src/rpc ./src/rpc
 COPY ./src/s3 ./src/s3
 COPY ./src/sdk ./src/sdk
@@ -22,6 +31,7 @@ COPY ./config.js ./
 COPY ./platform_restrictions.json ./
 COPY ./Makefile ./
 COPY ./package*.json ./
+COPY ./binding.gyp .
 COPY ./src/deploy/standalone/noobaa_rsyslog.conf ./src/deploy/standalone/noobaa_rsyslog.conf
 COPY ./src/deploy/standalone/noobaa_syslog.conf ./src/deploy/standalone/noobaa_syslog.conf
 COPY ./src/deploy/standalone/logrotate_noobaa.conf ./src/deploy/standalone/logrotate_noobaa.conf
@@ -29,10 +39,17 @@ COPY ./src/manage_nsfs ./src/manage_nsfs
 
 WORKDIR /build
 
-RUN tar -czvf noobaa-core.tar.gz /noobaa
-
 COPY ./src/deploy/RPM_build/* ./
 COPY ./package.json ./
+RUN bash ./preparesrc.sh /noobaa
 RUN chmod +x ./packagerpm.sh
 
+# These envs are used by the packagerpm.sh either directly or by
+# performing subsitutions in the noobaa.spec file
+ARG SRPM_ONLY=false
+
+ENV BUILD_S3SELECT=${BUILD_S3SELECT}
+ENV BUILD_S3SELECT_PARQUET=${BUILD_S3SELECT_PARQUET}
+ENV CENTOS_VER=${CENTOS_VER}
+ENV SRPM_ONLY=${SRPM_ONLY}
 CMD ./packagerpm.sh /export /build

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -1,28 +1,37 @@
+# Disable debuginfo -- it does not work well with nodejs apps
+%global debug_package %{nil}
+# This speeds up the build a lot and it is not really required
+%global __os_install_post %{nil}
+
 %define revision null
 %define noobaaver null
 %define nodever null
 %define releasedate null
 %define changelogdata null
+%define BUILD_S3SELECT null
+%define BUILD_S3SELECT_PARQUET null
+%define CENTOS_VER null
+%define _build_id_links none
 
 %define noobaatar %{name}-%{version}-%{revision}.tar.gz
-%define nodetar node-%{nodever}.tar.xz
 %define buildroot %{_tmppath}/%{name}-%{version}-%{release}
 
-Name:		noobaa-core
-Version:	%{noobaaver}
-Release:	%{revision}%{?dist}
-Summary:	NooBaa RPM
+Name: noobaa-core
+Version:  %{noobaaver}
+Release:  %{revision}%{?dist}
+Summary:  NooBaa RPM
 
-License:	Apache-2.0
-URL:        https://www.noobaa.io/
-Source0:	%{noobaatar}
-Source1:    %{nodetar}
+License:  Apache-2.0
+URL:  https://www.noobaa.io/
+Source0:  %{noobaatar}
 
-BuildRequires: systemd
+BuildRequires:  systemd
+BuildRequires:  python3
+BuildRequires:  make
+BuildRequires:  gcc-c++
+BuildRequires:  boost-devel
 
-Recommends: jemalloc
-
-%global __os_install_post %{nil}
+Recommends:     jemalloc
 
 %global __requires_exclude ^/usr/bin/python$
 
@@ -30,20 +39,37 @@ Recommends: jemalloc
 NooBaa is a data service for cloud environments, providing S3 object-store interface with flexible tiering, mirroring, and spread placement policies, over any storage resource that allows GET/PUT including S3, GCS, Azure Blob, Filesystems, etc.
 
 %prep
-mkdir noobaa-core-%{version}-%{revision}
-mkdir node-%{nodever}
-tar -xzf %{SOURCE0} -C noobaa-core-%{version}-%{revision}/
-tar -xJf %{SOURCE1} -C node-%{nodever}/
+%setup -n noobaa -q
 
-%clean
-[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+%build
+NODEJS_VERSION="%{nodever}"
+SKIP_NODE_INSTALL=1 source src/deploy/NVA_build/install_nodejs.sh $NODEJS_VERSION
+
+mkdir -p ../node/
+
+nodepath=$(download_node)
+tar -xJf ${nodepath} -C ../node/
+
+PATH=$PATH:%{_builddir}/node/node-v$NODEJS_VERSION-linux-$(get_arch)/bin
+
+npm install --omit=dev && npm cache clean --force
+
+./src/deploy/NVA_build/clone_s3select_submodules.sh
+
+if [[ "%{CENTOS_VER}" = "8" ]]
+then
+  sed -i 's/\/lib64\/libboost_thread.so.1.75.0/\/lib64\/libboost_thread.so.1.66.0/g' ./src/native/s3select/s3select.gyp
+  echo "Using libboost 1.66 for S3 Select"
+fi
+
+GYP_DEFINES="BUILD_S3SELECT=%{BUILD_S3SELECT} BUILD_S3SELECT_PARQUET=%{BUILD_S3SELECT_PARQUET}" npm run build
 
 %install
 rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT/usr/local/
 
-cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa $RPM_BUILD_ROOT/usr/local/noobaa-core
-cp -R %{_builddir}/node-%{nodever}/* $RPM_BUILD_ROOT/usr/local/noobaa-core/node
+mkdir -p $RPM_BUILD_ROOT/usr/local/
+cp -R %{_builddir}/noobaa $RPM_BUILD_ROOT/usr/local/noobaa-core
+mv %{_builddir}/node/* $RPM_BUILD_ROOT/usr/local/noobaa-core/node
 
 mkdir -p $RPM_BUILD_ROOT/usr/local/noobaa-core/bin
 ln -s /usr/local/noobaa-core/node/bin/node $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/node
@@ -51,12 +77,12 @@ ln -s /usr/local/noobaa-core/node/bin/npm $RPM_BUILD_ROOT/usr/local/noobaa-core/
 ln -s /usr/local/noobaa-core/node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npx
 
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}/
-cp -R %{_builddir}/%{name}-%{version}-%{revision}/noobaa/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT%{_unitdir}/noobaa_nsfs.service
+mv $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT%{_unitdir}/noobaa_nsfs.service
 ln -s /usr/local/noobaa-core/src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
 mkdir -p $RPM_BUILD_ROOT/etc/noobaa.conf.d/
 
 mkdir -p $RPM_BUILD_ROOT/etc/rsyslog.d/
-cp -R $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
+mv $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.conf $RPM_BUILD_ROOT/etc/rsyslog.d/noobaa_syslog.conf
 
 mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d/noobaa
 ln -s /usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.conf $RPM_BUILD_ROOT/etc/logrotate.d/noobaa/logrotate_noobaa.conf

--- a/src/deploy/RPM_build/preparesrc.sh
+++ b/src/deploy/RPM_build/preparesrc.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eou pipefail
+set -x
+
+TARGET="noobaa-core.tar.gz"
+
+SRC_DIR=$(realpath "${1:-$(pwd)}")
+
+function prepare_excludes() {
+	local exclude_flag_gitignore="$(grep -v '^#' $SRC_DIR/.gitignore | grep '[^[:blank:]]' | xargs -I{} printf '%s=%s ' '--exclude' '{}')"
+	local exclude_flag_local="--exclude ./build --exclude ./images --exclude ./tools --exclude ./submodules --exclude .github --exclude .travis --exclude .jenkins"
+
+	echo "${exclude_flag_gitignore} ${exclude_flag_local}"
+}
+
+function archive() {
+	local tar="$1"
+	local exclude_flag="$(prepare_excludes)"
+
+	# No quotes here is intentional
+	tar $exclude_flag --exclude-vcs -czvf "$tar" "$SRC_DIR"
+}
+
+echo "Using source: $SRC_DIR"
+if [ "$SRC_DIR" = "$(pwd)" ]; then
+	pushd ..
+	tpath="$TMPDIR$TARGET"
+	archive "$tpath"
+	popd
+
+	mv "$tpath" .
+else
+	tpath="./$TARGET"
+	archive "$tpath"
+fi

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -312,6 +312,13 @@ ManageCLIError.BucketCreationNotAllowed = Object.freeze({
     http_code: 403,
 });
 
+ManageCLIError.BucketDeleteForbiddenHasObjects = Object.freeze({
+    code: 'BucketDeleteForbiddenHasObjects',
+    message: 'Cannot delete non-empty bucket. ' +
+    'You must delete all object before deleting the bucket or use --force flag',
+    http_code: 403,
+});
+
 /////////////////////////////////
 //// BUCKET ARGUMENTS ERRORS ////
 /////////////////////////////////

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -43,7 +43,7 @@ const VALID_OPTIONS_ACCOUNT = {
 const VALID_OPTIONS_BUCKET = {
     'add': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
     'update': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'new_name', ...GLOBAL_CONFIG_OPTIONS]),
-    'delete': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
+    'delete': new Set(['name', 'force', ...GLOBAL_CONFIG_OPTIONS]),
     'list': new Set(['wide', 'name', ...GLOBAL_CONFIG_OPTIONS]),
     'status': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
 };
@@ -87,6 +87,7 @@ const OPTION_TYPE = {
     wide: 'boolean',
     show_secrets: 'boolean',
     ips: 'string',
+    force: 'boolean'
 };
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -167,6 +167,7 @@ bucket delete [flags]
 
 Flags:
 --name <string>                                                         The name of the bucket
+--force                                               (optional)        Forcefully delete bucket if the bucket is not empty
 `;
 
 const BUCKET_FLAGS_STATUS = `

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -235,7 +235,6 @@ const static std::vector<std::string> USER_XATTRS{
     "user.noobaa.part_etag",
     "user.storage_class",
     "user.noobaa.restore.request",
-    "user.noobaa.restore.ongoing",
     "user.noobaa.restore.expiry",
 };
 
@@ -1346,7 +1345,7 @@ struct FileWrap : public Napi::ObjectWrap<FileWrap>
     }
     ~FileWrap()
     {
-        if (_fd) {
+        if (_fd >= 0) {
             LOG("FS::FileWrap::dtor: file not closed " << DVAL(_path) << DVAL(_fd));
             int r = ::close(_fd);
             if (r) LOG("FS::FileWrap::dtor: file close failed " << DVAL(_path) << DVAL(_fd) << DVAL(r));

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -550,7 +550,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             const bucket_config_path = this._get_bucket_config_path(name);
             const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
             const bucket = JSON.parse(data.toString());
-            return bucket.website;
+            return {website: bucket.website};
         } catch (err) {
             throw this._translate_bucket_error_codes(err);
         }

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -86,6 +86,9 @@ const copy_status_enum = {
     FALLBACK: 'FALLBACK'
 };
 
+const XATTR_METADATA_IGNORE_LIST = [
+    XATTR_STORAGE_CLASS_KEY,
+];
 
 /**
  * @param {fs.Dirent} a
@@ -266,9 +269,19 @@ function make_named_dirent(name) {
 }
 
 function to_xattr(fs_xattr) {
-    const xattr = _.mapKeys(fs_xattr, (val, key) =>
-        (key.startsWith(XATTR_USER_PREFIX) && !key.startsWith(XATTR_NOOBAA_INTERNAL_PREFIX) ? key.slice(XATTR_USER_PREFIX.length) : '')
-    );
+    const xattr = _.mapKeys(fs_xattr, (val, key) => {
+        // Prioritize ignore list
+        if (XATTR_METADATA_IGNORE_LIST.includes(key)) return '';
+
+        // Fallback to rules
+
+        if (key.startsWith(XATTR_USER_PREFIX) && !key.startsWith(XATTR_NOOBAA_INTERNAL_PREFIX)) {
+            return key.slice(XATTR_USER_PREFIX.length);
+        }
+
+        return '';
+    });
+
     // keys which do not start with prefix will all map to the empty string key, so we remove it once
     delete xattr[''];
     // @ts-ignore
@@ -1173,7 +1186,7 @@ class NamespaceFS {
             const src_file_path = await this._find_version_path(fs_context, params.copy_source);
             const stat = await nb_native().fs.stat(fs_context, src_file_path);
             const src_storage_class = s3_utils.parse_storage_class(stat.xattr[XATTR_STORAGE_CLASS_KEY]);
-            const src_restore_status = this._get_object_restore_status(stat, src_storage_class);
+            const src_restore_status = GlacierBackend.get_restore_status(stat.xattr, new Date(), src_file_path);
 
             if (src_storage_class === s3_utils.STORAGE_CLASS_GLACIER) {
                 if (src_restore_status?.ongoing || !src_restore_status?.expiry_time) {
@@ -1940,9 +1953,8 @@ class NamespaceFS {
      * restore_object simply sets the restore request xattr
      * which should be picked by another mechanism.
      * 
-     * restore_object internally relies on 3 xattrs:
+     * restore_object internally relies on 2 xattrs:
      * - XATTR_RESTORE_REQUEST
-     * - XATTR_RESTORE_ONGOING
      * - XATTR_RESTORE_EXPIRY
      * @param {*} params 
      * @param {nb.ObjectSDK} object_sdk 
@@ -1960,74 +1972,51 @@ class NamespaceFS {
             file = await nb_native().fs.open(fs_context, file_path);
             const stat = await file.stat(fs_context);
 
-            if (stat.xattr[XATTR_STORAGE_CLASS_KEY] !== s3_utils.STORAGE_CLASS_GLACIER) {
+            const now = new Date();
+            const restore_status = GlacierBackend.get_restore_status(stat.xattr, now, file_path);
+            dbg.log1(
+                'namespace_fs.restore_object:', file_path,
+                'restore_status:', restore_status,
+            );
+
+            if (!restore_status) {
+                // The function returns undefined only when the storage class isn't glacier
                 throw new S3Error(S3Error.InvalidObjectStorageClass);
             }
 
-            // Total 8 states
-            const restore_request = stat.xattr[GlacierBackend.XATTR_RESTORE_REQUEST] ?
-                parseInt(stat.xattr[GlacierBackend.XATTR_RESTORE_REQUEST], 10) : null;
-            const restore_ongoing = stat.xattr[GlacierBackend.XATTR_RESTORE_ONGOING] === 'true';
-            const restore_expiry = stat.xattr[GlacierBackend.XATTR_RESTORE_EXPIRY] ?
-                new Date(stat.xattr[GlacierBackend.XATTR_RESTORE_EXPIRY]) : null;
+            if (restore_status.state === GlacierBackend.RESTORE_STATUS_CAN_RESTORE) {
+                // First add it to the log and then add the extended attribute as if we fail after
+                // this point then the restore request can be triggered again without issue but
+                // the reverse doesn't works.
+                await this.append_to_restore_wal(file_path);
 
-            // 5 Valid States
-            if (restore_request) {
-                // It is possible that the restore request was made but we haven't yet
-                // started the restore process. Batching is an implementation detail
-                // and need not be leaked to the client.
-                if (!restore_ongoing && !restore_expiry) {
-                    dbg.log0('namespace_fs.restore_object: state - (restore_request, !restore_ongoing, !restore_expiry)');
-                    throw new S3Error(S3Error.RestoreAlreadyInProgress);
-                }
-            } else if (restore_ongoing) {
-                if (!restore_expiry) {
-                    dbg.log0('namespace_fs.restore_object: state - (!restore_request, restore_ongoing, !restore_expiry)');
-                    throw new S3Error(S3Error.RestoreAlreadyInProgress);
-                }
-            } else {
-                const now = new Date();
+                await file.replacexattr(fs_context, {
+                    [GlacierBackend.XATTR_RESTORE_REQUEST]: params.days.toString(),
+                });
 
-                // The only entity that can remove the restore request is the underlying
-                // restore mechanism, implying that at some point it must have picked
-                // up the request to restore and finished the process.
-                if (restore_expiry && restore_expiry > now) {
-                    dbg.log0('namespace_fs.restore_object: state - (!restore_request, !restore_ongoing, restore_expiry > now)');
-
-                    const expires_on = now;
-                    expires_on.setDate(expires_on.getDate() + params.days);
-
-                    await file.replacexattr(fs_context, {
-                        [GlacierBackend.XATTR_RESTORE_EXPIRY]: expires_on.toISOString(),
-                    });
-
-                    // Should result in HTTP: 200 OK
-                    return false;
-                }
-
-                // If neither the restore is ongoing nor a restore expiry is set, we can set the xattr
-                // essentially adding the object to the batch.
-                if (!restore_expiry || restore_expiry <= now) {
-                    dbg.log0('namespace_fs.restore_object: state - (!restore_request, !restore_ongoing, !restore_expiry or restore_expiry <= now)');
-
-                    // First add it to the log and then add the extended attribute as if we fail after
-                    // this point then the restore request can be triggered again without issue but
-                    // the reverse doesn't works.
-                    await this.append_to_restore_wal(file_path);
-
-                    await file.replacexattr(fs_context, {
-                        [GlacierBackend.XATTR_RESTORE_REQUEST]: params.days.toString(),
-                    });
-
-                    // Should result in HTTP: 202 Accepted
-                    return true;
-                }
+                // Should result in HTTP: 202 Accepted
+                return true;
             }
 
-            // 3 Invalid States
-            // 1. Restore request is set along with 1 or more than 1 attribute (2 different states)
-            // 2. Restore request is unset but both request ongoing and expiry are set
-            throw new RpcError('INTERNAL_ERROR');
+            if (restore_status.state === GlacierBackend.RESTORE_STATUS_ONGOING) {
+                throw new S3Error(S3Error.RestoreAlreadyInProgress);
+            }
+
+            if (restore_status.state === GlacierBackend.RESTORE_STATUS_RESTORED) {
+                const expires_on = GlacierBackend.generate_expiry(
+                    now,
+                    params.days,
+                    config.NSFS_GLACIER_EXPIRY_TIME_OF_DAY,
+                    config.NSFS_GLACIER_EXPIRY_TZ,
+                );
+
+                await file.replacexattr(fs_context, {
+                    [GlacierBackend.XATTR_RESTORE_EXPIRY]: expires_on.toISOString(),
+                });
+
+                // Should result in HTTP: 200 OK
+                return false;
+            }
         } catch (error) {
             dbg.error('namespace_fs.restore_object: failed with error: ', error, file_path);
             throw this._translate_object_error_codes(error);
@@ -2228,7 +2217,7 @@ class NamespaceFS {
             is_latest,
             delete_marker,
             storage_class,
-            restore_status: this._get_object_restore_status(stat, storage_class),
+            restore_status: GlacierBackend.get_restore_status(stat.xattr, new Date(), this._get_file_path({key})),
             xattr: to_xattr(stat.xattr),
 
             // temp:
@@ -2240,46 +2229,6 @@ class NamespaceFS {
             stats: undefined,
             tagging: undefined,
         };
-    }
-
-    /**
-     * _get_object_restore_status returns the restore status of the object if the object is
-     * in "GLACIER" storage class
-     * @param {nb.NativeFSStats} stat stat of the object file
-     * @param {string} [storage_class] optional storage class of the target object
-     * @returns {{ ongoing: boolean, expiry_time?: Date } | undefined}
-     */
-    _get_object_restore_status(stat, storage_class) {
-        if (!storage_class) storage_class = s3_utils.parse_storage_class(stat.xattr[XATTR_STORAGE_CLASS_KEY]);
-
-        let restore_status;
-        if (storage_class === s3_utils.STORAGE_CLASS_GLACIER) {
-            const restore_request = stat.xattr[GlacierBackend.XATTR_RESTORE_REQUEST] ?
-                parseInt(stat.xattr[GlacierBackend.XATTR_RESTORE_REQUEST], 10) : null;
-            const restore_ongoing = stat.xattr[GlacierBackend.XATTR_RESTORE_ONGOING] === 'true';
-            const restore_expiry = stat.xattr[GlacierBackend.XATTR_RESTORE_EXPIRY] ?
-                new Date(stat.xattr[GlacierBackend.XATTR_RESTORE_EXPIRY]) : null;
-
-            // Assume the state invariants to hold true
-
-            // Restore is ongoing if,
-            // 1. Restore request is set
-            // 2. Restore ongoing is set to true
-            // Restore completed if
-            // 1. Expiry is set and expiry is in the future
-            if (restore_request || restore_ongoing) {
-                restore_status = {
-                    ongoing: true,
-                };
-            } else if (restore_expiry && restore_expiry > new Date()) {
-                restore_status = {
-                    ongoing: false,
-                    expiry_time: restore_expiry,
-                };
-            }
-        }
-
-        return restore_status;
     }
 
     _get_upload_info(stat, version_id) {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -1065,3 +1065,11 @@ interface S3Select {
 }
 
 type NodeCallback<T = void> = (err: Error | null, res?: T) => void;
+
+type RestoreState = 'CAN_RESTORE' | 'ONGOING' | 'RESTORED';
+
+interface RestoreStatus {
+  state: nb.RestoreState;
+  ongoing?: boolean;
+  expiry_time?: Date;
+}

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -22,7 +22,7 @@ const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_response
 const tmp_fs_path = path.join(TMP_PATH, 'test_bucketspace_fs');
 const DEFAULT_FS_CONFIG = get_process_fs_context();
 
-const timeout = 10000;
+const timeout = 50000;
 
 // eslint-disable-next-line max-lines-per-function
 describe('manage nsfs cli account flow', () => {

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -19,7 +19,7 @@ const { TYPES, ACTIONS, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 
-const tmp_fs_path = path.join(TMP_PATH, 'test_bucketspace_fs');
+const tmp_fs_path = path.join(TMP_PATH, 'test_nc_nsfs_account_cli');
 const DEFAULT_FS_CONFIG = get_process_fs_context();
 
 const timeout = 50000;
@@ -33,7 +33,7 @@ describe('manage nsfs cli account flow', () => {
             _id: 'account1',
             type: TYPES.ACCOUNT,
             name: 'account1',
-            new_buckets_path: `${root_path}new_buckets_path_user1/`,
+            new_buckets_path: `${root_path}new_buckets_path_user10/`,
             uid: 999,
             gid: 999,
             access_key: 'GIGiFAnjaaE7OKD5N7hA',
@@ -341,7 +341,7 @@ describe('manage nsfs cli account flow', () => {
         const type = TYPES.ACCOUNT;
         const defaults = {
             name: 'account1',
-            new_buckets_path: `${root_path}new_buckets_path_user1/`,
+            new_buckets_path: `${root_path}new_buckets_path_user/`,
             uid: 999,
             gid: 999,
             access_key: 'GIGiFAnjaaE7OKD5N7hA',
@@ -794,7 +794,7 @@ describe('manage nsfs cli account flow', () => {
         const defaults = {
             type: TYPES.ACCOUNT,
             name: 'account11',
-            new_buckets_path: `${root_path}new_buckets_path_user11/`,
+            new_buckets_path: `${root_path}new_buckets_path_user111/`,
             uid: 1011,
             gid: 1011,
             access_key: 'GIGiFAnjaaE7OKD5N7h1',
@@ -937,7 +937,7 @@ describe('manage nsfs cli account flow', () => {
         const path_to_json_account_options_dir = path.join(tmp_fs_path, 'options');
         const defaults = {
             name: 'account3',
-            new_buckets_path: `${root_path}new_buckets_path_user3/`,
+            new_buckets_path: `${root_path}new_buckets_path_user33/`,
             uid: 1003,
             gid: 1003,
             access_key: 'GIGiFAnjaaE7OKD5N722',

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -970,7 +970,7 @@ describe('manage nsfs cli account flow', () => {
             // write the json_file_options
             const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
             const command_flags = {config_root, from_file: path_to_option_json_file_name};
-            // create tha account and check the details
+            // create the account and check the details
             await exec_manage_cli(type, action, command_flags);
             // compare the details
             const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
@@ -984,7 +984,7 @@ describe('manage nsfs cli account flow', () => {
             // write the json_file_options
             const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
             const command_flags = {config_root, from_file: path_to_option_json_file_name};
-            // create tha account and check the details
+            // create the account and check the details
             await exec_manage_cli(type, action, command_flags);
             // compare the details
             const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
@@ -1002,7 +1002,7 @@ describe('manage nsfs cli account flow', () => {
             // write the json_file_options
             const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
             const command_flags = {config_root, from_file: path_to_option_json_file_name};
-            // create tha account and check the details
+            // create the account
             const res = await exec_manage_cli(type, action, command_flags);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.AccountAccessKeyFlagComplexity.code);
         });
@@ -1014,7 +1014,7 @@ describe('manage nsfs cli account flow', () => {
             // write the json_file_options
             const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
             const command_flags = {config_root, from_file: path_to_option_json_file_name, name }; // name should be in file only
-            // create tha account and check the details
+            // create the account
             const res = await exec_manage_cli(type, action, command_flags);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
         });
@@ -1026,7 +1026,7 @@ describe('manage nsfs cli account flow', () => {
             // write the json_file_options
             const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
             const command_flags = {config_root, from_file: path_to_option_json_file_name};
-            // create tha account and check the details
+            // create the account
             const res = await exec_manage_cli(type, action, command_flags);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
         });
@@ -1038,7 +1038,7 @@ describe('manage nsfs cli account flow', () => {
             // write the json_file_options
             const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
             const command_flags = {config_root, from_file: path_to_option_json_file_name};
-            // create tha account and check the details
+            // create the account
             const res = await exec_manage_cli(type, action, command_flags);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
         });
@@ -1050,7 +1050,7 @@ describe('manage nsfs cli account flow', () => {
             // write the json_file_options
             const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
             const command_flags = {config_root, from_file: path_to_option_json_file_name};
-            // create tha account and check the details
+            // create the account
             const res = await exec_manage_cli(type, action, command_flags);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
         });
@@ -1062,7 +1062,7 @@ describe('manage nsfs cli account flow', () => {
             // write the json_file_options
             const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
             const command_flags = {config_root, from_file: path_to_option_json_file_name};
-            // create tha account and check the details
+            // create the account
             const res = await exec_manage_cli(type, action, command_flags);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgumentType.code);
         });
@@ -1085,7 +1085,7 @@ describe('manage nsfs cli account flow', () => {
             await fs.promises.writeFile(path_to_option_json_file_name, content);
             // write the json_file_options
             const command_flags = {config_root, from_file: path_to_option_json_file_name};
-            // create tha account
+            // create the account
             await exec_manage_cli(type, action, command_flags);
             // compare the details
             const res = await exec_manage_cli(type, action, command_flags);

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -5,11 +5,13 @@
 // disabling init_rand_seed as it takes longer than the actual test execution
 process.env.DISABLE_INIT_RANDOM_SEED = "true";
 
+const fs = require('fs');
 const path = require('path');
 const os_util = require('../../../util/os_utils');
 const fs_utils = require('../../../util/fs_utils');
 const config_module = require('../../../../config');
-const { set_path_permissions_and_owner, TMP_PATH } = require('../../system_tests/test_utils');
+const nb_native = require('../../../util/nb_native');
+const { set_path_permissions_and_owner, TMP_PATH, generate_s3_policy } = require('../../system_tests/test_utils');
 const { ACTIONS, TYPES, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const { get_process_fs_context, is_path_exists } = require('../../../util/native_fs_utils');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
@@ -17,17 +19,13 @@ const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').Ma
 const tmp_fs_path = path.join(TMP_PATH, 'test_bucketspace_fs');
 const DEFAULT_FS_CONFIG = get_process_fs_context();
 
-let bucket_storage_path;
-let bucket_temp_dir_path;
-
-
 // eslint-disable-next-line max-lines-per-function
 describe('manage nsfs cli bucket flow', () => {
 
     describe('cli create bucket', () => {
         const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs');
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs/');
-        bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs', 'bucket1');
+        const bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs', 'bucket1');
 
         const account_defaults = {
             name: 'account_test',
@@ -85,7 +83,8 @@ describe('manage nsfs cli bucket flow', () => {
     describe('cli delete bucket', () => {
         const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs2');
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs2/');
-        bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs2', 'bucket1');
+        const bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs2', 'bucket1');
+        let bucket_temp_dir_path;
 
         const account_name = 'account_test';
         const account_defaults = {
@@ -165,6 +164,171 @@ describe('manage nsfs cli bucket flow', () => {
     });
 });
 
+describe('cli create bucket using from_file', () => {
+    const type = TYPES.BUCKET;
+    const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs3');
+    const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs3/');
+    const bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs3', 'bucket1');
+    const path_to_json_bucket_options_dir = path.join(tmp_fs_path, 'options');
+
+    const account_name = 'account_test';
+    const account_defaults = {
+        name: account_name,
+        new_buckets_path: `${root_path}new_buckets_path_user1/`,
+        uid: 1001,
+        gid: 1001,
+    };
+
+    const bucket_defaults = {
+        name: 'bucket1',
+        owner: account_name,
+        path: bucket_storage_path,
+    };
+
+    beforeEach(async () => {
+        await fs_utils.create_fresh_path(`${config_root}/${CONFIG_SUBDIRS.BUCKETS}`);
+        await fs_utils.create_fresh_path(root_path);
+        await fs_utils.create_fresh_path(bucket_storage_path);
+        await fs_utils.create_fresh_path(path_to_json_bucket_options_dir);
+        const action = ACTIONS.ADD;
+        // account add
+        const { new_buckets_path: account_path } = account_defaults;
+        const account_options = { config_root, ...account_defaults };
+        await fs_utils.create_fresh_path(account_path);
+        await fs_utils.file_must_exist(account_path);
+        await set_path_permissions_and_owner(account_path, account_options, 0o700);
+        await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
+    });
+
+    afterEach(async () => {
+        await fs_utils.folder_delete(`${config_root}`);
+        await fs_utils.folder_delete(`${root_path}`);
+        await fs_utils.folder_delete(`${path_to_json_bucket_options_dir}`);
+    });
+
+    it('cli create bucket using from_file with required options', async () => {
+        const action = ACTIONS.ADD;
+        const bucket_options = { name: bucket_defaults.name, owner: bucket_defaults.owner, path: bucket_defaults.path };
+        // write the json_file_options
+        const path_to_option_json_file_name = await create_json_bucket_options(path_to_json_bucket_options_dir, bucket_options);
+        const command_flags = {config_root, from_file: path_to_option_json_file_name};
+        // create tha bucket and check the details
+        await exec_manage_cli(type, action, command_flags);
+        // compare the details
+        const bucket = await read_config_file(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name);
+        assert_bucket(bucket, bucket_options);
+    });
+
+    it('cli create bucket using from_file with optional options (fs_backend)', async () => {
+        const action = ACTIONS.ADD;
+        const fs_backend = 'GPFS';
+        const bucket_options = { name: bucket_defaults.name, owner: bucket_defaults.owner, path: bucket_defaults.path,
+            fs_backend: fs_backend };
+        // write the json_file_options
+        const path_to_option_json_file_name = await create_json_bucket_options(path_to_json_bucket_options_dir, bucket_options);
+        const command_flags = {config_root, from_file: path_to_option_json_file_name};
+        // create tha bucket and check the details
+        await exec_manage_cli(type, action, command_flags);
+        // compare the details
+        const bucket = await read_config_file(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name);
+        assert_bucket(bucket, bucket_options);
+        expect(bucket.fs_backend).toEqual(bucket_options.fs_backend);
+    });
+
+    it('cli create bucket using from_file with optional options (bucket_policy)', async () => {
+        const action = ACTIONS.ADD;
+        const bucket_policy = generate_s3_policy('*', bucket_defaults.name, ['s3:*']).policy;
+        const bucket_options = { name: bucket_defaults.name, owner: bucket_defaults.owner, path: bucket_defaults.path,
+            bucket_policy: bucket_policy };
+        // write the json_file_options
+        const path_to_option_json_file_name = await create_json_bucket_options(path_to_json_bucket_options_dir, bucket_options);
+        const command_flags = {config_root, from_file: path_to_option_json_file_name};
+        // create tha bucket and check the details
+        await exec_manage_cli(type, action, command_flags);
+        // compare the details
+        const bucket = await read_config_file(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name);
+        assert_bucket(bucket, bucket_options);
+        expect(bucket.bucket_policy).toEqual(bucket_options.s3_policy);
+    });
+
+    it('should fail - cli create bucket using from_file with additional flags (name)', async () => {
+        const action = ACTIONS.ADD;
+        const name = bucket_defaults.name;
+        // write the json_file_options
+        const path_to_option_json_file_name = await create_json_bucket_options(path_to_json_bucket_options_dir, bucket_defaults);
+        const command_flags = {config_root, from_file: path_to_option_json_file_name, name }; // name should be in file only
+        const res = await exec_manage_cli(type, action, command_flags);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
+    });
+
+    it('should fail - cli create bucket using from_file with invalid option (lala) in the file', async () => {
+        const action = ACTIONS.ADD;
+        const bucket_options = { name: bucket_defaults.name, owner: bucket_defaults.owner, path: bucket_defaults.path, lala: 'lala'}; // lala invalid option
+        // write the json_file_options
+        const path_to_option_json_file_name = await create_json_bucket_options(path_to_json_bucket_options_dir, bucket_options);
+        const command_flags = {config_root, from_file: path_to_option_json_file_name };
+        const res = await exec_manage_cli(type, action, command_flags);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
+    });
+
+    it('should fail - cli create bucket using from_file with invalid option (creation_date) in the file', async () => {
+        const action = ACTIONS.ADD;
+        const bucket_options = { name: bucket_defaults.name, owner: bucket_defaults.owner, path: bucket_defaults.path,
+            creation_date: new Date().toISOString()}; // creation_date invalid option (user cannot set it)
+        // write the json_file_options
+        const path_to_option_json_file_name = await create_json_bucket_options(path_to_json_bucket_options_dir, bucket_options);
+        const command_flags = {config_root, from_file: path_to_option_json_file_name };
+        const res = await exec_manage_cli(type, action, command_flags);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
+    });
+
+    it('should fail - cli create bucket using from_file with from_file inside the JSON file', async () => {
+        const action = ACTIONS.ADD;
+        const bucket_options = { name: bucket_defaults.name, owner: bucket_defaults.owner, path: bucket_defaults.path,
+            from_file: 'blabla' }; //from_file inside options JSON file
+        // write the json_file_options
+        const path_to_option_json_file_name = await create_json_bucket_options(path_to_json_bucket_options_dir, bucket_options);
+        const command_flags = {config_root, from_file: path_to_option_json_file_name };
+        const res = await exec_manage_cli(type, action, command_flags);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
+    });
+
+    it('should fail - cli create bucket using from_file with invalid option type (in the file)', async () => {
+        const action = ACTIONS.ADD;
+        const bucket_options = { name: bucket_defaults.name, owner: 1234, path: bucket_defaults.path }; // owner should be string (not number)
+        // write the json_file_options
+        const path_to_option_json_file_name = await create_json_bucket_options(path_to_json_bucket_options_dir, bucket_options);
+        const command_flags = {config_root, from_file: path_to_option_json_file_name };
+        const res = await exec_manage_cli(type, action, command_flags);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgumentType.code);
+    });
+
+    it('should fail - cli create bucket using from_file with invalid path', async () => {
+        const action = ACTIONS.ADD;
+        const command_flags = {config_root, from_file: 'blabla'}; //invalid path 
+        const res = await exec_manage_cli(type, action, command_flags);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidFilePath.code);
+    });
+
+    it('should fail - cli create bucket using from_file with invalid JSON file', async () => {
+        const action = ACTIONS.ADD;
+        const bucket_options = { name: bucket_defaults.name, owner: bucket_defaults.owner, path: bucket_defaults.path };
+        // write invalid json_file_options
+        const option_json_file_name = `${bucket_options.name}_options.json`;
+        const path_to_option_json_file_name = path.join(path_to_json_bucket_options_dir, option_json_file_name);
+        const content = JSON.stringify(bucket_options) + 'blabla'; // invalid JSON
+        await fs.promises.writeFile(path_to_option_json_file_name, content);
+        // write the json_file_options
+        const command_flags = {config_root, from_file: path_to_option_json_file_name};
+        // create tha bucket
+        await exec_manage_cli(type, action, command_flags);
+        // compare the details
+        const res = await exec_manage_cli(type, action, command_flags);
+        expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidJSONFile.code);
+    });
+
+});
+
 /**
  * exec_manage_cli will get the flags for the cli and runs the cli with it's flags
  * @param {string} type
@@ -194,3 +358,40 @@ async function exec_manage_cli(type, action, options) {
     return res;
 }
 
+/**
+ * read_config_file will read the config files 
+ * @param {string} config_root
+ * @param {string} schema_dir 
+ * @param {string} config_file_name the name of the config file
+ * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
+ */
+async function read_config_file(config_root, schema_dir, config_file_name, is_symlink) {
+    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
+    const config = JSON.parse(data.toString());
+    return config;
+}
+
+/** 
+ * create_json_bucket_options would create a JSON file with the options (key-value) inside file
+ * @param {string} path_to_json_bucket_options_dir
+ * @param {object} bucket_options
+ */
+async function create_json_bucket_options(path_to_json_bucket_options_dir, bucket_options) {
+    const option_json_file_name = `${bucket_options.name}_options.json`;
+    const path_to_option_json_file_name = path.join(path_to_json_bucket_options_dir, option_json_file_name);
+    const content = JSON.stringify(bucket_options);
+    await fs.promises.writeFile(path_to_option_json_file_name, content);
+    return path_to_option_json_file_name;
+}
+
+/**
+ * assert_bucket will verify the fields of the buckets (only required fields)
+ * @param {object} bucket
+ * @param {object} bucket_options
+ */
+function assert_bucket(bucket, bucket_options) {
+    expect(bucket.name).toEqual(bucket_options.name);
+    expect(bucket.bucket_owner).toEqual(bucket_options.owner);
+    expect(bucket.path).toEqual(bucket_options.path);
+}

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -16,7 +16,7 @@ const { ACTIONS, TYPES, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_
 const { get_process_fs_context, is_path_exists } = require('../../../util/native_fs_utils');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 
-const tmp_fs_path = path.join(TMP_PATH, 'test_bucketspace_fs');
+const tmp_fs_path = path.join(TMP_PATH, 'test_nc_nsfs_bucket_cli');
 const DEFAULT_FS_CONFIG = get_process_fs_context();
 
 // eslint-disable-next-line max-lines-per-function
@@ -89,7 +89,7 @@ describe('manage nsfs cli bucket flow', () => {
         const account_name = 'account_test';
         const account_defaults = {
             name: account_name,
-            new_buckets_path: `${root_path}new_buckets_path_user1/`,
+            new_buckets_path: `${root_path}new_buckets_path_user2/`,
             uid: 999,
             gid: 999,
             access_key: 'GIGiFAnjaaE7OKD5N7hX',
@@ -174,7 +174,7 @@ describe('cli create bucket using from_file', () => {
     const account_name = 'account_test';
     const account_defaults = {
         name: account_name,
-        new_buckets_path: `${root_path}new_buckets_path_user1/`,
+        new_buckets_path: `${root_path}new_buckets_path_3/`,
         uid: 1001,
         gid: 1001,
     };

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -418,7 +418,7 @@ async function put_bucket_policy_manage(options) {
  * @returns {Promise<void>}
  */
 async function delete_bucket_manage(options) {
-    const cli_options = { name: options.name };
+    const cli_options = { name: options.name, force: true };
     await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, cli_options);
 }
 

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -429,13 +429,13 @@ mocha.describe('bucketspace_fs', function() {
             const param = {name: test_bucket, website: website};
             await bucketspace_fs.put_bucket_website(param);
             const output_web = await bucketspace_fs.get_bucket_website(param);
-            assert.deepEqual(output_web, website);
+            assert.deepEqual(output_web.website, website);
         });
         mocha.it('delete_bucket_website ', async function() {
             const param = {name: test_bucket};
             await bucketspace_fs.delete_bucket_website(param);
             const output_web = await bucketspace_fs.get_bucket_website(param);
-            assert.ok(output_web === undefined);
+            assert.ok(output_web.website === undefined);
         });
     });
 

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -561,12 +561,10 @@ mocha.describe('namespace_fs', function() {
 
                 // Don't leak the xattrs to the user
                 assert.strictEqual(restore_objectmd.xattr['user.noobaa.restore.request'], undefined);
-                assert.strictEqual(restore_objectmd.xattr['user.noobaa.restore.ongoing'], undefined);
                 assert.strictEqual(restore_objectmd.xattr['user.noobaa.restore.expiry'], undefined);
 
                 const xattr = await get_xattr(path.join(ns_tmp_bucket_path, temp_restore_key));
                 assert.strictEqual(xattr['user.noobaa.restore.request'], '1');
-                assert.strictEqual(xattr['user.noobaa.restore.ongoing'], undefined);
                 assert.strictEqual(xattr['user.noobaa.restore.expiry'], undefined);
 
                 // disallows duplicate restore requests

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -449,10 +449,10 @@ function get_process_fs_context(backend = '', warn_threshold_ms = config.NSFS_WA
 
 /**
  * @param {Object} nsfs_account_config
- * @param {string} [config_root_backend]
+ * @param {string} [fs_backend]
  * @returns {Promise<nb.NativeFSContext>}
  */
-async function get_fs_context(nsfs_account_config, config_root_backend) {
+async function get_fs_context(nsfs_account_config, fs_backend) {
     let account_ids_by_dn;
     if (nsfs_account_config.distinguished_name) {
         account_ids_by_dn = await get_user_by_distinguished_name({ distinguished_name: nsfs_account_config.distinguished_name });
@@ -461,7 +461,7 @@ async function get_fs_context(nsfs_account_config, config_root_backend) {
         uid: (account_ids_by_dn && account_ids_by_dn.uid) ?? nsfs_account_config.uid,
         gid: (account_ids_by_dn && account_ids_by_dn.gid) ?? nsfs_account_config.gid,
         warn_threshold_ms: config.NSFS_WARN_THRESHOLD_MS,
-        backend: config_root_backend
+        backend: fs_backend
     };
 }
 


### PR DESCRIPTION
Commits added:
fc6060bad9d7f7f461302b39f3320c9c53f8deeb NSFS | NC | from_file in bucket add
ae6d42485c1cf46a736c15cfb480df42fa08f52a NSFS | NC | health giving trimmed output in pipe
8a29bc963a8ec33c8c80f58b4b19a10ecaf0c0bc NSFS | NC | CLI | Change the fs_context
f8d37bf64ef6f36a3a6bf4a5da3dffac5890663c CI | NSFS | NC | Jest test - rename tmp_fs_path for concurrent run
e315e741b3cc896268a71a7c9068d6b943bfecc3 NSFS | NC | fix get-bucket-website function for bucketspace fs
3f48984e75a0d5afe47b2b236e438be90bdc547c simplify GLACIER xattr + minor fixes
eedd390ac5bb86b8d78bf40243d572dad2b43b0e NSFS | CLI | Delete the bucket only if the bucket is empty or with --force
5ec2eaefc01e708d3e21828f7c5c3226f7135170 NSFS | NC | Symlinks should contain a relative path
8f0d2cc7b4e4147dd75c9a1c965bce96058483ba Restructure RPM Build process

- [ ] Doc added/updated
- [ ] Tests added
