### PR TITLE
5.14 | Backport | NSFS | Open TMP file flags manual backport - 'wt' flow

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -196,7 +196,7 @@ parse_open_flags(std::string flags)
         case 't':
 #ifdef O_TMPFILE
             bits |= O_TMPFILE | O_RDWR;
-            bits &= ~(O_RDONLY | O_WRONLY);
+            bits &= ~(O_RDONLY | O_WRONLY | O_TRUNC | O_CREAT);
 #else
             LOG("FS: Unsupported O_TMPFILE " << flags);
 #endif

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -187,6 +187,9 @@ parse_open_flags(std::string flags)
             bits |= O_RDWR;
             bits &= ~(O_RDONLY | O_WRONLY);
             break;
+        case '*':
+            bits &= ~(O_TRUNC);
+            break;
         case 's':
             bits |= O_SYNC;
             break;
@@ -220,10 +223,13 @@ const static std::vector<std::string> GPFS_XATTRS{ GPFS_ENCRYPTION_XATTR_NAME };
 const static std::vector<std::string> USER_XATTRS{
     "user.content_type",
     "user.content_md5",
-    "user.version_id",
-    "user.prev_version_id",
-    "user.delete_marker",
-    "user.dir_content",
+    "user.noobaa.version_id",
+    "user.noobaa.prev_version_id",
+    "user.noobaa.delete_marker",
+    "user.noobaa.dir_content",
+    "user.noobaa.part_offset",
+    "user.noobaa.part_size",
+    "user.noobaa.part_etag",
 };
 
 struct Entry
