### PR TITLE
NC | Fix master_keys.json timestamp typo

### DIFF
--- a/src/manage_nsfs/nc_master_key_manager.js
+++ b/src/manage_nsfs/nc_master_key_manager.js
@@ -166,7 +166,7 @@ class NCMasterKeysManager {
         const active_master_key_id = new_master_key.id;
         const master_keys_by_id = { ...this.master_keys_by_id, [active_master_key_id]: new_master_key };
         return JSON.stringify({
-            timestemp: Date.now(),
+            timestamp: Date.now(),
             [ACTIVE_MASTER_KEY]: active_master_key_id,
             master_keys_by_id
         });


### PR DESCRIPTION
### Explain the changes
1. Fix master_keys.json timestamp typo

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: #8025
2. Gap: we still don't know if there is a need to do an upgrade, so I didn't do this change now.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
