### PR TITLE
Remove `eslint-disable no-undef` And Add Jest in Eslint Config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     env: {
         node: true,
         es2022: true,
+        jest: true,
     },
 
     // See https://eslint.org/docs/latest/user-guide/configuring/language-options#specifying-environments

--- a/src/test/unit_tests/jest_tests/test_bucket_diff.test.js
+++ b/src/test/unit_tests/jest_tests/test_bucket_diff.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2023 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 // disabling init_rand_seed as it takes longer than the actual test execution

--- a/src/test/unit_tests/jest_tests/test_bucket_log_based_replication.test.js
+++ b/src/test/unit_tests/jest_tests/test_bucket_log_based_replication.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2023 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 // disabling init_rand_seed as it takes longer than the actual test execution

--- a/src/test/unit_tests/jest_tests/test_list_object.test.js
+++ b/src/test/unit_tests/jest_tests/test_list_object.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2016 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 

--- a/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2024 NooBaa */
-/* eslint-disable no-undef */
 
 'use strict';
 
@@ -135,4 +134,11 @@ async function read_master_keys_json() {
     const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, MASTER_KEYS_JSON_PATH);
     const master_keys = JSON.parse(data.toString());
     return master_keys;
+}
+
+// Jest has builtin function fail that based on Jasmine
+// in case Jasmine would get removed from jest, created this one
+// based on this: https://stackoverflow.com/a/55526098/16571658
+function fail(reason) {
+    throw new Error(reason);
 }

--- a/src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2024 NooBaa */
-/* eslint-disable no-undef */
 
 'use strict';
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2016 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 // disabling init_rand_seed as it takes longer than the actual test execution

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2024 NooBaa */
-/* eslint-disable no-undef */
 
 'use strict';
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2016 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 // disabling init_rand_seed as it takes longer than the actual test execution

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2024 NooBaa */
-/* eslint-disable no-undef */
 
 'use strict';
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2024 NooBaa */
-/* eslint-disable no-undef */
 
 'use strict';
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_new_buckets_path_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_new_buckets_path_validation.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2016 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 // disabling init_rand_seed as it takes longer than the actual test execution

--- a/src/test/unit_tests/jest_tests/test_noobaa_s3_client.test.js
+++ b/src/test/unit_tests/jest_tests/test_noobaa_s3_client.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2023 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 const { NodeHttpHandler } = require("@smithy/node-http-handler");

--- a/src/test/unit_tests/jest_tests/test_os_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_os_utils.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2016 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 const child_process = require('child_process');

--- a/src/test/unit_tests/jest_tests/test_s3_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_s3_utils.test.js
@@ -1,5 +1,4 @@
 /* Copyright (C) 2016 NooBaa */
-/* eslint-disable no-undef */
 'use strict';
 
 const s3_utils = require('../../../endpoint/s3/s3_utils');


### PR DESCRIPTION
### Explain the changes
1. Remove `eslint-disable no-undef` in the Jest test files and add jest in eslint config.
2. Add the function `fail` in file `test_nc_master_keys.test`.

### Issues: Fixed #xxx / Gap #xxx
1. According to the Jest documentation we can avoid using `eslint-disable no-undef`, by adding the jest environment ([here](https://jestjs.io/docs/getting-started#using-eslint)).

### Testing Instructions:
1. Tested in the CI in `Jest Unit Tests`.
2. For the change in 
After removing the `eslint-disable no-undef` I saw that:

> `/root/node_modules/noobaa-core/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
>   72:13  error  'fail' is not defined  no-undef
>   85:13  error  'fail' is not defined  no-undef`

Please run: `sudo npx jest test_nc_master_keys.test.js`.

- [ ] Doc added/updated
- [ ] Tests added
