### PR TITLE
NC | generate_entropy() - add dasd disks to the supported devices 

### DIFF
--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -120,7 +120,7 @@ async function generate_entropy(loop_cond) {
                 const count = 32;
                 let disk;
                 let disk_size;
-                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda']) {
+                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda']) {
                     try {
                         const res = await async_exec(`blockdev --getsize64 ${disk}`);
                         disk_size = res.stdout;


### PR DESCRIPTION
### Explain the changes
1. Add dasd disks to the supported devices (as the suggested on the bug) for not failing generate_entropy()

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #7982

### Testing Instructions:
1. ```Start NooBaa nsfs service on a RHEL9.3 (s390x) the following error can be found on systems with dasd disks (ECKD) only```


- [ ] Doc added/updated
- [ ] Tests added
