### PR TITLE
NSFS | NC | Refactor Bucketspace_fs.delete_bucket() and others

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -256,8 +256,8 @@ async function delete_bucket(data, force) {
     const fs_context_fs_backend = native_fs_utils.get_process_fs_context(data.fs_backend);
     const bucket_config_path = get_config_file_path(buckets_dir_path, data.name);
     try {
-        const temp_dir_name = config.NSFS_TEMP_DIR_NAME + "_" + data._id;
-        const bucket_temp_dir_path = path.join(data.path, temp_dir_name);
+        const temp_dir_name = native_fs_utils.get_bucket_tmpdir_name(data._id);
+        const bucket_temp_dir_path = native_fs_utils.get_bucket_tmpdir_full_path(data.path, data._id);
         const entries = await nb_native().fs.readdir(fs_context_fs_backend, data.path);
         const object_entries = entries.filter(element => !element.name.endsWith(temp_dir_name));
         if (object_entries.length === 0 || force) {

--- a/src/sdk/bucketspace_simple_fs.js
+++ b/src/sdk/bucketspace_simple_fs.js
@@ -120,7 +120,12 @@ class BucketSpaceSimpleFS {
         }
     }
 
-    async delete_bucket(params) {
+    /**
+    * @param {object} params
+    * @param {nb.ObjectSDK} object_sdk
+    * @returns {Promise<object>}
+    */
+    async delete_bucket(params, object_sdk) {
         try {
             const { name } = params;
             const bucket_path = path.join(this.fs_root, name);
@@ -203,6 +208,10 @@ class BucketSpaceSimpleFS {
         // TODO
     }
 
+    /**
+    * @param {object} params
+    * @returns {Promise<object>}
+    */
     async get_bucket_website(params) {
         // TODO
     }
@@ -234,6 +243,23 @@ class BucketSpaceSimpleFS {
     }
 
     async put_object_lock_configuration(params, object_sdk) {
+        // TODO
+    }
+
+
+    /////////////////////
+    // BUCKET LOGGING  //
+    /////////////////////
+
+    async put_bucket_logging(params) {
+        // TODO
+    }
+
+    async delete_bucket_logging(params) {
+        // TODO
+    }
+
+    async get_bucket_logging(params) {
         // TODO
     }
 }

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -933,7 +933,7 @@ interface NativeFS {
     realpath(fs_context: NativeFSContext, path: string): Promise<string>;
     checkAccess(fs_context: NativeFSContext, path: string): Promise<void>;
     getsinglexattr(fs_context: NativeFSContext, path: string, key: string): Promise<string>;
-    getpwname(fs_context: NativeFSContext, user: string): Promise<object>;
+    getpwname(fs_context: NativeFSContext, user: string): Promise<NativeFSUserObject>;
 
     readFile(
         fs_context: NativeFSContext,
@@ -1028,6 +1028,12 @@ type NativeFSStats = fs.Stats & {
     ctimeNsBigint: bigint;
     mtimeNsBigint: bigint;
     xattr?: NativeFSXattr;
+};
+
+type NativeFSUserObject = {
+    uid: number;
+    gid: number;
+    name: string;
 };
 
 interface HasherSync {

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -206,6 +206,10 @@ class ObjectSDK {
         return bucket.bucket_info.data;
     }
 
+    async read_bucket_full_info(name) {
+        return bucket_namespace_cache.get_with_cache({ sdk: this, name });
+    }
+
     async load_requesting_account(req) {
         try {
             const token = this.get_auth_token();

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -8,12 +8,11 @@ const fs = require('fs');
 const path = require('path');
 const os_util = require('../../../util/os_utils');
 const fs_utils = require('../../../util/fs_utils');
-const config_module = require('../../../../config');
 const nb_native = require('../../../util/nb_native');
 const { set_path_permissions_and_owner, TMP_PATH, generate_s3_policy,
     set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
 const { ACTIONS, TYPES, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_nsfs_constants');
-const { get_process_fs_context, is_path_exists } = require('../../../util/native_fs_utils');
+const { get_process_fs_context, is_path_exists, get_bucket_tmpdir_full_path } = require('../../../util/native_fs_utils');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const { ManageCLIResponse } = require('../../../manage_nsfs/manage_nsfs_cli_responses');
 
@@ -192,8 +191,7 @@ describe('manage nsfs cli bucket flow', () => {
             const bucket_resp = JSON.parse(resp);
             expect(bucket_resp.response.reply._id).not.toBeNull();
             //create temp dir
-            bucket_temp_dir_path = path.join(bucket_storage_path,
-                config_module.NSFS_TEMP_DIR_NAME + "_" + bucket_resp.response.reply._id);
+            bucket_temp_dir_path = get_bucket_tmpdir_full_path(bucket_storage_path, bucket_resp.response.reply._id);
             await fs_utils.create_fresh_path(bucket_temp_dir_path);
             await fs_utils.file_must_exist(bucket_temp_dir_path);
         });

--- a/src/test/unit_tests/test_nsfs_versioning.js
+++ b/src/test/unit_tests/test_nsfs_versioning.js
@@ -88,7 +88,7 @@ mocha.describe('namespace_fs - versioning', function() {
         const to_path = path.join(ns_tmp_bucket_path, file_key + '_mtime-1-ino-2');
         const fake_mtime_ino = { mtimeNsBigint: BigInt(0), ino: 0 };
         try {
-            const bucket_tmp_dir_path = path.join(ns_tmp.bucket_path, ns_tmp.get_bucket_tmpdir());
+            const bucket_tmp_dir_path = ns_tmp.get_bucket_tmpdir_full_path();
             await native_fs_utils.safe_move_posix(
                 dummy_object_sdk.requesting_account.nsfs_account_config,
                 from_path,
@@ -108,7 +108,7 @@ mocha.describe('namespace_fs - versioning', function() {
         const to_path = path.join(ns_tmp_bucket_path, file_key2 + '_mtime-1-ino-2');
         const fake_mtime_ino = { mtimeNsBigint: BigInt(0), ino: 0 };
         try {
-            const bucket_tmp_dir_path = path.join(ns_tmp.bucket_path, ns_tmp.get_bucket_tmpdir());
+            const bucket_tmp_dir_path = ns_tmp.get_bucket_tmpdir_full_path();
             await native_fs_utils.safe_move_posix(
                 dummy_object_sdk.requesting_account.nsfs_account_config,
                 from_path,

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -559,6 +559,27 @@ async function read_file(fs_context, _path) {
     return data_parsed;
 }
 
+
+/**
+ * get_bucket_tmpdir_name returns the bucket tmp dir name
+ * @param {string} bucket_id 
+ * @returns {string}
+ */
+function get_bucket_tmpdir_name(bucket_id) {
+    return config.NSFS_TEMP_DIR_NAME + '_' + bucket_id;
+}
+
+
+/**
+ * get_bucket_tmpdir_full_path returns the bucket tmp dir path
+ * @param {string} bucket_path 
+ * @param {string} bucket_id 
+ * @return {string} 
+ */
+function get_bucket_tmpdir_full_path(bucket_path, bucket_id) {
+    return path.join(bucket_path, get_bucket_tmpdir_name(bucket_id));
+}
+
 exports.get_umasked_mode = get_umasked_mode;
 exports._make_path_dirs = _make_path_dirs;
 exports._create_path = _create_path;
@@ -592,3 +613,5 @@ exports.validate_bucket_creation = validate_bucket_creation;
 exports.is_path_exists = is_path_exists;
 exports.is_dir_rw_accessible = is_dir_rw_accessible;
 exports.folder_delete = folder_delete;
+exports.get_bucket_tmpdir_full_path = get_bucket_tmpdir_full_path;
+exports.get_bucket_tmpdir_name = get_bucket_tmpdir_name;


### PR DESCRIPTION
### Explain the changes
1. Refactored `delete_bucket()` function in 2 aspects - 
    * **Bucketspace_fs.js** - 
              - The 3 (different functions) calls to namespace_bucket_cache functions  
were merged to a new function call that returns bucket and ns info. 
              - Moved inline tmpdir path to a function in native_fs_utils (called this function from other places as well)
    * **object_sdk.js** - Added a new function called `read_bucket_full_info()`.
    * **native_fs_utils.js -** 
           -  Added 2 new functions called `get_bucket_tmpdir_full_path()` and `get_bucket_tmpdir_name()` and changed the calls from different files to re-use this code block.
    * **namespace_fs.js -** 
            - Renamed `get_bucket_tmpdir() `to `get_bucket_tmpdir_name()` and changed the 
implementation to call the native_fs_utils function. 
           - Added `get_bucket_tmpdir_full_path() ` to call the compatible `native_fs_utils.js` function with the namespace bucket_path and bucket_id.

**VSC error fixes -** 

- **bucketspace_simple_fs.js**  - 
       -  Added missing put_bucket_logging(), get_bucket_logging(), delete_bucket_logging() function declerations (unimplemented). 
       -  Added function declaretions to delete_bucket() and get_bucket_website() 
 

- **nb.d.ts** - Added a new type **NativeFSUserObject** and added it to the return value of getpwname() (fixed errors in test_bucketspace_fs.js)
- 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
