### PR TITLE
NC | CLI | Quick fixes

### DIFF
--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -51,10 +51,10 @@ const VALID_OPTIONS_ACCOUNT = {
 };
 
 const VALID_OPTIONS_ANONYMOUS_ACCOUNT = {
-    'add': new Set(['uid', 'gid', 'user', 'anonymous', CONFIG_ROOT_FLAG]),
-    'update': new Set(['uid', 'gid', 'user', 'anonymous', CONFIG_ROOT_FLAG]),
-    'delete': new Set(['anonymous', CONFIG_ROOT_FLAG]),
-    'status': new Set(['anonymous', CONFIG_ROOT_FLAG]),
+    'add': new Set(['uid', 'gid', 'user', 'anonymous', ...CLI_MUTUAL_OPTIONS]),
+    'update': new Set(['uid', 'gid', 'user', 'anonymous', ...CLI_MUTUAL_OPTIONS]),
+    'delete': new Set(['anonymous', ...CLI_MUTUAL_OPTIONS]),
+    'status': new Set(['anonymous', ...CLI_MUTUAL_OPTIONS]),
 };
 
 const VALID_OPTIONS_BUCKET = {

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -335,6 +335,7 @@ async function check_new_name_exists(type, config_fs, action, data) {
 async function check_new_access_key_exists(config_fs, action, data) {
     const new_access_key = action === ACTIONS.ADD ? data.access_keys?.[0]?.access_key : data.new_access_key;
     if (action === ACTIONS.UPDATE && !is_access_key_update(data)) return;
+    if (!new_access_key) return; // for anonymous account and users without access keys
     const exists = await config_fs.is_account_exists_by_access_key(new_access_key);
     if (exists) throw_cli_error(ManageCLIError.AccountAccessKeyAlreadyExists, new_access_key, { account: new_access_key });
 }
@@ -457,11 +458,12 @@ async function validate_account_args(config_fs, data, action, is_flag_iam_operat
         if (!exists) {
             throw_cli_error(ManageCLIError.InvalidAccountNewBucketsPath, data.nsfs_account_config.new_buckets_path);
         }
-        if (config.NC_DISABLE_ACCESS_CHECK) return;
-        const account_fs_context = await native_fs_utils.get_fs_context(data.nsfs_account_config, data.fs_backend);
-        const accessible = await native_fs_utils.is_dir_rw_accessible(account_fs_context, data.nsfs_account_config.new_buckets_path);
-        if (!accessible) {
-            throw_cli_error(ManageCLIError.InaccessibleAccountNewBucketsPath, data.nsfs_account_config.new_buckets_path);
+        if (!config.NC_DISABLE_ACCESS_CHECK) {
+            const account_fs_context = await native_fs_utils.get_fs_context(data.nsfs_account_config, data.fs_backend);
+            const accessible = await native_fs_utils.is_dir_rw_accessible(account_fs_context, data.nsfs_account_config.new_buckets_path);
+            if (!accessible) {
+                throw_cli_error(ManageCLIError.InaccessibleAccountNewBucketsPath, data.nsfs_account_config.new_buckets_path);
+            }
         }
         if (action === ACTIONS.UPDATE && is_flag_iam_operate_on_root_account_update_action) {
             await validate_root_accounts_manager_update(config_fs, data);


### PR DESCRIPTION
### Explain the changes
1. Added `--debug` flag to Anonymous CLI.
2. changed the access check from `if (config.NC_DISABLE_ACCESS_CHECK) return `to if `(!config.NC_DISABLE_ACCESS_CHECK) {}` because validate_root_accounts_manager_update won't happen if access check is disabled.
3. Added a skip of skip access keys existence check for users without access keys/ anonymous 

This should be backported to 5.17.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
