### PR TITLE
NSFS | Versioning | Concurrency tests

### DIFF
--- a/docs/NooBaaNonContainerized/CI&Tests.md
+++ b/docs/NooBaaNonContainerized/CI&Tests.md
@@ -104,6 +104,8 @@ The following is a list of `NC jest tests` files -
 9. `test_nc_nsfs_account_schema_validation.test.js` - Tests NC account schema validation.  
 10. `test_nc_nsfs_new_buckets_path_validation.test.js` - Tests new_buckets_path RW access.  
 11. `test_config_fs.test.js` - Tests ConfigFS methods.
+12. `test_nsfs_concurrency` - Tests concurrent operations.
+13. `test_versioning_concurrency` - Tests concurrent operations on versioned enabled bucket.
 
 #### nc_index.js File
 * The `nc_index.js` is a file that runs several NC and NSFS mocha related tests.  

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2930,9 +2930,9 @@ class NamespaceFS {
                     const bucket_tmp_dir_path = this.get_bucket_tmpdir_full_path();
                     if (this._is_versioning_enabled() || suspended_and_latest_is_not_null) {
                         await native_fs_utils._make_path_dirs(versioned_path, fs_context);
-                         await native_fs_utils.safe_move(fs_context, latest_ver_path, versioned_path, latest_ver_info,
+                        await native_fs_utils.safe_move(fs_context, latest_ver_path, versioned_path, latest_ver_info,
                             gpfs_options && gpfs_options.delete_version, bucket_tmp_dir_path);
-                         if (suspended_and_latest_is_not_null) {
+                        if (suspended_and_latest_is_not_null) {
                             // remove a version (or delete marker) with null version ID from .versions/ (if exists)
                             await this._delete_null_version_from_versions_directory(params.key, fs_context);
                         }
@@ -2945,9 +2945,9 @@ class NamespaceFS {
                 }
                 break;
             } catch (err) {
+                dbg.warn(`NamespaceFS._delete_latest_version: Retrying retries=${retries} latest_ver_path=${latest_ver_path}`, err);
                 retries -= 1;
                 if (retries <= 0 || !native_fs_utils.should_retry_link_unlink(is_gpfs, err)) throw err;
-                dbg.warn(`NamespaceFS._delete_latest_version: Retrying retries=${retries} latest_ver_path=${latest_ver_path}`, err);
             } finally {
                 if (gpfs_options) await this._close_files_gpfs(fs_context, gpfs_options.delete_version, undefined, true);
             }

--- a/src/test/unit_tests/jest_tests/test_versioning_concurrency.test.js
+++ b/src/test/unit_tests/jest_tests/test_versioning_concurrency.test.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
+/* eslint-disable max-lines-per-function */
 'use strict';
 
 const path = require('path');
@@ -56,16 +57,20 @@ describe('test versioning concurrency', () => {
         const bucket = 'bucket1';
         const key = 'key1';
         const failed_operations = [];
-        for (let i = 0; i < 5; i++) {
+        const successful_operations = [];
+        const num_of_concurrency = 5;
+        for (let i = 0; i < num_of_concurrency; i++) {
             const random_data = Buffer.from(String(i));
             const body = buffer_utils.buffer_to_read_stream(random_data);
             nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK)
-                .catch(err => failed_operations.push(err));
+                .catch(err => failed_operations.push(err))
+                .then(res => successful_operations.push(res));
         }
-        await P.delay(1000);
-        expect(failed_operations.length).toBe(0);
+        await P.delay(2000);
+        expect(successful_operations).toHaveLength(num_of_concurrency);
+        expect(failed_operations).toHaveLength(0);
         const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
-        expect(versions.objects.length).toBe(5);
+        expect(versions.objects.length).toBe(num_of_concurrency);
     });
 
     it('multiple delete version id and key', async () => {
@@ -74,17 +79,18 @@ describe('test versioning concurrency', () => {
         const number_of_versions = 5;
         const versions_arr = await _upload_versions(bucket, key, number_of_versions);
 
-        const mid_version_id = versions_arr[3];
-        const number_of_successful_operations = [];
+        const mid_version_id = versions_arr[3].version_id;
+        const successful_operations = [];
         const failed_operations = [];
-        for (let i = 0; i < 15; i++) {
+        const num_of_concurrency = 15;
+        for (let i = 0; i < num_of_concurrency; i++) {
             nsfs.delete_object({ bucket: bucket, key: key, version_id: mid_version_id }, DUMMY_OBJECT_SDK)
-                .then(res => number_of_successful_operations.push(res))
+                .then(res => successful_operations.push(res))
                 .catch(err => failed_operations.push(err));
         }
         await P.delay(1000);
-        expect(failed_operations.length).toBe(0);
-        expect(number_of_successful_operations.length).toBe(15);
+        expect(successful_operations).toHaveLength(num_of_concurrency);
+        expect(failed_operations).toHaveLength(0);
     });
 
     // same as s3tests_boto3/functional/test_s3.py::test_versioning_concurrent_multi_object_delete, 
@@ -97,11 +103,11 @@ describe('test versioning concurrency', () => {
         const delete_objects_arr = [];
         for (let i = 0; i < concurrency_num; i++) {
             const key = `key${i}`;
-            const random_data = Buffer.from(String(crypto_random_string(7)));
-            const body = buffer_utils.buffer_to_read_stream(random_data);
-            const res = await nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK);
-            delete_objects_arr.push({ key: key, version_id: res.version_id });
+            const versions_arr = await _upload_versions(bucket, key, 1);
+            const version = versions_arr[0];
+            delete_objects_arr.push({ key: key, version_id: version.version_id });
         }
+
         const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
 
         for (const { key, version_id } of delete_objects_arr) {
@@ -181,6 +187,256 @@ describe('test versioning concurrency', () => {
         const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
         expect(versions.objects.length).toBe(number_of_iterations + 1); // 1 version before + 10 versions concurrent
     });
+    it('concurrent puts & delete latest objects', async () => {
+        const bucket = 'bucket1';
+        const key = 'key3';
+        const upload_res_arr = [];
+        const delete_res_arr = [];
+        const delete_err_arr = [];
+        const upload_err_arr = [];
+        const initial_num_of_versions = 3;
+        await _upload_versions(bucket, key, initial_num_of_versions);
+
+        const num_of_concurrency = 2;
+        for (let i = 0; i < num_of_concurrency; i++) {
+            const random_data = Buffer.from(String(crypto_random_string(7)));
+            const body = buffer_utils.buffer_to_read_stream(random_data);
+            nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK)
+                .then(res => upload_res_arr.push(res.etag))
+                .catch(err => upload_err_arr.push(err));
+            nsfs.delete_object({ bucket: bucket, key: key }, DUMMY_OBJECT_SDK)
+                .then(res => delete_res_arr.push(res.created_version_id))
+                .catch(err => delete_err_arr.push(err));
+        }
+        await P.delay(2000);
+        expect(upload_res_arr).toHaveLength(num_of_concurrency);
+        expect(delete_res_arr).toHaveLength(num_of_concurrency);
+        expect(upload_err_arr).toHaveLength(0);
+        expect(delete_err_arr).toHaveLength(0);
+        const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
+        expect(versions.objects.length).toBe(initial_num_of_versions + 2 * num_of_concurrency);
+        const num_of_delete_markers = (versions.objects.filter(version => version.delete_marker === true)).length;
+        expect(num_of_delete_markers).toBe(num_of_concurrency);
+        const num_of_latest_versions = (versions.objects.filter(version => version.is_latest === true)).length;
+        expect(num_of_latest_versions).toBe(1);
+    }, 6000);
+
+    it('concurrent puts & delete objects by version id', async () => {
+        const bucket = 'bucket1';
+        const key = 'key4';
+        const upload_res_arr = [];
+        const delete_res_arr = [];
+        const delete_err_arr = [];
+        const upload_err_arr = [];
+        const initial_num_of_versions = 3;
+        const versions_arr = await _upload_versions(bucket, key, initial_num_of_versions);
+
+        const num_of_concurrency = 3;
+        for (let i = 0; i < num_of_concurrency; i++) {
+            const random_data = Buffer.from(String(crypto_random_string(7)));
+            const body = buffer_utils.buffer_to_read_stream(random_data);
+            nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK)
+                .then(res => upload_res_arr.push(res.etag))
+                .catch(err => upload_err_arr.push(err));
+            nsfs.delete_object({ bucket: bucket, key: key, version_id: versions_arr[i].version_id }, DUMMY_OBJECT_SDK)
+                .then(res => delete_res_arr.push(res.deleted_version_id))
+                .catch(err => delete_err_arr.push(err));
+        }
+        await P.delay(2000);
+        expect(upload_res_arr).toHaveLength(num_of_concurrency);
+        expect(delete_res_arr).toHaveLength(num_of_concurrency);
+        expect(upload_err_arr).toHaveLength(0);
+        expect(delete_err_arr).toHaveLength(0);
+        const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
+        expect(versions.objects.length).toBe(num_of_concurrency);
+        const num_of_delete_markers = (versions.objects.filter(version => version.delete_marker === true)).length;
+        expect(num_of_delete_markers).toBe(0);
+        const num_of_latest_versions = (versions.objects.filter(version => version.is_latest === true)).length;
+        expect(num_of_latest_versions).toBe(1);
+    }, 6000);
+
+    // currently being skipped because it's not passing - probably a bug that we need to fix
+    it.skip('concurrent delete objects by version id/latest', async () => {
+        const bucket = 'bucket1';
+        const key = 'key5';
+        const delete_ver_res_arr = [];
+        const delete_ver_err_arr = [];
+        const delete_res_arr = [];
+        const delete_err_arr = [];
+        const initial_num_of_versions = 1;
+        const versions_arr = await _upload_versions(bucket, key, initial_num_of_versions);
+        const version_id_to_delete = versions_arr[initial_num_of_versions - 1].version_id;
+        const num_of_concurrency = initial_num_of_versions;
+        for (let i = 0; i < num_of_concurrency; i++) {
+            nsfs.delete_object({ bucket: bucket, key: key, version_id: version_id_to_delete }, DUMMY_OBJECT_SDK)
+                .then(res => delete_ver_res_arr.push(res.deleted_version_id))
+                .catch(err => delete_ver_err_arr.push(err));
+            nsfs.delete_object({ bucket: bucket, key: key }, DUMMY_OBJECT_SDK)
+                .then(res => delete_res_arr.push(res))
+                .catch(err => delete_err_arr.push(err));
+        }
+        await P.delay(2000);
+        expect(delete_ver_res_arr).toHaveLength(num_of_concurrency);
+        expect(delete_res_arr).toHaveLength(num_of_concurrency);
+        expect(delete_ver_err_arr).toHaveLength(0);
+        expect(delete_err_arr).toHaveLength(0);
+        const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
+
+        expect(versions.objects).toHaveLength(num_of_concurrency);
+        const num_of_delete_markers = (versions.objects.filter(version => version.delete_marker === true)).length;
+        expect(num_of_delete_markers).toBe(num_of_concurrency);
+        const num_of_latest_versions = (versions.objects.filter(version => version.is_latest === true)).length;
+        expect(num_of_latest_versions).toBe(1);
+    }, 6000);
+
+    it('nested key - concurrent delete multiple objects', async () => {
+        const bucket = 'bucket1';
+        const key = 'dir2/key2';
+        const initial_num_of_versions = 10;
+        const num_of_concurrency = 10;
+        const delete_successful_operations = [];
+        const delete_failed_operations = [];
+
+        const inital_versions = await _upload_versions(bucket, key, initial_num_of_versions);
+        expect(inital_versions).toHaveLength(initial_num_of_versions);
+
+        const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
+        expect(versions.objects).toHaveLength(initial_num_of_versions);
+        for (const { version_id } of inital_versions) {
+            const found = versions.objects.find(object => object.key === key && object.version_id === version_id);
+            expect(found).toBeDefined();
+        }
+        for (let i = 0; i < num_of_concurrency; i++) {
+            nsfs.delete_multiple_objects({ bucket, objects: inital_versions }, DUMMY_OBJECT_SDK)
+                .then(res => delete_successful_operations.push(res))
+                .catch(err => delete_failed_operations.push(err));
+        }
+
+        await P.delay(2000);
+        expect(delete_successful_operations).toHaveLength(num_of_concurrency);
+        expect(delete_failed_operations).toHaveLength(0);
+
+        for (const res of delete_successful_operations) {
+            expect(res).toHaveLength(initial_num_of_versions);
+            for (const single_delete_res of res) {
+                expect(single_delete_res.err_message).toBe(undefined);
+            }
+        }
+        const list_res = await nsfs.list_objects({ bucket: bucket }, DUMMY_OBJECT_SDK);
+        expect(list_res.objects).toHaveLength(0);
+    }, 8000);
+
+
+    it('nested key - concurrent puts & deletes', async () => {
+        const bucket = 'bucket1';
+        const key = 'dir3/key3';
+        const num_of_concurrency = 5;
+        const upload_successful_operations = [];
+        const upload_failed_operations = [];
+        const delete_successful_operations = [];
+        const delete_failed_operations = [];
+
+        for (let i = 0; i < num_of_concurrency; i++) {
+            const random_data = Buffer.from(String(crypto_random_string(7)));
+            const body = buffer_utils.buffer_to_read_stream(random_data);
+            nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK)
+                .catch(err => upload_failed_operations.push(err))
+                .then(res => {
+                    upload_successful_operations.push(res.etag);
+                    nsfs.delete_object({ bucket: bucket, key: key, version_id: res.version_id }, DUMMY_OBJECT_SDK)
+                        .then(delete_res => delete_successful_operations.push(delete_res))
+                        .catch(err => delete_failed_operations.push(err));
+                });
+        }
+        await P.delay(3000);
+        expect(upload_successful_operations).toHaveLength(num_of_concurrency);
+        expect(upload_failed_operations).toHaveLength(0);
+        expect(delete_successful_operations).toHaveLength(num_of_concurrency);
+        expect(delete_failed_operations).toHaveLength(0);
+    }, 6000);
+
+    it('concurrent puts & list versions', async () => {
+        const bucket = 'bucket1';
+        const upload_res_arr = [];
+        const list_res_arr = [];
+        const list_err_arr = [];
+        const upload_err_arr = [];
+        const initial_num_of_versions = 20;
+        const initial_num_of_objects = 20;
+
+        for (let i = 0; i < initial_num_of_objects; i++) {
+            const key = 'key_put' + i;
+            await _upload_versions(bucket, key, initial_num_of_versions);
+        }
+
+        const num_of_concurrency = 20;
+        for (let i = 0; i < num_of_concurrency; i++) {
+            const key = 'key_put' + i;
+            const random_data = Buffer.from(String(crypto_random_string(7)));
+            const body = buffer_utils.buffer_to_read_stream(random_data);
+            nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK)
+                .then(res => upload_res_arr.push(res.etag))
+                .catch(err => upload_err_arr.push(err));
+            nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK)
+                .then(res => list_res_arr.push(res))
+                .catch(err => list_err_arr.push(err));
+        }
+        await P.delay(10000);
+        expect(upload_res_arr).toHaveLength(num_of_concurrency);
+        expect(list_res_arr).toHaveLength(num_of_concurrency);
+        expect(upload_err_arr).toHaveLength(0);
+        expect(list_err_arr).toHaveLength(0);
+        const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
+        expect(versions.objects).toHaveLength(initial_num_of_versions * initial_num_of_objects + num_of_concurrency);
+
+        const num_of_delete_markers = (versions.objects.filter(version => version.delete_marker === true)).length;
+        expect(num_of_delete_markers).toBe(0);
+        const num_of_latest_versions = (versions.objects.filter(version => version.is_latest === true)).length;
+        expect(num_of_latest_versions).toBe(initial_num_of_objects);
+    }, 60000);
+
+    it('concurrent puts & list versions - version id paging', async () => {
+        const bucket = 'bucket1';
+        const upload_res_arr = [];
+        const list_res_arr = [];
+        const list_err_arr = [];
+        const upload_err_arr = [];
+        const initial_num_of_versions = 50;
+        const initial_num_of_objects = 50;
+
+        for (let i = 0; i < initial_num_of_objects; i++) {
+            const key = 'key_put' + i;
+            await _upload_versions(bucket, key, initial_num_of_versions);
+        }
+        const merged_initial_versions = await get_all_versions(bucket);
+        expect(merged_initial_versions).toHaveLength(initial_num_of_objects * initial_num_of_versions);
+
+        const num_of_concurrency = 20;
+        for (let i = 0; i < num_of_concurrency; i++) {
+            const key = 'key_put' + i;
+            const random_data = Buffer.from(String(crypto_random_string(7)));
+            const body = buffer_utils.buffer_to_read_stream(random_data);
+            nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK)
+                .then(res => upload_res_arr.push(res.etag))
+                .catch(err => upload_err_arr.push(err));
+            nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK)
+                .then(res => list_res_arr.push(res))
+                .catch(err => list_err_arr.push(err));
+        }
+        await P.delay(20000);
+        expect(upload_res_arr).toHaveLength(num_of_concurrency);
+        expect(list_res_arr).toHaveLength(num_of_concurrency);
+        expect(upload_err_arr).toHaveLength(0);
+        expect(list_err_arr).toHaveLength(0);
+
+        const merged_versions = await get_all_versions(bucket);
+        const expected_num_of_versions = initial_num_of_objects * initial_num_of_versions + num_of_concurrency;
+        expect(merged_versions).toHaveLength(expected_num_of_versions);
+        const num_of_delete_markers = (merged_versions.filter(version => version.delete_marker === true)).length;
+        expect(num_of_delete_markers).toBe(0);
+        const num_of_latest_versions = (merged_versions.filter(version => version.is_latest === true)).length;
+        expect(num_of_latest_versions).toBe(initial_num_of_objects);
+    }, 50000);
 });
 
 /**
@@ -193,11 +449,25 @@ describe('test versioning concurrency', () => {
 async function _upload_versions(bucket, key, number_of_versions) {
     const versions_arr = [];
     for (let i = 0; i < number_of_versions; i++) {
-        const random_data = Buffer.from(String(i));
+        const random_data = Buffer.from(String(crypto_random_string(7)));
         const body = buffer_utils.buffer_to_read_stream(random_data);
-        const res = await nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK)
-            .catch(err => console.log('put error - ', err));
-        versions_arr.push(res.etag);
+        const res = await nsfs.upload_object({ bucket: bucket, key: key, source_stream: body }, DUMMY_OBJECT_SDK);
+        versions_arr.push({ ...res, key });
     }
     return versions_arr;
+}
+
+
+async function get_all_versions(bucket) {
+    let merged_versions = [];
+    let key_marker;
+    let version_id_marker;
+    for (;;) {
+        const versions = await nsfs.list_object_versions({ bucket, key_marker, version_id_marker }, DUMMY_OBJECT_SDK);
+        merged_versions = merged_versions.concat(versions.objects);
+        version_id_marker = versions.next_version_id_marker;
+        key_marker = versions.next_marker;
+        if (!version_id_marker) break;
+    }
+    return merged_versions;
 }


### PR DESCRIPTION
### Explain the changes
1. Added 7 concurrency tests - 
   a. concurrent puts & delete latest objects
   b. concurrent puts & delete objects by version id
   c. concurrent delete objects by version id/latest - **currently being skipped - there is probably a bug in that flow, Opened an issue - https://github.com/noobaa/noobaa-core/issues/8414**
   d. nested key - concurrent delete multiple objects.
   e. nested key - concurrent puts & deletes.
   f. concurrent puts & list versions
   g. concurrent puts & list versions - version id paging - **currently being skipped - there is probably a bug in that flow, opened an issue -  https://github.com/noobaa/noobaa-core/issues/8406**
3. Fixed indentation and moved up a printing.
4. Refactored some existing concurrency tests.

### Issues: Fixed #xxx / Gap #xxx
1. Remove the skip from these tests.
2. List object versions + version id marker not working - https://github.com/noobaa/noobaa-core/issues/8406
3. Delete latest + delete object version id which is also the latest bug - https://github.com/noobaa/noobaa-core/issues/8414

### Testing Instructions:
1. `sudo jest --testRegex=jest_tests/test_versioning_conc`


- [ ] Doc added/updated
- [ ] Tests added
