### PR TITLE
NC | NSFS | Change Config of `config.NSFS_GLACIER_LOGS_ENABLED` to `false`

### DIFF
--- a/config.js
+++ b/config.js
@@ -771,7 +771,7 @@ config.NSFS_GLACIER_LOGS_POLL_INTERVAL = 10 * 1000;
 // NSFS_GLACIER_ENABLED can override internal autodetection and will force
 // the use of restore for all objects.
 config.NSFS_GLACIER_ENABLED = false;
-config.NSFS_GLACIER_LOGS_ENABLED = true;
+config.NSFS_GLACIER_LOGS_ENABLED = false;
 config.NSFS_GLACIER_BACKEND = 'TAPECLOUD';
 
 // TAPECLOUD Glacier backend specific configs


### PR DESCRIPTION
### Explain the changes
1. Change config of `config.NSFS_GLACIER_LOGS_ENABLED` to `false`

### Issues: Fixed #xxx / Gap #xxx
1. Noticed that on a CES cluster we can see this error in the logs:
`OnError: Stat _path=/var/run/noobaa-nsfs/wal  error.Message()=Invalid argument`, it doesn't create an actual failure, but it is a system call we can avoid.

### Testing Instructions:
### Manual Test:
1. Create an account with the CLI with flag debug: `sudo node src/cmd/manage_nsfs account add --name shira-1004 --new_buckets_path /tmp/nsfs_root1 --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
Notice that after the fix we don't `stat` to the path `var/run/noobaa-nsfs/wal`.

- [ ] Doc added/updated
- [ ] Tests added
