### PR TITLE
NSFS | S3 throwing error for empty header and default port for STS

### DIFF
--- a/config.js
+++ b/config.js
@@ -898,7 +898,8 @@ config.NSFS_NC_CONFIG_DIR_BACKEND = '';
 config.NSFS_NC_STORAGE_BACKEND = '';
 config.ENDPOINT_PORT = Number(process.env.ENDPOINT_PORT) || 6001;
 config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
-config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || -1;
+// Remove the NSFS condition when NSFS starts to support STS.
+config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || (process.env.NC_NSFS_NO_DB_ENV === 'true' ? -1 : 7443);
 config.ENDPOINT_SSL_IAM_PORT = Number(process.env.ENDPOINT_SSL_IAM_PORT) || -1;
 config.ALLOW_HTTP = false;
 // config files should allow access to the owner of the files

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -197,7 +197,7 @@ async function main(options = {}) {
         // START S3, STS & IAM SERVERS & CERTS
         const http_port_s3 = options.http_port || config.ENDPOINT_PORT;
         const https_port_s3 = options.https_port || config.ENDPOINT_SSL_PORT;
-        const https_port_sts = options.https_port_sts || Number(process.env.ENDPOINT_SSL_PORT_STS) || 7443; // || (process.env.NC_NSFS_NO_DB_ENV === 'true' ? -1 : 7443);
+        const https_port_sts = options.https_port_sts || config.ENDPOINT_SSL_STS_PORT;
         const https_port_iam = options.https_port_iam || config.ENDPOINT_SSL_IAM_PORT;
 
         await start_server_and_cert(SERVICES_TYPES_ENUM.S3, init_request_sdk,


### PR DESCRIPTION
### Explain the changes
1. Added check for host header if its missing return empty response
2. set default port for STS only if its not NC

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8509

### Testing Instructions:
1. Start the NSFS server with: sudo node src/cmd/nsfs
2. Send S3 request without host header
```
curl https://localhost:6443 --http1.0 -H 'Host:' --insecure
```
3. Request should not return any response
4. S3 request with host header should return error response
```
curl https://localhost:6443 --http1.0 --insecure
```

- [ ] Doc added/updated
- [ ] Tests added
