### PR TITLE
NC | NSFS | Versioning | Avoid Errors On Put Object of Directory Content 

### DIFF
--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -339,6 +339,21 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
                 }
                 assert.deepEqual(res_version_ids, res_put_version_ids);
             });
+
+            // dir_content is not supported in versioning, but we want to make sure there are no errors
+            mocha.it('put object - versioning enabled - directory content', async function() {
+                await s3_uid6.putBucketVersioning({ Bucket: nested_keys_bucket_name, VersioningConfiguration: { MFADelete: 'Disabled', Status: 'Enabled' } });
+                const key_as_dir_content = '/a/b/c/';
+                const size = 4; // in the original issue the error started on the 3rd PUT of dir content
+                const res_put_object = [];
+                for (let i = 0; i < size; i++) {
+                    const res = await s3_uid6.putObject({ Bucket: nested_keys_bucket_name, Key: key_as_dir_content, Body: body1 });
+                    res_put_object.push(res);
+                }
+                assert(res_put_object.length === size);
+                const check_version_id_exists = res_put_object.every(res => res.VersionId !== undefined);
+                assert.ok(check_version_id_exists);
+            });
         });
 
         mocha.describe('mpu object', function() {


### PR DESCRIPTION
### Explain the changes
1. directory content (for example, in AWS CLI you see the name of the key as dir, for example '/a/' and also passes the body with a size greater than 0) is not supported in NSFS Versioning, but we want to avoid errors in case someone sends these requests. In `_move_to_dest` if the versioning of the bucket is enabled and it is the case of the directory bucket we will treat same as the versioning disabled.
2. In function `_move_to_dest` add the argument of `is_dir_content` for checking the condition mentioned above, and add a printing of all the arguments in the function.

### Issues: Fixed #8483
1. Currently, after the 3rd PUT of dir content when versioning is Enabled we start to see an error `InternalError ` and the logs we can see `EEXIST`.

### Testing Instructions:
#### Automatic Test
Please run: `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace_versioning.js`

#### Manual Test
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /tmp/nsfs_root1 --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /tmp/nsfs_root1`, `chmod 777 /tmp/nsfs_root1`.
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
Notes: 
- I Change the `config.NSFS_CHECK_BUCKET_BOUNDARIES = false; //SDSD` because I’m using the `/tmp/` and not `/private/tmp/`.
3. Create the alias for S3 service:`alias nc-user-1-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443’`.
4. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-1-s3 s3 ls; echo $?`
5. Add bucket to the account using AWS CLI: `nc-user-1-s3 s3 mb s3://bucket-v` (`bucket-v` is the bucket name in this example)
6. Put bucket versioning Enabled: `nc-user-1-s3 s3api put-bucket-versioning --bucket bucket-v --versioning-configuration Status=Enabled`
7. Create the content for the body: `echo hello > test-data.txt`
8. Put object of directory content: `nc-user-1-s3 s3api put-object --bucket bucket-v --key /a/b/c/ --body test-data.txt` - run it 3 times (before the fix it was failing on the 3rd PUT).

- [ ] Doc added/updated
- [X] Tests added
