### PR TITLE
NSFS | Add support for list multipart uploads in namespace_fs, pagination not handled

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1505,10 +1505,43 @@ class NamespaceFS {
     //////////////////////
 
     async list_uploads(params, object_sdk) {
-        // TODO for now we do not support listing of multipart uploads
+        // TODO: Need to support pagination.
+        const fs_context = this.prepare_fs_context(object_sdk);
+        await this._load_bucket(params, fs_context);
+        const mpu_root_path = this._mpu_root_path();
+        await this._check_path_in_bucket_boundaries(fs_context, mpu_root_path);
+        const multipart_upload_dirs = await nb_native().fs.readdir(fs_context, mpu_root_path);
+        const common_prefixes_set = new Set();
+        const multipart_uploads = await P.map(multipart_upload_dirs, async obj => {
+            const create_path = path.join(mpu_root_path, obj.name, 'create_object_upload');
+            const { data: create_params_buffer } = await nb_native().fs.readFile(
+                fs_context,
+                create_path
+            );
+            const create_params_parsed = JSON.parse(create_params_buffer.toString());
+
+            // dont add keys that dont start with the prefix
+            if (params.prefix && !create_params_parsed.key.startsWith(params.prefix)) {
+                return undefined;
+            }
+
+            // common_prefix contains (if there are any) prefixes between the provide prefix
+            // and the next occurrence of the string specified by the delimiter
+            if (params.delimiter) {
+                const start_idx = params.prefix ? params.prefix.length : 0;
+                const delimiter_idx = create_params_parsed.key.indexOf(params.delimiter, start_idx);
+                if (delimiter_idx > 0) {
+                    common_prefixes_set.add(create_params_parsed.key.substring(0, delimiter_idx + 1));
+                    // if key has common prefix it should not be returned as an upload object 
+                    return undefined;
+                }
+            }
+            const stat = await nb_native().fs.stat(fs_context, create_path);
+            return this._get_mpu_info(create_params_parsed, stat);
+        });
         return {
-            objects: [],
-            common_prefixes: [],
+            objects: _.compact(multipart_uploads),
+            common_prefixes: [...common_prefixes_set],
             is_truncated: false,
             next_marker: undefined,
             next_upload_id_marker: undefined,
@@ -2248,7 +2281,7 @@ class NamespaceFS {
      * @param {nb.NativeFSStats} stat 
      * @returns {nb.ObjectInfo}
      */
-     _get_object_info(bucket, key, stat, return_version_id, isDir, is_latest = true) {
+    _get_object_info(bucket, key, stat, return_version_id, isDir, is_latest = true) {
         const etag = this._get_etag(stat);
         const create_time = stat.mtime.getTime();
         const encryption = this._get_encryption_info(stat);
@@ -2336,11 +2369,28 @@ class NamespaceFS {
         }
     }
 
-    _mpu_path(params) {
+    _get_mpu_info(create_params, stat) {
+        return {
+            obj_id: create_params.obj_id,
+            bucket: create_params.bucket,
+            key: create_params.key,
+            storage_class: create_params.storage_class,
+            create_time: stat.mtime.getTime(),
+            upload_started: stat.mtime.getTime(),
+            content_type: create_params.content_type,
+        };
+    }
+
+    _mpu_root_path() {
         return path.join(
             this.bucket_path,
             this.get_bucket_tmpdir(),
-            'multipart-uploads',
+            'multipart-uploads');
+    }
+
+    _mpu_path(params) {
+        return path.join(
+            this._mpu_root_path(),
             params.obj_id
         );
     }


### PR DESCRIPTION
### Explain the changes
1. add support for list multiple uploads in namespace_fs. currently without marker support
NB :  pagination not handled.

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2271804

### Testing Instructions:
1. run `sudo node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_namespace_fs.js` or
you run the s3 api while uploading the file or folder and response should have a uploading file details
`s3api list-multipart-uploads --bucket {bucket_name}`


- [ ] Doc added/updated
- [x] Tests added