### PR TITLE
[NC | NSFS] Fix GLACIER issues

### DIFF
--- a/src/endpoint/s3/ops/s3_get_object_uploadId.js
+++ b/src/endpoint/s3/ops/s3_get_object_uploadId.js
@@ -37,7 +37,7 @@ async function get_object_uploadId(req) {
                 UploadId: req.query.uploadId,
                 Initiator: s3_utils.DEFAULT_S3_USER,
                 Owner: s3_utils.DEFAULT_S3_USER,
-                StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+                StorageClass: s3_utils.parse_storage_class(reply.storage_class),
                 MaxParts: max,
                 PartNumberMarker: num_marker,
                 IsTruncated: reply.is_truncated,

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -546,11 +546,6 @@ S3Error.InvalidObjectStorageClass = Object.freeze({
     message: 'Restore is not allowed for the object\'s current storage class.',
     http_code: 403,
 });
-S3Error.StorageClassNotImplemented = Object.freeze({
-    code: 'NotImplemented',
-    message: 'This storage class is not implemented.',
-    http_code: 501,
-});
 
 S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     UNAUTHORIZED: S3Error.AccessDenied,

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1575,6 +1575,11 @@ class NamespaceFS {
             const fs_context = this.prepare_fs_context(object_sdk);
             await this._load_multipart(params, fs_context);
             await this._check_path_in_bucket_boundaries(fs_context, params.mpu_path);
+            const { data } = await nb_native().fs.readFile(
+                fs_context,
+                path.join(params.mpu_path, 'create_object_upload')
+            );
+            const create_multipart_upload_params = JSON.parse(data.toString());
             const entries = await nb_native().fs.readdir(fs_context, params.mpu_path);
             const multiparts = await Promise.all(
                 entries
@@ -1595,6 +1600,7 @@ class NamespaceFS {
                 is_truncated: false,
                 next_num_marker: undefined,
                 multiparts,
+                storage_class: create_multipart_upload_params.storage_class
             };
         } catch (err) {
             throw this._translate_object_error_codes(err);
@@ -2974,7 +2980,7 @@ class NamespaceFS {
 
     async _throw_if_storage_class_not_supported(storage_class) {
         if (!await this._is_storage_class_supported(storage_class)) {
-            throw new S3Error(S3Error.StorageClassNotImplemented);
+            throw new S3Error(S3Error.InvalidStorageClass);
         }
     }
 

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -483,9 +483,9 @@ mocha.describe('namespace_fs', function() {
                     assert.fail('restore_object should fail');
                 } catch (err) {
                     assert.strictEqual(err instanceof S3Error, true);
-                    assert.strictEqual(err.code, S3Error.StorageClassNotImplemented.code);
-                    assert.strictEqual(err.message, S3Error.StorageClassNotImplemented.message);
-                    assert.strictEqual(err.http_code, S3Error.StorageClassNotImplemented.http_code);
+                    assert.strictEqual(err.code, S3Error.InvalidStorageClass.code);
+                    assert.strictEqual(err.message, S3Error.InvalidStorageClass.message);
+                    assert.strictEqual(err.http_code, S3Error.InvalidStorageClass.http_code);
                 }
             });
 

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -265,21 +265,18 @@ class MultiSizeBuffersPool {
     }
 
     /**
-     * @returns BuffersPool
+     * @returns {BuffersPool}
     */
     get_buffers_pool(size) {
         const largest = this.pools[this.pools.length - 1];
         if (typeof size !== 'number' || size < 0) {
-            dbg.log1('MultiSizeBuffersPool.get_buffers_pool: sem value', largest.sem._value, 'waiting_value', largest.sem._waiting_value, 'buffers length', largest.buffers.length);
             return largest;
         }
         for (const bp of this.pools) {
             if (size <= bp.buf_size) {
-                dbg.log1('MultiSizeBuffersPool.get_buffers_pool: sem value', bp.sem._value, 'waiting_value', bp.sem._waiting_value, 'buffers length', bp.buffers.length);
                 return bp;
             }
         }
-        dbg.log1('MultiSizeBuffersPool.get_buffers_pool: sem value', largest.sem._value, 'waiting_value', largest.sem._waiting_value, 'buffers length', largest.buffers.length);
         return largest;
     }
 }


### PR DESCRIPTION
### Explain the changes
This PR attempts to do the following to resolve issues reported by TC team:
1. Removes buffer pool logging
2. Throws invalid storage class error whenever any storage class other than `STANDARD` or `GLACIER` is used.
3. Displays correct storage class in the output of `list-parts` S3 API call instead of hardcoded `STANDARD`.

- [ ] Doc added/updated
- [ ] Tests added
