### PR TITLE
s3select - bump rapid json commit to include parsing bug fix

### DIFF
--- a/src/deploy/NVA_build/clone_s3select_submodules.sh
+++ b/src/deploy/NVA_build/clone_s3select_submodules.sh
@@ -2,6 +2,6 @@
 
 #Clone S3Select and its two submodules, but only if BUILD_S3SELECT=1.
 ./src/deploy/NVA_build/clone_submodule.sh submodules/s3select https://github.com/ceph/s3select 58875a5ee76261cc0a3d943bb168f9f9292c34a4 BUILD_S3SELECT
-./src/deploy/NVA_build/clone_submodule.sh submodules/s3select/rapidjson https://github.com/Tencent/rapidjson fcb23c2dbf561ec0798529be4f66394d3e4996d8 BUILD_S3SELECT
+./src/deploy/NVA_build/clone_submodule.sh submodules/s3select/rapidjson https://github.com/Tencent/rapidjson 7c73dd7de7c4f14379b781418c6e947ad464c818 BUILD_S3SELECT
 ./src/deploy/NVA_build/clone_submodule.sh submodules/s3select/include/csvparser https://github.com/ben-strasser/fast-cpp-csv-parser 5a417973b4cea674a5e4a3b88a23098a2ab75479 BUILD_S3SELECT
 


### PR DESCRIPTION
### Explain the changes
1. rapid json has a parsing bug fixed in the new commit.

### Issues: Fixed #xxx / Gap #xxx
1. The parsing error is related to CVE https://access.redhat.com/security/cve/CVE-2024-39684.
I'm still trying to get a written explicit confirmation for this.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
