### PR TITLE
Fix Bug 7941 | Fix URL Decoding for Copyobject

### DIFF
--- a/src/endpoint/endpoint_utils.js
+++ b/src/endpoint/endpoint_utils.js
@@ -17,21 +17,24 @@ function prepare_rest_request(req) {
 }
 
 function parse_source_url(source_url) {
-    let slash_index = source_url.indexOf('/');
-    let start_index = 0;
-    if (slash_index === 0) {
-        start_index = 1;
-        slash_index = source_url.indexOf('/', 1);
-    }
-    let query_index = source_url.indexOf('?', slash_index);
+    let query_index = source_url.indexOf('?');
     let query;
     if (query_index < 0) {
         query_index = source_url.length;
     } else {
         query = querystring.parse(source_url.slice(query_index + 1));
     }
-    const bucket = decodeURIComponent(source_url.slice(start_index, slash_index));
-    const key = decodeURIComponent(source_url.slice(slash_index + 1, query_index));
+
+    // '/' may be encoded, first decde the bucket/key part
+    const decoded_source_url = decodeURIComponent(source_url.slice(0, query_index));
+    let slash_index = decoded_source_url.indexOf('/');
+    let start_index = 0;
+    if (slash_index === 0) {
+        start_index = 1;
+        slash_index = decoded_source_url.indexOf('/', 1);
+    }
+    const bucket = decoded_source_url.slice(start_index, slash_index);
+    const key = decoded_source_url.slice(slash_index + 1);
     return { query, bucket, key };
 }
 


### PR DESCRIPTION
### Explain the changes
1. Cherry-pick from PR #7965:

> When url part of bucket is encoded, the '/' is encoded as well. change the order so we un-escaped the URL before we search for '/'. still search for ? in encoded state, since it isn't encoded as part of the bucket/key
2. Add tests (1) regular `/bucket/key` (2) encoded `%2bucket%2key`.

### Issues: Fixed #7941
1. Currently we return an error when the property `CopySource` is encoded (see the comments inside the issue).

### Testing Instructions:
1. `make CONTAINER_PLATFORM=linux/arm64 run-single-test testname=test_s3_ops.js` (added the flag `CONTAINER_PLATFORM` because I run it on MacOS M1).

- [ ] Doc added/updated
- [X] Tests added
