### PR TITLE
NC | nsfs.js | Lower fork_utils dependancy down after process.env.NC_NSFS_NO_DB_ENV=true setting

### DIFF
--- a/config.js
+++ b/config.js
@@ -926,6 +926,12 @@ config.TIERING_TTL_MS = 30 * 60 * 1000; // 30 minutes
 config.AWS_SDK_VERSION_3_ENABLED = true;
 config.DEFAULT_REGION = 'us-east-1';
 
+/////////////////////////
+///  VACCUM ANALYZER  ///
+/////////////////////////
+
+config.VACCUM_ANALYZER_INTERVAL = 86400000;
+
 /////////////////////
 //                 //
 //    OVERRIDES    //

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -4,12 +4,12 @@
 
 require('../util/dotenv').load();
 require('aws-sdk/lib/maintenance_mode_message').suppress = true;
-const { cluster } = require('../util/fork_utils');
 
 const dbg = require('../util/debug_module')(__filename);
 if (!dbg.get_process_name()) dbg.set_process_name('nsfs');
 dbg.original_console();
 
+// DO NOT PUT NEW REQUIREMENTS BEFORE SETTING process.env.NC_NSFS_NO_DB_ENV = 'true' 
 // NC nsfs deployments specifying process.env.LOCAL_MD_SERVER=true deployed together with a db
 // when a system_store object is initialized VaccumAnalyzer is being called once a day.
 // when NC nsfs deployed without db we would like to avoid running VaccumAnalyzer in any flow there is
@@ -33,6 +33,7 @@ const nb_native = require('../util/nb_native');
 //const schema_utils = require('../util/schema_utils');
 const RpcError = require('../rpc/rpc_error');
 const ObjectSDK = require('../sdk/object_sdk');
+const { cluster } = require('../util/fork_utils');
 const NamespaceFS = require('../sdk/namespace_fs');
 const BucketSpaceSimpleFS = require('../sdk/bucketspace_simple_fs');
 const BucketSpaceFS = require('../sdk/bucketspace_fs');

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -142,7 +142,10 @@ async function config_dir_setup() {
     await fs.promises.writeFile(CONFIG_FILE_PATH, JSON.stringify({
         ALLOW_HTTP: true,
         OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS: 1,
-        NC_RELOAD_CONFIG_INTERVAL: 1
+        NC_RELOAD_CONFIG_INTERVAL: 1,
+        // DO NOT CHANGE - setting VACCUM_ANALYZER_INTERVAL=1 needed for failing the tests
+        // in case where vaccumAnalyzer is being called before setting process.env.NC_NSFS_NO_DB_ENV = 'true' on nsfs.js
+        VACCUM_ANALYZER_INTERVAL: 1
     }));
     await fs.promises.mkdir(FIRST_BUCKET_PATH, { recursive: true });
 

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -610,7 +610,7 @@ class PostgresTable {
         if (!process.env.CORETEST && !process.env.NC_NSFS_NO_DB_ENV) {
             // Run once a day
             // TODO: Configure from PostgreSQL
-            setInterval(this.vacuumAndAnalyze, 86400000, this).unref();
+            setInterval(this.vacuumAndAnalyze, config.VACCUM_ANALYZER_INTERVAL, this).unref();
         }
     }
 
@@ -705,7 +705,6 @@ class PostgresTable {
             dbg.log0('vacuumAndAnalyze finished', context.name);
         } catch (err) {
             dbg.error('vacuumAndAnalyze failed', err);
-            throw err;
         }
     }
 


### PR DESCRIPTION
### Explain the changes
 **Background:**
1. VaccumAnalyzer issue hit once again after adding `const { cluster } = require('../util/fork_utils');` dependency before setting `process.env.NC_NSFS_NO_DB_ENV=true` on nsfs.js.
2. The dependency chain causing the issue is as follows - 
`nsfs.js` -> require `forks_utils` -> requires `prometheus_reporting` -> requires `stats_aggregator` -> many files like `system_store`, `bucket_server` etc -> requires `db_client` -> requires `postgres_client` that setInterval() for VaccumAnalyzer.
3. Since `process.env.NC_NSFS_NO_DB_ENV` is `false` when requiring forks_utils, we will hit nsfs.js crash after 24 hours.

 **Changes:**
1. nsfs.js | Lower fork_utils dependancy down to be after process.env.NC_NSFS_NO_DB_ENV=true setting.
2. config.js | moved vaccum analyzer interval to be a configuration called VACCUM_ANALYZER_INTERVAL instead of a constant.
3. nc_coretes | Set VACCUM_ANALYZER_INTERVAL = 1 on NC_CORETEST config.json so every time we will have a higher dependency before setting `process.env.NC_NSFS_NO_DB_ENV=true` we will fail.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
**Manual no code changes -** 
1. Keep nsfs.js running for more than 24 hours.

**Manual with setting config/code changes -**
1. Edit config.json/config.js (code) and set VACCUM_ANALYZER_INTERVAL=1;
2. Start nsfs.js and expect to not fail with -
```
[32mJun-25 10:43:04.141[35m [nsfs/24010] [31m[ERROR][39m core.util.postgres_client:: postgres_client: T00000000|Q00000001: failed with error: TypeError: Cannot read properties of undefined (reading 'query')
at _do_query noobaa-core/src/util/postgres_client.js:254:37)[
at PostgresTable.single_query (noobaa-core/[39msrc/util/postgres_client.js:683:16)
at runNextTicks (node:internal/process/task_queues:60:5)[
at listOnTimeout (node:internal/timers:540:9)
at process.processTimers (node:internal/timers:514:7)
at async Timeout.vacuumAndAnalyze [as _onTimeout](noobaa-core/[39msrc/util/postgres_client.js:704:13)
```
**Automatic tests -**
1. Run `sudo NC_CORETEST=true node --trace-warnings ./node_modules/mocha/bin/mocha noobaa-core/src/test/unit_tests/test_bucketspace.js`
2. Check error message above does not appear at the run logfile and that all the tests passed successfully.

- [ ] Doc added/updated
- [ ] Tests added
