### PR TITLE
Fix db_cleaner.js to keep updating from_time

### DIFF
--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -35,7 +35,8 @@ async function background_worker() {
     this.last_check = now;
     const { from_time } = md_aggregator.find_minimal_range({
         target_now: now,
-        system_store: system_store
+        system_store: system_store,
+        global_last_update: system.global_last_update
     });
     dbg.log2('DB_CLEANER: md_aggregator at', new Date(from_time));
     if (from_time < last_date_to_remove) {


### PR DESCRIPTION
### Explain the changes
1. As part of fixes to md_aggregator and system_store we stopped loading the system_store on every md_aggregator cycle, instead, we added an option to support `global_last_update` in the system.
2. As part of this change we missed updating db_cleaner as well with this new structure. Now it was added and `from time` can advance and allow db_cleaner to run.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://bugzilla.redhat.com/show_bug.cgi?id=2305978

### Testing Instructions:
1. Go over the steps in the BZ above and make sure you eventually stop seeing/not seeing any
`waiting for md_aggregator to advance to later than`, and you see `md_aggregator at` keep updating 
like this:
```
Aug-21 13:38:18.302 [BGWorkers/36]    [L2] core.server.bg_services.db_cleaner:: DB_CLEANER: md_aggregator at 2024-08-21T13:36:17.104Z
Aug-21 13:38:18.303 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: found less than 1000 objects in MD-STORE
Aug-21 13:38:18.305 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: found less than 1000 nodes in nodes-store
Aug-21 13:38:18.306 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: found less than 1000 docs in system-store
Aug-21 13:38:18.306 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: END
Aug-21 13:39:18.310 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: START
Aug-21 13:39:18.310 [BGWorkers/36]    [L2] core.server.bg_services.db_cleaner:: DB_CLEANER: md_aggregator at 2024-08-21T13:37:21.638Z
Aug-21 13:39:18.311 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: found less than 1000 objects in MD-STORE
Aug-21 13:39:18.312 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: found less than 1000 nodes in nodes-store
Aug-21 13:39:18.316 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: found less than 1000 docs in system-store
Aug-21 13:39:18.316 [BGWorkers/36]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: END
```


- [ ] Doc added/updated
- [ ] Tests added
