### PR TITLE
NSFS | Empty 'logs' directory is getting created under 's3-config' directory

### DIFF
--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -35,13 +35,6 @@ if (process.env.NOOBAA_LOG_LEVEL) {
     }
 }
 
-function _should_log_to_file() {
-    if (process.env.container === 'docker') return false;
-    if (process.env.CONTAINER_PLATFORM === 'KUBERNETES') return false;
-    if (global.document) return false;
-    return true;
-}
-
 // override the default inspect options
 if (!util.inspect.defaultOptions) util.inspect.defaultOptions = {};
 util.inspect.defaultOptions.depth = 10;
@@ -204,19 +197,6 @@ class InternalDebugLogger {
         this._log_console = console;
         this._log_console_silent = false;
         this._log_file = null;
-
-        if (!_should_log_to_file()) {
-            return;
-        }
-
-        //if logs directory doesn't exist, create it
-        try {
-            fs.mkdirSync('./logs');
-        } catch (e) {
-            if (e.code !== 'EEXIST') {
-                throw e;
-            }
-        }
 
     }
 


### PR DESCRIPTION
### Explain the changes
An empty 'logs' directory is created when running manage nsfs cli. Dubug module is creating this empty `logs` folder but couldnt find the use of it.
1. remove code that create `logs` folder.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7930

### Testing Instructions:
1. run manage nsfs cli and verify `logs` folder created in the command executed folder path.


- [ ] Doc added/updated
- [ ] Tests added
