### PR TITLE
NC | config.json - Remove host_customization pattern

### DIFF
--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -143,9 +143,7 @@ module.exports = {
         ...nsfs_node_config_schema.properties,
         host_customization: {
             type: 'object',
-            patternProperties: {
-                '^[a-zA-Z0-9]$': { $ref: '#/definitions/nsfs_node_config_schema' }
-            },
+            additionalProperties: { $ref: '#/definitions/nsfs_node_config_schema' },
             description: 'nsfs configuration per host'
         }
     },

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -187,6 +187,47 @@ describe('schema validation NC NSFS config', () => {
             nsfs_schema_utils.validate_nsfs_config_schema(config_data);
         });
 
+        it('nsfs_config invalid config hostname - invalid configuration in hostname', () => {
+            const hostname = "hostname1";
+            const config_data = {
+                "ALLOW_HTTP": false,
+                host_customization: {
+                    [hostname]: {
+                        "ALLOW_HTTP": 'str'
+                    }
+                }
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+                'host_customization - ALLOW HTTP must be boolean';
+            const message = `must be boolean | {"type":"boolean"} | "/host_customization/${hostname}/ALLOW_HTTP"`;
+            assert_validation(config_data, reason, message);
+        });
+
+        it('nsfs_config invalid config hostname - invalid hostname - should succeed', () => {
+            const invalid_hostname = "not.$a.valid!.hostname";
+            const config_data = {
+                "ALLOW_HTTP": false,
+                host_customization: {
+                    [invalid_hostname]: {
+                        "ALLOW_HTTP": true
+                    }
+                }
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('nsfs_config valid config hostname', () => {
+            const config_data = {
+                "ALLOW_HTTP": false,
+                host_customization: {
+                    "a.valid-valid.hostname": {
+                        "ALLOW_HTTP": true
+                    }
+                }
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
     });
 });
 


### PR DESCRIPTION
### Explain the changes
1. Bug fix - incorrect host_customization regexp, removed it and changed that only the value will be checked by the schema.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Auto - `sudo jest --testRegex=jest_tests/test_nc_nsfs_config_schema`
3. Manual - 
```
Tab 1 -
1. edit config.json - vi /etc/noobaa.conf.d/config.json
2. Insert invalid hostname configuration- 
{
 "host_customization": {
    "hostname1": {
      "ALLOW_HTTP": 'str'
    },
    "hostname2": {
     "ALLOW_HTTP": false
    }
  }
}

Tab 2 - 
1. Start the nsfs endpoint - sudo node src/cmd/nsfs.js --debug=5
2. Expect a failure -
RpcError: must be boolean | {"type":"boolean"} | "/host_customization/hostname1/ALLOW_HTTP"
    at Object.validate_nsfs_config_schema (noobaa-core/src/manage_nsfs/nsfs_schema_utils.js:81:15)
```


- [ ] Doc added/updated
- [x] Tests added
