### PR TITLE
fix default repos for centos8

### DIFF
--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -1,5 +1,7 @@
 ARG CENTOS_VER=9
 FROM quay.io/centos/centos:stream${CENTOS_VER}
+#Needs to reapply ARG, it was cleaned by FROM command.
+ARG CENTOS_VER
 LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 
 ##############################################################
@@ -10,6 +12,10 @@ LABEL maintainer="Liran Mauda (lmauda@redhat.com)"
 ##############################################################
 # RUN dnf --enablerepo=PowerTools install -y -q nasm && \
 #     dnf clean all
+
+COPY ./src/deploy/NVA_build/fix_centos8_repo.sh ./src/deploy/NVA_build/
+#default repos for centos8 are outdated, this will point to new repos
+RUN CENTOS_VER=${CENTOS_VER} ./src/deploy/NVA_build/fix_centos8_repo.sh
 RUN dnf update -y -q --nobest && \
     dnf clean all
 COPY ./src/deploy/NVA_build/install_arrow_build.sh ./src/deploy/NVA_build/install_arrow_build.sh

--- a/src/deploy/NVA_build/fix_centos8_repo.sh
+++ b/src/deploy/NVA_build/fix_centos8_repo.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ "$CENTOS_VER" == "8" ]; then
+	sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+	sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi


### PR DESCRIPTION
### Explain the changes
Centos8 reached EOL.
Its official repositories have closed, there are backups we can use, so the repo url need to change manually.

### Issues: Fixed #xxx / Gap #xxx
Build fails for centos8.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
