### PR TITLE
Encode copy-source in replication utils

### DIFF
--- a/src/server/bg_services/replication_server.js
+++ b/src/server/bg_services/replication_server.js
@@ -79,7 +79,7 @@ async function copy_objects_mixed_types(req) {
         if (keys_diff_map[key].length === 1) {
             const params = {
                 Bucket: dst_bucket_name.unwrap(),
-                CopySource: `/${src_bucket_name.unwrap()}/${key}`, // encodeURI for special chars is needed
+                CopySource: encodeURI(`/${src_bucket_name.unwrap()}/${key}`),
                 Key: key
             };
             try {
@@ -96,7 +96,7 @@ async function copy_objects_mixed_types(req) {
                 const version = keys_diff_map[key][i].VersionId;
                 const params = {
                     Bucket: dst_bucket_name.unwrap(),
-                    CopySource: `/${src_bucket_name.unwrap()}/${key}?versionId=${version}`, // encodeURI for special chars is needed
+                    CopySource: encodeURI(`/${src_bucket_name.unwrap()}/${key}?versionId=${version}`),
                     Key: key
                 };
                 try {


### PR DESCRIPTION
### Explain the changes
This PR encodes the copy-source in the replication utils. This is to ensure that we encode the keys properly. This being absent results in replication failure, multiple failed GetObject requests (CopySource internally calls this) and failed PutObject requests.

### Issues: Fixed #xxx / Gap #xxx
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2277298

### Testing Instructions:
1. `make run-single-test testname=test_bucket_replication.js`


- [ ] Doc added/updated
- [x] Tests added
