### PR TITLE
NC | Flag to control syslog and console log

### DIFF
--- a/config.js
+++ b/config.js
@@ -464,6 +464,9 @@ config.EVENT_FACILITY = 'LOG_LOCAL2';
 config.EVENT_LOGGING_ENABLED = true;
 config.EVENT_LEVEL = 5;
 
+config.LOG_TO_SYSLOG_ENABLED = true;
+config.LOG_TO_STDERR_ENABLED = true;
+
 // TEST Mode
 config.test_mode = false;
 

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -495,6 +495,43 @@ Example:
 3. systemctl restart noobaa
 ```
 
+## 25. Syslog enable flag -
+**Description -** This flag will enable syslog logging for the application.
+
+**Configuration Key -** LOG_TO_SYSLOG_ENABLED
+
+**Type -** boolean
+
+**Default -** true
+
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"LOG_TO_SYSLOG_ENABLED": true
+3. systemctl restart noobaa
+```
+
+## 26. Stderr enable flag -
+**Description -** This flag will decide whether need to push logs to the stderr or not.
+
+**Configuration Key -** LOG_TO_STDERR_ENABLED
+
+**Type -** boolean
+
+**Default -** false
+
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the config key -
+Example:
+"LOG_TO_STDERR_ENABLED": false
+3. systemctl restart noobaa
+```
+
+```
 > cat /path/to/config_dir/config.json
 {
     "ENDPOINT_PORT": 80,

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -129,7 +129,15 @@ const nsfs_node_config_schema = {
         ENDPOINT_PROCESS_TITLE: {
             type: 'string',
             doc: 'This flag will set noobaa process title for letting GPFS to identify the noobaa endpoint processes.'
-        }
+        },
+        LOG_TO_SYSLOG_ENABLED: {
+            type: 'boolean',
+            doc: 'This flag will enable syslog logging for the application.'
+        },
+        LOG_TO_STDERR_ENABLED: {
+            type: 'boolean',
+            doc: 'This flag will decide whether need to push logs to the console or not.'
+        },
     }
 };
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -339,6 +339,28 @@ describe('schema validation NC NSFS config', () => {
             const message = `must be boolean | {"type":"boolean"} | "/NC_DISABLE_SCHEMA_CHECK"`;
             assert_validation(config_data, reason, message);
         });
+
+        it('unskip schema check - config.LOG_TO_SYSLOG_ENABLED=false nsfs_config.LOG_TO_SYSLOG_ENABLED=bla - invalid config - should fail', () => {
+            config.LOG_TO_SYSLOG_ENABLED = false;
+            const config_data = {
+                LOG_TO_SYSLOG_ENABLED: 'bla',
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'LOG_TO_SYSLOG_ENABLED must be boolean';
+            const message = `must be boolean | {"type":"boolean"} | "/LOG_TO_SYSLOG_ENABLED"`;
+            assert_validation(config_data, reason, message);
+        });
+
+        it('unskip schema check - config.LOG_TO_STDERR_ENABLED=false nsfs_config.LOG_TO_STDERR_ENABLED=bla - invalid config - should fail', () => {
+            config.LOG_TO_STDERR_ENABLED = false;
+            const config_data = {
+                LOG_TO_STDERR_ENABLED: 'bla',
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'LOG_TO_STDERR_ENABLED must be boolean';
+            const message = `must be boolean | {"type":"boolean"} | "/LOG_TO_STDERR_ENABLED"`;
+            assert_validation(config_data, reason, message);
+        });
     });
 });
 

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -379,7 +379,7 @@ class InternalDebugLogger {
     }
 
     log_internal(msg_info) {
-        if (syslog) {
+        if (syslog && config.LOG_TO_SYSLOG_ENABLED) {
             // syslog path
             syslog(this._levels_to_syslog[msg_info.level], msg_info.message_syslog, config.DEBUG_FACILITY);
         } else if (this._log_file) {
@@ -389,7 +389,7 @@ class InternalDebugLogger {
         // This is also used in order to log to the console
         // browser workaround, don't use rotating file steam. Add timestamp and level
         const logfunc = LOG_FUNC_PER_LEVEL[msg_info.level] || 'log';
-        if (this._log_console_silent) {
+        if (this._log_console_silent || !config.LOG_TO_STDERR_ENABLED) {
             // noop
         } else if (console_wrapper) {
             process.stderr.write(msg_info.message_console + '\n');


### PR DESCRIPTION
### Explain the changes
1. add two properties that will decide syslog and console flow in debug module.
- LOG_TO_SYSLOG_ENABLED : This flag will enable syslog logging for the application.
- LOG_TO_STDERR_ENABLED: decide whether need to push logs to the console or not

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8032

### Testing Instructions:
1. update the flags and verify logs are pushed to var/log/noobaa.log or var/log/message 


- [X] Doc added/updated
- [X] Tests added
