### PR TITLE
NSFS | NC | IAM Service - Users CRUD API Implementation

### DIFF
--- a/docs/dev_guide/nc_nsfs_iam_developer_doc.md
+++ b/docs/dev_guide/nc_nsfs_iam_developer_doc.md
@@ -1,0 +1,26 @@
+# Non Containerized NSFS IAM (Developers Documentation)
+
+## Related files:
+1. [NC NSFS](../non_containerized_NSFS.md)
+2. [NC NSFS Design Documentation](../design/NonContainerizedNooBaaDesign.md)
+2. [IAM Design Documentation](../design/iam.md)
+
+## Get Started
+Currently, we do not validate the input, so the test should use only valid input.
+
+1. Create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/` `chmod 777 /tmp/nsfs_root1/my-bucket`.
+This will be the argument for:
+  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
+  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
+2. Create the root user account with the CLI:
+`sudo node src/cmd/manage_nsfs account add --name <name>> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`.
+2. Start the NSFS server (using debug mode and the port for IAM): `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
+Note: before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
+4. Create the alias for IAM service: 
+`alias s3-nc-user-1-iam='AWS_ACCESS_KEY_ID=<acess-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005'`.
+11. Use AWS CLI to send requests to the IAM service, for example:
+ `s3-nc-user-1-iam iam create-user --user-name Bob --path /division_abc/subdivision_xyz/`
+ `s3-nc-user-1-iam iam get-user --user-name Bob`
+ `s3-nc-user-1-iam iam update-user --user-name Bob --new-path /division_abc/subdivision_abc/`
+ `s3-nc-user-1-iam iam delete-user --user-name Bob`
+ `s3-nc-user-1-iam iam list-users`

--- a/src/endpoint/iam/iam_errors.js
+++ b/src/endpoint/iam/iam_errors.js
@@ -121,6 +121,69 @@ IamError.NotImplemented = Object.freeze({
     type: error_type_enum.RECEIVER,
 });
 
