### PR TITLE
NSFS | NC | IAM | IAM, S3, And STS Mutual Code Reuse

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -102,10 +102,10 @@ async function main(options = {}) {
         const metrics_port = options.metrics_port || config.EP_METRICS_SERVER_PORT;
         if (fork_utils.start_workers(metrics_port, fork_count)) return;
 
-        const http_port = options.http_port || Number(process.env.ENDPOINT_PORT) || 6001;
-        const https_port = options.https_port || Number(process.env.ENDPOINT_SSL_PORT) || 6443;
+        const http_port = options.http_port || config.ENDPOINT_PORT;
+        const https_port = options.https_port || config.ENDPOINT_SSL_PORT;
         const https_port_sts = options.https_port_sts || Number(process.env.ENDPOINT_SSL_PORT_STS) || 7443;
-        const https_port_iam = options.https_port_iam || Number(process.env.ENDPOINT_SSL_PORT_IAM) || 7444;
+        const https_port_iam = options.https_port_iam || config.ENDPOINT_SSL_IAM_PORT;
         const endpoint_group_id = process.env.ENDPOINT_GROUP_ID || 'default-endpoint-group';
 
         const virtual_hosts = Object.freeze(

--- a/src/endpoint/iam/iam_rest.js
+++ b/src/endpoint/iam/iam_rest.js
@@ -121,17 +121,7 @@ async function handle_request(req, res) {
 
 function authenticate_request(req) {
     try {
-        const auth_token = signature_utils.make_auth_token_from_request(req);
-        if (auth_token) {
-            auth_token.client_ip = http_utils.parse_client_ip(req);
-        }
-        if (req.session_token) {
-            auth_token.access_key = req.session_token.assumed_role_access_key;
-            auth_token.temp_access_key = req.session_token.access_key;
-            auth_token.temp_secret_key = req.session_token.secret_key;
-        }
-        req.account_sdk.set_auth_token(auth_token);
-        signature_utils.check_request_expiry(req);
+        signature_utils.authenticate_request_by_service(req, req.account_sdk);
     } catch (err) {
         dbg.error('authenticate_request: ERROR', err.stack || err);
         if (err.code) {
@@ -145,7 +135,7 @@ function authenticate_request(req) {
 // authorize_request_account authorizes the account of the requester
 async function authorize_request(req) {
     await req.account_sdk.load_requesting_account(req);
-    await req.account_sdk.authorize_request_account(req);
+    req.account_sdk.authorize_request_account(req);
 }
 
 function parse_op_name(req, action) {

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -179,17 +179,7 @@ async function _get_redirection_bucket(req, bucket) {
 
 function authenticate_request(req) {
     try {
-        const auth_token = signature_utils.make_auth_token_from_request(req);
-        if (auth_token) {
-            auth_token.client_ip = http_utils.parse_client_ip(req);
-        }
-        if (req.session_token) {
-            auth_token.access_key = req.session_token.assumed_role_access_key;
-            auth_token.temp_access_key = req.session_token.access_key;
-            auth_token.temp_secret_key = req.session_token.secret_key;
-        }
-        req.object_sdk.set_auth_token(auth_token);
-        signature_utils.check_request_expiry(req);
+        signature_utils.authenticate_request_by_service(req, req.object_sdk);
     } catch (err) {
         dbg.error('authenticate_request: ERROR', err.stack || err);
         if (err.code) {

--- a/src/endpoint/sts/ops/sts_post_assume_role.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role.js
@@ -5,6 +5,7 @@ const dbg = require('../../../util/debug_module')(__filename);
 const { StsError } = require('../sts_errors');
 const jwt_utils = require('../../../util/jwt_utils');
 const config = require('../../../../config');
+const { CONTENT_TYPE_APP_FORM_URLENCODED } = require('../../../util/http_utils');
 
 /**
  * https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
@@ -56,7 +57,7 @@ function generate_session_token(auth_options, expiry) {
 module.exports = {
     handler: assume_role,
     body: {
-        type: 'application/x-www-form-urlencoded',
+        type: CONTENT_TYPE_APP_FORM_URLENCODED,
     },
     reply: {
         type: 'xml',

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -106,17 +106,7 @@ async function handle_request(req, res) {
 
 function authenticate_request(req) {
     try {
-        const auth_token = signature_utils.make_auth_token_from_request(req);
-        if (auth_token) {
-            auth_token.client_ip = http_utils.parse_client_ip(req);
-        }
-        if (req.session_token) {
-            auth_token.access_key = req.session_token.assumed_role_access_key;
-            auth_token.temp_access_key = req.session_token.access_key;
-            auth_token.temp_secret_key = req.session_token.secret_key;
-        }
-        req.sts_sdk.set_auth_token(auth_token);
-        signature_utils.check_request_expiry(req);
+        signature_utils.authenticate_request_by_service(req, req.sts_sdk);
     } catch (err) {
         dbg.error('authenticate_request: ERROR', err.stack || err);
         if (err.code) {
@@ -132,7 +122,7 @@ function authenticate_request(req) {
 // by the role's assume role policy permissions
 async function authorize_request(req) {
     await req.sts_sdk.load_requesting_account(req);
-    await req.sts_sdk.authorize_request_account(req);
+    req.sts_sdk.authorize_request_account(req);
     await authorize_request_policy(req);
 }
 

--- a/src/sdk/account_sdk.js
+++ b/src/sdk/account_sdk.js
@@ -73,14 +73,12 @@ class AccountSDK {
         }
     }
 
-    // copied from function in object_sdk, sts_sdk
-    async authorize_request_account(req) {
+    // copied from function in sts_sdk
+    authorize_request_account(req) {
         const token = this.get_auth_token();
         // If the request is signed (authenticated)
         if (token) {
-            const signature_secret = token.temp_secret_key || this.requesting_account?.access_keys?.[0]?.secret_key?.unwrap();
-            const signature = signature_utils.get_signature_from_auth_token(token, signature_secret);
-            if (token.signature !== signature) throw new RpcError('SIGNATURE_DOES_NOT_MATCH', `Signature that was calculated did not match`);
+            signature_utils.authorize_request_account_by_token(token, this.requesting_account, false);
             return;
         }
         throw new RpcError('UNAUTHORIZED', `No permission to access`);

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -239,11 +239,7 @@ class ObjectSDK {
         const token = this.get_auth_token();
         // If the request is signed (authenticated)
         if (token) {
-            const signature_secret = token.temp_secret_key || this.requesting_account?.access_keys?.[0]?.secret_key?.unwrap();
-            if (signature_secret) {
-                const signature = signature_utils.get_signature_from_auth_token(token, signature_secret);
-                if (token.signature !== signature) throw new RpcError('SIGNATURE_DOES_NOT_MATCH', `Signature that was calculated did not match`);
-            }
+            signature_utils.authorize_request_account_by_token(token, this.requesting_account, true);
         }
         // check for a specific bucket
         if (bucket && req.op_name !== 'put_bucket') {

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -82,15 +82,11 @@ class StsSDK {
         return cloud_utils.generate_access_keys();
     }
 
-    // similar function to object_sdk - should we merge them?
-    // where should we put the account_cache
-    async authorize_request_account(req) {
+    authorize_request_account(req) {
         const token = this.get_auth_token();
         // If the request is signed (authenticated)
         if (token) {
-            const signature_secret = token.temp_secret_key || this.requesting_account?.access_keys?.[0]?.secret_key?.unwrap();
-            const signature = signature_utils.get_signature_from_auth_token(token, signature_secret);
-            if (token.signature !== signature) throw new RpcError('SIGNATURE_DOES_NOT_MATCH', `Signature that was calculated did not match`);
+            signature_utils.authorize_request_account_by_token(token, this.requesting_account, false);
             return;
         }
         throw new RpcError('UNAUTHORIZED', `No permission to access bucket`);

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -301,7 +301,7 @@ async function parse_request_body(req, options) {
             throw new options.ErrorClass(options.error_invalid_body);
         }
     }
-    if (options.body.type.includes('application/x-www-form-urlencoded')) {
+    if (options.body.type.includes(CONTENT_TYPE_APP_FORM_URLENCODED)) {
         try {
             const res = querystring.parse(req.body.toString());
             const renamed = _.mapKeys(res, (value, key) => _.snakeCase(key));


### PR DESCRIPTION
### Explain the changes
1. Reuse constant `CONTENT_TYPE_APP_FORM_URLENCODED` in STS and http_utils
2. Reuse config environment variables in the endpoint file (except `ENDPOINT_SSL_PORT_STS` - see gaps).
3. Move the `authorize_request_account` and `authenticate_request` mutual code and reuse it.

### Issues:
Gaps:
1. In `endpomit.js`, we could not reuse config because `ENDPOINT_SSL_PORT_STS` in config defaults to -1 while in the endpoint it is 7443.
2. Was asked to combine `http_utils.authorize_session_token(req, headers_options);` and `authenticate_request(req);` - but they do not not seems related.

### Testing Instructions:
These tests will only test the flow of the service:
1. Create the root user account with the CLI: `sudo node src/cmd/manage_nsfs account add --name shira-1002 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account, you need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
Note: before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
3. Create the alias for IAM service: `alias s3-nc-user-1-iam='AWS_ACCESS_KEY_ID=<acess-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005'`.
4. Use AWS CLI to send requests to the IAM service, for example: `s3-nc-user-1-iam iam create-user --user-name Bob --path '/division_abc/subdivision_xyz/'` (more examples in the comment below)

- [ ] Doc added/updated
- [ ] Tests added
