### PR TITLE
[Glacier] Fix AMZ restore status header

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -314,7 +314,7 @@ function set_response_object_md(res, object_md) {
     if (storage_class !== STORAGE_CLASS_STANDARD) {
         res.setHeader('x-amz-storage-class', storage_class);
     }
-    if (object_md.restore_status) {
+    if (object_md.restore_status?.ongoing || object_md.restore_status?.expiry_time) {
         const restore = [`ongoing-request="${object_md.restore_status.ongoing}"`];
         if (!object_md.restore_status.ongoing && object_md.restore_status.expiry_time) {
             // Expiry time is in UTC format

--- a/src/sdk/nsfs_glacier_backend/backend.js
+++ b/src/sdk/nsfs_glacier_backend/backend.js
@@ -156,7 +156,7 @@ class GlacierBackend {
     static get_restore_status(xattr, now, file_path) {
         if (xattr[GlacierBackend.STORAGE_CLASS_XATTR] !== s3_utils.STORAGE_CLASS_GLACIER) return;
 
-        // Total 6 states (2x restore_request, 3x restore_expiry)
+        // Total 8 states (2x restore_request, 4x restore_expiry)
         let restore_request;
         let restore_expiry;
 

--- a/src/test/unit_tests/jest_tests/test_s3_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_s3_utils.test.js
@@ -5,6 +5,19 @@ const s3_utils = require('../../../endpoint/s3/s3_utils');
 const { S3Error } = require('../../../endpoint/s3/s3_errors');
 const config = require('../../../../config');
 
+function create_dummy_nb_response() {
+    return {
+        headers: {},
+        setHeader: function(k, v) {
+            if (Array.isArray(v)) {
+                v = v.join(',');
+            }
+
+            this.headers[k] = v;
+        }
+    };
+}
+
 describe('s3_utils', () => {
     describe('parse_restrore_request_days', () => {
         it('should parse correctly when 0 < days < max days', () => {
@@ -55,6 +68,51 @@ describe('s3_utils', () => {
             expect(days).toBe(config.S3_RESTORE_REQUEST_MAX_DAYS);
 
             config.S3_RESTORE_REQUEST_MAX_DAYS_BEHAVIOUR = initial;
+        });
+    });
+
+    describe('set_response_object_md', () => {
+        it('should return no restore status when restore_status is absent', () => {
+            const object_md = {
+                xattr: {}
+            };
+            const res = create_dummy_nb_response();
+
+            // @ts-ignore
+            s3_utils.set_response_object_md(res, object_md);
+
+            expect(res.headers['x-amz-restore']).toBeUndefined();
+        });
+
+        it('should return restore status when restore is requested and ongoing', () => {
+            const object_md = {
+                xattr: {},
+                restore_status: {
+                    ongoing: true,
+                },
+            };
+            const res = create_dummy_nb_response();
+
+            // @ts-ignore
+            s3_utils.set_response_object_md(res, object_md);
+
+            expect(res.headers['x-amz-restore']).toBeDefined();
+        });
+
+        it('should return restore status when restore is completed', () => {
+            const object_md = {
+                xattr: {},
+                restore_status: {
+                    ongoing: false,
+                    expiry_time: new Date(),
+                },
+            };
+            const res = create_dummy_nb_response();
+
+            // @ts-ignore
+            s3_utils.set_response_object_md(res, object_md);
+
+            expect(res.headers['x-amz-restore']).toBeDefined();
         });
     });
 });


### PR DESCRIPTION
### Explain the changes
This PR fixes the bug where NooBaa will report restore status for all the objects regardless if restore was requested or not for them.

### Issues: Fixed #xxx / Gap #xxx
Fixes some DBS3 hosted prototype issues

### Testing Instructions:
1. `./node_modules/.bin/jest src/test/unit_tests/jest_tests/test_s3_utils.test.js`


- [ ] Doc added/updated
- [x] Tests added
