### PR TITLE
CORS - support AWS APIs (NC and containerized)

### DIFF
--- a/config.js
+++ b/config.js
@@ -64,7 +64,7 @@ config.BUFFERS_MEM_LIMIT_MIN = 32 * 1024 * 1024; // just some workable minimum s
 config.BUFFERS_MEM_LIMIT_MAX = 4 * 1024 * 1024 * 1024;
 config.BUFFERS_MEM_LIMIT = Math.min(
     config.BUFFERS_MEM_LIMIT_MAX,
-    Math.max(Math.floor(config.CONTAINER_MEM_LIMIT / 4), config.BUFFERS_MEM_LIMIT_MIN, )
+    Math.max(Math.floor(config.CONTAINER_MEM_LIMIT / 4), config.BUFFERS_MEM_LIMIT_MIN)
 );
 
 ////////////////////////
@@ -152,9 +152,8 @@ config.ENDPOINT_HTTP_SERVER_REQUEST_TIMEOUT = 300 * 1000;
 config.ENDPOINT_HTTP_SERVER_KEEPALIVE_TIMEOUT = 5 * 1000;
 config.ENDPOINT_HTTP_MAX_REQUESTS_PER_SOCKET = 0; // 0 = no limit
 
-// For now we enable fixed CORS for all buckets
-// but this should become a setting per bucket which is configurable
-// with the s3 put-bucket-cors api.
+// For now we enable fixed CORS only for sts
+// for S3 per bucket is configurabl with the s3 put-bucket-cors api.
 // note that browsers do not really allow origin=* with credentials,
 // but we just allow both from our side for simplicity.
 config.S3_CORS_ENABLED = true;
@@ -502,6 +501,7 @@ config.LOG_COLOR_ENABLED = process.env.NOOBAA_LOG_COLOR ? process.env.NOOBAA_LOG
 
 // TEST Mode
 config.test_mode = false;
+config.allow_anonymous_access_in_test = false; // used for emulating ACL='public-read' for ceph-s3 tests
 
 // On Premise NVA params
 config.on_premise = {
@@ -753,11 +753,11 @@ config.NSFS_BUF_POOL_MEM_LIMIT_XS = Math.min(Math.floor(config.NSFS_MAX_MEM_SIZE
 config.NSFS_BUF_POOL_MEM_LIMIT_S = Math.min(Math.floor(config.NSFS_MAX_MEM_SIZE_S / config.NSFS_BUF_SIZE_S),
     config.NSFS_WANTED_BUFFERS_NUMBER) * config.NSFS_BUF_SIZE_S;
 // Semaphore size will give 90% of remainning memory to large buffer size, 10% to medium
-config.NSFS_BUF_POOL_MEM_LIMIT_M = range_utils.align_down((config.BUFFERS_MEM_LIMIT -
-        config.NSFS_BUF_POOL_MEM_LIMIT_S - config.NSFS_BUF_POOL_MEM_LIMIT_XS) * 0.1,
+config.NSFS_BUF_POOL_MEM_LIMIT_M = range_utils.align_down(
+    (config.BUFFERS_MEM_LIMIT - config.NSFS_BUF_POOL_MEM_LIMIT_S - config.NSFS_BUF_POOL_MEM_LIMIT_XS) * 0.1,
     config.NSFS_BUF_SIZE_M);
-config.NSFS_BUF_POOL_MEM_LIMIT_L = range_utils.align_down((config.BUFFERS_MEM_LIMIT -
-        config.NSFS_BUF_POOL_MEM_LIMIT_S - config.NSFS_BUF_POOL_MEM_LIMIT_XS) * 0.9,
+config.NSFS_BUF_POOL_MEM_LIMIT_L = range_utils.align_down(
+    (config.BUFFERS_MEM_LIMIT - config.NSFS_BUF_POOL_MEM_LIMIT_S - config.NSFS_BUF_POOL_MEM_LIMIT_XS) * 0.9,
     config.NSFS_BUF_SIZE_L);
 
 config.NSFS_BUF_WARMUP_SPARSE_FILE_READS = true;

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -343,7 +343,7 @@ module.exports = {
                     notifications: {
                         type: 'array',
                         items: {
-                             $ref: 'common_api#/definitions/bucket_notification'
+                            $ref: 'common_api#/definitions/bucket_notification'
                         }
                     }
                 }
@@ -890,6 +890,65 @@ module.exports = {
                 system: ['admin', 'user']
             }
         },
+
+        get_bucket_cors: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: {
+                        $ref: 'common_api#/definitions/bucket_name'
+                    },
+                },
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    cors: {
+                        $ref: 'common_api#/definitions/bucket_cors_configuration'
+                    }
+                }
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
+
+        put_bucket_cors: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: ['name', 'cors_rules'],
+                properties: {
+                    name: {
+                        $ref: 'common_api#/definitions/bucket_name'
+                    },
+                    cors_rules: {
+                        $ref: 'common_api#/definitions/bucket_cors_configuration'
+                    },
+                },
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
+
+        delete_bucket_cors: {
+            method: 'DELETE',
+            params: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: {
+                        $ref: 'common_api#/definitions/bucket_name'
+                    },
+                },
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
     },
 
     definitions: {
@@ -1200,6 +1259,9 @@ module.exports = {
                     items: {
                         $ref: 'common_api#/definitions/bucket_notification'
                     }
+                },
+                cors_configuration_rules: {
+                    $ref: 'common_api#/definitions/bucket_cors_configuration',
                 }
             }
         },

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -271,6 +271,50 @@ module.exports = {
             }
         },
 
