### PR TITLE
NSFS | versioning | don't show .versions folder on list-object-versions

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -718,8 +718,8 @@ class NamespaceFS {
                     if ((!ent.name.startsWith(prefix_ent) ||
                         ent.name < marker_curr ||
                         ent.name === this.get_bucket_tmpdir_name() ||
-                        ent.name === config.NSFS_FOLDER_OBJECT_NAME) &&
-                        !this._is_hidden_version_path(ent.name)) {
+                        ent.name === config.NSFS_FOLDER_OBJECT_NAME) ||
+                        this._is_hidden_version_path(ent.name)) {
                         return;
                     }
                     const isDir = await is_directory_or_symlink_to_directory(ent, fs_context, path.join(dir_path, ent.name));

--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -3053,6 +3053,13 @@ mocha.describe('List-objects', function() {
             }
         });
     });
+
+    mocha.it('list object versions - should not list .versions folder', async function() {
+        const res = await s3_client.listObjectVersions({Bucket: bucket_name, Delimiter: "/"});
+        res.CommonPrefixes?.forEach(obj => {
+            assert.notEqual(obj.Prefix, ".versions/");
+        });
+    });
 });
 
 async function create_object(object_path, data, version_id, return_fd) {


### PR DESCRIPTION
### Explain the changes
1. change condition in list-object to not add .version folder to common prifixes

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8231

### Testing Instructions:
1. `sudo node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_bucketspace_versioning.js`


- [ ] Doc added/updated
- [x] Tests added
