### PR TITLE
[NC | NSFS] Hourly accurate glacier expiry

### DIFF
--- a/config.js
+++ b/config.js
@@ -788,7 +788,10 @@ config.NSFS_GLACIER_EXPIRY_RUN_DELAY_LIMIT_MINS = 2 * 60;
 config.NSFS_GLACIER_EXPIRY_TZ = 'LOCAL';
 
 // Format must be HH:MM:SS
-config.NSFS_GLACIER_EXPIRY_TIME_OF_DAY = '00:00:00';
+//
+// if set to empty string then time of processing
+// the request will be used
+config.NSFS_GLACIER_EXPIRY_TIME_OF_DAY = '';
 
 config.NSFS_STATFS_CACHE_SIZE = 10000;
 config.NSFS_STATFS_CACHE_EXPIRY_MS = 1 * 1000;

--- a/src/util/time_utils.js
+++ b/src/util/time_utils.js
@@ -82,6 +82,36 @@ function format_time_duration(millis, show_millis) {
     return `${hours_str}:${mins_str}:${secs_str}`;
 }
 
+/**
+ * round_up_to_next_time_of_day takes a date and rounds it up based on
+ * the given hours, mins and secs.
+ * The function is timezone aware but expects the given hours, mins and
+ * secs to be already timezone adjusted.
+ *
+ * @param {Date} date
+ * @param {number} hours 
+ * @param {number} mins 
+ * @param {number} secs 
+ * @param {'UTC' | 'LOCAL'} tz 
+ */
+function round_up_to_next_time_of_day(date, hours, mins, secs, tz) {
+    const desired_date = new Date(date);
+    if (tz === 'UTC') {
+        desired_date.setUTCHours(hours, mins, secs, date.getUTCMilliseconds());
+        if (date > desired_date) {
+            date.setUTCDate(date.getUTCDate() + 1);
+        }
+
+        date.setUTCHours(hours, mins, secs, 0);
+    } else {
+        desired_date.setHours(hours, mins, secs, date.getMilliseconds());
+        if (date > desired_date) {
+            date.setDate(date.getDate() + 1);
+        }
+
+        date.setHours(hours, mins, secs, 0);
+    }
+}
 
 exports.millistamp = millistamp;
 exports.microstamp = microstamp;
@@ -93,3 +123,4 @@ exports.format_http_header_date = format_http_header_date;
 exports.parse_http_header_date = parse_http_header_date;
 exports.parse_amz_date = parse_amz_date;
 exports.format_time_duration = format_time_duration;
+exports.round_up_to_next_time_of_day = round_up_to_next_time_of_day;


### PR DESCRIPTION
### Explain the changes
This PR adds a small configuration which allows setting restored item expiry based on the time of operation instead of midnight.

For example, if `NSFS_GLACIER_EXPIRY_TIME_OF_DAY` is set to `""` (default) and a restore request (days = 1) is issued at 5:00PM and it is processed at 5:10PM then the expiry will be set to next day 5:10PM (roughly).

### Testing Instructions:
1. Run `./node_modules/.bin/mocha src/test/unit_tests/test_nsfs_glacier_backend.js`


- [ ] Doc added/updated
- [ ] Tests added
