### PR TITLE
NC | ConfigFS Refactoring

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -8,6 +8,7 @@ const minimist = require('minimist');
 const config = require('../../config');
 const P = require('../util/promise');
 const nb_native = require('../util/nb_native');
+const { ConfigFS, JSON_SUFFIX } = require('../sdk/config_fs');
 const cloud_utils = require('../util/cloud_utils');
 const native_fs_utils = require('../util/native_fs_utils');
 const mongo_utils = require('../util/mongo_utils');
@@ -19,27 +20,12 @@ const manage_nsfs_logging = require('../manage_nsfs/manage_nsfs_logging');
 const noobaa_cli_diagnose = require('../manage_nsfs/diagnose');
 const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
 const { print_usage } = require('../manage_nsfs/manage_nsfs_help_utils');
-const { TYPES, ACTIONS, CONFIG_SUBDIRS,
-    LIST_ACCOUNT_FILTERS, LIST_BUCKET_FILTERS,
-    GLACIER_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
-const { throw_cli_error, write_stdout_response, get_config_file_path, get_symlink_config_file_path,
-    get_config_data, get_boolean_or_string_value, has_access_keys, set_debug_level, get_config_data_if_exists,
-    check_and_create_config_dirs } = require('../manage_nsfs/manage_nsfs_cli_utils');
+const { TYPES, ACTIONS, LIST_ACCOUNT_FILTERS, LIST_BUCKET_FILTERS, GLACIER_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
+const { throw_cli_error, write_stdout_response, get_boolean_or_string_value, has_access_keys, set_debug_level } = require('../manage_nsfs/manage_nsfs_cli_utils');
 const manage_nsfs_validations = require('../manage_nsfs/manage_nsfs_validations');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 
-const global_config = Object.seal({
-    buckets_dir_name: '/' + CONFIG_SUBDIRS.BUCKETS,
-    access_keys_dir_name: '/' + CONFIG_SUBDIRS.ACCESS_KEYS,
-    accounts_dir_name: '/' + CONFIG_SUBDIRS.ACCOUNTS,
-    accounts_dir_relative_path: '../' + CONFIG_SUBDIRS.ACCOUNTS + '/',
-    // will be defined during runtime (type is string)
-    config_root: '',
-    config_root_backend: '',
-    buckets_dir_path: '',
-    access_keys_dir_path: '',
-    accounts_dir_path: '',
-});
+let config_fs;
 
 async function main(argv = minimist(process.argv.slice(2))) {
     try {
@@ -54,20 +40,19 @@ async function main(argv = minimist(process.argv.slice(2))) {
         const user_input_from_file = await manage_nsfs_validations.validate_input_types(type, action, argv);
         const user_input = user_input_from_file || argv;
         if (argv.debug) set_debug_level(argv.debug);
-        global_config.config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
-        if (!global_config.config_root) throw_cli_error(ManageCLIError.MissingConfigDirPath);
+        const config_root = argv.config_root ? String(argv.config_root) : config.NSFS_NC_CONF_DIR;
+        if (!config_root) throw_cli_error(ManageCLIError.MissingConfigDirPath);
         if (argv.config_root) {
             config.NSFS_NC_CONF_DIR = String(argv.config_root);
             config.load_nsfs_nc_config();
             config.reload_nsfs_nc_config();
         }
+        const config_root_backend = argv.config_root_backend ? String(argv.config_root_backend) : config.NSFS_NC_CONFIG_DIR_BACKEND;
+        const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
 
-        global_config.accounts_dir_path = path.join(global_config.config_root, global_config.accounts_dir_name);
-        global_config.access_keys_dir_path = path.join(global_config.config_root, global_config.access_keys_dir_name);
-        global_config.buckets_dir_path = path.join(global_config.config_root, global_config.buckets_dir_name);
-        global_config.config_root_backend = argv.config_root_backend ? String(argv.config_root_backend) : config.NSFS_NC_CONFIG_DIR_BACKEND;
+        config_fs = new ConfigFS(config_root, config_root_backend, fs_context);
 
-        await check_and_create_config_dirs(global_config);
+        await config_fs.create_config_dirs_if_missing();
         if (type === TYPES.ACCOUNT) {
             await account_management(action, user_input);
         } else if (type === TYPES.BUCKET) {
@@ -77,9 +62,9 @@ async function main(argv = minimist(process.argv.slice(2))) {
         } else if (type === TYPES.GLACIER) {
             await glacier_management(argv);
         } else if (type === TYPES.LOGGING) {
-            await logging_management(user_input);
+            await logging_management();
         } else if (type === TYPES.DIAGNOSE) {
-            await noobaa_cli_diagnose.manage_diagnose_operations(action, user_input, global_config);
+            await noobaa_cli_diagnose.manage_diagnose_operations(action, user_input, config_fs);
         } else {
             // we should not get here (we check it before)
             throw_cli_error(ManageCLIError.InvalidType);
@@ -153,8 +138,7 @@ async function fetch_bucket_data(action, user_input) {
 async function fetch_existing_bucket_data(target) {
     let source;
     try {
-        const bucket_config_path = get_config_file_path(global_config.buckets_dir_path, target.name);
-        source = await get_config_data(global_config.config_root_backend, bucket_config_path);
+        source = await config_fs.get_bucket_by_name(target.name);
     } catch (err) {
         throw_cli_error(ManageCLIError.NoSuchBucket, target.name);
     }
@@ -163,10 +147,8 @@ async function fetch_existing_bucket_data(target) {
 }
 
 async function add_bucket(data) {
-    await manage_nsfs_validations.validate_bucket_args(global_config, data, ACTIONS.ADD);
-    const fs_context = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
-    const bucket_conf_path = get_config_file_path(global_config.buckets_dir_path, data.name);
-    const exists = await native_fs_utils.is_path_exists(fs_context, bucket_conf_path);
+    await manage_nsfs_validations.validate_bucket_args(config_fs, data, ACTIONS.ADD);
+    const exists = await config_fs.is_bucket_exists(data.name);
     if (exists) throw_cli_error(ManageCLIError.BucketAlreadyExists, data.name, { bucket: data.name });
     data._id = mongo_utils.mongoObjectId();
     const data_json = JSON.stringify(data);
@@ -174,16 +156,15 @@ async function add_bucket(data) {
     // (it unwraps ths sensitive strings, creation_date to string and removes undefined parameters)
     // for validating against the schema we need an object, hence we parse it back to object
     nsfs_schema_utils.validate_bucket_schema(JSON.parse(data_json));
-    await native_fs_utils.create_config_file(fs_context, global_config.buckets_dir_path, bucket_conf_path, data_json);
+    await config_fs.create_bucket_config_file(data.name, data_json);
     write_stdout_response(ManageCLIResponse.BucketCreated, data_json, { bucket: data.name });
 }
 
 async function get_bucket_status(data) {
-    await manage_nsfs_validations.validate_bucket_args(global_config, data, ACTIONS.STATUS);
+    await manage_nsfs_validations.validate_bucket_args(config_fs, data, ACTIONS.STATUS);
 
     try {
-        const bucket_path = get_config_file_path(global_config.buckets_dir_path, data.name);
-        const config_data = await get_config_data(global_config.config_root_backend, bucket_path);
+        const config_data = await config_fs.get_bucket_by_name(data.name);
         write_stdout_response(ManageCLIResponse.BucketStatus, config_data);
     } catch (err) {
         const err_code = err.code === 'EACCES' ? ManageCLIError.AccessDenied : ManageCLIError.NoSuchBucket;
@@ -192,32 +173,25 @@ async function get_bucket_status(data) {
 }
 
 async function update_bucket(data) {
-    await manage_nsfs_validations.validate_bucket_args(global_config, data, ACTIONS.UPDATE);
-
-    const fs_context = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
-
+    await manage_nsfs_validations.validate_bucket_args(config_fs, data, ACTIONS.UPDATE);
     const cur_name = data.name;
     const new_name = data.new_name;
     const update_name = new_name && cur_name && new_name !== cur_name;
 
     if (!update_name) {
-        const bucket_config_path = get_config_file_path(global_config.buckets_dir_path, data.name);
         data = JSON.stringify(data);
         // We take an object that was stringify
         // (it unwraps ths sensitive strings, creation_date to string and removes undefined parameters)
         // for validating against the schema we need an object, hence we parse it back to object
         nsfs_schema_utils.validate_bucket_schema(JSON.parse(data));
-        await native_fs_utils.update_config_file(fs_context, global_config.buckets_dir_path, bucket_config_path, data);
+        await config_fs.update_bucket_config_file(cur_name, data);
         write_stdout_response(ManageCLIResponse.BucketUpdated, data);
         return;
     }
 
     data.name = new_name;
 
-    const cur_bucket_config_path = get_config_file_path(global_config.buckets_dir_path, cur_name);
-    const new_bucket_config_path = get_config_file_path(global_config.buckets_dir_path, data.name);
-
-    const exists = await native_fs_utils.is_path_exists(fs_context, new_bucket_config_path);
+    const exists = await config_fs.is_bucket_exists(data.name);
     if (exists) throw_cli_error(ManageCLIError.BucketAlreadyExists, data.name);
 
     data = JSON.stringify(_.omit(data, ['new_name']));
@@ -225,20 +199,18 @@ async function update_bucket(data) {
     // (it unwraps ths sensitive strings, creation_date to string and removes undefined parameters)
     // for validating against the schema we need an object, hence we parse it back to object
     nsfs_schema_utils.validate_bucket_schema(JSON.parse(data));
-    await native_fs_utils.create_config_file(fs_context, global_config.buckets_dir_path, new_bucket_config_path, data);
-    await native_fs_utils.delete_config_file(fs_context, global_config.buckets_dir_path, cur_bucket_config_path);
+    await config_fs.create_bucket_config_file(new_name, data);
+    await config_fs.delete_bucket_config_file(cur_name);
     write_stdout_response(ManageCLIResponse.BucketUpdated, data);
 }
 
 async function delete_bucket(data, force) {
-    await manage_nsfs_validations.validate_bucket_args(global_config, data, ACTIONS.DELETE);
-    // we have fs_contexts: (1) fs_backend for bucket temp dir (2) config_root_backend for config files
-    const fs_context_config_root_backend = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
-    const fs_context_fs_backend = native_fs_utils.get_process_fs_context(data.fs_backend);
-    const bucket_config_path = get_config_file_path(global_config.buckets_dir_path, data.name);
+    await manage_nsfs_validations.validate_bucket_args(config_fs, data, ACTIONS.DELETE);
     try {
         const temp_dir_name = native_fs_utils.get_bucket_tmpdir_name(data._id);
         const bucket_temp_dir_path = native_fs_utils.get_bucket_tmpdir_full_path(data.path, data._id);
+        // fs_contexts for bucket temp dir (storage path)
+        const fs_context_fs_backend = native_fs_utils.get_process_fs_context(data.fs_backend);
         let entries;
         try {
             entries = await nb_native().fs.readdir(fs_context_fs_backend, data.path);
@@ -255,7 +227,7 @@ async function delete_bucket(data, force) {
             }
         }
         await native_fs_utils.folder_delete(bucket_temp_dir_path, fs_context_fs_backend, true);
-        await native_fs_utils.delete_config_file(fs_context_config_root_backend, global_config.buckets_dir_path, bucket_config_path);
+        await config_fs.delete_bucket_config_file(data.name);
         write_stdout_response(ManageCLIResponse.BucketDeleted, '', { bucket: data.name });
     } catch (err) {
         if (err.code === 'ENOENT') throw_cli_error(ManageCLIError.NoSuchBucket, data.name);
@@ -276,7 +248,7 @@ async function manage_bucket_operations(action, data, user_input) {
     } else if (action === ACTIONS.LIST) {
         const bucket_filters = _.pick(user_input, LIST_BUCKET_FILTERS);
         const wide = get_boolean_or_string_value(user_input.wide);
-        const buckets = await list_config_files(TYPES.BUCKET, global_config.buckets_dir_path, wide, undefined, bucket_filters);
+        const buckets = await list_config_files(TYPES.BUCKET, config_fs.buckets_dir_path, wide, undefined, bucket_filters);
         write_stdout_response(ManageCLIResponse.BucketList, buckets);
     } else {
         // we should not get here (we check it before)
@@ -377,13 +349,12 @@ async function fetch_account_data(action, user_input) {
 }
 
 async function fetch_existing_account_data(action, target, decrypt_secret_key) {
+    const options = { show_secrets: true, decrypt_secret_key };
     let source;
     try {
-        const account_path = target.name ?
-            get_config_file_path(global_config.accounts_dir_path, target.name) :
-            get_symlink_config_file_path(global_config.access_keys_dir_path, target.access_keys[0].access_key);
-        source = await get_config_data(global_config.config_root_backend, account_path, true);
-        if (decrypt_secret_key) source.access_keys = await nc_mkm.decrypt_access_keys(source);
+        source = target.name ?
+            await config_fs.get_account_by_name(target.name, options) :
+            await config_fs.get_account_by_access_key(target.access_keys[0].access_key, options);
     } catch (err) {
         dbg.log1('NSFS Manage command: Could not find account', target, err);
         if (err.code === 'ENOENT') {
@@ -414,16 +385,11 @@ async function fetch_existing_account_data(action, target, decrypt_secret_key) {
 }
 
 async function add_account(data) {
-    await manage_nsfs_validations.validate_account_args(global_config, data, ACTIONS.ADD, undefined);
+    await manage_nsfs_validations.validate_account_args(config_fs, data, ACTIONS.ADD, undefined);
 
-    const fs_context = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
     const access_key = has_access_keys(data.access_keys) ? data.access_keys[0].access_key : undefined;
-    const account_config_path = get_config_file_path(global_config.accounts_dir_path, data.name);
-    const account_config_relative_path = get_config_file_path(global_config.accounts_dir_relative_path, data.name);
-    const account_config_access_key_path = get_symlink_config_file_path(global_config.access_keys_dir_path, access_key);
-
-    const name_exists = await native_fs_utils.is_path_exists(fs_context, account_config_path);
-    const access_key_exists = await native_fs_utils.is_path_exists(fs_context, account_config_access_key_path, true);
+    const name_exists = await config_fs.is_account_exists({ name: data.name });
+    const access_key_exists = access_key && await config_fs.is_account_exists({ access_key });
 
     const event_arg = data.name ? data.name : access_key;
     if (name_exists || access_key_exists) {
@@ -440,19 +406,14 @@ async function add_account(data) {
     // for validating against the schema we need an object, hence we parse it back to object
     const account = encrypted_data ? JSON.parse(encrypted_data) : data;
     nsfs_schema_utils.validate_account_schema(account);
-    await native_fs_utils.create_config_file(fs_context, global_config.accounts_dir_path, account_config_path, JSON.stringify(account));
-    if (has_access_keys(data.access_keys)) {
-        await native_fs_utils._create_path(global_config.access_keys_dir_path, fs_context, config.BASE_MODE_CONFIG_DIR);
-        await nb_native().fs.symlink(fs_context, account_config_relative_path, account_config_access_key_path);
-    }
+    await config_fs.create_account_config_file(data.name, account, true);
     write_stdout_response(ManageCLIResponse.AccountCreated, data, { account: event_arg });
 }
 
 
 async function update_account(data, is_flag_iam_operate_on_root_account) {
-    await manage_nsfs_validations.validate_account_args(global_config, data, ACTIONS.UPDATE, is_flag_iam_operate_on_root_account);
+    await manage_nsfs_validations.validate_account_args(config_fs, data, ACTIONS.UPDATE, is_flag_iam_operate_on_root_account);
 
-    const fs_context = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
     const cur_name = data.name;
     const new_name = data.new_name;
     const cur_access_key = has_access_keys(data.access_keys) ? data.access_keys[0].access_key : undefined;
@@ -465,7 +426,6 @@ async function update_account(data, is_flag_iam_operate_on_root_account) {
             data.access_keys[0] = _.pick(data.access_keys[0], ['access_key', 'secret_key']);
             data = _.omit(data, ['new_access_key']);
         }
-        const account_config_path = get_config_file_path(global_config.accounts_dir_path, data.name);
         const encrypted_account = await nc_mkm.encrypt_access_keys(data);
         data.master_key_id = encrypted_account.master_key_id;
         const encrypted_data = JSON.stringify(encrypted_account);
@@ -475,7 +435,7 @@ async function update_account(data, is_flag_iam_operate_on_root_account) {
         // for validating against the schema we need an object, hence we parse it back to object
         const account = encrypted_data ? JSON.parse(encrypted_data) : data;
         nsfs_schema_utils.validate_account_schema(account);
-        await native_fs_utils.update_config_file(fs_context, global_config.accounts_dir_path, account_config_path, JSON.stringify(account));
+        await config_fs.update_account_config_file(data.name, account, undefined, undefined);
         write_stdout_response(ManageCLIResponse.AccountUpdated, data);
         return;
     }
@@ -486,13 +446,11 @@ async function update_account(data, is_flag_iam_operate_on_root_account) {
         access_key: data.new_access_key || cur_access_key,
         secret_key: data.access_keys[0].secret_key,
     };
-    const cur_account_config_path = get_config_file_path(global_config.accounts_dir_path, cur_name);
-    const new_account_config_path = get_config_file_path(global_config.accounts_dir_path, data.name);
-    const new_account_relative_config_path = get_config_file_path(global_config.accounts_dir_relative_path, data.name);
-    const cur_access_key_config_path = get_symlink_config_file_path(global_config.access_keys_dir_path, cur_access_key);
-    const new_access_key_config_path = get_symlink_config_file_path(global_config.access_keys_dir_path, data.access_keys[0].access_key);
-    const name_exists = update_name && await native_fs_utils.is_path_exists(fs_context, new_account_config_path);
-    const access_key_exists = update_access_key && await native_fs_utils.is_path_exists(fs_context, new_access_key_config_path, true);
+
+    const name_exists = update_name && await config_fs.is_account_exists({ name: data.name });
+    const access_key_exists = update_access_key &&
+        await config_fs.is_account_exists({ access_key: data.access_keys[0].access_key.unwrap() });
+
     if (name_exists || access_key_exists) {
         const err_code = name_exists ? ManageCLIError.AccountNameAlreadyExists : ManageCLIError.AccountAccessKeyAlreadyExists;
         throw_cli_error(err_code);
@@ -506,44 +464,31 @@ async function update_account(data, is_flag_iam_operate_on_root_account) {
     // We take an object that was stringify
     // (it unwraps ths sensitive strings, creation_date to string and removes undefined parameters)
     // for validating against the schema we need an object, hence we parse it back to object
-    nsfs_schema_utils.validate_account_schema(JSON.parse(encrypted_data));
+    const parsed_data = JSON.parse(encrypted_data);
+    nsfs_schema_utils.validate_account_schema(parsed_data);
     if (update_name) {
-        await native_fs_utils.create_config_file(fs_context, global_config.accounts_dir_path, new_account_config_path, encrypted_data);
-        await native_fs_utils.delete_config_file(fs_context, global_config.accounts_dir_path, cur_account_config_path);
+        await config_fs.create_account_config_file(new_name, parsed_data, true, [cur_access_key]);
+        await config_fs.delete_account_config_file(cur_name, data.access_keys);
     } else if (update_access_key) {
-        await native_fs_utils.update_config_file(fs_context, global_config.accounts_dir_path, cur_account_config_path, encrypted_data);
+        await config_fs.update_account_config_file(cur_name, parsed_data, parsed_data.access_keys, [cur_access_key]);
     }
-    // TODO: safe_unlink can be better but the current impl causing ELOOP - Too many levels of symbolic links
-    // need to find a better way for atomic unlinking of symbolic links
-    // handle atomicity for symlinks
-    await nb_native().fs.unlink(fs_context, cur_access_key_config_path);
-    await nb_native().fs.symlink(fs_context, new_account_relative_config_path, new_access_key_config_path);
     write_stdout_response(ManageCLIResponse.AccountUpdated, data);
 }
 
 async function delete_account(data) {
-    await manage_nsfs_validations.validate_account_args(global_config, data, ACTIONS.DELETE, undefined);
-
-    const fs_context = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
-    const account_config_path = get_config_file_path(global_config.accounts_dir_path, data.name);
-    await native_fs_utils.delete_config_file(fs_context, global_config.accounts_dir_path, account_config_path);
-    if (has_access_keys(data.access_keys)) {
-        for (const access_key_object of data.access_keys) {
-            const access_key_config_path = get_symlink_config_file_path(global_config.access_keys_dir_path, access_key_object.access_key);
-            await nb_native().fs.unlink(fs_context, access_key_config_path);
-        }
-    }
-    write_stdout_response(ManageCLIResponse.AccountDeleted, '', {account: data.name});
+    await manage_nsfs_validations.validate_account_args(config_fs, data, ACTIONS.DELETE, undefined);
+    await config_fs.delete_account_config_file(data.name, data.access_keys);
+    write_stdout_response(ManageCLIResponse.AccountDeleted, '', { account: data.name });
 }
 
 async function get_account_status(data, show_secrets) {
-    await manage_nsfs_validations.validate_account_args(global_config, data, ACTIONS.STATUS, undefined);
+    await manage_nsfs_validations.validate_account_args(config_fs, data, ACTIONS.STATUS, undefined);
+    const options = { show_secrets, decrypt_secret_key: show_secrets };
+
     try {
-        const account_path = _.isUndefined(data.name) ?
-            get_symlink_config_file_path(global_config.access_keys_dir_path, data.access_keys[0].access_key) :
-            get_config_file_path(global_config.accounts_dir_path, data.name);
-        const config_data = await get_config_data(global_config.config_root_backend, account_path, show_secrets);
-        if (config_data.access_keys) config_data.access_keys = await nc_mkm.decrypt_access_keys(config_data);
+        const config_data = _.isUndefined(data.name) ?
+            await config_fs.get_account_by_access_key(data.access_keys[0].access_key, options) :
+            await config_fs.get_account_by_name(data.name, options);
         write_stdout_response(ManageCLIResponse.AccountStatus, config_data);
     } catch (err) {
         if (err.code !== 'ENOENT') throw err;
@@ -568,7 +513,8 @@ async function manage_account_operations(action, data, show_secrets, user_input)
     } else if (action === ACTIONS.LIST) {
         const account_filters = _.pick(user_input, LIST_ACCOUNT_FILTERS);
         const wide = get_boolean_or_string_value(user_input.wide);
-        const accounts = await list_config_files(TYPES.ACCOUNT, global_config.accounts_dir_path, wide, show_secrets, account_filters);
+        const accounts = await list_config_files(TYPES.ACCOUNT, config_fs.accounts_dir_path, wide,
+            show_secrets, account_filters);
         write_stdout_response(ManageCLIResponse.AccountList, accounts);
     } else {
         // we should not get here (we check it before)
@@ -634,24 +580,30 @@ function filter_bucket(bucket, filters) {
  * @param {object} [filters]
  */
 async function list_config_files(type, config_path, wide, show_secrets, filters) {
-    const fs_context = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
-    const entries = await nb_native().fs.readdir(fs_context, config_path);
+    const entries = type === TYPES.ACCOUNT ?
+        await config_fs.list_root_accounts() :
+        await config_fs.list_buckets();
+
     const should_filter = Object.keys(filters).length > 0;
+    // decryption causing mkm initalization
+    // decrypt only if data has access_keys and show_secrets = true (no need to decrypt if show_secrets = false but should_filter = true)
+    const options = {
+        show_secrets: show_secrets || should_filter,
+        should_decrypt: show_secrets,
+        silent_if_missing: true
+    };
 
     let config_files_list = await P.map_with_concurrency(10, entries, async entry => {
-        if (entry.name.endsWith('.json')) {
+        if (entry.name.endsWith(JSON_SUFFIX)) {
             if (wide || should_filter) {
                 const full_path = path.join(config_path, entry.name);
-                const data = await get_config_data_if_exists(global_config.config_root_backend, full_path, show_secrets || should_filter);
+                const data = await config_fs.get_config_data(full_path, options);
                 if (!data) return undefined;
-                // decryption causing mkm initalization
-                // decrypt only if data has access_keys and show_secrets = true (no need to decrypt if show_secrets = false but should_filter = true)
-                if (data.access_keys && show_secrets) data.access_keys = await nc_mkm.decrypt_access_keys(data);
                 if (should_filter && !filter_list_item(type, data, filters)) return undefined;
                 // remove secrets on !show_secrets && should filter
-                return wide ? _.omit(data, show_secrets ? [] : ['access_keys']) : { name: entry.name.slice(0, entry.name.indexOf('.json')) };
+                return wide ? _.omit(data, show_secrets ? [] : ['access_keys']) : { name: entry.name.slice(0, entry.name.indexOf(JSON_SUFFIX)) };
             } else {
-                return { name: entry.name.slice(0, entry.name.indexOf('.json')) };
+                return { name: entry.name.slice(0, entry.name.indexOf(JSON_SUFFIX)) };
             }
         }
     });
@@ -695,13 +647,12 @@ async function whitelist_ips_management(args) {
 
     const whitelist_ips = JSON.parse(ips);
     manage_nsfs_validations.validate_whitelist_ips(whitelist_ips);
-    const config_path = path.join(global_config.config_root, 'config.json');
+    const config_path = path.join(config_fs.config_root, 'config.json');
     try {
         const config_data = require(config_path);
         config_data.S3_SERVER_IP_WHITELIST = whitelist_ips;
-        const fs_context = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
         const data = JSON.stringify(config_data);
-        await native_fs_utils.update_config_file(fs_context, global_config.config_root, config_path, data);
+        await config_fs.update_config_json_file(data);
     } catch (err) {
         dbg.error('manage_nsfs.whitelist_ips_management: Error while updation config.json,  path ' + config_path, err);
         throw_cli_error(ManageCLIError.WhiteListIPUpdateFailed, config_path);
@@ -730,8 +681,8 @@ async function manage_glacier_operations(action, argv) {
     }
 }
 
-async function logging_management(user_input) {
-    await manage_nsfs_logging.export_bucket_logging(user_input);
+async function logging_management() {
+    await manage_nsfs_logging.export_bucket_logging(config_fs);
 }
 
 exports.main = main;

--- a/src/manage_nsfs/diagnose.js
+++ b/src/manage_nsfs/diagnose.js
@@ -15,13 +15,13 @@ const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').Ma
  * manage_diagnose_operations handles cli diagnose operations
  * @param {string} action 
  * @param {Object} user_input 
- * @param {Object} global_config 
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs 
  * @returns {Promise<Void>}
  */
-async function manage_diagnose_operations(action, user_input, global_config) {
+async function manage_diagnose_operations(action, user_input, config_fs) {
     switch (action) {
         case DIAGNOSE_ACTIONS.HEALTH:
-            await health.get_health_status(user_input, global_config);
+            await health.get_health_status(user_input, config_fs);
             break;
         case DIAGNOSE_ACTIONS.GATHER_LOGS:
             await gather_logs();

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -3,8 +3,6 @@
 
 const dbg = require('../util/debug_module')(__filename);
 const _ = require('lodash');
-const path = require('path');
-const config = require('../../config');
 const nb_native = require('../util/nb_native');
 const native_fs_utils = require('../util/native_fs_utils');
 const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
@@ -15,36 +13,6 @@ const { BOOLEAN_STRING_VALUES } = require('../manage_nsfs/manage_nsfs_constants'
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 const mongo_utils = require('../util/mongo_utils');
 
-/**
- * @param {object} global_config
- */
-async function check_and_create_config_dirs(global_config) {
-    const pre_req_dirs = [
-        global_config.config_root,
-        global_config.buckets_dir_path,
-        global_config.accounts_dir_path,
-        global_config.access_keys_dir_path,
-    ];
-
-    if (config.NSFS_GLACIER_LOGS_ENABLED) {
-        pre_req_dirs.push(config.NSFS_GLACIER_LOGS_DIR);
-    }
-
-    for (const dir_path of pre_req_dirs) {
-        try {
-            const fs_context = native_fs_utils.get_process_fs_context(global_config.config_root_backend);
-            const dir_exists = await native_fs_utils.is_path_exists(fs_context, dir_path);
-            if (dir_exists) {
-                dbg.log1('nsfs.check_and_create_config_dirs: config dir exists:', dir_path);
-            } else {
-                await native_fs_utils._create_path(dir_path, fs_context, config.BASE_MODE_CONFIG_DIR);
-                dbg.log1('nsfs.check_and_create_config_dirs: config dir was created:', dir_path);
-            }
-        } catch (err) {
-            dbg.log1('nsfs.check_and_create_config_dirs: could not create pre requisite path', dir_path);
-        }
-    }
-}
 
 function throw_cli_error(error, detail, event_arg) {
     const error_event = NSFS_CLI_ERROR_EVENT_MAP[error.code];
@@ -66,56 +34,15 @@ function write_stdout_response(response_code, detail, event_arg) {
     });
 }
 
-function get_config_file_path(config_type_path, file_name) {
-    return path.join(config_type_path, file_name + '.json');
-}
-
-function get_symlink_config_file_path(config_type_path, file_name) {
-    return path.join(config_type_path, file_name + '.symlink');
-}
-
-/**
- * get_config_data will read a config file and return its content 
- * while omitting secrets if show_secrets flag was not provided
- * @param {string} config_root_backend
- * @param {string} config_file_path
- * @param {boolean} [show_secrets]
- */
-async function get_config_data(config_root_backend, config_file_path, show_secrets = false) {
-    const fs_context = native_fs_utils.get_process_fs_context(config_root_backend);
-    const { data } = await nb_native().fs.readFile(fs_context, config_file_path);
-    const config_data = _.omit(JSON.parse(data.toString()), show_secrets ? [] : ['access_keys']);
-    return config_data;
-}
-
-/**
- * get_config_data_if_exists will read a config file and return its content 
- * while omitting secrets if show_secrets flag was not provided
- * if the config file was deleted (encounter ENOENT error) - continue (returns undefined)
- * @param {string} config_root_backend
- * @param {string} config_file_path
- * @param {boolean} [show_secrets]
- */
-async function get_config_data_if_exists(config_root_backend, config_file_path, show_secrets = false) {
-    try {
-        const config_data = await get_config_data(config_root_backend, config_file_path, show_secrets);
-        return config_data;
-    } catch (err) {
-        dbg.warn('get_config_data_if_exists: with config_file_path', config_file_path, 'got an error', err);
-        if (err.code !== 'ENOENT') throw err;
-    }
-}
-
 /**
  * get_bucket_owner_account will return the account of the bucket_owner
  * otherwise it would throw an error
- * @param {object} global_config
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
  * @param {string} bucket_owner
  */
-async function get_bucket_owner_account(global_config, bucket_owner) {
-    const account_config_path = get_config_file_path(global_config.accounts_dir_path, bucket_owner);
+async function get_bucket_owner_account(config_fs, bucket_owner) {
     try {
-        const account = await get_config_data(global_config.config_root_backend, account_config_path);
+        const account = await config_fs.get_account_by_name(bucket_owner);
         return account;
     } catch (err) {
         if (err.code === 'ENOENT') {
@@ -206,15 +133,10 @@ function check_root_account_owns_user(root_account, account) {
 // EXPORTS
 exports.throw_cli_error = throw_cli_error;
 exports.write_stdout_response = write_stdout_response;
-exports.get_config_file_path = get_config_file_path;
-exports.get_symlink_config_file_path = get_symlink_config_file_path;
 exports.get_boolean_or_string_value = get_boolean_or_string_value;
-exports.get_config_data = get_config_data;
 exports.get_bucket_owner_account = get_bucket_owner_account;
 exports.get_options_from_file = get_options_from_file;
 exports.has_access_keys = has_access_keys;
 exports.generate_id = generate_id;
 exports.set_debug_level = set_debug_level;
 exports.check_root_account_owns_user = check_root_account_owns_user;
-exports.get_config_data_if_exists = get_config_data_if_exists;
-exports.check_and_create_config_dirs = check_and_create_config_dirs;

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -30,11 +30,6 @@ const DIAGNOSE_ACTIONS = {
     METRICS: 'metrics'
 };
 
-const CONFIG_SUBDIRS = {
-    ACCOUNTS: 'accounts',
-    BUCKETS: 'buckets',
-    ACCESS_KEYS: 'access_keys'
-};
 
 const CONFIG_ROOT_FLAG = 'config_root';
 const CLI_MUTUAL_OPTIONS = new Set([CONFIG_ROOT_FLAG, 'config_root_backend', 'debug']);
@@ -139,7 +134,6 @@ exports.TYPES = TYPES;
 exports.ACTIONS = ACTIONS;
 exports.GLACIER_ACTIONS = GLACIER_ACTIONS;
 exports.DIAGNOSE_ACTIONS = DIAGNOSE_ACTIONS;
-exports.CONFIG_SUBDIRS = CONFIG_SUBDIRS;
 exports.VALID_OPTIONS = VALID_OPTIONS;
 exports.OPTION_TYPE = OPTION_TYPE;
 exports.FROM_FILE = FROM_FILE;

--- a/src/manage_nsfs/manage_nsfs_logging.js
+++ b/src/manage_nsfs/manage_nsfs_logging.js
@@ -1,32 +1,17 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
-const path = require('path');
 const config = require('../../config');
-const { throw_cli_error, get_config_file_path, get_config_data, write_stdout_response} = require('../manage_nsfs/manage_nsfs_cli_utils');
+const { throw_cli_error, write_stdout_response} = require('../manage_nsfs/manage_nsfs_cli_utils');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 const { export_logs_to_target } = require('../util/bucket_logs_utils');
-const native_fs_utils = require('../util/native_fs_utils');
 const http_utils = require('../util/http_utils');
 const AWS = require('aws-sdk');
-const { RpcError } = require('../rpc');
-
-const buckets_dir_name = '/buckets';
-const accounts_dir_name = '/accounts';
-let config_root;
-let config_root_backend;
-let buckets_dir_path;
-let accounts_dir_path;
 
 // This command goes over the logs in the persistent log and move the entries to log objects in the target buckets 
-async function export_bucket_logging(user_input) {
-    const fs_context = native_fs_utils.get_process_fs_context();
-    config_root_backend = user_input.config_root_backend || config.NSFS_NC_CONFIG_DIR_BACKEND;
-    config_root = user_input.config_root || config.NSFS_NC_CONF_DIR;
-    buckets_dir_path = path.join(config_root, buckets_dir_name);
-    accounts_dir_path = path.join(config_root, accounts_dir_name);
+async function export_bucket_logging(config_fs) {
     const endpoint = `https://127.0.0.1:${config.ENDPOINT_SSL_PORT}`;
     const noobaa_con = new AWS.S3({
         endpoint,
@@ -36,7 +21,7 @@ async function export_bucket_logging(user_input) {
             agent: http_utils.get_unsecured_agent(endpoint)
         }
     });
-    const success = await export_logs_to_target(fs_context, noobaa_con, get_bucket_owner_keys);
+    const success = await export_logs_to_target(config_fs, noobaa_con, get_bucket_owner_keys);
     if (success) {
         write_stdout_response(ManageCLIResponse.LoggingExported);
     } else {
@@ -46,21 +31,14 @@ async function export_bucket_logging(user_input) {
 
 /**
  * return bucket owner's access and secret key
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
  * @param {string} log_bucket_name
  * @returns {Promise<Object>} 
  */
-async function get_bucket_owner_keys(log_bucket_name) {
-    const log_bucket_path = get_config_file_path(buckets_dir_path, log_bucket_name);
-    let log_bucket_owner;
-    try {
-        const log_bucket_config_data = await get_config_data(config_root_backend, log_bucket_path);
-        log_bucket_owner = log_bucket_config_data.bucket_owner;
-    } catch (err) {
-        if (err.code === 'ENOENT') throw new RpcError('NO_SUCH_BUCKET', 'No such bucket: ' + log_bucket_name);
-        throw err;
-    }
-    const owner_path = get_config_file_path(accounts_dir_path, log_bucket_owner);
-    const owner_config_data = await get_config_data(config_root_backend, owner_path, true);
+async function get_bucket_owner_keys(config_fs, log_bucket_name) {
+    const log_bucket_config_data = await config_fs.get_bucket_by_name(log_bucket_name);
+    const log_bucket_owner = log_bucket_config_data.bucket_owner;
+    const owner_config_data = await config_fs.get_account_by_name(log_bucket_owner, { show_secrets: true, decrypt_secret_key: true });
     return nc_mkm.decrypt_access_keys(owner_config_data);
 }
 

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -15,14 +15,12 @@ const util = require('util');
 const bucket_policy_utils = require('../endpoint/s3/s3_bucket_policy_utils');
 const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
-
+const { ConfigFS, JSON_SUFFIX } = require('./config_fs');
 const mongo_utils = require('../util/mongo_utils');
-const { CONFIG_SUBDIRS } = require('../manage_nsfs/manage_nsfs_constants');
 
 const KeysSemaphore = require('../util/keys_semaphore');
-const { get_umasked_mode, isDirectory, validate_bucket_creation,
-    create_config_file, delete_config_file, get_bucket_tmpdir_full_path, folder_delete,
-    entity_enum, translate_error_codes, update_config_file } = require('../util/native_fs_utils');
+const { get_umasked_mode, isDirectory, validate_bucket_creation, get_bucket_tmpdir_full_path, folder_delete,
+    entity_enum, translate_error_codes, get_process_fs_context} = require('../util/native_fs_utils');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 const { anonymous_access_key } = require('./object_sdk');
 
@@ -35,18 +33,15 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
     constructor({config_root}, stats) {
         super({ fs_root: ''});
         this.fs_root = '';
-        this.accounts_dir = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS);
-        this.access_keys_dir = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS);
-        this.bucket_schema_dir = path.join(config_root, CONFIG_SUBDIRS.BUCKETS);
         this.config_root = config_root;
         this.stats = stats;
-        this.fs_context = {
-            uid: process.getuid(),
-            gid: process.getgid(),
-            warn_threshold_ms: config.NSFS_WARN_THRESHOLD_MS,
-            fs_backend: config.NSFS_NC_CONFIG_DIR_BACKEND,
-            report_fs_stats: this.stats?.update_fs_stats
-        };
+        this.fs_context = get_process_fs_context(
+            config.NSFS_NC_CONFIG_DIR_BACKEND,
+            config.NSFS_WARN_THRESHOLD_MS,
+            this.stats?.update_fs_stats
+        );
+
+        this.config_fs = new ConfigFS(config_root, config.NSFS_NC_CONFIG_DIR_BACKEND, this.fs_context);
     }
 
     //TODO:  dup from namespace_fs - need to handle and not dup code
@@ -65,35 +60,14 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         return fs_context;
     }
 
-    _get_bucket_config_path(bucket_name) {
-       return path.join(this.bucket_schema_dir, bucket_name + '.json');
-    }
-
-    _get_account_config_path(name) {
-        return path.join(this.accounts_dir, name + '.json');
-    }
-
-    _get_access_keys_config_path(access_key) {
-        return path.join(this.access_keys_dir, access_key + '.symlink');
-    }
-
-    async _get_account_by_name(name) {
-        const account_config_path = this._get_account_config_path(name);
-        try {
-            await nb_native().fs.stat(this.fs_context, account_config_path);
-            return true;
-        } catch (err) {
-            return false;
-        }
-    }
-
     async read_account_by_access_key({ access_key }) {
         try {
             if (!access_key) throw new Error('no access key');
-            const iam_path = access_key === anonymous_access_key ? this._get_account_config_path(config.ANONYMOUS_ACCOUNT_NAME) :
-                this._get_access_keys_config_path(access_key);
-            const { data } = await nb_native().fs.readFile(this.fs_context, iam_path);
-            const account = JSON.parse(data.toString());
+            const options = { show_secrets: true };
+            const account = access_key === anonymous_access_key ?
+                await this.config_fs.get_account_by_name(config.ANONYMOUS_ACCOUNT_NAME, options) :
+                await this.config_fs.get_account_by_access_key(access_key, options);
+
             nsfs_schema_utils.validate_account_schema(account);
             account.name = new SensitiveString(account.name);
             account.email = new SensitiveString(account.email);
@@ -119,15 +93,16 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
 
     async read_bucket_sdk_info({ name }) {
         try {
-            const bucket_config_path = this._get_bucket_config_path(name);
-            dbg.log0('BucketSpaceFS.read_bucket_sdk_info: bucket_config_path', bucket_config_path);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            dbg.log0('BucketSpaceFS.read_bucket_sdk_info: bucket name', name);
+
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             nsfs_schema_utils.validate_bucket_schema(bucket);
+
             const is_valid = await this.check_bucket_config(bucket);
             if (!is_valid) {
                 dbg.warn('BucketSpaceFS: one or more bucket config check is failed for bucket : ', name);
             }
+
             const nsr = {
                 resource: {
                     fs_root_path: this.fs_root,
@@ -207,10 +182,10 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
     async list_buckets(object_sdk) {
         let entries;
         try {
-            entries = await nb_native().fs.readdir(this.fs_context, this.bucket_schema_dir);
+            entries = await this.config_fs.list_buckets();
         } catch (err) {
             if (err.code === 'ENOENT') {
-                dbg.error('BucketSpaceFS: root dir not found', err, this.bucket_schema_dir);
+                dbg.error('BucketSpaceFS: root dir not found', err, this.config_fs.buckets_dir_path);
                 throw new S3Error(S3Error.NoSuchBucket);
             }
             throw translate_error_codes(err, entity_enum.BUCKET);
@@ -218,7 +193,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
 
         const account = object_sdk.requesting_account;
         const buckets = await P.map_with_concurrency(10, entries, async entry => {
-            if (isDirectory(entry) || !entry.name.endsWith('.json')) {
+            if (isDirectory(entry) || !entry.name.endsWith(JSON_SUFFIX)) {
                 return;
             }
             const bucket_name = this.get_bucket_name(entry.name);
@@ -242,7 +217,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
 
     get_bucket_name(bucket_config_file_name) {
         let bucket_name = path.basename(bucket_config_file_name);
-        bucket_name = bucket_name.slice(0, bucket_name.indexOf('.json'));
+        bucket_name = bucket_name.slice(0, bucket_name.indexOf(JSON_SUFFIX));
         return bucket_name;
     }
 
@@ -268,7 +243,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             validate_bucket_creation(params);
 
             const { name } = params;
-            const bucket_config_path = this._get_bucket_config_path(name);
+            const bucket_config_path = this.config_fs.get_bucket_path_by_name(name);
             const bucket_storage_path = path.join(sdk.requesting_account.nsfs_account_config.new_buckets_path, name);
 
             dbg.log0(`BucketSpaceFS.create_bucket
@@ -290,7 +265,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 const bucket_to_validate = JSON.parse(bucket_config);
                 dbg.log2("create_bucket: bucket properties before validate_bucket_schema", bucket_to_validate);
                 nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
-                await create_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, bucket_config);
+                await this.config_fs.create_bucket_config_file(name, bucket_config);
             } catch (err) {
                 new NoobaaEvent(NoobaaEvent.BUCKET_CREATION_FAILED).create_event(name, {bucket_name: name}, err);
                 throw translate_error_codes(err, entity_enum.BUCKET);
@@ -342,7 +317,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
     async delete_bucket(params, object_sdk) {
         const { name } = params;
         return bucket_semaphore.surround_key(String(name), async () => {
-            const bucket_config_path = this._get_bucket_config_path(name);
+            const bucket_config_path = this.config_fs.get_bucket_path_by_name(name);
             try {
                 const { ns, bucket } = await object_sdk.read_bucket_full_info(name);
                 const namespace_bucket_config = bucket && bucket.namespace;
@@ -377,7 +352,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 }
                 // 3. delete bucket config json file
                 dbg.log1(`BucketSpaceFS: delete_bucket: deleting config file ${bucket_config_path}`);
-                await delete_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path);
+                await this.config_fs.delete_bucket_config_file(name);
                 new NoobaaEvent(NoobaaEvent.BUCKET_DELETE).create_event(name, { bucket_name: name });
             } catch (err) {
                 dbg.error('BucketSpaceFS: delete_bucket: bucket name', name, 'error', err);
@@ -415,15 +390,13 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             await ns.set_bucket_versioning(params.versioning, object_sdk);
             const { name, versioning } = params;
             dbg.log0('BucketSpaceFS.set_bucket_versioning: Bucket name, versioning', name, versioning);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             bucket.versioning = versioning;
             dbg.log2("set_bucket_versioning: bucket properties before validate_bucket_schema",
                 bucket);
             nsfs_schema_utils.validate_bucket_schema(bucket);
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -437,17 +410,10 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name, tagging } = params;
             dbg.log0('BucketSpaceFS.put_bucket_tagging: Bucket name, tagging', name, tagging);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             bucket.tag = tagging;
             nsfs_schema_utils.validate_bucket_schema(bucket);
-            await update_config_file(
-                this.fs_context,
-                this.bucket_schema_dir,
-                bucket_config_path,
-                JSON.stringify(bucket),
-            );
+            await this.config_fs.update_bucket_config_file(name, JSON.stringify(bucket));
         } catch (error) {
             throw translate_error_codes(error, entity_enum.BUCKET);
         }
@@ -457,17 +423,10 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.delete_bucket_tagging: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             delete bucket.tag;
             nsfs_schema_utils.validate_bucket_schema(bucket);
-            await update_config_file(
-                this.fs_context,
-                this.bucket_schema_dir,
-                bucket_config_path,
-                JSON.stringify(bucket),
-            );
+            await this.config_fs.update_bucket_config_file(name, JSON.stringify(bucket));
         } catch (error) {
             throw translate_error_codes(error, entity_enum.BUCKET);
         }
@@ -477,9 +436,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.get_bucket_tagging: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             return { tagging: bucket.tag || [] };
         } catch (error) {
             throw translate_error_codes(error, entity_enum.BUCKET);
@@ -494,21 +451,17 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name, logging } = params;
             dbg.log0('BucketSpaceFS.put_bucket_logging: Bucket name, logging', name, logging);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             bucket.logging = logging;
-            const target_bucket_config_path = this._get_bucket_config_path(logging.log_bucket);
-            let target_data;
+
+            let target_bucket;
             try {
-                const { data: data1 } = await nb_native().fs.readFile(this.fs_context, target_bucket_config_path);
-                target_data = data1;
+                target_bucket = await this.config_fs.get_bucket_by_name(logging.log_bucket);
             } catch (err) {
                 dbg.error('ERROR with reading TARGET BUCKET data', logging.log_bucket, err);
                 if (err.code === 'ENOENT') throw new RpcError('INVALID_TARGET_BUCKET', 'The target bucket for logging does not exist');
                 throw err;
             }
-            const target_bucket = JSON.parse(target_data.toString());
             if (target_bucket.owner_account !== bucket.owner_account) {
                 dbg.error('TARGET BUCKET NOT OWNED BY USER', target_bucket, bucket);
                 throw new RpcError('INVALID_TARGET_BUCKET', 'The owner for the bucket to be logged and the target bucket must be the same');
@@ -516,7 +469,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             dbg.log2('put_bucket_logging: bucket properties before validate_bucket_schema', bucket);
             nsfs_schema_utils.validate_bucket_schema(bucket);
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -526,15 +479,13 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.delete_bucket_logging: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             delete bucket.logging;
-            dbg.log2("delete_bucket_logging: bucket properties before validate_bucket_schema", bucket);
+            dbg.log2('delete_bucket_logging: bucket properties before validate_bucket_schema', bucket);
             // on the safe side validate before changing configuration
             nsfs_schema_utils.validate_bucket_schema(bucket);
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -544,9 +495,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.get_bucket_logging: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             return bucket.logging;
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
@@ -561,9 +510,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name, encryption } = params;
             dbg.log0('BucketSpaceFS.put_bucket_encryption: Bucket name, encryption', name, encryption);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             bucket.encryption = encryption;
             // in case it is algorithm: 'AES256', the property would be undefined
             const bucket_to_validate = _.omitBy(bucket, _.isUndefined);
@@ -571,7 +518,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             bucket_to_validate);
             nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -581,9 +528,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.get_bucket_encryption: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             return bucket.encryption;
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
@@ -594,15 +539,13 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.delete_bucket_encryption: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             delete bucket.encryption;
             dbg.log2("delete_bucket_encryption: bucket properties before validate_bucket_schema", bucket);
             // on the safe side validate before changing configuration
             nsfs_schema_utils.validate_bucket_schema(bucket);
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -616,16 +559,14 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name, website } = params;
             dbg.log0('BucketSpaceFS.put_bucket_website: Bucket name, website', name, website);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             bucket.website = website;
             const bucket_to_validate = _.omitBy(bucket, _.isUndefined);
             dbg.log2("put_bucket_website: bucket properties before validate_bucket_schema",
             bucket_to_validate);
             nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -635,15 +576,13 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.delete_bucket_website: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             delete bucket.website;
             dbg.log2("delete_bucket_website: bucket properties before validate_bucket_schema", bucket);
             // on the safe side validate before changing configuration
             nsfs_schema_utils.validate_bucket_schema(bucket);
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -657,9 +596,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.get_bucket_website: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             return { website: bucket.website };
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
@@ -675,18 +612,15 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name, policy } = params;
             dbg.log0('BucketSpaceFS.put_bucket_policy: Bucket name, policy', name, policy);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             bucket.s3_policy = policy;
             const bucket_to_validate = _.omitBy(bucket, _.isUndefined);
-            dbg.log2("put_bucket_policy: bucket properties before validate_bucket_schema",
-            bucket_to_validate);
+            dbg.log2('put_bucket_policy: bucket properties before validate_bucket_schema', bucket_to_validate);
             nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
             await bucket_policy_utils.validate_s3_policy(bucket.s3_policy, bucket.name, async principal =>
-                 this._get_account_by_name(principal));
+                 this.config_fs.get_account_by_name(principal, { silent_if_missing: true }));
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -696,15 +630,13 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name } = params;
             dbg.log0('BucketSpaceFS.delete_bucket_policy: Bucket name', name);
-            const bucket_config_path = this._get_bucket_config_path(name);
-            const { data } = await nb_native().fs.readFile(this.fs_context, bucket_config_path);
-            const bucket = JSON.parse(data.toString());
+            const bucket = await this.config_fs.get_bucket_by_name(name);
             delete bucket.s3_policy;
             dbg.log2("delete_bucket_policy: bucket properties before validate_bucket_schema", bucket);
             // on the safe side validate before changing configuration
             nsfs_schema_utils.validate_bucket_schema(bucket);
             const update_bucket = JSON.stringify(bucket);
-            await update_config_file(this.fs_context, this.bucket_schema_dir, bucket_config_path, update_bucket);
+            await this.config_fs.update_bucket_config_file(name, update_bucket);
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }
@@ -716,9 +648,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             dbg.log0('BucketSpaceFS.get_bucket_policy: Bucket name', name);
             const bucket_policy_info = await object_sdk.read_bucket_sdk_policy_info(name);
             dbg.log0('BucketSpaceFS.get_bucket_policy: policy', bucket_policy_info);
-            return {
-                policy: bucket_policy_info.s3_policy
-            };
+            return { policy: bucket_policy_info.s3_policy };
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -1,0 +1,449 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const config = require('../../config');
+const dbg = require('../util/debug_module')(__filename);
+const _ = require('lodash');
+const path = require('path');
+const nb_native = require('../util/nb_native');
+const native_fs_utils = require('../util/native_fs_utils');
+const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
+
+const CONFIG_SUBDIRS = Object.freeze({
+    ACCOUNTS: 'accounts',
+    BUCKETS: 'buckets',
+    ACCESS_KEYS: 'access_keys'
+});
+
+const JSON_SUFFIX = '.json';
+const SYMLINK_SUFFIX = '.symlink';
+
+// TODO: A General Disclaimer about symlinks manipulated by this class - 
+// currently we use direct symlink()/ unlink()
+// safe_link / safe_unlink can be better but the current impl causing ELOOP - Too many levels of symbolic links
+// need to find a better way for atomic unlinking of symbolic links
+// handle atomicity for symlinks
+
+class ConfigFS {
+
+    /**
+     * @param {string} config_root configuration directory path
+     * @param {string} [config_root_backend] configuration directory backend type
+     * @param {nb.NativeFSContext} [fs_context]
+     */
+    constructor(config_root, config_root_backend, fs_context) {
+        this.config_root = config_root;
+        this.config_root_backend = config_root_backend || config.NSFS_NC_CONFIG_DIR_BACKEND;
+        this.accounts_dir_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS);
+        this.access_keys_dir_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS);
+        this.buckets_dir_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS);
+        this.config_json_path = path.join(config_root, 'config.json');
+        this.fs_context = fs_context || native_fs_utils.get_process_fs_context(this.config_root_backend);
+    }
+
+    /**
+     * add_config_file_suffix returns the config_file_name follwed by the given suffix
+     * @param {string} config_file_name
+     * @param {string} suffix
+     * @returns {string} 
+     */
+    add_config_file_suffix(config_file_name, suffix) {
+        if (!config_file_name) throw new Error(`Config file name is missing - ${config_file_name}`);
+        if (String(config_file_name).endsWith(suffix)) return config_file_name;
+        return config_file_name + suffix;
+    }
+
+
+    /**
+     * json returns the config_file_name with .json suffix
+     * @param {string} config_file_name
+     * @returns {string} 
+     */
+    json(config_file_name) {
+        return this.add_config_file_suffix(config_file_name, JSON_SUFFIX);
+    }
+
+    /**
+     * symlink returns the config_file_name with .symlink suffix
+     * @param {string} config_file_name
+     * @returns {string} 
+     */
+    symlink(config_file_name) {
+        return this.add_config_file_suffix(config_file_name, SYMLINK_SUFFIX);
+    }
+
+    /**
+    * validate_config_dir_exists validates the existance of config sub directory path
+    * @param {string} config_dir_path 
+    * @returns {Promise<boolean>}
+    */
+    async validate_config_dir_exists(config_dir_path) {
+        return native_fs_utils.is_path_exists(this.fs_context, config_dir_path);
+    }
+
+    /**
+    * create_config_dirs_if_missing creates config directory sub directories if missing
+    */
+    async create_config_dirs_if_missing() {
+        const pre_req_dirs = [
+            this.config_root,
+            this.buckets_dir_path,
+            this.accounts_dir_path,
+            this.access_keys_dir_path,
+        ];
+
+        if (config.NSFS_GLACIER_LOGS_ENABLED) {
+            pre_req_dirs.push(config.NSFS_GLACIER_LOGS_DIR);
+        }
+
+        for (const dir_path of pre_req_dirs) {
+            try {
+                const dir_exists = await this.validate_config_dir_exists(dir_path);
+                if (dir_exists) {
+                    dbg.log1('create_config_dirs_if_missing: config dir exists:', dir_path);
+                } else {
+                    await native_fs_utils._create_path(dir_path, this.fs_context, config.BASE_MODE_CONFIG_DIR);
+                    dbg.log1('create_config_dirs_if_missing: config dir was created:', dir_path);
+                }
+            } catch (err) {
+                dbg.log1('create_config_dirs_if_missing: could not create prerequisite path', dir_path);
+            }
+        }
+    }
+
+    /**
+     * update_config_json_file updates the config.json file with the new configuration data
+     * @param {object} data
+     * @returns {Promise<void>} 
+     */
+    async update_config_json_file(data) {
+        await native_fs_utils.update_config_file(this.fs_context, this.config_root, this.config_json_path, data);
+    }
+
+    /**
+     * get_config_data reads a config file and returns its content 
+     * while omitting secrets if show_secrets flag was not provided
+     * and decrypts the account's secret_key if decrypt_secret_key is true
+     * if silent_if_missing is true -      
+     *   if the config file was deleted (encounter ENOENT error) - continue (returns undefined)
+     * @param {string} config_file_path
+     * @param {{show_secrets?: boolean, decrypt_secret_key?: boolean, silent_if_missing?: boolean}} [options]
+     * @returns {Promise<Object>}
+     */
+    async get_config_data(config_file_path, options = {}) {
+        const { show_secrets = false, decrypt_secret_key = false, silent_if_missing = false } = options;
+        try {
+            const { data } = await nb_native().fs.readFile(this.fs_context, config_file_path);
+            const config_data = _.omit(JSON.parse(data.toString()), show_secrets ? [] : ['access_keys']);
+            if (decrypt_secret_key) config_data.access_keys = await nc_mkm.decrypt_access_keys(config_data);
+            return config_data;
+        } catch (err) {
+            dbg.warn('get_config_data: with config_file_path', config_file_path, 'got an error', err);
+            if (silent_if_missing && err.code === 'ENOENT') return;
+            throw err;
+        }
+    }
+
+    ///////////////////////////////////////
+    ////// ACCOUNT CONFIG DIR FUNCS  //////
+    ///////////////////////////////////////
+
+    /**
+     * get_account_path_by_name returns the full account path by name
+     * @param {string} account_name
+     * @param {string} [owner_root_account_id]
+     * @returns {string} 
+     */
+    get_account_path_by_name(account_name, owner_root_account_id) {
+        // TODO -  change to this.symlink(account_name) on identities/ PR;
+        return owner_root_account_id ?
+            this.get_iam_account_path_by_name(account_name, owner_root_account_id) :
+            this.get_root_account_path_by_name(account_name);
+    }
+
+    /**
+     * get_root_account_path_by_name returns the full account path by name
+     * @param {string} account_name
+     * @returns {string} 
+     */
+    get_root_account_path_by_name(account_name) {
+        // TODO -  change to this.symlink(account_name) on identities/ PR;
+        return path.join(this.accounts_dir_path, this.json(account_name));
+    }
+
+    /**
+     * get_iam_account_path_by_name returns the full account path by name
+     * @param {string} account_name
+     * @param {string} owner_root_account_id
+     * @returns {string} 
+    */
+    get_iam_account_path_by_name(account_name, owner_root_account_id) {
+       // TODO -  change to this.symlink(account_name) on identities/ PR;
+       // update IAM user location identities/root_id_number/iam_account_name.symlink
+       return path.join(this.accounts_dir_path, this.json(account_name));
+    }
+
+    /**
+     * get_account_relative_path_by_name returns the full account path by name
+     * @param {string} account_name
+     * @returns {string} 
+    */
+    get_account_relative_path_by_name(account_name) {
+       // TODO -  change to this.symlink(account_name) on identities/ PR;
+       return path.join('../', CONFIG_SUBDIRS.ACCOUNTS, this.json(account_name));
+    }
+
+    /**
+     * get_account_path_by_access_key returns the full account path by access key
+     * @param {string} access_key
+     * @returns {string} 
+     */
+    get_account_path_by_access_key(access_key) {
+        return path.join(this.access_keys_dir_path, this.symlink(access_key));
+    }
+
+    /**
+     * get_old_account_path_by_name returns the full account path by name based on old config dir structure
+     * @param {string} account_name
+     * @returns {string} 
+    */
+    get_old_account_path_by_name(account_name) {
+        return path.join(this.accounts_dir_path, this.json(account_name));
+    }
+
+    /**
+     * is_account_exists returns true if account config path exists in config dir
+     * it can be determined by any account identifier - name, access_key and in the future id
+     * @param {{ name?: string, access_key?: string }} identifier_object
+     * @returns {Promise<boolean>} 
+    */
+    async is_account_exists(identifier_object) {
+        if (!identifier_object || typeof identifier_object !== 'object') throw new Error('config_fs.is_account_exists - no identifier provided');
+       let path_to_check;
+       let use_lstat = false;
+       if (identifier_object.name) {
+           // TODO - when users/ move to be symlink we need to use_lstat by name, id is not using lstat
+           path_to_check = this.get_account_path_by_name(identifier_object.name);
+        } else if (identifier_object.access_key) {
+            path_to_check = this.get_account_path_by_access_key(identifier_object.access_key);
+            use_lstat = true;
+       } else {
+            throw new Error(`config_fs.is_account_exists - invalid identifier provided ${identifier_object}`);
+        }
+        // TODO - add is_account_exists by id when idenetities/ added
+        // else if (identifier_object.id) {}
+        return native_fs_utils.is_path_exists(this.fs_context, path_to_check, use_lstat);
+    }
+
+    /**
+     * get_account_by_access_key returns the account data based on access key
+     * while omitting secrets if show_secrets flag was not provided
+     * and decrypts the account's secret_key if decrypt_secret_key is true
+     * @param {string} access_key
+     * @param {{show_secrets?: boolean, decrypt_secret_key?: boolean, silent_if_missing?: boolean}} [options]
+     * @returns {Promise<Object>}
+     */
+    async get_account_by_access_key(access_key, options = {}) {
+        const account_path = this.get_account_path_by_access_key(access_key);
+        const account = await this.get_config_data(account_path, options);
+        return account;
+    }
+
+    /**
+     * get_account_by_name returns the account data based on name
+     * while omitting secrets if show_secrets flag was not provided
+     * and decrypts the account's secret_key if decrypt_secret_key is true
+     * silent_if_missing -  is important when dealing with concurrency.
+     * When we iterate files (for example for listing them) between the time we read the entries
+     * from the directory and the time we we are trying to read the config file,
+     * a file might be deleted (by another process), and we would not want to throw this error
+     * as a part of iterating the file, therefore we continue
+     * (not throwing this error and return undefined)
+     * @param {string} account_name
+     * @param {{show_secrets?: boolean, decrypt_secret_key?: boolean, silent_if_missing?: boolean}} [options]
+     * @returns {Promise<Object>}
+     */
+    async get_account_by_name(account_name, options = {}) {
+        const account_path = this.get_account_path_by_name(account_name);
+        const account = await this.get_config_data(account_path, options);
+        return account;
+    }
+
+    /**
+     * list_root_accounts returns the root accounts array exists under the config dir
+     * @returns {Promise<Dirent[]>} 
+     */
+    async list_root_accounts(options) {
+        return nb_native().fs.readdir(this.fs_context, this.accounts_dir_path);
+    }
+
+    /**
+     * create_account_config_file creates account config file
+     * if account_data.access_keys is an array that contains at least 1 item -
+     * link all item in account_data.access_keys to the relative path of the newly created config file
+     * @param {string} account_name
+     * @param {*} account_data
+     * @param {boolean} symlink_new_access_keys
+     * @param {String[]} old_access_keys
+     * @returns {Promise<void>} 
+     */
+    async create_account_config_file(account_name, account_data, symlink_new_access_keys, old_access_keys = []) {
+        const account_path = this.get_account_path_by_name(account_name);
+        await native_fs_utils.create_config_file(this.fs_context, this.accounts_dir_path, account_path, JSON.stringify(account_data));
+
+        if (old_access_keys.length > 0) {
+            for (const access_key of old_access_keys) {
+                const access_key_config_path = this.get_account_path_by_access_key(access_key);
+                await nb_native().fs.unlink(this.fs_context, access_key_config_path);
+            }
+        }
+        if (symlink_new_access_keys && account_data.access_keys?.length > 0) {
+            for (const access_key_obj of account_data.access_keys) {
+                const account_config_access_key_path = this.get_account_path_by_access_key(access_key_obj.access_key);
+                const account_config_relative_path = this.get_account_relative_path_by_name(account_name);
+                await native_fs_utils._create_path(this.access_keys_dir_path, this.fs_context, config.BASE_MODE_CONFIG_DIR);
+                await nb_native().fs.symlink(this.fs_context, account_config_relative_path, account_config_access_key_path);
+            }
+        }
+    }
+
+    /**
+     * update_account_config_file updates account config file
+     * if old_access_keys is an array that contains at least 1 item -
+     * unlink old access_keys and link new access_keys
+     * @param {string} account_name
+     * @param {Object} account_new_data
+     * @param {Object[]} [new_access_keys_to_link]
+     * @param {String[]} [old_access_keys_to_remove]
+     * @returns {Promise<void>}
+     */
+    async update_account_config_file(account_name, account_new_data, new_access_keys_to_link = [], old_access_keys_to_remove = []) {
+        const account_config_path = this.get_account_path_by_name(account_name);
+        await native_fs_utils.update_config_file(this.fs_context, this.accounts_dir_path,
+            account_config_path, JSON.stringify(account_new_data));
+
+        if (new_access_keys_to_link.length > 0) {
+            for (const access_keys of new_access_keys_to_link) {
+                const new_access_key_path = this.get_account_path_by_access_key(access_keys.access_key);
+                const account_config_relative_path = this.get_account_relative_path_by_name(account_name);
+                await nb_native().fs.symlink(this.fs_context, account_config_relative_path, new_access_key_path);
+            }
+        }
+
+        if (old_access_keys_to_remove.length > 0) {
+            for (const access_key of old_access_keys_to_remove) {
+                const cur_access_key_path = this.get_account_path_by_access_key(access_key);
+                await nb_native().fs.unlink(this.fs_context, cur_access_key_path);
+            }
+        }
+    }
+
+    /**
+     * delete_account_config_file deletes account config file
+     * if access_keys_to_delete is an array that contains at least 1 item -
+     * unlink all items in access_keys_to_delete
+     * @param {string} account_name
+     * @param {Object[]} [access_keys_to_delete]
+     * @returns {Promise<void>} 
+     */
+    async delete_account_config_file(account_name, access_keys_to_delete = []) {
+        const account_config_path = this.get_account_path_by_name(account_name);
+        await native_fs_utils.delete_config_file(this.fs_context, this.accounts_dir_path, account_config_path);
+        for (const access_keys of access_keys_to_delete) {
+            const access_key_config_path = this.get_account_path_by_access_key(access_keys.access_key);
+            await nb_native().fs.unlink(this.fs_context, access_key_config_path);
+        }
+    }
+
+    /**
+     * unlink_access_key_symlink unlinks the access key from the file system
+     * @param {string} access_key
+     * @returns {Promise<void>} 
+     */
+    async unlink_access_key_symlink(access_key) {
+        const acces_key_path = this.get_account_path_by_access_key(access_key);
+        await nb_native().fs.unlink(this.fs_context, acces_key_path);
+    }
+
+    //////////////////////////////////////
+    ////// BUCKET CONFIG DIR FUNCS  //////
+    //////////////////////////////////////
+
+    /**
+     * get_bucket_by_name returns the full bucket path by name
+     * @param {string} bucket_name
+     * @returns {string} 
+     */
+    get_bucket_path_by_name(bucket_name) {
+        const new_path = path.join(this.buckets_dir_path, this.json(bucket_name));
+        return new_path;
+    }
+
+    /**
+     * is_bucket_exists returns true if bucket config path exists in config dir
+     * @param {string} bucket_name
+     * @returns {Promise<boolean>} 
+     */
+    async is_bucket_exists(bucket_name) {
+        const path_to_check = this.get_bucket_path_by_name(bucket_name);
+        return native_fs_utils.is_path_exists(this.fs_context, path_to_check);
+    }
+
+    /**
+     * get_bucket_by_name returns the full bucket info by name
+     * @param {string} bucket_name
+     * @param {{silent_if_missing?: boolean}} [options]
+     * @returns {Promise<any>} 
+     */
+    async get_bucket_by_name(bucket_name, options = {}) {
+        const bucket_path = this.get_bucket_path_by_name(bucket_name);
+        const bucket = await this.get_config_data(bucket_path, options);
+        return bucket;
+    }
+
+    /**
+     * list_buckets returns the array of buckets that exists under the config dir
+     * @returns {Promise<Dirent[]>} 
+     */
+    async list_buckets() {
+        return nb_native().fs.readdir(this.fs_context, this.buckets_dir_path);
+    }
+
+    /**
+     * create_bucket_config_file creates bucket config file
+     * @param {string} bucket_name
+     * @param {*} data
+     * @returns {Promise<void>} 
+     */
+    async create_bucket_config_file(bucket_name, data) {
+        const bucket_path = this.get_bucket_path_by_name(bucket_name);
+        await native_fs_utils.create_config_file(this.fs_context, this.buckets_dir_path, bucket_path, data);
+    }
+
+    /**
+     * update_bucket_config_file updates bucket config file
+     * @param {string} bucket_name
+     * @param {*} data
+     * @returns {Promise<void>} 
+     */
+    async update_bucket_config_file(bucket_name, data) {
+        const bucket_config_path = this.get_bucket_path_by_name(bucket_name);
+        await native_fs_utils.update_config_file(this.fs_context, this.buckets_dir_path, bucket_config_path, data);
+    }
+
+    /**
+     * delete_bucket_config_file deletes bucket config file
+     * @param {string} bucket_name
+     * @returns {Promise<void>} 
+     */
+    async delete_bucket_config_file(bucket_name) {
+        const bucket_config_path = this.get_bucket_path_by_name(bucket_name);
+        await native_fs_utils.delete_config_file(this.fs_context, this.buckets_dir_path, bucket_config_path);
+    }
+}
+
+// EXPORTS
+exports.SYMLINK_SUFFIX = SYMLINK_SUFFIX;
+exports.JSON_SUFFIX = JSON_SUFFIX;
+exports.CONFIG_SUBDIRS = CONFIG_SUBDIRS;
+exports.ConfigFS = ConfigFS;

--- a/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
@@ -6,11 +6,11 @@
  * This file is written as a part of TDD (Test Driven Development)
  * The asserts reflects the current state of implementation (not final)
  */
-
 const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
 const nb_native = require('../../../util/nb_native');
+const { JSON_SUFFIX, SYMLINK_SUFFIX } = require('../../../sdk/config_fs');
 const SensitiveString = require('../../../util/sensitive_string');
 const AccountSpaceFS = require('../../../sdk/accountspace_fs');
 const { TMP_PATH } = require('../../system_tests/test_utils');
@@ -184,9 +184,9 @@ function make_dummy_account_sdk_root_accounts_manager() {
 describe('Accountspace_FS tests', () => {
 
     beforeAll(async () => {
-        await fs_utils.create_fresh_path(accountspace_fs.accounts_dir);
-        await fs_utils.create_fresh_path(accountspace_fs.access_keys_dir);
-        await fs_utils.create_fresh_path(accountspace_fs.buckets_dir);
+        await fs_utils.create_fresh_path(accountspace_fs.config_fs.accounts_dir_path);
+        await fs_utils.create_fresh_path(accountspace_fs.config_fs.access_keys_dir_path);
+        await fs_utils.create_fresh_path(accountspace_fs.config_fs.buckets_dir_path);
         await fs_utils.create_fresh_path(new_buckets_path1);
         await fs_utils.create_fresh_path(new_buckets_path3);
         await fs.promises.chown(new_buckets_path1,
@@ -196,9 +196,9 @@ describe('Accountspace_FS tests', () => {
 
 
         for (const account of [root_user_account, root_user_account2, root_user_root_accounts_manager]) {
-            const account_path = accountspace_fs._get_account_config_path(account.name);
+            const account_path = accountspace_fs.config_fs.get_account_path_by_name(account.name);
             // assuming that the root account has only 1 access key in the 0 index
-            const account_access_path = accountspace_fs._get_access_keys_config_path(account.access_keys[0].access_key);
+            const account_access_path = accountspace_fs.config_fs.get_account_path_by_access_key(account.access_keys[0].access_key);
             await fs.promises.writeFile(account_path, JSON.stringify(account));
             await fs.promises.chmod(account_path, 0o600);
             await fs.promises.symlink(account_path, account_access_path);
@@ -248,7 +248,7 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
@@ -271,7 +271,7 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
@@ -300,7 +300,7 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
@@ -330,7 +330,7 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
@@ -499,7 +499,7 @@ describe('Accountspace_FS tests', () => {
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.iam_path).toBe(dummy_user1.iam_path);
             });
@@ -515,7 +515,7 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(dummy_user1.username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.iam_path).toBe(dummy_iam_path2);
                 // back as it was
@@ -537,7 +537,7 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(dummy_user_root_account.username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.iam_path).toBe(dummy_iam_path);
             });
@@ -631,7 +631,7 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(params.new_username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.new_username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.new_username);
                 expect(user_account_config_file.name).toBe(params.new_username);
                 // back as it was
                 params = {
@@ -665,11 +665,12 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(params.new_username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.new_username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.new_username);
                 expect(user_account_config_file.name).toBe(params.new_username);
-                const symlink_config_path = path.join(accountspace_fs.access_keys_dir, access_key + '.symlink');
+                const symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
                 await fs_utils.file_must_exist(symlink_config_path);
-                const user_account_config_file_from_symlink = await read_config_file(accountspace_fs.access_keys_dir, access_key, true);
+                const user_account_config_file_from_symlink = await read_config_file(
+                    accountspace_fs.config_fs.access_keys_dir_path, access_key, true);
                 expect(user_account_config_file_from_symlink.name).toBe(params.new_username);
             });
         });
@@ -682,7 +683,7 @@ describe('Accountspace_FS tests', () => {
                 const account_sdk = make_dummy_account_sdk();
                 const res = await accountspace_fs.delete_user(params, account_sdk);
                 expect(res).toBeUndefined();
-                const user_account_config_path = path.join(accountspace_fs.accounts_dir, params.username + '.json');
+                const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
                 await fs_utils.file_must_not_exist(user_account_config_path);
             });
 
@@ -693,7 +694,7 @@ describe('Accountspace_FS tests', () => {
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
                 const res = await accountspace_fs.delete_user(params, account_sdk);
                 expect(res).toBeUndefined();
-                const user_account_config_path = path.join(accountspace_fs.accounts_dir, params.username + '.json');
+                const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
                 await fs_utils.file_must_not_exist(user_account_config_path);
             });
 
@@ -769,7 +770,7 @@ describe('Accountspace_FS tests', () => {
                     expect(err).toHaveProperty('code', IamError.DeleteConflict.code);
                     expect(err).toHaveProperty('message');
                     expect(err.message).toMatch(/must delete access keys first/i);
-                    const user_account_config_path = path.join(accountspace_fs.accounts_dir, params.username + '.json');
+                    const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
                     await fs_utils.file_must_exist(user_account_config_path);
                 }
             });
@@ -787,7 +788,8 @@ describe('Accountspace_FS tests', () => {
                     // same params
                     await accountspace_fs.create_access_key(params, account_sdk);
                     // create a user with the root account
-                    const account_config_file = await read_config_file(accountspace_fs.accounts_dir, username_for_root_account);
+                    const account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path,
+                        username_for_root_account);
                     const root_account_manager_id = account_sdk.requesting_account._id;
                     const account_sdk_root = make_dummy_account_sdk_from_root_accounts_manager(
                         account_config_file, root_account_manager_id);
@@ -805,7 +807,7 @@ describe('Accountspace_FS tests', () => {
                     expect(err).toHaveProperty('code', IamError.DeleteConflict.code);
                     expect(err).toHaveProperty('message');
                     expect(err.message).toMatch(/must delete IAM users first/i);
-                    const user_account_config_path = path.join(accountspace_fs.accounts_dir, params.username + '.json');
+                    const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
                     await fs_utils.file_must_exist(user_account_config_path);
                 }
             });
@@ -821,7 +823,7 @@ describe('Accountspace_FS tests', () => {
                     await accountspace_fs.create_user(params, account_sdk);
                     // create a dummy bucket
                     const bucket_name = `my-bucket-${params.username}`;
-                    const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                     await create_dummy_bucket(user_account_config_file, bucket_name);
                     await accountspace_fs.delete_user(params, account_sdk);
                     throw new NoErrorThrownError();
@@ -830,7 +832,7 @@ describe('Accountspace_FS tests', () => {
                     expect(err).toHaveProperty('code', IamError.DeleteConflict.code);
                     expect(err).toHaveProperty('message');
                     expect(err.message).toMatch(/must delete buckets first/i);
-                    const user_account_config_path = path.join(accountspace_fs.accounts_dir, params.username + '.json');
+                    const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
                     await fs_utils.file_must_exist(user_account_config_path);
                 }
             });
@@ -931,17 +933,17 @@ describe('Accountspace_FS tests', () => {
         };
 
         beforeAll(async () => {
-            await fs_utils.create_fresh_path(accountspace_fs.accounts_dir);
-            await fs_utils.create_fresh_path(accountspace_fs.access_keys_dir);
-            await fs_utils.create_fresh_path(accountspace_fs.buckets_dir);
+            await fs_utils.create_fresh_path(accountspace_fs.config_fs.accounts_dir_path);
+            await fs_utils.create_fresh_path(accountspace_fs.config_fs.access_keys_dir_path);
+            await fs_utils.create_fresh_path(accountspace_fs.config_fs.buckets_dir_path);
             await fs_utils.create_fresh_path(new_buckets_path1);
             await fs.promises.chown(new_buckets_path1,
                 root_user_root_accounts_manager.nsfs_account_config.uid, root_user_root_accounts_manager.nsfs_account_config.gid);
 
             for (const account of [root_user_root_accounts_manager]) {
-                const account_path = accountspace_fs._get_account_config_path(account.name);
+                const account_path = accountspace_fs.config_fs.get_account_path_by_name(account.name);
                 // assuming that the root account has only 1 access key in the 0 index
-                const account_access_path = accountspace_fs._get_access_keys_config_path(account.access_keys[0].access_key);
+                const account_access_path = accountspace_fs.config_fs.get_account_path_by_access_key(account.access_keys[0].access_key);
                 await fs.promises.writeFile(account_path, JSON.stringify(account));
                 await fs.promises.chmod(account_path, 0o600);
                 await fs.promises.symlink(account_path, account_access_path);
@@ -1014,14 +1016,18 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(1);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await read_config_file(accountspace_fs.access_keys_dir, access_key, true);
+                const user_account_config_file_from_symlink = await read_config_file(
+                    accountspace_fs.config_fs.access_keys_dir_path,
+                    access_key,
+                    true
+                );
                 expect(user_account_config_file_from_symlink.name).toBe(params.username);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1040,14 +1046,18 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(2);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await read_config_file(accountspace_fs.access_keys_dir, access_key, true);
+                const user_account_config_file_from_symlink = await read_config_file(
+                    accountspace_fs.config_fs.access_keys_dir_path,
+                    access_key,
+                    true
+                );
                 expect(user_account_config_file_from_symlink.name).toBe(params.username);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1082,7 +1092,7 @@ describe('Accountspace_FS tests', () => {
                     username: dummy_username5,
                 };
                 await accountspace_fs.create_access_key(params_for_access_key_creation, account_sdk);
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username5);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
                 // create the second access key
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file,
@@ -1094,14 +1104,18 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username5);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
                 expect(user_account_config_file.name).toBe(dummy_username5);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(2);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await read_config_file(accountspace_fs.access_keys_dir, access_key, true);
+                const user_account_config_file_from_symlink = await read_config_file(
+                    accountspace_fs.config_fs.access_keys_dir_path,
+                    access_key,
+                    true
+                );
                 expect(user_account_config_file_from_symlink.name).toBe(dummy_username5);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1112,7 +1126,7 @@ describe('Accountspace_FS tests', () => {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username5);
+                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
                     // create the second access key
                     // by the IAM user
                     account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file,
@@ -1143,14 +1157,18 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, params.username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(1);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await read_config_file(accountspace_fs.access_keys_dir, access_key, true);
+                const user_account_config_file_from_symlink = await read_config_file(
+                    accountspace_fs.config_fs.access_keys_dir_path,
+                    access_key,
+                    true
+                );
                 expect(user_account_config_file_from_symlink.name).toBe(params.username);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1247,7 +1265,7 @@ describe('Accountspace_FS tests', () => {
             it('get_access_key_last_used should return user access key params (requester is an IAM user)', async function() {
                 const username = dummy_user2.username;
                 let account_sdk = make_dummy_account_sdk();
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[0].access_key;
@@ -1264,11 +1282,17 @@ describe('Accountspace_FS tests', () => {
             it('get_access_key_last_used return an error if user is not owned by the root account (requester is an IAM user)', async function() {
                 try {
                     let account_sdk = make_dummy_account_sdk();
-                    const requester_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_user2.username);
+                    const requester_account_config_file = await read_config_file(
+                        accountspace_fs.config_fs.accounts_dir_path,
+                        dummy_user2.username
+                    );
                     // by the IAM user
                     account_sdk = make_dummy_account_sdk_created_from_another_account(requester_account_config_file,
                         requester_account_config_file.owner);
-                    const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_user_root_account.username);
+                    const user_account_config_file = await read_config_file(
+                        accountspace_fs.config_fs.accounts_dir_path,
+                        dummy_user_root_account.username
+                    );
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         access_key: access_key,
@@ -1339,7 +1363,7 @@ describe('Accountspace_FS tests', () => {
             });
 
             it('update_access_key should return an error if user account does not exist', async function() {
-                const user_account = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                const user_account = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
@@ -1359,7 +1383,7 @@ describe('Accountspace_FS tests', () => {
 
             it('update_access_key should return an error if access key belongs to another account ' +
                     'without passing the username flag', async function() {
-                const user_account = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                const user_account = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
@@ -1376,10 +1400,10 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_access_key should not return an error if access key is on another root account', async function() {
+            it('update_access_key should return an error if access key is on another root account', async function() {
                 try {
                     const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
-                    const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         username: dummy_username1,
@@ -1396,7 +1420,7 @@ describe('Accountspace_FS tests', () => {
 
             it('update_access_key should not return any param (update status to Inactive) (requesting account is root account to create IAM user)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1405,13 +1429,13 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(true);
             });
 
             it('update_access_key should not return any param (update status to Active) (requesting account is root account to create IAM user)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1420,13 +1444,13 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(false);
             });
 
             it('update_access_key should not return any param (update status to Active, already was Active) (requesting account is root account to create IAM user)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1435,14 +1459,14 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(false);
             });
 
             it('update_access_key should not return any param (requester is an IAM user)', async function() {
                 const dummy_username = dummy_username5;
                 let account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username);
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[1].access_key;
@@ -1452,7 +1476,7 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username);
                 expect(user_account_config_file.access_keys[1].deactivated).toBe(true);
             });
 
@@ -1460,7 +1484,7 @@ describe('Accountspace_FS tests', () => {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username5);
+                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
@@ -1482,7 +1506,7 @@ describe('Accountspace_FS tests', () => {
             it('update_access_key should not return any param (update status to Inactive) (requesting account is root accounts manager requested account is root account)', async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, username);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: username,
@@ -1491,7 +1515,7 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, username);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(true);
             });
         });
@@ -1530,7 +1554,7 @@ describe('Accountspace_FS tests', () => {
             });
 
             it('delete_access_key should return an error if user account does not exist', async function() {
-                const user_account = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                const user_account = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
@@ -1549,7 +1573,7 @@ describe('Accountspace_FS tests', () => {
 
             it('delete_access_key should return an error if access key belongs to another account ' +
                 'without passing the username flag', async function() {
-            const user_account = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+            const user_account = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
             const dummy_access_key = user_account.access_keys[0].access_key;
             try {
                 const params = {
@@ -1568,7 +1592,7 @@ describe('Accountspace_FS tests', () => {
             it('delete_access_key should not return an error if access key is on another root account', async function() {
                 try {
                     const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
-                    const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         username: dummy_username1,
@@ -1584,7 +1608,7 @@ describe('Accountspace_FS tests', () => {
 
             it('delete_access_key should not return any param (requesting account is root account to create IAM user)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1592,9 +1616,9 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 expect(user_account_config_file.access_keys.length).toBe(1);
-                const symlink_config_path = path.join(accountspace_fs.access_keys_dir, access_key + '.symlink');
+                const symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
                 await fs_utils.file_must_not_exist(symlink_config_path);
             });
 
@@ -1622,19 +1646,19 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, username);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
                 expect(user_account_config_file.access_keys.length).toBe(1);
                 expect(user_account_config_file.access_keys[0].access_key).toBe(access_key);
                 expect(user_account_config_file.access_keys[0].access_key).not.toBe(access_key_to_delete);
-                let symlink_config_path = path.join(accountspace_fs.access_keys_dir, access_key_to_delete + '.symlink');
+                let symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key_to_delete + SYMLINK_SUFFIX);
                 await fs_utils.file_must_not_exist(symlink_config_path);
-                symlink_config_path = path.join(accountspace_fs.access_keys_dir, access_key + '.symlink');
+                symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
                 await fs_utils.file_must_exist(symlink_config_path);
             });
 
             it('delete_access_key should not return any param (requester is an IAM user)', async function() {
                 let account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username5);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[1].access_key;
@@ -1643,10 +1667,10 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username1);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
                 expect(user_account_config_file.access_keys.length).toBe(1);
                 expect(user_account_config_file.access_keys[0].access_key).not.toBe(access_key);
-                const symlink_config_path = path.join(accountspace_fs.access_keys_dir, access_key + '.symlink');
+                const symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
                 await fs_utils.file_must_not_exist(symlink_config_path);
             });
 
@@ -1654,7 +1678,7 @@ describe('Accountspace_FS tests', () => {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username5);
+                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
@@ -1675,7 +1699,7 @@ describe('Accountspace_FS tests', () => {
             it('delete_access_key should not return any param (requesting account is root accounts manager requested account is root account)', async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
-                let user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, username);
+                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: username,
@@ -1683,9 +1707,9 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, username);
+                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
                 expect(user_account_config_file.access_keys.length).toBe(1);
-                const symlink_config_path = path.join(accountspace_fs.access_keys_dir, access_key + '.symlink');
+                const symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
                 await fs_utils.file_must_not_exist(symlink_config_path);
             });
         });
@@ -1755,7 +1779,7 @@ describe('Accountspace_FS tests', () => {
 
             it('list_access_keys return array of access_keys and value of is_truncated (requester is an IAM user)', async function() {
                 let account_sdk = make_dummy_account_sdk();
-                const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username5);
+                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
                 const params = {};
@@ -1769,7 +1793,7 @@ describe('Accountspace_FS tests', () => {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await read_config_file(accountspace_fs.accounts_dir, dummy_username5);
+                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
@@ -1815,7 +1839,7 @@ describe('Accountspace_FS tests', () => {
  */
 
 async function read_config_file(account_path, config_file_name, is_symlink) {
-    const config_path = path.join(account_path, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const config_path = path.join(account_path, config_file_name + (is_symlink ? SYMLINK_SUFFIX : JSON_SUFFIX));
     const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
     const config_data = JSON.parse(data.toString());
     if (config_data.access_keys.length > 0) {
@@ -1832,8 +1856,13 @@ async function create_dummy_bucket(account, bucket_name) {
     const bucket_config = JSON.stringify(bucket);
     const bucket_to_validate = JSON.parse(bucket_config);
     nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
-    const bucket_config_path = path.join(accountspace_fs.buckets_dir, bucket_name + '.json');
-    await native_fs_utils.create_config_file(accountspace_fs.fs_context, accountspace_fs.buckets_dir, bucket_config_path, bucket_config);
+    const bucket_config_path = path.join(accountspace_fs.config_fs.buckets_dir_path, bucket_name + JSON_SUFFIX);
+    await native_fs_utils.create_config_file(
+        accountspace_fs.fs_context,
+        accountspace_fs.config_fs.buckets_dir_path,
+        bucket_config_path,
+        bucket_config
+    );
     return bucket_config_path;
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.test.js
@@ -9,8 +9,9 @@ const _ = require('lodash');
 const path = require('path');
 const P = require('../../../util/promise');
 const fs_utils = require('../../../util/fs_utils');
+const { CONFIG_SUBDIRS } = require('../../../sdk/config_fs');
 const { exec_manage_cli, set_path_permissions_and_owner, TMP_PATH, set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
-const { TYPES, ACTIONS, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -13,10 +13,11 @@ const P = require('../../../util/promise');
 const os_util = require('../../../util/os_utils');
 const fs_utils = require('../../../util/fs_utils');
 const nb_native = require('../../../util/nb_native');
+const { CONFIG_SUBDIRS, JSON_SUFFIX, SYMLINK_SUFFIX } = require('../../../sdk/config_fs');
 const { set_path_permissions_and_owner, create_fs_user_by_platform,
     delete_fs_user_by_platform, TMP_PATH, set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
 const { get_process_fs_context, update_config_file } = require('../../../util/native_fs_utils');
-const { TYPES, ACTIONS, CONFIG_SUBDIRS, ANONYMOUS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const { TYPES, ACTIONS, ANONYMOUS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 
@@ -363,8 +364,8 @@ describe('manage nsfs cli account flow', () => {
             assert_account(account, account_options, false);
             const account_symlink = await read_config_file(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key, true);
             assert_account(account_symlink, account_options);
-            const real_path = fs.readlinkSync(path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key + '.symlink'));
-            expect(real_path).toContain('../accounts/' + account_options.name + '.json');
+            const real_path = fs.readlinkSync(path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key + SYMLINK_SUFFIX));
+            expect(real_path).toContain('../accounts/' + account_options.name + JSON_SUFFIX);
         });
 
         it('cli account add - use flag force_md5_etag', async function() {
@@ -767,8 +768,8 @@ describe('manage nsfs cli account flow', () => {
                 //fixing the new_account_details for compare. 
                 new_account_details = { ...new_account_details, ...new_account_details.nsfs_account_config };
                 assert_account(account_symlink, new_account_details);
-                const real_path = fs.readlinkSync(path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key + '.symlink'));
-                expect(real_path).toContain('../accounts/' + new_name + '.json');
+                const real_path = fs.readlinkSync(path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key + SYMLINK_SUFFIX));
+                expect(real_path).toContain('../accounts/' + new_name + JSON_SUFFIX);
             });
 
             it('cli update account set flag force_md5_etag', async function() {
@@ -861,7 +862,7 @@ describe('manage nsfs cli account flow', () => {
 
                 // update the account to have the property owner
                 // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
+                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + JSON_SUFFIX);
                 const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
                 const config_data = JSON.parse(data.toString());
                 config_data.owner = account_id; // just so we can identify this account as IAM user
@@ -879,7 +880,7 @@ describe('manage nsfs cli account flow', () => {
                 // update the account to have the property owner
                 // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
                 const { name } = defaults;
-                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + JSON_SUFFIX);
                 const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
                 const config_data = JSON.parse(data.toString());
                 config_data.owner = '65a62e22ceae5e5f1a758aa9'; // just so we can identify this account as IAM user
@@ -958,7 +959,7 @@ describe('manage nsfs cli account flow', () => {
 
                 // update the account to have the property owner
                 // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
+                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + JSON_SUFFIX);
                 const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
                 const config_data = JSON.parse(data.toString());
                 config_data.owner = account_id; // just so we can identify this account as IAM user
@@ -987,7 +988,7 @@ describe('manage nsfs cli account flow', () => {
 
                 // update the account to have the property owner
                 // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
+                const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + JSON_SUFFIX);
                 const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
                 const config_data = JSON.parse(data.toString());
                 config_data.owner = account_id; // just so we can identify this account as IAM user
@@ -1346,7 +1347,7 @@ describe('manage nsfs cli account flow', () => {
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(account_options.new_buckets_path, account_options, 0o700);
             await exec_manage_cli(type, action, account_options);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + JSON_SUFFIX);
             await fs_utils.file_must_exist(config_path);
         });
 
@@ -1365,9 +1366,9 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli(type, action, account_options);
             const res_json = JSON.parse(res.trim());
             expect(res_json.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + JSON_SUFFIX);
             await fs_utils.file_must_not_exist(config_path);
-            const symlink_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, defaults.access_key + '.symlink');
+            const symlink_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, defaults.access_key + SYMLINK_SUFFIX);
             await fs_utils.file_must_not_exist(symlink_config_path);
         });
 
@@ -1388,11 +1389,11 @@ describe('manage nsfs cli account flow', () => {
                 creation_date: new Date().toISOString(),
                 deactivated: false,
             });
-            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + JSON_SUFFIX);
             await update_config_file(DEFAULT_FS_CONFIG, CONFIG_SUBDIRS.ACCOUNTS,
                 account_config_path, JSON.stringify(account_with_2_access_keys_objects));
-            const account_config_relative_path = path.join(config_root, '../' + CONFIG_SUBDIRS.ACCOUNTS + '/', name + '.json');
-            const account_config_access_key_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key2 + '.symlink');
+            const account_config_relative_path = path.join(config_root, '../' + CONFIG_SUBDIRS.ACCOUNTS + '/', name + JSON_SUFFIX);
+            const account_config_access_key_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key2 + SYMLINK_SUFFIX);
             await nb_native().fs.symlink(DEFAULT_FS_CONFIG, account_config_relative_path, account_config_access_key_path);
 
             // cli delete account
@@ -1401,11 +1402,11 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli(type, action, account_options);
             const res_json = JSON.parse(res.trim());
             expect(res_json.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + JSON_SUFFIX);
             await fs_utils.file_must_not_exist(config_path);
-            const symlink_config_path1 = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, defaults.access_key + '.symlink');
+            const symlink_config_path1 = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, defaults.access_key + SYMLINK_SUFFIX);
             await fs_utils.file_must_not_exist(symlink_config_path1);
-            const symlink_config_path2 = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key2 + '.symlink');
+            const symlink_config_path2 = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS, access_key2 + SYMLINK_SUFFIX);
             await fs_utils.file_must_not_exist(symlink_config_path2);
         });
 
@@ -1420,7 +1421,7 @@ describe('manage nsfs cli account flow', () => {
             const account_name = defaults.name;
             const bucket_options = { config_root, path: new_buckets_path, name: bucket_name, owner: account_name};
             await exec_manage_cli(type, action, bucket_options);
-            let config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_name + '.json');
+            let config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_name + JSON_SUFFIX);
             await fs_utils.file_must_exist(config_path);
 
             // cli delete account
@@ -1430,7 +1431,7 @@ describe('manage nsfs cli account flow', () => {
             const account_options = { config_root, name };
             const res = await exec_manage_cli(type, action, account_options);
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.AccountDeleteForbiddenHasBuckets.code);
-            config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + '.json');
+            config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, name + JSON_SUFFIX);
             await fs_utils.file_must_exist(config_path);
         });
 
@@ -1470,7 +1471,7 @@ describe('manage nsfs cli account flow', () => {
 
             // update the account to have the property owner
             // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
+            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + JSON_SUFFIX);
             const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
             const config_data = JSON.parse(data.toString());
             config_data.owner = account_id; // just so we can identify this account as IAM user;
@@ -1961,7 +1962,7 @@ describe('cli account flow distinguished_name - permissions', function() {
  * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
  */
 async function read_config_file(config_root, schema_dir, config_file_name, is_symlink) {
-    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? SYMLINK_SUFFIX : JSON_SUFFIX));
     const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
     const config_data = JSON.parse(data.toString());
     const encrypted_secret_key = config_data.access_keys[0].encrypted_secret_key;

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_anonymous_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_anonymous_cli.test.js
@@ -10,9 +10,10 @@ const P = require('../../../util/promise');
 const os_util = require('../../../util/os_utils');
 const fs_utils = require('../../../util/fs_utils');
 const nb_native = require('../../../util/nb_native');
+const { CONFIG_SUBDIRS, JSON_SUFFIX, SYMLINK_SUFFIX } = require('../../../sdk/config_fs');
 const { TMP_PATH, set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
 const { get_process_fs_context } = require('../../../util/native_fs_utils');
-const { TYPES, ACTIONS, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 
@@ -289,7 +290,7 @@ describe('manage nsfs cli anonymous account flow', () => {
  * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
  */
 async function read_config_file(config_root, schema_dir, config_file_name, is_symlink) {
-    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? SYMLINK_SUFFIX : JSON_SUFFIX));
     const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
     const config_data = JSON.parse(data.toString());
     return config_data;

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -9,9 +9,10 @@ const path = require('path');
 const os_util = require('../../../util/os_utils');
 const fs_utils = require('../../../util/fs_utils');
 const nb_native = require('../../../util/nb_native');
+const { CONFIG_SUBDIRS, JSON_SUFFIX, SYMLINK_SUFFIX } = require('../../../sdk/config_fs');
 const { set_path_permissions_and_owner, TMP_PATH, generate_s3_policy,
     set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
-const { ACTIONS, TYPES, CONFIG_SUBDIRS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const { ACTIONS, TYPES } = require('../../../manage_nsfs/manage_nsfs_constants');
 const { get_process_fs_context, is_path_exists, get_bucket_tmpdir_full_path, update_config_file } = require('../../../util/native_fs_utils');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const { ManageCLIResponse } = require('../../../manage_nsfs/manage_nsfs_cli_responses');
@@ -183,7 +184,7 @@ describe('manage nsfs cli bucket flow', () => {
 
             // update the account to have the property owner
             // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + '.json');
+            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name + JSON_SUFFIX);
             const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
             const config_data = JSON.parse(data.toString());
             config_data.owner = account_id; // just so we can identify this account as IAM user;
@@ -556,7 +557,7 @@ describe('manage nsfs cli bucket flow', () => {
 
             // update the account to have the property owner
             // (we use this way because now we don't have the way to create IAM users through the noobaa cli)
-            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name_iam_account + '.json');
+            const account_config_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS, account_name_iam_account + JSON_SUFFIX);
             const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, account_config_path);
             const config_data = JSON.parse(data.toString());
             config_data.owner = account_id; // just so we can identify this account as IAM user;
@@ -647,7 +648,7 @@ describe('manage nsfs cli bucket flow', () => {
             const delete_bucket_options = { config_root, name: bucket_defaults.name, force: true};
             const resp = await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, delete_bucket_options);
             expect(JSON.parse(resp.trim()).response.code).toBe(ManageCLIResponse.BucketDeleted.code);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + JSON_SUFFIX);
             await fs_utils.file_must_not_exist(config_path);
         });
 
@@ -657,7 +658,7 @@ describe('manage nsfs cli bucket flow', () => {
             const delete_bucket_options = { config_root, name: bucket_defaults.name};
             const resp = await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, delete_bucket_options);
             expect(JSON.parse(resp.stdout).error.code).toBe(ManageCLIError.BucketDeleteForbiddenHasObjects.code);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + JSON_SUFFIX);
             await fs_utils.file_must_exist(config_path);
         });
 
@@ -668,7 +669,7 @@ describe('manage nsfs cli bucket flow', () => {
             const delete_bucket_options = { config_root, name: bucket_defaults.name, force: 'true'};
             const resp = await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, delete_bucket_options);
             expect(JSON.parse(resp.trim()).response.code).toBe(ManageCLIResponse.BucketDeleted.code);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + JSON_SUFFIX);
             await fs_utils.file_must_not_exist(config_path);
         });
 
@@ -693,7 +694,7 @@ describe('manage nsfs cli bucket flow', () => {
             const action = ACTIONS.DELETE;
             const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             expect(JSON.parse(res.trim()).response.code).toBe(ManageCLIResponse.BucketDeleted.code);
-            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + '.json');
+            const config_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS, bucket_defaults.name + JSON_SUFFIX);
             await fs_utils.file_must_not_exist(config_path);
         });
     });
@@ -866,7 +867,7 @@ async function exec_manage_cli(type, action, options) {
  * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
  */
 async function read_config_file(config_root, schema_dir, config_file_name, is_symlink) {
-    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? SYMLINK_SUFFIX : JSON_SUFFIX));
     const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
     const config = JSON.parse(data.toString());
     return config;

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -14,6 +14,7 @@ const mocha = require('mocha');
 const assert = require('assert');
 const config = require('../../../config');
 const fs_utils = require('../../util/fs_utils');
+const { JSON_SUFFIX } = require('../../sdk/config_fs');
 const test_utils = require('../system_tests/test_utils');
 const { stat, open } = require('../../util/nb_native')().fs;
 const { get_process_fs_context } = require('../../util/native_fs_utils');
@@ -1778,7 +1779,7 @@ mocha.describe('Namespace s3_bucket_policy', function() {
     let account_config_path;
     if (is_nc_coretest) {
         accounts_dir_path = path.join(NC_CORETEST_CONFIG_DIR_PATH, accounts_dir_name);
-        account_config_path = path.join(accounts_dir_path, config.ANONYMOUS_ACCOUNT_NAME + '.json');
+        account_config_path = path.join(accounts_dir_path, config.ANONYMOUS_ACCOUNT_NAME + JSON_SUFFIX);
     }
 
     mocha.before(async function() {

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -18,7 +18,7 @@ const SensitiveString = require('../../util/sensitive_string');
 const NamespaceFS = require('../../sdk/namespace_fs');
 const BucketSpaceFS = require('../../sdk/bucketspace_fs');
 const { TMP_PATH } = require('../system_tests/test_utils');
-const { CONFIG_SUBDIRS } = require('../../manage_nsfs/manage_nsfs_constants');
+const { CONFIG_SUBDIRS, JSON_SUFFIX, SYMLINK_SUFFIX } = require('../../sdk/config_fs');
 const nc_mkm = require('../../manage_nsfs/nc_master_key_manager').get_instance();
 
 
@@ -775,11 +775,11 @@ async function create_bucket(bucket_name) {
 
 
 function get_config_file_path(config_type_path, file_name) {
-    return path.join(config_root, config_type_path, file_name + '.json');
+    return path.join(config_root, config_type_path, file_name + JSON_SUFFIX);
 }
 
 // returns the path of the access_key symlink to the config file json
 function get_access_key_symlink_path(config_type_path, file_name) {
-    return path.join(config_root, config_type_path, file_name + '.symlink');
+    return path.join(config_root, config_type_path, file_name + SYMLINK_SUFFIX);
 }
 

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -12,12 +12,13 @@ const config = require('../../../config');
 const fs_utils = require('../../util/fs_utils');
 const config_module = require('../../../config');
 const nb_native = require('../../util/nb_native');
+const { CONFIG_SUBDIRS, JSON_SUFFIX, SYMLINK_SUFFIX } = require('../../sdk/config_fs');
 const { get_process_fs_context } = require('../../util/native_fs_utils');
 const { ManageCLIError } = require('../../manage_nsfs/manage_nsfs_cli_errors');
 const { ManageCLIResponse } = require('../../manage_nsfs/manage_nsfs_cli_responses');
 const { exec_manage_cli, generate_s3_policy, create_fs_user_by_platform, delete_fs_user_by_platform,
     set_path_permissions_and_owner, TMP_PATH, set_nc_config_dir_in_config } = require('../system_tests/test_utils');
-const { TYPES, ACTIONS, CONFIG_SUBDIRS } = require('../../manage_nsfs/manage_nsfs_constants');
+const { TYPES, ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
 const nc_mkm = require('../../manage_nsfs/nc_master_key_manager').get_instance();
 
 const tmp_fs_path = path.join(TMP_PATH, 'test_bucketspace_fs');
@@ -1042,7 +1043,7 @@ mocha.describe('manage_nsfs cli', function() {
 });
 
 async function read_config_file(config_root, schema_dir, config_file_name, is_symlink) {
-    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? SYMLINK_SUFFIX : JSON_SUFFIX));
     const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
     const config_data = JSON.parse(data.toString());
     if (config_data.access_keys) {
@@ -1054,7 +1055,7 @@ async function read_config_file(config_root, schema_dir, config_file_name, is_sy
 }
 
 async function write_config_file(config_root, schema_dir, config_file_name, data, is_symlink) {
-    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? SYMLINK_SUFFIX : JSON_SUFFIX));
     await nb_native().fs.writeFile(DEFAULT_FS_CONFIG, config_path,
         Buffer.from(JSON.stringify(data)), {
             mode: config_module.BASE_MODE_FILE,
@@ -1062,7 +1063,7 @@ async function write_config_file(config_root, schema_dir, config_file_name, data
 }
 
 async function assert_config_file_permissions(config_root, schema_dir, config_file_name, is_symlink) {
-    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? '.symlink' : '.json'));
+    const config_path = path.join(config_root, schema_dir, config_file_name + (is_symlink ? SYMLINK_SUFFIX : JSON_SUFFIX));
     const { stat } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
     // 33152 means 600 (only owner has read and write permissions)
     assert.equal(stat.mode, 33152);


### PR DESCRIPTION
### Explain the changes
1. Added ConfigFS file for config directory manipulation.
2. Removed functions from manage_nsfs_utils.js.
3. Updated callers to use configFS - 
    a. manage_nsfs.js (noobaa-cli) including manage_nsfs_validations.js.
    b. bucketspaceFS.js.
    c. accountspaceFS.js.
    d. Health CLI.
    e. NC Bucket Logging CLI.

### Issues: Fixed #xxx / Gap #xxx

1. Gap - ConfigFS API is not finalized.
2. Gap - Tests were not updated to use ConfigFS, this way we can also test the correctness of ConfigFS itself without adding new tests. but we might want eventually to do it.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
