### PR TITLE
Throw an appropriate exception when user provides an empty object version ID

### DIFF
--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -59,7 +59,7 @@ async function get_object(req, res) {
         md_conditions,
         encryption,
     };
-    if (params.version_id.length === 0) {
+    if (params.version_id?.length === 0) {
         throw new S3Error(S3Error.InvalidArgumentEmptyVersionId);
     }
     if (md_params.get_from_cache) {

--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -59,6 +59,9 @@ async function get_object(req, res) {
         md_conditions,
         encryption,
     };
+    if (params.version_id.length === 0) {
+        throw new S3Error(S3Error.InvalidArgumentEmptyVersionId);
+    }
     if (md_params.get_from_cache) {
         params.get_from_cache = true;
     }

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -144,6 +144,11 @@ S3Error.InvalidArgument = Object.freeze({
     message: 'Invalid Argument',
     http_code: 400,
 });
+S3Error.InvalidArgumentEmptyVersionId = Object.freeze({
+    code: 'InvalidArgument',
+    message: 'Version id cannot be the empty string',
+    http_code: 400,
+});
 S3Error.InvalidBucketName = Object.freeze({
     code: 'InvalidBucketName',
     message: 'The specified bucket is not valid.',


### PR DESCRIPTION
### Explain the changes
1. Throw an appropriate exception when a user provides an empty object version ID

### Issues: Fixed #xxx / Gap #xxx
1. [BZ#2265562](https://bugzilla.redhat.com/show_bug.cgi?id=2265562)

### Testing Instructions:
1. Upload an object to a bucket
2. Use the AWS CLI (`s3api` with `--version-id ""`) to try and access an existing object's version ID by providing an empty string
3. Verify that NooBaa throws the appropriate error (`An error occurred (InvalidArgument) when calling the GetObject operation: Version id cannot be the empty string`)


- [ ] Doc added/updated
- [ ] Tests added
