### PR TITLE
NC | NSFS | CLI Basic Support of IAM Accounts Configs

### DIFF
--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -417,10 +417,17 @@ function validate_username(input_username, parameter_name = iam_constants.USERNA
             const { code, http_code, type } = IamError.ValidationError;
             throw new IamError({ code, message: message_with_details, http_code, type });
     }
+    // internal limitations
     const invalid_internal_names = new Set(['anonymous', '/', '.']);
     if (invalid_internal_names.has(input_username)) {
         const message_with_details = `The specified value for ${_.lowerFirst(parameter_name)} is invalid. ` +
         `Should not be one of: ${[...invalid_internal_names].join(' ').toString()}`;
+        const { code, http_code, type } = IamError.ValidationError;
+        throw new IamError({ code, message: message_with_details, http_code, type });
+    }
+    if (input_username !== input_username.trim()) {
+        const message_with_details = `The specified value for ${_.lowerFirst(parameter_name)} is invalid. ` +
+        `Must not contain leading or trailing spaces`;
         const { code, http_code, type } = IamError.ValidationError;
         throw new IamError({ code, message: message_with_details, http_code, type });
     }

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -208,6 +208,13 @@ ManageCLIError.AccountDeleteForbiddenHasBuckets = Object.freeze({
     http_code: 403,
 });
 
