### PR TITLE
NSFS | RPM installation failing with missing module error

### DIFF
--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -36,6 +36,7 @@ COPY ./src/deploy/standalone/noobaa_rsyslog.conf ./src/deploy/standalone/noobaa_
 COPY ./src/deploy/standalone/noobaa_syslog.conf ./src/deploy/standalone/noobaa_syslog.conf
 COPY ./src/deploy/standalone/noobaa-logrotate ./src/deploy/standalone/noobaa-logrotate
 COPY ./src/manage_nsfs ./src/manage_nsfs
+COPY ./src/nc ./src/nc
 
 WORKDIR /build
 


### PR DESCRIPTION
### Explain the changes
1. module added in RPM docker file
### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8472

### Testing Instructions:
1. make rpm 
2. install rpm


- [ ] Doc added/updated
- [ ] Tests added
