### PR TITLE
NC | remove input from spawn options print and fix exec test

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js
@@ -21,10 +21,15 @@ key="$1"
 file_name="${TMP_PATH}/noobaa.$key"
 current_version="$2"
 
+TMPFILE="$(mktemp)"
+trap 'rm -f &>/dev/null -- "$TMPFILE"' EXIT
+# write stdin of the script to temp file
+cat > "$TMPFILE"
+
 if [ -e "$file_name" ]; then
     echo '{ "status": "VERSION_MISMATCH" }'
 else
-    out=$(cat > "$file_name" 2>/dev/null)
+    out=$(cat "$TMPFILE" > "$file_name" 2>/dev/null)
     rc=$?
     if [ $rc -eq 0 ]; then
         echo '{ "status": "OK" }'

--- a/src/util/os_utils.js
+++ b/src/util/os_utils.js
@@ -123,7 +123,7 @@ function spawn(command, args, options, ignore_rc, unref, timeout_ms) {
     return new Promise((resolve, reject) => {
         options = options || {};
         args = args || [];
-        dbg.log0('spawn:', command, args.join(' '), options, ignore_rc);
+        dbg.log0('spawn:', command, args.join(' '), _.omit(options, 'input'), ignore_rc);
         options.stdio = options.stdio || 'inherit';
         const return_stdout = options.return_stdout;
         const proc = child_process.spawn(command, args, options);


### PR DESCRIPTION
### Explain the changes
1. Omit input from spawn - input contains the master key json
2. Try fixing unit test that failed inconsistently by first reading stdin to temp file and then check if a file exists - 
The failure was on `NC master key manager tests - exec store type › _create_master_keys_exec when master keys exist` test and the error was - 
```
 
write EPIPE
130 |         const return_stdout = options.return_stdout;
131 |         const proc = child_process.spawn(command, args, options);
> 132 |         if (options.input) proc.stdin.end(options.input);
|                                       ^
133 |         let stdout = return_stdout ? '' : undefined;
134 |         if (return_stdout) {
135 |             proc.stdout.on('data', data => {

at end (src/util/os_utils.js:132:39)
at Object.spawn (src/util/os_utils.js:125:12)
at NCMasterKeysManager.spawn [as _create_master_keys_exec] (src/manage_nsfs/nc_master_key_manager.js:217:55)
at Object._create_master_keys_exec (src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js:120:31)

```
I couldn't reproduce it locally, the base assumption of this fix, is that on fput script of these tests, when there is already an existing master_keys.json file, we will first check if the file exists and return VERSION_MISMATCH if it exists, else we will write the input into the file. When first returning without reading the input at the beginning we might result with EPIPE, where we didn't have a chance to write the data to stdin.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
