### PR TITLE
NC | Online Upgrade | Health CLI update config directory and upgrade checks

### DIFF
--- a/docs/NooBaaNonContainerized/CI&Tests.md
+++ b/docs/NooBaaNonContainerized/CI&Tests.md
@@ -88,7 +88,7 @@ Run `NC mocha tests` with root permissions -
 #### NC mocha tests 
 The following is a list of `NC mocha test` files -   
 1. `test_nc_nsfs_cli.js` - Tests NooBaa CLI.  
-2. `test_nc_nsfs_health` - Tests NooBaa Health CLI.  
+2. `test_nc_health` - Tests NooBaa Health CLI.  
 3. `test_nsfs_glacier_backend.js` - Tests NooBaa Glacier Backend.  
 4. `test_nc_with_a_couple_of_forks.js` - Tests the `bucket_namespace_cache` when running with a couple of forks. Please notice that it uses `nc_coretest` with setup that includes a couple of forks.
 

--- a/src/test/unit_tests/nc_index.js
+++ b/src/test/unit_tests/nc_index.js
@@ -11,7 +11,7 @@ require('./test_chunk_fs');
 require('./test_namespace_fs_mpu');
 require('./test_nb_native_fs');
 require('./test_nc_nsfs_cli');
-require('./test_nc_nsfs_health');
+require('./test_nc_health');
 require('./test_nsfs_access');
 require('./test_nsfs_integration');
 require('./test_bucketspace_fs');

--- a/src/test/unit_tests/sudo_index.js
+++ b/src/test/unit_tests/sudo_index.js
@@ -21,5 +21,5 @@ require('./test_bucketspace_versioning');
 require('./test_bucketspace_fs');
 require('./test_nsfs_versioning');
 require('./test_nc_nsfs_cli');
-require('./test_nc_nsfs_health');
+require('./test_nc_health');
 

--- a/src/upgrade/nc_upgrade_manager.js
+++ b/src/upgrade/nc_upgrade_manager.js
@@ -6,10 +6,9 @@ const _ = require('lodash');
 const path = require('path');
 const util = require('util');
 const pkg = require('../../package.json');
-const dbg = require('../util/debug_module')('UPGRADE');
+const dbg = require('../util/debug_module')(__filename);
 const { should_upgrade, run_upgrade_scripts, version_compare } = require('./upgrade_utils');
 
-dbg.set_process_name('Upgrade');
 const hostname = os.hostname();
 
 const CONFIG_DIR_LOCKED = 'CONFIG_DIR_LOCKED';

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -4,9 +4,7 @@
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
-const dbg = require('../util/debug_module')('UPGRADE');
-dbg.set_process_name('Upgrade');
-
+const dbg = require('../util/debug_module')(__filename);
 
 /**
  * @param {string} ver


### PR DESCRIPTION
### Explain the changes
1. Added a check in the Health CLI that shows the config directory status if exists.
2. Added a check in the Health CLI that asserts if the upgrade of the config directory has issues, this situation can be discovered by phase of the config directory is locked and there is no ongoing upgrade.
3. Added unit tests (and did some refactoring).
4. Fixed a bug that sets the process name to be `Upgrade`, it's showing in the logs of the endpoint, CLI etc.

### Issues: Fixed #xxx / Gap #xxx
1. Another idea for a health check - check per host if config directory is locked.

### Testing Instructions:
1.  `sudo node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_nc_health.js`


- [x] Doc added/updated
- [x] Tests added
