### PR TITLE
NC | NSFS | Config Dir Restructure - Add `users/` Dir

### DIFF
--- a/docs/NooBaaNonContainerized/Configuration.md
+++ b/docs/NooBaaNonContainerized/Configuration.md
@@ -49,7 +49,7 @@ For Developers - Use `--config_root` flag for specifying a custom configuration 
 
 ### Configuration files permissions
 Mode
-* Configuration files generated under the `accounts/` or `buckets/` directories will have 600 permissions, granting read and write access exclusively to the owner of each configuration file.
+* Configuration files generated under the `identities/` or `buckets/` directories will have 600 permissions, granting read and write access exclusively to the owner of each configuration file.
 
 Ownership
 * Configuration file created by the NooBaa CLI tool will be owned by the user who ran the NooBaa CLI command.
@@ -62,8 +62,9 @@ The default config directory structure contains the following files/directories 
 > sudo ls /etc/noobaa.conf.d/
 system.json                 // Required
 access_keys/                // Required
-accounts/                   // Required
+accounts_by_name/           // Required
 buckets/                    // Required
+identities/                 // Required
 config.json                 // Optional
 master_keys.json            // Optional
 certificates/               // Optional
@@ -81,8 +82,9 @@ config_dir_redirect                             // Required
 > sudo ls /path/to/custom/config/dir/
 system.json                                     // Required
 access_keys/                                    // Required
-accounts/                                       // Required
+accounts_by_name/                               // Required
 buckets/                                        // Required
+identities/                                     // Required
 config.json                                     // Optional
 master_keys.json                                // Optional
 certificates/                                   // Optional
@@ -113,29 +115,33 @@ certificates/                                   // Optional
         }
     }
     ```
-`accounts/` - 
+
+`accounts_by_name/`
 * <u>Type</u>: Directory.
 * <u>Required</u>: Yes.
-* <u>Description</u>: A directory that contains configuration files for individual accounts, each account configuration file is named {account_name}.json and adheres to the [account schema](../../src/server/system_services/schemas/nsfs_account_schema.js).
+* <u>Description</u>: A directory that contains symlinks to accounts configurations, each symlink named 
+{account_name}.symlink, linking to the account config within `identities/<account-id>` directory,
+configuration file is named identity.json and adheres to the [account schema](../../src/server/system_services/schemas/nsfs_account_schema.js). The account name symlink points to a relative path of the account rather than an absolute path, for example: `../identities/1111/identity.json`.
 * <u>Example</u>:
     ```sh
-    > ls /etc/noobaa.conf.d/accounts/
-    alice.json
-    bob.json
-    charlie.json
+    > ls /etc/noobaa.conf.d/accounts_by_name/
+    alice.symlink -> ../identities/1111/identity.json
+    bob.symlink -> ../identities/2222/identity.json
+    charlie.symlink -> ../identities/333/identity.json
     ```
 
 `access_keys/` 
 * <u>Type</u>: Directory.
 * <u>Required</u>: Yes.
-* <u>Description</u>: A directory that contains symlinks to accounts configurations, each symlink named {access_key}.symlink, linking to an account within `accounts/` directory. The access key symlink points to a relative path of the account rather than an absolute path, for example: `../accounts/alice.json`.
+* <u>Description</u>: A directory that contains symlinks to accounts configurations, each symlink named {access_key}.symlink, linking to an account within `identities/<account-id>/` directory. The access key symlink points to a relative path of the account rather than an absolute path, for example: `../identities/3333/identity.json`.
 * <u>Example</u>:
     ```sh
     > ls -la /etc/noobaa.conf.d/access_keys/
-    0kbUZlNM9k4SCvrw1pftEXAMPLE.symlink -> ../accounts/alice.json
-    1kbUTlNM9k4SCvrw2pfxEXAMPLE.symlink -> ../accounts/bob.json
-    2kbUMlNM9k4SCvrw3pfyEXAMPLE.symlink -> ../accounts/charlie.json
+    0kbUZlNM9k4SCvrw1pftEXAMPLE.symlink -> ../identities/3333/identity.json
+    1kbUTlNM9k4SCvrw2pfxEXAMPLE.symlink -> ../identities/1111/identity.json
+    2kbUMlNM9k4SCvrw3pfyEXAMPLE.symlink -> ../identities/2222/identity.json
     ```
+
 `buckets/`
 * <u>Type</u>: Directory.
 * <u>Required</u>: Yes.
@@ -147,6 +153,23 @@ certificates/                                   // Optional
     bucket2.json
     bucket3.json
     ```
+
+`identities/`
+* <u>Type</u>: Directory.
+* <u>Required</u>: Yes.
+* <u>Description</u>: A directory that contains configuration files for individual identities, each identity configuration file is named {identity}.json. In case the identity is an account it adheres to the [account schema](../../src/server/system_services/schemas/nsfs_account_schema.js).
+* <u>Example</u>:
+    ```sh
+    > tree /etc/noobaa.conf.d/identities/
+    /etc/noobaa.conf.d/identities
+    ├── 1111
+    │   └── identity.json
+    └── 2222
+        └── identity.json
+    └── 3333
+    └── identity.json
+    ```
+
 `config.json`
 * <u>Type</u>: File.
 * <u>Required</u>: No.

