### PR TITLE
NSFS | NC |  Removal of NSFS prefix from user facing components - service, cli, configs and events 

### DIFF
--- a/config.js
+++ b/config.js
@@ -836,10 +836,10 @@ config.ALLOW_HTTP = false;
 config.BASE_MODE_CONFIG_FILE = 0o600;
 config.BASE_MODE_CONFIG_DIR = 0o700;
 
-config.NSFS_WHITELIST = [];
+config.S3_SERVER_IP_WHITELIST = [];
 
-config.NSFS_HEALTH_ENDPOINT_RETRY_COUNT = 3;
-config.NSFS_HEALTH_ENDPOINT_RETRY_DELAY = 10;
+config.NC_HEALTH_ENDPOINT_RETRY_COUNT = 3;
+config.NC_HEALTH_ENDPOINT_RETRY_DELAY = 10;
 
 
 /** @type {'file' | 'executable'} */

--- a/docs/design/NSFSGlacierStorageClass.md
+++ b/docs/design/NSFSGlacierStorageClass.md
@@ -75,7 +75,7 @@ even if the file is on disk unless the user explicitly issues a `RestoreObject` 
 does as well).
 
 #### Phase 2
-1. A scheduler (eg. Cron, human, script, etc) issues `node src/cmd/manage_nsfs glacier migrate --interval <val>`.
+1. A scheduler (eg. Cron, human, script, etc) issues `noobaa-cli glacier migrate --interval <val>`.
 2. The command will first acquire an "EXCLUSIVE" lock so as to ensure that only one tape management command is running at once.
 3. Once the process has the lock it will start to iterate over the potentially currently inactive files.
 4. Before processing a log file, the proceess will get an "EXCLUSIVE" lock to the file ensuring that it is indeed the only
@@ -108,7 +108,7 @@ restore request going on etc).
 5. Returns the request with success indicating that the restore request has been accepted.
 
 #### Phase 2
-1. A scheduler (eg. Cron, human, script, etc) issues `node src/cmd/manage_nsfs glacier restore --interval <val>`.
+1. A scheduler (eg. Cron, human, script, etc) issues `noobaa-cli glacier restore --interval <val>`.
 2. The command will first acquire an "EXCLUSIVE" lock so as to ensure that only one tape management command is running at once.
 3. Once the process has the lock it will start to iterate over the potentially currently inactive files.
 4. Before processing a log file, the proceess will get an "EXCLUSIVE" lock to the file ensuring that it is indeed the only

--- a/docs/design/NonContainerizedNooBaaDesign.md
+++ b/docs/design/NonContainerizedNooBaaDesign.md
@@ -1,8 +1,8 @@
-# NSFS Non Containerized
+# NooBaa Non Containerized
 
-Running noobaa-core non containerized is useful for development, testing, or deploying in Linux without depending on Kubernetes, NSFS FS is different from the simple standalone in such a way that it doesn't depend on the Noobaa postgres db. All the Global configurations, Accounts, and Bucket related schemas are saved in FS. And it gives a more lightweight flavor to the Noobaa standalone version. Permissions are handled by uid and gid, or by providing a distinguished name (LDAP/AD) that will be resolved to uid/gid by the operating system.
+Running noobaa-core non containerized is useful for development, testing, or deploying in Linux without depending on Kubernetes, NooBaa NC is different from the simple standalone in such a way that it doesn't depend on the Noobaa postgres db. All the Global configurations, Accounts, and Bucket related schemas are saved in FS. And it gives a more lightweight flavor to the Noobaa standalone version. Permissions are handled by uid and gid, or by providing a distinguished name (LDAP/AD) that will be resolved to uid/gid by the operating system.
 
-Users can switch between Noobaa standalone and NSFS FS standalone by adding/removing the argument `config_dir`.
+Users can switch between Noobaa standalone and NooBaa FS standalone by adding/removing the argument `config_dir`.
 
 ```
 node src/cmd/nsfs ../standalon/nsfs_root --config_dir ../standalon/fs_config
@@ -121,10 +121,10 @@ node src/cmd/nsfs ../standalon/nsfs_root --config_dir ../standalon/fs_config
     - Check uid/gid access to the bucket path
 
 ## Code Structure
-To simplify the flow new SDK `BucketSpaceFS` is added for the NSFS FS standalone by extending the `BucketSpaceSimpleFS`. `BucketSpaceFS` will handle all the FS related functionalities on the other hand `BucketSpaceSimpleFS` keeps serving existing NSFS simple standalone functionalities.
+To simplify the flow new SDK `BucketSpaceFS` is added for the NooBaa standalone by extending the `BucketSpaceSimpleFS`. `BucketSpaceFS` will handle all the FS related functionalities on the other hand `BucketSpaceSimpleFS` keeps serving existing NooBaa simple standalone functionalities.
 
 ### BucketSpaceSimpleFS
-- simplified nsfs bucket manager - single root dir for all buckets under it, and a single account.
+- simplified NooBaa bucket manager - single root dir for all buckets under it, and a single account.
 - CLI: node nsfs /fsroot/
 
 ### BucketSpaceFS
@@ -137,9 +137,9 @@ To simplify the flow new SDK `BucketSpaceFS` is added for the NSFS FS standalone
 
 High level configuration - 
 
-1. /etc/noobaa.conf.d/config_dir_redirect - a fixed starting point, the noobaa nsfs service will try to read this file, and if this file does not exist it will use /etc/noobaa.conf.d/ as the wanted config_dir
+1. /etc/noobaa.conf.d/config_dir_redirect - a fixed starting point, the NooBaa service will try to read this file, and if this file does not exist it will use /etc/noobaa.conf.d/ as the wanted config_dir
 
-2. /etc/sysconfig/noobaa_nsfs - env file, one should avoid using it, should be used only for configurations that can not be set using config.json
+2. /etc/sysconfig/noobaa - env file, one should avoid using it, should be used only for configurations that can not be set using config.json
 
 3. /path/to/config_dir - the user's config_dir, contains the following files/subdirectories - 
 
@@ -167,9 +167,9 @@ High level configuration -
 * Please be aware that when a node is designated in the host_customization, Noobaa will combine the shared configuration with the node's configuration. If a configuration value is provided under the node's configuration, it will take precedence as the final configuration value applied to the noobaa_nsds service on that specific node.
 
 #### config.json schema - 
-See [NSFS config.json schema](https://github.com/noobaa/noobaa-core/src/server/object_services/schemas/nsfs_config_schema.js)
+See [NooBaa config.json schema](https://github.com/noobaa/noobaa-core/src/server/object_services/schemas/nsfs_config_schema.js)
 config.json will be reloaded every 10 seconds automatically, please notice that some config.json properties require restart of the service, for more details check the schema.
 
 ### Configuration files (accounts/buckets) permissions
 - Configuration files created under accounts/ or buckets/ will have 600 permissions (read, write, execute) for the owner of the config file only. 
-- config_file created by manage_nsfs.js CLI tool will be owned by the user who ran the command. 
+- configuration file created by the CLI tool will be owned by the user who ran the command. 

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -21,7 +21,7 @@ The following list consists of supported optional developer customization  -
 2. Set the ENDPOINT_FORKS key to the desired level.
 Example:
 "ENDPOINT_FORKS":8
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 2. Log debug level -
@@ -47,7 +47,7 @@ Supported log debug levels:
 2. Set the NOOBAA_LOG_LEVEL key to the desired level.
 Example:
 "NOOBAA_LOG_LEVEL": "nsfs"
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 3. Ports -
@@ -73,7 +73,7 @@ The following S3 endpoint ports can be customized:
 2. Set the config key -
 Example:
 "ENDPOINT_PORT": 5555
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 4. Allow http requests-
@@ -91,7 +91,7 @@ Example:
 2. Set the config key -
 Example:
 "ALLOW_HTTP": true
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 5. MD5 calculation -
@@ -126,7 +126,7 @@ Example:
 2. Set the config key -
 Example:
 "UV_THREADPOOL_SIZE": 8
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 7. GPFS library path -
@@ -144,7 +144,7 @@ Example:
 2. Set the config key -
 Example:
 "GPFS_DL_PATH": "/usr/lib64/libgpfs.so"
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 8. Buffer pool memory limit -
@@ -161,7 +161,7 @@ Example:
 2. Set the config key in bytes-
 Example: 
 "NSFS_BUF_POOL_MEM_LIMIT" : 52428800
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 9. Buffer size -
@@ -179,7 +179,7 @@ Example:
 2. Set the config key in bytes-
 Example:
 "NSFS_BUF_SIZE": 10485760
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 10. Open read mode -
@@ -236,7 +236,7 @@ Example:
 ## 13. Whitelist IPs -
 **Description -** List of whitelist IPs. Access is restricted to these IPs only. If there are no IPs mentioned all IPs are allowed.
 
-**Configuration Key -** NSFS_WHITELIST
+**Configuration Key -** S3_SERVER_IP_WHITELIST
 
 **Type -** array
 
@@ -245,7 +245,7 @@ Example:
 **Steps -**
 ```
 1. run CLI command
