### PR TITLE
LIFECYCLE - fix issue with delete only 3K objects a day

### DIFF
--- a/config.js
+++ b/config.js
@@ -431,6 +431,8 @@ config.DEFAULT_S3_AUTH_METHOD = {
 //////////////////////
 
 config.LIFECYCLE_INTERVAL = 8 * 60 * 60 * 1000; // 8h
+config.LIFECYCLE_BATCH_SIZE = 1000;
+config.LIFECYCLE_SCHEDULE_MIN = 5 * 1000 * 60; // run every 5 minutes
 config.LIFECYCLE_ENABLED = true;
 
 //////////////////////////

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1154,8 +1154,8 @@ module.exports = {
             reply: {
                 type: 'object',
                 properties: {
-                    is_empty: {
-                        type: 'boolean'
+                    num_objects_deleted: {
+                        type: 'integer'
                     }
                 }
             },

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -969,8 +969,7 @@ async function delete_multiple_objects_by_filter(req) {
             }))
         }
     }));
-    const bucket_has_objects = await MDStore.instance().has_any_objects_for_bucket(bucket_id);
-    return { is_empty: !bucket_has_objects };
+    return { objects_deleted: objects.length };
 }
 
 /**


### PR DESCRIPTION
### Explain the changes
1. delete_multiple_objects_by_filter will return the number of objects deleted
2. lifecycle will run every 5 minutes if any of its rules has deleted the max objects it can (1K - meaning he can delete more and we shouldn't wait to the next cycle)

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2279964

### Testing Instructions:
1. create more than 3K of objects on a bucket (let's say 3.5K)
2. set this lifecycle rule: 
```
{
    "Rules": [{
          "Expiration": {
                "Days": 1
            },
            "ID": "data-expire-withoutprefix",
            "Filter": {
                "Prefix": ""
            },
            "Status": "Enabled"
        }
    ]
}
```
3. wait till LIFECYCLE runs a day after - see that it deleted all the objects and not just 1K object every 8 hours.


- [ ] Doc added/updated
- [ ] Tests added
