### PR TITLE
NSFS | Bucket Policy Should Be Managed Only by Bucket Owner

### DIFF
--- a/src/endpoint/s3/s3_bucket_policy_utils.js
+++ b/src/endpoint/s3/s3_bucket_policy_utils.js
@@ -281,6 +281,19 @@ async function validate_s3_policy(policy, bucket_name, get_account_handler) {
     }
 }
 
+/**
+ * CRUD action on bucket policy only allow to bucket owner.
+ * @param {string} bucket_owner_id
+ * @param {string} account_id
+ */
+async function validate_s3_policy_owner(bucket_owner_id, account_id) {
+    dbg.log0('validate_s3_policy_owner : bucket_owner_id ', bucket_owner_id, 'account_id : ', account_id);
+    if (bucket_owner_id !== account_id) {
+        throw new RpcError('METHOD_NOT_ALLOWED');
+    }
+}
+
 exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;
 exports.has_bucket_policy_permission = has_bucket_policy_permission;
 exports.validate_s3_policy = validate_s3_policy;
+exports.validate_s3_policy_owner = validate_s3_policy_owner;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -848,8 +848,8 @@ interface BucketSpace {
     delete_bucket_website(params: object): Promise<any>;
     get_bucket_website(params: object): Promise<any>;
 
-    put_bucket_policy(params: object): Promise<any>;
-    delete_bucket_policy(params: object): Promise<any>;
+    put_bucket_policy(params: object, object_sdk: ObjectSDK): Promise<any>;
+    delete_bucket_policy(params: object, object_sdk: ObjectSDK): Promise<any>;
     get_bucket_policy(params: object, object_sdk: ObjectSDK): Promise<any>;
 
     get_object_lock_configuration(params: object, object_sdk: ObjectSDK): Promise<any>;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -1022,7 +1022,7 @@ class ObjectSDK {
 
     async put_bucket_policy(params) {
         const bs = this._get_bucketspace();
-        const result = await bs.put_bucket_policy(params);
+        const result = await bs.put_bucket_policy(params, this);
         bucket_namespace_cache.invalidate_key(params.name);
         return result;
     }
@@ -1030,7 +1030,7 @@ class ObjectSDK {
     async delete_bucket_policy(params) {
         const bs = this._get_bucketspace();
         bucket_namespace_cache.invalidate_key(params.name);
-        return bs.delete_bucket_policy(params);
+        return bs.delete_bucket_policy(params, this);
     }
 
     async get_bucket_policy(params) {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -479,6 +479,7 @@ async function put_bucket_encryption(req) {
 async function get_bucket_policy(req) {
     dbg.log0('get_bucket_policy:', req.rpc_params);
     const bucket = find_bucket(req, req.rpc_params.name);
+    await bucket_policy_utils.validate_s3_policy_owner(bucket.owner_account._id, req.account._id);
     return {
         policy: bucket.s3_policy,
     };
@@ -488,6 +489,7 @@ async function get_bucket_policy(req) {
 async function put_bucket_policy(req) {
     dbg.log0('put_bucket_policy:', req.rpc_params);
     const bucket = find_bucket(req, req.rpc_params.name);
+    await bucket_policy_utils.validate_s3_policy_owner(bucket.owner_account._id, req.account._id);
     await bucket_policy_utils.validate_s3_policy(req.rpc_params.policy, bucket.name,
         principal => system_store.get_account_by_email(principal));
     await system_store.make_changes({
@@ -505,6 +507,7 @@ async function put_bucket_policy(req) {
 async function delete_bucket_policy(req) {
     dbg.log0('delete_bucket_policy:', req.rpc_params);
     const bucket = find_bucket(req, req.rpc_params.name);
+    await bucket_policy_utils.validate_s3_policy_owner(bucket.owner_account._id, req.account._id);
     await system_store.make_changes({
         update: {
             buckets: [{

--- a/src/test/unit_tests/test_s3_bucket_policy.js
+++ b/src/test/unit_tests/test_s3_bucket_policy.js
@@ -221,7 +221,8 @@ mocha.describe('s3_bucket_policy', function() {
             Bucket: BKT,
             Policy: JSON.stringify(policy)
         });
-        const res_a = await s3_a.getBucketPolicy({ // should work - user a has get_bucket_policy permission
+        // Bucket Policy Should Be Managed Only by Bucket Owner
+        const res_a = await s3_owner.getBucketPolicy({
             Bucket: BKT,
         });
         console.log('Policy set', res_a);
@@ -1033,7 +1034,8 @@ mocha.describe('s3_bucket_policy', function() {
             Bucket: BKT,
             Policy: JSON.stringify(encryption_policy)
         });
-       const res = await s3_a.getBucketPolicy({Bucket: BKT});
+        // Bucket Policy Should Be Managed Only by Bucket Owner
+       const res = await s3_owner.getBucketPolicy({Bucket: BKT});
        const policy = JSON.parse(res.Policy);
        const actualEncryptionCondition = policy.Statement[1].Condition;
        assert.strictEqual(Object.keys(actualEncryptionCondition)[0], "StringNotEquals");

--- a/src/test/unit_tests/test_upgrade_scripts.js
+++ b/src/test/unit_tests/test_upgrade_scripts.js
@@ -20,7 +20,8 @@ let s3;
 
 async function _clean_all_bucket_policies() {
     for (const bucket of system_store.data.buckets) {
-        if (bucket.s3_policy) {
+        // delete policy only for test-bucket
+        if (bucket.s3_policy && bucket.name === BKT) {
             await s3.deleteBucketPolicy({ Bucket: bucket.name.unwrap() });
         }
     }
@@ -31,7 +32,7 @@ mocha.describe('test upgrade scripts', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await system_store.load();
 
-        const account_info = await rpc_client.account.read_account({ email: EMAIL, });
+        const account_info = await rpc_client.account.read_account({ email: EMAIL });
         s3 = new S3({
             endpoint: coretest.get_http_address(),
             credentials: {


### PR DESCRIPTION
### Explain the changes
1. add bucket owner id and account id validation for both nsfs and containerized deployment(bucket_server)

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8288

### Testing Instructions:
1. please find it in issue


- [ ] Doc added/updated
- [X] Tests added
