### PR TITLE
NC | Online Upgrade CLI

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -18,6 +18,7 @@ const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').Ma
 const manage_nsfs_glacier = require('../manage_nsfs/manage_nsfs_glacier');
 const manage_nsfs_logging = require('../manage_nsfs/manage_nsfs_logging');
 const noobaa_cli_diagnose = require('../manage_nsfs/diagnose');
+const noobaa_cli_upgrade = require('../manage_nsfs/upgrade');
 const { print_usage } = require('../manage_nsfs/manage_nsfs_help_utils');
 const { TYPES, ACTIONS, LIST_ACCOUNT_FILTERS, LIST_BUCKET_FILTERS, GLACIER_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
 const { throw_cli_error, get_bucket_owner_account, write_stdout_response, get_boolean_or_string_value, has_access_keys, set_debug_level,
@@ -65,6 +66,8 @@ async function main(argv = minimist(process.argv.slice(2))) {
             await logging_management();
         } else if (type === TYPES.DIAGNOSE) {
             await noobaa_cli_diagnose.manage_diagnose_operations(action, user_input, config_fs);
+        } else if (type === TYPES.UPGRADE) {
+            await noobaa_cli_upgrade.manage_upgrade_operations(action, config_fs);
         } else {
             throw_cli_error(ManageCLIError.InvalidType);
         }

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -89,7 +89,7 @@ ManageCLIError.InvalidArgumentType = Object.freeze({
 
 ManageCLIError.InvalidType = Object.freeze({
     code: 'InvalidType',
-    message: 'Invalid type, available types are account, bucket, logging or whitelist',
+    message: 'Invalid type, available types are account, bucket, logging, whitelist or upgrade',
     http_code: 400,
 });
 
@@ -444,6 +444,40 @@ ManageCLIError.BucketNotEmpty = Object.freeze({
     message: 'The bucket you tried to delete is not empty. You must delete all versions in the bucket',
     http_code: 400,
 });
+
+
+///////////////////////////////
+//      UPGRADE ERRORS       //
+///////////////////////////////
+
+ManageCLIError.InvalidUpgradeAction = Object.freeze({
+    code: 'InvalidUpgradeAction',
+    message: 'Invalid Upgrade action',
+    http_code: 400,
+});
+
+ManageCLIError.UpgradeFailed = Object.freeze({
+    code: 'UpgradeFailed',
+    message: 'Upgrade request failed',
+    http_code: 500,
+});
+
+ManageCLIError.UpgradeStatusFailed = Object.freeze({
+    code: 'UpgradeStatusFailed',
+    message: 'Upgrade status request failed',
+    http_code: 500,
+});
+
+ManageCLIError.UpgradeHistoryFailed = Object.freeze({
+    code: 'UpgradeHistoryFailed',
+    message: 'Upgrade history request failed',
+    http_code: 500,
+});
+
+///////////////////////////////
+//       ERRORS MAPPING      //
+///////////////////////////////
+
 
 ManageCLIError.FS_ERRORS_TO_MANAGE = Object.freeze({
     EACCES: ManageCLIError.AccessDenied,

--- a/src/manage_nsfs/manage_nsfs_cli_responses.js
+++ b/src/manage_nsfs/manage_nsfs_cli_responses.js
@@ -117,12 +117,36 @@ ManageCLIResponse.BucketList = Object.freeze({
 });
 
 ///////////////////////////////
-// LOGGING RESPONSES ///
+//     LOGGING RESPONSES     //
 ///////////////////////////////
+
 ManageCLIResponse.LoggingExported = Object.freeze({
     code: 'LoggingExported',
     status: {}
 });
+
+///////////////////////////////
+//     UPGRADE RESPONSES     //
+///////////////////////////////
+
+ManageCLIResponse.UpgradeSuccessful = Object.freeze({
+    code: 'UpgradeSuccessful',
+    status: {}
+});
+
+ManageCLIResponse.UpgradeStatus = Object.freeze({
+    code: 'UpgradeStatus',
+    status: {}
+});
+
+ManageCLIResponse.UpgradeHistory = Object.freeze({
+    code: 'UpgradeHistory',
+    status: {}
+});
+
+///////////////////////////////
+//  RESPONSES-EVENT MAPPING  //
+///////////////////////////////
 
 const NSFS_CLI_SUCCESS_EVENT_MAP = {
     AccountCreated: NoobaaEvent.ACCOUNT_CREATED,

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -1,35 +1,41 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
-const TYPES = {
+const TYPES = Object.freeze({
     ACCOUNT: 'account',
     BUCKET: 'bucket',
     IP_WHITELIST: 'whitelist',
     GLACIER: 'glacier',
     LOGGING: 'logging',
-    DIAGNOSE: 'diagnose'
-};
+    DIAGNOSE: 'diagnose',
+    UPGRADE: 'upgrade'
+});
 
-const ACTIONS = {
+const ACTIONS = Object.freeze({
     ADD: 'add',
     UPDATE: 'update',
     DELETE: 'delete',
     LIST: 'list',
     STATUS: 'status'
-};
+});
 
-const GLACIER_ACTIONS = {
+const GLACIER_ACTIONS = Object.freeze({
     MIGRATE: 'migrate',
     RESTORE: 'restore',
     EXPIRY: 'expiry',
-};
+});
 
-const DIAGNOSE_ACTIONS = {
+const DIAGNOSE_ACTIONS = Object.freeze({
     HEALTH: 'health',
     GATHER_LOGS: 'gather-logs',
     METRICS: 'metrics'
-};
+});
 
+const UPGRADE_ACTIONS = Object.freeze({
+    START: 'start',
+    STATUS: 'status',
+    HISTORY: 'history'
+});
 
 const CONFIG_ROOT_FLAG = 'config_root';
 const CLI_MUTUAL_OPTIONS = new Set([CONFIG_ROOT_FLAG, 'config_root_backend', 'debug']);
@@ -134,6 +140,7 @@ exports.TYPES = TYPES;
 exports.ACTIONS = ACTIONS;
 exports.GLACIER_ACTIONS = GLACIER_ACTIONS;
 exports.DIAGNOSE_ACTIONS = DIAGNOSE_ACTIONS;
+exports.UPGRADE_ACTIONS = UPGRADE_ACTIONS;
 exports.VALID_OPTIONS = VALID_OPTIONS;
 exports.OPTION_TYPE = OPTION_TYPE;
 exports.FROM_FILE = FROM_FILE;

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -1,7 +1,7 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
-const { TYPES, ACTIONS, GLACIER_ACTIONS, DIAGNOSE_ACTIONS } = require('./manage_nsfs_constants');
+const { TYPES, ACTIONS, GLACIER_ACTIONS, DIAGNOSE_ACTIONS, UPGRADE_ACTIONS } = require('./manage_nsfs_constants');
 
 const HELP = `
 Help:
@@ -281,6 +281,43 @@ Usage:
 
 `;
 
+
+const UPGRADE_OPTIONS = `
+Usage:
+
+    noobaa-cli upgrade <action> [flags]
+
+List of actions supported:
+
+    start
+    status
+    history
+    
+`;
+
+const UPGRADE_START_OPTIONS = `
+'upgrade start' is a noobaa-cli command that will start config directory upgrade run.
+Run 'upgrade start' after upgrading NooBaa RPMs on all the cluster nodes, after starting an upgrade of the config directory,
+S3 I/O, S3 Buckets getters and NooBaa CLI Account/Buckets/Whitelist getters operations will still be working
+But updates of the config directory will be blocked during the upgrade of the config directory.
+'upgrade start' should be executed on one node, the config directory changes will be available for all the nodes of the cluster.
+`;
+
+const UPGRADE_STATUS_OPTIONS = `
+'upgrade status' is a noobaa-cli command that will return the status of an ongoing upgrade run,
+the available status information is upgrade start timestmp, from_version, to_version, config_dir_from_version,
+config_dir_to_version, running_host etc.
+
+`;
+
+const UPGRADE_HISTORY_OPTIONS = `
+'upgrade history' is a noobaa-cli command that will return the history of past upgrades,
+the available history information is an array of upgrade information - upgrade start timestmp, from_version, to_version, config_dir_from_version,
+config_dir_to_version, running_host etc.
+
+`;
+
+
 /** 
  * print_usage would print the help according to the arguments that were passed
  * @param {string} type
@@ -305,6 +342,9 @@ function print_usage(type, action) {
             break;
         case TYPES.DIAGNOSE:
             print_help_diagnose(action);
+            break;
+        case TYPES.UPGRADE:
+            print_help_upgrade(action);
             break;
         default:
             process.stdout.write(HELP + '\n');
@@ -368,6 +408,9 @@ function print_help_bucket(action) {
     process.exit(0);
 }
 
+/**
+ * @param {string} action
+ */
 function print_help_glacier(action) {
     switch (action) {
         case GLACIER_ACTIONS.MIGRATE:
@@ -384,6 +427,9 @@ function print_help_glacier(action) {
     }
 }
 
+/**
+ * @param {string} action
+ */
 function print_help_diagnose(action) {
     switch (action) {
         case DIAGNOSE_ACTIONS.HEALTH:
@@ -399,6 +445,26 @@ function print_help_diagnose(action) {
             process.stdout.write(DIAGNOSE_OPTIONS.trimStart());
     }
 }
+
+/**
+ * @param {string} action
+ */
+function print_help_upgrade(action) {
+    switch (action) {
+        case UPGRADE_ACTIONS.START:
+            process.stdout.write(UPGRADE_START_OPTIONS.trimStart());
+            break;
+        case UPGRADE_ACTIONS.STATUS:
+            process.stdout.write(UPGRADE_STATUS_OPTIONS.trimStart());
+            break;
+        case UPGRADE_ACTIONS.HISTORY:
+            process.stdout.write(UPGRADE_HISTORY_OPTIONS.trimStart());
+            break;
+        default:
+            process.stdout.write(UPGRADE_OPTIONS.trimStart());
+    }
+}
+
 
 // EXPORTS
 exports.print_usage = print_usage;

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -12,7 +12,7 @@ const bucket_policy_utils = require('../endpoint/s3/s3_bucket_policy_utils');
 const { throw_cli_error, get_bucket_owner_account, get_options_from_file, get_boolean_or_string_value,
     check_root_account_owns_user, is_name_update, is_access_key_update } = require('../manage_nsfs/manage_nsfs_cli_utils');
 const { TYPES, ACTIONS, VALID_OPTIONS, OPTION_TYPE, FROM_FILE, BOOLEAN_STRING_VALUES, BOOLEAN_STRING_OPTIONS,
-    GLACIER_ACTIONS, LIST_UNSETABLE_OPTIONS, ANONYMOUS, DIAGNOSE_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
+    GLACIER_ACTIONS, LIST_UNSETABLE_OPTIONS, ANONYMOUS, DIAGNOSE_ACTIONS, UPGRADE_ACTIONS } = require('../manage_nsfs/manage_nsfs_constants');
 const iam_utils = require('../endpoint/iam/iam_utils');
 
 /////////////////////////////
@@ -76,6 +76,8 @@ function validate_type_and_action(type, action) {
         if (!Object.values(GLACIER_ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidAction);
     } else if (type === TYPES.DIAGNOSE) {
         if (!Object.values(DIAGNOSE_ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidDiagnoseAction);
+    } else if (type === TYPES.UPGRADE) {
+        if (!Object.values(UPGRADE_ACTIONS).includes(action)) throw_cli_error(ManageCLIError.InvalidUpgradeAction);
     }
 }
 

--- a/src/manage_nsfs/upgrade.js
+++ b/src/manage_nsfs/upgrade.js
@@ -1,0 +1,79 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const dbg = require('../util/debug_module')(__filename);
+const { ManageCLIError } = require('./manage_nsfs_cli_errors');
+const { UPGRADE_ACTIONS } = require('./manage_nsfs_constants');
+const { ManageCLIResponse } = require('../manage_nsfs/manage_nsfs_cli_responses');
+const { throw_cli_error, write_stdout_response } = require('./manage_nsfs_cli_utils');
+
+/**
+ * manage_upgrade_operations handles cli upgrade operations
+ * @param {string} action 
+ * @returns {Promise<Void>}
+ */
+async function manage_upgrade_operations(action, config_fs) {
+    switch (action) {
+        case UPGRADE_ACTIONS.START:
+            await exec_config_dir_upgrade();
+            break;
+        case UPGRADE_ACTIONS.STATUS:
+            await get_upgrade_status(config_fs);
+            break;
+        case UPGRADE_ACTIONS.HISTORY:
+            await get_upgrade_history(config_fs);
+            break;
+        default:
+            throw_cli_error(ManageCLIError.InvalidUpgradeAction);
+    }
+}
+
+/**
+ * exec_config_dir_upgrade handles cli upgrade operation
+ * @returns {Promise<Void>}
+ */
+async function exec_config_dir_upgrade() {
+    try {
+        // TODO - add verifications and a call to the config directory upgrade
+        throw new Error('Upgrade Config Directory is not implemented yet');
+    } catch (err) {
+        dbg.error('could not upgrade config directory successfully - err', err);
+        throw_cli_error({ ...ManageCLIError.UpgradeFailed, cause: err });
+    }
+}
+
+/**
+ * get_upgrade_status handles cli upgrade status operation
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<Void>}
+ */
+async function get_upgrade_status(config_fs) {
+    try {
+        const system_config = await config_fs.get_system_config_file({ silent_if_missing: true });
+        let upgrade_status = system_config?.config_directory?.in_progress_upgrade;
+        if (!upgrade_status) upgrade_status = { message: 'Config directory upgrade status is empty, there is no ongoing config directory upgrade' };
+        write_stdout_response(ManageCLIResponse.UpgradeStatus, upgrade_status);
+    } catch (err) {
+        dbg.error('could not get upgrade status response', err);
+        throw_cli_error({ ...ManageCLIError.UpgradeStatusFailed, cause: err });
+    }
+}
+
+/**
+ * get_upgrade_history handles cli upgrade history operation
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<Void>}
+ */
+async function get_upgrade_history(config_fs) {
+    try {
+        const system_config = await config_fs.get_system_config_file({ silent_if_missing: true });
+        let upgrade_history = system_config?.config_directory?.upgrade_history;
+        if (!upgrade_history) upgrade_history = { message: 'Config directory upgrade history is empty' };
+        write_stdout_response(ManageCLIResponse.UpgradeHistory, upgrade_history);
+    } catch (err) {
+        dbg.error('could not get upgrade history response', err);
+        throw_cli_error({ ...ManageCLIError.UpgradeHistoryFailed, cause: err });
+    }
+}
+
+exports.manage_upgrade_operations = manage_upgrade_operations;

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -67,6 +67,7 @@ class ConfigFS {
         this.identities_dir_path = path.join(config_root, CONFIG_SUBDIRS.IDENTITIES);
         this.access_keys_dir_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS);
         this.buckets_dir_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS);
+        this.system_json_path = path.join(config_root, 'system.json');
         this.config_json_path = path.join(config_root, 'config.json');
         this.fs_context = fs_context || native_fs_utils.get_process_fs_context(this.config_root_backend);
     }
@@ -349,7 +350,7 @@ class ConfigFS {
      * @returns {string} 
     */
     get_identity_dir_path_by_id(id) {
-        return path.join(this.config_root, CONFIG_SUBDIRS.IDENTITIES, id, '/');
+        return path.join(this.identities_dir_path, id, '/');
     }
 
     /**
@@ -841,6 +842,15 @@ class ConfigFS {
         await native_fs_utils.delete_config_file(this.fs_context, this.buckets_dir_path, bucket_config_path);
     }
 
+    /**
+     * get_system_config_file read system.json file
+     * @param {{silent_if_missing?: boolean}} options 
+     * @returns {Promise<Object>}
+     */
+    async get_system_config_file(options) {
+        const system_data = await this.get_config_data(this.system_json_path, options);
+        return system_data;
+    }
 
     ////////////////////////
     ///     HELPERS     ////

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -239,7 +239,7 @@ function get_coretest_path() {
  * @param {string} type
  * @param {string} action
  * @param {object} options
- * @returns {Promise<string>}
+ * @returns {Promise<string | Error>}
  */
 async function exec_manage_cli(type, action, options, is_silent, env) {
     let flags = ``;

--- a/src/test/unit_tests/jest_tests/test_cli_upgrade.test.js
+++ b/src/test/unit_tests/jest_tests/test_cli_upgrade.test.js
@@ -1,0 +1,97 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = 'true';
+
+
+const os = require('os');
+const path = require('path');
+const fs_utils = require('../../../util/fs_utils');
+const { ConfigFS } = require('../../../sdk/config_fs');
+const { TMP_PATH, exec_manage_cli } = require('../../system_tests/test_utils');
+const { ManageCLIError } = require('../../../manage_nsfs/manage_nsfs_cli_errors');
+const { ManageCLIResponse } = require('../../../manage_nsfs/manage_nsfs_cli_responses');
+const { TYPES, UPGRADE_ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
+
+const config_root = path.join(TMP_PATH, 'config_root_cli_upgrade_test');
+const config_fs = new ConfigFS(config_root);
+const hostname = os.hostname();
+const expected_system_json = {
+    [hostname]: {
+        'current_version': '5.18.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.17.0',
+                'to_version': '5.18.0'
+            }]
+        },
+    },
+    config_directory: {
+        'schema_version': 1,
+        'in_progress_upgrade': {
+            'start_timestamp': 1724687496424,
+            'phase': 'CONFIG_DIR_LOCK',
+            'from_version': '5.18.0',
+            'to_version': '5.18.1'
+        },
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'completed_scripts': [],
+                'from_version': '5.17.0',
+                'to_version': '5.18.0'
+            }]
+        }
+    }
+};
+
+describe('noobaa cli - upgrade', () => {
+    afterEach(async () => await fs_utils.file_delete(config_fs.system_json_path));
+
+    it('upgrade invalid action - should fail', async () => {
+        const res = await exec_manage_cli(TYPES.UPGRADE, 'invalid_action', { config_root }, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.code).toBe(ManageCLIError.InvalidUpgradeAction.code);
+        expect(parsed_res.error.message).toBe(ManageCLIError.InvalidUpgradeAction.message);
+    });
+
+    it('upgrade start - should fail with not implemented', async () => {
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root }, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.code).toBe(ManageCLIError.UpgradeFailed.code);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+    });
+
+    it('upgrade status - should fail - there is no ongoing upgrade', async () => {
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.STATUS, { config_root }, true);
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeStatus.code);
+        expect(parsed_res.response.reply.message).toEqual('Config directory upgrade status is empty, there is no ongoing config directory upgrade');
+    });
+
+    it('upgrade status', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(expected_system_json));
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.STATUS, { config_root }, true);
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeStatus.code);
+        expect(parsed_res.response.reply).toEqual(expected_system_json.config_directory.in_progress_upgrade);
+    });
+
+    it('upgrade history - should fail - there is no config directory upgrade history', async () => {
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.HISTORY, { config_root }, true);
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeHistory.code);
+        expect(parsed_res.response.reply.message).toEqual('Config directory upgrade history is empty');
+    });
+
+    it('upgrade history', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(expected_system_json));
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.HISTORY, { config_root }, true);
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeHistory.code);
+        expect(parsed_res.response.reply).toEqual(expected_system_json.config_directory.upgrade_history);
+    });
+});
+


### PR DESCRIPTION
### Explain the changes
1. `CLI` - 

    1. Added `upgrade` TYPE to noobaa-cli.
    2. Added `upgrade` - `start`, `status`, `history` actions.
    3. Created upgrade CLI errors, responses, help and validations.

2. `ConfigFS `- Added get_system_config_file() function used by status and history actions.
3. `Tests` - Added upgrade cli unit tests.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - currently `start` throws not implemented error - its logic will be added in the PR that implements the upgrade process.
2.  Gap - Documentation will be added after all the PRs are done.
3. Gap/Idea - Currently on status/history we return the status/history of the config directory upgrade - we can also add `--hostname`/`--all` flag for providing the status/history of the RPM upgrade record of a specific host/all hosts.
### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
