### PR TITLE
Add context to fs_napi errors

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -399,7 +399,9 @@ function handle_error(req, res, err) {
     dbg.error('S3 ERROR', reply,
         req.method, req.originalUrl,
         JSON.stringify(req.headers),
-        err.stack || err);
+        err.stack || err,
+        err.context ? `- context: ${err.context?.trim()}` : '',
+    );
     if (res.headersSent) {
         dbg.log0('Sending error xml in body, but too late for headers...');
     } else {

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -655,6 +655,9 @@ struct FSWorker : public Napi::AsyncWorker
         if (_errno) {
             obj.Set("code", Napi::String::New(env, uv_err_name(uv_translate_sys_error(_errno))));
         }
+
+        obj.Set("context", Napi::String::New(env, _desc));
+
         _deferred.Reject(obj);
     }
 };
@@ -1311,7 +1314,7 @@ struct Fsync : public FSWorker
 };
 
 /**
- * GetPwName is an os op 
+ * GetPwName is an os op
  */
 struct GetPwName : public FSWorker
 {
@@ -2206,7 +2209,7 @@ fs_napi(Napi::Env env, Napi::Object exports)
             if (sizeof(struct gpfsRequest_t) != 256) {
                 PANIC("The gpfs get extended attributes is of wrong size" << sizeof(struct gpfsRequest_t));
             }
-            
+
             auto gpfs = Napi::Object::New(env);
             gpfs["register_gpfs_noobaa"] = Napi::Function::New(env, register_gpfs_noobaa);
             // we export the gpfs object, which can be checked to indicate that

--- a/src/native/util/common.h
+++ b/src/native/util/common.h
@@ -23,7 +23,11 @@ namespace noobaa
 {
 
 #ifndef __func__
-#define __func__ __FUNCTION__
+    #ifdef __PRETTY_FUNCTION__
+    #define __func__ __PRETTY_FUNCTION__
+    #else
+    #define __func__ __FUNCTION__
+    #endif
 #endif
 
 #define DVAL(x) #x "=" << x << " "


### PR DESCRIPTION
### Explain the changes
This PR attempts to add `context` to the errors coming from `fs_napi`. The `context` field is then used in the S3 error reporting if it's available. The PR also reduces the log level for `OnError` method. 

This sometimes means duplicate logging, however it was still kept this way as not all the errors coming from the `fs_napi` necessarily fails an S3 operation. It could be helpful to see all the errors that we encountered and the error that resulted in the operation failure.

Another approach that was tested but I decided against it was to add the context info in the error message itself. It removes the construct of `context` but that also means that the error message will be more verbose and hard/fragile `===` tests against them.

Example of current fix:
<img width="1717" alt="image" src="https://github.com/noobaa/noobaa-core/assets/45818886/55bd4e6d-b28c-48bd-9565-bbaa35d930e8">

### Issues: Fixed #xxx / Gap #xxx
Fixes #8065 

- [ ] Doc added/updated
- [ ] Tests added
