### PR TITLE
Tests | NSFS | Remove redundant config root assignments

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -44,7 +44,6 @@ describe('manage nsfs cli account flow', () => {
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
-            config.NSFS_NC_CONF_DIR = config_root;
         });
 
         afterEach(async () => {
@@ -399,7 +398,6 @@ describe('manage nsfs cli account flow', () => {
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
-            config.NSFS_NC_CONF_DIR = config_root;
             const action = ACTIONS.ADD;
             const { new_buckets_path } = defaults;
             const account_options = { config_root, ...defaults };
@@ -729,7 +727,6 @@ describe('manage nsfs cli account flow', () => {
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
-            config.NSFS_NC_CONF_DIR = config_root;
             // Creating the account
             const action = ACTIONS.ADD;
             for (const account_defaults of Object.values(defaults)) {
@@ -945,7 +942,6 @@ describe('manage nsfs cli account flow', () => {
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
-            config.NSFS_NC_CONF_DIR = config_root;
         });
 
         beforeEach(async () => {
@@ -1044,7 +1040,6 @@ describe('manage nsfs cli account flow', () => {
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
-            config.NSFS_NC_CONF_DIR = config_root;
             const action = ACTIONS.ADD;
             const { new_buckets_path } = defaults;
             const account_options = { config_root, ...defaults };
@@ -1094,7 +1089,6 @@ describe('manage nsfs cli account flow', () => {
             await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             set_nc_config_dir_in_config(config_root);
-            config.NSFS_NC_CONF_DIR = config_root;
             await fs_utils.create_fresh_path(root_path);
             await fs_utils.create_fresh_path(path_to_json_account_options_dir);
             // create the new_buckets_path and set permissions
@@ -1298,7 +1292,6 @@ describe('cli account flow distinguished_name - permissions', function() {
 
     beforeAll(async () => {
         set_nc_config_dir_in_config(config_root);
-        config.NSFS_NC_CONF_DIR = config_root;
         await fs_utils.create_fresh_path(config_root);
         await fs_utils.file_must_exist(config_root);
         for (const account of Object.values(accounts)) {

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -28,7 +28,6 @@ mocha.describe('manage_nsfs cli', function() {
     const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs');
     const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs/');
     set_nc_config_dir_in_config(config_root);
-    config.NSFS_NC_CONF_DIR = config_root;
     // TODO: needed for NC_CORETEST FLOW - should be handled better
     const nc_coretes_location = config.NC_MASTER_KEYS_FILE_LOCATION;
     mocha.before(async () => {


### PR DESCRIPTION
### Explain the changes
1. The removed assignment occurs inside set_nc_config_dir_in_config(config_root) function, thus the second assignemnt is redundant.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
