### PR TITLE
Bucket Logging: Accept Log Prefix as per S3 bucket logging

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -391,12 +391,6 @@ async function delete_bucket_tagging(req) {
 async function put_bucket_logging(req) {
     dbg.log0('put_bucket_logging:', req.rpc_params);
     const bucket = find_bucket(req);
-    const prefix = req.rpc_params.log_prefix;
-    // TODO: THIS CHECK IS NOT CORRECT - as prefix can contain any character - leaving it here for now, but need to be fixed!
-    const prefix_regex = /^[a-zA-Z0-9.-]+$/;
-    if (!prefix_regex.test(prefix)) {
-        throw new RpcError('INVALID_ARGUMENT', 'Log prefix should only contain alphanumeric characters, hyphens, or periods');
-    }
     const log_bucket_name = req.rpc_params.log_bucket;
     const log_bucket = req.system.buckets_by_name && req.system.buckets_by_name[log_bucket_name.unwrap()];
     if (!log_bucket) {


### PR DESCRIPTION
We need to change the log prefix restriction and accept it in accordance with AWS S3 guidelines.

As we do that, it is better to fetch the log prefix from the configuration of the source bucket instead of depending on log object names.

It's because the log prefix can have any character in it, and it would be difficult to have a delimiter that can segregate the log prefix from other strings in the log object name.



### Testing Instructions:
Testing Commands - 

ON end point run following command to create buckets and set bucket logging.

nb bucket create data.bucket
nb bucket create log.bucket
nb bucket create data.bucket-1
nb bucket create log.bucket-1

nb api bucket_api put_bucket_logging '{
  "name" : "data.bucket",
  "log_bucket": "log.bucket",
  "log_prefix": "data-bucket-logs"
}'

nb api bucket_api put_bucket_logging '{
  "name" : "data.bucket-1",
  "log_bucket": "log.bucket-1",
  "log_prefix": "data-b^*&^^@$%#&#)((&F/"
}'

nb api bucket_api get_bucket_logging '{
  "name" : "data.bucket-1"
}'

**On log-processor-container- cd /log/noobaa_bucket_logs/**
touch data.bucket_log.bucket_1576521528.log
touch data.bucket-1_log.bucket-1_1576524645645.log

After some time you should see these files uploaded to respective log buckets.

