### PR TITLE
NC | NSFS | Delete a Bucket When Its Path Was Deleted First

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -618,6 +618,18 @@ describe('manage nsfs cli bucket flow', () => {
             const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingBucketNameFlag.code);
         });
+
+        it('cli delete bucket when path was deleted first', async () => {
+            await fs_utils.folder_delete(`${bucket_defaults.path}`);
+            const path_exists = await is_path_exists(DEFAULT_FS_CONFIG, bucket_defaults.path);
+            expect(path_exists).toBe(false);
+            const bucket_options = { config_root, name: 'bucket1'};
+            const action = ACTIONS.DELETE;
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res.trim()).response.code).toBe(ManageCLIResponse.BucketDeleted.code);
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + '.json');
+            await fs_utils.file_must_not_exist(config_path);
+        });
     });
 
     describe('cli status bucket ', () => {


### PR DESCRIPTION
### Explain the changes
1. Change the flow in `delete_bucket` in case the bucket's path was deleted first - not to check it there are objects inside and not fail it on `ENOENT` (which translated to `NoSuchBucket`).

### Issues: Fixed #8180
1. Currently, if someone deletes the path before the bucket it would not be able to delete the bucket and would see the error `NoSuchBucket` error.

### Testing Instructions:
#### Unit Tests:
- Please run: `sudo npx jest test_nc_nsfs_bucket_cli.test.js`.

#### Manual Tests:
1. First, create the `FS_ROOT` and a directory for a bucket: `mkdir -p /tmp/nsfs_root1/my-bucket` and give permissions `chmod 777 /tmp/nsfs_root1/` `chmod 777 /tmp/nsfs_root1/my-bucket`.
This will be the argument for:
  - `new_buckets_path` flag  `/tmp/nsfs_root1` (that we will use in the account commands)
  - `path` in the buckets commands `/tmp/nsfs_root1/my-bucket` (that we will use in bucket commands).
2. Create an account: `sudo node src/cmd/manage_nsfs account add --name <account-name> --uid <uid> --gid <gid> --new_buckets_path <new_buckets_path>`.
3. Create a bucket: `sudo node src/cmd/manage_nsfs bucket add --name <bucket-name> --path /tmp/nsfs_root1/my-bucket --owner <account-name>`
4. Delete the bucket's path: `sudo rmdir /tmp/nsfs_root1/my-bucket` (you can run `ls -al /tmp/nsfs_root1/` to make sure you do not see it).
5. Delete the bucket: `sudo node src/cmd/manage_nsfs bucket delete --name <bucket-name>` (should receive response with `"code": "BucketDeleted"`).
6. Delete non-existing bucket (should throw an error of `NoSuchBucket`): `sudo node src/cmd/manage_nsfs bucket delete --name bucket-1001-not-exsits`

- [ ] Doc added/updated
- [X] Tests added