-node src/cmd/manage_nsfs whitelist --ips '["127.0.0.1", "192.000.10.000", "3002:0bd6:0000:0000:0000:ee00:0033:000"]'  2>/dev/null
+sudo noobaa-cli whitelist --ips '["127.0.0.1", "192.000.10.000", "3002:0bd6:0000:0000:0000:ee00:0033:000"]'  2>/dev/null
 ```
 
 ## 14. Config directory backend -
@@ -280,7 +280,7 @@ Example:
 2. Set the config key -
 Example:
 "NSFS_NC_STORAGE_BACKEND": "GPFS"
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 16. Directories cache max directory size -
@@ -298,7 +298,7 @@ Example:
 2. Set the config key -
 Example:
 "NSFS_DIR_CACHE_MAX_DIR_SIZE": 268435456
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 17. Directories cache max total usage size -
@@ -316,7 +316,7 @@ Example:
 2. Set the config key -
 Example:
 "NSFS_DIR_CACHE_MAX_TOTAL_SIZE": 805306368
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 
@@ -334,7 +334,7 @@ Example:
 2. Set the config key -
 Example:
 "ENABLE_DEV_RANDOM_SEED": false
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 19. Set Master Keys Store type-
@@ -351,7 +351,7 @@ Example:
 2. Set the config key -
 Example:
 "NC_MASTER_KEYS_STORE_TYPE": 'executable'
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 20. Set Master Keys File Location -
@@ -368,7 +368,7 @@ Example:
 2. Set the config key -
 Example:
 "NC_MASTER_KEYS_FILE_LOCATION": '/private/tmp/master_keys.json'
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 21. Set Master Keys GET executable script -
@@ -385,7 +385,7 @@ Example:
 2. Set the config key -
 Example:
 "NC_MASTER_KEYS_GET_EXECUTABLE": '/private/tmp/get_master_keys.sh'
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## 22. Set Master Keys PUT executable script -
@@ -402,7 +402,7 @@ Example:
 2. Set the config key -
 Example:
 "NC_MASTER_KEYS_PUT_EXECUTABLE": '/private/tmp/put_master_keys.sh'
-3. systemctl restart noobaa_nsfs
+3. systemctl restart noobaa
 ```
 
 ## Config.json example 
@@ -419,7 +419,7 @@ Example:
     "NSFS_OPEN_READ_MODE": "rd",
     "NSFS_CHECK_BUCKET_BOUNDARIES": false,
     "ALLOW_HTTP": true,
-    "NSFS_WHITELIST":["127.0.0.1","192.000.10.000","3002:0bd6:0000:0000:0000:ee00:0033:000"]
+    "S3_SERVER_IP_WHITELIST":["127.0.0.1","192.000.10.000","3002:0bd6:0000:0000:0000:ee00:0033:000"]
 }
 
 ```

--- a/docs/dev_guide/non_containerized_NSFS_events.md
+++ b/docs/dev_guide/non_containerized_NSFS_events.md
@@ -1,10 +1,10 @@
-# Non Containerized NSFS Events
+# NooBaa Non Containerized Events
 
-This document will list all the possible Noobaa non-containerized NSFS events and possible reasons and resolutions.
+This document will list all the possible NooBaa non-containerized events and possible reasons and resolutions.
 
 ## Events
 
-### 1. noobaa_nsfs_crashed
+### 1. noobaa_s3_crashed
 #### Reasons
 - Noobaa endpoint module failed to load.
 - High Noobaa resource utilization.

--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -1,6 +1,6 @@
-# Non Containerized NSFS
+# Non Containerized NooBaa
 
-Running nsfs non containerized is useful for deploying in linux without depending on kubernetes, but requires some steps which are described next.
+Running NooBaa non containerized is useful for deploying in linux without depending on kubernetes, but requires some steps which are described next.
 
 
 ## Build
@@ -78,7 +78,7 @@ Install NooBaa RPM by running the following command -
 rpm -i <rpm_file_name>.rpm
 ```
 
-After installing NooBaa RPM, it's expected to have noobaa-core source code under /usr/local/noobaa-core and an nsfs systemd example script under /usr/lib/systemd/system/.
+After installing NooBaa RPM, it's expected to have noobaa-core source code under /usr/local/noobaa-core and an noobaa systemd example script under /usr/lib/systemd/system/.
 
 ## Create config dir redirect file -
 NooBaa will try locate a text file that contains a path to the configuration directory, the user should create the redirect file in the fixed location - /etc/noobaa.conf.d/config_dir_redirect
