### PR TITLE
[NC | NSFS] Replace flock with fcntl based locks

### DIFF
--- a/src/manage_nsfs/manage_nsfs_glacier.js
+++ b/src/manage_nsfs/manage_nsfs_glacier.js
@@ -223,7 +223,7 @@ async function lock_and_run(fs_context, lockfilename, cb) {
     const lockfd = await nb_native().fs.open(fs_context, path.join(config.NSFS_GLACIER_LOGS_DIR, lockfilename), 'w');
 
     try {
-        await lockfd.flock(fs_context, 'EXCLUSIVE');
+        await lockfd.fcntllock(fs_context, 'EXCLUSIVE');
         await cb();
     } finally {
         await lockfd.close(fs_context);

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -1002,8 +1002,9 @@ interface NativeFile {
     replacexattr(fs_context: NativeFSContext, xattr: NativeFSXattr, clear_prefix?: string): Promise<void>;
     linkfileat(fs_context: NativeFSContext, path: string, fd?: number): Promise<void>;
     fsync(fs_context: NativeFSContext): Promise<void>;
-    fd: number
+    fd: number;
     flock(fs_context: NativeFSContext, operation: "EXCLUSIVE" | "SHARED" | "UNLOCK"): Promise<void>;
+    fcntllock(fs_context: NativeFSContext, operation: "EXCLUSIVE" | "SHARED" | "UNLOCK"): Promise<void>;
 }
 
 interface NativeDir {


### PR DESCRIPTION
### Explain the changes
This PR replaces the use of `flock` with `fcntl` based locks. This was done as it was observed that `flock` does **not** work in GPFS.

### Testing Instructions:
Run regular tests and they should pass.

Some tests were performed (on GPFS, CephFS and AWS EFS) using the following code:
```c
#include <sys/fcntl.h>
#include <unistd.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

void lock(int fd, int mode) {
        struct flock fl = {};
        fl.l_type = mode;
        fl.l_whence = SEEK_SET;
        fl.l_start = 0;
        fl.l_len = 0;

        printf("acquiring lock\n");
       // 38 is the value for macro F_OFD_SETLKW
        if (fcntl(fd, 38, &fl) == -1) {
                perror("fcntl");
                exit(1);
        }
        printf("acquired lock\n");
}

int main(int argc, char **argv) {
        if (argc != 3) {
                fprintf(stderr, "usage: %s file mode\n", argv[0]);
                exit(1);
        }

        if (strcmp(argv[2], "s") == 0) {
                // try to acquire a shared a lock
                int fd1 = open(argv[1], O_RDWR);
                if (fd1 == -1) {
                        perror("open");
                        exit(1);
                }
                lock(fd1, F_RDLCK);

                // get another shared lock
                int fd2 = open(argv[1], O_RDWR);
                if (fd2 == -1) {
                        perror("open");
                        exit(1);
                }
                lock(fd2, F_RDLCK);

                // close the first descriptor
                close(fd1);

                sleep(30);
        }

        if (strcmp(argv[2],"x") == 0) {
                // get an exclusive lock
                int fd = open(argv[1], O_RDWR);
                if (fd == -1) {
                        perror("open");
                        exit(1);
                }
                lock(fd, F_WRLCK);
                sleep(30);
        }

    exit(0);
}
```

The result is the following and is desirable:

https://github.com/user-attachments/assets/af68a0d4-b5c3-464c-b619-334691959895

- [ ] Doc added/updated
- [ ] Tests added
