### PR TITLE
Fix Bug BZ 2272900 | NSFS | Remove Issues Updates with System Store

### DIFF
--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -377,6 +377,26 @@ module.exports = {
             }
         },
 
+        update_last_monitoring: {
+            doc: 'Update last namespace monitoring',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['namespace_resource_id', 'last_monitoring'],
+                properties: {
+                    last_monitoring: {
+                        idate: true,
+                    },
+                    namespace_resource_id: {
+                        objectid: true
+                    },
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
         scale_hosts_pool: {
             doc: 'Change the pool\'s underlaying host count',
             method: 'POST',

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -73,18 +73,18 @@ class NamespaceMonitor {
                 } else {
                     dbg.error('namespace_monitor: invalid endpoint type', endpoint_type);
                 }
-                await this.update_last_monitoring(nsr._id, nsr.name, endpoint_type);
+                this.update_last_monitoring(nsr._id, nsr.name, endpoint_type);
             } catch (err) {
-                await this.run_update_issues_report(err, nsr);
+                this.run_update_issues_report(err, nsr);
                 dbg.log1(`test_namespace_resource_validity: namespace resource ${nsr.name} has error as expected`);
             }
         });
         dbg.log1(`test_namespace_resource_validity finished successfully..`);
     }
 
-    async run_update_issues_report(err, nsr) {
+    run_update_issues_report(err, nsr) {
         if (!err.code) return;
-        await this.client.pool.update_issues_report({
+        this.client.pool.update_issues_report({
             namespace_resource_id: nsr._id,
             error_code: String(err.code),
             time: Date.now(),
@@ -98,17 +98,17 @@ class NamespaceMonitor {
         });
     }
 
-    async update_last_monitoring(nsr_id, nsr_name, endpoint_type) {
+    update_last_monitoring(nsr_id, nsr_name, endpoint_type) {
         dbg.log0(`update_last_monitoring: monitoring namespace ${nsr_name} type ${endpoint_type}, ${nsr_id} finished successfully..`);
-        await system_store.make_changes({
-            update: {
-                namespace_resources: [{
-                    _id: nsr_id,
-                    $set: {
-                        last_monitoring: Date.now()
-                    }
-                }]
-            }
+        this.client.pool.update_last_monitoring({
+            namespace_resource_id: nsr_id,
+            last_monitoring: Date.now(),
+        }, {
+            auth_token: auth_server.make_auth_token({
+                system_id: system_store.data.systems[0]._id,
+                account_id: system_store.data.systems[0].owner._id,
+                role: 'admin'
+            })
         });
     }
 

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -48,6 +48,11 @@ const POOL_HOSTS_INFO_DEFAULTS = Object.freeze({
     by_service: {},
 });
 
+
+// key: namespace_resource_id, value: { last_monitoring: date, issues: array of issues } 
+// (see namespace_resource_schema)
+const map_issues_and_monitoring_report = new Map();
+
 const NO_CAPAITY_LIMIT = 1024 ** 2; // 1MB
 const LOW_CAPACITY_HARD_LIMIT = 30 * (1024 ** 3); // 30GB
 
@@ -1101,7 +1106,12 @@ function calc_namespace_resource_mode(namespace_resource) {
         AuthenticationFailed: 'auth_failed',
     };
 
-    const errors_count = _.reduce(namespace_resource.issues_report, (acc, issue) => {
+    const namespace_resource_id = namespace_resource._id.toString();
+    if (!map_issues_and_monitoring_report.has(namespace_resource_id)) {
+        map_issues_and_monitoring_report.set(namespace_resource_id, { last_monitoring: undefined, issues: [] });
+    }
+    const issues_report = map_issues_and_monitoring_report.get(namespace_resource_id).issues;
+    const errors_count = _.reduce(issues_report, (acc, issue) => {
         // skip if error timestamp is before of the latest monitoring
         if (issue.time < namespace_resource.last_monitoring) {
             return acc;
@@ -1406,24 +1416,32 @@ function update_issues_report(req) {
         dbg.log0('update_issues_report: can not find namespace_resource, ignoring update of issues report');
         return;
     }
-    const cur_issues_report = ns_resource.issues_report || [];
+
+    if (!map_issues_and_monitoring_report.has(namespace_resource_id)) {
+        map_issues_and_monitoring_report.set(namespace_resource_id, { last_monitoring: undefined, issues: [] });
+    }
+    const cur_issues_report = map_issues_and_monitoring_report.get(namespace_resource_id).issues;
 
     // save the last 10 errors
     if (cur_issues_report.length === 10) {
         cur_issues_report.shift();
     }
     cur_issues_report.push({ error_code, time });
-    const updates = { issues_report: cur_issues_report };
-    if (monitoring) updates.last_monitoring = time;
+    if (monitoring) {
+        map_issues_and_monitoring_report.get(namespace_resource_id).last_monitoring = time;
+    }
+    dbg.log3('update_issues_report:', namespace_resource_id, cur_issues_report);
+}
 
-    return system_store.make_changes({
-        update: {
-            namespace_resources: [{
-                _id: ns_resource._id,
-                $set: updates
-            }]
-        }
-    });
+function update_last_monitoring(req) {
+    const { namespace_resource_id, last_monitoring } = req.rpc_params;
+
+    if (!map_issues_and_monitoring_report.has(namespace_resource_id)) {
+        map_issues_and_monitoring_report.set(namespace_resource_id, { last_monitoring: undefined, issues: [] });
+    }
+
+    map_issues_and_monitoring_report.get(namespace_resource_id).last_monitoring = last_monitoring;
+    dbg.log3('update_last_monitoring:', namespace_resource_id, last_monitoring);
 }
 
 // EXPORTS
@@ -1454,4 +1472,5 @@ exports.update_cloud_pool = update_cloud_pool;
 exports.get_optimal_non_mongo_pool_id = get_optimal_non_mongo_pool_id;
 exports.get_hosts_pool_agent_config = get_hosts_pool_agent_config;
 exports.update_issues_report = update_issues_report;
+exports.update_last_monitoring = update_last_monitoring;
 exports.calc_namespace_resource_mode = calc_namespace_resource_mode;


### PR DESCRIPTION
### Explain the changes
1. Remove issues updates with the system store.
2. Avoid updating the issues report in case of no such key when using a head object in NSFS.
3. Move the update last monitoring to the memory instead of the system store, since it is also used by the issues report.

### Issues: Fixed [BZ 2272900](https://bugzilla.redhat.com/show_bug.cgi?id=2272900)
1. Currently we update the issues report with the system store, and if we encounter 10/10 issues it's changing the namespace mode to `IO_ERRORS`. In this fix, we suggest saving this information in memory in the pool server and not updating the issue report when we don't find the key metadata (head object).
2. GAP - avoid updating the issues report was done only in NSFS.

### Testing Instructions:
General:
1. Deploy noobaa on a local cluster (MInikube or Rancher Desktop) (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
3. Deploy NSFS on a local cluster (Based on the instructions [here](https://github.com/noobaa/noobaa-core/wiki/NSFS-on-Kubernetes/8fa95c3b827c40f2435a63f60fae5f7285e6b221)).

NSFS Change:
1. Use AWS CLI and use the head-object command on a noobaa bucket in NSFS on non-existing key.
You can use a loop for this, for example: `for i in {1..10}; do s3-nb-user-1 s3api head-object --bucket fs1-jenia-bucket --key non_exist.txt; done` (`s3-nb-user-1` is an alias `alias s3-nb-user-1='AWS_ACCESS_KEY=<access_key_nsfs_account> AWS_SECRET_ACCESS_KEY=<secret_access_key_nsfs_account> aws --no-verify-ssl --endpoint-url https://localhost:12443'`.
2. Before: the namespace phase was changed from `Ready` to `Rejected` with mode `IO_ERRORS` after 10 failure.
After: the namespace phase is still `Ready`.

System store change:
1. Set higher debug level (at least 3): `noobaa system set-debug-level 5`.
2. Search for the logs `update_last_monitoring: update_last_monitoring` in the core logs (`kubectl logs pod noobaa-core-0 -f`).

- [ ] Doc added/updated
- [ ] Tests added
