### PR TITLE
NC | Bucket Owner Removal

### DIFF
--- a/docs/NooBaaNonContainerized/GettingStarted.md
+++ b/docs/NooBaaNonContainerized/GettingStarted.md
@@ -187,7 +187,7 @@ make_bucket: s3bucket
 #### 3. Check that the bucket configuration file was created successfully -
 ```sh
 sudo cat /etc/noobaa.conf.d/buckets/s3bucket.json
-{"_id":"65cb1efcbec92b33220112d7","name":"s3bucket","owner_account":"65cb1e7c9e6ae40d499c0ae4","bucket_owner":"account1","versioning":"DISABLED","creation_date":"2023-09-26T05:56:16.252Z","path":"/tmp/fs1/s3bucket","should_create_underlying_storage":true}
+{"_id":"65cb1efcbec92b33220112d7","name":"s3bucket","owner_account":"65cb1e7c9e6ae40d499c0ae4","versioning":"DISABLED","creation_date":"2023-09-26T05:56:16.252Z","path":"/tmp/fs1/s3bucket","should_create_underlying_storage":true}
 ```
 
 #### 4. Check that the underlying file system bucket directory was created successfully -

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -207,7 +207,6 @@ class NsfsObjectSDK extends ObjectSDK {
                     Principal: [new SensitiveString('*')],
                 }]
             },
