### PR TITLE
NC | CLI | trimmed output fix

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -79,7 +79,11 @@ async function main(argv = minimist(process.argv.slice(2))) {
         const user_input = user_input_from_file || argv;
         config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
         if (!config_root) throw_cli_error(ManageCLIError.MissingConfigDirPath);
-        if (argv.config_root) config.NSFS_NC_CONF_DIR = String(argv.config_root);
+        if (argv.config_root) {
+            config.NSFS_NC_CONF_DIR = String(argv.config_root);
+            config.load_nsfs_nc_config();
+            config.reload_nsfs_nc_config();
+        }
 
         accounts_dir_path = path.join(config_root, accounts_dir_name);
         access_keys_dir_path = path.join(config_root, access_keys_dir_name);
@@ -102,10 +106,13 @@ async function main(argv = minimist(process.argv.slice(2))) {
     } catch (err) {
         dbg.log1('NSFS Manage command: exit on error', err.stack || err);
         const manage_err = ((err instanceof ManageCLIError) && err) ||
-            new ManageCLIError(ManageCLIError.FS_ERRORS_TO_MANAGE[err.code] ||
+            new ManageCLIError({
+                ...(ManageCLIError.FS_ERRORS_TO_MANAGE[err.code] ||
                 ManageCLIError.RPC_ERROR_TO_MANAGE[err.rpc_code] ||
-                ManageCLIError.InternalError);
-        throw_cli_error(manage_err, err.stack || err);
+                ManageCLIError.InternalError), cause: err });
+        process.stdout.write(manage_err.to_string() + '\n', () => {
+            process.exit(1);
+        });
     }
 }
 
@@ -256,7 +263,8 @@ async function delete_bucket(data, force) {
         if (object_entries.length === 0 || force) {
             await native_fs_utils.folder_delete(bucket_temp_dir_path, fs_context_fs_backend, true);
             await native_fs_utils.delete_config_file(fs_context_config_root_backend, buckets_dir_path, bucket_config_path);
-            write_stdout_response(ManageCLIResponse.BucketDeleted, '', {bucket: data.name});
+            write_stdout_response(ManageCLIResponse.BucketDeleted, '', { bucket: data.name });
+            return;
         }
         throw_cli_error(ManageCLIError.BucketDeleteForbiddenHasObjects, data.name);
     } catch (err) {

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -8,6 +8,8 @@ const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEve
  *      code?: string, 
  *      message: string, 
  *      http_code: number,
+ *      detail: string,
+ *      cause?: Error  
  * }} ManageCLIErrorSpec
  */
 
@@ -16,18 +18,20 @@ class ManageCLIError extends Error {
     /**
      * @param {ManageCLIErrorSpec} error_spec 
      */
-    constructor({ code, message, http_code }) {
-        super(message); // sets this.message
+    constructor({ code, message, http_code, detail, cause }) {
+        super(message, { cause });
         this.code = code;
         this.http_code = http_code;
+        this.detail = detail;
     }
 
-    to_string(detail) {
+    to_string() {
         const json = {
             error: {
                 code: this.code,
                 message: this.message,
-                detail: detail
+                detail: this.detail,
+                cause: this.cause?.stack || this.cause?.message
             }
         };
         return JSON.stringify(json, null, 2);

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -12,14 +12,13 @@ const NSFS_CLI_SUCCESS_EVENT_MAP = require('../manage_nsfs/manage_nsfs_cli_respo
 const { BOOLEAN_STRING_VALUES } = require('../manage_nsfs/manage_nsfs_constants');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 
-function throw_cli_error(error_code, detail, event_arg) {
-    const error_event = NSFS_CLI_ERROR_EVENT_MAP[error_code.code];
+function throw_cli_error(error, detail, event_arg) {
+    const error_event = NSFS_CLI_ERROR_EVENT_MAP[error.code];
     if (error_event) {
         new NoobaaEvent(error_event).create_event(undefined, event_arg, undefined);
     }
-    const err = new ManageCLIError(error_code).to_string(detail);
-    process.stdout.write(err + '\n');
-    process.exit(1);
+    const err = new ManageCLIError({ ...error, detail });
+    throw err;
 }
 
 function write_stdout_response(response_code, detail, event_arg) {
@@ -28,8 +27,9 @@ function write_stdout_response(response_code, detail, event_arg) {
         new NoobaaEvent(response_event).create_event(undefined, event_arg, undefined);
     }
     const res = new ManageCLIResponse(response_code).to_string(detail);
-    process.stdout.write(res + '\n');
-    process.exit(0);
+    process.stdout.write(res + '\n', () => {
+        process.exit(0);
+    });
 }
 
 function get_config_file_path(config_type_path, file_name) {


### PR DESCRIPTION
### Explain the changes
1. A follow up to https://github.com/noobaa/noobaa-core/pull/7898, doing the same changes but for noobaa_cli.
2. Had to move the stdout write on error to the catch scope of main() in manage_nsfs due to https://github.com/noobaa/noobaa-core/issues/7894.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #8111 
2. We should consider making the same changes of bullet 2 for success flow (write_stdout_output).

### Testing Instructions:
1. `env LC_ALL=C /usr/local/bin/noobaa-cli bucket 2>/dev/null list --wide`


- [ ] Doc added/updated
- [ ] Tests added
