### PR TITLE
NSFS | NC | Add Validate Flags Combination

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -113,6 +113,12 @@ ManageCLIError.MissingUpdateProperty = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.InvalidFlagsCombination = Object.freeze({
+    code: 'InvalidFlagsCombination',
+    message: 'The flags combination that you used is invalid',
+    http_code: 400,
+});
+
 //////////////////////////////
 //// IP WHITE LIST ERRORS ////
 //////////////////////////////

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -378,6 +378,29 @@ describe('manage nsfs cli account flow', () => {
             expect(account.force_md5_etag).toBe(true);
         });
 
+        it('should fail - cli account add invalid flags combination (gid and user)', async function() {
+            const action = ACTIONS.ADD;
+            const { type, name, gid } = defaults;
+            const account_options = { config_root, name, gid, user: 'root' };
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidFlagsCombination.code);
+        });
+
+        it('should fail - cli account add invalid flags combination (uid and user)', async function() {
+            const action = ACTIONS.ADD;
+            const { type, name, uid } = defaults;
+            const account_options = { config_root, name, uid, user: 'root' };
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidFlagsCombination.code);
+        });
+
+        it('should fail - cli account add invalid flags combination (uid, gid and user)', async function() {
+            const action = ACTIONS.ADD;
+            const { type, name, uid, gid } = defaults;
+            const account_options = { config_root, name, uid, gid, user: 'root' };
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidFlagsCombination.code);
+        });
     });
 
     describe('cli update account', () => {
@@ -916,6 +939,13 @@ describe('manage nsfs cli account flow', () => {
                 .toEqual([]);
         });
 
+        it('should fail - cli account list invalid flags combination (show_secrets without wide)', async () => {
+            const account_options = { config_root, show_secrets: true}; // without wide it's invalid
+            const action = ACTIONS.LIST;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidFlagsCombination.message);
+        });
+
         it('cli account status without name and access_key', async function() {
             const action = ACTIONS.STATUS;
             const res = await exec_manage_cli(TYPES.ACCOUNT, action, { config_root });
@@ -1232,6 +1262,42 @@ describe('manage nsfs cli account flow', () => {
             // compare the details
             const res = await exec_manage_cli(type, action, command_flags);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidJSONFile.code);
+        });
+
+        it('should fail - cli create account using from_file with invalid option combination (in the file uid and user)', async () => {
+            const action = ACTIONS.ADD;
+            const { name, uid } = defaults;
+            const account_options = { name, uid, user: 'root'}; // no need user and uid
+            // write the json_file_options
+            const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
+            const command_flags = {config_root, from_file: path_to_option_json_file_name};
+            // create the account
+            const res = await exec_manage_cli(type, action, command_flags);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidFlagsCombination.code);
+        });
+
+        it('should fail - cli create account using from_file with invalid option combination (in the file gid and user)', async () => {
+            const action = ACTIONS.ADD;
+            const { name, gid } = defaults;
+            const account_options = { name, gid, user: 'root'}; // no need user and gid
+            // write the json_file_options
+            const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
+            const command_flags = {config_root, from_file: path_to_option_json_file_name};
+            // create the account
+            const res = await exec_manage_cli(type, action, command_flags);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidFlagsCombination.code);
+        });
+
+        it('should fail - cli create account using from_file with invalid option combination (in the file uid, gid and user)', async () => {
+            const action = ACTIONS.ADD;
+            const { name, uid, gid } = defaults;
+            const account_options = { name, uid, gid, user: 'root'}; // no need user and gid
+            // write the json_file_options
+            const path_to_option_json_file_name = await create_json_account_options(path_to_json_account_options_dir, account_options);
+            const command_flags = {config_root, from_file: path_to_option_json_file_name};
+            // create the account
+            const res = await exec_manage_cli(type, action, command_flags);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.InvalidFlagsCombination.code);
         });
 
     });


### PR DESCRIPTION
### Explain the changes
1. Add validate flags combination.

### Issues: Fixed #7918 
1. Currently, an Invalid flags combination is ignored, examples:
   - `--show_secrets` without `wide` in the account list (`--show_secrets` is ignored).
   - `--user` with `--gid` and `--uid` (`gid` and `uid` are ignored).

### Testing Instructions:
#### Unit Tests
1. Please run: `sudo npx jest test_nc_nsfs_account_cli.test.js`.

#### Manual Tests
1. First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/` `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
2. Create an account with `user` and also `uid` and `gid`: `sudo node src/cmd/manage_nsfs account add --name <account-name> --user root --uid <uid> --gid <gid> --new_buckets_path <new_buckets_path>` (should throw an error).
3. Create an account with `uid` and `gid` (we will try to update it): `sudo node src/cmd/manage_nsfs account add --name <account-name> --uid <uid> --gid <gid> --new_buckets_path <new_buckets_path>` (should throw an error).
4. Update the account using the `user`, `uid` and `gid` flags: `sudo node src/cmd/manage_nsfs account update --name <account-name> --user root --uid <uid> --gid <gid>` (should throw an error).
5. List accounts with `--show_secrets` without `wide`: `sudo node src/cmd/manage_nsfs account list --show_secrets`
6. From-file option: `sudo node src/cmd/manage_nsfs account add --from_file <path-to-json-file>`  (should throw an error), a file for example (includes `uid` and `user`):
```json
{
    "name": "shira-account-1024",
    "uid": 1024,
    "user": "root",
    "new_buckets_path": "/tmp/nsfs_root1/my-bucket"
}
```

- [ ] Doc added/updated
- [X] Tests added
