### PR TITLE
[NSFS] Fix version listing

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -811,10 +811,6 @@ class NamespaceFS {
                     }
                     for (let i = marker_index; i < sorted_entries.length; ++i) {
                         const ent = sorted_entries[i];
-                        if (list_versions && marker_curr) {
-                            const ent_name = _get_filename(ent.name);
-                            if (ent_name !== marker_curr) break;
-                        }
                         // when entry is NSFS_FOLDER_OBJECT_NAME=.folder file,
                         // and the dir key marker is the name of the curr directory - skip on adding it
                         if (ent.name === config.NSFS_FOLDER_OBJECT_NAME && dir_key === marker_dir) {


### PR DESCRIPTION
### Explain the changes
This PR attempts to fix version listing. Previously, there was an assumption that when both `KeyMarker` and `NextIdVersion` is provided then only the items belonging to that `KeyMarker` starting from the given `IdVersion` should be returned. This behaviour sounds sane but upon checking with AWS S3 it turns out that AWS would keep on listing items beyond `KeyMarker` as well (and the way to control the key is by using `Prefix` and `MaxKeys`).

This PR simply removes that additional check.

### Issues: Fixed #xxx / Gap #xxx
Fixes https://github.com/noobaa/noobaa-core/issues/8406

### Testing Instructions:
1. sudo jest --testRegex=jest_tests/test_versioning_conc -t 'concurrent puts & list versions' (After https://github.com/noobaa/noobaa-core/pull/8405 gets merged)

- [ ] Doc added/updated
- [ ] Tests added
