### PR TITLE
nsfs - monitor only nsrs that are mounted. DFBUGS-153

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -213,16 +213,12 @@ async function main(options = {}) {
         // there for namespace monitor won't be registered
         if (internal_rpc_client && config.NAMESPACE_MONITOR_ENABLED) {
             endpoint_stats_collector.instance().set_rpc_client(internal_rpc_client);
-
-            //wait with monitoring until pod has started
-            setTimeout(() => {
-                // Register a bg monitor on the endpoint
-                background_scheduler.register_bg_worker(new NamespaceMonitor({
-                    name: 'namespace_fs_monitor',
-                    client: internal_rpc_client,
-                    should_monitor: nsr => Boolean(nsr.nsfs_config),
-                }));
-            }, 1000 * 60);
+            // Register a bg monitor on the endpoint
+            background_scheduler.register_bg_worker(new NamespaceMonitor({
+                name: 'namespace_fs_monitor',
+                client: internal_rpc_client,
+                should_monitor: nsr => Boolean(nsr.nsfs_config && process.env['NSFS_NSR_' + nsr.name]),
+            }));
         }
 
         if (config.ENABLE_SEMAPHORE_MONITOR) {


### PR DESCRIPTION
### Explain the changes
1. Namespace monitor should not monitor nsfs nsrs that are not mounted on the endpoint.
Use the new NSFS_NSR_ env variable to test whether nsr should be mounted.
(see https://github.com/noobaa/noobaa-operator/pull/1481)

This commit reverts 2789d60757b925cba05d0062ef677ca0bcc4d16b.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-153

### Testing Instructions:
Reduce config.NAMESPACE_MONITOR_DELAY to 1000ms.
Create nsfs nsr
nsr should not be rejected (by endpoints existing before its creation).


- [ ] Doc added/updated
- [ ] Tests added
