### PR TITLE
Fix Bug BZ 2271067 | NSFS | Change Mapping in Pool Server

### DIFF
--- a/config.js
+++ b/config.js
@@ -607,6 +607,11 @@ config.WORM_ENABLED = false;
 config.NAMESPACE_MONITOR_ENABLED = true;
 config.NAMESPACE_MONITOR_DELAY = 3 * 60 * 1000;
 
+//////////////////////////////////
+//      NAMESPACE MODE CALC     //
+//////////////////////////////////
+
+config.NS_MAX_ALLOWED_IO_ERRORS = 9;
 
 ////////////////////////////////
 //      BUCKET REPLICATOR     //

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -13,6 +13,7 @@ const nb_native = require('../../util/nb_native');
 const config = require('../../../config');
 const P = require('../../util/promise');
 const noobaa_s3_client = require('../../sdk/noobaa_s3_client/noobaa_s3_client');
+const S3Error = require('../../endpoint/s3/s3_errors').S3Error;
 
 class NamespaceMonitor {
 
@@ -205,7 +206,12 @@ class NamespaceMonitor {
         }
     }
 
+    // In test_nsfs_resource we check readdir and stat - 
+    // readdir checks read permissions and in the past stat didn't check read permissions.
+    // Nowadays stat also checks read permissions so now readdir is redundant - decided to keep it.
     async test_nsfs_resource(nsr) {
+        dbg.log1('test_nsfs_resource: (name, namespace_store, nsfs_config):',
+            nsr.name, nsr.namespace_store, nsr.nsfs_config);
         try {
             const fs_context = {
                 backend: nsr.nsfs_config.fs_backend || '',
@@ -214,12 +220,21 @@ class NamespaceMonitor {
             await nb_native().fs.readdir(fs_context, nsr.nsfs_config.fs_root_path);
             const stat = await nb_native().fs.stat(fs_context, nsr.nsfs_config.fs_root_path);
             //In the event of deleting the nsr.nsfs_config.fs_root_path in the FS side, 
-            // The number of link will be 0, then we will throw ENOENT which translate to STORAGE_NOT_EXIST
+            // The number of link will be 0, then we will throw an error which translate to STORAGE_NOT_EXIST
             if (stat.nlink === 0) {
+                dbg.log1('test_nsfs_resource: the number of links is 0', nsr.nsfs_config);
                 throw Object.assign(new Error('FS root path has no links'), { code: 'ENOENT' });
             }
         } catch (err) {
-            dbg.log1('test_nsfs_resource: got error:', err, nsr.nsfs_config);
+            dbg.error('test_nsfs_resource: got error:', err, nsr.nsfs_config);
+            // we change the code to control the mapping in pool server when calc the namespace mode
+            if (err.code === 'ENOENT') {
+                // it can happen if (1) stat/readdir threw ENOENT or (2) the number of links is 0 
+                throw Object.assign(err, { code: S3Error.NoSuchBucket.code });
+            }
+            if (err.code === `EPERM` || err.code === `EACCES`) {
+                throw Object.assign(err, { code: S3Error.AccessDenied.code });
+            }
             throw err;
         }
     }

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1097,7 +1097,6 @@ function calc_namespace_resource_mode(namespace_resource) {
     const map_err_to_type_count = {
         ContainerNotFound: 'storage_not_exist',
         NoSuchBucket: 'storage_not_exist',
-        ENOENT: 'storage_not_exist',
         AccessDenied: 'auth_failed',
         AuthenticationFailed: 'auth_failed',
     };
@@ -1114,7 +1113,7 @@ function calc_namespace_resource_mode(namespace_resource) {
 
     const mode = (errors_count.storage_not_exist && 'STORAGE_NOT_EXIST') ||
         (errors_count.auth_failed && 'AUTH_FAILED') ||
-        (errors_count.io_errors > config.CLOUD_MAX_ALLOWED_IO_TEST_ERRORS && 'IO_ERRORS') ||
+        (errors_count.io_errors > config.NS_MAX_ALLOWED_IO_ERRORS && 'IO_ERRORS') ||
         'OPTIMAL';
 
     return mode;


### PR DESCRIPTION
### Explain the changes
1. In `pool_server` inside `calc_namespace_resource_mode` remove the mapping of `ENOENT` to `storage_not_exist`.
2. In the `namespace_monitor` change the error code either from a thrown error or an error that we created to a code that we choose and add log printing (could be seen in the endpoint logs).
3. Add a config `NS_MAX_ALLOWED_IO_ERRORS` that we will use in the `calc_namespace_resource_mode`.

### Issues: Fixed [BZ 2271067](https://bugzilla.redhat.com/show_bug.cgi?id=2271067)
1. Currently, when someone tries to head an object that doesn't exist in NSFS it will be mapped to `ENOENT` and then the namespace mode will be `STORAGE_NOT_EXISTS` (instead of `IO_ERROR`).
2. GAP (more info [here](https://github.com/noobaa/noobaa-core/pull/7936#discussion_r1546039726)) - with the suggested change we would not be able to to know if the origin of `NoSuchBucket` or `AccessDenied` error code is from the namespace monitor or requests that were updated in the issues report (we would only have the printing in the endpoint logs to guide us that it is from the namespace monitor, example:

> [Endpoint/98] [ERROR] core.server.bg_services.namespace_monitor:: test_nsfs_resource: got error: [Error: No such file or directory] { code: 'ENOENT' } { fs_root_path: '/nsfs/fs1' }

### Testing Instructions:
#### Manual Tests:
General:
1. Deploy noobaa on a local cluster (MInikube or Rancher Desktop) (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
4. Deploy NSFS on a local cluster (Based on the instructions [here](https://github.com/noobaa/noobaa-core/wiki/NSFS-on-Kubernetes/8fa95c3b827c40f2435a63f60fae5f7285e6b221)).

Mapping Change:
Use AWS CLI and use the head-object command on a noobaa bucket in NSFS on non-existing key.
1. Before: the namespace phase was changed from `Ready` to `Rejected` with mode `STORAGE_NOT_EXIST` after 1 failure.
2. After: the namespace phase was changed from `Ready` to `Rejected` with mode `IO_ERRORS` after a couple of failures.
You can use a loop for this, for example: `for i in {1..10}; do s3-nb-user-1 s3api head-object --bucket fs1-jenia-bucket --key non_exist.txt; done` (`s3-nb-user-1` is an alias `alias s3-nb-user-1='AWS_ACCESS_KEY=<access_key_nsfs_account> AWS_SECRET_ACCESS_KEY=<secret_access_key_nsfs_account> aws --no-verify-ssl --endpoint-url https://localhost:12443'`.

Updating the env:
If you wish to update the `NS_MAX_ALLOWED_IO_ERRORS` you would need to:
1. `kubectl exec statefulset/noobaa-core -c core -- printenv | grep IO_ERRORS` (should be empty).
2. `kubectl set env statefulset/noobaa-core CONFIG_JS_NS_MAX_ALLOWED_IO_ERRORS=3` (a different number that we defined in the config, then it should output `statefulset.apps/noobaa-core env updated` and `noobaa-core-0` pod will be terminated and start running again). Please notice that to override envs we will need to add the prefix `CONFIG_JS_` in the variable name.
3. `kubectl exec statefulset/noobaa-core -c core -- printenv | grep IO_ERRORS` (should be `NS_MAX_ALLOWED_IO_ERRORS=6`).
4. You can run the loop mention above with `for i in {1..7};` and see that the namespace phase was changed from `Ready` to `Rejected` with mode `STORAGE_NOT_EXIST`.

- [ ] Doc added/updated
- [ ] Tests added
