### PR TITLE
NC | NSFS | S3 Flow `delete_bucket` When ULS Was Deleted + Refactor Function `translate_error_codes`

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -891,7 +891,7 @@ class NamespaceFS {
             }
             return res;
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
     }
 
@@ -926,7 +926,7 @@ class NamespaceFS {
             if (this._should_update_issues_report(params, file_path, err)) {
                 this.run_update_issues_report(object_sdk, err);
             }
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
     }
 
@@ -1085,7 +1085,7 @@ class NamespaceFS {
             //failed to get object
             new NoobaaEvent(NoobaaEvent.OBJECT_STREAM_GET_FAILED).create_event(params.key,
                                     {bucket_path: this.bucket_path, object_name: params.key}, err);
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
 
         } finally {
             try {
@@ -1151,7 +1151,7 @@ class NamespaceFS {
             new NoobaaEvent(NoobaaEvent.OBJECT_UPLOAD_FAILED).create_event(params.key,
                 {bucket_path: this.bucket_path, object_name: params.key}, err);
             dbg.warn('NamespaceFS: upload_object buffer pool cleanup error', err);
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         } finally {
             try {
                 if (upload_params && upload_params.target_file) await upload_params.target_file.close(fs_context);
@@ -1581,7 +1581,7 @@ class NamespaceFS {
             );
             return { obj_id: params.obj_id };
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
     }
 
@@ -1653,7 +1653,7 @@ class NamespaceFS {
             return upload_info;
         } catch (err) {
             this.run_update_issues_report(object_sdk, err);
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         } finally {
             await native_fs_utils.finally_close_files(fs_context, [target_file, part_md_file]);
         }
@@ -1693,7 +1693,7 @@ class NamespaceFS {
                 storage_class: create_multipart_upload_params.storage_class
             };
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
     }
 
@@ -1798,7 +1798,7 @@ class NamespaceFS {
             return upload_info;
         } catch (err) {
             dbg.error(err);
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         } finally {
             await this.complete_object_upload_finally(undefined, [...part_size_to_fd_map.values()], target_file, fs_context);
         }
@@ -1849,7 +1849,7 @@ class NamespaceFS {
             }
             return res || {};
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
     }
 
@@ -1890,7 +1890,7 @@ class NamespaceFS {
             }
             return res;
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
     }
 
@@ -1920,7 +1920,7 @@ class NamespaceFS {
             await nb_native().fs.checkAccess(fs_context, this.bucket_path);
             this.versioning = versioning;
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.BUCKET);
         }
     }
 
@@ -1953,7 +1953,7 @@ class NamespaceFS {
             }
         } catch (err) {
             dbg.error(`NamespaceFS.get_object_tagging: failed in dir ${file_path} with error: `, err);
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
         dbg.log0('NamespaceFS.get_object_tagging: return tagging ', tag_set, 'file_path :', file_path);
         return { tagging: tag_set };
@@ -1972,7 +1972,7 @@ class NamespaceFS {
             await this._clear_user_xattr(fs_context, file_path, XATTR_NOOBAA_CUSTOM_PREFIX);
         } catch (err) {
             dbg.error(`NamespaceFS.delete_object_tagging: failed in dir ${file_path} with error: `, err);
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
         return {version_id: params.version_id};
     }
@@ -1992,7 +1992,7 @@ class NamespaceFS {
             await this.set_fs_xattr_op(fs_context, file_path, fs_xattr, undefined);
         } catch (err) {
             dbg.error(`NamespaceFS.put_object_tagging: failed in dir ${file_path} with error: `, err);
-            throw this._translate_object_error_codes(err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);
         }
         return { tagging: [], version_id: params.version_id };
     }
@@ -2121,7 +2121,7 @@ class NamespaceFS {
             }
         } catch (error) {
             dbg.error('namespace_fs.restore_object: failed with error: ', error, file_path);
-            throw this._translate_object_error_codes(error);
+            throw native_fs_utils.translate_error_codes(error, native_fs_utils.entity_enum.OBJECT);
         } finally {
             if (file) await file.close(fs_context);
         }
@@ -2200,7 +2200,7 @@ class NamespaceFS {
             file = null;
         } catch (error) {
             dbg.error('NamespaceFS.handle_fs_xattr_op: failed with error: ', error, file_path);
-            throw this._translate_object_error_codes(error);
+            throw native_fs_utils.translate_error_codes(error, native_fs_utils.entity_enum.OBJECT);
         } finally {
             if (file) await file.close(fs_context);
         }
@@ -2372,21 +2372,12 @@ class NamespaceFS {
         }
     }
 
-    _translate_object_error_codes(err) {
-        if (err.rpc_code) return err;
-        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') err.rpc_code = 'NO_SUCH_OBJECT';
-        if (err.code === 'EEXIST') err.rpc_code = 'BUCKET_ALREADY_EXISTS';
-        if (err.code === 'EPERM' || err.code === 'EACCES') err.rpc_code = 'UNAUTHORIZED';
-        if (err.code === 'IO_STREAM_ITEM_TIMEOUT') err.rpc_code = 'IO_STREAM_ITEM_TIMEOUT';
-        if (err.code === 'INTERNAL_ERROR') err.rpc_code = 'INTERNAL_ERROR';
-        return err;
-    }
-
     async _load_bucket(params, fs_context) {
         try {
             await nb_native().fs.stat(fs_context, this.bucket_path);
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            dbg.warn('_load_bucket failed, on bucket_path', this.bucket_path, 'got error', err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.BUCKET);
         }
     }
 
