### PR TITLE
CI | NC | Upload RPM to AWS github action fix

### DIFF
--- a/.github/workflows/upload-rpm-to-aws.yaml
+++ b/.github/workflows/upload-rpm-to-aws.yaml
@@ -16,7 +16,6 @@
           uses: actions/download-artifact@v4
           with:
             name: ${{ inputs.rpm_full_path }}
-            path: ${{ inputs.rpm_full_path }}
 
         - name: Setup AWS CLI
           uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
### Explain the changes
1. Download artifact - Removed `path: ${{ inputs.rpm_full_path }}`, it created a directory and in it stored the RPM. without specifying anything it works as expected. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
