### PR TITLE
Set default bucket encryption during bucket creation

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -73,6 +73,9 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, owner_account_i
         object_lock_configuration: config.WORM_ENABLED ? {
             object_lock_enabled: lock_enabled ? 'Enabled' : 'Disabled',
         } : undefined,
+        encryption: {
+            "algorithm": "AES256",
+        },
     };
 }
 

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -141,3 +141,5 @@ s3tests_boto3/functional/test_s3.py::test_object_lock_delete_multipart_object_wi
 s3tests_boto3/functional/test_s3.py::test_object_lock_delete_multipart_object_with_legal_hold_on
 s3tests_boto3/functional/test_s3.py::test_get_undefined_public_block
 s3tests_boto3/functional/test_s3.py::test_get_public_block_deny_bucket_policy
+s3tests_boto3/functional/test_s3.py::test_get_bucket_encryption_s3
+s3tests_boto3/functional/test_s3.py::test_get_bucket_encryption_kms

--- a/src/test/unit_tests/test_s3_encryption.js
+++ b/src/test/unit_tests/test_s3_encryption.js
@@ -71,14 +71,22 @@ mocha.describe('Bucket Encryption Operations', async () => {
         await local_s3.createBucket({ Bucket: BKT });
     });
 
-    mocha.it('should get bucket encryption error without encryption configured', async () => {
+    mocha.it('getBucketEncryption should return the default server side encryption configuration', async () => {
         try {
             const res = await local_s3.getBucketEncryption({ Bucket: BKT });
-            throw new Error(`Expected to get error with unconfigured bucket encryption ${res}`);
+            const expected_response = {
+                ServerSideEncryptionConfiguration: {
+                    Rules: [{
+                        ApplyServerSideEncryptionByDefault: {
+                            SSEAlgorithm: 'AES256'
+                        }
+                    }]
+                }
+            };
+            const res_without_metadata = _.omit(res, '$metadata');
+            assert.deepEqual(res_without_metadata, expected_response);
         } catch (error) {
-            assert(error.message === 'The server side encryption configuration was not found.', `Error message does not match got: ${error.message}`);
-            assert(error.Code === 'ServerSideEncryptionConfigurationNotFoundError', `Error code does not match got: ${error.Code}`);
-            assert(error.$metadata.httpStatusCode === 404, `Error status code does not match got: ${error.$metadata.httpStatusCode}`);
+            throw new Error(`The server side encryption configuration was not found ${error.message}`);
         }
     });
 


### PR DESCRIPTION
All S3 buckets have encryption configured by default, and objects are automatically encrypted by using server side encryption. When we do get-bucker-encryption on any bucket we get the the default encryption configuration.

With this patch we set default encryption on bucket while creating the bucket and follow the behavior of S3 bucket

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2318715
