### PR TITLE
NC | S3 Flow | Get-Bucket-Policy-Status fix

### DIFF
--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -615,16 +615,14 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         }
     }
 
-    async get_bucket_policy(params) {
+    async get_bucket_policy(params, object_sdk) {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.get_bucket_policy: Bucket name', name);
-            const bucket_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_path);
-            const bucket = JSON.parse(data.toString());
-            dbg.log0('BucketSpaceFS.get_bucket_policy: policy', bucket.s3_policy);
+            const bucket_policy_info = await object_sdk.read_bucket_sdk_policy_info(name);
+            dbg.log0('BucketSpaceFS.get_bucket_policy: policy', bucket_policy_info);
             return {
-                policy: bucket.s3_policy
+                policy: bucket_policy_info.s3_policy
             };
         } catch (err) {
             throw this._translate_bucket_error_codes(err);

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -844,7 +844,7 @@ interface BucketSpace {
 
     put_bucket_policy(params: object): Promise<any>;
     delete_bucket_policy(params: object): Promise<any>;
-    get_bucket_policy(params: object): Promise<any>;
+    get_bucket_policy(params: object, object_sdk: ObjectSDK): Promise<any>;
 
     get_object_lock_configuration(params: object, object_sdk: ObjectSDK): Promise<any>;
     put_object_lock_configuration(params: object, object_sdk: ObjectSDK): Promise<any>;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -1033,7 +1033,7 @@ class ObjectSDK {
     async get_bucket_policy(params) {
         const bs = this._get_bucketspace();
         bucket_namespace_cache.invalidate_key(params.name);
-        return bs.get_bucket_policy(params);
+        return bs.get_bucket_policy(params, this);
     }
 
     should_run_triggers({ active_triggers, operation, obj }) {

--- a/src/test/unit_tests/nc_index.js
+++ b/src/test/unit_tests/nc_index.js
@@ -16,10 +16,10 @@ require('./test_nsfs_access');
 require('./test_bucketspace');
 require('./test_bucketspace_fs');
 require('./test_nsfs_glacier_backend');
+require('./test_s3_bucket_policy');
 
 // TODO: uncomment when supported
 //require('./test_s3_ops');
-//require('./test_s3_bucket_policy');
 //require('./test_s3_list_objects');
 //require('./test_s3_encryption');
 // require('./test_s3select');


### PR DESCRIPTION
### Explain the changes
1. **BucketspaceFS.js -** get-bucket-policy read the bucket json file and returned the policy without converting strings to senstiveStrings (specifically in this case it failed on bucket policy principal unwrap() not a function).
Instead of reading the file, get the bucket policy from bucket namespace cache (which already converts strings to sensitiveStrings)  
3. **nc_index.js -** Added test_s3_bucket_policy.js, there was already a test for this case but it was not supported on NC env.
4. **test_s3_bucket_policy.js** - added the relevant changes to NC env (adds 26 tests, skipped 14).
### Issues: Fixed #xxx / Gap #xxx
1. Fixed #7924

### Testing Instructions:
1. Auto tests - 
```
sudo NC_CORETEST=true node --trace-warnings ./node_modules/mocha/bin/mocha /Users/romy/github/noobaa-core/src/test/unit_tests/test_s3_bucket_policy.js
```

3. Manual tests - 
```
Tab 1 - 
1. start nsfs endpoint - 
sudo node src/cmd/nsfs.js --debug=5

Tab 2 - 
1. Create Account - 
sudo node src/cmd/manage_nsfs.js account add --name account1 --uid=0 --gid=0 --new_buckets_path=/private/tmp/

2. Create s3 alias with account1 credentials, pointing to NooBaa endpoint -
alias s3api='AWS_ACCESS_KEY_ID=x AWS_SECRET_ACCESS_KEY=y aws --endpoint https://127.0.0.1:6443 --no-verify-ssl s3api'

4. create a bucket -
s3api create-bucket --bucket=buck1

5. put bucket policy -
s3api put-bucket-policy --bucket buck1 --policy="{\"Statement\":[{\"Sid\":\"AllowEveryoneReadOnlyAccess\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\",\"s3:ListBucket\"],\"Resource\":[\"arn:aws:s3:::buck1\",\"arn:aws:s3:::buck1/*\"]}]}"

6. get bucket policy status -
s3api get-bucket-policy-status --bucket=buck1
```


- [ ] Doc added/updated
- [x] Tests added
