### PR TITLE
NSFS | versioning | copy_object - close chunkfs read stream to prevent stream being closed after stat

### DIFF
--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -773,6 +773,16 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
             assert.ok(exist2);
         });
 
+        mocha.it('copy object version id - version matches mtime and inode', async function() {
+            const key = 'copied_key5.txt';
+            const res = await s3_uid6.copyObject({ Bucket: bucket_name, Key: key,
+                CopySource: `${bucket_name}/${key1}?versionId=${key1_ver1}`});
+            const obj_path = path.join(full_path, key);
+            const stat = await nb_native().fs.stat(DEFAULT_FS_CONFIG, obj_path);
+            const expcted_version = 'mtime-' + stat.mtimeNsBigint.toString(36) + '-ino-' + stat.ino.toString(36);
+            assert.equal(expcted_version, res.VersionId);
+        });
+
         mocha.it('delete object - versioning enabled - nested key (more than 1 level)- delete partial directory', async function() {
             const parital_nested_directory = dir_path_complete.slice(0, -1); // the directory without the last slash
             const folder_path_nested = path.join(nested_keys_full_path, dir_path_complete, NSFS_FOLDER_OBJECT_NAME);


### PR DESCRIPTION
### Explain the changes
1. chunkfs is a Transform stream, however read_object_stream expects a write stream, so it only closes the write part. so the stream itself is still alive. it is later closed automatically (probably by garbage collector?), but this may happen after we call stat on the written file, so the mtime we stat is later modified when the stream is closed. this causes the mtime of the file to be different then that of the version. on GPFS we will not notice this until we call safe_move_posix that validates the inode and mtime of the file with the version, causing it to fail.

### Issues: Fixed #8469 

### Testing Instructions:
1. run `NC_CORETEST=true GPFS_ROOT_PATH=/ibm/fs1/tmp GPFS_DL_PATH="/usr/lpp/mmfs/lib/libgpfs.so" node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_bucketspace_versioning.js` on GPFS machine
2. ceph test: `test_versioning_obj_suspended_copy`


- [ ] Doc added/updated
- [x] Tests added
