### PR TITLE
NSFS | Healthcheck is not reporting error for buckets with out access

### DIFF
--- a/docs/NooBaaNonContainerized/Health.md
+++ b/docs/NooBaaNonContainerized/Health.md
@@ -351,3 +351,18 @@ The following error codes will be associated with a specific Bucket or Account s
   - Resolutions:
     - Check for FS user on the host running the Health CLI.
 
+#### 6. Bucket with invalid account owner
+  - Error code: `INVALID_ACCOUNT_OWNER`
+  - Error message: Bucket account owner is invalid
+  - Reasons:
+    - The bucket owner account is invalid.
+  - Resolutions:
+    - Compare bucket account owner and account ids in account dir.
+
+#### 7. Bucket missing account owner
+  - Error code: `MISSING_ACCOUNT_OWNER`
+  - Error message: Bucket account owner not found
+  - Reasons:
+    - Bucket missing owner account.
+  - Resolutions:
+    - Check for owner_account property in bucket config file.

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -57,10 +57,12 @@ async function get_bucket_owner_account_by_name(config_fs, bucket_owner) {
  * otherwise it would throw an error
  * @param {import('../sdk/config_fs').ConfigFS} config_fs
  * @param {string} owner_account
+ * @param {boolean} show_secrets
+ * @param {boolean} decrypt_secret_key
  */
-async function get_bucket_owner_account_by_id(config_fs, owner_account) {
+async function get_bucket_owner_account_by_id(config_fs, owner_account, show_secrets = true, decrypt_secret_key = true) {
     try {
-        const account = await account_id_cache.get_with_cache({ _id: owner_account, config_fs });
+        const account = await account_id_cache.get_with_cache({ _id: owner_account, show_secrets, decrypt_secret_key, config_fs });
         return account;
     } catch (err) {
         if (err.code === 'ENOENT') {

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -30,12 +30,18 @@ const account_id_cache = new LRUCache({
     name: 'AccountIDCache',
     // TODO: Decide on a time that we want to invalidate
     expiry_ms: Number(config.ACCOUNTS_ID_CACHE_EXPIRY),
-    /**
-     * @param {{ _id: string, config_fs: import('./config_fs').ConfigFS }} params
-     */
     make_key: ({ _id }) => _id,
-    load: async ({ _id, config_fs }) => config_fs.get_identity_by_id(_id, CONFIG_TYPES.ACCOUNT,
-        { show_secrets: true, decrypt_secret_key: true }),
+    /**
+     * Accounts are added to the cache based on id, Default value for show_secrets and decrypt_secret_key will be true, 
+     * and show_secrets and decrypt_secret_key `false` only when we load cache from the health script, 
+     * health script doesn't need to fetch or decrypt the secret.
+     * @param {{ _id: string, 
+     * show_secrets?: boolean,
+     * decrypt_secret_key?: boolean, 
+     * config_fs: import('./config_fs').ConfigFS }} params
+    */
+    load: async ({ _id, show_secrets = true, decrypt_secret_key = true, config_fs}) =>
+        config_fs.get_identity_by_id(_id, CONFIG_TYPES.ACCOUNT, { show_secrets: show_secrets, decrypt_secret_key: decrypt_secret_key }),
 });
 
 

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -51,7 +51,7 @@ const http_address = `http://localhost:${http_port}`;
 const https_address = `https://localhost:${https_port}`;
 
 const FIRST_BUCKET = 'first.bucket';
-const NC_CORETEST_STORAGE_PATH = p.join(TMP_PATH, '/nc_coretest_storage_root_path/');
+const NC_CORETEST_STORAGE_PATH = p.join(TMP_PATH, 'nc_coretest_storage_root_path/');
 const FIRST_BUCKET_PATH = p.join(NC_CORETEST_STORAGE_PATH, FIRST_BUCKET, '/');
 const CONFIG_FILE_PATH = p.join(NC_CORETEST_CONFIG_DIR_PATH, 'config.json');
 const NC_CORETEST_CONFIG_FS = new ConfigFS(NC_CORETEST_CONFIG_DIR_PATH);

--- a/src/test/unit_tests/test_nc_nsfs_cli.js
+++ b/src/test/unit_tests/test_nc_nsfs_cli.js
@@ -80,6 +80,7 @@ mocha.describe('manage_nsfs cli', function() {
         };
 
         mocha.before(async () => {
+            config.NSFS_NC_CONF_DIR = config_root;
             await fs_utils.create_fresh_path(root_path);
         });
         mocha.after(async () => {


### PR DESCRIPTION
### Explain the changes
1. user account specific context for checking bucket storage, not the root context
2. add test to validate bucket owner and modify invalid storage check to identify storage condition

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8428

### Testing Instructions:
1. Please check the same issue 


- [X] Doc added/updated
- [X] Tests added
