### PR TITLE
NSFS | NC | CLI Refactor Validation (Partial) - Part 2

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -269,18 +269,6 @@ ManageCLIError.InvalidBooleanValue = Object.freeze({
     http_code: 400,
 });
 
-ManageCLIError.InvalidNewNameAccountIdentifier = Object.freeze({
-    code: 'InvalidNewNameAccountIdentifier',
-    message: 'Account new_name can not be used on add command, please remove the --new_name flag',
-    http_code: 400,
-});
-
-ManageCLIError.InvalidNewAccessKeyIdentifier = Object.freeze({
-    code: 'InvalidNewAccessKeyIdentifier',
-    message: 'Account new_access_key can not be used on add command, please remove the --new_access_key flag',
-    http_code: 400,
-});
-
 ManageCLIError.InaccessibleAccountNewBucketsPath = Object.freeze({
     code: 'InaccessibleAccountNewBucketsPath',
     message: 'Account should have read & write access to the specified new_buckets_path',
@@ -370,12 +358,6 @@ ManageCLIError.MissingBucketPathFlag = Object.freeze({
     http_code: 400,
 });
 
-ManageCLIError.InvalidNewNameBucketIdentifier = Object.freeze({
-    code: 'InvalidNewNameBucketIdentifier',
-    message: 'Bucket new_name can not be used on add command, please remove the --new_name flag',
-    http_code: 400,
-});
-
 ManageCLIError.InvalidFSBackend = Object.freeze({
     code: 'InvalidFSBackend',
     message: 'FS backend supported types are GPFS, CEPH_FS, NFSv4 default is POSIX',
@@ -415,7 +397,8 @@ ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
 ManageCLIError.RPC_ERROR_TO_MANAGE = Object.freeze({
     INVALID_SCHEMA: ManageCLIError.InvalidSchema,
     NO_SUCH_USER: ManageCLIError.InvalidAccountDistinguishedName,
-    INVALID_MASTER_KEY: ManageCLIError.InvalidMasterKey
+    INVALID_MASTER_KEY: ManageCLIError.InvalidMasterKey,
+    INVALID_BUCKET_NAME: ManageCLIError.InvalidBucketName
 });
 
 const NSFS_CLI_ERROR_EVENT_MAP = {

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -111,12 +111,13 @@ async function get_options_from_file(file_path) {
 }
 
 /**
- * has_access_keys will return anonymous or not depending on the access key length 
- * (instead of flags) and return its content
+ * has_access_keys will return if the array has at least one object of access keys
+ * (depending on the access key length)
+ * Note: when there is no access key array it might indicate that it is anonymous account
  * @param {object[]} access_keys
  */
 function has_access_keys(access_keys) {
-    return access_keys.length === 0;
+    return access_keys.length > 0;
 }
 
 /**

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
+/* eslint-disable max-lines-per-function */
 'use strict';
 
 // disabling init_rand_seed as it takes longer than the actual test execution
@@ -410,6 +411,34 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidAccountName.code);
         });
+
+        it('should fail - cli account add - without identifier', async function() {
+            const action = ACTIONS.ADD;
+            const { type, new_buckets_path, uid, gid } = defaults; // without name
+            const account_options = { config_root, new_buckets_path, uid, gid };
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingAccountNameFlag.code);
+        });
+
+        it('should fail - cli create account invalid option (new_name)', async () => {
+            const { type, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, name, new_buckets_path, uid, gid, new_name: 'lala'}; // new_name invalid option in add
+            const action = ACTIONS.ADD;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
+        });
+
+        it('should fail - cli create account invalid option (new_access_key)', async () => {
+            const { type, name, new_buckets_path, uid, gid } = defaults;
+            const account_options = { config_root, name, new_buckets_path, uid, gid, new_access_key: 'GIGiFAnjaaE7OKD5N7lB'}; // new_access_key invalid option
+            const action = ACTIONS.ADD;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidArgument.code);
+        });
+
     });
 
     describe('cli update account', () => {
@@ -741,6 +770,13 @@ describe('manage nsfs cli account flow', () => {
                 const res = await exec_manage_cli(type, action, account_options);
                 expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidAccountName.message);
             });
+
+            it('should fail - cli account update - without identifier', async () => {
+                const account_options = { config_root, regenerate: true }; // without name
+                const action = ACTIONS.UPDATE;
+                const res = await exec_manage_cli(type, action, account_options);
+                expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingAccountNameFlag.code);
+            });
         });
 
         describe('cli update account (has distinguished name)', () => {
@@ -1026,12 +1062,6 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidFlagsCombination.message);
         });
 
-        it('cli account status without name and access_key', async function() {
-            const action = ACTIONS.STATUS;
-            const res = await exec_manage_cli(TYPES.ACCOUNT, action, { config_root });
-            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingIdentifier.code);
-        });
-
     });
 
     describe('cli delete account', () => {
@@ -1128,6 +1158,14 @@ describe('manage nsfs cli account flow', () => {
             const account_options = { config_root, access_key};
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidArgument.message);
+        });
+
+        it('should fail - cli account delete - without identifier', async () => {
+            const action = ACTIONS.DELETE;
+            const { type } = defaults;
+            const account_options = { config_root}; // without name
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingAccountNameFlag.code);
         });
 
     });

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -987,7 +987,7 @@ mocha.describe('manage_nsfs cli', function() {
                 await exec_manage_cli(type, '', { config_root, ips: '' });
                 assert.fail('should have failed with whitelist ips should not be empty.');
             } catch (err) {
-                assert_error(err, ManageCLIError.MissingWhiteListIPFlag);
+                assert_error(err, ManageCLIError.InvalidWhiteListIPFormat);
             }
         });
 


### PR DESCRIPTION
### Explain the changes
1. Change the require to the file name (instead of destructor in the require with the functions name).
2. Change all functions which start with "verify" to "validate".
3. Create a function for checking the identifier for each command.
4. Remove a duplicate test (`cli account status without name and access_key`).
5. Remove dead code inside `validate_bucket_args` and `validate_account_args`.
6. Change the operator in the function `has_access_keys` to match its name.

Note: This PR is continuing PR #7917.

### Issues:
List of GAPs:
1. We need to update the JSDoc in a couple of functions in file manage_nsfs_validations.js.
2. We still want to call the validations function earlier in the code (some of them are after we fetch the data).

### Testing Instructions:
#### Unit Tests
Please run:
1. `sudo npx jest test_nc_nsfs_account_cli.test.js`
3. `sudo npx jest test_nc_nsfs_bucket_cli.test.js`
4. `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`
5. `sudo npx jest test_nc_nsfs_anonymous_cli.test`

- [ ] Doc added/updated
- [X] Tests added
