### PR TITLE
NC | Online Upgrade GPFS fixes + new host but existing system fix

### DIFF
--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -23,7 +23,7 @@ Usage:
 const ARGUMENTS = `
 Arguments:
 
-    <type>    Set the resource type: account, bucket, whitelist, diagnose or logging
+    <type>    Set the resource type: account, bucket, whitelist, diagnose, logging or upgrade
     <action>  Action could be: add, update, list, status, and delete for accounts/buckets
 `;
 

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -1063,7 +1063,7 @@ class ConfigFS {
             } else {
                 if (updated_system_json[hostname]?.current_version) return;
                 const new_host_data = this._get_new_hostname_data();
-                updated_system_json = { ...updated_system_json, new_host_data };
+                updated_system_json = { ...updated_system_json, ...new_host_data };
                 await this.update_system_config_file(JSON.stringify(updated_system_json));
                 dbg.log0('updated NC system data with version: ', pkg.version);
                 return updated_system_json;
@@ -1171,7 +1171,7 @@ class ConfigFS {
         return {
             [os.hostname()]: {
                 current_version: pkg.version,
-                    upgrade_history: {
+                upgrade_history: {
                     successful_upgrades: []
                 },
             },

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -189,12 +189,12 @@ async function safe_unlink(fs_context, src_path, src_ver_info, gpfs_options, tmp
 
 async function safe_link(fs_context, src_path, dst_path, src_ver_info, gpfs_options) {
     if (_is_gpfs(fs_context)) {
-        const { src_file = undefined, dir_file = undefined } = gpfs_options;
-        if (dir_file) {
-            await safe_link_gpfs(fs_context, src_path, src_file, dir_file);
+        const { src_file = undefined, dst_file = undefined } = gpfs_options;
+        if (dst_file) {
+            await safe_link_gpfs(fs_context, dst_path, src_file, dst_file);
         } else {
-            dbg.error(`safe_link: dir_file is ${dir_file}, cannot use it to call safe_unlink_gpfs`);
-            throw new Error(`dir_file is ${dir_file}, need a value to safe unlink GPFS`);
+            dbg.error(`safe_link: dst_file is ${dst_file}, cannot use it to call safe_link_gpfs`);
+            throw new Error(`dst_file is ${dst_file}, need a value to safe link GPFS`);
         }
     } else {
         await safe_link_posix(fs_context, src_path, dst_path, src_ver_info);


### PR DESCRIPTION
### Explain the changes
1. Fixes for upgrade script run on GPFS flow - 
2. `config_dir_retructure.prepare_account_upgrade_params()` - change the open mode of the dst file to be w*
3. `config_dir_retructure.create_account_access_keys_index_if_missing()`Changed tmp_access_keys_path to be a backup dir under the config root.
4. `config_dir_retructure.create_account_access_keys_index_if_missing()` - Changed the linkfileat() usage to rename, this is not working as expected on GPFS, hence used the POSIX method that works as expected also on GPFS machine.
5. `safe_link()` - changed dir_file to dst_file and src_path to dst_path.
 
General fixes - 
1. `config_dir_retructure.run()` - Added util.inspect() for printing failed accounts.
2. `config_fs.init_nc_system()` - when system exists but there is a new host - Changed the property new_host_data  to be the host_name.

```
// when a new node rise and it does not exist in system.json it puts its data in "new_host_data" instead of in the top layer
// incorrect - the bug 
sudo cat /etc/noobaa.conf.d/system.json | jq
{
  "host1": {
    "current_version": "5.18.0",
    "upgrade_history": {
      "successful_upgrades": [
        {
          "timestamp": 1733068872760,
          "from_version": "5.17.1",
          "to_version": "5.18.0"
        }
      ]
    }
  },
....,
  "new_host_data": {
    "host-2": {
      "current_version": "5.18.0",
      "upgrade_history": {
        "successful_upgrades": []
      }
    }
  }
}

// correct - after fix - 
sudo cat /etc/noobaa.conf.d/system.json | jq
{
  "host-1": {
    "current_version": "5.18.0",
    "upgrade_history": {
      "successful_upgrades": [
        {
          "timestamp": 1733068872760,
          "from_version": "5.17.1",
          "to_version": "5.18.0"
        }
      ]
    }
  },
  ...., 
  "host-2": {
    "current_version": "5.18.0",
    "upgrade_history": {
      "successful_upgrades": []
    }
  }
}
```
### Issues: Fixed #xxx / Gap #xxx
1. Issues seen on NooBaa upgrade on GPFS cluster + a small fix found locally.

### Testing Instructions:
1.   GPFS flow - 
- Install NooBaa 5.17.z, run nsfs.js or the start the service, stop the service
- Upgrade NooBaa RPM to NooBaa 5.18.0, start the service. 
- Run - `/usr/local/bin/noobaa-cli upgrade start  --expected_version 5.18.0 --expected_hosts host1,host2,host3` on a GPFS cluster
- Check that the upgrade finished successfully and the new structure is as it should be.
3. hostname bug - run nsfs.js, stop it, manually edit system.json and change the name of the node to something else and then run again nsfs.js, stop it, check system.json.


- [ ] Doc added/updated
- [ ] Tests added
