### PR TITLE
NSFS | MPU | Support of part-number parameter for get/head object for parts with the same size

### DIFF
--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -433,6 +433,7 @@ interface ObjectInfo {
     s3_signed_url?: string;
     capacity_size?: number;
     num_multiparts?: number;
+    multipart_size?: number;
     first_range_data?: Buffer;
     content_length?: number;
     content_range?: string;

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -211,6 +211,15 @@ function _format_one_http_range({ start, end }) {
     return `${start_str}-${end_str}`;
 }
 
+function set_response_range(ranges, obj_size, res) {
+    if (!ranges || !ranges.length) return;
+    // reply with HTTP 206 Partial Content
+    res.statusCode = 206;
+    const content_range = `bytes ${ranges[0].start}-${ranges[0].end - 1}/${obj_size}`;
+    res.setHeader('Content-Range', content_range);
+    res.setHeader('Content-Length', ranges[0].end - ranges[0].start);
+}
+
 /**
  * @param {Array} ranges array of {start,end} from parse_http_range
  * @param {Number} size entity size in bytes
@@ -745,6 +754,7 @@ exports.authorize_session_token = authorize_session_token;
 exports.get_agent_by_endpoint = get_agent_by_endpoint;
 exports.validate_server_ip_whitelist = validate_server_ip_whitelist;
 exports.http_get = http_get;
+exports.set_response_range = set_response_range;
 exports.CONTENT_TYPE_TEXT_PLAIN = CONTENT_TYPE_TEXT_PLAIN;
 exports.CONTENT_TYPE_APP_OCTET_STREAM = CONTENT_TYPE_APP_OCTET_STREAM;
 exports.CONTENT_TYPE_APP_JSON = CONTENT_TYPE_APP_JSON;


### PR DESCRIPTION
### Explain the changes
1. add object xattr for multipart sizes
2. add get and head object for specific part using the part size

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/7226 

### Testing Instructions:
1. run `sudo node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_namespace_fs.js`

- [ ] Doc added/updated
- [x] Tests added
