### PR TITLE
[Backport 5.16] send x-amz-restore header as one single header instead of 2 headers with same name

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -273,12 +273,12 @@ function set_response_object_md(res, object_md) {
         res.setHeader('x-amz-storage-class', storage_class);
     }
     if (object_md.restore_status?.ongoing || object_md.restore_status?.expiry_time) {
-        const restore = [`ongoing-request="${object_md.restore_status.ongoing}"`];
+        let restore = `ongoing-request="${object_md.restore_status.ongoing}"`;
         if (!object_md.restore_status.ongoing && object_md.restore_status.expiry_time) {
             // Expiry time is in UTC format
             const expiry_date = new Date(object_md.restore_status.expiry_time).toUTCString();
 
-            restore.push(`expiry-date="${expiry_date}"`);
+            restore += `, expiry-date="${expiry_date}"`;
         }
 
         res.setHeader('x-amz-restore', restore);


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>
(cherry picked from commit fed95e189146ef4275e86a907d8a57e1402c4289)

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
