### PR TITLE
Adding unsupported ceph test to pending list

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -7,6 +7,7 @@ s3tests_boto3/functional/test_s3.py::test_bucket_listv2_delimiter_none
 s3tests_boto3/functional/test_s3.py::test_bucket_list_delimiter_not_skip_special
 s3tests_boto3/functional/test_s3.py::test_bucket_list_prefix_basic
 s3tests_boto3/functional/test_s3.py::test_bucket_list_prefix_delimiter_basic
+s3tests_boto3/functional/test_s3.py::test_bucket_list_return_data
 s3tests_boto3/functional/test_s3.py::test_account_usage
 s3tests_boto3/functional/test_s3.py::test_head_bucket_usage
 s3tests_boto3/functional/test_s3.py::test_post_object_invalid_signature


### PR DESCRIPTION
The PR https://github.com/noobaa/noobaa-core/pull/8062 is returning the 'DisplayName' taking it from
'bucket_info.bucket_owner where noobaa is preserving the the actual bucket owner info. Ealier we were just returning what user was providing and test was passing as it the expected value was getting reflected in the response.

The test is failing now since we are returning actually info coming from the bucket_info.bucket_owner and not from the 'owner' field of the parent object.

testname name that is moved to pending_lists is
s3tests_boto3/functional/test_s3.py::test_bucket_list_return_data
