### PR TITLE
NC | Online upgrade process small fix & refactoring

### DIFF
--- a/src/upgrade/nc_upgrade_manager.js
+++ b/src/upgrade/nc_upgrade_manager.js
@@ -137,6 +137,7 @@ class NCUpgradeManager {
     /**
      * config_directory_defaults returns a default initial config directory object
      * @param {Object} system_data
+     * @returns {Object}
      */
     config_directory_defaults(system_data) {
         const hosts_old_package_version = system_data?.[hostname]?.upgrade_history?.successful_upgrades?.[0]?.from_version;
@@ -241,6 +242,7 @@ class NCUpgradeManager {
     /**
      * _run_nc_upgrade_scripts runs the config directory upgrade scripts 
      * @param {Object} this_upgrade
+     * @returns {Promise<Void>}
      */
     async _run_nc_upgrade_scripts(this_upgrade) {
         try {
@@ -259,6 +261,7 @@ class NCUpgradeManager {
      * 3. upgrade_package_version is the new source code version
      * 4. add the finished upgrade to the successful_upgrades array
      * @param {Object} system_data
+     * @param {Object} this_upgrade 
      * @returns {Promise<Void>}
      */
     async _update_config_dir_upgrade_finish(system_data, this_upgrade) {
@@ -281,6 +284,9 @@ class NCUpgradeManager {
     /**
      * _update_config_dir_upgrade_failed updates the system.json on failure of the upgrade
      * @param {Object} system_data 
+     * @param {Object} this_upgrade 
+     * @param {Error} error
+     * @returns {Promise<Void>}
      */
     async _update_config_dir_upgrade_failed(system_data, this_upgrade, error) {
         system_data.config_directory.upgrade_history.last_failure = this_upgrade;

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -67,6 +67,7 @@ function should_upgrade(server_version, container_version) {
  * load_required_scripts loads all scripts that should be run according to the given versions
  * @param {string} server_version
  * @param {string} container_version
+ * @param {string} upgrade_scripts_dir
  */
 async function load_required_scripts(server_version, container_version, upgrade_scripts_dir) {
     // expecting scripts directories to be in a semver format. e.g. ./upgrade_scripts/5.0.1


### PR DESCRIPTION
### Explain the changes
1. fix -  
    a. changed init_nc_system() to set config_directory properties only on a completely new system. otherwise, config_directory data will be set only via nc_upgrade_manager. Due to this change, I had to check config_directory data exists also on throw_if_config_dir_locked(), and if not, this is an old system.json and we do not allow updating config directory in that case, hence we will throw an error.
3. refactoring - 
    a. Moved init_nc_system from nsfs.js to config_fs.js, re-arranged the function and added some helper functions.
    b. Added missing JSdocs.

### Issues: Fixed #xxx / Gap #xxx
1. Open question - should we allow using the CLI without having system.json?
Wondering if there can be scenarios where the user wants to create a bucket/account without starting the S3 service ever, if so, we don't have any version information about the already existing accounts/buckets, we won't know if updates on the config directory should be allowed or not in that case.  - optional solution, create system.json via the CLI.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
