### PR TITLE
NSFS | NC | IAM Service - Root Accounts Manager

### DIFF
--- a/docs/design/iam.md
+++ b/docs/design/iam.md
@@ -88,3 +88,18 @@ Source: AccessKeys
   - AccessKey (Create, Update, Delete, List)
     - root account
     - all IAM users only for themselves (except the first creation that can be done only by the root account).
+
+### Root Accounts Manager
+The root accounts managers are a solution for creating root accounts using the IAM API.
+
+- The root accounts managers will be created only using the CLI (can have more than one root account manager).
+- It is not mandatory to have a root account manager, it is only for allowing the IAM API for creating new root accounts, but this account does not owns the root accounts.
+- The root accounts manager functionality is like root account in the IAM API perspective:
+  - We use root accounts to create IAM users: We use root accounts manager to create root accounts
+  - We use root accounts to create the first access key of an IAM user: We use root accounts manager to create the first access key of a root account.
+- When using IAM users API:
+  - root accounts manager can run IAM users create/update/delete/list - only on root accounts (not on other IAM users).
+root accounts manager can run IAM access keys create/update/delete/list - only on root accounts and himself.
+
+Here attached a diagram with all the accounts that we have in our system:
+![All accounts diagram](https://github.com/noobaa/noobaa-core/assets/57721533/c4395c06-3ab3-4425-838b-c020ef7cc38a)

--- a/docs/dev_guide/nc_nsfs_iam_developer_doc.md
+++ b/docs/dev_guide/nc_nsfs_iam_developer_doc.md
@@ -13,7 +13,7 @@ This will be the argument for:
   - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
   - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
 2. Create the root user account with the CLI:
-`sudo node src/cmd/manage_nsfs account add --name <name>> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`.
+`sudo node src/cmd/manage_nsfs account add --name <name> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`.
 3. Start the NSFS server (using debug mode and the port for IAM): `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
 Note: before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
 4. Create the alias for IAM service: 
@@ -40,7 +40,7 @@ Create the alias for IAM service for the user that was created (with its access 
 1. Use the root account credentials to create a user: `nc-user-1-iam iam create-user --user-name <username>`
 2. Use the root account credentials to create access keys for the user: `nc-user-1-iam iam create-access-key --user-name <username>`
 3. The alias for s3 service: `alias nc-user-1-s3-regular='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443'` 
-2. Create a bucket (so we can list it) `nc-user-1-s3-regular s3 mb s3://<bucket-name>>`
+2. Create a bucket (so we can list it) `nc-user-1-s3-regular s3 mb s3://<bucket-name`
 3. List bucket (use s3 service)`nc-user-1-s3-regular s3 ls`
 4. List access keys (use IAM service) `nc-user-1-iam-regular iam list-access-keys`
 5. Deactivate access keys: `nc-user-1-iam iam update-access-key --access-key-id <access-key> --user-name <username> --status Inactive`
@@ -52,3 +52,12 @@ Note: Currently we clean the cache after update, but it happens for the specific
 2. Use the root account credentials to create access keys for the user:(first time): `nc-user-1-iam iam create-access-key --user-name <username>` (You should see the first symbolic link in under the access_keys directory).
 3. Use the root account credentials to create access keys for the user (second time): `nc-user-1-iam iam create-access-key --user-name <username>` (You should see the second symbolic link in under the access_keys directory).
 4. Update the username: `nc-user-1-iam iam update-user --user-name <username> --new-user-name <new-username>` (You should see the following changes: config file name updated, symlinks updated according to the current config).
+
+#### Create root account using the IAM API (requesting account is root accounts manager):
+1. Create the root accounts manager with the CLI:
+`sudo node src/cmd/manage_nsfs account add --name <name> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid> --iam_operate_on_root_account`.
+2. Use the root accounts manager details in the alias:
+`alias nc-user-manager-iam='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005'`.
+3. Use the root accounts manager account credentials to create a root account:
+ `nc-user-manager-iam create-user --user-name <username>`
+4. Use the root account credentials to create access keys for the root account: `nc-user-manager-iam iam create-access-key --user-name <username>`

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -198,6 +198,20 @@ ManageCLIError.AccountDeleteForbiddenHasBuckets = Object.freeze({
     http_code: 403,
 });
 
+ManageCLIError.AccountCannotCreateRootAccountsRequesterIAMUser = Object.freeze({
+    code: 'AccountCannotCreateRootAccounts',
+    message: 'Cannot update account to have iam_operate_on_root_account. ' +
+        'You must use root account for this action',
+    http_code: 409,
+});
+
+ManageCLIError.AccountCannotBeRootAccountsManager = Object.freeze({
+    code: 'AccountCannotBeRootAccountsManager',
+    message: 'Cannot update account to have iam_operate_on_root_account. ' +
+        'You must delete all IAM accounts before update or ' +
+        'use root accounts that does not owns any IAM accounts',
+    http_code: 409,
+});
 
 //////////////////////////////////
 //// ACCOUNT ARGUMENTS ERRORS ////

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -142,6 +142,17 @@ function generate_id() {
     return mongo_utils.mongoObjectId();
 }
 
+/**
+ * check_root_account_owns_user checks if an account is owned by root account
+ * @param {object} root_account
+ * @param {object} account
+ */
+function check_root_account_owns_user(root_account, account) {
+    if (account.owner === undefined) return false;
+    return root_account._id === account.owner;
+}
+
+
 // EXPORTS
 exports.throw_cli_error = throw_cli_error;
 exports.write_stdout_response = write_stdout_response;
@@ -154,3 +165,4 @@ exports.get_options_from_file = get_options_from_file;
 exports.has_access_keys = has_access_keys;
 exports.generate_id = generate_id;
 exports.set_debug_level = set_debug_level;
+exports.check_root_account_owns_user = check_root_account_owns_user;

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -35,8 +35,8 @@ const FROM_FILE = 'from_file';
 const ANONYMOUS = 'anonymous';
 
 const VALID_OPTIONS_ACCOUNT = {
-    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
     'delete': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
     'list': new Set(['wide', 'show_secrets', 'gid', 'uid', 'user', 'name', 'access_key', ...GLOBAL_CONFIG_OPTIONS]),
     'status': new Set(['name', 'access_key', 'show_secrets', ...GLOBAL_CONFIG_OPTIONS]),
@@ -91,6 +91,7 @@ const OPTION_TYPE = {
     fs_backend: 'string',
     allow_bucket_creation: 'boolean',
     force_md5_etag: 'boolean',
+    iam_operate_on_root_account: 'boolean',
     config_root: 'string',
     from_file: 'string',
     config_root_backend: 'string',
@@ -113,7 +114,7 @@ const OPTION_TYPE = {
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];
 const BOOLEAN_STRING_OPTIONS = new Set(['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force',
-    'force_md5_etag', 'all_account_details', 'all_bucket_details', 'anonymous']);
+    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous']);
 
 //options that can be unset using ''
 const LIST_UNSETABLE_OPTIONS = ['fs_backend', 's3_policy', 'force_md5_etag'];

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -80,6 +80,7 @@ Flags:
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
 --allow_bucket_creation <true | false>                (optional)        Set the account to explicitly allow or block bucket creation
 --force_md5_etag <true | false>                       (optional)        Set the account to force md5 etag calculation. (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
+--iam_operate_on_root_account <true | false>          (optional)        Set the account to create root accounts instead of IAM users in IAM API requests.
 --from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
 `;
 
@@ -100,6 +101,7 @@ Flags:
 --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
 --allow_bucket_creation <true | false>                (optional)        Update the account to explicitly allow or block bucket creation
 --force_md5_etag <true | false>                       (optional)        Update the account to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
+--iam_operate_on_root_account <true | false>          (optional)        Update the account to create root accounts instead of IAM users in IAM API requests.
 `;
 
 const ACCOUNT_FLAGS_DELETE = `

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -48,6 +48,11 @@ module.exports = {
         force_md5_etag: {
             type: 'boolean',
         },
+        // account with iam_operate_on_root_account property will create root accounts using the IAM API 
+        // (instead of IAM accounts)
+        iam_operate_on_root_account: {
+            type: 'boolean'
+        },
         access_keys: {
             type: 'array',
             items: {

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -75,6 +75,12 @@ describe('schema validation NC NSFS account', () => {
             nsfs_schema_utils.validate_account_schema(account_data);
         });
 
+        it('account with iam_operate_on_root_account', () => {
+            const account_data = get_account_data();
+            account_data.iam_operate_on_root_account = true;
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
         it('account with 2 access_keys objects (with additional properties) in the access_key array', () => {
             const account_data = get_account_data();
             account_data.access_keys[1] = get_access_key_with_additional_properties();
@@ -425,6 +431,15 @@ describe('schema validation NC NSFS account', () => {
             const reason = 'Test should have failed because of wrong type for' +
                 'iam_path with number (instead of string)';
             const message = 'must be string';
+            assert_validation(account_data, reason, message);
+        });
+
+        it('account with iam_operate_on_root_account as a number (instead of boolean)', () => {
+            const account_data = get_account_data();
+            account_data.iam_operate_on_root_account = 123;
+            const reason = 'Test should have failed because of wrong type for' +
+                'iam_operate_on_root_account with number (instead of boolean)';
+            const message = 'must be boolean';
             assert_validation(account_data, reason, message);
         });
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -143,6 +143,23 @@ describe('manage nsfs cli bucket flow', () => {
             expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.BucketCreated.code);
         });
 
+        it('cli create bucket - owner has iam_operate_on_root_account true', async () => {
+            // update the account to have iam_operate_on_root_account true
+            const { name } = account_defaults;
+            const account_options = { config_root, name, iam_operate_on_root_account: 'true'};
+            let action = ACTIONS.UPDATE;
+            await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
+
+            // create the bucket
+            action = ACTIONS.ADD;
+            const bucket_options = { config_root, ...bucket_defaults};
+            await fs_utils.create_fresh_path(bucket_options.path);
+            await fs_utils.file_must_exist(bucket_options.path);
+            await set_path_permissions_and_owner(bucket_options.path, account_defaults, 0o700);
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.BucketCreated.code);
+        });
+
         it('should fail - cli bucket add - without identifier', async () => {
             const action = ACTIONS.ADD;
             const bucket_options = { config_root, owner: bucket_defaults.owner, path: bucket_defaults.path };
@@ -472,6 +489,22 @@ describe('manage nsfs cli bucket flow', () => {
             const bucket_options = { config_root };
             const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingBucketNameFlag.code);
+        });
+
+        it('cli update bucket owner - owner has iam_operate_on_root_account true', async () => {
+            // update the account to have iam_operate_on_root_account true
+            const { name } = account_defaults2;
+            const account_options = { config_root, name, iam_operate_on_root_account: 'true'};
+            let action = ACTIONS.UPDATE;
+            await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
+
+            action = ACTIONS.UPDATE;
+            const bucket_options = { config_root, name: bucket_defaults.name, owner: account_defaults2.name};
+            await fs_utils.create_fresh_path(bucket_defaults.path);
+            await fs_utils.file_must_exist(bucket_defaults.path);
+            await set_path_permissions_and_owner(bucket_defaults.path, account_defaults2, 0o700);
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.BucketUpdated.code);
         });
     });
 


### PR DESCRIPTION
### Explain the changes
1. Add more properties to `nsfs_account_schema` (not required):
- `iam_operate_on_root_account` = boolean (if an account was set with true. then it is a roots accounts manager).
2.   Add the option of `iam_operate_on_root_account` in noobaa cli.
3. Edit all the functions in `AccountSpaceFS` (CRUD) to operate on root accounts when the requesting account is a root accounts manager.

### Issues:
List of GAPs:
1. Parsing and validating the params (for example: username).
2. No `NoobaaEvent` at this point.
3. Change the IamError class to have a template message.

### Testing Instructions:
#### Unit Tests
Please run:
1. `sudo npx jest test_accountspace_fs.test.js`
2. `npx jest test_nc_nsfs_account_schema_validation.test.js`
3. `sudo npx jest test_nc_nsfs_account_cli.test.js`
4. `sudo npx jest test_nc_nsfs_bucket_cli.test.js`
5. `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`

#### Manual Tests
IAM changes in NC NSFS
Currently, we do not validate the input, so the test should use only valid input.
1. Create the root accounts manager with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid> --iam_operate_on_root_account`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
Note: before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
3. Create the alias for IAM service: `alias s3-nc-user-manager-iam='AWS_ACCESS_KEY_ID=<acess-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005'`.
6. Use AWS CLI to send requests to the IAM service, for example:
 `s3-nc-manager-1-iam iam create-user --user-name Bob-root --path '/division_abc/subdivision_xyz/'`
 `s3-nc-manager-1-iam iam create-access-key --user-name Bob-root `
 `s3-nc-manager-1-iam iam get-access-key-last-used --access-key-id <access-key>`
 `s3-nc-manager-1-iam iam update-access-key --access-key-id <access-key> --user-name Bob-root  --status Inactive`
 `s3-nc-manager-1-iam iam delete-access-key --access-key-id <access-key> --user-name Bob-root`
 `s3-nc-manager-1-iam iam list-access-keys --user-name Bob-root`
Note: the account created by a root accounts manager using the IAM API is a root account.

- [x] Doc added/updated
- [X] Tests added
