### PR TITLE
CI | RPM build | Added missing secrets: inherit to workflow_calls

### DIFF
--- a/.github/workflows/nightly-rpm-master-build.yaml
+++ b/.github/workflows/nightly-rpm-master-build.yaml
@@ -6,5 +6,6 @@ on:
 jobs:
   call-master-rpm-build-and-upload:
     uses: ./.github/workflows/rpm-build-and-upload-flow.yaml
+    secrets: inherit
     with:
       branch: 'master'

--- a/.github/workflows/nightly-rpm-stage-5.15.4.yaml
+++ b/.github/workflows/nightly-rpm-stage-5.15.4.yaml
@@ -6,5 +6,6 @@ on:
 jobs:
   call-stage-5-15-4-rpm-build-and-upload:
     uses: ./.github/workflows/rpm-build-and-upload-flow.yaml
+    secrets: inherit
     with:
       branch: 'stage_5.15.4'

--- a/.github/workflows/rpm-build-and-upload-flow.yaml
+++ b/.github/workflows/rpm-build-and-upload-flow.yaml
@@ -25,9 +25,11 @@ jobs:
     uses: ./.github/workflows/upload-rpm-to-aws.yaml
     with:
       rpm_full_path: ${{ needs.build-rpm-centos8.outputs.rpm_full_path }}
+    secrets: inherit
 
   upload-centos9-rpm-to-aws:
     needs: build-rpm-centos9
     uses: ./.github/workflows/upload-rpm-to-aws.yaml
     with:
       rpm_full_path: ${{ needs.build-rpm-centos9.outputs.rpm_full_path }}
+    secrets: inherit


### PR DESCRIPTION
### Explain the changes
1. The [latest changes](https://github.com/noobaa/noobaa-core/pull/8036) of the nightly RPM builds added usage of reusable calls (workflow_call). This change requires also passing secrets between the workflows that was missing in the recent change, therefore the nightly builds failed with the following error -
`Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers`

Attaching the failing actions for reference - 
https://github.com/noobaa/noobaa-core/actions/runs/9166097989
https://github.com/noobaa/noobaa-core/actions/runs/9166089527

Github actions doc reference - 
https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-secrets-to-nested-workflows
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
