### PR TITLE
Block access_keys updation if duplicate access_key is found

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -319,6 +319,10 @@ async function update_account_keys(req) {
     }
     const access_keys = req.rpc_params.access_keys;
 
+    if (!_.isUndefined(system_store.get_account_by_access_key(access_keys.access_key))) {
+        throw new RpcError('ACCESS_KEY_DUPLICATION', 'Duplicate access key is found, each access_key must be unique');
+    }
+
     access_keys.secret_key = system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
         access_keys.secret_key, account.master_key_id._id);
 

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -804,6 +804,12 @@ class SystemStore extends EventEmitter {
         }
     }
 
+    get_account_by_access_key(access_key_id) {
+        return _.find(this.data.accounts, acc =>
+            _.find(acc.access_keys, key => key.access_key.unwrap() === access_key_id.unwrap())
+        );
+    }
+
     get_accounts_by_nsfs_account_config(nsfs_account_config) {
         if (this.data && !_.isEmpty(this.data.accounts)) {
             return this.data.accounts.filter(account => account.nsfs_account_config &&


### PR DESCRIPTION
### Explain the changes
1.  Added a function to check if access_key provided for updation is already available for an account, throws an Rpc error if duplication is found.

### Issues: Fixed #xxx / Gap #xxx
1. Gap #7972

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
