### PR TITLE
NC | Revert url encode/decode of xattr values

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -64,7 +64,7 @@ function get_request_xattr(req) {
         if (!hdr.startsWith(X_AMZ_META)) return;
         const key = hdr.slice(X_AMZ_META.length);
         if (!key) return;
-        xattr[key] = decodeURIComponent(val);
+        xattr[key] = val;
     });
     return xattr;
 }
@@ -82,9 +82,7 @@ function set_response_xattr(res, xattr) {
     }
     let returned_keys = 0;
     for (const key of keys) {
-        // when xattr is set directly on the object (NSFS for example) and it's already encoded
-        // we should not encode it again 
-        const val = encode_uri_unless_already_encoded(xattr[key]);
+        const val = xattr[key];
 
         const md_header_size =
             X_AMZ_META.length +
@@ -97,7 +95,11 @@ function set_response_xattr(res, xattr) {
         }
         returned_keys += 1;
         size_for_md_left -= md_header_size;
-        res.setHeader(X_AMZ_META + key, val);
+        try {
+            res.setHeader(X_AMZ_META + key, val);
+        } catch (err) {
+            dbg.warn(`s3_utils.set_response_xattr set_header failed, skipping... res.req.url=${res.req?.url} xattr key=${key} xattr value=${val}`);
+        }
     }
 }
 
@@ -630,15 +632,6 @@ function parse_decimal_int(str) {
 }
 
 /**
- * encode_uri_unless_already_encoded encodes a string uri if it's not already encoded
- * @param {string} uri
- * @returns {string}
- */
-function encode_uri_unless_already_encoded(uri = '') {
-    return is_uri_already_encoded(uri) ? uri : encodeURIComponent(uri);
-}
-
-/**
  * parse_version_id throws an error if version_id is an empty string, and returns it otherwise
  * @param {string|undefined} version_id
  * @param {import('./s3_errors').S3ErrorSpec} [empty_err]
@@ -648,15 +641,6 @@ function parse_version_id(version_id, empty_err = S3Error.InvalidArgumentEmptyVe
         throw new S3Error(empty_err);
     }
     return version_id;
-}
-
-/**
- * is_uri_already_encoded returns true if string uri is URIEncoded
- * @param {string} uri
- * @returns {boolean}
- */
-function is_uri_already_encoded(uri = '') {
-    return uri !== decodeURIComponent(uri);
 }
 
 /**


### PR DESCRIPTION
### Explain the changes
1. Revert code added in https://github.com/noobaa/noobaa-core/pull/7986
2. Added try & catch that skips xattr headers that can not be set during setHeader() by assuming that xattrs that can be returned are coming through s3. If invalid xattrs were set directly on the file system and can not return through http header, the best behavior is not to fail the head object but to not return the invalid xattr. If customer wants to get invalid headers via s3 the xattr should be encoded on the file system if they are not us-ascii.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
