### PR TITLE
Add S3 GetObjectAttributes API Implementation

### DIFF
--- a/src/endpoint/s3/ops/index.js
+++ b/src/endpoint/s3/ops/index.js
@@ -39,6 +39,7 @@ exports.get_bucket_versions = require('./s3_get_bucket_versions');
 exports.get_bucket_website = require('./s3_get_bucket_website');
 exports.get_object = require('./s3_get_object');
 exports.get_object_acl = require('./s3_get_object_acl');
+exports.get_object_attributes = require('./s3_get_object_attributes');
 exports.get_object_legal_hold = require('./s3_get_object_legal_hold');
 exports.get_object_retention = require('./s3_get_object_retention');
 exports.get_object_tagging = require('./s3_get_object_tagging');

--- a/src/endpoint/s3/ops/s3_get_object_attributes.js
+++ b/src/endpoint/s3/ops/s3_get_object_attributes.js
@@ -1,0 +1,93 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const s3_utils = require('../s3_utils');
+const http_utils = require('../../../util/http_utils');
+const S3Error = require('../s3_errors').S3Error;
+
+/**
+ * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETacl.html
+ */
+async function get_object_attributes(req, res) {
+    const version_id = s3_utils.parse_version_id(req.query.versionId);
+    const encryption = s3_utils.parse_encryption(req);
+    const attributes = _parse_attributes(req);
+
+    const params = {
+        bucket: req.params.bucket,
+        key: req.params.key,
+        version_id: version_id,
+        encryption: encryption, // GAP - we don't use it currently
+        md_conditions: http_utils.get_md_conditions(req), // GAP - we don't use it currently in all namespaces (for example - not in NSFS)
+        attributes: attributes,
+    };
+    dbg.log2('params after parsing', params);
+    const reply = await req.object_sdk.get_object_attributes(params);
+    s3_utils.set_response_headers_get_object_attributes(req, res, reply, version_id);
+    return _make_reply_according_to_attributes(reply, attributes);
+}
+
+/**
+ * _parse_attributes parses the header in which the attributes are passed as tring with ',' as separator
+ * and returns array with the the attributes according to the valid attributes list (otherwise it throws an error)
+ * @param {nb.S3Request} req
+ * @returns {string[]}
+ */
+function _parse_attributes(req) {
+    const attributes_str = req.headers['x-amz-object-attributes'];
+    if (!attributes_str) {
+        dbg.error('get_object_attributes: must pass at least one attribute from:',
+            s3_utils.OBJECT_ATTRIBUTES);
+        throw new S3Error(S3Error.InvalidArgument);
+    }
+    const attributes = attributes_str.split(',').map(item => item.trim());
+    const all_valid = attributes.every(item => s3_utils.OBJECT_ATTRIBUTES.includes(item));
+    if (!all_valid) {
+        dbg.error('get_object_attributes: received attributes:', attributes,
+            'at least one of the attributes is not from:', s3_utils.OBJECT_ATTRIBUTES);
+        throw new S3Error(S3Error.InvalidArgument);
+    }
+    return attributes;
+}
+
+/**
+ * _make_reply_according_to_attributes currently the reply is md_object in most of the namespaces
+ * and we return the properties according to the attributes the client asked for
+ * @param {object} reply
+ * @param {object} attributes
+ * @returns {object}
+ */
+function _make_reply_according_to_attributes(reply, attributes) {
+    const reply_without_filter = {
+        ETag: `"${reply.etag}"`,
+        Checksum: reply.checksum,
+        ObjectParts: reply.object_parts,
+        StorageClass: reply.storage_class,
+        ObjectSize: reply.size
+    };
+    const filtered_reply = {
+        GetObjectAttributesOutput: {
+        }
+    };
+    for (const key of attributes) {
+        if (reply_without_filter[key] === undefined) {
+            dbg.warn('Requested for attributes', attributes,
+                'but currently NooBaa does not support these attributes:',
+                s3_utils.OBJECT_ATTRIBUTES_UNSUPPORTED, '(expect namespace s3)');
+        } else {
+            filtered_reply.GetObjectAttributesOutput[key] = reply_without_filter[key];
+        }
+    }
+    return filtered_reply;
+}
+
+module.exports = {
+    handler: get_object_attributes,
+    body: {
+        type: 'empty',
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/endpoint/s3/s3_bucket_policy_utils.js
+++ b/src/endpoint/s3/s3_bucket_policy_utils.js
@@ -45,6 +45,7 @@ const OP_NAME_TO_ACTION = Object.freeze({
     get_bucket_object_lock: { regular: "s3:GetBucketObjectLockConfiguration" },
     get_bucket: { regular: "s3:ListBucket" },
     get_object_acl: { regular: "s3:GetObjectAcl" },
+    get_object_attributes: { regular: ["s3:GetObject", "s3:GetObjectAttributes"], versioned: ["s3:GetObjectVersion", "s3:GetObjectVersionAttributes"] }, // Notice - special case
     get_object_tagging: { regular: "s3:GetObjectTagging", versioned: "s3:GetObjectVersionTagging" },
     get_object_uploadId: { regular: "s3:ListMultipartUploadParts" },
     get_object_retention: { regular: "s3:GetObjectRetention"},
@@ -139,11 +140,16 @@ async function _is_object_tag_fit(req, predicate, value) {
 async function has_bucket_policy_permission(policy, account, method, arn_path, req) {
     const [allow_statements, deny_statements] = _.partition(policy.Statement, statement => statement.Effect === 'Allow');
 
+    // the case where the permission is an array started in op get_object_attributes
+    const method_arr = Array.isArray(method) ? method : [method];
+
     // look for explicit denies
-    if (await _is_statements_fit(deny_statements, account, method, arn_path, req)) return 'DENY';
+    const res_arr_deny = await is_statement_fit_of_method_array(deny_statements, account, method_arr, arn_path, req);
+    if (res_arr_deny.every(item => item)) return 'DENY';
 
     // look for explicit allows
-    if (await _is_statements_fit(allow_statements, account, method, arn_path, req)) return 'ALLOW';
+    const res_arr_allow = await is_statement_fit_of_method_array(allow_statements, account, method_arr, arn_path, req);
+    if (res_arr_allow.every(item => item)) return 'ALLOW';
 
     // implicit deny
     return 'IMPLICIT_DENY';
@@ -156,6 +162,7 @@ function _is_action_fit(method, statement) {
         dbg.log1('bucket_policy: ', statement.Action ? 'Action' : 'NotAction', ' fit?', action, method);
         if ((action === '*') || (action === 's3:*') || (action === method)) {
             action_fit = true;
+            break;
         }
     }
     return statement.Action ? action_fit : !action_fit;
@@ -170,6 +177,7 @@ function _is_principal_fit(account, statement) {
         dbg.log1('bucket_policy: ', statement.Principal ? 'Principal' : 'NotPrincipal', ' fit?', principal, account);
         if ((principal.unwrap() === '*') || (principal.unwrap() === account)) {
             principal_fit = true;
+            break;
         }
     }
     return statement.Principal ? principal_fit : !principal_fit;
@@ -184,9 +192,15 @@ function _is_resource_fit(arn_path, statement) {
         dbg.log1('bucket_policy: ', statement.Resource ? 'Resource' : 'NotResource', ' fit?', resource_regex, arn_path);
         if (resource_regex.test(arn_path)) {
             resource_fit = true;
+            break;
         }
     }
     return statement.Resource ? resource_fit : !resource_fit;
+}
+
+async function is_statement_fit_of_method_array(statements, account, method_arr, arn_path, req) {
+    return Promise.all(method_arr.map(method_permission =>
+        _is_statements_fit(statements, account, method_permission, arn_path, req)));
 }
 
 async function _is_statements_fit(statements, account, method, arn_path, req) {
@@ -237,7 +251,7 @@ function _parse_condition_keys(condition_statement) {
 }
 
 async function validate_s3_policy(policy, bucket_name, get_account_handler) {
-    const all_op_names = _.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned]));
+    const all_op_names = _.flatten(_.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned])));
     for (const statement of policy.Statement) {
 
         const statement_principal = statement.Principal || statement.NotPrincipal;

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -57,6 +57,7 @@ const OBJECT_SUB_RESOURCES = Object.freeze({
     'legal-hold': 'legal_hold',
     'retention': 'retention',
     'select': 'select',
+    'attributes': 'attributes',
 });
 
 let usage_report = new_usage_report();
@@ -296,6 +297,11 @@ async function authorize_anonymous_access(s3_policy, method, arn_path, req) {
     throw new S3Error(S3Error.AccessDenied);
 }
 
+/**
+ * _get_method_from_req parses the permission needed according to the bucket policy
+ * @param {nb.S3Request} req
+ * @returns {string|string[]}
+ */
 function _get_method_from_req(req) {
     const s3_op = s3_bucket_policy_utils.OP_NAME_TO_ACTION[req.op_name];
     if (!s3_op) {

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2390,7 +2390,8 @@ class NamespaceFS {
         const etag = this._get_etag(stat);
         const create_time = stat.mtime.getTime();
         const encryption = this._get_encryption_info(stat);
-        const version_id = (this._is_versioning_enabled() || this._is_versioning_suspended()) && this._get_version_id_by_xattr(stat);
+        const version_id = ((this._is_versioning_enabled() || this._is_versioning_suspended()) && this._get_version_id_by_xattr(stat)) ||
+            undefined;
         const delete_marker = stat.xattr?.[XATTR_DELETE_MARKER] === 'true';
         const dir_content_type = stat.xattr?.[XATTR_DIR_CONTENT] && ((Number(stat.xattr?.[XATTR_DIR_CONTENT]) > 0 && 'application/octet-stream') || 'application/x-directory');
         const content_type = stat.xattr?.[XATTR_CONTENT_TYPE] ||

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -5,6 +5,7 @@ import * as mongodb from 'mongodb';
 import { EventEmitter } from 'events';
 import { Readable, Writable } from 'stream';
 import { IncomingMessage, ServerResponse } from 'http';
+import { ObjectPart, Checksum} from '@aws-sdk/client-s3';
 
 type Semaphore = import('../util/semaphore');
 type KeysSemaphore = import('../util/keys_semaphore');
@@ -439,6 +440,8 @@ interface ObjectInfo {
     ns?: Namespace;
     storage_class?: StorageClass;
     restore_status?: { ongoing?: boolean; expiry_time?: Date; };
+    checksum?: Checksum;
+    object_parts?: GetObjectAttributesParts;
 }
 
 
@@ -814,6 +817,7 @@ interface Namespace {
     get_blob_block_lists(params: object, object_sdk: ObjectSDK): Promise<any>;
 
     restore_object(params: object, object_sdk: ObjectSDK): Promise<any>;
+    get_object_attributes(params: object, object_sdk: ObjectSDK): Promise<any>;
 }
 
 interface BucketSpace {
@@ -1129,3 +1133,20 @@ interface RestoreStatus {
     ongoing?: boolean;
     expiry_time?: Date;
 }
+
+/**********************************************************
+ *
+ * OTHER - S3 Structure
+ *
+ **********************************************************/
+
+// Since the interface is a bit different between the SDKs
+// we couldn't import and reuse
+interface GetObjectAttributesParts {
+    TotalPartsCount?: number;
+    PartNumberMarker?: string; // in AWS SDK V2 it is number
+    NextPartNumberMarker?: string; // in AWS SDK V2 it is number
+    MaxParts?: number;
+    IsTruncated?: boolean;
+    Parts?: ObjectPart[];
+  }

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -1127,6 +1127,24 @@ class ObjectSDK {
         this._check_is_readonly_namespace(ns);
         return ns.put_object_acl(params, this);
     }
+
+    //////////////////////////
+    //  OBJECT ATTRIBUTES   //
+    //////////////////////////
+
+    async get_object_attributes(params) {
+        const ns = await this._get_bucket_namespace(params.bucket);
+        if (ns.get_object_attributes) {
+            return ns.get_object_attributes(params, this);
+          } else {
+            // fallback to calling get_object_md without attributes params
+            dbg.warn('namespace does not implement get_object_attributes action, fallback to read_object_md');
+            const md_params = { ...params };
+            delete md_params.attributes; // not part of the schema of read_object_md
+            return ns.read_object_md(md_params, this);
+          }
+    }
+
 }
 
 // EXPORT

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -777,7 +777,7 @@ async function read_node_mapping(req) {
  */
 async function read_object_md(req) {
     dbg.log1('object_server.read_object_md:', req.rpc_params);
-    const { bucket, key, md_conditions, adminfo, encryption } = req.rpc_params;
+    const { bucket, key, md_conditions, adminfo, encryption, version_id } = req.rpc_params;
 
     if (adminfo && req.role !== 'admin') {
         throw new RpcError('UNAUTHORIZED', 'read_object_md: role should be admin');
@@ -786,7 +786,8 @@ async function read_object_md(req) {
     const obj = await find_object_md(req);
 
     // Check if the requesting account is authorized to read the object
-    if (!await req.has_s3_bucket_permission(req.bucket, 's3:GetObject', '/' + obj.key)) {
+    const action = version_id ? 's3:GetObjectVersion' : 's3:GetObject';
+    if (!await req.has_s3_bucket_permission(req.bucket, action, '/' + obj.key)) {
         throw new RpcError('UNAUTHORIZED', 'requesting account is not authorized to read the object');
     }
 

--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -32,6 +32,7 @@ async function assert_throws_async(promise, expected_message = 'Access Denied') 
 }
 const BKT = 'test2-bucket-policy-ops';
 const BKT_B = 'test2-bucket-policy-ops-1';
+const BKT_C = 'test2-bucket-policy-ops-2';
 const KEY = 'file1.txt';
 const user_a = 'alice';
 const user_b = 'bob';
@@ -132,6 +133,7 @@ async function setup() {
     };
     s3_owner = new S3(s3_creds);
     await s3_owner.createBucket({ Bucket: BKT });
+    await s3_owner.createBucket({ Bucket: BKT_C });
     s3_anon = new S3({
         ...s3_creds,
         credentials: {
@@ -145,7 +147,7 @@ async function setup() {
     });
 }
 
-/*eslint max-lines-per-function: ["error", 1300]*/
+/*eslint max-lines-per-function: ["error", 1600]*/
 mocha.describe('s3_bucket_policy', function() {
     mocha.before(setup);
     mocha.it('should fail setting bucket policy when user doesn\'t exist', async function() {
@@ -582,6 +584,249 @@ mocha.describe('s3_bucket_policy', function() {
             Bucket: BKT,
             Key: new_key,
             VersionId: process.env.NC_CORETEST ? first_version_etag : 'nbver-' + (seq - 1)
+        });
+    });
+
+    mocha.describe('bucket policy on get object attributes', async function() {
+        const new_key = 'file105.txt';
+        const body = 'Some data for the file... bla bla bla...';
+
+        mocha.describe('bucket policy on get object attributes - versioning disabled', async function() {
+            mocha.before('put object', async function() {
+                await s3_owner.putObject({
+                    Body: body,
+                    Bucket: BKT_C,
+                    Key: new_key
+                });
+            });
+
+            mocha.after('delete object', async function() {
+                await s3_owner.deleteObject({
+                    Body: body,
+                    Bucket: BKT_C,
+                    Key: new_key
+                });
+            });
+
+            mocha.it('should be able to get object attributes when bucket policy permits - 1 statement (versioning disabled)', async function() {
+                const self = this; // eslint-disable-line no-invalid-this
+                self.timeout(15000);
+
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: 'id-1',
+                        Effect: 'Allow',
+                        Principal: { AWS: user_a },
+                        Action: ['s3:GetObject', 's3:GetObjectAttributes'],
+                        Resource: [`arn:aws:s3:::${BKT_C}/*`]
+                    }]
+                };
+                await s3_owner.putBucketPolicy({
+                    Bucket: BKT_C,
+                    Policy: JSON.stringify(policy)
+                });
+                await s3_a.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    ObjectAttributes: ['ObjectSize'],
+                });
+                await assert_throws_async(s3_b.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    ObjectAttributes: ['ObjectSize'],
+                }));
+            });
+
+            mocha.it('should be able to get object attributes when bucket policy permits - 2 statements (versioning disabled)', async function() {
+                const self = this; // eslint-disable-line no-invalid-this
+                self.timeout(15000);
+
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: 'id-1',
+                        Effect: 'Allow',
+                        Principal: { AWS: user_a },
+                        Action: ['s3:GetObject'],
+                        Resource: [`arn:aws:s3:::${BKT_C}/*`]
+                    },
+                    {
+                        Sid: 'id-1',
+                        Effect: 'Allow',
+                        Principal: { AWS: user_a },
+                        Action: ['s3:GetObjectAttributes'],
+                        Resource: [`arn:aws:s3:::${BKT_C}/*`]
+                    }]
+                };
+                await s3_owner.putBucketPolicy({
+                    Bucket: BKT_C,
+                    Policy: JSON.stringify(policy)
+                });
+                await s3_a.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    ObjectAttributes: ['ObjectSize'],
+                });
+                await assert_throws_async(s3_b.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    ObjectAttributes: ['ObjectSize'],
+                }));
+            });
+
+            mocha.it('should not be able to get object attributes when bucket policy permits - partial permissions (versioning disabled)', async function() {
+                const self = this; // eslint-disable-line no-invalid-this
+                self.timeout(15000);
+
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: 'id-1',
+                        Effect: 'Allow',
+                        Principal: { AWS: user_a },
+                        Action: ['s3:GetObject'], // missing 's3:GetObjectAttributes'
+                        Resource: [`arn:aws:s3:::${BKT_C}/*`]
+                    }]
+                };
+                await s3_owner.putBucketPolicy({
+                    Bucket: BKT_C,
+                    Policy: JSON.stringify(policy)
+                });
+                await assert_throws_async(s3_a.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    ObjectAttributes: ['ObjectSize'],
+                }));
+            });
+        });
+
+        mocha.describe('bucket policy on get object attributes - versioning enabled', async function() {
+            // currently the read_object in the object server is hard-coded on regular head object permission
+            // and not flexible to versioned way
+            let version_id;
+
+            mocha.before('put object', async function() {
+                await s3_owner.putBucketVersioning({
+                    Bucket: BKT_C,
+                    VersioningConfiguration: {
+                        MFADelete: 'Disabled',
+                        Status: 'Enabled'
+                    }
+                });
+
+                const res_put = await s3_owner.putObject({
+                    Body: body,
+                    Bucket: BKT_C,
+                    Key: new_key
+                });
+                version_id = res_put.VersionId;
+            });
+
+            mocha.after('delete object', async function() {
+                await s3_owner.deleteObject({
+                    Body: body,
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    VersionId: version_id
+                });
+            });
+
+            mocha.it('should be able to get object attributes when bucket policy permits - 1 statement (versioning enabled)', async function() {
+                const self = this; // eslint-disable-line no-invalid-this
+                self.timeout(15000);
+
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: 'id-1',
+                        Effect: 'Allow',
+                        Principal: { AWS: user_a },
+                        Action: ['s3:GetObjectVersion', 's3:GetObjectVersionAttributes'],
+                        Resource: [`arn:aws:s3:::${BKT_C}/*`]
+                    }]
+                };
+                await s3_owner.putBucketPolicy({
+                    Bucket: BKT_C,
+                    Policy: JSON.stringify(policy)
+                });
+                await s3_a.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    VersionId: version_id,
+                    ObjectAttributes: ['ETag'],
+                });
+                await assert_throws_async(s3_b.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    VersionId: version_id,
+                    ObjectAttributes: ['VersionId'],
+                }));
+            });
+
+            mocha.it('should be able to get object attributes when bucket policy permits - 2 statements (versioning enabled)', async function() {
+                const self = this; // eslint-disable-line no-invalid-this
+                self.timeout(15000);
+
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: 'id-1',
+                        Effect: 'Allow',
+                        Principal: { AWS: user_a },
+                        Action: ['s3:GetObjectVersion'],
+                        Resource: [`arn:aws:s3:::${BKT_C}/*`]
+                    },
+                    {
+                        Sid: 'id-1',
+                        Effect: 'Allow',
+                        Principal: { AWS: user_a },
+                        Action: ['s3:GetObjectVersionAttributes'],
+                        Resource: [`arn:aws:s3:::${BKT_C}/*`]
+                    }]
+                };
+                await s3_owner.putBucketPolicy({
+                    Bucket: BKT_C,
+                    Policy: JSON.stringify(policy)
+                });
+                await s3_a.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    VersionId: version_id,
+                    ObjectAttributes: ['ObjectSize'],
+                });
+                await assert_throws_async(s3_b.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    VersionId: version_id,
+                    ObjectAttributes: ['ObjectSize'],
+                }));
+            });
+
+            mocha.it('should not be able to get object attributes when bucket policy permits - partial permissions (versioning enabled)', async function() {
+                const self = this; // eslint-disable-line no-invalid-this
+                self.timeout(15000);
+
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: 'id-1',
+                        Effect: 'Allow',
+                        Principal: { AWS: user_a },
+                        Action: ['s3:GetObjectVersion'], // missing 's3:GetObjectVersionAttributes'
+                        Resource: [`arn:aws:s3:::${BKT_C}/*`]
+                    }]
+                };
+                await s3_owner.putBucketPolicy({
+                    Bucket: BKT_C,
+                    Policy: JSON.stringify(policy)
+                });
+                await assert_throws_async(s3_a.getObjectAttributes({
+                    Bucket: BKT_C,
+                    Key: new_key,
+                    ObjectAttributes: ['ObjectSize'],
+                }));
+            });
         });
     });
 

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -1312,6 +1312,29 @@ mocha.describe('s3_ops', function() {
             assert.equal(res_copy.$metadata.httpStatusCode, 200);
         });
 
