### PR TITLE
Removing `unique` and the unused `NAN_SET_BUF_DETACH`

### DIFF
--- a/src/native/util/buf.h
+++ b/src/native/util/buf.h
@@ -168,12 +168,6 @@ public:
     }
 
     inline bool
-    unique_alloc()
-    {
-        return _alloc.unique();
-    }
-
-    inline bool
     same(const Buf& buf) const
     {
         return (_len == buf._len) && !memcmp(_data, buf._data, _len);

--- a/src/native/util/nan.h
+++ b/src/native/util/nan.h
@@ -71,12 +71,6 @@ NanKey(std::string s)
 #define NAN_SET_NUM(obj, key, val) (NAN_SET(obj, key, Nan::New<v8::Number>(val)))
 #define NAN_SET_BUF_COPY(obj, key, buf) \
     (NAN_SET(obj, key, Nan::CopyBuffer(buf.cdata(), buf.length()).ToLocalChecked()))
-#define NAN_SET_BUF_DETACH(obj, key, buf)                                              \
-    do {                                                                               \
-        assert(buf.unique_alloc());                                                    \
-        NAN_SET(obj, key, Nan::NewBuffer(buf.cdata(), buf.length()).ToLocalChecked()); \
-        buf.detach_alloc();                                                            \
-    } while (0)
 
 #define NAN_ERR(msg) (Nan::To<v8::Object>(Nan::Error(msg)).ToLocalChecked())
 #define NAN_RETURN(val)                 \


### PR DESCRIPTION
### Explain the changes
`unique` was removed from `shared_ptr`
This PR removes `unique` and the unused `NAN_SET_BUF_DETACH`
 

### Testing Instructions:
1. see that we can compile using c++20 
