### PR TITLE
NC | Add backwards compatibility on get_bucket_owner() for error accuracy

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -3,6 +3,7 @@
 
 const dbg = require('../util/debug_module')(__filename);
 const nb_native = require('../util/nb_native');
+const { CONFIG_TYPES } = require('../sdk/config_fs');
 const native_fs_utils = require('../util/native_fs_utils');
 const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const NSFS_CLI_ERROR_EVENT_MAP = require('../manage_nsfs/manage_nsfs_cli_errors').NSFS_CLI_ERROR_EVENT_MAP;
@@ -44,7 +45,7 @@ async function get_bucket_owner_account(config_fs, bucket_owner, owner_account_i
     try {
         const account = bucket_owner ?
             await config_fs.get_account_by_name(bucket_owner) :
-            await config_fs.get_identity_by_id(owner_account_id);
+            await config_fs.get_identity_by_id(owner_account_id, CONFIG_TYPES.ACCOUNT);
         return account;
     } catch (err) {
         if (err.code === 'ENOENT') {


### PR DESCRIPTION
### Explain the changes
1. Added 'ACCOUNT' type param to get_identity_by_id() for backward compatibility - it was intentionally not added to get_bucket_owner_account() becuase this function is being called only on bucket add/update so we don't really need backwards compatibility here but I added it for not failing on missing account but on the config directory update blocked error on _throw_if_config_dir_locked().
For more info see - https://github.com/noobaa/noobaa-core/pull/8326
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
