### PR TITLE
CI | Update Commit Hash in Ceph Tests

### DIFF
--- a/docs/dev_guide/ceph_s3_tests/ceph_s3_tests_pending_list_status.md
+++ b/docs/dev_guide/ceph_s3_tests/ceph_s3_tests_pending_list_status.md
@@ -46,3 +46,7 @@ Attached a table with tests that where investigated and their status (this table
 | test_object_create_bad_date_none_aws2                     | Internal Component | [438](https://github.com/ceph/s3-tests/issues/438)                    | It used to pass in the past (not related to code change in our repo) |
 | test_bucket_create_bad_authorization_invalid_aws2         | Internal Component | [438](https://github.com/ceph/s3-tests/issues/438)                    | It used to pass in the past (not related to code change in our repo) |
 | test_bucket_create_bad_date_none_aws2                     | Internal Component | [438](https://github.com/ceph/s3-tests/issues/438)                    | It used to pass in the past (not related to code change in our repo) |
+| test_get_object_ifnonematch_good                     | Internal Component |                    | It used to pass in the past (not related to code 
+change in our repo) - stopped passing between the update of commit hash 6861c3d81081a6883fb90d66cb60392e1abdf3ca to da91ad8bbf899c72199df35b69e9393c706aabee |
+| test_get_object_ifmodifiedsince_failed                     | Internal Component |                    | It used to pass in the past (not related to code 
+change in our repo) - stopped passing between the update of commit hash 6861c3d81081a6883fb90d66cb60392e1abdf3ca to da91ad8bbf899c72199df35b69e9393c706aabee |

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -129,3 +129,5 @@ s3tests/functional/test_headers.py::test_object_create_bad_authorization_invalid
 s3tests/functional/test_headers.py::test_object_create_bad_date_none_aws2
 s3tests/functional/test_headers.py::test_bucket_create_bad_authorization_invalid_aws2
 s3tests/functional/test_headers.py::test_bucket_create_bad_date_none_aws2
+s3tests_boto3/functional/test_s3.py::test_get_object_ifnonematch_good
+s3tests_boto3/functional/test_s3.py::test_get_object_ifmodifiedsince_failed

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -17,7 +17,7 @@ DIRECTORY="s3-tests"
 CEPH_LINK="https://github.com/ceph/s3-tests.git"
 # using a fixed version (commit) of ceph tests to avoid sudden changes. 
 # we should retest and update the version once in a while
-CEPH_TESTS_VERSION=6861c3d81081a6883fb90d66cb60392e1abdf3ca
+CEPH_TESTS_VERSION=da91ad8bbf899c72199df35b69e9393c706aabee
 if [ ! -d $DIRECTORY ]; then
     echo "Downloading Ceph S3 Tests..."
     git clone $CEPH_LINK


### PR DESCRIPTION
### Explain the changes
1. Update commit hash in Ceph tests.
2. Added failed tests to the pending list of Ceph tests and updated the doc file of "Ceph S3 Tests - Pending List Status".

### Issues:
1. We need to update the hash every 180 days - this commit hash will add about 44 days to the counter (see comment below).

### Testing Instructions:
1. none (tested through the CI).
3. If you wish to run it locally: 
`make test-cephs3 CONTAINER_PLATFORM=linux/arm64`
`make test-nsfs-cephs3 CONTAINER_PLATFORM=linux/arm64`
(I'm using the flag `CONTAINER_PLATFORM` because I have MacOS M1).

- [X] Doc updated
- [ ] Tests added
