### PR TITLE
[5.15] Bumping version from 5.15.4 to 5.15.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noobaa-core",
-  "version": "5.15.4",
+  "version": "5.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noobaa-core",
-      "version": "5.15.4",
+      "version": "5.15.6",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noobaa-core",
-  "version": "5.15.4",
+  "version": "5.15.6",
   "license": "SEE LICENSE IN LICENSE",
   "description": "",
   "homepage": "https://github.com/noobaa/noobaa-core",


### PR DESCRIPTION
### Explain the changes
[5.15] Bumping version from 5.15.4 to 5.15.6

- We are skipping 5.15.5 as it was used for a quick respin on the downstream, with no code changes in NooBaa.
