### PR TITLE
[GLACIER] Send x-amz-restore header as one single header instead of 2 headers with same name

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -315,12 +315,12 @@ function set_response_object_md(res, object_md) {
         res.setHeader('x-amz-storage-class', storage_class);
     }
     if (object_md.restore_status?.ongoing || object_md.restore_status?.expiry_time) {
-        const restore = [`ongoing-request="${object_md.restore_status.ongoing}"`];
+        let restore = `ongoing-request="${object_md.restore_status.ongoing}"`;
         if (!object_md.restore_status.ongoing && object_md.restore_status.expiry_time) {
             // Expiry time is in UTC format
             const expiry_date = new Date(object_md.restore_status.expiry_time).toUTCString();
 
-            restore.push(`expiry-date="${expiry_date}"`);
+            restore += `, expiry-date="${expiry_date}"`;
         }
 
         res.setHeader('x-amz-restore', restore);


### PR DESCRIPTION
### Explain the changes
This PR changes the way we send `x-amz-restore` header. Previously, we used to send `x-amz-restore` header with 2 different values if the restore was completed. This works with most of the HTTP client but fails on some (it is valid from HTTP RFC perspective) but it is **not** the way AWS S3 sends this header hence the change.


- [ ] Doc added/updated
- [ ] Tests added
