### PR TITLE
NSFS | versioning | use linkat in gpfs safe_link to not override existing versions

### DIFF
--- a/.github/workflows/jest-unit-tests.yaml
+++ b/.github/workflows/jest-unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Run Jest Unit Test
         run: |
-          sudo apt-get -y install nasm
+          sudo apt-get -y install nasm libcap-dev
           npm install
           npm run build
           npm run jest

--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -21,7 +21,7 @@ RUN dnf update -y -q --nobest && \
 COPY ./src/deploy/NVA_build/install_arrow_build.sh ./src/deploy/NVA_build/install_arrow_build.sh
 ARG BUILD_S3SELECT_PARQUET=0
 RUN ./src/deploy/NVA_build/install_arrow_build.sh $BUILD_S3SELECT_PARQUET
-RUN dnf install -y -q wget unzip which vim python3 boost-devel && \
+RUN dnf install -y -q wget unzip which vim python3 boost-devel libcap-devel && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
 RUN version="2.15.05" && \

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -30,6 +30,7 @@ BuildRequires:  python3
 BuildRequires:  make
 BuildRequires:  gcc-c++
 BuildRequires:  boost-devel
+BuildRequires:  libcap-devel
 
 Recommends:     jemalloc
 

--- a/src/native/common.gypi
+++ b/src/native/common.gypi
@@ -40,6 +40,7 @@
                 ],
                 'ldflags': [
                     '-lrt', # librt
+                    '-lcap',
                 ],
             }],
 

--- a/src/native/util/os.h
+++ b/src/native/util/os.h
@@ -38,6 +38,8 @@ public:
         change_user();
     }
 
+    int add_thread_capabilities();
+
     const static uid_t orig_uid;
     const static gid_t orig_gid;
     const static std::vector<gid_t> orig_groups;

--- a/src/native/util/os_darwin.cpp
+++ b/src/native/util/os_darwin.cpp
@@ -54,6 +54,14 @@ ThreadScope::restore_user()
     }
 }
 
