### PR TITLE
NC | NSFS | CLI | `list_config_files` Small Fix

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -247,7 +247,7 @@ async function manage_bucket_operations(action, data, user_input) {
     } else if (action === ACTIONS.LIST) {
         const bucket_filters = _.pick(user_input, LIST_BUCKET_FILTERS);
         const wide = get_boolean_or_string_value(user_input.wide);
-        const buckets = await list_config_files(TYPES.BUCKET, config_fs.buckets_dir_path, wide, undefined, bucket_filters);
+        const buckets = await list_config_files(TYPES.BUCKET, wide, undefined, bucket_filters);
         write_stdout_response(ManageCLIResponse.BucketList, buckets);
     } else {
         // we should not get here (we check it before)
@@ -506,8 +506,7 @@ async function manage_account_operations(action, data, show_secrets, user_input)
     } else if (action === ACTIONS.LIST) {
         const account_filters = _.pick(user_input, LIST_ACCOUNT_FILTERS);
         const wide = get_boolean_or_string_value(user_input.wide);
-        const accounts = await list_config_files(TYPES.ACCOUNT, config_fs.accounts_dir_path, wide,
-            show_secrets, account_filters);
+        const accounts = await list_config_files(TYPES.ACCOUNT, wide, show_secrets, account_filters);
         write_stdout_response(ManageCLIResponse.AccountList, accounts);
     } else {
         // we should not get here (we check it before)
@@ -567,12 +566,12 @@ function filter_bucket(bucket, filters) {
 }
 /**
  * list_config_files will list all the config files (json) in a given config directory
- * @param {string} config_path
+ * @param {string} type
  * @param {boolean} [wide]
  * @param {boolean} [show_secrets]
  * @param {object} [filters]
  */
-async function list_config_files(type, config_path, wide, show_secrets, filters) {
+async function list_config_files(type, wide, show_secrets, filters) {
     const entries = type === TYPES.ACCOUNT ?
         await config_fs.list_root_accounts() :
         await config_fs.list_buckets();
@@ -582,7 +581,7 @@ async function list_config_files(type, config_path, wide, show_secrets, filters)
     // decrypt only if data has access_keys and show_secrets = true (no need to decrypt if show_secrets = false but should_filter = true)
     const options = {
         show_secrets: show_secrets || should_filter,
-        should_decrypt: show_secrets,
+        decrypt_secret_key: show_secrets,
         silent_if_missing: true
     };
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1316,6 +1316,19 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidFlagsCombination.message);
         });
 
+        it('cli list wide and show_secrets', async () => {
+            const account_options = { config_root, wide: true, show_secrets: true };
+            const action = ACTIONS.LIST;
+            const res = await exec_manage_cli(type, action, account_options);
+            expect(JSON.parse(res).response.reply.map(item => item.name))
+                .toEqual(expect.arrayContaining(['account3', 'account2', 'account1']));
+            const res_arr = JSON.parse(res).response.reply;
+            for (const item of res_arr) {
+                expect(item.access_keys[0].secret_key).toBeDefined();
+                expect(item.access_keys[0].encrypted_secret_key).toBeUndefined();
+            }
+        });
+
     });
 
     describe('cli delete account', () => {


### PR DESCRIPTION
### Explain the changes
1. `list_config_files` change function signature (remove unused `config_path`), and edit JSDoc (add missing type).
2. Rename the option from `should_decrypt` to `decrypt_secret_key` as the destructor of options uses.

### Issues:
1. Currently, when using list we get the `encrypted_secret_key` instead of `secret_key`.

### Testing Instructions:
1. Create an account with the CLI: sudo node src/cmd/manage_nsfs account add --name shira-1001 --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>
Note: before creating the account need to give permission to the new_buckets_path: chmod 777 /tmp/nsfs_root1.
2. Account list with decryption: `sudo node src/cmd/manage_nsfs account list --wide --show_secrets` (you will see the property `secret_key` instead of `encrypted_secret_key`).


- [ ] Doc added/updated
- [ ] Tests added
