### PR TITLE
Update stale actions with exempt rules

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,8 +18,12 @@ jobs:
       pull-requests: write
 
     steps:
+    # Handle non exempted issues
     - uses: actions/stale@v5
       with:
+        exempt-issue-labels: 'Type:Enhancement, Type:Question, Type:Technical Debt'
+        exempt-all-milestones: true
+
         days-before-stale: 90
         days-before-pr-stale: 90
         days-before-issue-stale: 90
@@ -30,4 +34,17 @@ jobs:
         days-before-pr-close: 30
         days-before-issue-close: 30
         close-pr-message: 'This PR is stale and had no activity for too long - it will now be closed.'
+        close-issue-message: 'This issue is stale and had no activity for too long - it will now be closed.'
+
+  # Handle exempted issues
+    - uses: actions/stale@v5
+      with:
+
+        days-before-stale: 180        
+        days-before-issue-stale: 180
+        stale-issue-message: 'This issue had no activity for too long - it will now be labeled stale. Update it to prevent it from getting closed.'
+
+        days-before-close: 30
+        days-before-pr-close: 30
+        days-before-issue-close: 30
         close-issue-message: 'This issue is stale and had no activity for too long - it will now be closed.'


### PR DESCRIPTION
### Explain the changes
1. Add a 2nd more lenient threshold for getting issues and PRs to a stale state (from stale to close does not change)
2. Add exempt rules to our stale action
  2.1 Special Labels (Question, Feature Technical Debt) will not be handled by the regular threshold.
  2.2 Issues and PRs with Milestones attached will not be handled by the regular threshold.



- [ ] Doc added/updated
- [ ] Tests added