+int
+ThreadScope::add_thread_capabilities()
+{
+    //set capabilities not used in darwin
+    LOG("function set_capabilities_linkat is unsupported in darwin");
+    return -1;
+}
+
 } // namespace noobaa
 
 #endif

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -1000,7 +1000,7 @@ interface NativeFile {
     write(fs_context: NativeFSContext, buffer: Buffer, len: number, offset?: number): Promise<void>;
     writev(fs_context: NativeFSContext, buffers: Buffer[], offset?: number): Promise<void>;
     replacexattr(fs_context: NativeFSContext, xattr: NativeFSXattr, clear_prefix?: string): Promise<void>;
-    linkfileat(fs_context: NativeFSContext, path: string, fd?: number): Promise<void>;
+    linkfileat(fs_context: NativeFSContext, path: string, fd?: number, should_not_override?: boolean): Promise<void>;
     fsync(fs_context: NativeFSContext): Promise<void>;
     fd: number;
     flock(fs_context: NativeFSContext, operation: "EXCLUSIVE" | "SHARED" | "UNLOCK"): Promise<void>;

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
@@ -128,7 +128,6 @@ s3tests_boto3/functional/test_s3.py::test_object_copy_canned_acl
 s3tests_boto3/functional/test_s3.py::test_multipart_upload_missing_part
 s3tests_boto3/functional/test_s3.py::test_multipart_upload_incorrect_etag
 s3tests_boto3/functional/test_s3.py::test_atomic_dual_conditional_write_1mb
-s3tests_boto3/functional/test_s3.py::test_versioned_concurrent_object_create_concurrent_remove
 s3tests_boto3/functional/test_s3.py::test_encrypted_transfer_1b
 s3tests_boto3/functional/test_s3.py::test_encrypted_transfer_1kb
 s3tests_boto3/functional/test_s3.py::test_encrypted_transfer_1MB

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -167,7 +167,7 @@ function _is_gpfs(fs_context) {
 
 async function safe_move(fs_context, src_path, dst_path, src_ver_info, gpfs_options, tmp_dir_path) {
     if (_is_gpfs(fs_context)) {
-        await safe_move_gpfs(fs_context, src_path, dst_path, gpfs_options, src_ver_info);
+        await safe_move_gpfs(fs_context, src_path, dst_path, gpfs_options);
     } else {
         await safe_move_posix(fs_context, src_path, dst_path, src_ver_info, tmp_dir_path);
     }
@@ -199,15 +199,10 @@ async function safe_move_posix(fs_context, src_path, dst_path, src_ver_info, tmp
 // safe_link_posix links src_path to dst_path while verifing dst_path has the expected ino and mtimeNsBigint values
 // src_file exists on uploads (open mode = 'w' ) or deletions
 // on uploads (open mode 'wt') the dir_file is used as the link source
-async function safe_move_gpfs(fs_context, src_path, dst_path, gpfs_options, src_ver_info) {
-    const { src_file = undefined, dst_file = undefined, dir_file = undefined, should_unlink = false,
-        should_override = true } = gpfs_options;
+async function safe_move_gpfs(fs_context, src_path, dst_path, gpfs_options) {
+    const { src_file = undefined, dst_file = undefined, dir_file = undefined, should_unlink = false } = gpfs_options;
     dbg.log1('Namespace_fs.safe_move_gpfs', src_path, dst_path, dst_file, should_unlink);
-    if (should_override) {
-        await safe_link_gpfs(fs_context, dst_path, src_file || dir_file, dst_file);
-    } else {
-        await safe_link_posix(fs_context, src_path, dst_path, src_ver_info);
-    }
+    await safe_link_gpfs(fs_context, dst_path, src_file || dir_file, dst_file);
     if (should_unlink) await safe_unlink_gpfs(fs_context, src_path, src_file, dir_file);
 }
 
@@ -253,8 +248,9 @@ async function unlink_ignore_enoent(fs_context, to_delete_path) {
 
 // safe_link_gpfs links source_path to dest_path while verifing dest.fd
 async function safe_link_gpfs(fs_context, dst_path, src_file, dst_file) {
-    dbg.log1('Namespace_fs.safe_link_gpfs source_file:', src_file, src_file.fd, dst_file, dst_file && dst_file.fd);
-    await src_file.linkfileat(fs_context, dst_path, dst_file && dst_file.fd);
+    const should_not_override = !(dst_file && dst_file.fd);
+    dbg.log1('Namespace_fs.safe_link_gpfs source_file:', src_file, src_file.fd, dst_file, dst_file && dst_file.fd, should_not_override);
+    await src_file.linkfileat(fs_context, dst_path, dst_file && dst_file.fd, should_not_override);
 }
 
 // safe_unlink_gpfs unlinks to_delete_path while verifing to_delete_path.fd


### PR DESCRIPTION

### Explain the changes
1. add option to fail if target file exist in gpfs linkat function using posix linkat
2. add CAP_DAC_READ_SEARCH capability when changing uid/gid so user to permit use of linkat for non-root user (see ENOENT in  https://man7.org/linux/man-pages/man2/link.2.html)
3. get latest version from fd opened using open_files_gpfs rather then from path to avoid concurrency issues with mismatch version between the version we got and the actual version of the file. change open_gpfs to not use version_id

### Issues: Fixed #xxx / Gap #xxx

### Testing Instructions:
1. on gpfs machine run: `GPFS_ROOT_PATH=/ibm/fs1/tmp multiple puts of the same key'`
2. run following ceph_test: `S3TEST_CONF=s3tests3.conf tox -- s3tests_boto3/functional/test_s3.py::test_versioned_concurrent_object_create_concurrent_remove`


- [ ] Doc added/updated
- [ ] Tests added
