### PR TITLE
Noobaa Account: Replace bcrypt password hashing by crypto

### DIFF
--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -3,6 +3,7 @@
 
 const _ = require('lodash');
 const bcrypt = require('bcrypt');
+const node_hash = require('../../util/account_password_hash');
 const ip_module = require('ip');
 
 const P = require('../../util/promise');
@@ -20,6 +21,14 @@ const jwt_utils = require('../../util/jwt_utils');
 const config = require('../../../config');
 const s3_bucket_policy_utils = require('../../endpoint/s3/s3_bucket_policy_utils');
 
+
+
+function compare_password_hash(password, target_account) {
+    if (bcrypt.compare(password.unwrap(), target_account.password.unwrap())) {
+        return true;
+    }
+    return (node_hash.verify_node_password_hash(password.unwrap(), target_account.password.unwrap()));
+}
 
 /**
  *
@@ -66,7 +75,7 @@ function create_auth(req) {
             if (!password) return;
 
             return P.resolve()
-                .then(() => bcrypt.compare(password.unwrap(), target_account.password.unwrap()))
+                .then(() => compare_password_hash(password, target_account))
                 .then(match => {
                     if (!match) {
                         dbg.log0('password mismatch', email, system_name);

--- a/src/util/account_password_hash.js
+++ b/src/util/account_password_hash.js
@@ -1,0 +1,38 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const CRYPTO_SALT_BUFFER_SIZE = 8;
+const CRYPTO_SALT_KEY_LENGTH = 32;
+const CRYPTO_PBKDF2_ITERATIONS = 100;
+
+const crypto = require('crypto');
+
+function create_node_password_hash(password) {
+    return new Promise((resolve, reject) => {
+        const salt = crypto.randomBytes(CRYPTO_SALT_BUFFER_SIZE).toString('hex');
+        crypto.pbkdf2(password, salt, CRYPTO_PBKDF2_ITERATIONS, CRYPTO_SALT_KEY_LENGTH, 'sha512', (err, derivedKey) => {
+            if (err) {
+                reject(err);
+                return err;
+            }
+            resolve(salt + ':' + derivedKey.toString('hex'));
+        });
+    });
+}
+
+function verify_node_password_hash(password, hashedPassword) {
+    return new Promise((resolve, reject) => {
+        const [salt, key] = hashedPassword.split(':');
+        crypto.pbkdf2(password, salt, CRYPTO_PBKDF2_ITERATIONS, CRYPTO_SALT_KEY_LENGTH, 'sha512', (err, derivedKey) => {
+            if (err) {
+                reject(err);
+                return err;
+            }
+            resolve(key === derivedKey.toString('hex'));
+        });
+    });
+}
+
+
+exports.create_node_password_hash = create_node_password_hash;
+exports.verify_node_password_hash = verify_node_password_hash;


### PR DESCRIPTION
As bcrypt is not under active maintenance, we need to replace it with node.js crypto hashing module.

This PR is in line with https://github.com/noobaa/noobaa-core/pull/8213

IN this PR I tried to implement in-built node.js crypto module. Over all approach is same. 
We just need to implement two addition functions to create hash and verify that hash.