+ManageCLIError.AccountDeleteForbiddenHasIAMAccounts = Object.freeze({
+    code: 'AccountDeleteForbiddenHasIAMAccounts',
+    message: 'Cannot delete account that is owner of IAM accounts. ' +
+        'You must delete all IAM accounts before deleting the root account',
+    http_code: 403,
+});
+
 ManageCLIError.AccountCannotCreateRootAccountsRequesterIAMUser = Object.freeze({
     code: 'AccountCannotCreateRootAccounts',
     message: 'Cannot update account to have iam_operate_on_root_account. ' +
@@ -339,10 +346,17 @@ ManageCLIError.BucketAlreadyExists = Object.freeze({
     http_code: 409,
 });
 
-ManageCLIError.BucketSetForbiddenNoBucketOwner = Object.freeze({
-    code: 'BucketSetForbiddenNoBucketOwner',
+ManageCLIError.BucketSetForbiddenBucketOwnerNotExists = Object.freeze({
+    code: 'BucketSetForbiddenBucketOwnerNotExists',
     message: 'The bucket owner you set for the bucket does not exist. ' +
         'Please set the bucket owner from existing account',
+    http_code: 403,
+});
+
+ManageCLIError.BucketSetForbiddenBucketOwnerIsIAMAccount = Object.freeze({
+    code: 'BucketSetForbiddenBucketOwnerIsIAMAccount',
+    message: 'The bucket owner you set for the bucket is an IAM account. ' +
+        'Please set root account as bucket owner',
     http_code: 403,
 });
 
@@ -432,7 +446,8 @@ const NSFS_CLI_ERROR_EVENT_MAP = {
     AccountNameAlreadyExists: NoobaaEvent.ACCOUNT_ALREADY_EXISTS,
     AccountDeleteForbiddenHasBuckets: NoobaaEvent.ACCOUNT_DELETE_FORBIDDEN,
     BucketAlreadyExists: NoobaaEvent.BUCKET_ALREADY_EXISTS,
-    BucketSetForbiddenNoBucketOwner: NoobaaEvent.UNAUTHORIZED,
+    BucketSetForbiddenBucketOwnerNotExists: NoobaaEvent.UNAUTHORIZED, // GAP - add event
+    BucketSetForbiddenBucketOwnerIsIAMAccount: NoobaaEvent.UNAUTHORIZED, // // GAP - add event
     LoggingExportFailed: NoobaaEvent.LOGGING_FAILED,
 };
 

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -120,7 +120,7 @@ async function get_bucket_owner_account(global_config, bucket_owner) {
     } catch (err) {
         if (err.code === 'ENOENT') {
             const detail_msg = `bucket owner ${bucket_owner} does not exists`;
-            throw_cli_error(ManageCLIError.BucketSetForbiddenNoBucketOwner, detail_msg, {bucket_owner: bucket_owner});
+            throw_cli_error(ManageCLIError.BucketSetForbiddenBucketOwnerNotExists, detail_msg, {bucket_owner: bucket_owner});
         }
         throw err;
     }

--- a/src/test/unit_tests/jest_tests/test_iam_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_iam_utils.test.js
@@ -337,9 +337,19 @@ describe('validate_user_input_iam', () => {
             }
         });
 
-        it('should throw error when username is invalid - internal limitation', () => {
+        it('should throw error when username is invalid - internal limitation (anonymous)', () => {
             try {
                 iam_utils.validate_username('anonymous', iam_constants.USERNAME);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+            }
+        });
+
+        it('should throw error when username is invalid - internal limitation (with leading or trailing spaces)', () => {
+            try {
+                iam_utils.validate_username('    name-with-spaces    ', iam_constants.USERNAME);
                 throw new NoErrorThrownError();
             } catch (err) {
                 expect(err).toBeInstanceOf(IamError);

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -12,7 +12,7 @@ const nb_native = require('../../../util/nb_native');
 const { set_path_permissions_and_owner, TMP_PATH, generate_s3_policy,
     set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
 const { ACTIONS, TYPES, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_nsfs_constants');
-const { get_process_fs_context, is_path_exists, get_bucket_tmpdir_full_path } = require('../../../util/native_fs_utils');
+const { get_process_fs_context, is_path_exists, get_bucket_tmpdir_full_path, update_config_file } = require('../../../util/native_fs_utils');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const { ManageCLIResponse } = require('../../../manage_nsfs/manage_nsfs_cli_responses');
 
@@ -165,6 +165,39 @@ describe('manage nsfs cli bucket flow', () => {
             const bucket_options = { config_root, owner: bucket_defaults.owner, path: bucket_defaults.path };
             const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.MissingBucketNameFlag.code);
+        });
+
+        it('should fail - cli create bucket - owner is an IAM account', async () => {
+            const { name } = account_defaults;
+            const accounts_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account_id = accounts_details._id;
+
+            const { new_buckets_path: account_path } = account_defaults;
+            const account_name = 'account-to-be-owned';
+            const account_options1 = { config_root, name: account_name, uid: 5555, gid: 5555,
+                new_buckets_path: account_path};
+            await fs_utils.create_fresh_path(account_path);
+            await fs_utils.file_must_exist(account_path);
+            await set_path_permissions_and_owner(account_path, account_options1, 0o700);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, account_options1);
+
+            // update the account to have the property owner
+            // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
+            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
+            const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
+            const config_data = JSON.parse(data.toString());
+            config_data.owner = account_id; // just so we can identify this account as IAM user;
+            await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
+                account_config_path, JSON.stringify(config_data));
+
+            // create the bucket
+            const action = ACTIONS.ADD;
+            const bucket_options = { config_root, ...bucket_defaults, owner: account_name};
+            await fs_utils.create_fresh_path(bucket_options.path);
+            await fs_utils.file_must_exist(bucket_options.path);
+            await set_path_permissions_and_owner(bucket_options.path, { uid: account_options1.uid, gid: account_options1.gid }, 0o700);
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.BucketSetForbiddenBucketOwnerIsIAMAccount.code);
         });
     });
 
@@ -505,6 +538,39 @@ describe('manage nsfs cli bucket flow', () => {
             await set_path_permissions_and_owner(bucket_defaults.path, account_defaults2, 0o700);
             const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.BucketUpdated.code);
+        });
+
+        it('should fail - cli update bucket - owner is an IAM account', async () => {
+            const { name } = account_defaults;
+            const accounts_details = await read_config_file(config_root, CONFIG_SUBDIRS.ACCOUNTS, name);
+            const account_id = accounts_details._id;
+
+            const { new_buckets_path: account_path } = account_defaults;
+            const account_name_iam_account = 'account-to-be-owned';
+            const account_options1 = { config_root, name: account_name_iam_account, uid: 5555, gid: 5555,
+                new_buckets_path: account_path};
+            await fs_utils.create_fresh_path(account_path);
+            await fs_utils.file_must_exist(account_path);
+            await set_path_permissions_and_owner(account_path, account_options1, 0o700);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, account_options1);
+
+            // update the account to have the property owner
+            // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
+            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name_iam_account + '.json');
+            const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
+            const config_data = JSON.parse(data.toString());
+            config_data.owner = account_id; // just so we can identify this account as IAM user;
+            await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
+                account_config_path, JSON.stringify(config_data));
+
+            // update the bucket
+            const action = ACTIONS.UPDATE;
+            const bucket_options = { config_root, name: bucket_defaults.name, owner: account_name_iam_account};
+            await fs_utils.create_fresh_path(bucket_defaults.path);
+            await fs_utils.file_must_exist(bucket_defaults.path);
+            await set_path_permissions_and_owner(bucket_defaults.path, account_options1, 0o700);
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.BucketSetForbiddenBucketOwnerIsIAMAccount.code);
         });
     });
 

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -98,7 +98,7 @@ mocha.describe('manage_nsfs cli', function() {
                 await exec_manage_cli(type, action, bucket_options);
                 assert.fail('should have failed since the bucket owner does not exist');
             } catch (err) {
-                assert_error(err, ManageCLIError.BucketSetForbiddenNoBucketOwner);
+                assert_error(err, ManageCLIError.BucketSetForbiddenBucketOwnerNotExists);
             }
         });
 


