### PR TITLE
Move crt, not signing request to certificate dir

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -578,7 +578,7 @@ Note - The default config_dir is /etc/noobaa.conf.d/.
 
 ```bash
 sudo mv tls.key {config_dir_path}/certificates/
-sudo mv tls.csr {config_dir_path}/certificates/
+sudo mv tls.crt {config_dir_path}/certificates/
 ```
 #### 4. Restart the NooBaa NSFS service -
 ```bash


### PR DESCRIPTION
### Explain the changes
1.  Document instructs to move csr-file instead of crt-file to certicates/ directory. Correct that.


