### PR TITLE
NC | Adding NC_DISABLE_ACCESS_CHECK and NC_DISABLE_SCHEMA_CHECK configurations

### DIFF
--- a/config.js
+++ b/config.js
@@ -857,6 +857,9 @@ config.NC_MASTER_KEYS_PUT_EXECUTABLE = '';
 config.NC_MASTER_KEYS_MANAGER_REFRESH_THRESHOLD = -1; // currently we want to disable automatic refresh
 config.MASTER_KEYS_EXEC_MAX_RETRIES = 3;
 
+config.NC_DISABLE_ACCESS_CHECK = false;
+config.NC_DISABLE_SCHEMA_CHECK = false;
+
 //Quota
 config.QUOTA_LOW_THRESHOLD = 80;
 config.QUOTA_MAX_OBJECTS = Number.MAX_SAFE_INTEGER;

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -422,6 +422,43 @@ Example:
 3. systemctl restart noobaa_nsfs
 ```
 
+## 24. Disable schema check -
+**Description -** This flag will disable configuration/account/bucket schema checks. Warning: After setting this configuration, NooBaa will skip schema validations and one can create invalid accounts/buckets entities or apply invalid configuration which may cause an unexpected behavior.    
+
+**Configuration Key -** NC_DISABLE_SCHEMA_CHECK
+
+**Type -** boolean
+
+**Default -**  false
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"NC_DISABLE_SCHEMA_CHECK": true
+```
+
+
+## 25. Disable Read/Write accessibility check -
+**Description -** This flag will disable Read/Write accessibility validations in the following flows - 
+1. Bucket creation/update - NooBaa will not validate that the bucket owner has read/write permissions to the bucket's path.
+2. Account creation/update - NooBaa will not validate that the account owner has read/write permissions to the account's new_buckets_path.
+Warning - setting this configuration to true might result with unexpected behavior.
+
+**Configuration Key -** NC_DISABLE_ACCESS_CHECK
+
+**Type -** boolean
+
+**Default -**  false
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"NC_DISABLE_ACCESS_CHECK": true
+```
+
+
 ## Config.json example 
 ```
 > cat /path/to/config_dir/config.json

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -113,6 +113,14 @@ const nsfs_node_config_schema = {
         VIRTUAL_HOSTS: {
             type: 'string',
             doc: 'This flag will set the virtual hosts, service restart required, Set the virtual hosts as string of domains sepreated by spaces.'
+        },
+        NC_DISABLE_SCHEMA_CHECK: {
+            type: 'boolean',
+            doc: 'indicate whether account/bucket/config.json schema will be validated.'
+        },
+        NC_DISABLE_ACCESS_CHECK: {
+            type: 'boolean',
+            doc: 'indicate whether read/write access will be validated on bucket/account creation/update.'
         }
     }
 };

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1422,6 +1422,20 @@ describe('cli account flow distinguished_name - permissions', function() {
         const res = await exec_manage_cli(type, action, update_options);
         expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InaccessibleAccountNewBucketsPath.code);
     });