### PR DESCRIPTION
### Explain the changes
1. In noobaa-cli account update - with the flag `regenerate` or flags `access_key` and `secret_key` to change the whole access keys object, not just the properties `access_key` and `secret_key`.
2. In noobaa-cli account delete  - make sure the root account doesn’t have accounts under it.
3. In noobaa-cli bucket add/update with the flag `owner` - make sure the owner is not an IAM account (only a root account owns buckets).
4. Change the error `BucketSetForbiddenNoBucketOwner` to `BucketSetForbiddenNoBucketOwnerNotExists` and add the error `BucketSetForbiddenNoBucketOwnerIAMAccount`.
5. Add `SensitiveString` on `new_access_key`.
6. Add a restriction to the account name based on IAM username validation.
7. Fix a small bug in the `validate_flags_value_combination` is used to send the `input_options_with_data` (data of the original command) and not `input_options_with_data_from_file` data from the file, and I also added a test for this.
8. Remove leftovers of `expect(true).toBe(true);` from tests.

### Issues: #7818 
1. Currently, we don't have any limitation to account name in our code, in this PR we would use the same username validation that we created for IAM accounts for validating the account name.

List of GAPS:
1. We cannot create IAM accounts using the noobaa-cli (only using the IAM API).
2. With noobaa-cli we can update only the access key in index 0 (if a user created another access key pair with the IAM API, it would be managed only using the IAM API).
3. Currently in `manage_nsfs_validations` we have `validate_flags_value_combination` and we added in this PR `validate_account_name` - we would not like to maintain 2 functions with overlapping logic (see [this comment](https://github.com/noobaa/noobaa-core/pull/8195#discussion_r1685743149)). Also, move the list of names to a constant file.

### Testing Instructions:
#### Unit Tests:
Please run:
1. `sudo npx jest test_nc_nsfs_account_cli.test.js`
2. `sudo npx jest test_nc_nsfs_bucket_cli.test.js`

### Manual Tests:
1. Create the root user account with the CLI: `sudo node src/cmd/manage_nsfs account add --name shira-1001 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
4. Create the alias for IAM service: `alias s3-nc-user-1-iam='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005'`.
5. Use AWS CLI to create an IAM account with 2 access keys:
    - `s3-nc-user-1-iam iam create-user --user-name Benny`
    - `s3-nc-user-1-iam iam create-access-key --user-name Benny`
    - `s3-nc-user-1-iam iam create-access-key --user-name Benny`
6. Test noobaa-cli account update - with the flag `regenerate` or flags `access_key` and `secret_key` (should only change the index 0 access keys object).:
    - `sudo node src/cmd/manage_nsfs account update --name Benny --regenerate`
    - `sudo node src/cmd/manage_nsfs account update --name Benny --access_key <access-key> --secret_key <secret-key>`
 7.  Test noobaa-cli account delete root account (expect an error): `sudo node src/cmd/manage_nsfs account delete --name shira-1001`
 8. Test noobaa-cli bucket add/update with the flag `owner` on an IAM account  (expect an error): 
    - `sudo node src/cmd/manage_nsfs bucket add --name bucket-check --path /tmp/nsfs_root1/my-bucket --owner Benny`
    - `sudo node src/cmd/manage_nsfs bucket update --name bucket-check --owner Benny`
 9. Test  noobaa-cli account add with invalid name  (expect an error):
    - `sudo node src/cmd/manage_nsfs account add --name '  name-with-spaces   ' --new_buckets_path /tmp/nsfs_root1 --uid 1004 --gid 1004`
 10. Test  noobaa-cli account add with invalid name  (expect an error):
    - `sudo node src/cmd/manage_nsfs account add --name shira-1004 --new_buckets_path /tmp/nsfs_root1 --uid 1004 --gid 1004`
    - `sudo node src/cmd/manage_nsfs account update --name shira-1004 --new_name '  name-with-spaces   '`

- [ ] Doc added/updated
- [X] Tests added
