### PR TITLE
NC | Online Upgrade Process

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -67,7 +67,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
         } else if (type === TYPES.DIAGNOSE) {
             await noobaa_cli_diagnose.manage_diagnose_operations(action, user_input, config_fs);
         } else if (type === TYPES.UPGRADE) {
-            await noobaa_cli_upgrade.manage_upgrade_operations(action, config_fs);
+            await noobaa_cli_upgrade.manage_upgrade_operations(action, user_input, config_fs);
         } else {
             throw_cli_error(ManageCLIError.InvalidType);
         }

--- a/src/deploy/noobaa.service
+++ b/src/deploy/noobaa.service
@@ -7,7 +7,6 @@ Restart=always
 RestartSec=2
 User=root
 Group=root
-ExecStartPre=/usr/local/noobaa-core/bin/node /usr/local/noobaa-core/src/upgrade/upgrade_manager.js --nsfs true --upgrade_scripts_dir /usr/local/noobaa-core/src/upgrade/nsfs_upgrade_scripts
 ExecStart=/usr/local/noobaa-core/bin/node /usr/local/noobaa-core/src/cmd/nsfs.js
 EnvironmentFile=-/etc/sysconfig/noobaa
 ExecStop=/bin/kill $MAINPID

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -479,6 +479,12 @@ ManageCLIError.UpgradeHistoryFailed = Object.freeze({
     http_code: 500,
 });
 
+ManageCLIError.ConfigDirUpdateBlocked = Object.freeze({
+    code: 'ConfigDirUpdateBlocked',
+    message: 'Config directory updates are not allowed on mismatch of the config directory version mentioned in system.json and the config directory version of the source code',
+    http_code: 500,
+});
+
 ///////////////////////////////
 //       ERRORS MAPPING      //
 ///////////////////////////////
@@ -500,7 +506,8 @@ ManageCLIError.RPC_ERROR_TO_MANAGE = Object.freeze({
     INVALID_SCHEMA: ManageCLIError.InvalidSchema,
     NO_SUCH_USER: ManageCLIError.InvalidAccountDistinguishedName,
     INVALID_MASTER_KEY: ManageCLIError.InvalidMasterKey,
-    INVALID_BUCKET_NAME: ManageCLIError.InvalidBucketName
+    INVALID_BUCKET_NAME: ManageCLIError.InvalidBucketName,
+    CONFIG_DIR_VERSION_MISMATCH: ManageCLIError.ConfigDirUpdateBlocked
 });
 
 const NSFS_CLI_ERROR_EVENT_MAP = {

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -77,6 +77,12 @@ const VALID_OPTIONS_DIAGNOSE = {
     'metrics': new Set([CONFIG_ROOT_FLAG])
 };
 
+const VALID_OPTIONS_UPGRADE = {
+    'start': new Set([ 'skip_verification', 'expected_version', 'expected_hosts', 'custom_upgrade_scripts_dir', ...CLI_MUTUAL_OPTIONS]),
+    'status': new Set([ ...CLI_MUTUAL_OPTIONS]),
+    'history': new Set([...CLI_MUTUAL_OPTIONS])
+};
+
 
 const VALID_OPTIONS_WHITELIST = new Set(['ips', ...CLI_MUTUAL_OPTIONS]);
 
@@ -89,7 +95,8 @@ const VALID_OPTIONS = {
     whitelist_options: VALID_OPTIONS_WHITELIST,
     from_file_options: VALID_OPTIONS_FROM_FILE,
     anonymous_account_options: VALID_OPTIONS_ANONYMOUS_ACCOUNT,
-    diagnose_options: VALID_OPTIONS_DIAGNOSE
+    diagnose_options: VALID_OPTIONS_DIAGNOSE,
+    upgrade_options: VALID_OPTIONS_UPGRADE
 };
 
 const OPTION_TYPE = {
@@ -123,6 +130,11 @@ const OPTION_TYPE = {
     all_bucket_details: 'boolean',
     https_port: 'number',
     debug: 'number',
+    // upgrade options
+    expected_version: 'string',
+    expected_hosts: 'string',
+    custom_upgrade_scripts_dir: 'string',
+    skip_verification: 'boolean'
 };
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -301,6 +301,19 @@ Run 'upgrade start' after upgrading NooBaa RPMs on all the cluster nodes, after 
 S3 I/O, S3 Buckets getters and NooBaa CLI Account/Buckets/Whitelist getters operations will still be working
 But updates of the config directory will be blocked during the upgrade of the config directory.
 'upgrade start' should be executed on one node, the config directory changes will be available for all the nodes of the cluster.
+
+Usage:
+        
+    noobaa-cli upgrade start [flags]
+
+Flags:
+
+--expected_version                             <string>                             The expected target version of the upgrade
+--expected_hosts                               <string>                             The expected hosts running NooBaa NC, a string of hosts separated by , 
+--skip_verification                            <boolean>        (optional)          skip verification of the hosts package version
+                                                                                    WARNING: can cause corrupted config dir files created by hosts running old code
+--custom_upgrade_scripts_dir                   <string>         (optional)          custom upgrade scripts dir, use for running custom config dir upgrade scripts
+
 `;
 
 const UPGRADE_STATUS_OPTIONS = `

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -125,6 +125,8 @@ function validate_no_extra_options(type, action, input_options, is_options_from_
         valid_options = VALID_OPTIONS.glacier_options[action];
     } else if (type === TYPES.DIAGNOSE) {
         valid_options = VALID_OPTIONS.diagnose_options[action];
+    } else if (type === TYPES.UPGRADE) {
+        valid_options = VALID_OPTIONS.upgrade_options[action];
     } else {
         valid_options = VALID_OPTIONS.whitelist_options;
     }

--- a/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_accountspace_fs.test.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const SensitiveString = require('../../../util/sensitive_string');
 const AccountSpaceFS = require('../../../sdk/accountspace_fs');
-const { TMP_PATH } = require('../../system_tests/test_utils');
+const { TMP_PATH, set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
 const { IAM_DEFAULT_PATH, ACCESS_KEY_STATUS_ENUM } = require('../../../endpoint/iam/iam_constants');
 const fs_utils = require('../../../util/fs_utils');
 const { IamError } = require('../../../endpoint/iam/iam_errors');
@@ -26,6 +26,7 @@ const new_buckets_path3 = path.join(tmp_fs_path, 'new_buckets_path3', '/');
 
 const accountspace_fs = new AccountSpaceFS({ config_root });
 const config_fs_account_options = { show_secrets: true, decrypt_secret_key: true };
+set_nc_config_dir_in_config(config_root);
 
 const root_user_account = {
     _id: '65a8edc9bc5d5bbf9db71b91',

--- a/src/test/unit_tests/jest_tests/test_cli_upgrade.test.js
+++ b/src/test/unit_tests/jest_tests/test_cli_upgrade.test.js
@@ -7,6 +7,7 @@ process.env.DISABLE_INIT_RANDOM_SEED = 'true';
 
 const os = require('os');
 const path = require('path');
+const pkg = require('../../../../package.json');
 const fs_utils = require('../../../util/fs_utils');
 const { ConfigFS } = require('../../../sdk/config_fs');
 const { TMP_PATH, exec_manage_cli } = require('../../system_tests/test_utils');
@@ -17,6 +18,173 @@ const { TYPES, UPGRADE_ACTIONS } = require('../../../manage_nsfs/manage_nsfs_con
 const config_root = path.join(TMP_PATH, 'config_root_cli_upgrade_test');
 const config_fs = new ConfigFS(config_root);
 const hostname = os.hostname();
+const expected_hosts = `${hostname}`;
+
+const old_rpm_expected_system_json = {
+    [hostname]: {
+        'current_version': '5.16.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.16.0',
+                'to_version': '5.17.0'
+            }]
+        },
+    }
+};
+
+const old_expected_system_json = {
+    [hostname]: {
+        'current_version': '5.18.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.17.0',
+                'to_version': '5.18.0'
+            }]
+        },
+    }
+};
+
+const old_expected_system_json3 = {
+    [hostname]: {
+        'current_version': '200',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '700',
+                'to_version': '200'
+            }]
+        },
+    }
+};
+
+const old_expected_system_json2 = {
+    [hostname]: {
+        'current_version': '5.18.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.17.0',
+                'to_version': '5.18.0'
+            }]
+        },
+    },
+    config_directory: {
+        'config_dir_version': '1.0.0',
+        'upgrade_package_version': '5.18.0',
+        'phase': 'CONFIG_DIR_UNLOCKED',
+        'upgrade_history': {
+            'successful_upgrades': [
+                {
+                    'timestamp': 1724687496424,
+                    'running_host': hostname,
+                    'package_from_version': '5.17.0',
+                    'package_to_version': '5.18.0',
+                    'config_dir_from_version': '0.0.0',
+                    'config_dir_to_version': '1.0.0'
+                }]
+        }
+    }
+};
+
+const old_expected_system_json5 = {
+    [hostname]: {
+        'current_version': '5.18.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.17.0',
+                'to_version': '5.18.0'
+            }]
+        },
+    },
+    config_directory: {
+        'config_dir_version': '0.0.0',
+        'upgrade_package_version': '5.17.0',
+        'phase': 'CONFIG_DIR_UNLOCKED',
+        'upgrade_history': {
+            'successful_upgrades': [
+                {
+                    'timestamp': 1724687496424,
+                    'running_host': hostname,
+                    'package_from_version': '5.16.0',
+                    'package_to_version': '5.17.0',
+                    'config_dir_from_version': '-1.0.0',
+                    'config_dir_to_version': '0.0.0'
+                }]
+        }
+    }
+};
+
+const new_expected_system_json = {
+    [hostname]: {
+        'current_version': '5.18.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.17.0',
+                'to_version': '5.18.0'
+            }]
+        },
+    },
+    config_directory: {
+        'config_dir_version': '1.0.0',
+        'phase': 'CONFIG_DIR_UNLOCKED',
+        'upgrade_history': {
+            'successful_upgrades': [
+                {
+                    'timestamp': 1724687496424,
+                    'running_host': hostname,
+                    'package_from_version': '5.17.0',
+                    'package_to_version': '5.18.0',
+                    'config_dir_from_version': '0.0.0',
+                    'config_dir_to_version': '1.0.0'
+                },
+                {
+                'timestamp': 1724687496424,
+                'completed_scripts': [],
+                'from_version': '5.16.0',
+                'to_version': '5.17.0'
+            }]
+        }
+    }
+};
+
+// const new_expected_system_json2 = {
+//     [hostname]: {
+//         'current_version': '5.16.0',
+//         'upgrade_history': {
+//             'successful_upgrades': [{
+//                 'timestamp': 1724687496424,
+//                 'from_version': '5.16.0',
+//                 'to_version': '5.17.0'
+//             }]
+//         },
+//     },
+//     config_directory: {
+//         'config_dir_version': '1',
+//         'phase': 'CONFIG_DIR_UNLOCKED',
+//         'upgrade_history': {
+//             'successful_upgrades': [
+//                 {
+//                     'timestamp': 1724687496424,
+//                     'running_host': hostname,
+//                     'from_version': '5.18.0',
+//                     'to_version': '5.18.1',
+//                     'config_dir_from_version': '0',
+//                     'config_dir_to_version': '1'
+//                 },
+//                 {
+//                 'timestamp': 1724687496424,
+//                 'completed_scripts': [],
+//                 'from_version': '5.17.0',
+//                 'to_version': '5.18.0'
+//             }]
+//         }
+//     }
+// };
+
 const expected_system_json = {
     [hostname]: {
         'current_version': '5.18.0',
@@ -29,39 +197,178 @@ const expected_system_json = {
         },
     },
     config_directory: {
-        'schema_version': 1,
+        'config_dir_version': '1',
+        'phase': 'CONFIG_DIR_LOCK',
         'in_progress_upgrade': {
             'start_timestamp': 1724687496424,
-            'phase': 'CONFIG_DIR_LOCK',
-            'from_version': '5.18.0',
-            'to_version': '5.18.1'
+            'running_host': hostname,
+            'package_from_version': '5.18.0',
+            'package_to_version': '5.18.1',
+            'config_dir_from_version': '0',
+            'config_dir_to_version': '1'
         },
         'upgrade_history': {
             'successful_upgrades': [{
                 'timestamp': 1724687496424,
                 'completed_scripts': [],
-                'from_version': '5.17.0',
-                'to_version': '5.18.0'
+                'package_from_version': '5.17.0',
+                'package_to_version': '5.18.0'
             }]
         }
     }
 };
 
