### PR TITLE
NC | NSFS | CLI | Make Update Account Tolerance to Missing Master Key

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.test.js
@@ -11,19 +11,29 @@ const { exec_manage_cli, set_path_permissions_and_owner, TMP_PATH, set_nc_config
 const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
+const { get_process_fs_context } = require('../../../util/native_fs_utils');
+const nb_native = require('../../../util/nb_native');
 
 const tmp_fs_path = path.join(TMP_PATH, 'test_nc_nsfs_account_cli');
 const config_root = path.join(tmp_fs_path, 'config_root_account_mkm_integration');
 const root_path = path.join(tmp_fs_path, 'root_path_account_mkm_integration/');
-const defaults = {
-    _id: 'account1',
+const defaults_account1 = {
     type: TYPES.ACCOUNT,
     name: 'account1',
-    new_buckets_path: `${root_path}new_buckets_path_mkm_integration/`,
-    uid: 999,
-    gid: 999,
+    new_buckets_path: `${root_path}new_buckets_path_mkm_integration_account1/`,
+    uid: 1001,
+    gid: 1001,
     access_key: 'GIGiFAnjaaE7OKD5N7hA',
     secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
+};
+const defaults_account2 = {
+    type: TYPES.ACCOUNT,
+    name: 'account2',
+    new_buckets_path: `${root_path}new_buckets_path_mkm_integration_account2/`,
+    uid: 1002,
+    gid: 1002,
+    access_key: 'HIHiFAnjaaE7OKD5N7hA',
+    secret_key: 'U3BYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
 };
 
 describe('manage nsfs cli account flow + fauly master key flow', () => {
@@ -49,13 +59,13 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
         });
 
         it('cli account list', async () => {
-            const { name } = defaults;
+            const { name } = defaults_account1;
             const list_res = await list_account_flow();
             expect(list_res.response.reply[0].name).toBe(name);
         });
 
         it('cli account status', async () => {
-            const { name, uid, gid, new_buckets_path } = defaults;
+            const { name, uid, gid, new_buckets_path } = defaults_account1;
             const status_res = await status_account();
             expect(status_res.response.reply.name).toBe(name);
             expect(status_res.response.reply.email).toBe(name);
@@ -99,7 +109,7 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
 
         it('should fail | cli create account', async () => {
             try {
-                await create_account({ ...defaults, name: 'account_corrupted_mk' });
+                await create_account({ ...defaults_account1, name: 'account_corrupted_mk' });
                 fail('should have failed with InvalidMasterKey');
             } catch (err) {
                 expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
@@ -116,13 +126,13 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
         });
 
         it('cli account list', async () => {
-            const { name } = defaults;
+            const { name } = defaults_account1;
             const list_res = await list_account_flow();
             expect(list_res.response.reply[0].name).toBe(name);
         });
 
         it('cli account status', async () => {
-            const { name, uid, gid, new_buckets_path } = defaults;
+            const { name, uid, gid, new_buckets_path } = defaults_account1;
             const status_res = await status_account();
             expect(status_res.response.reply.name).toBe(name);
             expect(status_res.response.reply.email).toBe(name);
@@ -165,7 +175,7 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
 
         it('should fail | cli create account', async () => {
             try {
-                await create_account({ ...defaults, name: 'account_corrupted_mk' });
+                await create_account({ ...defaults_account1, name: 'account_corrupted_mk' });
                 fail('should have failed with InvalidMasterKey');
             } catch (err) {
                 expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
@@ -182,13 +192,13 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
         });
 
         it('cli account list', async () => {
-            const { name } = defaults;
+            const { name } = defaults_account1;
             const list_res = await list_account_flow();
             expect(list_res.response.reply[0].name).toBe(name);
         });
 
         it('cli account status', async () => {
-            const { name, uid, gid, new_buckets_path } = defaults;
+            const { name, uid, gid, new_buckets_path } = defaults_account1;
             const status_res = await status_account();
             expect(status_res.response.reply.name).toBe(name);
             expect(status_res.response.reply.email).toBe(name);
@@ -211,6 +221,50 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
             expect(delete_res.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
         });
     });
+
+    describe('cli with renamed master key file (invalid)', () => {
+        const type = TYPES.ACCOUNT;
+
+        beforeEach(async () => {
+            await setup_nc_system_and_first_account();
+            await setup_account(defaults_account2);
+            await master_key_file_rename(true);
+        });
+
+        afterEach(async () => {
+            await master_key_file_rename(false);
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('should fail - cli update uid (without master key id - only allowed to update access keys)',
+                async () => {
+            try {
+                const account_options = { config_root, name: defaults_account1.name, uid: 2050 };
+                const action = ACTIONS.UPDATE;
+                await exec_manage_cli(type, action, account_options);
+            } catch (err) {
+                expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
+            }
+        });
+
+        it('cli update access keys with regenerate', async () => {
+            const account_options = { config_root, name: defaults_account1.name, regenerate: true };
+            const action = ACTIONS.UPDATE;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.AccountUpdated.code);
+        });
+
+        it('cli update access keys with access_key and secret_key flags', async () => {
+            const new_access_key = 'BIBiFAnjaaE7OKD5N7hZ';
+            const new_secret_key = 'ZIBYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE';
+            const account_options = { config_root, name: defaults_account1.name,
+                access_key: new_access_key, secret_key: new_secret_key };
+            const action = ACTIONS.UPDATE;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res).response.code).toEqual(ManageCLIResponse.AccountUpdated.code);
+        });
+    });
 });
 
 async function create_account(account_options) {
@@ -224,7 +278,7 @@ async function create_account(account_options) {
 
 async function update_account() {
     const action = ACTIONS.UPDATE;
-    const { type, name, new_buckets_path } = defaults;
+    const { type, name, new_buckets_path } = defaults_account1;
     const new_uid = '1111';
     const account_options = { config_root, name, new_buckets_path, uid: new_uid };
     const res = await exec_manage_cli(type, action, account_options);
@@ -234,7 +288,7 @@ async function update_account() {
 
 async function status_account(show_secrets) {
     const action = ACTIONS.STATUS;
-    const { type, name } = defaults;
+    const { type, name } = defaults_account1;
     const account_options = { config_root, name, show_secrets };
     const res = await exec_manage_cli(type, action, account_options);
     const parsed_res = JSON.parse(res);
@@ -243,7 +297,7 @@ async function status_account(show_secrets) {
 
 async function list_account_flow() {
     const action = ACTIONS.LIST;
-    const { type } = defaults;
+    const { type } = defaults_account1;
     const account_options = { config_root };
     const res = await exec_manage_cli(type, action, account_options);
     const parsed_res = JSON.parse(res);
@@ -252,7 +306,7 @@ async function list_account_flow() {
 
 async function delete_account_flow() {
     const action = ACTIONS.DELETE;
-    const { type, name } = defaults;
+    const { type, name } = defaults_account1;
     const account_options = { config_root, name };
     const res = await exec_manage_cli(type, action, account_options);
     const parsed_res = JSON.parse(res);
@@ -269,11 +323,34 @@ function fail(reason) {
 async function setup_nc_system_and_first_account() {
     await fs_utils.create_fresh_path(root_path);
     set_nc_config_dir_in_config(config_root);
+    await setup_account(defaults_account1);
+}
+
+async function setup_account(account_defaults) {
     const action = ACTIONS.ADD;
-    const { type, name, new_buckets_path, uid, gid } = defaults;
+    const { type, name, new_buckets_path, uid, gid } = account_defaults;
     const account_options = { config_root, name, new_buckets_path, uid, gid };
     await fs_utils.create_fresh_path(new_buckets_path);
     await fs_utils.file_must_exist(new_buckets_path);
     await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
     await exec_manage_cli(type, action, account_options);
+}
+
+
+/**
+ * master_key_file_rename will rename the master_keys.json file
+ * to mock a situation where master_key_id points to a missing master key
+ * use the to_rename_temp false to rename it back (after the test)
+ * @param {boolean} to_rename_temp
+ */
+async function master_key_file_rename(to_rename_temp) {
+    const default_fs_config = get_process_fs_context();
+    const source_path = path.join(config_root, 'master_keys.json');
+    const dest_path = path.join(config_root, 'temp_master_keys.json');
+    // eliminate the master key file by renaming it
+    if (to_rename_temp) {
+        await nb_native().fs.rename(default_fs_config, source_path, dest_path);
+    } else {
+        await nb_native().fs.rename(default_fs_config, dest_path, source_path);
+    }
 }

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -842,7 +842,7 @@ describe('manage nsfs cli bucket flow', () => {
 
     });
 
-    describe('cli list bucket', () => {
+    describe('cli list buckets', () => {
         const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs5');
         const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs5/');
         const bucket_storage_path = path.join(tmp_fs_path, 'root_path_manage_nsfs5', 'bucket1');
@@ -896,6 +896,7 @@ describe('manage nsfs cli bucket flow', () => {
             const bucket_options = { config_root, name: 'bucket2' };
             const action = ACTIONS.LIST;
             const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(Array.isArray(JSON.parse(res).response.reply)).toBe(true);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining([]));
         });
@@ -904,6 +905,7 @@ describe('manage nsfs cli bucket flow', () => {
             const bucket_options = { config_root, name: 'bucket1' };
             const action = ACTIONS.LIST;
             const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            expect(Array.isArray(JSON.parse(res).response.reply)).toBe(true);
             expect(JSON.parse(res).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining(['bucket1']));
         });


### PR DESCRIPTION
### Explain the changes
1. Allow account update (only `regenerate` and `access_key` and `secret_key`) when we cannot decrypt the current access keys.
2. Edit the bucket list tests to validate that we receive an array in the response (as we did in PR #8272).
3. In `config_fs` fix JSDoc of the function `get_identity_config_data`.
4. In `mamage_nsfs` add JSDoc to the function `fetch_existing_account_data`.

### Issues: Fixed partially #8104 
1. Currently, if an account's `master_key_id` points to a missing master key, the commands: `account update` and `account status`  in noobaa-cli (manage_nsfs) will fail with an error.
Note: A missing master key can happen when the master keys that were previously used cannot be recovered due to some issue.
2. GAP: in this PR we didn't make list accounts tolerance to missing master key and list buckets/accounts with Invalid JSON (it was in past of this PR but due to code changes that happened this code fix will be added separately).

### Testing Instructions:
#### Unit Tests
Please run: 
1. `sudo npx jest test_nc_nsfs_bucket_cli.test.js` (for the change in point number 2 in the changes above).
2. `sudo npx jest test_nc_account_invalid_mkm_integration.test.js`

#### Manual Testing
A. Missing master key
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name shira-1001 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`.
2. Make the master key invalid by renaming the file `master_key.json`: `sudo mv /etc/noobaa.conf.d/master_keys.json /etc/noobaa.conf.d/temp_master_keys.json`
3. Account list with decryption: `sudo node src/cmd/manage_nsfs account list --wide --show_secrets` (doesn't fail, but you will see the property `encrypted_secret_key`).
7. Account status with decryption: `sudo node src/cmd/manage_nsfs account status --name shira-1001 --show_secrets` (will fail).
8. Account update - can update the access keys (other update options will result in an error): `sudo node src/cmd/manage_nsfs account update --name shira-1001 --regenerate` or `sudo node src/cmd/manage_nsfs account update --access_key <access-key-id> --secret_key <secret-key>`.

- [ ] Doc added/updated
- [X] Tests added
