### PR TITLE
[NC | NSFS | Glacier] handle `ENOENT` in `_finalize_restore` and fix glacier tests not running

### DIFF
--- a/src/sdk/nsfs_glacier_backend/tapecloud.js
+++ b/src/sdk/nsfs_glacier_backend/tapecloud.js
@@ -359,7 +359,17 @@ class TapeCloudGlacierBackend extends GlacierBackend {
         const entry = new NewlineReaderEntry(fs_context, entry_path);
         let fh = null;
         try {
-            fh = await entry.open("r");
+            try {
+                fh = await entry.open("r");
+            } catch (error) {
+                // restore does check if a file exist or not before triggering eeadm call but the file could get deleted
+                // after `restore` performs that check so check it here once again
+                if (error.code === 'ENOENT') {
+                    dbg.warn(`TapeCloudGlacierBackend._finalize_restore: log entry unexpectedly not found: ${entry.path}`);
+                    return;
+                }
+                throw error;
+            }
 
             const stat = await fh.stat(fs_context, {
                 xattr_get_keys: [

--- a/src/test/unit_tests/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/test_nsfs_glacier_backend.js
@@ -19,12 +19,10 @@ const { PersistentLogger } = require('../../util/persistent_logger');
 const { GlacierBackend } = require('../../sdk/nsfs_glacier_backend/backend');
 const nb_native = require('../../util/nb_native');
 const { handler: s3_get_bucket } = require('../../endpoint/s3/ops/s3_get_bucket');
-const BucketSpaceFS = require('../../sdk/bucketspace_fs');
 
 const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null, maxArrayLength: max_arr });
 
 function make_dummy_object_sdk(config_root) {
-    const bucketspace_fs = new BucketSpaceFS({ config_root }, undefined);
     return {
         requesting_account: {
             force_md5_etag: false,
@@ -38,7 +36,7 @@ function make_dummy_object_sdk(config_root) {
             if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
         },
         read_bucket_sdk_config_info(name) {
-            return bucketspace_fs.read_bucket_sdk_info({ name });
+            return undefined;
         },
     };
 }
@@ -103,6 +101,7 @@ mocha.describe('nsfs_glacier', async () => {
 	mocha.before(async () => {
         await fs.mkdir(ns_src_bucket_path, { recursive: true });
 
+        config.NSFS_GLACIER_LOGS_ENABLED = true;
 		config.NSFS_GLACIER_LOGS_DIR = await fs.mkdtemp(path.join(os.tmpdir(), 'nsfs-wal-'));
 
 		// Replace the logger by custom one

--- a/src/test/unit_tests/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/test_nsfs_glacier_backend.js
@@ -294,6 +294,11 @@ mocha.describe('nsfs_glacier', async () => {
             assert(failure_stats.xattr[GlacierBackend.XATTR_RESTORE_REQUEST]);
         });
 
+		mocha.it('_finalize_restore should tolerate deleted objects', async () => {
+            // should not throw error if the path does not exist
+            await backend._finalize_restore(glacier_ns.prepare_fs_context(dummy_object_sdk), '/path/does/not/exist');
+		});
+
         mocha.it('generate_expiry should round up the expiry', () => {
             const now = new Date();
             const pivot_time = new Date(now);


### PR DESCRIPTION
### Explain the changes
This PR simply adds the handler in `_finalize_restore` to make sure that it doesn't errors out if encounters `ENOENT`.

Fixes #8251

### Testing Instructions:
1. `./node_modules/.bin/mocha src/test/unit_tests/test_nsfs_glacier_backend.js`


- [ ] Doc added/updated
- [ ] Tests added
