### PR TITLE
bucket_api: Pagination support for list_bucket API

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -441,6 +441,17 @@ module.exports = {
 
         list_buckets: {
             method: 'GET',
+            params: {
+                type: 'object',
+                properties: {
+                    continuation_token: { $ref: 'common_api#/definitions/continuation_token' },
+                    max_buckets: {
+                        type: 'integer',
+                        minimum: 1,
+                        maximum: 1000
+                    }
+                }
+            },
             reply: {
                 type: 'object',
                 required: ['buckets'],
@@ -454,10 +465,11 @@ module.exports = {
                                 name: { $ref: 'common_api#/definitions/bucket_name' },
                                 creation_date: {
                                     idate: true
-                                },
+                                }
                             }
                         }
-                    }
+                    },
+                    continuation_token: { $ref: 'common_api#/definitions/continuation_token' }
                 }
             },
             auth: {

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1210,6 +1210,10 @@ module.exports = {
             wrapper: SensitiveString,
         },
 
+        continuation_token: {
+            wrapper: SensitiveString,
+        },
+
         port: {
             type: 'integer',
             minimum: 0,

--- a/src/endpoint/s3/ops/s3_get_service.js
+++ b/src/endpoint/s3/ops/s3_get_service.js
@@ -7,8 +7,17 @@ const s3_utils = require('../s3_utils');
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
  */
 async function list_buckets(req) {
-    const reply = await req.object_sdk.list_buckets();
+
+    const params = {
+        continuation_token: s3_utils.cont_tok_to_key_marker(req.query['continuation-token']),
+        max_buckets: req.query['max-buckets'] ? Number(req.query['max-buckets']) : undefined
+    };
+
+    const reply = await req.object_sdk.list_buckets(params);
     const date = s3_utils.format_s3_xml_date(new Date());
+    const bucket_cont_token = s3_utils.key_marker_to_cont_tok(reply.continuation_token, null, false);
+    // const bucket_cont_token = bucket_name_to_cont_token(reply.continuation_token);
+
     return {
         ListAllMyBucketsResult: {
             Owner: s3_utils.DEFAULT_S3_USER,
@@ -17,7 +26,8 @@ async function list_buckets(req) {
                     Name: bucket.name.unwrap(),
                     CreationDate: bucket.creation_date ? s3_utils.format_s3_xml_date(bucket.creation_date) : date,
                 }
-            }))
+            })),
+            ContinuationToken: bucket_cont_token,
         }
     };
 }

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -724,6 +724,42 @@ function parse_restore_request_days(req) {
     return days;
 }
 
+/**
+ * cont_tok_to_key_marker takes an encoded string and decodes it.
+ * cont_tok is the token which represents the next item in
+ * the list which some API returns to user in parts.
+ * @param {string} cont_tok
+ * @returns {string}
+ */
+function cont_tok_to_key_marker(cont_tok) {
+    if (!cont_tok) return;
+    try {
+        const b = Buffer.from(cont_tok, 'base64');
+        const j = JSON.parse(b.toString());
+        return j.key;
+    } catch (err) {
+        throw new S3Error(S3Error.InvalidArgument);
+    }
+}
+
+/**
+ * key_marker_to_cont_tok takes a string and returns an encoded
+ * string. key_marker is the token which represents the next item in
+ * the list which some API returns to user in parts.
+ * @param {string} key_marker
+ * @param {array} objects_arr
+ * @param {boolean} is_truncated
+ * @returns {string}
+ */
+
+function key_marker_to_cont_tok(key_marker, objects_arr, is_truncated) {
+    if (!key_marker && !is_truncated) return;
+    // next marker is the key marker we got or the key of the last item in the objects list.
+    const next_marker = key_marker || (objects_arr && objects_arr.length > 0 ? objects_arr[objects_arr.length - 1].key : undefined);
+    const j = JSON.stringify({ key: next_marker });
+    return Buffer.from(j).toString('base64');
+}
+
 exports.STORAGE_CLASS_STANDARD = STORAGE_CLASS_STANDARD;
 exports.STORAGE_CLASS_GLACIER = STORAGE_CLASS_GLACIER;
 exports.STORAGE_CLASS_GLACIER_IR = STORAGE_CLASS_GLACIER_IR;
