### PR TITLE
change bucket policy validation order in bucketspace-fs

### DIFF
--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -568,12 +568,13 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             const bucket_config_path = this._get_bucket_config_path(name);
             const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
             const bucket = JSON.parse(data.toString());
-            await bucket_policy_utils.validate_s3_policy(policy, bucket.name, async principal => this._get_account_by_name(principal));
             bucket.s3_policy = policy;
             const bucket_to_validate = _.omitBy(bucket, _.isUndefined);
             dbg.log2("put_bucket_policy: bucket properties before validate_bucket_schema",
             bucket_to_validate);
             nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
+            await bucket_policy_utils.validate_s3_policy(bucket.s3_policy, bucket.name, async principal =>
+                 this._get_account_by_name(principal));
             const update_bucket = JSON.stringify(bucket);
             await nb_native().fs.writeFile(
                 this.fs_context,


### PR DESCRIPTION
### Explain the changes
1. in bucketspace-fs validate_s3_policy was called before the policy schema validation, causing it to fail with an internal error. changed the order so the schema will be validated before. That way in the case of schema error, we will return malformed policy

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2272386

### Testing Instructions:
1. create a bucket policy without a principal
2. using NSFS try to push this policy: `aws s3api put-bucket-policy --bucket <bucket-name> --policy file://policy.json`
3. should fail with MalformedPolicy. should not fail with InternalError


- [ ] Doc added/updated
- [ ] Tests added
