### PR TITLE
Adding node support for bucket logging

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -130,8 +130,9 @@ async function main(options = {}) {
         dbg.log0('Configured Virtual Hosts:', virtual_hosts);
         dbg.log0('Configured Location Info:', location_info);
 
+        const node_name = process.env.NODE_NAME || os.hostname();
         bucket_logger = config.BUCKET_LOG_TYPE === 'PERSISTENT' &&
-            new PersistentLogger(config.PERSISTENT_BUCKET_LOG_DIR, config.PERSISTENT_BUCKET_LOG_NS, {
+            new PersistentLogger(config.PERSISTENT_BUCKET_LOG_DIR, config.PERSISTENT_BUCKET_LOG_NS + '_' + node_name, {
                 locking: 'SHARED',
                 poll_interval: config.NSFS_GLACIER_LOGS_POLL_INTERVAL,
             });


### PR DESCRIPTION
### Explain the changes
1. Change default behavior to create a persistent log per node instead of per system. both for NC and for containerized.
2. When containerized we will use a new env variable with the node name. See here: https://github.com/noobaa/noobaa-operator/pull/1403

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
