### PR TITLE
Nc account by id

### DIFF
--- a/docs/NooBaaNonContainerized/Configuration.md
+++ b/docs/NooBaaNonContainerized/Configuration.md
@@ -63,6 +63,7 @@ The default config directory structure contains the following files/directories 
 system.json                 // Required
 access_keys/                // Required
 accounts/                   // Required
+root_accounts/              // Required
 buckets/                    // Required
 config.json                 // Optional
 master_keys.json            // Optional
@@ -82,6 +83,7 @@ config_dir_redirect                             // Required
 system.json                                     // Required
 access_keys/                                    // Required
 accounts/                                       // Required
+root_accounts/                                  // Required
 buckets/                                        // Required
 config.json                                     // Optional
 master_keys.json                                // Optional
@@ -116,13 +118,31 @@ certificates/                                   // Optional
 `accounts/` - 
 * <u>Type</u>: Directory.
 * <u>Required</u>: Yes.
-* <u>Description</u>: A directory that contains configuration files for individual accounts, each account configuration file is named {account_name}.json and adheres to the [account schema](../../src/server/system_services/schemas/nsfs_account_schema.js).
+* <u>Description</u>: A directory that contains configuration files for individual accounts, each account configuration file is named {account_id}.json and adheres to the [account schema](../../src/server/system_services/schemas/nsfs_account_schema.js).
 * <u>Example</u>:
     ```sh
     > ls /etc/noobaa.conf.d/accounts/
-    alice.json
-    bob.json
-    charlie.json
+    abcd.json
+    1234.json
+    ab12.json
+    ```
+`root_accounts/` -
+* <u>Type</u>: Directory.
+* <u>Required</u>: Yes.
+* <u>Description</u>: A directory that contains a directory per root account, named {root_account_name}.
+Inside each such directory, there is a symlink for the root account, named {root_account_name}.symlink.
+There will be also the symlinks for the IAM accounts that are owned by the root account, named {account_name}.symlink.
+Symlinks link to an account within account/.
+The account symlink points to the relative path of the account rather than an absolute path, eg: `../../accounts/abcd.json`.
+* <u>Example</u>:
+    ```sh
+    > ls /etc/noobaa.conf.d/root_accounts/
+    alice/
+    bob/
+    charlie/
+    > ls -la /etc/noobaa.conf.d/root_accounts/alice/
+    alice.symlink -> ../../accounts/abcd.json
+    bob.symlink   -> ../../accounts/1234.json
     ```
 
 `access_keys/` 
@@ -132,9 +152,9 @@ certificates/                                   // Optional
 * <u>Example</u>:
     ```sh
     > ls -la /etc/noobaa.conf.d/access_keys/
-    0kbUZlNM9k4SCvrw1pftEXAMPLE.symlink -> ../accounts/alice.json
-    1kbUTlNM9k4SCvrw2pfxEXAMPLE.symlink -> ../accounts/bob.json
-    2kbUMlNM9k4SCvrw3pfyEXAMPLE.symlink -> ../accounts/charlie.json
+    0kbUZlNM9k4SCvrw1pftEXAMPLE.symlink -> ../accounts/abcd.json
+    1kbUTlNM9k4SCvrw2pfxEXAMPLE.symlink -> ../accounts/1234.json
+    2kbUMlNM9k4SCvrw3pfyEXAMPLE.symlink -> ../accounts/ab12.json
     ```
 `buckets/`
 * <u>Type</u>: Directory.

