### PR TITLE
lifecycle fixes

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_lifecycle.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_lifecycle.js
@@ -47,6 +47,7 @@ async function get_bucket_lifecycle(req) {
             current_rule.Expiration = {
                 Days: rule.expiration.days,
                 Date: rule.expiration.date ? new Date(rule.expiration.date).toISOString() : undefined,
+                ExpiredObjectDeleteMarker: rule.expiration.expired_object_delete_marker,
             };
             _.omitBy(current_rule.Expiration, _.isUndefined);
         }


### PR DESCRIPTION
### Explain the changes
1. reject empty fields in s3_put_bucket_lifecycle 
2. return ExpiredObjectDeleteMarker in get_bucket_lifecycle 

### Issues: Fixed #xxx / Gap #xxx
1. Fixes #8462 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
