### PR TITLE
NSFS | Object Version when trying to delete, logs a WARN message

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2740,7 +2740,7 @@ class NamespaceFS {
             };
         } catch (err) {
             if (err.code !== 'ENOENT') throw err;
-            dbg.warn(`NamespaceFS._get_version_info version of ${version_path} doesn't exist`, err);
+            dbg.log1(`NamespaceFS._get_version_info version of ${version_path} doesn't exist`, err);
         }
         // if stat failed, undefined will return
     }


### PR DESCRIPTION
### Explain the changes
1. change warning to debug log when version path is missing

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8415

### Testing Instructions:
1. enable versioning on the bucket
2. upload the objects
3. delete the objects
4. check the logs
warning `NamespaceFS._get_version_info version of ${version_path} doesn't exist` should be removed from logs




- [ ] Doc added/updated
- [ ] Tests added
