### PR TITLE
NC | Add `--debug` flag to health CLI

### DIFF
--- a/src/cmd/health.js
+++ b/src/cmd/health.js
@@ -14,7 +14,7 @@ const { read_stream_join } = require('../util/buffer_utils');
 const { make_https_request } = require('../util/http_utils');
 const { TYPES } = require('../manage_nsfs/manage_nsfs_constants');
 const { validate_input_types } = require('../manage_nsfs/manage_nsfs_validations');
-const { get_boolean_or_string_value } = require('../manage_nsfs/manage_nsfs_cli_utils');
+const { get_boolean_or_string_value, set_debug_level } = require('../manage_nsfs/manage_nsfs_cli_utils');
 const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 
 const HELP = `
@@ -34,12 +34,13 @@ Usage:
 
 const OPTIONS = `
 Flags:
-
-    --deployment_type <string>        (optional)                             Set the nsfs type for heath check.(default nc; Non Containerized)
-    --config_root <string>            (optional)                             Set Configuration files path for Noobaa standalon NSFS. (default config.NSFS_NC_DEFAULT_CONF_DIR)
-    --https_port                      (optional)                             Set the S3 endpoint listening HTTPS port to serve. (default config.ENDPOINT_SSL_PORT)
-    --all_account_details             (optional)                             Set a flag for returning all account details.
-    --all_bucket_details              (optional)                             Set a flag for returning all bucket details.
+    
+    --deployment_type       <string>        (optional)          Set the nsfs type for heath check.(default nc; Non Containerized)
+    --https_port            <number>        (optional)          Set the S3 endpoint listening HTTPS port to serve. (default config.ENDPOINT_SSL_PORT)
+    --all_account_details   <boolean>       (optional)          Set a flag for returning all account details.
+    --all_bucket_details    <boolean>       (optional)          Set a flag for returning all bucket details.
+    --debug                 <number>        (optional)          Use for increasing the log verbosity of health cli commands.
+    --config_root           <string>        (optional)          Set Configuration files path for Noobaa standalon NSFS. (default config.NSFS_NC_DEFAULT_CONF_DIR)
 `;
 
 function print_usage() {
@@ -411,6 +412,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         }
         if (argv.help || argv.h) return print_usage();
         await validate_input_types(TYPES.HEALTH, '', argv);
+        if (argv.debug) set_debug_level(argv.debug);
         const config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
         const https_port = Number(argv.https_port) || config.ENDPOINT_SSL_PORT;
         const deployment_type = argv.deployment_type || 'nc';

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -20,7 +20,7 @@ const { print_usage } = require('../manage_nsfs/manage_nsfs_help_utils');
 const { TYPES, ACTIONS, LIST_ACCOUNT_FILTERS, LIST_BUCKET_FILTERS,
     GLACIER_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
 const { throw_cli_error, write_stdout_response, get_config_file_path, get_symlink_config_file_path,
-    get_config_data, get_boolean_or_string_value, has_access_keys} = require('../manage_nsfs/manage_nsfs_cli_utils');
+    get_config_data, get_boolean_or_string_value, has_access_keys, set_debug_level} = require('../manage_nsfs/manage_nsfs_cli_utils');
 const manage_nsfs_validations = require('../manage_nsfs/manage_nsfs_validations');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 
@@ -68,11 +68,6 @@ async function main(argv = minimist(process.argv.slice(2))) {
         if (process.getuid() !== 0 || process.getgid() !== 0) {
             throw new Error('Root permissions required for Manage NSFS execution.');
         }
-        if (argv.debug) {
-            const debug_level = Number(argv.debug) || 5;
-            dbg.set_module_level(debug_level, 'core');
-            nb_native().fs.set_debug_level(debug_level);
-        }
         const type = argv._[0] || '';
         const action = argv._[1] || '';
         if (argv.help || argv.h) {
@@ -80,6 +75,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         }
         const user_input_from_file = await manage_nsfs_validations.validate_input_types(type, action, argv);
         const user_input = user_input_from_file || argv;
+        if (argv.debug) set_debug_level(argv.debug);
         config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
         if (!config_root) throw_cli_error(ManageCLIError.MissingConfigDirPath);
         if (argv.config_root) {

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -46,6 +46,7 @@ const pkg = require('../../package.json');
 const AccountSDK = require('../sdk/account_sdk');
 const AccountSpaceFS = require('../sdk/accountspace_fs');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
+const { set_debug_level } = require('../manage_nsfs/manage_nsfs_cli_utils');
 
 const HELP = `
 Help:
@@ -277,11 +278,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         config.ENABLE_OBJECT_IO_SEMAPHORE_MONITOR = false;
 
         if (argv.help || argv.h) return print_usage();
-        if (argv.debug) {
-            const debug_level = Number(argv.debug) || 5;
-            dbg.set_module_level(debug_level, 'core');
-            nb_native().fs.set_debug_level(debug_level);
-        }
+        if (argv.debug) set_debug_level(argv.debug);
         const simple_mode = Boolean(argv.simple);
         if (!simple_mode) {
             nsfs_config_root = config.NSFS_NC_CONF_DIR;

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -1,6 +1,7 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
+const dbg = require('../util/debug_module')(__filename);
 const _ = require('lodash');
 const path = require('path');
 const nb_native = require('../util/nb_native');
@@ -121,6 +122,16 @@ function has_access_keys(access_keys) {
 }
 
 /**
+ * set_debug_level will set the debug log level
+ * @param {string} debug
+ */
+function set_debug_level(debug) {
+    const debug_level = Number(debug) || 5;
+    dbg.set_module_level(debug_level, 'core');
+    nb_native().fs.set_debug_level(debug_level);
+}
+
+/**
  * generate_id will generate an id that we use to identify entities (such as account, bucket, etc.). 
  */
 // TODO: 
@@ -142,3 +153,4 @@ exports.get_bucket_owner_account = get_bucket_owner_account;
 exports.get_options_from_file = get_options_from_file;
 exports.has_access_keys = has_access_keys;
 exports.generate_id = generate_id;
+exports.set_debug_level = set_debug_level;


### PR DESCRIPTION
### Explain the changes
1. Added `--debug` flag to Health CLI for supporting higher debug logs on the Health CLI process.
2. Merged set_debug_level() code to a single function from various places.

### Testing Instructions:
1. Manual - 
Run - `sudo node src/cmd/health --debug=5` and check for logs from higher levels, for example - 
`Jun-25 17:52:23.987 [/46080]    [L2] core.util.http_utils:: should_proxy: hostname undefined isIp false`
- [ ] Doc added/updated
- [ ] Tests added
