### PR TITLE
NSFS | NC | GPFS | modify versioning tests to work with GPFS

### DIFF
--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -15,11 +15,25 @@ const { CONFIG_TYPES } = require('../../sdk/config_fs');
 const native_fs_utils = require('../../util/native_fs_utils');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
 
+const GPFS_ROOT_PATH = process.env.GPFS_ROOT_PATH;
+const IS_GPFS = !_.isUndefined(GPFS_ROOT_PATH);
+const TMP_PATH = get_tmp_path();
+
 /**
  * TMP_PATH is a path to the tmp path based on the process platform
  * in contrast to linux, /tmp/ path on mac is a symlink to /private/tmp/
+ * on gpfs should point to GPFS file system. should create tmp dir on file system and pass it as process.env.GPFS_ROOT_PATH
  */
-const TMP_PATH = os_utils.IS_MAC ? '/private/tmp/' : '/tmp/';
+function get_tmp_path() {
+    if (os_utils.IS_MAC) {
+        return '/private/tmp/';
+    } else if (IS_GPFS) {
+        return GPFS_ROOT_PATH;
+    } else {
+        return '/tmp/';
+    }
+}
+
 
 /**
  * is_nc_coretest returns true when the test runs on NC env
@@ -606,6 +620,7 @@ exports.set_path_permissions_and_owner = set_path_permissions_and_owner;
 exports.set_nc_config_dir_in_config = set_nc_config_dir_in_config;
 exports.generate_anon_s3_client = generate_anon_s3_client;
 exports.TMP_PATH = TMP_PATH;
+exports.IS_GPFS = IS_GPFS;
 exports.is_nc_coretest = is_nc_coretest;
 exports.generate_nsfs_account = generate_nsfs_account;
 exports.get_new_buckets_path_by_test_env = get_new_buckets_path_by_test_env;

--- a/src/test/unit_tests/jest_tests/test_versioning_concurrency.test.js
+++ b/src/test/unit_tests/jest_tests/test_versioning_concurrency.test.js
@@ -7,7 +7,7 @@ const P = require('../../../util/promise');
 const fs_utils = require('../../../util/fs_utils');
 const NamespaceFS = require('../../../sdk/namespace_fs');
 const buffer_utils = require('../../../util/buffer_utils');
-const { TMP_PATH } = require('../../system_tests/test_utils');
+const { TMP_PATH, IS_GPFS } = require('../../system_tests/test_utils');
 const { crypto_random_string } = require('../../../util/string_utils');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
 const SECONDS = 1000;
@@ -19,7 +19,7 @@ function make_dummy_object_sdk(nsfs_config, uid, gid) {
             nsfs_account_config: nsfs_config && {
                 uid: uid || process.getuid(),
                 gid: gid || process.getgid(),
-                backend: '',
+                backend: IS_GPFS ? 'GPFS' : '',
             }
         },
         abort_controller: new AbortController(),

--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -12,7 +12,7 @@ const P = require('../../util/promise');
 const fs_utils = require('../../util/fs_utils');
 const nb_native = require('../../util/nb_native');
 const size_utils = require('../../util/size_utils');
-const { TMP_PATH, is_nc_coretest, set_path_permissions_and_owner, generate_nsfs_account, get_new_buckets_path_by_test_env,
+const { TMP_PATH, IS_GPFS, is_nc_coretest, set_path_permissions_and_owner, generate_nsfs_account, get_new_buckets_path_by_test_env,
     invalid_nsfs_root_permissions, generate_s3_client, get_coretest_path } = require('../system_tests/test_utils');
 const { get_process_fs_context } = require('../../util/native_fs_utils');
 
@@ -27,7 +27,7 @@ const XATTR_DELETE_MARKER = XATTR_INTERNAL_NOOBAA_PREFIX + 'delete_marker';
 const NULL_VERSION_ID = 'null';
 const HIDDEN_VERSIONS_PATH = '.versions';
 
-const DEFAULT_FS_CONFIG = get_process_fs_context();
+const DEFAULT_FS_CONFIG = get_process_fs_context(IS_GPFS ? 'GPFS' : '');
 let CORETEST_ENDPOINT;
 
 const tmp_fs_root = path.join(TMP_PATH, 'test_bucket_namespace_fs_versioning');


### PR DESCRIPTION
### Explain the changes
1. add process.env.GPFS_ROOT_PATH flag to tell TMP_FILE to use provided gpfs path
2. change tests to set backend to GPFS in fs_context in case  GPFS_ROOT_PATH is used
3. change xattr to filter out os external attributes (selinux)
4. add timeouts

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. copy test files to GPFS node: `scp <path_to_noobaa>/src/test <node ip>:/usr/local/noobaa-core/src/ `
2. install nvm, and run `npm run build`
3. run tests with `NC_CORETEST`, `GPFS_DL_PATH`, and `GPFS_ROOT_PATH` flags:
`NC_CORETEST=true GPFS_ROOT_PATH=/ibm/fs1/tmp GPFS_DL_PATH="/usr/lpp/mmfs/lib/libgpfs.so" node ./node_modules/mocha/bin/mocha src/test/unit_tests/<test_name.js>`

jest test:
`GPFS_ROOT_PATH=/ibm/fs1/tmp GPFS_DL_PATH="/usr/lpp/mmfs/lib/libgpfs.so" npx jest 
 testRegex=jest_tests/test_versioning_concurrency.test.js` 


- [ ] Doc added/updated
- [ ] Tests added
