### PR TITLE
use delete_version src file instead of move_to_dest dest_file to get latest version

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -3025,7 +3025,7 @@ class NamespaceFS {
                     if (is_gpfs) {
                     gpfs_options = await this._open_files_gpfs(fs_context, latest_ver_path, undefined, undefined, undefined,
                             undefined, true);
-                        const latest_fd = gpfs_options?.move_to_dst?.dst_file;
+                        const latest_fd = gpfs_options?.delete_version?.src_file;
                         latest_ver_info = latest_fd && await this._get_version_info(fs_context, undefined, latest_fd);
                         if (!latest_ver_info) break;
                     }


### PR DESCRIPTION
### Explain the changes
1. in delete_latest function we use delete_version from open_files_gpfs and not move_to_dst like in put-object. in this case  move_to_dst will always be undefined. change so we get the version from the correct file descriptor.
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. run `NC_CORETEST=true GPFS_ROOT_PATH=/ibm/fs1/tmp GPFS_DL_PATH="/usr/lpp/mmfs/lib/libgpfs.so" node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_bucketspace_versioning.js` on GPFS machine to test delete_latest works properly.


- [ ] Doc added/updated
- [ ] Tests added
