### PR TITLE
github stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 11 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        days-before-stale: 90
+        days-before-pr-stale: 90
+        days-before-issue-stale: 90
+        stale-pr-message: 'This PR had no activity for too long - it will now be labeled stale. Update it to prevent it from getting closed.'
+        stale-issue-message: 'This issue had no activity for too long - it will now be labeled stale. Update it to prevent it from getting closed.'
+
+        days-before-close: 30
+        days-before-pr-close: 30
+        days-before-issue-close: 30
+        close-pr-message: 'This PR is stale and had no activity for too long - it will now be closed.'
+        close-issue-message: 'This issue is stale and had no activity for too long - it will now be closed.'


### PR DESCRIPTION
### Explain the changes
1. We have too many stale issues and PR's.
2. Added the [stale action](https://github.com/marketplace/actions/close-stale-issue).
