### PR TITLE
NC | Pass noobaa args to GPFS on initialization

### DIFF
--- a/config.js
+++ b/config.js
@@ -869,6 +869,10 @@ config.MASTER_KEYS_EXEC_MAX_RETRIES = 3;
 config.NC_DISABLE_ACCESS_CHECK = false;
 config.NC_DISABLE_SCHEMA_CHECK = false;
 
+////////// GPFS //////////
+config.GPFS_DOWN_DELAY = 1000;
+
+
 //Quota
 config.QUOTA_LOW_THRESHOLD = 80;
 config.QUOTA_MAX_OBJECTS = Number.MAX_SAFE_INTEGER;
@@ -1063,7 +1067,8 @@ function load_nsfs_nc_config() {
         const merged_config = _.merge(shared_config, node_config || {});
 
         Object.keys(merged_config).forEach(function(key) {
-            if (key === 'NOOBAA_LOG_LEVEL' || key === 'UV_THREADPOOL_SIZE' || key === 'GPFS_DL_PATH') {
+            const config_to_env = ['NOOBAA_LOG_LEVEL', 'UV_THREADPOOL_SIZE', 'GPFS_DL_PATH'];
+            if (config_to_env.includes(key)) {
                 process.env[key] = merged_config[key];
                 return;
             }

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -476,6 +476,25 @@ Example:
 3. systemctl restart noobaa_nsfs
 ## Config.json example 
 ```
+
+## 24. GPFS down delay -
+**Description -** Set delay (ms) of GPFS syscalls when daemon is down, to hold client replies during failover, service restart required.
+
+**Configuration Key -** GPFS_DOWN_DELAY
+
+**Type -** number
+
+**Default -** 1000
+
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"GPFS_DOWN_DELAY": "60000"
+3. systemctl restart noobaa
+```
+
 > cat /path/to/config_dir/config.json
 {
     "ENDPOINT_PORT": 80,

--- a/src/native/common.gypi
+++ b/src/native/common.gypi
@@ -36,7 +36,7 @@
                     '-std=gnu99', # c99 -> gnu99 to allow asm()
                 ],
                 'cflags_cc': [
-                    '-std=c++17'
+                    '-std=c++20'
                 ],
                 'ldflags': [
                     '-lrt', # librt
@@ -65,7 +65,7 @@
                     # Reference - http://help.apple.com/xcode/mac/8.0/#/itcaec37c2a6
                     'MACOSX_DEPLOYMENT_TARGET': '12.4',
                     'CLANG_CXX_LIBRARY': 'libc++',
-                    'CLANG_CXX_LANGUAGE_STANDARD': 'c++17', # -std=c++17
+                    'CLANG_CXX_LANGUAGE_STANDARD': 'c++20', # -std=c++20
                     'GCC_C_LANGUAGE_STANDARD': 'c99', # -std=c99
                     'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                 },

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -158,6 +158,7 @@ DBG_INIT(0);
 typedef std::map<std::string, std::string> XattrMap;
 
 const char* gpfs_dl_path = std::getenv("GPFS_DL_PATH");
+
 int gpfs_lib_file_exists = -1;
 
 static int (*dlsym_gpfs_fcntl)(gpfs_file_t file, void* arg) = 0;
@@ -170,6 +171,17 @@ static int (*dlsym_gpfs_linkatif)(
 
 static int (*dlsym_gpfs_unlinkat)(
     gpfs_file_t fileDesc, const char* path, gpfs_file_t fd) = 0;
+
+static int (*dlsym_gpfs_ganesha)(
+    int op, void *oarg) = 0;
+
+struct gpfs_ganesha_noobaa_arg
+{
+    int noobaa_version;
+    int noobaa_delay;
+    int noobaa_flags;
+};
+#define OPENHANDLE_REGISTER_NOOBAA 157
 
 static const int DIO_BUFFER_MEMALIGN = 4096;
 
@@ -2116,6 +2128,30 @@ set_debug_level(const Napi::CallbackInfo& info)
 }
 
 /**
+ * register noobaa args to GPFS
+ */
+static Napi::Value
+register_gpfs_noobaa(const Napi::CallbackInfo& info)
+{
+    Napi::Object params = info[0].As<Napi::Object>();
+    struct gpfs_ganesha_noobaa_arg args = {
+        .noobaa_version = params.Get("version").ToNumber(),
+        .noobaa_delay = params.Get("delay").ToNumber(),
+        .noobaa_flags = params.Get("flags").ToNumber(),
+    };
+    LOG("FS::GPFS gpfs_ganesha_noobaa_arg=" << DVAL(args.noobaa_version) << DVAL(args.noobaa_delay) << DVAL(args.noobaa_flags));
+
+    if (dlsym_gpfs_ganesha(OPENHANDLE_REGISTER_NOOBAA, &args)) {
+        if (errno == EOPNOTSUPP) {
+            LOG("Warning: register with libgpfs gpfs_ganesha returned EOPNOTSUPP" );
+        } else {
+            PANIC("Error: register with libgpfs gpfs_ganesha failed");
+        }
+    }
+    return info.Env().Undefined();
+}
+
+/**
  * Allocate memory aligned buffer for direct IO.
  */
 static Napi::Value
@@ -2163,15 +2199,18 @@ fs_napi(Napi::Env env, Napi::Object exports)
                 PANIC("Error: %s\n"
                     << uv_dlerror(lib));
             }
+            if (uv_dlsym(lib, "gpfs_ganesha", (void**)&dlsym_gpfs_ganesha)) {
+                PANIC("Error: %s\n"
+                    << uv_dlerror(lib));
+            }
             if (sizeof(struct gpfsRequest_t) != 256) {
                 PANIC("The gpfs get extended attributes is of wrong size" << sizeof(struct gpfsRequest_t));
             }
+            
             auto gpfs = Napi::Object::New(env);
-            // for now we export an (empty) object, which can be checked to indicate that
+            gpfs["register_gpfs_noobaa"] = Napi::Function::New(env, register_gpfs_noobaa);
+            // we export the gpfs object, which can be checked to indicate that
             // gpfs lib was loaded and its api's can be used.
-            // e.g: gpfs["version"] = Napi::String::New(env,  gpfs_get_version());
-            // e.g: gpfs["foo"] = Napi::Function::New(env, api<Foo>);
-            // gpfs.Freeze();
             exports_fs["gpfs"] = gpfs;
         }
     } else {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -981,7 +981,9 @@ interface NativeFS {
     O_DIRECT?: number;
     O_TMPFILE?: number;
 
-    gpfs?: object;
+    gpfs?: {
+        register_gpfs_noobaa(gpfs_noobaa_args: GPFSNooBaaArgs);
+    };
 }
 
 interface NativeFile {
@@ -1013,6 +1015,12 @@ interface NativeFSContext {
     report_fs_stats?: Function;
     disable_ctime_check?: boolean;
 }
+
+type GPFSNooBaaArgs = {
+    version: number;
+    delay: number;
+    flags: number;
+};
 
 type NativeFSXattr = { [key: string]: string };
 type NativeFSStats = fs.Stats & {

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -46,6 +46,10 @@ const nsfs_node_config_schema = {
             type: 'string',
             doc: 'indicates the location of the gpfs library file, service restart required, usually should be set to /usr/lib64/libgpfs.so'
         },
+        GPFS_DOWN_DELAY: {
+            type: 'number',
+            doc: 'delay (ms) of GPFS syscalls when daemon is down, to hold client replies during failover, service restart required'
+        },
         NSFS_NC_STORAGE_BACKEND: {
             $ref: 'common_api#/definitions/fs_backend',
             doc: 'indicates the global storage backend type, service restart required'

--- a/src/util/fork_utils.js
+++ b/src/util/fork_utils.js
@@ -134,3 +134,4 @@ function _set_op_stats(op_name, stats) {
 }
 
 exports.start_workers = start_workers;
+exports.cluster = cluster;


### PR DESCRIPTION
### Explain the changes
1. Added a new function called register_gpfs_noobaa() that calls gpfs_ganesha(157, noobaa_args) function (a gpfs function) in order to register NooBaa process and pass the following args -  
{ int noobaa_version, int noobaa_delay, int noobaa_flags }, currently version and flags are set to 0, delay is configurable by a new configuration called GPFS_DOWN_DELAY.
noobaa_delay = delay (ms) of GPFS syscalls when daemon is down, to hold client replies during failover.
2. nsfs.js calls register_gpfs_noobaa() from verify_gpfs_lib() fucntion from the primary noobaa process.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #8049 

### Testing Instructions:
1. Install NooBaa RPM 
2. Start noobaa service
3. Start io and check the calling processes and threads (in GPFS) called NooBaa.
4. Change the delay by editing GPFS_DOWN_DELAY=60000 in config.json.
5. Restart the service
6. Check the updated delay.


- [ ] Doc added/updated
- [ ] Tests added
