### PR TITLE
Fix STS SessionToken generation

### DIFF
--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -745,7 +745,7 @@ function make_auth_token(options) {
         jwt_options.expiresIn = options.expiry;
     }
     // create and return the signed token
-    return jwt_utils.make_auth_token(auth, jwt_options);
+    return jwt_utils.make_internal_auth_token(auth, jwt_options);
 }
 
 

--- a/src/server/server_rpc.js
+++ b/src/server/server_rpc.js
@@ -11,7 +11,7 @@ class ServerRpc {
 
     constructor() {
         this.rpc = api.new_rpc();
-        this.client = this.rpc.new_client({ auth_token: jwt_utils.make_auth_token() });
+        this.client = this.rpc.new_client({ auth_token: jwt_utils.make_internal_auth_token() });
 
         // n2n proxy allows any service reach n2n agents
         // without registering an n2n agent by proxying requests

--- a/src/util/jwt_utils.js
+++ b/src/util/jwt_utils.js
@@ -16,10 +16,15 @@ function get_jwt_secret() {
 }
 
 function make_auth_token(object = {}, jwt_options = {}) {
-    // Remote services/endpoints should not sign tokens - unless required for STS
-    if (config.NOOBAA_AUTH_TOKEN && object.assumed_role_access_key === undefined) return config.NOOBAA_AUTH_TOKEN;
     // create and return the signed token
     return jwt.sign(object, get_jwt_secret(), jwt_options);
+}
+
+function make_internal_auth_token(object = {}, jwt_options = {}) {
+    // Remote services/endpoints should not sign tokens
+    if (config.NOOBAA_AUTH_TOKEN) return config.NOOBAA_AUTH_TOKEN;
+    // If an auth token isn't provided, fall back to signing normally
+    return make_auth_token(object, jwt_options);
 }
 
 function authorize_jwt_token(token) {
@@ -33,4 +38,5 @@ function authorize_jwt_token(token) {
 
 exports.get_jwt_secret = get_jwt_secret;
 exports.make_auth_token = make_auth_token;
+exports.make_internal_auth_token = make_internal_auth_token;
 exports.authorize_jwt_token = authorize_jwt_token;

--- a/src/util/jwt_utils.js
+++ b/src/util/jwt_utils.js
@@ -16,8 +16,8 @@ function get_jwt_secret() {
 }
 
 function make_auth_token(object = {}, jwt_options = {}) {
-    // Remote services/endpoints should not sign tokens
-    if (config.NOOBAA_AUTH_TOKEN) return config.NOOBAA_AUTH_TOKEN;
+    // Remote services/endpoints should not sign tokens - unless required for STS
+    if (config.NOOBAA_AUTH_TOKEN && object.assumed_role_access_key === undefined) return config.NOOBAA_AUTH_TOKEN;
     // create and return the signed token
     return jwt.sign(object, get_jwt_secret(), jwt_options);
 }


### PR DESCRIPTION
### Explain the changes
1. This PR fixes STS functionality by separating `jwt_utils.make_auth_token` into two functions - `make_auth_token` which always signs the request, and  `make_internal_auth_token` that's used for RPC calls and only falls back to `make_auth_token` in case `NOOBAA_AUTH_TOKEN` isn't provided. Now, STS requests use `make_auth_token` directly, while internal callers were changed to use `make_internal_auth_token`

### Issues: Fixed #xxx / Gap #xxx
1. https://bugzilla.redhat.com/show_bug.cgi?id=2009627

### Testing Instructions:
1. See [the following comment](https://github.com/noobaa/noobaa-core/pull/8119#issuecomment-2180089580)

- [ ] Doc added/updated
- [ ] Tests added
