### PR TITLE
nsfs | wait for endpoint startup before namespace monitor registration

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -231,12 +231,15 @@ async function main(options = {}) {
         if (internal_rpc_client && config.NAMESPACE_MONITOR_ENABLED) {
             endpoint_stats_collector.instance().set_rpc_client(internal_rpc_client);
 
-            // Register a bg monitor on the endpoint
-            background_scheduler.register_bg_worker(new NamespaceMonitor({
-                name: 'namespace_fs_monitor',
-                client: internal_rpc_client,
-                should_monitor: nsr => Boolean(nsr.nsfs_config),
-            }));
+            //wait with monitoring until pod has started
+            setTimeout(() => {
+                // Register a bg monitor on the endpoint
+                background_scheduler.register_bg_worker(new NamespaceMonitor({
+                    name: 'namespace_fs_monitor',
+                    client: internal_rpc_client,
+                    should_monitor: nsr => Boolean(nsr.nsfs_config),
+                }));
+            }, 1000 * 60);
         }
 
         if (config.ENABLE_SEMAPHORE_MONITOR) {


### PR DESCRIPTION
### Explain the changes
Wait for endpoint startup before registering namespace resource monitor.

### Issues: Fixed #xxx / Gap #xxx
Nsr can enter "Rejected" status if endpoint is deleted by kubernetes before it is in "Ready" state.
https://bugzilla.redhat.com/show_bug.cgi?id=2284585.

### Testing Instructions:
Repoduction
Sagie details scenario for ODS in bz.

I've reproduced with this scenario on minikube:
Start with a nsfs nsr on a pvc. A single endpoint A is in "Ready" state.
-Delete nsr. A new endpoint B is being spun.
-While endpoint B is done creating but NOT ready yet (endpoint A is still in "Ready" state), create nsr.
-Kubernetes will delete endpoint B and will leave endpoint A running.
-Endpoint B loads nsr from system store, but nsr is not mounted on it. Endpoint B issues NO_SUCH_BUCKET report on nsr (and then it is deleted by kubernetes).

- [ ] Doc added/updated
- [ ] Tests added
[local_nsfs.yaml.txt](https://github.com/user-attachments/files/17442342/local_nsfs.yaml.txt)
