### PR TITLE
NC | CLI | Add Diagnose command

### DIFF
--- a/docs/NooBaaNonContainerized/Health.md
+++ b/docs/NooBaaNonContainerized/Health.md
@@ -44,7 +44,7 @@ For more details about NooBaa RPM installation, see - [Getting Started](./Gettin
 The `health` command is used to analyze NooBaa health with customizable options.
 
 ```sh
-sudo node /usr/local/noobaa-core/src/cmd/health [--deployment_type][--https_port]
+noobaa-cli diagnose health [--deployment_type][--https_port]
 [--all_account_details][--all_bucket_details][--config_root][--debug]
 ```
 ### Flags -
@@ -151,7 +151,7 @@ The output of the Health CLI is a JSON object containing the following propertie
 
 ## Example 
 ```sh
-sudo node usr/local/noobaa-core/src/cmd/health --all_account_details --all_bucket_details
+noobaa-cli diagnose health --all_account_details --all_bucket_details
 ```
 
 Output:

--- a/docs/NooBaaNonContainerized/Monitoring.md
+++ b/docs/NooBaaNonContainerized/Monitoring.md
@@ -4,7 +4,7 @@
 2. [Metrics Endpoint Configuration](#metrics-endpoint-configuration)
 3. [Metrics description](#metrics-description) 
 4. [Getting Started](#getting-started)
-5. [Example](#example)
+5. [Examples](#examples)
 
 ## Introduction
 
@@ -136,10 +136,57 @@ For specific command examples, refer to the steps outlined in [NooBaa Non Contai
 Once the NSFS service is enabled, you can fetch the Prometheus metrics to monitor your system. Open a new tab and follow these steps:
 
 ```sh
+noobaa-cli diagnose metrics
+# OR directly fetch
 curl -s http://127.0.0.1:7004/metrics/nsfs_stats | jq .
 ```
+ 
+## Examples
 
-## Example
+### NooBaa CLI Metrics Command Example
+
+The following is an example of the JSON output containing system metrics -
+
+```shell
+> noobaa-cli diagnose metrics
+{
+    "response": {
+    "code": "MetricsStatus",
+    "reply": {
+        "nsfs_counters": {
+            "noobaa_nsfs_io_read_count":1,
+            "noobaa_nsfs_io_write_count":2,
+            "noobaa_nsfs_io_read_bytes":49,
+            "noobaa_nsfs_io_write_bytes":98
+        },
+        "op_stats_counters": {
+            "noobaa_nsfs_op_create_bucket_min_time_milisec":15,
+            "noobaa_nsfs_op_create_bucket_max_time_milisec":15,
+            "noobaa_nsfs_op_create_bucket_avg_time_milisec":15,
+            "noobaa_nsfs_op_create_bucket_count":1,
+            "noobaa_nsfs_op_create_bucket_error_count":0,
+            "noobaa_nsfs_op_upload_object_min_time_milisec":15,
+            "noobaa_nsfs_op_upload_object_max_time_milisec":20,
+            "noobaa_nsfs_op_upload_object_avg_time_milisec":17,
+            "noobaa_nsfs_op_upload_object_count":2,
+            "noobaa_nsfs_op_upload_object_error_count":0,
+            "noobaa_nsfs_op_head_object_min_time_milisec":2,
+            "noobaa_nsfs_op_head_object_max_time_milisec":3,
+            "noobaa_nsfs_op_head_object_avg_time_milisec":2,
+            "noobaa_nsfs_op_head_object_count":2,
+            "noobaa_nsfs_op_head_object_error_count":0,
+            "noobaa_nsfs_op_read_object_min_time_milisec":12,
+            "noobaa_nsfs_op_read_object_max_time_milisec":12,
+            "noobaa_nsfs_op_read_object_avg_time_milisec":12,
+            "noobaa_nsfs_op_read_object_count":1,
+            "noobaa_nsfs_op_read_object_error_count":0
+        }
+    }
+}
+```
+
+
+### Direct Metrics Fetch Example
 
 The following is an example of the JSON output containing system metrics -
 

--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -17,8 +17,12 @@
     5. [Delete Bucket](#delete-bucket)
 6. [Managing Server IP White List](#managing-server-ip-white-list)
 7. [Managing Glacier](#managing-glacier)
-8. [Global Options](#global-options)
-9. [Examples](#examples)
+8. [Diagnose](#diagnose)
+    1. [Health](#health)
+    2. [Metrics](#metrics)
+    3. [Gather Logs](#gather-logs)
+9. [Global Options](#global-options)
+10. [Examples](#examples)
     1. [Bucket Commands Examples](#bucket-commands-examples)
     2. [Account Commands Examples](#account-commands-examples)
     3. [White List Server IP Command Example](#white-list-server-ip-command-example)
@@ -425,6 +429,26 @@ noobaa-cli whitelist --ips <ips>
 ## Managing Glacier
 
 TODO
+
+## Diagnose
+
+
+### Health
+The Health CLI tool designed to analyze the NooBaa service, endpoints, accounts and buckets health. For more info please see - [Health CLI Documentation](Health.md).
+
+### Metrics
+
+The `metrics` command is used for extracting NooBaa non containerized metrics.
+For more info please see - [Monitoring Documentation](./Monitoring.md).
+#### Usage
+```sh
+noobaa-cli diagnose metrics
+```
+
+### Gather Logs
+
+The `gather-logs` command is used for extract NooBaa non containerized logs.
+Not implemented yet, running this command will fail with not implemented error.
 
 
 ## Global Flags

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -16,7 +16,6 @@ const CORE_COMMANDS = Object.freeze({
     s3: () => require('../endpoint/endpoint'),
     bg: () => require('../server/bg_workers'),
     s3cat: () => require('../tools/s3cat'),
-    health: () => require('./health'),
     manage_nsfs: () => require('./manage_nsfs'),
 });
 

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -16,6 +16,7 @@ const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCL
 const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 const manage_nsfs_glacier = require('../manage_nsfs/manage_nsfs_glacier');
 const manage_nsfs_logging = require('../manage_nsfs/manage_nsfs_logging');
+const noobaa_cli_diagnose = require('../manage_nsfs/diagnose');
 const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
 const { print_usage } = require('../manage_nsfs/manage_nsfs_help_utils');
 const { TYPES, ACTIONS, CONFIG_SUBDIRS,
@@ -77,6 +78,8 @@ async function main(argv = minimist(process.argv.slice(2))) {
             await glacier_management(argv);
         } else if (type === TYPES.LOGGING) {
             await logging_management(user_input);
+        } else if (type === TYPES.DIAGNOSE) {
+            await noobaa_cli_diagnose.manage_diagnose_operations(action, user_input, global_config);
         } else {
             // we should not get here (we check it before)
             throw_cli_error(ManageCLIError.InvalidType);

--- a/src/manage_nsfs/diagnose.js
+++ b/src/manage_nsfs/diagnose.js
@@ -1,0 +1,71 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const dbg = require('../util/debug_module')(__filename);
+const health = require('./health');
+const config = require('../../config');
+const http_utils = require('../util/http_utils');
+const buffer_utils = require('../util/buffer_utils');
+const { DIAGNOSE_ACTIONS } = require('./manage_nsfs_constants');
+const ManageCLIError = require('./manage_nsfs_cli_errors').ManageCLIError;
+const { throw_cli_error, write_stdout_response } = require('./manage_nsfs_cli_utils');
+const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
+
+/**
+ * manage_diagnose_operations handles cli diagnose operations
+ * @param {string} action 
+ * @param {Object} user_input 
+ * @param {Object} global_config 
+ * @returns {Promise<Void>}
+ */
+async function manage_diagnose_operations(action, user_input, global_config) {
+    switch (action) {
+        case DIAGNOSE_ACTIONS.HEALTH:
+            await health.get_health_status(user_input, global_config);
+            break;
+        case DIAGNOSE_ACTIONS.GATHER_LOGS:
+            await gather_logs();
+            break;
+        case DIAGNOSE_ACTIONS.METRICS:
+            await gather_metrics();
+            break;
+        default:
+            throw_cli_error(ManageCLIError.InvalidAction);
+    }
+}
+
+/**
+ * gather_logs handles cli diagnose gather-logs operation
+ * @returns {Promise<Void>}
+ */
+async function gather_logs() {
+    throw_cli_error(ManageCLIError.NotImplemented);
+}
+
+/**
+ * gather_metrics handles cli diagnose metrics operation
+ * @returns {Promise<Void>}
+ */
+async function gather_metrics() {
+    try {
+        let metrics_output;
+        const res = await http_utils.make_http_request({
+            hostname: 'localhost',
+            port: config.EP_METRICS_SERVER_PORT,
+            path: '/metrics/nsfs_stats',
+            method: 'GET'
+        });
+        if (res.statusCode === 200) {
+            const buffer = await buffer_utils.read_stream_join(res);
+            const body = buffer.toString('utf8');
+            metrics_output = JSON.parse(body);
+        }
+        if (!metrics_output) throw new Error('recieved empty metrics response', { cause: res.statusCode });
+        write_stdout_response(ManageCLIResponse.MetricsStatus, metrics_output);
+    } catch (err) {
+        dbg.warn('could not receive metrics response', err);
+        throw_cli_error({ ...ManageCLIError.MetricsStatusFailed, cause: err?.errors?.[0] || err });
+    }
+}
+
+exports.manage_diagnose_operations = manage_diagnose_operations;

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -69,6 +69,12 @@ ManageCLIError.InvalidAction = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.InvalidDiagnoseAction = Object.freeze({
+    code: 'InvalidDiagnoseAction',
+    message: 'Invalid action, available actions are health, gather-logs and metrics',
+    http_code: 400,
+});
+
 ManageCLIError.InvalidArgument = Object.freeze({
     code: 'InvalidArgument',
     message: 'Invalid argument',
@@ -164,6 +170,25 @@ ManageCLIError.InvalidMasterKey = Object.freeze({
 ManageCLIError.LoggingExportFailed = Object.freeze({
     code: 'LoggingExportFailed',
     message: 'Logging export attmept failed',
+});
+
+//////////////////////////////
+/////// METRICS ERRORS ///////
+//////////////////////////////
+
+ManageCLIError.MetricsStatusFailed = Object.freeze({
+    code: 'MetricsStatusFailed',
+    message: 'Metrics fetch request failed',
+    http_code: 500,
+});
+
+//////////////////////////////
+//////// HEALTH ERRORS ///////
+//////////////////////////////
+
+ManageCLIError.HealthStatusFailed = Object.freeze({
+    code: 'HealthStatusFailed',
+    message: 'Health status request failed',
     http_code: 500,
 });
 

--- a/src/manage_nsfs/manage_nsfs_cli_responses.js
+++ b/src/manage_nsfs/manage_nsfs_cli_responses.js
@@ -39,6 +39,20 @@ class ManageCLIResponse {
 // See Manage NSFS CLI error codes docs - TODO: add docs
 
 ///////////////////////////////
+//////  DIAGNOSE RESPONSES ////
+///////////////////////////////
+
+ManageCLIResponse.HealthStatus = Object.freeze({
+    code: 'HealthStatus',
+    status: {}
+});
+
+ManageCLIResponse.MetricsStatus = Object.freeze({
+    code: 'MetricsStatus',
+    status: {}
+});
+
+///////////////////////////////
 // IPS WHITE LIST RESPONSES ///
 ///////////////////////////////
 ManageCLIResponse.WhiteListIPUpdated = Object.freeze({

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -6,8 +6,8 @@ const TYPES = {
     BUCKET: 'bucket',
     IP_WHITELIST: 'whitelist',
     GLACIER: 'glacier',
-    HEALTH: 'health',
     LOGGING: 'logging',
+    DIAGNOSE: 'diagnose'
 };
 
 const ACTIONS = {
@@ -22,6 +22,12 @@ const GLACIER_ACTIONS = {
     MIGRATE: 'migrate',
     RESTORE: 'restore',
     EXPIRY: 'expiry',
+};
+
+const DIAGNOSE_ACTIONS = {
+    HEALTH: 'health',
+    GATHER_LOGS: 'gather-logs',
+    METRICS: 'metrics'
 };
 
 const CONFIG_SUBDIRS = {
@@ -64,7 +70,12 @@ const VALID_OPTIONS_GLACIER = {
     'expiry': new Set([ GLOBAL_CONFIG_ROOT]),
 };
 
-const VALID_OPTIONS_HEALTH = new Set(['https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', ...GLOBAL_CONFIG_OPTIONS]);
+const VALID_OPTIONS_DIAGNOSE = {
+    'health': new Set([ 'https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', ...GLOBAL_CONFIG_OPTIONS]),
+    'gather-logs': new Set([ GLOBAL_CONFIG_ROOT]),
+    'metrics': new Set([GLOBAL_CONFIG_ROOT])
+};
+
 
 const VALID_OPTIONS_WHITELIST = new Set(['ips', ...GLOBAL_CONFIG_OPTIONS]);
 
@@ -77,7 +88,7 @@ const VALID_OPTIONS = {
     whitelist_options: VALID_OPTIONS_WHITELIST,
     from_file_options: VALID_OPTIONS_FROM_FILE,
     anonymous_account_options: VALID_OPTIONS_ANONYMOUS_ACCOUNT,
-    health_options: VALID_OPTIONS_HEALTH
+    diagnose_options: VALID_OPTIONS_DIAGNOSE
 };
 
 const OPTION_TYPE = {
@@ -127,6 +138,7 @@ const LIST_BUCKET_FILTERS = ['name'];
 exports.TYPES = TYPES;
 exports.ACTIONS = ACTIONS;
 exports.GLACIER_ACTIONS = GLACIER_ACTIONS;
+exports.DIAGNOSE_ACTIONS = DIAGNOSE_ACTIONS;
 exports.CONFIG_SUBDIRS = CONFIG_SUBDIRS;
 exports.VALID_OPTIONS = VALID_OPTIONS;
 exports.OPTION_TYPE = OPTION_TYPE;

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -1,7 +1,7 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
-const { TYPES, ACTIONS, GLACIER_ACTIONS } = require('./manage_nsfs_constants');
+const { TYPES, ACTIONS, GLACIER_ACTIONS, DIAGNOSE_ACTIONS } = require('./manage_nsfs_constants');
 
 const HELP = `
 Help:
@@ -23,7 +23,7 @@ Usage:
 const ARGUMENTS = `
 Arguments:
 
-    <type>    Set the resource type: account, bucket, logging or whitelist
+    <type>    Set the resource type: account, bucket, whitelist, diagnose or logging
     <action>  Action could be: add, update, list, status, and delete for accounts/buckets
 `;
 
@@ -211,6 +211,76 @@ const GLACIER_RESTORE_OPTIONS = ``;
 
 const GLACIER_EXPIRY_OPTIONS = ``;
 
+
+const DIAGNOSE_OPTIONS = `
+Usage:
+
+    execute with root permission or use sudo before each command
+    
+    noobaa-cli diagnose <action> [flags]
+
+List of actions supported:
+
+    health
+    gather-logs
+    metrics
+    
+`;
+
+const DIAGNOSE_HEALTH_OPTIONS = `
+Help:
+
+'health' is a noobaa-core command that will return the health status of deployed noobaa system.
+
+Usage:
+
+    execute with root permission or use sudo before each command
+        
+    noobaa-cli diagnose health [flags]
+
+Flags:
+
+--deployment_type       <string>        (optional)          Set the nsfs type for heath check.(default nc; Non Containerized)
+--https_port            <number>        (optional)          Set the S3 endpoint listening HTTPS port to serve. (default config.ENDPOINT_SSL_PORT)
+--all_account_details   <boolean>       (optional)          Set a flag for returning all account details.
+--all_bucket_details    <boolean>       (optional)          Set a flag for returning all bucket details.
+--debug                 <number>        (optional)          Use for increasing the log verbosity of health cli commands.
+--config_root           <string>        (optional)          Set Configuration files path for Noobaa standalon NSFS. (default config.NSFS_NC_DEFAULT_CONF_DIR)
+
+`;
+
+const DIAGNOSE_GATHER_LOGS_OPTIONS = `
+Help:
+
+'gather-logs' is a noobaa-core command that will collect NooBaa diagnostics logs tar file
+
+Usage:
+
+    execute with root permission or use sudo before each command
+        
+    noobaa-cli diagnose gather-logs [flags]
+
+Flags:
+
+--dir_path              <string>         (optional)          collect noobaa diagnostics tar file into destination directory
+--config_dir_dump       <boolean>        (optional)          collect config directory in addition to diagnostics
+--metrics_dump          <boolean>        (optional)          collect metrics in addition to diagnostics
+
+`;
+
+const DIAGNOSE_METRICS_OPTIONS = `
+Help:
+
+'metrics' is a noobaa-core command that will return the exported metrics of the deployed NooBaa system.
+
+Usage:
+
+    execute with root permission or use sudo before each command
+        
+    noobaa-cli diagnose metrics
+
+`;
+
 /** 
  * print_usage would print the help according to the arguments that were passed
  * @param {string} type
@@ -232,6 +302,9 @@ function print_usage(type, action) {
             break;
         case TYPES.GLACIER:
             print_help_glacier(action);
+            break;
+        case TYPES.DIAGNOSE:
+            print_help_diagnose(action);
             break;
         default:
             process.stdout.write(HELP + '\n');
@@ -308,6 +381,22 @@ function print_help_glacier(action) {
             break;
         default:
             process.stdout.write(GLACIER_OPTIONS.trimStart());
+    }
+}
+
+function print_help_diagnose(action) {
+    switch (action) {
+        case DIAGNOSE_ACTIONS.HEALTH:
+            process.stdout.write(DIAGNOSE_HEALTH_OPTIONS.trimStart());
+            break;
+        case DIAGNOSE_ACTIONS.GATHER_LOGS:
+            process.stdout.write(DIAGNOSE_GATHER_LOGS_OPTIONS.trimStart());
+            break;
+        case DIAGNOSE_ACTIONS.METRICS:
+            process.stdout.write(DIAGNOSE_METRICS_OPTIONS.trimStart());
+            break;
+        default:
+            process.stdout.write(DIAGNOSE_OPTIONS.trimStart());
     }
 }
 

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -16,7 +16,7 @@ const { throw_cli_error, get_config_file_path, get_bucket_owner_account,
     get_config_data, get_options_from_file, get_boolean_or_string_value,
     check_root_account_owns_user, get_config_data_if_exists } = require('../manage_nsfs/manage_nsfs_cli_utils');
 const { TYPES, ACTIONS, VALID_OPTIONS, OPTION_TYPE, FROM_FILE, BOOLEAN_STRING_VALUES, BOOLEAN_STRING_OPTIONS,
-    GLACIER_ACTIONS, LIST_UNSETABLE_OPTIONS, ANONYMOUS } = require('../manage_nsfs/manage_nsfs_constants');
+    GLACIER_ACTIONS, LIST_UNSETABLE_OPTIONS, ANONYMOUS, DIAGNOSE_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
 const iam_utils = require('../endpoint/iam/iam_utils');
 
 /////////////////////////////
@@ -74,10 +74,12 @@ function validate_type_and_action(type, action) {
     if (!Object.values(TYPES).includes(type)) throw_cli_error(ManageCLIError.InvalidType);
     if (type === TYPES.ACCOUNT || type === TYPES.BUCKET) {
         if (!Object.values(ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidAction);
-    } else if (type === TYPES.IP_WHITELIST || type === TYPES.HEALTH) {
+    } else if (type === TYPES.IP_WHITELIST) {
         if (action !== '') throw_cli_error(ManageCLIError.InvalidAction);
     } else if (type === TYPES.GLACIER) {
         if (!Object.values(GLACIER_ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidAction);
+    } else if (type === TYPES.DIAGNOSE) {
+        if (!Object.values(DIAGNOSE_ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidDiagnoseAction);
     }
 }
 
@@ -123,8 +125,8 @@ function validate_no_extra_options(type, action, input_options, is_options_from_
         }
     } else if (type === TYPES.GLACIER) {
         valid_options = VALID_OPTIONS.glacier_options[action];
-    } else if (type === TYPES.HEALTH) {
-        valid_options = VALID_OPTIONS.health_options;
+    } else if (type === TYPES.DIAGNOSE) {
+        valid_options = VALID_OPTIONS.diagnose_options[action];
     } else {
         valid_options = VALID_OPTIONS.whitelist_options;
     }

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -239,7 +239,7 @@ function get_coretest_path() {
  * @param {object} options
  * @returns {Promise<string>}
  */
-async function exec_manage_cli(type, action, options) {
+async function exec_manage_cli(type, action, options, is_silent) {
     let flags = ``;
     for (const key in options) {
         if (options[key] !== undefined) {
@@ -268,35 +268,7 @@ async function exec_manage_cli(type, action, options) {
         return res;
     } catch (err) {
         console.error('test_utils.exec_manage_cli error', err);
-        throw err;
-    }
-}
-
-/**
- * exec_health_cli runs the health cli
- * @param {object} options
- * @returns {Promise<string>}
- */
-async function exec_health_cli(options) {
-    let flags = ``;
-    for (const key in options) {
-        if (options[key] !== undefined) {
-            const value = options[key];
-            if (typeof options[key] === 'boolean') {
-                flags += `--${key} `;
-                continue;
-            }
-            flags += `--${key} ${value} `;
-        }
-    }
-    flags = flags.trim();
-
-    const command = `node src/cmd/health ${flags}`;
-    try {
-        const res = await os_utils.exec(command, { return_stdout: true });
-        return res;
-    } catch (err) {
-        console.error('test_utils.exec_health_cli error', err);
+        if (is_silent) return err;
         throw err;
     }
 }
@@ -460,7 +432,6 @@ exports.generate_s3_client = generate_s3_client;
 exports.invalid_nsfs_root_permissions = invalid_nsfs_root_permissions;
 exports.get_coretest_path = get_coretest_path;
 exports.exec_manage_cli = exec_manage_cli;
-exports.exec_health_cli = exec_health_cli;
 exports.create_fs_user_by_platform = create_fs_user_by_platform;
 exports.delete_fs_user_by_platform = delete_fs_user_by_platform;
 exports.set_path_permissions_and_owner = set_path_permissions_and_owner;

--- a/src/test/unit_tests/jest_tests/test_cli_diagnose.test.js
+++ b/src/test/unit_tests/jest_tests/test_cli_diagnose.test.js
@@ -1,0 +1,104 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = "true";
+
+const express = require('express');
+const config = require('../../../../config');
+const { exec_manage_cli } = require('../../system_tests/test_utils');
+const { TYPES, DIAGNOSE_ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
+const { ManageCLIResponse } = require('../../../manage_nsfs/manage_nsfs_cli_responses');
+
+const metrics_url = `http://127.0.0.1:${config.EP_METRICS_SERVER_PORT}/metrics/nsfs_stats`;
+const metrics_obj_mock = {
+    "nsfs_counters": {
+        "noobaa_nsfs_io_read_count": 1,
+        "noobaa_nsfs_io_write_count": 2,
+        "noobaa_nsfs_io_read_bytes": 49,
+        "noobaa_nsfs_io_write_bytes": 98
+    },
+    "op_stats_counters": {
+        "noobaa_nsfs_op_create_bucket_min_time_milisec": 15,
+        "noobaa_nsfs_op_create_bucket_max_time_milisec": 15,
+        "noobaa_nsfs_op_create_bucket_avg_time_milisec": 15,
+        "noobaa_nsfs_op_create_bucket_count": 1,
+        "noobaa_nsfs_op_create_bucket_error_count": 0,
+        "noobaa_nsfs_op_upload_object_min_time_milisec": 15,
+        "noobaa_nsfs_op_upload_object_max_time_milisec": 20,
+        "noobaa_nsfs_op_upload_object_avg_time_milisec": 17,
+        "noobaa_nsfs_op_upload_object_count": 2,
+        "noobaa_nsfs_op_upload_object_error_count": 0,
+        "noobaa_nsfs_op_head_object_min_time_milisec": 2,
+        "noobaa_nsfs_op_head_object_max_time_milisec": 3,
+        "noobaa_nsfs_op_head_object_avg_time_milisec": 2,
+        "noobaa_nsfs_op_head_object_count": 2,
+        "noobaa_nsfs_op_head_object_error_count": 0,
+        "noobaa_nsfs_op_read_object_min_time_milisec": 12,
+        "noobaa_nsfs_op_read_object_max_time_milisec": 12,
+        "noobaa_nsfs_op_read_object_avg_time_milisec": 12,
+        "noobaa_nsfs_op_read_object_count": 1,
+        "noobaa_nsfs_op_read_object_error_count": 0
+    }
+};
+
+describe('noobaa cli - diagnose flow', () => {
+
+    describe('gather-logs flow', async => {
+        it('gather-logs - should fail with not implemented', async () => {
+            const res = await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.GATHER_LOGS, {}, true);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.NotImplemented.message);
+        });
+    });
+
+    describe('metrics flow', () => {
+
+        it('diagnose metrics - should fail', async () => {
+            let metrics_server;
+            try {
+                metrics_server = start_metrics_mock_server();
+                const res = await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.METRICS, {}, true);
+                const parsed_res = JSON.parse(res);
+                expect(parsed_res.response.code).toBe(ManageCLIResponse.MetricsStatus.code);
+                expect(parsed_res.response.reply).toMatchObject(metrics_obj_mock);
+            } finally {
+                stop_metrics_mock_server(metrics_server);
+            }
+        });
+
+        it('diagnose metrics - should fail, metrics server is down', async () => {
+            const res = await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.METRICS, {}, true);
+            const parsed_res = JSON.parse(res.stdout);
+            expect(parsed_res.error.code).toBe(ManageCLIError.MetricsStatusFailed.code);
+            expect(parsed_res.error.message).toBe(ManageCLIError.MetricsStatusFailed.message);
+        });
+    });
+});
+
+
+/**
+ * start_metrics_mock_server starts a metrics mock server
+ * currently returns always the same metrics mock object
+ * @returns {Object}
+ */
+function start_metrics_mock_server() {
+    const app = express();
+    const metrics_mock_handler = async (req, res) => {
+        res.send(JSON.stringify(metrics_obj_mock));
+    };
+
+    app.get('/metrics/nsfs_stats', metrics_mock_handler);
+    return app.listen(config.EP_METRICS_SERVER_PORT, () => {
+        console.info(`HTTP server is listening on ${metrics_url}`);
+    });
+}
+
+/**
+ * stop_metrics_mock_server stops a metrics mock server
+ * @param {Object} metrics_server 
+ */
+function stop_metrics_mock_server(metrics_server) {
+    if (metrics_server) metrics_server.close();
+}
+

--- a/src/test/unit_tests/test_nc_nsfs_health.js
+++ b/src/test/unit_tests/test_nc_nsfs_health.js
@@ -10,12 +10,12 @@ const sinon = require('sinon');
 const assert = require('assert');
 const P = require('../../util/promise');
 const config = require('../../../config');
-const NSFSHealth = require('../../cmd/health');
+const NSFSHealth = require('../../manage_nsfs/health').NSFSHealth;
 const fs_utils = require('../../util/fs_utils');
 const nb_native = require('../../util/nb_native');
-const { CONFIG_SUBDIRS } = require('../../manage_nsfs/manage_nsfs_constants');
+const { CONFIG_SUBDIRS, TYPES, DIAGNOSE_ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
 const { get_process_fs_context, get_umasked_mode } = require('../../util/native_fs_utils');
-const { TMP_PATH, create_fs_user_by_platform, delete_fs_user_by_platform, exec_health_cli } = require('../system_tests/test_utils');
+const { TMP_PATH, create_fs_user_by_platform, delete_fs_user_by_platform, exec_manage_cli } = require('../system_tests/test_utils');
 const { ManageCLIError } = require('../../manage_nsfs/manage_nsfs_cli_errors');
 
 const tmp_fs_path = path.join(TMP_PATH, 'test_bucketspace_fs');
@@ -47,7 +47,7 @@ mocha.describe('nsfs nc health', function() {
     mocha.describe('nsfs nc health cli validations', function() {
         mocha.it('https_port flag type validation - should fail', async function() {
             try {
-                await exec_health_cli({ 'http_port': '' });
+                await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.HEALTH, { 'http_port': '' });
                 assert.fail('should have failed with InvalidArgument');
             } catch (err) {
                 const res = JSON.parse(err.stdout);
@@ -57,7 +57,7 @@ mocha.describe('nsfs nc health', function() {
 
         mocha.it('all_account_details flag type validation - should fail', async function() {
             try {
-                await exec_health_cli({ 'all_account_details': 'bla' });
+                await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.HEALTH, { 'all_account_details': 'bla' });
                 assert.fail('should have failed with InvalidBooleanValue');
             } catch (err) {
                 const res = JSON.parse(err.stdout);
@@ -67,7 +67,7 @@ mocha.describe('nsfs nc health', function() {
 
         mocha.it('all_bucket_details flag type validation - should fail', async function() {
             try {
-                await exec_health_cli({ 'all_bucket_details': 7000 });
+                await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.HEALTH, { 'all_bucket_details': 7000 });
                 assert.fail('should have failed with InvalidArgumentType');
             } catch (err) {
                 const res = JSON.parse(err.stdout);
@@ -76,8 +76,8 @@ mocha.describe('nsfs nc health', function() {
         });
 
         mocha.it('all_bucket_details flag type validation', async function() {
-            const res = await exec_health_cli({ 'all_bucket_details': true });
-            const parsed_res = JSON.parse(res);
+            const res = await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.HEALTH, { 'all_bucket_details': true });
+            const parsed_res = JSON.parse(res).response.reply;
             assert.notEqual(parsed_res.checks.buckets_status, undefined);
             assert.ok(parsed_res.checks.buckets_status.invalid_buckets.length >= 0);
             assert.ok(parsed_res.checks.buckets_status.valid_buckets.length >= 0);
@@ -85,8 +85,8 @@ mocha.describe('nsfs nc health', function() {
         });
 
         mocha.it('all_account_details flag type validation', async function() {
-            const res = await exec_health_cli({ 'all_account_details': true });
-            const parsed_res = JSON.parse(res);
+            const res = await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.HEALTH, { 'all_account_details': true });
+            const parsed_res = JSON.parse(res).response.reply;
             assert.notEqual(parsed_res.checks.accounts_status, undefined);
             assert.ok(parsed_res.checks.accounts_status.invalid_accounts.length >= 0);
             assert.ok(parsed_res.checks.accounts_status.valid_accounts.length >= 0);

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -491,6 +491,13 @@ function make_https_request(options, body, body_encoding) {
     });
 }
 
+async function make_http_request(options, body) {
+    return new Promise((resolve, reject) => {
+        http.request(options, resolve)
+            .on('error', reject)
+            .end(body);
+    });
+}
 
 // Write periodically to keep the connection alive
 // TODO: Every complete above the S3_KEEP_ALIVE_WHITESPACE_INTERVAL
@@ -725,6 +732,7 @@ exports.get_unsecured_agent = get_unsecured_agent;
 exports.update_http_agents = update_http_agents;
 exports.update_https_agents = update_https_agents;
 exports.make_https_request = make_https_request;
+exports.make_http_request = make_http_request;
 exports.set_keep_alive_whitespace_interval = set_keep_alive_whitespace_interval;
 exports.parse_xml_to_js = parse_xml_to_js;
 exports.check_headers = check_headers;


### PR DESCRIPTION
### Explain the changes
1. Add NooBaa diagnose CLI command - 
```
noobaa-cli diagnose health
noobaa-cli diagnose gather-logs
noobaa-cli diagnose metrics
```
2. `Health script` moved to be a part of `noobaa-cli` and it's no longer a standalone script. Output is wrapped by `noobaa-cli` response/errors.
3. Added `gather-logs` action (logic unimplemented yet).
4. Added `metrics` action for fetching NooBaa NC metrics.

### Issues: Fixed #xxx / Gap #xxx
1. gather-logs logic.

### Testing Instructions:
1. Manual - 
Install NooBaa RPM, enable the service and run the following commands - 

```
noobaa-cli diagnose health
noobaa-cli diagnose gather-logs
noobaa-cli diagnose metrics
```
2. Automatic - 
` sudo jest --testRegex=jest_tests/test_cli_diagnose`
`sudo ./node_modules/mocha/bin/mocha src/test/unit_tests/test_nc_nsfs_health.js`

- [x] Doc added/updated
- [x] Tests added