+const invalid_hostname_system_json = {
+    [hostname]: {
+        'current_version': '5.18.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.17.0',
+                'to_version': '5.18.0'
+            }]
+        },
+    },
+    'hostname1': {
+        'current_version': '5.18.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.17.0',
+                'to_version': '5.18.0'
+            }]
+        },
+    },
+};
+
 describe('noobaa cli - upgrade', () => {
     afterEach(async () => await fs_utils.file_delete(config_fs.system_json_path));
 
-    it('upgrade invalid action - should fail', async () => {
-        const res = await exec_manage_cli(TYPES.UPGRADE, 'invalid_action', { config_root }, true);
+    it('upgrade start - should fail on no system', async () => {
+        const options = { config_root, expected_version: pkg.version, expected_hosts };
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
         const parsed_res = JSON.parse(res.stdout);
-        expect(parsed_res.error.code).toBe(ManageCLIError.InvalidUpgradeAction.code);
-        expect(parsed_res.error.message).toBe(ManageCLIError.InvalidUpgradeAction.message);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain('system does not exist');
     });
 
-    it('upgrade start - should fail with not implemented', async () => {
-        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root }, true);
+    it('upgrade start - should fail on no expected_version', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_rpm_expected_system_json));
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_hosts }, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain('expected_version flag is required');
+    });
+
+    it('upgrade start - should fail on no expected_hosts', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_rpm_expected_system_json));
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version: pkg.version }, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain('expected_hosts flag is required');
+    });
+
+    it('upgrade start - should fail on missing expected_hosts in system.json', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_rpm_expected_system_json));
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version: pkg.version, expected_hosts: `${hostname},bla1,bla2` }, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started - expected_hosts missing one or more hosts specified in system.json  hosts_data=');
+    });
+
+    it('upgrade start - should fail on missing system.json hosts in expected_hosts', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(invalid_hostname_system_json));
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version: pkg.version, expected_hosts: `${hostname}` }, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started - system.json missing one or more hosts info specified in expected_hosts hosts_data');
+    });
+
+    it('upgrade start - should fail on missing system.json hosts in expected_hosts1', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(invalid_hostname_system_json));
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version: pkg.version, expected_hosts: `${hostname},` }, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started - system.json missing one or more hosts info specified in expected_hosts hosts_data');
+    });
+
+    it('upgrade start - should fail expected_version invalid', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_rpm_expected_system_json));
+        const expected_version = '5.16.0';
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version, expected_hosts }, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain(`config dir upgrade can not be started - the host's package version=${pkg.version} does not match the user's expected version=${expected_version}`);
+    });
+
+    it('upgrade start - should fail on old rpm version', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_rpm_expected_system_json));
+        const options = { config_root, expected_version: pkg.version, expected_hosts };
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
+        const parsed_res = JSON.parse(res.stdout);
+        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started until all nodes have the expected version');
+    });
+
+    it('upgrade start - should fail - RPM version is higher than source code version', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_expected_system_json3));
+        const system_data_before_upgrade = await config_fs.get_system_config_file();
+        const options = { config_root, expected_version: pkg.version, expected_hosts };
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
         const parsed_res = JSON.parse(res.stdout);
         expect(parsed_res.error.code).toBe(ManageCLIError.UpgradeFailed.code);
-        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
+        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started until all nodes have the expected');
+        const system_data_after_upgrade = await config_fs.get_system_config_file();
+        // check that in the hostname section nothing changed
+        expect(system_data_before_upgrade[hostname]).toStrictEqual(system_data_after_upgrade[hostname]);
+        expect(system_data_after_upgrade.config_directory).toBeUndefined();
+    });
+
+    it('upgrade start - should succeed - same version, nothing to upgrade - config directory property exists', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_expected_system_json2));
+        const system_data_before_upgrade = await config_fs.get_system_config_file();
+        const options = { config_root, expected_version: pkg.version, expected_hosts };
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeSuccessful.code);
+        expect(parsed_res.response.reply.message).toBe('config_dir_version on system.json and config_fs.config_dir_version match, nothing to upgrade');
+        const system_data_after_upgrade = await config_fs.get_system_config_file();
+        // check that in the hostname section nothing changed
+        expect(system_data_before_upgrade[hostname]).toStrictEqual(system_data_after_upgrade[hostname]);
+        expect(system_data_after_upgrade.config_directory).toStrictEqual(old_expected_system_json2.config_directory);
+    });
+
+    it('upgrade start - should succeed - no old config directory', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_expected_system_json));
+        const system_data_before_upgrade = await config_fs.get_system_config_file();
+        const options = { config_root, expected_version: pkg.version, expected_hosts };
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeSuccessful.code);
+        const system_data_after_upgrade = await config_fs.get_system_config_file();
+        assert_config_dir_upgrade(system_data_before_upgrade, system_data_after_upgrade);
+    });
+
+    it('upgrade start - should succeed - old config directory exists', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_expected_system_json5));
+        const system_data_before_upgrade = await config_fs.get_system_config_file();
+        const options = { config_root, expected_version: pkg.version, expected_hosts };
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeSuccessful.code);
+        const system_data_after_upgrade = await config_fs.get_system_config_file();
+        assert_config_dir_upgrade(system_data_before_upgrade, system_data_after_upgrade);
+    });
+
+    it('upgrade start - should succeed - old config directory missing', async () => {
+        await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_expected_system_json));
+        const system_data_before_upgrade = await config_fs.get_system_config_file();
+        const options = { config_root, expected_version: pkg.version, expected_hosts };
+        const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeSuccessful.code);
+        const system_data_after_upgrade = await config_fs.get_system_config_file();
+        assert_config_dir_upgrade(system_data_before_upgrade, system_data_after_upgrade);
     });
 
     it('upgrade status - should fail - there is no ongoing upgrade', async () => {
@@ -95,3 +402,34 @@ describe('noobaa cli - upgrade', () => {
     });
 });
 
+/**
+ * assert_upgrade assert that -
+ * 1. hosts data was not changed
+ * 2. config_directory data properties were upgraded - 
+ *    2.1. config_dir_version
+ *    2.2. phase
+ * 3. config_directory.successful_upgrades is updated - 
+ *    3.1. running_host
+ *    3.2. from_version
+ *    3.3. to_version
+ *    3.4. config_dir_from_version
+ *    3.5. config_dir_to_version
+ * @param {Object} system_data_before_upgrade
+ * @param {Object} system_data_after_upgrade
+ */
+function assert_config_dir_upgrade(system_data_before_upgrade, system_data_after_upgrade) {
+    // check that in the hostname section nothing changed
+    expect(system_data_before_upgrade[hostname]).toStrictEqual(system_data_after_upgrade[hostname]);
+    const actual_config_directory = system_data_after_upgrade.config_directory;
+    const expected_config_directory = new_expected_system_json.config_directory;
+
+    expect(actual_config_directory.config_dir_version).toBe(expected_config_directory.config_dir_version);
+    expect(actual_config_directory.phase).toBe(expected_config_directory.phase);
+    const actual_upgrade = system_data_after_upgrade.config_directory.upgrade_history.successful_upgrades[0];
+    const expected_upgrade = new_expected_system_json.config_directory.upgrade_history.successful_upgrades[0];
+    expect(actual_upgrade.running_host).toBe(expected_upgrade.running_host);
+    expect(actual_upgrade.package_from_version).toBe(expected_upgrade.package_from_version);
+    expect(actual_upgrade.package_to_version).toBe(expected_upgrade.package_to_version);
+    expect(actual_upgrade.config_dir_from_version).toBe(expected_upgrade.config_dir_from_version);
+    expect(actual_upgrade.config_dir_to_version).toBe(expected_upgrade.config_dir_to_version);
+}

--- a/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_master_keys.test.js
@@ -11,6 +11,7 @@ const cloud_utils = require('../../../util/cloud_utils');
 const nc_mkm = require('../../../manage_nsfs/nc_master_key_manager');
 const { get_process_fs_context } = require('../../../util/native_fs_utils');
 const nsfs_schema_utils = require('../../../manage_nsfs/nsfs_schema_utils');
+const { fail_test_if_default_config_dir_exists } = require('../../../test/system_tests/test_utils');
 
 const DEFAULT_FS_CONFIG = get_process_fs_context();
 const MASTER_KEYS_JSON_PATH = path.join(config.NSFS_NC_DEFAULT_CONF_DIR, 'master_keys.json');
