### PR TITLE
NC | Health fix cli arguments validation and some small fixes

### DIFF
--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -6,6 +6,7 @@ const TYPES = {
     BUCKET: 'bucket',
     IP_WHITELIST: 'whitelist',
     GLACIER: 'glacier',
+    HEALTH: 'health'
 };
 
 const ACTIONS = {
@@ -62,6 +63,8 @@ const VALID_OPTIONS_GLACIER = {
     'expiry': new Set([ GLOBAL_CONFIG_ROOT]),
 };
 
+const VALID_OPTIONS_HEALTH = new Set(['https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', ...GLOBAL_CONFIG_OPTIONS]);
+
 const VALID_OPTIONS_WHITELIST = new Set(['ips', ...GLOBAL_CONFIG_OPTIONS]);
 
 const VALID_OPTIONS_FROM_FILE = new Set(['from_file', ...GLOBAL_CONFIG_OPTIONS]);
@@ -73,6 +76,7 @@ const VALID_OPTIONS = {
     whitelist_options: VALID_OPTIONS_WHITELIST,
     from_file_options: VALID_OPTIONS_FROM_FILE,
     anonymous_account_options: VALID_OPTIONS_ANONYMOUS_ACCOUNT,
+    health_options: VALID_OPTIONS_HEALTH
 };
 
 const OPTION_TYPE = {
@@ -98,10 +102,17 @@ const OPTION_TYPE = {
     show_secrets: 'boolean',
     ips: 'string',
     force: 'boolean',
-    anonymous: 'boolean'
+    anonymous: 'boolean',
+    // health options
+    deployment_type: 'string',
+    all_account_details: 'boolean',
+    all_bucket_details: 'boolean',
+    https_port: 'number'
 };
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];
+const BOOLEAN_STRING_OPTIONS = new Set(['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force',
+    'force_md5_etag', 'all_account_details', 'all_bucket_details', 'anonymous']);
 
 //options that can be unset using ''
 const LIST_UNSETABLE_OPTIONS = ['fs_backend', 's3_policy', 'force_md5_etag'];
@@ -118,6 +129,7 @@ exports.VALID_OPTIONS = VALID_OPTIONS;
 exports.OPTION_TYPE = OPTION_TYPE;
 exports.FROM_FILE = FROM_FILE;
 exports.BOOLEAN_STRING_VALUES = BOOLEAN_STRING_VALUES;
+exports.BOOLEAN_STRING_OPTIONS = BOOLEAN_STRING_OPTIONS;
 exports.LIST_UNSETABLE_OPTIONS = LIST_UNSETABLE_OPTIONS;
 
 exports.LIST_ACCOUNT_FILTERS = LIST_ACCOUNT_FILTERS;

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -14,7 +14,7 @@ const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCL
 const bucket_policy_utils = require('../endpoint/s3/s3_bucket_policy_utils');
 const { throw_cli_error, get_config_file_path, get_bucket_owner_account,
     get_config_data, get_options_from_file, has_access_keys } = require('../manage_nsfs/manage_nsfs_cli_utils');
-const { TYPES, ACTIONS, VALID_OPTIONS, OPTION_TYPE, FROM_FILE, BOOLEAN_STRING_VALUES,
+const { TYPES, ACTIONS, VALID_OPTIONS, OPTION_TYPE, FROM_FILE, BOOLEAN_STRING_VALUES, BOOLEAN_STRING_OPTIONS,
     GLACIER_ACTIONS, LIST_UNSETABLE_OPTIONS, ANONYMOUS } = require('../manage_nsfs/manage_nsfs_constants');
 
 /////////////////////////////
@@ -68,7 +68,7 @@ function validate_type_and_action(type, action) {
     if (!Object.values(TYPES).includes(type)) throw_cli_error(ManageCLIError.InvalidType);
     if (type === TYPES.ACCOUNT || type === TYPES.BUCKET) {
         if (!Object.values(ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidAction);
-    } else if (type === TYPES.IP_WHITELIST) {
+    } else if (type === TYPES.IP_WHITELIST || type === TYPES.HEALTH) {
         if (action !== '') throw_cli_error(ManageCLIError.InvalidAction);
     } else if (type === TYPES.GLACIER) {
         if (!Object.values(GLACIER_ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidAction);
@@ -99,6 +99,8 @@ function validate_no_extra_options(type, action, input_options, is_options_from_
         }
     } else if (type === TYPES.GLACIER) {
         valid_options = VALID_OPTIONS.glacier_options[action];
+    } else if (type === TYPES.HEALTH) {
+        valid_options = VALID_OPTIONS.health_options;
     } else {
         valid_options = VALID_OPTIONS.whitelist_options;
     }
@@ -139,7 +141,7 @@ function validate_options_type_by_value(input_options_with_data) {
                 continue;
             }
             // special case for boolean values
-            if (['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force', 'force_md5_etag', 'anonymous'].includes(option) && validate_boolean_string_value(value)) {
+            if (BOOLEAN_STRING_OPTIONS.has(option) && validate_boolean_string_value(value)) {
                 continue;
             }
             // special case for bucket_policy (from_file)

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -267,6 +267,35 @@ async function exec_manage_cli(type, action, options) {
 }
 
 /**
+ * exec_health_cli runs the health cli
+ * @param {object} options
+ * @returns {Promise<string>}
+ */
+async function exec_health_cli(options) {
+    let flags = ``;
+    for (const key in options) {
+        if (options[key] !== undefined) {
+            const value = options[key];
+            if (typeof options[key] === 'boolean') {
+                flags += `--${key} `;
+                continue;
+            }
+            flags += `--${key} ${value} `;
+        }
+    }
+    flags = flags.trim();
+
+    const command = `node src/cmd/health ${flags}`;
+    try {
+        const res = await os_utils.exec(command, { return_stdout: true });
+        return res;
+    } catch (err) {
+        console.error('test_utils.exec_health_cli error', err);
+        throw err;
+    }
+}
+
+/**
  * create_fs_user_by_platform creates a file system user by platform
  * @param {string} new_user
  * @param {string} new_password
@@ -368,6 +397,7 @@ exports.generate_s3_client = generate_s3_client;
 exports.invalid_nsfs_root_permissions = invalid_nsfs_root_permissions;
 exports.get_coretest_path = get_coretest_path;
 exports.exec_manage_cli = exec_manage_cli;
+exports.exec_health_cli = exec_health_cli;
 exports.create_fs_user_by_platform = create_fs_user_by_platform;
 exports.delete_fs_user_by_platform = delete_fs_user_by_platform;
 exports.set_path_permissions_and_owner = set_path_permissions_and_owner;


### PR DESCRIPTION
### Explain the changes
1. **Health.js -** 

- Added CLI arguments type validation (validate_input_types).
- Called  get_boolean_or_string_value(arg) on every boolean argument.
- Added try catch when calling exec(), and changed `ignore_rc` to - when ignore_rc=true service_status/pid/memory are undefined, when ignore_rc=false, setting them as missing so the user will know the command failed and didn't succeed.

2. **Manage_nsfs_constants.js -** Added Health related type and options.
3. **Manage_nsfs_validations.js -** Added Health options to be validated.
4. **test_utils.js -** added exec_health_cli.js function.
5. **test_nc_nsfs_health.js -** added relevant tests and fixed failing.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2262777
2. all_account_details/all_bucket_details defined check Uday mentioned on slack channel.

### Testing Instructions:
1. `sudo node --trace-warnings ./node_modules/mocha/bin/mocha /Users/romy/github/noobaa-core/src/test/unit_tests/test_nc_nsfs_health.js`
2. Gap - a follow-up Refactoring PR 

- [ ] Doc added/updated
- [x] Tests added
