### PR TITLE
Utilize the correct certificates for the STS HTTPS server

### DIFF
--- a/config.js
+++ b/config.js
@@ -64,6 +64,14 @@ config.BUFFERS_MEM_LIMIT = Math.min(
     Math.max(Math.floor(config.CONTAINER_MEM_LIMIT / 4), config.BUFFERS_MEM_LIMIT_MIN,)
 );
 
+////////////////////////
+// CERTIFICATE CONFIG //
+////////////////////////
+
+config.STS_SERVICE_CERT_PATH = process.env.STS_SERVICE_CERT_PATH || '/etc/sts-secret';
+config.S3_SERVICE_CERT_PATH = process.env.S3_SERVICE_CERT_PATH || '/etc/s3-secret';
+config.MGMT_SERVICE_CERT_PATH = process.env.MGMT_SERVICE_CERT_PATH || '/etc/mgmt-secret';
+config.EXTERNAL_DB_SERVICE_CERT_PATH = process.env.EXTERNAL_DB_CERT_PATH || '/etc/external-db-secret';
 
 //////////////////
 // NODES CONFIG //

--- a/config.js
+++ b/config.js
@@ -68,10 +68,10 @@ config.BUFFERS_MEM_LIMIT = Math.min(
 // CERTIFICATE CONFIG //
 ////////////////////////
 
-config.STS_SERVICE_CERT_PATH = process.env.STS_SERVICE_CERT_PATH || '/etc/sts-secret';
-config.S3_SERVICE_CERT_PATH = process.env.S3_SERVICE_CERT_PATH || '/etc/s3-secret';
-config.MGMT_SERVICE_CERT_PATH = process.env.MGMT_SERVICE_CERT_PATH || '/etc/mgmt-secret';
-config.EXTERNAL_DB_SERVICE_CERT_PATH = process.env.EXTERNAL_DB_CERT_PATH || '/etc/external-db-secret';
+config.STS_SERVICE_CERT_PATH = '/etc/sts-secret';
+config.S3_SERVICE_CERT_PATH = '/etc/s3-secret';
+config.MGMT_SERVICE_CERT_PATH = '/etc/mgmt-secret';
+config.EXTERNAL_DB_SERVICE_CERT_PATH = '/etc/external-db-secret';
 
 //////////////////
 // NODES CONFIG //

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -205,6 +205,8 @@ async function main(options = {}) {
         if (https_port_iam > 0) {
             dbg.log0('Starting IAM HTTPS', https_port_iam);
             const endpoint_request_handler_iam = create_endpoint_handler_iam(init_request_sdk);
+            // NOTE: The IAM server currently uses the S3 server's certificate. This *will* cause route failures in Openshift.
+            // TODO: Generate, mount and utilize an appropriate IAM certificate once the service and route are implemented
             const https_server_iam = create_https_server(ssl_cert_info, true, endpoint_request_handler_iam);
             await listen_http(https_port_iam, https_server_iam);
             dbg.log0('Started IAM HTTPS successfully');

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -205,7 +205,7 @@ async function main(options = {}) {
         if (https_port_iam > 0) {
             dbg.log0('Starting IAM HTTPS', https_port_iam);
             const endpoint_request_handler_iam = create_endpoint_handler_iam(init_request_sdk);
-            const https_server_iam = https.createServer(s3_ssl_options, endpoint_request_handler_iam);
+            const https_server_iam = create_https_server(ssl_cert_info, true, endpoint_request_handler_iam);
             await listen_http(https_port_iam, https_server_iam);
             dbg.log0('Started IAM HTTPS successfully');
         }

--- a/src/util/ssl_utils.js
+++ b/src/util/ssl_utils.js
@@ -44,6 +44,7 @@ const certs = {
     MGMT: new CertInfo('/etc/mgmt-secret'),
     S3: new CertInfo('/etc/s3-secret'),
     EXTERNAL_DB: new CertInfo('/etc/external-db-secret'),
+    STS: new CertInfo('/etc/sts-secret'),
 };
 
 function generate_ssl_certificate() {

--- a/src/util/ssl_utils.js
+++ b/src/util/ssl_utils.js
@@ -1,6 +1,7 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const config = require('../../config');
 const fs = require('fs');
 const tls = require('tls');
 const path = require('path');
@@ -41,10 +42,10 @@ class CertInfo extends EventEmitter {
 }
 
 const certs = {
-    MGMT: new CertInfo('/etc/mgmt-secret'),
-    S3: new CertInfo('/etc/s3-secret'),
-    EXTERNAL_DB: new CertInfo('/etc/external-db-secret'),
-    STS: new CertInfo('/etc/sts-secret'),
+    MGMT: new CertInfo(config.MGMT_SERVICE_CERT_PATH),
+    S3: new CertInfo(config.S3_SERVICE_CERT_PATH),
+    EXTERNAL_DB: new CertInfo(config.EXTERNAL_DB_SERVICE_CERT_PATH),
+    STS: new CertInfo(config.STS_SERVICE_CERT_PATH),
 };
 
 function generate_ssl_certificate() {


### PR DESCRIPTION
### Explain the changes
Up until now, the STS HTTPS server reused the certificate that was generated for the S3 service. This has led to a problem with Openshift's internal HAProxy not letting requests through since it was set to `verifyhost` - which subsequently failed since the requests contained the cert for `s3.` instead of `sts.` This PR modifies the code to use the appropriate STS service cert for STS.

The PR also adds support for the user to provide a custom cert path via env vars,

This PR is the other half of https://github.com/noobaa/noobaa-operator/pull/1370

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2009627

### Testing Instructions:
1. Deploy NooBaa over Openshift
2. Try to use the STS route (not the service) for STS actions
3. Make sure they work

- [ ] Doc added/updated
- [ ] Tests added