+        mocha.it('should getObjectAttributes', async function() {
+            if (is_azure_mock) this.skip();
+            this.timeout(120000);
+            const key = 'HappyDay';
+            const body = 'hello_world';
+            await s3.putObject({
+                Bucket: bucket_name,
+                Key: key,
+                Body: body
+            });
+            const res = await s3.getObjectAttributes({
+                Bucket: bucket_name,
+                Key: key,
+                ObjectAttributes: ['ETag'],
+            });
+            assert.equal(res.$metadata.httpStatusCode, 200);
+            assert.ok(res.ETag !== undefined);
+            await s3.deleteObject({
+                Bucket: bucket_name,
+                Key: key,
+            });
+        });
+
         mocha.after(async function() {
             this.timeout(100000);
             if (bucket_type === "regular") {

--- a/src/upgrade/upgrade_scripts/5.15.6/upgrade_bucket_policy.js
+++ b/src/upgrade/upgrade_scripts/5.15.6/upgrade_bucket_policy.js
@@ -9,6 +9,11 @@ const _ = require('lodash');
 function _create_actions_map() {
     const actions_map = new Map();
     for (const action of Object.values(OP_NAME_TO_ACTION)) {
+        if (Array.isArray(action.regular)) {
+            // API's with array actions were added after version 5.15.z (e.g get_object_attributes)
+            // we skip this because there were no policies to fix
+            continue;
+        }
         actions_map.set(action.regular.toLowerCase(), action.regular);
         if (action.versioned) {
             actions_map.set(action.versioned.toLowerCase(), action.versioned);


### PR DESCRIPTION
### Explain the changes
1. Create the file `s3_get_object_attributes.js` and add the API in `src/endpoint/s3/ops/index.js` and `nb.d.ts` and `object_sdk.js` and the implementation in every namespace so it removes properties that are not in the schema of `read_object_md` and reuse it. In `s3_rest.js` add the `attributes` in `OBJECT_SUB_RESOURCES` (else it was using only GetObject instead).
2. In `s3_bucket_policy_utils.js` add the `get_object_attributes` permissions, since this is the first case where we have 2 permissions, it is an array and I changed the code to iterate an array (see function `is_statement_fit_of_method_array`). Therefore, had to add the `_.flatten` to ensure that the array that was added is also flattened. I also added to `s3_rest.js` a JSDoc to the function `_get_method_from_req` since it might be also an array and not just a string.
3. In `s3_bucket_policy_utils.js` add `break` in every loop where it is found true (since we do not need to continue after we found a match.
4. In `namespace_fs.js` in function `_get_object_info` add `|| undefined` in case there is no version-id the value won't be `false` but `undefined`.
5. In `src/upgrade/upgrade_scripts/5.15.6/upgrade_bucket_policy.js` do not use the `get_object_attributes` key in the map, as it harms the function `_create_actions_map`.
6. In `object_server.js` add the case for permission check where passing version-id.
7. In `namespace_s3` for using the function `_get_s3_object_info` added the properties `checksum` and `object_parts`, to add them had to add them in file `src/sdk/nb.d.ts` under the `interface ObjectInfo` and add the definitions from AWS SDK V3 (where there was a type change defined in the file itself).

### Issues: Fixed #8209
1. The suggested fix is to add "HeadObject" with the returned XML.

List of GAPs:
- Encryption is not internally used.
- Condition headers (`If-Match` and `If-Unmodified-Since`) were not tested specifically in this API (as they were copied from HeadObject), and are not used in all namespaces.
- In `object_server` there is a hard-coded check on the permission, it might be redundant today as we have in `s3_rest` permission check by the bucket policy (more details can be found in [this comment](https://github.com/noobaa/noobaa-core/pull/8418#discussion_r1799445241)). Note: the origin of it is from the `object_api` where we have `anonymous: true` and it appears in a few actions.
- Define all the headers that we work with as const.

### Testing Instructions:
#### Automatic Tests:
1. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_s3_bucket_policy.js -g 'bucket policy on get object attributes'`
2. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace_versioning.js`
3. `make run-single-test testname=test_s3_bucket_policy.js CONTAINER_PLATFORM=linux/arm64`
4. `make run-single-test testname=test_s3_ops.js CONTAINER_PLATFORM=linux/arm64` (currently, in a local run it shows 2 errors that are not directly related: (1) "before all" hook for "should tag text file": RestError: The API version 2024-08-04 is not supported by Azurite; (2) "after all" hook for "should getObjectAttributes": NoSuchBucket: The specified bucket does not exist (the bucket was copied from the previous test).

#### Manual Tests:
##### NC
**1) A basic test on a bucket with versioning disabled:**
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`, `chmod 777 /tmp/nsfs_root2`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
Notes: 
- I Change the `config.NSFS_CHECK_BUCKET_BOUNDARIES = false; //SDSD` because I’m using the `/tmp/` and not `/private/tmp/`.
3. Create the alias for S3 service:`alias nc-user-1-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443’`.
4. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-1-s3 s3 ls; echo $?`
5. Add bucket to the account using AWS CLI: `nc-user-1-s3 s3 mb s3://bucket-1` (`bucket-1` is the bucket name in this example)
6. Put an object: `nc-user-1-s3 s3api put-object --bucket bucket-1 --key hello.txt`
8. Get object attributes: `nc-user-1-s3 s3api get-object-attributes --bucket bucket-1 --key hello.txt --object-attributes "StorageClass" "ETag" "ObjectSize"`

**2) A basic test on a bucket with versioning enabled:**
9. Put bucket versioning Enabled: `nc-user-1-s3 s3api put-bucket-versioning --bucket bucket-1 --versioning-configuration Status=Enabled`
10. Put an object: `nc-user-1-s3 s3api put-object --bucket bucket-1 --key hello.txt` (save the version-id in the output)
11. Get object attributes with version-id: `nc-user-1-s3 s3api get-object-attributes --bucket bucket-1 --key hello.txt --version-id <version-id-from-previous-call>--object-attributes "StorageClass" "ETag" "ObjectSize"`

**3) A basic test on a bucket with bucket policy**
12. Create an additional account: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>` (same `uid` and `gid`).
13. Create the alias for S3 service:`alias nc-user-2-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443’`.
14. Add bucket policy: `nc-user-1-s3 s3api put-bucket-policy --bucket bucket-1 --policy file://policy.json`
policy.json:
```
{
  "Version": "2012-10-17",
  "Statement": [ 
    { 
     "Effect": "Allow", 
     "Principal": { "AWS": [ "<account-name-2>" ] }, 
     "Action": ["s3:GetObject", "s3:GetObjectAttributes"], 
     "Resource": [ "arn:aws:s3:::bucket-1/*", "arn:aws:s3:::bucket-1" ] 
    }
  ]
}
```
15. Call get object attributes (from account2): `nc-user-2-s3 s3api get-object-attributes --bucket bucket-1 --key hello.txt --object-attributes "StorageClass" "ETag" "ObjectSize"`
16. Add bucket policy (versioned): `nc-user-1-s3 s3api put-bucket-policy --bucket bucket-1 --policy file://policy2.json`
policy2.json:
```
{
  "Version": "2012-10-17",
  "Statement": [ 
    { 
     "Effect": "Allow", 
     "Principal": { "AWS": [ "<account-name-2>" ] }, 
     "Action": ["s3:GetObjectVersion", "s3:GetObjectVersionAttributes"], 
     "Resource": [ "arn:aws:s3:::bucket-1/*", "arn:aws:s3:::bucket-1" ] 
    }
  ]
}
```
17. Call get object attributes with version-d: `nc-user-2-s3 s3api get-object-attributes --bucket bucket-1 --key hello.txt --version-id <version-id-from-previous-call>--object-attributes "StorageClass" "ETag" "ObjectSize"`

**Containerized:**
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
3. I'm using port-forward (in a different tab): `kubectl port-forward -n test1 service/s3 12443:443`
**PV**
4. Create the alias for the admin - first, need to get the credentials: `nb status --show-secrets -n test1` and then `alias s3-nb-user-1='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
5. Check the connection to the endpoint and try to list the buckets (should have first.bucket): `s3-nb-user-1 s3 ls; echo $?`
6. Create the second account and create its alias: `nb account create user2 -n test1` and then `nb account status user2 -n test1 --show-secrets` for the credentials and then `alias s3-nb-user-2='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
7. Create a new bucket: `s3-nb-user-1 s3 mb s3://bucket1`
8. Add bucket versioning: `s3-nb-user-1 s3api put-bucket-versioning --bucket bucket1 --versioning-configuration Status=Enabled`
9. Put object: `s3-nb-user-1 s3api put-object --bucket bucket1 --key nice_day2` (save the version-id we will use it).
10. Check access to the new bucket by the new account (should be Access Denied): `s3-nb-user-2 s3 ls s3://bucket1`
11. Add bucket policy: `s3-nb-user-1 s3api put-bucket-policy --bucket bucket1 --policy file://policy.json`
policy.json:
```
{
  "Version": "2012-10-17",
  "Statement": [ 
    { 
     "Effect": "Allow", 
     "Principal": { "AWS": [ "user2" ] }, 
     "Action": ["s3:GetObject", "s3:GetObjectAttributes"], 
     "Resource": [ "arn:aws:s3:::bucket1/*", "arn:aws:s3:::bucket1" ] 
    }
  ]
}
```
12. Call get object attributes (from account2): `s3-nb-user-2 s3api get-object-attributes --bucket bucket1 --key nice_day2 --object-attributes "StorageClass" "ETag" "ObjectSize"`
13. Add bucket policy (versioned): `s3-nb-user-1 s3api put-bucket-policy --bucket bucket1 --policy file://policy2.json`
policy2.json:
```
{
  "Version": "2012-10-17",
  "Statement": [ 
    { 
     "Effect": "Allow", 
     "Principal": { "AWS": [ "user2" ] }, 
     "Action": ["s3:GetObjectVersion", "s3:GetObjectVersionAttributes"], 
     "Resource": [ "arn:aws:s3:::bucket1/*", "arn:aws:s3:::bucket1" ] 
    }
  ]
}
```
14. Call get object attributes with version-id: `s3-nb-user-2 s3api get-object-attributes --bucket bucket1 --key nice_day2 --version-id <version-id-from-previous-call> --object-attributes "StorageClass" "ETag" "ObjectSize"`
**namespace S3**
1. Create namespacestore type aws-s3: `nb namespacestore create aws-s3 ns-shira-aws -n test1`
2. Create bucketclass: `nb bucketclass create namespace-bucketclass single bc1 --resource=ns-shira-aws -n test1`
3. Create OBC: `nb obc create obc1 --bucketclass=bc1 -n test1`
4. Create the alias (credentials from the printed output): `alias alias s3-nb-user-3='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
5. Put object: `s3-nb-user-3 s3api put-object --bucket <obc-name> --key mimi`
6. Get objects attributes: `s3-nb-user-3 s3api get-object-attributes --bucket <obc-name> --key mimi --object-attributes "StorageClass" "ETag" "ObjectSize"`

- [X] Doc added/updated
- [X] Tests added
