### PR TITLE
Prevent issue report on read_object_md if the object doesn't exist

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -170,11 +170,17 @@ class NamespaceBlob {
         } catch (err) {
             this._translate_error_code(err);
             dbg.warn('NamespaceBlob.read_object_md:', inspect(err));
-            object_sdk.rpc_client.pool.update_issues_report({
-                namespace_resource_id: this.namespace_resource_id,
-                error_code: err.code || (err.details && err.details.errorCode) || 'InternalError',
-                time: Date.now(),
-            });
+
+            // It's totally expected to issue `HeadObject` against an object that doesn't exist
+            // this shouldn't be counted as an issue for the namespace store
+            if (err.rpc_code !== 'NO_SUCH_OBJECT') {
+                object_sdk.rpc_client.pool.update_issues_report({
+                    namespace_resource_id: this.namespace_resource_id,
+                    error_code: err.code || (err.details && err.details.errorCode) || 'InternalError',
+                    time: Date.now(),
+                });
+            }
+
             throw err;
         }
     }

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -217,11 +217,21 @@ class NamespaceS3 {
         } catch (err) {
             this._translate_error_code(params, err);
             dbg.warn('NamespaceS3.read_object_md:', inspect(err));
-            object_sdk.rpc_client.pool.update_issues_report({
-                namespace_resource_id: this.namespace_resource_id,
-                error_code: String(err.code),
-                time: Date.now(),
-            });
+
+            // It's totally expected to issue `HeadObject` against an object that doesn't exist
+            // this shouldn't be counted as an issue for the namespace store
+            //
+            // @TODO: Another error to tolerate is 'InvalidObjectState'. This shouldn't also
+            // result in IO_ERROR for the namespace however that means we can not do `getObject`
+            // even when `can_use_get_inline` is true.
+            if (err.rpc_code !== 'NO_SUCH_OBJECT') {
+                object_sdk.rpc_client.pool.update_issues_report({
+                    namespace_resource_id: this.namespace_resource_id,
+                    error_code: String(err.code),
+                    time: Date.now(),
+                });
+            }
+
             throw err;
         }
     }


### PR DESCRIPTION
### Explain the changes
This PR prevents issue report when an object doesn't exist in a target bucket. It is quite common and OK for clients to issue `HeadObject` against an object that doesn't exist in the bucket. This should not be counted as an issue with the namespace store. Counting it as an issue leads to it being marked as `REJECTED` in k8s.

This situation gets even stranger when we account for the fact that our `namespace_monitor` does take into account such scenarios which leads to NamespaceStore continuously switching between `OPTIMAL` and `REJECTED`.

And it gets worse when NooBaa internal replication engine is the entity issuing `HeadObject`. In such scenarios it isn't clear what is causing the NS to get into `REJECTED` state at all as the customer might not be even touching the bucket by themselves.

### Issues: Fixed #xxx / Gap #xxx
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2277298

- [ ] Doc added/updated
- [ ] Tests added
