### PR TITLE
NSFS | NC | fix list-objecs-versions issues

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -106,7 +106,7 @@ function _get_version_id_by_stat({ino, mtimeNsBigint}) {
     return 'mtime-' + mtimeNsBigint.toString(36) + '-ino-' + ino.toString(36);
 }
 
-function _is_version_object_including_null_version(filename) {
+function _is_version_or_null_in_file_name(filename) {
     const is_version_object = _is_version_object(filename);
     if (!is_version_object) {
         return _is_version_null_version(filename);
@@ -637,6 +637,7 @@ class NamespaceFS {
              *  key: string,
              *  common_prefix: boolean,
              *  stat?: nb.NativeFSStats,
+             *  is_latest: boolean,
              * }} Result
              */
 
@@ -725,15 +726,17 @@ class NamespaceFS {
                     const isDir = await is_directory_or_symlink_to_directory(ent, fs_context, path.join(dir_path, ent.name));
 
                     let r;
-                    if (list_versions && _is_version_object_including_null_version(ent.name)) {
+                    if (list_versions && _is_version_or_null_in_file_name(ent.name)) {
                         r = {
                             key: this._get_version_entry_key(dir_key, ent),
                             common_prefix: isDir,
+                            is_latest: false
                         };
                     } else {
                         r = {
                             key: this._get_entry_key(dir_key, ent, isDir),
                             common_prefix: isDir,
+                            is_latest: true
                         };
                     }
                     await insert_entry_to_results_arr(r);
@@ -848,6 +851,20 @@ class NamespaceFS {
                 }
             };
 
+            let previous_key;
+            /**
+             * delete markers are always in the .versions folder, so we need to have special case to determine
+             * if they are delete markers. since the result list is ordered by latest entries first, the first
+             * entry of every key is the latest
+             * TODO need different way to check for isLatest in case of unordered list object versions
+             * @param {Object} obj_info
+             */
+            const set_latest_delete_marker = obj_info => {
+                if (obj_info.delete_marker && previous_key !== obj_info.key) {
+                    obj_info.is_latest = true;
+                }
+            };
+
             const prefix_dir_key = prefix.slice(0, prefix.lastIndexOf('/') + 1);
             await process_dir(prefix_dir_key);
             await Promise.all(results.map(async r => {
@@ -869,15 +886,17 @@ class NamespaceFS {
                 if (r.common_prefix) {
                     res.common_prefixes.push(r.key);
                 } else {
-                    obj_info = this._get_object_info(bucket, r.key, r.stat, 'null', false, true);
+                    obj_info = this._get_object_info(bucket, r.key, r.stat, false, r.is_latest);
                     if (!list_versions && obj_info.delete_marker) {
                         continue;
                     }
                     if (this._is_hidden_version_path(obj_info.key)) {
                         obj_info.key = path.normalize(obj_info.key.replace(HIDDEN_VERSIONS_PATH + '/', ''));
                         obj_info.key = _get_filename(obj_info.key);
+                        set_latest_delete_marker(obj_info);
                     }
                     res.objects.push(obj_info);
+                    previous_key = obj_info.key;
                 }
                 if (res.is_truncated) {
                     if (list_versions && _is_version_object(r.key)) {
@@ -921,7 +940,7 @@ class NamespaceFS {
                 }
             }
             this._throw_if_delete_marker(stat);
-            return this._get_object_info(params.bucket, params.key, stat, params.version_id || 'null', isDir);
+            return this._get_object_info(params.bucket, params.key, stat, isDir);
         } catch (err) {
             if (this._should_update_issues_report(params, file_path, err)) {
                 this.run_update_issues_report(object_sdk, err);
@@ -2293,16 +2312,18 @@ class NamespaceFS {
     }
 
     /**
-     * @param {string} bucket 
-     * @param {string} key 
-     * @param {nb.NativeFSStats} stat 
+     * @param {string} bucket
+     * @param {string} key
+     * @param {nb.NativeFSStats} stat
+     * @param {Boolean} isDir
+     * @param {boolean} [is_latest=true]
      * @returns {nb.ObjectInfo}
      */
-    _get_object_info(bucket, key, stat, return_version_id, isDir, is_latest = true) {
+    _get_object_info(bucket, key, stat, isDir, is_latest = true) {
         const etag = this._get_etag(stat);
         const create_time = stat.mtime.getTime();
         const encryption = this._get_encryption_info(stat);
-        const version_id = return_version_id && this._is_versioning_enabled() && this._get_version_id_by_xattr(stat);
+        const version_id = (this._is_versioning_enabled() || this._is_versioning_suspended()) && this._get_version_id_by_xattr(stat);
         const delete_marker = stat.xattr?.[XATTR_DELETE_MARKER] === 'true';
         const dir_content_type = stat.xattr?.[XATTR_DIR_CONTENT] && ((Number(stat.xattr?.[XATTR_DIR_CONTENT]) > 0 && 'application/octet-stream') || 'application/x-directory');
         const content_type = stat.xattr?.[XATTR_CONTENT_TYPE] ||


### PR DESCRIPTION
### Explain the changes
1. change _get_object_list to return version id in suspended mode, causing list-object-versions to return version-id in suspended mode as well
2. set isLatest flags for objects in the main bucket folder and not in .version
3. add special case to check if delete marker is the latest version by checking if its the most recent entry of the key

### Issues: Fixed #7372 

### Testing Instructions:
1. sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_bucketspace.js


- [ ] Doc added/updated
- [x] Tests added
