### PR TITLE
NSFS | add fs_worker data for stats collector

### DIFF
--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -136,7 +136,7 @@ class NsfsObjectSDK extends ObjectSDK {
         // };
         let bucketspace;
         if (config_root) {
-            bucketspace = new BucketSpaceFS({ config_root });
+            bucketspace = new BucketSpaceFS({ config_root }, endpoint_stats_collector.instance());
         } else {
             bucketspace = new BucketSpaceSimpleFS({ fs_root });
         }
@@ -221,7 +221,7 @@ class NsfsAccountSDK extends AccountSDK {
         let bucketspace;
         let accountspace;
         if (config_root) {
-            bucketspace = new BucketSpaceFS({ config_root });
+            bucketspace = new BucketSpaceFS({ config_root }, endpoint_stats_collector.instance());
             accountspace = new AccountSpaceFS({ config_root });
         } else {
             bucketspace = new BucketSpaceSimpleFS({ fs_root });

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -102,7 +102,7 @@ const account_user3 = {
     creation_date: '2023-10-30T04:46:33.815Z',
 };
 
-const bucketspace_fs = new BucketSpaceFS({ config_root });
+const bucketspace_fs = new BucketSpaceFS({ config_root }, undefined);
 const dummy_object_sdk = make_dummy_object_sdk();
 const dummy_ns = {
     read_resources: [

--- a/src/test/unit_tests/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/test_nsfs_glacier_backend.js
@@ -24,7 +24,7 @@ const BucketSpaceFS = require('../../sdk/bucketspace_fs');
 const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null, maxArrayLength: max_arr });
 
 function make_dummy_object_sdk(config_root) {
-    const bucketspace_fs = new BucketSpaceFS({ config_root });
+    const bucketspace_fs = new BucketSpaceFS({ config_root }, undefined);
     return {
         requesting_account: {
             force_md5_etag: false,

--- a/src/util/stats_collector_utils.js
+++ b/src/util/stats_collector_utils.js
@@ -1,0 +1,52 @@
+/* Copyright (C) 2023 NooBaa */
+'use strict';
+
+// Predefined op_names
+const op_names = [
+    `upload_object`,
+    `delete_object`,
+    `create_bucket`,
+    `list_buckets`,
+    `delete_bucket`,
+    `list_objects`,
+    `head_object`,
+    `read_object`,
+    `initiate_multipart`,
+    `upload_part`,
+    `complete_object_upload`,
+];
+
+function update_nsfs_stats(op_name, stats, new_data) {
+    //In the event of all of the same ops are failing (count = error_count) we will not masseur the op times
+    // As this is intended as a timing masseur and not a counter.
+    if (stats[op_name]) {
+        const count = stats[op_name].count + new_data.count;
+        const error_count = stats[op_name].error_count + new_data.error_count;
+        const old_sum_time = stats[op_name].avg_time_milisec * stats[op_name].count;
+        //Min time and Max time are not being counted in the endpoint stat collector if it was error
+        const min_time_milisec = Math.min(stats[op_name].min_time_milisec, new_data.min_time);
+        const max_time_milisec = Math.max(stats[op_name].max_time_milisec, new_data.max_time);
+        // At this point, as we populate only when there is at least one successful op, there must be old_sum_time
+        const avg_time_milisec = Math.floor((old_sum_time + new_data.sum_time) / (count - error_count));
+        stats[op_name] = {
+            min_time_milisec,
+            max_time_milisec,
+            avg_time_milisec,
+            count,
+            error_count,
+        };
+        // When it is the first time we populate the stats with op_name we do it
+        // only if there are more successful ops than errors.
+    } else if (new_data.count > new_data.error_count) {
+        stats[op_name] = {
+            min_time_milisec: new_data.min_time,
+            max_time_milisec: new_data.max_time,
+            avg_time_milisec: Math.floor(new_data.sum_time / new_data.count),
+            count: new_data.count,
+            error_count: new_data.error_count,
+        };
+    }
+}
+
+exports.op_names = op_names;
+exports.update_nsfs_stats = update_nsfs_stats;


### PR DESCRIPTION
### Explain the changes
1. enable collection of fs_worker stats for the stats collector for both forked an unforked scenarios
2. enable collection of stats in bucketspace
3. collect time data when there are multiple forks
4. create a common file stats_collector_utils for constants and duplicate code

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. run s3 command, for example create-bucket.
2. wait a few seconds
3. run curl on metrics server (`curl -s http://127.0.0.1:7004/metrics/nsfs_stats | jq .`)
4. fs_worker metrics should show including times and counts 


- [ ] Doc added/updated
- [ ] Tests added