@@ -18,12 +19,13 @@ const MASTER_KEYS_JSON_PATH = path.join(config.NSFS_NC_DEFAULT_CONF_DIR, 'master
 describe('NC master key manager tests - file store type', () => {
 
     beforeAll(async () => {
+        await fail_test_if_default_config_dir_exists('test_nc_master_keys');
         await fs_utils.create_fresh_path(config.NSFS_NC_DEFAULT_CONF_DIR);
     });
 
     afterAll(async () => {
         await fs.promises.rm(MASTER_KEYS_JSON_PATH);
-        //await fs.promises.rm(config.NSFS_NC_DEFAULT_CONF_DIR, { recursive: true, force: true });
+        await fs.promises.rm(config.NSFS_NC_DEFAULT_CONF_DIR, { recursive: true, force: true });
     });
 
     let initial_master_key;

--- a/src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_master_keys_exec.test.js
@@ -4,12 +4,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const config = require('../../../../config');
 const fs_utils = require('../../../util/fs_utils');
 const cloud_utils = require('../../../util/cloud_utils');
-const { TMP_PATH } = require('../../system_tests/test_utils');
-const crypto = require('crypto');
 const db_client = require('../../../util/db_client').instance();
+const { TMP_PATH, fail_test_if_default_config_dir_exists } = require('../../system_tests/test_utils');
 
 const MKM_GET_EXEC_PATH = path.join(config.NSFS_NC_DEFAULT_CONF_DIR, 'file_get');
 const MKM_PUT_EXEC_PATH = path.join(config.NSFS_NC_DEFAULT_CONF_DIR, 'file_put');
@@ -70,6 +70,7 @@ describe('NC master key manager tests - exec store type', () => {
     const MASTER_KEYS_JSON_PATH = path.join(TMP_PATH, 'noobaa.master_keys');
 
     beforeAll(async () => {
+        await fail_test_if_default_config_dir_exists('test_nc_master_keys_exec');
         await fs_utils.create_fresh_path(config.NSFS_NC_DEFAULT_CONF_DIR);
         await fs.promises.writeFile(MKM_GET_EXEC_PATH, Buffer.from(get_script_content));
         await fs.promises.writeFile(MKM_PUT_EXEC_PATH, Buffer.from(put_script_content));
@@ -84,6 +85,7 @@ describe('NC master key manager tests - exec store type', () => {
         await fs.promises.rm(MASTER_KEYS_JSON_PATH);
         await fs.promises.rm(MKM_GET_EXEC_PATH);
         await fs.promises.rm(MKM_PUT_EXEC_PATH);
+        await fs.promises.rm(config.NSFS_NC_DEFAULT_CONF_DIR, { recursive: true, force: true });
     });
 
     let initial_master_key;

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1848,8 +1848,6 @@ describe('cli account flow distinguished_name - permissions', function() {
             await delete_fs_user_by_platform(distinguished_name);
         }
         await fs_utils.folder_delete(config_root);
-        await fs_utils.folder_delete(config_root);
-        await fs_utils.folder_delete(config.NSFS_NC_DEFAULT_CONF_DIR);
     }, timeout);
 
     it('cli account create - should fail - user does not exist', async function() {

--- a/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
@@ -1,0 +1,758 @@
+/* Copyright (C) 2016 NooBaa */
+/*eslint max-lines-per-function: ["error", 1300]*/
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = 'true';
+
+const fs = require('fs');
+const os = require('os');
+const _ = require('lodash');
+const path = require('path');
+const fs_utils = require('../../../util/fs_utils');
+const config = require('../../../../config');
+const pkg = require('../../../../package.json');
+const { NCUpgradeManager, DEFAULT_NC_UPGRADE_SCRIPTS_DIR, OLD_DEFAULT_PACKAGE_VERSION,
+    OLD_DEFAULT_CONFIG_DIR_VERSION, CONFIG_DIR_UNLOCKED, CONFIG_DIR_LOCKED } = require('../../../upgrade/nc_upgrade_manager');
+const { ConfigFS } = require('../../../sdk/config_fs');
+const { TMP_PATH, create_redirect_file, create_config_dir,
+    fail_test_if_default_config_dir_exists, clean_config_dir } = require('../../system_tests/test_utils');
+
+const config_root = path.join(TMP_PATH, 'config_root_nc_upgrade_manager_test');
+const config_fs = new ConfigFS(config_root);
+const hostname = os.hostname();
+
+const dummy_upgrade_script_1 =
+`/* Copyright (C) 2024 NooBaa */
+'use strict';
+async function run() {
+    console.log('script number 1');
+}
+module.exports = {
+    run,
+    description: 'dummy upgrade script file 1'
+};
+`;
+const dummy_upgrade_script_2 =
+`/* Copyright (C) 2024 NooBaa */
+'use strict';
+async function run() {
+    console.log('script number 2');
+}
+module.exports = {
+    run,
+    description: 'dummy upgrade script file 2'
+};`;
+
+const dummy_failing_upgrade_script_3 =
+`/* Copyright (C) 2024 NooBaa */
+'use strict';
+async function run() {
+    console.log('script number 3');
+    throw new Error('script number 3 failed')
+}
+module.exports = {
+    run,
+    description: 'dummy upgrade script file 1'
+};
+`;
+const old_expected_system_json = {
+    [hostname]: {
+        'current_version': '5.17.0',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.16.0',
+                'to_version': '5.17.0'
+            }]
+        },
+    }
+};
+
+const old_expected_system_json_has_config_directory = {
+    [hostname]: {
+        'current_version': '5.18.1',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.18.0',
+                'to_version': '5.18.1'
+            }]
+        },
+    },
+    config_directory: {
+        'config_dir_version': '1.0.0',
+        'upgrade_package_version': '5.18.0',
+        'phase': 'CONFIG_DIR_UNLOCKED',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'completed_scripts': [],
+                'package_from_version': '5.17.0',
+                'package_to_version': '5.18.0'
+            }]
+        }
+    }
+};
+
+const old_expected_system_json_no_successful_upgrades = {
+    [hostname]: {
+        'current_version': '5.17.0',
+        'upgrade_history': {
+            'successful_upgrades': []
+        },
+    }
+};
+
+const current_expected_system_json = {
+    [hostname]: {
+        'current_version': pkg.version,
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.17.0',
+                'to_version': pkg.version
+            }]
+        },
+    }
+};
+
+
+const current_expected_system_json_no_successful_upgrades = {
+    [hostname]: {
+        'current_version': pkg.version,
+        'upgrade_history': {
+            'successful_upgrades': []
+        },
+    }
+};
+
+// invalid system.json
+const current_expected_system_json_no_upgrade_history = {
+    [hostname]: {
+        'current_version': pkg.version,
+    }
+};
+
+// invalid system.json
+const current_expected_system_json_invalid_hostname = {
+    'invalid_hostname': {
+        'current_version': pkg.version,
+        'upgrade_history': {
+            'successful_upgrades': []
+        },
+    }
+};
+
+const old_expected_system_json_empty_successful_upgrades = {
+    [hostname]: {
+        'current_version': '5.18.1',
+        'upgrade_history': {
+            'successful_upgrades': [{
+                'timestamp': 1724687496424,
+                'from_version': '5.18.0',
+                'to_version': '5.18.1'
+            }]
+        },
+    },
+    config_directory: {
+        'config_dir_version': '1',
+        'phase': 'CONFIG_DIR_UNLOCKED',
+        'upgrade_history': {
+            'successful_upgrades': []
+        }
+    }
+};
+
+
+// WARNING:
+// The following test file will check the directory structure created using create_config_dirs_if_missing()
+// which is called when using noobaa-cli, for having an accurate test, it'll be blocked from running on an 
+// env having an existing default config directory and the test executer will be asked to remove the default 
+// config directory before running the test again, do not run on production env or on any env where the existing config directory is being used
+describe('nc upgrade manager - upgrade RPM', () => {
+    let nc_upgrade_manager;
+    beforeAll(async () => {
+        await fail_test_if_default_config_dir_exists('test_config_dir_nc_upgrade_manager', config_fs);
+    });
+
+    beforeEach(async () => {
+        await create_config_dir(config.NSFS_NC_DEFAULT_CONF_DIR);
+        await create_config_dir(config_root);
+        await create_redirect_file(config_fs, config_root);
+        nc_upgrade_manager = new NCUpgradeManager(config_fs);
+    });
+
+    afterEach(async () => {
+        await clean_config_dir(config_fs, config_root);
+    });
+
+    it('upgrade rpm - nothing to upgrade - no changes in system.json', async () => {
+        await config_fs.create_system_config_file(JSON.stringify(current_expected_system_json));
+        await nc_upgrade_manager.update_rpm_upgrade(config_fs);
+        const system_data_after_upgrade_run = await config_fs.get_system_config_file();
+        expect(current_expected_system_json).toStrictEqual(system_data_after_upgrade_run);
+    });
+
+    it('upgrade rpm - nothing to upgrade - no changes in system.json - no successful upgrades', async () => {
+        await config_fs.create_system_config_file(JSON.stringify(current_expected_system_json_no_successful_upgrades));
+        await nc_upgrade_manager.update_rpm_upgrade(config_fs);
+        const system_data_after_upgrade_run = await config_fs.get_system_config_file();
+        expect(current_expected_system_json_no_successful_upgrades).toStrictEqual(system_data_after_upgrade_run);
+    });
+
+    it('upgrade status - RPM was upgraded, should update system.json', async () => {
+        await config_fs.create_system_config_file(JSON.stringify(old_expected_system_json));
+        await nc_upgrade_manager.update_rpm_upgrade(config_fs);
+        const system_data_after_upgrade_run = await config_fs.get_system_config_file();
+        const new_version = pkg.version;
+        const host_data_after_upgrade = system_data_after_upgrade_run[hostname];
+        expect(host_data_after_upgrade.current_version).toStrictEqual(new_version);
+        expect(host_data_after_upgrade.upgrade_history.successful_upgrades[0].from_version).toStrictEqual(
+            old_expected_system_json[hostname].current_version);
+        expect(host_data_after_upgrade.upgrade_history.successful_upgrades[0].to_version).toStrictEqual(new_version);
+    });
+
+    it('upgrade status - RPM was upgraded, should update system.json', async () => {
+        await config_fs.create_system_config_file(JSON.stringify(old_expected_system_json_no_successful_upgrades));
+        await nc_upgrade_manager.update_rpm_upgrade(config_fs);
+        const system_data_after_upgrade_run = await config_fs.get_system_config_file();
+        const new_version = pkg.version;
+        const host_data_after_upgrade = system_data_after_upgrade_run[hostname];
+        expect(host_data_after_upgrade.current_version).toStrictEqual(new_version);
+        expect(host_data_after_upgrade.upgrade_history.successful_upgrades[0].from_version).toStrictEqual(
+            old_expected_system_json_no_successful_upgrades[hostname].current_version);
+        expect(host_data_after_upgrade.upgrade_history.successful_upgrades[0].to_version).toStrictEqual(new_version);
+    });
+});
+
+describe('nc upgrade manager - upgrade config directory', () => {
+    let nc_upgrade_manager;
+
+    beforeAll(async () => {
+        nc_upgrade_manager = new NCUpgradeManager(config_fs);
+        await fail_test_if_default_config_dir_exists('test_config_dir_nc_upgrade_manager', config_fs);
+    });
+
+    describe('nc upgrade manager - config_directory_defaults', () => {
+
+        it('config_directory_defaults - hostname from_version exists - 5.16.0', () => {
+            const system_data = old_expected_system_json;
+            const config_dir_defaults = nc_upgrade_manager.config_directory_defaults(system_data);
+            assert_config_dir_defaults(config_dir_defaults, system_data);
+        });
+
+        it('config_directory_defaults - hostname from_version exists - 5.17.0', () => {
+            const system_data = current_expected_system_json;
+            const config_dir_defaults = nc_upgrade_manager.config_directory_defaults(system_data);
+            assert_config_dir_defaults(config_dir_defaults, system_data);
+        });
+
+        it('config_directory_defaults - missing hostname successful_upgrades', () => {
+            const system_data = current_expected_system_json_no_successful_upgrades;
+            const config_dir_defaults = nc_upgrade_manager.config_directory_defaults(system_data);
+            assert_config_dir_defaults(config_dir_defaults, system_data);
+        });
+
+        it('config_directory_defaults - missing hostname upgrade_history', () => {
+            const system_data = current_expected_system_json_no_upgrade_history;
+            const config_dir_defaults = nc_upgrade_manager.config_directory_defaults(system_data);
+            assert_config_dir_defaults(config_dir_defaults, system_data);
+        });
+
+        it('config_directory_defaults - missing hostname', () => { // should throw
+            const system_data = current_expected_system_json_invalid_hostname;
+            const config_dir_defaults = nc_upgrade_manager.config_directory_defaults(system_data);
+            assert_config_dir_defaults(config_dir_defaults, system_data);
+        });
+    });
+
+    describe('nc upgrade manager - _verify_config_dir_upgrade', () => {
+        it('_verify_config_dir_upgrade - empty hosts system_data', async () => {
+            const system_data = {};
+            const expected_err_msg = 'config dir upgrade can not be started missing hosts_data hosts_data={}';
+            await expect(nc_upgrade_manager._verify_config_dir_upgrade(system_data, pkg.version, [hostname]))
+                .rejects.toThrow(expected_err_msg);
+        });
+
+        it('_verify_config_dir_upgrade - empty host current_version', async () => {
+            const system_data = { [hostname]: []};
+            const expected_err_msg = `config dir upgrade can not be started until all nodes have the expected version=${pkg.version}, host=${hostname} host's current_version=undefined`;
+            await expect(nc_upgrade_manager._verify_config_dir_upgrade(system_data, pkg.version, [hostname]))
+                .rejects.toThrow(expected_err_msg);
+        });
+
+        it('_verify_config_dir_upgrade - host current_version < new_version should upgrade RPM', async () => {
+            const old_version = '5.16.0';
+            const system_data = { [hostname]: { current_version: old_version }, other_hostname: { current_version: pkg.version } };
+            const expected_err_msg = `config dir upgrade can not be started until all nodes have the expected version=${pkg.version}, host=${hostname} host's current_version=${old_version}`;
+            await expect(nc_upgrade_manager._verify_config_dir_upgrade(system_data, pkg.version, [hostname, 'other_hostname']))
+                .rejects.toThrow(expected_err_msg);
+        });
+
+        it('_verify_config_dir_upgrade - should upgrade config dir', async () => {
+            const system_data = {[hostname]: { current_version: pkg.version, other_hostname: { current_version: pkg.version } }};
+            await nc_upgrade_manager._verify_config_dir_upgrade(system_data, pkg.version, [hostname]);
+        });
+
+        it('_verify_config_dir_upgrade - host current_version > new_version should upgrade RPM', async () => {
+            const newer_version = pkg.version + '.1';
+            const system_data = { [hostname]: { current_version: newer_version }, other_hostname: { current_version: pkg.version } };
+            const expected_err_msg = `config dir upgrade can not be started until all nodes have the expected version=${pkg.version}, host=${hostname} host's current_version=${newer_version}`;
+            await expect(nc_upgrade_manager._verify_config_dir_upgrade(system_data, pkg.version, [hostname, 'other_hostname']))
+                .rejects.toThrow(expected_err_msg);
+        });
+
+        it('_verify_config_dir_upgrade - should upgrade config dir', async () => {
+            const expected_version = pkg.version;
+            const system_data = {
+                [hostname]: { current_version: pkg.version, other_hostname: { current_version: pkg.version } }
+            };
+            await nc_upgrade_manager._verify_config_dir_upgrade(system_data, expected_version, [hostname]);
+        });
+
+        it('_verify_config_dir_upgrade - fail on mismatch expected_version', async () => {
+            const expected_version = pkg.version + '.1';
+            const system_data = { [hostname]: { current_version: pkg.version, other_hostname: { current_version: pkg.version } }};
+            const nc_upgrade_manager_higher_version = new NCUpgradeManager(config_fs);
+            const expected_err_msg = `config dir upgrade can not be started - the host's package version=${pkg.version} does not match the user's expected version=${expected_version}`;
+            await expect(nc_upgrade_manager_higher_version._verify_config_dir_upgrade(system_data, expected_version, [hostname]))
+                .rejects.toThrow(expected_err_msg);
+        });
+    });
+
+    describe('nc upgrade manager - _run_nc_upgrade_scripts', () => {
+        const from_version = '0.0.0';
+        const to_version = '1.0.0';
+        const custom_upgrade_scripts_dir = path.join(TMP_PATH, 'custom_upgrade_scripts_dir');
+        const custom_upgrade_scripts_dir_version_path = path.join(TMP_PATH, 'custom_upgrade_scripts_dir', to_version);
+        const default_upgrade_script_dir_version_path = path.join(DEFAULT_NC_UPGRADE_SCRIPTS_DIR, to_version);
+        const successful_upgrade_scripts_obj = { dummy_upgrade_script_1, dummy_upgrade_script_2 };
+        const failing_upgrade_scripts_obj = { ...successful_upgrade_scripts_obj, dummy_failing_upgrade_script_3 };
+        const default_this_upgrade = Object.freeze({
+            config_dir_from_version: from_version, config_dir_to_version: to_version,
+            completed_scripts: []
+        });
+        const default_upgrade_script_paths = Object.keys(successful_upgrade_scripts_obj).map(script_name =>
+            get_upgrade_script_path(DEFAULT_NC_UPGRADE_SCRIPTS_DIR, to_version, script_name));
+        const custom_upgrade_script_paths = Object.keys(successful_upgrade_scripts_obj).map(script_name =>
+            get_upgrade_script_path(custom_upgrade_scripts_dir, to_version, script_name));
+
+        const nc_upgrade_manager_custom_dir = new NCUpgradeManager(config_fs, { custom_upgrade_scripts_dir });
+
+        beforeEach(async () => {
+            await fs_utils.create_path(custom_upgrade_scripts_dir_version_path, 777);
+
+            try {
+                await fs_utils.create_path(DEFAULT_NC_UPGRADE_SCRIPTS_DIR, 777);
+                await fs_utils.create_path(default_upgrade_script_dir_version_path, 777);
+            } catch (err) {
+                console.log('couldnt create upgrade scripts dir err', default_upgrade_script_dir_version_path, err);
+            }
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(custom_upgrade_scripts_dir_version_path);
+            await fs_utils.folder_delete(custom_upgrade_scripts_dir);
+        });
+
+        it('_run_nc_upgrade_scripts - no scripts', async () => {
+            const this_upgrade = _.cloneDeep(default_this_upgrade);
+            await nc_upgrade_manager._run_nc_upgrade_scripts(this_upgrade);
+            expect(this_upgrade.completed_scripts).toEqual([]);
+        });
+
+        it('_run_nc_upgrade_scripts - custom_upgrade_scripts_dir - no upgrade scripts dir', async () => {
+            const this_upgrade = _.cloneDeep(default_this_upgrade);
+            await fs_utils.folder_delete(custom_upgrade_scripts_dir_version_path);
+            await fs_utils.folder_delete(custom_upgrade_scripts_dir);
+            await nc_upgrade_manager_custom_dir._run_nc_upgrade_scripts(this_upgrade);
+            expect(this_upgrade.completed_scripts).toEqual([]);
+        });
+
+        it('_run_nc_upgrade_scripts - custom_upgrade_scripts_dir - successful scripts', async () => {
+            await populate_upgrade_scripts_dir(custom_upgrade_scripts_dir, to_version, successful_upgrade_scripts_obj);
+            const this_upgrade = _.cloneDeep(default_this_upgrade);
+            await nc_upgrade_manager_custom_dir._run_nc_upgrade_scripts(this_upgrade);
+            expect(this_upgrade.completed_scripts).toEqual(custom_upgrade_script_paths);
+        });
+
+        it('_run_nc_upgrade_scripts - custom_upgrade_scripts_dir - failing scripts', async () => {
+            await populate_upgrade_scripts_dir(custom_upgrade_scripts_dir, to_version, failing_upgrade_scripts_obj);
+            const this_upgrade = _.cloneDeep(default_this_upgrade);
+            const expected_err_msg = '_run_nc_upgrade_scripts: nc upgrade manager failed!!!, Error: script number 3 failed';
+            await expect(nc_upgrade_manager_custom_dir._run_nc_upgrade_scripts(this_upgrade)).rejects.toThrow(expected_err_msg);
+            expect(this_upgrade.completed_scripts).toEqual([]);
+            expect(this_upgrade.error).toContain('Error: script number 3 failed');
+        });
+
+        it('_run_nc_upgrade_scripts - default upgrade scripts dir - successful scripts', async () => {
+            await populate_upgrade_scripts_dir(DEFAULT_NC_UPGRADE_SCRIPTS_DIR, to_version, successful_upgrade_scripts_obj);
+            const this_upgrade = _.cloneDeep(default_this_upgrade);
+            await nc_upgrade_manager._run_nc_upgrade_scripts(this_upgrade);
+            expect(this_upgrade.completed_scripts).toEqual(default_upgrade_script_paths);
+            await delete_upgrade_scripts(DEFAULT_NC_UPGRADE_SCRIPTS_DIR, to_version, successful_upgrade_scripts_obj);
+        });
+
+        it('_run_nc_upgrade_scripts - default upgrade scripts dir - failing scripts', async () => {
+            await populate_upgrade_scripts_dir(DEFAULT_NC_UPGRADE_SCRIPTS_DIR, to_version, failing_upgrade_scripts_obj);
+            const this_upgrade = _.cloneDeep(default_this_upgrade);
+            const expected_err_msg = '_run_nc_upgrade_scripts: nc upgrade manager failed!!!, Error: script number 3 failed';
+            await expect(nc_upgrade_manager._run_nc_upgrade_scripts(this_upgrade)).rejects.toThrow(expected_err_msg);
+            expect(this_upgrade.completed_scripts).toEqual([]);
+            expect(this_upgrade.error).toContain('Error: script number 3 failed');
+            await delete_upgrade_scripts(DEFAULT_NC_UPGRADE_SCRIPTS_DIR, to_version, failing_upgrade_scripts_obj);
+        });
+    });
+
+    describe('nc upgrade manager - _update_config_dir_upgrade_start', () => {
+
+        beforeAll(async () => {
+            await fail_test_if_default_config_dir_exists('test_config_dir_nc_upgrade_manager', config_fs);
+        });
+
+        beforeEach(async () => {
+            await create_config_dir(config.NSFS_NC_DEFAULT_CONF_DIR);
+            await create_config_dir(config_root);
+            await create_redirect_file(config_fs, config_root);
+        });
+
+        afterEach(async () => {
+            await clean_config_dir(config_fs, config_root);
+        });
+
+        it('_update_config_dir_upgrade_start - system_data doesn\'t contain old config_directory data', async () => {
+            const system_data = old_expected_system_json;
+            const options = {
+                config_dir_from_version: '0.0.0',
+                config_dir_to_version: '1.0.0',
+                package_from_version: '5.16.0',
+                package_to_version: '5.17.0',
+            };
+            await config_fs.create_system_config_file(JSON.stringify(system_data));
+            const upgrade_start_data = await nc_upgrade_manager._update_config_dir_upgrade_start(system_data, options);
+            const expected_data = {
+                ...system_data,
+                config_directory: {
+                    config_dir_version: options.config_dir_from_version,
+                    upgrade_package_version: options.package_from_version,
+                    in_progress_upgrade: {
+                        completed_scripts: [],
+                        running_host: hostname,
+                        ...options
+                    }
+                }
+            };
+            assert_upgrade_start_data(upgrade_start_data, expected_data);
+            const system_json_data = await config_fs.get_system_config_file();
+            assert_upgrade_start_data(system_json_data, expected_data);
+        });
+
+        it('_update_config_dir_upgrade_start - system_data contains old config_directory data', async () => {
+            const system_data = old_expected_system_json_has_config_directory;
+            const options = {
+                config_dir_from_version: old_expected_system_json_has_config_directory.config_directory.config_dir_version,
+                config_dir_to_version: '2.0.0',
+                package_from_version: old_expected_system_json_has_config_directory.config_directory.upgrade_package_version,
+                package_to_version: '5.18.1',
+            };
+            await config_fs.create_system_config_file(JSON.stringify(system_data));
+
+            const upgrade_start_data = await nc_upgrade_manager._update_config_dir_upgrade_start(system_data, options);
+            system_data.config_directory.in_progress_upgrade = {
+                completed_scripts: [],
+                running_host: hostname,
+                    ...options
+            };
+            assert_upgrade_start_data(upgrade_start_data, system_data);
+            const system_json_data = await config_fs.get_system_config_file();
+            assert_upgrade_start_data(system_json_data, system_data);
+        });
+    });
+
+    describe('nc upgrade manager - _update_config_dir_upgrade_finish', () => {
+
+        beforeAll(async () => {
+            await fail_test_if_default_config_dir_exists('test_config_dir_nc_upgrade_manager', config_fs);
+        });
+
+        beforeEach(async () => {
+            await create_config_dir(config.NSFS_NC_DEFAULT_CONF_DIR);
+            await create_config_dir(config_root);
+            await create_redirect_file(config_fs, config_root);
+        });
+
+        afterEach(async () => {
+            await clean_config_dir(config_fs, config_root);
+        });
+
+        it('_update_config_dir_upgrade_finish - system_data doesn\'t contain old successful_upgrades data', async () => {
+            const system_data = _.cloneDeep(old_expected_system_json_empty_successful_upgrades);
+            const this_upgrade = {
+                timestamp: 1714687496424,
+                running_host: hostname,
+                completed_scripts: [],
+                config_dir_from_version: '1.0.0',
+                config_dir_to_version: '2.0.0',
+                package_from_version: '5.18.0',
+                package_to_version: '5.18.1',
+            };
+            await config_fs.create_system_config_file(JSON.stringify(system_data));
+            await nc_upgrade_manager._update_config_dir_upgrade_finish(system_data, this_upgrade);
+            const expected_data = {
+                ...system_data,
+                config_directory: {
+                    phase: CONFIG_DIR_UNLOCKED,
+                    config_dir_version: this_upgrade.config_dir_to_version,
+                    upgrade_package_version: this_upgrade.package_to_version,
+                    upgrade_history: {
+                        successful_upgrades: [this_upgrade]
+                    }
+                }
+            };
+            const system_json_data = await config_fs.get_system_config_file();
+            assert_upgrade_finish_or_fail_data(system_json_data, expected_data);
+        });
+
+        it('_update_config_dir_upgrade_finish - system_data contains old successful_upgrades and last_failure data', async () => {
+            const system_data = _.cloneDeep(old_expected_system_json_empty_successful_upgrades);
+            system_data.config_directory.upgrade_history.successful_upgrades = [{
+                'timestamp': 1724687496424,
+                'completed_scripts': [],
+                'package_from_version': '5.17.0',
+                'package_to_version': '5.18.0'
+            }];
+            system_data.config_directory.upgrade_history.last_failure = {
+                'timestamp': 1714687496424,
+                'running_host': hostname,
+                'completed_scripts': [],
+                'config_dir_from_version': '0.0.0',
+                'config_dir_to_version': '1.0.0',
+                'package_from_version': '5.17.0',
+                'package_to_version': '5.18.0',
+                'error': new Error('this is a last failure error').stack
+            };
+            const this_upgrade = {
+                timestamp: 1714687496424,
+                running_host: hostname,
+                completed_scripts: [],
+                config_dir_from_version: '1.0.0',
+                config_dir_to_version: '2.0.0',
+                package_from_version: '5.18.0',
+                package_to_version: '5.18.1',
+            };
+            await config_fs.create_system_config_file(JSON.stringify(system_data));
+
+            await nc_upgrade_manager._update_config_dir_upgrade_finish(system_data, this_upgrade);
+            const expected_data = {
+                ...system_data,
+                config_directory: {
+                    phase: CONFIG_DIR_UNLOCKED,
+                    config_dir_version: this_upgrade.config_dir_to_version,
+                    upgrade_package_version: this_upgrade.package_to_version,
+                    upgrade_history: {
+                        last_failure: system_data.config_directory.upgrade_history.last_failure,
+                        successful_upgrades: [this_upgrade, ...system_data.config_directory.upgrade_history.successful_upgrades]
+                    }
+                }
+            };
+            const system_json_data = await config_fs.get_system_config_file();
+            assert_upgrade_finish_or_fail_data(system_json_data, expected_data);
+        });
+    });
+
+    describe('nc upgrade manager - _update_config_dir_upgrade_failed', () => {
+
+        beforeAll(async () => {
+            await fail_test_if_default_config_dir_exists('test_config_dir_nc_upgrade_manager', config_fs);
+        });
+
+        beforeEach(async () => {
+            await create_config_dir(config.NSFS_NC_DEFAULT_CONF_DIR);
+            await create_config_dir(config_root);
+            await create_redirect_file(config_fs, config_root);
+        });
+
+        afterEach(async () => {
+            await clean_config_dir(config_fs, config_root);
+        });
+
+        it('_update_config_dir_upgrade_failed - system_data doesn\'t contain old upgrade_history data', async () => {
+            const system_data = _.cloneDeep(old_expected_system_json_empty_successful_upgrades);
+            const this_upgrade = {
+                timestamp: 1714687496424,
+                running_host: hostname,
+                completed_scripts: [],
+                config_dir_from_version: system_data.config_directory.config_dir_version,
+                config_dir_to_version: '2.0.0',
+                package_from_version: '5.18.0',
+                package_to_version: '5.18.1',
+            };
+            system_data.config_directory.phase = CONFIG_DIR_LOCKED;
+            const new_error = new Error('this is a new last failure error');
+            await config_fs.create_system_config_file(JSON.stringify(system_data));
+            await nc_upgrade_manager._update_config_dir_upgrade_failed(system_data, this_upgrade, new_error);
+            const expected_data = {
+                ...system_data,
+                config_directory: {
+                    phase: CONFIG_DIR_LOCKED,
+                    config_dir_version: system_data.config_directory.config_dir_version,
+                    upgrade_package_version: system_data.config_directory.upgrade_package_version,
+                    upgrade_history: {
+                        last_failure: { ...this_upgrade, error: new_error.stack },
+                        successful_upgrades: []
+                    }
+                }
+            };
+            const system_json_data = await config_fs.get_system_config_file();
+            assert_upgrade_finish_or_fail_data(system_json_data, expected_data);
+        });
+
+        it('_update_config_dir_upgrade_failed - system_data contains old successful_upgrades and last_failure data', async () => {
+            const system_data = _.cloneDeep(old_expected_system_json_empty_successful_upgrades);
+            system_data.config_directory.upgrade_history.successful_upgrades = [{
+                'timestamp': 1724687496424,
+                'completed_scripts': [],
+                'package_from_version': '5.17.0',
+                'package_to_version': '5.18.0'
+            }];
+            system_data.config_directory.phase = CONFIG_DIR_LOCKED;
+            system_data.config_directory.upgrade_history.last_failure = {
+                'timestamp': 1714687496424,
+                'running_host': hostname,
+                'completed_scripts': [],
+                'config_dir_from_version': '0.0.0',
+                'config_dir_to_version': '1.0.0',
+                'package_from_version': '5.17.0',
+                'package_to_version': '5.18.0',
+                'error': new Error('this is a last failure error').stack
+            };
+            const this_upgrade = {
+                timestamp: 1714687496424,
+                running_host: hostname,
+                completed_scripts: [],
+                config_dir_from_version: '1.0.0',
+                config_dir_to_version: '2.0.0',
+                package_from_version: '5.18.0',
+                package_to_version: '5.18.1'
+            };
+            await config_fs.create_system_config_file(JSON.stringify(system_data));
+            const new_error = new Error('this is a new last failure error');
+            await nc_upgrade_manager._update_config_dir_upgrade_failed(system_data, this_upgrade, new_error);
+            const expected_data = {
+                ...system_data,
+                config_directory: {
+                    phase: CONFIG_DIR_LOCKED,
+                    config_dir_version: system_data.config_directory.config_dir_version,
+                    upgrade_package_version: system_data.config_directory.upgrade_package_version,
+                    upgrade_history: {
+                        last_failure: { ...this_upgrade, error: new_error.stack },
+                        successful_upgrades: system_data.config_directory.upgrade_history.successful_upgrades
+                    }
+                }
+            };
+            const system_json_data = await config_fs.get_system_config_file();
+            assert_upgrade_finish_or_fail_data(system_json_data, expected_data);
+        });
+    });
+});
+
+/**
+ * assert_upgrade_start_data asserts that 
+ * 1. the expected upgrade start properties in the system_data matches the actual system_data written to system.json
+ * 2. the expected upgrade start properties in the system_data matches the return value
+ * @param {Object} actual_upgrade_start 
+ * @param {Object} expected_system_data 
+ */
+function assert_upgrade_start_data(actual_upgrade_start, expected_system_data) {
+    const { config_dir_version, upgrade_package_version, phase, upgrade_history, in_progress_upgrade, current_version } =
+        actual_upgrade_start.config_directory;
+    const expected_in_progress_upgrade = expected_system_data.config_directory?.in_progress_upgrade;
+
+    expect(phase).toBe(CONFIG_DIR_LOCKED);
+    expect(config_dir_version).toBe(expected_system_data.config_directory?.config_dir_version);
+    expect(upgrade_package_version).toBe(expected_system_data.config_directory?.upgrade_package_version);
+    expect(upgrade_history).toEqual(expected_system_data.config_directory?.upgrade_history);
+    expect(current_version).toEqual(expected_system_data.config_directory?.current_version);
+
+    expect(in_progress_upgrade.completed_scripts).toEqual(expected_in_progress_upgrade?.completed_scripts);
+    expect(in_progress_upgrade.running_host).toEqual(expected_in_progress_upgrade?.running_host);
+    expect(in_progress_upgrade.config_dir_from_version).toEqual(expected_in_progress_upgrade?.config_dir_from_version);
+    expect(in_progress_upgrade.config_dir_to_version).toEqual(expected_in_progress_upgrade?.config_dir_to_version);
+    expect(in_progress_upgrade.package_from_version).toEqual(expected_in_progress_upgrade?.package_from_version);
+    expect(in_progress_upgrade.package_to_version).toEqual(expected_in_progress_upgrade?.package_to_version);
+
+    expect(actual_upgrade_start[hostname]).toEqual(expected_system_data[hostname]);
+}
+
+/**
+ * assert_upgrade_finish_or_fail_data asserts that 
+ * 1. the expected system_data properties in the system_data matches the actual system_data written to system.json
+ * @param {Object} actual_system_data
+ * @param {Object} expected_system_data 
+ */
+function assert_upgrade_finish_or_fail_data(actual_system_data, expected_system_data) {
+    const { config_dir_version, upgrade_package_version, phase, upgrade_history, in_progress_upgrade, current_version } =
+        actual_system_data.config_directory;
+
+    expect(phase).toBe(expected_system_data.config_directory?.phase);
+    expect(config_dir_version).toBe(expected_system_data.config_directory?.config_dir_version);
+    expect(upgrade_package_version).toBe(expected_system_data.config_directory?.upgrade_package_version);
+    expect(upgrade_history).toStrictEqual(expected_system_data.config_directory?.upgrade_history);
+    expect(current_version).toEqual(expected_system_data.config_directory?.current_version);
+
+    expect(in_progress_upgrade).toEqual(undefined);
+    expect(actual_system_data[hostname]).toEqual(expected_system_data[hostname]);
+}
+
+/**
+ * assert_config_dir_defaults asserts that the expected config dir properties in the system_data matches the actual config dir defaults
+ * @param {Object} actual_config_dir_defaults 
+ * @param {Object} system_data 
+ */
+function assert_config_dir_defaults(actual_config_dir_defaults, system_data) {
+    const { config_dir_version, upgrade_package_version, phase, upgrade_history } = actual_config_dir_defaults;
+    const expected_package_from_version = system_data?.[hostname]?.upgrade_history?.successful_upgrades?.[0]?.from_version ||
+        OLD_DEFAULT_PACKAGE_VERSION;
+    expect(config_dir_version).toBe(OLD_DEFAULT_CONFIG_DIR_VERSION);
+    expect(upgrade_package_version).toBe(expected_package_from_version);
+    expect(phase).toBe(CONFIG_DIR_UNLOCKED);
+    expect(upgrade_history).toEqual({ successful_upgrades: [] });
+}
+
+/**
+ * populate_upgrade_scripts_dir created all upgrade scripts based on the patameters
+ * @param {String} upgrade_scripts_dir 
+ * @param {String} version 
+ * @param {Object} scripts_obj 
+ */
+async function populate_upgrade_scripts_dir(upgrade_scripts_dir, version, scripts_obj) {
+    for (const [script_name, upgrade_script] of Object.entries(scripts_obj)) {
+        const dummy_script_path = get_upgrade_script_path(upgrade_scripts_dir, version, script_name);
+        await fs.promises.writeFile(dummy_script_path, Buffer.from(upgrade_script));
+    }
+}
+
+/**
+ * delete_upgrade_scripts deletes all upgrade scripts based on the patameters
+ * @param {String} upgrade_scripts_dir 
+ * @param {String} version 
+ * @param {Object} scripts_obj 
+ */
+async function delete_upgrade_scripts(upgrade_scripts_dir, version, scripts_obj) {
+    for (const [script_name] of Object.entries(scripts_obj)) {
+        const dummy_script_path = get_upgrade_script_path(upgrade_scripts_dir, version, script_name);
+        await fs_utils.file_delete(dummy_script_path);
+    }
+}
+
+/**
+ * get_upgrade_script_path returns upgrade script full path
+ * @param {String} upgrade_scripts_dir 
+ * @param {String} version 
+ * @param {String} script_name 
+ * @returns {String}
+ */
+function get_upgrade_script_path(upgrade_scripts_dir, version, script_name) {
+    return path.join(upgrade_scripts_dir, version, script_name + '.js');
+}

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -8,7 +8,7 @@ const mocha = require('mocha');
 const child_process = require('child_process');
 const argv = require('minimist')(process.argv);
 const SensitiveString = require('../../util/sensitive_string');
