### PR TITLE
Add support for configurable max bucket & key length

### DIFF
--- a/config.js
+++ b/config.js
@@ -198,6 +198,22 @@ config.S3_RESTORE_REQUEST_MAX_DAYS = 30;
  */
 config.S3_RESTORE_REQUEST_MAX_DAYS_BEHAVIOUR = 'TRUNCATE';
 
+/**
+ * S3_MAX_KEY_LENGTH controls the maximum key length that will be accepted
+ * by NooBaa endpoints.
+ * 
+ * This value is 1024 bytes for S3 but the default is `Infinity`
+ */
+config.S3_MAX_KEY_LENGTH = Infinity;
+
+/**
+ * S3_MAX_BUCKET_NAME_LENGTH controls the maximum bucket name length that
+ * will be accepted by NooBaa endpoints.
+ * 
+ * This value is 63 bytes for S3 but the default is `Infinity`
+ */
+config.S3_MAX_BUCKET_NAME_LENGTH = Infinity;
+
 /////////////////////
 // SECRETS CONFIG  //
 /////////////////////

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -249,8 +249,8 @@ S3Error.InvalidURI = Object.freeze({
     message: 'Couldn\'t parse the specified URI.',
     http_code: 400,
 });
-S3Error.KeyTooLong = Object.freeze({
-    code: 'KeyTooLong',
+S3Error.KeyTooLongError = Object.freeze({
+    code: 'KeyTooLongError',
     message: 'Your key is too long.',
     http_code: 400,
 });

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -362,6 +362,14 @@ function get_bucket_and_key(req) {
             key = suffix;
         }
     }
+
+    if (key?.length > config.S3_MAX_KEY_LENGTH) {
+        throw new S3Error(S3Error.KeyTooLongError);
+    }
+    if (bucket?.length > config.S3_MAX_BUCKET_NAME_LENGTH) {
+        throw new S3Error(S3Error.InvalidBucketName);
+    }
+
     return {
         bucket,
         // decode and replace hadoop _$folder$ in key


### PR DESCRIPTION
### Explain the changes
This PR adds support for configurable max key length in NooBaa. Amazon S3 supports maximum of 1024 bytes long key name while NooBaa does not have any such limits. This sometimes become problematic hence this PR adds support for a config variable named `S3_MAX_KEY_LENGTH` which defaults to `Infinity` for now implying no limit, however this can be changed to 1024 in `config-local.js`.

### Issues: Fixed #xxx / Gap #xxx
Some known DBS3 issues.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
