### PR TITLE
NSFS : S3 rm with --recursive option does not delete all the objects

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nsfs_list_object.test.js
+++ b/src/test/unit_tests/jest_tests/test_nsfs_list_object.test.js
@@ -1,0 +1,227 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-disable no-undef */
+'use strict';
+const path = require('path');
+const fs_utils = require('../../../util/fs_utils');
+const { TMP_PATH } = require('../../system_tests/test_utils');
+const NamespaceFS = require('../../../sdk/namespace_fs');
+const buffer_utils = require('../../../util/buffer_utils');
+const tmp_ns_nsfs_path = path.join(TMP_PATH, 'test_nsfs_namespace_list');
+const nsfs_src_bkt = 'nsfs_src';
+const ns_nsfs_tmp_bucket_path = `${tmp_ns_nsfs_path}/${nsfs_src_bkt}`;
+const list_bkt = 'test_namespace_list_object';
+const timeout = 50000;
+const files_without_folders_to_upload = make_keys(264, i => `file_without_folder${i}`);
+const folders_to_upload = make_keys(264, i => `folder${i}/`);
+const files_in_folders_to_upload = make_keys(264, i => `folder1/file${i}`);
+const files_in_inner_folders_to_upload = make_keys(264, i => `folder1/inner_folder/file${i}`);
+const files_in_inner_backup_folders_to_upload = make_keys(264, i => `folder1/inner_folder.backup/file${i}`);
+const files_in_inner_all_backup_folders_to_upload = make_keys(264, i => `folder1/inner.folder.all.backup/file${i}`);
+const files_in_inner_all_folders_to_upload = make_keys(264, i => `folder1/inner_folder.all/file${i}`);
+const dummy_object_sdk = make_dummy_object_sdk();
+const ns_nsfs_tmp = new NamespaceFS({ bucket_path: ns_nsfs_tmp_bucket_path, bucket_id: '3', namespace_resource_id: undefined });
+let sorted_all_dir_entries;
+function make_dummy_object_sdk() {
+    return {
+        requesting_account: {
+            force_md5_etag: false,
+            nsfs_account_config: {
+                uid: process.getuid(),
+                gid: process.getgid(),
+            }
+        },
+        abort_controller: new AbortController(),
+        throw_if_aborted() {
+            if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        }
+    };
+}
+function sort_entries_by_name(a, b) {
+    if (a.replaceAll('/', ' ') < b.replaceAll('/', ' ')) return -1;
+    if (a.replaceAll('/', ' ') > b.replaceAll('/', ' ')) return 1;
+    return 0;
+}
+// eslint-disable-next-line max-lines-per-function
+describe('manage sorted list flow', () => {
+    describe('list objects - pagination', () => {
+        beforeAll(async () => {
+            await fs_utils.create_fresh_path(ns_nsfs_tmp_bucket_path);
+            await create_keys(list_bkt, ns_nsfs_tmp, [
+                ...files_without_folders_to_upload,
+                ...folders_to_upload,
+                ...files_in_folders_to_upload,
+                ...files_in_inner_folders_to_upload,
+                ...files_in_inner_backup_folders_to_upload,
+                ...files_in_inner_all_backup_folders_to_upload,
+                ...files_in_inner_all_folders_to_upload,
+            ]);
+            sorted_all_dir_entries = [
+                ...files_without_folders_to_upload,
+                ...folders_to_upload,
+                ...files_in_folders_to_upload,
+                ...files_in_inner_folders_to_upload,
+                ...files_in_inner_backup_folders_to_upload,
+                ...files_in_inner_all_backup_folders_to_upload,
+                ...files_in_inner_all_folders_to_upload,
+            ];
+            sorted_all_dir_entries.sort(sort_entries_by_name);
+        }, timeout);
+        afterAll(async function() {
+            await delete_keys(list_bkt, ns_nsfs_tmp, [
+                ...folders_to_upload,
+                ...files_in_folders_to_upload,
+                ...files_without_folders_to_upload,
+                ...files_in_inner_folders_to_upload,
+                ...files_in_inner_backup_folders_to_upload,
+                ...files_in_inner_all_backup_folders_to_upload,
+                ...files_in_inner_all_folders_to_upload,
+            ]);
+            await fs_utils.folder_delete(`${ns_nsfs_tmp_bucket_path}`);
+        });
+        it('page=1000', async () => {
+            let r;
+            let total_items = 0;
+            let object_item_start_index = 0;
+            for (;;) {
+                r = await ns_nsfs_tmp.list_objects({
+                    bucket: list_bkt,
+                    key_marker: r ? r.next_marker : "",
+                }, dummy_object_sdk);
+                object_item_start_index = total_items;
+                total_items += r.objects.length;
+                await validat_pagination(r, total_items, object_item_start_index);
+                if (!r.next_marker) {
+                    break;
+                }
+            }
+        }, timeout);
+        it('page=500', async () => {
+            let r;
+            let total_items = 0;
+            let object_item_start_index = 0;
+            for (;;) {
+                r = await ns_nsfs_tmp.list_objects({
+                    bucket: list_bkt,
+                    limit: 500,
+                    key_marker: r ? r.next_marker : "",
+                }, dummy_object_sdk);
+                object_item_start_index = total_items;
+                total_items += r.objects.length;
+                await validat_pagination(r, total_items, object_item_start_index);
+                if (!r.next_marker) {
+                    break;
+                }
+            }
+        }, timeout);
+        it('page=264', async () => {
+            let r;
+            let total_items = 0;
+            let object_item_start_index = 0;
+            for (;;) {
+                r = await ns_nsfs_tmp.list_objects({
+                    bucket: list_bkt,
+                    limit: 264,
+                    key_marker: r ? r.next_marker : "",
+                }, dummy_object_sdk);
+                object_item_start_index = total_items;
+                total_items += r.objects.length;
+                await validat_pagination(r, total_items, object_item_start_index);
+                if (!r.next_marker) {
+                    break;
+                }
+            }
+        }, timeout);
+        it('page=250', async () => {
+            let r;
+            let total_items = 0;
+            let object_item_start_index = 0;
+            for (;;) {
+                r = await ns_nsfs_tmp.list_objects({
+                    bucket: list_bkt,
+                    limit: 250,
+                    key_marker: r ? r.next_marker : "",
+                }, dummy_object_sdk);
+                object_item_start_index = total_items;
+                total_items += r.objects.length;
+                await validat_pagination(r, total_items, object_item_start_index);
+                if (!r.next_marker) {
+                    break;
+                }
+            }
+        }, timeout);
+        it('page=100', async () => {
+            let r;
+            let total_items = 0;
+            let object_item_start_index = 0;
+            for (;;) {
+                r = await ns_nsfs_tmp.list_objects({
+                    bucket: list_bkt,
+                    limit: 100,
+                    key_marker: r ? r.next_marker : "",
+                }, dummy_object_sdk);
+                object_item_start_index = total_items;
+                total_items += r.objects.length;
+                await validat_pagination(r, total_items, object_item_start_index);
+                if (!r.next_marker) {
+                    break;
+                }
+            }
+        }, timeout);
+        it('page=10', async () => {
+            let r;
+            let total_items = 0;
+            let object_item_start_index = 0;
+            for (;;) {
+                r = await ns_nsfs_tmp.list_objects({
+                    bucket: list_bkt,
+                    limit: 10,
+                    key_marker: r ? r.next_marker : "",
+                }, dummy_object_sdk);
+                object_item_start_index = total_items;
+                total_items += r.objects.length;
+                await validat_pagination(r, total_items, object_item_start_index);
+                if (!r.next_marker) {
+                    break;
+                }
+            }
+        }, timeout);
+    });
+});
+async function validat_pagination(r, total_items, object_item_start_index) {
+    if (r.next_marker) {
+        expect(r.is_truncated).toStrictEqual(true);
+        expect(r.objects.map(it => it.key)).toEqual(sorted_all_dir_entries.slice(object_item_start_index, total_items));
+    } else {
+        expect(total_items).toEqual(1848);
+        expect(r.is_truncated).toStrictEqual(false);
+    }
+}
+/**
+ * @param {number} count
+ * @param {(i:number)=>string} gen
+ * @returns {string[]}
+ */
+function make_keys(count, gen) {
+    const arr = new Array(count);
+    for (let i = 0; i < count; ++i) arr[i] = gen(i);
+    arr.sort();
+    Object.freeze(arr);
+    return arr;
+}
+async function delete_keys(bkt, nsfs_delete_tmp, keys) {
+    await nsfs_delete_tmp.delete_multiple_objects({
+        bucket: bkt,
+        objects: keys.map(key => ({ key })),
+    }, dummy_object_sdk);
+}
+async function create_keys(bkt, nsfs_create_tmp, keys) {
+    return Promise.all(keys.map(async key => {
+        await nsfs_create_tmp.upload_object({
+            bucket: bkt,
+            key,
+            content_type: 'application/octet-stream',
+            source_stream: buffer_utils.buffer_to_read_stream(null),
+            size: 0
+        }, dummy_object_sdk);
+    }));
+}

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -142,19 +142,27 @@ mocha.describe('namespace_fs', function() {
 
         function assert_sorted_list(res) {
             let prev_key = '';
+            const regex = /[^A-Za-z0-9]/;
             for (const { key } of res.objects) {
                 if (res.next_marker) {
                     assert(key <= res.next_marker, 'bad next_marker at key ' + key);
                 }
-                assert(prev_key <= key, 'objects not sorted at key ' + key);
+                // String comparison will fail when with special character and backslash cases, 
+                // Where special characters such as dot, hyphen are listed before backslash in sorted list.
+                // compare string only if key contains no special characters 
+                if (!regex.test(key)) {
+                    assert(prev_key <= key, 'objects not sorted at key ' + key + " prev_key: " + prev_key);
+                }
                 prev_key = key;
             }
-            prev_key = '';
             for (const key of res.common_prefixes) {
                 if (res.next_marker) {
                     assert(key <= res.next_marker, 'next_marker at key ' + key);
                 }
-                assert(prev_key <= key, 'prefixes not sorted at key ' + key);
+
+                if (!regex.test(key)) {
+                    assert(prev_key <= key, 'prefixes not sorted at key ' + key + " prev_key: " + prev_key);
+                }
                 prev_key = key;
             }
         }

--- a/src/util/js_utils.js
+++ b/src/util/js_utils.js
@@ -237,6 +237,31 @@ function omit_symbol(maybe_obj, sym) {
     return _.omit(obj, sym);
 }
 
+/**
+ * sortedLastIndexBy is like lodash's sortedLastIndexBy except that
+ * instead of taking a iteratee, it takes a function `less` which should
+ * return `true` when `curr < value`.
+ * @template T
+ * @param {Array<T>} array 
+ * @param {(curr: T) => Boolean} less 
+ * @returns 
+ */
+function sortedLastIndexBy(array, less) {
+    let low = 0;
+    let high = array === null ? low : array.length;
+
+    while (low < high) {
+        const mid = Math.floor(low + ((high - low) / 2));
+        if (less(array[mid])) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+
+    return high;
+}
+
 exports.self_bind = self_bind;
 exports.array_push_all = array_push_all;
 exports.array_push_keep_latest = array_push_keep_latest;
@@ -250,3 +275,4 @@ exports.inspect_lazy = inspect_lazy;
 exports.make_array = make_array;
 exports.map_get_or_create = map_get_or_create;
 exports.omit_symbol = omit_symbol;
+exports.sortedLastIndexBy = sortedLastIndexBy;


### PR DESCRIPTION
### Explain the changes
1. Issue is with list_object api, list_object is failing with specific dir strucute and not returning complete items in that bucket. 
2. dir_key and marker_dir comparison will fail when there are dir with structure slimier to  "-/migrateDir.popFSDir.3803140/" and "/migrateDir.popFSDir.3803140.OldSet/" because "/" considered greater than "."  to fix this all the backslash is replaced with space. This updated marker and dir_key used only for comparison.

Dir structure like this is will fail
> /populatefs_dir
  --/migrateDir.popFSDir.3803140
  ----/sparseDir
   -----lnk.0.qqqqqqqqqqqqqq
   -----lnk.1.qqqqqqqqqqqqqq
   -----lnk.2.qqqqqqqqqqqqqq
--/migrateDir.popFSDir.3803140.OldSet
 ----/sparseDir
  -----lnk.0.qqqqqqqqqqqqqq
  -----lnk.1.qqqqqqqqqqqqqq
  -----lnk.2.qqqqqqqqqqqqqq
    

### Issues: Fixed #xxx / Gap #xxx

1. S3 upload is successful for a data set (mix of all type of objects, sparse files, files with long name, compressed files etc)
2.  When download via "aws-alias s3 rm s3://bucket-10909 --recursive" , this still displays the left over directories and objects in the bucket. I checked from the FS that the dataset still exists there.

https://github.com/noobaa/noobaa-core/issues/8197

closed : PR https://github.com/noobaa/noobaa-core/pull/8317

### Testing Instructions:
1. run NC_CORETEST=true node  ./node_modules/.bin/mocha ./src/test/unit_tests/test_namespace_fs.js


- [ ] Doc added/updated
- [ ] Tests added