+        bucket_cors_configuration: {
+            type: 'array',
+            items: {
+                $ref: '#/definitions/bucket_cors_rule'
+            }
+        },
+
+        bucket_cors_rule: {
+            type: 'object',
+            required: ['allowed_methods', 'allowed_origins'],
+            properties: {
+                id: {
+                    type: 'string'
+                },
+                allowed_methods: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    }
+                },
+                allowed_origins: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    }
+                },
+                allowed_headers: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    }
+                },
+                expose_headers: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    }
+                },
+                max_age_seconds: {
+                    type: 'integer'
+                },
+            }
+        },
+
         bucket_policy_principal: {
             anyOf: [{
                 wrapper: SensitiveString

--- a/src/endpoint/s3/ops/s3_delete_bucket_cors.js
+++ b/src/endpoint/s3/ops/s3_delete_bucket_cors.js
@@ -5,8 +5,9 @@
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEcors.html
  */
 async function delete_bucket_cors(req) {
-    await req.object_sdk.read_bucket({ name: req.params.bucket });
-    // TODO S3 delete_bucket_cors not implemented
+    await req.object_sdk.delete_bucket_cors({
+        name: req.params.bucket,
+    });
 }
 
 module.exports = {

--- a/src/endpoint/s3/ops/s3_get_bucket_cors.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_cors.js
@@ -1,14 +1,25 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const S3Error = require('../s3_errors').S3Error;
+
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETcors.html
  */
 async function get_bucket_cors(req) {
-    await req.object_sdk.read_bucket({ name: req.params.bucket });
-    return {
-        CORSConfiguration: ''
-    };
+    const reply = await req.object_sdk.get_bucket_cors({ name: req.params.bucket });
+    if (!reply.cors.length) throw new S3Error(S3Error.NoSuchCORSConfiguration);
+    const cors_rules = reply.cors.map(rule => {
+        const new_rule = [];
+        new_rule.push(...rule.allowed_methods.map(m => ({ AllowedMethod: m })));
+        new_rule.push(...rule.allowed_origins.map(o => ({ AllowedOrigin: o })));
+        if (rule.allowed_headers) new_rule.push(...rule.allowed_headers.map(h => ({ AllowedHeader: h })));
+        if (rule.expose_headers) new_rule.push(...rule.expose_headers.map(e => ({ ExposeHeader: e })));
+        if (rule.id) new_rule.push({ ID: rule.id });
+        if (rule.max_age_seconds) new_rule.push({ MaxAgeSeconds: rule.max_age_seconds });
+        return { CORSRule: new_rule };
+    });
+    return { CORSConfiguration: cors_rules.length ? cors_rules : '' };
 }
 
 module.exports = {

--- a/src/endpoint/s3/ops/s3_put_bucket_cors.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_cors.js
@@ -1,15 +1,26 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const S3Error = require('../s3_errors').S3Error;
+const _ = require('lodash');
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTcors.html
  */
 async function put_bucket_cors(req) {
-    await req.object_sdk.read_bucket({ name: req.params.bucket });
-    // TODO S3 put_bucket_cors not implemented
-    throw new S3Error(S3Error.NotImplemented);
+    const cors_rules = req.body.CORSConfiguration.CORSRule.map(rule =>
+        _.omitBy({
+            allowed_headers: rule.AllowedHeader,
+            allowed_methods: rule.AllowedMethod,
+            allowed_origins: rule.AllowedOrigin,
+            expose_headers: rule.ExposeHeader,
+            id: rule.ID,
+            max_age_seconds: rule.MaxAgeSeconds,
+        }, _.isUndefined)
+    );
+    await req.object_sdk.put_bucket_cors({
+        name: req.params.bucket,
+        cors_rules
+    });
 }
 
 module.exports = {

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -339,6 +339,11 @@ S3Error.NoSuchLifecycleConfiguration = Object.freeze({
     message: 'The lifecycle configuration does not exist.',
     http_code: 404,
 });
+S3Error.NoSuchCORSConfiguration = Object.freeze({
+    code: 'NoSuchCORSConfiguration',
+    message: 'The specified bucket does not have a CORS configuration.',
+    http_code: 404,
+});
 S3Error.NoSuchUpload = Object.freeze({
     code: 'NoSuchUpload',
     message: 'The specified multipart upload does not exist. The upload ID might be invalid, or the multipart upload might have been aborted or completed.',

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -697,6 +697,47 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         }
     }
 
+    ////////////////////
+    // BUCKET CORS //
+    ////////////////////
+
+    async put_bucket_cors(params) {
+        try {
+            const { name, cors_rules } = params;
+            dbg.log0('BucketSpaceFS.put_bucket_cors: Bucket name', name, ", cors configuration ", cors_rules);
+            const bucket = await this.config_fs.get_bucket_by_name(name);
+            bucket.cors_configuration_rules = cors_rules;
+            await this.config_fs.update_bucket_config_file(bucket);
+        } catch (error) {
+            throw translate_error_codes(error, entity_enum.BUCKET);
+        }
+    }
+
+    async delete_bucket_cors(params) {
+        try {
+            const { name } = params;
+            dbg.log0('BucketSpaceFS.delete_bucket_cors: Bucket name', name);
+            const bucket = await this.config_fs.get_bucket_by_name(name);
+            delete bucket.cors_configuration_rules;
+            await this.config_fs.update_bucket_config_file(bucket);
+        } catch (err) {
+            throw translate_error_codes(err, entity_enum.BUCKET);
+        }
+    }
+
+    async get_bucket_cors(params) {
+        try {
+            const { name } = params;
+            dbg.log0('BucketSpaceFS.get_bucket_cors: Bucket name', name);
+            const bucket = await this.config_fs.get_bucket_by_name(name);
+            return {
+                cors: bucket.cors_configuration_rules || [],
+            };
+        } catch (error) {
+            throw translate_error_codes(error, entity_enum.BUCKET);
+        }
+    }
+
     /////////////////////////
     // DEFAULT OBJECT LOCK //
     /////////////////////////

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -33,7 +33,7 @@ class BucketSpaceNB {
     ////////////
 
     async list_buckets(params, object_sdk) {
-        const { buckets, continuation_token} = (await this.rpc_client.bucket.list_buckets(params));
+        const { buckets, continuation_token } = (await this.rpc_client.bucket.list_buckets(params));
 
         const has_access_buckets = (await P.all(_.map(
             buckets,
@@ -44,7 +44,7 @@ class BucketSpaceNB {
                     object_sdk.has_non_nsfs_bucket_access(object_sdk.requesting_account, ns);
                 return has_access_to_bucket && bucket;
             }))).filter(bucket => bucket);
-        return { buckets: has_access_buckets, continuation_token};
+        return { buckets: has_access_buckets, continuation_token };
     }
 
     async read_bucket(params) {
@@ -244,6 +244,29 @@ class BucketSpaceNB {
     async get_bucket_notification(params) {
         return this.rpc_client.bucket.get_bucket_notification({
             name: params.bucket_name
+        });
+    }
+
+    ////////////////////
+    // BUCKET CORS //
+    ////////////////////
+
+    async put_bucket_cors(params) {
+        return this.rpc_client.bucket.put_bucket_cors({
+            name: params.name,
+            cors_rules: params.cors_rules
+        });
+    }
+
+    async delete_bucket_cors(params) {
+        return this.rpc_client.bucket.delete_bucket_cors({
+            name: params.name
+        });
+    }
+
+    async get_bucket_cors(params) {
+        return this.rpc_client.bucket.get_bucket_cors({
+            name: params.name
         });
     }
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -860,6 +860,10 @@ interface BucketSpace {
     put_bucket_notification(params: object): Promise<any>;
     get_bucket_notification(params: object): Promise<any>;
 
+    put_bucket_cors(params: object): Promise<any>;
+    delete_bucket_cors(params: object): Promise<any>;
+    get_bucket_cors(params: object): Promise<any>;
+
     get_object_lock_configuration(params: object, object_sdk: ObjectSDK): Promise<any>;
     put_object_lock_configuration(params: object, object_sdk: ObjectSDK): Promise<any>;
 

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -668,7 +668,7 @@ function _get_auth_info(account, system, authorized_by, role, extra) {
  * @param {Record<string, any>} account requesting account
  * @param {string} action s3 bucket action (lowercased only)
  * @param {string} bucket_path s3 bucket path (must start from "/")
- * @returns {boolean} true if the account has permission to perform the action on the bucket
+ * @returns  {Promise<boolean>} true if the account has permission to perform the action on the bucket
  */
 async function has_bucket_action_permission(bucket, account, action, bucket_path = "") {
     dbg.log1('has_bucket_action_permission:', bucket.name, account.email, bucket.owner_account.email);
@@ -703,7 +703,7 @@ async function has_bucket_action_permission(bucket, account, action, bucket_path
  * @param {Record<string, any>} bucket bucket
  * @param {string} action s3 action (lowercased)
  * @param {string} bucket_path bucket path
- * @returns {boolean} true if the bucket is configured to serve anonymous requests
+ * @returns {Promise<boolean>} true if the bucket is configured to serve anonymous requests
  */
 async function has_bucket_anonymous_permission(bucket, action, bucket_path = "") {
     const bucket_policy = bucket.s3_policy;

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -203,6 +203,10 @@ module.exports = {
         lifecycle_configuration_rules: {
             $ref: 'common_api#/definitions/bucket_lifecycle_configuration'
         },
+        //cors rules if exist
+        cors_configuration_rules: {
+            $ref: 'common_api#/definitions/bucket_cors_configuration'
+        },
         tagging: {
             $ref: 'common_api#/definitions/tagging',
         },
@@ -278,7 +282,7 @@ module.exports = {
         notifications: {
             type: 'array',
             items: {
-                 $ref: 'common_api#/definitions/bucket_notification'
+                $ref: 'common_api#/definitions/bucket_notification'
             }
         },
     }

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -81,8 +81,11 @@ module.exports = {
         notifications: {
             type: 'array',
             items: {
-                 $ref: 'common_api#/definitions/bucket_notification'
+                $ref: 'common_api#/definitions/bucket_notification'
             }
+        },
+        cors_configuration_rules: {
+            $ref: 'common_api#/definitions/bucket_cors_configuration'
         },
     }
 };

--- a/src/test/system_tests/ceph_s3_tests/run_ceph_nsfs_test_on_test_container.sh
+++ b/src/test/system_tests/ceph_s3_tests/run_ceph_nsfs_test_on_test_container.sh
@@ -24,6 +24,7 @@ export CEPH_TEST_LOGS_DIR=/logs/ceph-nsfs-test-logs
 export CONFIG_DIR=/etc/noobaa.conf.d/
 export FS_ROOT_1=/tmp/nsfs_root1/
 export FS_ROOT_2=/tmp/nsfs_root2/
+export CONFIG_JS_allow_anonymous_access_in_test=true # Needed for allowing anon access for tests using ACL='public-read-write'
 
 # ====================================================================================
 

--- a/src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh
+++ b/src/test/system_tests/ceph_s3_tests/run_ceph_test_on_test_container.sh
@@ -32,6 +32,9 @@ export HOSTED_AGENTS_ADDR=wss://localhost:5446
 
 export CEPH_TEST_LOGS_DIR=/logs/ceph-test-logs
 
+export CONFIG_JS_OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS=0 # Needed for disabling cache for ceph cors test and maybe some more
+export CONFIG_JS_allow_anonymous_access_in_test=true # Needed for allowing anon access for tests using ACL='public-read-write'
+
 # ====================================================================================
 
 # Create the logs directory

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_black_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_black_list.txt
@@ -207,10 +207,6 @@ s3tests_boto3/functional/test_s3.py::test_multipart_upload_size_too_small
 s3tests_boto3/functional/test_s3.py::test_abort_multipart_upload
 s3tests_boto3/functional/test_s3.py::test_multipart_copy_improper_range
 s3tests_boto3/functional/test_s3.py::test_100_continue
-s3tests_boto3/functional/test_s3.py::test_set_cors
-s3tests_boto3/functional/test_s3.py::test_cors_origin_wildcard
-s3tests_boto3/functional/test_s3.py::test_cors_origin_response
-s3tests_boto3/functional/test_s3.py::test_cors_header_option
 s3tests_boto3/functional/test_s3.py::test_set_tagging
 s3tests_boto3/functional/test_s3.py::test_multipart_resend_first_finishes_last
 s3tests_boto3/functional/test_s3.py::test_versioned_object_acl
@@ -400,9 +396,7 @@ s3tests_boto3/functional/test_s3.py::test_sse_s3_encrypted_upload_1b
 s3tests_boto3/functional/test_s3.py::test_sse_s3_encrypted_upload_1kb
 s3tests_boto3/functional/test_s3.py::test_sse_s3_encrypted_upload_1mb
 s3tests_boto3/functional/test_s3.py::test_sse_s3_encrypted_upload_8mb
-s3tests_boto3/functional/test_s3.py::test_cors_presigned_get_object
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_get_object_tenant
-s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_with_acl
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant_with_acl

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_black_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_black_list.txt
@@ -130,6 +130,7 @@ s3tests_boto3/functional/test_s3.py::test_object_delete_key_bucket_gone
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_object_gone
 s3tests_boto3/functional/test_s3.py::test_bucket_head_extended
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_bucket_acl
+s3tests_boto3/functional/test_s3.py::test_object_raw_get_object_acl
 s3tests_boto3/functional/test_s3.py::test_object_raw_response_headers
 s3tests_boto3/functional/test_s3.py::test_object_raw_authenticated_bucket_acl
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_x_amz_expires_out_range_zero
@@ -208,10 +209,6 @@ s3tests_boto3/functional/test_s3.py::test_multipart_upload_size_too_small
 s3tests_boto3/functional/test_s3.py::test_abort_multipart_upload
 s3tests_boto3/functional/test_s3.py::test_multipart_copy_improper_range
 s3tests_boto3/functional/test_s3.py::test_100_continue
-s3tests_boto3/functional/test_s3.py::test_set_cors
-s3tests_boto3/functional/test_s3.py::test_cors_origin_wildcard
-s3tests_boto3/functional/test_s3.py::test_cors_origin_response
-s3tests_boto3/functional/test_s3.py::test_cors_header_option
 s3tests_boto3/functional/test_s3.py::test_set_tagging
 s3tests_boto3/functional/test_s3.py::test_multipart_resend_first_finishes_last
 s3tests_boto3/functional/test_s3.py::test_versioned_object_acl
@@ -353,3 +350,5 @@ s3tests_boto3/functional/test_sts.py::test_assume_role_with_web_identity_wrong_r
 s3tests_boto3/functional/test_sts.py::test_assume_role_with_web_identity_resource_tag_princ_tag
 s3tests_boto3/functional/test_sts.py::test_assume_role_with_web_identity_resource_tag_copy_obj
 s3tests_boto3/functional/test_sts.py::test_assume_role_with_web_identity_role_resource_tag
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_with_acl
+s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant_with_acl

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -117,7 +117,6 @@ s3tests/functional/test_headers.py::test_bucket_create_bad_amz_date_before_epoch
 s3tests_boto3/functional/test_s3.py::test_post_object_wrong_bucket
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_x_amz_expires_not_expired
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_x_amz_expires_not_expired_tenant
-s3tests_boto3/functional/test_s3.py::test_cors_presigned_get_object
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_get_object_tenant
 s3tests_boto3/functional/test_s3.py::test_multipart_get_part
 s3tests_boto3/functional/test_s3.py::test_non_multipart_get_part
@@ -133,10 +132,7 @@ s3tests/functional/test_headers.py::test_bucket_create_bad_date_none_aws2
 s3tests_boto3/functional/test_s3.py::test_get_object_ifnonematch_good
 s3tests_boto3/functional/test_s3.py::test_get_object_ifmodifiedsince_failed
 s3tests_boto3/functional/test_s3.py::test_post_object_wrong_bucket
-s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object
-s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_with_acl
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant
-s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant_with_acl
 s3tests_boto3/functional/test_s3.py::test_object_presigned_put_object_with_acl_tenant
 s3tests_boto3/functional/test_s3.py::test_lifecycle_expiration_newer_noncurrent
 s3tests_boto3/functional/test_s3.py::test_lifecycle_expiration_size_gt


### PR DESCRIPTION
### Explain the changes
1. Adding support to the S3 CORS API: PUT/GET/DELETE
2. Changing default CORS behavior from a set of defaults to supporting the API following AWS documentation:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html
with some ideas from Azure documentation here:  https://learn.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services
3. Adding an option to create an anonymous bucket policy for read when getting a public-read acl, used by ceph-s3 tests

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #6080 

### Testing Instructions:
1.  Added a few tests from ceph-tests suite.


- [ ] Doc added/updated
- [X] Tests added
