### PR TITLE
CI | RPM action | Bump versions and share files between re-usable workflows

### DIFF
--- a/.github/workflows/rpm-build-base.yaml
+++ b/.github/workflows/rpm-build-base.yaml
@@ -79,7 +79,7 @@ jobs:
           echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
-          name: noobaa_rpm
+          name: ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }}
           path: ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }}

--- a/.github/workflows/upload-rpm-to-aws.yaml
+++ b/.github/workflows/upload-rpm-to-aws.yaml
@@ -1,23 +1,30 @@
-name: Upload RPM to AWS
-on: 
-  workflow_call:
-    inputs:
-      rpm_full_path: 
-        type: string
-        description: 'RPM path to be uploaded to AWS bucket'
+  name: Upload RPM to AWS
+  on: 
+    workflow_call:
+      inputs:
+        rpm_full_path: 
+          type: string
+          description: 'RPM path to be uploaded to AWS bucket'
 
-jobs:
-  upload-rpm-to-aws:
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    steps:
-      - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.NEWAWSPROJKEY }}
-          aws-secret-access-key: ${{ secrets.NEWAWSPROJSECRET }}
-          aws-region: us-east-1
 
-      - name: Copy RPM to S3 bucket
-        run: |
-          aws s3 cp ${{ inputs.rpm_full_path }} s3://noobaa-core-rpms/
+  jobs:
+    upload-rpm-to-aws:
+      runs-on: ubuntu-latest
+      timeout-minutes: 90
+      steps:
+        - name: Download artifact
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ inputs.rpm_full_path }}
+            path: ${{ inputs.rpm_full_path }}
+
+        - name: Setup AWS CLI
+          uses: aws-actions/configure-aws-credentials@v4
+          with:
+            aws-access-key-id: ${{ secrets.NEWAWSPROJKEY }}
+            aws-secret-access-key: ${{ secrets.NEWAWSPROJSECRET }}
+            aws-region: us-east-1
+
+        - name: Copy RPM to S3 bucket
+          run: |
+            aws s3 cp ${{ inputs.rpm_full_path }} s3://noobaa-core-rpms/


### PR DESCRIPTION
### Explain the changes
1. Bump versions of -
- actions/upload-artifact@v1.0.0 -> actions/upload-artifact@v4
- aws-actions/configure-aws-credentials@v1 -> aws-actions/configure-aws-credentials@v4
2. rpm-build-base.yaml - upload rpm - switch name from `noobaa-rpm` to rpm_full_path variable name.
3. upload-rpm-to-aws.yaml - download the artifact by input.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #7880

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
