### PR TITLE
[Backport Into 5.16] bucket logging: Change logrotate configuration from daily to hourly

### DIFF
--- a/src/deploy/NVA_build/logrotate_noobaa.conf
+++ b/src/deploy/NVA_build/logrotate_noobaa.conf
@@ -30,8 +30,9 @@
 
 /var/log/bucket_logs.log
 {
-        daily
-        size 100k
+        hourly
+        minsize 10
+        maxsize 50k
         start 1
         missingok
         rotate 100


### PR DESCRIPTION
### Explain the changes
Changing conf to rotate the log file every hour if it meets minimum size criteria.

hourly
minsize 10
maxsize 50k

It means that for every hour (01:00 AM, 02:00 AM and so on) when logrotate is called, it will see if the size of the log is atleast 10 bytes or not. If it is, it will rotate the logs.

maxsize makes sure that if the log size is 50k or more than as soon as logrotate is executed this log will be rotated. Even if it happens every minute or 5 minutes or so.

Signed-off-by: Ashish Pandey <aspandey@redhat.com>
(cherry picked from commit 864f9f073854e1b7f576fd5dd563481da43a13ca)
