### PR TITLE
NC | Add linux/ppc64le to nightly RPM builds

### DIFF
--- a/.github/workflows/rpm-build-and-upload-flow.yaml
+++ b/.github/workflows/rpm-build-and-upload-flow.yaml
@@ -19,6 +19,20 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       centos_ver: '9'
+  
+  build-rpm-centos8-ppc64le:
+    uses: ./.github/workflows/rpm-build-base.yaml
+    with:
+      branch: ${{ inputs.branch }}
+      centos_ver: '8'
+      architecture: 'linux/ppc64le'
+
+  build-rpm-centos9-ppc64le:
+    uses: ./.github/workflows/rpm-build-base.yaml
+    with:
+      branch: ${{ inputs.branch }}
+      centos_ver: '9'
+      architecture: 'linux/ppc64le'
 
   upload-centos8-rpm-to-aws:
     needs: build-rpm-centos8
@@ -32,4 +46,18 @@ jobs:
     uses: ./.github/workflows/upload-rpm-to-aws.yaml
     with:
       rpm_full_path: ${{ needs.build-rpm-centos9.outputs.rpm_full_path }}
+    secrets: inherit
+  
+  upload-centos8-ppc64le-rpm-to-aws:
+    needs: build-rpm-centos8-ppc64le
+    uses: ./.github/workflows/upload-rpm-to-aws.yaml
+    with:
+      rpm_full_path: ${{ needs.build-rpm-centos8-ppc64le.outputs.rpm_full_path }}
+    secrets: inherit
+
+  upload-centos9-ppc64le-rpm-to-aws:
+    needs: build-rpm-centos9-ppc64le
+    uses: ./.github/workflows/upload-rpm-to-aws.yaml
+    with:
+      rpm_full_path: ${{ needs.build-rpm-centos9-ppc64le.outputs.rpm_full_path }}
     secrets: inherit


### PR DESCRIPTION
### Explain the changes
1. Added linux/ppc64le to nightly RPM builds

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/8131

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
