### PR TITLE
bucket_logging: Store log objects inside log prefix directory

### DIFF
--- a/src/endpoint/s3/s3_bucket_logging.js
+++ b/src/endpoint/s3/s3_bucket_logging.js
@@ -89,6 +89,7 @@ function get_bucket_log_record(op_name, source_bucket, req, res) {
         source_bucket: req.params.bucket,
         object_key: req.originalUrl,
         log_bucket: source_bucket.bucket_info.logging.log_bucket,
+        log_prefix: source_bucket.bucket_info.logging.log_prefix,
         remote_ip: client_ip,
         request_uri: req.originalUrl,
         http_status: status_code,

--- a/src/server/bg_services/bucket_logs_upload.js
+++ b/src/server/bg_services/bucket_logs_upload.js
@@ -76,8 +76,10 @@ class BucketLogUploader {
         if (!log_objects) return buckets;
         for (const file of log_objects) {
             const bucket_name = file.split(BUCKET_NAME_DEL)[0];
+            const log_prefix = file.split(BUCKET_NAME_DEL)[1];
             buckets.push({
                 bucket_name: bucket_name,
+                log_prefix: log_prefix,
                 log_object_name: file,
             });
         }
@@ -113,9 +115,10 @@ class BucketLogUploader {
             throw new Error('noobaa endpoint connection is not started yet...');
         }
         const log_file_path = BUCKET_LOGS_PATH + log_object.log_object_name;
+        const log_object_key = log_object.log_prefix + '/' + log_object.log_object_name;
         const params = {
             Bucket: log_object.bucket_name,
-            Key: log_object.log_object_name,
+            Key: log_object_key,
             Body: fs.readFileSync(log_file_path),
         };
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -392,6 +392,17 @@ async function put_bucket_logging(req) {
 
     dbg.log0('put_bucket_logging:', req.rpc_params);
     const bucket = find_bucket(req);
+    const prefix = req.rpc_params.log_prefix;
+
+    if (!prefix) {
+        throw new RpcError('INVALID_ARGUMENT', 'Log prefix is not provided');
+    }
+
+    const prefix_regex = /^[a-zA-Z0-9.-]+$/;
+    if (!prefix_regex.test(prefix)) {
+        throw new RpcError('INVALID_ARGUMENT', 'Log prefix should only contain alphanumeric characters, hyphens, or periods');
+    }
+
     const logging = {
                         "log_bucket": req.rpc_params.log_bucket,
                         "log_prefix": req.rpc_params.log_prefix


### PR DESCRIPTION
We provide log prefix while setting bucket logging for a noobaa bucket. When log objects are uploaded on log bucket, it should be saved under a directory named as log prefix.

