### PR TITLE
NSFS | NC | IAM Service - Accounts Permission When No Bucket Policy

### DIFF
--- a/docs/design/iam.md
+++ b/docs/design/iam.md
@@ -89,6 +89,14 @@ Source: AccessKeys
     - root account
     - all IAM users only for themselves (except the first creation that can be done only by the root account).
 
+### No Bucket Policy
+If the resource doesn’t have a bucket policy the IAM user accounts can have access to the resources of the same root account.
+For example: 
+- root account creates 2 users (both are owned by it): user1, user2 and a bucket (bucket owner: <root-account-id>, bucket creator: <account-id-user1>).
+- user1 upload a file to the bucket 
+- user2 can delete this bucket (after it is empty): although user2 is not the creator, without a bucket policy his root account is the owner so he can delete the bucket.
+Note: Currently, we do not allow users to create a bucket.
+
 ### Root Accounts Manager
 The root accounts managers are a solution for creating root accounts using the IAM API.
 

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -23,6 +23,10 @@ module.exports = {
         owner_account: {
             type: 'string',
         },
+        // creator is the account id that created this bucket (internal information)
+        creator: {
+            type: 'string',
+        },
         name: {
             type: 'string',
         },

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -100,6 +100,11 @@ describe('schema validation NC NSFS bucket', () => {
             nsfs_schema_utils.validate_bucket_schema(bucket_data);
         });
 
+        it('nsfs_bucket with creator', () => {
+            const bucket_data = get_bucket_data();
+            bucket_data.creator = '65a62e22ceae5e5f1a758ab1';
+            nsfs_schema_utils.validate_bucket_schema(bucket_data);
+        });
     });
 
     describe('bucket with additional properties', () => {
@@ -434,6 +439,14 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
+        it('bucket with creator as a number (instead of string)', () => {
+            const bucket_data = get_bucket_data();
+            bucket_data.creator = 123; // number instead of string
+            const reason = 'Test should have failed because of wrong type for' +
+                'creator with number (instead of string)';
+            const message = 'must be string';
+            assert_validation(bucket_data, reason, message);
+        });
     });
 
     describe('skip schema check by config test', () => {


### PR DESCRIPTION
### Explain the changes
1. Add more properties to `nsfs_bucket_schema `(not required) and update the `new_bucket_defaults` in `BucketSpaceFS`:
- `creator` = creator is the account ID that created this bucket (internal information).
Notes:  Currently we do not allow IAM accounts to create a bucket (temporary), it will be changed after we have the config structure, therefore in the future, we could see the IAM account ID in the creator property.
2. Change the condition in `authorize_request_policy` (in `s3_rest`) and `has_bucket_action_permission` (in `bucketspace_fs`) for the same root account (alternative for ownership when there is no bucket policy).

Those next changes are not related to IAM, but were raised as a part of the code review:
3. In `authorize_request_policy` (in `s3_rest`) remove the condition `req.object_sdk.nsfs_config_root` from the owner condition.
4. In `has_bucket_action_permission` (in `bucketspace_fs`) change the condition of `is_owner` from account name to id.

### Issues: 
List of GAPs:
1. Move the mutual code of AccountSpaceFS, BucketSpaceFS, and Manage NSFS to a specific file.
2. Allow IAM users to create buckets (see [comment below](https://github.com/noobaa/noobaa-core/pull/8175#issuecomment-2254463451)).

### Testing Instructions:
#### Unit Tests
Please run:
1. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace_fs.js`.
3. `npx jest test_nc_nsfs_bucket_schema_validation.test.js`.

#### Manual Tests:
1. Create the root user account with the CLI: `sudo node src/cmd/manage_nsfs account add --name shira-1001 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
Notes: 
- Before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
- I Change the `config.NSFS_CHECK_BUCKET_BOUNDARIES = false; //SDSD` because I'm using the `/tmp/` and not `/private/tmp/`.
4. Create the alias for IAM service: `alias s3-nc-user-1-iam='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005'`.
5. Use AWS CLI to create 2 IAM accounts: 
 user1: `s3-nc-user-1-iam iam create-user --user-name Bob` + `s3-nc-user-1-iam iam create-access-key --user-name Bob`
 user2: `s3-nc-user-1-iam iam create-user --user-name Robert` + `s3-nc-user-1-iam iam create-access-key --user-name Robert`
6. Create an alias for each one of the accounts for using S3 endpoint, for example: `alias s3-nc-user-1-s3-regular='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443'` (using different port). (the second one will be `s3-nc-user-2-s3-regular`).
7. List the buckets from user1 and user2 (expect no buckets): `s3-nc-user-1-s3-regular s3 ls`, `s3-nc-user-2-s3-regular s3 ls`
8. Create a bucket from the root account: `s3-nc-user-1-s3 s3 mb s3://bucket-01`
9. List the buckets from user1 and user2 (expect to see the bucket from both users, same root account): `s3-nc-user-1-s3-regular s3 ls`, `s3-nc-user-2-s3-regular s3 ls`.
10. Delete the bucket by user2: `s3-nc-user-2-s3-regular s3 rb s3://bucket-01/`.

- [X] Doc added/updated
- [X] Tests added
