### PR TITLE
CI | NSFS | Ceph S3 Tests

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
@@ -158,10 +158,8 @@ s3tests_boto3/functional/test_s3.py::test_object_copy_canned_acl
 s3tests_boto3/functional/test_s3.py::test_object_copy_retaining_metadata
 s3tests_boto3/functional/test_s3.py::test_object_copy_replacing_metadata
 s3tests_boto3/functional/test_s3.py::test_object_copy_versioning_multipart_upload
-s3tests_boto3/functional/test_s3.py::test_list_multipart_upload
 s3tests_boto3/functional/test_s3.py::test_multipart_upload_missing_part
 s3tests_boto3/functional/test_s3.py::test_multipart_upload_incorrect_etag
-s3tests_boto3/functional/test_s3.py::test_set_bucket_tagging
 s3tests_boto3/functional/test_s3.py::test_atomic_dual_conditional_write_1mb
 s3tests_boto3/functional/test_s3.py::test_versioned_concurrent_object_create_concurrent_remove
 s3tests_boto3/functional/test_s3.py::test_encrypted_transfer_1b
@@ -173,11 +171,6 @@ s3tests_boto3/functional/test_s3.py::test_encryption_sse_c_present
 s3tests_boto3/functional/test_s3.py::test_encryption_sse_c_other_key
 s3tests_boto3/functional/test_s3.py::test_sse_kms_method_head
 s3tests_boto3/functional/test_s3.py::test_bucket_policy
-s3tests_boto3/functional/test_s3.py::test_bucketv2_policy
-s3tests_boto3/functional/test_s3.py::test_bucket_policy_another_bucket
-s3tests_boto3/functional/test_s3.py::test_bucketv2_policy_another_bucket
-s3tests_boto3/functional/test_s3.py::test_get_obj_tagging
-s3tests_boto3/functional/test_s3.py::test_put_max_tags
 s3tests_boto3/functional/test_s3.py::test_bucket_policy_put_obj_s3_noenc
 s3tests_boto3/functional/test_s3.py::test_copy_object_ifmatch_failed
 s3tests_boto3/functional/test_s3.py::test_copy_object_ifnonematch_good
@@ -200,7 +193,6 @@ s3tests_boto3/functional/test_s3.py::test_sse_s3_encrypted_upload_1kb
 s3tests_boto3/functional/test_s3.py::test_sse_s3_encrypted_upload_1mb
 s3tests_boto3/functional/test_s3.py::test_sse_s3_encrypted_upload_8mb
 s3tests/functional/test_s3.py::test_atomic_write_bucket_gone
-s3tests_boto3/functional/test_s3.py::test_bucket_create_delete
 s3tests_boto3/functional/test_s3.py::test_atomic_write_bucket_gone
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_x_amz_expires_not_expired
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_x_amz_expires_not_expired_tenant


### PR DESCRIPTION
### Explain the changes
1. Add tests to run in the CI.

### Issues:
None

### Testing Instructions:
1. It's running in the CI, on a local machine can use: `make test-nsfs-cephs3 CONTAINER_PLATFORM=linux/arm64` (I'm using the flag `CONTAINER_PLATFORM=linux/arm64` because I run it on my Mac M1).


- [ ] Doc added/updated
- [ ] Tests added
