### PR TITLE
Fix log-based replication Prometheus field

### DIFF
--- a/src/server/bg_services/replication_server.js
+++ b/src/server/bg_services/replication_server.js
@@ -85,7 +85,10 @@ async function copy_objects_mixed_types(req) {
             try {
                 await noobaa_con.copyObject(params).promise();
                 copy_res.num_of_objects += 1;
-                copy_res.size_of_objects += keys_diff_map[key][0].ContentLength;
+                // The size of the object can be in either Size or ContentLength, depending on whether
+                // the request was ListObjectVersions or HeadObject
+                const size_of_objects = keys_diff_map[key][0].ContentLength || keys_diff_map[key][0].Size;
+                copy_res.size_of_objects += size_of_objects;
             } catch (err) {
                 dbg.error('replication_server copy_objects_mixed_types: got error:', err);
             }
@@ -100,7 +103,7 @@ async function copy_objects_mixed_types(req) {
                 try {
                     await noobaa_con.copyObject(params).promise();
                     copy_res.num_of_objects += 1;
-                    copy_res.size_of_objects += keys_diff_map[key][i].ContentLength;
+                    copy_res.size_of_objects += keys_diff_map[key][i].Size;
                 } catch (err) {
                     dbg.error('replication_server copy_objects_mixed_types: got error:', err);
                 }

--- a/src/server/bg_services/replication_server.js
+++ b/src/server/bg_services/replication_server.js
@@ -87,8 +87,7 @@ async function copy_objects_mixed_types(req) {
                 copy_res.num_of_objects += 1;
                 // The size of the object can be in either Size or ContentLength, depending on whether
                 // the request was ListObjectVersions or HeadObject
-                const size_of_objects = keys_diff_map[key][0].ContentLength || keys_diff_map[key][0].Size;
-                copy_res.size_of_objects += size_of_objects;
+                copy_res.size_of_objects += keys_diff_map[key][0].ContentLength || keys_diff_map[key][0].Size;
             } catch (err) {
                 dbg.error('replication_server copy_objects_mixed_types: got error:', err);
             }

--- a/src/server/bg_services/replication_server.js
+++ b/src/server/bg_services/replication_server.js
@@ -85,7 +85,7 @@ async function copy_objects_mixed_types(req) {
             try {
                 await noobaa_con.copyObject(params).promise();
                 copy_res.num_of_objects += 1;
-                copy_res.size_of_objects += keys_diff_map[key][0].Size;
+                copy_res.size_of_objects += keys_diff_map[key][0].ContentLength;
             } catch (err) {
                 dbg.error('replication_server copy_objects_mixed_types: got error:', err);
             }
@@ -100,7 +100,7 @@ async function copy_objects_mixed_types(req) {
                 try {
                     await noobaa_con.copyObject(params).promise();
                     copy_res.num_of_objects += 1;
-                    copy_res.size_of_objects += keys_diff_map[key][i].Size;
+                    copy_res.size_of_objects += keys_diff_map[key][i].ContentLength;
                 } catch (err) {
                     dbg.error('replication_server copy_objects_mixed_types: got error:', err);
                 }


### PR DESCRIPTION
### Explain the changes
`size_of_objects` is used to update the Prometheus status of log-based replication, specifically for the values of `last_cycle_writes_size` and `last_cycle_error_writes_size`. However, the attribute (`Size`) that was allocated to `size_of_objects` does not exist, which has led to errors in our logs, and possibly malfunctioning Prometheus reports.
This PR replaces `Size` with `ContentLength`, which also resolves the exceptions that were observed in the logs.

### Testing Instructions:
1. Set up an environment with log-based replication optimization
2. Disable the regular replication via `config.js`
3. Verify log-based replication works
4. Make sure no related errors were printed in the core logs

- [ ] Doc added/updated
- [ ] Tests added