@@ -763,3 +799,5 @@ exports.parse_version_id = parse_version_id;
 exports.get_object_owner = get_object_owner;
 exports.get_default_object_owner = get_default_object_owner;
 exports.set_response_supported_storage_classes = set_response_supported_storage_classes;
+exports.cont_tok_to_key_marker = cont_tok_to_key_marker;
+exports.key_marker_to_cont_tok = key_marker_to_cont_tok;

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -192,7 +192,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
      */
-    async list_buckets(object_sdk) {
+    async list_buckets(params, object_sdk) {
         let bucket_names;
         try {
             bucket_names = await this.config_fs.list_buckets();

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -32,8 +32,9 @@ class BucketSpaceNB {
     // BUCKET //
     ////////////
 
-    async list_buckets(object_sdk) {
-        const { buckets } = (await this.rpc_client.bucket.list_buckets());
+    async list_buckets(params, object_sdk) {
+        const { buckets, continuation_token} = (await this.rpc_client.bucket.list_buckets(params));
+
         const has_access_buckets = (await P.all(_.map(
             buckets,
             async bucket => {
@@ -43,7 +44,7 @@ class BucketSpaceNB {
                     object_sdk.has_non_nsfs_bucket_access(object_sdk.requesting_account, ns);
                 return has_access_to_bucket && bucket;
             }))).filter(bucket => bucket);
-        return { buckets: has_access_buckets };
+        return { buckets: has_access_buckets, continuation_token};
     }
 
     async read_bucket(params) {

--- a/src/sdk/bucketspace_s3.js
+++ b/src/sdk/bucketspace_s3.js
@@ -27,7 +27,7 @@ class BucketSpaceS3 {
     // BUCKET //
     ////////////
 
-    async list_buckets() {
+    async list_buckets(params) {
         try {
             console.log(`bss3: list_buckets`);
             const res = await this.s3.listBuckets({});

--- a/src/sdk/bucketspace_simple_fs.js
+++ b/src/sdk/bucketspace_simple_fs.js
@@ -40,7 +40,7 @@ class BucketSpaceSimpleFS {
     * @param {nb.ObjectSDK} object_sdk
     * @returns {Promise<object>}
     */
-    async list_buckets(object_sdk) {
+    async list_buckets(params, object_sdk) {
         try {
             const entries = await nb_native().fs.readdir(this.fs_context, this.fs_root);
             const dirs_only = entries.filter(entree => native_fs_utils.isDirectory(entree));

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -821,7 +821,7 @@ interface BucketSpace {
     read_account_by_access_key({ access_key: string }): Promise<any>;
     read_bucket_sdk_info({ name: string }): Promise<any>;
 
-    list_buckets(object_sdk: ObjectSDK): Promise<any>;
+    list_buckets(params: object, object_sdk: ObjectSDK): Promise<any>;
     read_bucket(params: object): Promise<any>;
     create_bucket(params: object, object_sdk: ObjectSDK): Promise<any>;
     delete_bucket(params: object, object_sdk: ObjectSDK): Promise<any>;
@@ -1099,7 +1099,7 @@ interface X509Name {
     O: string;
 }
 
-type select_input_format =  'CSV' | 'JSON' | 'Parquet';
+type select_input_format = 'CSV' | 'JSON' | 'Parquet';
 interface S3SelectOptions {
     query: string;
     input_format: select_input_format;
@@ -1125,7 +1125,7 @@ type NodeCallback<T = void> = (err: Error | null, res?: T) => void;
 type RestoreState = 'CAN_RESTORE' | 'ONGOING' | 'RESTORED';
 
 interface RestoreStatus {
-  state: nb.RestoreState;
-  ongoing?: boolean;
-  expiry_time?: Date;
+    state: nb.RestoreState;
+    ongoing?: boolean;
+    expiry_time?: Date;
 }

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -877,12 +877,12 @@ class ObjectSDK {
     // BUCKET //
     ////////////
 
-    async list_buckets() {
+    async list_buckets(params = {}) {
         return this._call_op_and_update_stats({
             op_name: 'list_buckets',
             op_func: async () => {
                 const bs = this._get_bucketspace();
-                return bs.list_buckets(this);
+                return bs.list_buckets(params, this);
             },
         });
     }

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -489,34 +489,33 @@ mocha.describe('bucketspace_fs', function() {
             await create_bucket(test_bucket);
         });
         mocha.it('list buckets', async function() {
-            const objects = await bucketspace_fs.list_buckets(dummy_object_sdk);
+            const objects = await bucketspace_fs.list_buckets({}, dummy_object_sdk);
             assert.equal(objects.buckets.length, 1);
             assert.equal(objects.buckets[0].name.unwrap(), 'bucket1');
         });
         mocha.it('list buckets - only for bucket with config', async function() {
             await fs_utils.create_path(`${new_buckets_path}/${test_bucket_invalid}`);
-            const objects = await bucketspace_fs.list_buckets(dummy_object_sdk);
+            const objects = await bucketspace_fs.list_buckets({}, dummy_object_sdk);
             assert.equal(objects.buckets.length, 1);
         });
         mocha.it('list buckets - iam accounts', async function() {
             // root account created a bucket
-
             // account_iam_user2 can list the created bucket (the implicit policy - same root account)
             const dummy_object_sdk_for_iam_account = make_dummy_object_sdk_for_account(dummy_object_sdk, account_iam_user1);
-            const res = await bucketspace_fs.list_buckets(dummy_object_sdk_for_iam_account);
+            const res = await bucketspace_fs.list_buckets({}, dummy_object_sdk_for_iam_account);
             assert.equal(res.buckets.length, 1);
             assert.equal(res.buckets[0].name.unwrap(), test_bucket);
 
             // account_iam_user2 can list the created bucket (the implicit policy - same root account)
             const dummy_object_sdk_for_iam_account2 = make_dummy_object_sdk_for_account(dummy_object_sdk, account_iam_user2);
-            const res2 = await bucketspace_fs.list_buckets(dummy_object_sdk_for_iam_account2);
+            const res2 = await bucketspace_fs.list_buckets({}, dummy_object_sdk_for_iam_account2);
             assert.equal(res2.buckets.length, 1);
             assert.equal(res2.buckets[0].name.unwrap(), test_bucket);
         });
         mocha.it('list buckets - different account', async function() {
             // another user created a bucket (account_user3 cannot list it)
             const dummy_object_sdk_for_iam_account = make_dummy_object_sdk_for_account(dummy_object_sdk, account_user3);
-            const res = await bucketspace_fs.list_buckets(dummy_object_sdk_for_iam_account);
+            const res = await bucketspace_fs.list_buckets({}, dummy_object_sdk_for_iam_account);
             assert.equal(res.buckets.length, 0);
         });
         mocha.it('list buckets - different account with bucket policy (principal by name)', async function() {
@@ -526,7 +525,7 @@ mocha.describe('bucketspace_fs', function() {
             const param = { name: test_bucket, policy: policy };
             await bucketspace_fs.put_bucket_policy(param);
             const dummy_object_sdk_for_iam_account = make_dummy_object_sdk_for_account(dummy_object_sdk, account_user4);
-            const res = await bucketspace_fs.list_buckets(dummy_object_sdk_for_iam_account);
+            const res = await bucketspace_fs.list_buckets({}, dummy_object_sdk_for_iam_account);
             assert.equal(res.buckets.length, 1);
             assert.equal(res.buckets[0].name.unwrap(), test_bucket);
         });
@@ -537,7 +536,7 @@ mocha.describe('bucketspace_fs', function() {
             const param = { name: test_bucket, policy: policy };
             await bucketspace_fs.put_bucket_policy(param);
             const dummy_object_sdk_for_iam_account = make_dummy_object_sdk_for_account(dummy_object_sdk, account_user4);
-            const res = await bucketspace_fs.list_buckets(dummy_object_sdk_for_iam_account);
+            const res = await bucketspace_fs.list_buckets({}, dummy_object_sdk_for_iam_account);
             assert.equal(res.buckets.length, 1);
             assert.equal(res.buckets[0].name.unwrap(), test_bucket);
         });
@@ -548,7 +547,7 @@ mocha.describe('bucketspace_fs', function() {
         });
         mocha.it('list buckets - validate creation_date', async function() {
             const expected_bucket_name = 'bucket1';
-            const objects = await bucketspace_fs.list_buckets(dummy_object_sdk);
+            const objects = await bucketspace_fs.list_buckets({}, dummy_object_sdk);
             assert.equal(objects.buckets.length, 1);
             assert.equal(objects.buckets[0].name.unwrap(), expected_bucket_name);
             const bucket_config_path = get_config_file_path(CONFIG_SUBDIRS.BUCKETS, expected_bucket_name);
@@ -565,7 +564,7 @@ mocha.describe('bucketspace_fs', function() {
         mocha.it('delete_bucket with valid bucket name ', async function() {
             const param = { name: test_bucket };
             await bucketspace_fs.delete_bucket(param, dummy_object_sdk);
-            const objects = await bucketspace_fs.list_buckets(dummy_object_sdk);
+            const objects = await bucketspace_fs.list_buckets({}, dummy_object_sdk);
             assert.equal(objects.buckets.length, 0);
         });
         mocha.it('delete_bucket with invalid bucket name ', async function() {
@@ -628,7 +627,7 @@ mocha.describe('bucketspace_fs', function() {
 
             // account_iam_user1 can see the bucket in the list
             const dummy_object_sdk_for_account_iam_user1 = make_dummy_object_sdk_for_account(dummy_object_sdk, account_iam_user1);
-            const res = await bucketspace_fs.list_buckets(dummy_object_sdk_for_account_iam_user1);
+            const res = await bucketspace_fs.list_buckets({}, dummy_object_sdk_for_account_iam_user1);
             assert.ok(res.buckets.length > 0);
             assert.ok(res.buckets.some(bucket => bucket.name.unwrap() === test_bucket_iam_account));
 

--- a/src/test/unit_tests/test_s3_list_buckets.js
+++ b/src/test/unit_tests/test_s3_list_buckets.js
@@ -1,0 +1,131 @@
+/* Copyright (C) 2016 NooBaa */
+/* eslint-disable max-lines-per-function */
+/* eslint-disable no-invalid-this */
+
+'use strict';
+// setup coretest first to prepare the env
+const coretest = require('./coretest');
+coretest.setup({ pools_to_create: coretest.POOL_LIST });
+const config = require('../../../config');
+const { S3Client, ListBucketsCommand, CreateBucketCommand, DeleteBucketCommand } = require("@aws-sdk/client-s3");
+const { NodeHttpHandler } = require("@smithy/node-http-handler");
+const http_utils = require('../../util/http_utils');
+const mocha = require('mocha');
+const assert = require('assert');
+
+const { rpc_client, EMAIL } = coretest;
+
+const bucket_names = ['a.bucket1',
+                        'b.bucket2',
+                        'f.bucket3',
+                        'c.bucket4',
+                        'h.bucket5',
+                        'd.bucket6',
+                        'e.bucket7',
+                        'g.bucket8'
+                    ];
+
+mocha.describe('s3_ops', function() {
+
+    let s3;
+    let s3_client_params;
+
+    mocha.before(async function() {
+        const self = this;
+        self.timeout(60000);
+        const account_info = await rpc_client.account.read_account({ email: EMAIL, });
+        s3_client_params = {
+            endpoint: coretest.get_http_address(),
+            credentials: {
+                accessKeyId: account_info.access_keys[0].access_key.unwrap(),
+                secretAccessKey: account_info.access_keys[0].secret_key.unwrap(),
+            },
+            forcePathStyle: true,
+            region: config.DEFAULT_REGION,
+            requestHandler: new NodeHttpHandler({
+                httpAgent: http_utils.get_unsecured_agent(coretest.get_http_address()),
+            }),
+        };
+        s3 = new S3Client(s3_client_params);
+        coretest.log('S3 CONFIG', s3.config);
+    });
+
+    mocha.after(async () => {
+        let delete_bucket;
+        for (const bucket of bucket_names) {
+                delete_bucket = new DeleteBucketCommand({
+                Bucket: bucket,
+            });
+            await s3.send(delete_bucket);
+        }
+    });
+
+    mocha.describe('list paginated bucket op', function() {
+        this.timeout(60000);
+        let res;
+        let create_bucket;
+        mocha.it('Create 8 buckets', async function() {
+            for (const bucket of bucket_names) {
+                create_bucket = new CreateBucketCommand({
+                    Bucket: bucket,
+                });
+                await s3.send(create_bucket);
+            }
+        });
+
+        mocha.it('Delete first.bucket', async function() {
+                const delete_bucket = new DeleteBucketCommand({
+                    Bucket: "first.bucket",
+                });
+                await s3.send(delete_bucket);
+        });
+
+        mocha.it('List Buckets with pagination: MaxBuckets < Number of Buckets', async function() {
+            let input = {
+                MaxBuckets: 3
+            };
+            let command = new ListBucketsCommand(input);
+            res = await s3.send(command);
+            assert(res.Buckets.length === 3);
+            assert(res.ContinuationToken !== undefined);
+
+            input = {
+                MaxBuckets: 3,
+                ContinuationToken: res.ContinuationToken
+            };
+            command = new ListBucketsCommand(input);
+            res = await s3.send(command);
+            assert(res.Buckets.length === 3);
+            assert(res.ContinuationToken !== undefined);
+
+            input = {
+                MaxBuckets: 3,
+                ContinuationToken: res.ContinuationToken
+            };
+            command = new ListBucketsCommand(input);
+            res = await s3.send(command);
+            assert(res.Buckets.length === 2);
+            assert(res.ContinuationToken === undefined);
+
+        });
+
+        mocha.it('List Buckets with pagination: MaxBuckets > Number of Buckets', async function() {
+            const input = {
+                MaxBuckets: 20
+            };
+            const command = new ListBucketsCommand(input);
+            res = await s3.send(command);
+            assert(res.Buckets.length === 8);
+            assert(res.ContinuationToken === undefined);
+
+        });
+
+        mocha.it('List Buckets without pagination', async function() {
+            const command = new ListBucketsCommand();
+            res = await s3.send(command);
+            assert(res.Buckets.length === 8);
+        });
+    });
+
+});
+

--- a/src/test/unit_tests/test_system_servers.js
+++ b/src/test/unit_tests/test_system_servers.js
@@ -445,7 +445,7 @@ mocha.describe('system_servers', function() {
             .then(() => rpc_client.bucket.read_bucket({
                 name: BUCKET,
             }))
-            .then(() => rpc_client.bucket.list_buckets())
+            .then(() => rpc_client.bucket.list_buckets({}))
             .then(() => rpc_client.bucket.update_bucket({
                 name: BUCKET,
                 new_name: BUCKET + 1,


### PR DESCRIPTION
### Explain the changes
This change provides support for the pagination of list_buckets.

GET /?continuation-token=ContinuationToken&max-buckets=MaxBuckets HTTP/1.1
Host: s3.amazonaws.com

Important links - 
https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html

https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#listBuckets-property

We can call list buckets using API like this-
nb api bucket_api list_buckets '{
  "max_buckets" : 10                                       
}'


Or using S3 call like - 

const input = {
                MaxBuckets: 20
            };
const command = new ListBucketsCommand(input);




