### PR TITLE
Support the wildcard principal `("*")` in STS role config

### DIFF
--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -215,7 +215,7 @@ function _is_statements_fit(statements, method, cur_account_email) {
         // who can do that action
         for (const principal of statement.principal) {
             dbg.log0('assume_role_policy: principal fit?', principal.unwrap().toString(), cur_account_email);
-            if (principal.unwrap() === cur_account_email) {
+            if ((principal.unwrap() === cur_account_email) || (principal.unwrap() === '*')) {
                 principal_fit = true;
             }
         }


### PR DESCRIPTION
### Explain the changes
1. Currently, if a user sets the principal which can assume a role via STS as "*", it always fails since it compares "*" to the email of the requester. This PR checks whether the policy principle is "*" and allows it

### Testing Instructions:
1. Create two NooBaa accounts - 'assumed' and 'assumer'
2. Assign a role config to assumed that allows anyone ("principal": ["*"]) to assume it
3. Try to assume it with the credentials of assumer
4. Test the received credentials


- [ ] Doc added/updated
- [ ] Tests added
