### PR TITLE
NC | NSFS | Rename Constants With Prefix `GLOBAL_CONFIG`

### DIFF
--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -36,50 +36,50 @@ const CONFIG_SUBDIRS = {
     ACCESS_KEYS: 'access_keys'
 };
 
-const GLOBAL_CONFIG_ROOT = 'config_root';
-const GLOBAL_CONFIG_OPTIONS = new Set([GLOBAL_CONFIG_ROOT, 'config_root_backend', 'debug']);
+const CONFIG_ROOT_FLAG = 'config_root';
+const CLI_MUTUAL_OPTIONS = new Set([CONFIG_ROOT_FLAG, 'config_root_backend', 'debug']);
 const FROM_FILE = 'from_file';
 const ANONYMOUS = 'anonymous';
 
 const VALID_OPTIONS_ACCOUNT = {
-    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', ...GLOBAL_CONFIG_OPTIONS]),
-    'delete': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
-    'list': new Set(['wide', 'show_secrets', 'gid', 'uid', 'user', 'name', 'access_key', ...GLOBAL_CONFIG_OPTIONS]),
-    'status': new Set(['name', 'access_key', 'show_secrets', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
+    'update': new Set(['name', 'uid', 'gid', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', ...CLI_MUTUAL_OPTIONS]),
+    'delete': new Set(['name', ...CLI_MUTUAL_OPTIONS]),
+    'list': new Set(['wide', 'show_secrets', 'gid', 'uid', 'user', 'name', 'access_key', ...CLI_MUTUAL_OPTIONS]),
+    'status': new Set(['name', 'access_key', 'show_secrets', ...CLI_MUTUAL_OPTIONS]),
 };
 
 const VALID_OPTIONS_ANONYMOUS_ACCOUNT = {
-    'add': new Set(['uid', 'gid', 'user', 'anonymous', GLOBAL_CONFIG_ROOT]),
-    'update': new Set(['uid', 'gid', 'user', 'anonymous', GLOBAL_CONFIG_ROOT]),
-    'delete': new Set(['anonymous', GLOBAL_CONFIG_ROOT]),
-    'status': new Set(['anonymous', GLOBAL_CONFIG_ROOT]),
+    'add': new Set(['uid', 'gid', 'user', 'anonymous', CONFIG_ROOT_FLAG]),
+    'update': new Set(['uid', 'gid', 'user', 'anonymous', CONFIG_ROOT_FLAG]),
+    'delete': new Set(['anonymous', CONFIG_ROOT_FLAG]),
+    'status': new Set(['anonymous', CONFIG_ROOT_FLAG]),
 };
 
 const VALID_OPTIONS_BUCKET = {
-    'add': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'force_md5_etag', FROM_FILE, ...GLOBAL_CONFIG_OPTIONS]),
-    'update': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'new_name', 'force_md5_etag', ...GLOBAL_CONFIG_OPTIONS]),
-    'delete': new Set(['name', 'force', ...GLOBAL_CONFIG_OPTIONS]),
-    'list': new Set(['wide', 'name', ...GLOBAL_CONFIG_OPTIONS]),
-    'status': new Set(['name', ...GLOBAL_CONFIG_OPTIONS]),
+    'add': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'force_md5_etag', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
+    'update': new Set(['name', 'owner', 'path', 'bucket_policy', 'fs_backend', 'new_name', 'force_md5_etag', ...CLI_MUTUAL_OPTIONS]),
+    'delete': new Set(['name', 'force', ...CLI_MUTUAL_OPTIONS]),
+    'list': new Set(['wide', 'name', ...CLI_MUTUAL_OPTIONS]),
+    'status': new Set(['name', ...CLI_MUTUAL_OPTIONS]),
 };
 
 const VALID_OPTIONS_GLACIER = {
-    'migrate': new Set([ GLOBAL_CONFIG_ROOT]),
-    'restore': new Set([ GLOBAL_CONFIG_ROOT]),
-    'expiry': new Set([ GLOBAL_CONFIG_ROOT]),
+    'migrate': new Set([ CONFIG_ROOT_FLAG]),
+    'restore': new Set([ CONFIG_ROOT_FLAG]),
+    'expiry': new Set([ CONFIG_ROOT_FLAG]),
 };
 
 const VALID_OPTIONS_DIAGNOSE = {
-    'health': new Set([ 'https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', ...GLOBAL_CONFIG_OPTIONS]),
-    'gather-logs': new Set([ GLOBAL_CONFIG_ROOT]),
-    'metrics': new Set([GLOBAL_CONFIG_ROOT])
+    'health': new Set([ 'https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', ...CLI_MUTUAL_OPTIONS]),
+    'gather-logs': new Set([ CONFIG_ROOT_FLAG]),
+    'metrics': new Set([CONFIG_ROOT_FLAG])
 };
 
 
