### PR TITLE
Add a separate clients pool for md_store queries

### DIFF
--- a/config.js
+++ b/config.js
@@ -199,7 +199,7 @@ config.S3_RESTORE_REQUEST_MAX_DAYS_BEHAVIOUR = 'TRUNCATE';
 /**
  * S3_MAX_KEY_LENGTH controls the maximum key length that will be accepted
  * by NooBaa endpoints.
- * 
+ *
  * This value is 1024 bytes for S3 but the default is `Infinity`
  */
 config.S3_MAX_KEY_LENGTH = Infinity;
@@ -207,7 +207,7 @@ config.S3_MAX_KEY_LENGTH = Infinity;
 /**
  * S3_MAX_BUCKET_NAME_LENGTH controls the maximum bucket name length that
  * will be accepted by NooBaa endpoints.
- * 
+ *
  * This value is 63 bytes for S3 but the default is `Infinity`
  */
 config.S3_MAX_BUCKET_NAME_LENGTH = Infinity;
@@ -229,7 +229,8 @@ config.ROOT_KEY_MOUNT = '/etc/noobaa-server/root_keys';
 
 config.DB_TYPE = /** @type {nb.DBType} */ (process.env.DB_TYPE || 'postgres');
 
-config.POSTGRES_MAX_CLIENTS = (process.env.LOCAL_MD_SERVER === 'true') ? 80 : 10;
+config.POSTGRES_DEFAULT_MAX_CLIENTS = 10;
+config.POSTGRES_MD_MAX_CLIENTS = (process.env.LOCAL_MD_SERVER === 'true') ? 70 : 10;
 
 ///////////////////
 // SYSTEM CONFIG //

--- a/src/deploy/NVA_build/standalone_deploy.sh
+++ b/src/deploy/NVA_build/standalone_deploy.sh
@@ -15,7 +15,7 @@ const config = exports;
 config.DEFAULT_POOL_TYPE = 'HOSTS';
 config.AGENT_RPC_PORT = '9999';
 config.AGENT_RPC_PROTOCOL = 'tcp';
-config.POSTGRES_MAX_CLIENTS = 10;
+config.POSTGRES_DEFAULT_MAX_CLIENTS = 10;
 EOF
 
 # setup_env is not needed when running inside a container because the container

--- a/src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh
+++ b/src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh
@@ -25,6 +25,10 @@ export JWT_SECRET=123456789
 export NOOBAA_ROOT_SECRET='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
 export LOCAL_MD_SERVER=true
 
+#The default max connections for postgres is 100. limit max clients to 10 per pool (per process). 
+export CONFIG_JS_POSTGRES_MD_MAX_CLIENTS=10
+export CONFIG_JS_POSTGRES_DEFAULT_MAX_CLIENTS=10
+
 export POSTGRES_HOST=${POSTGRES_HOST:-localhost}
 export MGMT_ADDR=wss://${NOOBAA_MGMT_SERVICE_HOST:-localhost}:${NOOBAA_MGMT_SERVICE_PORT:-5443}
 export BG_ADDR=wss://localhost:5445


### PR DESCRIPTION
### Explain the changes
This PR aims to prevent the unavailability of Postgres clients in the client pool for system queries when there is a high load of md_store queries. 

#### The Problem
1. In `postgres_client.js,` we access the DB through a single client pool. By default, this pool's max size is 10, and the endpoints' max size is 80. 
2. In systems with a high load and many objects, the number of md_store queries and the time it takes to perform them cause the pool to reach its maximum. As a result, non-md queries are also stuck in the waiting queue, and the entire system may become unresponsive.

#### The Solution
1. Maintain two separate pools in `postgres_client.js`, a default pool and a dedicated md_store pool
2. If the md_store pool is overused, the default pool is left to handle all other, typically short queries, so the default pool should remain relatively available.  


- [ ] Doc added/updated
- [ ] Tests added
