### PR TITLE
Fixed issue for wrong creation_time for non-nsfs buckets while listin…

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -399,6 +399,9 @@ module.exports = {
                             required: ['name'],
                             properties: {
                                 name: { $ref: 'common_api#/definitions/bucket_name' },
+                                creation_date: {
+                                    idate: true
+                                },
                             }
                         }
                     }

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -985,7 +985,10 @@ async function list_buckets(req) {
     );
     return {
         buckets: _.map(buckets_by_name, function(bucket) {
-            return _.pick(bucket, 'name');
+            return {
+                name: bucket.name,
+                creation_date: bucket._id.getTimestamp().getTime()
+            };
         })
     };
 }


### PR DESCRIPTION
### Explain the changes
1. The fix has been implemented to display of the correct creation_time when listing non-NSFS buckets.

### Issues: Fixed #xxx / Gap #xxx
1. [Issue](https://github.ibm.com/ProjectAbell/abell-tracking/issues/35309)

