### PR TITLE
[MCG] Store relevant Owner metadata for MCG objects

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1444,6 +1444,12 @@ module.exports = {
                 s3_signed_url: { type: 'string' },
                 lock_settings: { $ref: 'common_api#/definitions/lock_settings' },
                 storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
+                // currently no properties for the object as there is no implementation
+                object_owner: {
+                    type: 'object',
+                    properties: {
+                    }
+                },
             }
         },
 

--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -72,7 +72,7 @@ async function get_bucket(req) {
                 NextMarker: req.query.delimiter ? reply.next_marker : undefined,
             }),
         },
-        _.map(reply.objects, obj => ({
+        await Promise.all(_.map(reply.objects, async obj => ({
             Contents: {
                 Key: field_encoder(obj.key),
                 // if the object specifies last_modified_time we use it, otherwise take create_time.
@@ -81,11 +81,11 @@ async function get_bucket(req) {
                 LastModified: s3_utils.format_s3_xml_date(obj.last_modified_time || obj.create_time),
                 ETag: `"${obj.etag}"`,
                 Size: obj.size,
-                Owner: (!list_type || req.query['fetch-owner']) && s3_utils.get_object_owner(reply),
+                Owner: (!list_type || req.query['fetch-owner']) && (await s3_utils.get_object_owner(obj, req.object_sdk)),
                 StorageClass: s3_utils.parse_storage_class(obj.storage_class),
                 RestoreStatus: get_object_restore_status(obj, restore_status_requested)
             }
-        })),
+        }))),
         _.map(reply.common_prefixes, prefix => ({
             CommonPrefixes: {
                 Prefix: field_encoder(prefix) || ''

--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -81,7 +81,7 @@ async function get_bucket(req) {
                 LastModified: s3_utils.format_s3_xml_date(obj.last_modified_time || obj.create_time),
                 ETag: `"${obj.etag}"`,
                 Size: obj.size,
-                Owner: (!list_type || req.query['fetch-owner']) && s3_utils.DEFAULT_S3_USER,
+                Owner: (!list_type || req.query['fetch-owner']) && s3_utils.get_object_owner(reply),
                 StorageClass: s3_utils.parse_storage_class(obj.storage_class),
                 RestoreStatus: get_object_restore_status(obj, restore_status_requested)
             }

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -675,6 +675,16 @@ function parse_restore_request_days(req) {
     return days;
 }
 
+function get_object_owner(obj) {
+    if (obj.object_owner) {
+        return Object.freeze({
+            ID: obj.object_owner.id,
+            DisplayName: obj.object_owner.name,
+        });
+    }
+    return DEFAULT_S3_USER;
+}
+
 exports.STORAGE_CLASS_STANDARD = STORAGE_CLASS_STANDARD;
 exports.STORAGE_CLASS_GLACIER = STORAGE_CLASS_GLACIER;
 exports.STORAGE_CLASS_GLACIER_IR = STORAGE_CLASS_GLACIER_IR;
@@ -711,3 +721,4 @@ exports.get_response_field_encoder = get_response_field_encoder;
 exports.parse_decimal_int = parse_decimal_int;
 exports.parse_restore_request_days = parse_restore_request_days;
 exports.parse_version_id = parse_version_id;
+exports.get_object_owner = get_object_owner;

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -79,6 +79,14 @@ class NamespaceBlob {
         return this.access_mode === 'READ_ONLY';
     }
 
+    /**
+     * _get_object_owner in the future we will return object owner
+     * currently not implemented because ACLs are not implemented as well
+     */
+     _get_object_owner() {
+        return undefined;
+    }
+
     /////////////////
     // OBJECT LIST //
     /////////////////
@@ -111,17 +119,7 @@ class NamespaceBlob {
             common_prefixes: _.map(response.segment.blobPrefixes, prefix => prefix.name),
             is_truncated: Boolean(response.continuationToken),
             next_marker: response.continuationToken,
-            object_owner: await this.get_object_owner(object_sdk, params.bucket)
         };
-    }
-
-    async get_object_owner(object_sdk, bucket) {
-        // TODO: in the future we will add extra implementation per namespace
-        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
-        return {
-              name: info.bucket_owner.unwrap(),
-              id: info.bucket_info.owner_account.id,
-          };
     }
 
     async list_uploads(params, object_sdk) {
@@ -741,7 +739,7 @@ class NamespaceBlob {
                 }
             }
         }
-
+        const object_owner = this._get_object_owner();
         return {
             obj_id: blob_etag,
             bucket,
@@ -751,7 +749,8 @@ class NamespaceBlob {
             create_time: flat_obj.lastModified,
             content_type: flat_obj.contentType,
             xattr: modified_xattr,
-            tag_count: tag_count
+            tag_count: tag_count,
+            object_owner
         };
     }
 

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -110,8 +110,18 @@ class NamespaceBlob {
             objects: _.map(response.segment.blobItems, obj => this._get_blob_object_info(obj, params.bucket)),
             common_prefixes: _.map(response.segment.blobPrefixes, prefix => prefix.name),
             is_truncated: Boolean(response.continuationToken),
-            next_marker: response.continuationToken
+            next_marker: response.continuationToken,
+            object_owner: await this.get_object_owner(object_sdk, params.bucket)
         };
+    }
+
+    async get_object_owner(object_sdk, bucket) {
+        // TODO: in the future we will add extra implementation per namespace
+        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
+        return {
+              name: info.bucket_owner.unwrap(),
+              id: info.bucket_info.owner_account.id,
+          };
     }
 
     async list_uploads(params, object_sdk) {

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -195,7 +195,18 @@ class NamespaceCache {
         if (get_from_cache) {
             return this.namespace_nb.list_objects(params, object_sdk);
         }
-        return this.namespace_hub.list_objects(params, object_sdk);
+        const object_info = await this.namespace_hub.list_objects(params, object_sdk);
+        object_info.object_owner = await this.get_object_owner(object_sdk, params.bucket);
+        return object_info;
+    }
+
+    async get_object_owner(object_sdk, bucket) {
+        // TODO: in the future we will add extra implementation per namespace
+        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
+        return {
+              name: info.bucket_owner.unwrap(),
+              id: info.bucket_info.owner_account.id,
+          };
     }
 
     async list_uploads(params, object_sdk) {

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -195,18 +195,7 @@ class NamespaceCache {
         if (get_from_cache) {
             return this.namespace_nb.list_objects(params, object_sdk);
         }
-        const object_info = await this.namespace_hub.list_objects(params, object_sdk);
-        object_info.object_owner = await this.get_object_owner(object_sdk, params.bucket);
-        return object_info;
-    }
-
-    async get_object_owner(object_sdk, bucket) {
-        // TODO: in the future we will add extra implementation per namespace
-        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
-        return {
-              name: info.bucket_owner.unwrap(),
-              id: info.bucket_info.owner_account.id,
-          };
+        return this.namespace_hub.list_objects(params, object_sdk);
     }
 
     async list_uploads(params, object_sdk) {

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -587,7 +587,26 @@ class NamespaceFS {
      * @param {ListParams} params
      */
     async list_objects(params, object_sdk) {
-        return this._list_objects(params, object_sdk, false);
+        const object_info = await this._list_objects(params, object_sdk, false);
+        object_info.object_owner = await this.get_object_owner(object_sdk, params.bucket);
+        return object_info;
+    }
+
+    async get_object_owner(object_sdk, bucket) {
+        // TODO: in the future we will add extra implementation per namespace
+        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
+
+        if (info.bucket_info && info.bucket_info.owner_account) {
+            return {
+                name: info.bucket_owner.unwrap(),
+                id: info.bucket_info.owner_account.id,
+            };
+        } else {
+            return {
+                name: info.bucket_owner.unwrap(),
+                id: info.owner_account.id,
+            };
+        }
     }
 
     /**

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -588,25 +588,7 @@ class NamespaceFS {
      */
     async list_objects(params, object_sdk) {
         const object_info = await this._list_objects(params, object_sdk, false);
-        object_info.object_owner = await this.get_object_owner(object_sdk, params.bucket);
         return object_info;
-    }
-
-    async get_object_owner(object_sdk, bucket) {
-        // TODO: in the future we will add extra implementation per namespace
-        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
-
-        if (info.bucket_info && info.bucket_info.owner_account) {
-            return {
-                name: info.bucket_owner.unwrap(),
-                id: info.bucket_info.owner_account.id,
-            };
-        } else {
-            return {
-                name: info.bucket_owner.unwrap(),
-                id: info.owner_account.id,
-            };
-        }
     }
 
     /**
@@ -2348,7 +2330,16 @@ class NamespaceFS {
             sha256_b64: undefined,
             stats: undefined,
             tagging: undefined,
+            object_owner: this._get_object_owner()
         };
+    }
+
+    /**
+     * _get_object_owner in the future we will return object owner
+     * currently not implemented because ACLs are not implemented as well
+     */
+    _get_object_owner() {
+        return undefined;
     }
 
     _get_upload_info(stat, version_id) {

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -112,7 +112,17 @@ class NamespaceGCP {
             common_prefixes: additional_info.prefixes || [],
             is_truncated,
             next_marker,
+            object_owner: await this.get_object_owner(object_sdk, params.bucket)
         };
+    }
+
+    async get_object_owner(object_sdk, bucket) {
+        // TODO: in the future we will add extra implementation per namespace
+        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
+        return {
+              name: info.bucket_owner.unwrap(),
+              id: info.bucket_info.owner_account.id,
+          };
     }
 
     async list_uploads(params, object_sdk) {

--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -112,17 +112,15 @@ class NamespaceGCP {
             common_prefixes: additional_info.prefixes || [],
             is_truncated,
             next_marker,
-            object_owner: await this.get_object_owner(object_sdk, params.bucket)
         };
     }
 
-    async get_object_owner(object_sdk, bucket) {
-        // TODO: in the future we will add extra implementation per namespace
-        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
-        return {
-              name: info.bucket_owner.unwrap(),
-              id: info.bucket_info.owner_account.id,
-          };
+    /**
+     * _get_object_owner in the future we will return object owner
+     * currently not implemented because ACLs are not implemented as well
+     */
+    _get_object_owner() {
+        return undefined;
     }
 
     async list_uploads(params, object_sdk) {
@@ -454,6 +452,7 @@ class NamespaceGCP {
         const xattr = _.extend(metadata.metadata, {
             'noobaa-namespace-gcp-bucket': metadata.bucket,
         });
+        const object_owner = this._get_object_owner();
         return {
             obj_id: metadata.id,
             bucket: metadata.bucket,
@@ -475,6 +474,7 @@ class NamespaceGCP {
             lock_settings: undefined,
             encryption: undefined,
             stats: undefined,
+            object_owner
         };
     }
 

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -61,7 +61,6 @@ class NamespaceNB {
     async list_objects(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
         const object_info = await object_sdk.rpc_client.object.list_objects(params);
-        object_info.object_owner = await this.get_object_owner(object_sdk, params.bucket);
         return object_info;
     }
 
@@ -75,14 +74,6 @@ class NamespaceNB {
         return object_sdk.rpc_client.object.list_object_versions(params);
     }
 
-    async get_object_owner(object_sdk, bucket) {
-        // TODO: in the future we will add extra implementation per namespace
-        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
-        return {
-              name: info.bucket_owner.unwrap(),
-              id: info.bucket_info.owner_account.id,
-          };
-    }
     /////////////////
     // OBJECT READ //
     /////////////////

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -58,9 +58,11 @@ class NamespaceNB {
     // OBJECT LIST //
     /////////////////
 
-    list_objects(params, object_sdk) {
+    async list_objects(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        return object_sdk.rpc_client.object.list_objects(params);
+        const object_info = await object_sdk.rpc_client.object.list_objects(params);
+        object_info.object_owner = await this.get_object_owner(object_sdk, params.bucket);
+        return object_info;
     }
 
     list_uploads(params, object_sdk) {
@@ -73,6 +75,14 @@ class NamespaceNB {
         return object_sdk.rpc_client.object.list_object_versions(params);
     }
 
+    async get_object_owner(object_sdk, bucket) {
+        // TODO: in the future we will add extra implementation per namespace
+        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
+        return {
+              name: info.bucket_owner.unwrap(),
+              id: info.bucket_info.owner_account.id,
+          };
+    }
     /////////////////
     // OBJECT READ //
     /////////////////

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -94,18 +94,16 @@ class NamespaceS3 {
             objects: _.map(res.Contents, obj => this._get_s3_object_info(obj, params.bucket)),
             common_prefixes: _.map(res.CommonPrefixes, 'Prefix'),
             is_truncated: res.IsTruncated,
-            next_marker: res.NextMarker,
-            object_owner: await this.get_object_owner(object_sdk, params.bucket),
+            next_marker: res.NextMarker
         };
     }
 
-    async get_object_owner(object_sdk, bucket) {
-        // TODO: in the future we will add extra implementation per namespace
-        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
-        return {
-              name: info.bucket_owner.unwrap(),
-              id: info.bucket_info.owner_account.id,
-          };
+    /**
+     * _get_object_owner in the future we will return object owner
+     * currently not implemented because ACLs are not implemented as well
+     */
+    _get_object_owner() {
+        return undefined;
     }
 
     async list_uploads(params, object_sdk) {
@@ -788,6 +786,7 @@ class NamespaceS3 {
             sha256_b64: undefined,
             stats: undefined,
             tagging: undefined,
+            object_owner: this._get_object_owner()
         };
     }
 

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -95,7 +95,17 @@ class NamespaceS3 {
             common_prefixes: _.map(res.CommonPrefixes, 'Prefix'),
             is_truncated: res.IsTruncated,
             next_marker: res.NextMarker,
+            object_owner: await this.get_object_owner(object_sdk, params.bucket),
         };
+    }
+
+    async get_object_owner(object_sdk, bucket) {
+        // TODO: in the future we will add extra implementation per namespace
+        const info = await object_sdk.read_bucket_sdk_config_info(bucket);
+        return {
+              name: info.bucket_owner.unwrap(),
+              id: info.bucket_info.owner_account.id,
+          };
     }
 
     async list_uploads(params, object_sdk) {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -399,10 +399,16 @@ interface ObjectMD {
     lock_settings: { retention: { mode: string; retain_until_date: Date; }, legal_hold: { status: string } };
 }
 
+interface ObjectOwner {
+    id: string,
+    name: string;
+}
+
 interface ObjectInfo {
     obj_id: string;
     bucket: string;
     key: string;
+    object_owner?: ObjectOwner;
     version_id: string;
     lock_settings: { retention: { mode: string; retain_until_date: Date; }, legal_hold: { status: string } };
     is_latest: boolean;

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1430,7 +1430,16 @@ function get_object_info(md, options = {}) {
         tagging: md.tagging,
         encryption: md.encryption,
         tag_count: (md.tagging && md.tagging.length) || 0,
+        object_owner: _get_object_owner()
     };
+}
+
+/**
+ * _get_object_owner in the future we will return object owner
+ * currently not implemented because ACLs are not implemented as well
+ */
+function _get_object_owner() {
+    return undefined;
 }
 
 function load_bucket(req, { include_deleting } = {}) {

--- a/src/test/unit_tests/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/test_nsfs_glacier_backend.js
@@ -19,10 +19,12 @@ const { PersistentLogger } = require('../../util/persistent_logger');
 const { GlacierBackend } = require('../../sdk/nsfs_glacier_backend/backend');
 const nb_native = require('../../util/nb_native');
 const { handler: s3_get_bucket } = require('../../endpoint/s3/ops/s3_get_bucket');
+const BucketSpaceFS = require('../../sdk/bucketspace_fs');
 
 const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null, maxArrayLength: max_arr });
 
-function make_dummy_object_sdk() {
+function make_dummy_object_sdk(config_root) {
+    const bucketspace_fs = new BucketSpaceFS({ config_root });
     return {
         requesting_account: {
             force_md5_etag: false,
@@ -34,9 +36,13 @@ function make_dummy_object_sdk() {
         abort_controller: new AbortController(),
         throw_if_aborted() {
             if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
-        }
+        },
+        read_bucket_sdk_config_info(name) {
+            return bucketspace_fs.read_bucket_sdk_info({ name });
+        },
     };
 }
+
 function generate_noobaa_req_obj() {
     return {
         query: {},

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -527,6 +527,34 @@ mocha.describe('s3_ops', function() {
             assert.strictEqual(res2.Contents.length, (res1.Contents.length + 2));
         });
 
+        mocha.it('list-objects should return proper object owner and id', async function() {
+            if (is_azure_mock) this.skip();
+            this.timeout(120000);
+            await s3.copyObject({
+                Bucket: bucket_name,
+                Key: text_file2,
+                CopySource: `/${bucket_name}/${text_file1}`,
+            });
+            await s3.copyObject({
+                Bucket: bucket_name,
+                Key: text_file3,
+                CopySource: `/${BKT5}/${text_file5}`,
+            });
+            const res = await s3.listObjects({ Bucket: bucket_name });
+
+            assert.strictEqual(res.Contents[0].Key, text_file1);
+            assert.strictEqual(res.Contents[0].Owner.DisplayName, "coretest@noobaa.com");
+            assert.notEqual(res.Contents[0].Owner.ID, undefined);
+
+            assert.strictEqual(res.Contents[1].Key, text_file2);
+            assert.strictEqual(res.Contents[1].Owner.DisplayName, "coretest@noobaa.com");
+            assert.notEqual(res.Contents[1].Owner.ID, undefined);
+
+            assert.strictEqual(res.Contents[2].Key, text_file3);
+            assert.strictEqual(res.Contents[2].Owner.DisplayName, "coretest@noobaa.com");
+            assert.notEqual(res.Contents[2].Owner.ID, undefined);
+        });
+
         mocha.it('should copy text-file tagging', async function() {
             if (is_azure_mock) this.skip();
             this.timeout(120000);


### PR DESCRIPTION
### Goal

Allow customers to keep track of object owner of an object via the S3 API

### Problem

Currently when using boto3.client.list_objects, the metadata in the response under the "Owner" property is always set to

{'DisplayName': 'NooBaa', 'ID': '123'}

regardless of the name of the account that created the bucket.

### Why is this important?

Currently when using boto3.client.list_objects, the metadata in the response under the "Owner" property is always set to

{'DisplayName': 'NooBaa', 'ID': '123'}

regardless of the name of the account that created the bucket.

### Prioritized Scenarios
**In Scope**

Assign obc name or access key as the owner

### Documentation Requirements

Yes. document the approach we take

### Customers

No

### Customer Facing Story

As an administrator, I should be able to check which account uploaded a given object to an MCG bucket.

### Gap: 
Since ACLs are not suported, we are assigning obc owner as the owner of the object

**Fixes**: https://issues.redhat.com/browse/RHSTOR-5501