### PR TITLE
NC | NSFS | Versioning | Delete Objects | Add a Test | GPFS

### DIFF
--- a/src/test/unit_tests/test_nsfs_versioning_gpfs.js
+++ b/src/test/unit_tests/test_nsfs_versioning_gpfs.js
@@ -208,6 +208,16 @@ mocha.describe('namespace_fs gpfs- versioning', async function() {
         assert.equal(delete_res.version_id, put_res2.version_id);
     });
 
+    mocha.it('delete objects - versioning enabled - use delete_multiple_objects to delete a single non-existing key', async function() {
+        // 1. put bucket versioning enabled
+        await ns_obj.set_bucket_versioning('ENABLED', dummy_object_sdk);
+        // 2. delete objects (a single non existing key)
+        const objects = [{ key: 'non-existing-key', version_id: undefined }];
+        const delete_objects_res = await delete_multiple_objects(dummy_object_sdk, ns_obj, gpfs_bucket, objects);
+        assert.equal(delete_objects_res.created_delete_marker, true);
+        assert.ok(delete_objects_res.created_version_id !== undefined);
+    });
+
 });
 
 async function put_object(dummy_object_sdk, ns, bucket, key) {
@@ -239,6 +249,15 @@ async function delete_object(dummy_object_sdk, ns, bucket, key, version_id) {
     }, dummy_object_sdk);
     console.log('delete_object response', util.inspect(delete_res));
     return delete_res;
+}
+
+async function delete_multiple_objects(dummy_object_sdk, ns, bucket, objects) {
+    const delete_objects_res = await ns.delete_multiple_objects({
+        bucket,
+        objects
+    }, dummy_object_sdk);
+    console.log('delete_multiple_objects response', util.inspect(delete_objects_res));
+    return delete_objects_res;
 }
 
 


### PR DESCRIPTION
### Explain the changes
1. Adding tests for deleting objects in GPFS.

### Issues: 
1. As a part of #8360 issue we should test delete objects on GPFS machine after the fix of #8358 and add this test to the tests that we can run on the GPFS machine.

### Testing Instructions:
1. Not yet, would be tested on the GPFS machine.


- [ ] Doc added/updated
- [ ] Tests added
