### PR TITLE
NSFS | fix copy_object issues

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -483,7 +483,7 @@ class NamespaceFS {
     }
 
     /**
-     * @param {nb.ObjectSDK} object_sdk 
+     * @param {nb.ObjectSDK} object_sdk
      * @returns {nb.NativeFSContext}
      */
     prepare_fs_context(object_sdk) {
@@ -1090,7 +1090,9 @@ class NamespaceFS {
             // end the stream
             res.end();
 
-            await stream_utils.wait_finished(res, { signal: object_sdk.abort_controller.signal });
+            // in case of transform streams such as ChunkFS there is also a readable part. since we expect write stream
+            // and don't care about the readable part, set readable: false
+            await stream_utils.wait_finished(res, { readable: false, signal: object_sdk.abort_controller.signal });
             object_sdk.throw_if_aborted();
 
             dbg.log0('NamespaceFS: read_object_stream completed file', file_path, {
@@ -1209,9 +1211,7 @@ class NamespaceFS {
         }
 
         if (copy_res) {
-            if (copy_res === copy_status_enum.FALLBACK) {
-                params.copy_source.nsfs_copy_fallback();
-            } else {
+            if (copy_res !== copy_status_enum.FALLBACK) {
                 // open file after copy link/same inode should use read open mode
                 open_mode = config.NSFS_OPEN_READ_MODE;
                 if (copy_res === copy_status_enum.SAME_INODE) open_path = file_path;
@@ -1294,10 +1294,8 @@ class NamespaceFS {
         const stat = await target_file.stat(fs_context);
         this._verify_encryption(params.encryption, this._get_encryption_info(stat));
 
-        // handle xattr
-        // assign user xattr on non copy / copy with xattr_copy header provided
         const copy_xattr = params.copy_source && params.xattr_copy;
-        let fs_xattr = copy_xattr ? undefined : to_fs_xattr(params.xattr);
+        let fs_xattr = to_fs_xattr(params.xattr);
 
         // assign noobaa internal xattr - content type, md5, versioning xattr
         if (params.content_type) {
@@ -1339,7 +1337,6 @@ class NamespaceFS {
 
         // when object is a dir, xattr are set on the folder itself and the content is in .folder file
         if (is_dir_content) {
-            if (params.copy_source) fs_xattr = await this._get_copy_source_xattr(params, fs_context, fs_xattr);
             await this._assign_dir_content_to_xattr(fs_context, fs_xattr, { ...params, size: stat.size }, copy_xattr);
         }
         stat.xattr = { ...stat.xattr, ...fs_xattr };
@@ -1351,12 +1348,11 @@ class NamespaceFS {
         await native_fs_utils._make_path_dirs(file_path, fs_context);
         const copy_xattr = params.copy_source && params.xattr_copy;
 
-        let fs_xattr = copy_xattr ? {} : to_fs_xattr(params.xattr) || {};
+        let fs_xattr = to_fs_xattr(params.xattr) || {};
         if (params.content_type) {
             fs_xattr = fs_xattr || {};
             fs_xattr[XATTR_CONTENT_TYPE] = params.content_type;
         }
-        if (params.copy_source) fs_xattr = await this._get_copy_source_xattr(params, fs_context, fs_xattr);
 
         await this._assign_dir_content_to_xattr(fs_context, fs_xattr, params, copy_xattr);
         // when .folder exist and it's no upload flow - .folder should be deleted if it exists
@@ -1370,13 +1366,6 @@ class NamespaceFS {
         const stat = await nb_native().fs.stat(fs_context, dir_path);
         const upload_info = this._get_upload_info(stat, fs_xattr[XATTR_VERSION_ID]);
         return upload_info;
-    }
-
-    async _get_copy_source_xattr(params, fs_context, fs_xattr) {
-        const is_source_dir = params.copy_source.key.endsWith('/');
-        const source_file_md_path = await this._find_version_path(fs_context, params.copy_source, is_source_dir);
-        const source_stat = await nb_native().fs.stat(fs_context, source_file_md_path);
-        return { ...source_stat.xattr, ...fs_xattr };
     }
 
     // move to dest GPFS (wt) / POSIX (w / undefined) - non part upload
@@ -1511,7 +1500,7 @@ class NamespaceFS {
     // Can be finetuned further on if needed and inserting the Semaphore logic inside
     // Instead of wrapping the whole _upload_stream function (q_buffers lives outside of the data scope of the stream)
     async _upload_stream({ fs_context, params, target_file, object_sdk, offset }) {
-        const { source_stream } = params;
+        const { source_stream, copy_source } = params;
         try {
             // Not using async iterators with ReadableStreams due to unsettled promises issues on abort/destroy
             const md5_enabled = this._is_force_md5_enabled(object_sdk);
@@ -1526,8 +1515,14 @@ class NamespaceFS {
                 large_buf_size: multi_buffer_pool.get_buffers_pool(undefined).buf_size
             });
             chunk_fs.on('error', err1 => dbg.error('namespace_fs._upload_stream: error occured on stream ChunkFS: ', err1));
-            await stream_utils.pipeline([source_stream, chunk_fs]);
-            await stream_utils.wait_finished(chunk_fs);
+            if (copy_source) {
+                await this.read_object_stream(copy_source, object_sdk, chunk_fs);
+            } else if (params.source_params) {
+                await params.source_ns.read_object_stream(params.source_params, object_sdk, chunk_fs);
+            } else {
+                await stream_utils.pipeline([source_stream, chunk_fs]);
+                await stream_utils.wait_finished(chunk_fs);
+            }
             return { digest: chunk_fs.digest, total_bytes: chunk_fs.total_bytes };
         } catch (error) {
             dbg.error('_upload_stream had error: ', error);
@@ -1813,6 +1808,7 @@ class NamespaceFS {
             upload_params.params.xattr = create_params_parsed.xattr;
             upload_params.params.storage_class = create_params_parsed.storage_class;
             upload_params.digest = MD5Async && (((await MD5Async.digest()).toString('hex')) + '-' + multiparts.length);
+            upload_params.params.content_type = create_params_parsed.content_type;
 
             const upload_info = await this._finish_upload(upload_params);
 

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
@@ -153,11 +153,7 @@ s3tests_boto3/functional/test_s3.py::test_put_object_ifmatch_failed
 s3tests_boto3/functional/test_s3.py::test_put_object_ifnonmatch_failed
 s3tests_boto3/functional/test_s3.py::test_put_object_ifnonmatch_overwrite_existed_failed
 s3tests_boto3/functional/test_s3.py::test_object_raw_authenticated_bucket_gone
-s3tests_boto3/functional/test_s3.py::test_object_copy_to_itself_with_metadata
 s3tests_boto3/functional/test_s3.py::test_object_copy_canned_acl
-s3tests_boto3/functional/test_s3.py::test_object_copy_retaining_metadata
-s3tests_boto3/functional/test_s3.py::test_object_copy_replacing_metadata
-s3tests_boto3/functional/test_s3.py::test_object_copy_versioning_multipart_upload
 s3tests_boto3/functional/test_s3.py::test_multipart_upload_missing_part
 s3tests_boto3/functional/test_s3.py::test_multipart_upload_incorrect_etag
 s3tests_boto3/functional/test_s3.py::test_atomic_dual_conditional_write_1mb


### PR DESCRIPTION
### Explain the changes
1. change _upload_stream to call read_object_stream directly during fallback copy instead of piping the stream to passthroughStream
2. add content_type to multipart upload
3. always copy xattr during copy object
4. remove old copy for source xattr and change copy_object tests
5. enable copy_object ceph_tests

### Issues: Fixed https://github.com/noobaa/noobaa-core/issues/8315

### Testing Instructions:
1. run ceph_test: s3tests_boto3/functional/test_s3.py::test_object_copy_versioning_multipart_upload 


- [ ] Doc added/updated
- [x] Tests added
