### PR TITLE
[NC | NSFS | Glacier] Change finalize restore open mode to RDONLY

### DIFF
--- a/src/sdk/nsfs_glacier_backend/tapecloud.js
+++ b/src/sdk/nsfs_glacier_backend/tapecloud.js
@@ -359,7 +359,7 @@ class TapeCloudGlacierBackend extends GlacierBackend {
         const entry = new NewlineReaderEntry(fs_context, entry_path);
         let fh = null;
         try {
-            fh = await entry.open();
+            fh = await entry.open("r");
 
             const stat = await fh.stat(fs_context, {
                 xattr_get_keys: [


### PR DESCRIPTION
### Explain the changes
This PR changes the changes the finalize restore open mode to RDONLY. This is done to get rid of `O_CREAT` which is part of our `w` flag.

I tested (C code) that write permissions are not required for xattr manipulations hence removed them.
<details>
<summary> Test Code </summary>

```c
#include <stdio.h>
#include <stdlib.h>
#include <fcntl.h>
#include <sys/types.h>
#include <sys/xattr.h>

int main () {
    int fd = open("xattr_test.c", O_RDONLY);
    if (fd == 0) {
        printf("something went wrong\n");
        exit(1);
    }

    int err = fsetxattr(fd, "abc", "abc", 5, 0, 0);
    if (err != 0) {
        printf("failed to set attr\n");
    }
}
```
</details>

This also means that we can sometimes error out when a file that we expect to exist does not exist.

- [ ] Doc added/updated
- [ ] Tests added
