### PR TITLE
[Backport 5.17] add support for "Server" and "x-noobaa-available-storage-classes" headers

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -269,6 +269,7 @@ function create_endpoint_handler(init_request_sdk, virtual_hosts, sts, logger) {
 
     /** @type {EndpointHandler} */
     const endpoint_request_handler = (req, res) => {
+        endpoint_utils.set_noobaa_server_header(res);
         endpoint_utils.prepare_rest_request(req);
         req.virtual_hosts = virtual_hosts;
         if (logger) req.bucket_logger = logger;
@@ -287,6 +288,7 @@ function create_endpoint_handler(init_request_sdk, virtual_hosts, sts, logger) {
     };
     /** @type {EndpointHandler} */
     const endpoint_sts_request_handler = (req, res) => {
+        endpoint_utils.set_noobaa_server_header(res);
         endpoint_utils.prepare_rest_request(req);
         init_request_sdk(req, res);
         return sts_rest(req, res);
@@ -298,6 +300,7 @@ function create_endpoint_handler(init_request_sdk, virtual_hosts, sts, logger) {
 function create_endpoint_handler_iam(init_request_sdk) {
     /** @type {EndpointHandler} */
     const endpoint_iam_request_handler = (req, res) => {
+        endpoint_utils.set_noobaa_server_header(res);
         endpoint_utils.prepare_rest_request(req);
         init_request_sdk(req, res);
         return iam_rest(req, res);

--- a/src/endpoint/endpoint_utils.js
+++ b/src/endpoint/endpoint_utils.js
@@ -3,6 +3,7 @@
 
 const querystring = require('querystring');
 const http_utils = require('../util/http_utils');
+const pkg = require('../../package.json');
 
 function prepare_rest_request(req) {
     // generate request id, this is lighter than uuid
@@ -38,6 +39,10 @@ function parse_source_url(source_url) {
     return { query, bucket, key };
 }
 
+function set_noobaa_server_header(res) {
+    res.setHeader('Server', `NooBaa/${pkg.version}`);
+}
 
 exports.prepare_rest_request = prepare_rest_request;
 exports.parse_source_url = parse_source_url;
+exports.set_noobaa_server_header = set_noobaa_server_header;

--- a/src/endpoint/s3/ops/s3_head_bucket.js
+++ b/src/endpoint/s3/ops/s3_head_bucket.js
@@ -1,13 +1,14 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const s3_utils = require("../s3_utils");
+
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html
  */
-async function head_bucket(req) {
-    await req.object_sdk.read_bucket({ name: req.params.bucket });
-    // only called to check for existence
-    // no headers or reply needed
+async function head_bucket(req, res) {
+    const bucket_info = await req.object_sdk.read_bucket({ name: req.params.bucket });
+    s3_utils.set_response_supported_storage_classes(res, bucket_info.supported_storage_classes);
 }
 
 module.exports = {

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -36,6 +36,8 @@ const DEFAULT_OBJECT_ACL = Object.freeze({
 const XATTR_SORT_SYMBOL = Symbol('XATTR_SORT_SYMBOL');
 const base64_regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
+const X_NOOBAA_AVAILABLE_STORAGE_CLASSES = 'x-noobaa-available-storage-classes';
+
  /**
  * get_default_object_owner returns bucket_owner info if exists
  * else it'll return the default owner
@@ -320,6 +322,14 @@ function set_response_object_md(res, object_md) {
 
         res.setHeader('x-amz-restore', restore);
     }
+}
+
+/**
+ * @param {nb.S3Response} res 
+ * @param {Array<string>} [supported_storage_classes]
+ */
+function set_response_supported_storage_classes(res, supported_storage_classes = []) {
+    res.setHeader(X_NOOBAA_AVAILABLE_STORAGE_CLASSES, supported_storage_classes);
 }
 
 /**
@@ -752,4 +762,4 @@ exports.parse_restore_request_days = parse_restore_request_days;
 exports.parse_version_id = parse_version_id;
 exports.get_object_owner = get_object_owner;
 exports.get_default_object_owner = get_default_object_owner;
-
+exports.set_response_supported_storage_classes = set_response_supported_storage_classes;

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -31,6 +31,7 @@ const {
 } = require('../util/native_fs_utils');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 const { anonymous_access_key } = require('./object_sdk');
+const s3_utils = require('../endpoint/s3/s3_utils');
 
 const dbg = require('../util/debug_module')(__filename);
 const bucket_semaphore = new KeysSemaphore(1);
@@ -134,6 +135,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 id: bucket.owner_account,
                 email: bucket.bucket_owner
             };
+            bucket.supported_storage_classes = this._supported_storage_class();
             if (bucket.s3_policy) {
                 for (const [s_index, statement] of bucket.s3_policy.Statement.entries()) {
                     const statement_principal = statement.Principal || statement.NotPrincipal;
@@ -777,6 +779,22 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
 
     is_nsfs_non_containerized_user_anonymous(token) {
         return !token && process.env.NC_NSFS_NO_DB_ENV;
+    }
+
+    /**
+     * returns a list of storage class supported by this bucketspace
+     * @returns {Array<string>}
+     */
+    _supported_storage_class() {
+        const storage_classes = [];
+        if (!config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD) {
+            storage_classes.push(s3_utils.STORAGE_CLASS_STANDARD);
+        }
+        if (config.NSFS_GLACIER_ENABLED) {
+            storage_classes.push(s3_utils.STORAGE_CLASS_GLACIER);
+        }
+
+        return storage_classes;
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

make supported storage classes bucketspace specific

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

add server header to IAM handler

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>
(cherry picked from commit 4e7790f0bb94481d60e3f6b7324869a3d097ae03)

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
