### PR TITLE
NC | CLI | CLI errors handling when master key is invalid

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -345,7 +345,8 @@ async function fetch_account_data(action, user_input) {
     if (action === ACTIONS.UPDATE || action === ACTIONS.DELETE) {
         // @ts-ignore
         data = _.omitBy(data, _.isUndefined);
-        data = await fetch_existing_account_data(action, data);
+        const decrypt_secret_key = action === ACTIONS.UPDATE;
+        data = await fetch_existing_account_data(action, data, decrypt_secret_key);
     }
 
     // override values
@@ -375,14 +376,14 @@ async function fetch_account_data(action, user_input) {
     return data;
 }
 
-async function fetch_existing_account_data(action, target) {
+async function fetch_existing_account_data(action, target, decrypt_secret_key) {
     let source;
     try {
         const account_path = target.name ?
             get_config_file_path(accounts_dir_path, target.name) :
             get_symlink_config_file_path(access_keys_dir_path, target.access_keys[0].access_key);
         source = await get_config_data(config_root_backend, account_path, true);
-        source.access_keys = await nc_mkm.decrypt_access_keys(source);
+        if (decrypt_secret_key) source.access_keys = await nc_mkm.decrypt_access_keys(source);
     } catch (err) {
         dbg.log1('NSFS Manage command: Could not find account', target, err);
         if (err.code === 'ENOENT') {
@@ -536,6 +537,7 @@ async function get_account_status(data, show_secrets) {
         if (config_data.access_keys) config_data.access_keys = await nc_mkm.decrypt_access_keys(config_data);
         write_stdout_response(ManageCLIResponse.AccountStatus, config_data);
     } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
         if (_.isUndefined(data.name)) {
             throw_cli_error(ManageCLIError.NoSuchAccountAccessKey, data.access_keys[0].access_key.unwrap());
         } else {

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -147,6 +147,12 @@ ManageCLIError.WhiteListIPUpdateFailed = Object.freeze({
     http_code: 500,
 });
 
+ManageCLIError.InvalidMasterKey = Object.freeze({
+    code: 'InvalidMasterKey',
+    message: 'Master key manager had issues loading master key, can not decrypt/encrypt secrets.',
+    http_code: 500,
+});
+
 ////////////////////////
 //// ACCOUNT ERRORS ////
 ////////////////////////
@@ -404,7 +410,8 @@ ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
 
 ManageCLIError.RPC_ERROR_TO_MANAGE = Object.freeze({
     INVALID_SCHEMA: ManageCLIError.InvalidSchema,
-    NO_SUCH_USER: ManageCLIError.InvalidAccountDistinguishedName
+    NO_SUCH_USER: ManageCLIError.InvalidAccountDistinguishedName,
+    INVALID_MASTER_KEY: ManageCLIError.InvalidMasterKey
 });
 
 const NSFS_CLI_ERROR_EVENT_MAP = {

--- a/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.js
@@ -1,0 +1,283 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = "true";
+
+const fs = require('fs');
+const _ = require('lodash');
+const path = require('path');
+const P = require('../../../util/promise');
+const fs_utils = require('../../../util/fs_utils');
+const { exec_manage_cli, set_path_permissions_and_owner, TMP_PATH, set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
+const { TYPES, ACTIONS, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
+const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
+
+const tmp_fs_path = path.join(TMP_PATH, 'test_nc_nsfs_account_cli');
+const config_root = path.join(tmp_fs_path, 'config_root_account_mkm_integration');
+const root_path = path.join(tmp_fs_path, 'root_path_account_mkm_integration/');
+const defaults = {
+    _id: 'account1',
+    type: TYPES.ACCOUNT,
+    name: 'account1',
+    new_buckets_path: `${root_path}new_buckets_path_mkm_integration/`,
+    uid: 999,
+    gid: 999,
+    access_key: 'GIGiFAnjaaE7OKD5N7hA',
+    secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
+};
+
+describe('manage nsfs cli account flow + fauly master key flow', () => {
+    describe('cli account ops - master key is missing', () => {
+        beforeEach(async () => {
+            await setup_nc_system_and_first_account();
+            // delete master key json file
+            await fs_utils.file_delete(`${config_root}/master_keys.json`);
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('should fail | cli create update', async () => {
+            try {
+                await update_account();
+                fail('should have failed with InvalidMasterKey');
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('cli account list', async () => {
+            const { name } = defaults;
+            const list_res = await list_account_flow();
+            expect(list_res.response.reply[0].name).toBe(name);
+        });
+
+        it('cli account status', async () => {
+            const { name, uid, gid, new_buckets_path } = defaults;
+            const status_res = await status_account();
+            expect(status_res.response.reply.name).toBe(name);
+            expect(status_res.response.reply.email).toBe(name);
+            expect(status_res.response.reply.nsfs_account_config.uid).toBe(uid);
+            expect(status_res.response.reply.nsfs_account_config.gid).toBe(gid);
+            expect(status_res.response.reply.nsfs_account_config.new_buckets_path).toBe(new_buckets_path);
+        });
+
+        it('should fail | cli account status show secret ', async () => {
+            try {
+                await status_account(true);
+                fail('should have failed with InvalidMasterKey');
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('cli account delete', async () => {
+            const delete_res = await delete_account_flow();
+            expect(delete_res.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
+        });
+    });
+
+    describe('cli account mkm integrations - active master key is corrupted', () => {
+
+        beforeEach(async () => {
+            await setup_nc_system_and_first_account();
+            // corrupt active master key in master key json file
+            const master_keys_json_path = `${config_root}/master_keys.json`;
+            const master_keys_data = await fs.promises.readFile(master_keys_json_path);
+            const master_keys_json = JSON.parse(master_keys_data.toString());
+            master_keys_json.active_master_key = 'bla';
+            await fs_utils.file_delete(master_keys_json_path);
+            await fs.promises.writeFile(master_keys_json_path, JSON.stringify(master_keys_json));
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('should fail | cli create account', async () => {
+            try {
+                await create_account({ ...defaults, name: 'account_corrupted_mk' });
+                fail('should have failed with InvalidMasterKey');
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('should fail | cli update account', async () => {
+            try {
+                await update_account();
+                fail('should have failed with InvalidMasterKey');
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('cli account list', async () => {
+            const { name } = defaults;
+            const list_res = await list_account_flow();
+            expect(list_res.response.reply[0].name).toBe(name);
+        });
+
+        it('cli account status', async () => {
+            const { name, uid, gid, new_buckets_path } = defaults;
+            const status_res = await status_account();
+            expect(status_res.response.reply.name).toBe(name);
+            expect(status_res.response.reply.email).toBe(name);
+            expect(status_res.response.reply.nsfs_account_config.uid).toBe(uid);
+            expect(status_res.response.reply.nsfs_account_config.gid).toBe(gid);
+            expect(status_res.response.reply.nsfs_account_config.new_buckets_path).toBe(new_buckets_path);
+        });
+
+        it('should fail | cli account status show secret ', async () => {
+            try {
+                await status_account(true);
+                fail('should have failed with InvalidMasterKey');
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('cli account delete', async () => {
+            const delete_res = await delete_account_flow();
+            expect(delete_res.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
+        });
+    });
+    describe('cli account mkm integrations - master_keys_by_id is corrupted', () => {
+
+        beforeEach(async () => {
+            await setup_nc_system_and_first_account();
+            // corrupt master_keys_by_id in master key json file
+            const master_keys_json_path = `${config_root}/master_keys.json`;
+            const master_keys_data = await fs.promises.readFile(master_keys_json_path);
+            const master_keys_json = JSON.parse(master_keys_data.toString());
+            master_keys_json.master_keys_by_id = undefined;
+            await fs_utils.file_delete(master_keys_json_path);
+            await fs.promises.writeFile(master_keys_json_path, JSON.stringify(master_keys_json));
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('should fail | cli create account', async () => {
+            try {
+                await create_account({ ...defaults, name: 'account_corrupted_mk' });
+                fail('should have failed with InvalidMasterKey');
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('should fail | cli update account', async () => {
+            try {
+                await update_account();
+                fail('should have failed with InvalidMasterKey');
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('cli account list', async () => {
+            const { name } = defaults;
+            const list_res = await list_account_flow();
+            expect(list_res.response.reply[0].name).toBe(name);
+        });
+
+        it('cli account status', async () => {
+            const { name, uid, gid, new_buckets_path } = defaults;
+            const status_res = await status_account();
+            expect(status_res.response.reply.name).toBe(name);
+            expect(status_res.response.reply.email).toBe(name);
+            expect(status_res.response.reply.nsfs_account_config.uid).toBe(uid);
+            expect(status_res.response.reply.nsfs_account_config.gid).toBe(gid);
+            expect(status_res.response.reply.nsfs_account_config.new_buckets_path).toBe(new_buckets_path);
+        });
+
+        it('should fail | cli account status show secret ', async () => {
+            try {
+                await status_account(true);
+                fail('should have failed with InvalidMasterKey');
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('cli account delete', async () => {
+            const delete_res = await delete_account_flow();
+            expect(delete_res.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
+        });
+    });
+});
+
+async function create_account(account_options) {
+    const action = ACTIONS.ADD;
+    const { type, name, new_buckets_path, uid, gid } = account_options;
+    const account_cmd_options = { config_root, name, new_buckets_path, uid, gid };
+    const res = await exec_manage_cli(type, action, account_cmd_options);
+    const parsed_res = JSON.parse(res);
+    return parsed_res;
+}
+
+async function update_account() {
+    const action = ACTIONS.UPDATE;
+    const { type, name, new_buckets_path } = defaults;
+    const new_uid = '1111';
+    const account_options = { config_root, name, new_buckets_path, uid: new_uid };
+    const res = await exec_manage_cli(type, action, account_options);
+    const parsed_res = JSON.parse(res);
+    return parsed_res;
+}
+
+async function status_account(show_secrets) {
+    const action = ACTIONS.STATUS;
+    const { type, name } = defaults;
+    const account_options = { config_root, name, show_secrets };
+    const res = await exec_manage_cli(type, action, account_options);
+    const parsed_res = JSON.parse(res);
+    return parsed_res;
+}
+
+async function list_account_flow() {
+    const action = ACTIONS.LIST;
+    const { type } = defaults;
+    const account_options = { config_root };
+    const res = await exec_manage_cli(type, action, account_options);
+    const parsed_res = JSON.parse(res);
+    return parsed_res;
+}
+
+async function delete_account_flow() {
+    const action = ACTIONS.DELETE;
+    const { type, name } = defaults;
+    const account_options = { config_root, name };
+    const res = await exec_manage_cli(type, action, account_options);
+    const parsed_res = JSON.parse(res);
+    return parsed_res;
+}
+
+// Jest has builtin function fail that based on Jasmine
+// in case Jasmine would get removed from jest, created this one
+// based on this: https://stackoverflow.com/a/55526098/16571658
+function fail(reason) {
+    throw new Error(reason);
+}
+
+async function setup_nc_system_and_first_account() {
+    await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
+        fs_utils.create_fresh_path(`${config_root}/${dir}`)));
+    await fs_utils.create_fresh_path(root_path);
+    set_nc_config_dir_in_config(config_root);
+    const action = ACTIONS.ADD;
+    const { type, name, new_buckets_path, uid, gid } = defaults;
+    const account_options = { config_root, name, new_buckets_path, uid, gid };
+    await fs_utils.create_fresh_path(new_buckets_path);
+    await fs_utils.file_must_exist(new_buckets_path);
+    await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
+    await exec_manage_cli(type, action, account_options);
+}

--- a/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
@@ -71,8 +71,8 @@ describe('NC master key manager tests - file store type', () => {
             await new_nc_mkm_instance.init();
             fail('should have failed on invalid master_keys.json file');
         } catch (err) {
-            expect(err.rpc_code).toEqual('INVALID_MASTER_KEYS_FILE');
-            expect(err.message).toEqual('Invalid master_keys.json file');
+            expect(err.rpc_code).toEqual('INVALID_MASTER_KEY');
+            expect(err.message).toEqual('Invalid master_keys.json');
         }
     });
 
@@ -82,10 +82,24 @@ describe('NC master key manager tests - file store type', () => {
         const new_nc_mkm_instance = nc_mkm.get_instance();
         try {
             await new_nc_mkm_instance.init();
+            fail('should have failed on invalid master_keys.json');
+        } catch (err) {
+            expect(err.rpc_code).toEqual('INVALID_MASTER_KEY');
+            expect(err.message).toEqual('Invalid master_keys.json');
+        }
+    });
+
+    it('should fail - init nc_mkm - empty master_keys.json', async () => {
+        await fs.promises.rm(MASTER_KEYS_JSON_PATH);
+        await fs.promises.writeFile(MASTER_KEYS_JSON_PATH, JSON.stringify({}));
+
+        const new_nc_mkm_instance = nc_mkm.get_instance();
+        try {
+            await new_nc_mkm_instance.init();
             fail('should have failed on invalid master_keys.json file');
         } catch (err) {
-            expect(err.rpc_code).toEqual('INVALID_MASTER_KEYS_FILE');
-            expect(err.message).toEqual('Invalid master_keys.json file');
+            expect(err.rpc_code).toEqual('INVALID_MASTER_KEY');
+            expect(err.message).toEqual('Invalid master_keys.json');
         }
     });
 });


### PR DESCRIPTION
### Explain the changes
1. **manage_nsfs.js -** 
- Account Delete - skipped the decryption in this case as we might want to delete accounts even if master key has issues.
- Account status --show_secrets / Account update - 

2. **manage_nsfs_cli_errors.js -** Created a new CLI error InvalidMasterKey and added a mapping between RPC INVALID_MASTER_KEY to InvalidMasterKey.

3. **nc_master_key_manager.js -** threw INVALID_MASTER_KEY and changed the error messages to be more accurate.

4. **test_nc_account_invalid_mkm_intergration.test.js -** added integration tests for scenarios of CLI account functions and missing/corrupted master key file.

5. **test_nc_master_keys.test.js** - updated errors on tests and added a new empty file case.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #8083
2. Fixed #8084 

### Testing Instructions:
1. Automatic -
```
sudo jest --testRegex=jest_tests/test_nc_master_keys.test.js
sudo jest --testRegex=jest_tests/test_nc_account_invalid_mkm
```
Manual - 
There are many scenarios for testing it - 
1. `sudo node src/cmd/manage_nsfs account add --name=account1 --allow_bucket_creation=true --uid=0 --gid=0  --new_buckets_path=/tmp/new_buckets_path1/`
2. delete or corrupt /etc/noobaa.conf.d/master_keys.json
3. Run `sudo node src/cmd/manage_nsfs account update --name account1 --uid=1111` and expect the following error instead of an internal error - 
```
{
  "error": {
    "code": "InvalidMasterKey",
    "message": "Master key manager had issues loading master key, can not decrypt/encrypt secrets.",
    "detail": "Error: master key id is missing in master_keys_by_id\n    at NCMasterKeysManager._validate_master_key_manager (noobaa-core/src/manage_nsfs/nc_master_key_manager.js:347:59)\n    at NCMasterKeysManager.decryptSync (noobaa-core/src/manage_nsfs/nc_master_key_manager.js:305:14)\n    at NCMasterKeysManager.decrypt (noobaa-core/src/manage_nsfs/nc_master_key_manager.js:295:21)\n    at asyncnoobaa-core/src/manage_nsfs/nc_master_key_manager.js:335:29\n    at async Promise.all (index 0)\n    at async NCMasterKeysManager.decrypt_access_keys (noobaa-core/src/manage_nsfs/nc_master_key_manager.js:333:39)\n    at async fetch_existing_account_data (noobaa-core/src/cmd/manage_nsfs.js:376:54)\n    at async fetch_account_data (noobaa-core/src/cmd/manage_nsfs.js:341:16)\n    at async account_management (noobaa-core/src/cmd/manage_nsfs.js:291:18)\n    at async main (noobaa-core/src/cmd/manage_nsfs.js:91:13)"
  }
}
```
4. `sudo node src/cmd/manage_nsfs account status --name account1 --show_secrets` and expect the same error as in the previous bullet.
5. `sudo node src/cmd/manage_nsfs account delete --name account1` - should expect a successful response and account be deleted from `/etc/noobaa.conf.d/accounts/` and from `/etc/noobaa.conf.d/access_keys`-
```
{
  "response": {
    "code": "AccountDeleted"
  }
}
```
- [ ] Doc added/updated
- [x] Tests added
