### PR TITLE
NSFS | noobaa-cli Help format Update

### DIFF
--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -10,6 +10,7 @@ Help:
     Each subdirectory of the root filesystem represents an S3 bucket.
     "noobaa-cli" will provide a command line interface (CLI) to create new accounts and map existing directories 
     to NooBaa as buckets. For more information refer to the NooBaa docs.
+
 `;
 
 const USAGE = `
@@ -18,191 +19,298 @@ Usage:
     execute with root permission or use sudo before each command
 
     noobaa-cli <type> <action> [flags]
+
 `;
 
 const ARGUMENTS = `
 Arguments:
 
-    <type>    Set the resource type: account, bucket, whitelist, diagnose, logging or upgrade
-    <action>  Action could be: add, update, list, status, and delete for accounts/buckets
+    <type>    Set the resource type: account, bucket, whitelist, diagnose, logging or upgrade.
+    <action>  Actions are dependent on the selected type.
+
 `;
 
 const ACCOUNT_ACTIONS = `
+Help:
+
+    Use this CLI to execute all the account related actions.
+
 Usage:
-account <action> [flags]
+
+    account <action> [flags]
 
 List of actions supported:
-add
-update
-list
-status
-delete
+
+    add
+    update
+    list
+    status
+    delete
+
 `;
 
 const BUCKET_ACTIONS = `
+Help:
+
+    Use this CLI to execute all the bucket related actions.
+
 Usage:
-bucket <action> [flags]
+
+    bucket <action> [flags]
 
 List of actions supported:
-add
-update
-list
-status
-delete
+
+    add
+    update
+    list
+    status
+    delete
+
 `;
 
 const WHITELIST_FLAGS = `
-whitelist [flags]
+Help:
+
+    Use this to set the general configuration to allow only incoming requests from a given list of IP addresses
+
+Usage:
+
+    whitelist [flags]
 
 Flags:
---ips <string>                                                          Set the general configuration to allow only incoming requests from a given list of IP addresses
-                                                                        in format: '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]'
+
+    --ips <string>                                          Set configuring for allowed IP addresses; format: '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]'
+
 `;
 
 const LOGGING_FLAGS = `
-logging                                                                 Use this to upload all the bucket logging collected in the system to their target buckets
+Help:
+
+    Use this to upload all the bucket logging collected in the system to their target buckets
+
+Usage:
+
+    logging [flags]
 
 `;
 
 const CLI_MUTUAL_FLAGS = `
---config_root <string>                                (optional)        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
---config_root_backend <none | GPFS | CEPH_FS | NFSv4> (optional)        Use the filesystem type in the configuration (default config.NSFS_NC_CONFIG_DIR_BACKEND)
---debug <number>                                      (optional)        Use for increasing the log verbosity of cli commands
+    --config_root <string>                                (optional)        Use configuration files path (default config.NSFS_NC_DEFAULT_CONF_DIR)
+    --config_root_backend <none | GPFS | CEPH_FS | NFSv4> (optional)        Use the filesystem type in the configuration (default config.NSFS_NC_CONFIG_DIR_BACKEND)
+    --debug <number>                                      (optional)        Use for increasing the log verbosity of cli commands
+
 `;
 
 const ACCOUNT_FLAGS_ADD = `
+Help:
+
+    Use this CLI to add account.
+
 Usage:
-account add [flags]
+
+    account add [flags]
 
 Flags:
