### PR TITLE
CI | Update Commit Hash in Ceph Tests

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_black_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_black_list.txt
@@ -123,7 +123,6 @@ s3tests_boto3/functional/test_s3.py::test_post_object_missing_content_length_arg
 s3tests_boto3/functional/test_s3.py::test_post_object_invalid_content_length_argument
 s3tests_boto3/functional/test_s3.py::test_post_object_upload_size_below_minimum
 s3tests_boto3/functional/test_s3.py::test_post_object_empty_conditions
-s3tests_boto3/functional/test_s3.py::test_post_object_wrong_bucket
 s3tests_boto3/functional/test_s3.py::test_put_object_ifmatch_nonexisted_failed
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_bucket_gone
 s3tests_boto3/functional/test_s3.py::test_object_raw_get

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
@@ -217,3 +217,9 @@ s3tests/functional/test_headers.py::test_object_create_bad_date_none_aws2
 s3tests/functional/test_headers.py::test_bucket_create_bad_authorization_invalid_aws2
 s3tests/functional/test_headers.py::test_bucket_create_bad_date_none_aws2
 s3tests_boto3/functional/test_s3.py::test_versioned_concurrent_object_create_and_remove
+s3tests_boto3/functional/test_s3.py::test_post_object_wrong_bucket
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_with_acl
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant_with_acl
+s3tests_boto3/functional/test_s3.py::test_object_presigned_put_object_with_acl_tenant

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_black_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_black_list.txt
@@ -123,7 +123,6 @@ s3tests_boto3/functional/test_s3.py::test_post_object_missing_content_length_arg
 s3tests_boto3/functional/test_s3.py::test_post_object_invalid_content_length_argument
 s3tests_boto3/functional/test_s3.py::test_post_object_upload_size_below_minimum
 s3tests_boto3/functional/test_s3.py::test_post_object_empty_conditions
-s3tests_boto3/functional/test_s3.py::test_post_object_wrong_bucket
 s3tests_boto3/functional/test_s3.py::test_put_object_ifmatch_nonexisted_failed
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_bucket_gone
 s3tests_boto3/functional/test_s3.py::test_object_raw_get

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -131,3 +131,9 @@ s3tests/functional/test_headers.py::test_bucket_create_bad_authorization_invalid
 s3tests/functional/test_headers.py::test_bucket_create_bad_date_none_aws2
 s3tests_boto3/functional/test_s3.py::test_get_object_ifnonematch_good
 s3tests_boto3/functional/test_s3.py::test_get_object_ifmodifiedsince_failed
+s3tests_boto3/functional/test_s3.py::test_post_object_wrong_bucket
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_with_acl
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant_with_acl
+s3tests_boto3/functional/test_s3.py::test_object_presigned_put_object_with_acl_tenant

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -17,7 +17,7 @@ DIRECTORY="s3-tests"
 CEPH_LINK="https://github.com/ceph/s3-tests.git"
 # using a fixed version (commit) of ceph tests to avoid sudden changes. 
 # we should retest and update the version once in a while
-CEPH_TESTS_VERSION=da91ad8bbf899c72199df35b69e9393c706aabee
+CEPH_TESTS_VERSION=997f78d58ac7b991e555328953fc8e72d912a303
 if [ ! -d $DIRECTORY ]; then
     echo "Downloading Ceph S3 Tests..."
     git clone $CEPH_LINK


### PR DESCRIPTION
### Explain the changes
1. Update commit hash in Ceph tests.
2. Move a test that was added to the blacklist to the pending list (`test_post_object_wrong_bucket`).
3. Move new tests of pre-signed URLs to the pending list:
- `s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object`
- `s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_with_acl`
- `s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant`
- `s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant_with_acl`
- `s3tests_boto3/functional/test_s3.py::test_object_presigned_put_object_with_acl_tenant`

### Issues: Fixed #xxx / Gap #xxx
1. We need to update the hash every 180 days - this commit hash will add a few days to the counter (assuming it will be until 10 August 2024).
Note: I cannot update to the latest commit hash because I saw issues with one of the commits ([here](https://github.com/noobaa/noobaa-core/pull/8078#issuecomment-2132762799)).
2. [edit]: Gap - update the table (Ceph S3 Tests - Pending List Status) about`test_post_object_wrong_bucket` - the link of explanation is [here](https://github.com/noobaa/noobaa-core/pull/7997#issuecomment-2222232996).

### Testing Instructions:
1. none (tested through the CI).
2. If you wish to run it locally:
`make test-cephs3 CONTAINER_PLATFORM=linux/arm64`
`make test-nsfs-cephs3 CONTAINER_PLATFORM=linux/arm64`
(I'm using the flag `CONTAINER_PLATFORM` because I have MacOS M1).


- [ ] Doc added/updated
- [ ] Tests added
