### PR TITLE
NSFS | Logrotate is not performing for noobaa logs

### DIFF
--- a/docs/non_containerized_NSFS.md
+++ b/docs/non_containerized_NSFS.md
@@ -612,7 +612,9 @@ Noobaa logs are pushed to `var/log/noobaa.log` and the log is rotated and compre
 
 Verify the rsyslog and logrotate rpm configuration is complete by checking the files `etc/rsyslog.d/noobaa_syslog.conf` for rsyslog and `etc/logrotate.d/noobaa/logrotate_noobaa.conf` for logrotate.These files contain the noobaa specific configuration for rsyslog and logrotate.
 
-Rotate the logs manually.
+Logrotate configuration is set up under `/etc/logrotate.d/noobaa/`. In order to trigger rotation when log files reache size threshold, each log file (`/var/log/noobaa.log` and `/var/log/noobaa_events.log`) uses its own rsyslog `outchannel` that triggers logrotate once file size reaches a limit (105MB). Logrotate is also typically called from cron on daily schedule.
+
+To rotate the logs manually run.
 
 ```
 logrotate /etc/logrotate.d/noobaa/logrotate_noobaa.conf

--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -36,6 +36,7 @@ COPY ./binding.gyp .
 COPY ./src/deploy/standalone/noobaa_rsyslog.conf ./src/deploy/standalone/noobaa_rsyslog.conf
 COPY ./src/deploy/standalone/noobaa_syslog.conf ./src/deploy/standalone/noobaa_syslog.conf
 COPY ./src/deploy/standalone/logrotate_noobaa.conf ./src/deploy/standalone/logrotate_noobaa.conf
+COPY ./src/deploy/standalone/logrotate_noobaa.sh ./src/deploy/standalone/logrotate_noobaa.sh
 COPY ./src/manage_nsfs ./src/manage_nsfs
 
 WORKDIR /build

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -89,6 +89,7 @@ mv $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/standalone/noobaa_syslog.con
 
 mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d/noobaa
 ln -s /usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.conf $RPM_BUILD_ROOT/etc/logrotate.d/noobaa/logrotate_noobaa.conf
+chmod +x $RPM_BUILD_ROOT/usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.sh
 
 %files
 /usr/local/noobaa-core

--- a/src/deploy/standalone/logrotate_noobaa.conf
+++ b/src/deploy/standalone/logrotate_noobaa.conf
@@ -1,7 +1,25 @@
 /var/log/noobaa.log
 {
     daily
-    size 100M
+    maxsize 100M
+    minsize 50M
+    start 1
+    missingok
+    rotate 100
+    compress
+    create 644 root root
+    sharedscripts
+    postrotate 
+        killall -HUP rsyslogd || true
+        killall -HUP syslogd || true
+    endscript
+}
+
+/var/log/noobaa_events.log
+{
+    daily
+    maxsize 100M
+    minsize 10M
     start 1
     missingok
     rotate 100
@@ -9,14 +27,13 @@
     create 644 root root
     sharedscripts
     postrotate
-        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
-        /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+        killall -HUP rsyslogd || true
+        killall -HUP syslogd || true
     endscript
 }
 
 /var/log/client_noobaa.log
 {
-    daily
     size 100M
     start 1
     missingok
@@ -25,22 +42,7 @@
     create 644 root root
     sharedscripts
     postrotate
-        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
-        /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
-    endscript
-}
-
-/var/log/noobaa_events.log
-{
-    monthly
-    size 10M
-    start 1
-    missingok
-    rotate 10
-    create 644 root root
-    sharedscripts
-    postrotate
-        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
-        /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+        killall -HUP rsyslogd || true
+        killall -HUP syslogd || true
     endscript
 }

--- a/src/deploy/standalone/logrotate_noobaa.sh
+++ b/src/deploy/standalone/logrotate_noobaa.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/sbin/logrotate -v /etc/logrotate.d/noobaa/logrotate_noobaa.conf || true

--- a/src/deploy/standalone/noobaa_syslog.conf
+++ b/src/deploy/standalone/noobaa_syslog.conf
@@ -28,14 +28,17 @@ template(name="LogseneFormat" type="list" option.json="on") {
   constant(value="\"}\n")
 }
 
-# For servers
-local0.*        /var/log/noobaa.log;RSYSLOG_FileFormat
+# 105M limit(110100480), 5MB bigger than logrotate value. When updating this value update logrotate also.
+$outchannel log_rotation,/var/log/noobaa.log,110100480,/usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.sh
+local0.* :omfile:$log_rotation
+&stop
+
+# For events
+$outchannel event_rotation,/var/log/noobaa_events.log,110100480,/usr/local/noobaa-core/src/deploy/standalone/logrotate_noobaa.sh
+local2.* :omfile:$event_rotation;LogseneFormat
 &stop
 
 # For clients
 local1.*        /var/log/client_noobaa.log;RSYSLOG_FileFormat
 &stop
 
-# For events
-local2.*        /var/log/noobaa_events.log;LogseneFormat
-&stop


### PR DESCRIPTION
### Explain the changes
1. add script to run logrotate in regular interval

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7993

### Testing Instructions:
1. Verify the noobaa log is getting zipped once log size is more than configure limit.


- [X] Doc added/updated
- [ ] Tests added
