### PR TITLE
NSFS | NC | Handle Concurrency When Reading Entries and They Deleted by Another Process

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -20,7 +20,7 @@ const { print_usage } = require('../manage_nsfs/manage_nsfs_help_utils');
 const { TYPES, ACTIONS, LIST_ACCOUNT_FILTERS, LIST_BUCKET_FILTERS,
     GLACIER_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
 const { throw_cli_error, write_stdout_response, get_config_file_path, get_symlink_config_file_path,
-    get_config_data, get_boolean_or_string_value, has_access_keys, set_debug_level} = require('../manage_nsfs/manage_nsfs_cli_utils');
+    get_config_data, get_boolean_or_string_value, has_access_keys, set_debug_level, get_config_data_if_exists } = require('../manage_nsfs/manage_nsfs_cli_utils');
 const manage_nsfs_validations = require('../manage_nsfs/manage_nsfs_validations');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 
@@ -642,7 +642,8 @@ async function list_config_files(type, config_path, wide, show_secrets, filters)
         if (entry.name.endsWith('.json')) {
             if (wide || should_filter) {
                 const full_path = path.join(config_path, entry.name);
-                const data = await get_config_data(config_root_backend, full_path, show_secrets || should_filter);
+                const data = await get_config_data_if_exists(config_root_backend, full_path, show_secrets || should_filter);
+                if (!data) return undefined;
                 // decryption causing mkm initalization
                 // decrypt only if data has access_keys and show_secrets = true (no need to decrypt if show_secrets = false but should_filter = true)
                 if (data.access_keys && show_secrets) data.access_keys = await nc_mkm.decrypt_access_keys(data);
@@ -655,6 +656,7 @@ async function list_config_files(type, config_path, wide, show_secrets, filters)
         }
     });
     // it inserts undefined for the entry '.noobaa-config-nsfs' and we wish to remove it
+    // in case the entry was deleted during the list it also inserts undefined
     config_files_list = config_files_list.filter(item => item);
 
     return config_files_list;

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -56,6 +56,23 @@ async function get_config_data(config_root_backend, config_file_path, show_secre
 }
 
 /**
+ * get_config_data_if_exists will read a config file and return its content 
+ * while omitting secrets if show_secrets flag was not provided
+ * if the config file was deleted (encounter ENOENT error) - continue (returns undefined)
+ * @param {string} config_file_path
+ * @param {boolean} [show_secrets]
+ */
+async function get_config_data_if_exists(config_root_backend, config_file_path, show_secrets = false) {
+    try {
+        const config_data = await get_config_data(config_root_backend, config_file_path, show_secrets);
+        return config_data;
+    } catch (err) {
+        dbg.warn('get_config_data_if_exists: with config_file_path', config_file_path, 'got an error', err);
+        if (err.code !== 'ENOENT') throw err;
+    }
+}
+
+/**
  * get_bucket_owner_account will return the account of the bucket_owner
  * otherwise it would throw an error
  * @param {string} config_root_backend
@@ -166,3 +183,4 @@ exports.has_access_keys = has_access_keys;
 exports.generate_id = generate_id;
 exports.set_debug_level = set_debug_level;
 exports.check_root_account_owns_user = check_root_account_owns_user;
+exports.get_config_data_if_exists = get_config_data_if_exists;

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -597,6 +597,7 @@ class AccountSpaceFS {
         const entries = await nb_native().fs.readdir(this.fs_context, this.accounts_dir);
         const should_filter_by_prefix = check_iam_path_was_set(iam_path_prefix);
 
+        // TODO - add silent get config to handle config deletion during list (concurrency)
         const config_files_list = await P.map_with_concurrency(10, entries, async entry => {
             if (entry.name.endsWith('.json')) {
                 const full_path = path.join(this.accounts_dir, entry.name);

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -231,7 +231,15 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 return;
             }
             const bucket_name = this.get_bucket_name(entry.name);
-            const bucket = await object_sdk.read_bucket_sdk_config_info(bucket_name);
+            let bucket;
+            try {
+                bucket = await object_sdk.read_bucket_sdk_config_info(bucket_name);
+            } catch (err) {
+                dbg.warn('list_buckets: read_bucket_sdk_config_info of bucket', bucket_name, 'got an error', err);
+                // in case the config file was deleted during the bucket list - we will continue
+                if (err.rpc_code !== 'NO_SUCH_BUCKET') throw err;
+            }
+            if (!bucket) return;
             const bucket_policy_accessible = await this.has_bucket_action_permission(bucket, account, 's3:ListBucket');
             if (!bucket_policy_accessible) return;
             const fs_accessible = await this.validate_fs_bucket_access(bucket, object_sdk);

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1194,6 +1194,14 @@ describe('manage nsfs cli account flow', () => {
                 .toEqual([]);
         });
 
+        it('cli list filter by access key (non existing) and name (of account3) - (none)', async () => {
+            const account_options = { config_root, name: 'account3', access_key: 'non-existing-access-key' };
+            const action = ACTIONS.LIST;
+            const res = await exec_manage_cli(TYPES.ACCOUNT, action, account_options);
+            expect(JSON.parse(res).response.reply.map(item => item.name))
+                .toEqual([]);
+        });
+
         it('should fail - cli account list invalid flags combination (show_secrets without wide)', async () => {
             const account_options = { config_root, show_secrets: true}; // without wide it's invalid
             const action = ACTIONS.LIST;


### PR DESCRIPTION
### Explain the changes
1. Fix the concurrency issue on the CLI delete account (when a bucket was deleted during account deletion)
2. Fix the concurrency issue on the CLI list:
   - CLI list buckets (when a bucket was deleted during the list)
   - CLI list accounts (when an account was deleted during the list)
4. Fix the concurrency issue on S3 API list buckets (when a bucket was deleted during the list)
5. Add TODO in `accountspace_fs`.
6. Add test (not related to the issue, was added during debug) 

### Issues: Fixed #7920 
1. GAP - `accountspace_fs` list (IAM ListUsers API) should also be fixed.

### Testing Instructions:
#### Manual Tests:
1. To see the failure and the changes with a manual test we will simulate 2 processes: the first process executes the operation that reads the directory content and we add sleep after it in the code (for more information see [comment below](https://github.com/noobaa/noobaa-core/pull/8183#issuecomment-2209149169)), and the second process deletes one of the entries.
2. First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/` `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
3. Create an account: `sudo node src/cmd/manage_nsfs account add --name <account-name> --uid <uid> --gid <gid> --new_buckets_path <new_buckets_path>`
4. Create 3 buckets: `sudo node src/cmd/manage_nsfs bucket add --name <bucket-name> --owner <account-name> --path <path>` (use the `--owner` from the previous account add command, for example: bucket-1, bucket-2, bucket-3).

For example - when deleting an account we check if the account has buckets (hence we list them):
5. (process 1 - open a tab in the terminal) Delete account: `sudo node src/cmd/manage_nsfs account delete --name <account-name> --debug 5` (we use the debug flag to see printing related to the filesystem, we expect to see on the deleted config file an error message "No such file or directory")
6. (process 2 - open a tab in the terminal) Delete bucket (bucket-2 for example): `sudo node src/cmd/manage_nsfs bucket delete --name <bucket-name> `

- [ ] Doc added/updated
- [ ] Tests added
