### PR TITLE
fix url decoding for copyObject

### DIFF
--- a/src/endpoint/endpoint_utils.js
+++ b/src/endpoint/endpoint_utils.js
@@ -17,21 +17,24 @@ function prepare_rest_request(req) {
 }
 
 function parse_source_url(source_url) {
-    let slash_index = source_url.indexOf('/');
-    let start_index = 0;
-    if (slash_index === 0) {
-        start_index = 1;
-        slash_index = source_url.indexOf('/', 1);
-    }
-    let query_index = source_url.indexOf('?', slash_index);
+    let query_index = source_url.indexOf('?');
     let query;
     if (query_index < 0) {
         query_index = source_url.length;
     } else {
         query = querystring.parse(source_url.slice(query_index + 1));
     }
-    const bucket = decodeURIComponent(source_url.slice(start_index, slash_index));
-    const key = decodeURIComponent(source_url.slice(slash_index + 1, query_index));
+
+    // '/' may be encoded, first decde the bucket/key part
+    const decoded_source_url = decodeURIComponent(source_url.slice(0, query_index));
+    let slash_index = decoded_source_url.indexOf('/');
+    let start_index = 0;
+    if (slash_index === 0) {
+        start_index = 1;
+        slash_index = decoded_source_url.indexOf('/', 1);
+    }
+    const bucket = decoded_source_url.slice(start_index, slash_index);
+    const key = decoded_source_url.slice(slash_index + 1);
     return { query, bucket, key };
 }
 


### PR DESCRIPTION
### Explain the changes
1. when url part of bucket is encoded, the '/' is encoded as well. change the order so we un-escaped the URL before we search for '/'. still search for ? in encoded state, since it isn't encoded as part of the bucket/key

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7941

### Testing Instructions:
1. call copy-object-input with escaped parameter combining bucket name and key (<bucket>/<key>). 
3. command should work 


- [ ] Doc added/updated
- [ ] Tests added