+
+    it('cli account create - account cant access new_bucket_path - NC_DISABLE_ACCESS_CHECK = true', async function() {
+        let action = ACTIONS.ADD;
+        config.NC_DISABLE_ACCESS_CHECK = true;
+        set_nc_config_dir_in_config(config_root);
+        await fs.promises.writeFile(path.join(config_root, 'config.json'), JSON.stringify({ NC_DISABLE_ACCESS_CHECK: true }));
+        const res = await exec_manage_cli(type, action, accounts.inaccessible_user.cli_options);
+        expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.AccountCreated.code);
+        assert_account(JSON.parse(res).response.reply, { ...accounts.inaccessible_user.cli_options }, false);
+        action = ACTIONS.DELETE;
+        const delete_inaccessible_options = _.omit(accounts.inaccessible_user.cli_options, ['new_buckets_path', 'user']);
+        await exec_manage_cli(type, action, delete_inaccessible_options);
+        config.NC_DISABLE_ACCESS_CHECK = false;
+    }, timeout);
 });
 
 /**

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -4,6 +4,7 @@
 
 const nsfs_schema_utils = require('../../../manage_nsfs/nsfs_schema_utils');
 const RpcError = require('../../../rpc/rpc_error');
+const config = require('../../../../config');
 
 describe('schema validation NC NSFS account', () => {
     const access_key1 = 'GIGiFAnjaaE7OKD5N7hA';
@@ -362,6 +363,16 @@ describe('schema validation NC NSFS account', () => {
                 'force_md5_etag (string instead of boolean)';
             const message = 'must be boolean';
             assert_validation(account_data, reason, message);
+        });
+    });
+
+    describe('skip schema check by config test', () => {
+        it('skip schema check by config test - invalid account - should pass', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = true;
+            const account_data = get_account_data();
+            account_data._id = undefined;
+            nsfs_schema_utils.validate_account_schema(account_data);
+            config.NC_DISABLE_SCHEMA_CHECK = false;
         });
     });
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -132,6 +132,17 @@ describe('manage nsfs cli bucket flow', () => {
             assert_bucket(bucket, bucket_options);
         });
 
+        it('cli create bucket - account can not access path  NC_DISABLE_ACCESS_CHECK = true - should succeed', async () => {
+            const action = ACTIONS.ADD;
+            const bucket_options = { config_root, ...bucket_defaults};
+            await fs_utils.create_fresh_path(bucket_options.path);
+            await fs_utils.file_must_exist(bucket_options.path);
+            set_nc_config_dir_in_config(config_root);
+            await create_json_file(config_root, 'config.json', { NC_DISABLE_ACCESS_CHECK: true });
+            await set_path_permissions_and_owner(bucket_options.path, account_defaults, 0o000);
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.BucketCreated.code);
+        });
     });
 
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -1,10 +1,12 @@
 /* Copyright (C) 2024 NooBaa */
+/*eslint max-lines-per-function: ["error", 500]*/
 
 'use strict';
 
 const nsfs_schema_utils = require('../../../manage_nsfs/nsfs_schema_utils');
 const RpcError = require('../../../rpc/rpc_error');
 const test_utils = require('../../system_tests/test_utils');
