### PR TITLE
NC | S3 flow | Put-Bucket-Policy Invalid Body error fix

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_policy.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_policy.js
@@ -29,6 +29,7 @@ async function put_bucket_policy(req) {
 module.exports = {
     handler: put_bucket_policy,
     body: {
+        invalid_error: S3Error.MalformedPolicyNotAJSON,
         type: 'json',
     },
     reply: {

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -501,6 +501,14 @@ S3Error.MalformedPolicy = Object.freeze({
     http_code: 400,
     detail: '...', // will be overridden from rpc_data, see handle_error in s3_rest.js
 });
+
+S3Error.MalformedPolicyNotAJSON = Object.freeze({
+    code: 'MalformedPolicy',
+    message: 'The specified policy syntax is not valid.',
+    http_code: 400,
+    detail: '...', // will be overridden from rpc_data, see handle_error in s3_rest.js
+});
+
 S3Error.NoSuchObjectLockConfiguration = Object.freeze({
     code: 'NoSuchObjectLockConfiguration',
     message: 'The specified object does not have a ObjectLock configuration',

--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -1181,6 +1181,23 @@ mocha.describe('s3_bucket_policy', function() {
                 }
             }
         });
+
+        mocha.it('should not allow invalid json', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            const s3_policy = "this is not a json";
+            try {
+                await s3_owner.putBucketPolicy({
+                    Bucket: BKT,
+                    Policy: s3_policy
+                });
+                assert.fail('Test was suppose to fail on ' + S3Error.MalformedPolicy.code);
+            } catch (err) {
+                if (err.Code !== S3Error.MalformedPolicy.code) {
+                    throw err;
+                }
+            }
+        });
     });
 
     mocha.describe('get-bucket-policy status should work', async function() {


### PR DESCRIPTION
### Explain the changes
1. Added invalid_body error to S3 put-bucket-policy - S3Error.MalformedPolicyNotAJSON

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #7870
2. Gaps - open an issue for other scenarios in which we throw incorrect error msg.

### Testing Instructions:
1. Auto - 
`sudo NC_CORETEST=true node --trace-warnings ./node_modules/mocha/bin/mocha /Users/romy/github/noobaa-core/src/test/unit_tests/test_s3_bucket_policy.js`
2. Manual - 



- [ ] Doc added/updated
- [x] Tests added