@@ -87,7 +87,7 @@ NooBaa will try locate a text file that contains a path to the configuration dir
 echo "/path/to/config/dir" > /etc/noobaa.conf.d/config_dir_redirect
 ```
 
-If config_root flag was not provided to the nsfs service and /etc/noobaa.conf.d/config_dir_redirect file does not exist, nsfs service will use /etc/noobaa.conf.d/ as its default config_dir.
+If config_root flag was not provided to the NooBaa service and /etc/noobaa.conf.d/config_dir_redirect file does not exist, NooBaa service will use /etc/noobaa.conf.d/ as its default config_dir.
 
 ## Create configuration files -
 **IMPORTANT NOTE** - It's not mendatory to create the config_root under /etc/noobaa.conf.d/. config_dir path can be set using an CONFIG_JS_NSFS_NC_DEFAULT_CONF_DIR.
@@ -108,8 +108,8 @@ If it's not already existing, create the fs root path in which buckets (director
 mkdir -p /tmp/fs1/
 ```
 
-## Developer customization of the nsfs service (OPTIONAL) -
-One can customize noobaa nsfs service by creation of config.json file under the config_dir/ directory (/path/to/config_dir/config.json).
+## Developer customization of the NooBaa service (OPTIONAL) -
+One can customize NooBaa service by creation of config.json file under the config_dir/ directory (/path/to/config_dir/config.json).
 The following are some of the properties that can be customized -
 1. Number of forks
 2. Log debug level
@@ -118,28 +118,28 @@ The following are some of the properties that can be customized -
 5. GPFS library path
 etc...
 
