### PR TITLE
Load balancing config option to limit server.maxRequestsPerSocket and force clients to reconnect and rebalance

### DIFF
--- a/config.js
+++ b/config.js
@@ -140,6 +140,7 @@ config.ENABLE_OBJECT_IO_SEMAPHORE_MONITOR = true;
 
 config.ENDPOINT_HTTP_SERVER_REQUEST_TIMEOUT = 300 * 1000;
 config.ENDPOINT_HTTP_SERVER_KEEPALIVE_TIMEOUT = 5 * 1000;
+config.ENDPOINT_HTTP_MAX_REQUESTS_PER_SOCKET = 0; // 0 = no limit
 
 // For now we enable fixed CORS for all buckets
 // but this should become a setting per bucket which is configurable

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -466,6 +466,7 @@ function setup_http_server(server) {
 
     server.keepAliveTimeout = config.ENDPOINT_HTTP_SERVER_KEEPALIVE_TIMEOUT;
     server.requestTimeout = config.ENDPOINT_HTTP_SERVER_REQUEST_TIMEOUT;
+    server.maxRequestsPerSocket = config.ENDPOINT_HTTP_MAX_REQUESTS_PER_SOCKET;
 
     server.on('error', handle_server_error);
 


### PR DESCRIPTION
### Explain the changes
1. Add `config.ENDPOINT_HTTP_MAX_REQUESTS_PER_SOCKET` to set [http server.maxRequestsPerSocket option](https://nodejs.org/docs/latest-v20.x/api/http.html#servermaxrequestspersocket).
2. When using [DNS round-robin](https://en.wikipedia.org/wiki/Round-robin_DNS) for load balancing, every clients resolve the DNS to a "random" server ip, and might keep the its connections open for a long time (if there is a continuous flow of requests this can keep using the same connections indefinitely).
3. This creates cases where the initial spread is bad, and wouldn't rebalance itself overtime.
4. We need the option to limit the lifetime of a socket before we close it, which will simply cause the clients to re-create a new connection for their next request and hopefully resolve the DNS to a new IP. 
5. Notice that we might add an overhead with that setting because reconnecting requires quite a few round trips.
6. Notice also that the DNS might resolve to the same server because of TTL or other caches.
7. It might also be a good idea to limit a socket by TTL to match the DNS TTL settings.
8. This was tested for DNS-LB, and will most likely not be helpful for TCP-LB (aka NLB) and HTTP-LB (aka ALB) where a proxy connects to the endpoint by IP and not DNS name.

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. I tested both with a cloud DNS that has minimum TTL of 1 minute, and using kubernetes internal DNS that uses TTL of 5 seconds (see [Using Kubernetes Service for proxying to external services](https://www.kristhecodingunicorn.com/post/kubernetes-service-to-proxy-to-external-services/)).
2. I tried maxRequestsPerSocket with values of both 5 and 10 - both seemed to work just as well for benchmarks.

