### PR TITLE
NC | Config Dir Restructure

### DIFF
--- a/src/deploy/NVA_build/standalone_deploy_nsfs.sh
+++ b/src/deploy/NVA_build/standalone_deploy_nsfs.sh
@@ -10,13 +10,8 @@ function execute() {
 
 # Please note that the command we use here are without "sudo" because we are running from the container with Root permissions
 function main() {
-    # Add accounts to run ceph tests
-    execute "node src/cmd/manage_nsfs account add --name cephalt --new_buckets_path ${FS_ROOT_1} --uid 1000 --gid 1000" nsfs_cephalt.log
-    execute "node src/cmd/manage_nsfs account add --name cephtenant --new_buckets_path ${FS_ROOT_2} --uid 2000 --gid 2000" nsfs_cephtenant.log
-
     # Start noobaa service
     execute "node src/cmd/nsfs" nsfs.log
-
     # Wait for sometime to process to start
     sleep 10
 }

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -5,14 +5,40 @@ const config = require('../../config');
 const dbg = require('../util/debug_module')(__filename);
 const _ = require('lodash');
 const path = require('path');
+const os_utils = require('../util/os_utils');
 const nb_native = require('../util/nb_native');
 const native_fs_utils = require('../util/native_fs_utils');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 
+/* Config directory sub directory comments - 
+   On 5.18 - 
+   1. accounts/ will be deprecated
+   2. A new identities/ directory will be created that represents an account identity, 
+      for example -
+      when an account called alice is created (id = 111) and an IAM user called bob (id = 222) 
+      was created for alice, in the FS it will look as the folloing - 
+      2.1. config_dir/identities/111/identity.json -> represents the account properties (alice)
+      2.2. config_dir/identities/111/users/ -> represents the account's iam users
+      2.3. config_dir/identities/111/users/bob.symlink -> config_dir/identities/222/identity.json (an index to another identity)
+      2.4. config_dir/identities/222/identity.json -> represents the account properties (bob)     
+      in the future the identity directory will contain more features like policies, roles etc.
+   3. A new accounts_by_name/ directory will be created that represents an index which is a 
+      a symlink from account name to its actual identity.
+      For example - 
+      config_dir/accounts_by_name/alice.symlink -> config_dir/identities/111/identity.json
+*/
+
 const CONFIG_SUBDIRS = Object.freeze({
-    ACCOUNTS: 'accounts',
     BUCKETS: 'buckets',
-    ACCESS_KEYS: 'access_keys'
+    ACCESS_KEYS: 'access_keys',
+    IDENTITIES: 'identities',
+    ACCOUNTS_BY_NAME: 'accounts_by_name',
+    ACCOUNTS: 'accounts', // deprecated on 5.18
+});
+
+const CONFIG_TYPES = Object.freeze({
+    ACCOUNT: 'account',
+    BUCKET: 'bucket',
 });
 
 const JSON_SUFFIX = '.json';
@@ -34,7 +60,9 @@ class ConfigFS {
     constructor(config_root, config_root_backend, fs_context) {
         this.config_root = config_root;
         this.config_root_backend = config_root_backend || config.NSFS_NC_CONFIG_DIR_BACKEND;
-        this.accounts_dir_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS);
+        this.old_accounts_dir_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS);
+        this.accounts_by_name_dir_path = path.join(config_root, CONFIG_SUBDIRS.ACCOUNTS_BY_NAME);
+        this.identities_dir_path = path.join(config_root, CONFIG_SUBDIRS.IDENTITIES);
         this.access_keys_dir_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS);
         this.buckets_dir_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS);
         this.config_json_path = path.join(config_root, 'config.json');