--- a/docs/NooBaaNonContainerized/GettingStarted.md
+++ b/docs/NooBaaNonContainerized/GettingStarted.md
@@ -31,7 +31,7 @@ NooBaa Non Containerized solution includes the following components -
 5. [Storage File System](#create-storage-file-system-paths) - A File system for storing objects.
 
 ### NooBaa High Level Diagram
-![NooBaa Non Containerized Components Diagram](https://github.com/noobaa/noobaa-core/assets/35330373/8d6cce71-e9e8-4e6a-ad88-5c65255bacc7)
+![NooBaa Non Containerized Components Diagram](https://github.com/user-attachments/assets/601a6220-f236-446e-9ead-404d41a5ffc5)
 
 
 ## Build NooBaa RPM

--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -63,14 +63,21 @@ The `account add` command is used to create a new account with customizable opti
 
 #### Usage
 ```sh
-noobaa-cli account add --name <account_name> --uid <uid> --gid <gid> [--user]
-[--new_buckets_path][--access_key][--secret_key][--fs_backend]
+noobaa-cli account add --name <root_account_name> --uid <uid> --gid <gid> [--user]
+[--iam_name][--new_buckets_path][--access_key][--secret_key][--fs_backend]
 [--allow_bucket_creation][--force_md5_etag][--anonymous][--from_file][--iam_operate_on_root_account]
 ```
 #### Flags -
 - `name` (Required)
     - Type: String
-    - Description: Specifies the name of the new account.
+    - Description: Specifies the name of the root account.
+    If creating an IAM account, specify the name of the new IAM account with `--iam_name` param in 
+    addition to `--name` param which is the root account that owns this IAM account.
+
+- `iam_name`
+    - Type: String
+    - Description: If creating a new IAM account, specifies the name of the new IAM account.
+    The new IAM account belongs to the root account specified with --name param.
 
 - `uid` (Required)
     - Type: Number
@@ -127,14 +134,21 @@ The `account update` command is used to update an existing account with customiz
 
 #### Usage
 ```sh
-noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--user]
-[--new_buckets_path][--access_key][--secret_key][--regenerate][--fs_backend]
+noobaa-cli account update --name <root_account_name> [--new_name][--uid][--gid][--user]
+[--iam_name][--new_buckets_path][--access_key][--secret_key][--regenerate][--fs_backend]
 [--allow_bucket_creation][--force_md5_etag][--anonymous][--iam_operate_on_root_account]
 ```
 #### Flags -
 - `name` (Required)
     - Type: String
-    - Description: Specifies the name of the account to be updated.
+    - Description: Specifies the name of the root account to be updated.
+    If updating an IAM account, specify its name with `--iam_name` param, in addition to `--name` 
+    param which is the root account that owns this IAM account.
+
+- `iam_name`
+    - Type: String
+    - Description: If updating an IAM account, specifies the name of the IAM account to be updated.
+    The update IAM account belongs to the root account specified with --name param.
 
 - `new_name` 
     - Type: String
@@ -195,12 +209,16 @@ The `account status` command is used to print the status of the account.
 
 #### Usage
 ```sh
-noobaa-cli account status --name <account_name> [--access_key][--anonymous][--show_secrets]
+noobaa-cli account status --name <root_account_name> [--iam_name][--access_key][--anonymous][--show_secrets]
 ```
 #### Flags -
 - `name` (Required)
     - Type: String
-    - Description: Specifies the name of the account.
+    - Description: Specifies the name of the root account.
+
+- `iam_name`
+    - Type: String
+    - Description: If requesting an IAM account, specifies the name of the IAM account (owned by root account).
 
 - `access_key`
     - Type: String
@@ -260,12 +278,18 @@ The `account delete` command is used to delete an existing account.
 
 #### Usage
 ```sh
-noobaa-cli account delete --name <account_name> [--anonymous]
+noobaa-cli account delete --name <root_account_name> [--iam_name][--anonymous]
 ```
 #### Flags -
 - `name` (Required)
     - Type: String
-    - Description: Specifies the name of the bucket to be deleted.
+    - Description: If deleting a root account, specifies the name of the account to be deleted.
+    If deleting an IAM account, specify the name of the IAM account to be deleted in addition
+    to `--name` param which is the root account that owns this IAM account.
+
+- `iam_name`
+    - Type: String
+    - Description: If deleting an IAM account, specifies the name of the IAM account the be deleted.
 
 - `anonymous`
     - Type: Boolean

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -229,16 +229,25 @@ async function authorize_request_policy(req) {
     }
 
     const account = req.object_sdk.requesting_account;
-    const account_identifier = req.object_sdk.nsfs_config_root ? account.name.unwrap() : account.email.unwrap();
-    const is_system_owner = account_identifier === system_owner.unwrap();
+    const account_identifier_name = req.object_sdk.nsfs_config_root ? account.name.unwrap() : account.email.unwrap();
+    const account_identifier_id = req.object_sdk.nsfs_config_root ? account._id : undefined;
+    //In old buckets (until 5.17), system_owner is account name (sensitive string).
+    //In new buckets (since 5.18), system_owner is account id (string).
+    const system_owner_equatable = system_owner.unwrap ? system_owner.unwrap() : system_owner;
+    const is_system_owner =
+        //name check is only for root accounts,
+        //check if account has owner to verify account is not iam account
+        (!account.owner && account_identifier_name === system_owner_equatable) ||
+        (account_identifier_id && account_identifier_id === system_owner_equatable);
 
     // @TODO: System owner as a construct should be removed - Temporary
     if (is_system_owner) return;
 
     const is_owner = (function() {
         if (account.bucket_claim_owner && account.bucket_claim_owner.unwrap() === req.params.bucket) return true;
-        if (owner_account && owner_account.id === account._id) return true;
-        if (account_identifier === bucket_owner.unwrap()) return true;
+        if (owner_account && account._id === owner_account.id) return true;
+        //name check - only for root accounts
+        if (!account.owner && account_identifier_name === bucket_owner.unwrap()) return true;
         return false;
     }());
 
@@ -250,8 +259,20 @@ async function authorize_request_policy(req) {
         if (is_owner || is_iam_account_and_same_root_account_owner) return;
         throw new S3Error(S3Error.AccessDenied);
     }
-    const permission = await s3_bucket_policy_utils.has_bucket_policy_permission(
-        s3_policy, account_identifier, method, arn_path, req);
+
+    let permission;
+    //for backwards compatibility, in nsfs, we allow principal to be either
+    //account name or account id.
+    if (account_identifier_id) {
+        permission = await s3_bucket_policy_utils.has_bucket_policy_permission(
+            s3_policy, account_identifier_id, method, arn_path, req);
+    }
+
+    if (!account_identifier_id || permission === "IMPLICIT_DENY") {
+        permission = await s3_bucket_policy_utils.has_bucket_policy_permission(
+            s3_policy, account_identifier_name, method, arn_path, req);
+    }
+
     if (permission === "DENY") throw new S3Error(S3Error.AccessDenied);
     if (permission === "ALLOW" || is_owner) return;
 

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -32,6 +32,7 @@ const DIAGNOSE_ACTIONS = {
 
 const CONFIG_SUBDIRS = {
     ACCOUNTS: 'accounts',
+    ROOT_ACCOUNTS: 'root_accounts',
     BUCKETS: 'buckets',
     ACCESS_KEYS: 'access_keys'
 };
@@ -42,11 +43,11 @@ const FROM_FILE = 'from_file';
 const ANONYMOUS = 'anonymous';
 
 const VALID_OPTIONS_ACCOUNT = {
-    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
-    'delete': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'iam_name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
+    'update': new Set(['name', 'iam_name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
+    'delete': new Set(['name', 'iam_name', ...GLOBAL_CONFIG_OPTIONS]),
     'list': new Set(['wide', 'show_secrets', 'gid', 'uid', 'user', 'name', 'access_key', ...GLOBAL_CONFIG_OPTIONS]),
-    'status': new Set(['name', 'access_key', 'show_secrets', ...GLOBAL_CONFIG_OPTIONS]),
+    'status': new Set(['name', 'iam_name', 'access_key', 'show_secrets', ...GLOBAL_CONFIG_OPTIONS]),
 };
 
 const VALID_OPTIONS_ANONYMOUS_ACCOUNT = {
@@ -93,6 +94,7 @@ const VALID_OPTIONS = {
 
 const OPTION_TYPE = {
     name: 'string',
+    iam_name: 'string',
     owner: 'string',
     uid: 'number',
     gid: 'number',

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -75,7 +75,8 @@ Usage:
 account add [flags]
 
 Flags:
---name <string>                                                         Set the name for the account
+--name <string>                                                         Set the name for the root account
+--iam_name <string>                                   (optional)        Set the name for the iam account
 --uid <number>                                                          Set the User Identifier (UID) (UID and GID can be replaced by --user option)
 --gid <number>                                                          Set the Group Identifier (GID) (UID and GID can be replaced by --user option)
 --new_buckets_path <string>                           (optional)        Set the filesystem's root path where each subdirectory is a bucket
@@ -94,7 +95,8 @@ Usage:
 account update [flags]
 
 Flags:
---name <string>                                                         The name of the account
+--name <string>                                                         Set the name for the root account
+--iam_name <string>                                   (optional)        Set the name for the iam account
 --new_name <string>                                   (optional)        Update the account name
 --uid <number>                                        (optional)        Update the User Identifier (UID)
 --gid <number>                                        (optional)        Update the Group Identifier (GID)
@@ -122,7 +124,8 @@ Usage:
 account status [flags]
 
 Flags:
---name <string>                                                         The name of the account
+--name <string>                                                         Set the name for the root account
+--iam_name <string>                                   (optional)        Set the name for the iam account
 --access_key <string>                                 (optional)        The access key of the account (identify the account instead of name)
 --show_secrets                                        (optional)        Print the access key and secret key of the account
 `;

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -8,7 +8,6 @@ module.exports = {
         '_id',
         'name',
         'system_owner',
-        'bucket_owner',
         'owner_account',
         'versioning',
         'path',
@@ -31,10 +30,6 @@ module.exports = {
             type: 'string',
         },
         system_owner: {
-            type: 'string',
-        },
-        // bucket_owner is the account name
-        bucket_owner: {
             type: 'string',
         },
         tag: {

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_nsfs_s3_config_setup.js
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_nsfs_s3_config_setup.js
@@ -8,6 +8,7 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const dbg = require('../../../util/debug_module')(__filename);
 dbg.set_process_name('test_ceph_s3');
 
@@ -73,8 +74,8 @@ async function ceph_test_setup() {
 
 }
 
-async function get_access_keys(path) {
-    const account_data = await fs.promises.readFile(path, 'utf8');
+async function get_access_keys(access_key_path) {
+    const account_data = await fs.promises.readFile(access_key_path, 'utf8');
     const data_json = JSON.parse(account_data);
     const access_key = data_json.access_keys[0].access_key;
     const encrypted_secret_key = data_json.access_keys[0].encrypted_secret_key;
@@ -100,6 +101,7 @@ async function create_anonymous_account() {
         master_key_id: master_key_id,
     };
     const account_data = JSON.stringify(data);
+    await fs.promises.mkdir(path.dirname(anonymous_account_path));
     await fs.promises.writeFile(anonymous_account_path, account_data);
     console.log('Anonymous account created');
 }

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_constants.js
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_constants.js
@@ -21,9 +21,9 @@ const CEPH_TEST = {
 };
 
 // For NSFS NC path (using default values)
-const account_path = '/etc/noobaa.conf.d/accounts/cephalt.json';
-const account_tenant_path = '/etc/noobaa.conf.d/accounts/cephtenant.json';
-const anonymous_account_path = '/etc/noobaa.conf.d/accounts/anonymous.json';
+const account_path = '/etc/noobaa.conf.d/root_accounts/cephalt/cephalt.symlink';
+const account_tenant_path = '/etc/noobaa.conf.d/root_accounts/cephtenant/cephtenant.symlink';
+const anonymous_account_path = '/etc/noobaa.conf.d/root_accounts/anonymous/anonymous.symlink';
 
 const DEFAULT_NUMBER_OF_WORKERS = 5; //5 was the number of workers in the previous CI/CD process
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -42,7 +42,7 @@ describe('manage nsfs cli account flow', () => {
             secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
         };
         beforeEach(async () => {
-            await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
+            await P.all(_.map([CONFIG_SUBDIRS.ROOT_ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
@@ -61,13 +61,13 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
             const access_key = account.access_keys[0].access_key;
             const secret_key = account.access_keys[0].secret_key;
             expect(access_key).toBeDefined();
             expect(secret_key).toBeDefined();
-            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key);
             assert_account(account_symlink, account_options);
         });
 
@@ -101,9 +101,9 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, true);
-            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key);
             assert_account(account_symlink, account_options);
         });
 
@@ -147,9 +147,9 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
-            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key);
             assert_account(account_symlink, account_options);
         });
 
@@ -266,7 +266,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
             expect(account.allow_bucket_creation).toBe(true);
         });
@@ -280,7 +280,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
             expect(account.allow_bucket_creation).toBe(true);
         });
@@ -294,7 +294,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
             expect(account.allow_bucket_creation).toBe(true);
         });
@@ -308,7 +308,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
             expect(account.allow_bucket_creation).toBe(false);
         });
@@ -322,7 +322,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
             expect(account.allow_bucket_creation).toBe(false);
         });
@@ -359,12 +359,12 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
-            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+            const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key);
             assert_account(account_symlink, account_options);
             const real_path = fs.readlinkSync(path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key + '.symlink'));
-            expect(real_path).toContain('../accounts/' + account_options.name + '.json');
+            expect(real_path).toContain('../accounts/' + account._id + '.json');
         });
 
         it('cli account add - use flag force_md5_etag', async function() {
@@ -376,7 +376,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             expect(account.force_md5_etag).toBe(true);
         });
 
@@ -390,7 +390,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             expect(account.iam_operate_on_root_account).toBe(true);
             expect(account.allow_bucket_creation).toBe(true);
         });
@@ -405,7 +405,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             expect(account.iam_operate_on_root_account).toBe(false);
             expect(account.allow_bucket_creation).toBe(true); // by default it is inferred when we have new_buckets_path
         });
@@ -525,7 +525,7 @@ describe('manage nsfs cli account flow', () => {
             };
 
             beforeEach(async () => {
-                await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
+                await P.all(_.map([CONFIG_SUBDIRS.ROOT_ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
                     fs_utils.create_fresh_path(`${config_root}/${dir}`)));
                 await fs_utils.create_fresh_path(root_path);
                 set_nc_config_dir_in_config(config_root);
@@ -543,16 +543,16 @@ describe('manage nsfs cli account flow', () => {
                 await fs_utils.folder_delete(`${root_path}`);
             });
 
-            it('cli regenerate account access_keys', async () => {
+            it('cli regenerate account access_keys2', async () => {
                 const { name } = defaults;
                 const account_options = { config_root, name, regenerate: true };
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
                 const new_access_key = new_account_details.access_keys[0].access_key;
-                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, new_access_key, true);
+                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, new_access_key);
                 //fixing the new_account_details for compare. 
                 new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
                 assert_account(account_symlink, new_account_details);
@@ -561,13 +561,13 @@ describe('manage nsfs cli account flow', () => {
             it('cli regenerate account access_keys with value "true"', async () => {
                 const { name } = defaults;
                 const account_options = { config_root, name, regenerate: 'true' };
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
                 const new_access_key = new_account_details.access_keys[0].access_key;
-                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, new_access_key, true);
+                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, new_access_key);
                 //fixing the new_account_details for compare. 
                 new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
                 assert_account(account_symlink, new_account_details);
@@ -576,13 +576,13 @@ describe('manage nsfs cli account flow', () => {
             it('cli regenerate account access_keys with value "TRUE" (case insensitive)', async () => {
                 const { name } = defaults;
                 const account_options = { config_root, name, regenerate: 'TRUE' };
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
                 const new_access_key = new_account_details.access_keys[0].access_key;
-                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, new_access_key, true);
+                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, new_access_key);
                 //fixing the new_account_details for compare. 
                 new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
                 assert_account(account_symlink, new_account_details);
@@ -591,20 +591,20 @@ describe('manage nsfs cli account flow', () => {
             it('cli regenerate account access_keys with value "false"', async () => {
                 const { name } = defaults;
                 const account_options = { config_root, name, regenerate: 'false' };
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                const new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(account_details.access_keys[0].access_key).toBe(new_account_details.access_keys[0].access_key);
             });
 
             it('cli regenerate account access_keys with value "FALSE" (case insensitive)', async () => {
                 const { name } = defaults;
                 const account_options = { config_root, name, regenerate: 'FALSE' };
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                const new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(account_details.access_keys[0].access_key).toBe(new_account_details.access_keys[0].access_key);
             });
 
@@ -631,10 +631,10 @@ describe('manage nsfs cli account flow', () => {
                 const action = ACTIONS.UPDATE;
                 account_options.new_name = 'account1_new_name';
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, new_name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, new_name);
                 expect(new_account_details.name).toBe(new_name);
                 const access_key = new_account_details.access_keys[0].access_key;
-                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key);
                 //fixing the new_account_details for compare. 
                 new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
                 assert_account(account_symlink, new_account_details);
@@ -647,7 +647,7 @@ describe('manage nsfs cli account flow', () => {
                 let account_options = { config_root, name, new_name };
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, new_name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, new_name);
                 expect(new_account_details.name).toBe(new_name);
 
                 // set the name as back as it was
@@ -656,7 +656,7 @@ describe('manage nsfs cli account flow', () => {
                 new_name = temp;
                 account_options = { config_root, name, new_name };
                 await exec_manage_cli(type, action, account_options);
-                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, new_name);
+                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, new_name);
                 expect(new_account_details.name).toBe(new_name);
 
                 // set the name as undefined (not string)
@@ -664,7 +664,7 @@ describe('manage nsfs cli account flow', () => {
                 new_name = undefined;
                 account_options = { config_root, name, new_name };
                 await exec_manage_cli(type, action, account_options);
-                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, new_name);
+                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, 'undefined');
                 expect(new_account_details.name).toBe(String(new_name));
 
                 // set the name as back as it was
@@ -673,7 +673,7 @@ describe('manage nsfs cli account flow', () => {
                 new_name = temp;
                 account_options = { config_root, name, new_name };
                 await exec_manage_cli(type, action, account_options);
-                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, new_name);
+                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, new_name);
                 expect(new_account_details.name).toBe(new_name);
             });
 
@@ -683,16 +683,16 @@ describe('manage nsfs cli account flow', () => {
                 const access_key = 'GIGiFAnjaaE7OKD5N7hB';
                 const secret_key = 'U3AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
                 const account_options = { config_root, name, new_name, access_key, secret_key };
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 const action = ACTIONS.UPDATE;
                 account_options.new_name = 'account1_new_name';
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, new_name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, new_name);
                 expect(new_account_details.name).toBe(new_name);
                 expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
                 expect(account_details.access_keys[0].secret_key).not.toBe(new_account_details.access_keys[0].secret_key);
                 expect(new_account_details.access_keys[0].access_key).toBe(access_key);
-                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key);
                 //fixing the new_account_details for compare. 
                 new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
                 assert_account(account_symlink, new_account_details);
@@ -703,14 +703,14 @@ describe('manage nsfs cli account flow', () => {
                 const access_key = 'GIGiFAnjaaE7OKD5N7hB';
                 const secret_key = 'U3AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
                 const account_options = { config_root, name, access_key, secret_key };
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(account_details.access_keys[0].access_key).not.toBe(new_account_details.access_keys[0].access_key);
                 expect(account_details.access_keys[0].secret_key).not.toBe(new_account_details.access_keys[0].secret_key);
                 expect(new_account_details.access_keys[0].access_key).toBe(access_key);
-                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key);
                 //fixing the new_account_details for compare. 
                 new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
                 assert_account(account_symlink, new_account_details);
@@ -741,14 +741,14 @@ describe('manage nsfs cli account flow', () => {
                 const account_options = { config_root, name, new_buckets_path: empty_string};
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.nsfs_account_config.new_buckets_path).toBeUndefined();
                 expect(new_account_details.allow_bucket_creation).toBe(false);
 
                 //set new_buckets_path value back to its original value
                 account_options.new_buckets_path = defaults.new_buckets_path;
                 await exec_manage_cli(type, action, account_options);
-                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.nsfs_account_config.new_buckets_path).toBe(defaults.new_buckets_path);
                 expect(new_account_details.allow_bucket_creation).toBe(true);
             });
@@ -762,13 +762,13 @@ describe('manage nsfs cli account flow', () => {
                 const action = ACTIONS.UPDATE;
                 account_options.new_name = 'account1_new_name';
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, new_name);
-                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, new_name);
+                const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key);
                 //fixing the new_account_details for compare. 
                 new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
                 assert_account(account_symlink, new_account_details);
                 const real_path = fs.readlinkSync(path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key + '.symlink'));
-                expect(real_path).toContain('../accounts/' + new_name + '.json');
+                expect(real_path).toContain('../accounts/' + new_account_details._id + '.json');
             });
 
             it('cli update account set flag force_md5_etag', async function() {
@@ -776,12 +776,12 @@ describe('manage nsfs cli account flow', () => {
                 const account_options = { config_root, name, force_md5_etag: 'true'};
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.force_md5_etag).toBe(true);
 
                 account_options.force_md5_etag = 'false';
                 await exec_manage_cli(type, action, account_options);
-                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.force_md5_etag).toBe(false);
             });
 
@@ -791,14 +791,14 @@ describe('manage nsfs cli account flow', () => {
                 const account_options = { config_root, name, force_md5_etag: 'true'};
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.force_md5_etag).toBe(true);
 
                 // unset force_md5_etag
                 const empty_string = '\'\'';
                 account_options.force_md5_etag = empty_string;
                 await exec_manage_cli(type, action, account_options);
-                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.force_md5_etag).toBeUndefined();
             });
 
@@ -807,12 +807,12 @@ describe('manage nsfs cli account flow', () => {
                 const account_options = { config_root, name, iam_operate_on_root_account: 'true'};
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                let new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.iam_operate_on_root_account).toBe(true);
 
                 account_options.iam_operate_on_root_account = 'false';
                 await exec_manage_cli(type, action, account_options);
-                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.iam_operate_on_root_account).toBe(false);
             });
 
@@ -822,7 +822,7 @@ describe('manage nsfs cli account flow', () => {
                 const account_options = { config_root, name, iam_operate_on_root_account: 'true'};
                 const action = ACTIONS.UPDATE;
                 await exec_manage_cli(type, action, account_options);
-                const new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const new_account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(new_account_details.iam_operate_on_root_account).toBe(true);
 
                 // unset iam_operate_on_root_account (is not allowed)
@@ -852,21 +852,10 @@ describe('manage nsfs cli account flow', () => {
 
             it('should fail - cli update account iam_operate_on_root_account true when account owns IAM accounts', async function() {
                 const { name } = defaults;
-                const accounts_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
-                const account_id = accounts_details._id;
 
                 const account_name = 'account-to-be-owned';
-                const account_options1 = { config_root, name: account_name, uid: 5555, gid: 5555 };
+                const account_options1 = { config_root, name, iam_name: account_name, uid: 5555, gid: 5555 };
                 await exec_manage_cli(type, ACTIONS.ADD, account_options1);
-
-                // update the account to have the property owner
-                // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
-                const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
-                const config_data = JSON.parse(data.toString());
-                config_data.owner = account_id; // just so we can identify this account as IAM user
-                await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
-                    account_config_path, JSON.stringify(config_data));
 
                 // set the value of iam_operate_on_root_account to be true
                 const account_options2 = { config_root, name, iam_operate_on_root_account: true};
@@ -879,11 +868,11 @@ describe('manage nsfs cli account flow', () => {
                 // update the account to have the property owner
                 // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
                 const { name } = defaults;
-                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name, name + '.symlink');
                 const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
                 const config_data = JSON.parse(data.toString());
                 config_data.owner = '65a62e22ceae5e5f1a758aa9'; // just so we can identify this account as IAM user
-                await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
+                await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ROOT_ACCOUNTS,
                     account_config_path, JSON.stringify(config_data));
 
                 // set the value of iam_operate_on_root_account to be true
@@ -917,7 +906,7 @@ describe('manage nsfs cli account flow', () => {
                 const account_options = { config_root, name, user: distinguished_name };
                 await set_path_permissions_and_owner(new_buckets_path, { uid: 0, gid: 0 }, 0o700);
                 await exec_manage_cli(type, action, account_options);
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(account_details.nsfs_account_config.uid).toBeUndefined();
                 expect(account_details.nsfs_account_config.gid).toBeUndefined();
                 expect(account_details.nsfs_account_config.distinguished_name).toBe(distinguished_name);
@@ -949,27 +938,13 @@ describe('manage nsfs cli account flow', () => {
 
             it('cli update iam account with regenerate (only object access keys in index 0 changes)', async function() {
                 const { name } = defaults;
-                const accounts_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
-                const account_id = accounts_details._id;
 
                 const account_name = 'account-to-be-owned';
-                const account_options1 = { config_root, name: account_name, uid: 5555, gid: 5555 };
+                const account_options1 = { config_root, name: name, iam_name: account_name, uid: 5555, gid: 5555};
                 await exec_manage_cli(type, ACTIONS.ADD, account_options1);
 
-                // update the account to have the property owner
-                // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
-                const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
-                const config_data = JSON.parse(data.toString());
-                config_data.owner = account_id; // just so we can identify this account as IAM user
-                // add additional properties to access_keys_object
-                config_data.access_keys[0].creation_date = '2024-07-10T11:26:34.569Z';
-                config_data.access_keys[0].deactivated = false;
-                await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
-                    account_config_path, JSON.stringify(config_data));
-
                 // regenerate (auto change the access keys in index 0 only)
-                const account_options2 = { config_root, name, regenerate: true};
+                const account_options2 = { config_root, name, iam_name: account_name, regenerate: true};
                 const res = await exec_manage_cli(type, ACTIONS.UPDATE, account_options2);
                 expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.AccountUpdated.code);
                 expect(JSON.parse(res).response.reply.access_keys[0].creation_date).toBeUndefined();
@@ -978,29 +953,15 @@ describe('manage nsfs cli account flow', () => {
 
             it('cli update iam account with access_key and secret_key flag (only object access keys in index 0 changes)', async function() {
                 const { name } = defaults;
-                const accounts_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
-                const account_id = accounts_details._id;
 
                 const account_name = 'account-to-be-owned';
-                const account_options1 = { config_root, name: account_name, uid: 5555, gid: 5555 };
+                const account_options1 = { config_root, name, iam_name: account_name, uid: 5555, gid: 5555 };
                 await exec_manage_cli(type, ACTIONS.ADD, account_options1);
-
-                // update the account to have the property owner
-                // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
-                const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
-                const config_data = JSON.parse(data.toString());
-                config_data.owner = account_id; // just so we can identify this account as IAM user
-                // add additional properties to access_keys_object
-                config_data.access_keys[0].creation_date = '2024-07-10T11:26:34.569Z';
-                config_data.access_keys[0].deactivated = false;
-                await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
-                    account_config_path, JSON.stringify(config_data));
 
                 // update access_key and secret_key (change the access keys in index 0 only)
                 const access_key = 'GIGiFAnjsaE7OKg5N7hB';
                 const secret_key = 'U3AYaMpU3zRDcRKWmvzgTr9MoHIAsD+3oEXAMPLE';
-                const account_options2 = { config_root, name, access_key, secret_key};
+                const account_options2 = { config_root, name, iam_name: account_name, access_key, secret_key};
                 const res = await exec_manage_cli(type, ACTIONS.UPDATE, account_options2);
                 expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.AccountUpdated.code);
                 expect(JSON.parse(res).response.reply.access_keys[0].creation_date).toBeUndefined();
@@ -1038,7 +999,7 @@ describe('manage nsfs cli account flow', () => {
             };
 
             beforeEach(async () => {
-                await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
+                await P.all(_.map([ CONFIG_SUBDIRS.ROOT_ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
                     fs_utils.create_fresh_path(`${config_root}/${dir}`)));
                 await fs_utils.create_fresh_path(root_path);
                 set_nc_config_dir_in_config(config_root);
@@ -1064,7 +1025,7 @@ describe('manage nsfs cli account flow', () => {
                 const account_options = { config_root, name, uid, gid };
                 await set_path_permissions_and_owner(new_buckets_path, { uid, gid }, 0o700);
                 await exec_manage_cli(type, action, account_options);
-                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+                const account_details = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
                 expect(account_details.nsfs_account_config.uid).toBe(uid);
                 expect(account_details.nsfs_account_config.gid).toBe(gid);
                 expect(account_details.nsfs_account_config.distinguished_name).toBeUndefined();
@@ -1107,7 +1068,7 @@ describe('manage nsfs cli account flow', () => {
         }];
 
         beforeAll(async () => {
-            await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
+            await P.all(_.map([ CONFIG_SUBDIRS.ROOT_ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
@@ -1329,9 +1290,10 @@ describe('manage nsfs cli account flow', () => {
             access_key: 'GIGiFAnjaaE7OKD5N7h1',
             secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+31EXAMPLE',
         };
+        let account_id;
 
         beforeEach(async () => {
-            await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS, CONFIG_SUBDIRS.BUCKETS], async dir =>
+            await P.all(_.map([ CONFIG_SUBDIRS.ROOT_ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS, CONFIG_SUBDIRS.BUCKETS], async dir =>
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
@@ -1339,14 +1301,15 @@ describe('manage nsfs cli account flow', () => {
 
         beforeEach(async () => {
             // cli create account
-            const action = ACTIONS.ADD;
-            const { type, name, new_buckets_path, uid, gid } = defaults;
+            //const action = ACTIONS.ADD;
+            const { name, new_buckets_path, uid, gid } = defaults;
             const account_options = { config_root, name, new_buckets_path, uid, gid };
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(account_options.new_buckets_path, account_options, 0o700);
-            await exec_manage_cli(type, action, account_options);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            //await exec_manage_cli(type, action, account_options);
+            account_id = await create_account_and_get_id(account_options);
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name, name + '.symlink');
             await fs_utils.file_must_exist(config_path);
         });
 
@@ -1365,10 +1328,11 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli(type, action, account_options);
             const res_json = JSON.parse(res.trim());
             expect(res_json.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name, name + '.json');
             await fs_utils.file_must_not_exist(config_path);
             const symlink_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, defaults.access_key + '.symlink');
             await fs_utils.file_must_not_exist(symlink_config_path);
+            await fs_utils.file_must_not_exist(path.join(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name));
         });
 
         it('cli delete account (account has 2 access keys objects)', async () => {
@@ -1378,7 +1342,7 @@ describe('manage nsfs cli account flow', () => {
             // currently we don't have the ability to create 2 access keys in the noobaa-cli
             // therefore, we will mock the config as there are 2 access keys objects
             // and also create the symlink for the one that manually added
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_id);
             const account_with_2_access_keys_objects = _.cloneDeep(account);
             const access_key2 = 'AIGiFAnjaaE7OKD5N7hA';
             const secret_key2 = 'A2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3AEXAMPLE';
@@ -1388,7 +1352,7 @@ describe('manage nsfs cli account flow', () => {
                 creation_date: new Date().toISOString(),
                 deactivated: false,
             });
-            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_id + '.json');
             await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
                 account_config_path, JSON.stringify(account_with_2_access_keys_objects));
             const account_config_relative_path = path.join(config_root, '../' + CONFIG_SUBDIRS.ACCOUNTS + '/', name + '.json');
@@ -1401,7 +1365,7 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli(type, action, account_options);
             const res_json = JSON.parse(res.trim());
             expect(res_json.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_id + '.json');
             await fs_utils.file_must_not_exist(config_path);
             const symlink_config_path1 = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, defaults.access_key + '.symlink');
             await fs_utils.file_must_not_exist(symlink_config_path1);
@@ -1430,7 +1394,7 @@ describe('manage nsfs cli account flow', () => {
             const account_options = { config_root, name };
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.AccountDeleteForbiddenHasBuckets.code);
-            config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            config_path = path.join(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name, name + '.symlink');
             await fs_utils.file_must_exist(config_path);
         });
 
@@ -1461,26 +1425,32 @@ describe('manage nsfs cli account flow', () => {
 
         it('should fail - cli account delete - root account has IAM accounts', async function() {
             const { name, type } = defaults;
-            const accounts_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
-            const account_id = accounts_details._id;
 
             const account_name = 'account-to-be-owned';
-            const account_options1 = { config_root, name: account_name, uid: 5555, gid: 5555 };
+            const account_options1 = { config_root, name, iam_name: account_name, uid: 5555, gid: 5555 };
             await exec_manage_cli(type, ACTIONS.ADD, account_options1);
-
-            // update the account to have the property owner
-            // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
-            const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
-            const config_data = JSON.parse(data.toString());
-            config_data.owner = account_id; // just so we can identify this account as IAM user;
-            await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
-                account_config_path, JSON.stringify(config_data));
 
             const action = ACTIONS.DELETE;
             const account_options2 = { config_root, name };
             const res = await exec_manage_cli(type, action, account_options2);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.AccountDeleteForbiddenHasIAMAccounts.code);
+        });
+
+        it('cli account delete - delete iam account', async function() {
+            const { name, type } = defaults;
+
+            const account_name = 'account-to-be-owned';
+            const account_options1 = { config_root, name, iam_name: account_name, uid: 5555, gid: 5555 };
+            await exec_manage_cli(type, ACTIONS.ADD, account_options1);
+
+            const action = ACTIONS.DELETE;
+            const account_options2 = { config_root, name, iam_name: account_name };
+            const res = await exec_manage_cli(type, action, account_options2);
+            const res_json = JSON.parse(res.trim());
+            expect(res_json.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name, account_name + '.json');
+            await fs_utils.file_must_not_exist(config_path);
+            await fs_utils.file_must_exist(path.join(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name));
         });
 
     });
@@ -1499,7 +1469,7 @@ describe('manage nsfs cli account flow', () => {
         };
 
         beforeEach(async () => {
-            await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
+            await P.all(_.map([ CONFIG_SUBDIRS.ROOT_ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
@@ -1549,7 +1519,7 @@ describe('manage nsfs cli account flow', () => {
         };
 
         beforeEach(async () => {
-            await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
+            await P.all(_.map([ CONFIG_SUBDIRS.ROOT_ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
                 fs_utils.create_fresh_path(`${config_root}/${dir}`)));
             set_nc_config_dir_in_config(config_root);
             await fs_utils.create_fresh_path(root_path);
@@ -1578,7 +1548,7 @@ describe('manage nsfs cli account flow', () => {
             // create the account and check the details
             await exec_manage_cli(type, action, command_flags);
             // compare the details
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, false);
         });
 
@@ -1592,7 +1562,7 @@ describe('manage nsfs cli account flow', () => {
             // create the account and check the details
             await exec_manage_cli(type, action, command_flags);
             // compare the details
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, name);
             assert_account(account, account_options, true);
             expect(account.access_keys[0].access_key).toBe(access_key);
             expect(account.access_keys[0].secret_key).toBe(secret_key);
@@ -1958,10 +1928,16 @@ describe('cli account flow distinguished_name - permissions', function() {
  * @param {string} config_root
  * @param {string} schema_dir 
  * @param {string} config_file_name the name of the config file
- * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
  */
-async function read_config_file(config_root, schema_dir, config_file_name, is_symlink) {
-    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+async function read_config_file(config_root, schema_dir, config_file_name) {
+    let config_path;
+    if (schema_dir === CONFIG_SUBDIRS.ROOT_ACCOUNTS) {
+        config_path = path.join(config_root, schema_dir, config_file_name, config_file_name + '.symlink');
+    } else if (schema_dir === CONFIG_SUBDIRS.ACCESS_KEYS) {
+        config_path = path.join(config_root, schema_dir, config_file_name + '.symlink');
+    } else {
+        config_path = path.join(config_root, schema_dir, config_file_name + '.json');
+    }
     const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
     const config_data = JSON.parse(data.toString());
     const encrypted_secret_key = config_data.access_keys[0].encrypted_secret_key;
@@ -2060,4 +2036,14 @@ async function create_json_account_options(path_to_json_account_options_dir, acc
     const content = JSON.stringify(account_options);
     await fs.promises.writeFile(path_to_option_json_file_name, content);
     return path_to_option_json_file_name;
+}
+
+/**
+ * Invoke cli to create an account, parses new account id from the response
+ * @param {object} account
+ */
+
+async function create_account_and_get_id(account) {
+    const res = JSON.parse(await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, account));
+    return res.response.reply._id;
 }

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_anonymous_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_anonymous_cli.test.js
@@ -52,7 +52,7 @@ describe('manage nsfs cli anonymous account flow', () => {
             const { type, uid, gid, anonymous } = defaults;
             const account_options = { anonymous, config_root, uid, gid };
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
             assert_account(account, account_options);
         });
 
@@ -115,7 +115,7 @@ describe('manage nsfs cli anonymous account flow', () => {
             action = ACTIONS.ADD;
             account_options = { anonymous, config_root, user };
             resp = await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
             assert_account(account, account_options);
         });
 
@@ -159,14 +159,14 @@ describe('manage nsfs cli anonymous account flow', () => {
             let { type, uid, gid, anonymous } = defaults;
             const account_options = { anonymous, config_root, uid, gid };
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
             assert_account(account, account_options);
 
             action = ACTIONS.UPDATE;
             gid = 1001;
             const account_update_options = { anonymous, config_root, uid, gid };
             await exec_manage_cli(type, action, account_update_options);
-            const update_account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
+            const update_account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
             assert_account(update_account, account_update_options);
         });
 
@@ -219,7 +219,7 @@ describe('manage nsfs cli anonymous account flow', () => {
             const { type, uid, gid, anonymous } = defaults;
             const account_options = { anonymous, config_root, uid, gid };
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
             assert_account(account, account_options);
 
             action = ACTIONS.DELETE;
@@ -268,7 +268,7 @@ describe('manage nsfs cli anonymous account flow', () => {
             const { type, uid, gid, anonymous } = defaults;
             const account_options = { anonymous, config_root, uid, gid };
             await exec_manage_cli(type, action, account_options);
-            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
+            const account = await read_config_file(config_root, CONFIG_SUBDIRS.ROOT_ACCOUNTS, config.ANONYMOUS_ACCOUNT_NAME);
             assert_account(account, account_options);
 
             action = ACTIONS.STATUS;
@@ -286,10 +286,16 @@ describe('manage nsfs cli anonymous account flow', () => {
  * @param {string} config_root
  * @param {string} schema_dir 
  * @param {string} config_file_name the name of the config file
- * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
  */
-async function read_config_file(config_root, schema_dir, config_file_name, is_symlink) {
-    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+async function read_config_file(config_root, schema_dir, config_file_name) {
+    let config_path;
+    if (schema_dir === CONFIG_SUBDIRS.ROOT_ACCOUNTS) {
+        config_path = path.join(config_root, schema_dir, config_file_name, config_file_name + '.symlink');
+    } else if (schema_dir === CONFIG_SUBDIRS.ACCESS_KEYS) {
+        config_path = path.join(config_root, schema_dir, config_file_name + '.symlink');
+    } else {
+        config_path = path.join(config_root, schema_dir, config_file_name + '.json');
+    }
     const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
     const config_data = JSON.parse(data.toString());
     return config_data;

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -199,24 +199,6 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
-        it('bucket without bucket_owner', () => {
-            const bucket_data = get_bucket_data();
-            delete bucket_data.bucket_owner;
-            const reason = 'Test should have failed because of missing required property ' +
-                'bucket_owner';
-            const message = "must have required property 'bucket_owner'";
-            assert_validation(bucket_data, reason, message);
-        });
-
-        it('bucket with undefined bucket_owner', () => {
-            const bucket_data = get_bucket_data();
-            bucket_data.bucket_owner = undefined;
-            const reason = 'Test should have failed because of missing required property ' +
-                'bucket_owner';
-            const message = "must have required property 'bucket_owner'";
-            assert_validation(bucket_data, reason, message);
-        });
-
         it('bucket without versioning', () => {
             const bucket_data = get_bucket_data();
             delete bucket_data.versioning;
@@ -463,8 +445,7 @@ describe('schema validation NC NSFS bucket', () => {
 function get_bucket_data() {
     const bucket_name = 'bucket1';
     const id = '65a62e22ceae5e5f1a758aa8';
-    const system_owner = 'account1'; // GAP - currently account name
-    const bucket_owner = 'account1'; // account name
+    const system_owner = '65b3c68b59ab67b16f98c26e'; // GAP - currently bucker owner account id
     const owner_account = '65b3c68b59ab67b16f98c26e';
     const versioning_disabled = 'DISABLED';
     const creation_date = new Date('December 17, 2023 09:00:00').toISOString();
@@ -474,7 +455,6 @@ function get_bucket_data() {
         _id: id,
         name: bucket_name,
         system_owner: system_owner,
-        bucket_owner: bucket_owner,
         owner_account: owner_account,
         versioning: versioning_disabled,
         creation_date: creation_date,

--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -956,7 +956,8 @@ mocha.describe('s3_bucket_policy', function() {
         }));
     });
 
-    mocha.it('should be able to use notPrincipal', async function() {
+    mocha.it.skip('should be able to use notPrincipal', async function() {
+        //This test is broken - Effect Allow can't be used with NotPrincipal.
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(15000);
         const auth_put_policy = {

--- a/src/upgrade/upgrade_scripts/5.18.0/upgrade_conf_518.js
+++ b/src/upgrade/upgrade_scripts/5.18.0/upgrade_conf_518.js
@@ -1,0 +1,173 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const minimist = require('minimist');
+const {statSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, symlinkSync, rmSync} = require('fs');
+const {join} = require('path');
+const { CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const config = require('../../../../config');
+
+const dbg = require('../../../util/debug_module')(__filename);
+
+const account_id_to_name = new Map();
+
+function validate_dir_exists(path, print_error) {
+    if (!existsSync(path)) {
+        if (print_error) {
+            dbg.error("path ", path, " does not exist.");
+        }
+        return false;
+    }
+    const conf_path_stat = statSync(path);
+    if (!conf_path_stat.isDirectory) {
+        if (print_error) {
+            dbg.error("path ", path, " is not a directory.");
+        }
+        return false;
+    }
+    return true;
+}
+
+function assert_dir_exists(path) {
+    if (!validate_dir_exists(path, true)) {
+        process.exit(1);
+    }
+}
+
+function account_file_to_object(dir_ent) {
+    if (!dir_ent.isFile()) {
+        dbg.warn("Entry in account dir is not a file. dir_ent = ", dir_ent);
+        return {account: undefined, error: 1};
+    }
+    const filename = join(dir_ent.parentPath, dir_ent.name);
+    if (!filename.endsWith(".json")) {
+        dbg.warn("File in accounts dir is not a json file. Filename = ", filename);
+        return {account: undefined, error: 2};
+    }
+
+    const account_str = readFileSync(filename);
+    const account = JSON.parse(account_str);
+
+    if ((account.name + ".json") !== dir_ent.name) {
+        dbg.error("Account name mismatch filename. Account name = ", account.name, ", filename = ", dir_ent.name);
+        return {account: undefined, error: 3};
+    }
+
+    return {account, error: undefined};
+}
+
+function handle_account_file(dir_ent, conf_dir) {
+    const { account, error} = account_file_to_object(dir_ent);
+    if (error) {
+        return error;
+    }
+
+    if (account.access_keys) {
+        for (const access_key_obj of account.access_keys) {
+            const access_key_symlink = join(conf_dir, CONFIG_SUBDIRS.ACCESS_KEYS, access_key_obj.access_key + ".symlink");
+            if (!existsSync(access_key_symlink)) {
+                dbg.error("Access key not found. Account name = ", account.name, ", access key = ", access_key_obj.access_key);
+                return 4;
+            }
+        }
+    }
+
+    const account_new_name = join(dir_ent.parentPath, account._id + ".json");
+    const filename = join(dir_ent.parentPath, dir_ent.name);
+    dbg.log("Renaming account file, old =", dir_ent.name, ", new =", account._id + ".json");
+    renameSync(filename, account_new_name);
+
+    const symlink_target = join('..', CONFIG_SUBDIRS.ACCOUNTS, account._id + ".json");
+    const symlink_target_double = join('..', '..', CONFIG_SUBDIRS.ACCOUNTS, account._id + ".json");
+
+    if (account.access_keys) {
+        for (const access_key_obj of account.access_keys) {
+            const access_key_symlink = join(conf_dir, CONFIG_SUBDIRS.ACCESS_KEYS, access_key_obj.access_key + ".symlink");
+            dbg.log("Updating access key symlink ", access_key_symlink, ", new target =", symlink_target);
+            rmSync(access_key_symlink);
+            symlinkSync(symlink_target, access_key_symlink);
+        }
+    }
+
+    //the by-name symlink is root_accounts/<root_account_name>/<account_name>.symlink
+    const root_account_name = account.owner ? account_id_to_name.get(account.owner) : account.name;
+    const root_account_dir = join(conf_dir, CONFIG_SUBDIRS.ROOT_ACCOUNTS, root_account_name);
+    if (!validate_dir_exists(root_account_dir)) {
+        dbg.log("Create the root acccount dir ", root_account_dir);
+        mkdirSync(root_account_dir);
+    }
+    const root_account_symlink = join(root_account_dir, account.name + ".symlink");
+    dbg.log("Creating account-by-name symlink ", root_account_symlink, ", new target =", symlink_target_double);
+    symlinkSync(symlink_target_double, root_account_symlink);
+
+    return 0;
+}
+
+function map_account_id_to_name(dir_ent) {
+    const { account, error} = account_file_to_object(dir_ent);
+    if (error) {
+        return error;
+    }
+
+    account_id_to_name.set(account._id, account.name);
+    return 0;
+}
+
+function run({conf_path}) {
+
+    conf_path = conf_path || config.NSFS_NC_CONF_DIR;
+    dbg.log0("Configuration directory = ", conf_path);
+
+    //check all dirs exist
+    assert_dir_exists(conf_path);
+
+    const account_dir = join(conf_path, CONFIG_SUBDIRS.ACCOUNTS);
+    const bucket_dir = join(conf_path, CONFIG_SUBDIRS.BUCKETS);
+    assert_dir_exists(account_dir);
+    assert_dir_exists(bucket_dir);
+    assert_dir_exists(join(conf_path, CONFIG_SUBDIRS.ACCESS_KEYS));
+
+    //create new root_accounts dir
+    const root_accounts_path = join(conf_path, CONFIG_SUBDIRS.ROOT_ACCOUNTS);
+    if (!validate_dir_exists(root_accounts_path)) {
+        dbg.log("Creating root accounts dir at ", root_accounts_path);
+        mkdirSync(root_accounts_path);
+        if (!validate_dir_exists(root_accounts_path)) {
+            dbg.error("Failed to create root accounts directory at ", root_accounts_path);
+            return 1;
+        }
+    }
+
+    //read all accounts
+    const account_files = readdirSync(account_dir, {withFileTypes: true});
+
+    //map account id to name (used to create symlinks of iam accounts)
+    for (const account_file of account_files) {
+        const res = map_account_id_to_name(account_file);
+        if (res !== 0) {
+            return res;
+        }
+    }
+
+    //upgrade accounts
+    for (const account_file of account_files) {
+        const res = handle_account_file(account_file, conf_path);
+        if (res !== 0) {
+            return res;
+        }
+    }
+
+    dbg.log("Completed successfully.");
+    return 0;
+}
+
+function main(argv = minimist(process.argv.slice(2))) {
+
+    //optionally get the conf_path from argv (if not we'll use config.NSFS_NC_CONF_DIR)
+    const conf_path = argv.conf_path;
+    return run({conf_path});
+}
+
+if (require.main === module) {
+    process.exit(main());
+}


### PR DESCRIPTION
### Explain the changes
1. This PR removes references of account name from bucket json files.
2. The  bucket_owner field is removed from bucket schema.
3. Principal in bucket policy is account id instead of account name.
4. In order to find account id by account name, a new dir root_accounts was added with symlinks from account name to account json.

### Issues: Fixed #xxx / Gap #xxx
1. A Change to account name doesn't require updating bucket json files. bugs:
https://github.com/noobaa/noobaa-core/issues/8080
https://github.com/noobaa/noobaa-core/issues/7734 (though we still allow root account name as principal for backward compatibility).

### Testing Instructions:
1. Same tests


- [ ] Doc added/updated
- [ ] Tests added


![NooBaa Non Containerized Components Diagram  (added root accounts 230724)](https://github.com/user-attachments/assets/4ee60215-cb4f-48f7-8943-a85dc7f931aa)
