### PR TITLE
notifications - add missing package-lock.json update after npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "nan": "2.20.0",
         "ncp": "2.0.0",
         "node-addon-api": "8.1.0",
+        "node-rdkafka": "3.0.1",
         "performance-now": "2.1.0",
         "pg": "8.13.0",
         "ping": "0.4.4",
@@ -8868,6 +8869,19 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
+    },
+    "node_modules/node-rdkafka": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.0.1.tgz",
+      "integrity": "sha512-USTFu7ylRj+fEiGz0hA92GWSqmX/hu/xSTqtgmInPPmh5zKhjauTciRjDEG3yK5m6yChwyHKQTIgmr56DfhiaQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.1",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.18",


### PR DESCRIPTION
### Explain the changes
1. Notifications commit adds a dependency on librdkafka, but does not update package-json.lock.
This commit has the needed update.