-            system_owner: new SensitiveString('nsfs'),
             bucket_owner: new SensitiveString('nsfs'),
             owner_account: new SensitiveString('nsfs-id'), // temp
         };

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -37,15 +37,20 @@ function write_stdout_response(response_code, detail, event_arg) {
  * get_bucket_owner_account will return the account of the bucket_owner
  * otherwise it would throw an error
  * @param {import('../sdk/config_fs').ConfigFS} config_fs
- * @param {string} bucket_owner
+ * @param {string} [bucket_owner]
+ * @param {string} [owner_account_id]
  */
-async function get_bucket_owner_account(config_fs, bucket_owner) {
+async function get_bucket_owner_account(config_fs, bucket_owner, owner_account_id) {
     try {
-        const account = await config_fs.get_account_by_name(bucket_owner);
+        const account = bucket_owner ?
+            await config_fs.get_account_by_name(bucket_owner) :
+            await config_fs.get_identity_by_id(owner_account_id);
         return account;
     } catch (err) {
         if (err.code === 'ENOENT') {
-            const detail_msg = `bucket owner ${bucket_owner} does not exists`;
+            const detail_msg = bucket_owner ?
+                `bucket owner name ${bucket_owner} does not exists` :
+                `bucket owner id ${owner_account_id} does not exists`;
             throw_cli_error(ManageCLIError.BucketSetForbiddenBucketOwnerNotExists, detail_msg, {bucket_owner: bucket_owner});
         }
         throw err;

--- a/src/manage_nsfs/manage_nsfs_logging.js
+++ b/src/manage_nsfs/manage_nsfs_logging.js
@@ -1,13 +1,14 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
+const AWS = require('aws-sdk');
 const config = require('../../config');
-const { throw_cli_error, write_stdout_response} = require('../manage_nsfs/manage_nsfs_cli_utils');
+const http_utils = require('../util/http_utils');
+const { CONFIG_TYPES } = require('../sdk/config_fs');
+const { export_logs_to_target } = require('../util/bucket_logs_utils');
 const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
-const { export_logs_to_target } = require('../util/bucket_logs_utils');
-const http_utils = require('../util/http_utils');
-const AWS = require('aws-sdk');
+const { throw_cli_error, write_stdout_response} = require('../manage_nsfs/manage_nsfs_cli_utils');
 
 let config_fs;
 /** This command goes over the logs in the persistent log and move the entries to log objects in the target buckets 
@@ -39,8 +40,9 @@ async function export_bucket_logging(shared_config_fs) {
  */
 async function get_bucket_owner_keys(log_bucket_name) {
     const log_bucket_config_data = await config_fs.get_bucket_by_name(log_bucket_name);
-    const log_bucket_owner = log_bucket_config_data.bucket_owner;
-    const owner_config_data = await config_fs.get_account_by_name(log_bucket_owner, { show_secrets: true, decrypt_secret_key: true });
+    const log_bucket_owner = log_bucket_config_data.owner_account;
+    const owner_config_data = await config_fs.get_identity_by_id(log_bucket_owner,
+        CONFIG_TYPES.ACCOUNT, { show_secrets: true, decrypt_secret_key: true });
     return owner_config_data.access_keys;
 }
 

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -672,7 +672,7 @@ class AccountSpaceFS {
         const bucket_names = await this.config_fs.list_buckets();
         await P.map_with_concurrency(10, bucket_names, async bucket_name => {
             const bucket_data = await this.config_fs.get_bucket_by_name(bucket_name, { silent_if_missing: true});
-            if (bucket_data && bucket_data.bucket_owner === account_to_delete.name) {
+            if (bucket_data && bucket_data.owner_account === account_to_delete._id) {
                 this._throw_error_delete_conflict(action, account_to_delete, resource_name);
             }
             return bucket_data;

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -787,6 +787,10 @@ class ConfigFS {
         if (bucket.system_owner !== undefined) {
             delete bucket.system_owner;
         }
+        // bucket_owner is deprecated since version 5.18
+        if (bucket.bucket_owner !== undefined) {
+            delete bucket.bucket_owner;
+        }
     }
 
     /**

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -7,7 +7,6 @@ module.exports = {
     required: [
         '_id',
         'name',
-        'bucket_owner',
         'owner_account',
         'versioning',
         'path',
@@ -36,7 +35,10 @@ module.exports = {
         system_owner: {
             type: 'string',
         },
-        // bucket_owner is the account name
+        /** 
+         * @deprecated bucket_owner is kept for backward compatibility,
+         * but will no longer be included in new / updated bucket json.
+         */
         bucket_owner: {
             type: 'string',
         },

--- a/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
@@ -1861,7 +1861,6 @@ function _new_bucket_defaults(account, bucket_name, bucket_storage_path) {
         _id: '65a8edc9bc5d5bbf9db71c75',
         name: bucket_name,
         owner_account: account._id,
-        bucket_owner: new SensitiveString(account.name),
         creation_date: new Date().toISOString(),
         path: bucket_storage_path,
         should_create_underlying_storage: true,

--- a/src/test/unit_tests/jest_tests/test_config_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_config_fs.test.js
@@ -21,10 +21,11 @@ describe('adjust_bucket_with_schema_updates', () => {
         expect(bucket).toBeUndefined();
     });
 
-    it('should return bucket without deprecated properties (system_owner)', () => {
-        const bucket = {name: 'bucket1', system_owner: 'account1-system-owner'};
+    it('should return bucket without deprecated properties', () => {
+        const bucket = {name: 'bucket1', system_owner: 'account1-system-owner', bucket_owner: 'account1-bucket_owner'};
         config_fs.adjust_bucket_with_schema_updates(bucket);
         expect(bucket).toBeDefined();
         expect(bucket).not.toHaveProperty('system_owner');
+        expect(bucket).not.toHaveProperty('bucket_owner');
     });
 });

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_schema_validation.test.js
@@ -181,24 +181,6 @@ describe('schema validation NC NSFS bucket', () => {
             assert_validation(bucket_data, reason, message);
         });
 
-        it('bucket without bucket_owner', () => {
-            const bucket_data = get_bucket_data();
-            delete bucket_data.bucket_owner;
-            const reason = 'Test should have failed because of missing required property ' +
-                'bucket_owner';
-            const message = "must have required property 'bucket_owner'";
-            assert_validation(bucket_data, reason, message);
-        });
-
-        it('bucket with undefined bucket_owner', () => {
-            const bucket_data = get_bucket_data();
-            bucket_data.bucket_owner = undefined;
-            const reason = 'Test should have failed because of missing required property ' +
-                'bucket_owner';
-            const message = "must have required property 'bucket_owner'";
-            assert_validation(bucket_data, reason, message);
-        });
-
         it('bucket without versioning', () => {
             const bucket_data = get_bucket_data();
             delete bucket_data.versioning;
@@ -445,7 +427,6 @@ describe('schema validation NC NSFS bucket', () => {
 function get_bucket_data() {
     const bucket_name = 'bucket1';
     const id = '65a62e22ceae5e5f1a758aa8';
-    const bucket_owner = 'account1'; // account name
     const owner_account = '65b3c68b59ab67b16f98c26e';
     const versioning_disabled = 'DISABLED';
     const creation_date = new Date('December 17, 2023 09:00:00').toISOString();
@@ -454,7 +435,6 @@ function get_bucket_data() {
     const bucket_data = {
         _id: id,
         name: bucket_name,
-        bucket_owner: bucket_owner,
         owner_account: owner_account,
         versioning: versioning_disabled,
         creation_date: creation_date,

--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -2255,6 +2255,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
         const version_body = 'A1A1A1A';
 
         mocha.before(async function() {
+            this.timeout(600000); // eslint-disable-line no-invalid-this
             if (invalid_nsfs_root_permissions()) this.skip(); // eslint-disable-line no-invalid-this
             // create paths
             await fs_utils.create_fresh_path(tmp_fs_root2, 0o777);
@@ -2889,6 +2890,7 @@ mocha.describe('List-objects', function() {
     let file_pointer;
 
     mocha.before(async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
         if (process.getgid() !== 0 || process.getuid() !== 0) {
             console.log('No Root permissions found in env. Skipping test');
             this.skip(); // eslint-disable-line no-invalid-this


### PR DESCRIPTION
### Disclaimers - 
1. This PR is based on the bucket owner removal part of https://github.com/noobaa/noobaa-core/pull/8167 written by @alphaprinz.
2. ~~This PR is dependent on merging - https://github.com/noobaa/noobaa-core/pull/8279 and currently, cherry-picking its only commit, which will be removed after its merge.~~

### Explain the changes
1. Schema - Removal of bucket_owner property requirement from nsfs_bucket_schema.js. Didn't remove it completely from the schema for backward compatibility.
2. CLI - Create/Update flows - removal of bucket_owner property usage from the schema, but left it on the CLI API which means that on create/update bucket `--owner` flag is still the name of the account, and it'll be mapped to an id internally - owner_account.
3. S3 API (BucketspaceFS) - 
- read_bucket_sdk_info() - since we don't keep the bucket owner name we now read the account config file by its id (owner account) and set the bucket_owner run time object.
- create_bucket() - removed bucket_owner from new_bucket_defaults.
4. IAM API (AccountspaceFS) - 
- _check_if_root_account_does_not_have_buckets_before_deletion() - Updated usage by id instead of by name.  
6. Tests/Docs - Removed and updated bucket_owner related changes.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #https://github.com/noobaa/noobaa-core/issues/8080
2. Gap - we need to remove [the following line](https://github.com/noobaa/noobaa-core/pull/8167/files#diff-11cc61806e3f6607fe678e081751019f21db0f09d48a56a26713203b3ada1db5L241) when having IAM users in users/ directory (this will mean that a root account can have the same name as an IAM user) @shirady 

```diff
-   if (account_identifier === bucket_owner.unwrap()) return true;
+   if (owner_account && account._id === owner_account.id) return true;
+   //name check - only for root accounts
+   if (!account.owner && account_identifier_name === bucket_owner.unwrap()) return true;
```
### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