+const config = require('../../../../config');
 
 describe('schema validation NC NSFS bucket', () => {
     const versioning_enabled = 'ENABLED';
@@ -404,6 +406,15 @@ describe('schema validation NC NSFS bucket', () => {
 
     });
 
+    describe('skip schema check by config test', () => {
+        it('skip schema check by config test - invalid bucket should pass', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = true;
+            const bucket_data = get_bucket_data();
+            bucket_data.name = '1'; // invalid name
+            nsfs_schema_utils.validate_bucket_schema(bucket_data);
+            config.NC_DISABLE_SCHEMA_CHECK = false;
+        });
+    });
 });
 
 function get_bucket_data() {

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -4,6 +4,7 @@
 
 const nsfs_schema_utils = require('../../../manage_nsfs/nsfs_schema_utils');
 const RpcError = require('../../../rpc/rpc_error');
+const config = require('../../../../config');
 
 describe('schema validation NC NSFS config', () => {
 
@@ -227,6 +228,94 @@ describe('schema validation NC NSFS config', () => {
             nsfs_schema_utils.validate_nsfs_config_schema(config_data);
         });
 
+    });
+
+    describe('skip/unskip schema check by config test', () => {
+        afterAll(async () => {
+            config.NC_DISABLE_SCHEMA_CHECK = false;
+        });
+
+        it('skip schema check - config.NC_DISABLE_SCHEMA_CHECK=false nsfs_config.NC_DISABLE_SCHEMA_CHECK=true - invalid config - should pass', () => {
+            const config_data = {
+                NC_DISABLE_SCHEMA_CHECK: true,
+                ENABLE_DEV_RANDOM_SEED: 'not boolean', // string instead of boolean
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('unskip schema check - config.NC_DISABLE_SCHEMA_CHECK=true nsfs_config.NC_DISABLE_SCHEMA_CHECK=false - invalid config - should fail', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = true;
+            const config_data = {
+                NC_DISABLE_SCHEMA_CHECK: false,
+                ENABLE_DEV_RANDOM_SEED: 'not boolean', // string instead of boolean
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'ENABLE_DEV_RANDOM_SEED must be boolean';
+            const message = `must be boolean | {"type":"boolean"} | "/ENABLE_DEV_RANDOM_SEED"`;
+            assert_validation(config_data, reason, message);
+        });
+
+        it('skip schema check - config.NC_DISABLE_SCHEMA_CHECK=true nsfs_config.NC_DISABLE_SCHEMA_CHECK=undefined - invalid config - should pass', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = true;
+            const config_data = {
+                ENABLE_DEV_RANDOM_SEED: 'not boolean', // string instead of boolean
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('unskip schema check - config.NC_DISABLE_SCHEMA_CHECK=false nsfs_config.NC_DISABLE_SCHEMA_CHECK=undefined - invalid config - should fail', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = false;
+            const config_data = {
+                ENABLE_DEV_RANDOM_SEED: 'not boolean', // string instead of boolean
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'ENABLE_DEV_RANDOM_SEED must be boolean';
+            const message = `must be boolean | {"type":"boolean"} | "/ENABLE_DEV_RANDOM_SEED"`;
+            assert_validation(config_data, reason, message);
+        });
+
+        it('skip schema check - config.NC_DISABLE_SCHEMA_CHECK=true nsfs_config.NC_DISABLE_SCHEMA_CHECK=true - invalid config - should pass', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = true;
+            const config_data = {
+                NC_DISABLE_SCHEMA_CHECK: true,
+                ENABLE_DEV_RANDOM_SEED: 'not boolean', // string instead of boolean
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('unskip schema check - config.NC_DISABLE_SCHEMA_CHECK=false nsfs_config.NC_DISABLE_SCHEMA_CHECK=false - invalid config - should fail', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = false;
+            const config_data = {
+                NC_DISABLE_SCHEMA_CHECK: false,
+                ENABLE_DEV_RANDOM_SEED: 'not boolean', // string instead of boolean
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'ENABLE_DEV_RANDOM_SEED must be boolean';
+            const message = `must be boolean | {"type":"boolean"} | "/ENABLE_DEV_RANDOM_SEED"`;
+            assert_validation(config_data, reason, message);
+        });
+
+        it('unskip schema check - config.NC_DISABLE_SCHEMA_CHECK=true nsfs_config.NC_DISABLE_SCHEMA_CHECK=bla - invalid config - should pass', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = true;
+            const config_data = {
+                NC_DISABLE_SCHEMA_CHECK: 'bla',
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'NC_DISABLE_SCHEMA_CHECK must be boolean';
+            const message = `must be boolean | {"type":"boolean"} | "/NC_DISABLE_SCHEMA_CHECK"`;
+            assert_validation(config_data, reason, message);
+        });
+
+        it('unskip schema check - config.NC_DISABLE_SCHEMA_CHECK=false nsfs_config.NC_DISABLE_SCHEMA_CHECK=bla - invalid config - should fail', () => {
+            config.NC_DISABLE_SCHEMA_CHECK = false;
+            const config_data = {
+                NC_DISABLE_SCHEMA_CHECK: 'bla',
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'NC_DISABLE_SCHEMA_CHECK must be boolean';
+            const message = `must be boolean | {"type":"boolean"} | "/NC_DISABLE_SCHEMA_CHECK"`;
+            assert_validation(config_data, reason, message);
+        });
     });
 });
 


### PR DESCRIPTION
### Explain the changes

1. Adding NC_DISABLE_ACCESS_CHECK and NC_DISABLE_SCHEMA_CHECK in order to have a less strict behavior.
2. NC_DISABLE_ACCESS_CHECK description - 
```
This flag will disable Read/Write accessibility validations in the following flows - 
1. Bucket creation/update - NooBaa will not validate that the bucket owner has read/write permissions to the bucket's path.
2. Account creation/update - NooBaa will not validate that the account owner has read/write permissions to the account's new_buckets_path.
Warning - setting this configuration to true might result with unexpected behavior.
```
3. NC_DISABLE_SCHEMA_CHECK description - 
```
This flag will disable configuration/account/bucket schema checks. Warning: After setting this configuration, NooBaa will skip schema validations and one can create invalid accounts/buckets entities or apply invalid configuration which may cause an unexpected behavior.    
```

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `sudo jest --testRegex=jest_tests/test_nc_nsfs_config_schema`
2. `sudo jest --testRegex=jest_tests/test_nc_nsfs_account_schema`
3. `sudo jest --testRegex=jest_tests/test_nc_nsfs_bucket_schema`
4. `sudo jest --testRegex=jest_tests/test_nc_nsfs_account_cli`
5. `sudo jest --testRegex=jest_tests/test_nc_nsfs_bucket_cli`


- [ ] Doc added/updated
- [ ] Tests added
