### PR TITLE
NSFS | Versioning | Delete of partial directory of nested key results in AccessDeniedError

### DIFF
--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -254,9 +254,9 @@ async function unlink_ignore_enoent(fs_context, to_delete_path) {
     try {
         await nb_native().fs.unlink(fs_context, to_delete_path);
     } catch (err) {
-        dbg.warn(`native_fs_utils.unlink_ignore_enoent unlink error: file path ${to_delete_path} error`, err);
-        if (err.code !== 'ENOENT') throw err;
-        dbg.warn(`native_fs_utils.unlink_ignore_enoent unlink: file ${to_delete_path} already deleted, ignoring..`);
+        dbg.warn(`native_fs_utils.unlink_ignore_enoent unlink error: file path ${to_delete_path} error`, err, err.code, err.code !== 'EISDIR');
+        if (err.code !== 'ENOENT' && err.code !== 'EISDIR') throw err;
+        dbg.warn(`native_fs_utils.unlink_ignore_enoent unlink: file ${to_delete_path} already deleted or key is pointing to dir, ignoring..`);
     }
 }
 


### PR DESCRIPTION
### Explain the changes
1. Version bucket does not support dir versioning, Deleting dir key(`a/b/c/`) just deletes the .folder file and does not create delete_marker.
2.  If the bucket has key `a/b/c/test.txt` and then tries to delete key `a/b/c` code will throw `AccessDenied` error.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8454

### Testing Instructions:
1. Please check the issue

- [ ] Doc added/updated
- [X] Tests added
