### PR TITLE
NC | NSFS | Stop Setting `system_owner` in Bucket Config

### DIFF
--- a/docs/NooBaaNonContainerized/CI&Tests.md
+++ b/docs/NooBaaNonContainerized/CI&Tests.md
@@ -103,6 +103,7 @@ The following is a list of `NC jest tests` files -
 8. `test_nc_nsfs_bucket_schema_validation.test.js` - Tests NC bucket schema validation.  
 9. `test_nc_nsfs_account_schema_validation.test.js` - Tests NC account schema validation.  
 10. `test_nc_nsfs_new_buckets_path_validation.test.js` - Tests new_buckets_path RW access.  
+11. `test_config_fs.test.js` - Tests ConfigFS methods.
 
 #### nc_index.js File
 * The `nc_index.js` is a file that runs several NC and NSFS mocha related tests.  

--- a/docs/NooBaaNonContainerized/GettingStarted.md
+++ b/docs/NooBaaNonContainerized/GettingStarted.md
@@ -187,7 +187,7 @@ make_bucket: s3bucket
 #### 3. Check that the bucket configuration file was created successfully -
 ```sh
 sudo cat /etc/noobaa.conf.d/buckets/s3bucket.json
-{"_id":"65cb1efcbec92b33220112d7","name":"s3bucket","owner_account":"65cb1e7c9e6ae40d499c0ae4","system_owner":"account1","bucket_owner":"account1","versioning":"DISABLED","creation_date":"2023-09-26T05:56:16.252Z","path":"/tmp/fs1/s3bucket","should_create_underlying_storage":true}
+{"_id":"65cb1efcbec92b33220112d7","name":"s3bucket","owner_account":"65cb1e7c9e6ae40d499c0ae4","bucket_owner":"account1","versioning":"DISABLED","creation_date":"2023-09-26T05:56:16.252Z","path":"/tmp/fs1/s3bucket","should_create_underlying_storage":true}
 ```
 
 #### 4. Check that the underlying file system bucket directory was created successfully -

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -94,7 +94,6 @@ async function fetch_bucket_data(action, user_input) {
         _id: undefined,
         name: user_input.name === undefined ? undefined : String(user_input.name),
         owner_account: undefined,
-        system_owner: user_input.owner, // GAP - needs to be the system_owner (currently it is the account name)
         bucket_owner: user_input.owner,
         tag: undefined, // if we would add the option to tag a bucket using CLI, this should be changed
         versioning: action === ACTIONS.ADD ? 'DISABLED' : undefined,
@@ -596,8 +595,9 @@ async function list_config_files(type, config_path, wide, show_secrets, filters)
     let config_files_list = await P.map_with_concurrency(10, entries, async entry => {
         if (entry.name.endsWith(JSON_SUFFIX)) {
             if (wide || should_filter) {
-                const full_path = path.join(config_path, entry.name);
-                const data = await config_fs.get_config_data(full_path, options);
+                const data = type === TYPES.ACCOUNT ?
+                    await config_fs.get_account_by_name(entry.name, options) :
+                    await config_fs.get_bucket_by_name(entry.name, options);
                 if (!data) return undefined;
                 if (should_filter && !filter_list_item(type, data, filters)) return undefined;
                 // remove secrets on !show_secrets && should filter

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -230,7 +230,7 @@ async function authorize_request_policy(req) {
 
     const account = req.object_sdk.requesting_account;
     const account_identifier = req.object_sdk.nsfs_config_root ? account.name.unwrap() : account.email.unwrap();
-    const is_system_owner = account_identifier === system_owner.unwrap();
+    const is_system_owner = Boolean(system_owner) && system_owner.unwrap() === account_identifier;
 
     // @TODO: System owner as a construct should be removed - Temporary
     if (is_system_owner) return;

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -121,7 +121,6 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             };
 
             bucket.name = new SensitiveString(bucket.name);
-            bucket.system_owner = new SensitiveString(bucket.system_owner);
             bucket.bucket_owner = new SensitiveString(bucket.bucket_owner);
             bucket.owner_account = {
                 id: bucket.owner_account,
@@ -291,7 +290,6 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             tag: js_utils.default_value(tag, undefined),
             owner_account: account._id,
             creator: account._id,
-            system_owner: new SensitiveString(account.name),
             bucket_owner: new SensitiveString(account.name),
             versioning: config.NSFS_VERSIONING_ENABLED && lock_enabled ? 'ENABLED' : 'DISABLED',
             object_lock_configuration: config.WORM_ENABLED ? {
@@ -675,7 +673,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         const account_identifier = account.name.unwrap();
         dbg.log1('has_bucket_action_permission:', bucket.name.unwrap(), account_identifier, bucket.bucket_owner.unwrap());
 
-        const is_system_owner = account_identifier === bucket.system_owner.unwrap();
+        const is_system_owner = Boolean(bucket.system_owner) && bucket.system_owner.unwrap() === account_identifier;
 
         // If the system owner account wants to access the bucket, allow it
         if (is_system_owner) return true;

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -398,6 +398,7 @@ class ConfigFS {
     async get_bucket_by_name(bucket_name, options = {}) {
         const bucket_path = this.get_bucket_path_by_name(bucket_name);
         const bucket = await this.get_config_data(bucket_path, options);
+        this.adjust_bucket_with_schema_updates(bucket);
         return bucket;
     }
 
@@ -439,6 +440,18 @@ class ConfigFS {
     async delete_bucket_config_file(bucket_name) {
         const bucket_config_path = this.get_bucket_path_by_name(bucket_name);
         await native_fs_utils.delete_config_file(this.fs_context, this.buckets_dir_path, bucket_config_path);
+    }
+
+    /**
+     * adjust_bucket_with_schema_updates changes the bucket properties according to the schema
+     * @param {object} bucket
+     */
+    adjust_bucket_with_schema_updates(bucket) {
+        if (!bucket) return;
+        // system_owner is deprecated since version 5.18
+        if (bucket.system_owner !== undefined) {
+            delete bucket.system_owner;
+        }
     }
 }
 

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -194,7 +194,7 @@ class ObjectSDK {
         const { bucket } = await bucket_namespace_cache.get_with_cache({ sdk: this, name });
         const policy_info = {
             s3_policy: bucket.s3_policy,
-            system_owner: bucket.system_owner,
+            system_owner: bucket.system_owner, // note that bucketspace_fs currently doesn't return system_owner
             bucket_owner: bucket.bucket_owner,
             owner_account: bucket.owner_account, // in NC NSFS this is the account id that owns the bucket
         };

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -7,7 +7,6 @@ module.exports = {
     required: [
         '_id',
         'name',
-        'system_owner',
         'bucket_owner',
         'owner_account',
         'versioning',
@@ -30,6 +29,10 @@ module.exports = {
         name: {
             type: 'string',
         },
+        /** 
+         * @deprecated system_owner is kept for backward compatibility,
+         * but will no longer be included in new / updated bucket json.
+         */
         system_owner: {
             type: 'string',
         },

--- a/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
@@ -1872,7 +1872,6 @@ function _new_bucket_defaults(account, bucket_name, bucket_storage_path) {
         _id: '65a8edc9bc5d5bbf9db71c75',
         name: bucket_name,
         owner_account: account._id,
-        system_owner: new SensitiveString(account.name),
         bucket_owner: new SensitiveString(account.name),
         creation_date: new Date().toISOString(),
         path: bucket_storage_path,

--- a/src/test/unit_tests/jest_tests/test_config_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_config_fs.test.js
@@ -1,0 +1,30 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const path = require('path');
+const config = require('../../../../config');
+const { TMP_PATH } = require('../../system_tests/test_utils');
+const { get_process_fs_context } = require('../../../util/native_fs_utils');
+const { ConfigFS } = require('../../../sdk/config_fs');
+
+const tmp_fs_path = path.join(TMP_PATH, 'test_config_fs');
+const config_root = path.join(tmp_fs_path, 'config_root');
+const config_root_backend = config.NSFS_NC_CONFIG_DIR_BACKEND;
+const fs_context = get_process_fs_context(config_root_backend);
+
+const config_fs = new ConfigFS(config_root, config_root_backend, fs_context);
+
+describe('adjust_bucket_with_schema_updates', () => {
+    it('should return undefined on undefined bucket', () => {
+        const bucket = undefined;
+        config_fs.adjust_bucket_with_schema_updates(bucket);
+        expect(bucket).toBeUndefined();
+    });
+
+    it('should return bucket without deprecated properties (system_owner)', () => {
+        const bucket = {name: 'bucket1', system_owner: 'account1-system-owner'};
+        config_fs.adjust_bucket_with_schema_updates(bucket);
+        expect(bucket).toBeDefined();
+        expect(bucket).not.toHaveProperty('system_owner');
+    });
+});

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -181,24 +181,6 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
-        it('bucket without system_owner', () => {
-            const bucket_data = get_bucket_data();
-            delete bucket_data.system_owner;
-            const reason = 'Test should have failed because of missing required property ' +
-                'system_owner';
-            const message = "must have required property 'system_owner'";
-            assert_validation(bucket_data, reason, message);
-        });
-
-        it('bucket with undefined system_owner', () => {
-            const bucket_data = get_bucket_data();
-            bucket_data.system_owner = undefined;
-            const reason = 'Test should have failed because of missing required property ' +
-                'system_owner';
-            const message = "must have required property 'system_owner'";
-            assert_validation(bucket_data, reason, message);
-        });
-
         it('bucket without bucket_owner', () => {
             const bucket_data = get_bucket_data();
             delete bucket_data.bucket_owner;
@@ -463,7 +445,6 @@ describe('schema validation NC NSFS bucket', () => {
 function get_bucket_data() {
     const bucket_name = 'bucket1';
     const id = '65a62e22ceae5e5f1a758aa8';
-    const system_owner = 'account1'; // GAP - currently account name
     const bucket_owner = 'account1'; // account name
     const owner_account = '65b3c68b59ab67b16f98c26e';
     const versioning_disabled = 'DISABLED';
@@ -473,7 +454,6 @@ function get_bucket_data() {
     const bucket_data = {
         _id: id,
         name: bucket_name,
-        system_owner: system_owner,
         bucket_owner: bucket_owner,
         owner_account: owner_account,
         versioning: versioning_disabled,

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -1126,7 +1126,6 @@ function assert_response(action, type, actual_res, expected_res, show_secrets, w
 
 function assert_bucket(bucket, bucket_options) {
     assert.strictEqual(bucket.name, bucket_options.name);
-    assert.strictEqual(bucket.system_owner, bucket_options.owner);
     assert.strictEqual(bucket.bucket_owner, bucket_options.owner);
     assert.strictEqual(bucket.path, bucket_options.path);
     assert.strictEqual(bucket.should_create_underlying_storage, false);

--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -467,8 +467,6 @@ mocha.describe('s3_bucket_policy', function() {
     });
 
     mocha.it('should deny bucket owner access', async function() {
-        // test fails on NC_CORETEST because system_owner === bucket_owner, until this behavior changes skipping the test
-        if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         const policy = {
             Version: '2012-10-17',
             Statement: [{
@@ -500,6 +498,8 @@ mocha.describe('s3_bucket_policy', function() {
     });
 
     mocha.it('should set and delete bucket policy when system owner', async function() {
+    // test fails on NC_CORETEST because we do not set system_owner in buckets
+    if (process.env.NC_CORETEST) this.skip(); // eslint-disable-line no-invalid-this
         const policy = {
             Version: '2012-10-17',
             Statement: [{


### PR DESCRIPTION
### Explain the changes
1. Remove the property `system_owner` as required property in `nsfs_bucket_schema`.
2. On the newly created bucket, do not set the `system_owner` value (on `manage_nsfs` and `bucketspace_fs`).
3. Remove the `system_owner` (with the value of the account name) from the current docs in NC NSFS.
4. Update unit test tests and remove the property `system_owner`.
5. Add the function `modify_bucket_on_read` in class `ConfigFS`, and use it from `get_bucket_by_name` and inside the bucket list in noobaa-cli.

### Issues: Fixed #7793 [BZ 2280212](https://bugzilla.redhat.com/show_bug.cgi?id=2280212)
1. Currently, in the NC NSFS bucket config the `system_owner` is the account name, and therefore bucket policies can't limit a bucket owner's access to buckets that he created.

### Testing Instructions:
#### Unit Tests:
Please run:
1. `sudo NC_CORETEST=true node --trace-warnings ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_s3_bucket_policy.js` (for NC environment, currently you will 3 failing tests - not related to this PR)
3. `make CONTAINER_PLATFORM=linux/arm64 run-single-test testname=test_s3_bucket_policy.js` (for Containerized environment)
Note: I have MacOS M1 so I need to add the flag `CONTAINER_PLATFORM=linux/arm64`.
4. `npx jest test_nc_nsfs_bucket_schema_validation.test.js`
6. `sudo node ./node_modules/.bin/_mocha src/test/unit_tests/test_nc_nsfs_cli.js`
7. `npx jest test_config_fs.test.js`

#### Manual Tests:
(1) On new buckets:
1. First, create the `FS_ROOT` and a directory for a `new_buckets_path`: `mkdir -p /tmp/nsfs_root1/` and give permissions `chmod 777 /tmp/nsfs_root1/`.
2. Create an account: `sudo node src/cmd/manage_nsfs account add --name <account-name> --uid <uid> --gid <gid> --new_buckets_path <new_buckets_path>` (use those credentials in the alias step below).
3. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
4. Create the alias for the created account in the S3 service: `alias s3-nc-user-1='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443/'`
Note: I Change the `config.NSFS_CHECK_BUCKET_BOUNDARIES = false; //SDSD` because I'm using the `/tmp/` and not `/private/tmp/`.
5. Check the connection to the server (should not have buckets): `s3-nc-user-1 s3 ls`
8. Create a bucket: `s3-nc-user-1 s3 mb s3://my-bucket-to-check`
9. Create a file: `touch denied_test_obj.txt`
10. Upload the file to the bucket: `s3-nc-user-1 s3 cp denied_test_obj.txt s3://my-bucket-to-check`
11. See that the user can download the file: `s3-nc-user-1 s3 cp s3://my-bucket-to-check/denied_test_obj.txt ~/Downloads/`
12. Put bucket policy: `s3-nc-user-1 s3api put-bucket-policy --bucket my-bucket-to-check --policy file://policy.json`, the policy is:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Deny",
            "Action": "s3:*",
            "Principal": {
                "AWS": "*"
            },
            "Resource": "arn:aws:s3:::my-bucket-to-check/denied_test_obj.txt"
        }
    ]
}
```
(this policy would deny a bucket owner account from accessing an object inside its bucket)
13. See that you cannot download the file: `s3-nc-user-1 s3 cp s3://my-bucket-to-check/denied_test_obj.txt ~/Downloads/` (I saw: fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden).
14. (optional) Delete the bucket policy and try again (should download the file):
  - `s3-nc-user-1 s3api delete-bucket-policy --bucket my-bucket-to-check`
  - `s3-nc-user-1 s3 cp s3://my-bucket-to-check/denied_test_obj.txt ~/Downloads/`

(2) On buckets that already exist and had the `system_owner` property - they would still have the mentioned issue.
So want to test that we can operate on buckets that has the property `system_owner`:
1. First, create the `FS_ROOT` and a directory for a `new_buckets_path`: `mkdir -p /tmp/nsfs_root1/` and give permissions `chmod 777 /tmp/nsfs_root1/`.
2. Create an account: `sudo node src/cmd/manage_nsfs account add --name shira-1001 --uid 1001 --gid 1001 --new_buckets_path /tmp/nsfs_root1/` (use those credentials in the alias step below).
3. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
4. Create the alias for the created account in the S3 service: `alias s3-nc-user-1='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443/'`
Note: I Change the `config.NSFS_CHECK_BUCKET_BOUNDARIES = false; //SDSD` because I'm using the `/tmp/` and not `/private/tmp/`.
5. Check the connection to the server (should not have buckets): `s3-nc-user-1 s3 ls`
6. Create a bucket using the CLI (it doesn't matter if CLI or S3 flow for this purpose): ` sudo node src/cmd/manage_nsfs bucket add --name my-bucket --path /tmp/nsfs_root1/my-bucket --owner shira-1001`
7. List the bucket: `s3-nc-user-1 s3 ls`
8. Edit the bucket config file using `sudo vi /etc/noobaa.conf.d/buckets/my-bucket.json` and add to it: `"system_owner":"shira-1001"`
9. List the bucket: `s3-nc-user-1 s3 ls` (to test that we can list the bucket even if we have this property).
10. Create a file: `touch denied_test_obj.txt`
8. Upload the file to the bucket: `s3-nc-user-1 s3 cp denied_test_obj.txt s3://my-bucket`
9. See that the user can download the file: `s3-nc-user-1 s3 cp s3://my-bucket/denied_test_obj.txt ~/Downloads/`
* As mentioned on buckets that were already created in the system, could not use bucket policy to limit a bucket owner's access to buckets that he created.

- [X] Doc added/updated
- [X] Tests added
