### PR TITLE
Added a fix for prometheusDuplicateTimestamp error

### DIFF
--- a/src/server/analytic_services/prometheus_reports/nodejs_report.js
+++ b/src/server/analytic_services/prometheus_reports/nodejs_report.js
@@ -12,6 +12,9 @@ class NodeJsReport extends BasePrometheusReport {
     constructor() {
         super();
 
+        // creating new instance of registry to collect default metrics for nodejs
+        this._register = new this.prom_client.Registry();
+
         if (this.enabled) {
             this.prom_client.collectDefaultMetrics({
                 register: this.register,


### PR DESCRIPTION
### Explain the changes
`PrometheusDuplicateTimestamps` is a type of warning or error in Prometheus indicating that multiple samples with the same timestamp but different values were encountered.

The `nodejs` report was generating default metrics that were overlapping with those from the `core` report. This overlap led to metrics with identical timestamps but different values being ingested by Prometheus, causing the warnings.

Solution: We are creating a new registry for collecting all the default metrics for nodejs.

[Read About prom-client](https://www.npmjs.com/package/prom-client#default-metrics)

Before changes: 
![Screenshot from 2024-09-23 15-25-53](https://github.com/user-attachments/assets/74c84d99-f394-4f51-999d-93d21dec7ecd)

After fixes:
![Screenshot from 2024-09-23 15-20-49](https://github.com/user-attachments/assets/4a4a2391-347e-43dc-baf6-899200fcca34)

### Issues: Fixed #xxx / Gap #xxx
1. BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2304076
2. Related PR: #7562 

### Testing Instructions:
1.  After installing noobaa should check for duplicate metrics using command : `kubectl exec -it noobaa-core-0 -- curl localhost:8080/metrics/web_server | grep NooBaa_odf_health_status`
