### PR TITLE
NC | Warp concurrent directories creation/deletion

### DIFF
--- a/config.js
+++ b/config.js
@@ -765,6 +765,7 @@ config.NSFS_BUF_POOL_WARNING_TIMEOUT = 2 * 60 * 1000;
 config.NSFS_SEM_WARNING_TIMEOUT = 10 * 60 * 1000;
 // number of rename retries in case of deleted destination directory
 config.NSFS_RENAME_RETRIES = 10;
+config.NSFS_MKDIR_PATH_RETRIES = 3;
 
 config.NSFS_VERSIONING_ENABLED = true;
 config.NSFS_UPDATE_ISSUES_REPORT_ENABLED = true;

--- a/src/test/unit_tests/jest_tests/test_nsfs_concurrency.test.js
+++ b/src/test/unit_tests/jest_tests/test_nsfs_concurrency.test.js
@@ -1,0 +1,72 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const path = require('path');
+const P = require('../../../util/promise');
+const fs_utils = require('../../../util/fs_utils');
+const NamespaceFS = require('../../../sdk/namespace_fs');
+const buffer_utils = require('../../../util/buffer_utils');
+const { TMP_PATH } = require('../../system_tests/test_utils');
+const { crypto_random_string } = require('../../../util/string_utils');
+const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
+
+function make_dummy_object_sdk(nsfs_config, uid, gid) {
+    return {
+        requesting_account: {
+            nsfs_account_config: nsfs_config && {
+                uid: uid || process.getuid(),
+                gid: gid || process.getgid(),
+                backend: '',
+            }
+        },
+        abort_controller: new AbortController(),
+        throw_if_aborted() {
+            if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        }
+    };
+}
+
+const DUMMY_OBJECT_SDK = make_dummy_object_sdk(true);
+describe('test nsfs concurrency', () => {
+    const tmp_fs_path = path.join(TMP_PATH, 'test_nsfs_concurrency');
+
+    const nsfs = new NamespaceFS({
+        bucket_path: tmp_fs_path,
+        bucket_id: '1',
+        namespace_resource_id: undefined,
+        access_mode: undefined,
+        versioning: 'DISABLED',
+        force_md5_etag: false,
+        stats: endpoint_stats_collector.instance(),
+    });
+
+    beforeEach(async () => {
+        await fs_utils.create_fresh_path(tmp_fs_path);
+    });
+
+    afterEach(async () => {
+        await fs_utils.folder_delete(tmp_fs_path);
+    });
+
+    it('multiple puts of the same nested key', async () => {
+        const bucket = 'bucket1';
+        const key = 'dir1/key1';
+        const res_etags = [];
+        for (let i = 0; i < 15; i++) {
+            const random_data = Buffer.from(String(crypto_random_string(7)));
+            const body = buffer_utils.buffer_to_read_stream(random_data);
+            nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK)
+            .catch(err => {
+                console.log('put the same key error - ', err);
+                throw err;
+            }).then(res => {
+                console.log('upload res', res);
+                res_etags.push(res.etag);
+            });
+            await nsfs.delete_object({ bucket: bucket, key: key }, DUMMY_OBJECT_SDK).catch(err => console.log('delete the same key error - ', err));
+
+        }
+        await P.delay(5000);
+        expect(res_etags).toHaveLength(15);
+    }, 6000);
+});


### PR DESCRIPTION
### Explain the changes
High Level -
1. On `warp mixed` run we saw PUT nested Object (for example - `/dir1/key1`) failures with error code 'ENOENT' on folders, from the logs we saw it happened on openFile() and on Fsync().
2. Locally, it was reproduced on stat(), Rename() and Fsync() - when deleting and putting an object with the same key concurrently.

Changes - 
1. In order to fix that, we added retries on OpenFile(), Moved the Fsync to be inside a loop with retries, removed the redundant stat() call, the rename() is already inside a retries loop, we can consider increase the number of retries for fixing that as well although 3 should be enough.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - Automatic Tests
2. Fixed #8159
### Testing Instructions:
1. Manual - 
```
async function main() {
    for (let i = 1; i < 1000; i++) {
        s3.putObject({ Bucket: BUCKET, Key: KEY, Body: crypto_random_string(7) }).catch(err => dbg.log0('putObject_err', err));
        s3.deleteObject({ Bucket: BUCKET, Key: KEY}).catch(err => dbg.log0('deleteObject_err', err));
    }
    await P.delay(20000);
}
```


- [ ] Doc added/updated
- [ ] Tests added
