### PR TITLE
NC | Test S3 Bucket Policy Fixes 

### DIFF
--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -79,8 +79,8 @@ async function setup() {
                 await rpc_client.account.create_account({
                     name: config.ANONYMOUS_ACCOUNT_NAME,
                     nsfs_account_config: {
-                        uid: 0,
-                        gid: 0
+                        uid: process.getuid(),
+                        gid: process.getgid()
                     }
                 });
             }


### PR DESCRIPTION
### Explain the changes
1. When Running `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha noobaa-core/src/test/unit_tests/test_s3_bucket_policy.js` singly (not as part of the nc_index.js file)
there were some issues - 
1. Anonymous account was not created, Added its creation if it doesn't exist, and anonymous account creation and reading support. 
2. Some changes added on https://github.com/noobaa/noobaa-core/pull/8220 - causing that we no longer need to create the namespace_resource and instead we need to add absolute paths on the account's new_bucket_path.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha noobaa-core/src/test/unit_tests/test_s3_bucket_policy.js`


- [ ] Doc added/updated
- [ ] Tests added
