### PR TITLE
Bucket_logging: Time bound bucket logs delivery

### DIFF
--- a/src/deploy/NVA_build/noobaa_log_segregate.sh
+++ b/src/deploy/NVA_build/noobaa_log_segregate.sh
@@ -8,10 +8,23 @@
 # into respective log files. These files will be moved to the final location
 # /log/noobaa_bucket_logs/ which will be scanned by the background worker.
 
-
 log_dir="/var/log/noobaa_logs"
+NOOBAA_BUCKET_LOGS_DIR="/var/log/noobaa_bucket_logs/"
+NOOBAA_BUCKET_LOGS_FINAL="/log/noobaa_bucket_logs/"
+BUCKET_LOG_FILE_SIZE_LIMIT=51200
+# Delimiter for the file name. To separate the file name from the timestamp.
+# S3 Bucket name are not allowed to have "_" in its name.
+File_Name_Del="_"
+
 # Lock file to make sure that the script is not running multiple times.
 lock_file="/var/log/noobaa_bucket_logs/noobaa_log_segregate.lock"
+
+# It might happen that some bucket logs in NOOBAA_BUCKET_LOGS_DIR are less than 50KB.
+# We need to have a time interval after which we have to move these logs to final location
+# to make sure timly transfer of logs.
+# For now, we will wait for 5 minutes before we move bucket logs, which are
+# smaller than 50K, to final log location.
+NOOBAA_BUCKET_LOGS_WAIT_TIME=300
 
 if [ -e "$lock_file" ]; then
     echo "Script is already running. Exiting."
@@ -27,12 +40,7 @@ remove_lock_file() {
 
 #make sure clean up of the lock file in case it gets killed.
 trap 'remove_lock_file; exit' SIGINT SIGTERM
-
 touch "$lock_file"
-
-# Delimiter for the file name. To separate the file name from the timestamp.
-# S3 Bucket name are not allowed to have "_" in its name.
-File_Name_Del="_"
 
 # Get the oldest log file in the /var/log/noobaa_logs directory
 # by iterating over all the files in the directory that start with
@@ -49,28 +57,43 @@ oldest_log_file() {
     echo "$earliest_filename"
 }
 
+move_old_small_bucket_logs() {
+    current_time=$(date +%s)
+    for filename in "/var/log/noobaa_bucket_logs/"*.log; do
+
+        timestamp=$(echo "$filename" | sed -E 's/.*_([0-9]{10}).log/\1/')
+        time_diff=$((current_time - timestamp))
+        if [[ $time_diff -gt $NOOBAA_BUCKET_LOGS_WAIT_TIME ]]; then
+            mv "$filename" "$NOOBAA_BUCKET_LOGS_FINAL"
+            echo "File older than 300 seconds: $filename : $time_diff seconds" >> /tmp/logs
+        fi
+    done
+}
+
 if [ ! -d "$log_dir" ] || [ -z "$(ls -A "$log_dir")" ]; then
     echo "log_dir $log_dir does not exist or is empty."
+    move_old_small_bucket_logs
     remove_lock_file
 fi
 
 while [ -n "$(ls -A "$log_dir")" ]; do
     log_file=$(oldest_log_file)
-    echo "processing $log_file"
     mv "$log_dir/$log_file" "$log_dir/$log_file.processing"
     log_file="$log_dir/$log_file.processing"
     # Iterate over each log records in the log file and do the following -
     # - Fetch the log bucket name from the log entry.
     # - Fetch the log prefix from the log entry.
     # - Create a file based on this log bucket name and log prefix if the file is not there.
-    # - Append the log entry to this file.
-    # - Check the size of this file, if it is 50KB, then rename the file by
-    # - appending the current timestamp to the file name.
+    # - append the current timestamp to the file name.
+    # - Append the log entries to this file.
+    # - Check the size of this file, if it is 50KB, move it to final location.
     # - Remove the log file once all log entries are processed.
     while read -r log; do
         IFS=, read -r -a log_fields <<< "$log"
         log_bucket_name=""
         log_prefix_value=""
+        bucket_log_file=""
+        existing_log_file=""
         for log_field in "${log_fields[@]}"; do
             if [[ "$log_field" =~ "log_bucket" ]]; then
                 IFS=: read -r -a log_values <<< "$log_field"
@@ -83,17 +106,28 @@ while [ -n "$(ls -A "$log_dir")" ]; do
             fi
         done
         if [[ $log_prefix_value && $log_bucket_name ]]; then
-            log_bucket_name=$log_bucket_name$File_Name_Del$log_prefix_value
-            echo "$log" >> "/var/log/noobaa_bucket_logs/$log_bucket_name.log"
-                            file_size=$(stat -c "%s" "/var/log/noobaa_bucket_logs/$log_bucket_name.log")
 
-            if [[ $file_size -gt 50000 ]]; then
-                time_string=$(date +"%Y-%m-%d-%H-%M-%S.%N")
-                mv "/var/log/noobaa_bucket_logs/$log_bucket_name.log" "/log/noobaa_bucket_logs/$log_bucket_name$File_Name_Del$time_string.log"
+            log_bucket_name_prefix="$log_bucket_name$File_Name_Del$log_prefix_value"
+            existing_log_file=$(find $NOOBAA_BUCKET_LOGS_DIR -type f -name "$log_bucket_name_prefix*" -print | head -n 1)
+
+            if [[ -n "$existing_log_file" ]]; then
+                bucket_log_file=$(basename "$existing_log_file")
+            else
+                time_string=$(date +%s)
+                bucket_log_file="$log_bucket_name_prefix$File_Name_Del$time_string.log"
+            fi
+
+            bucket_log_file="$NOOBAA_BUCKET_LOGS_DIR$bucket_log_file"
+            echo "$log" >> "$bucket_log_file"
+            file_size=$(stat -c "%s" "$bucket_log_file")
+
+            if [[ $file_size -gt $BUCKET_LOG_FILE_SIZE_LIMIT ]]; then
+                mv "$bucket_log_file" "$NOOBAA_BUCKET_LOGS_FINAL"
             fi
         fi
     done < "$log_file"
     rm "$log_file"
 done
 
+move_old_small_bucket_logs
 remove_lock_file


### PR DESCRIPTION
BZ: [2272932](https://bugzilla.redhat.com/show_bug.cgi?id=2272932)
Log rotation, segregation and upload of log objects for different buckets happens based on size and time. If the size of logs are less than the configured value, it might take time to upload the log objects.

We need to consider the following factors behind log collection and processing. 1 - logrotation depends on size of the log file, bucket_logs.log, or time of the day. Currently, the size is set to 100KB. logrotate wakes up every 1 minute. That means, once the bucket_logs.log file size reaches more than 100KB, logrotates will come up and rotate this file. If the size has not reached 100K, it still rotates the file after every 24hr.

2 - After rotation, bucket_logs.log gets processed by logsegregate.sh which gets executed every 5 min. This creates log objects for individual buckets. We have a limit of size of log objects which is 50K. Once a log object reaches 50K, it will be transferred to the log bucket.

3 - Background process, which actually copies the log object in log buckets, scans the log path every 5 minutes. If it finds any log object, it copies it to a log bucket.

If log is not delivered because it is not rotated in step 1 based on size, then that can only be rotated on daily basis. We can not do anything there.

However, we have control on step 2. If the size of the log object for a bucket is less than 50K, it is not being uploaded even after 2-3 hours or even 24 hr.

Solution: We need to make sure that even if the size of log object for a bucket is less than 50K, it get uploaded once the threshold of time reaches, which is set to be 5 minutes.
