### PR TITLE
(REST) Handle the Case Where the Endpoint Port Was Wrong

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -114,6 +114,11 @@ async function handle_request(req, res) {
     }
 
     const op_name = parse_op_name(req);
+    const op = s3_ops[op_name];
+    if (!op || !op.handler) {
+        dbg.error('S3 NotImplemented', op_name, req.method, req.originalUrl);
+        throw new S3Error(S3Error.NotImplemented);
+    }
     req.op_name = op_name;
 
     http_utils.authorize_session_token(req, headers_options);
@@ -138,12 +143,6 @@ async function handle_request(req, res) {
             dbg.error('S3 Version request not (NotImplemented) for buckets with caching', op_name, req.method, req.originalUrl);
             throw new S3Error(S3Error.NotImplemented);
         }
-    }
-
-    const op = s3_ops[op_name];
-    if (!op || !op.handler) {
-        dbg.error('S3 TODO (NotImplemented)', op_name, req.method, req.originalUrl);
-        throw new S3Error(S3Error.NotImplemented);
     }
 
     const options = {


### PR DESCRIPTION
### Explain the changes
1. Handle the case where the endpoint port was wrong - for example:
  - S3 port with IAM action
  - IAM port with S3 action

### Issues:
1. Currently the error that is thrown is later in the flow, and in this PR we throw it earlier.

### Testing Instructions:
1. Create the root user account with the CLI: `sudo node src/cmd/manage_nsfs account add --name shira-1001 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
Notes: 
- Before starting the server please add this line: `process.env.NOOBAA_LOG_LEVEL = 'nsfs';` in the endpoint.js (before the condition `if (process.env.NOOBAA_LOG_LEVEL) {`)
- I Change the `config.NSFS_CHECK_BUCKET_BOUNDARIES = false; //SDSD` because I'm using the `/tmp/` and not `/private/tmp/`.
3. Create the alias for IAM service with a wrong port:
IAM service: `alias nc-iam-with-wrong-port='AWS_ACCESS_KEY_ID=<access-key-id> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443`. (port 6443 instead of 7005)
4. Use AWS CLI:  `nc-iam-with-wrong-port iam list-access-keys`, the output is:

> An error occurred (Unknown) when calling the ListAccessKeys operation: Unknown

In the logs:

> Jul-28 11:59:53.006 [nsfs/36784] [ERROR] core.endpoint.s3.s3_rest:: S3 NotImplemented post_service POST /
> Jul-28 11:59:53.007 [nsfs/36784] [ERROR] core.endpoint.s3.s3_rest:: S3 ERROR <?xml version="1.0" encoding="UTF-8"?><Error><Code>NotImplemented</Code><Message>A header you provided implies functionality that is not implemented.</Message><Resource>/</Resource><RequestId>lz5bxelm-566k9z-1vm</RequestId></Error> POST / {"host":"localhost:6443","accept-encoding":"identity","content-type":"application/x-www-form-urlencoded; charset=utf-8","user-agent":"aws-cli/2.17.11 md/awscrt#0.20.11 ua/2.0 os/macos#23.4.0 md/arch#arm64 lang/python#3.11.9 md/pyimpl#CPython cfg/retry-mode#standard md/installer#source md/prompt#off md/command#iam.list-access-keys","x-amz-date":"20240728T085952Z","authorization":"AWS4-HMAC-SHA256 Credential=Dwertyuiopasdfg11001/20240728/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=1d059d90db52a521b2913207ab04b09183935f9d3e95aa220f39b14659e51d81","content-length":"40"} Error: A header you provided implies functionality that is not implemented.
>     at handle_request (/Users/shiradymnik/SourceCode/noobaa-core/src/endpoint/s3/s3_rest.js:120:15)
>     at async Object.s3_rest [as handler] (/Users/shiradymnik/SourceCode/noobaa-core/src/endpoint/s3/s3_rest.js:66:9)

3. Create the alias for S3 service with a wrong port:
IAM service: `alias nc-s3-with-wrong-port='AWS_ACCESS_KEY_ID=<access-key-id> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005`. (port 7005 instead of 6443)
4. Use AWS CLI:  `nc-s3-with-wrong-port s3 ls`, the output is:

> An error occurred (InvalidParameterValue) when calling the ListBuckets operation: An invalid or out-of-range value was supplied for the input parameter.

In the logs:

> Jul-28 12:56:49.975 [nsfs/44433] [ERROR] core.endpoint.iam.iam_rest:: verify_op_request_body_type: should have header application/x-www-form-urlencoded in request, currently the headers are: undefined
> Jul-28 12:56:49.977 [nsfs/44433] [ERROR] core.endpoint.iam.iam_rest:: IAM ERROR <?xml version="1.0" encoding="UTF-8"?><ErrorResponse><Error><Type>Sender</Type><Code>InvalidParameterValue</Code><Message>An invalid or out-of-range value was supplied for the input parameter.</Message></Error><RequestId>lz5dyn5g-4sdn5v-uv</RequestId></ErrorResponse> GET / {"host":"localhost:7005","accept-encoding":"identity","user-agent":"aws-cli/2.17.11 md/awscrt#0.20.11 ua/2.0 os/macos#23.4.0 md/arch#arm64 lang/python#3.11.9 md/pyimpl#CPython cfg/retry-mode#standard md/installer#source md/prompt#off md/command#s3.ls","x-amz-date":"20240728T095649Z","x-amz-content-sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","authorization":"AWS4-HMAC-SHA256 Credential=Dwertyuiopasdfg11001/20240728/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=c8173f7f2293da0c247ba5d4880919e73193d4a00751ebcdd7b366d810dcf989"} Error: An invalid or out-of-range value was supplied for the input parameter.
>     at verify_op_request_body_type (/Users/shiradymnik/SourceCode/noobaa-core/src/endpoint/iam/iam_rest.js:177:15)
>     at handle_request (/Users/shiradymnik/SourceCode/noobaa-core/src/endpoint/iam/iam_rest.js:97:5)
>     at iam_rest (/Users/shiradymnik/SourceCode/noobaa-core/src/endpoint/iam/iam_rest.js:56:15)
>     at Server.endpoint_iam_request_handler (/Users/shiradymnik/SourceCode/noobaa-core/src/endpoint/endpoint.js:302:16)
>     at Server.emit (node:events:518:28)
>     at Server.emit (node:domain:488:12)
>     at parserOnIncoming (node:_http_server:1143:12)
>     at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17)

- [ ] Doc added/updated
- [ ] Tests added
