### PR TITLE
Adding debug option to manage_nsfs

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -70,6 +70,11 @@ async function main(argv = minimist(process.argv.slice(2))) {
         if (process.getuid() !== 0 || process.getgid() !== 0) {
             throw new Error('Root permissions required for Manage NSFS execution.');
         }
+        if (argv.debug) {
+            const debug_level = Number(argv.debug) || 5;
+            dbg.set_module_level(debug_level, 'core');
+            nb_native().fs.set_debug_level(debug_level);
+        }
         const type = argv._[0] || '';
         const action = argv._[1] || '';
         if (argv.help || argv.h) {

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -30,7 +30,7 @@ const CONFIG_SUBDIRS = {
 };
 
 const GLOBAL_CONFIG_ROOT = 'config_root';
-const GLOBAL_CONFIG_OPTIONS = new Set([GLOBAL_CONFIG_ROOT, 'config_root_backend']);
+const GLOBAL_CONFIG_OPTIONS = new Set([GLOBAL_CONFIG_ROOT, 'config_root_backend', 'debug']);
 const FROM_FILE = 'from_file';
 const ANONYMOUS = 'anonymous';
 
@@ -107,7 +107,8 @@ const OPTION_TYPE = {
     deployment_type: 'string',
     all_account_details: 'boolean',
     all_bucket_details: 'boolean',
-    https_port: 'number'
+    https_port: 'number',
+    debug: 'number',
 };
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -62,6 +62,7 @@ Flags:
 const GLOBAL_CONFIG_ROOT_ALL_FLAG = `
 --config_root <string>                                (optional)        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
 --config_root_backend <none | GPFS | CEPH_FS | NFSv4> (optional)        Use the filesystem type in the configuration (default config.NSFS_NC_CONFIG_DIR_BACKEND)
+--debug <number>                                      (optional)        Use for increasing the log verbosity of cli commands
 `;
 
 const ACCOUNT_FLAGS_ADD = `


### PR DESCRIPTION
### Explain the changes
1. Adding the option to run manage_nsfs_cli commands with higher log verbosity, for easier cli issues debugging.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
