### PR TITLE
NC | NSFS | Bucket Policy With Principal as account ID

### DIFF
--- a/docs/NooBaaNonContainerized/S3Ops.md
+++ b/docs/NooBaaNonContainerized/S3Ops.md
@@ -97,6 +97,7 @@ A bucket policy defines which principals can perform actions on the bucket. The 
 Currently we support a couple of options:
 1. Grant anonymous permissions (all principals): either `"Principal": { "AWS": "*" }` or `"Principal": { "*" }`.
 2. Principal by account name: `"Principal": { "AWS": [ "<account-name-1>", "<account-name-2>", ... ,"<account-name-n>"] }`
+3. Principal by account ID: `"Principal": { "AWS": [ "<account-ID-1>", "<account-ID-2>", ... ,"<account-ID-n>"] }`
 
 ### Anonymous Requests Support
 

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -354,7 +354,7 @@ async function validate_bucket_args(config_fs, data, action) {
         if (data.s3_policy) {
             try {
                 await bucket_policy_utils.validate_s3_policy(data.s3_policy, data.name,
-                    async principal => config_fs.is_account_exists_by_name(principal, owner_account_data.owner)
+                    async principal => config_fs.is_account_exists_by_principal(principal, { silent_if_missing: true })
                 );
             } catch (err) {
                 dbg.error('validate_bucket_args invalid bucket policy err:', err);


### PR DESCRIPTION
### Explain the changes
This PR is based on @alphaprinz https://github.com/noobaa/noobaa-core/pull/8167 PR.
1. In `s3_rest` under the function `authorize_request_policy ` rename `account_identifier` to `account_identifier_name` and add `account_identifier_id`.
2. In `bucketspace_fs` where we use `put_bucket_policy` and in  `manage_nsfs_validations` where we validate the bucket policy use `is_account_exists_by_principal` that accepts both account name and id.
3. Both in `authorize_request_policy` (`s3_rest`) and `has_bucket_action_permission` (`bucketspace_fs`) check the principal by ID first and then the principal by name.

### Issues: Fixed #xxx / Gap #xxx
List of GAPs
1. We have code duplication that we need to handle - see this comment in bucketspace_fs:
https://github.com/noobaa/noobaa-core/blob/906ba384fd9a35cd701cdabff03fc7619ab9de36/src/sdk/bucketspace_fs.js#L670-L671
2. Currently, we don't support the principal as ARN.
3. We need to fix issue #8176, in this PR the related test (that begun failing) was skipped.

### Testing Instructions:
#### Unit Tests:
Please run:
1. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace_fs.js`
2. `sudo npx jest test_nc_nsfs_bucket_cli.test.js`
3. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_s3_bucket_policy.js`

#### Manual Tests:
High level - more details in [the comment below](https://github.com/noobaa/noobaa-core/pull/8280#issuecomment-2285402978):
1. Create 2 root accounts (account-1, account-2).
2. Create a bucket for one of the users, for example, account-1.
4. Add bucket policy on this bucket where the Principal is the account id of the other account, account-2 (`"Principal": { "AWS": [ "<account-id>" ] }`).
5. List the buckets from account-2 (see the bucket in the list).

- [X] Doc added/updated
- [X] Tests added
