### PR TITLE
[NSFS] Fix list objects ordering to follow AWS S3

### DIFF
--- a/src/test/unit_tests/jest_tests/js_utils.test.js
+++ b/src/test/unit_tests/jest_tests/js_utils.test.js
@@ -1,0 +1,79 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const { sortedLastIndexBy } = require("../../../util/js_utils");
+
+describe('test js_utils.js', () => {
+    describe('sortedLastIndexBy', () => {
+        it('should correctly find position for number array', () => {
+            const test_table = [{
+                array: [1, 3, 4, 5],
+                target: 0,
+                expected_position: 0,
+            }, {
+                array: [1, 3, 4, 5],
+                target: 2,
+                expected_position: 1,
+            }, {
+                array: [1, 3, 4, 5],
+                target: 6,
+                expected_position: 4,
+            }];
+
+            for (const entry of test_table) {
+                expect(sortedLastIndexBy(entry.array, curr => curr < entry.target)).toBe(entry.expected_position);
+            }
+        });
+
+        it('should correctly find position for string array', () => {
+            const test_table = [{
+                array: ["a", "b", "c", "d"],
+                target: "A",
+                expected_position: 0,
+            }, {
+                array: ["a", "b", "d", "e"],
+                target: "c",
+                expected_position: 2,
+            }, {
+                array: ["a", "b", "c", "d"],
+                target: "z",
+                expected_position: 4,
+            }];
+
+            for (const entry of test_table) {
+                expect(sortedLastIndexBy(entry.array, curr => curr < entry.target)).toBe(entry.expected_position);
+            }
+        });
+
+        it('should correctly find position for utf8 string (buffer) array', () => {
+            // Editors might not render characters in this array properly but that's not a mistake,
+            // it's intentional to use such characters - sourced from:
+            // https://forum.moonwalkinc.com/t/determining-s3-listing-order/116
+            const array = ["file_ꦏ_1.txt", "file__2.txt", "file_￼_3.txt", "file_𐎣_4.txt"];
+            const array_of_bufs = array.map(item => Buffer.from(item, 'utf8'));
+
+            const test_table = [{
+                array: array_of_bufs,
+                target: array_of_bufs[0],
+                expected_position: 0,
+            }, {
+                array: array_of_bufs,
+                target: array_of_bufs[2],
+                expected_position: 2,
+            }, {
+                array: array_of_bufs,
+                target: array_of_bufs[3],
+                expected_position: 3,
+            }, {
+                array: array_of_bufs,
+                target: Buffer.from("file_𐎣_40.txt", 'utf8'),
+                expected_position: 4,
+            }];
+
+            for (const entry of test_table) {
+                expect(sortedLastIndexBy(entry.array, curr => curr.compare(entry.target) === -1)).toBe(entry.expected_position);
+            }
+        });
+    });
+});
+

--- a/src/util/js_utils.js
+++ b/src/util/js_utils.js
@@ -237,6 +237,31 @@ function omit_symbol(maybe_obj, sym) {
     return _.omit(obj, sym);
 }
 
+/**
+ * sortedLastIndexBy is like lodash's sortedLastIndexBy except that
+ * instead of taking a iteratee, it takes a function `less` which should
+ * return `true` when `curr < value`.
+ * @template T
+ * @param {Array<T>} array 
+ * @param {(curr: T) => Boolean} less 
+ * @returns 
+ */
+function sortedLastIndexBy(array, less) {
+    let low = 0;
+    let high = array === null ? low : array.length;
+
+    while (low < high) {
+        const mid = Math.floor(low + ((high - low) / 2));
+        if (less(array[mid])) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+
+    return high;
+}
+
 exports.self_bind = self_bind;
 exports.array_push_all = array_push_all;
 exports.array_push_keep_latest = array_push_keep_latest;
@@ -250,3 +275,4 @@ exports.inspect_lazy = inspect_lazy;
 exports.make_array = make_array;
 exports.map_get_or_create = map_get_or_create;
 exports.omit_symbol = omit_symbol;
+exports.sortedLastIndexBy = sortedLastIndexBy;


### PR DESCRIPTION
### Explain the changes
This PR replaces the pre-existing sorting functions in listObjects (NSFS) with a new one which tries to treat strings as UTF8 encoded Uint8Arrays. This helps with sorting the array of strings in a similar fashion as AWS S3 does.

### Issues: Fixed #xxx / Gap #xxx
Fixes #8218 

### Testing Instructions:
1. `./node_modules/.bin/mocha src/test/unit_tests/test_namespace_fs.js`
2. `./node_modules/.bin/jest src/test/unit_tests/jest_tests/js_utils.test.js`

- [ ] Doc added/updated
- [x] Tests added
