### PR TITLE
NC | NSFS | Docs | Bucket Policy

### DIFF
--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -365,7 +365,7 @@ The `bucket status` command is used to print the status of the bucket.
 
 #### Usage
 ```sh
-noobaa-cli bucket status --name <account_name>
+noobaa-cli bucket status --name <bucket_name>
 ```
 #### Flags -
 - `name` (Required)

--- a/docs/NooBaaNonContainerized/S3Ops.md
+++ b/docs/NooBaaNonContainerized/S3Ops.md
@@ -4,7 +4,8 @@
 1. [Overview](#overview)
 2. [Supported S3 Bucket Operations](#supported-s3-bucket-operations)
 3. [Supported S3 Object Operations](#supported-s3-object-operations)
-4. [Anonymous Requests Support](#anonymous-requests-support)
+4. [Bucket Policy Support](#bucket-policy-support)
+5. [Anonymous Requests Support](#anonymous-requests-support)
 
 ### Overview 
 
@@ -20,7 +21,10 @@ The following lists describe the bucket and object operations available in NooBa
 - S3 HeadBucket
 - S3 ListBuckets
 - S3 ListMultipartUploads 
-
+- S3 PutBucketPolicy
+- S3 DeleteBucketPolicy
+- S3 GetBucketPolicy
+- S3 GetBucketPolicyStatus
 
 ### Supported S3 Object Operations
 
@@ -39,6 +43,56 @@ The following lists describe the bucket and object operations available in NooBa
 - S3 GetObjectTagging
 - S3 PutObjectTagging
 - S3 DeleteObjectTagging
+
+### Bucket Policy Support
+- Bucket policies are an access policy option available to grant permission to buckets and objects (see [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html) in AWS documentation). You can use bucket policies to add or deny permissions for the objects in a bucket. Bucket policies can allow or deny requests based on the elements in the policy.
+- Bucket policies use JSON-based policy language (for more information see [basic elements in bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html) in AWS documentation)
+- Bucket policy can be added to a bucket using the S3 API or the noobaa-cli.
+- Bucket policy is an additional layer of permissions to the FS permissions (UID and GID), which means that if two accounts do not have the same permissions (UID, GID) just setting bucket policy on the bucket is not enough.
+
+#### Bucket Policy in NooBaa CLI
+1. Adding a bucket policy:
+  - On bucket creation using the command: `noobaa-cli bucket add --name <bucket_name> --owner <owner_name> --path <path> --bucket_policy <bucket-policy>`.
+  - On bucket update using the command: `noobaa-cli bucket update --name <bucket_name> --bucket_policy <bucket-policy>`.
+In both cases the argument for the bucket policy is a string
+2. Removing a bucket policy: `noobaa-cli bucket update --name <bucket_name> --bucket_policy ''` (using empty string)
+3. Get a bucket policy: `noobaa-cli bucket status --name <bucket_name>` (a bucket policy will be printed in the bucket details)
+
+bucket_policy as a string example:
+`'{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["<account-name>"]},"Action":["s3:*"],"Resource":["arn:aws:s3:::<bucket-name>/*","arn:aws:s3:::<bucket-name>"]}]}'`
+
+Replace `<account-name>` with account name and `<bucket-name>` with a bucket name.
+Note: `arn:aws:s3:::<bucket-name>` for S3 bucket operations and  `arn:aws:s3:::<bucket-name>/*` for S3 object operations.
+Warning: this policy allows `<account-name>` to run all S3 operations.
+
+#### Bucket Policy in S3 API (using AWS CLI)
+1. Adding bucket policy: `AWS_ACCESS_KEY_ID={access_key} AWS_SECRET_ACCESS_KEY={secret_key} aws s3api put-bucket-policy --endpoint-url {endpoint_address} --bucket {bucket_name} --policy file://policy.json`
+2. Removing a bucket policy: `AWS_ACCESS_KEY_ID={access_key} AWS_SECRET_ACCESS_KEY={secret_key} aws s3api delete-bucket-policy --endpoint-url {endpoint_address} --bucket {bucket_name} --policy file://policy.json`
+3. Get a bucket policy: `AWS_ACCESS_KEY_ID={access_key} AWS_SECRET_ACCESS_KEY={secret_key} aws s3api get-bucket-policy --endpoint-url {endpoint_address} --bucket {bucket_name} --policy file://policy.json`
+
+policy.json example:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [ 
+    { 
+     "Effect": "Allow", 
+     "Principal": { "AWS": [ "<account-name>" ] }, 
+     "Action": [ "s3:*" ], 
+     "Resource": [ "arn:aws:s3:::<bucket-name>/*", "arn:aws:s3:::<bucket-name>" ] 
+    }
+  ]
+}
+```
+Replace `<account-name>` with account name and `<bucket-name>` with a bucket name.
+Note: `arn:aws:s3:::<bucket-name>` for S3 bucket operations and  `arn:aws:s3:::<bucket-name>/*` for S3 object operations.
+Warning: this policy allows `<account-name>` to run all S3 operations.
+
+##### Principal Field:
+A bucket policy defines which principals can perform actions on the bucket. The Principal element specifies the user or account that is either allowed or denied access to a resource.
+Currently we support a couple of options:
+1. Grant anonymous permissions (all principals): either `"Principal": { "AWS": "*" }` or `"Principal": { "*" }`.
+2. Principal by account name: `"Principal": { "AWS": [ "<account-name-1>", "<account-name-2>", ... ,"<account-name-n>"] }`
 
 ### Anonymous Requests Support
 


### PR DESCRIPTION
### Explain the changes
1. Add bucket policy documentation.
2. Fix a typo in NooBaa CLI documentation about bucket status - change the argument from "account_name" to "bucket_name".

### Issues:
List of GAPs:
1. Anonymous in our code and example contains the option `"Principal": { "AWS": [ "*" ] }`, but it is not described in AWS docs (see [this documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security_iam_service-with-iam.html#security_iam_service-with-iam-id-based-policies-resources) the part "Grant anonymous permissions").
2. Add to the docs this line: "Only the bucket owner can associate a policy with a bucket." (see issue #8288 ). 

### Testing Instructions:
1. None


- [X] Doc added/updated
- [ ] Tests added
