### PR TITLE
NC | NSFS | Versioning | Fix Bug 8333 | Delete Object with Version ID | GPFS

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1429,7 +1429,8 @@ class NamespaceFS {
                 if (this._is_versioning_suspended()) {
                     if (latest_ver_info?.version_id_str === NULL_VERSION_ID) {
                         dbg.log1('NamespaceFS._move_to_dest_version suspended: version ID of the latest version is null - the file will be unlinked');
-                        await native_fs_utils.safe_unlink(fs_context, latest_ver_path, latest_ver_info, gpfs_options, bucket_tmp_dir_path);
+                        await native_fs_utils.safe_unlink(fs_context, latest_ver_path, latest_ver_info,
+                            gpfs_options?.delete_version, bucket_tmp_dir_path);
                     } else {
                         // remove a version (or delete marker) with null version ID from .versions/ (if exists)
                         await this._delete_null_version_from_versions_directory(key, fs_context);
@@ -2757,7 +2758,8 @@ class NamespaceFS {
                         await this._open_files_gpfs(fs_context, file_path, undefined, undefined, undefined, undefined, true) :
                         undefined;
                     const bucket_tmp_dir_path = this.get_bucket_tmpdir_full_path();
-                    await native_fs_utils.safe_unlink(fs_context, file_path, version_info, gpfs_options, bucket_tmp_dir_path);
+                    await native_fs_utils.safe_unlink(fs_context, file_path, version_info,
+                        gpfs_options?.delete_version, bucket_tmp_dir_path);
                     return { ...version_info, latest: true };
                 } else {
                     await native_fs_utils.unlink_ignore_enoent(fs_context, file_path);
@@ -2930,7 +2932,8 @@ class NamespaceFS {
                     } else {
                         // versioning suspended and version_id is null
                         dbg.log1('NamespaceFS._delete_latest_version: suspended mode version ID of the latest version is null - file will be unlinked');
-                        await native_fs_utils.safe_unlink(fs_context, latest_ver_path, latest_ver_info, gpfs_options, bucket_tmp_dir_path);
+                        await native_fs_utils.safe_unlink(fs_context, latest_ver_path, latest_ver_info,
+                            gpfs_options?.delete_version, bucket_tmp_dir_path);
                     }
                 }
                 break;

--- a/src/test/unit_tests/test_nsfs_versioning_gpfs.js
+++ b/src/test/unit_tests/test_nsfs_versioning_gpfs.js
@@ -196,6 +196,18 @@ mocha.describe('namespace_fs gpfs- versioning', async function() {
         assert.equal(head_res.version_id, latest_version_id);
     });
 
+    mocha.it('delete object with version id - versioning enabled', async function() {
+        // 1. put bucket versioning enabled
+        await ns_obj.set_bucket_versioning('ENABLED', dummy_object_sdk);
+        // 2. create multiple versions (2)
+        const key2 = 'my-key-to-delete.txt';
+        await put_object(dummy_object_sdk, ns_obj, gpfs_bucket, key2);
+        const put_res2 = await put_object(dummy_object_sdk, ns_obj, gpfs_bucket, key2);
+        // 3. delete object by version-id
+        const delete_res = await delete_object(dummy_object_sdk, ns_obj, gpfs_bucket, key, put_res2.version_id);
+        assert.equal(delete_res.version_id, put_res2.version_id);
+    });
+
 });
 
 async function put_object(dummy_object_sdk, ns, bucket, key) {


### PR DESCRIPTION
### Explain the changes
1. Change the calls of `native_fs_utils.safe_unlink` that are used `gpfs_options` as it was received from `_open_files_gpfs` which can return an object with property `delete_version` or an object with 2 properties `move_to_versions` and `move_to_dst`, hence when using this returned object to the function `native_fs_utils.safe_unlink` the argument `gpfs_options` should an object with the properties `src_file` and `dir_file`.

### Issues: Fixed #8333
1. Currently, on GPFS when using the delete-object with version ID there is an error, in the logs, we can see:

> core.util.native_fs_utils:: safe_unlink: dir_file is undefined, cannot use it to call safe_unlink_gpfs


### Testing Instructions:
1. Not yet, it Should be tested on a GPFS machine.

- [ ] Doc added/updated
- [ ] Tests added
