### PR TITLE
NSFS | NC | Add Condition in `authorize_request_policy`

### DIFF
--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -206,6 +206,7 @@ class NsfsObjectSDK extends ObjectSDK {
             },
             system_owner: new SensitiveString('nsfs'),
             bucket_owner: new SensitiveString('nsfs'),
+            owner_account: new SensitiveString('nsfs-id'), // temp
         };
     }
 }

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -214,7 +214,7 @@ async function authorize_request_policy(req) {
     if (!req.params.bucket) return;
     if (req.op_name === 'put_bucket') return;
 
-    const { s3_policy, system_owner, bucket_owner } = await req.object_sdk.read_bucket_sdk_policy_info(req.params.bucket);
+    const { s3_policy, system_owner, bucket_owner, owner_account } = await req.object_sdk.read_bucket_sdk_policy_info(req.params.bucket);
     const auth_token = req.object_sdk.get_auth_token();
     const arn_path = _get_arn_from_req_path(req);
     const method = _get_method_from_req(req);
@@ -234,6 +234,7 @@ async function authorize_request_policy(req) {
 
     const is_owner = (function() {
         if (account.bucket_claim_owner && account.bucket_claim_owner.unwrap() === req.params.bucket) return true;
+        if (req.object_sdk.nsfs_config_root && account._id === owner_account.id) return true; // NC NSFS case
         if (account_identifier === bucket_owner.unwrap()) return true;
         return false;
     }());

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -196,6 +196,7 @@ class ObjectSDK {
             s3_policy: bucket.s3_policy,
             system_owner: bucket.system_owner,
             bucket_owner: bucket.bucket_owner,
+            owner_account: bucket.owner_account, // in NC NSFS this is the account id that owns the bucket
         };
         return policy_info;
     }


### PR DESCRIPTION
### Explain the changes
1. Add Condition in `authorize_request_policy` in `s3_rest`.
2. To have the details of the account owner also return the `owner_account` in the function  `read_bucket_sdk_policy_info`.
3. In nsfs add the `owner_account` with mock value just to return a value like in the function `read_bucket_sdk_policy_info`.

### Issues: Fixed (partial) #8080 
1. Currently, after an account name is updated it results in failure in S3 request that the account tries to perform on the bucket (`AccessDenied`). It happens because the `bucket_owner` is with the previous name and the `account_identifier` is with the new name.

after this fix, the S3 request should not return an error, although there are still GAPS:
- The buckets that the account owns still have the properties `system_owner` and `bucket_owner` with the previous name (in the bucket config).
- Currently, the `s3_policy` is set in the bucket config files with the name of the account, and this will also not be updated, for example: `Principal: { AWS: 'user10' }`.

### Testing Instructions:
#### Manual Test:
Before you start: Change the `config.NSFS_CHECK_BUCKET_BOUNDARIES = false;`
1. First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/` `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
2. Run the nsfs server: `sudo node src/cmd/nsfs --debug 5`
3. Create an account with an access key and secret key:
`sudo node src/cmd/manage_nsfs account add --name shira-1003 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid 1003 --gid 1003`
4. Create a bucket for the account
`sudo node src/cmd/manage_nsfs bucket add --name shira-1003-bucket-1 --owner shira-1003 --path /tmp/nsfs_root1/my-bucket`
5. Create the alias for sending the requests using AWS CLI (access key and secret key were omitted):
`alias s3-nc-user-1='AWS_ACCESS_KEY_ID=<access-key>  AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443'`
6. Send S3 requests, for example: `s3-nc-user-1 s3api put-object --bucket shira-1003-bucket-1 --key hello.txt` (should work).
7. Rename the account (account update):
`sudo node src/cmd/manage_nsfs account update --name shira-1003 --new_name shira-1003-new`
8. See that the owner of the bucket was not changed (still with the previous name shira-1003)
`sudo node src/cmd/manage_nsfs bucket status --name shira-1003-bucket-1`
9. Send S3 request, for example: `s3-nc-user-1 s3api put-object --bucket shira-1003-bucket-1 --key hello.txt` (should work after the fix, before that it throws an error). Please make sure that you send the request after the `bucket_namespace_cache` is clear, else you would not be able to reproduce the initial issue).

- [ ] Doc added/updated
- [ ] Tests added
