### PR TITLE
noobaa/core:  remove global websocket

### DIFF
--- a/src/rpc/rpc_ws.js
+++ b/src/rpc/rpc_ws.js
@@ -1,7 +1,7 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const WS = global.WebSocket || require('ws');
+const WS = require('ws');
 
 const dbg = require('../util/debug_module')(__filename);
 const http_utils = require('../util/http_utils');

--- a/src/rpc/rpc_ws_server.js
+++ b/src/rpc/rpc_ws_server.js
@@ -5,7 +5,7 @@ const url = require('url');
 const EventEmitter = require('events').EventEmitter;
 const RpcWsConnection = require('./rpc_ws');
 const dbg = require('../util/debug_module')(__filename);
-const WS = global.WebSocket || require('ws');
+const WS = require('ws');
 
 
 /**


### PR DESCRIPTION
**Prep PR for node 22**

In node v22, websocket is enabled by default
https://github.com/nodejs/node/pull/51594

This will cause an error on following line when the global.Websocket would be true.
const WS = global.WebSocket || require('ws');

global.WebSocket: This will points to Node.js's native WebSocket, which does not include a Server class.
require('ws'): The ws package includes both WebSocket and WebSocket.Server, but this fallback is skipped because global.WebSocket is already defined in Node.js v22
