### PR TITLE
NC | ConfigFS | Create prepare for schema functions and some manage_nsfs refactoring

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -134,6 +134,30 @@ function check_root_account_owns_user(root_account, account) {
 }
 
 
+/**
+ * is_name_update returns true if a new_name flag was provided and it's not equal to 
+ * the current name
+ * @param {Object} data
+ * @returns {Boolean} 
+ */
+function is_name_update(data) {
+    const cur_name = data.name;
+    const new_name = data.new_name;
+    return new_name && cur_name && new_name !== cur_name;
+}
+
+/**
+ * is_access_key_update returns true if a new_access_key flag was provided and it's not equal to 
+ * the current access_key at index 0
+ * @param {Object} data
+ * @returns {Boolean} 
+ */
+function is_access_key_update(data) {
+    const cur_access_key = has_access_keys(data.access_keys) ? data.access_keys[0].access_key.unwrap() : undefined;
+    const new_access_key = data.new_access_key;
+    return new_access_key && cur_access_key && new_access_key !== cur_access_key;
+}
+
 // EXPORTS
 exports.throw_cli_error = throw_cli_error;
 exports.write_stdout_response = write_stdout_response;
@@ -144,3 +168,5 @@ exports.has_access_keys = has_access_keys;
 exports.generate_id = generate_id;
 exports.set_debug_level = set_debug_level;
 exports.check_root_account_owns_user = check_root_account_owns_user;
+exports.is_name_update = is_name_update;
+exports.is_access_key_update = is_access_key_update;

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -9,8 +9,8 @@ const string_utils = require('../util/string_utils');
 const native_fs_utils = require('../util/native_fs_utils');
 const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const bucket_policy_utils = require('../endpoint/s3/s3_bucket_policy_utils');
