### PR TITLE
[Backport into 5.16] Removing `unique` and the unused `NAN_SET_BUF_DETACH`

### DIFF
--- a/src/native/util/buf.h
+++ b/src/native/util/buf.h
@@ -168,12 +168,6 @@ public:
     }
 
     inline bool
-    unique_alloc()
-    {
-        return _alloc.unique();
-    }
-
-    inline bool
     same(const Buf& buf) const
     {
         return (_len == buf._len) && !memcmp(_data, buf._data, _len);

--- a/src/native/util/nan.h
+++ b/src/native/util/nan.h
@@ -71,12 +71,6 @@ NanKey(std::string s)
 #define NAN_SET_NUM(obj, key, val) (NAN_SET(obj, key, Nan::New<v8::Number>(val)))
 #define NAN_SET_BUF_COPY(obj, key, buf) \
     (NAN_SET(obj, key, Nan::CopyBuffer(buf.cdata(), buf.length()).ToLocalChecked()))
-#define NAN_SET_BUF_DETACH(obj, key, buf)                                              \
-    do {                                                                               \
-        assert(buf.unique_alloc());                                                    \
-        NAN_SET(obj, key, Nan::NewBuffer(buf.cdata(), buf.length()).ToLocalChecked()); \
-        buf.detach_alloc();                                                            \
-    } while (0)
 
 #define NAN_ERR(msg) (Nan::To<v8::Object>(Nan::Error(msg)).ToLocalChecked())
 #define NAN_RETURN(val)                 \

--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -38,7 +38,7 @@ commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}'
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
 
-max_days="360"
+max_days="540"
 if [ $((current_date-commit_date)) -gt $((3600*24*${max_days})) ]
 then
     echo "ceph tests were not updated for ${max_days} days, Exiting"


### PR DESCRIPTION
### Explain the changes
1. `unique` was removed from `shared_ptr`
This PR removes `unique` and the unused `NAN_SET_BUF_DETACH`

Signed-off-by: liranmauda <liran.mauda@gmail.com>
(cherry picked from commit 0215f392174253bfbfc334cd043c8f85001a3aef)

More details in the original PR: #8513

2. Extend Ceph commit date to a year and a half (so the CI won't fail).

### Issues: 
1. After updating Mac OS M1 we started to face the error (on `npm run rebuild`):

> In file included from ../src/native/fs/fs_napi.cpp:3:
> ../src/native/fs/../util/buf.h:173:23: error: no member named 'unique' in 'std::shared_ptr<noobaa::Buf::Alloc>'
>   173 |         return _alloc.unique();
>       |                ~~~~~~ ^
> 1 error generated.
> make: *** [Release/obj.target/nb_native/src/native/fs/fs_napi.o] Error 1
> gyp ERR! build error
> gyp ERR! stack Error: `make` failed with exit code: 2
> gyp ERR! stack at ChildProcess.<anonymous> (/Users/shiradymnik/SourceCode/noobaa-core/node_modules/node-gyp/lib/build.js:216:23)
> gyp ERR! System Darwin 24.0.0
> gyp ERR! command "/Users/shiradymnik/.nvm/versions/node/v20.11.0/bin/node" "/Users/shiradymnik/SourceCode/noobaa-core/node_modules/.bin/node-gyp" "build"
> gyp ERR! cwd /Users/shiradymnik/SourceCode/noobaa-core
> gyp ERR! node -v v20.11.0
> gyp ERR! node-gyp -v v10.2.0
> gyp ERR! not ok

### Testing Instructions:
1. I run: `npm run rebuild`.

Note: original instruction - 

> see that we can compile using c++20

- [ ] Doc added/updated
- [ ] Tests added
