### PR TITLE
Add missing bucket name to params while calling list_objects()

### DIFF
--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -359,7 +359,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                     await ns.delete_uls({ name, full_path: bucket_storage_path }, object_sdk);
                 } else {
                     // 2. delete only bucket tmpdir
-                    const list = await ns.list_objects({ ...params, limit: 1 }, object_sdk);
+                    const list = await ns.list_objects({ ...params, bucket: name, limit: 1 }, object_sdk);
                     if (list && list.objects && list.objects.length > 0) throw new RpcError('NOT_EMPTY', 'underlying directory has files in it');
                     const bucket_tmpdir_path = get_bucket_tmpdir_full_path(namespace_bucket_config.write_resource.path, bucket._id);
                     await folder_delete(bucket_tmpdir_path, this.fs_context, true);

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2450,7 +2450,7 @@ class NamespaceFS {
         dbg.log0('NamespaceFS: delete_uls fs_context:', fs_context, 'to_delete_dir_path: ', params.full_path);
 
         try {
-            const list = await this.list_objects({ ...params, limit: 1 }, object_sdk);
+            const list = await this.list_objects({ ...params, bucket: params.name, limit: 1 }, object_sdk);
 
             if (list && list.objects && list.objects.length > 0) {
                 throw new RpcError('NOT_EMPTY', 'underlying directory has files in it');


### PR DESCRIPTION
The params object is missing with params.name i.e bucket name while calling the list_objects. list_objects tries to get the bucket info and missing bucket name leads to failure

Author: Romy Ayalon<rayalon@redhat.com>