@@ -48,7 +76,7 @@ class ConfigFS {
      * @returns {string} 
      */
     add_config_file_suffix(config_file_name, suffix) {
-        if (!config_file_name) throw new Error(`Config file name is missing - ${config_file_name}`);
+        if (!config_file_name) dbg.warn(`Config file name is missing - ${config_file_name}`);
         if (String(config_file_name).endsWith(suffix)) return config_file_name;
         return config_file_name + suffix;
     }
@@ -88,7 +116,8 @@ class ConfigFS {
         const pre_req_dirs = [
             this.config_root,
             this.buckets_dir_path,
-            this.accounts_dir_path,
+            this.accounts_by_name_dir_path,
+            this.identities_dir_path,
             this.access_keys_dir_path,
         ];
 
@@ -112,6 +141,32 @@ class ConfigFS {
     }
 
     /**
+     * get_config_json_path returns config.json file path
+     * @returns {String} 
+     */
+    get_config_json_path() {
+        return this.config_json_path;
+    }
+
+    /**
+     * get_config_json returns config.json file data
+     * @returns {Promise<Object>} 
+     */
+    async get_config_json() {
+        const config_json_data = await this.get_config_data(this.config_json_path);
+        return config_json_data;
+    }
+
+    /**
+     * create_config_json_file created the config.json file with the configuration data
+     * @param {object} data
+     * @returns {Promise<void>} 
+     */
+    async create_config_json_file(data) {
+        await native_fs_utils.create_config_file(this.fs_context, this.config_root, this.config_json_path, data);
+    }
+
+    /**
      * update_config_json_file updates the config.json file with the new configuration data
      * @param {object} data
      * @returns {Promise<void>} 
@@ -119,6 +174,7 @@ class ConfigFS {
     async update_config_json_file(data) {
         await native_fs_utils.update_config_file(this.fs_context, this.config_root, this.config_json_path, data);
     }
+
 
     /**
      * get_config_data reads a config file and returns its content 
@@ -130,16 +186,34 @@ class ConfigFS {
      * @param {{show_secrets?: boolean, decrypt_secret_key?: boolean, silent_if_missing?: boolean}} [options]
      * @returns {Promise<Object>}
      */
-    async get_config_data(config_file_path, options = {}) {
+    async get_identity_config_data(config_file_path, options = {}) {
         const { show_secrets = false, decrypt_secret_key = false, silent_if_missing = false } = options;
         try {
-            const { data } = await nb_native().fs.readFile(this.fs_context, config_file_path);
-            const config_data = _.omit(JSON.parse(data.toString()), show_secrets ? [] : ['access_keys']);
+            const data = await this.get_config_data(config_file_path, options);
+            if (!data && silent_if_missing) return;
+            const config_data = _.omit(data, show_secrets ? [] : ['access_keys']);
             if (decrypt_secret_key) config_data.access_keys = await nc_mkm.decrypt_access_keys(config_data);
             return config_data;
         } catch (err) {
+            dbg.warn('get_identity_config_data: with config_file_path', config_file_path, 'got an error', err);
+            if (err.code === 'ENOENT' && silent_if_missing) return;
+            throw err;
+        }
+    }
+    /**
+     * get_config_data reads a config file and returns its content
+     * @param {string} config_file_path
+     * @param {{ silent_if_missing?: boolean }} [options]
+     * @returns {Promise<Object>}
+     */
+    async get_config_data(config_file_path, options = {}) {
+        try {
+            const { data } = await nb_native().fs.readFile(this.fs_context, config_file_path);
+            const config_data = JSON.parse(data.toString());
+            return config_data;
+        } catch (err) {
             dbg.warn('get_config_data: with config_file_path', config_file_path, 'got an error', err);
-            if (silent_if_missing && err.code === 'ENOENT') return;
+            if (err.code === 'ENOENT' && options.silent_if_missing) return;
             throw err;
         }
     }
@@ -151,88 +225,200 @@ class ConfigFS {
     /**
      * get_account_path_by_name returns the full account path by name
      * @param {string} account_name
-     * @param {string} [owner_root_account_id]
+     * @param {string} [owner_account_id]
      * @returns {string} 
      */
-    get_account_path_by_name(account_name, owner_root_account_id) {
-        // TODO -  change to this.symlink(account_name) on identities/ PR;
-        return owner_root_account_id ?
-            this.get_iam_account_path_by_name(account_name, owner_root_account_id) :
-            this.get_root_account_path_by_name(account_name);
+    get_account_or_user_path_by_name(account_name, owner_account_id) {
+        return owner_account_id ?
+            this.get_user_path_by_name(account_name, owner_account_id) :
+            this.get_account_path_by_name(account_name);
     }
 
     /**
-     * get_root_account_path_by_name returns the full account path by name
+     * get_account_path_by_name returns the full account path by name
+     * root account can be found by name under accounts_by_name/account_name.symlink
      * @param {string} account_name
      * @returns {string} 
      */
-    get_root_account_path_by_name(account_name) {
-        // TODO -  change to this.symlink(account_name) on identities/ PR;
-        return path.join(this.accounts_dir_path, this.json(account_name));
+    get_account_path_by_name(account_name) {
+        return path.join(this.accounts_by_name_dir_path, this.symlink(account_name));
     }
 
     /**
-     * get_iam_account_path_by_name returns the full account path by name
+     * get_user_path_by_name returns the full iam user path by name
+     * iam user can be found by name under identities/owner_account_id/users/iam_account_name.symlink
      * @param {string} account_name
-     * @param {string} owner_root_account_id
+     * @param {string} owner_account_id
      * @returns {string} 
     */
-    get_iam_account_path_by_name(account_name, owner_root_account_id) {
-       // TODO -  change to this.symlink(account_name) on identities/ PR;
-       // update IAM user location identities/root_id_number/iam_account_name.symlink
-       return path.join(this.accounts_dir_path, this.json(account_name));
+    get_user_path_by_name(account_name, owner_account_id) {
+        // TODO - change to return path.join(this.identities_dir_path, owner_account_id, 'users', this.symlink(account_name));
+        return path.join(this.accounts_by_name_dir_path, this.symlink(account_name));
     }
 
     /**
-     * get_account_relative_path_by_name returns the full account path by name
+     * get_old_account_relative_path_by_name returns the old (5.17) full account path by name
      * @param {string} account_name
      * @returns {string} 
     */
-    get_account_relative_path_by_name(account_name) {
-       // TODO -  change to this.symlink(account_name) on identities/ PR;
-       return path.join('../', CONFIG_SUBDIRS.ACCOUNTS, this.json(account_name));
+    get_old_account_relative_path_by_name(account_name) {
+        return path.join('../', CONFIG_SUBDIRS.ACCOUNTS, this.json(account_name));
     }
 
     /**
-     * get_account_path_by_access_key returns the full account path by access key
+     * get_account_relative_path_by_id returns the full account path by id
+     * the target of symlinks will be the 
+     * @param {string} account_id
+     * @returns {string} 
+    */
+    get_account_relative_path_by_id(account_id) {
+       return path.join('../', CONFIG_SUBDIRS.IDENTITIES, account_id, this.json('identity'));
+    }
+
+    /**
+     * get_identity_path_by_id returns the full identity path by id as following - 
+     * {config_dir}/identities/{id}/identity.json
+     * @param {string} id
+     * @returns {string} 
+    */
+    get_identity_path_by_id(id) {
+        return path.join(this.identities_dir_path, id, this.json('identity'));
+    }
+
+    /**
+     * get_identity_by_id returns the full account/user data by id from the following path
+     * {config_dir}/identities/{account_id}/identity.json
+     * @param {string} id
+     * @param {string} [type]
+     * @param {{show_secrets?: boolean, decrypt_secret_key?: boolean, silent_if_missing?: boolean}} [options]
+     * @returns {Promise<Object>} 
+    */
+    async get_identity_by_id(id, type, options = {}) {
+        const identity_path = this.get_identity_path_by_id(id);
+        let identity = await this.get_identity_config_data(identity_path, { ...options, silent_if_missing: true });
+
+        if (!identity && type === CONFIG_TYPES.ACCOUNT) {
+            identity = await this.search_accounts_by_id(id, options);
+        }
+        if (!identity && !options.silent_if_missing) {
+            const err = new Error(`Could not find identity by id ${id}`);
+            err.code = 'ENOENT';
+            throw err;
+        }
+        return identity;
+    }
+
+    /**
+     * search_accounts_by_id searches old accounts directory and finds an account that its _id matches the given id param
+     * @param {string} id
+     * @param {{show_secrets?: boolean, decrypt_secret_key?: boolean, silent_if_missing?: boolean}} [options]
+     * @returns {Promise<Object>} 
+    */
+    async search_accounts_by_id(id, options = {}) {
+        const old_account_names = await this.list_old_accounts();
+        for (const account_name of old_account_names) {
+            const account_data = await this.get_account_by_name(account_name, { ...options, silent_if_missing: true });
+            if (!account_data) continue;
+            if (account_data._id === id) return account_data;
+        }
+    }
+
+    /**
+     * get_identities_by_id returns the full account/user data by id from the following path
+     * {config_dir}/identities/{id}/identity.json
+     * @param {string[]} ids
+     * @returns {Promise<Object>} 
+    */
+    async get_identities_by_id(ids, options = {}) {
+        const res = [];
+        for (const id of ids) {
+            const id_path = this.get_identity_path_by_id(id);
+            const id_data = await this.get_identity_config_data(id_path, { ...options, silent_if_missing: true });
+            if (!id_data) continue;
+            res.push(id_data);
+        }
+        return res;
+    }
+
+    /**
+     * get_identity_path_by_id returns the account/user identity dir path by id as follows
+     * {config_dir}/identities/{account_id}/
+     * @param {string} id
+     * @returns {string} 
+    */
+    get_identity_dir_path_by_id(id) {
+        return path.join(this.config_root, CONFIG_SUBDIRS.IDENTITIES, id, '/');
+    }
+
+    /**
+     * get_account_or_user_path_by_access_key returns the full account path by access key as follows
+     * {config_dir}/access_keys/{access_key}.symlink
      * @param {string} access_key
      * @returns {string} 
      */
-    get_account_path_by_access_key(access_key) {
+    get_account_or_user_path_by_access_key(access_key) {
         return path.join(this.access_keys_dir_path, this.symlink(access_key));
     }
 
     /**
-     * get_old_account_path_by_name returns the full account path by name based on old config dir structure
+     * _get_old_account_path_by_name returns the full account path by name based on old config dir structure
+     * as follows - {config_dir}/accounts/{access_name}.json
      * @param {string} account_name
      * @returns {string} 
     */
-    get_old_account_path_by_name(account_name) {
-        return path.join(this.accounts_dir_path, this.json(account_name));
+    _get_old_account_path_by_name(account_name) {
+        return path.join(this.old_accounts_dir_path, this.json(account_name));
     }
 
     /**
-     * is_account_exists returns true if account config path exists in config dir
-     * it can be determined by any account identifier - name, access_key and in the future id
-     * @param {{ name?: string, access_key?: string }} identifier_object
+     * is_account_exists_by_name returns true if account config path exists in config dir
+     * if account does not exist and it's a regular account (not an IAM user) 
+     * try to locate it under the old accounts/ directory
+     * @param {string} account_name
+     * @param {string} [owner_account_id]
      * @returns {Promise<boolean>} 
     */
-    async is_account_exists(identifier_object) {
-        if (!identifier_object || typeof identifier_object !== 'object') throw new Error('config_fs.is_account_exists - no identifier provided');
-       let path_to_check;
-       let use_lstat = false;
-       if (identifier_object.name) {
-           // TODO - when users/ move to be symlink we need to use_lstat by name, id is not using lstat
-           path_to_check = this.get_account_path_by_name(identifier_object.name);
-        } else if (identifier_object.access_key) {
-            path_to_check = this.get_account_path_by_access_key(identifier_object.access_key);
-            use_lstat = true;
-       } else {
-            throw new Error(`config_fs.is_account_exists - invalid identifier provided ${identifier_object}`);
+    async is_account_exists_by_name(account_name, owner_account_id) {
+        const path_to_check = this.get_account_or_user_path_by_name(account_name, owner_account_id);
+        let account_exists = await native_fs_utils.is_path_exists(this.fs_context, path_to_check);
+
+        if (!account_exists && account_name !== undefined && owner_account_id === undefined) {
+            const old_path_to_check = this._get_old_account_path_by_name(account_name);
+            account_exists = await native_fs_utils.is_path_exists(this.fs_context, old_path_to_check);
         }
-        // TODO - add is_account_exists by id when idenetities/ added
-        // else if (identifier_object.id) {}
-        return native_fs_utils.is_path_exists(this.fs_context, path_to_check, use_lstat);
+        return account_exists;
+    }
+
+    /**
+     * is_identity_exists returns true if identity config path exists in config dir
+     * @param {string} id
+     * @param {string} [type]
+     * @param {{show_secrets?: boolean, decrypt_secret_key?: boolean, silent_if_missing?: boolean}} [options]
+     * @returns {Promise<boolean>} 
+    */
+    async is_identity_exists(id, type, options) {
+        const path_to_check = this.get_identity_path_by_id(id);
+        let identity = await native_fs_utils.is_path_exists(this.fs_context, path_to_check);
+
+        if (!identity && type === CONFIG_TYPES.ACCOUNT) {
+            identity = await this.search_accounts_by_id(id, options);
+        }
+        if (!identity && !options.silent_if_missing) {
+            const err = new Error(`Could not find identity by id ${id}`);
+            err.code = 'ENOENT';
+            throw err;
+        }
+        return identity;
+    }
+
+    /**
+     * is_account_exists_by_access_key returns true if account config path exists in config dir
+     * @param {string} access_key
+     * @returns {Promise<boolean>} 
+    */
+    async is_account_exists_by_access_key(access_key) {
+        const path_to_check = this.get_account_or_user_path_by_access_key(access_key);
+        return native_fs_utils.is_path_exists(this.fs_context, path_to_check);
     }
 
     /**
@@ -244,8 +430,8 @@ class ConfigFS {
      * @returns {Promise<Object>}
      */
     async get_account_by_access_key(access_key, options = {}) {
-        const account_path = this.get_account_path_by_access_key(access_key);
-        const account = await this.get_config_data(account_path, options);
+        const account_path = this.get_account_or_user_path_by_access_key(access_key);
+        const account = await this.get_identity_config_data(account_path, options);
         return account;
     }
 
@@ -265,104 +451,246 @@ class ConfigFS {
      */
     async get_account_by_name(account_name, options = {}) {
         const account_path = this.get_account_path_by_name(account_name);
-        const account = await this.get_config_data(account_path, options);
+        let account = await this.get_identity_config_data(account_path, { ...options, silent_if_missing: true });
+        if (!account) {
+            const old_account_path = this._get_old_account_path_by_name(account_name);
+            account = await this.get_identity_config_data(old_account_path, { ...options, silent_if_missing: true });
+        }
+        if (!account && !options.silent_if_missing) {
+            const err = new Error(`Could not find account by name ${account_name}`);
+            err.code = 'ENOENT';
+            throw err;
+        }
         return account;
     }
 
     /**
-     * list_root_accounts returns the root accounts array exists under the config dir
-     * @returns {Promise<Dirent[]>} 
+     * list_accounts returns the account names array - 
+     * 1. get new accounts names
+     * 2. check old accounts/ dir exists
+     * 3. if old accounts dir exists return the union of new accounts and old accounts names array
+     * 4. else return new account names array
+     * and add accounts from old accounts/ directory if exists
+     * during upgrade - list accounts is a very expensive operation as it's iterating old accounts and adds the entries that still do not appear in the new accounts folder
+     * @returns {Promise<string[]>} 
      */
-    async list_root_accounts(options) {
-        return nb_native().fs.readdir(this.fs_context, this.accounts_dir_path);
+    async list_accounts() {
+        const new_entries = await nb_native().fs.readdir(this.fs_context, this.accounts_by_name_dir_path);
+        const new_accounts_names = this._get_config_entries_names(new_entries, SYMLINK_SUFFIX);
+        const old_accounts_names = await this.list_old_accounts();
+        return this.unify_old_and_new_accounts(new_accounts_names, old_accounts_names);
+    }
+
+    /**
+     * unify_old_and_new_accounts list the old accounts directory and add them to a set of the accounts
+     * this will create a union of accounts and old accounts under accounts/ directory.
+     * @returns {Promise<string[] | undefined>} 
+     */
+    async unify_old_and_new_accounts(new_entries, old_entries) {
+        if (!old_entries?.length) return new_entries;
+        const set = new Set([...new_entries, ...old_entries]);
+        return Array.from(set);
+    }
+
+    /**
+     * list_old_accounts lists the old accounts under accounts/ directory and return their names.
+     * @returns {Promise<string[]>} 
+     */
+    async list_old_accounts() {
+        const old_accounts_dir_exists = await native_fs_utils.is_path_exists(this.fs_context, this.old_accounts_dir_path);
+        if (!old_accounts_dir_exists) return [];
+
+        const old_entries = await nb_native().fs.readdir(this.fs_context, this.old_accounts_dir_path);
+        if (old_entries.length === 0) return [];
+
+        return this._get_config_entries_names(old_entries, JSON_SUFFIX);
     }
 
     /**
      * create_account_config_file creates account config file
-     * if account_data.access_keys is an array that contains at least 1 item -
-     * link all item in account_data.access_keys to the relative path of the newly created config file
-     * @param {string} account_name
-     * @param {*} account_data
-     * @param {boolean} symlink_new_access_keys
-     * @param {String[]} old_access_keys
+     * 1. create /identities/account_id/ directory
+     * 2. create /identities/account_id/identity.json file
+     * 3. symlink /accounts_by_name/account_name -> /identities/account_id/identity.json
+     * 4. symlink new access keys if account_data.access_keys is an array that contains at least 1 item -
+     *      link each item in account_data.access_keys to the relative path of the newly created config file
+     * @param {Object} account_data
      * @returns {Promise<void>} 
      */
-    async create_account_config_file(account_name, account_data, symlink_new_access_keys, old_access_keys = []) {
-        const account_path = this.get_account_path_by_name(account_name);
-        await native_fs_utils.create_config_file(this.fs_context, this.accounts_dir_path, account_path, JSON.stringify(account_data));
+    async create_account_config_file(account_data) {
+        const { _id, name, owner = undefined } = account_data;
+        const data_string = JSON.stringify(account_data);
+        const account_path = this.get_identity_path_by_id(_id);
+        const account_dir_path = this.get_identity_dir_path_by_id(_id);
 
-        if (old_access_keys.length > 0) {
-            for (const access_key of old_access_keys) {
-                const access_key_config_path = this.get_account_path_by_access_key(access_key);
-                await nb_native().fs.unlink(this.fs_context, access_key_config_path);
-            }
-        }
-        if (symlink_new_access_keys && account_data.access_keys?.length > 0) {
-            for (const access_key_obj of account_data.access_keys) {
-                const account_config_access_key_path = this.get_account_path_by_access_key(access_key_obj.access_key);
-                const account_config_relative_path = this.get_account_relative_path_by_name(account_name);
-                await native_fs_utils._create_path(this.access_keys_dir_path, this.fs_context, config.BASE_MODE_CONFIG_DIR);
-                await nb_native().fs.symlink(this.fs_context, account_config_relative_path, account_config_access_key_path);
-            }
-        }
+        await native_fs_utils._create_path(account_dir_path, this.fs_context, config.BASE_MODE_CONFIG_DIR);
+        await native_fs_utils.create_config_file(this.fs_context, account_dir_path, account_path, data_string);
+        await this.link_account_name_index(_id, name, owner);
+        await this.link_access_keys_index(_id, account_data.access_keys);
     }
 
     /**
      * update_account_config_file updates account config file
      * if old_access_keys is an array that contains at least 1 item -
      * unlink old access_keys and link new access_keys
-     * @param {string} account_name
+     * 1. update /identities/account_id/identity.json
+     * 2. if name updated -
+     *    link /accounts_by_name/new_account_name -> /identities/account_id/identity.json
+     *    unlink /accounts_by_name/old_account_name
+     * 3. if access key was updated -
+     *    for all new_access_keys - link /access_keys/new_access_key -> /identities/account_id/identity.json
+     *    for all old_access_keys - unlink /access_keys/old_access_key
      * @param {Object} account_new_data
-     * @param {Object[]} [new_access_keys_to_link]
-     * @param {String[]} [old_access_keys_to_remove]
+     * @param {{old_name?: string, new_access_keys_to_link?: Object[], access_keys_to_delete?: { access_key: string }[]}} [options]
      * @returns {Promise<void>}
      */
-    async update_account_config_file(account_name, account_new_data, new_access_keys_to_link = [], old_access_keys_to_remove = []) {
-        const account_config_path = this.get_account_path_by_name(account_name);
-        await native_fs_utils.update_config_file(this.fs_context, this.accounts_dir_path,
-            account_config_path, JSON.stringify(account_new_data));
+    async update_account_config_file(account_new_data, options = {}) {
+        const { _id, name, owner = undefined } = account_new_data;
+        const data_string = JSON.stringify(account_new_data);
+        const account_path = this.get_identity_path_by_id(_id);
+        const account_dir_path = this.get_identity_dir_path_by_id(_id);
+        await native_fs_utils.update_config_file(this.fs_context, account_dir_path, account_path, data_string);
 
-        if (new_access_keys_to_link.length > 0) {
-            for (const access_keys of new_access_keys_to_link) {
-                const new_access_key_path = this.get_account_path_by_access_key(access_keys.access_key);
-                const account_config_relative_path = this.get_account_relative_path_by_name(account_name);
-                await nb_native().fs.symlink(this.fs_context, account_config_relative_path, new_access_key_path);
-            }
+        if (options.old_name) {
+            await this.link_account_name_index(_id, name, owner);
+            await this.unlink_account_name_index(options.old_name, account_path);
         }
-
-        if (old_access_keys_to_remove.length > 0) {
-            for (const access_key of old_access_keys_to_remove) {
-                const cur_access_key_path = this.get_account_path_by_access_key(access_key);
-                await nb_native().fs.unlink(this.fs_context, cur_access_key_path);
-            }
-        }
+        await this.link_access_keys_index(_id, options.new_access_keys_to_link);
+        await this.unlink_access_keys_indexes(options.access_keys_to_delete, account_path);
     }
 
     /**
      * delete_account_config_file deletes account config file
-     * if access_keys_to_delete is an array that contains at least 1 item -
-     * unlink all items in access_keys_to_delete
+     * 1. unlink /access_keys/access_key if access_keys_to_delete is an array that contains at least 1 item -
+     *    unlink all item in access_keys_to_delete
+     * 2. unlink /root_accounts/account_name
+     * 3. delete /identities/account_id/identity.json
+     * 4. delete /identities/account_id/ folder
+     * @param {Object} data
+     * @returns {Promise<void>}
+     */
+    async delete_account_config_file(data) {
+        const { _id, name, access_keys = [] } = data;
+        const account_id_config_path = this.get_identity_path_by_id(_id);
+        const account_dir_path = this.get_identity_dir_path_by_id(_id);
+
+        await this.unlink_access_keys_indexes(access_keys, account_id_config_path);
+        await this.unlink_account_name_index(name, account_id_config_path);
+        await native_fs_utils.delete_config_file(this.fs_context, account_dir_path, account_id_config_path);
+        await native_fs_utils.folder_delete(account_dir_path, this.fs_context, undefined, true);
+    }
+
+    /////////////////////////////////////
+    //////   ACCOUNT NAME INDEX    //////
+    /////////////////////////////////////
+
+    /**
+     * link_account_name_index links the access key to the relative path of the account id config file
+     * @param {string} account_id
      * @param {string} account_name
-     * @param {Object[]} [access_keys_to_delete]
+     * @param {string} owner_id
      * @returns {Promise<void>} 
      */
-    async delete_account_config_file(account_name, access_keys_to_delete = []) {
-        const account_config_path = this.get_account_path_by_name(account_name);
-        await native_fs_utils.delete_config_file(this.fs_context, this.accounts_dir_path, account_config_path);
-        for (const access_keys of access_keys_to_delete) {
-            const access_key_config_path = this.get_account_path_by_access_key(access_keys.access_key);
-            await nb_native().fs.unlink(this.fs_context, access_key_config_path);
+    async link_account_name_index(account_id, account_name, owner_id) {
+        const account_name_path = this.get_account_or_user_path_by_name(account_name, owner_id);
+        const account_id_relative_path = this.get_account_relative_path_by_id(account_id);
+        await nb_native().fs.symlink(this.fs_context, account_id_relative_path, account_name_path);
+    }
+
+    /**
+     * unlink_account_name_index unlinks the access key from the config directory
+     * 1. get the account name path
+     * 2. check realpath on the account name path to make sure it belongs to the account id we meant to delete
+     * 3. check if the account id path is the same as the account name path 
+     * 4. unlink the account name path
+     * 5. else, do nothing as the name path might already point to a new identity/deleted by concurrent calls 
+     * @param {string} account_name
+     * @returns {Promise<void>} 
+     */
+    async unlink_account_name_index(account_name, account_id_config_path) {
+        const account_name_path = this.get_account_path_by_name(account_name);
+        const should_unlink = await this._is_symlink_pointing_to_identity(account_name_path, account_id_config_path);
+        if (should_unlink) {
+            try {
+                await nb_native().fs.unlink(this.fs_context, account_name_path);
+            } catch (err) {
+                if (err.code === 'ENOENT') {
+                    dbg.warn(`config_fs.unlink_account_name_index: account name already unlinked ${account_name} ${account_id_config_path}`);
+                    return;
+                }
+                throw err;
+            }
+        }
+    }
+
+    //////////////////////////////////////
+    //////   ACCESS KEYS INDEXES    //////
+    //////////////////////////////////////
+
+    /**
+     * link_access_keys_index links the access keys symlinks
+     * @param {Object[]} access_keys_to_link
+     * @returns {Promise<void>} 
+     */
+    async link_access_keys_index(account_id, access_keys_to_link = []) {
+        if (!access_keys_to_link?.length) return;
+        const account_config_relative_path = this.get_account_relative_path_by_id(account_id);
+        for (const access_keys of access_keys_to_link) {
+            const new_access_key_path = this.get_account_or_user_path_by_access_key(access_keys.access_key);
+            await nb_native().fs.symlink(this.fs_context, account_config_relative_path, new_access_key_path);
         }
     }
 
     /**
-     * unlink_access_key_symlink unlinks the access key from the file system
+     * unlink_access_key_index unlinks the access key from the config directory
+     * 1. get the account access_key path
+     * 2. check realpath on the account access_key path to make sure it belongs to the account id we meant to delete
+     * 3. check if the account id path is the same as the account name path 
+     * 4. unlink the account name path
+     * 5. else, do nothing as the name path might already point to a new identity/deleted by concurrent calls 
      * @param {string} access_key
      * @returns {Promise<void>} 
      */
-    async unlink_access_key_symlink(access_key) {
-        const acces_key_path = this.get_account_path_by_access_key(access_key);
-        await nb_native().fs.unlink(this.fs_context, acces_key_path);
+    async unlink_access_key_index(access_key, account_id_config_path) {
+        const access_key_path = this.get_account_or_user_path_by_access_key(access_key);
+        const should_unlink = await this._is_symlink_pointing_to_identity(access_key_path, account_id_config_path);
+        if (should_unlink) {
+            try {
+                await nb_native().fs.unlink(this.fs_context, access_key_path);
+            } catch (err) {
+                if (err.code === 'ENOENT') {
+                    dbg.warn(`config_fs.unlink_access_key_index: account access_key already unlinked ${access_key} ${account_id_config_path}`);
+                    return;
+                }
+                throw err;
+            }
+        }
+    }
+
+    /**
+     * unlink_access_keys_index unlinks the access keys from the config directory
+     *  iterate access_keys_to_delete array and for each call unlink_access_key_index()
+     * @param {Object[]} access_keys_to_delete
+     * @param {String} account_id_config_path
+     * @returns {Promise<void>} 
+     */
+    async unlink_access_keys_indexes(access_keys_to_delete, account_id_config_path) {
+        if (!access_keys_to_delete?.length) return;
+        for (const access_keys of access_keys_to_delete) {
+            await this.unlink_access_key_index(access_keys.access_key, account_id_config_path);
+        }
+    }
+
+    /**
+     * _is_symlink_pointing_to_identity checks if the index symlink (name/access_key)
+     * is pointing to the identity file path
+     * @param {string} symlink_path 
+     * @param {string} identity_path 
+     * @returns {Promise<Boolean>}
+     */
+    async _is_symlink_pointing_to_identity(symlink_path, identity_path) {
+        const full_path = await nb_native().fs.realpath(this.fs_context, symlink_path);
+        return (full_path === identity_path ||
+            (os_utils.IS_MAC && full_path === path.join('/private/', identity_path)));
     }
 
     //////////////////////////////////////
@@ -404,10 +732,12 @@ class ConfigFS {
 
     /**
      * list_buckets returns the array of buckets that exists under the config dir
-     * @returns {Promise<Dirent[]>} 
+     * @returns {Promise<string[]>} 
      */
     async list_buckets() {
-        return nb_native().fs.readdir(this.fs_context, this.buckets_dir_path);
+        const bucket_entries = await nb_native().fs.readdir(this.fs_context, this.buckets_dir_path);
+        const bucket_names = this._get_config_entries_names(bucket_entries, JSON_SUFFIX);
+        return bucket_names;
     }
 
     /**
@@ -442,6 +772,11 @@ class ConfigFS {
         await native_fs_utils.delete_config_file(this.fs_context, this.buckets_dir_path, bucket_config_path);
     }
 
+
+    ////////////////////////
+    ///     HELPERS     ////
+    ////////////////////////
+
     /**
      * adjust_bucket_with_schema_updates changes the bucket properties according to the schema
      * @param {object} bucket
@@ -453,10 +788,51 @@ class ConfigFS {
             delete bucket.system_owner;
         }
     }
+
+    /**
+    * @param {fs.Dirent} entry
+    * @param {string} suffix
+    * @returns {boolean}
+    */
+    _has_config_file_name_format(entry, suffix) {
+        return entry.name.endsWith(suffix) &&
+            !entry.name.includes(config.NSFS_TEMP_CONF_DIR_NAME) &&
+            !native_fs_utils.isDirectory(entry);
+    }
+
+    /**
+    * _get_config_entry_name returns config file entry name if it adheres a config file name format, 
+    * else returns undefined
+    * @param {fs.Dirent} entry
+    * @param {string} suffix
+    * @returns {string | undefined}
+    */
+    _get_config_entry_name(entry, suffix) {
+        return (this._has_config_file_name_format(entry, suffix)) ?
+            path.parse(entry.name).name :
+            undefined;
+    }
+
+    /**
+    * _get_config_entries_names returns config file names array 
+    * @param {fs.Dirent[]} entries
+    * @param {string} suffix
+    * @returns {string[]}
+    */
+    _get_config_entries_names(entries, suffix) {
+        const config_file_names = [];
+        for (const entry of entries) {
+            if (this._has_config_file_name_format(entry, suffix)) {
+                config_file_names.push(path.parse(entry.name).name);
+            }
+        }
+        return config_file_names;
+    }
 }
 
 // EXPORTS
 exports.SYMLINK_SUFFIX = SYMLINK_SUFFIX;
 exports.JSON_SUFFIX = JSON_SUFFIX;
 exports.CONFIG_SUBDIRS = CONFIG_SUBDIRS;
+exports.CONFIG_TYPES = CONFIG_TYPES;
 exports.ConfigFS = ConfigFS;

--- a/src/test/system_tests/ceph_s3_tests/run_ceph_nsfs_test_on_test_container.sh
+++ b/src/test/system_tests/ceph_s3_tests/run_ceph_nsfs_test_on_test_container.sh
@@ -21,31 +21,29 @@ export NOOBAA_MGMT_SERVICE_PROTO=wss
 export S3_SERVICE_HOST=localhost
 
 export CEPH_TEST_LOGS_DIR=/logs/ceph-nsfs-test-logs
-export FS_ROOT_1=/tmp/nsfs_root1
-export FS_ROOT_2=/tmp/nsfs_root2
 export CONFIG_DIR=/etc/noobaa.conf.d/
+export FS_ROOT_1=/tmp/nsfs_root1/
+export FS_ROOT_2=/tmp/nsfs_root2/
 
 # ====================================================================================
 
-# Create the logs directory
-mkdir -p ${CEPH_TEST_LOGS_DIR}
-
-# Create configuration directory
+# 1. Create configuration directory
+# 2. Create config.json file
 mkdir -p ${CONFIG_DIR}
+config='{"ALLOW_HTTP":true}'
+echo "$config" > ${CONFIG_DIR}/config.json
 
-# Create root directory for bucket creation
-mkdir -p ${FS_ROOT_1}
-mkdir -p ${FS_ROOT_2}
-
-# Add permission to all users
+# 1. Create root directory for bucket creation
+# 2. Add permission to all users
 # this will allow the new accounts to create directories (buckets),
 # else we would see [Error: Permission denied] { code: 'EACCES' }
+mkdir -p ${FS_ROOT_1}
+mkdir -p ${FS_ROOT_2}
 chmod 777 ${FS_ROOT_1}
 chmod 777 ${FS_ROOT_2}
 
-# Create config.json file
-config='{"ALLOW_HTTP":true}'
-echo "$config" > ${CONFIG_DIR}/config.json
+# Create the logs directory
+mkdir -p ${CEPH_TEST_LOGS_DIR}
 
 # Deploy standalone NooBaa on the test container
 # And create the accounts needed for the Ceph tests

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_nsfs_s3_config_setup.js
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_nsfs_s3_config_setup.js
@@ -7,16 +7,14 @@
  * In the past this script was a part of file test_ceph_s3.
  */
 
-const fs = require('fs');
 const dbg = require('../../../util/debug_module')(__filename);
 dbg.set_process_name('test_ceph_s3');
 
+const fs = require('fs');
 const os_utils = require('../../../util/os_utils');
-const config = require('../../../../config');
-const mongo_utils = require('../../../util/mongo_utils');
-const { CEPH_TEST, account_path, account_tenant_path, anonymous_account_path } = require('./test_ceph_s3_constants.js');
-const nc_mkm = require('../../../manage_nsfs/nc_master_key_manager').get_instance();
-
+const test_utils = require('../../system_tests/test_utils');
+const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
+const { CEPH_TEST } = require('./test_ceph_s3_constants.js');
 
 async function main() {
     try {
@@ -46,62 +44,54 @@ async function ceph_test_setup() {
     await fs.promises.writeFile(conf_file, new_conf_file_content);
     console.log('conf file updated');
 
-    console.info('CEPH TEST CONFIGURATION:', JSON.stringify(CEPH_TEST));
-    let access_keys = await get_access_keys(account_path);
-    const access_key = access_keys.access_key;
-    const secret_key = access_keys.secret_key;
+    console.info('CEPH TEST CONFIGURATION: CREATE ACCOUNTS', JSON.stringify(CEPH_TEST));
+    await create_account(CEPH_TEST.nc_cephalt_account_params);
+    await create_account(CEPH_TEST.nc_cephtenant_account_params);
+    await create_account(CEPH_TEST.nc_anonymous_account_params);
 
-    await os_utils.exec(`echo access_key = ${access_key} >> ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
-    await os_utils.exec(`echo secret_key = ${secret_key} >> ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+    console.info('CEPH TEST CONFIGURATION: GET ACCESS KEYS', JSON.stringify(CEPH_TEST));
+    const cephalt_access_keys = await get_access_keys(CEPH_TEST.nc_cephalt_account_params.name);
+    const cephalt_access_key = cephalt_access_keys.access_key;
+    const cephalt_secret_key = cephalt_access_keys.secret_key;
 
-    access_keys = await get_access_keys(account_tenant_path);
-    const access_key_tenant = access_keys.access_key;
-    const secret_key_tenant = access_keys.secret_key;
+    await os_utils.exec(`echo access_key = ${cephalt_access_key} >> ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+    await os_utils.exec(`echo secret_key = ${cephalt_secret_key} >> ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+
+    const cephtenant_access_keys = await get_access_keys(CEPH_TEST.nc_cephtenant_account_params.name);
+    const cephtenant_access_key = cephtenant_access_keys.access_key;
+    const cephtenant_secret_key = cephtenant_access_keys.secret_key;
 
     if (os_utils.IS_MAC) {
-        await os_utils.exec(`sed -i "" "s|tenant_access_key|"${access_key_tenant}"|g" ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
-        await os_utils.exec(`sed -i "" "s|tenant_secret_key|${secret_key_tenant}|g" ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
-
+        await os_utils.exec(`sed -i "" "s|tenant_access_key|"${cephtenant_access_key}"|g" ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+        await os_utils.exec(`sed -i "" "s|tenant_secret_key|${cephtenant_secret_key}|g" ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
     } else {
-        await os_utils.exec(`sed -i -e 's:tenant_access_key:${access_key_tenant}:g' ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
-        await os_utils.exec(`sed -i -e 's:tenant_secret_key:${secret_key_tenant}:g' ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
-        await os_utils.exec(`sed -i -e 's:s3_access_key:${access_key}:g' ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
-        await os_utils.exec(`sed -i -e 's:s3_secret_key:${secret_key}:g' ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+        await os_utils.exec(`sed -i -e 's:tenant_access_key:${cephtenant_access_key}:g' ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+        await os_utils.exec(`sed -i -e 's:tenant_secret_key:${cephtenant_secret_key}:g' ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+        await os_utils.exec(`sed -i -e 's:s3_access_key:${cephalt_access_key}:g' ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
+        await os_utils.exec(`sed -i -e 's:s3_secret_key:${cephalt_secret_key}:g' ${CEPH_TEST.test_dir}${CEPH_TEST.ceph_config}`);
     }
-    // create anonymous account
-    await create_anonymous_account();
-
+    console.info('CEPH TEST CONFIGURATION: DONE');
 }
 
-async function get_access_keys(path) {
-    const account_data = await fs.promises.readFile(path, 'utf8');
-    const data_json = JSON.parse(account_data);
-    const access_key = data_json.access_keys[0].access_key;
-    const encrypted_secret_key = data_json.access_keys[0].encrypted_secret_key;
-    const secret_key = await nc_mkm.decrypt(encrypted_secret_key, data_json.master_key_id);
-    return {access_key, secret_key};
+/**
+ * get_access_keys returns account access keys using noobaa-cli
+ * @param {string} account_name 
+ */
+async function get_access_keys(account_name) {
+    const options = { name: account_name, show_secrets: true };
+    const res = await test_utils.exec_manage_cli(TYPES.ACCOUNT, ACTIONS.STATUS, options);
+    const json_account = JSON.parse(res);
+    const account_data = json_account.response.reply;
+    return account_data.access_keys[0];
 }
 
-// Create an anonymous account for anonymous request. Use this account UID and GID for bucket access.
-async function create_anonymous_account() {
-    const nsfs_account_config = {
-        uid: process.getuid(),
-        gid: process.getgid(),
-    };
-    const { master_key_id } = await nc_mkm.encrypt_access_keys({});
-    const data = {
-        _id: mongo_utils.mongoObjectId(),
-        name: config.ANONYMOUS_ACCOUNT_NAME,
-        email: config.ANONYMOUS_ACCOUNT_NAME,
-        nsfs_account_config: nsfs_account_config,
-        access_keys: [],
-        allow_bucket_creation: false,
-        creation_date: new Date().toISOString(),
-        master_key_id: master_key_id,
-    };
-    const account_data = JSON.stringify(data);
-    await fs.promises.writeFile(anonymous_account_path, account_data);
-    console.log('Anonymous account created');
+/**
+ * create_account creates accounts using noobaa-cli
+ * @param {{ name?: string, uid?: number, gid?: number, anonymous?: boolean }} [options] 
+ */
+async function create_account(options = {}) {
+    const res = await test_utils.exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, options);
+    console.log('Account Created', res);
 }
 
 if (require.main === module) {

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_constants.js
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_constants.js
@@ -1,30 +1,48 @@
 /* Copyright (C) 2022 NooBaa */
 "use strict";
 
+const cephalt_name = 'cephalt';
+const cephtenant_name = 'cephtenant';
+
+// NC ceph tests paths for bucket creation
+const FS_ROOT_1 = '/tmp/nsfs_root1/';
+const FS_ROOT_2 = '/tmp/nsfs_root2/';
+
 const CEPH_TEST = {
     test_dir: 'src/test/system_tests/ceph_s3_tests/',
     s3_test_dir: 's3-tests/',
     ceph_config: 'test_ceph_s3_config.conf',
     tox_config: 'tox.ini',
     new_account_params: {
-        name: 'cephalt',
+        name: cephalt_name,
         email: 'ceph.alt@noobaa.com',
         has_login: false,
         s3_access: true,
     },
     new_account_params_tenant: {
-        name: 'cephtenant',
+        name: cephtenant_name,
         email: 'ceph.tenant@noobaa.com',
         has_login: false,
         s3_access: true,
     },
+    nc_cephalt_account_params: {
+        name: cephalt_name,
+        uid: 1000,
+        gid: 1000,
+        new_buckets_path: FS_ROOT_1
+    },
+    nc_cephtenant_account_params: {
+        name: cephtenant_name,
+        uid: 2000,
+        gid: 2000,
+        new_buckets_path: FS_ROOT_2
+    },
+    nc_anonymous_account_params: {
+        anonymous: true,
+        uid: process.getuid(),
+        gid: process.getgid()
+    }
 };
-
-// For NSFS NC path (using default values)
-const account_path = '/etc/noobaa.conf.d/accounts/cephalt.json';
-const account_tenant_path = '/etc/noobaa.conf.d/accounts/cephtenant.json';
-const anonymous_account_path = '/etc/noobaa.conf.d/accounts/anonymous.json';
-
 const DEFAULT_NUMBER_OF_WORKERS = 5; //5 was the number of workers in the previous CI/CD process
 
 const TOX_ARGS = `-c ${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir}${CEPH_TEST.tox_config}`;
@@ -32,9 +50,9 @@ const TOX_ARGS = `-c ${CEPH_TEST.test_dir}${CEPH_TEST.s3_test_dir}${CEPH_TEST.to
 const AWS4_TEST_SUFFIX = '_aws4';
 
 exports.CEPH_TEST = CEPH_TEST;
-exports.account_path = account_path;
-exports.anonymous_account_path = anonymous_account_path;
-exports.account_tenant_path = account_tenant_path;
 exports.DEFAULT_NUMBER_OF_WORKERS = DEFAULT_NUMBER_OF_WORKERS;
 exports.TOX_ARGS = TOX_ARGS;
 exports.AWS4_TEST_SUFFIX = AWS4_TEST_SUFFIX;
+exports.FS_ROOT_1 = FS_ROOT_1;
+exports.FS_ROOT_2 = FS_ROOT_2;
+

--- a/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
@@ -9,22 +9,16 @@
 const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
-const nb_native = require('../../../util/nb_native');
-const { JSON_SUFFIX, SYMLINK_SUFFIX } = require('../../../sdk/config_fs');
 const SensitiveString = require('../../../util/sensitive_string');
 const AccountSpaceFS = require('../../../sdk/accountspace_fs');
 const { TMP_PATH } = require('../../system_tests/test_utils');
-const { get_process_fs_context } = require('../../../util/native_fs_utils');
 const { IAM_DEFAULT_PATH, ACCESS_KEY_STATUS_ENUM } = require('../../../endpoint/iam/iam_constants');
 const fs_utils = require('../../../util/fs_utils');
 const { IamError } = require('../../../endpoint/iam/iam_errors');
-const nc_mkm = require('../../../manage_nsfs/nc_master_key_manager').get_instance();
-const native_fs_utils = require('../../../util/native_fs_utils');
 const nsfs_schema_utils = require('../../../manage_nsfs/nsfs_schema_utils');
 
 class NoErrorThrownError extends Error {}
 
-const DEFAULT_FS_CONFIG = get_process_fs_context();
 const tmp_fs_path = path.join(TMP_PATH, 'test_accountspace_fs');
 const config_root = path.join(tmp_fs_path, 'config_root');
 const new_buckets_path1 = path.join(tmp_fs_path, 'new_buckets_path1', '/');
@@ -32,6 +26,7 @@ const new_buckets_path2 = path.join(tmp_fs_path, 'new_buckets_path2', '/');
 const new_buckets_path3 = path.join(tmp_fs_path, 'new_buckets_path3', '/');
 
 const accountspace_fs = new AccountSpaceFS({ config_root });
+const config_fs_account_options = { show_secrets: true, decrypt_secret_key: true };
 
 const root_user_account = {
     _id: '65a8edc9bc5d5bbf9db71b91',
@@ -184,9 +179,7 @@ function make_dummy_account_sdk_root_accounts_manager() {
 describe('Accountspace_FS tests', () => {
 
     beforeAll(async () => {
-        await fs_utils.create_fresh_path(accountspace_fs.config_fs.accounts_dir_path);
-        await fs_utils.create_fresh_path(accountspace_fs.config_fs.access_keys_dir_path);
-        await fs_utils.create_fresh_path(accountspace_fs.config_fs.buckets_dir_path);
+        await accountspace_fs.config_fs.create_config_dirs_if_missing();
         await fs_utils.create_fresh_path(new_buckets_path1);
         await fs_utils.create_fresh_path(new_buckets_path3);
         await fs.promises.chown(new_buckets_path1,
@@ -196,12 +189,7 @@ describe('Accountspace_FS tests', () => {
 
 
         for (const account of [root_user_account, root_user_account2, root_user_root_accounts_manager]) {
-            const account_path = accountspace_fs.config_fs.get_account_path_by_name(account.name);
-            // assuming that the root account has only 1 access key in the 0 index
-            const account_access_path = accountspace_fs.config_fs.get_account_path_by_access_key(account.access_keys[0].access_key);
-            await fs.promises.writeFile(account_path, JSON.stringify(account));
-            await fs.promises.chmod(account_path, 0o600);
-            await fs.promises.symlink(account_path, account_access_path);
+            await accountspace_fs.config_fs.create_account_config_file(account);
         }
     });
     afterAll(async () => {
@@ -248,7 +236,8 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
@@ -271,7 +260,8 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
@@ -300,7 +290,8 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
@@ -330,7 +321,8 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
@@ -499,7 +491,8 @@ describe('Accountspace_FS tests', () => {
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.iam_path).toBe(dummy_user1.iam_path);
             });
@@ -515,7 +508,8 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(dummy_user1.username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.iam_path).toBe(dummy_iam_path2);
                 // back as it was
@@ -537,7 +531,8 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(dummy_user_root_account.username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.iam_path).toBe(dummy_iam_path);
             });
@@ -631,7 +626,8 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(params.new_username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.new_username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.new_username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.new_username);
                 // back as it was
                 params = {
@@ -665,12 +661,13 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(params.new_username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.new_username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.new_username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.new_username);
-                const symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
-                await fs_utils.file_must_exist(symlink_config_path);
-                const user_account_config_file_from_symlink = await read_config_file(
-                    accountspace_fs.config_fs.access_keys_dir_path, access_key, true);
+                const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key);
+                expect(is_path_exists).toBe(true);
+                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
+                    config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(params.new_username);
             });
         });
@@ -683,8 +680,8 @@ describe('Accountspace_FS tests', () => {
                 const account_sdk = make_dummy_account_sdk();
                 const res = await accountspace_fs.delete_user(params, account_sdk);
                 expect(res).toBeUndefined();
-                const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
-                await fs_utils.file_must_not_exist(user_account_config_path);
+                const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username);
+                expect(is_path_exists).toBe(false);
             });
 
             it('delete_user does not return any params (requesting account is root accounts manager to create root account user)', async function() {
@@ -694,8 +691,8 @@ describe('Accountspace_FS tests', () => {
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
                 const res = await accountspace_fs.delete_user(params, account_sdk);
                 expect(res).toBeUndefined();
-                const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
-                await fs_utils.file_must_not_exist(user_account_config_path);
+                const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username);
+                expect(is_path_exists).toBe(false);
             });
 
             it('delete_user should return an error if requesting user is not a root account user', async function() {
@@ -770,8 +767,8 @@ describe('Accountspace_FS tests', () => {
                     expect(err).toHaveProperty('code', IamError.DeleteConflict.code);
                     expect(err).toHaveProperty('message');
                     expect(err.message).toMatch(/must delete access keys first/i);
-                    const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
-                    await fs_utils.file_must_exist(user_account_config_path);
+                    const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username);
+                    expect(is_path_exists).toBe(true);
                 }
             });
 
@@ -788,8 +785,8 @@ describe('Accountspace_FS tests', () => {
                     // same params
                     await accountspace_fs.create_access_key(params, account_sdk);
                     // create a user with the root account
-                    const account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path,
-                        username_for_root_account);
+                    const account_config_file = await accountspace_fs.config_fs.get_account_by_name(username_for_root_account,
+                        config_fs_account_options);
                     const root_account_manager_id = account_sdk.requesting_account._id;
                     const account_sdk_root = make_dummy_account_sdk_from_root_accounts_manager(
                         account_config_file, root_account_manager_id);
@@ -807,8 +804,8 @@ describe('Accountspace_FS tests', () => {
                     expect(err).toHaveProperty('code', IamError.DeleteConflict.code);
                     expect(err).toHaveProperty('message');
                     expect(err.message).toMatch(/must delete IAM users first/i);
-                    const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
-                    await fs_utils.file_must_exist(user_account_config_path);
+                    const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username);
+                    expect(is_path_exists).toBe(true);
                 }
             });
 
@@ -823,7 +820,8 @@ describe('Accountspace_FS tests', () => {
                     await accountspace_fs.create_user(params, account_sdk);
                     // create a dummy bucket
                     const bucket_name = `my-bucket-${params.username}`;
-                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                        config_fs_account_options);
                     await create_dummy_bucket(user_account_config_file, bucket_name);
                     await accountspace_fs.delete_user(params, account_sdk);
                     throw new NoErrorThrownError();
@@ -832,8 +830,8 @@ describe('Accountspace_FS tests', () => {
                     expect(err).toHaveProperty('code', IamError.DeleteConflict.code);
                     expect(err).toHaveProperty('message');
                     expect(err.message).toMatch(/must delete buckets first/i);
-                    const user_account_config_path = path.join(accountspace_fs.config_fs.accounts_dir_path, params.username + JSON_SUFFIX);
-                    await fs_utils.file_must_exist(user_account_config_path);
+                    const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username);
+                    expect(is_path_exists).toBe(true);
                 }
             });
         });
@@ -933,7 +931,8 @@ describe('Accountspace_FS tests', () => {
         };
 
         beforeAll(async () => {
-            await fs_utils.create_fresh_path(accountspace_fs.config_fs.accounts_dir_path);
+            await fs_utils.create_fresh_path(accountspace_fs.config_fs.identities_dir_path);
+            await fs_utils.create_fresh_path(accountspace_fs.config_fs.accounts_by_name_dir_path);
             await fs_utils.create_fresh_path(accountspace_fs.config_fs.access_keys_dir_path);
             await fs_utils.create_fresh_path(accountspace_fs.config_fs.buckets_dir_path);
             await fs_utils.create_fresh_path(new_buckets_path1);
@@ -941,12 +940,7 @@ describe('Accountspace_FS tests', () => {
                 root_user_root_accounts_manager.nsfs_account_config.uid, root_user_root_accounts_manager.nsfs_account_config.gid);
 
             for (const account of [root_user_root_accounts_manager]) {
-                const account_path = accountspace_fs.config_fs.get_account_path_by_name(account.name);
-                // assuming that the root account has only 1 access key in the 0 index
-                const account_access_path = accountspace_fs.config_fs.get_account_path_by_access_key(account.access_keys[0].access_key);
-                await fs.promises.writeFile(account_path, JSON.stringify(account));
-                await fs.promises.chmod(account_path, 0o600);
-                await fs.promises.symlink(account_path, account_access_path);
+                await accountspace_fs.config_fs.create_account_config_file(account);
             }
         });
         afterAll(async () => {
@@ -1016,18 +1010,16 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(1);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await read_config_file(
-                    accountspace_fs.config_fs.access_keys_dir_path,
-                    access_key,
-                    true
-                );
+                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
+                    config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(params.username);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1046,18 +1038,16 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(2);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await read_config_file(
-                    accountspace_fs.config_fs.access_keys_dir_path,
-                    access_key,
-                    true
-                );
+                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
+                    config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(params.username);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1092,7 +1082,8 @@ describe('Accountspace_FS tests', () => {
                     username: dummy_username5,
                 };
                 await accountspace_fs.create_access_key(params_for_access_key_creation, account_sdk);
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
+                    config_fs_account_options);
                 // create the second access key
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file,
@@ -1104,18 +1095,16 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(dummy_username5);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(2);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await read_config_file(
-                    accountspace_fs.config_fs.access_keys_dir_path,
-                    access_key,
-                    true
-                );
+                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
+                    config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(dummy_username5);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1126,7 +1115,8 @@ describe('Accountspace_FS tests', () => {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
+                        config_fs_account_options);
                     // create the second access key
                     // by the IAM user
                     account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file,
@@ -1157,18 +1147,16 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, params.username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
+                    config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(1);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await read_config_file(
-                    accountspace_fs.config_fs.access_keys_dir_path,
-                    access_key,
-                    true
-                );
+                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
+                    config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(params.username);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1265,7 +1253,8 @@ describe('Accountspace_FS tests', () => {
             it('get_access_key_last_used should return user access key params (requester is an IAM user)', async function() {
                 const username = dummy_user2.username;
                 let account_sdk = make_dummy_account_sdk();
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
+                    config_fs_account_options);
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[0].access_key;
@@ -1282,17 +1271,13 @@ describe('Accountspace_FS tests', () => {
             it('get_access_key_last_used return an error if user is not owned by the root account (requester is an IAM user)', async function() {
                 try {
                     let account_sdk = make_dummy_account_sdk();
-                    const requester_account_config_file = await read_config_file(
-                        accountspace_fs.config_fs.accounts_dir_path,
-                        dummy_user2.username
-                    );
+                    const requester_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_user2.username,
+                        config_fs_account_options);
                     // by the IAM user
                     account_sdk = make_dummy_account_sdk_created_from_another_account(requester_account_config_file,
                         requester_account_config_file.owner);
-                    const user_account_config_file = await read_config_file(
-                        accountspace_fs.config_fs.accounts_dir_path,
-                        dummy_user_root_account.username
-                    );
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_user_root_account.username,
+                        config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         access_key: access_key,
@@ -1363,7 +1348,8 @@ describe('Accountspace_FS tests', () => {
             });
 
             it('update_access_key should return an error if user account does not exist', async function() {
-                const user_account = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                const user_account = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
@@ -1383,7 +1369,8 @@ describe('Accountspace_FS tests', () => {
 
             it('update_access_key should return an error if access key belongs to another account ' +
                     'without passing the username flag', async function() {
-                const user_account = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                const user_account = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
@@ -1403,7 +1390,8 @@ describe('Accountspace_FS tests', () => {
             it('update_access_key should return an error if access key is on another root account', async function() {
                 try {
                     const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
-                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                        config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         username: dummy_username1,
@@ -1420,7 +1408,8 @@ describe('Accountspace_FS tests', () => {
 
             it('update_access_key should not return any param (update status to Inactive) (requesting account is root account to create IAM user)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1429,13 +1418,15 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(true);
             });
 
             it('update_access_key should not return any param (update status to Active) (requesting account is root account to create IAM user)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1444,13 +1435,15 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(false);
             });
 
             it('update_access_key should not return any param (update status to Active, already was Active) (requesting account is root account to create IAM user)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1459,14 +1452,16 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(false);
             });
 
             it('update_access_key should not return any param (requester is an IAM user)', async function() {
                 const dummy_username = dummy_username5;
                 let account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username,
+                    config_fs_account_options);
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[1].access_key;
@@ -1476,7 +1471,8 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys[1].deactivated).toBe(true);
             });
 
@@ -1484,7 +1480,8 @@ describe('Accountspace_FS tests', () => {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
+                        config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
@@ -1506,7 +1503,8 @@ describe('Accountspace_FS tests', () => {
             it('update_access_key should not return any param (update status to Inactive) (requesting account is root accounts manager requested account is root account)', async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
+                    config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: username,
@@ -1515,7 +1513,8 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(true);
             });
         });
@@ -1554,7 +1553,8 @@ describe('Accountspace_FS tests', () => {
             });
 
             it('delete_access_key should return an error if user account does not exist', async function() {
-                const user_account = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                const user_account = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
@@ -1573,7 +1573,8 @@ describe('Accountspace_FS tests', () => {
 
             it('delete_access_key should return an error if access key belongs to another account ' +
                 'without passing the username flag', async function() {
-            const user_account = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+            const user_account = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                config_fs_account_options);
             const dummy_access_key = user_account.access_keys[0].access_key;
             try {
                 const params = {
@@ -1592,7 +1593,8 @@ describe('Accountspace_FS tests', () => {
             it('delete_access_key should not return an error if access key is on another root account', async function() {
                 try {
                     const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
-                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                        config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         username: dummy_username1,
@@ -1608,7 +1610,9 @@ describe('Accountspace_FS tests', () => {
 
             it('delete_access_key should not return any param (requesting account is root account to create IAM user)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
+
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1616,10 +1620,11 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys.length).toBe(1);
-                const symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
-                await fs_utils.file_must_not_exist(symlink_config_path);
+                const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key);
+                expect(is_path_exists).toBe(false);
             });
 
             it('delete_access_key should not return any param (account with 2 access keys) (requesting account is root account to create IAM user)', async function() {
@@ -1646,19 +1651,21 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys.length).toBe(1);
                 expect(user_account_config_file.access_keys[0].access_key).toBe(access_key);
                 expect(user_account_config_file.access_keys[0].access_key).not.toBe(access_key_to_delete);
-                let symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key_to_delete + SYMLINK_SUFFIX);
-                await fs_utils.file_must_not_exist(symlink_config_path);
-                symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
-                await fs_utils.file_must_exist(symlink_config_path);
+                const is_path_exists1 = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key_to_delete);
+                expect(is_path_exists1).toBe(false);
+                const is_path_exists2 = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key);
+                expect(is_path_exists2).toBe(true);
             });
 
             it('delete_access_key should not return any param (requester is an IAM user)', async function() {
                 let account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
+                    config_fs_account_options);
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[1].access_key;
@@ -1667,18 +1674,20 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username1);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys.length).toBe(1);
                 expect(user_account_config_file.access_keys[0].access_key).not.toBe(access_key);
-                const symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
-                await fs_utils.file_must_not_exist(symlink_config_path);
+                const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key);
+                expect(is_path_exists).toBe(false);
             });
 
             it('delete_access_key should return an error if user is not owned by the root account (requester is an IAM user)', async function() {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
+                        config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
@@ -1699,7 +1708,8 @@ describe('Accountspace_FS tests', () => {
             it('delete_access_key should not return any param (requesting account is root accounts manager requested account is root account)', async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
-                let user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
+                    config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: username,
@@ -1707,10 +1717,11 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, username);
+                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
+                    config_fs_account_options);
                 expect(user_account_config_file.access_keys.length).toBe(1);
-                const symlink_config_path = path.join(accountspace_fs.config_fs.access_keys_dir_path, access_key + SYMLINK_SUFFIX);
-                await fs_utils.file_must_not_exist(symlink_config_path);
+                const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key);
+                expect(is_path_exists).toBe(false);
             });
         });
 
@@ -1779,7 +1790,8 @@ describe('Accountspace_FS tests', () => {
 
             it('list_access_keys return array of access_keys and value of is_truncated (requester is an IAM user)', async function() {
                 let account_sdk = make_dummy_account_sdk();
-                const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
+                    config_fs_account_options);
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
                 const params = {};
@@ -1793,7 +1805,8 @@ describe('Accountspace_FS tests', () => {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await read_config_file(accountspace_fs.config_fs.accounts_dir_path, dummy_username5);
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
+                        config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
@@ -1831,38 +1844,14 @@ describe('Accountspace_FS tests', () => {
 });
 
 
-/**
- * read_config_file will read the config files 
- * @param {string} account_path full account path
- * @param {string} config_file_name the name of the config file
- * @param {boolean} [is_symlink] a flag to set the suffix as a symlink instead of json
- */
-
-async function read_config_file(account_path, config_file_name, is_symlink) {
-    const config_path = path.join(account_path, config_file_name + (is_symlink ? SYMLINK_SUFFIX : JSON_SUFFIX));
-    const { data } = await nb_native().fs.readFile(DEFAULT_FS_CONFIG, config_path);
-    const config_data = JSON.parse(data.toString());
-    if (config_data.access_keys.length > 0) {
-        const encrypted_secret_key = config_data.access_keys[0].encrypted_secret_key;
-        config_data.access_keys[0].secret_key = await nc_mkm.decrypt(encrypted_secret_key, config_data.master_key_id);
-        delete config_data.access_keys[0].encrypted_secret_key;
-    }
-    return config_data;
-}
-
 async function create_dummy_bucket(account, bucket_name) {
     const bucket_storage_path = path.join(account.nsfs_account_config.new_buckets_path, bucket_name);
     const bucket = _new_bucket_defaults(account, bucket_name, bucket_storage_path);
     const bucket_config = JSON.stringify(bucket);
     const bucket_to_validate = JSON.parse(bucket_config);
     nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
-    const bucket_config_path = path.join(accountspace_fs.config_fs.buckets_dir_path, bucket_name + JSON_SUFFIX);
-    await native_fs_utils.create_config_file(
-        accountspace_fs.fs_context,
-        accountspace_fs.config_fs.buckets_dir_path,
-        bucket_config_path,
-        bucket_config
-    );
+    await accountspace_fs.config_fs.create_bucket_config_file(bucket_name, bucket_config);
+    const bucket_config_path = accountspace_fs.config_fs.get_bucket_path_by_name(bucket_name);
     return bucket_config_path;
 }
 

--- a/src/test/unit_tests/jest_tests/test_config_dir_structure.js
+++ b/src/test/unit_tests/jest_tests/test_config_dir_structure.js
@@ -1,0 +1,150 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const nb_native = require('../../../util/nb_native');
+const config = require('../../../../config');
+const fs_utils = require('../../../util/fs_utils');
+const { ConfigFS } = require('../../../sdk/config_fs');
+const { TMP_PATH } = require('../../system_tests/test_utils');
+const { get_process_fs_context, is_path_exists } = require('../../../util/native_fs_utils');
+
+const tmp_fs_path = path.join(TMP_PATH, 'test_config_fs');
+const config_root = path.join(tmp_fs_path, 'config_root');
+const config_root_backend = config.NSFS_NC_CONFIG_DIR_BACKEND;
+const fs_context = get_process_fs_context(config_root_backend);
+
+
+const DEFAULT_CONF_DIR_PATH = config.NSFS_NC_DEFAULT_CONF_DIR;
+const CUSTOM_CONF_DIR_PATH = path.join(TMP_PATH, 'redirected_config_dir');
+const REDIRECT_FILE_PATH = path.join(DEFAULT_CONF_DIR_PATH, config.NSFS_NC_CONF_DIR_REDIRECT_FILE);
+const default_config_fs = new ConfigFS(DEFAULT_CONF_DIR_PATH, config_root_backend, fs_context);
+const custom_config_fs = new ConfigFS(CUSTOM_CONF_DIR_PATH, config_root_backend, fs_context);
+const config_fs = new ConfigFS(config_root, config_root_backend, fs_context);
+
+const buckets_dir_name = '/buckets/';
+const identities_dir_name = '/identities/';
+const accounts_by_name = '/accounts_by_name/';
+const access_keys_dir_name = '/access_keys/';
+const old_accounts_dir_name = '/accounts/';
+
+// WARNING:
+// The following test file will check the directory structure created using create_config_dirs_if_missing()
+// which is called when using noobaa-cli, for having an accurate test, it'll be blocked from running on an 
+// env having an existing default config directory and the test executer will be asked to remove the default 
+// config directory before running the test again, do not run on production env or on any env where the existing config directory is being used
+describe('create_config_dirs_if_missing', () => {
+
+    beforeAll(async () => {
+        const config_dir_exists = await is_path_exists(fs_context, DEFAULT_CONF_DIR_PATH);
+        const msg = `test_config_dir_restructure found an existing default config directory ${DEFAULT_CONF_DIR_PATH},` +
+            `this test needs to test the creation of the config directory elements, therefore make sure ` +
+            `the content of the config directory is not needed and remove it for ensuring a used config directory will not get deleted`;
+        if (config_dir_exists) {
+            console.error(msg);
+            process.exit(1);
+        }
+    });
+
+    afterEach(async () => {
+        await clean_config_dir();
+    });
+
+    it('create_config_dirs_if_missing() first time - nothing exists - everything should be created', async () => {
+        await default_config_fs.create_config_dirs_if_missing();
+        await assert_config_dir(DEFAULT_CONF_DIR_PATH);
+    });
+
+    it('create_config_dirs_if_missing() first time - config_dir exists - all subdirs should be created under the default config dir', async () => {
+        const config_dir = DEFAULT_CONF_DIR_PATH;
+        await create_config_dir(config_dir);
+        await default_config_fs.create_config_dirs_if_missing();
+        await assert_config_dir(config_dir);
+    });
+
+    it('create_config_dirs_if_missing() first time - default_config_dir exists and redirect file, redirected config_dir missing - all subdirs should be created under the redirect folder', async () => {
+        const default_config_dir = DEFAULT_CONF_DIR_PATH;
+        const config_dir = CUSTOM_CONF_DIR_PATH;
+        await create_config_dir(default_config_dir);
+        await create_redirect_file();
+        await custom_config_fs.create_config_dirs_if_missing();
+        await assert_config_dir(config_dir);
+    });
+
+    it('create_config_dirs_if_missing() first time - default_config_dir, redirect file, redirected config_dir exist - all subdirs should be created under the redirect folder', async () => {
+        const default_config_dir = DEFAULT_CONF_DIR_PATH;
+        const config_dir = CUSTOM_CONF_DIR_PATH;
+        await create_config_dir(default_config_dir);
+        await create_config_dir(CUSTOM_CONF_DIR_PATH);
+        await create_redirect_file();
+        await custom_config_fs.create_config_dirs_if_missing();
+        await assert_config_dir(config_dir);
+    });
+});
+
+
+/**
+ * assert_config_dir asserts the config dir structure was created appropriately  
+ * 1. default config dir exists
+ * 2. if redirect file exists - 
+ *    redirect config dir exists 
+ * 3. sub directories exists under the redirect config dir if exists else under the default config dir
+ * 4. old accounts/ folder does not exist
+ * @param {String} config_dir_path 
+ */
+async function assert_config_dir(config_dir_path) {
+    // config dir exists
+    let path_exists = await is_path_exists(fs_context, config_dir_path);
+    expect(path_exists).toBe(true);
+
+    // config subdirs do not exist
+    for (const dir of [buckets_dir_name, identities_dir_name, access_keys_dir_name, accounts_by_name]) {
+        const path_to_check = path.join(config_dir_path, dir);
+        path_exists = await is_path_exists(fs_context, path_to_check);
+        expect(path_exists).toBe(true);
+    }
+
+    // old accounts directory does not exist - (5.17)
+    const path_to_check = path.join(config_dir_path, old_accounts_dir_name);
+    path_exists = await is_path_exists(fs_context, path_to_check);
+    expect(path_exists).toBe(false);
+}
+
+/**
+ * clean_config_dir cleans the config directory
+ * @returns {Promise<Void>}
+ */
+async function clean_config_dir() {
+    for (const dir of [buckets_dir_name, identities_dir_name, access_keys_dir_name, accounts_by_name]) {
+        const default_path = path.join(config.NSFS_NC_DEFAULT_CONF_DIR, dir);
+        await fs_utils.folder_delete(default_path);
+        const custom_path = path.join(CUSTOM_CONF_DIR_PATH, dir);
+        await fs_utils.folder_delete(custom_path);
+
+    }
+    await fs_utils.file_delete(REDIRECT_FILE_PATH);
+    await fs_utils.folder_delete(config.NSFS_NC_DEFAULT_CONF_DIR);
+    await fs_utils.folder_delete(CUSTOM_CONF_DIR_PATH);
+}
+
+/**
+ * create_config_dir will create the config directory on the file system
+ * @param {String} config_dir 
+ * @returns {Promise<Void>}
+ */
+async function create_config_dir(config_dir) {
+    await fs.promises.mkdir(config_dir);
+}
+
+/**
+ * create_redirect_file will create the redirect file on the file system
+ * @returns {Promise<Void>}
+ */
+async function create_redirect_file() {
+    await nb_native().fs.writeFile(
+        config_fs.fs_context,
+        REDIRECT_FILE_PATH,
+        Buffer.from(CUSTOM_CONF_DIR_PATH)
+    );
+}

--- a/src/test/unit_tests/jest_tests/test_config_fs_backward_compatibility.test.js
+++ b/src/test/unit_tests/jest_tests/test_config_fs_backward_compatibility.test.js
@@ -1,0 +1,176 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const path = require('path');
+const fs_utils = require('../../../util/fs_utils');
+const { ConfigFS, CONFIG_TYPES } = require('../../../sdk/config_fs');
+const { TMP_PATH, write_manual_config_file, write_manual_old_account_config_file } = require('../../system_tests/test_utils');
+
+
+const tmp_fs_path = path.join(TMP_PATH, 'test_config_fs_backward_compatibility');
+const config_root = path.join(tmp_fs_path, 'config_root');
+const config_fs = new ConfigFS(config_root);
+
+const silent_options = { silent_if_missing: true };
+const accounts = {
+    '1': {
+        old: { _id: '1', name: 'backwards_account1', user: 'root' },
+        new: { _id: '1', name: 'backwards_account1', user: 'staff' }
+    },
+    '2': {
+        old: { _id: '2', name: 'backwards_account2', user: 'root' },
+        new: { _id: '2', name: 'backwards_account2', user: 'staff' }
+    },
+    '3': {
+        old: { _id: '3', name: 'backwards_account3', user: 'root' },
+        new: { _id: '3', name: 'backwards_account3', user: 'staff' }
+    }
+};
+
+describe('ConfigFS Backwards Compatibility', () => {
+    const old_accounts_path = config_fs.old_accounts_dir_path;
+
+    beforeAll(async () => {
+        await fs_utils.create_fresh_path(old_accounts_path);
+        await fs_utils.create_fresh_path(config_fs.identities_dir_path);
+        await fs_utils.create_fresh_path(config_fs.accounts_by_name_dir_path);
+    });
+
+    afterAll(async () => {
+        await fs_utils.folder_delete(config_root);
+    });
+
+    afterEach(async () => {
+        await clean_accounts();
+    });
+
+    ///////////////////////////
+    /// GET ACCOUNT BY NAME ///
+    ///////////////////////////
+
+    it('get_account_by_name() - {config_dir}/accounts_by_name/{account_name} is missing', async () => {
+        const old_account_data = accounts['1'].old;
+        await write_manual_old_account_config_file(config_fs, old_account_data);
+        const res = await config_fs.get_account_by_name(old_account_data.name, silent_options);
+        assert_account(res, old_account_data);
+    });
+
+    it('get_account_by_name() - {config_dir}/accounts_by_name/{account_name} exist', async () => {
+        const new_account_data = accounts['1'].new;
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, new_account_data);
+        const res = await config_fs.get_account_by_name(new_account_data.name, silent_options);
+        assert_account(res, new_account_data);
+    });
+
+    it('get_account_by_name() - both {config_dir}/accounts_by_name/{account_name}.symlink and {config_dir}/accounts/{account_name}.json missing', async () => {
+        const old_account_data = accounts['1'].old;
+        const new_account_data = accounts['1'].new;
+        await write_manual_old_account_config_file(config_fs, old_account_data);
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, new_account_data);
+        const res = await config_fs.get_account_by_name(new_account_data.name, silent_options);
+        assert_account(res, new_account_data);
+    });
+
+    it('get_account_by_name() - none exists', async () => {
+        const new_account_data = accounts['1'].new;
+        const res = await config_fs.get_account_by_name(new_account_data.name, silent_options);
+        expect(res).toBeUndefined();
+    });
+
+    /////////////////////////
+    /// IS ACCOUNT EXISTS ///
+    /////////////////////////
+
+
+    it('is_account_exists() - {config_dir}/accounts_by_name/{account_name} is missing', async () => {
+        const old_account_data = accounts['1'].old;
+        await write_manual_old_account_config_file(config_fs, old_account_data);
+        const res = await config_fs.is_account_exists_by_name(old_account_data.name, undefined);
+        expect(res).toBe(true);
+    });
+
+
+    it('is_account_exists() - {config_dir}/accounts_by_name/{account_name} exist', async () => {
+        const new_account_data = accounts['1'].new;
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, new_account_data);
+        const res = await config_fs.is_account_exists_by_name(new_account_data.name, undefined);
+        expect(res).toBe(true);
+    });
+
+    it('is_account_exists() - both {config_dir}/accounts_by_name/{account_name}.symlink and {config_dir}/accounts/{account_name}.json missing', async () => {
+        const old_account_data = accounts['1'].old;
+        const new_account_data = accounts['1'].new;
+        await write_manual_old_account_config_file(config_fs, old_account_data);
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, new_account_data);
+        const res = await config_fs.is_account_exists_by_name(new_account_data.name, undefined);
+        expect(res).toBe(true);
+    });
+
+    it('is_account_exists() - none exists', async () => {
+        const new_account_data = accounts['1'].new;
+        const res = await config_fs.is_account_exists_by_name(new_account_data.name, undefined);
+        expect(res).toBe(false);
+    });
+
+
+    ///////////////////////////
+    /// LIST ACCOUNT EXISTS ///
+    ///////////////////////////
+
+    it('list_accounts() - none exists', async () => {
+        const res = await config_fs.list_accounts();
+        expect(res.length).toBe(0);
+    });
+
+    it('list_accounts() - only new exists', async () => {
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, accounts['1'].new);
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, accounts['2'].new);
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, accounts['3'].new);
+
+        const res = await config_fs.list_accounts();
+        expect(res.length).toBe(3);
+    });
+
+    it('list_accounts() - only old exists', async () => {
+        await write_manual_old_account_config_file(config_fs, accounts['1'].old);
+        await write_manual_old_account_config_file(config_fs, accounts['2'].old);
+        await write_manual_old_account_config_file(config_fs, accounts['3'].old);
+        const res = await config_fs.list_accounts();
+        expect(res.length).toBe(3);
+    });
+
+    it('list_accounts() - both new and old exists', async () => {
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, accounts['1'].new);
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, accounts['2'].new);
+        await write_manual_config_file(CONFIG_TYPES.ACCOUNT, config_fs, accounts['3'].new);
+        await write_manual_old_account_config_file(config_fs, accounts['1'].old);
+        await write_manual_old_account_config_file(config_fs, accounts['2'].old);
+        await write_manual_old_account_config_file(config_fs, accounts['3'].old);
+        const res = await config_fs.list_accounts();
+        expect(res.length).toBe(3);
+    });
+});
+
+function assert_account(result_account, expected_account) {
+    expect(result_account._id).toBe(expected_account._id);
+    expect(result_account.name).toBe(expected_account.name);
+    expect(result_account.user).toBe(expected_account.user);
+}
+
+
+async function clean_accounts() {
+    for (const account of Object.values(accounts)) {
+        if (account.old) {
+            const old_account_path = config_fs._get_old_account_path_by_name(account.old.name);
+            await fs_utils.file_delete(old_account_path);
+        }
+        if (account.new) {
+            const new_account_path = config_fs.get_account_or_user_path_by_name(account.old.name);
+            const new_account_id_path = config_fs.get_identity_path_by_id(account.old._id);
+            const new_account_id_dir_path = config_fs.get_identity_dir_path_by_id(account.old._id);
+            await fs_utils.file_delete(new_account_path);
+            await fs_utils.file_delete(new_account_id_path);
+            await fs_utils.folder_delete(new_account_id_dir_path);
+        }
+    }
+}

--- a/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.test.js
@@ -5,11 +5,8 @@
 process.env.DISABLE_INIT_RANDOM_SEED = "true";
 
 const fs = require('fs');
-const _ = require('lodash');
 const path = require('path');
-const P = require('../../../util/promise');
 const fs_utils = require('../../../util/fs_utils');
-const { CONFIG_SUBDIRS } = require('../../../sdk/config_fs');
 const { exec_manage_cli, set_path_permissions_and_owner, TMP_PATH, set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
 const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
@@ -270,8 +267,6 @@ function fail(reason) {
 }
 
 async function setup_nc_system_and_first_account() {
-    await P.all(_.map([CONFIG_SUBDIRS.ACCOUNTS, CONFIG_SUBDIRS.ACCESS_KEYS], async dir =>
-        fs_utils.create_fresh_path(`${config_root}/${dir}`)));
     await fs_utils.create_fresh_path(root_path);
     set_nc_config_dir_in_config(config_root);
     const action = ACTIONS.ADD;

--- a/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
@@ -162,7 +162,7 @@ function validate_mkm_instance(nc_mkm_instance) {
     expect(nc_mkm_instance.active_master_key.id).toBeDefined();
     expect(nc_mkm_instance.active_master_key.cipher_key).toBeDefined();
     expect(nc_mkm_instance.active_master_key.cipher_iv).toBeDefined();
-    expect(Object.entries(master_keys_cache).length === 1).toBeTruthy();
+    expect(Object.entries(master_keys_cache).length === 1).toBe(true);
     expect(nc_mkm_instance.active_master_key).toEqual(active_master_key_by_cache);
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js
@@ -158,7 +158,7 @@ function validate_mkm_instance(nc_mkm_instance) {
     expect(nc_mkm_instance.active_master_key.id).toBeDefined();
     expect(nc_mkm_instance.active_master_key.cipher_key).toBeDefined();
     expect(nc_mkm_instance.active_master_key.cipher_iv).toBeDefined();
-    expect(Object.entries(master_keys_cache).length === 1).toBeTruthy();
+    expect(Object.entries(master_keys_cache).length === 1).toBe(true);
     expect(nc_mkm_instance.active_master_key).toEqual(active_master_key_by_cache);
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_schema_validation.test.js
@@ -518,7 +518,7 @@ function assert_validation(account_to_validate, reason, basic_message) {
     } catch (err) {
         expect(err).toBeInstanceOf(RpcError);
         expect(err).toHaveProperty('message');
-        expect((err.message).includes(basic_message)).toBeTruthy();
+        expect((err.message).includes(basic_message)).toBe(true);
     }
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -472,7 +472,7 @@ function assert_validation(bucket_to_validate, reason, basic_message) {
     } catch (err) {
         expect(err).toBeInstanceOf(RpcError);
         expect(err).toHaveProperty('message');
-        expect((err.message).includes(basic_message)).toBeTruthy();
+        expect((err.message).includes(basic_message)).toBe(true);
     }
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -371,7 +371,7 @@ function assert_validation(config_to_validate, reason, basic_message) {
     } catch (err) {
         expect(err).toBeInstanceOf(RpcError);
         expect(err).toHaveProperty('message');
-        expect((err.message).includes(basic_message)).toBeTruthy();
+        expect((err.message).includes(basic_message)).toBe(true);
     }
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_new_buckets_path_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_new_buckets_path_validation.test.js
@@ -239,8 +239,8 @@ async function path_accessible_to_account(path_to_check, account_data, is_access
     const fs_context = await get_fs_context(account_data);
     const accessible = await is_dir_rw_accessible(fs_context, path_to_check);
     if (is_accessible) {
-        expect(accessible).toBeTruthy();
+        expect(accessible).toBe(true);
     } else {
-        expect(accessible).toBeFalsy();
+        expect(accessible).toBe(false);
     }
 }

--- a/src/test/unit_tests/test_bucketspace.js
+++ b/src/test/unit_tests/test_bucketspace.js
@@ -14,7 +14,6 @@ const mocha = require('mocha');
 const assert = require('assert');
 const config = require('../../../config');
 const fs_utils = require('../../util/fs_utils');
-const { JSON_SUFFIX } = require('../../sdk/config_fs');
 const test_utils = require('../system_tests/test_utils');
 const { stat, open } = require('../../util/nb_native')().fs;
 const { get_process_fs_context } = require('../../util/native_fs_utils');
@@ -30,11 +29,10 @@ const { S3 } = require('@aws-sdk/client-s3');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
 const native_fs_utils = require('../../util/native_fs_utils');
 const mongo_utils = require('../../util/mongo_utils');
-const accounts_dir_name = '/accounts';
 
 const coretest_path = get_coretest_path();
 const coretest = require(coretest_path);
-const { rpc_client, EMAIL, PASSWORD, SYSTEM, get_admin_mock_account_details, NC_CORETEST_CONFIG_DIR_PATH } = coretest;
+const { rpc_client, EMAIL, PASSWORD, SYSTEM, get_admin_mock_account_details, NC_CORETEST_CONFIG_FS } = coretest;
 coretest.setup({});
 let CORETEST_ENDPOINT;
 const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null, maxArrayLength: max_arr });
@@ -1778,8 +1776,8 @@ mocha.describe('Namespace s3_bucket_policy', function() {
     let accounts_dir_path;
     let account_config_path;
     if (is_nc_coretest) {
-        accounts_dir_path = path.join(NC_CORETEST_CONFIG_DIR_PATH, accounts_dir_name);
-        account_config_path = path.join(accounts_dir_path, config.ANONYMOUS_ACCOUNT_NAME + JSON_SUFFIX);
+        accounts_dir_path = NC_CORETEST_CONFIG_FS.accounts_by_name_dir_path;
+        account_config_path = NC_CORETEST_CONFIG_FS.get_account_or_user_path_by_name(config.ANONYMOUS_ACCOUNT_NAME);
     }
 
     mocha.before(async function() {


### PR DESCRIPTION
### Explain the changes

This PR is based on @alphaprinz https://github.com/noobaa/noobaa-core/pull/8167 PR.

1. Added to the new structure the following paths - 
```
identities/
     {account_id}/account.json
     
accounts_by_name/
     {account_name}.symlink -> ../identities/{account_id}/account.json
```
3. Re-implemented create/update/delete account in configFS to adhere the new config dir structure.
4. Backwards compatibility - 
- Added backward compatibility to the following accounts getter functions - 
- get_account_by_name()
- is_account_exists({name: string})
- list_accounts()

5. Updated getter callers to these functions to have { fallback:true } options.
6. Converted tests to use config_fs.
7. Added backward compatibility tests.

### Issues: Fixed #xxx / Gap #xxx
1. Add structure tests.
2. Add list account backward compatibility tests after we agree on the expected result.
3. Update Docs.
4. Gap - When starting to use the new mapping 

### Testing Instructions:
1. `sudo npx jest --testRegex=jest_tests/test_config_fs_backward_compatibility.test.js`


- [ ] Doc added/updated
- [x] Tests added
