### PR TITLE
[Backport 5.16] add support for "Server" and "x-noobaa-available-storage-classes" headers

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -234,6 +234,7 @@ function create_endpoint_handler(init_request_sdk, virtual_hosts, sts) {
 
     /** @type {EndpointHandler} */
     const endpoint_request_handler = (req, res) => {
+        endpoint_utils.set_noobaa_server_header(res);
         endpoint_utils.prepare_rest_request(req);
         req.virtual_hosts = virtual_hosts;
         init_request_sdk(req, res);
@@ -251,6 +252,7 @@ function create_endpoint_handler(init_request_sdk, virtual_hosts, sts) {
     };
     /** @type {EndpointHandler} */
     const endpoint_sts_request_handler = (req, res) => {
+        endpoint_utils.set_noobaa_server_header(res);
         endpoint_utils.prepare_rest_request(req);
         init_request_sdk(req, res);
         return sts_rest(req, res);

--- a/src/endpoint/endpoint_utils.js
+++ b/src/endpoint/endpoint_utils.js
@@ -3,6 +3,7 @@
 
 const querystring = require('querystring');
 const http_utils = require('../util/http_utils');
+const pkg = require('../../package.json');
 
 function prepare_rest_request(req) {
     // generate request id, this is lighter than uuid
@@ -38,6 +39,10 @@ function parse_source_url(source_url) {
     return { query, bucket, key };
 }
 
+function set_noobaa_server_header(res) {
+    res.setHeader('Server', `NooBaa/${pkg.version}`);
+}
 
 exports.prepare_rest_request = prepare_rest_request;
 exports.parse_source_url = parse_source_url;
+exports.set_noobaa_server_header = set_noobaa_server_header;

--- a/src/endpoint/s3/ops/s3_head_bucket.js
+++ b/src/endpoint/s3/ops/s3_head_bucket.js
@@ -1,13 +1,14 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const s3_utils = require("../s3_utils");
+
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html
  */
-async function head_bucket(req) {
-    await req.object_sdk.read_bucket({ name: req.params.bucket });
-    // only called to check for existence
-    // no headers or reply needed
+async function head_bucket(req, res) {
+    const bucket_info = await req.object_sdk.read_bucket({ name: req.params.bucket });
+    s3_utils.set_response_supported_storage_classes(res, bucket_info.supported_storage_classes);
 }
 
 module.exports = {

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -36,6 +36,8 @@ const DEFAULT_OBJECT_ACL = Object.freeze({
 const XATTR_SORT_SYMBOL = Symbol('XATTR_SORT_SYMBOL');
 const base64_regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
+const X_NOOBAA_AVAILABLE_STORAGE_CLASSES = 'x-noobaa-available-storage-classes';
+
 function decode_chunked_upload(source_stream) {
     const decoder = new ChunkedContentDecoder();
     // pipeline will back-propagate errors from the decoder to stop streaming from the source,
@@ -281,6 +283,14 @@ function set_response_object_md(res, object_md) {
 
         res.setHeader('x-amz-restore', restore);
     }
+}
+
+/**
+ * @param {nb.S3Response} res 
+ * @param {Array<string>} [supported_storage_classes]
+ */
+function set_response_supported_storage_classes(res, supported_storage_classes = []) {
+    res.setHeader(X_NOOBAA_AVAILABLE_STORAGE_CLASSES, supported_storage_classes);
 }
 
 /**
@@ -694,3 +704,4 @@ exports.get_response_field_encoder = get_response_field_encoder;
 exports.parse_decimal_int = parse_decimal_int;
 exports.parse_restore_request_days = parse_restore_request_days;
 exports.parse_version_id = parse_version_id;
+exports.set_response_supported_storage_classes = set_response_supported_storage_classes;


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

make supported storage classes bucketspace specific

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

add server header to IAM handler

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>
(cherry picked from commit 4e7790f0bb94481d60e3f6b7324869a3d097ae03)

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
