### PR TITLE
NC | Noobaa debug and normal log sent to two different files.

### DIFF
--- a/config.js
+++ b/config.js
@@ -472,7 +472,7 @@ config.EVENT_FACILITY = 'LOG_LOCAL2';
 config.EVENT_LOGGING_ENABLED = true;
 config.EVENT_LEVEL = 5;
 
-config.LOG_TO_SYSLOG_ENABLED = true;
+config.LOG_TO_SYSLOG_ENABLED = false;
 config.LOG_TO_STDERR_ENABLED = true;
 
 // TEST Mode
@@ -1084,7 +1084,7 @@ function load_nsfs_nc_config() {
         const merged_config = _.merge(shared_config, node_config || {});
 
         Object.keys(merged_config).forEach(function(key) {
-            const config_to_env = ['NOOBAA_LOG_LEVEL', 'UV_THREADPOOL_SIZE', 'GPFS_DL_PATH'];
+            const config_to_env = ['NOOBAA_LOG_LEVEL', 'UV_THREADPOOL_SIZE', 'GPFS_DL_PATH', 'NOOBAA_DEBUG_LEVEL'];
             if (config_to_env.includes(key)) {
                 process.env[key] = merged_config[key];
                 return;

--- a/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
+++ b/docs/dev_guide/NonContainerizedDeveloperCustomizations.md
@@ -33,6 +33,7 @@ Supported log debug levels:
 2. warn - for only warning/errors debugging. 
 3. nsfs - for more nsfs detailed debugging.
 4. all - for all detailed debugging.
+5. off - do not print anything to logs
 
 
 **Configuration Key -** NOOBAA_LOG_LEVEL
@@ -47,6 +48,21 @@ Supported log debug levels:
 2. Set the NOOBAA_LOG_LEVEL key to the desired level.
 Example:
 "NOOBAA_LOG_LEVEL": "nsfs"
+3. systemctl restart noobaa
+```
+
+**Configuration Key -** NOOBAA_DEBUG_LEVEL
+
+**Type -** string
+
+**Default -** "default"
+
+**Steps -**
+```
+1. Open /path/to/config_dir/config.json file.
+2. Set the NOOBAA_DEBUG_LEVEL key to the desired level.
+Example:
+"NOOBAA_DEBUG_LEVEL": "all"
 3. systemctl restart noobaa
 ```
 

--- a/src/server/bg_services/semaphore_monitor.js
+++ b/src/server/bg_services/semaphore_monitor.js
@@ -27,7 +27,6 @@ class SemaphoreMonitor {
     }
 
     async run_batch() {
-        dbg.log1("semaphore_monitor: START");
         if (!this._can_run()) return;
         try {
             this.run_semaphore_monitor();

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -35,8 +35,13 @@ const nsfs_node_config_schema = {
         },
         NOOBAA_LOG_LEVEL: {
             type: 'string',
-            enum: ['warn', 'default', 'nsfs', 'all'],
+            enum: ['warn', 'default', 'nsfs', 'all', 'off'],
             doc: 'logging verbosity level for the NooBaa system, service restart required'
+        },
+        NOOBAA_DEBUG_LEVEL: {
+            type: 'string',
+            enum: ['warn', 'default', 'nsfs', 'all', 'off'],
+            doc: 'logging verbosity level for the NooBaa debug logs, service restart required'
         },
         UV_THREADPOOL_SIZE: {
             type: 'number',

--- a/src/util/debug_config.js
+++ b/src/util/debug_config.js
@@ -37,6 +37,12 @@ const default_level = {
     endpoint: ['core'],
 };
 
+const off = {
+    level: -1,
+    core: ['core'],
+    endpoint: ['core'],
+};
+
 function get_debug_config(conf) {
     if (conf === 'all') {
         return all;
@@ -44,6 +50,8 @@ function get_debug_config(conf) {
         return nsfs;
     } else if (conf === 'warn') {
         return warn;
+    } else if (conf === 'off') {
+        return off;
     } else {
         return default_level;
     }

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -39,9 +39,7 @@ let dbg_syslog_conf;
 let LOG_DEBUG_LEVEL = 0;
 if (process.env.NOOBAA_DEBUG_LEVEL) {
     dbg_syslog_conf = debug_config.get_debug_config(process.env.NOOBAA_DEBUG_LEVEL);
-    if (process.env.NOOBAA_DEBUG_LEVEL !== 'nsfs') {
         LOG_DEBUG_LEVEL = dbg_syslog_conf.level;
-    }
 }
 
 // override the default inspect options
@@ -390,7 +388,7 @@ class InternalDebugLogger {
 
     log_internal(msg_info) {
         if (syslog && config.LOG_TO_SYSLOG_ENABLED &&
-            this._levels[msg_info.level] <= LOG_DEBUG_LEVEL) {
+            this._levels_to_syslog[msg_info.level] <= LOG_DEBUG_LEVEL) {
             // syslog path
             syslog(this._levels_to_syslog[msg_info.level], msg_info.message_syslog, config.DEBUG_FACILITY);
         } else if (this._log_file) {


### PR DESCRIPTION
### Explain the changes
1. Current implementation all the logs are pushed to both `iamjournal` and `syslog`

- syslog facility local0 - [rsyslog omfile](https://www.rsyslog.com/doc/configuration/modules/omfile.html) copies it to /var/log/noobaa.log
- stdout/stderr - [systemd copies it into its journal](https://www.freedesktop.org/software/systemd/man/latest/systemd-journald.service.html#) and then [rsyslog imjournal](https://www.rsyslog.com/doc/configuration/modules/imjournal.html) copies it to the file /var/log/messages

1. all the low level logs(ERROR, INFO, LOG, TRACE, L0) are pushed to var/log/message. Can be configured using property `LOG_TO_STDERR_LEVEL`), 
2. When debug enabled(LOG_TO_SYSLOG_ENABLED) all the messages will pushed to var/log/noobaa.log, Log level can be configued in using property LOG_TO_DEBUGLOG_LEVEL


### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8032

### Testing Instructions:
1. 


- [] Doc added/updated
- [ ] Tests added
