### PR TITLE
NSFS | NOOBAA_LOG_LEVEL is not working as expected

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -2176,7 +2176,7 @@ set_debug_level(const Napi::CallbackInfo& info)
 {
     int level = info[0].As<Napi::Number>();
     DBG_SET_LEVEL(level);
-    LOG("FS::set_debug_level " << level);
+    DBG1("FS::set_debug_level " << level);
     return info.Env().Undefined();
 }
 
@@ -2187,7 +2187,7 @@ set_log_config(const Napi::CallbackInfo& info)
     bool syslog_enabled = info[1].As<Napi::Boolean>();
     LOG_TO_STDERR_ENABLED = stderr_enabled;
     LOG_TO_SYSLOG_ENABLED = syslog_enabled;
-    LOG("FS::set_log_config: " <<  DVAL(LOG_TO_STDERR_ENABLED) << DVAL(LOG_TO_SYSLOG_ENABLED));
+    DBG1("FS::set_log_config: " <<  DVAL(LOG_TO_STDERR_ENABLED) << DVAL(LOG_TO_SYSLOG_ENABLED));
     return info.Env().Undefined();
 }
 

--- a/src/native/util/common.h
+++ b/src/native/util/common.h
@@ -45,7 +45,7 @@ extern bool LOG_TO_SYSLOG_ENABLED;
     do {                                                \
         const char* log_msg = x.c_str();                \
         int facility = LOG_LOCAL0;                      \
-        int priority = 0;                               \
+        int priority = 5;                               \
         ::syslog(priority | facility, "%s", log_msg);   \
     } while (0)
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -977,7 +977,7 @@ interface NativeFS {
 
     dio_buffer_alloc(size: number): Buffer;
     set_debug_level(level: number);
-    set_log_config(stderr_enabled: boolean, syslog_enabled: boolean,);
+    set_log_config(stderr_enabled: boolean, syslog_enabled: boolean);
 
     S_IFMT: number;
     S_IFDIR: number;


### PR DESCRIPTION
### Explain the changes
1. log in nappi layer which is getting printed every time config.json reloaded, Its adding longs to the console. Solution would be update priority for message to info(5)

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8380

### Testing Instructions:
1. update config.json
config.LOG_TO_STDERR_ENABLED = true;
config.LOG_TO_SYSLOG_ENABLED = true;
and check below logs printing on the console log, every time config.json relaod


- [ ] Doc added/updated
- [ ] Tests added