@@ -2451,7 +2442,9 @@ class NamespaceFS {
         try {
             await nb_native().fs.mkdir(fs_context, params.full_path, native_fs_utils.get_umasked_mode(0o777));
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            dbg.error('NamespaceFS: create_uls fs_context:', fs_context, 'new_dir_path: ',
+                params.full_path, 'got an error:', err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.BUCKET);
         }
     }
 
@@ -2468,7 +2461,9 @@ class NamespaceFS {
 
             await native_fs_utils.folder_delete(params.full_path, fs_context);
         } catch (err) {
-            throw this._translate_object_error_codes(err);
+            dbg.error('NamespaceFS: delete_uls fs_context:', fs_context, 'to_delete_dir_path: ',
+                params.full_path, 'got an error:', err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.BUCKET);
         }
     }
 


### PR DESCRIPTION
### Explain the changes
1. Wrap try-catch in the S3 flow `delete_bucket` in case the ULS (Underline Storage) was deleted (even though we are the ones that are supposed to delete it): for both bases - the ULS was created by NooBaa (S3 flow create_bucket) and when the ULS was created by the user (noobaa-cli flow bucket add).
2. Move the function `translate_error_codes` to `native_fs_utils` as mutual code for `accountspace_fs`, `bucketspace_fs`, and `namespace_fs`, the function was refactored to serve all the namespaces.
3. Changes in error codes entity:
- `_load_bucket` to bucket (from object)
- `set_bucket_versioning` to bucket (from object)
- `create_uls` and `delete_uls` to bucket (from object)
- The error `ENOTDIR` is now mapped to general `NO_SUCH_${entity}`, not just `NO_SUCH_OBJECT`.

### Issues: Fixed #8180 
1. The fix is only for S3 flow (in PR #8187 it was for the case where the bucket was created and deleted using the noobaa-cli).

### Testing Instructions:
#### Unit Tests:
Please run: `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace_fs.js`

#### Manual Tests:
I saw 2 cases:
(1) The bucket was created using an S3 request and deleted using an S3 request.
(2) The bucket was created using the CLI and deleted using an S3 request.

(1) The bucket was created using an S3 request and deleted using an S3 request (based on the [comment](https://github.com/noobaa/noobaa-core/issues/8180#issuecomment-2230787483))
1. Create the root user account with the CLI: `sudo node src/cmd/manage_nsfs account add --name shira-1001 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
5. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
Note: before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
6. Create the alias for S3 service: `alias s3-nc-user-1='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443'`.
7. Create the bucket using S3: `s3-nc-user-1-s3 s3 mb s3://bucket-1001-16-07`
8. Test that you are able to list the newly created bucket: `s3-nc-user-1-s3 s3 ls`
9. Remove the directory that was created for the bucket: `sudo rmdir /tmp/nsfs_root1/bucket-1001-16-07`
10. Try to delete the bucket: `s3-nc-user-1-s3 s3 rb s3://bucket-1001-16-07`, after this fix it should be: `remove_bucket: bucket-1001-16-07`, in the endpoint logs you can see:

> [nsfs/68124]  [WARN] core.sdk.bucketspace_fs:: delete_bucket: bucket name bucket-1001-19-07 with bucket_storage_path /tmp/nsfs_root1/bucket-1001-16-07 got an error while trying to delete_uls [Error: No such file or directory] { code: 'ENOENT', rpc_code: 'NO_SUCH_BUCKET' }

(2) The bucket was created using the CLI and deleted using an S3 request
1. Create the root user account with the CLI: `sudo node src/cmd/manage_nsfs account add --name shira-1001 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
Note: before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
3. Create the alias for S3 service: `alias s3-nc-user-1='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443'`.
5.  Create the bucket using the CLI: first create the `path` for the bucket and give permissions: `sudo mkdir -p /tmp/nsfs_root1/bucket-1001-16-07` and `sudo chmod -R 777 /tmp/nsfs_root1/bucket-1001-16-07`
6. Test that you are able to list the newly created bucket: `s3-nc-user-1-s3 s3 ls`
7. Remove the directory that was created for the bucket: `sudo rmdir /tmp/nsfs_root1/bucket-1001-16-07`
8. Try to delete the bucket: `s3-nc-user-1-s3 s3 rb s3://bucket-1001-16-07`, after this fix it should be: `remove_bucket: bucket-1001-16-07`, in the endpoint logs you can see:

> Jul-23 9:33:22.258 [nsfs/51199]  [WARN] core.sdk.namespace_fs:: _load_bucket failed, on bucket_path /tmp/nsfs_root1/bucket-1001-16-07 got error [Error: No such file or directory] { code: 'ENOENT' }
> Jul-23 9:33:22.258 [nsfs/51199]  [WARN] core.sdk.bucketspace_fs:: delete_bucket: bucket name bucket-1001-16-07 got an error while trying to list_objects [Error: No such file or directory] { code: 'ENOENT', rpc_code: 'NO_SUCH_BUCKET' }

- [ ] Doc added/updated
- [X] Tests added