---name <string>                                                         Set the name for the account
---uid <number>                                                          Set the User Identifier (UID) (UID and GID can be replaced by --user option)
---gid <number>                                                          Set the Group Identifier (GID) (UID and GID can be replaced by --user option)
---new_buckets_path <string>                           (optional)        Set the filesystem's root path where each subdirectory is a bucket
---user <string>                                       (optional)        Set the OS user name (instead of UID and GID)
---access_key <string>                                 (optional)        Set the access key for the account (default is generated)
---secret_key <string>                                 (optional)        Set the secret key for the account (default is generated)
---fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
---allow_bucket_creation <true | false>                (optional)        Set the account to explicitly allow or block bucket creation
---force_md5_etag <true | false>                       (optional)        Set the account to force md5 etag calculation. (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
---iam_operate_on_root_account <true | false>          (optional)        Set the account to create root accounts instead of IAM users in IAM API requests.
---from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
+
+    --name <string>                                                         Set the name for the account
+    --uid <number>                                                          Set the User Identifier (UID) (UID and GID can be replaced by --user option)
+    --gid <number>                                                          Set the Group Identifier (GID) (UID and GID can be replaced by --user option)
+    --new_buckets_path <string>                           (optional)        Set the filesystem's root path where each subdirectory is a bucket
+    --user <string>                                       (optional)        Set the OS user name (instead of UID and GID)
+    --access_key <string>                                 (optional)        Set the access key for the account (default is generated)
+    --secret_key <string>                                 (optional)        Set the secret key for the account (default is generated)
+    --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
+    --allow_bucket_creation <true | false>                (optional)        Set the account to explicitly allow or block bucket creation
+    --force_md5_etag <true | false>                       (optional)        Set the account to force md5 etag calculation. (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
+    --iam_operate_on_root_account <true | false>          (optional)        Set the account to create root accounts instead of IAM users in IAM API requests.
+    --from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
+
 `;
 
 const ACCOUNT_FLAGS_UPDATE = `
+Help:
+
+    Use this CLI to update account.
+
 Usage:
-account update [flags]
+
+    account update [flags]
 
 Flags:
---name <string>                                                         The name of the account
---new_name <string>                                   (optional)        Update the account name
---uid <number>                                        (optional)        Update the User Identifier (UID)
---gid <number>                                        (optional)        Update the Group Identifier (GID)
---new_buckets_path <string>                           (optional)        Update the filesystem's root path where each subdirectory is a bucket
---user <string>                                       (optional)        Update the OS user name (instead of uid and gid)
---regenerate                                          (optional)        Update automatically generated access key and secret key
---access_key <string>                                 (optional)        Update the access key
---secret_key <string>                                 (optional)        Update the secret key
---fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
---allow_bucket_creation <true | false>                (optional)        Update the account to explicitly allow or block bucket creation
---force_md5_etag <true | false>                       (optional)        Update the account to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
---iam_operate_on_root_account <true | false>          (optional)        Update the account to create root accounts instead of IAM users in IAM API requests.
+
+    --name <string>                                                         The name of the account
+    --new_name <string>                                   (optional)        Update the account name
+    --uid <number>                                        (optional)        Update the User Identifier (UID)
+    --gid <number>                                        (optional)        Update the Group Identifier (GID)
+    --new_buckets_path <string>                           (optional)        Update the filesystem's root path where each subdirectory is a bucket
+    --user <string>                                       (optional)        Update the OS user name (instead of uid and gid)
+    --regenerate                                          (optional)        Update automatically generated access key and secret key
+    --access_key <string>                                 (optional)        Update the access key
+    --secret_key <string>                                 (optional)        Update the secret key
+    --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
+    --allow_bucket_creation <true | false>                (optional)        Update the account to explicitly allow or block bucket creation
+    --force_md5_etag <true | false>                       (optional)        Update the account to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
+    --iam_operate_on_root_account <true | false>          (optional)        Update the account to create root accounts instead of IAM users in IAM API requests.
+
 `;
 
 const ACCOUNT_FLAGS_DELETE = `
+Help:
+
+    Use this CLI to delete account.
+
 Usage:
-account delete [flags]
+
+    account delete [flags]
 
 Flags:
---name <string>                                                         The name of the account
+
+    --name <string>                                                         The name of the account
+
 `;
 
 const ACCOUNT_FLAGS_STATUS = `
+Help:
+
+    Use this CLI to get account status.
+
 Usage:
-account status [flags]
+
+    account status [flags]
 
 Flags:
---name <string>                                                         The name of the account
---access_key <string>                                 (optional)        The access key of the account (identify the account instead of name)
---show_secrets                                        (optional)        Print the access key and secret key of the account
+
+    --name <string>                                                         The name of the account
+    --access_key <string>                                 (optional)        The access key of the account (identify the account instead of name)
+    --show_secrets                                        (optional)        Print the access key and secret key of the account
+
 `;
 
 const ACCOUNT_FLAGS_LIST = `
+Help:
+
+    Use this CLI to list accounts.
+
 Usage:
-account list [flags]
+
+    account list [flags]
 
 Flags:
---wide                                                (optional)        Print the additional details for each account
---show_secrets                                        (optional)        Print the access key and secret key of each account (only when using flag --wide)
---uid <number>                                        (optional)        Filter the list based on the provided account UID
---gid <number>                                        (optional)        Filter the list based on the provided account GID
---user <string>                                       (optional)        Filter the list based on the provided account user
---name <string>                                       (optional)        Filter the list based on the provided account name
---access_key <string>                                 (optional)        Filter the list based on the provided account access key
+
+    --wide                                                (optional)        Print the additional details for each account
+    --show_secrets                                        (optional)        Print the access key and secret key of each account (only when using flag --wide)
+    --uid <number>                                        (optional)        Filter the list based on the provided account UID
+    --gid <number>                                        (optional)        Filter the list based on the provided account GID
+    --user <string>                                       (optional)        Filter the list based on the provided account user
+    --name <string>                                       (optional)        Filter the list based on the provided account name
+    --access_key <string>                                 (optional)        Filter the list based on the provided account access key
+
 `;
 
 const BUCKET_FLAGS_ADD = `
+Help:
+
+    Use this CLI to add bucket.
+
 Usage:
-bucket add [flags]
+
+    bucket add [flags]
 
 Flags:
---name <string>                                                         Set the name for the bucket
---owner <string>                                                        Set the bucket owner name
---path <string>                                                         Set the bucket path
---bucket_policy <string>                              (optional)        Set the bucket policy, type is a string of valid JSON policy
---fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type (default config.NSFS_NC_STORAGE_BACKEND)
---force_md5_etag <true | false>                       (optional)        Set the bucket to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
---from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
+
+    --name <string>                                                         Set the name for the bucket
+    --owner <string>                                                        Set the bucket owner name
+    --path <string>                                                         Set the bucket path
+    --bucket_policy <string>                              (optional)        Set the bucket policy, type is a string of valid JSON policy
+    --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Set the filesystem type (default config.NSFS_NC_STORAGE_BACKEND)
+    --force_md5_etag <true | false>                       (optional)        Set the bucket to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
+    --from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
+
 `;
 
 const BUCKET_FLAGS_UPDATE = `
+Help:
+
+    Use this CLI to update bucket.
+
 Usage:
-bucket update [flags]
+
+    bucket update [flags]
 
 Flags:
---name <string>                                                         The name of the bucket
---new_name <string>                                   (optional)        Update the bucket name
---owner <string>                                      (optional)        Update the bucket owner name
---path <string>                                       (optional)        Update the bucket path
---bucket_policy <string>                              (optional)        Update the bucket policy, type is a string of valid JSON policy (unset with '')
---fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type (unset with '') (default config.NSFS_NC_STORAGE_BACKEND)
---force_md5_etag <true | false>                       (optional)        Update the bucket to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
+
+    --name <string>                                                         The name of the bucket
+    --new_name <string>                                   (optional)        Update the bucket name
+    --owner <string>                                      (optional)        Update the bucket owner name
+    --path <string>                                       (optional)        Update the bucket path
+    --bucket_policy <string>                              (optional)        Update the bucket policy, type is a string of valid JSON policy (unset with '')
+    --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type (unset with '') (default config.NSFS_NC_STORAGE_BACKEND)
+    --force_md5_etag <true | false>                       (optional)        Update the bucket to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
+
 `;
 
 const BUCKET_FLAGS_DELETE = `
+Help:
+
+    Use this CLI to delete bucket.
+
 Usage:
-bucket delete [flags]
+
+    bucket delete [flags]
 
 Flags:
---name <string>                                                         The name of the bucket
---force                                               (optional)        Forcefully delete bucket if the bucket is not empty
+
+    --name <string>                                                         The name of the bucket
+    --force                                               (optional)        Forcefully delete bucket if the bucket is not empty
+
 `;
 
 const BUCKET_FLAGS_STATUS = `
+Help:
+
+    Use this CLI to get bucket status.
+
 Usage:
-bucket status [flags]
+
+    bucket status [flags]
 
 Flags:
---name <string>                                                         The name of the bucket
+
+    --name <string>                                                         The name of the bucket
+
 `;
 
 const BUCKET_FLAGS_LIST = `
+Help:
+
+    Use this CLI to list buckets.
+
 Usage:
-bucket list [flags]
+
+    bucket list [flags]
 
 Flags:
---wide                                                (optional)        Print the additional details for each bucket
---name <string>                                       (optional)        Filter the list based on the provided bucket name
+
+    --wide                                                (optional)        Print the additional details for each bucket
+    --name <string>                                       (optional)        Filter the list based on the provided bucket name
+
 `;
 
 const GLACIER_OPTIONS = `
+Help:
+
+    Use this CLI to execute all the glacier related actions.
+
 Usage:
-glacier <action> [flags]
+
+    glacier <action> [flags]
 
 List of actions supported:
-migrate
-restore
-expiry
+
+    migrate
+    restore
+    expiry
+
 `;
 
 const GLACIER_MIGRATE_OPTIONS = ``;
@@ -213,10 +321,12 @@ const GLACIER_EXPIRY_OPTIONS = ``;
 
 
 const DIAGNOSE_OPTIONS = `
+Help:
+
+    Use this CLI to execute different Noobaa system diagnosis tools.
+
 Usage:
 
-    execute with root permission or use sudo before each command
-    
     noobaa-cli diagnose <action> [flags]
 
 List of actions supported:
@@ -230,59 +340,57 @@ List of actions supported:
 const DIAGNOSE_HEALTH_OPTIONS = `
 Help:
 
-'health' is a noobaa-core command that will return the health status of deployed noobaa system.
+    'health' is a noobaa-core command that will return the health status of deployed noobaa system.
 
 Usage:
 
-    execute with root permission or use sudo before each command
-        
     noobaa-cli diagnose health [flags]
 
 Flags:
 
---deployment_type       <string>        (optional)          Set the nsfs type for heath check.(default nc; Non Containerized)
---https_port            <number>        (optional)          Set the S3 endpoint listening HTTPS port to serve. (default config.ENDPOINT_SSL_PORT)
---all_account_details   <boolean>       (optional)          Set a flag for returning all account details.
---all_bucket_details    <boolean>       (optional)          Set a flag for returning all bucket details.
---debug                 <number>        (optional)          Use for increasing the log verbosity of health cli commands.
---config_root           <string>        (optional)          Set Configuration files path for Noobaa standalon NSFS. (default config.NSFS_NC_DEFAULT_CONF_DIR)
+    --deployment_type       <string>        (optional)          Set the nsfs type for heath check.(default nc; Non Containerized)
+    --https_port            <number>        (optional)          Set the S3 endpoint listening HTTPS port to serve. (default config.ENDPOINT_SSL_PORT)
+    --all_account_details   <boolean>       (optional)          Set a flag for returning all account details.
+    --all_bucket_details    <boolean>       (optional)          Set a flag for returning all bucket details.
+    --debug                 <number>        (optional)          Use for increasing the log verbosity of health cli commands.
+    --config_root           <string>        (optional)          Set Configuration files path for Noobaa standalon NSFS. (default config.NSFS_NC_DEFAULT_CONF_DIR)
 
 `;
 
 const DIAGNOSE_GATHER_LOGS_OPTIONS = `
 Help:
 
-'gather-logs' is a noobaa-core command that will collect NooBaa diagnostics logs tar file
+    'gather-logs' is a noobaa-core command that will collect NooBaa diagnostics logs tar file
 
 Usage:
 
-    execute with root permission or use sudo before each command
-        
     noobaa-cli diagnose gather-logs [flags]
 
 Flags:
 
---dir_path              <string>         (optional)          collect noobaa diagnostics tar file into destination directory
---config_dir_dump       <boolean>        (optional)          collect config directory in addition to diagnostics
---metrics_dump          <boolean>        (optional)          collect metrics in addition to diagnostics
+    --dir_path              <string>         (optional)          collect noobaa diagnostics tar file into destination directory
+    --config_dir_dump       <boolean>        (optional)          collect config directory in addition to diagnostics
+    --metrics_dump          <boolean>        (optional)          collect metrics in addition to diagnostics
 
 `;
 
 const DIAGNOSE_METRICS_OPTIONS = `
 Help:
 
-'metrics' is a noobaa-core command that will return the exported metrics of the deployed NooBaa system.
+    'metrics' is a noobaa-core command that will return the exported metrics of the deployed NooBaa system.
 
 Usage:
 
-    execute with root permission or use sudo before each command
-        
     noobaa-cli diagnose metrics
 
 `;
 
 
 const UPGRADE_OPTIONS = `
+Help:
+
+    'upgrade' noobaa-core command will initiate version upgrade and also return the upgrade status or history.
+
 Usage:
 
     noobaa-cli upgrade <action> [flags]
@@ -296,11 +404,13 @@ List of actions supported:
 `;
 
 const UPGRADE_START_OPTIONS = `
-'upgrade start' is a noobaa-cli command that will start config directory upgrade run.
-Run 'upgrade start' after upgrading NooBaa RPMs on all the cluster nodes, after starting an upgrade of the config directory,
-S3 I/O, S3 Buckets getters and NooBaa CLI Account/Buckets/Whitelist getters operations will still be working
-But updates of the config directory will be blocked during the upgrade of the config directory.
-'upgrade start' should be executed on one node, the config directory changes will be available for all the nodes of the cluster.
+Help:
+
+    'upgrade start' is a noobaa-cli command that will start config directory upgrade run.
+    Run 'upgrade start' after upgrading NooBaa RPMs on all the cluster nodes, after starting an upgrade of the config directory,
+    S3 I/O, S3 Buckets getters and NooBaa CLI Account/Buckets/Whitelist getters operations will still be working
+    But updates of the config directory will be blocked during the upgrade of the config directory.
+    'upgrade start' should be executed on one node, the config directory changes will be available for all the nodes of the cluster.
 
 Usage:
         
@@ -308,25 +418,37 @@ Usage:
 
 Flags:
 
---expected_version                             <string>                             The expected target version of the upgrade
---expected_hosts                               <string>                             The expected hosts running NooBaa NC, a string of hosts separated by , 
---skip_verification                            <boolean>        (optional)          skip verification of the hosts package version
-                                                                                    WARNING: can cause corrupted config dir files created by hosts running old code
---custom_upgrade_scripts_dir                   <string>         (optional)          custom upgrade scripts dir, use for running custom config dir upgrade scripts
+    --expected_version                             <string>                             The expected target version of the upgrade
+    --expected_hosts                               <string>                             The expected hosts running NooBaa NC, a string of hosts separated by , 
+    --skip_verification                            <boolean>        (optional)          skip verification of the hosts package version
+                                                                                        WARNING: can cause corrupted config dir files created by hosts running old code
+    --custom_upgrade_scripts_dir                   <string>         (optional)          custom upgrade scripts dir, use for running custom config dir upgrade scripts
 
 `;
 
 const UPGRADE_STATUS_OPTIONS = `
-'upgrade status' is a noobaa-cli command that will return the status of an ongoing upgrade run,
-the available status information is upgrade start timestmp, from_version, to_version, config_dir_from_version,
-config_dir_to_version, running_host etc.
+Help:
+
+    'upgrade status' is a noobaa-cli command that will return the status of an ongoing upgrade run,
+    the available status information is upgrade start timestmp, from_version, to_version, config_dir_from_version,
+    config_dir_to_version, running_host etc.
+
+Usage:
+
+    noobaa-cli upgrade status
 
 `;
 
 const UPGRADE_HISTORY_OPTIONS = `
-'upgrade history' is a noobaa-cli command that will return the history of past upgrades,
-the available history information is an array of upgrade information - upgrade start timestmp, from_version, to_version, config_dir_from_version,
-config_dir_to_version, running_host etc.
+Help:
+
+    'upgrade history' is a noobaa-cli command that will return the history of past upgrades,
+    the available history information is an array of upgrade information - upgrade start timestmp, from_version, to_version, config_dir_from_version,
+    config_dir_to_version, running_host etc.
+
+Usage:
+
+    noobaa-cli upgrade history
 
 `;
 
@@ -348,7 +470,7 @@ function print_usage(type, action) {
             process.stdout.write(WHITELIST_FLAGS.trimStart());
             break;
         case TYPES.LOGGING:
-            process.stdout.write(LOGGING_FLAGS.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(LOGGING_FLAGS.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case TYPES.GLACIER:
             print_help_glacier(action);
@@ -374,19 +496,19 @@ function print_usage(type, action) {
 function print_help_account(action) {
     switch (action) {
         case ACTIONS.ADD:
-            process.stdout.write(ACCOUNT_FLAGS_ADD.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_ADD.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case ACTIONS.UPDATE:
-            process.stdout.write(ACCOUNT_FLAGS_UPDATE.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_UPDATE.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case ACTIONS.DELETE:
-            process.stdout.write(ACCOUNT_FLAGS_DELETE.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_DELETE.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case ACTIONS.STATUS:
-            process.stdout.write(ACCOUNT_FLAGS_STATUS.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_STATUS.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case ACTIONS.LIST:
-            process.stdout.write(ACCOUNT_FLAGS_LIST.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(ACCOUNT_FLAGS_LIST.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         default:
             process.stdout.write(ACCOUNT_ACTIONS.trimStart());
@@ -401,19 +523,19 @@ function print_help_account(action) {
 function print_help_bucket(action) {
     switch (action) {
         case ACTIONS.ADD:
-            process.stdout.write(BUCKET_FLAGS_ADD.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(BUCKET_FLAGS_ADD.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case ACTIONS.UPDATE:
-            process.stdout.write(BUCKET_FLAGS_UPDATE.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(BUCKET_FLAGS_UPDATE.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case ACTIONS.DELETE:
-            process.stdout.write(BUCKET_FLAGS_DELETE.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(BUCKET_FLAGS_DELETE.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case ACTIONS.STATUS:
-            process.stdout.write(BUCKET_FLAGS_STATUS.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(BUCKET_FLAGS_STATUS.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         case ACTIONS.LIST:
-            process.stdout.write(BUCKET_FLAGS_LIST.trimStart() + CLI_MUTUAL_FLAGS.trimStart());
+            process.stdout.write(BUCKET_FLAGS_LIST.trimStart() + CLI_MUTUAL_FLAGS);
             break;
         default:
             process.stdout.write(BUCKET_ACTIONS.trimStart());


### PR DESCRIPTION
### Explain the changes
1. Noobaa CLI help output updated to below format for all the CLI commnds
```
node src/cmd/manage_nsfs upgrade --help 2>/dev/null
Help:

    'upgrade' noobaa-core command will initiate version upgrade and also return the upgrade status or history.

Usage:

    noobaa-cli upgrade <action> [flags]

List of actions supported:

    start
    status
    history
    
```

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8565

### Testing Instructions:
1. run `help` command for all the CLI combinations.

Note : Doc is not updated for the MD5 changes

- [ ] Doc added/updated
- [ ] Tests added

This PR fixes only formatting issues, to update `help` doc a new issue is created. : https://github.com/noobaa/noobaa-core/issues/8595