### PR TITLE
NSFS | Log events to stderr when stderr logging is enabled

### DIFF
--- a/src/deploy/standalone/noobaa_syslog.conf
+++ b/src/deploy/standalone/noobaa_syslog.conf
@@ -12,34 +12,15 @@ $imjournalRatelimitBurst 0
 # When changing this format make sure to change the relevant functions in os_utils
 #if $syslogfacility-text != 'local0' then @192.168.1.108:514
 
-template(name="LogseneFormat" type="list" option.json="on") {
-  constant(value="{")
-  constant(value="\"timestamp\":\"")
-  property(name="timereported" dateFormat="rfc3339")
-  constant(value="\",\"message\":\"")
-  property(name="msg")
-  constant(value="\",\"host\":\"")
-  property(name="hostname")
-  constant(value="\",\"severity\":\"")
-  property(name="syslogseverity-text")
-  constant(value="\",\"facility\":\"")
-  property(name="syslogfacility-text")
-  constant(value="\",\"syslog-tag\":\"")
-  property(name="syslogtag")
-  constant(value="\",\"source\":\"")
-  property(name="programname")
-  constant(value="\"}\n")
-}
-
 # For servers
-local0.*        /var/log/noobaa.log;RSYSLOG_FileFormat
+local0.*        /var/log/noobaa.log
 &stop
 
 # For events
-local2.*        /var/log/noobaa_events.log;LogseneFormat
+local2.*        /var/log/noobaa_events.log
 &stop
 
 # For clients
-local1.*        /var/log/client_noobaa.log;RSYSLOG_FileFormat
+local1.*        /var/log/client_noobaa.log
 &stop
 

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -494,14 +494,27 @@ function log_syslog_builder(syslevel) {
     };
 }
 
+/* When logging events message should not have any prefix such as time and processes id and 
+ *the message should be in json format because of this events are logged directly without using log_builder; 
+ * log_builder will format the message with prefix. 
+*/
 function log_event(event) {
     if (!config.EVENT_LOGGING_ENABLED) {
         console.info('Event logging not enabled');
         return;
     }
     event.pid = process.pid;
+    const updated_event = JSON.stringify({
+        timestamp: new Date(),
+        host: os.hostname(),
+        event: event,
+    });
     if (syslog) {
-        syslog(config.EVENT_LEVEL, JSON.stringify(event), config.EVENT_FACILITY);
+        syslog(config.EVENT_LEVEL, updated_event, config.EVENT_FACILITY);
+    }
+    if (console_wrapper && config.LOG_TO_STDERR_ENABLED) {
+        const formatted_event = int_dbg.message_format("EVENT", [updated_event]);
+        process.stderr.write(formatted_event.message_console + '\n');
     }
 }
 


### PR DESCRIPTION
### Explain the changes
1. Event are always logged to syslog(/var/log/noobaa_events.log), If customer choose to enable stderr also for logging event log should print in stderr
2. Eent json is generated from debug module, rsyslog templete is removed
3. removed syslog specific property from event, updated event log
> {"timestamp":"2024-08-07T09:29:00.286Z","host":"4c8c451cfb17","event":{"code":"noobaa_started","message":"Noobaa started","description":"Noobaa started running","entity_type":"NODE","event_type":"STATE_CHANGE","scope":"NODE","severity":"INFO","state":"HEALTHY","pid":477}}

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8206

### Testing Instructions:
1. check event are getting logged to stderr after enabling stder(LOG_TO_STDERR_ENABLED=true)

> Jul-16 16:01:17.591 [/170454] [EVENT]{"code":"noobaa_account_created","message":"Account created","description":"Noobaa Account created","entity_type":"NODE","event_type":"INFO", "scope":"NODE","severity":"INFO","state":"HEALTHY","arguments":{"account":"account-test2"},"pid":170454}

- [ ] Doc added/updated
- [ ] Tests added