--- a/docs/NooBaaNonContainerized/GettingStarted.md
+++ b/docs/NooBaaNonContainerized/GettingStarted.md
@@ -31,7 +31,7 @@ NooBaa Non Containerized solution includes the following components -
 5. [Storage File System](#create-storage-file-system-paths) - A File system for storing objects.
 
 ### NooBaa High Level Diagram
-![NooBaa Non Containerized Components Diagram](https://github.com/noobaa/noobaa-core/assets/35330373/8d6cce71-e9e8-4e6a-ad88-5c65255bacc7)
+![NooBaa Non Containerized Components Diagram](https://github.com/user-attachments/assets/dad9ecc8-7d8f-46cb-a832-4fc7e40a640d)
 
 
 ## Build NooBaa RPM

--- a/docs/design/iam.md
+++ b/docs/design/iam.md
@@ -127,6 +127,76 @@ Here attached a diagram with all the accounts that we have in our system:
 - IAM DeleteAccessKey: AccessKeyId, UserName
 - IAM ListAccessKeys: UserName (not supported: Marker, MaxItems)
 
+### Configuration Directory Components With users
+If account creates a user its config file will be created under identities/<user-id>.identity.json and under the account will be created `users/` directory and inside it it will link to the config.
+Example:
+Note: In this example, we didn't use `system.json`, `config.json`, and `certificates/`.
+1. Configuration directory with 1 account (name: alice, ID: 1111):
+
+```sh
+  > tree /etc/noobaa.conf.d/
+├── access_keys
+│   └── Zzto3OwtGflQrqD41h3SEXAMPLE.symlink -> ../identities/1111/identity.json
+├── accounts_by_name
+│   └── alice.symlink -> ../identities/1111/identity.json
+├── buckets
+├── identities
+│   └── 1111
+│       └── identity.json
+└── master_keys.json
+```
+
+2. Configuration directory with 1 account (name: alice, ID: 1111) and 1 user (name: Robert, ID: 9999, without access key) - 
+Notice the `users/` directory with a symlink of the username to its config file
+
+```sh
+├── access_keys
+│   └── Zzto3OwtGflQrqD41h3SEXAMPLE.symlink -> ../identities/1111/identity.json
+├── accounts_by_name
+│   └── alice.symlink -> ../identities/1111/identity.json
+├── buckets
+├── identities
+│   ├── 1111
+│   │   ├── identity.json
+│   │   └── users
+│   │       └── Robert.symlink -> ../../9999/identity.json
+│   └── 9999
+│       └── identity.json
+├── master_keys.json
+└── system.json
+```
+
+#### Naming Scope
+- Account names are unique between the accounts, for example, if we have account with name John, you cannot create a new account with the name John (and also cannot update the name of an existing account to John).
+- Usernames are unique only inside the account, for example: username Robert can be under account-1, and another user with username Robert can be under account-2.
+Note: The username cannot be the same as the account, for example: under account John we cannot create a username John (and also cannot update the name of an existing username to John). The reason for limiting it is that in the IAM API of Access Key (for example ListAccessKeys) it can be done by account on himself or on another user, and it passes the `--user-name` flag.
+
+Example: 2 accounts (alice and bob) both of them have user with username Robert (notice the different ID number).
+```sh
+├── access_keys
+│   ├── Zzto3OwtGflQrqD41h3SEXAMPLE.symlink -> ../identities/66d81ec79eac82ed43cdee73/identity.json
+│   └── Yser45gyHaghebY62wsUEXAMPLE.symlink -> ../identities/66d8351a92b8dd91b550aa71/identity.json
+├── accounts_by_name
+│   ├── alice.symlink -> ../identities/66d81ec79eac82ed43cdee73/identity.json
+│   └── bob.symlink -> ../identities/66d8351a92b8dd91b550aa71/identity.json
+├── buckets
+├── identities
+│   ├── 66d81ec79eac82ed43cdee73
+│   │   ├── identity.json
+│   │   └── users
+│   │       └── Robert.symlink -> ../../66d834df78e973023abd80cb/identity.json
+│   ├── 66d834df78e973023abd80cb
+│   │   └── identity.json
+│   ├── 66d8351a92b8dd91b550aa71
+│   │   ├── identity.json
+│   │   └── users
+│   │       └── Robert.symlink -> ../../66d83529e09267f53e705373/identity.json
+│   └── 66d83529e09267f53e705373
+│       └── identity.json
+├── master_keys.json
+└── system.json
+```
+
 ## Other
 ### Terminology - AWS vs NooBaa
 |   | AWS | NooBaa |

--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -19,13 +19,23 @@ function format_iam_xml_date(input) {
 }
 
 /**
- * create_arn creates the AWS ARN for user
+ * create_arn_for_root creates the AWS ARN for root account user
+ * see: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns
+ * @param {string} account_id (the root user account id)
+ */
+function create_arn_for_root(account_id) {
+    return `arn:aws:iam::${account_id}:root`;
+
+}
+
+/**
+ * create_arn_for_user creates the AWS ARN for user
  * see: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns
  * @param {string} account_id (the root user account id)
  * @param {string} username
  * @param {string} iam_path
  */
-function create_arn(account_id, username, iam_path) {
+function create_arn_for_user(account_id, username, iam_path) {
     const basic_structure = `arn:aws:iam::${account_id}:user`;
     if (username === undefined) return `${basic_structure}/`;
     if (check_iam_path_was_set(iam_path)) {
@@ -508,7 +518,8 @@ function validate_status(input_status) {
 
 // EXPORTS
 exports.format_iam_xml_date = format_iam_xml_date;
-exports.create_arn = create_arn;
+exports.create_arn_for_user = create_arn_for_user;
+exports.create_arn_for_root = create_arn_for_root;
 exports.get_action_message_title = get_action_message_title;
 exports.check_iam_path_was_set = check_iam_path_was_set;
 exports.parse_max_items = parse_max_items;

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -696,7 +696,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         );
         // we (currently) allow account identified to be both id and name,
         // so if by-id failed, try also name
-        if (permission === 'IMPLICIT_DENY') {
+        if (account.owner === undefined && permission === 'IMPLICIT_DENY') {
             permission = await bucket_policy_utils.has_bucket_policy_permission(
                 bucket_policy,
                 account.name.unwrap(),

--- a/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
@@ -1,11 +1,8 @@
 /* Copyright (C) 2024 NooBaa */
 /* eslint-disable max-lines-per-function */
+/* eslint-disable max-lines */
 'use strict';
 
-/*
- * This file is written as a part of TDD (Test Driven Development)
- * The asserts reflects the current state of implementation (not final)
- */
 const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
@@ -15,6 +12,7 @@ const { TMP_PATH, set_nc_config_dir_in_config } = require('../../system_tests/te
 const { IAM_DEFAULT_PATH, ACCESS_KEY_STATUS_ENUM } = require('../../../endpoint/iam/iam_constants');
 const fs_utils = require('../../../util/fs_utils');
 const { IamError } = require('../../../endpoint/iam/iam_errors');
+const nsfs_schema_utils = require('../../../manage_nsfs/nsfs_schema_utils');
 
 class NoErrorThrownError extends Error {}
 
@@ -23,7 +21,6 @@ const config_root = path.join(tmp_fs_path, 'config_root');
 const new_buckets_path1 = path.join(tmp_fs_path, 'new_buckets_path1', '/');
 const new_buckets_path2 = path.join(tmp_fs_path, 'new_buckets_path2', '/');
 const new_buckets_path3 = path.join(tmp_fs_path, 'new_buckets_path3', '/');
-
 const accountspace_fs = new AccountSpaceFS({ config_root });
 const config_fs_account_options = { show_secrets: true, decrypt_secret_key: true };
 set_nc_config_dir_in_config(config_root);
@@ -35,7 +32,7 @@ const root_user_account = {
     allow_bucket_creation: true,
     access_keys: [{
         access_key: 'a-abcdefghijklmn123456',
-        secret_key: 's-abcdefghijklmn123456EXAMPLE'
+        encrypted_secret_key: 's-abcdefghijklmn123456EXAMPLE'
     }],
     nsfs_account_config: {
         uid: 1001,
@@ -45,6 +42,7 @@ const root_user_account = {
     creation_date: '2023-10-30T04:46:33.815Z',
     master_key_id: '65a62e22ceae5e5f1a758123',
 };
+nsfs_schema_utils.validate_account_schema(root_user_account);
 
 const root_user_account2 = {
     _id: '65a8edc9bc5d5bbf9db71b92',
@@ -53,7 +51,7 @@ const root_user_account2 = {
     allow_bucket_creation: true,
     access_keys: [{
         access_key: 'a-bbcdefghijklmn123456',
-        secret_key: 's-bbcdefghijklmn123456EXAMPLE'
+        encrypted_secret_key: 's-bbcdefghijklmn123456EXAMPLE'
     }],
     nsfs_account_config: {
         uid: 1002,
@@ -63,6 +61,7 @@ const root_user_account2 = {
     creation_date: '2023-11-30T04:46:33.815Z',
     master_key_id: '65a62e22ceae5e5f1a758123',
 };
+nsfs_schema_utils.validate_account_schema(root_user_account2);
 
 const root_user_root_accounts_manager = {
     _id: '65a8edc9bc5d5bbf9db71b93',
@@ -71,7 +70,7 @@ const root_user_root_accounts_manager = {
     allow_bucket_creation: true,
     access_keys: [{
         access_key: 'a-cccdefghijklmn123456',
-        secret_key: 's-cccdefghijklmn123456EXAMPLE'
+        encrypted_secret_key: 's-cccdefghijklmn123456EXAMPLE'
     }],
     nsfs_account_config: {
         uid: 1003,
@@ -82,6 +81,7 @@ const root_user_root_accounts_manager = {
     master_key_id: '65a62e22ceae5e5f1a758123',
     iam_operate_on_root_account: true,
 };
+nsfs_schema_utils.validate_account_schema(root_user_root_accounts_manager);
 
 // I'm only interested in the requesting_account field
 function make_dummy_account_sdk() {
@@ -93,7 +93,10 @@ function make_dummy_account_sdk() {
                 creation_date: root_user_account.creation_date,
                 access_keys: [{
                     access_key: new SensitiveString(root_user_account.access_keys[0].access_key),
-                    secret_key: new SensitiveString(root_user_account.access_keys[0].secret_key)
+                    // we don't use the secret_key actually and we don't want to involve the master key,
+                    // hence in the dummy we will wrap the encrypted_secret_key as secret_key
+                    // (instead of decrypt it as needed) - COMMENT ABOUT SECRET_KEY
+                    secret_key: new SensitiveString(root_user_account.access_keys[0].encrypted_secret_key)
                 }],
                 nsfs_account_config: root_user_account.nsfs_account_config,
                 allow_bucket_creation: root_user_account.allow_bucket_creation,
@@ -119,7 +122,8 @@ function make_dummy_account_sdk_created_from_another_account(account, root_accou
             creation_date: account.creation_date,
             access_keys: [{
                 access_key: new SensitiveString(account.access_keys[0].access_key),
-                secret_key: new SensitiveString(account.access_keys[0].secret_key)
+                // see COMMENT ABOUT SECRET_KEY above
+                secret_key: new SensitiveString(account.access_keys[0].encrypted_secret_key)
             }],
             nsfs_account_config: account.nsfs_account_config,
             allow_bucket_creation: account.allow_bucket_creation,
@@ -136,8 +140,7 @@ function make_dummy_account_sdk_from_root_accounts_manager(account, root_account
     return dummy_account_sdk;
 }
 
-// use it for root user that doesn't create the resources
-// (only tries to get, update and delete resources that it doesn't own)
+// use it for root user that doesn't create the resources (only tries to get, update and delete resources that it doesn't own)
 function make_dummy_account_sdk_not_for_creating_resources() {
     return {
             requesting_account: {
@@ -147,7 +150,8 @@ function make_dummy_account_sdk_not_for_creating_resources() {
                 creation_date: root_user_account2.creation_date,
                 access_keys: [{
                     access_key: new SensitiveString(root_user_account2.access_keys[0].access_key),
-                    secret_key: new SensitiveString(root_user_account2.access_keys[0].secret_key)
+                // see COMMENT ABOUT SECRET_KEY above
+                    secret_key: new SensitiveString(root_user_account2.access_keys[0].encrypted_secret_key)
                 }],
                 nsfs_account_config: root_user_account2.nsfs_account_config,
                 allow_bucket_creation: root_user_account2.allow_bucket_creation,
@@ -166,7 +170,8 @@ function make_dummy_account_sdk_root_accounts_manager() {
                 creation_date: root_user_root_accounts_manager.creation_date,
                 access_keys: [{
                     access_key: new SensitiveString(root_user_root_accounts_manager.access_keys[0].access_key),
-                    secret_key: new SensitiveString(root_user_root_accounts_manager.access_keys[0].secret_key)
+                // see COMMENT ABOUT SECRET_KEY above
+                    secret_key: new SensitiveString(root_user_root_accounts_manager.access_keys[0].encrypted_secret_key)
                 }],
                 nsfs_account_config: root_user_root_accounts_manager.nsfs_account_config,
                 allow_bucket_creation: root_user_root_accounts_manager.allow_bucket_creation,
@@ -223,32 +228,59 @@ describe('Accountspace_FS tests', () => {
         };
 
         describe('create_user', () => {
-            it('create_user should return user params (requesting account is root account to create IAM user)', async function() {
+            it('create_user should return user params (requesting account is root account ' +
+                    'to create IAM user)', async function() {
                 const params = {
                     username: dummy_user1.username,
                     iam_path: dummy_user1.iam_path,
                 };
                 const account_sdk = make_dummy_account_sdk();
                 const res = await accountspace_fs.create_user(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res.iam_path).toBe(params.iam_path);
                 expect(res.username).toBe(params.username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
+                expect(res.arn).toContain(owner_account_id);
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    params.username, owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file.email).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(0);
-                expect(user_account_config_file.owner).toBe(account_sdk.requesting_account._id);
-                expect(user_account_config_file.creator).toBe(account_sdk.requesting_account._id);
+                expect(user_account_config_file.owner).toBe(owner_account_id);
+                expect(user_account_config_file.creator).toBe(owner_account_id);
+
+                expect(res.arn).toBe(`arn:aws:iam::${owner_account_id}:user${params.iam_path}${params.username}`);
             });
 
-            it('create_user should return user params (requesting account is root accounts manager - has allow_bucket_creation true with new_buckets_path - to create root account user)', async function() {
+            it('create_user should return user params (requesting account is root account ' +
+                'to create IAM user) - username same in another account', async function() {
+            const account_sdk = make_dummy_account_sdk_not_for_creating_resources(); // root account 2
+            const params = {
+                username: dummy_user1.username,
+            };
+            const res = await accountspace_fs.create_user(params, account_sdk);
+            const owner_account_id = account_sdk.requesting_account._id;
+            expect(res.username).toBe(params.username);
+
+            const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                params.username, owner_account_id, config_fs_account_options);
+            expect(user_account_config_file.name).toBe(params.username);
+            expect(user_account_config_file.email).toBe(params.username);
+
+            // back as it was (without the user)
+            await accountspace_fs.delete_user(params, account_sdk);
+        });
+
+            it('create_user should return user params (requesting account is root accounts manager - ' +
+                    'has allow_bucket_creation true with new_buckets_path - to create root account)',
+                    async function() {
                 const params = {
                     username: dummy_user_root_account.username,
                 };
@@ -260,9 +292,10 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(
+                    params.username, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file.email).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
                 expect(user_account_config_file.access_keys).toBeDefined();
@@ -272,9 +305,14 @@ describe('Accountspace_FS tests', () => {
                 expect(user_account_config_file.iam_operate_on_root_account).toBeUndefined();
                 expect(user_account_config_file.owner).toBeUndefined();
                 expect(user_account_config_file.creator).toBe(account_sdk.requesting_account._id);
+
+                expect(res.arn).toContain(user_account_config_file._id);
+                expect(res.arn).toBe(`arn:aws:iam::${user_account_config_file._id}:root`);
             });
 
-            it('create_user should return user params (requesting account is root accounts manager - has allow_bucket_creation false with new_buckets_path - to create root account user)', async function() {
+            it('create_user should return user params (requesting account is root accounts manager - ' +
+                    'has allow_bucket_creation false with new_buckets_path - to create root account)',
+                    async function() {
                 const params = {
                     username: dummy_username9,
                 };
@@ -290,9 +328,10 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(
+                    params.username, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file.email).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
                 expect(user_account_config_file.access_keys).toBeDefined();
@@ -302,9 +341,13 @@ describe('Accountspace_FS tests', () => {
                 expect(user_account_config_file.iam_operate_on_root_account).toBeUndefined();
                 expect(user_account_config_file.owner).toBeUndefined();
                 expect(user_account_config_file.creator).toBe(account_sdk.requesting_account._id);
+
+                expect(res.arn).toContain(user_account_config_file._id);
             });
 
-            it('create_user should return user params (requesting account is root accounts manager - has allow_bucket_creation false without new_buckets_path - to create root account user)', async function() {
+            it('create_user should return user params (requesting account is root accounts manager - ' +
+                    'has allow_bucket_creation false without new_buckets_path - to create root account)',
+                    async function() {
                 const params = {
                     username: dummy_username10,
                 };
@@ -321,9 +364,10 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
 
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(
+                    params.username, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file.email).toBe(params.username);
                 expect(user_account_config_file._id).toBeDefined();
                 expect(user_account_config_file.creation_date).toBeDefined();
                 expect(user_account_config_file.access_keys).toBeDefined();
@@ -333,9 +377,12 @@ describe('Accountspace_FS tests', () => {
                 expect(user_account_config_file.iam_operate_on_root_account).toBeUndefined();
                 expect(user_account_config_file.owner).toBeUndefined();
                 expect(user_account_config_file.creator).toBe(account_sdk.requesting_account._id);
+
+                expect(res.arn).toContain(user_account_config_file._id);
             });
 
-            it('create_user should return an error if requesting user is not a root account user', async function() {
+            it('create_user should throw an error if requesting user is not a root account',
+                    async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -350,14 +397,13 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('create_user should return an error if username already exists', async function() {
+            it('create_user should throw an error if username already exists (same account)', async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
                         iam_path: dummy_user1.iam_path,
                     };
                     const account_sdk = make_dummy_account_sdk();
-                    await accountspace_fs.create_user(params, account_sdk);
                     // now username already exists
                     await accountspace_fs.create_user(params, account_sdk);
                     throw new NoErrorThrownError();
@@ -366,24 +412,49 @@ describe('Accountspace_FS tests', () => {
                     expect(err).toHaveProperty('code', IamError.EntityAlreadyExists.code);
                 }
             });
+
+            it('create_user should return user params (requesting account is root account ' +
+                'to create IAM user) - username same as root account', async function() {
+            const account_sdk = make_dummy_account_sdk_not_for_creating_resources(); // root account 2
+            const params = {
+                username: dummy_user1.username,
+            };
+            const res = await accountspace_fs.create_user(params, account_sdk);
+            const owner_account_id = account_sdk.requesting_account._id;
+            expect(res.username).toBe(params.username);
+
+            const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                params.username, owner_account_id, config_fs_account_options);
+            expect(user_account_config_file.name).toBe(params.username);
+            expect(user_account_config_file.email).toBe(params.username);
+
+            // back as it was (without the user)
+            await accountspace_fs.delete_user(params, account_sdk);
+        });
         });
 
         describe('get_user', () => {
-            it('get_user should return user params (requesting account is root account to create IAM user)', async function() {
+            it('get_user should return user params (requesting account is root account ' +
+                    'to get IAM user)', async function() {
                 const params = {
                     username: dummy_user1.username,
                 };
                 const account_sdk = make_dummy_account_sdk();
                 const res = await accountspace_fs.get_user(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res.user_id).toBeDefined();
                 expect(res.iam_path).toBe(dummy_user1.iam_path);
                 expect(res.username).toBe(dummy_user1.username);
                 expect(res.arn).toBeDefined();
+                expect(res.arn).toContain(owner_account_id);
                 expect(res.create_date).toBeDefined();
                 expect(res.password_last_used).toBeDefined();
+
+                expect(res.arn).toBe(`arn:aws:iam::${owner_account_id}:user${dummy_user1.iam_path}${params.username}`);
             });
 
-            it('get_user should return user params (requesting account is root accounts manager to create root account user)', async function() {
+            it('get_user should return user params (requesting account is root accounts manager ' +
+                    'to get root account)', async function() {
                 const params = {
                     username: dummy_user_root_account.username,
                 };
@@ -395,9 +466,15 @@ describe('Accountspace_FS tests', () => {
                 expect(res.arn).toBeDefined();
                 expect(res.create_date).toBeDefined();
                 expect(res.password_last_used).toBeDefined();
+
+                const account_config_file = await accountspace_fs.config_fs.get_account_by_name(
+                    params.username, config_fs_account_options);
+                expect(res.arn).toContain(account_config_file._id);
+                expect(res.arn).toBe(`arn:aws:iam::${account_config_file._id}:root`);
             });
 
-            it('get_user should return an error if requesting user is not a root account user', async function() {
+            it('get_user should throw an error if requesting user is not a root account',
+                    async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -411,7 +488,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('get_user should return an error if user to get is a root account user', async function() {
+            it('get_user should throw an error if user to get is a username of root account ' +
+                '(user account does not exist)', async function() {
                 try {
                     const params = {
                         username: root_user_root_accounts_manager.name,
@@ -425,7 +503,7 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('get_user should return an error if user account does not exist', async function() {
+            it('get_user should throw an error if user account does not exist', async function() {
                 try {
                     const params = {
                         username: 'non-existing-user',
@@ -439,7 +517,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('get_user should return an error if user is not owned by the root account', async function() {
+            it('get_user should throw an error if user is not owned by the root account' +
+                '(user account does not exist)', async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -480,37 +559,46 @@ describe('Accountspace_FS tests', () => {
         });
 
         describe('update_user', () => {
-            it('update_user without actual property to update should return user params', async function() {
+            it('update_user without actual property to update should return user params',
+                    async function() {
                 const params = {
                     username: dummy_user1.username,
                 };
                 const account_sdk = make_dummy_account_sdk();
                 const res = await accountspace_fs.update_user(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res.iam_path).toBe(dummy_user1.iam_path);
                 expect(res.username).toBe(dummy_user1.username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                expect(res.arn).toContain(owner_account_id);
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    params.username, owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file.email).toBe(params.username);
                 expect(user_account_config_file.iam_path).toBe(dummy_user1.iam_path);
             });
 
-            it('update_user with new_iam_path should return user params and update the iam_path (requesting account is root account to create IAM user)', async function() {
+            it('update_user with new_iam_path should return user params and update the iam_path ' +
+                    '(requesting account is root account to create IAM user)', async function() {
                 let params = {
                     username: dummy_user1.username,
                     new_iam_path: dummy_iam_path2,
                 };
                 const account_sdk = make_dummy_account_sdk();
                 const res = await accountspace_fs.update_user(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res.iam_path).toBe(dummy_iam_path2);
                 expect(res.username).toBe(dummy_user1.username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                expect(res.arn).toContain(owner_account_id);
+                expect(res.arn).toContain(params.new_iam_path);
+                expect(res.arn).toBe(`arn:aws:iam::${owner_account_id}:user${params.new_iam_path}${params.username}`);
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    params.username, owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
+                expect(user_account_config_file.email).toBe(params.username);
                 expect(user_account_config_file.iam_path).toBe(dummy_iam_path2);
                 // back as it was
                 params = {
@@ -520,7 +608,9 @@ describe('Accountspace_FS tests', () => {
                 await accountspace_fs.update_user(params, account_sdk);
             });
 
-            it('update_user with new_iam_path should return user params and update the iam_path (requesting account is root accounts manager to create root account user)', async function() {
+            it('update_user with new_iam_path should return user params and update the iam_path ' +
+                    '(requesting account is root accounts manager to create root account)',
+                    async function() {
                 const params = {
                     username: dummy_user_root_account.username,
                     new_iam_path: dummy_iam_path,
@@ -531,13 +621,18 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(dummy_user_root_account.username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
-                expect(user_account_config_file.name).toBe(params.username);
-                expect(user_account_config_file.iam_path).toBe(dummy_iam_path);
+                const account_config_file = await accountspace_fs.config_fs.get_account_by_name(
+                    params.username, config_fs_account_options);
+                expect(account_config_file.name).toBe(params.username);
+                expect(account_config_file.email).toBe(params.username);
+                expect(account_config_file.iam_path).toBe(dummy_iam_path);
+
+                expect(res.arn).toContain(account_config_file._id);
+                expect(res.arn).toBe(`arn:aws:iam::${account_config_file._id}:root`);
             });
 
-            it('update_user should return an error if requesting user is not a root account user', async function() {
+            it('update_user should throw an error if requesting user is not a root account',
+                    async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -551,7 +646,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_user should return an error if user to update is a root account user', async function() {
+            it('update_user should throw an error if user to update is a root account',
+                    async function() {
                 try {
                     const params = {
                         username: root_user_root_accounts_manager.name,
@@ -565,7 +661,7 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_user should return an error if user account does not exist', async function() {
+            it('update_user should throw an error if user account does not exist', async function() {
                 try {
                     const params = {
                         username: 'non-existing-user',
@@ -579,7 +675,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_user should return an error if user is not owned by the root account', async function() {
+            it('update_user should throw an error if user is not owned by the root account',
+                    async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -593,7 +690,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_user with new_username should return an error if username already exists', async function() {
+            it('update_user with new_username should throw an error if username already exists',
+                    async function() {
                 try {
                     let params = {
                         username: dummy_user2.username,
@@ -622,13 +720,17 @@ describe('Accountspace_FS tests', () => {
                 };
                 const account_sdk = make_dummy_account_sdk();
                 const res = await accountspace_fs.update_user(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res.iam_path).toBe(IAM_DEFAULT_PATH);
                 expect(res.username).toBe(params.new_username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.new_username,
-                    config_fs_account_options);
+                expect(res.arn).toContain(owner_account_id);
+                expect(res.arn).toContain(params.new_username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    params.new_username, owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.new_username);
+                expect(user_account_config_file.email).toBe(params.new_username);
                 // back as it was
                 params = {
                     username: dummy_user2_new_username,
@@ -657,34 +759,42 @@ describe('Accountspace_FS tests', () => {
                     new_username: dummy_new_username,
                 };
                 const res = await accountspace_fs.update_user(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res.iam_path).toBe(IAM_DEFAULT_PATH);
                 expect(res.username).toBe(params.new_username);
                 expect(res.user_id).toBeDefined();
                 expect(res.arn).toBeDefined();
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.new_username,
-                    config_fs_account_options);
+                expect(res.arn).toContain(owner_account_id);
+                expect(res.arn).toContain(params.new_username);
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    params.new_username, owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.new_username);
+                expect(user_account_config_file.email).toBe(params.new_username);
                 const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key);
                 expect(is_path_exists).toBe(true);
-                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
-                    config_fs_account_options);
+                const user_account_config_file_from_symlink =
+                    await accountspace_fs.config_fs.get_account_by_access_key(access_key, config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(params.new_username);
+                expect(user_account_config_file_from_symlink.email).toBe(params.new_username);
             });
         });
 
         describe('delete_user', () => {
-            it('delete_user does not return any params (requesting account is root account to create IAM user)', async function() {
+            it('delete_user does not return any params (requesting account is root account ' +
+                    'to delete IAM user)', async function() {
                 const params = {
                     username: dummy_user1.username,
                 };
                 const account_sdk = make_dummy_account_sdk();
                 const res = await accountspace_fs.delete_user(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res).toBeUndefined();
-                const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username);
+                const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username, owner_account_id);
                 expect(is_path_exists).toBe(false);
             });
 
-            it('delete_user does not return any params (requesting account is root accounts manager to create root account user)', async function() {
+            it('delete_user does not return any params (requesting account is root accounts manager ' +
+                    'to delete root account)', async function() {
                 const params = {
                     username: dummy_user_root_account.username,
                 };
@@ -695,7 +805,8 @@ describe('Accountspace_FS tests', () => {
                 expect(is_path_exists).toBe(false);
             });
 
-            it('delete_user should return an error if requesting user is not a root account user', async function() {
+            it('delete_user should throw an error if requesting user is not a root account',
+                    async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -709,7 +820,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_user should return an error if user to delete is a root account user', async function() {
+            it('delete_user should throw an error if user to delete is a root account ' +
+                '(user account does not exist)', async function() {
                 try {
                     const params = {
                         username: root_user_root_accounts_manager.name,
@@ -723,7 +835,7 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_user should return an error if user account does not exist', async function() {
+            it('delete_user should throw an error if user account does not exist', async function() {
                 try {
                     const params = {
                         username: 'non-existing-user',
@@ -737,7 +849,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_user should return an error if user is not owned by the root account', async function() {
+            it('delete_user should throw an error if user is not owned by the root account ' +
+                '(user account does not exist)', async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -751,12 +864,14 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_user should return an error if user has access keys', async function() {
+            it('delete_user should throw an error if user has access keys', async function() {
                 const params = {
                     username: dummy_user2.username,
                 };
+                let owner_account_id;
                 try {
                     const account_sdk = make_dummy_account_sdk();
+                    owner_account_id = account_sdk.requesting_account._id;
                     // create the access key
                     // same params
                     await accountspace_fs.create_access_key(params, account_sdk);
@@ -767,12 +882,12 @@ describe('Accountspace_FS tests', () => {
                     expect(err).toHaveProperty('code', IamError.DeleteConflict.code);
                     expect(err).toHaveProperty('message');
                     expect(err.message).toMatch(/must delete access keys first/i);
-                    const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username);
+                    const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_name(params.username, owner_account_id);
                     expect(is_path_exists).toBe(true);
                 }
             });
 
-            it('delete_user should return an error if user has IAM users', async function() {
+            it('delete_user should throw an error if account has IAM users', async function() {
                 const username_for_root_account = dummy_username6;
                 const params = {
                     username: username_for_root_account,
@@ -785,7 +900,7 @@ describe('Accountspace_FS tests', () => {
                     // same params
                     await accountspace_fs.create_access_key(params, account_sdk);
                     // create a user with the root account
-                    const account_config_file = await accountspace_fs.config_fs.get_account_by_name(username_for_root_account,
+                    const account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
                         config_fs_account_options);
                     const root_account_manager_id = account_sdk.requesting_account._id;
                     const account_sdk_root = make_dummy_account_sdk_from_root_accounts_manager(
@@ -809,7 +924,7 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_user should return an error if user has buckets', async function() {
+            it('delete_user should throw an error if account has buckets', async function() {
                 const username_for_root_account = dummy_username8;
                 const params = {
                     username: username_for_root_account,
@@ -837,25 +952,35 @@ describe('Accountspace_FS tests', () => {
         });
 
         describe('list_users', () => {
-            it('list_users return array of users and value of is_truncated (requesting account is root account to create IAM user)', async function() {
+            it('list_users return array of users and value of is_truncated (requesting account is root account ' +
+                    'on IAM users)', async function() {
                 const params = {};
                 const account_sdk = make_dummy_account_sdk();
+                const owner_account_id = account_sdk.requesting_account._id;
                 const res = await accountspace_fs.list_users(params, account_sdk);
                 expect(Array.isArray(res.members)).toBe(true);
                 expect(res.members.length).toBeGreaterThan(0);
+                expect(res.members.length).toBe(3);
                 expect(typeof res.is_truncated === 'boolean').toBe(true);
+                for (const member of res.members) {
+                    expect(member.arn).toBe(`arn:aws:iam::${owner_account_id}:user${member.iam_path}${member.username}`);
+                }
             });
 
-            it('list_users return array of users and value of is_truncated (requesting account is root accounts manager to create root account user)', async function() {
+            it('list_users return array of users and value of is_truncated (requesting account is root accounts manager ' +
+                    'on accounts)', async function() {
                 const params = {};
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
                 const res = await accountspace_fs.list_users(params, account_sdk);
                 expect(Array.isArray(res.members)).toBe(true);
                 expect(res.members.length).toBeGreaterThan(1); //  will always have at least 1 account (himself)
                 expect(typeof res.is_truncated === 'boolean').toBe(true);
+                expect(res.members[0].user_id).toBeDefined();
+                expect(res.members[0].arn).toBe(`arn:aws:iam::${res.members[0].user_id}:root`);
             });
 
-            it('list_users return an empty array of users and value of is_truncated if non of the users has the iam_path_prefix', async function() {
+            it('list_users return an empty array of users and value of is_truncated ' +
+                    '(if none of the users has the iam_path_prefix)', async function() {
                 const params = {
                     iam_path_prefix: 'non_existing_division/non-existing_subdivision'
                 };
@@ -866,7 +991,8 @@ describe('Accountspace_FS tests', () => {
                 expect(typeof res.is_truncated === 'boolean').toBe(true);
             });
 
-            it('list_users return an array with users that their iam_path starts with iam_path_prefix and value of is_truncated', async function() {
+            it('list_users return an array with users that their iam_path starts with iam_path_prefix ' +
+                    'and value of is_truncated', async function() {
                 // add iam_path in a user so we can use the iam_path_prefix and get a user
                 const iam_path_to_add = dummy_iam_path;
                 let params_for_update = {
@@ -891,7 +1017,7 @@ describe('Accountspace_FS tests', () => {
                 await accountspace_fs.update_user(params_for_update, account_sdk);
             });
 
-            it('list_users should return an error if requesting user is not a root account user', async function() {
+            it('list_users should throw an error if requesting user is not a root account', async function() {
                 try {
                     const params = {};
                     const account_sdk = make_dummy_account_sdk_non_root_user();
@@ -949,7 +1075,8 @@ describe('Accountspace_FS tests', () => {
         });
 
         describe('create_access_key', () => {
-            it('create_access_key should return an error if requesting user is not a root account user', async function() {
+            it('create_access_key should throw an error if requesting user is not a root account',
+                    async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -964,7 +1091,7 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('create_access_key should return an error if user account does not exist', async function() {
+            it('create_access_key should throw an error if user account does not exist', async function() {
                 try {
                     const params = {
                         username: 'non-existing-user',
@@ -978,7 +1105,7 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('create_access_key should return an error if user is not owned by the root account', async function() {
+            it('create_access_key should throw an error if user is not owned by the root account', async function() {
                 try {
                     const params = {
                         username: dummy_user1.username,
@@ -1005,21 +1132,22 @@ describe('Accountspace_FS tests', () => {
                     username: dummy_username1,
                 };
                 const res = await accountspace_fs.create_access_key(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res.username).toBe(dummy_username1);
                 expect(res.access_key).toBeDefined();
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    params.username, owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(1);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
-                    config_fs_account_options);
+                const user_account_config_file_from_symlink =
+                    await accountspace_fs.config_fs.get_account_by_access_key(access_key, config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(params.username);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
@@ -1033,28 +1161,29 @@ describe('Accountspace_FS tests', () => {
                     username: dummy_username1,
                 };
                 const res = await accountspace_fs.create_access_key(params, account_sdk);
+                const owner_account_id = account_sdk.requesting_account._id;
                 expect(res.username).toBe(dummy_username1);
                 expect(res.access_key).toBeDefined();
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(params.username,
+                    owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(2);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
-                    config_fs_account_options);
+                const user_account_config_file_from_symlink =
+                    await accountspace_fs.config_fs.get_account_by_access_key(access_key, config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(params.username);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
                 expect(user_account_config_file_from_symlink.access_keys.length).toBe(2);
             });
 
-            it('create_access_key should return an error if user already has 2 access keys', async function() {
+            it('create_access_key should throw an error if user already has 2 access keys', async function() {
                 try {
                     const account_sdk = make_dummy_account_sdk();
                     // user was already created
@@ -1072,6 +1201,7 @@ describe('Accountspace_FS tests', () => {
 
             it('create_access_key should return user access key params (requester is an IAM user)', async function() {
                 let account_sdk = make_dummy_account_sdk();
+                const owner_account_id = account_sdk.requesting_account._id;
                 // create the user
                 const params_for_user_creation = {
                     username: dummy_username5,
@@ -1082,8 +1212,8 @@ describe('Accountspace_FS tests', () => {
                     username: dummy_username5,
                 };
                 await accountspace_fs.create_access_key(params_for_access_key_creation, account_sdk);
-                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
-                    config_fs_account_options);
+                let user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username5,
+                    owner_account_id, config_fs_account_options);
                 // create the second access key
                 // by the IAM user
                 account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file,
@@ -1095,28 +1225,30 @@ describe('Accountspace_FS tests', () => {
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
-                    config_fs_account_options);
+                user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username5,
+                    owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(dummy_username5);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
                 expect(user_account_config_file.access_keys.length).toBe(2);
 
                 const access_key = res.access_key;
-                const user_account_config_file_from_symlink = await accountspace_fs.config_fs.get_account_by_access_key(access_key,
-                    config_fs_account_options);
+                const user_account_config_file_from_symlink =
+                    await accountspace_fs.config_fs.get_account_by_access_key(access_key, config_fs_account_options);
                 expect(user_account_config_file_from_symlink.name).toBe(dummy_username5);
                 expect(user_account_config_file_from_symlink.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
                 expect(user_account_config_file_from_symlink.access_keys.length).toBe(2);
             });
 
-            it('create_access_key should return an error if user is not owned by the root account (requester is an IAM user)', async function() {
+            it('create_access_key should throw an error if user is not owned by the root account ' +
+                    '(requester is an IAM user)', async function() {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
-                        config_fs_account_options);
+                    const owner_account_id = account_sdk.requesting_account._id;
+                    const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                        dummy_username5, owner_account_id, config_fs_account_options);
                     // create the second access key
                     // by the IAM user
                     account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file,
@@ -1132,7 +1264,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('create_access_key should return user access key params (requesting account is root accounts manager to create access keys for root account user)', async function() {
+            it('create_access_key should return user access key params (requesting account is root accounts manager ' +
+                    'to create access keys for account)', async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
                 // create the user
@@ -1142,13 +1275,13 @@ describe('Accountspace_FS tests', () => {
                 await accountspace_fs.create_user(params, account_sdk);
                 // create the access key
                 const res = await accountspace_fs.create_access_key(params, account_sdk);
-                expect(res.username).toBe(username);
+                expect(res.username).toBeUndefined(); // in accounts creation we don't return the username (no username, but account name)
                 expect(res.access_key).toBeDefined();
                 expect(res.status).toBe('Active');
                 expect(res.secret_key).toBeDefined();
 
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(params.username,
-                    config_fs_account_options);
+                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(
+                    params.username, config_fs_account_options);
                 expect(user_account_config_file.name).toBe(params.username);
                 expect(user_account_config_file.access_keys).toBeDefined();
                 expect(Array.isArray(user_account_config_file.access_keys)).toBe(true);
@@ -1162,7 +1295,8 @@ describe('Accountspace_FS tests', () => {
                 expect(Array.isArray(user_account_config_file_from_symlink.access_keys)).toBe(true);
             });
 
-            it('create_access_key should return an error if user is IAM user (requesting account is root accounts manager)', async function() {
+            it('create_access_key should throw an error if user is IAM user (requesting account is root accounts manager)',
+                    async function() {
                 try {
                     // user already created (IAM user)
                     // create the access key
@@ -1174,14 +1308,16 @@ describe('Accountspace_FS tests', () => {
                     throw new NoErrorThrownError();
                 } catch (err) {
                     expect(err).toBeInstanceOf(IamError);
-                    expect(err).toHaveProperty('code', IamError.NotAuthorized.code);
+                    // the user is searched under the accounts (and not under the /users specific directory)
+                    expect(err).toHaveProperty('code', IamError.NoSuchEntity.code);
                 }
             });
         });
 
         describe('get_access_key_last_used', () => {
             const dummy_region = 'us-west-2';
-            it('get_access_key_last_used should return user access key params (requesting account is root account to create IAM user)', async function() {
+            it('get_access_key_last_used should return user access key params (requesting account is root account ' +
+                    'to get IAM user access keys)', async function() {
                 const account_sdk = make_dummy_account_sdk();
                 // create the user
                 const params_for_user_creation = {
@@ -1203,10 +1339,10 @@ describe('Accountspace_FS tests', () => {
                 expect(res.region).toBe(dummy_region);
                 expect(res).toHaveProperty('last_used_date');
                 expect(res).toHaveProperty('service_name');
-                expect(res.username).toBe(dummy_user2.username);
+                expect(res.username).toBe(params_for_access_key_creation.username);
             });
 
-            it('get_access_key_last_used should return an error if access key does not exist', async function() {
+            it('get_access_key_last_used should throw an error if access key does not exist', async function() {
                 try {
                     const dummy_access_key = 'AKIAIOSFODNN7EXAMPLE';
                     const account_sdk = make_dummy_account_sdk();
@@ -1222,7 +1358,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('get_access_key_last_used should return an error if access key exists in another root account', async function() {
+            it('get_access_key_last_used should throw an error if access key exists in another root account',
+                    async function() {
                 try {
                     const account_sdk = make_dummy_account_sdk();
                     // create the user
@@ -1253,10 +1390,12 @@ describe('Accountspace_FS tests', () => {
             it('get_access_key_last_used should return user access key params (requester is an IAM user)', async function() {
                 const username = dummy_user2.username;
                 let account_sdk = make_dummy_account_sdk();
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
-                    config_fs_account_options);
+                const owner_account_id = account_sdk.requesting_account._id;
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    username, owner_account_id, config_fs_account_options);
                 // by the IAM user
-                account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
+                account_sdk = make_dummy_account_sdk_created_from_another_account(
+                    user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     access_key: access_key,
@@ -1268,16 +1407,18 @@ describe('Accountspace_FS tests', () => {
                 expect(res.username).toBe(username);
             });
 
-            it('get_access_key_last_used return an error if user is not owned by the root account (requester is an IAM user)', async function() {
+            it('get_access_key_last_used throw an error if user is not owned by the root account ' +
+                    '(requester is an IAM user)', async function() {
                 try {
                     let account_sdk = make_dummy_account_sdk();
-                    const requester_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_user2.username,
-                        config_fs_account_options);
+                    const owner_account_id = account_sdk.requesting_account._id;
+                    const requester_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                        dummy_user2.username, owner_account_id, config_fs_account_options);
                     // by the IAM user
                     account_sdk = make_dummy_account_sdk_created_from_another_account(requester_account_config_file,
                         requester_account_config_file.owner);
-                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_user_root_account.username,
-                        config_fs_account_options);
+                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(
+                        dummy_user_root_account.username, config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         access_key: access_key,
@@ -1290,7 +1431,9 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('get_access_key_last_used should return user access key params (requesting account is root accounts manager requested account is root account)', async function() {
+            it('get_access_key_last_used should return user access key params ' +
+                    '(requesting account is root accounts manager requested account is root account)',
+                    async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
                 // user was already created
@@ -1308,12 +1451,13 @@ describe('Accountspace_FS tests', () => {
                 expect(res.region).toBe(dummy_region);
                 expect(res).toHaveProperty('last_used_date');
                 expect(res).toHaveProperty('service_name');
-                expect(res.username).toBe(username);
+                expect(res.username).toBeUndefined(); // in accounts we don't return the username (no username, but account name)
             });
         });
 
         describe('update_access_key', () => {
-            it('update_access_key should return an error if requesting user is not a root account user', async function() {
+            it('update_access_key should throw an error if requesting user is not a root account ' +
+                    '(on another user)', async function() {
                 const dummy_access_key = 'pHqFNglDiq7eA0Q4XETq';
                 try {
                     const params = {
@@ -1330,7 +1474,7 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_access_key should return an error if access key does not exist', async function() {
+            it('update_access_key should throw an error if access key does not exist', async function() {
                 const dummy_access_key = 'pHqFNglDiq7eA0Q4XETq';
                 try {
                     const params = {
@@ -1347,9 +1491,11 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_access_key should return an error if user account does not exist', async function() {
-                const user_account = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+            it('update_access_key should throw an error if user account does not exist', async function() {
+                const account_sdk = make_dummy_account_sdk();
+                const owner_account_id = account_sdk.requesting_account._id;
+                const user_account = await accountspace_fs.config_fs.get_user_by_name(dummy_username1,
+                    owner_account_id, config_fs_account_options);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
@@ -1357,7 +1503,6 @@ describe('Accountspace_FS tests', () => {
                         access_key: dummy_access_key,
                         status: ACCESS_KEY_STATUS_ENUM.ACTIVE,
                     };
-                    const account_sdk = make_dummy_account_sdk();
                     await accountspace_fs.update_access_key(params, account_sdk);
                     throw new NoErrorThrownError();
                 } catch (err) {
@@ -1367,10 +1512,12 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_access_key should return an error if access key belongs to another account ' +
-                    'without passing the username flag', async function() {
-                const user_account = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+            it('update_access_key should throw an error if access key belongs to a user and not the account ' +
+                    '(without passing the username flag)', async function() {
+                const account_sdk = make_dummy_account_sdk();
+                const owner_account_id = account_sdk.requesting_account._id;
+                const user_account = await accountspace_fs.config_fs.get_user_by_name(dummy_username1,
+                    owner_account_id, config_fs_account_options);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
@@ -1378,7 +1525,6 @@ describe('Accountspace_FS tests', () => {
                         access_key: dummy_access_key,
                         status: ACCESS_KEY_STATUS_ENUM.ACTIVE,
                     };
-                    const account_sdk = make_dummy_account_sdk();
                     await accountspace_fs.update_access_key(params, account_sdk);
                     throw new NoErrorThrownError();
                 } catch (err) {
@@ -1387,11 +1533,12 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_access_key should return an error if access key is on another root account', async function() {
+            it('update_access_key should throw an error if access key is on another root account', async function() {
                 try {
                     const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
-                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                        config_fs_account_options);
+                    const owner_account_id = make_dummy_account_sdk().requesting_account._id;
+                    const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                        dummy_username1, owner_account_id, config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         username: dummy_username1,
@@ -1406,10 +1553,12 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_access_key should not return any param (update status to Inactive) (requesting account is root account to create IAM user)', async function() {
+            it('update_access_key should not return any param (update status to Inactive) ' +
+                '(requesting account is root account to update IAM user access key)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                const owner_account_id = account_sdk.requesting_account._id;
+                let user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    dummy_username1, owner_account_id, config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1418,15 +1567,17 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username1,
+                    owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(true);
             });
 
-            it('update_access_key should not return any param (update status to Active) (requesting account is root account to create IAM user)', async function() {
+            it('update_access_key should not return any param (update status to Active) ' +
+                '(requesting account is root account to update IAM user access key)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                const owner_account_id = account_sdk.requesting_account._id;
+                let user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    dummy_username1, owner_account_id, config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1435,15 +1586,17 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    dummy_username1, owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(false);
             });
 
-            it('update_access_key should not return any param (update status to Active, already was Active) (requesting account is root account to create IAM user)', async function() {
+            it('update_access_key should not return any param (update status to Active, already was Active) ' +
+                '(requesting account is root account to update IAM user access key)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                const owner_account_id = account_sdk.requesting_account._id;
+                let user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    dummy_username1, owner_account_id, config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: dummy_username1,
@@ -1452,18 +1605,20 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username1,
+                    owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.access_keys[0].deactivated).toBe(false);
             });
 
             it('update_access_key should not return any param (requester is an IAM user)', async function() {
                 const dummy_username = dummy_username5;
                 let account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username,
-                    config_fs_account_options);
+                const owner_account_id = account_sdk.requesting_account._id;
+                let user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    dummy_username, owner_account_id, config_fs_account_options);
                 // by the IAM user
-                account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
+                account_sdk = make_dummy_account_sdk_created_from_another_account(
+                    user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[1].access_key;
                 const params = {
                     access_key: access_key,
@@ -1471,17 +1626,19 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.update_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username,
-                    config_fs_account_options);
+                user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username,
+                    owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.access_keys[1].deactivated).toBe(true);
             });
 
-            it('update_access_key should return an error if user is not owned by the root account (requester is an IAM user)', async function() {
+            it('update_access_key should throw an error if user is not owned by the root account ' +
+                '(requester is an IAM user)', async function() {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
-                        config_fs_account_options);
+                    const owner_account_id = account_sdk.requesting_account._id;
+                    const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username5,
+                        owner_account_id, config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
@@ -1500,11 +1657,12 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('update_access_key should not return any param (update status to Inactive) (requesting account is root accounts manager requested account is root account)', async function() {
+            it('update_access_key should not return any param (update status to Inactive) ' +
+                '(requesting account is root accounts manager requested account is root account)', async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
-                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
-                    config_fs_account_options);
+                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(
+                    username, config_fs_account_options);
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
                     username: username,
@@ -1520,7 +1678,7 @@ describe('Accountspace_FS tests', () => {
         });
 
         describe('delete_access_key', () => {
-            it('delete_access_key should return an error if requesting user is not a root account user', async function() {
+            it('delete_access_key should throw an error if requesting user is not a root account', async function() {
                 const dummy_access_key = 'pHqFNglDiq7eA0Q4XETq';
                 try {
                     const params = {
@@ -1536,7 +1694,7 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_access_key should return an error if access key does not exist', async function() {
+            it('delete_access_key should throw an error if access key does not exist', async function() {
                 const dummy_access_key = 'pHqFNglDiq7eA0Q4XETq';
                 try {
                     const params = {
@@ -1552,16 +1710,17 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_access_key should return an error if user account does not exist', async function() {
-                const user_account = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+            it('delete_access_key should throw an error if user account does not exist', async function() {
+                const account_sdk = make_dummy_account_sdk();
+                const owner_account_id = account_sdk.requesting_account._id;
+                const user_account = await accountspace_fs.config_fs.get_user_by_name(dummy_username1,
+                    owner_account_id, config_fs_account_options);
                 const dummy_access_key = user_account.access_keys[0].access_key;
                 try {
                     const params = {
                         username: 'non-existing-user',
                         access_key: dummy_access_key,
                     };
-                    const account_sdk = make_dummy_account_sdk();
                     await accountspace_fs.delete_access_key(params, account_sdk);
                     throw new NoErrorThrownError();
                 } catch (err) {
@@ -1571,17 +1730,18 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_access_key should return an error if access key belongs to another account ' +
+            it('delete_access_key should throw an error if access key belongs to another account ' +
                 'without passing the username flag', async function() {
-            const user_account = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                config_fs_account_options);
+            const account_sdk = make_dummy_account_sdk();
+            const owner_account_id = account_sdk.requesting_account._id;
+            const user_account = await accountspace_fs.config_fs.get_user_by_name(dummy_username1,
+                owner_account_id, config_fs_account_options);
             const dummy_access_key = user_account.access_keys[0].access_key;
             try {
                 const params = {
                     // without username of dummy_username1
                     access_key: dummy_access_key,
                 };
-                const account_sdk = make_dummy_account_sdk();
                 await accountspace_fs.delete_access_key(params, account_sdk);
                 throw new NoErrorThrownError();
             } catch (err) {
@@ -1590,11 +1750,12 @@ describe('Accountspace_FS tests', () => {
             }
         });
 
-            it('delete_access_key should not return an error if access key is on another root account', async function() {
+            it('delete_access_key should throw an error if access key belongs to user in on another account', async function() {
                 try {
                     const account_sdk = make_dummy_account_sdk_not_for_creating_resources();
-                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                        config_fs_account_options);
+                    const owner_account_id = make_dummy_account_sdk().requesting_account._id;
+                    const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                        dummy_username1, owner_account_id, config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     const params = {
                         username: dummy_username1,
@@ -1608,10 +1769,12 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_access_key should not return any param (requesting account is root account to create IAM user)', async function() {
+            it('delete_access_key should not return any param (requesting account is root account ' +
+                    'to delete IAM user access key id)', async function() {
                 const account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                const owner_account_id = account_sdk.requesting_account._id;
+                let user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    dummy_username1, owner_account_id, config_fs_account_options);
 
                 const access_key = user_account_config_file.access_keys[0].access_key;
                 const params = {
@@ -1620,16 +1783,18 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username1,
+                    owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.access_keys.length).toBe(1);
                 const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key);
                 expect(is_path_exists).toBe(false);
             });
 
-            it('delete_access_key should not return any param (account with 2 access keys) (requesting account is root account to create IAM user)', async function() {
+            it('delete_access_key should not return any param (account with 2 access keys) ' +
+                    '(requesting account is root account to delete IAM user access key id)', async function() {
                 const username = dummy_username6;
                 const account_sdk = make_dummy_account_sdk();
+                const owner_account_id = account_sdk.requesting_account._id;
                 // create the user
                 let params = {
                     username: username,
@@ -1651,8 +1816,8 @@ describe('Accountspace_FS tests', () => {
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
-                    config_fs_account_options);
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    username, owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.access_keys.length).toBe(1);
                 expect(user_account_config_file.access_keys[0].access_key).toBe(access_key);
                 expect(user_account_config_file.access_keys[0].access_key).not.toBe(access_key_to_delete);
@@ -1664,30 +1829,34 @@ describe('Accountspace_FS tests', () => {
 
             it('delete_access_key should not return any param (requester is an IAM user)', async function() {
                 let account_sdk = make_dummy_account_sdk();
-                let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
-                    config_fs_account_options);
+                const owner_account_id = account_sdk.requesting_account._id;
+                let user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username5,
+                    owner_account_id, config_fs_account_options);
                 // by the IAM user
-                account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
+                account_sdk = make_dummy_account_sdk_created_from_another_account(
+                    user_account_config_file, user_account_config_file.owner);
                 const access_key = user_account_config_file.access_keys[1].access_key;
                 const params = {
                     access_key: access_key,
                 };
                 const res = await accountspace_fs.delete_access_key(params, account_sdk);
                 expect(res).toBeUndefined();
-                user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username1,
-                    config_fs_account_options);
+                user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(dummy_username1,
+                    owner_account_id, config_fs_account_options);
                 expect(user_account_config_file.access_keys.length).toBe(1);
                 expect(user_account_config_file.access_keys[0].access_key).not.toBe(access_key);
                 const is_path_exists = await accountspace_fs.config_fs.is_account_exists_by_access_key(access_key);
                 expect(is_path_exists).toBe(false);
             });
 
-            it('delete_access_key should return an error if user is not owned by the root account (requester is an IAM user)', async function() {
+            it('delete_access_key should throw an error if user is not owned by the root account ' +
+                    '(requester is an IAM user)', async function() {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
-                        config_fs_account_options);
+                    const owner_account_id = account_sdk.requesting_account._id;
+                    const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                        dummy_username5, owner_account_id, config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
@@ -1705,7 +1874,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('delete_access_key should not return any param (requesting account is root accounts manager requested account is root account)', async function() {
+            it('delete_access_key should not return any param (requesting account is root accounts manager ' +
+                    'requested account is root account)', async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
                 let user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(username,
@@ -1726,7 +1896,8 @@ describe('Accountspace_FS tests', () => {
         });
 
         describe('list_access_keys', () => {
-            it('list_access_keys return array of access_keys and value of is_truncated (requesting account is root account and requested account is IAM user)', async function() {
+            it('list_access_keys return array of access_keys and value of is_truncated ' +
+                    '(requesting account is root account and requested account is IAM user)', async function() {
                 const params = {
                     username: dummy_username1,
                 };
@@ -1739,9 +1910,10 @@ describe('Accountspace_FS tests', () => {
                 expect(res.members[0].access_key).toBeDefined();
                 expect(res.members[0].status).toBeDefined();
                 expect(res.members[0].create_date).toBeDefined();
+                expect(res.username).toBe(params.username);
             });
 
-            it('list_access_keys should return an error when username does not exists', async function() {
+            it('list_access_keys should throw an error when username does not exists', async function() {
                 const non_exsting_user = 'non_exsting_user';
                 try {
                     const params = {
@@ -1757,7 +1929,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('list_access_keys should return an error when username does not exists (in the root account)', async function() {
+            it('list_access_keys should throw an error when username does not exists (in the root account)',
+                    async function() {
                 try {
                     const params = {
                         username: dummy_username1,
@@ -1771,7 +1944,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('list_access_keys return empty array of access_keys is user does not have access_keys', async function() {
+            it('list_access_keys return empty array of access_keys is user does not have access_keys',
+                    async function() {
                 const account_sdk = make_dummy_account_sdk();
                 // create the user
                 const params_for_user_creation = {
@@ -1786,14 +1960,18 @@ describe('Accountspace_FS tests', () => {
                 expect(Array.isArray(res.members)).toBe(true);
                 expect(typeof res.is_truncated === 'boolean').toBe(true);
                 expect(res.members.length).toBe(0);
+                expect(res.username).toBe(params.username);
             });
 
-            it('list_access_keys return array of access_keys and value of is_truncated (requester is an IAM user)', async function() {
+            it('list_access_keys return array of access_keys and value of is_truncated ' +
+                    '(requester is an IAM user)', async function() {
                 let account_sdk = make_dummy_account_sdk();
-                const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
-                    config_fs_account_options);
+                const owner_account_id = account_sdk.requesting_account._id;
+                const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                    dummy_username5, owner_account_id, config_fs_account_options);
                 // by the IAM user
-                account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file, user_account_config_file.owner);
+                account_sdk = make_dummy_account_sdk_created_from_another_account(
+                    user_account_config_file, user_account_config_file.owner);
                 const params = {};
                 const res = await accountspace_fs.list_access_keys(params, account_sdk);
                 expect(Array.isArray(res.members)).toBe(true);
@@ -1801,17 +1979,19 @@ describe('Accountspace_FS tests', () => {
                 expect(res.members.length).toBe(1);
             });
 
-            it('list_access_keys should return an error if user is not owned by the root account (requester is an IAM user)', async function() {
+            it('list_access_keys should throw an error if user is not owned by the root account ' +
+                    '(requester is an IAM user)', async function() {
                 try {
                     // both IAM users are under the same root account (owner property)
                     let account_sdk = make_dummy_account_sdk();
-                    const user_account_config_file = await accountspace_fs.config_fs.get_account_by_name(dummy_username5,
-                        config_fs_account_options);
+                    const owner_account_id = account_sdk.requesting_account._id;
+                    const user_account_config_file = await accountspace_fs.config_fs.get_user_by_name(
+                        dummy_username5, owner_account_id, config_fs_account_options);
                     const access_key = user_account_config_file.access_keys[0].access_key;
                     // create the second access key
                     // by the IAM user
-                    account_sdk = make_dummy_account_sdk_created_from_another_account(user_account_config_file,
-                        account_sdk.requesting_account._id);
+                    account_sdk = make_dummy_account_sdk_created_from_another_account(
+                        user_account_config_file, account_sdk.requesting_account._id);
                     const params = {
                         username: dummy_user1.username,
                         access_key: access_key,
@@ -1824,7 +2004,8 @@ describe('Accountspace_FS tests', () => {
                 }
             });
 
-            it('list_access_keys return array of access_keys and value of is_truncated (requesting account is root accounts manager requested account is root account)', async function() {
+            it('list_access_keys return array of access_keys and value of is_truncated ' +
+                    '(requesting account is root accounts manager requested account is root account)', async function() {
                 const username = dummy_user_root_account.username;
                 const account_sdk = make_dummy_account_sdk_root_accounts_manager();
                 const params = {
@@ -1834,7 +2015,7 @@ describe('Accountspace_FS tests', () => {
                 expect(Array.isArray(res.members)).toBe(true);
                 expect(typeof res.is_truncated === 'boolean').toBe(true);
                 expect(res.members.length).toBe(1);
-                expect(res.members[0]).toHaveProperty('username', username);
+                expect(res.members[0].username).toBeUndefined(); // // in accounts we don't return the username (no username, but account name)
                 expect(res.members[0].access_key).toBeDefined();
                 expect(res.members[0].status).toBeDefined();
                 expect(res.members[0].create_date).toBeDefined();

--- a/src/test/unit_tests/jest_tests/test_iam_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_iam_utils.test.js
@@ -7,42 +7,52 @@ const { IamError } = require('../../../endpoint/iam/iam_errors');
 
 class NoErrorThrownError extends Error {}
 
-describe('create_arn', () => {
+describe('create_arn_for_user', () => {
     const dummy_account_id = '12345678012'; // for the example
     const dummy_username = 'Bob';
     const dummy_iam_path = '/division_abc/subdivision_xyz/';
     const arn_prefix = 'arn:aws:iam::';
 
-    it('create_arn without username should return basic structure', () => {
+    it('create_arn_for_user without username should return basic structure', () => {
         const user_details = {};
-        const res = iam_utils.create_arn(dummy_account_id, user_details.username, user_details.iam_path);
+        const res = iam_utils.create_arn_for_user(dummy_account_id, user_details.username, user_details.iam_path);
         expect(res).toBe(`${arn_prefix}${dummy_account_id}:user/`);
     });
 
-    it('create_arn with username and no iam_path should return only username in arn', () => {
+    it('create_arn_for_user with username and no iam_path should return only username in arn', () => {
         const user_details = {
             username: dummy_username,
         };
-        const res = iam_utils.create_arn(dummy_account_id, user_details.username, user_details.iam_path);
+        const res = iam_utils.create_arn_for_user(dummy_account_id, user_details.username, user_details.iam_path);
         expect(res).toBe(`${arn_prefix}${dummy_account_id}:user/${dummy_username}`);
     });
 
-    it('create_arn with username and AWS DEFAULT PATH should return only username in arn', () => {
+    it('create_arn_for_user with username and AWS DEFAULT PATH should return only username in arn', () => {
         const user_details = {
             username: dummy_username,
             iam_path: iam_constants.IAM_DEFAULT_PATH
         };
-        const res = iam_utils.create_arn(dummy_account_id, user_details.username, user_details.iam_path);
+        const res = iam_utils.create_arn_for_user(dummy_account_id, user_details.username, user_details.iam_path);
         expect(res).toBe(`${arn_prefix}${dummy_account_id}:user/${dummy_username}`);
     });
 
-    it('create_arn with username and iam_path should return them in arn', () => {
+    it('create_arn_for_user with username and iam_path should return them in arn', () => {
         const user_details = {
             username: dummy_username,
             iam_path: dummy_iam_path,
         };
-        const res = iam_utils.create_arn(dummy_account_id, user_details.username, user_details.iam_path);
+        const res = iam_utils.create_arn_for_user(dummy_account_id, user_details.username, user_details.iam_path);
         expect(res).toBe(`${arn_prefix}${dummy_account_id}:user${dummy_iam_path}${dummy_username}`);
+    });
+});
+
+describe('create_arn_for_root', () => {
+    const dummy_account_id = '12345678012'; // for the example
+    const arn_prefix = 'arn:aws:iam::';
+
+    it('create_arn_for_user without username should root arn', () => {
+        const res = iam_utils.create_arn_for_root(dummy_account_id);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:root`);
     });
 });
 


### PR DESCRIPTION
### Explain the changes
1. Update IAM API Users, Access Keys and additional changes in `accountspace_fs`:
- Move the config creation from the function `_copy_data_from_requesting_account_to_account_config` to the `create_user`.
- Fix the ARN account ID for root accounts that were operated by the roots accounts manager (before we copied the `requesting_account._id` which was true only for root accounts on IAM users).
- Fix `_check_root_account` as it has a redundant line that was not relevant (it was there when we thought of additional case, but we never get to it).
- Add 2 helper functions: `_get_account_owner_id_for_arn`, `_get_owner_account_argument`.
- Improve performance in the function `_check_if_root_account_does_not_have_IAM_users_before_deletion` after we have the new structure.
2. Update the `ConfigFS` module to support the new structure and operate on users configs. 
3. Update docs:
 - With the config dire restructure (`identities/`, `accounts_by_name/`, `users/`directories).
 - IAM docs - regarding the naming scope (that we have with the new structure) and about the new structure with `users/` directory.
4. Update the IAM API tests:
 - Mainly reading the config file in the new structure.
 - Add account validation to accounts created hardcoded (to avoid schema changes without them updated).
 - Refactor `it` names to multiple lines.
5. In `rest_s3` change the 'is_owner` part (the gap mentioned in #8289), where it checks the name,  to make sure the account is not a user with the same name.

### Issues:
List of GAPS:
1. Add JSDoc in `accountspace_fs` methods.

### Testing Instructions:
#### Unit Tests:
Please run: `sudo npx jest test_accountspace_fs.test.js`

#### Manual Tests:
Operate any IAM actions on users and access keys on the NSFS server as described in [Non Containerized NSFS IAM (Developers Documentation)](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/nc_nsfs_iam_developer_doc.md)

- [X] Doc added/updated
- [X] Tests added