-const { exec_manage_cli, TMP_PATH } = require('../system_tests/test_utils');
+const { exec_manage_cli, TMP_PATH, create_redirect_file, delete_redirect_file } = require('../system_tests/test_utils');
 const { TYPES, ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
 const { ConfigFS } = require('../../sdk/config_fs');
 
@@ -51,7 +51,6 @@ const http_address = `http://localhost:${http_port}`;
 const https_address = `https://localhost:${https_port}`;
 
 const FIRST_BUCKET = 'first.bucket';
-const NC_CORETEST_REDIRECT_FILE_PATH = p.join(config.NSFS_NC_DEFAULT_CONF_DIR, '/config_dir_redirect');
 const NC_CORETEST_STORAGE_PATH = p.join(TMP_PATH, '/nc_coretest_storage_root_path/');
 const FIRST_BUCKET_PATH = p.join(NC_CORETEST_STORAGE_PATH, FIRST_BUCKET, '/');
 const CONFIG_FILE_PATH = p.join(NC_CORETEST_CONFIG_DIR_PATH, 'config.json');
@@ -141,7 +140,7 @@ async function config_dir_setup() {
     await fs.promises.mkdir(NC_CORETEST_STORAGE_PATH, { recursive: true });
     await fs.promises.mkdir(config.NSFS_NC_DEFAULT_CONF_DIR, { recursive: true });
     await fs.promises.mkdir(NC_CORETEST_CONFIG_DIR_PATH, { recursive: true });
-    await fs.promises.writeFile(NC_CORETEST_REDIRECT_FILE_PATH, NC_CORETEST_CONFIG_DIR_PATH);
+    await create_redirect_file(NC_CORETEST_CONFIG_FS, NC_CORETEST_CONFIG_DIR_PATH);
     await fs.promises.writeFile(CONFIG_FILE_PATH, JSON.stringify({
         ALLOW_HTTP: true,
         OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS: 1,
@@ -160,7 +159,7 @@ async function config_dir_setup() {
 async function config_dir_teardown() {
     await announce('config_dir_teardown');
     await fs.promises.rm(NC_CORETEST_STORAGE_PATH, { recursive: true });
-    await fs.promises.rm(NC_CORETEST_REDIRECT_FILE_PATH);
+    await delete_redirect_file(NC_CORETEST_CONFIG_FS);
     await fs.promises.rm(NC_CORETEST_CONFIG_DIR_PATH, { recursive: true, force: true });
 }
 

--- a/src/upgrade/nc_upgrade_manager.js
+++ b/src/upgrade/nc_upgrade_manager.js
@@ -1,0 +1,299 @@
+/* Copyright (C) 2016 NooBaa */
+"use strict";
+
+const os = require('os');
+const _ = require('lodash');
+const path = require('path');
+const util = require('util');
+const pkg = require('../../package.json');
+const dbg = require('../util/debug_module')('UPGRADE');
+const { should_upgrade, run_upgrade_scripts, version_compare } = require('./upgrade_utils');
+
+dbg.set_process_name('Upgrade');
+const hostname = os.hostname();
+
+const CONFIG_DIR_LOCKED = 'CONFIG_DIR_LOCKED';
+const CONFIG_DIR_UNLOCKED = 'CONFIG_DIR_UNLOCKED';
+// prior to 5.18.0 - there is no config dir version, the config dir version to be used on the first upgrade is 0.0.0 (5.17.0 -> 5.18.0)
+const OLD_DEFAULT_CONFIG_DIR_VERSION = '0.0.0';
+const OLD_DEFAULT_PACKAGE_VERSION = '5.17.0';
+const DEFAULT_NC_UPGRADE_SCRIPTS_DIR = path.join(__dirname, 'nc_upgrade_scripts');
+
+/////////////////////////////
+//       NC UPGRADES       //
+/////////////////////////////
+
+class NCUpgradeManager {
+
+    /**
+     * @param {import('../sdk/config_fs').ConfigFS} config_fs
+     * @param {{custom_upgrade_scripts_dir?: string}} [options]
+     */
+    constructor(config_fs, { custom_upgrade_scripts_dir } = {}) {
+        this.config_fs = config_fs;
+        this.config_dir_version = config_fs.config_dir_version;
+        this.package_version = pkg.version;
+        this.upgrade_scripts_dir = custom_upgrade_scripts_dir || DEFAULT_NC_UPGRADE_SCRIPTS_DIR;
+    }
+
+    /**
+     * NC upgrades are Online(*) upgrades that should be executed as follows - 
+     * 1. Backup the config directory.
+     * 2. Iterate all hosts one by one - 
+     *    2.1. Upgrade the host's RPM
+     *    2.2. Restart noobaa service on the host.
+     * 3. Run `noobaa-cli upgrade start` - will initialize config directory upgrade
+     * 
+     * * Online upgrade - during the config directory upgrade, all creations/updates/deletions of entities like buckets/accounts will be blocked.
+     * 
+     * system.json upgrade information - 
+     * 1. RPM upgrades are per host, therefore they will be presented under the hostname object, in the upgrade history section.
+     * 2. Config Directory are cluster scoped - therefore, the config_directory key will be on the first level and in_progress_upgrade and upgrade_history of the config directory will be under it.
+     * Example -
+     * {
+     *   [hostname]: { current_version: 5.18.0, upgrade_history: {{ from_version: 5.17.0, to_version: 5.18.0, completed_scripts: [], timestamp }}}
+     *   config_directory: { config_dir_version: 1,
+     *                       upgrade_package_version: 5.17.0,
+     *                       phase: 'CONFIG_DIR_LOCKED',
+     *                       in_progress_upgrade: { from_version: 5.17.0, to_version: 5.18.0, config_dir_from_version: 0, config_dir_to_version: 1, completed_scripts: [], timestamp }},
+     *                       upgrade_history: {}
+     * }
+     */
+
+
+    /**
+     * update_rpm_upgrade updates an RPM upgrade of a specific host in the system.json file if there was an upgrade
+     * an upgrade is detected when the version in system.json is lower than the version in package.json.
+     * @returns {Promise<Void>}
+     */
+    async update_rpm_upgrade() {
+        const system_data = await this.config_fs.get_system_config_file({ silent_if_missing: true });
+        if (!system_data) return;
+
+        const from_version = system_data?.[hostname]?.current_version;
+        const to_version = this.package_version;
+
+        if (!should_upgrade(from_version, to_version)) return;
+
+        const this_upgrade = { timestamp: Date.now(), from_version, to_version };
+        system_data[hostname].current_version = to_version;
+        system_data[hostname]?.upgrade_history?.successful_upgrades.unshift(this_upgrade);
+        await this.config_fs.update_system_json_with_retries(JSON.stringify(system_data));
+    }
+
+    /**
+     * upgrade_config_dir does the following - 
+     * 1. verifies if an upgrade is available - the config directory version mentioned in the config directory in system json is lower than the version appears in config_fs
+     * 2. verifies if upgrade can start
+     * 3. set upgrade start on system.json - 
+     *    3.1. updates the phase to CONFIG_DIR_LOCKED
+     *    3.2. in_progess_upgrade on system.json 
+     * 3. runs upgrade scripts
+     * 4. set upgrade finish on system json - 
+     *    4.1. new config_dir_version
+     *    4.2. new upgrade_package_version
+     *    4.3. updates the phase to CONFIG_DIR_UNLOCKED
+     *    4.4. moves the current upgrade from in_progress_upgrade to the upgrade_history.successful_upgrades 
+     *    4.5. is 5.17.0 is a good default for from_version?
+     * @param {string} expected_version
+     * @param {[string]} hosts_list
+     * @param {{skip_verification?: boolean}} [options]
+     * @returns {Promise<Object>}
+     */
+    async upgrade_config_dir(expected_version, hosts_list, { skip_verification } = {}) {
+        let system_data = await this.config_fs.get_system_config_file({ silent_if_missing: true });
+        if (!system_data) throw new Error('system does not exist');
+
+        if (!system_data.config_directory) system_data.config_directory = this.config_directory_defaults(system_data);
+        const config_dir_from_version = system_data.config_directory.config_dir_version;
+        const config_dir_to_version = this.config_dir_version;
+        const package_from_version = system_data.config_directory.upgrade_package_version;
+        const package_to_version = this.package_version;
+        const this_upgrade_versions = { config_dir_from_version, config_dir_to_version, package_from_version, package_to_version };
+
+        if (!should_upgrade(config_dir_from_version, config_dir_to_version)) return { message: 'config_dir_version on system.json and config_fs.config_dir_version match, nothing to upgrade' };
+
+        if (!skip_verification) await this._verify_config_dir_upgrade(system_data, expected_version, hosts_list);
+
+        system_data = await this._update_config_dir_upgrade_start(system_data, this_upgrade_versions);
+        const this_upgrade = system_data.config_directory.in_progress_upgrade;
+
+        try {
+            await this._run_nc_upgrade_scripts(this_upgrade);
+        } catch (err) {
+            await this._update_config_dir_upgrade_failed(system_data, this_upgrade, err);
+            throw err;
+        }
+
+        await this._update_config_dir_upgrade_finish(system_data, this_upgrade);
+        return this_upgrade;
+    }
+
+    //////////////////////////////
+    //         HELPERS          //
+    //////////////////////////////
+
+
+    /**
+     * config_directory_defaults returns a default initial config directory object
+     * @param {Object} system_data
+     */
+    config_directory_defaults(system_data) {
+        const hosts_old_package_version = system_data?.[hostname]?.upgrade_history?.successful_upgrades?.[0]?.from_version;
+        return {
+            config_dir_version: OLD_DEFAULT_CONFIG_DIR_VERSION,
+            upgrade_package_version: hosts_old_package_version || OLD_DEFAULT_PACKAGE_VERSION,
+            phase: CONFIG_DIR_UNLOCKED,
+            upgrade_history: { successful_upgrades: [] }
+        };
+    }
+
+    /**
+     * _verify_config_dir_upgrade verifies that - 
+     * 1. All hosts appearing in system.json were RPM upgraded to the same version the host running the upgrade
+     * 2. The user's expected_version is the host's package version - 
+     *    expected_version is the expected source code version that the user asks to upgrade to, it's an optional verification, 
+     *    if expected_version was not provided we assume that the source code on this host is 
+     * 3. TODO? - verifies a backup confirmation of the config directory received by the user/location exists
+     * updated and that the source code version and the schema version is the one we want to upgrade to
+     * QUESTION -
+     * 3. should we verify a backup, by stat of the backup location just have a confirmation of the user in the CLI
+     * 4. are there more verifications we should do?
+     * @param {Object} system_data
+     * @param {String} expected_version
+     * @param {[String]} expected_hosts
+     * @returns {Promise<Void>}
+     */
+    async _verify_config_dir_upgrade(system_data, expected_version, expected_hosts) {
+        const new_version = this.package_version;
+        const hosts_data = _.omit(system_data, 'config_directory');
+        let err_message;
+        if (expected_version !== new_version) {
+            err_message = `config dir upgrade can not be started - the host's package version=${new_version} does not match the user's expected version=${expected_version}`;
+        }
+        const hostnames = Object.keys(hosts_data);
+
+        if (!err_message && !hostnames.length) {
+            err_message = `config dir upgrade can not be started missing hosts_data hosts_data=${util.inspect(hosts_data)}`;
+        }
+        const missing_expected_hosts = !(expected_hosts.every(item => hostnames.includes(item)));
+        const missing_hostnames = !(hostnames.every(item => expected_hosts.includes(item)));
+        if (!err_message && missing_expected_hosts) {
+            err_message = `config dir upgrade can not be started - expected_hosts missing one or more hosts specified in system.json  hosts_data=${util.inspect(hosts_data)}`;
+        }
+        if (!err_message && missing_hostnames) {
+            err_message = `config dir upgrade can not be started - system.json missing one or more hosts info specified in expected_hosts hosts_data=${util.inspect(hosts_data)}`;
+        }
+
+        if (!err_message) {
+            for (const [host, host_data] of Object.entries(hosts_data)) {
+                if (!host_data.current_version || version_compare(host_data.current_version, new_version) !== 0) {
+                    err_message = `config dir upgrade can not be started until all nodes have the expected version=${new_version}, host=${host} host's current_version=${host_data.current_version}`;
+                }
+            }
+        }
+        if (err_message) {
+            dbg.error(`_verify_config_dir_upgrade: ${err_message}`);
+            throw new Error(err_message);
+        }
+    }
+
+    /**
+     * _update_config_dir_upgrade_start updates system.json that a new upgrade was started - 
+     * 1. phase of the config dir is locked
+     * 2. config_dir_version is the config_dir_version in system.json or '0'
+     * 3. upgrade_package_version is the source code version in config_directory of system.json or the from_version appears in the last upgrade of this host 
+     *    because of the check that the RPM was already upgraded
+     * 4. in_progress_upgrade -
+     *    4.1. timestamp of the start of the upgrade
+     *    4.2. completed_scripts - currently empty array
+     *    4.3. running_host - the hosts that runs the config directory upgrade
+     *    4.4. config_dir_from_version - the current config directory version
+     *    4.5. config_dir_to_version - the new config directory version
+     *    4.6. from_version - the current source code version
+     *    4.7. to_version - the new source code version
+     * @param {Object} system_data
+     * @param {{ config_dir_from_version: string; config_dir_to_version: string; package_from_version: string; package_to_version: string; }} options
+     * @returns {Promise<Object>}
+    */
+    async _update_config_dir_upgrade_start(system_data, options) {
+        const updated_config_directory = {
+            ...system_data.config_directory,
+            phase: CONFIG_DIR_LOCKED,
+            config_dir_version: options.config_dir_from_version,
+            upgrade_package_version: options.package_from_version,
+            in_progress_upgrade: {
+                timestamp: Date.now(),
+                completed_scripts: [],
+                running_host: os.hostname(),
+                config_dir_from_version: options.config_dir_from_version,
+                config_dir_to_version: options.config_dir_to_version,
+                package_from_version: options.package_from_version,
+                package_to_version: options.package_to_version
+            }
+        };
+        const updated_system_data = { ...system_data, config_directory: updated_config_directory };
+        await this.config_fs.update_system_json_with_retries(JSON.stringify(updated_system_data));
+        return updated_system_data;
+    }
+
+
+    /**
+     * _run_nc_upgrade_scripts runs the config directory upgrade scripts 
+     * @param {Object} this_upgrade
+     */
+    async _run_nc_upgrade_scripts(this_upgrade) {
+        try {
+            await run_upgrade_scripts(this_upgrade, this.upgrade_scripts_dir, { dbg });
+        } catch (err) {
+            const upgrade_failed_msg = `_run_nc_upgrade_scripts: nc upgrade manager failed!!!, ${err}`;
+            dbg.error(upgrade_failed_msg);
+            throw new Error(upgrade_failed_msg);
+        }
+    }
+
+    /**
+     * _update_config_dir_upgrade_finish updates the system.json on finish of the upgrade, it updates that - 
+     * 1. config directory is unlocked
+     * 2. config_dir_version is the new version
+     * 3. upgrade_package_version is the new source code version
+     * 4. add the finished upgrade to the successful_upgrades array
+     * @param {Object} system_data
+     * @returns {Promise<Void>}
+     */
+    async _update_config_dir_upgrade_finish(system_data, this_upgrade) {
+        const upgrade_history = system_data?.config_directory?.upgrade_history;
+        const successful_upgrades = upgrade_history?.successful_upgrades || [];
+
+        const updated_config_directory = {
+            phase: CONFIG_DIR_UNLOCKED,
+            config_dir_version: this_upgrade.config_dir_to_version,
+            upgrade_package_version: this_upgrade.package_to_version,
+            upgrade_history: {
+                ...upgrade_history,
+                successful_upgrades: [this_upgrade, ...successful_upgrades]
+            }
+        };
+        const updated_system_data = { ...system_data, config_directory: updated_config_directory };
+        await this.config_fs.update_system_json_with_retries(JSON.stringify(updated_system_data));
+    }
+
+    /**
+     * _update_config_dir_upgrade_failed updates the system.json on failure of the upgrade
+     * @param {Object} system_data 
+     */
+    async _update_config_dir_upgrade_failed(system_data, this_upgrade, error) {
+        system_data.config_directory.upgrade_history.last_failure = this_upgrade;
+        system_data.config_directory.upgrade_history.last_failure.error = error.stack;
+        delete system_data.config_directory.in_progress_upgrade;
+        await this.config_fs.update_system_json_with_retries(JSON.stringify(system_data));
+    }
+}
+
+
+exports.NCUpgradeManager = NCUpgradeManager;
+exports.CONFIG_DIR_UNLOCKED = CONFIG_DIR_UNLOCKED;
+exports.CONFIG_DIR_LOCKED = CONFIG_DIR_LOCKED;
+exports.OLD_DEFAULT_CONFIG_DIR_VERSION = OLD_DEFAULT_CONFIG_DIR_VERSION;
+exports.OLD_DEFAULT_PACKAGE_VERSION = OLD_DEFAULT_PACKAGE_VERSION;
+exports.DEFAULT_NC_UPGRADE_SCRIPTS_DIR = DEFAULT_NC_UPGRADE_SCRIPTS_DIR;

--- a/src/upgrade/upgrade_manager.js
+++ b/src/upgrade/upgrade_manager.js
@@ -4,36 +4,16 @@
 const argv = require('minimist')(process.argv);
 const _ = require('lodash');
 const pkg = require('../../package.json');
-const fs = require('fs');
-const path = require('path');
-const json_utils = require('../util/json_utils');
-const config = require('../../config');
-const os = require('os');
-
+const { should_upgrade, run_upgrade_scripts } = require('./upgrade_utils');
 const dbg = require('../util/debug_module')('UPGRADE');
 dbg.set_process_name('Upgrade');
 
-function parse_ver(ver) {
-    const stripped_ver = ver.split('-')[0];
-    return stripped_ver.split('.').map(i => Number.parseInt(i, 10));
-}
+const { upgrade_scripts_dir } = argv;
 
-const { upgrade_scripts_dir, nsfs } = argv;
+/////////////////////////////
+//       DB UPGRADES       //
+/////////////////////////////
 
-// compares 2 versions. returns positive if ver1 is larger, negative if ver2, 0 if equal
-function version_compare(ver1, ver2) {
-    const ver1_arr = parse_ver(ver1);
-    const ver2_arr = parse_ver(ver2);
-    const max_length = Math.max(ver1_arr.length, ver2_arr.length);
-    for (let i = 0; i < max_length; ++i) {
-        const comp1 = ver1_arr[i] || 0;
-        const comp2 = ver2_arr[i] || 0;
-        const diff = comp1 - comp2;
-        // if version component is not the same, return the difference
-        if (diff) return diff;
-    }
-    return 0;
-}
 
 async function init_db_upgrade(db_client, system_store) {
     try {
@@ -72,18 +52,7 @@ async function upgrade_db() {
         };
         const upgrade_history = system_store.data.systems[0].upgrade_history;
         try {
-            const upgrade_scripts = await load_required_scripts(server_version, container_version);
-            for (const script of upgrade_scripts) {
-                dbg.log0(`running upgrade script ${script.file}: ${script.description}`);
-                try {
-                    await script.run({ dbg, db_client, system_store, system_server });
-                    this_upgrade.completed_scripts.push(script.file);
-                } catch (err) {
-                    dbg.error(`failed running upgrade script ${script.file}`, err);
-                    this_upgrade.error = err.stack;
-                    throw err;
-                }
-            }
+            await run_upgrade_scripts(this_upgrade, upgrade_scripts_dir, { dbg, db_client, system_store, system_server });
             upgrade_history.successful_upgrades = [this_upgrade, ...upgrade_history.successful_upgrades];
             current_version = container_version;
         } catch (err) {
@@ -113,137 +82,7 @@ async function upgrade_db() {
     return exit_code;
 }
 
-function should_upgrade(server_version, container_version) {
-    if (!server_version) {
-        dbg.log('system does not exist. no need for an upgrade');
-        return false;
-    }
-    const ver_comparison = version_compare(container_version, server_version);
-    if (ver_comparison === 0) {
-        if (server_version !== container_version) {
-            dbg.warn(`the container and server appear to be the same version but different builds. (container: ${container_version}), (server: ${server_version})`);
-            dbg.warn(`upgrade is not supported for different builds of the same version!!`);
-        }
-        dbg.log0('the versions of the container and the server match. no need to upgrade');
-        return false;
-    } else if (ver_comparison < 0) {
-        // container version is older than the server version - can't downgrade
-        dbg.error(`the container version (${container_version}) appear to be older than the current server version (${server_version}). cannot downgrade`);
-        throw new Error('attempt to run old container version with newer server version');
-    } else {
-        dbg.log0(`container version is ${container_version} and server version is ${server_version}. will upgrade`);
-        return true;
-    }
-}
-
-// load all scripts that should be run according to the given versions
-async function load_required_scripts(server_version, container_version) {
-    // expecting scripts directories to be in a semver format. e.g. ./upgrade_scripts/5.0.1
-    let upgrade_dir_content = [];
-    try {
-        upgrade_dir_content = fs.readdirSync(upgrade_scripts_dir);
-    } catch (err) {
-        if (err.code === 'ENOENT') {
-            dbg.warn(`upgrade scripts directory "${upgrade_scripts_dir}" was not found. treating it as empty`);
-        } else {
-            throw err;
-        }
-    }
-    // get all dirs for versions newer than server_version
-    const newer_versions = upgrade_dir_content.filter(ver =>
-            version_compare(ver, server_version) > 0 &&
-            version_compare(ver, container_version) <= 0)
-        .sort(version_compare);
-    dbg.log0(`found the following versions with upgrade scripts which are newer than server version (${server_version}):`, newer_versions);
-    // get all scripts under new_versions
-    const upgrade_scripts = _.flatMap(newer_versions, ver => {
-        const full_path = path.join(upgrade_scripts_dir, ver);
-        const scripts = fs.readdirSync(full_path);
-        return scripts.map(script => path.join(full_path, script));
-    });
-
-    // TODO: we might want to filter out scripts that have run in a previous run of upgrade(e.g. in case of a crash)
-    // for now assume that any upgrade script can be rerun safely
-
-    // for each script load the js file. expecting the export to return an object in the format
-    // {
-    //      description: 'what this upgrade script does'
-    //      run: run_func,
-    // }
-    return upgrade_scripts.map(script => ({
-        ...require(script), // eslint-disable-line global-require
-        file: script
-    }));
-}
-
-async function upgrade_nsfs() {
-    const system_data_path = path.join(config.NSFS_NC_CONF_DIR, 'system.json');
-    const system_data = new json_utils.JsonFileWrapper(system_data_path);
-
-    const system = await system_data.read();
-    const hostname = os.hostname();
-    const upgrade_history = system?.[hostname]?.upgrade_history;
-    let current_version = system?.[hostname]?.current_version;
-
-    const new_version = pkg.version;
-
-    let exit_code = 0;
-
-    if (!should_upgrade(current_version, new_version)) return exit_code;
-
-    const this_upgrade = {
-        timestamp: Date.now(),
-        completed_scripts: [],
-        from_version: current_version,
-        to_version: new_version
-    };
-
-    try {
-        const upgrade_scripts = await load_required_scripts(current_version, new_version);
-        for (const script of upgrade_scripts) {
-            dbg.log0(`running upgrade script ${script.file}: ${script.description}`);
-            try {
-                await script.run({ dbg, db_client: null, system_store: null, system_server: null });
-                this_upgrade.completed_scripts.push(script.file);
-            } catch (err) {
-                dbg.error(`failed running upgrade script ${script.file}`, err);
-                this_upgrade.error = err.stack;
-                throw err;
-            }
-        }
-
-        upgrade_history.successful_upgrades = [this_upgrade, ...upgrade_history.successful_upgrades];
-        current_version = new_version;
-    } catch (err) {
-        dbg.error('upgrade manager failed!!!', err);
-        exit_code = 1;
-        if (upgrade_history) {
-            upgrade_history.last_failure = this_upgrade;
-            upgrade_history.last_failure.error = err.stack;
-        }
-    }
-    // update upgrade_history
-    try {
-        await system_data.update({
-            ...system,
-            [hostname]: {
-                current_version,
-                upgrade_history
-            }
-        });
-    } catch (error) {
-        dbg.error('failed to update system_store with upgrade information');
-        exit_code = 1;
-    }
-
-    return exit_code;
-}
-
 async function run_upgrade() {
-    if (nsfs) {
-        return upgrade_nsfs();
-    }
-
     return upgrade_db();
 }
 
@@ -267,3 +106,4 @@ async function main() {
 if (require.main === module) {
     main();
 }
+

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -1,0 +1,136 @@
+/* Copyright (C) 2016 NooBaa */
+"use strict";
+
+const fs = require('fs');
+const _ = require('lodash');
+const path = require('path');
+const dbg = require('../util/debug_module')('UPGRADE');
+dbg.set_process_name('Upgrade');
+
+
+/**
+ * @param {string} ver
+ */
+function parse_ver(ver) {
+    const stripped_ver = ver.split('-')[0];
+    return stripped_ver.split('.').map(i => Number.parseInt(i, 10));
+}
+
+
+/**
+ * version_compare compares 2 versions. returns positive if ver1 is larger, negative if ver2, 0 if equal
+ * @param {string} ver1
+ * @param {string} ver2
+ */
+function version_compare(ver1, ver2) {
+    const ver1_arr = parse_ver(ver1);
+    const ver2_arr = parse_ver(ver2);
+    const max_length = Math.max(ver1_arr.length, ver2_arr.length);
+    for (let i = 0; i < max_length; ++i) {
+        const comp1 = ver1_arr[i] || 0;
+        const comp2 = ver2_arr[i] || 0;
+        const diff = comp1 - comp2;
+        // if version component is not the same, return the difference
+        if (diff) return diff;
+    }
+    return 0;
+}
+
+/**
+ * @param {string} server_version
+ * @param {string} container_version
+ */
+function should_upgrade(server_version, container_version) {
+    if (!server_version) {
+        dbg.log('system does not exist. no need for an upgrade');
+        return false;
+    }
+    const ver_comparison = version_compare(container_version, server_version);
+    if (ver_comparison === 0) {
+        if (server_version !== container_version) {
+            dbg.warn(`the container and server appear to be the same version but different builds. (container: ${container_version}), (server: ${server_version})`);
+            dbg.warn(`upgrade is not supported for different builds of the same version!!`);
+        }
+        dbg.log0('the versions of the container and the server match. no need to upgrade');
+        return false;
+    } else if (ver_comparison < 0) {
+        // container version is older than the server version - can't downgrade
+        dbg.error(`the container version (${container_version}) appear to be older than the current server version (${server_version}). cannot downgrade`);
+        throw new Error('attempt to run old container version with newer server version');
+    } else {
+        dbg.log0(`container version is ${container_version} and server version is ${server_version}. will upgrade`);
+        return true;
+    }
+}
+
+/**
+ * load_required_scripts loads all scripts that should be run according to the given versions
+ * @param {string} server_version
+ * @param {string} container_version
+ */
+async function load_required_scripts(server_version, container_version, upgrade_scripts_dir) {
+    // expecting scripts directories to be in a semver format. e.g. ./upgrade_scripts/5.0.1
+    let upgrade_dir_content = [];
+    try {
+        upgrade_dir_content = fs.readdirSync(upgrade_scripts_dir);
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            dbg.warn(`upgrade scripts directory "${upgrade_scripts_dir}" was not found. treating it as empty`);
+        } else {
+            throw err;
+        }
+    }
+    // get all dirs for versions newer than server_version
+    const newer_versions = upgrade_dir_content.filter(ver =>
+            version_compare(ver, server_version) > 0 &&
+            version_compare(ver, container_version) <= 0)
+        .sort(version_compare);
+    dbg.log0(`found the following versions with upgrade scripts which are newer than server version (${server_version}):`, newer_versions);
+    // get all scripts under new_versions
+    const upgrade_scripts = _.flatMap(newer_versions, ver => {
+        const full_path = path.join(upgrade_scripts_dir, ver);
+        const scripts = fs.readdirSync(full_path);
+        return scripts.map(script => path.join(full_path, script));
+    });
+
+    // TODO: we might want to filter out scripts that have run in a previous run of upgrade(e.g. in case of a crash)
+    // for now assume that any upgrade script can be rerun safely
+
+    // for each script load the js file. expecting the export to return an object in the format
+    // {
+    //      description: 'what this upgrade script does'
+    //      run: run_func,
+    // }
+    return upgrade_scripts.map(script => ({
+        ...require(script), // eslint-disable-line global-require
+        file: script
+    }));
+}
+
+/**
+ * 
+ * @param {Object} this_upgrade 
+ * @param {string} upgrade_scripts_dir 
+ * @param {Object} options 
+ */
+async function run_upgrade_scripts(this_upgrade, upgrade_scripts_dir, options) {
+    const from_version = this_upgrade.from_version || this_upgrade.config_dir_from_version;
+    const to_version = this_upgrade.to_version || this_upgrade.config_dir_to_version;
+    const upgrade_scripts = await load_required_scripts(from_version, to_version, upgrade_scripts_dir);
+    for (const script of upgrade_scripts) {
+        dbg.log0(`upgrade_utils.run_upgrade_scripts: running upgrade script ${script.file}: ${script.description}`);
+        try {
+            await script.run(options);
+            this_upgrade.completed_scripts.push(script.file);
+        } catch (err) {
+            dbg.error(`upgrade_utils.run_upgrade_scripts: failed running upgrade script ${script.file}`, err);
+            this_upgrade.error = err.stack;
+            throw err;
+        }
+    }
+}
+
+exports.should_upgrade = should_upgrade;
+exports.load_required_scripts = load_required_scripts;
+exports.version_compare = version_compare;
+exports.run_upgrade_scripts = run_upgrade_scripts;


### PR DESCRIPTION
### Explain the changes
High Level -
This PR is responsible for the core logic of the online upgrade of NooBaa NC, according to the design the online upgrade algorithm is as follows -
```
1. Backup config dir
2. Iterate hosts, upgrade RPM and restart service
    2.1. restart updates system.json host's source code version
4. Backup config dir
5. noobaa-cli upgrade start --expected_version 5.18.0 
    4.1. check should_upgrade()
    4.2. verification -
           4.2.1. Running CLI's host's package.json version is the same as the expected version
           4.2.2. All hosts in system.json were upgraded to the host's version.
    4.3. start - update system.json that phase = locked, in_progress_upgrade details
    4.4. run upgrade scripts
    4.5. finish - update system.json phase unlocked, in_progress_upgrade → upgrade_history
```

Details - 
1. CLI changes - 
    1.1.  upgrade.js - Instead of throwing NotImplemented we now call nc_upgrade_manager.upgrade_config_dir() that executes step 4 of the upgrade algorithm.
    1.2.  added new flags for `upgrade start` - `--skip_verification, --expected_version, --custom_upgrade_scripts_dir`.  
    1.3.  Updated help, constants and validations files of the cli to support the new flags.

2. Service changes -   

- `nsfs.js -` on init_nc_system() if config_directory information is missing, update the system.json with the hosts config directory information.

- `noobaa.service -` remove RPM upgrade from the PreExec, moved it to nsfs.js.

- `ConfigFS - `
 a. Added `this.config_dir_version = '1.0.0'.`
 b. Added a new function called - `throw_if_config_dir_locked()` that compares the config_dir version on system.json and this.config_dir_version, and if they do not match - throw a `BAD REQUEST` error. this function is called from all config_fs functions that do updates to the config directory, like create/update/delete_account_config_file(), create/update/delete_bucket_config_file(). 
c. Added system.json related functions to config_fs, like - `create/update_system_config_file()` etc.

- `Upgrade Manager - `
           a. Created 2 new files - `upgrade_utils.js` and `nc_upgrade_manager.js`. 
           b. `upgrade_utils -` moved utils functions that are being used by both `upgrade_manager.js and nc_upgrade_manager.js`.
           c. `nc_upgrade_manager -` `created update_rpm_upgrade() and upgrade_config_dir(), config_directory_defaults(), _verify_config_dir_upgrade(), _update_config_dir_upgrade_start(), _run_nc_upgrade_scripts(), _update_config_dir_upgrade_finish()` functions that implement step 4 of the online upgrade algorithm.

### Issues: Fixed #xxx / Gap #xxx
1. Docs - will be added at the end.
2. more integration tests
3. --backup-config-dir-completed TODO?
### Testing Instructions:

1. sudo jest --testRegex=jest_tests/test_nc_upgrade_manager


- [ ] Doc added/updated
- [x] Tests added
