### PR TITLE
CI | Update Ceph S3 Tests Days (Temporary Solution)

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -38,7 +38,7 @@ commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}'
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
 
-max_days="180"
+max_days="270"
 if [ $((current_date-commit_date)) -gt $((3600*24*${max_days})) ]
 then
     echo "ceph tests were not updated for ${max_days} days, Exiting"


### PR DESCRIPTION
### Explain the changes
1.  Updated the number of days as a temporary solution.

### Issues:
1. This issue was mentioned as a part of PR #8271, updating by one commit results in many failed tests, probably due to changes in the `s3tests.conf.SAMPLE` file and how our script attaches the information to it.
2. GAP - I opened a Jira ticket ([MCGI-254](https://issues.redhat.com/browse/MCGI-254)) to investigate it, after updating the commit hash the number of days should be 180 again.
Here are the logs after updating to commit [54c1488a4365afdbe7748eb31809bbb05fa25fb3](https://github.com/ceph/s3-tests/commit/54c1488a4365afdbe7748eb31809bbb05fa25fb3) ([PR 537](https://github.com/ceph/s3-tests/pull/537))
[ceph_s3](https://github.com/noobaa/noobaa-core/actions/runs/10988236625/job/30504313202?pr=8392):

> Sep-23 5:54:01.813 [test_ceph_s3/184]  [INFO] CONSOLE:: CEPH TEST SUMMARY: Suite contains 860, ran 389 tests, Passed: 6, Skipped: 6, Failed: 377

[nsfs_ceph_s3](https://github.com/noobaa/noobaa-core/actions/runs/10988236619/job/30504313206?pr=8392):

> Sep-23 5:48:55.040 [test_ceph_s3/120]  [INFO] CONSOLE:: CEPH TEST SUMMARY: Suite contains 860, ran 321 tests, Passed: 5, Skipped: 6, Failed: 310

### Testing Instructions:
1. none (tested through the CI).
3. If you wish to run it locally:
`make test-cephs3 CONTAINER_PLATFORM=linux/arm64`
`make test-nsfs-cephs3 CONTAINER_PLATFORM=linux/arm64`
(I'm using the flag `CONTAINER_PLATFORM` because I have MacOS M1).


- [ ] Doc added/updated
- [ ] Tests added
