### PR TITLE
NC | set noobaa as endpoint process title

### DIFF
--- a/config.js
+++ b/config.js
@@ -833,6 +833,7 @@ config.ANONYMOUS_ACCOUNT_NAME = 'anonymous';
 // NSFS NON CONTAINERIZED //
 ////////////////////////////
 
+config.ENDPOINT_PROCESS_TITLE = 'noobaa';
 config.NC_RELOAD_CONFIG_INTERVAL = 10 * 1000;
 config.NSFS_NC_CONF_DIR_REDIRECT_FILE = 'config_dir_redirect';
 config.NSFS_NC_DEFAULT_CONF_DIR = '/etc/noobaa.conf.d';

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -459,6 +459,21 @@ Example:
 ```
 
 
+## 23. Set Endpoint process title -
+**Description -** This flag will set noobaa process title for letting GPFS to identify the noobaa endpoint processes. see issue #8039.
+
+**Configuration Key -** ENDPOINT_PROCESS_TITLE
+
+**Type -** string
+
+**Default -**  'noobaa'
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"ENDPOINT_PROCESS_TITLE": 'noobaa_60'
+3. systemctl restart noobaa_nsfs
 ## Config.json example 
 ```
 > cat /path/to/config_dir/config.json

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -92,6 +92,11 @@ dbg.log0('endpoint: replacing old umask: ', old_umask.toString(8), 'with new uma
 /* eslint-disable max-statements */
 async function main(options = {}) {
     try {
+        // setting process title needed for letting GPFS to identify the noobaa endpoint processes see issue #8039.
+        if (config.ENDPOINT_PROCESS_TITLE) {
+            process.title = config.ENDPOINT_PROCESS_TITLE;
+        }
+
         // the primary just forks and returns, workers will continue to serve
         fork_count = options.forks ?? config.ENDPOINT_FORKS;
         const metrics_port = options.metrics_port || config.EP_METRICS_SERVER_PORT;

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -121,6 +121,10 @@ const nsfs_node_config_schema = {
         NC_DISABLE_ACCESS_CHECK: {
             type: 'boolean',
             doc: 'indicate whether read/write access will be validated on bucket/account creation/update.'
+        },
+        ENDPOINT_PROCESS_TITLE: {
+            type: 'string',
+            doc: 'This flag will set noobaa process title for letting GPFS to identify the noobaa endpoint processes.'
         }
     }
 };

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -228,6 +228,29 @@ describe('schema validation NC NSFS config', () => {
             nsfs_schema_utils.validate_nsfs_config_schema(config_data);
         });
 
+        it('nsfs_config invalid process title', () => {
+            const config_data = {
+                "ENDPOINT_PROCESS_TITLE": false,
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+                'ENDPOINT_PROCESS_TITLE must be string';
+            const message = `must be string | {"type":"string"} | "/ENDPOINT_PROCESS_TITLE"`;
+            assert_validation(config_data, reason, message);
+        });
+
+        it('nsfs_config valid process title', () => {
+            const config_data = {
+                "ENDPOINT_PROCESS_TITLE": 'noobaa_60',
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('nsfs_config valid and empty process title', () => {
+            const config_data = {
+                "ENDPOINT_PROCESS_TITLE": '',
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
     });
 
     describe('skip/unskip schema check by config test', () => {


### PR DESCRIPTION
### Explain the changes
1. setting process title needed for letting GPFS to identify the noobaa endpoint processes see issue #8039.


### Issues: Fixed #xxx / Gap #xxx
1. Fixed #8049

### Testing Instructions:
Manual Testing - 
1. Tab 1 - Run `sudo node src/cmd/nsfs.js --debug=5`  
2. Tab 2 - Run `ps -e | grep noobaa` and expect 1 result.
3. Try setting ENDPOINT_FORKS = 3 in config.json and expect 4 results of step 2.
```
% ps -e | grep noobaa
14536 ttys000    0:03.04 noobaa
14539 ttys000    0:03.28 noobaa
14540 ttys000    0:03.43 noobaa
14541 ttys000    0:03.31 noobaa
14563 ttys005    0:00.00 grep --color=auto noobaa
```

- [ ] Doc added/updated
- [ ] Tests added
