### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+[*.js]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{cpp,cc,c,hpp,h,hh}]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true


### PR DESCRIPTION
### Explain the changes
This PR adds editorconfig for JS and native code.

**Justification**
EditorConfig is widely supported in most of editors/IDEs - Goland (and other JetBrains IDEs), Neovim, VSCode (extention), emacs (extension), etc. This should really help in automatically configuring the editors in setting up tabs/spaces etc. 
I have accidentally committed code with tabs for indentation as my editor was unaware of the styling guide, this is to minimize the chances of such future accidents.

- [ ] Doc added/updated
- [ ] Tests added
