### PR TITLE
NSFS | NC | Account Has Distinguished Name and Update UID, GID (And Vice Versa)

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -337,7 +337,7 @@ async function fetch_account_data(action, user_input) {
     if (action === ACTIONS.UPDATE || action === ACTIONS.DELETE) {
         // @ts-ignore
         data = _.omitBy(data, _.isUndefined);
-        data = await fetch_existing_account_data(data);
+        data = await fetch_existing_account_data(action, data);
     }
 
     // override values
@@ -365,7 +365,7 @@ async function fetch_account_data(action, user_input) {
     return data;
 }
 
-async function fetch_existing_account_data(target) {
+async function fetch_existing_account_data(action, target) {
     let source;
     try {
         const account_path = target.name ?
@@ -385,6 +385,20 @@ async function fetch_existing_account_data(target) {
         throw err;
     }
     const data = _.merge({}, source, target);
+    if (action === ACTIONS.UPDATE) {
+        const uid_update = !_.isUndefined(target.nsfs_account_config.uid);
+        const gid_update = !_.isUndefined(target.nsfs_account_config.gid);
+        const dn_update = !_.isUndefined(target.nsfs_account_config.distinguished_name);
+        const user_fs_permissions_change = uid_update || gid_update || dn_update;
+        if (user_fs_permissions_change) {
+            if (dn_update) {
+                delete data.nsfs_account_config.uid;
+                delete data.nsfs_account_config.gid;
+            } else {
+                delete data.nsfs_account_config.distinguished_name;
+            }
+        }
+    }
     return data;
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -441,8 +441,8 @@ describe('cli create bucket using from_file', () => {
 });
 
 describe('cli update bucket', () => {
-    const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs3');
-    const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs3/');
+    const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs4');
+    const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs4/');
     const bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs3', 'bucket1');
     set_nc_config_dir_in_config(config_root);
 


### PR DESCRIPTION
### Explain the changes
1. Add the case of update in function `fetch_existing_account_data` to avoid merging the data that would contain `uid`, `gid` and `distinguished_name`.
2. Add 2 test cases for the fix above, add 2 `describe`s under `account update`.
3. Change the paths in tests to avoid concurrency issues in Jest.

### Issues: Fixed #8023 #8072
1. Currently, if an account was added with `gid` and `uid` flags, when attempting to update the flag `user` we will get an error (instead of updating the account).
2. Currently, if an account was added with `user`, when attempting to update the `uid` and `gid` flags we will get an error (instead of updating the account).

### Testing Instructions:
#### Unit Tests:
Please run: `sudo npx jest test_nc_nsfs_account_cli.test.js`.

#### Manual Tests:
1. First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/` `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
2. Create an account with `uid` and `gid`: `sudo node src/cmd/manage_nsfs account add --name <account-name> --uid <uid> --gid <gid> --new_buckets_path <new_buckets_path>`
3. Update the account using the `user` flag: `sudo node src/cmd/manage_nsfs account update --name <account-name> --user root`
4. Delete the account: `sudo node src/cmd/manage_nsfs account delete --name <account-name>`
5. Create an account with `user`: `sudo node src/cmd/manage_nsfs account add --name <account-name> --user root --new_buckets_path <new_buckets_path>`
6. Update the account using the `uid` and `gid` flags: `sudo node src/cmd/manage_nsfs account update --name <account-name> --uid 1001 --gid 1001` (uid and gid that are different from those of the user).
7. Delete the account: `sudo node src/cmd/manage_nsfs account delete --name <account-name>`

- [ ] Doc added/updated
- [X] Tests added
