### PR TITLE
NC | NSFS | Fix Bug | Head Object on a Tagged Object Does Not Return `x-amz-tagging-count` Header

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
@@ -177,7 +177,6 @@ s3tests_boto3/functional/test_s3.py::test_bucketv2_policy
 s3tests_boto3/functional/test_s3.py::test_bucket_policy_another_bucket
 s3tests_boto3/functional/test_s3.py::test_bucketv2_policy_another_bucket
 s3tests_boto3/functional/test_s3.py::test_get_obj_tagging
-s3tests_boto3/functional/test_s3.py::test_get_obj_head_tagging
 s3tests_boto3/functional/test_s3.py::test_put_max_tags
 s3tests_boto3/functional/test_s3.py::test_bucket_policy_put_obj_s3_noenc
 s3tests_boto3/functional/test_s3.py::test_copy_object_ifmatch_failed


### PR DESCRIPTION
### Explain the changes
1. In `namespace_fs` return  `tag_count` which is the sum of all the extended attribute that has the prefix `user.noobaa.tag.`.
2. Rename `XATTR_NOOBAA_CUSTOM_PREFIX` to `XATTR_TAG` and move the variable declaration to a lower place in the variable declaration list.

### Issues: Fixed #8353
1. Currently, in `namespace_fs` we always return `tag_count: 0`, therefore the client would not receive the `x-amz-tagging-count` header.

### Testing Instructions:
#### Automatic Test
Please run: `s3tests_boto3/functional/test_s3.py::test_get_obj_head_tagging` in NC deployment.

#### Manual Test
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`, `chmod 777 /tmp/nsfs_root1`.
3. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
Notes: 
- I Change the `config.NSFS_CHECK_BUCKET_BOUNDARIES = false; //SDSD` because I’m using the `/tmp/` and not `/private/tmp/`.
4. Create the alias for S3 service:`alias nc-user-1-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443’`.
5. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-1-s3 s3 ls; echo $?`
6. Add bucket to the account using AWS CLI: `nc-user-1-s3 s3 mb s3://bucket-1` (`bucket-1` is the bucket name in this example)
7. Put an object: `nc-user-1-s3 s3api put-object --bucket bucket-1 --key hello.txt`
8. Put object-tagging: `nc-user-1-s3 s3api put-object-tagging --tagging '{"TagSet": [{ "Key": "designation", "Value": "confidential" }, { "Key": "department", "Value": "finance" }, { "Key": "team", "Value": "payroll" } ]}' --bucket bucket-1 --key hello.txt` (in this example there are 3 added tags).
9. Head the object: `nc-user-1-s3 s3api get-object --bucket bucket-1 --key hello.txt --debug` (use the `debug` flag to validate the header of `x-amz-tagging-count, expected to see 3).


- [ ] Doc added/updated
- [ ] Tests added
