### PR TITLE
Added a fix in upload_object for azure namespace cache bucket

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -747,6 +747,7 @@ class NamespaceBlob {
             size,
             etag,
             create_time: flat_obj.lastModified,
+            last_modified_time: flat_obj.lastModified,
             content_type: flat_obj.contentType,
             xattr: modified_xattr,
             tag_count: tag_count,

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -683,6 +683,9 @@ class NamespaceCache {
                 async_get_last_modified_time: async () => {
                     const upload_res = await hub_promise;
                     const last_modified_time = (new Date(upload_res.last_modified_time)).getTime();
+                    if (isNaN(last_modified_time)) {
+                        throw new Error('Invalid last_modified_time returned from hub_promise, Expected a valid date or timestamp.');
+                    }
                     return last_modified_time;
                 },
                 upload_chunks_hook: this.update_cache_stats_hook(params.bucket),


### PR DESCRIPTION
### Explain the changes
 When we create a cache bucket with an Azure namespace store as the hub, there is an issue in uploading the cache object. Specifically, the `complete_object_upload` operation fails with a schema error (see error below). This error occurs because `last_modified_time` was not defined during the Azure object upload, resulting in `NaN` being passed instead of a valid timestamp.

The error message indicates that the `last_modified_time` field did not pass the required schema validation, as it must be a valid date. Since the field was missing, the code attempted to use an undefined value, leading to the `NaN` value in the schema validation.

To resolve this issue, the code has been updated to ensure that a valid timestamp is always provided for `last_modified_time`. The updated code now includes an additional check after retrieving the `last_modified_time` from the response, the code verifies whether the value is a valid timestamp. If the value is `NaN` (indicating an invalid or missing date), the function throws an error, ensuring that only valid timestamps are used. This prevents invalid data from being passed to the `complete_object_upload` operation.

> [Endpoint/13] [ERROR] core.rpc.rpc_schema:: INVALID_SCHEMA_PARAMS CLIENT object_api#/methods/complete_object_upload ERRORS: [ { instancePath: '/last_modified_time', schemaPath: '#/properties/last_modified_time/idate', keyword: 'idate', params: {}, message: 'must pass "idate" keyword validation', schema: true, parentSchema: { idate: true }, data: NaN }, [length]: 1 ] PARAMS: { bucket: SENSITIVE-f4398061c1658eaa, key: 'pvc.yaml', md_conditions: undefined, obj_id: '66c741df9d9543000d088587', size: 188, num_parts: 1, md5_b64: 'uuoc28T9df/955yph29XUA==', last_modified_time: NaN }

### Issues: Fixed #xxx / Gap #xxx
1. fix: https://bugzilla.redhat.com/show_bug.cgi?id=2243032

### Testing Instructions:
Create a cache bucket with azure namespacstore as the hub, now upload some objects to the bucket and check if they are listed using AWS or rpc command.  
