### PR TITLE
Fix Throw Error in `load_requesting_account` (object_sdk, account_sdk)

### DIFF
--- a/src/sdk/account_sdk.js
+++ b/src/sdk/account_sdk.js
@@ -64,12 +64,9 @@ class AccountSDK {
             }
         } catch (error) {
             dbg.error('load_requesting_account error:', error);
-            if (error.rpc_code) {
-                if (error.rpc_code === 'NO_SUCH_ACCOUNT') throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
-                if (error.rpc_code === 'NO_SUCH_USER') throw new RpcError('UNAUTHORIZED', `Distinguished name associated with access_key not found`);
-            } else {
-                throw error;
-            }
+            if (error.rpc_code === 'NO_SUCH_ACCOUNT') throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
+            if (error.rpc_code === 'NO_SUCH_USER') throw new RpcError('UNAUTHORIZED', `Distinguished name associated with access_key not found`);
+            throw error;
         }
     }
 

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -229,12 +229,9 @@ class ObjectSDK {
             }
         } catch (error) {
             dbg.error('load_requesting_account error:', error);
-            if (error.rpc_code) {
-                if (error.rpc_code === 'NO_SUCH_ACCOUNT') throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
-                if (error.rpc_code === 'NO_SUCH_USER') throw new RpcError('UNAUTHORIZED', `Distingushed name associated with access_key not found`);
-            } else {
-                throw error;
-            }
+            if (error.rpc_code === 'NO_SUCH_ACCOUNT') throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
+            if (error.rpc_code === 'NO_SUCH_USER') throw new RpcError('UNAUTHORIZED', `Distinguished name associated with access_key not found`);
+            throw error;
         }
     }
 

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -44,11 +44,10 @@ class StsSDK {
             });
         } catch (error) {
             dbg.error('authorize_request_account error:', error);
-            if (error.rpc_code && error.rpc_code === 'NO_SUCH_ACCOUNT') {
+            if (error.rpc_code === 'NO_SUCH_ACCOUNT') {
                 throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
-            } else {
-                throw error;
             }
+            throw error;
         }
     }
 


### PR DESCRIPTION
### Explain the changes
1. Fix Throw Error in `load_requesting_account` (object_sdk, account_sdk) - if the `error.rpc_code` exists and it neither 
'NO_SUCH_ACCOUNT' nor 'NO_SUCH_USER' (for example error.rpc_code INTERNAL) the error still should be thrown. 
Note: `account_sdk` was copied from `object_sdk` (we don't have this issue in `sts_sdk`).
2. Simplify the condition and remove the `error.rpc_code && ` from the condition since it is strings comparison (in `account_sdk`, `object_sdk`, and `sts_sdk`).
 
### Issues:
1. Currently, errors when  `load_requesting_account` with error.rpc_code different than 'NO_SUCH_ACCOUNT' and 'NO_SUCH_USER' will be cached and not thrown.
2. Known GAP - we currently have the `load_requesting_account` implementation in all sdk service files and would like to reuse mutual code.

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