-const { throw_cli_error, get_options_from_file, get_boolean_or_string_value,
-    check_root_account_owns_user, get_bucket_owner_account} = require('../manage_nsfs/manage_nsfs_cli_utils');
+const { throw_cli_error, get_bucket_owner_account, get_options_from_file, get_boolean_or_string_value,
+    check_root_account_owns_user, is_name_update, is_access_key_update } = require('../manage_nsfs/manage_nsfs_cli_utils');
 const { TYPES, ACTIONS, VALID_OPTIONS, OPTION_TYPE, FROM_FILE, BOOLEAN_STRING_VALUES, BOOLEAN_STRING_OPTIONS,
     GLACIER_ACTIONS, LIST_UNSETABLE_OPTIONS, ANONYMOUS, DIAGNOSE_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
 const iam_utils = require('../endpoint/iam/iam_utils');
@@ -300,10 +300,41 @@ function validate_account_name(type, action, input_options_with_data) {
  * @param {object} input_options
  */
 function validate_bucket_identifier(action, input_options) {
-if (action === ACTIONS.STATUS || action === ACTIONS.ADD || action === ACTIONS.UPDATE || action === ACTIONS.DELETE) {
+    if (action === ACTIONS.STATUS || action === ACTIONS.ADD || action === ACTIONS.UPDATE || action === ACTIONS.DELETE) {
         if (input_options.name === undefined) throw_cli_error(ManageCLIError.MissingBucketNameFlag);
     }
     // in list there is no identifier
+}
+
+/**
+ * check_new_name_exists will validate that a new account/bucket name does not exist
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @param {string} action
+ * @param {object} data
+ */
+async function check_new_name_exists(type, config_fs, action, data) {
+    const new_name = action === ACTIONS.ADD ? data.name : data.new_name;
+    if (action === ACTIONS.UPDATE && !is_name_update(data)) return;
+    if (type === TYPES.BUCKET) {
+        const exists = await config_fs.is_bucket_exists(new_name);
+        if (exists) throw_cli_error(ManageCLIError.BucketAlreadyExists, new_name, { bucket: new_name });
+    } else if (type === TYPES.ACCOUNT) {
+        const exists = await config_fs.is_account_exists_by_name(new_name);
+        if (exists) throw_cli_error(ManageCLIError.AccountNameAlreadyExists, new_name, { account: new_name });
+    }
+}
+
+/**
+ * check_new_access_key_exists will validate that a new access_key does not exist
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @param {string} action
+ * @param {object} data
+ */
+async function check_new_access_key_exists(config_fs, action, data) {
+    const new_access_key = action === ACTIONS.ADD ? data.access_keys?.[0]?.access_key : data.new_access_key;
+    if (action === ACTIONS.UPDATE && !is_access_key_update(data)) return;
+    const exists = await config_fs.is_account_exists_by_access_key(new_access_key);
+    if (exists) throw_cli_error(ManageCLIError.AccountAccessKeyAlreadyExists, new_access_key, { account: new_access_key });
 }
 
 /**
@@ -322,6 +353,7 @@ async function validate_bucket_args(config_fs, data, action) {
         if (data.fs_backend !== undefined && !['GPFS', 'CEPH_FS', 'NFSv4'].includes(data.fs_backend)) {
             throw_cli_error(ManageCLIError.InvalidFSBackend);
         }
+        await check_new_name_exists(TYPES.BUCKET, config_fs, action, data);
         // in case we have the fs_backend it changes the fs_context that we use for the path
         const fs_context_fs_backend = native_fs_utils.get_process_fs_context(data.fs_backend);
         const exists = await native_fs_utils.is_path_exists(fs_context_fs_backend, data.path);
@@ -396,6 +428,10 @@ function validate_account_identifier(action, input_options) {
  */
 async function validate_account_args(config_fs, data, action, is_flag_iam_operate_on_root_account_update_action) {
     if (action === ACTIONS.ADD || action === ACTIONS.UPDATE) {
+
+        await check_new_name_exists(TYPES.ACCOUNT, config_fs, action, data);
+        await check_new_access_key_exists(config_fs, action, data);
+
         if (data.nsfs_account_config.gid && data.nsfs_account_config.uid === undefined) {
             throw_cli_error(ManageCLIError.MissingAccountNSFSConfigUID, data.nsfs_account_config);
         }

--- a/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
@@ -15,7 +15,6 @@ const { TMP_PATH } = require('../../system_tests/test_utils');
 const { IAM_DEFAULT_PATH, ACCESS_KEY_STATUS_ENUM } = require('../../../endpoint/iam/iam_constants');
 const fs_utils = require('../../../util/fs_utils');
 const { IamError } = require('../../../endpoint/iam/iam_errors');
-const nsfs_schema_utils = require('../../../manage_nsfs/nsfs_schema_utils');
 
 class NoErrorThrownError extends Error {}
 
@@ -1847,10 +1846,7 @@ describe('Accountspace_FS tests', () => {
 async function create_dummy_bucket(account, bucket_name) {
     const bucket_storage_path = path.join(account.nsfs_account_config.new_buckets_path, bucket_name);
     const bucket = _new_bucket_defaults(account, bucket_name, bucket_storage_path);
-    const bucket_config = JSON.stringify(bucket);
-    const bucket_to_validate = JSON.parse(bucket_config);
-    nsfs_schema_utils.validate_bucket_schema(bucket_to_validate);
-    await accountspace_fs.config_fs.create_bucket_config_file(bucket_name, bucket_config);
+    await accountspace_fs.config_fs.create_bucket_config_file(bucket);
     const bucket_config_path = accountspace_fs.config_fs.get_bucket_path_by_name(bucket_name);
     return bucket_config_path;
 }

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -715,10 +715,10 @@ mocha.describe('bucketspace_fs', function() {
             };
             const param = { name: test_bucket, policy: policy };
             await bucketspace_fs.put_bucket_policy(param);
-            const policy_res = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
-            assert.deepEqual(policy_res.policy, policy);
+            const bucket_policy_res = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
+            assert_bucket_policies(bucket_policy_res.policy, policy);
             const info_res = await bucketspace_fs.read_bucket_sdk_info(param);
-            assert.deepEqual(info_res.s3_policy, policy);
+            assert_bucket_policies(info_res.s3_policy, policy);
         });
 
         mocha.it('delete_bucket_policy ', async function() {
@@ -761,10 +761,10 @@ mocha.describe('bucketspace_fs', function() {
                 };
             const param = { name: test_bucket, policy: policy };
             await bucketspace_fs.put_bucket_policy(param);
-            const bucket_policy = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
-            assert.deepEqual(bucket_policy.policy, policy);
+            const bucket_policy_res = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
+            assert_bucket_policies(bucket_policy_res.policy, policy);
             const info_res = await bucketspace_fs.read_bucket_sdk_info(param);
-            assert.deepEqual(info_res.s3_policy, policy);
+            assert_bucket_policies(info_res.s3_policy, policy);
         });
 
         mocha.it('put_bucket_policy other account object - account does not exist', async function() {
@@ -801,10 +801,10 @@ mocha.describe('bucketspace_fs', function() {
             };
             const param = { name: test_bucket, policy: policy };
             await bucketspace_fs.put_bucket_policy(param);
-            const bucket_policy = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
-            assert.deepEqual(bucket_policy.policy, policy);
+            const bucket_policy_res = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
+            assert_bucket_policies(bucket_policy_res.policy, policy);
             const info_res = await bucketspace_fs.read_bucket_sdk_info(param);
-            assert.deepEqual(info_res.s3_policy, policy);
+            assert_bucket_policies(info_res.s3_policy, policy);
         });
 
         mocha.it('put_bucket_policy other account all', async function() {
@@ -820,17 +820,17 @@ mocha.describe('bucketspace_fs', function() {
             };
             const param = { name: test_bucket, policy: policy };
             await bucketspace_fs.put_bucket_policy(param);
-            const bucket_policy = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
-            assert.deepEqual(bucket_policy.policy, policy);
+            const bucket_policy_res = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
+            assert_bucket_policies(bucket_policy_res.policy, policy);
             const info_res = await bucketspace_fs.read_bucket_sdk_info(param);
-            assert.deepEqual(info_res.s3_policy, policy);
+            assert_bucket_policies(info_res.s3_policy, policy);
         });
 
         mocha.it('delete_bucket_policy ', async function() {
             const param = { name: test_bucket };
             await bucketspace_fs.delete_bucket_policy(param);
-            const bucket_policy = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
-            assert.ok(bucket_policy.policy === undefined);
+            const bucket_policy_res = await bucketspace_fs.get_bucket_policy(param, dummy_object_sdk);
+            assert.ok(bucket_policy_res.policy === undefined);
         });
     });
 
@@ -904,3 +904,17 @@ async function create_bucket(bucket_name) {
 function get_config_file_path(config_type_path, file_name) {
     return path.join(config_root, config_type_path, file_name + JSON_SUFFIX);
 }
+
+/**
+ * assert_bucket_policies asserts equality of the stringified bucket policies
+ * we need to stringify before because the original policy prinicples are unwrapped and
+ * and read_bucket_sdk_info returns wrapped sensitive strings
+ * @param {Object} expected_policy 
+ * @param {Object} actual_policy 
+ */
+function assert_bucket_policies(expected_policy, actual_policy) {
+    const string_expected_policy = JSON.stringify(expected_policy);
+    const string_actual_policy = JSON.stringify(actual_policy);
+    assert.deepEqual(string_actual_policy, string_expected_policy);
+}
+

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -9,6 +9,7 @@ const assert = require('assert');
 const config = require('../../../config');
 const fs_utils = require('../../util/fs_utils');
 const nb_native = require('../../util/nb_native');
+const { crypto_random_string } = require('../../util/string_utils');
 const { CONFIG_SUBDIRS, JSON_SUFFIX, SYMLINK_SUFFIX, ConfigFS } = require('../../sdk/config_fs');
 const { get_process_fs_context } = require('../../util/native_fs_utils');
 const { ManageCLIError } = require('../../manage_nsfs/manage_nsfs_cli_errors');
@@ -655,7 +656,8 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - no uid gid - should fail', async function() {
             const action = ACTIONS.ADD;
             try {
-                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key });
+                const options = { config_root, name: crypto_random_string(7), access_key: crypto_random_string(20), secret_key };
+                await exec_manage_cli(type, action, options);
                 assert.fail('should have failed with account config should not be empty');
             } catch (err) {
                 assert_error(err, ManageCLIError.InvalidAccountNSFSConfig);
@@ -665,7 +667,8 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - no uid - should fail', async function() {
             const action = ACTIONS.ADD;
             try {
-                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, gid: 1001});
+                const options = { config_root, name: crypto_random_string(7), access_key: crypto_random_string(20), secret_key, gid: 1001 };
+                await exec_manage_cli(type, action, options);
                 assert.fail('should have failed with account config should include UID');
             } catch (err) {
                 assert_error(err, ManageCLIError.MissingAccountNSFSConfigUID);
@@ -675,7 +678,8 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - no gid - should fail', async function() {
             const action = ACTIONS.ADD;
             try {
-                await exec_manage_cli(type, action, { config_root, name: account_options.name, access_key, secret_key, uid: 1001});
+                const options = { config_root, name: crypto_random_string(7), access_key: crypto_random_string(20), secret_key, uid: 1001 };
+                await exec_manage_cli(type, action, options);
                 assert.fail('should have failed with account config should include GID');
             } catch (err) {
                 assert_error(err, ManageCLIError.MissingAccountNSFSConfigGID);
@@ -685,7 +689,8 @@ mocha.describe('manage_nsfs cli', function() {
         mocha.it('cli account create - new_buckets_path does not exist - should fail', async function() {
             const action = ACTIONS.ADD;
             try {
-                await exec_manage_cli(type, action, { ...account_options, new_buckets_path: 'path_does/not_exist' });
+                const options = { ...account_options, name: crypto_random_string(7), access_key: crypto_random_string(20), new_buckets_path: 'path_does/not_exist' };
+                await exec_manage_cli(type, action, options);
                 assert.fail('should have failed with new_buckets_path should be a valid dir path');
             } catch (err) {
                 assert_error(err, ManageCLIError.InvalidAccountNewBucketsPath);

--- a/src/test/unit_tests/test_nc_nsfs_health.js
+++ b/src/test/unit_tests/test_nc_nsfs_health.js
@@ -12,7 +12,7 @@ const NSFSHealth = require('../../manage_nsfs/health').NSFSHealth;
 const fs_utils = require('../../util/fs_utils');
 const test_utils = require('../system_tests/test_utils');
 const nb_native = require('../../util/nb_native');
-const { TYPES, DIAGNOSE_ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
+const { TYPES, DIAGNOSE_ACTIONS, ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
 const { get_process_fs_context } = require('../../util/native_fs_utils');
 const { TMP_PATH, create_fs_user_by_platform, delete_fs_user_by_platform, exec_manage_cli } = require('../system_tests/test_utils');
 const { ManageCLIError } = require('../../manage_nsfs/manage_nsfs_cli_errors');
@@ -93,25 +93,23 @@ mocha.describe('nsfs nc health', function() {
     });
 
     mocha.describe('health check', async function() {
-        const acount_name = 'account1';
-        const bucket_name = 'bucket1';
         const new_buckets_path = `${root_path}new_buckets_path_user1/`;
-        const account1 = {
-            _id: '1',
-            name: acount_name,
-            nsfs_account_config: {
-                uid: process.getuid(),
-                gid: process.getgid(),
-                new_buckets_path: new_buckets_path
-            }
+        const account1_options = {
+            name: 'account1',
+            uid: process.getuid(),
+            gid: process.getgid(),
+            new_buckets_path: new_buckets_path
         };
-        const bucket1 = { name: bucket_name, path: new_buckets_path + '/bucket1' };
-        const account_inaccessible = { _id: '2', name: 'account_inaccessible', nsfs_account_config: { uid: 999, gid: 999, new_buckets_path: bucket_storage_path } };
-        const account_inaccessible_dn = { _id: '3', name: 'account_inaccessible_dn', nsfs_account_config: { distinguished_name: 'inaccessible_dn', new_buckets_path: bucket_storage_path } };
-        const invalid_account_dn = { _id: '4', name: 'invalid_account_dn', nsfs_account_config: { distinguished_name: 'invalid_account_dn', new_buckets_path: bucket_storage_path } };
+        const bucket1_options = {
+            name: 'bucket1',
+            path: new_buckets_path + '/bucket1'
+        };
+        const account_inaccessible_options = { name: 'account_inaccessible', uid: 999, gid: 999, new_buckets_path: bucket_storage_path };
+        const account_inaccessible_dn_options = { name: 'account_inaccessible_dn', user: 'inaccessible_dn', new_buckets_path: bucket_storage_path };
+        const invalid_account_dn_options = { name: 'invalid_account_dn', user: 'invalid_account_dn', new_buckets_path: bucket_storage_path };
         const fs_users = {
             other_user: {
-                distinguished_name: account_inaccessible_dn.nsfs_account_config.distinguished_name,
+                distinguished_name: account_inaccessible_dn_options.nsfs_account_config.distinguished_name,
                 uid: 1312,
                 gid: 1312
             }
@@ -123,9 +121,8 @@ mocha.describe('nsfs nc health', function() {
             await fs_utils.file_must_exist(new_buckets_path);
             await fs_utils.create_fresh_path(new_buckets_path + '/bucket1');
             await fs_utils.file_must_exist(new_buckets_path + '/bucket1');
-            await config_fs.create_config_dirs_if_missing();
-            await config_fs.create_account_config_file(account1);
-            await config_fs.create_bucket_config_file(bucket1.name, JSON.stringify(bucket1));
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, {config_root, ...account1_options});
+            await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, {config_root, ...bucket1_options});
             const get_service_memory_usage = sinon.stub(Health, "get_service_memory_usage");
             get_service_memory_usage.onFirstCall().returns(Promise.resolve(100));
             for (const user of Object.values(fs_users)) {
@@ -136,8 +133,8 @@ mocha.describe('nsfs nc health', function() {
         mocha.after(async () => {
             fs_utils.folder_delete(new_buckets_path);
             fs_utils.folder_delete(path.join(new_buckets_path, 'bucket1'));
-            await config_fs.delete_bucket_config_file(bucket1.name);
-            await config_fs.delete_account_config_file(account1);
+            await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, {config_root, name: bucket1_options.name});
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, {config_root, name: account1_options.name});
             for (const user of Object.values(fs_users)) {
                 await delete_fs_user_by_platform(user.distinguished_name);
             }
@@ -189,8 +186,8 @@ mocha.describe('nsfs nc health', function() {
         mocha.it('NSFS account with invalid storage path', async function() {
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
-            const account_invalid = { _id: '5', name: 'account_invalid', nsfs_account_config: { new_buckets_path: new_buckets_path + '/invalid' } };
-            await config_fs.create_account_config_file(account_invalid);
+            const account_invalid_options = { name: 'account_invalid', new_buckets_path: new_buckets_path + '/invalid' };
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, {config_root, ...account_invalid_options});
             const get_service_state = sinon.stub(Health, "get_service_state");
             get_service_state.onFirstCall().returns(Promise.resolve({ service_status: 'active', pid: 1000 }))
                 .onSecondCall().returns(Promise.resolve({ service_status: 'active', pid: 2000 }));
@@ -200,14 +197,14 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.status, 'OK');
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 1);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].name, 'account_invalid');
-            await fs_utils.file_delete(config_fs.get_account_or_user_path_by_name(account_invalid.name));
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, {config_root, name: account_invalid_options.name});
         });
 
         mocha.it('NSFS bucket with invalid storage path', async function() {
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             const bucket_invalid = { name: 'bucket_invalid', path: new_buckets_path + '/bucket1/invalid' };
-            await config_fs.create_bucket_config_file(bucket_invalid.name, JSON.stringify(bucket_invalid));
+            await config_fs.create_bucket_config_file(bucket_invalid);
             const get_service_state = sinon.stub(Health, "get_service_state");
             get_service_state.onFirstCall().returns(Promise.resolve({ service_status: 'active', pid: 1000 }))
                 .onSecondCall().returns(Promise.resolve({ service_status: 'active', pid: 2000 }));
@@ -217,14 +214,14 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.status, 'OK');
             assert.strictEqual(health_status.checks.buckets_status.invalid_buckets.length, 1);
             assert.strictEqual(health_status.checks.buckets_status.invalid_buckets[0].name, 'bucket_invalid');
-            await fs_utils.file_delete(config_fs.get_bucket_path_by_name(bucket_invalid.name));
+            await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, { config_root, name: bucket_invalid.name });
         });
 
         mocha.it('NSFS invalid bucket schema json', async function() {
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             const bucket_invalid_schema = { name: 'bucket_invalid_schema', path: new_buckets_path };
-            await config_fs.create_bucket_config_file(bucket_invalid_schema.name, JSON.stringify(bucket_invalid_schema) + 'invalid');
+            await config_fs.create_bucket_config_file(bucket_invalid_schema);
             const get_service_state = sinon.stub(Health, "get_service_state");
             get_service_state.onFirstCall().returns(Promise.resolve({ service_status: 'active', pid: 1000 }))
                 .onSecondCall().returns(Promise.resolve({ service_status: 'active', pid: 2000 }));
@@ -234,7 +231,7 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.status, 'OK');
             assert.strictEqual(health_status.checks.buckets_status.invalid_buckets.length, 1);
             assert.strictEqual(health_status.checks.buckets_status.invalid_buckets[0].name, 'bucket_invalid_schema');
-            await fs_utils.file_delete(config_fs.get_bucket_path_by_name(bucket_invalid_schema.name));
+            await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, { config_root, name: bucket_invalid_schema.name });
         });
 
         mocha.it('NSFS invalid account schema json', async function() {
@@ -251,7 +248,7 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.status, 'OK');
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 1);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].name, account_invalid_schema.name);
-            await fs_utils.file_delete(config_fs.get_account_or_user_path_by_name(account_invalid_schema.name));
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, { config_root, name: account_invalid_schema.name });
         });
 
         mocha.it('Health all condition is success, all_account_details is false', async function() {
@@ -316,7 +313,7 @@ mocha.describe('nsfs nc health', function() {
         });
 
         mocha.it('Account with inaccessible path - uid gid', async function() {
-            await config_fs.create_account_config_file(account_inaccessible);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_inaccessible_options});
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             Health.all_account_details = true;
@@ -331,12 +328,12 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 1);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 1);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].code, "ACCESS_DENIED");
-            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].name, account_inaccessible.name);
-            await fs_utils.file_delete(config_fs.get_account_or_user_path_by_name(account_inaccessible.name));
+            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].name, account_inaccessible_options.name);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, {config_root, name: account_inaccessible_options.name});
         });
 
         mocha.it('Account with inaccessible path - dn', async function() {
-            await config_fs.create_account_config_file(account_inaccessible_dn);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_inaccessible_dn_options });
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             Health.all_account_details = true;
@@ -351,12 +348,12 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 1);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 1);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].code, "ACCESS_DENIED");
-            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].name, account_inaccessible_dn.name);
-            await fs_utils.file_delete(config_fs.get_account_or_user_path_by_name(account_inaccessible_dn.name));
+            assert.strictEqual(health_status.checks.accounts_status.invalid_accounts[0].name, account_inaccessible_dn_options.name);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, { config_root, name: account_inaccessible_dn_options.name });
         });
 
         mocha.it('Account with invalid dn', async function() {
-            await config_fs.create_account_config_file(invalid_account_dn);
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...invalid_account_dn_options });
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             Health.all_account_details = true;
@@ -371,14 +368,14 @@ mocha.describe('nsfs nc health', function() {
             assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 1);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 1);
             const found = health_status.checks.accounts_status.invalid_accounts.filter(account =>
-                account.name === invalid_account_dn.name);
+                account.name === invalid_account_dn_options.name);
             assert.strictEqual(found.length, 1);
             assert.strictEqual(found[0].code, "INVALID_DISTINGUISHED_NAME");
         });
 
         mocha.it('Account with new_buckets_path missing and allow_bucket_creation false, valid account', async function() {
-            const account_valid = { _id: '6', name: 'account_valid', nsfs_account_config: { uid: 999, gid: 999 }, allow_bucket_creation: false };
-            await config_fs.create_account_config_file(account_valid);
+            const account_valid = { name: 'account_valid', uid: 999, gid: 999, allow_bucket_creation: false };
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_valid });
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             Health.all_account_details = true;
@@ -394,8 +391,8 @@ mocha.describe('nsfs nc health', function() {
         });
 
         mocha.it('Account with new_buckets_path missing and allow_bucket_creation true, invalid account', async function() {
-            const account_invalid = { _id: '8', name: 'account_invalid', nsfs_account_config: { uid: 999, gid: 999 }, allow_bucket_creation: true };
-            await config_fs.create_account_config_file(account_invalid);
+            const account_invalid = { name: 'account_invalid', uid: 999, gid: 999, allow_bucket_creation: true };
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_invalid });
             Health.get_service_state.restore();
             Health.get_endpoint_response.restore();
             Health.all_account_details = true;
@@ -408,7 +405,7 @@ mocha.describe('nsfs nc health', function() {
             const health_status = await Health.nc_nsfs_health();
             assert.strictEqual(health_status.checks.accounts_status.valid_accounts.length, 2);
             assert.strictEqual(health_status.checks.accounts_status.invalid_accounts.length, 2);
-            await fs_utils.file_delete(config_fs.get_account_or_user_path_by_name(account_invalid.name));
+            await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.DELETE, { config_root, name: account_invalid.name });
         });
     });
 });


### PR DESCRIPTION
### Explain the changes
1. `ConfigFS` -
      1.  Created _prepare_for_account_schema() and _prepare_for_bucket_schema() function that prepares a json config file to be written to the config dir.
      2. moved the preparation impl from the callers to the prepare functions called from create/update_account_config_file() and create/update_bucket_config_file().
2. `CLI` - 
    1. Instead of calling write_stdout_response() from every action in the CLI, called it from the management functions.
    2. Removed account_management() and bucket_management().
    3. Removed old config file preparation code.
    4. moved name/access_key existence check from add_account()/update_account()/add_bucket()/update_bucket() to validate_account_args()/validate_bucket_args() in CLI validations.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests Updated
