### PR TITLE
NSFS | GPFS | fix put object over null version in suspended mode

### DIFF
--- a/src/test/unit_tests/test_nsfs_versioning_gpfs.js
+++ b/src/test/unit_tests/test_nsfs_versioning_gpfs.js
@@ -218,6 +218,16 @@ mocha.describe('namespace_fs gpfs- versioning', async function() {
         assert.ok(delete_objects_res.created_version_id !== undefined);
     });
 
+    mocha.it('Suspended mode - add object null version twice', async function() {
+        await ns_obj.set_bucket_versioning('SUSPENDED', dummy_object_sdk);
+        const key3 = 'key3';
+        const put_res = await put_object(dummy_object_sdk, ns_obj, gpfs_bucket, key3);
+        assert.equal(put_res.version_id, 'null');
+        //issue #8379, overwriting null value should not fail on GPFS
+        const put_res2 = await put_object(dummy_object_sdk, ns_obj, gpfs_bucket, key3);
+        assert.equal(put_res2.version_id, 'null');
+    });
+
 });
 
 async function put_object(dummy_object_sdk, ns, bucket, key) {


### PR DESCRIPTION
### Explain the changes
1. on Suspeded mode we need to delete the latest null version if a new object is created (as there can be only one object with null version). this delete fails on GPFS since we use the wrong gps_options. however since in GPFS link overrides existing file anyway, we don't need to call unlink at all in such scenario. changed so unlink will not be called to delete latest null version on Suspended mode for GPFS
2. add missing use of gpfs_options.delete_version instead of gpfs_options for deleting old null version

### Issues: Fixed #8379 

### Testing Instructions:
Run `test_nsfs_versioning_gpfs.js` tests on gpfs cluster
- [ ] Doc added/updated
- [x] Tests added