-For more details about the available properties and an example see - [Non Containerized NSFS Developer Customization](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/NonContainerizedDeveloperCustomizations.md)
+For more details about the available properties and an example see - [Non Containerized NooBaa Developer Customization](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/NonContainerizedDeveloperCustomizations.md)
 
 ## Create accounts and exported buckets configuration files - ##
 
 In order to create accounts and exported buckets see the management CLI instructions - [Bucket and Account Manage CLI](#bucket-and-account-manage-cli) <br />
-Design of Accounts and buckets configuration entities - [NonContainerizedNSFS](https://github.com/noobaa/noobaa-core/blob/master/docs/design/NonContainerizedNSFSDesign.md). <br />
+Design of Accounts and buckets configuration entities - [NonContainerizedNooBaa](https://github.com/noobaa/noobaa-core/blob/master/docs/design/NonContainerizedNooBaaDesign.md). <br />
 **Note** - All required paths on the configuration files (bucket - path, account - new_buckets_path) must be absolute paths.
 
 
-## Run the nsfs service -
+## Run the NooBaa service -
 The systemd script runs noobaa non containerized, and requires config_root in order to find the location of the system/accounts/buckets configuration file.
 Limitation - In a cluster each host should have a unique name.
 ```sh
-systemctl enable noobaa_nsfs.service
-systemctl start noobaa_nsfs.service
+systemctl enable noobaa.service
+systemctl start noobaa.service
 ```
 
-## NSFS service logs -
-Run the following command in order to get the nsfs service logs -
+## NooBaa service logs -
+Run the following command in order to get the NooBaa service logs -
 
 ```sh
-journalctl -u noobaa_nsfs.service
+journalctl -u noobaa.service
 ```
 
 
@@ -222,7 +222,7 @@ Output -
 ```
 
 ## Health script
-NSFS Health status can be fetched using the command line. Run `--help` to get all the available options.
+NooBaa Health status can be fetched using the command line. Run `--help` to get all the available options.
 
 NOTE - health script execution requires root permissions.
 
@@ -233,7 +233,7 @@ NOTE - health script execution requires root permissions.
  output:
  ```
 {
-  "service_name": "nsfs",
+  "service_name": "noobaa",
   "status": "NOTOK",
   "memory": "88.6M",
   "error": {
@@ -243,7 +243,7 @@ NOTE - health script execution requires root permissions.
   "checks": {
     "services": [
       {
-        "name": "nsfs",
+        "name": "noobaa",
         "service_status": "active",
         "pid": "1204",
         "error_type": "PERSISTENT"
@@ -317,13 +317,13 @@ NOTE - health script execution requires root permissions.
 
 `error_message`: Message explaining the issue with the health script.
 
-`service_status`: NSFS systemd status. Check for nsfs/rsyslog service up and running.
+`service_status`: NooBaa systemd status. Check for noobaa/rsyslog service up and running.
 
-`pid`: NSFS/Rsyslog systemd process id.
+`pid`: NooBaa/Rsyslog systemd process id.
 
 `endpoint_response`: Noobaa endpoint web service response code.
 
-`total_fork_count`: Total number of forks in NSFS.
+`total_fork_count`: Total number of forks in NooBaa.
 
 `running_workers`: Running endpoint workers ids in list.
 
@@ -345,25 +345,25 @@ Account without `new_buckets_path` and `allow_bucket_creation` value is `false` 
 
 #### 1. `check_syslog_ng`
 `check_syslog_ng` flag will add syslogng to the health status check. Health final status will depend on the syslogng status.
-Health script will check whether the syslogng service is active or not and its PID is a valid value. Syslogng status will get added along with nsfs and rsyslog.
+Health script will check whether the syslogng service is active or not and its PID is a valid value. Syslogng status will get added along with NooBaa and rsyslog.
 
 ### Health Error Codes
 These are the error codes populated in the health output if the system is facing some issues. If any of these error codes are present in health status then the overall status will be in `NOTOK` state.
-#### 1. `NOOBAA_NSFS_SERVICE_FAILED`
+#### 1. `NOOBAA_SERVICE_FAILED`
 #### Reasons
-- NSFS service is not started properly.
-- Stopped NSFS service is not removed.
+- NooBaa service is not started properly.
+- Stopped NooBaa service is not removed.
 
 #### Resolutions
-- Verify the NSFS service is running by checking the status and logs command.
+- Verify the NooBaa service is running by checking the status and logs command.
 ```
-systemctl status noobaa_nsfs.service
-journalctl -xeu noobaa_nsfs.service
+systemctl status noobaa.service
+journalctl -xeu noobaa.service
 ```
-If the NSFS is not started, start the service
+If the NooBaa service is not started, start the service
 ```
-systemctl enable noobaa_nsfs.service
-systemctl start noobaa_nsfs.service
+systemctl enable noobaa.service
+systemctl start noobaa.service
 ```
 #### 2. `RSYSLOG_SERVICE_FAILED`
 #### Reasons
@@ -382,24 +382,24 @@ systemctl enable rsyslog.service
 systemctl start rsyslog.service
 ```
 
-#### 3. `NSFS_ENDPOINT_FORK_MISSING`
+#### 3. `NOOBAA_ENDPOINT_FORK_MISSING`
 #### Reasons
 - One or more endpoint fork is not started properly.
 - Number of workers running is less than the configured `forks` value.
 
 #### Resolutions
-- Restart the NSFS service and also verify NSFS fork/s is exited with error in logs.
+- Restart the NooBaa service and also verify NooBaa fork/s is exited with error in logs.
 ```
 systemctl status rsyslog.service
 journalctl -xeu rsyslog.service
 ```
 
-#### 4. `NSFS_ENDPOINT_FAILED`
+#### 4. `NOOBAA_ENDPOINT_FAILED`
 #### Reasons
-- NSFS endpoint process is not running and Its not able to respond to any requests.
+- NooBaa endpoint process is not running and Its not able to respond to any requests.
 
 #### Resolutions
-- Restart the NSFS service and verify NSFS process is exited with errors in logs.
+- Restart the NooBaa service and verify NooBaa process is exited with errors in logs.
 ```
 systemctl status rsyslog
 journalctl -xeu rsyslog.service
@@ -437,35 +437,35 @@ Users can create, get status, update, delete, and list buckets and accounts usin
 CLI will never create or delete a bucket directory for the user if a bucket directory is missing CLI will return with error.
 
 NOTES -
-1. manage_nsfs execution requires root permissions.
+1. noobaa cli execution requires root permissions.
 2. While path specifies a GPFS path, it's recommended to add fs_backend=GPFS in order to increase performance by ordering NooBaa to use GPFS library.
 
 Account Commands
 ```
-sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --name noobaa --new_buckets_path ../standalon/nsfs_root/ --fs_backend GPFS 2>/dev/null
+sudo noobaa-cli account add --config_root ../standalon/config_root --name noobaa --new_buckets_path ../standalon/nsfs_root/ --fs_backend GPFS 2>/dev/null
 
-sudo node src/cmd/manage_nsfs account update --config_root ../standalon/config_root --name noobaa --fs_backend GPFS 2>/dev/null
+sudo noobaa-cli account update --config_root ../standalon/config_root --name noobaa --fs_backend GPFS 2>/dev/null
 
-sudo node src/cmd/manage_nsfs account status --config_root ../standalon/config_root --name noobaa 2>/dev/null
+sudo noobaa-cli account status --config_root ../standalon/config_root --name noobaa 2>/dev/null
 
-sudo node src/cmd/manage_nsfs account delete --config_root ../standalon/config_root --name noobaa 2>/dev/null
+sudo noobaa-cli account delete --config_root ../standalon/config_root --name noobaa 2>/dev/null
 
-sudo node src/cmd/manage_nsfs account list --config_root ../standalon/config_root 2>/dev/null
+sudo noobaa-cli account list --config_root ../standalon/config_root 2>/dev/null
 
  ```
 
 Bucket Commands
 Note: before creating a bucket, a user must create an account.
 ```
-sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --name bucket1 --owner noobaa --path ../standalon/nsfs_root/1 --fs_backend GPFS 2>/dev/null
+sudo noobaa-cli bucket add --config_root ../standalon/config_root --name bucket1 --owner noobaa --path ../standalon/nsfs_root/1 --fs_backend GPFS 2>/dev/null
 
-sudo node src/cmd/manage_nsfs bucket update --config_root ../standalon/config_root --name bucket1 --owner noobaa --fs_backend GPFS 2>/dev/null
+sudo noobaa-cli bucket update --config_root ../standalon/config_root --name bucket1 --owner noobaa --fs_backend GPFS 2>/dev/null
 
-sudo node src/cmd/manage_nsfs bucket status --config_root ../standalon/config_root --name bucket1 2>/dev/null
+sudo noobaa-cli bucket status --config_root ../standalon/config_root --name bucket1 2>/dev/null
 
-sudo node src/cmd/manage_nsfs bucket delete --config_root ../standalon/config_root --name bucket1 2>/dev/null
+sudo noobaa-cli bucket delete --config_root ../standalon/config_root --name bucket1 2>/dev/null
 
-sudo node src/cmd/manage_nsfs bucket list --config_root ../standalon/config_root 2>/dev/null
+sudo noobaa-cli bucket list --config_root ../standalon/config_root 2>/dev/null
 
 ```
 NSFS management CLI run will create both accounts, access_keys, and buckets directories if they are missing under the config_root directory.
@@ -476,8 +476,8 @@ Using `from_file` flag:
 - General use:
 
 ```bash
-sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --from_file <options_JSON_file_path>
-sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --from_file <options_JSON_file_path>
+sudo noobaa-cli account add --config_root ../standalon/config_root --from_file <options_JSON_file_path>
+sudo noobaa-cli bucket add --config_root ../standalon/config_root --from_file <options_JSON_file_path>
 ```
 
 - The options are key-value, where the key is the same as suggested flags, for example:
@@ -494,7 +494,7 @@ sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root 
 ```
 
 ```bash
-sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root --from_file <options_account_JSON_file_path>
+sudo noobaa-cli account add --config_root ../standalon/config_root --from_file <options_account_JSON_file_path>
 ```
 
 (2) Create JSON file for bucket:
@@ -508,7 +508,7 @@ sudo node src/cmd/manage_nsfs account add --config_root ../standalon/config_root
 ```
 
 ```
-sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root --from_file <options_bucket_JSON_file_path>
+sudo noobaa-cli bucket add --config_root ../standalon/config_root --from_file <options_bucket_JSON_file_path>
 ```
 
 - When using `from_file` flag the details about the account/bucket should be only inside the options JSON file.
@@ -516,22 +516,22 @@ sudo node src/cmd/manage_nsfs bucket add --config_root ../standalon/config_root 
 
 ## NSFS Certificate
 
-Non containerized NSFS certificates/ directory location will be under the config_root path. <br />
+Non containerized NooBaa certificates/ directory location will be under the config_root path. <br />
 The certificates/ directory should contain SSL files tls.key and tls.crt. <br />
-System will use a cert from this dir to create a valid HTTPS connection. If cert is missing in this dir a self-signed SSL certificate will be generated. Make sure the path to certificates/ directory is valid before running nsfs command, If the path is invalid then cert flow will fail.
+System will use a cert from this dir to create a valid HTTPS connection. If cert is missing in this dir a self-signed SSL certificate will be generated. Make sure the path to certificates/ directory is valid before running the service, If the path is invalid then cert flow will fail.
 
-Non containerized NSFS restrict insecure HTTP connections when `ALLOW_HTTP` is set to false in cofig.json. This is the default behaviour.
+Non containerized NooBaa restrict insecure HTTP connections when `ALLOW_HTTP` is set to false in cofig.json. This is the default behaviour.
 
-### Setting Up Self signed SSL/TLS Certificates for Secure Communication Between S3 Client and NooBaa NSFS Service -
+### Setting Up Self signed SSL/TLS Certificates for Secure Communication Between S3 Client and NooBaa Service -
 
 #### 1. Creating a SAN (Subject Alternative Name) Config File -
 **Important**: This step is needed only if S3 Client and NooBaa Service Running on different nodes.
 
-To accommodate S3 requests originating from a different node than the one running the NooBaa NSFS service, it is recommended to create a Subject Alternative Name (SAN) configuration file. <br />
+To accommodate S3 requests originating from a different node than the one running the NooBaa service, it is recommended to create a Subject Alternative Name (SAN) configuration file. <br />
 This file specifies the domain names or IP addresses that will be included in the SSL certificate.<br />
 The Common Name (CN) sets the primary domain for the certificate, and additional domains or IPs can be listed under subjectAltName.<br />
 
-Ensure to replace placeholders such as nsfs-domain-name-example.com and <nsfs-server-ip> with your actual domain and IP address.
+Ensure to replace placeholders such as noobaa-domain-name-example.com and <noobaa-server-ip> with your actual domain and IP address.
 
 Example SAN Config File (san.cnf):
 ```
@@ -550,9 +550,9 @@ CN = localhost
 
 # Example:
 # 'DNS:localhost' makes the certificate valid when accessing S3 storage via 'localhost'.
-# 'DNS:nsfs-domain-name-example.com' adds a specific domain to the certificate. Replace 'nsfs-domain-name-example.com' with your actual domain.
-# 'IP:<nsfs-server-ip>' includes an IP address. Replace '<nsfs-server-ip>' with the actual IP address of your S3 server.
-subjectAltName = DNS:localhost,DNS:nsfs-domain-name-example.com,IP:<nsfs-server-ip>
+# 'DNS:noobaa-domain-name-example.com' adds a specific domain to the certificate. Replace 'noobaa-domain-name-example.com' with your actual domain.
+# 'IP:<noobaa-server-ip>' includes an IP address. Replace '<noobaa-server-ip>' with the actual IP address of your S3 server.
+subjectAltName = DNS:localhost,DNS:noobaa-domain-name-example.com,IP:<noobaa-server-ip>
 ```
 
 
@@ -578,14 +578,14 @@ Note - The default config_dir is /etc/noobaa.conf.d/.
 
 ```bash
 sudo mv tls.key {config_dir_path}/certificates/
-sudo mv tls.csr {config_dir_path}/certificates/
+sudo mv tls.crt {config_dir_path}/certificates/
 ```
-#### 4. Restart the NooBaa NSFS service -
+#### 4. Restart the NooBaa service -
 ```bash
-sudo systemctl restart noobaa_nsfs
+sudo systemctl restart noobaa
 ```
 #### 5. Create S3 CLI alias while including tls.crt at the s3 commands via AWS_CA_BUNDLE=/path/to/tls.crt -
-* Make sure to replace credentials placeholders with their respective values, and the <endpoint> placeholder either with `localhost` or the domain name or IP of the node which is running the NSFS service.
+* Make sure to replace credentials placeholders with their respective values, and the <endpoint> placeholder either with `localhost` or the domain name or IP of the node which is running the NooBaa service.
 ```bash
 alias s3_ssl='AWS_CA_BUNDLE=/path/to/tls.crt AWS_ACCESS_KEY_ID=add_your_access_key AWS_SECRET_ACCESS_KEY=add_your_secret_key aws --endpoint https://<endpoint>:6443 s3'
 ```
@@ -597,8 +597,8 @@ s3_ssl ls
 
 ## Monitoring
 
-Prometheus metrics port can be passed through the argument `--metrics_port` while executing the nsfs command.
-NSFS state and output metrics can be fetched from URL `http:{host}:{metrics_port}/metrics/nsfs_stats`.
+Prometheus metrics port can be passed through the argument `--metrics_port` while executing the noobaa command.
+NooBaa state and output metrics can be fetched from URL `http:{host}:{metrics_port}/metrics/nsfs_stats`.
 
 ## Log and Logrotate
 Noobaa logs are configured using rsyslog and logrotate. RPM will configure rsyslog and logrotate if both are already running.
@@ -620,17 +620,17 @@ logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf
 
 **Create env file under the configuration directory (OPTIONAL) -**
 
-In order to apply env variables changes on the service, edit /etc/sysconfig/noobaa_nsfs env file as you wish before starting the service, notice that the env file format is key-value pair -
+In order to apply env variables changes on the service, edit /etc/sysconfig/noobaa env file as you wish before starting the service, notice that the env file format is key-value pair -
 
 ```sh
-vim  /etc/sysconfig/noobaa_nsfs
+vim  /etc/sysconfig/noobaa
 ```
-**Note** - If another /usr/local/noobaa-core/.env exists it should be merged into /etc/sysconfig/noobaa_nsfs carefully.
+**Note** - If another /usr/local/noobaa-core/.env exists it should be merged into /etc/sysconfig/noobaa carefully.
 
-In order to apply env changes after the service was started, edit the /etc/sysconfig/noobaa_nsfs env file and restart the service -
+In order to apply env changes after the service was started, edit the /etc/sysconfig/noobaa env file and restart the service -
 ```sh
-vim  /etc/sysconfig/noobaa_nsfs
-systemctl restart noobaa_nsfs
+vim  /etc/sysconfig/noobaa
+systemctl restart noobaa
 ```
 
 ## WhiteList IPs
@@ -638,5 +638,5 @@ systemctl restart noobaa_nsfs
 Access is restricted to these whitelist IPs. If there are no IPs mentioned all IPs are allowed. WhiteList IPs are added to cnfig.json.
 
 ```
-node src/cmd/manage_nsfs whitelist --ips '["127.0.0.1", "192.000.10.000", "3002:0bd6:0000:0000:0000:ee00:0033:000"]'  2>/dev/null
+sudo noobaa-cli whitelist --ips '["127.0.0.1", "192.000.10.000", "3002:0bd6:0000:0000:0000:ee00:0033:000"]'  2>/dev/null
 ```

--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -48,24 +48,24 @@ function print_usage() {
 }
 
 const HOSTNAME = 'localhost';
-const NSFS_SERVICE = 'noobaa_nsfs';
+const NOOBAA_SERVICE = 'noobaa';
 const RSYSLOG_SERVICE = 'rsyslog';
 const SYSLOG_NG_SERVICE = 'syslog-ng';
 const health_errors = {
-    NSFS_SERVICE_FAILED: {
-        error_code: 'NOOBAA_NSFS_SERVICE_FAILED',
-        error_message: 'NSFS service is not started properly, Please verify the service with status command.',
+    NOOBAA_SERVICE_FAILED: {
+        error_code: 'NOOBAA_SERVICE_FAILED',
+        error_message: 'NooBaa service is not started properly, Please verify the service with status command.',
     },
     RSYSLOG_SERVICE_FAILED: {
         error_code: 'RSYSLOG_SERVICE_FAILED',
         error_message: 'RSYSLOG service is not started properly, Please verify the service with status command.',
     },
-    NSFS_ENDPOINT_FAILED: {
-        error_code: 'NSFS_ENDPOINT_FAILED',
-        error_message: 'NSFS endpoint process is not running. Restart the endpoint process.',
+    NOOBAA_ENDPOINT_FAILED: {
+        error_code: 'NOOBAA_ENDPOINT_FAILED',
+        error_message: 'S3 endpoint process is not running. Restart the endpoint process.',
     },
-    NSFS_ENDPOINT_FORK_MISSING: {
-        error_code: 'NSFS_ENDPOINT_FORK_MISSING',
+    NOOBAA_ENDPOINT_FORK_MISSING: {
+        error_code: 'NOOBAA_ENDPOINT_FORK_MISSING',
         error_message: 'One or more endpoint fork is not started properly. Verify the total and missing fork count in response.',
     },
     STORAGE_NOT_EXIST: {
@@ -131,7 +131,7 @@ class NSFSHealth {
         let endpoint_state;
         let memory;
         let syslog_ng;
-        const { service_status, pid } = await this.get_service_state(NSFS_SERVICE);
+        const { service_status, pid } = await this.get_service_state(NOOBAA_SERVICE);
         if (pid !== '0') {
             endpoint_state = await this.get_endpoint_response();
             memory = await this.get_service_memory_usage();
@@ -156,13 +156,13 @@ class NSFSHealth {
         if (this.all_bucket_details) bucket_details = await this.get_bucket_status(this.config_root);
         if (this.all_account_details) account_details = await this.get_account_status(this.config_root);
         const health = {
-            service_name: NSFS_SERVICE,
+            service_name: NOOBAA_SERVICE,
             status: service_health,
             memory: memory,
             error: error_code,
             checks: {
                 services: [{
-                        name: NSFS_SERVICE,
+                        name: NOOBAA_SERVICE,
                         service_status: service_status,
                         pid: pid,
                         error_type: health_errors_tyes.PERSISTENT,
@@ -207,8 +207,8 @@ class NSFSHealth {
         let endpoint_state;
         try {
             await P.retry({
-                attempts: config.NSFS_HEALTH_ENDPOINT_RETRY_COUNT,
-                delay_ms: config.NSFS_HEALTH_ENDPOINT_RETRY_DELAY,
+                attempts: config.NC_HEALTH_ENDPOINT_RETRY_COUNT,
+                delay_ms: config.NC_HEALTH_ENDPOINT_RETRY_DELAY,
                 func: async () => {
                     endpoint_state = await this.get_endpoint_fork_response();
                     if (endpoint_state.response.response_code === fork_response_code.NOT_RUNNING.response_code) {
@@ -227,13 +227,13 @@ class NSFSHealth {
 
     async get_error_code(nsfs_status, pid, rsyslog_status, endpoint_response_code) {
         if (nsfs_status !== 'active' || pid === '0') {
-            return health_errors.NSFS_SERVICE_FAILED;
+            return health_errors.NOOBAA_SERVICE_FAILED;
         } else if (rsyslog_status !== 'active') {
             return health_errors.RSYSLOG_SERVICE_FAILED;
         } else if (endpoint_response_code === 'NOT_RUNNING') {
-            return health_errors.NSFS_ENDPOINT_FAILED;
+            return health_errors.NOOBAA_ENDPOINT_FAILED;
         } else if (endpoint_response_code === 'MISSING_FORKS') {
-            return health_errors.NSFS_ENDPOINT_FORK_MISSING;
+            return health_errors.NOOBAA_ENDPOINT_FORK_MISSING;
         }
     }
 
@@ -316,7 +316,7 @@ class NSFSHealth {
     }
 
     async get_service_memory_usage() {
-        const memory_status = await os_util.exec('systemctl status ' + NSFS_SERVICE + ' | grep Memory ', {
+        const memory_status = await os_util.exec('systemctl status ' + NOOBAA_SERVICE + ' | grep Memory ', {
             ignore_rc: true,
             return_stdout: true,
             trim_stdout: true,

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -1038,7 +1038,7 @@ async function whitelist_ips_management(args) {
     const config_path = path.join(config_root, 'config.json');
     try {
         const config_data = require(config_path);
-        config_data.NSFS_WHITELIST = whitelist_ips;
+        config_data.S3_SERVER_IP_WHITELIST = whitelist_ips;
         const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
         const data = JSON.stringify(config_data);
         await native_fs_utils.update_config_file(fs_context, config_root, config_path, data);

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -338,7 +338,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
     } catch (err) {
         console.error('nsfs: exit on error', err.stack || err);
         //noobaa crashed
-        new NoobaaEvent(NoobaaEvent.NSFS_CRASHED).create_event(undefined, undefined, err);
+        new NoobaaEvent(NoobaaEvent.S3_CRASHED).create_event(undefined, undefined, err);
         process.exit(2);
     }
 }

--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -19,7 +19,7 @@ RUN npm install --omit=dev && \
 ##############################################################
 COPY ./binding.gyp .
 COPY ./src/native ./src/native/
-COPY ./src/deploy/noobaa_nsfs.service ./src/deploy/
+COPY ./src/deploy/noobaa.service ./src/deploy/
 COPY ./src/deploy/nsfs_env.env ./src/deploy/
 COPY ./src/deploy/NVA_build/clone_submodule.sh ./src/deploy/NVA_build/
 COPY ./src/deploy/NVA_build/clone_s3select_submodules.sh ./src/deploy/NVA_build/

--- a/src/deploy/NVA_build/standalone_deploy_nsfs.sh
+++ b/src/deploy/NVA_build/standalone_deploy_nsfs.sh
@@ -14,7 +14,7 @@ function main() {
     execute "node src/cmd/manage_nsfs account add --name cephalt --new_buckets_path ${FS_ROOT_1} --uid 1000 --gid 1000" nsfs_cephalt.log
     execute "node src/cmd/manage_nsfs account add --name cephtenant --new_buckets_path ${FS_ROOT_2} --uid 2000 --gid 2000" nsfs_cephtenant.log
 
-    # Start nsfs server
+    # Start noobaa service
     execute "node src/cmd/nsfs" nsfs.log
 
     # Wait for sometime to process to start

--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -12,7 +12,8 @@ COPY ./src/agent ./src/agent
 COPY ./src/api ./src/api
 COPY ./src/cmd ./src/cmd
 COPY ./src/deploy/spectrum_archive ./src/deploy/spectrum_archive
-COPY ./src/deploy/noobaa_nsfs.service ./src/deploy/
+COPY ./src/deploy/noobaa.service ./src/deploy/
+COPY ./src/deploy/noobaa-cli ./src/deploy/
 COPY ./src/deploy/nsfs_env.env ./src/deploy/
 COPY ./src/deploy/NVA_build/clone_submodule.sh ./src/deploy/NVA_build/
 COPY ./src/deploy/NVA_build/clone_s3select_submodules.sh ./src/deploy/NVA_build/

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -76,9 +76,12 @@ ln -s /usr/local/noobaa-core/node/bin/node $RPM_BUILD_ROOT/usr/local/noobaa-core
 ln -s /usr/local/noobaa-core/node/bin/npm $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npm
 ln -s /usr/local/noobaa-core/node/bin/npx $RPM_BUILD_ROOT/usr/local/noobaa-core/bin/npx
 
+mkdir -p $RPM_BUILD_ROOT/usr/local/bin/
+chmod +x $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/noobaa-cli
+cp $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/noobaa-cli $RPM_BUILD_ROOT/usr/local/bin/noobaa-cli
+
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}/
-mv $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/noobaa_nsfs.service $RPM_BUILD_ROOT%{_unitdir}/noobaa_nsfs.service
-ln -s /usr/local/noobaa-core/src/deploy/nsfs_env.env $RPM_BUILD_ROOT/usr/local/noobaa-core/nsfs_env.env
+mv $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/noobaa.service $RPM_BUILD_ROOT%{_unitdir}/noobaa.service
 mkdir -p $RPM_BUILD_ROOT/etc/noobaa.conf.d/
 
 mkdir -p $RPM_BUILD_ROOT/etc/rsyslog.d/
@@ -89,10 +92,11 @@ ln -s /usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.conf $RPM_BU
 
 %files
 /usr/local/noobaa-core
-%{_unitdir}/noobaa_nsfs.service
+%{_unitdir}/noobaa.service
 /etc/logrotate.d/noobaa/logrotate_noobaa.conf
 /etc/rsyslog.d/noobaa_syslog.conf
 /etc/noobaa.conf.d/
+/usr/local/bin/noobaa-cli
 %doc
 
 %post

--- a/src/deploy/noobaa-cli
+++ b/src/deploy/noobaa-cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /usr/local/noobaa-core/
+./bin/node --unhandled-rejections=warn ./src/cmd/manage_nsfs.js "$@"

--- a/src/deploy/noobaa.service
+++ b/src/deploy/noobaa.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=The NooBaa nsfs service.
+Description=The NooBaa service.
 After=gpfs-wait-mount.service
 
 [Service]
@@ -9,7 +9,7 @@ User=root
 Group=root
 ExecStartPre=/usr/local/noobaa-core/bin/node /usr/local/noobaa-core/src/upgrade/upgrade_manager.js --nsfs true --upgrade_scripts_dir /usr/local/noobaa-core/src/upgrade/nsfs_upgrade_scripts
 ExecStart=/usr/local/noobaa-core/bin/node /usr/local/noobaa-core/src/cmd/nsfs.js
-EnvironmentFile=-/etc/sysconfig/noobaa_nsfs
+EnvironmentFile=-/etc/sysconfig/noobaa
 ExecStop=/bin/kill $MAINPID
 WorkingDirectory=/usr/local/noobaa-core/
 LimitNOFILE=65536

--- a/src/deploy/spectrum_archive/deployment_guide.md
+++ b/src/deploy/spectrum_archive/deployment_guide.md
@@ -13,7 +13,7 @@ NooBaa is packaged as a RPM which needs to be installed in order to be able to u
 1. Install by using `dnf`, `yum` or `rpm`.
    - Example: `rpm -i noobaa-core-5.15.0-1.el8.x86_64.20231009`.
 2. NooBaa RPM installation should provide the following things
-	1. `noobaa_nsfs.service` file located at `/usr/lib/systemd/system/noobaa_nsfs.service`.
+	1. `noobaa.service` file located at `/usr/lib/systemd/system/noobaa.service`.
 	2. NooBaa source available at `/usr/local/noobaa-core`.
 
 ## NooBaa Configuration
@@ -25,7 +25,7 @@ Before proceeding, please ensure there are no stale items in `/etc/noobaa.conf.d
 In order to be able to access NooBaa, the user should create a account. This can be done in the following way.
 ```console
 $ cd /usr/local/noobaa-core
-$ bin/node src/cmd/manage_nsfs.js account add --access_key <access-key> --secret_key <secret-key> --name <name-of-user> --new_buckets_path <path-to-store-bucket-data>
+$ noobaa-cli account add --access_key <access-key> --secret_key <secret-key> --name <name-of-user> --new_buckets_path <path-to-store-bucket-data>
 ```
 
 NOTE: `<path-to-store-bucket-data>` should already exist or else the above command will throw error.
@@ -38,7 +38,7 @@ $ cd /usr/local/noobaa-core
 $ mkdir /ibm/gpfs/noobaadata #Bucket Data Path should already exist
 $ export AWS_ACCESS_KEY_ID=$(openssl rand -hex 20)
 $ export AWS_SECRET_ACCESS_KEY=$(openssl rand -hex 20)
-$ bin/node src/cmd/manage_nsfs.js account add --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY --name noobaa --new_buckets_path /ibm/gpfs/noobaadata
+$ noobaa-cli account add --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY --name noobaa --new_buckets_path /ibm/gpfs/noobaadata
 ```
 
 ### Configure NooBaa
@@ -86,9 +86,9 @@ $ ./src/deploy/spectrum_archive/setup_policies.sh /ibm/gpfs /ibm/gpfs/noobaadata
 
 ## Start NooBaa
 ```console
-$ systemctl start noobaa_nsfs
-$ systemctl enable noobaa_nsfs #optional
-$ systemctl status noobaa_nsfs # You should see status "Active" in green color
+$ systemctl start noobaa
+$ systemctl enable noobaa #optional
+$ systemctl status noobaa # You should see status "Active" in green color
 ```
 
 ## Test NooBaa Installation

--- a/src/manage_nsfs/manage_nsfs_events_utils.js
+++ b/src/manage_nsfs/manage_nsfs_events_utils.js
@@ -88,12 +88,12 @@ NoobaaEvent.GPFSLIB_MISSING = Object.freeze({
     severity: 'ERROR',
     state: 'DEGRADED',
 });
-NoobaaEvent.NSFS_CRASHED = Object.freeze({
-    event_code: 'noobaa_nsfs_crashed',
+NoobaaEvent.S3_CRASHED = Object.freeze({
+    event_code: 'noobaa_s3_crashed',
     entity_type: 'NODE',
     event_type: 'STATE_CHANGE',
-    message: 'Noobaa NSFS crashed',
-    description: 'Noobaa NSFS crashed',
+    message: 'Noobaa S3 crashed',
+    description: 'Noobaa S3 crashed',
     scope: 'NODE',
     severity: 'ERROR',
     state: 'STOPPED'

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -8,7 +8,7 @@ Help:
 
     "NSFS" (Namespace FileSystem) is a NooBaa system that runs a local S3 endpoint on top of a filesystem.
     Each subdirectory of the root filesystem represents an S3 bucket.
-    "manage_nsfs" will provide a command line interface (CLI) to create new accounts and map existing directories 
+    "noobaa-cli" will provide a command line interface (CLI) to create new accounts and map existing directories 
     to NooBaa as buckets. For more information refer to the NooBaa docs.
 `;
 
@@ -17,7 +17,7 @@ Usage:
 
     execute with root permission or use sudo before each command
 
-    node src/cmd/manage_nsfs <type> <action> [flags]
+    noobaa-cli <type> <action> [flags]
 `;
 
 const ARGUMENTS = `

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -91,7 +91,7 @@ const nsfs_node_config_schema = {
             default: true,
             description: 'indicate whether fsync should be triggered, changing value to false is unsafe for production envs, hot reload'
         },
-        NSFS_WHITELIST: {
+        S3_SERVER_IP_WHITELIST: {
             type: 'array',
             default: [],
             description: 'List of whitelisted IPs for S3 access, Allow access from all the IPs if list is empty.'

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -36,7 +36,7 @@ describe('schema validation NC NSFS config', () => {
                 NSFS_OPEN_READ_MODE: 'rd',
                 NSFS_CHECK_BUCKET_BOUNDARIES: false,
                 ALLOW_HTTP: true,
-                NSFS_WHITELIST: [
+                S3_SERVER_IP_WHITELIST: [
                     '127.0.0.1',
                     '0000:0000:0000:0000:0000:ffff:7f00:0002',
                     '::ffff:7f00:3'

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -959,7 +959,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli add whitelist ips first time (IPV4 format)', async function() {
             const ips = ['127.0.0.1']; // IPV4 format
             const res = await exec_manage_cli(type, '', { config_root, ips: JSON.stringify(ips) });
-            config_options.NSFS_WHITELIST = ips;
+            config_options.S3_SERVER_IP_WHITELIST = ips;
             const config_data = await read_config_file(config_root, '', 'config');
             assert_response('', type, res, ips);
             assert_whitelist(config_data, config_options);
@@ -968,7 +968,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli update whitelist ips (IPV6 expanded format)', async function() {
             const ips = ['0000:0000:0000:0000:0000:ffff:7f00:0002']; // IPV6 expanded format
             const res = await exec_manage_cli(type, '', { config_root, ips: JSON.stringify(ips) });
-            config_options.NSFS_WHITELIST = ips;
+            config_options.S3_SERVER_IP_WHITELIST = ips;
             const config_data = await read_config_file(config_root, '', 'config');
             assert_response('', type, res, ips);
             assert_whitelist(config_data, config_options);
@@ -977,7 +977,7 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli update whitelist ips (IPV6 compressed format)', async function() {
             const ips = ['::ffff:7f00:3']; // IPV6 compressed format
             const res = await exec_manage_cli(type, '', { config_root, ips: JSON.stringify(ips) });
-            config_options.NSFS_WHITELIST = ips;
+            config_options.S3_SERVER_IP_WHITELIST = ips;
             const config_data = await read_config_file(config_root, '', 'config');
             assert_response('', type, res, ips);
             assert_whitelist(config_data, config_options);
@@ -1160,6 +1160,6 @@ function assert_account(account, account_options, skip_secrets) {
 function assert_whitelist(config_data, config_options) {
     assert.strictEqual(config_data.ENDPOINT_FORKS, config_options.ENDPOINT_FORKS);
     assert.strictEqual(config_data.UV_THREADPOOL_SIZE, config_options.UV_THREADPOOL_SIZE);
-    assert.strictEqual(config_data.NSFS_WHITELIST.length, config_options.NSFS_WHITELIST.length);
+    assert.strictEqual(config_data.S3_SERVER_IP_WHITELIST.length, config_options.S3_SERVER_IP_WHITELIST.length);
     return true;
 }

--- a/src/test/unit_tests/test_nc_nsfs_health.js
+++ b/src/test/unit_tests/test_nc_nsfs_health.js
@@ -106,7 +106,7 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.checks.buckets_status.valid_buckets[0].name, 'bucket1');
         });
 
-        mocha.it('NSFS service is inactive', async function() {
+        mocha.it('NooBaa service is inactive', async function() {
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             const get_service_state = sinon.stub(Health, "get_service_state");
@@ -116,10 +116,10 @@ mocha.describe('nsfs nc health', function() {
             get_endpoint_response.onFirstCall().returns(Promise.resolve({response: {response_code: 'RUNNING', total_fork_count: 0}}));
             const health_status = await Health.nc_nsfs_health();
             assert.strictEqual(health_status.status, 'NOTOK');
-            assert.strictEqual(health_status.error.error_code, 'NOOBAA_NSFS_SERVICE_FAILED');
+            assert.strictEqual(health_status.error.error_code, 'NOOBAA_SERVICE_FAILED');
         });
 
-        mocha.it('NSFS rsyslog service is inactive', async function() {
+        mocha.it('NooBaa rsyslog service is inactive', async function() {
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             const get_service_state = sinon.stub(Health, "get_service_state");
@@ -132,7 +132,7 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.error.error_code, 'RSYSLOG_SERVICE_FAILED');
         });
 
-        mocha.it('NSFS endpoint return error response is inactive', async function() {
+        mocha.it('NooBaa endpoint return error response is inactive', async function() {
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             const get_service_state = sinon.stub(Health, "get_service_state");
@@ -142,7 +142,7 @@ mocha.describe('nsfs nc health', function() {
             get_endpoint_response.onFirstCall().returns(Promise.resolve({response: {response_code: 'MISSING_FORKS', total_fork_count: 3, running_workers: ['1', '3']}}));
             const health_status = await Health.nc_nsfs_health();
             assert.strictEqual(health_status.status, 'NOTOK');
-            assert.strictEqual(health_status.error.error_code, 'NSFS_ENDPOINT_FORK_MISSING');
+            assert.strictEqual(health_status.error.error_code, 'NOOBAA_ENDPOINT_FORK_MISSING');
         });
 
         mocha.it('NSFS account with invalid storage path', async function() {

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -678,8 +678,8 @@ function authorize_session_token(req, options) {
 function validate_nsfs_whitelist(req) {
     // remove prefix for V4 IPs for whitelist validation
     const client_ip = parse_client_ip(req).replace(/^::ffff:/, '');
-    if (config.NSFS_WHITELIST.length === 0) return;
-    for (const whitelist_ip of config.NSFS_WHITELIST) {
+    if (config.S3_SERVER_IP_WHITELIST.length === 0) return;
+    for (const whitelist_ip of config.S3_SERVER_IP_WHITELIST) {
         if (client_ip === whitelist_ip) {
             return;
         }


### PR DESCRIPTION
### Explain the changes
### 1.The following PR renames the minimal user facing components having NSFS prefix - 
1. **Add CLI wrapper** - usage change - `node src/cmd/manage_nsfs.js` -> `noobaa-cli`
* add node noobaa-cli commands to /usr/local/bin on RPM  
3. **Service name** - noobaa_nsfs.service -> noobaa.service
4. **Configurations** - 
- NSFS_WHITELIST -> S3_SERVER_IP_WHITELIST
- NSFS_HEALTH_ENDPOINT_RETRY_COUNT -> NC_HEALTH_ENDPOINT_RETRY_COUNT
- NSFS_HEALTH_ENDPOINT_RETRY_DELAY -> NC_HEALTH_ENDPOINT_RETRY_DELAY
5. **Event** - 
- noobaa_nsfs_crashed -> noobaa_s3_crashed
6. **Health errors** - 
- NOOBAA_NSFS_SERVICE_FAILED -> NOOBAA_SERVICE_FAILED
- NSFS_ENDPOINT_FAILED -> NOOBAA_ENDPOINT_FAILED
- NSFS_ENDPOINT_FORK_MISSING -> NOOBAA_ENDPOINT_FORK_MISSING

7. All related **docs/tests** adopted the new namings as well.
9. Env file rename to noobaa
### Issues: Fixed #xxx / Gap #xxx
1. Gap - Rename of internal references of manage_nsfs will be a part of a follow-up PR.
2. move health script under noobaa-cli

### Testing Instructions:
1. Manual Tests in a linux container + RPM deployment - 
```
systemctl enable noobaa.service --now
noobaa-cli account add...
s3 ops using this account - ls, mb, cp etc
node src/cmd/health
```



- [ ] Doc added/updated
- [ ] Tests added