+// These errors were copied from IAM APIs errors
+// CreateUser errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html#API_CreateUser_Errors
+// DeleteUser errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteUser.html#API_DeleteUser_Errors
+// GetUser    errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUser.html#API_GetUser_Errors
+// UpdateUser errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateUser.html#API_UpdateUser_Errors
+// ListUsers  errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUsers.html
+IamError.ConcurrentModification = Object.freeze({
+    code: 'EntityAlreadyExists',
+    message: 'The request was rejected because multiple requests to change this object were submitted simultaneously. Wait a few minutes and submit your request again.',
+    http_code: 409,
+    type: error_type_enum.SENDER,
+});
+IamError.EntityAlreadyExists = Object.freeze({
+    code: 'EntityAlreadyExists',
+    message: 'The request was rejected because it attempted to create a resource that already exists.',
+    http_code: 409,
+    type: error_type_enum.SENDER,
+});
+IamError.InvalidInput = Object.freeze({
+    code: 'EntityAlreadyExists',
+    message: 'The request was rejected because an invalid or out-of-range value was supplied for an input parameter.',
+    http_code: 400,
+    type: error_type_enum.SENDER,
+});
+IamError.LimitExceeded = Object.freeze({
+    code: 'EntityAlreadyExists',
+    message: 'The request was rejected because it attempted to create resources beyond the current AWS account limits. The error message describes the limit exceeded.',
+    http_code: 409,
+    type: error_type_enum.SENDER,
+});
+IamError.NoSuchEntity = Object.freeze({
+    code: 'NoSuchEntity',
+    message: 'The request was rejected because it referenced a resource entity that does not exist. The error message describes the resource.',
+    http_code: 404,
+    type: error_type_enum.SENDER,
+});
+IamError.ServiceFailure = Object.freeze({
+    code: 'ServiceFailure',
+    message: 'The request processing has failed because of an unknown error, exception or failure.',
+    http_code: 500,
+    type: error_type_enum.RECEIVER,
+});
+IamError.DeleteConflict = Object.freeze({
+    code: 'DeleteConflict',
+    message: 'The request was rejected because it attempted to delete a resource that has attached subordinate entities. The error message describes these entities.',
+    http_code: 409,
+    type: error_type_enum.SENDER,
+});
+IamError.EntityTemporarilyUnmodifiable = Object.freeze({
+    code: 'EntityTemporarilyUnmodifiable',
+    message: 'The request was rejected because it referenced an entity that is temporarily unmodifiable, such as a user name that was deleted and then recreated. The error indicates that the request is likely to succeed if you try again after waiting several minutes. The error message describes the entity.',
+    http_code: 409,
+    type: error_type_enum.SENDER,
+});
+// These errors were actually send after performing IAM actions
+IamError.AccessDenied = Object.freeze({
+    code: 'AccessDenied',
+    message: 'user is not authorized to perform action on resource',
+    http_code: 400,
+    type: error_type_enum.SENDER,
+});
+
+
 // These errors were copied from STS errors
 // TODO - can be deleted after verifying we will not use them
 IamError.InvalidParameterCombination = Object.freeze({

--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -1,10 +1,28 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const _ = require('lodash');
 const s3_utils = require('../s3/s3_utils');
 
-const AWS_DEFAULT_PATH = '/';
+const IAM_DEFAULT_PATH = '/';
 const AWS_NOT_USED = 'N/A'; // can be used in case the region or the service name were not used
+const IAM_SERVICE_SMALL_LETTERS = 'iam';
+
+// key: action - the function name on accountspace_fs (snake case style)
+// value: AWS action name (camel case style)
+// we use it for error message to match AWS style 
+const ACTION_MESSAGE_TITLE_MAP = {
+    'create_user': 'CreateUser',
+    'get_user': 'GetUser',
+    'delete_user': 'DeleteUser',
+    'update_user': 'UpdateUser',
+    'list_users': 'ListUsers',
+    'create_access_key': 'CreateAccessKey',
+    'get_access_key_last_used': 'GetAccessKeyLastUsed',
+    'update_access_key': 'UpdateAccessKey',
+    'delete_access_key': 'DeleteAccessKey',
+    'list_access_keys': 'ListAccessKeys',
+};
 
 /**
  * format_iam_xml_date return the date without milliseconds
@@ -19,20 +37,39 @@ function format_iam_xml_date(input) {
 /**
  * create_arn creates the AWS ARN for user
  * see: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns
- * @param {string} account_id
+ * @param {string} account_id (the root user account id)
  * @param {string} username
- * @param {string} path (AWS Path)
+ * @param {string} iam_path
  */
-function create_arn(account_id, username, path) {
-    const basic_structure = `arn:aws:iam:${account_id}:user`;
-    if (path && path !== AWS_DEFAULT_PATH) {
-        return `${basic_structure}${path}${username}`;
+function create_arn(account_id, username, iam_path) {
+    const basic_structure = `arn:aws:iam::${account_id}:user`;
+    if (_.isUndefined(username)) return `${basic_structure}/`;
+    if (check_iam_path_was_set(iam_path)) {
+        return `${basic_structure}${iam_path}${username}`;
     }
     return `${basic_structure}/${username}`;
+}
+
+/**
+ * get_action_message_title returns the full action name
+ * @param {string} action (The action name as it is in AccountSpace)
+ */
+function get_action_message_title(action) {
+    return `${IAM_SERVICE_SMALL_LETTERS}:${ACTION_MESSAGE_TITLE_MAP[action]}`;
+}
+
+/**
+ * check_iam_path_was_set return true if the iam_path was set
+ * @param {string} iam_path
+ */
+function check_iam_path_was_set(iam_path) {
+    return iam_path && iam_path !== IAM_DEFAULT_PATH;
 }
 
 // EXPORTS
 exports.format_iam_xml_date = format_iam_xml_date;
 exports.create_arn = create_arn;
-exports.AWS_DEFAULT_PATH = AWS_DEFAULT_PATH;
+exports.IAM_DEFAULT_PATH = IAM_DEFAULT_PATH;
 exports.AWS_NOT_USED = AWS_NOT_USED;
+exports.get_action_message_title = get_action_message_title;
+exports.check_iam_path_was_set = check_iam_path_was_set;

--- a/src/endpoint/iam/ops/iam_create_user.js
+++ b/src/endpoint/iam/ops/iam_create_user.js
@@ -11,7 +11,7 @@ const { CONTENT_TYPE_APP_FORM_URLENCODED } = require('../../../util/http_utils')
 async function create_user(req, res) {
 
     const params = {
-        path: req.body.path,
+        iam_path: req.body.path,
         username: req.body.user_name,
     };
     dbg.log1('IAM CREATE USER', params);
@@ -22,7 +22,7 @@ async function create_user(req, res) {
         CreateUserResponse: {
             CreateUserResult: {
                 User: {
-                    Path: reply.path || iam_utils.AWS_DEFAULT_PATH,
+                    Path: reply.iam_path || iam_utils.IAM_DEFAULT_PATH,
                     UserName: reply.username,
                     UserId: reply.user_id,
                     Arn: reply.arn,

--- a/src/endpoint/iam/ops/iam_get_user.js
+++ b/src/endpoint/iam/ops/iam_get_user.js
@@ -22,7 +22,7 @@ async function get_user(req, res) {
             GetUserResult: {
                 User: {
                     UserId: reply.user_id,
-                    Path: reply.path || iam_utils.AWS_DEFAULT_PATH,
+                    Path: reply.iam_path || iam_utils.IAM_DEFAULT_PATH,
                     UserName: reply.username,
                     Arn: reply.arn,
                     CreateDate: iam_utils.format_iam_xml_date(reply.create_date),

--- a/src/endpoint/iam/ops/iam_list_users.js
+++ b/src/endpoint/iam/ops/iam_list_users.js
@@ -13,7 +13,7 @@ async function list_users(req, res) {
     const params = {
         marker: req.body.marker,
         max_items: req.body.max_items,
-        path_prefix: req.body.path_prefix,
+        iam_path_prefix: req.body.path_prefix,
     };
     dbg.log1('IAM LIST USERS', params);
     const reply = await req.account_sdk.list_users(params);
@@ -25,7 +25,7 @@ async function list_users(req, res) {
                 Users: reply.members.map(member => ({
                     member: {
                         UserId: member.user_id,
-                        Path: member.path || iam_utils.AWS_DEFAULT_PATH,
+                        Path: member.iam_path || iam_utils.IAM_DEFAULT_PATH,
                         UserName: member.username,
                         Arn: member.arn,
                         CreateDate: iam_utils.format_iam_xml_date(member.create_date),

--- a/src/endpoint/iam/ops/iam_update_user.js
+++ b/src/endpoint/iam/ops/iam_update_user.js
@@ -13,7 +13,7 @@ async function update_user(req, res) {
     const params = {
         username: req.body.user_name,
         new_username: req.body.new_user_name,
-        new_path: req.body.new_path,
+        new_iam_path: req.body.new_path,
     };
     dbg.log1('IAM UPDATE USER', params);
     const reply = await req.account_sdk.update_user(params);
@@ -23,7 +23,7 @@ async function update_user(req, res) {
         UpdateUserResponse: {
             UpdateUserResult: {
                 User: {
-                    Path: reply.path || iam_utils.AWS_DEFAULT_PATH,
+                    Path: reply.iam_path || iam_utils.IAM_DEFAULT_PATH,
                     UserName: reply.username,
                     UserId: reply.user_id,
                     Arn: reply.arn,

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -11,6 +11,7 @@ const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').Ma
 const NSFS_CLI_SUCCESS_EVENT_MAP = require('../manage_nsfs/manage_nsfs_cli_responses').NSFS_CLI_SUCCESS_EVENT_MAP;
 const { BOOLEAN_STRING_VALUES } = require('../manage_nsfs/manage_nsfs_constants');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
+const mongo_utils = require('../util/mongo_utils');
 
 function throw_cli_error(error, detail, event_arg) {
     const error_event = NSFS_CLI_ERROR_EVENT_MAP[error.code];
@@ -118,6 +119,17 @@ function has_access_keys(access_keys) {
     return access_keys.length === 0;
 }
 
+/**
+ * generate_id will generate an id that we use to identify entities (such as account, bucket, etc.). 
+ */
+// TODO: 
+// - reuse this function in NC NSFS where we used the mongo_utils module
+// - this function implantation should be db_client.new_object_id(), 
+//   but to align with manage nsfs we won't change it now
+function generate_id() {
+    return mongo_utils.mongoObjectId();
+}
+
 // EXPORTS
 exports.throw_cli_error = throw_cli_error;
 exports.write_stdout_response = write_stdout_response;
@@ -128,3 +140,4 @@ exports.get_config_data = get_config_data;
 exports.get_bucket_owner_account = get_bucket_owner_account;
 exports.get_options_from_file = get_options_from_file;
 exports.has_access_keys = has_access_keys;
+exports.generate_id = generate_id;

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -1,16 +1,28 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
+const _ = require('lodash');
 const path = require('path');
 const config = require('../../config');
 const dbg = require('../util/debug_module')(__filename);
+const P = require('../util/promise');
+const nb_native = require('../util/nb_native');
 const native_fs_utils = require('../util/native_fs_utils');
 const { CONFIG_SUBDIRS } = require('../manage_nsfs/manage_nsfs_constants');
-const { create_arn, AWS_DEFAULT_PATH } = require('../endpoint/iam/iam_utils');
+const { create_arn, IAM_DEFAULT_PATH, get_action_message_title,
+    check_iam_path_was_set } = require('../endpoint/iam/iam_utils');
+const { generate_id } = require('../manage_nsfs/manage_nsfs_cli_utils');
+const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
+const IamError = require('../endpoint/iam/iam_errors').IamError;
 
 const access_key_status_enum = {
     ACTIVE: 'Active',
     INACTIVE: 'Inactive',
+};
+
+const entity_enum = {
+    USER: 'USER',
+    ACCESS_KEY: 'ACCESS_KEY',
 };
 
 ////////////////////
@@ -23,25 +35,20 @@ const dummy_account_id = '12345678012'; // for the example
 // user_id should be taken from config file of the new created user user (account._id in the config file);
 const dummy_user_id = '12345678013'; // for the example
 // user should be from the the config file and the details (this for the example)
-const dummy_path = '/division_abc/subdivision_xyz/';
+const dummy_iam_path = '/division_abc/subdivision_xyz/';
 const dummy_username1 = 'Bob';
 const dummy_username2 = 'Robert';
 const dummy_username_requester = 'Alice';
 const dummy_user1 = {
     username: dummy_username1,
     user_id: dummy_user_id,
-    path: dummy_path,
-};
-const dummy_user2 = {
-    username: dummy_username2,
-    user_id: dummy_user_id + 4,
-    path: dummy_path,
+    iam_path: dummy_iam_path,
 };
 // the requester at current implementation is the root user (this is for the example)
 const dummy_requester = {
     username: dummy_username_requester,
     user_id: dummy_account_id,
-    path: AWS_DEFAULT_PATH,
+    iam_path: IAM_DEFAULT_PATH,
 };
 const MS_PER_MINUTE = 60 * 1000;
 const dummy_access_key1 = {
@@ -94,70 +101,158 @@ class AccountSpaceFS {
     // USER   //
     ////////////
 
+    // 1 - check that the requesting account is a root user account
+    // 2 - check if username already exists
+    //     GAP - it should be only under the root account in the future
+    // 3 - copy the data from the root account user details to a new config file
     async create_user(params, account_sdk) {
-        dbg.log1('create_user', params);
-        return {
-            path: params.path || AWS_DEFAULT_PATH,
-            username: params.username,
-            user_id: dummy_user1.user_id,
-            arn: create_arn(dummy_account_id, params.username, params.path),
-            create_date: new Date(),
-        };
+        const action = 'create_user';
+        dbg.log1(`AccountSpaceFS.${action}`, params, account_sdk);
+        try {
+            const requesting_account = account_sdk.requesting_account;
+            this._check_if_requesting_account_is_root_account(action, requesting_account,
+                { username: params.username, iam_path: params.iam_path });
+            await this._check_username_already_exists(action, params.username);
+            const created_account = await this._copy_data_from_requesting_account_to_account_config(action, requesting_account, params);
+            return {
+                iam_path: created_account.iam_path || IAM_DEFAULT_PATH,
+                username: created_account.name,
+                user_id: created_account._id,
+                arn: create_arn(requesting_account._id, created_account.name, created_account.iam_path),
+                create_date: created_account.creation_date,
+            };
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw this._translate_error_codes(err, entity_enum.USER);
+        }
     }
 
+    // 1 - check that the requesting account is a root user account
+    // 2 - check that the user account config file exists
+    // 3 - read the account config file
+    // 4 - check that the user to get is not a root account
+    // 5 - check that the user account to get is owned by the root account
     async get_user(params, account_sdk) {
-        dbg.log1('get_user', params);
-        const { dummy_user } = get_user_details(params.username);
-        return {
-            user_id: dummy_user.user_id,
-            path: dummy_user.path || AWS_DEFAULT_PATH,
-            username: dummy_user.username,
-            arn: create_arn(dummy_account_id, dummy_user.username, dummy_user.path),
-            create_date: new Date(Date.now() - 30 * MS_PER_MINUTE),
-            password_last_used: new Date(Date.now() - MS_PER_MINUTE),
-        };
+        const action = 'get_user';
+        dbg.log1(`AccountSpaceFS.${action}`, params, account_sdk);
+        try {
+            const requesting_account = account_sdk.requesting_account;
+            // GAP - we do not have the user iam_path at this point (error message)
+            this._check_if_requesting_account_is_root_account(action, requesting_account,
+                { username: params.username });
+            const account_config_path = this._get_account_config_path(params.username);
+            await this._check_if_account_config_file_exists(action, params.username, account_config_path);
+            const account_to_get = await native_fs_utils.read_file(this.fs_context, account_config_path);
+            this._check_if_requested_account_is_root_account(action, requesting_account, account_to_get, params);
+            this._check_if_user_is_owned_by_root_account(action, requesting_account, account_to_get);
+            return {
+                user_id: account_to_get._id,
+                iam_path: account_to_get.iam_path || IAM_DEFAULT_PATH,
+                username: account_to_get.name,
+                arn: create_arn(requesting_account._id, account_to_get.name, account_to_get.iam_path),
+                create_date: account_to_get.creation_date,
+                password_last_used: account_to_get.creation_date, // GAP
+            };
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw this._translate_error_codes(err, entity_enum.USER);
+        }
     }
 
+    // 1 - check that the requesting account is a root user account
+    // 2 - check that the user account config file exists
+    // 3 - read the account config file
+    // 4 - check that the user to update is not a root account
+    // 5 - check that the user account to get is owned by the root account
+    // 6 - check if username was updated
+    //   6.1 - check if username already exists (global scope - all config files names)
+    //   6.2 - create the new config file (with the new name same data) and delete the the existing config file
+    // 7 - (else not an update of username) update the config file
     async update_user(params, account_sdk) {
-        dbg.log1('update_user', params);
-        const path_friendly = params.new_path ? params.new_path : dummy_user1.path;
-        const username = params.new_username ? params.new_username : params.username;
-        return {
-            path: path_friendly || AWS_DEFAULT_PATH,
-            username: username,
-            user_id: dummy_user1.user_id,
-            arn: create_arn(dummy_account_id, username, path_friendly),
-        };
-    }
-
-    async delete_user(params, account_sdk) {
-        dbg.log1('delete_user', params);
-        // nothing to do at this point
-    }
-
-    async list_users(params, account_sdk) {
-        dbg.log1('list_users', params);
-        const is_truncated = false;
-        // path_prefix is not supported in the example
-        const members = [{
-                user_id: dummy_user1.user_id,
-                path: dummy_user1.path || AWS_DEFAULT_PATH,
-                username: dummy_user1.username,
-                arn: create_arn(dummy_account_id, dummy_user1.username, dummy_user1.path),
-                create_date: new Date(Date.now() - 30 * MS_PER_MINUTE),
-                password_last_used: new Date(Date.now() - MS_PER_MINUTE),
-            },
-            {
-                user_id: dummy_user2.user_id,
-                path: dummy_user2.path || AWS_DEFAULT_PATH,
-                username: dummy_user2.username,
-                arn: create_arn(dummy_account_id, dummy_user2.username, dummy_user1.path),
-                create_date: new Date(Date.now() - 30 * MS_PER_MINUTE),
-                password_last_used: new Date(Date.now() - MS_PER_MINUTE),
+        const action = 'update_user';
+        try {
+            dbg.log1(`AccountSpaceFS.${action}`, params, account_sdk);
+            const requesting_account = account_sdk.requesting_account;
+            // GAP - we do not have the user iam_path at this point (error message)
+            this._check_if_requesting_account_is_root_account(action, requesting_account,
+                { username: params.username});
+            const account_config_path = this._get_account_config_path(params.username);
+            await this._check_if_account_config_file_exists(action, params.username, account_config_path);
+            const account_to_update = await native_fs_utils.read_file(this.fs_context, account_config_path);
+            this._check_if_requested_account_is_root_account(action, requesting_account, account_to_update, params);
+            this._check_if_user_is_owned_by_root_account(action, requesting_account, account_to_update);
+            const is_username_update = !_.isUndefined(params.new_username) &&
+                params.new_username !== params.username;
+            if (!_.isUndefined(params.new_iam_path)) account_to_update.iam_path = params.new_iam_path;
+            if (is_username_update) {
+                dbg.log1(`AccountSpaceFS.${action} username was updated, is_username_update`,
+                    is_username_update);
+                await this._update_account_config_new_username(action, params, account_to_update);
+            } else {
+                const account_to_update_string = JSON.stringify(account_to_update);
+                nsfs_schema_utils.validate_account_schema(JSON.parse(account_to_update_string));
+                await native_fs_utils.update_config_file(this.fs_context, this.accounts_dir,
+                    account_config_path, account_to_update_string);
             }
-        ];
-        // members should be sorted by username (a to z)
+            return {
+                iam_path: account_to_update.iam_path || IAM_DEFAULT_PATH,
+                username: account_to_update.name,
+                user_id: account_to_update._id,
+                arn: create_arn(requesting_account._id, account_to_update.name, account_to_update.iam_path),
+            };
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw this._translate_error_codes(err, entity_enum.USER);
+        }
+    }
+
+    // 1 - check that the requesting account is a root user account
+    // 2 - check that the user account config file exists
+    // 3 - read the account config file
+    // 4 - check that the deleted user is not a root account
+    // 5 - check that the deleted user is owned by the root account
+    // 6 - check if the user doesn’t have resources related to it (in IAM users only access keys)
+    //     note: buckets are owned by the root account
+    // 7 - delete the account config file
+    async delete_user(params, account_sdk) {
+        const action = 'delete_user';
+        dbg.log1(`AccountSpaceFS.${action}`, params, account_sdk);
+        try {
+            const requesting_account = account_sdk.requesting_account;
+            // GAP - we do not have the user iam_path at this point (error message)
+            this._check_if_requesting_account_is_root_account(action, requesting_account,
+                { username: params.username });
+            const account_config_path = this._get_account_config_path(params.username);
+            await this._check_if_account_config_file_exists(action, params.username, account_config_path);
+            const account_to_delete = await native_fs_utils.read_file(this.fs_context, account_config_path);
+            this._check_if_requested_account_is_root_account(action, requesting_account, account_to_delete, params);
+            this._check_if_user_is_owned_by_root_account(action, requesting_account, account_to_delete);
+            this._check_if_user_does_not_have_access_keys_before_deletion(action, account_to_delete);
+            await native_fs_utils.delete_config_file(this.fs_context, this.accounts_dir, account_config_path);
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw this._translate_error_codes(err, entity_enum.USER);
+        }
+    }
+
+    // 1 - check that the requesting account is a root user account
+    // 2 - list the config files that are owned by the root user account
+    //   2.1 - if the request has path_prefix check if the user’s path starts with this path
+    // 3- sort the members by username (a to z)
+    async list_users(params, account_sdk) {
+        const action = 'list_users';
+        dbg.log1(`AccountSpaceFS.${action}`, params, account_sdk);
+        try {
+        const requesting_account = account_sdk.requesting_account;
+        this._check_if_requesting_account_is_root_account(action, requesting_account, { });
+        const is_truncated = false; // GAP - no pagination at this point
+        let members = await this._list_config_files_for_users(requesting_account, params.iam_path_prefix);
+        members = members.sort((a, b) => a.username.localeCompare(b.username));
         return { members, is_truncated };
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw this._translate_error_codes(err, entity_enum.USER);
+        }
     }
 
     ////////////////
@@ -201,7 +296,7 @@ class AccountSpaceFS {
         const is_truncated = false;
         const { dummy_user } = get_user_details(params.username);
         const username = dummy_user.username;
-        // path_prefix is not supported in the example
+        // iam_path_prefix is not supported in the example
         const members = [{
                 username: dummy_access_key1.username,
                 access_key: dummy_access_key1.access_key,
@@ -216,6 +311,204 @@ class AccountSpaceFS {
             },
         ];
         return { members, is_truncated, username };
+    }
+
+    ////////////////////////
+    // INTERNAL FUNCTIONS //
+    ////////////////////////
+
+     _get_account_config_path(name) {
+         return path.join(this.accounts_dir, name + '.json');
+     }
+
+     _get_access_keys_config_path(access_key) {
+         return path.join(this.access_keys_dir, access_key + '.symlink');
+     }
+
+     _new_user_defaults(requesting_account, params) {
+        const distinguished_name = requesting_account.nsfs_account_config.distinguished_name;
+        return {
+            _id: generate_id(),
+            name: params.username,
+            email: params.username,
+            creation_date: new Date().toISOString(),
+            owner: requesting_account._id,
+            creator: requesting_account._id,
+            iam_path: params.iam_path || IAM_DEFAULT_PATH,
+            master_key_id: requesting_account.master_key_id, // doesn't have meaning when user has just created (without access keys), TODO: tke from current master key manage and not just copy from the root account
+            allow_bucket_creation: requesting_account.allow_bucket_creation,
+            force_md5_etag: requesting_account.force_md5_etag,
+            access_keys: [],
+            nsfs_account_config: {
+                distinguished_name: distinguished_name,
+                uid: distinguished_name ? undefined : requesting_account.nsfs_account_config.uid,
+                gid: distinguished_name ? undefined : requesting_account.nsfs_account_config.gid,
+                new_buckets_path: requesting_account.nsfs_account_config.new_buckets_path,
+                fs_backend: requesting_account.nsfs_account_config.fs_backend,
+            }
+        };
+    }
+
+    // this function was copied from namespace_fs and bucketspace_fs
+    // It is a fallback that we use, but might be not accurate
+    _translate_error_codes(err, entity) {
+        if (err.rpc_code) return err;
+        if (err.code === 'ENOENT') err.rpc_code = `NO_SUCH_${entity}`;
+        if (err.code === 'EEXIST') err.rpc_code = `${entity}_ALREADY_EXISTS`;
+        if (err.code === 'EPERM' || err.code === 'EACCES') err.rpc_code = 'UNAUTHORIZED';
+        if (err.code === 'IO_STREAM_ITEM_TIMEOUT') err.rpc_code = 'IO_STREAM_ITEM_TIMEOUT';
+        if (err.code === 'INTERNAL_ERROR') err.rpc_code = 'INTERNAL_ERROR';
+        return err;
+    }
+
+    _check_root_account(account) {
+        if (_.isUndefined(account.owner) ||
+            account.owner === account._id) {
+            return true;
+        }
+        return false;
+    }
+
+    _check_root_account_owns_user(root_account, user_account) {
+        if (_.isUndefined(user_account.owner)) return false;
+        return root_account._id === user_account.owner;
+    }
+
+    _throw_access_denied_error(action, requesting_account, user_details = {}) {
+        const arn_for_requesting_account = create_arn(requesting_account._id,
+            requesting_account.name.unwrap(), requesting_account.iam_path);
+        const arn_for_user = create_arn(requesting_account._id, user_details.username, user_details.iam_path);
+        const full_action_name = get_action_message_title(action);
+        const message_with_details = `User: ${arn_for_requesting_account} is not authorized to perform:` +
+            `${full_action_name} on resource: ` +
+            `${arn_for_user} because no identity-based policy allows the ${full_action_name} action`;
+        const { code, http_code, type } = IamError.AccessDenied;
+        throw new IamError({ code, message: message_with_details, http_code, type });
+    }
+
+    // based on the function from manage_nsfs
+    async _list_config_files_for_users(requesting_account, iam_path_prefix) {
+        const entries = await nb_native().fs.readdir(this.fs_context, this.accounts_dir);
+        const should_filter_by_prefix = check_iam_path_was_set(iam_path_prefix);
+
+        const config_files_list = await P.map_with_concurrency(10, entries, async entry => {
+            if (entry.name.endsWith('.json')) {
+                const full_path = path.join(this.accounts_dir, entry.name);
+                const account_data = await native_fs_utils.read_file(this.fs_context, full_path);
+                if (entry.name.includes(config.NSFS_TEMP_CONF_DIR_NAME)) return undefined;
+                if (this._check_root_account_owns_user(requesting_account, account_data)) {
+                    if (should_filter_by_prefix) {
+                        if (_.isUndefined(account_data.iam_path)) return undefined;
+                        if (!account_data.iam_path.startsWith(iam_path_prefix)) return undefined;
+                    }
+                    const user_data = {
+                        user_id: account_data._id,
+                        iam_path: account_data.iam_path || IAM_DEFAULT_PATH,
+                        username: account_data.name,
+                        arn: create_arn(requesting_account._id, account_data.name, account_data.iam_path),
+                        create_date: account_data.creation_date,
+                        password_last_used: Date.now(), // GAP
+                    };
+                    return user_data;
+                }
+                return undefined;
+            }
+        });
+        // remove undefined entries
+        return config_files_list.filter(item => item);
+    }
+
+    _check_if_requesting_account_is_root_account(action, requesting_account, user_details = {}) {
+        const is_root_account = this._check_root_account(requesting_account);
+        dbg.log1(`AccountSpaceFS.${action} requesting_account`, requesting_account,
+            'is_root_account', is_root_account);
+        if (!is_root_account) {
+            dbg.error(`AccountSpaceFS.${action} requesting account is not a root account`,
+                requesting_account);
+            this._throw_access_denied_error(action, requesting_account, user_details);
+        }
+    }
+
+    _check_if_requested_account_is_root_account(action, requesting_account, requested_account, user_details = {}) {
+        const is_requested_account_root_account = this._check_root_account(requested_account);
+        dbg.log1(`AccountSpaceFS.${action} requested_account`, requested_account,
+            'is_requested_account_root_account', is_requested_account_root_account);
+        if (is_requested_account_root_account) {
+            dbg.error(`AccountSpaceFS.${action} requested account is a root account`,
+            requested_account);
+            this._throw_access_denied_error(action, requesting_account, user_details);
+        }
+    }
+
+    async _check_username_already_exists(action, username) {
+            const account_config_path = this._get_account_config_path(username);
+            const name_exists = await native_fs_utils.is_path_exists(this.fs_context,
+                account_config_path);
+            if (name_exists) {
+                dbg.error(`AccountSpaceFS.${action} username already exists`, username);
+                const message_with_details = `User with name ${username} already exists.`;
+                const { code, http_code, type } = IamError.EntityAlreadyExists;
+                throw new IamError({ code, message: message_with_details, http_code, type });
+            }
+    }
+
+    async _copy_data_from_requesting_account_to_account_config(action, requesting_account, params) {
+        const created_account = this._new_user_defaults(requesting_account, params);
+        dbg.log1(`AccountSpaceFS.${action} new_account`, created_account);
+        const new_account_string = JSON.stringify(created_account);
+        nsfs_schema_utils.validate_account_schema(JSON.parse(new_account_string));
+        const account_config_path = this._get_account_config_path(params.username);
+        await native_fs_utils.create_config_file(this.fs_context, this.accounts_dir,
+            account_config_path, new_account_string);
+        return created_account;
+    }
+
+    async _check_if_account_config_file_exists(action, username, account_config_path) {
+        const is_user_account_exists = await native_fs_utils.is_path_exists(this.fs_context,
+            account_config_path);
+        if (!is_user_account_exists) {
+            dbg.error(`AccountSpaceFS.${action} username does not exist`, username);
+            const message_with_details = `The user with name ${username} cannot be found.`;
+            const { code, http_code, type } = IamError.NoSuchEntity;
+            throw new IamError({ code, message: message_with_details, http_code, type });
+        }
+    }
+
+    _check_if_user_is_owned_by_root_account(action, requesting_account, requested_account) {
+        const is_user_account_to_get_owned_by_root_user = this._check_root_account_owns_user(requesting_account, requested_account);
+        if (!is_user_account_to_get_owned_by_root_user) {
+            dbg.error(`AccountSpaceFS.${action} requested account is not owned by root account`,
+                requested_account);
+            const message_with_details = `The user with name ${requested_account.name} cannot be found.`;
+            const { code, http_code, type } = IamError.NoSuchEntity;
+            throw new IamError({ code, message: message_with_details, http_code, type });
+        }
+    }
+
+
+    _check_if_user_does_not_have_access_keys_before_deletion(action, account_to_delete) {
+        const is_access_keys_removed = account_to_delete.access_keys.length === 0;
+        if (!is_access_keys_removed) {
+            dbg.error(`AccountSpaceFS.${action} requested account has access keys`,
+                account_to_delete);
+            const message_with_details = `Cannot delete entity, must delete access keys first.`;
+            const { code, http_code, type } = IamError.DeleteConflict;
+            throw new IamError({ code, message: message_with_details, http_code, type });
+        }
+    }
+
+    async _update_account_config_new_username(action, params, account_to_update) {
+        await this._check_username_already_exists(action, params.new_username);
+        account_to_update.name = params.new_username;
+        account_to_update.email = params.new_username; // internally saved
+        const account_to_update_string = JSON.stringify(account_to_update);
+        nsfs_schema_utils.validate_account_schema(JSON.parse(account_to_update_string));
+        const new_username_account_config_path = this._get_account_config_path(params.new_username);
+        await native_fs_utils.create_config_file(this.fs_context, this.accounts_dir,
+            new_username_account_config_path, account_to_update_string);
+        const account_config_path = this._get_account_config_path(params.username);
+        await native_fs_utils.delete_config_file(this.fs_context, this.accounts_dir,
+            account_config_path);
     }
 }
 

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -27,6 +27,18 @@ module.exports = {
         creation_date: {
             type: 'string',
         },
+        // owner is the account id that owns this account (permission wise)
+        owner: {
+            type: 'string'
+        },
+        // creator is the account id that created this account (internal information)
+        creator: {
+            type: 'string',
+        },
+        // AWS IAM path (identifier)
+        iam_path: {
+            type: 'string'
+        },
         master_key_id: {
             objectid: true
         },

--- a/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2024 NooBaa */
+/* eslint-disable max-lines-per-function */
 'use strict';
 
 /*
@@ -6,171 +7,629 @@
  * The asserts reflects the current state of implementation (not final)
  */
 
+const _ = require('lodash');
+const fs = require('fs');
 const path = require('path');
+const nb_native = require('../../../util/nb_native');
 const SensitiveString = require('../../../util/sensitive_string');
 const AccountSpaceFS = require('../../../sdk/accountspace_fs');
 const { TMP_PATH } = require('../../system_tests/test_utils');
+const { get_process_fs_context } = require('../../../util/native_fs_utils');
+const { IAM_DEFAULT_PATH } = require('../../../endpoint/iam/iam_utils');
+const fs_utils = require('../../../util/fs_utils');
+const { IamError } = require('../../../endpoint/iam/iam_errors');
+const nc_mkm = require('../../../manage_nsfs/nc_master_key_manager').get_instance();
 
+class NoErrorThrownError extends Error {}
+
+const DEFAULT_FS_CONFIG = get_process_fs_context();
 const tmp_fs_path = path.join(TMP_PATH, 'test_accountspace_fs');
 const config_root = path.join(tmp_fs_path, 'config_root');
-const new_buckets_path = path.join(tmp_fs_path, 'new_buckets_path', '/');
+const new_buckets_path1 = path.join(tmp_fs_path, 'new_buckets_path1', '/');
+const new_buckets_path2 = path.join(tmp_fs_path, 'new_buckets_path2', '/');
 
 const accountspace_fs = new AccountSpaceFS({ config_root });
+
+const root_user_account = {
+    _id: '65a8edc9bc5d5bbf9db71b91',
+    name: 'test-root-account-1001',
+    email: 'test-root-account-1001',
+    allow_bucket_creation: true,
+    access_keys: [{
+        access_key: 'a-abcdefghijklmn123456',
+        secret_key: 's-abcdefghijklmn123456EXAMPLE'
+    }],
+    nsfs_account_config: {
+        uid: 1001,
+        gid: 1001,
+        new_buckets_path: new_buckets_path1,
+    },
+    creation_date: '2023-10-30T04:46:33.815Z',
+    master_key_id: '65a62e22ceae5e5f1a758123',
+};
+
+const root_user_account2 = {
+    _id: '65a8edc9bc5d5bbf9db71b92',
+    name: 'test-root-account-1002',
+    email: 'test-root-account-1002',
+    allow_bucket_creation: true,
+    access_keys: [{
+        access_key: 'a-bbcdefghijklmn123456',
+        secret_key: 's-bbcdefghijklmn123456EXAMPLE'
+    }],
+    nsfs_account_config: {
+        uid: 1002,
+        gid: 1002,
+        new_buckets_path: new_buckets_path2,
+    },
+    creation_date: '2023-11-30T04:46:33.815Z',
+    master_key_id: '65a62e22ceae5e5f1a758123',
+};
 
 // I'm only interested in the requesting_account field
 function make_dummy_account_sdk() {
     return {
-        requesting_account: {
-            _id: '65b3c68b59ab67b16f98c26e',
-            name: new SensitiveString('user2'),
-            email: new SensitiveString('user2@noobaa.io'),
-            allow_bucket_creation: true,
-            nsfs_account_config: {
-                uid: 1001,
-                gid: 1001,
-                new_buckets_path: new_buckets_path,
+            requesting_account: {
+                _id: root_user_account._id,
+                name: new SensitiveString(root_user_account.name),
+                email: new SensitiveString(root_user_account.email),
+                creation_date: root_user_account.creation_date,
+                access_keys: [{
+                    access_key: new SensitiveString(root_user_account.access_keys[0].access_key),
+                    secret_key: new SensitiveString(root_user_account.access_keys[0].secret_key)
+                }],
+                nsfs_account_config: root_user_account.nsfs_account_config,
+                allow_bucket_creation: root_user_account.allow_bucket_creation,
+                master_key_id: root_user_account.master_key_id,
             },
-            master_key_id: '65a62e22ceae5e5f1a758123',
-        },
     };
 }
 
-describe('Accountspace_FS Users tests', () => {
-    const dummy_path = '/division_abc/subdivision_xyz/';
-    const dummy_username1 = 'Bob';
-    const dummy_user1 = {
-        username: dummy_username1,
-        path: dummy_path,
+function make_dummy_account_sdk_non_root_user() {
+    const account_sdk = _.cloneDeep(make_dummy_account_sdk());
+    account_sdk.requesting_account.owner = '65a8edc9bc5d5bbf9db71b92';
+    account_sdk.requesting_account.name = new SensitiveString('test-not-root-account-1001');
+    account_sdk.requesting_account.email = new SensitiveString('test-not-root-account-1001');
+    return account_sdk;
+}
+
+// use it for root user that doesn't create the resources
+// (only tries to get, update and delete resources that it doesn't own)
+function make_dummy_account_sdk_not_for_creating_resources() {
+    return {
+            requesting_account: {
+                _id: root_user_account2._id,
+                name: new SensitiveString(root_user_account2.name),
+                email: new SensitiveString(root_user_account2.email),
+                creation_date: root_user_account2.creation_date,
+                access_keys: [{
+                    access_key: new SensitiveString(root_user_account2.access_keys[0].access_key),
+                    secret_key: new SensitiveString(root_user_account2.access_keys[0].secret_key)
+                }],
+                nsfs_account_config: root_user_account2.nsfs_account_config,
+                allow_bucket_creation: root_user_account2.allow_bucket_creation,
+                master_key_id: root_user_account2.master_key_id,
+            },
     };
+}
 
-    describe('create_user', () => {
-        it('create_user should return user params', async function() {
-            const params = {
-                username: dummy_user1.username,
-                path: dummy_user1.path,
-            };
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.create_user(params, account_sdk);
-            expect(res.path).toBe(dummy_user1.path);
-            expect(res.username).toBe(dummy_user1.username);
-            expect(res.user_id).toBeDefined();
-            expect(res.arn).toBeDefined();
-            expect(res.create_date).toBeDefined();
+
+describe('Accountspace_FS tests', () => {
+
+    beforeAll(async () => {
+        await fs_utils.create_fresh_path(accountspace_fs.accounts_dir);
+        await fs_utils.create_fresh_path(accountspace_fs.access_keys_dir);
+        await fs_utils.create_fresh_path(accountspace_fs.buckets_dir);
+        await fs_utils.create_fresh_path(new_buckets_path1);
+        await fs.promises.chown(new_buckets_path1, root_user_account.nsfs_account_config.uid, root_user_account.nsfs_account_config.gid);
+
+        for (const account of [root_user_account]) {
+            const account_path = accountspace_fs._get_account_config_path(account.name);
+            // assuming that the root account has only 1 access key in the 0 index
+            const account_access_path = accountspace_fs._get_access_keys_config_path(account.access_keys[0].access_key);
+            await fs.promises.writeFile(account_path, JSON.stringify(account));
+            await fs.promises.chmod(account_path, 0o600);
+            await fs.promises.symlink(account_path, account_access_path);
+        }
+    });
+    afterAll(async () => {
+        fs_utils.folder_delete(config_root);
+        fs_utils.folder_delete(new_buckets_path1);
+    });
+
+    describe('Accountspace_FS Users tests', () => {
+        const dummy_iam_path = '/division_abc/subdivision_xyz/';
+        const dummy_iam_path2 = '/division_def/subdivision_uvw/';
+        const dummy_username1 = 'Bob';
+        const dummy_username2 = 'Robert';
+        const dummy_user1 = {
+            username: dummy_username1,
+            iam_path: dummy_iam_path,
+        };
+        const dummy_user2 = {
+            username: dummy_username2,
+            iam_path: dummy_iam_path,
+        };
+
+        describe('create_user', () => {
+            it('create_user should return user params', async function() {
+                const params = {
+                    username: dummy_user1.username,
+                    iam_path: dummy_user1.iam_path,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.create_user(params, account_sdk);
+                expect(res.iam_path).toBe(params.iam_path);
+                expect(res.username).toBe(params.username);
+                expect(res.user_id).toBeDefined();
+                expect(res.arn).toBeDefined();
+                expect(res.create_date).toBeDefined();
+
+                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file._id).toBeDefined();
+                expect(user_account_config_file.creation_date).toBeDefined();
+                expect(user_account_config_file.access_keys).toBeDefined();
+                expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
+                expect(user_account_config_file.access_keys.length).toBe(0);
+            });
+
+            it('create_user should return an error if requesting user is not a root account user', async function() {
+                try {
+                    const params = {
+                        username: dummy_user1.username,
+                        iam_path: dummy_user1.iam_path,
+                    };
+                    const account_sdk = make_dummy_account_sdk_non_root_user();
+                    await accountspace_fs.create_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.AccessDenied.code);
+                }
+            });
+
+            it('create_user should return an error if username already exists', async function() {
+                try {
+                    const params = {
+                        username: dummy_user1.username,
+                        iam_path: dummy_user1.iam_path,
+                    };
+                    const account_sdk = make_dummy_account_sdk();
+                    await accountspace_fs.create_user(params, account_sdk);
+                    // now username already exists
+                    await accountspace_fs.create_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.EntityAlreadyExists.code);
+                }
+            });
+        });
+
+        describe('get_user', () => {
+            it('get_user should return user params', async function() {
+                const params = {
+                    username: dummy_user1.username,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.get_user(params, account_sdk);
+                expect(res.user_id).toBeDefined();
+                expect(res.iam_path).toBe(dummy_user1.iam_path);
+                expect(res.username).toBe(dummy_user1.username);
+                expect(res.arn).toBeDefined();
+                expect(res.create_date).toBeDefined();
+                expect(res.password_last_used).toBeDefined();
+            });
+
+            it('get_user should return an error if requesting user is not a root account user', async function() {
+                try {
+                    const params = {
+                        username: dummy_user1.username,
+                    };
+                    const account_sdk = make_dummy_account_sdk_non_root_user();
+                    await accountspace_fs.get_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.AccessDenied.code);
+                }
+            });
+
+            it('get_user should return an error if user to get is a root account user', async function() {
+                try {
+                    const params = {
+                        username: root_user_account.name,
+                    };
+                    const account_sdk = make_dummy_account_sdk();
+                    await accountspace_fs.get_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.AccessDenied.code);
+                }
+            });
+
+            it('get_user should return an error if user account does not exists', async function() {
+                try {
+                    const params = {
+                        username: 'non-existing-user',
+                    };
+                    const account_sdk = make_dummy_account_sdk();
+                    await accountspace_fs.get_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NoSuchEntity.code);
+                }
+            });
+
+            it('get_user should return an error if user is not owned by the root account', async function() {
+                try {
+                    const params = {
+                        username: dummy_user1.username,
+                    };
+                    const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
+                    await accountspace_fs.get_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NoSuchEntity.code);
+                }
+            });
+        });
+
+        describe('update_user', () => {
+            it('update_user without actual property to update should return user params', async function() {
+                const params = {
+                    username: dummy_user1.username,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.update_user(params, account_sdk);
+                expect(res.iam_path).toBe(dummy_user1.iam_path);
+                expect(res.username).toBe(dummy_user1.username);
+                expect(res.user_id).toBeDefined();
+                expect(res.arn).toBeDefined();
+
+                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file.iam_path).toBe(dummy_user1.iam_path);
+            });
+
+            it('update_user with new_iam_path should return user params and update the iam_path', async function() {
+                let params = {
+                    username: dummy_user1.username,
+                    new_iam_path: dummy_iam_path2,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.update_user(params, account_sdk);
+                expect(res.iam_path).toBe(dummy_iam_path2);
+                expect(res.username).toBe(dummy_user1.username);
+                expect(res.user_id).toBeDefined();
+                expect(res.arn).toBeDefined();
+                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file.iam_path).toBe(dummy_iam_path2);
+                // back as it was
+                params = {
+                    username: dummy_user1.username,
+                    new_iam_path: dummy_user1.iam_path,
+                };
+                await accountspace_fs.update_user(params, account_sdk);
+            });
+
+            it('update_user should return an error if requesting user is not a root account user', async function() {
+                try {
+                    const params = {
+                        username: dummy_user1.username,
+                    };
+                    const account_sdk = make_dummy_account_sdk_non_root_user();
+                    await accountspace_fs.update_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.AccessDenied.code);
+                }
+            });
+
+            it('update_user should return an error if user to update is a root account user', async function() {
+                try {
+                    const params = {
+                        username: root_user_account.name,
+                    };
+                    const account_sdk = make_dummy_account_sdk();
+                    await accountspace_fs.update_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.AccessDenied.code);
+                }
+            });
+
+            it('update_user should return an error if user account does not exists', async function() {
+                try {
+                    const params = {
+                        username: 'non-existing-user',
+                    };
+                    const account_sdk = make_dummy_account_sdk();
+                    await accountspace_fs.update_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NoSuchEntity.code);
+                }
+            });
+
+            it('update_user should return an error if user is not owned by the root account', async function() {
+                try {
+                    const params = {
+                        username: dummy_user1.username,
+                    };
+                    const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
+                    await accountspace_fs.update_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NoSuchEntity.code);
+                }
+            });
+
+            it('update_user with new_username should return an error if username already exists', async function() {
+                try {
+                    let params = {
+                        username: dummy_user2.username,
+                    };
+                    const account_sdk = make_dummy_account_sdk();
+                    // create user2
+                    await accountspace_fs.create_user(params, account_sdk);
+                    params = {
+                        username: dummy_user2.username,
+                        new_username: dummy_user1.username,
+                    };
+                    // update user2 with username of user1
+                    await accountspace_fs.update_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.EntityAlreadyExists.code);
+                }
+            });
+
+            it('update_user with new_username should return user params', async function() {
+                const dummy_user2_new_username = dummy_user2.username + '-new-user-name';
+                let params = {
+                    username: dummy_user2.username,
+                    new_username: dummy_user2_new_username,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.update_user(params, account_sdk);
+                expect(res.iam_path).toBe(IAM_DEFAULT_PATH);
+                expect(res.username).toBe(params.new_username);
+                expect(res.user_id).toBeDefined();
+                expect(res.arn).toBeDefined();
+                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.new_username);
+                expect(user_account_config_file.name).toBe(params.new_username);
+                // back as it was
+                params = {
+                    username: dummy_user2_new_username,
+                    new_username: dummy_user2.username,
+                };
+                await accountspace_fs.update_user(params, account_sdk);
+            });
+        });
+
+        describe('delete_user', () => {
+            it('delete_user does not return any params', async function() {
+                const params = {
+                    username: dummy_user1.username,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.delete_user(params, account_sdk);
+                expect(res).toBeUndefined();
+            });
+
+            it('delete_user should return an error if requesting user is not a root account user', async function() {
+                try {
+                    const params = {
+                        username: dummy_user1.username,
+                    };
+                    const account_sdk = make_dummy_account_sdk_non_root_user();
+                    await accountspace_fs.delete_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.AccessDenied.code);
+                }
+            });
+
+            it('delete_user should return an error if user to delete is a root account user', async function() {
+                try {
+                    const params = {
+                        username: root_user_account.name,
+                    };
+                    const account_sdk = make_dummy_account_sdk();
+                    await accountspace_fs.delete_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.AccessDenied.code);
+                }
+            });
+
+            it('delete_user should return an error if user account does not exists', async function() {
+                try {
+                    const params = {
+                        username: 'non-existing-user',
+                    };
+                    const account_sdk = make_dummy_account_sdk();
+                    await accountspace_fs.delete_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NoSuchEntity.code);
+                }
+            });
+
+            it('delete_user should return an error if user is not owned by the root account', async function() {
+                try {
+                    const params = {
+                        username: dummy_user1.username,
+                    };
+                    const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
+                    await accountspace_fs.delete_user(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NoSuchEntity.code);
+                }
+            });
+
+            it.skip('delete_user should return an error if user has access keys', async function() {
+                // TODO after implementing create_access_key
+            });
+        });
+
+        describe('list_users', () => {
+            it('list_users return array of users and value of is_truncated', async function() {
+                const params = {};
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.list_users(params, account_sdk);
+                expect(Array.isArray(res.members)).toBe(true);
+                expect(res.members.length).toBeGreaterThan(0);
+                expect(typeof res.is_truncated === 'boolean').toBe(true);
+            });
+
+            it('list_users return an empty array of users and value of is_truncated if non of the users has the iam_path_prefix', async function() {
+                const params = {
+                    iam_path_prefix: 'non_existing_division/non-existing_subdivision'
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.list_users(params, account_sdk);
+                expect(Array.isArray(res.members)).toBe(true);
+                expect(res.members.length).toBe(0);
+                expect(typeof res.is_truncated === 'boolean').toBe(true);
+            });
+
+            it('list_users return an array with users that their iam_path starts with iam_path_prefix and value of is_truncated', async function() {
+                // add iam_path in a user so we can use the iam_path_prefix and get a user
+                const iam_path_to_add = dummy_iam_path;
+                let params_for_update = {
+                    username: dummy_user2.username,
+                    new_iam_path: iam_path_to_add,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                await accountspace_fs.update_user(params_for_update, account_sdk);
+                // list with iam_path_prefix
+                const params = {
+                    iam_path_prefix: '/division_abc/'
+                };
+                const res = await accountspace_fs.list_users(params, account_sdk);
+                expect(Array.isArray(res.members)).toBe(true);
+                expect(res.members.length).toBe(1);
+                expect(typeof res.is_truncated === 'boolean').toBe(true);
+                // back as it was
+                params_for_update = {
+                    username: dummy_user2.username,
+                    new_iam_path: IAM_DEFAULT_PATH,
+                };
+                await accountspace_fs.update_user(params_for_update, account_sdk);
+            });
+
+            it('list_users should return an error if requesting user is not a root account user', async function() {
+                try {
+                    const params = {};
+                    const account_sdk = make_dummy_account_sdk_non_root_user();
+                    await accountspace_fs.list_users(params, account_sdk);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.AccessDenied.code);
+                }
+            });
         });
     });
 
-    describe('get_user', () => {
-        it('get_user should return user params', async function() {
-            const params = {
-                username: dummy_user1.username,
-            };
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.get_user(params, account_sdk);
-            expect(res.user_id).toBeDefined();
-            expect(res.path).toBe(dummy_user1.path);
-            expect(res.username).toBe(dummy_user1.username);
-            expect(res.arn).toBeDefined();
-            expect(res.create_date).toBeDefined();
-            expect(res.password_last_used).toBeDefined();
+    describe('Accountspace_FS Access Keys tests', () => {
+        const dummy_username1 = 'Bob';
+        describe('create_access_key', () => {
+            it('create_access_key should return user access key params', async function() {
+                const params = {
+                    username: dummy_username1,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.create_access_key(params, account_sdk);
+                expect(res.username).toBe(dummy_username1);
+                expect(res.access_key).toBeDefined();
+                expect(res.status).toBe('Active');
+                expect(res.secret_key).toBeDefined();
+            });
         });
-    });
 
-    describe('update_user', () => {
-        it('update_user should return user params', async function() {
-            const params = {
-                username: dummy_user1.username,
-            };
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.update_user(params, account_sdk);
-            expect(res.path).toBe(dummy_user1.path);
-            expect(res.username).toBe(dummy_user1.username);
-            expect(res.user_id).toBeDefined();
-            expect(res.arn).toBeDefined();
+        describe('get_access_key_last_used', () => {
+            it('get_access_key_last_used should return user access key params', async function() {
+                const params = {
+                    username: dummy_username1,
+                };
+                const dummy_region = 'us-west-2';
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.get_access_key_last_used(params, account_sdk);
+                expect(res.region).toBe(dummy_region);
+                expect(res).toHaveProperty('last_used_date');
+                expect(res).toHaveProperty('service_name');
+                expect(res.username).toBe(dummy_username1);
+            });
         });
-    });
 
-    describe('delete_user', () => {
-        it('delete_user does not return any params', async function() {
-            const params = {
-                username: dummy_user1.username,
-            };
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.delete_user(params, account_sdk);
-            expect(res).toBeUndefined();
+        describe('update_access_key', () => {
+            it('update_access_key does not return any param', async function() {
+                const params = {
+                    username: dummy_username1,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.update_access_key(params, account_sdk);
+                expect(res).toBeUndefined();
+            });
         });
-    });
 
-    describe('list_users', () => {
-        it('list_users return array of users and value of is_truncated', async function() {
-            const params = {};
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.list_users(params, account_sdk);
-            expect(Array.isArray(res.members)).toBe(true);
-            expect(typeof res.is_truncated === 'boolean').toBe(true);
+        describe('delete_access_key', () => {
+            it('delete_access_key does not return any params', async function() {
+                const params = {
+                    username: dummy_username1,
+                };
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.delete_access_key(params, account_sdk);
+                expect(res).toBeUndefined();
+            });
+        });
+
+        describe('list_access_keys', () => {
+            it('list_access_keys return array of users and value of is_truncated', async function() {
+                const params = {};
+                const account_sdk = make_dummy_account_sdk();
+                const res = await accountspace_fs.list_users(params, account_sdk);
+                expect(Array.isArray(res.members)).toBe(true);
+                expect(typeof res.is_truncated === 'boolean').toBe(true);
+            });
         });
     });
 });
 
-describe('Accountspace_FS Access Keys tests', () => {
-    const dummy_username1 = 'Bob';
-    describe('create_access_key', () => {
-        it('create_access_key should return user access key params', async function() {
-            const params = {
-                username: dummy_username1,
-            };
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.create_access_key(params, account_sdk);
-            expect(res.username).toBe(dummy_username1);
-            expect(res.access_key).toBeDefined();
-            expect(res.status).toBe('Active');
-            expect(res.secret_key).toBeDefined();
-        });
-    });
 
-    describe('get_access_key_last_used', () => {
-        it('get_access_key_last_used should return user access key params', async function() {
-            const params = {
-                username: dummy_username1,
-            };
-            const dummy_region = 'us-west-2';
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.get_access_key_last_used(params, account_sdk);
-            expect(res.region).toBe(dummy_region);
-            expect(res).toHaveProperty('last_used_date');
-            expect(res).toHaveProperty('service_name');
-            expect(res.username).toBe(dummy_username1);
-        });
-    });
+/**
+ * read_config_file will read the config files 
+ * @param {string} account_path full account path
+ * @param {string} config_file_name the name of the config file
+ * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
+ */
 
-    describe('update_access_key', () => {
-        it('update_access_key does not return any param', async function() {
-            const params = {
-                username: dummy_username1,
-            };
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.update_access_key(params, account_sdk);
-            expect(res).toBeUndefined();
-        });
-    });
-
-    describe('delete_access_key', () => {
-        it('delete_access_key does not return any params', async function() {
-            const params = {
-                username: dummy_username1,
-            };
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.delete_access_key(params, account_sdk);
-            expect(res).toBeUndefined();
-        });
-    });
-
-    describe('list_access_keys', () => {
-        it('list_access_keys return array of users and value of is_truncated', async function() {
-            const params = {};
-            const account_sdk = make_dummy_account_sdk();
-            const res = await accountspace_fs.list_users(params, account_sdk);
-            expect(Array.isArray(res.members)).toBe(true);
-            expect(typeof res.is_truncated === 'boolean').toBe(true);
-        });
-    });
-});
+async function read_config_file(account_path, config_file_name, is_symlink) {
+    const config_path = path.join(account_path, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
+    const config_data = JSON.parse(data.toString());
+    if (config_data.access_keys.length > 0) {
+        const encrypted_secret_key = config_data.access_keys[0].encrypted_secret_key;
+        config_data.access_keys[0].secret_key = await nc_mkm.decrypt(encrypted_secret_key, config_data.master_key_id);
+        delete config_data.access_keys[0].encrypted_secret_key;
+    }
+    return config_data;
+}

--- a/src/test/unit_tests/jest_tests/test_iam_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_iam_utils.test.js
@@ -1,0 +1,134 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+const iam_utils = require('../../../endpoint/iam/iam_utils');
+
+describe('create_arn', () => {
+    const dummy_account_id = '12345678012'; // for the example
+    const dummy_username = 'Bob';
+    const dummy_iam_path = '/division_abc/subdivision_xyz/';
+    const arn_prefix = 'arn:aws:iam::';
+
+    it('create_arn without username should return basic structure', () => {
+        const user_details = {};
+        const res = iam_utils.create_arn(dummy_account_id, user_details.username, user_details.iam_path);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:user/`);
+    });
+
+    it('create_arn with username and no iam_path should return only username in arn', () => {
+        const user_details = {
+            username: dummy_username,
+        };
+        const res = iam_utils.create_arn(dummy_account_id, user_details.username, user_details.iam_path);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:user/${dummy_username}`);
+    });
+
+    it('create_arn with username and AWS DEFAULT PATH should return only username in arn', () => {
+        const user_details = {
+            username: dummy_username,
+            iam_path: iam_utils.IAM_DEFAULT_PATH
+        };
+        const res = iam_utils.create_arn(dummy_account_id, user_details.username, user_details.iam_path);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:user/${dummy_username}`);
+    });
+
+    it('create_arn with username and iam_path should return them in arn', () => {
+        const user_details = {
+            username: dummy_username,
+            iam_path: dummy_iam_path,
+        };
+        const res = iam_utils.create_arn(dummy_account_id, user_details.username, user_details.iam_path);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:user${dummy_iam_path}${dummy_username}`);
+    });
+});
+
+describe('get_action_message_title', () => {
+    it('create_user', () => {
+        const action = 'create_user';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:CreateUser`);
+    });
+
+    it('get_user', () => {
+        const action = 'get_user';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:GetUser`);
+    });
+
+    it('update_user', () => {
+        const action = 'update_user';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:UpdateUser`);
+    });
+
+    it('delete_user', () => {
+        const action = 'delete_user';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:DeleteUser`);
+    });
+
+    it('list_users', () => {
+        const action = 'list_users';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:ListUsers`);
+    });
+
+    it('create_access_key', () => {
+        const action = 'create_access_key';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:CreateAccessKey`);
+    });
+
+    it('get_access_key_last_used', () => {
+        const action = 'get_access_key_last_used';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:GetAccessKeyLastUsed`);
+    });
+
+    it('update_access_key', () => {
+        const action = 'update_access_key';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:UpdateAccessKey`);
+    });
+
+    it('delete_access_key', () => {
+        const action = 'delete_access_key';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:DeleteAccessKey`);
+    });
+
+    it('list_access_keys', () => {
+        const action = 'list_access_keys';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:ListAccessKeys`);
+    });
+});
+
+describe('check_iam_path_was_set', () => {
+    it('iam_path is undefined should return false in boolean context', () => {
+        let iam_path; // variable is undefined by default
+        const res = iam_utils.check_iam_path_was_set(iam_path);
+        expect(res).toBeFalsy();
+    });
+
+    it('iam_path is IAM_DEFAULT_PATH should return false in boolean context', () => {
+        const iam_path = iam_utils.IAM_DEFAULT_PATH;
+        const res = iam_utils.check_iam_path_was_set(iam_path);
+        expect(res).toBeFalsy();
+    });
+
+    it('iam_path is set should return true', () => {
+        const iam_path = '/division_abc/subdivision_xyz/';
+        const res = iam_utils.check_iam_path_was_set(iam_path);
+        expect(res).toBe(true);
+    });
+});
+
+describe('format_iam_xml_date', () => {
+    it('should not return milliseconds in date', () => {
+        const date_as_string = '2018-11-07T00:25:00.073876Z';
+        const res = iam_utils.format_iam_xml_date(date_as_string);
+        expect(res).not.toMatch(/073876/);
+        expect(res).toMatch(/2018-11-07/);
+        expect(res).toMatch(/00:25:00/);
+    });
+});

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2024 NooBaa */
+/* eslint-disable max-lines-per-function */
 
 'use strict';
 
@@ -44,10 +45,33 @@ describe('schema validation NC NSFS account', () => {
             nsfs_schema_utils.validate_account_schema(account_data);
         });
 
-        it('nsfs_account_config with force_md5_etag', () => {
+        it('account with force_md5_etag', () => {
             const account_data = get_account_data();
-            // @ts-ignore
             account_data.force_md5_etag = true; // added
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+        it('account without elements in the access_key array', () => {
+            const account_data = get_account_data();
+            account_data.access_keys = [];
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+        it('account with owner', () => {
+            const account_data = get_account_data();
+            account_data.owner = '65a62e22ceae5e5f1a758ab1';
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+        it('account with creator', () => {
+            const account_data = get_account_data();
+            account_data.creator = '65a62e22ceae5e5f1a758ab1';
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+        it('account with iam_path', () => {
+            const account_data = get_account_data();
+            account_data.iam_path = '/division_abc/subdivision_xyz/';
             nsfs_schema_utils.validate_account_schema(account_data);
         });
 
@@ -355,13 +379,39 @@ describe('schema validation NC NSFS account', () => {
             assert_validation(account_data, reason, message);
         });
 
-        it('nsfs_account_config with force_md5_etag as a string (instead of boolean)', () => {
+        it('account with force_md5_etag as a string (instead of boolean)', () => {
             const account_data = get_account_data();
-            // @ts-ignore
             account_data.force_md5_etag = ""; // added
             const reason = 'Test should have failed because of wrong type for' +
                 'force_md5_etag (string instead of boolean)';
             const message = 'must be boolean';
+            assert_validation(account_data, reason, message);
+        });
+
+        it('account with owner as a number (instead of string)', () => {
+            const account_data = get_account_data();
+            account_data.owner = 123; // number instead of string
+            const reason = 'Test should have failed because of wrong type for' +
+                'owner with number (instead of string)';
+            const message = 'must be string';
+            assert_validation(account_data, reason, message);
+        });
+
+        it('account with creator as a number (instead of string)', () => {
+            const account_data = get_account_data();
+            account_data.creator = 123; // number instead of string
+            const reason = 'Test should have failed because of wrong type for' +
+                'creator with number (instead of string)';
+            const message = 'must be string';
+            assert_validation(account_data, reason, message);
+        });
+
+        it('account with iam_path as a number (instead of string)', () => {
+            const account_data = get_account_data();
+            account_data.iam_path = 123;
+            const reason = 'Test should have failed because of wrong type for' +
+                'iam_path with number (instead of string)';
+            const message = 'must be string';
             assert_validation(account_data, reason, message);
         });
     });


### PR DESCRIPTION
### Explain the changes
1. Implement the functions related to users in `AccountSpaceFS` (CRUD) - all the functions here will only work on an IAM user without access keys (no encryption is involved at this point).
2. Add more properties to `nsfs_account_schema` (all of them are not required):
- `owner` = owner is the account ID that owns this account (permission-wise).
- `creator` = creator is the account ID that created this account (internal information).
- `path` = AWS path (identifier).
3. Add function `generate_id` in `manage_nsfs_cli_utils.js` to avoid importing MongoDB code in new files, and reuse this function only.
4. Add errors in `IamError` from the doc of users' action API.
5. Add functions in `iam_utils`.
6. Add unit tests for the function in `iam_utils`.
7. Update unit test for user function in `accountspace_fs`.
8. Add unit test in `account_schema_validation` for the case of an account without access keys (empty array), and for added properties in the schema.
9. Rename:
  - `path` to `iam_path`
  - `AWS_DEFAULT_PATH` to `IAM_DEFAULT_PATH`
  - Rename `path_prefix` to `iam_path_prefix`
10. Add `ResponseMetadata` protection in `reply`.
11. Add more details in IAM documentation:
  - Add documentation related to users in the design docs (`docs/design/iam.md`)
  - Add `Get Started` section that would be the demo for IAM user management (`docs/dev_guide/nc_nsfs_iam_developer_doc.md`)

### Issues: 
Gaps:
1. Currently naming scope of `username` is global scope - all config files names, it should be only under the root account in the future.
2. Currently the files are written in the config file at the same place as the root account, meaning by default in `/etc/noobaa.conf.d/accounts/`, no hierarchy in FS (under discussion if it would be changed in the future).
3. Data is read without encryption/decryption in users CRUD API implementation in accountspace_fs.
4. Parsing and validating the params (for example: username).
5. No pagination in the `list_users` implementation.
6. No `NoobaaEvent` at this point.
7. `_translate_error_codes` was copied from `NameSpaceFS` and `BucketSpaceFS`, but might need to be refactored to match the needs.
8. In some cases the ARN that we use will not contain the user's path in errors.
9. In `password_last_used` we send a dummy value.
10. Currently we copy the `master_key_id` from the root account, we should take the most updated `master_key_id`.
11. Clean the account cache after `update_user` (we will add this in the PR of IAM access keys).

### Testing Instructions:
#### Unit Tests
Please run:
1. `sudo npx jest test_accountspace_fs.test.js`
2. `npx jest test_iam_utils.test.js`
3. `npx jest test_nc_nsfs_account_schema_validation.test.js`

#### Manual Test
Currently, we do not validate the input, so the test should use only valid input.
1. Create the root user account with the CLI: `sudo node src/cmd/manage_nsfs account add --name shira-1002 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
Note: before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
3. Create the alias for IAM service: `alias s3-nc-user-1-iam='AWS_ACCESS_KEY_ID=<acess-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005'`.
4. Use AWS CLI to send requests to the IAM service, for example:
 `s3-nc-user-1-iam iam create-user --user-name Bob --path '/division_abc/subdivision_xyz/'`
 `s3-nc-user-1-iam iam get-user --user-name Bob`
 `s3-nc-user-1-iam iam update-user --user-name Bob --new-user-name Robert --new-path '/division_abc/subdivision_abc/'`
 `s3-nc-user-1-iam iam delete-user --user-name Bob`
 `s3-nc-user-1-iam iam list-users`

- [X] Doc added/updated
- [X] Tests added