@@ -1397,22 +1403,31 @@ struct FileWrite : public FSWrapWorker<FileWrap>
 {
     const uint8_t* _buf;
     size_t _len;
+    off_t _offset;
     FileWrite(const Napi::CallbackInfo& info)
         : FSWrapWorker<FileWrap>(info)
         , _buf(0)
         , _len(0)
+        , _offset(-1)
     {
         auto buf = info[1].As<Napi::Buffer<uint8_t>>();
         _buf = buf.Data();
         _len = buf.Length();
-        Begin(XSTR() << "FileWrite " << DVAL(_wrap->_path) << DVAL(_len));
+        if (info.Length() > 3 && !info[3].IsUndefined()) {
+            _offset = info[3].As<Napi::Number>();
+        }
+        Begin(XSTR() << "FileWrite " << DVAL(_wrap->_path) << DVAL(_len) << DVAL(_offset));
     }
     virtual void Work()
     {
         int fd = _wrap->_fd;
         CHECK_WRAP_FD(fd);
-        // TODO: Switch to pwrite when needed
-        ssize_t bw = write(fd, _buf, _len);
+        ssize_t bw = -1;
+        if (_offset >= 0) {
+            bw = pwrite(fd, _buf, _len, _offset);
+        } else {
+            bw = write(fd, _buf, _len);
+        }
         if (bw < 0) {
             SetSyscallError();
         } else if ((size_t)bw != _len) {
@@ -1425,9 +1440,11 @@ struct FileWritev : public FSWrapWorker<FileWrap>
 {
     std::vector<struct iovec> iov_vec;
     ssize_t _total_len;
+    off_t _offset;
     FileWritev(const Napi::CallbackInfo& info)
         : FSWrapWorker<FileWrap>(info)
         , _total_len(0)
+        , _offset(-1)
     {
         auto buffers = info[1].As<Napi::Array>();
         const int buffers_len = buffers.Length();
@@ -1441,13 +1458,21 @@ struct FileWritev : public FSWrapWorker<FileWrap>
             iov_vec[i] = iov;
             _total_len += iov.iov_len;
         }
-        Begin(XSTR() << "FileWritev " << DVAL(_wrap->_path) << DVAL(_total_len) << DVAL(buffers_len));
+        if (info.Length() > 2 && !info[2].IsUndefined()) {
+            _offset = info[2].As<Napi::Number>();
+        }
+        Begin(XSTR() << "FileWritev " << DVAL(_wrap->_path) << DVAL(_total_len) << DVAL(buffers_len) << DVAL(_offset));
     }
     virtual void Work()
     {
         int fd = _wrap->_fd;
         CHECK_WRAP_FD(fd);
-        ssize_t bw = writev(fd, iov_vec.data(), iov_vec.size());
+        ssize_t bw = -1;
+        if (_offset >= 0) {
+            bw = pwritev(fd, iov_vec.data(), iov_vec.size(), _offset);
+        } else {
+            bw = writev(fd, iov_vec.data(), iov_vec.size());
+        }
         if (bw < 0) {
             SetSyscallError();
         } else if (bw != _total_len) {

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2020 NooBaa */
-/*eslint max-lines: ["error", 3000]*/
+/*eslint max-lines: ["error", 4000]*/
 /*eslint max-statements: ["error", 80, { "ignoreTopLevelFunctions": true }]*/
 'use strict';
 
@@ -17,6 +17,7 @@ const error_utils = require('../util/error_utils');
 const stream_utils = require('../util/stream_utils');
 const buffer_utils = require('../util/buffer_utils');
 const size_utils = require('../util/size_utils');
+const native_fs_utils = require('../util/native_fs_utils');
 const ChunkFS = require('../util/chunk_fs');
 const LRUCache = require('../util/lru_cache');
 const Semaphore = require('../util/semaphore');
@@ -36,22 +37,19 @@ const buffers_pool = new buffer_utils.BuffersPool({
 });
 
 const XATTR_USER_PREFIX = 'user.';
+const XATTR_NOOBAA_INTERNAL_PREFIX = XATTR_USER_PREFIX + 'noobaa.';
 // TODO: In order to verify validity add content_md5_mtime as well
 const XATTR_CONTENT_TYPE = XATTR_USER_PREFIX + 'content_type';
 const XATTR_MD5_KEY = XATTR_USER_PREFIX + 'content_md5';
-const XATTR_VERSION_ID = XATTR_USER_PREFIX + 'version_id';
-const XATTR_PREV_VERSION_ID = XATTR_USER_PREFIX + 'prev_version_id';
-const XATTR_DELETE_MARKER = XATTR_USER_PREFIX + 'delete_marker';
-const XATTR_DIR_CONTENT = XATTR_USER_PREFIX + 'dir_content';
+const XATTR_PART_OFFSET = XATTR_NOOBAA_INTERNAL_PREFIX + 'part_offset';
+const XATTR_PART_SIZE = XATTR_NOOBAA_INTERNAL_PREFIX + 'part_size';
+const XATTR_PART_ETAG = XATTR_NOOBAA_INTERNAL_PREFIX + 'part_etag';
+const XATTR_VERSION_ID = XATTR_NOOBAA_INTERNAL_PREFIX + 'version_id';
+const XATTR_PREV_VERSION_ID = XATTR_NOOBAA_INTERNAL_PREFIX + 'prev_version_id';
+const XATTR_DELETE_MARKER = XATTR_NOOBAA_INTERNAL_PREFIX + 'delete_marker';
+const XATTR_DIR_CONTENT = XATTR_NOOBAA_INTERNAL_PREFIX + 'dir_content';
 const HIDDEN_VERSIONS_PATH = '.versions';
 const NULL_VERSION_ID = 'null';
-
-const INTERNAL_XATTR = [
-    XATTR_CONTENT_TYPE,
-    XATTR_DIR_CONTENT,
-    XATTR_PREV_VERSION_ID,
-    XATTR_DELETE_MARKER,
-];
 
 const versioning_status_enum = {
     VER_ENABLED: 'ENABLED',
@@ -222,7 +220,7 @@ function make_named_dirent(name) {
 
 function to_xattr(fs_xattr) {
     const xattr = _.mapKeys(fs_xattr, (val, key) =>
-        (key.startsWith(XATTR_USER_PREFIX) && !INTERNAL_XATTR.includes(key) ? key.slice(XATTR_USER_PREFIX.length) : '')
+        (key.startsWith(XATTR_USER_PREFIX) && !key.startsWith(XATTR_NOOBAA_INTERNAL_PREFIX) ? key.slice(XATTR_USER_PREFIX.length) : '')
     );
     // keys which do not start with prefix will all map to the empty string key, so we remove it once
     delete xattr[''];
@@ -983,8 +981,9 @@ class NamespaceFS {
             if (!params.copy_source || upload_params.copy_res === copy_status_enum.FALLBACK) {
             // TODO: Take up only as much as we need (requires fine-tune of the semaphore inside the _upload_stream)
             // Currently we are taking config.NSFS_BUF_SIZE for any sized upload (1KB upload will take a full buffer from semaphore)
-                upload_params.digest = await buffers_pool_sem.surround_count(
+                const upload_res = await buffers_pool_sem.surround_count(
                     config.NSFS_BUF_SIZE, async () => this._upload_stream(upload_params));
+                upload_params.digest = upload_res.digest;
             }
             const upload_info = await this._finish_upload(upload_params);
             return upload_info;
@@ -1035,7 +1034,7 @@ class NamespaceFS {
             dbg.log1(`NamespaceFS._open_file: mode=${open_mode} creating dirs`, open_path, this.bucket_path);
             await this._make_path_dirs(open_path, fs_context);
         }
-        dbg.log0(`NamespaceFS._open_file: mode=${open_mode}`, open_path);
+        dbg.log1(`NamespaceFS._open_file: mode=${open_mode}`, open_path);
         // for 'wt' open the tmpfile with the parent dir path
         const actual_open_path = open_mode === 'wt' ? dir_path : open_path;
         return nb_native().fs.open(fs_context, actual_open_path, open_mode, get_umasked_mode(config.BASE_MODE_FILE));
@@ -1073,7 +1072,7 @@ class NamespaceFS {
     // xattr_copy = false implies on non server side copy fallback copy (copy status = FALLBACK)
     // target file can be undefined when it's a folder created and size is 0
     async _finish_upload({ fs_context, params, open_mode, target_file, upload_path, file_path, digest = undefined,
-            copy_res = undefined }) {
+            copy_res = undefined, offset }) {
         const part_upload = file_path === upload_path;
         const same_inode = params.copy_source && copy_res === copy_status_enum.SAME_INODE;
         const is_dir_content = this._is_directory_content(file_path, params.key);
@@ -1096,6 +1095,9 @@ class NamespaceFS {
                     if (md5_hex !== digest) throw new Error('_upload_stream mismatch etag: ' + util.inspect({ key, bucket, upload_id, md5_hex, digest }));
                 }
                 fs_xattr = this._assign_md5_to_fs_xattr(digest, fs_xattr);
+            }
+            if (part_upload) {
+                fs_xattr = await this._assign_part_props_to_fs_xattr(fs_context, params.size, digest, offset, fs_xattr);
             }
             if (!part_upload && (this._is_versioning_enabled() || this._is_versioning_suspended())) {
                 const cur_ver_info = await this._get_version_info(fs_context, file_path);
@@ -1267,7 +1269,7 @@ class NamespaceFS {
     // This is due to MD5 calculation and data buffers
     // Can be finetuned further on if needed and inserting the Semaphore logic inside
     // Instead of wrapping the whole _upload_stream function (q_buffers lives outside of the data scope of the stream)
-    async _upload_stream({ fs_context, params, target_file, object_sdk }) {
+    async _upload_stream({ fs_context, params, target_file, object_sdk, offset }) {
         const { source_stream } = params;
         try {
             // Not using async iterators with ReadableStreams due to unsettled promises issues on abort/destroy
@@ -1278,12 +1280,13 @@ class NamespaceFS {
                 fs_context,
                 stats: this.stats,
                 namespace_resource_id: this.namespace_resource_id,
-                md5_enabled
+                md5_enabled,
+                offset
             });
             chunk_fs.on('error', err1 => dbg.error('namespace_fs._upload_stream: error occured on stream ChunkFS: ', err1));
             await stream_utils.pipeline([source_stream, chunk_fs]);
             await stream_utils.wait_finished(chunk_fs);
-            return chunk_fs.digest;
+            return { digest: chunk_fs.digest, total_bytes: chunk_fs.total_bytes };
         } catch (error) {
             dbg.error('_upload_stream had error: ', error);
             throw error;
@@ -1327,34 +1330,76 @@ class NamespaceFS {
         }
     }
 
+    _get_part_data_path(params) {
+        return path.join(params.mpu_path, `parts-size-${params.size}`);
+    }
+
+    _get_part_md_path(params) {
+        return path.join(params.mpu_path, `part-${params.num}`);
+    }
+
+    // optimized version of upload_multipart - 
+    // 1. if size is pre known -
+    //    1.1. calc offset
+    //    1.2. upload data to by_size file in offset position
+    //    1.3. set on the part_md_file size, offset and etag xattr
+    // 2. else -
+    //    2.1. upload data to part_md_file
+    //    2.2. calc offset
+    //    2.3. copy the bytes to by_size file
+    //    2.4. set on the part_md_file size, offset and etag xattr
     async upload_multipart(params, object_sdk) {
-        // We can use 'wt' for open mode like we do for upload_object() when
-        // we figure out how to create multipart upload using temp files.
-        const open_mode = 'w';
+        const data_open_mode = 'w*';
+        const md_open_mode = 'w+';
         const fs_context = this.prepare_fs_context(object_sdk);
         let target_file;
+        let part_md_file;
         try {
             await this._load_multipart(params, fs_context);
-            const upload_path = path.join(params.mpu_path, `part-${params.num}`);
-            // Will get populated in _upload_stream with the MD5 (if MD5 calculation is enabled)
-            target_file = await this._open_file(fs_context, upload_path, open_mode);
-            const upload_params = { fs_context, params, object_sdk, upload_path, open_mode, target_file, file_path: upload_path };
 
-            await buffers_pool_sem.surround_count(config.NSFS_BUF_SIZE, async () => this._upload_stream(upload_params));
+            const md_upload_path = this._get_part_md_path(params);
+            part_md_file = await this._open_file(fs_context, md_upload_path, md_open_mode);
+            let md_upload_params = {
+                fs_context, params, object_sdk, upload_path: md_upload_path, open_mode: md_open_mode,
+                target_file: part_md_file, file_path: md_upload_path
+            };
 
-            const upload_info = await this._finish_upload(upload_params);
+            let upload_res;
+            const pre_known_size = (params.size >= 0);
+            if (!pre_known_size) {
+                // 2.1
+                upload_res = await buffers_pool_sem.surround_count(config.NSFS_BUF_SIZE, async () => this._upload_stream(md_upload_params));
+                params.size = upload_res.total_bytes;
+            }
+            const offset = params.size * (params.num - 1);
+            const upload_path = this._get_part_data_path(params);
+            dbg.log1(`NamespaceFS: upload_multipart, data path=${upload_path} offset=${offset} data_open_mode=${data_open_mode}`);
+
+            target_file = await this._open_file(fs_context, upload_path, data_open_mode);
+            const data_upload_params = {
+                fs_context, params, object_sdk, upload_path, data_open_mode, target_file,
+                file_path: upload_path, offset
+            };
+
+            if (pre_known_size) {
+                upload_res = await buffers_pool_sem.surround_count(config.NSFS_BUF_SIZE,
+                    async () => this._upload_stream(data_upload_params));
+            } else {
+                // 2.3 if size was not pre known, copy data from part_md_file to by_size file
+                await native_fs_utils.copy_bytes(buffers_pool, fs_context, part_md_file, target_file, params.size, offset, 0);
+            }
+
+            md_upload_params = { ...md_upload_params, offset, digest: upload_res.digest };
+            const upload_info = await this._finish_upload(md_upload_params);
             return upload_info;
         } catch (err) {
             this.run_update_issues_report(object_sdk, err);
             throw this._translate_object_error_codes(err);
         } finally {
-            try {
-                if (target_file) await target_file.close(fs_context);
-            } catch (err) {
-                dbg.warn('NamespaceFS: _upload_stream file close error', err);
-            }
+            await native_fs_utils.finally_close_files(fs_context, [target_file, part_md_file]);
         }
     }
+
 
     async list_multiparts(params, object_sdk) {
         try {
@@ -1387,12 +1432,21 @@ class NamespaceFS {
         }
     }
 
+    // iterate over multiparts array - 
+    // 1. if num of unique sizes is 1
+    //    1.1. if this is the last part - link the size file and break the loop
+    //    1.2. else, continue the loop
+    // 2. if num of unique sizes is 2
+    //    2.1. if should_copy_file_prefix
+    //         2.1.1. if the cur part is the last, link the previous part file to upload_path and copy the last part (tail) to upload_path  
+    //         2.1.2. else - copy the prev part size file prefix to upload_path
+    // 3. copy bytes of the current's part size file
     async complete_object_upload(params, object_sdk) {
+        const part_size_to_fd_map = new Map(); // { size: fd }
         let read_file;
         let target_file;
-        let buffer_pool_cleanup = null;
         const fs_context = this.prepare_fs_context(object_sdk);
-        const open_mode = 'w';
+        const open_mode = 'w*';
         try {
             const md5_enabled = config.NSFS_CALCULATE_MD5 || (this.force_md5_etag ||
                 object_sdk?.requesting_account?.force_md5_etag);
@@ -1401,77 +1455,96 @@ class NamespaceFS {
             multiparts.sort((a, b) => a.num - b.num);
             await this._load_multipart(params, fs_context);
             const file_path = this._get_file_path(params);
+
             await this._check_path_in_bucket_boundaries(fs_context, file_path);
             const upload_path = path.join(params.mpu_path, 'final');
-            target_file = await this._open_file(fs_context, upload_path, open_mode);
-            const upload_params = { fs_context, upload_path, open_mode, file_path, params, target_file };
 
+            target_file = null;
+            let prev_part_size = 0;
+            let should_copy_file_prefix = true;
+            let total_size = 0;
             for (const { num, etag } of multiparts) {
-                const part_path = path.join(params.mpu_path, `part-${num}`);
-                read_file = await this._open_file(fs_context, part_path, config.NSFS_OPEN_READ_MODE);
-                const part_stat = await read_file.stat(fs_context);
-
-                if (etag !== this._get_etag(part_stat)) {
-                    throw new Error('mismatch part etag: ' + util.inspect({ num, etag, part_path, part_stat, params }));
+                const md_part_path = this._get_part_md_path({ ...params, num });
+                const md_part_stat = await nb_native().fs.stat(fs_context, md_part_path);
+                const part_size = Number(md_part_stat.xattr[XATTR_PART_SIZE]);
+                const part_offset = Number(md_part_stat.xattr[XATTR_PART_OFFSET]);
+                if (etag !== this._get_etag(md_part_stat)) {
+                    throw new Error('mismatch part etag: ' + util.inspect({ num, etag, md_part_path, md_part_stat, params }));
                 }
-
-                let read_pos = 0;
-                for (;;) {
-                    const { buffer, callback } = await buffers_pool.get_buffer();
-                    buffer_pool_cleanup = callback;
-                    const bytesRead = await read_file.read(fs_context, buffer, 0, config.NSFS_BUF_SIZE, read_pos);
-                    if (!bytesRead) {
-                        buffer_pool_cleanup = null;
-                        callback();
-                        break;
-                    }
-                    read_pos += bytesRead;
-                    const data = buffer.slice(0, bytesRead);
-                    await target_file.write(fs_context, data);
-                    // Returns the buffer to pool to avoid starvation
-                    buffer_pool_cleanup = null;
-                    callback();
-                }
-
-                await read_file.close(fs_context);
-                read_file = null;
                 if (MD5Async) await MD5Async.update(Buffer.from(etag, 'hex'));
+
+                const data_part_path = this._get_part_data_path({ ...params, size: part_size });
+                if (part_size_to_fd_map.has(part_size)) {
+                    read_file = part_size_to_fd_map.get(part_size);
+                } else {
+                    read_file = await this._open_file(fs_context, data_part_path, config.NSFS_OPEN_READ_MODE);
+                    part_size_to_fd_map.set(part_size, read_file);
+                }
+
+                // 1
+                if (part_size_to_fd_map.size === 1) {
+                    if (num === multiparts.length) {
+                        await nb_native().fs.link(fs_context, data_part_path, upload_path);
+                        break;
+                    } else {
+                        prev_part_size = part_size;
+                        total_size += part_size;
+                        continue;
+                    }
+                } else if (part_size_to_fd_map.size === 2 && should_copy_file_prefix) { // 2
+                    if (num === multiparts.length) {
+                        const prev_data_part_path = this._get_part_data_path({ ...params, size: prev_part_size });
+                        await nb_native().fs.link(fs_context, prev_data_part_path, upload_path);
+                    } else {
+                        const prev_read_file = part_size_to_fd_map.get(prev_part_size);
+                        if (!target_file) target_file = await this._open_file(fs_context, upload_path, open_mode);
+                        // copy (num - 1) parts, all the same size of the prev part
+                        const copy_size = prev_part_size * (num - 1);
+                        await native_fs_utils.copy_bytes(buffers_pool, fs_context, prev_read_file, target_file, copy_size, 0, 0);
+                    }
+                    should_copy_file_prefix = false;
+                }
+                // 3
+                if (!target_file) target_file = await this._open_file(fs_context, upload_path, open_mode);
+                await native_fs_utils.copy_bytes(buffers_pool, fs_context, read_file, target_file, part_size, total_size, part_offset);
+                prev_part_size = part_size;
+                total_size += part_size;
             }
+            if (!target_file) target_file = await this._open_file(fs_context, upload_path, open_mode);
 
             const { data: create_params_buffer } = await nb_native().fs.readFile(
                 fs_context,
                 path.join(params.mpu_path, 'create_object_upload')
             );
-            upload_params.params.xattr = (JSON.parse(create_params_buffer.toString())).xattr;
+
+            const upload_params = { fs_context, upload_path, open_mode, file_path, params, target_file };
+            const create_params_parsed = JSON.parse(create_params_buffer.toString());
+            upload_params.params.xattr = create_params_parsed.xattr;
             upload_params.digest = MD5Async && (((await MD5Async.digest()).toString('hex')) + '-' + multiparts.length);
             const upload_info = await this._finish_upload(upload_params);
 
             await target_file.close(fs_context);
             target_file = null;
             if (config.NSFS_REMOVE_PARTS_ON_COMPLETE) await this._folder_delete(params.mpu_path, fs_context);
-
             return upload_info;
         } catch (err) {
             dbg.error(err);
             throw this._translate_object_error_codes(err);
         } finally {
-            await this.complete_object_upload_finally(buffer_pool_cleanup, read_file, target_file, fs_context);
+            await this.complete_object_upload_finally(undefined, [...part_size_to_fd_map.values()], target_file, fs_context);
         }
     }
 
+
     // complete_object_upload method has too many statements
-    async complete_object_upload_finally(buffer_pool_cleanup, read_file, write_file, fs_context) {
+    async complete_object_upload_finally(buffer_pool_cleanup, read_file_arr, write_file, fs_context) {
         try {
             // release buffer back to pool if needed
             if (buffer_pool_cleanup) buffer_pool_cleanup();
         } catch (err) {
             dbg.warn('NamespaceFS: complete_object_upload buffer pool cleanup error', err);
         }
-        try {
-            if (read_file) await read_file.close(fs_context);
-        } catch (err) {
-            dbg.warn('NamespaceFS: complete_object_upload read file close error', err);
-        }
+        await native_fs_utils.finally_close_files(fs_context, read_file_arr);
         try {
             if (write_file) await write_file.close(fs_context);
         } catch (err) {
@@ -1683,6 +1756,16 @@ class NamespaceFS {
         if (prev_ver_info) fs_xattr[XATTR_PREV_VERSION_ID] = prev_ver_info.version_id_str;
         if (delete_marker) fs_xattr[XATTR_DELETE_MARKER] = delete_marker;
 
+        return fs_xattr;
+    }
+
+    async _assign_part_props_to_fs_xattr(fs_context, size, digest, offset, fs_xattr) {
+        fs_xattr = Object.assign(fs_xattr || {}, {
+            [XATTR_PART_SIZE]: size,
+            [XATTR_PART_OFFSET]: offset,
+            [XATTR_PART_ETAG]: digest
+
+        });
         return fs_xattr;
     }
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -941,8 +941,8 @@ interface NativeFile {
     close(fs_context: NativeFSContext): Promise<void>;
     stat(fs_context: NativeFSContext, options?: { skip_user_xattr?: boolean, xattr_get_keys?: string[] }): Promise<NativeFSStats>;
     read(fs_context: NativeFSContext, buffer: Buffer, offset: number, length: number, pos: number): Promise<number>;
-    write(fs_context: NativeFSContext, buffer: Buffer): Promise<void>;
-    writev(fs_context: NativeFSContext, buffers: Buffer[]): Promise<void>;
+    write(fs_context: NativeFSContext, buffer: Buffer, len: number, offset?: number): Promise<void>;
+    writev(fs_context: NativeFSContext, buffers: Buffer[], offset?: number): Promise<void>;
     replacexattr(fs_context: NativeFSContext, xattr: NativeFSXattr, clear_prefix?: string): Promise<void>;
     linkfileat(fs_context: NativeFSContext): Promise<void>;
     fsync(fs_context: NativeFSContext): Promise<void>;

--- a/src/test/unit_tests/index.js
+++ b/src/test/unit_tests/index.js
@@ -58,6 +58,9 @@ require('./test_mirror_writer');
 require('./test_namespace_fs');
 require('./test_ns_list_objects');
 require('./test_chunk_fs');
+require('./test_namespace_fs_mpu');
+require('./test_nb_native_fs');
+require('./test_nsfs_versioning');
 require('./test_s3select');
 
 // // SERVERS

--- a/src/test/unit_tests/sudo_index.js
+++ b/src/test/unit_tests/sudo_index.js
@@ -15,10 +15,6 @@ if (test_utils.invalid_nsfs_root_permissions()) {
 }
 
 // // CORE
-require('./test_nb_native_fs');
-require('./test_namespace_fs');
-require('./test_nsfs_versioning');
-require('./test_ns_list_objects');
 require('./test_nsfs_access');
 require('./test_bucketspace');
 require('./test_bucketspace_versioning');

--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -18,9 +18,10 @@ const test_utils = require('../system_tests/test_utils');
 coretest.setup({});
 
 const MAC_PLATFORM = 'darwin';
-const XATTR_VERSION_ID = 'user.version_id';
-const XATTR_PREV_VERSION_ID = 'user.prev_version_id';
-const XATTR_DELETE_MARKER = 'user.delete_marker';
+const XATTR_INTERNAL_NOOBAA_PREFIX = 'user.noobaa.';
+const XATTR_VERSION_ID = XATTR_INTERNAL_NOOBAA_PREFIX + 'version_id';
+const XATTR_PREV_VERSION_ID = XATTR_INTERNAL_NOOBAA_PREFIX + 'prev_version_id';
+const XATTR_DELETE_MARKER = XATTR_INTERNAL_NOOBAA_PREFIX + 'delete_marker';
 const NULL_VERSION_ID = 'null';
 
 const DEFAULT_FS_CONFIG = {
@@ -2478,7 +2479,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
         });
 
         mocha.it('get object, with version enabled, delete marker placed on latest object - should return NoSuchKey', async function() {
-            const xattr_delete_marker = { 'user.delete_marker': 'true' };
+            const xattr_delete_marker = { [XATTR_DELETE_MARKER]: 'true' };
             await file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
             try {
                 await s3_client.getObject({Bucket: bucket_name, Key: en_version_key}).promise();
@@ -2489,14 +2490,14 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
         });
 
         mocha.it('get object, with version enabled, delete marker placed on latest object, version id specified - should return the version object', async function() {
-            const xattr_delete_marker = { 'user.delete_marker': 'true' };
+            const xattr_delete_marker = { [XATTR_DELETE_MARKER]: 'true' };
             await file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
             const res = await s3_client.getObject({Bucket: bucket_name, Key: en_version_key, VersionId: versionID_2}).promise();
             assert.equal(res.Body, en_version_body_v1);
         });
 
         mocha.it('head object, with version enabled, delete marked xattr placed on latest object - should return ENOENT', async function() {
-            const xattr_delete_marker = { 'user.delete_marker': 'true' };
+            const xattr_delete_marker = { [XATTR_DELETE_MARKER]: 'true' };
             await file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
             try {
                 await s3_client.headObject({Bucket: bucket_name, Key: en_version_key}).promise();
@@ -2507,7 +2508,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
         });
 
         mocha.it('head object, with version enabled, delete marked xattr placed on latest object, version id specified - should return the version object', async function() {
-            const xattr_delete_marker = { 'user.delete_marker': 'true' };
+            const xattr_delete_marker = { [XATTR_DELETE_MARKER]: 'true' };
             await file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
             try {
                 await s3_client.headObject({Bucket: bucket_name, Key: en_version_key, VersionId: versionID_2}).promise();
@@ -2955,7 +2956,7 @@ mocha.describe('List-objects', function() {
     });
 
     mocha.it('list objects - deleted object should not be listed', async function() {
-        const xattr_delete_marker = { 'user.delete_marker': 'true' };
+        const xattr_delete_marker = { [XATTR_DELETE_MARKER]: 'true' };
         file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
         const res = await s3_client.listObjects({Bucket: bucket_name}).promise();
         let count = 0;
@@ -2968,7 +2969,7 @@ mocha.describe('List-objects', function() {
     });
 
     mocha.it('list object versions - All versions of the object should be listed', async function() {
-        const xattr_delete_marker = { 'user.delete_marker': 'true' };
+        const xattr_delete_marker = { [XATTR_DELETE_MARKER]: 'true' };
         file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
         const res = await s3_client.listObjectVersions({Bucket: bucket_name}).promise();
         let count = 0;
@@ -2981,7 +2982,7 @@ mocha.describe('List-objects', function() {
     });
 
     mocha.it('list object versions - Check whether the deleted object is the latest and should be present under delete markers as well', async function() {
-        const xattr_delete_marker = { 'user.delete_marker': 'true' };
+        const xattr_delete_marker = { [XATTR_DELETE_MARKER]: 'true' };
         file_pointer.replacexattr(DEFAULT_FS_CONFIG, xattr_delete_marker);
         const res = await s3_client.listObjectVersions({Bucket: bucket_name}).promise();
 
@@ -2999,7 +3000,7 @@ async function create_object(object_path, data, version_id, return_fd) {
     const target_file = await nb_native().fs.open(DEFAULT_FS_CONFIG, object_path, 'w+');
     await fs.promises.writeFile(object_path, data);
     if (version_id !== 'null') {
-        const xattr_version_id = { 'user.version_id': `${version_id}` };
+        const xattr_version_id = { [XATTR_VERSION_ID]: `${version_id}` };
         await target_file.replacexattr(DEFAULT_FS_CONFIG, xattr_version_id);
     }
     if (return_fd) return target_file;

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -24,7 +24,7 @@ const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null,
 
 // TODO: In order to verify validity add content_md5_mtime as well
 const XATTR_MD5_KEY = 'content_md5';
-const XATTR_DIR_CONTENT = 'user.dir_content';
+const XATTR_DIR_CONTENT = 'user.noobaa.dir_content';
 
 const MAC_PLATFORM = 'darwin';
 

--- a/src/test/unit_tests/test_namespace_fs_mpu.js
+++ b/src/test/unit_tests/test_namespace_fs_mpu.js
@@ -1,0 +1,570 @@
+/* Copyright (C) 2020 NooBaa */
+/*eslint max-lines-per-function: ["error", 900]*/
+/* eslint-disable max-params */
+'use strict';
+
+const _ = require('lodash');
+const fs = require('fs');
+const util = require('util');
+const mocha = require('mocha');
+const crypto = require('crypto');
+const assert = require('assert');
+
+const P = require('../../util/promise');
+const config = require('../../../config');
+const fs_utils = require('../../util/fs_utils');
+const s3_utils = require('../../endpoint/s3/s3_utils');
+const NamespaceFS = require('../../sdk/namespace_fs');
+const buffer_utils = require('../../util/buffer_utils');
+const endpoint_stats_collector = require('../../sdk/endpoint_stats_collector');
+const time_utils = require('../../util/time_utils');
+
+const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null, maxArrayLength: max_arr });
+
+const XATTR_MD5_KEY = 'content_md5';
+const MAC_PLATFORM = 'darwin';
+const DUMMY_OBJECT_SDK = make_DUMMY_OBJECT_SDK();
+
+const src_bkt = 'src';
+let tmp_fs_path = '/tmp/test_namespace_fs_mpu';
+if (process.platform === MAC_PLATFORM) {
+    tmp_fs_path = '/private/' + tmp_fs_path;
+}
+const ns_tmp_bucket_path = `${tmp_fs_path}/${src_bkt}`;
+
+function make_DUMMY_OBJECT_SDK() {
+    return {
+        requesting_account: {
+            force_md5_etag: false,
+            nsfs_account_config: {
+                uid: process.getuid(),
+                gid: process.getgid(),
+            }
+        },
+        abort_controller: new AbortController(),
+        throw_if_aborted() {
+            if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        }
+    };
+}
+
+
+mocha.describe('namespace_fs mpu optimization tests', function() {
+
+    const upload_bkt = 'test_ns_uploads_object';
+    const mpu_bkt = 'test_ns_multipart_upload';
+
+    const ns_tmp = new NamespaceFS({
+        bucket_path: ns_tmp_bucket_path,
+        bucket_id: '2',
+        namespace_resource_id: undefined,
+        access_mode: undefined,
+        versioning: undefined,
+        force_md5_etag: false,
+        stats: endpoint_stats_collector.instance(),
+    });
+
+    mocha.before(async () => {
+        await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
+            fs_utils.create_fresh_path(`${tmp_fs_path}/${buck}`)));
+    });
+    mocha.after(async () => {
+        await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
+            fs_utils.folder_delete(`${tmp_fs_path}/${buck}`)));
+    });
+    mocha.after(async () => fs_utils.folder_delete(tmp_fs_path));
+
+    mocha.it('MPU | MIX | 10000 different size', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_upload_10000_mix_size';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 10000;
+        const src_file_path = 'mpu_upload_10000_mix_size.txt';
+        const parts_properties = { mixed_sizes: {} };
+        for (let i = 1; i <= num_parts; i++) {
+            parts_properties.mixed_sizes[i] = { size: i, pass_size: true };
+        }
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | MIX | mid is different size', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_upload_mid_unique';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const src_file_path = 'mpu_upload_mid_unique.txt';
+        const parts_properties = {
+            mixed_sizes: {
+                1: { size: 10, pass_size: true },
+                2: { size: 5, pass_size: true },
+                3: { size: 10, pass_size: true }
+            }
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | MIX ', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_upload';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const src_file_path = 'mpu_mix.txt';
+        const parts_properties = {
+            mixed_sizes: {
+                1: { size: 10, pass_size: true },
+                2: { size: 5, pass_size: true },
+                3: { size: 1, pass_size: true }
+            }
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | MIX | no part size parameter in upload part ', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_mix_no_size_param';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const src_file_path = 'mpu_mix_no_size_param.txt';
+        const parts_properties = {
+            mixed_sizes: {
+                1: { size: 10, pass_size: false },
+                2: { size: 5, pass_size: false },
+                3: { size: 1, pass_size: false }
+            }
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | MIX | same size at the end ', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_mix_same_size_end';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 4;
+        const src_file_path = 'mpu_mix_same_size_end.txt';
+        const parts_properties = {
+            mixed_sizes: {
+                1: { size: 10, pass_size: false },
+                2: { size: 5, pass_size: false },
+                3: { size: 5, pass_size: false },
+                4: { size: 5, pass_size: false }
+            }
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | TAIL', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        ns_tmp.force_md5_etag = true;
+        const mpu_key = 'mpu_tail';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const src_file_path = 'mpu_tail.txt';
+        const part_size = 10;
+        const tail_part_size = 3;
+        const parts_properties = {
+            common_size: { size: part_size, pass_size: true},
+            tail: { size: tail_part_size, pass_size: true }
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | TAIL | no part size parameter in upload part ', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_tail_no_size_param';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 2;
+        const part_size = 10;
+        const tail_part_size = 5;
+        const src_file_path = 'mpu_tail_no_size_param.txt';
+        const parts_properties = {
+            common_size: { size: part_size, pass_size: false },
+            tail: { size: tail_part_size, pass_size: false }
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    /*
+    // the 8GB test throws error of no space left on device when running on CI
+    mocha.it('MPU | TAIL | 8GB ', async function() {
+        this.timeout(200000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_tail_no_size_param1';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 1000;
+        const part_size = 8000000;
+        const tail_part_size = 50;
+        const src_file_path = 'mpu_tail_no_size_param1.txt';
+        const parts_properties = {
+            common_size: { size: part_size, pass_size: false },
+            tail: { size: tail_part_size, pass_size: false }
+        };
+        // skip assert read true because size is too big
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path, true);
+    });*/
+
+    mocha.it('MPU | COMMON SIZE | single part ', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_single_part1';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 1;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_single_part1.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE | single part | no part size parameter in upload part', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_single_part2';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 1;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_single_part2.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: false } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE | no part size parameter in upload part', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_no_size_param';
+        const num_parts = 3;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_no_size_param.txt';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const parts_properties = { common_size: { size: part_size, pass_size: false } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | TAIL -> COMMON SIZE | override TAIL to COMMON SIZE', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        ns_tmp.force_md5_etag = true;
+        const mpu_key = 'mpu_tail_override_to_common_size';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const src_file_path = 'mpu_tail_override_to_common_size.txt';
+        const part_size = 10;
+        const tail_part_size = 3;
+        const parts_properties = {
+            common_size: { size: part_size, pass_size: true},
+            tail: { size: tail_part_size, pass_size: true, override: part_size}
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | TAIL -> TAIL | override TAIL to NEW UNIQUE SIZE', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        ns_tmp.force_md5_etag = true;
+        const mpu_key = 'mpu_tail_override_to_unique_size';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const src_file_path = 'mpu_tail_override_to_unique_size.txt';
+        const part_size = 10;
+        const tail_part_size = 3;
+        const tail_override_part_size = 5;
+        const parts_properties = {
+            common_size: { size: part_size, pass_size: true},
+            tail: { size: tail_part_size, pass_size: true, override: tail_override_part_size}
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | TAIL -> TAIL | override TAIL to tail size, different data', async function() {
+        this.timeout(20000); // eslint-disable-line no-invalid-this
+        ns_tmp.force_md5_etag = true;
+        const mpu_key = 'mpu_tail_override_to_tail_size';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const src_file_path = 'mpu_tail_override_to_tail_size.txt';
+        const part_size = 10;
+        const tail_part_size = 3;
+        const parts_properties = {
+            common_size: { size: part_size, pass_size: true},
+            tail: { size: tail_part_size, pass_size: true, override: tail_part_size}
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE -> TAIL | override last part of common size to be different size (TAIL)', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_to_tail';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_to_tail.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true, override: { part_num: 3, new_size: 15 } } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE -> COMMON SIZE | override last part of common size to be common size, different data', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_to_common_size1';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_to_common_size1.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true, override: { part_num: 3, new_size: 10 } } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE -> COMMON SIZE | override last part of common size to be common size, different data', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_to_common_size2';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_to_common_size2.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true, override: { part_num: 1, new_size: 10 } } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE -> COMMON SIZE | override mid part of common size to be common size, different data', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_to_common_size3';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_to_common_size3.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true, override: { part_num: 2, new_size: 10 } } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE -> MIX | override first part to be different size', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_to_mix1';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_to_mix1.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true, override: { part_num: 1, new_size: 15 } } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | COMMON SIZE -> MIX | override mid part to be different size', async function() {
+        this.timeout(2000000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_to_mix2';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const part_size = 10;
+        const src_file_path = 'mpu_common_size_to_mix2.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true, override: { part_num: 2, new_size: 15 } } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    // LARGE FILES 
+    mocha.it('MPU | COMMON SIZE - large files', async function() {
+        this.timeout(200000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_common_size_large';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const part_size = 17000000;
+        const src_file_path = 'mpu_common_size_large.txt';
+        const parts_properties = { common_size: { size: part_size, pass_size: true } };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | TAIL - large file', async function() {
+        this.timeout(200000); // eslint-disable-line no-invalid-this
+        ns_tmp.force_md5_etag = true;
+        const mpu_key = 'mpu_tail_large';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 2;
+        const src_file_path = 'mpu_tail_large';
+        const part_size = 8900000;
+        const tail_part_size = 5;
+        const parts_properties = {
+            common_size: { size: part_size, pass_size: true},
+            tail: { size: tail_part_size, pass_size: true }
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    mocha.it('MPU | MIX | mid is different size - large size', async function() {
+        this.timeout(200000); // eslint-disable-line no-invalid-this
+        const mpu_key = 'mpu_upload_mid_unique_large';
+        const xattr = { key: 'value', key2: 'value2' };
+        xattr[s3_utils.XATTR_SORT_SYMBOL] = true;
+        const num_parts = 3;
+        const src_file_path = 'mpu_upload_mid_unique_large.txt';
+        const parts_properties = {
+            mixed_sizes: {
+                1: { size: 9000000, pass_size: true },
+                2: { size: 5000000, pass_size: true },
+                3: { size: 9000000, pass_size: true }
+            }
+        };
+        await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+});
+
+
+// parts_sizes_obj - { tail: { size: number, pass_size } , common_size: { size: number, pass_size: bool }, mixed_sizes: { num number: { size: number, pass_size: bool } }}
+async function mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_sizes_obj, src_file_path, skip_assert_read) {
+
+    const create_mpu_res = await create_mpu(ns_tmp, mpu_bkt, mpu_key, xattr);
+    const upload_id = create_mpu_res.obj_id;
+    const result_file_path = `${ns_tmp_bucket_path}/${mpu_key}`;
+    const multiparts = await upload_parts(ns_tmp, num_parts, src_file_path, mpu_bkt, mpu_key, upload_id, parts_sizes_obj);
+
+    if (parts_sizes_obj.tail) {
+        const tail_part_num = num_parts + 1;
+        const to_be_override_size = parts_sizes_obj.tail.override;
+        const { size, pass_size } = parts_sizes_obj.tail;
+        let tail_multipart_res = await upload_single_part(ns_tmp, tail_part_num, src_file_path, mpu_bkt,
+            mpu_key, upload_id, size, pass_size, to_be_override_size);
+        if (to_be_override_size) {
+            tail_multipart_res = await upload_single_part(ns_tmp, tail_part_num, src_file_path, mpu_bkt,
+                mpu_key, upload_id, to_be_override_size, pass_size);
+        }
+        multiparts.push({ etag: tail_multipart_res.etag, num: tail_part_num });
+    }
+    const complete_res = await complete_mpu(ns_tmp, mpu_bkt, mpu_key, upload_id, multiparts);
+
+    if (config.NSFS_CALCULATE_MD5 ||
+        ns_tmp.force_md5_etag || DUMMY_OBJECT_SDK.requesting_account.force_md5_etag) xattr[XATTR_MD5_KEY] = complete_res.etag;
+
+
+    const md5_original_data = await calc_md5(src_file_path);
+    const md5_final_data = await calc_md5(result_file_path);
+    assert.strictEqual(md5_final_data, md5_original_data);
+
+    if (!skip_assert_read) {
+        const read_data = await read_object(ns_tmp, mpu_bkt, mpu_key);
+        const md5_read_res = await calc_md5_stream(read_data);
+        assert.strictEqual(md5_final_data, md5_read_res);
+    }
+
+    const md = await ns_tmp.read_object_md({
+        bucket: mpu_bkt,
+        key: mpu_key,
+    }, DUMMY_OBJECT_SDK);
+    assert.deepStrictEqual(xattr, md.xattr);
+
+    await ns_tmp.delete_object({
+        bucket: mpu_bkt,
+        key: mpu_key,
+    }, DUMMY_OBJECT_SDK);
+
+    fs.rm(src_file_path, _.noop);
+}
+
+async function create_mpu(namespace_fs_obj, mpu_bkt, mpu_key, xattr) {
+    const create_res = await namespace_fs_obj.create_object_upload({
+        bucket: mpu_bkt,
+        key: mpu_key,
+        xattr,
+    }, DUMMY_OBJECT_SDK);
+    return create_res;
+}
+
+async function upload_single_part(namespace_fs_obj, part_num, original_file, mpu_bkt, mpu_key, upload_id, size, pass_size, to_be_override) {
+
+    const data_part = crypto.randomBytes(size);
+    if (!to_be_override) {
+        fs.writeFileSync(original_file, data_part, { flag: 'a+' });
+    }
+    const part_res = await namespace_fs_obj.upload_multipart({
+        obj_id: upload_id,
+        bucket: mpu_bkt,
+        key: mpu_key,
+        num: part_num,
+        source_stream: buffer_utils.buffer_to_read_stream(data_part),
+        size: pass_size ? size : undefined
+    }, DUMMY_OBJECT_SDK);
+    console.log('upload_multipart response', inspect(part_res));
+    return part_res;
+}
+
+
+async function upload_parts(namespace_fs_obj, parts_num, original_file, mpu_bkt, mpu_key, upload_id, parts_props_obj) {
+    const multiparts = [];
+    for (let i = 0; i < parts_num; ++i) {
+        const part_num = i + 1;
+        const { size = undefined, pass_size = false, override = undefined } = parts_props_obj.common_size ||
+                    (parts_props_obj.mixed_sizes && parts_props_obj.mixed_sizes[part_num]);
+        if (!size) throw new Error('Invalid part properties');
+        const override_part = override && override.part_num === part_num;
+        let part_res = await upload_single_part(namespace_fs_obj, part_num, original_file, mpu_bkt, mpu_key,
+            upload_id, size, pass_size, override_part);
+        if (override_part) {
+            const { new_size } = parts_props_obj.common_size.override;
+            part_res = await upload_single_part(namespace_fs_obj, part_num, original_file, mpu_bkt, mpu_key, upload_id, new_size, true);
+        }
+        multiparts.push({ num: part_num, etag: part_res.etag });
+    }
+
+    return multiparts;
+}
+
+
+async function complete_mpu(namespace_fs_obj, mpu_bkt, mpu_key, upload_id, multiparts) {
+    const start = time_utils.millistamp();
+    const complete_res = await namespace_fs_obj.complete_object_upload({
+        obj_id: upload_id,
+        bucket: mpu_bkt,
+        key: mpu_key,
+        multiparts,
+    }, DUMMY_OBJECT_SDK);
+    const took = time_utils.millistamp() - start;
+    console.log(`test_namespace_fs_mpu: complete_mpu - ${upload_id} took ${took} ms`);
+    return complete_res;
+}
+
+async function read_object(namespace_fs_obj, mpu_bkt, mpu_key) {
+    const read_res = buffer_utils.write_stream();
+    await namespace_fs_obj.read_object_stream({
+        bucket: mpu_bkt,
+        key: mpu_key,
+    }, DUMMY_OBJECT_SDK, read_res);
+    const read_data = read_res.join();
+    return read_data;
+}
+
+async function calc_md5_stream(write_data) {
+    const hash = crypto.createHash('md5');
+    hash.update(write_data);
+    return hash.digest('hex');
+}
+
+async function calc_md5(path) {
+    return new Promise((resolve, reject) => {
+        const hash = crypto.createHash('md5');
+        fs.createReadStream(path)
+            .on('error', reject)
+            .pipe(hash)
+            .on('error', reject)
+            .on('finish', () => resolve(hash.digest('hex')));
+    });
+}

--- a/src/test/unit_tests/test_nsfs_versioning_gpfs.js
+++ b/src/test/unit_tests/test_nsfs_versioning_gpfs.js
@@ -14,9 +14,9 @@ const path = require('path');
 const nb_native = require('../../util/nb_native');
 const size_utils = require('../../util/size_utils');
 
-const XATTR_VERSION_ID = 'user.version_id';
-const XATTR_PREV_VERSION_ID = 'user.prev_version_id';
-//const XATTR_DELETE_MARKER = 'user.delete_marker';
+const XATTR_VERSION_ID = 'user.noobaa.version_id';
+const XATTR_PREV_VERSION_ID = 'user.noobaa.prev_version_id';
+//const XATTR_DELETE_MARKER = 'user.noobaa.delete_marker';
 
 const DEFAULT_FS_CONFIG = {
     uid: process.getuid(),

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -1,0 +1,78 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const dbg = require('../util/debug_module')(__filename);
+const P = require('../util/promise');
+
+/** @typedef {import('../util/buffer_utils').BuffersPool} BuffersPool */
+
+/**
+ * @param {BuffersPool} buffers_pool 
+ * @param {nb.NativeFSContext} fs_context 
+ * @param {nb.NativeFile} src_file
+ * @param {nb.NativeFile} dst_file 
+ * @param {number} size 
+ * @param {number} write_offset 
+ * @param {number} read_offset 
+ */
+async function copy_bytes(buffers_pool, fs_context, src_file, dst_file, size, write_offset, read_offset) {
+    dbg.log1(`Native_fs_utils.copy_bytes size=${size} read_offset=${read_offset} write_offset=${write_offset}`);
+    let buffer_pool_cleanup = null;
+    try {
+        let read_pos = Number(read_offset || 0);
+        let bytes_written = 0;
+        const total_bytes_to_write = Number(size);
+        let write_pos = write_offset >= 0 ? write_offset : 0;
+        for (;;) {
+            const total_bytes_left = total_bytes_to_write - bytes_written;
+            if (total_bytes_left <= 0) break;
+            const { buffer, callback } = await buffers_pool.get_buffer();
+            buffer_pool_cleanup = callback;
+            const bytesRead = await src_file.read(fs_context, buffer, 0, buffer.length, read_pos);
+            if (!bytesRead) {
+                buffer_pool_cleanup = null;
+                callback();
+                break;
+            }
+            read_pos += bytesRead;
+
+            let data = buffer.slice(0, bytesRead);
+            if (total_bytes_left < bytesRead) data = data.slice(0, total_bytes_left);
+            await dst_file.write(fs_context, data, undefined, write_pos);
+            write_pos += data.byteLength;
+            bytes_written += data.byteLength;
+            // Returns the buffer to pool to avoid starvation
+            buffer_pool_cleanup = null;
+            callback();
+        }
+    } catch (err) {
+        dbg.error('Native_fs_utils.copy_bytes: error - ', err);
+        throw err;
+    } finally {
+        try {
+            // release buffer back to pool if needed
+            if (buffer_pool_cleanup) buffer_pool_cleanup();
+        } catch (err) {
+            dbg.warn('Native_fs_utils.copy_bytes file close error', err);
+        }
+    }
+}
+
+
+
+/**
+ * @param {nb.NativeFSContext} fs_context 
+ * @param {nb.NativeFile[]} list_of_files
+ */
+async function finally_close_files(fs_context, list_of_files = []) {
+    await P.map_with_concurrency(5, list_of_files, async file => {
+        try {
+            if (file) await file.close(fs_context);
+        } catch (err) {
+            dbg.warn('Native_fs_utils.finally_close_files file close error', err);
+        }
+    });
+}
+
+exports.copy_bytes = copy_bytes;
+exports.finally_close_files = finally_close_files;


### PR DESCRIPTION
### Explain the changes
1. Manual backport of https://github.com/noobaa/noobaa-core/pull/7522/files#diff-62761181e6530a79f3af1ab5b72a734fa264d75c1f932fa6035852c40a5ef774R203 to 5.14 
** Original commit contains irrelevant changes

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2274927

### Testing Instructions:
**Manual tests -** 
```
1. Deploy 5.14 
3. Export env GPFS_DL_PATH=<libgpfs path>
4. Create a namespacestore ns1 while specifying GPFS backend
5. Create a bucket on top of ns1
6. Run PUT object (open file with 'wt' mode) and check if the operation will fail with Internal Error (EINVAL error code Invalid Argument)
```

**Automatic tests -** 
`sudo node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_nb_native_gpfs.js`

- [ ] Doc added/updated
- [x] Tests exist
