### PR TITLE
NSFS | versioning | change open_files_gpfs log on failed file open from error to warn

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -3212,7 +3212,7 @@ class NamespaceFS {
                 move_to_dst: { src_file, dst_file, dir_file}
             };
         } catch (err) {
-            dbg.error('NamespaceFS._open_files_gpfs couldn\'t open files', err);
+            dbg.warn('NamespaceFS._open_files_gpfs couldn\'t open files', err);
             await this._close_files_gpfs(fs_context, { src_file, dst_file, dir_file, versioned_file }, open_mode, delete_version);
             throw err;
         }


### PR DESCRIPTION
### Explain the changes
1. during concurrent operations file might be moved or deleted before its opened in _open_files_gpfs. in this case we will retry. change the log for failing to open file from error to warn. in case all retries were exhausted the error will be printed on the retry end

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
