### PR TITLE
Implement pool ownership

### DIFF
--- a/config.js
+++ b/config.js
@@ -416,6 +416,8 @@ config.DB_CLEANER_MAX_TOTAL_DOCS = 10000;
 /////////////////////
 // CLOUD RESOURCES //
 /////////////////////
+// This parameter is used to toggle pool deletion checks that enforce that only the pool and system owners can delete the pool
+config.RESTRICT_RESOURCE_DELETION = false;
 // EXPERIMENTAL!! switch to turn off the use of signed urls to delegate cloud read\writes to object_io (s3 compatible only)
 // when this is set to true, block_store_s3 will return s3 credentials to the block_store_client so it can
 // connect directly to the cloud target (and not via a signed url)

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -27,7 +27,8 @@ module.exports = {
         '_id',
         'system',
         'name',
-        'resource_type'
+        'resource_type',
+        'owner_id',
     ],
     properties: {
         _id: {
@@ -48,6 +49,9 @@ module.exports = {
         },
         region: {
             type: 'string'
+        },
+        owner_id: {
+            objectid: true
         },
         pool_node_type: node_schema.properties.node_type,
         mongo_pool_info: {

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -190,12 +190,12 @@ function new_system_changes(req, name, owner_account_id) {
     let default_pool;
     if (config.DEFAULT_POOL_TYPE === 'INTERNAL') {
         const pool_name = `${config.INTERNAL_STORAGE_POOL_NAME}-${system._id}`;
-        const mongo_pool = pool_server.new_pool_defaults(pool_name, system._id, 'INTERNAL', 'BLOCK_STORE_MONGO');
+        const mongo_pool = pool_server.new_pool_defaults(pool_name, system._id, 'INTERNAL', 'BLOCK_STORE_MONGO', owner_account_id);
         mongo_pool.mongo_pool_info = {};
         default_pool = mongo_pool;
     } else if (config.DEFAULT_POOL_TYPE === 'HOSTS') {
         const pool_name = config.DEFAULT_POOL_NAME;
-        const fs_pool = pool_server.new_pool_defaults(pool_name, system._id, 'HOSTS', 'BLOCK_STORE_FS');
+        const fs_pool = pool_server.new_pool_defaults(pool_name, system._id, 'HOSTS', 'BLOCK_STORE_FS', owner_account_id);
         fs_pool.hosts_pool_info = { is_managed: false, host_count: 0 };
         default_pool = fs_pool;
     } else {

--- a/src/upgrade/upgrade_scripts/5.17.0/assign_owner_id_to_all_resources.js
+++ b/src/upgrade/upgrade_scripts/5.17.0/assign_owner_id_to_all_resources.js
@@ -1,0 +1,31 @@
+/* Copyright (C) 2024 NooBaa */
+"use strict";
+
+const config = require('../../../../config');
+
+async function run({ dbg, system_store }) {
+
+    try {
+        const operator_account = system_store.accounts.find(account => account.email.unwrap() === config.OPERATOR_ACCOUNT_EMAIL);
+        const operator_account_id = operator_account._id;
+        dbg.log0('Assigning account ID ', operator_account_id, ' as owner_id to all pools and resources');
+        const updated_pools = system_store.data.pools
+            .filter(pool => !pool.owner_id)
+            .map(pool => ({
+                _id: pool._id,
+                $set: { 'owner_id': operator_account_id }
+            }));
+        if (updated_pools.length > 0) {
+            dbg.log0('Assigning ownership to all pools');
+            await system_store.make_changes({ update: { pools: updated_pools } });
+        }
+    } catch (err) {
+        dbg.error('An error ocurred in the upgrade process:', err);
+        throw err;
+    }
+}
+
+module.exports = {
+    run,
+    description: 'Assign an owner_id to all resources and pools based on the ID of the system owner'
+};


### PR DESCRIPTION
### Explain the changes
1. Each pool and namespace resource now contain a new `owner_id` field that's used for access enforcement
2. Only a resource's owner and system owners (with the `operator` role) can delete resources with the field
3. The deletion check from the previous point can be toggled on and off with the `POOL_DELETION_ONLY_BY_OWNER_AND_OPERATOR` environment variable
4. Implement a `config.js` variable that allows toggling the check in point 3

### Issues: Fixed #xxx / Gap #xxx
1. This implementation supports [RHSTOR-5187 - Support Provider & Consumer mode](https://issues.redhat.com/browse/RHSTOR-5187)

### Testing Instructions:
1. WIP

- [ ] Doc added/updated
- [x] Tests added
