### PR TITLE
fixed get lifecycle conf to support all possible fields

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -211,6 +211,9 @@ module.exports = {
                 filter: {
                     $ref: '#/definitions/bucket_lifecycle_rule_filter'
                 },
+                uses_prefix: {
+                    type: 'boolean'
+                },
                 expiration: {
                     $ref: '#/definitions/bucket_lifecycle_rule_expiration'
                 },
@@ -1359,7 +1362,9 @@ module.exports = {
 
         storage_class_enum: {
             type: 'string',
-            enum: ['STANDARD', 'GLACIER', 'GLACIER_IR']
+            // added values according to the docs here:
+            // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-noncurrentversiontransition.html#cfn-s3-bucket-noncurrentversiontransition-storageclass
+            enum: ['STANDARD', 'GLACIER', 'GLACIER_IR', 'Glacier', 'DEEP_ARCHIVE', 'INTELLIGENT_TIERING', 'ONEZONE_IA', 'STANDARD_IA']
         },
         bucket_logging: {
             type: 'object',

--- a/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
@@ -99,6 +99,7 @@ async function put_bucket_lifecycle(req) {
                 throw new S3Error(S3Error.InvalidArgument);
             }
             current_rule.filter.prefix = rule.Prefix[0];
+            current_rule.uses_prefix = true;
 
         } else {
             if (rule.Filter?.length !== 1) {

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -195,6 +195,219 @@ mocha.describe('s3_ops', function() {
             // cleanup
             await rpc_client.account.delete_account({ email: "obc-account@noobaa.io" });
         });
+
+
+        mocha.describe('bucket-lifecycle', function() {
+
+            mocha.before(async function() {
+                await s3.createBucket({ Bucket: "lifecycle-bucket" });
+            });
+
+            mocha.it('should put and get bucket lifecycle with Prefix', async function() {
+
+                // put bucket lifecycle
+                const params = {
+                    Bucket: "lifecycle-bucket",
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'rule1',
+                            Status: 'Enabled',
+                            Prefix: 'prefix1-prefix',
+                            Expiration: {
+                                Days: 1
+                            }
+                        }]
+                    }
+                };
+                await s3.putBucketLifecycleConfiguration(params);
+
+                // get` bucket lifecycle
+                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
+                assert.strictEqual(res.Rules.length, 1);
+                assert.strictEqual(res.Rules[0].ID, 'rule1');
+                assert.strictEqual(res.Rules[0].Status, 'Enabled');
+                assert.strictEqual(res.Rules[0].Prefix, 'prefix1-prefix');
+                assert.strictEqual(res.Rules[0].Expiration.Days, 1);
+            });
+
+            mocha.it('should put and get bucket lifecycle with Filter', async function() {
+                // put bucket lifecycle
+                const params = {
+                    Bucket: "lifecycle-bucket",
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'rule1',
+                            Status: 'Enabled',
+                            Filter: {
+                                And: {
+                                    Prefix: 'prefix1',
+                                    Tags: [{
+                                        Key: 'key1',
+                                        Value: 'value1'
+                                    }]
+                                }
+                            },
+                            Expiration: {
+                                Days: 1
+                            }
+                        }]
+                    }
+                };
+                await s3.putBucketLifecycleConfiguration(params);
+
+                // get bucket lifecycle
+                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
+                assert.strictEqual(res.Rules.length, 1);
+                assert.strictEqual(res.Rules[0].ID, 'rule1');
+                assert.strictEqual(res.Rules[0].Status, 'Enabled');
+                assert.strictEqual(res.Rules[0].Filter.And.Prefix, 'prefix1');
+                assert.strictEqual(res.Rules[0].Filter.And.Tags[0].Key, 'key1');
+                assert.strictEqual(res.Rules[0].Filter.And.Tags[0].Value, 'value1');
+                assert.strictEqual(res.Rules[0].Expiration.Days, 1);
+            });
+
+            mocha.it('should put and get bucket lifecycle with Transitions', async function() {
+                // put bucket lifecycle
+                const params = {
+                    Bucket: "lifecycle-bucket",
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'rule1',
+                            Status: 'Enabled',
+                            Prefix: 'prefix1-transition',
+                            Transitions: [{
+                                Days: 1,
+                                StorageClass: 'STANDARD_IA'
+                            }]
+                        }]
+                    }
+                };
+                await s3.putBucketLifecycleConfiguration(params);
+
+                // get bucket lifecycle
+                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
+                assert.strictEqual(res.Rules.length, 1);
+                assert.strictEqual(res.Rules[0].ID, 'rule1');
+                assert.strictEqual(res.Rules[0].Status, 'Enabled');
+                assert.strictEqual(res.Rules[0].Prefix, 'prefix1-transition');
+                assert.strictEqual(res.Rules[0].Transitions[0].Days, 1);
+                assert.strictEqual(res.Rules[0].Transitions[0].StorageClass, 'STANDARD_IA');
+            });
+
+            mocha.it('should put and get bucket lifecycle with NoncurrentVersionTransition', async function() {
+                // put bucket lifecycle
+                const params = {
+                    Bucket: "lifecycle-bucket",
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'rule1',
+                            Status: 'Enabled',
+                            Prefix: 'prefix1-noncurrent-version-transition',
+                            NoncurrentVersionTransitions: [{
+                                NoncurrentDays: 1,
+                                StorageClass: 'STANDARD_IA'
+                            }]
+                        }]
+                    }
+                };
+                await s3.putBucketLifecycleConfiguration(params);
+
+                // get bucket lifecycle
+                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
+                assert.strictEqual(res.Rules.length, 1);
+                assert.strictEqual(res.Rules[0].ID, 'rule1');
+                assert.strictEqual(res.Rules[0].Status, 'Enabled');
+                assert.strictEqual(res.Rules[0].Prefix, 'prefix1-noncurrent-version-transition');
+                assert.strictEqual(res.Rules[0].NoncurrentVersionTransitions[0].NoncurrentDays, 1);
+                assert.strictEqual(res.Rules[0].NoncurrentVersionTransitions[0].StorageClass, 'STANDARD_IA');
+            });
+
+            mocha.it('should put and get bucket lifecycle with AbortIncompleteMultipartUpload', async function() {
+                // put bucket lifecycle
+                const params = {
+                    Bucket: "lifecycle-bucket",
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'rule1',
+                            Status: 'Enabled',
+                            Prefix: 'prefix1-abort-incomplete',
+                            AbortIncompleteMultipartUpload: {
+                                DaysAfterInitiation: 1
+                            }
+                        }]
+                    }
+                };
+                await s3.putBucketLifecycleConfiguration(params);
+
+                // get bucket lifecycle
+                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
+                assert.strictEqual(res.Rules.length, 1);
+                assert.strictEqual(res.Rules[0].ID, 'rule1');
+                assert.strictEqual(res.Rules[0].Status, 'Enabled');
+                assert.strictEqual(res.Rules[0].Prefix, 'prefix1-abort-incomplete');
+                assert.strictEqual(res.Rules[0].AbortIncompleteMultipartUpload.DaysAfterInitiation, 1);
+
+            });
+
+            mocha.it('should put and get bucket lifecycle with Expiration', async function() {
+                // put bucket lifecycle
+                const params = {
+                    Bucket: "lifecycle-bucket",
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'rule1',
+                            Status: 'Enabled',
+                            Prefix: 'prefix1-expiration',
+                            Expiration: {
+                                Days: 1
+                            }
+                        }]
+                    }
+                };
+                await s3.putBucketLifecycleConfiguration(params);
+
+                // get bucket lifecycle
+                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
+                assert.strictEqual(res.Rules.length, 1);
+                assert.strictEqual(res.Rules[0].ID, 'rule1');
+                assert.strictEqual(res.Rules[0].Status, 'Enabled');
+                assert.strictEqual(res.Rules[0].Prefix, 'prefix1-expiration');
+                assert.strictEqual(res.Rules[0].Expiration.Days, 1);
+            });
+
+            mocha.it('should put and get bucket lifecycle with NoncurrentVersionExpiration', async function() {
+                // put bucket lifecycle
+                const params = {
+                    Bucket: "lifecycle-bucket",
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'rule1',
+                            Status: 'Enabled',
+                            Filter: {
+                                Prefix: 'prefix1-noncurrent-version-expiration'
+                            },
+                            NoncurrentVersionExpiration: {
+                                NoncurrentDays: 1
+                            }
+                        }]
+                    }
+                };
+                await s3.putBucketLifecycleConfiguration(params);
+
+                // get bucket lifecycle
+                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
+                assert.strictEqual(res.Rules.length, 1);
+                assert.strictEqual(res.Rules[0].ID, 'rule1');
+                assert.strictEqual(res.Rules[0].Status, 'Enabled');
+                assert.strictEqual(res.Rules[0].Filter.Prefix, 'prefix1-noncurrent-version-expiration');
+                assert.strictEqual(res.Rules[0].NoncurrentVersionExpiration.NoncurrentDays, 1);
+            });
+
+            mocha.after(async function() {
+                await s3.deleteBucket({ Bucket: "lifecycle-bucket" });
+            });
+
+        });
     });
 
     async function test_object_ops(bucket_name, bucket_type, caching, remote_endpoint_options) {


### PR DESCRIPTION
### Explain the changes
1. In PR #8432, we added the ability to store more lifecycle actions, but `s3_get_bucket_lifecycle` was not updated to support these fields, so they are not returned in get.
2. In addition, in the previous implementation, the expiration field was required, but now it is not. if it doesn't exist, than an error is returned on get.
3. Also, added a flag to indicate that `Prefix` was used in the rule, so we can return it as such and not in the filter.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