-const VALID_OPTIONS_WHITELIST = new Set(['ips', ...GLOBAL_CONFIG_OPTIONS]);
+const VALID_OPTIONS_WHITELIST = new Set(['ips', ...CLI_MUTUAL_OPTIONS]);
 
-const VALID_OPTIONS_FROM_FILE = new Set(['from_file', ...GLOBAL_CONFIG_OPTIONS]);
+const VALID_OPTIONS_FROM_FILE = new Set(['from_file', ...CLI_MUTUAL_OPTIONS]);
 
 const VALID_OPTIONS = {
     account_options: VALID_OPTIONS_ACCOUNT,

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -64,7 +64,7 @@ logging                                                                 Use this
 
 `;
 
-const GLOBAL_CONFIG_ROOT_ALL_FLAG = `
+const CLI_MUTUAL_FLAGS = `
 --config_root <string>                                (optional)        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
 --config_root_backend <none | GPFS | CEPH_FS | NFSv4> (optional)        Use the filesystem type in the configuration (default config.NSFS_NC_CONFIG_DIR_BACKEND)
 --debug <number>                                      (optional)        Use for increasing the log verbosity of cli commands
@@ -298,7 +298,7 @@ function print_usage(type, action) {
             process.stdout.write(WHITELIST_FLAGS.trimStart());
             break;
         case TYPES.LOGGING:
-            process.stdout.write(LOGGING_FLAGS.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(LOGGING_FLAGS.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case TYPES.GLACIER:
             print_help_glacier(action);
@@ -321,19 +321,19 @@ function print_usage(type, action) {
 function print_help_account(action) {
     switch (action) {
         case ACTIONS.ADD:
-            process.stdout.write(ACCOUNT_FLAGS_ADD.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_ADD.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case ACTIONS.UPDATE:
-            process.stdout.write(ACCOUNT_FLAGS_UPDATE.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_UPDATE.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case ACTIONS.DELETE:
-            process.stdout.write(ACCOUNT_FLAGS_DELETE.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_DELETE.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case ACTIONS.STATUS:
-            process.stdout.write(ACCOUNT_FLAGS_STATUS.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_STATUS.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case ACTIONS.LIST:
-            process.stdout.write(ACCOUNT_FLAGS_LIST.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_LIST.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         default:
             process.stdout.write(ACCOUNT_ACTIONS.trimStart());
@@ -348,19 +348,19 @@ function print_help_account(action) {
 function print_help_bucket(action) {
     switch (action) {
         case ACTIONS.ADD:
-            process.stdout.write(BUCKET_FLAGS_ADD.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(BUCKET_FLAGS_ADD.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case ACTIONS.UPDATE:
-            process.stdout.write(BUCKET_FLAGS_UPDATE.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(BUCKET_FLAGS_UPDATE.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case ACTIONS.DELETE:
-            process.stdout.write(BUCKET_FLAGS_DELETE.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(BUCKET_FLAGS_DELETE.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case ACTIONS.STATUS:
-            process.stdout.write(BUCKET_FLAGS_STATUS.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(BUCKET_FLAGS_STATUS.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         case ACTIONS.LIST:
-            process.stdout.write(BUCKET_FLAGS_LIST.trimStart() + GLOBAL_CONFIG_ROOT_ALL_FLAG.trimStart());
+            process.stdout.write(BUCKET_FLAGS_LIST.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
             break;
         default:
             process.stdout.write(BUCKET_ACTIONS.trimStart());


### PR DESCRIPTION
### Explain the changes
As part of adding the class `ConfigFS` (in PR #8258) and removing the term `global_config` in manage_nsfs - since this term was not clear enough and might cause confusion - we will change the constants that had `GLOBAL_CONFIG_` as a prefix:
1. rename `GLOBAL_CONFIG_ROOT_ALL_FLAG` to `CLI_MUTUAL_FLAGS`
2. rename `GLOBAL_CONFIG_ROOT` to `CONFIG_ROOT_FLAG`
3. rename `GLOBAL_CONFIG_OPTIONS` to `CLI_MUTUAL_OPTIONS`

### Issues:
1. None, it is a small step in the plan that was mentioned in [this comment](https://github.com/noobaa/noobaa-core/pull/8161#discussion_r1660695401).

### Testing Instructions:
1. None (would be tested in the CI)


- [ ] Doc added/updated
- [ ] Tests added
