### PR TITLE
NC | NSFS | Add stat to `account_cache`

### DIFF
--- a/config.js
+++ b/config.js
@@ -637,9 +637,14 @@ config.INLINE_MAX_SIZE = 4096;
 
 // Object SDK bucket cache expiration time
 config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS = 60000;
+// Object SDK account cache expiration time
+config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS = Number(process.env.ACCOUNTS_CACHE_EXPIRY) || 10 * 60 * 1000; // TODO: Decide on a time that we want to invalidate
+
 
 // Object SDK bucket_namespace_cache allow stat of the config file
 config.NC_ENABLE_BUCKET_NS_CACHE_STAT_VALIDATION = true;
+// Object SDK account_cache allow stat of the config file
+config.NC_ENABLE_ACCOUNT_CACHE_STAT_VALIDATION = true;
 
 //////////////////////////////
 // OPERATOR RELATED         //

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -17,6 +17,7 @@ const { RpcError } = require('../rpc');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
 const { version_compare } = require('../upgrade/upgrade_utils');
+const { anonymous_access_key } = require('./object_sdk');
 
 /** @typedef {import('fs').Dirent} Dirent */
 
@@ -446,6 +447,25 @@ class ConfigFS {
     */
     _get_old_account_path_by_name(account_name) {
         return path.join(this.old_accounts_dir_path, this.json(account_name));
+    }
+
+    /**
+     * stat_account_config_file will return the stat output on account config file
+     * please notice that stat might throw an error - you should wrap it with try-catch and handle the error
+     * Note: access_key type of anonymous_access_key is a symbol, otherwise it is a string (not SensitiveString)
+     * @param {Symbol|string} access_key
+     * @returns {Promise<nb.NativeFSStats>}
+     */
+    stat_account_config_file(access_key) {
+        let path_for_account_or_user_config_file;
+        if (typeof access_key === 'symbol' && access_key === anonymous_access_key) { // anonymous account case
+            path_for_account_or_user_config_file = this.get_account_path_by_name(config.ANONYMOUS_ACCOUNT_NAME);
+        } else if (typeof access_key === 'string') { // rest of the cases
+            path_for_account_or_user_config_file = this.get_account_or_user_path_by_access_key(access_key);
+        } else { // we should not get here
+            throw new Error(`access_key must be a from valid type ${typeof access_key} ${access_key}`);
+        }
+        return nb_native().fs.stat(this.fs_context, path_for_account_or_user_config_file);
     }
 
     /**

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -824,7 +824,8 @@ interface BucketSpace {
 
     read_account_by_access_key({ access_key: string }): Promise<any>;
     read_bucket_sdk_info({ name: string }): Promise<any>;
-    check_same_stat(bucket_name: string, bucket_stat:  nb.NativeFSStats); // only implemented in bucketspace_fs
+    check_same_stat_bucket(bucket_name: string, bucket_stat:  nb.NativeFSStats); // only implemented in bucketspace_fs
+    check_same_stat_account(account_name: string|Symbol, account_stat:  nb.NativeFSStats); // only implemented in bucketspace_fs
 
     list_buckets(params: object, object_sdk: ObjectSDK): Promise<any>;
     read_bucket(params: object): Promise<any>;

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -18,7 +18,7 @@ const config_dir_name = 'nc_coretest_config_root_path';
 const master_key_location = `${TMP_PATH}/${config_dir_name}/master_keys.json`;
 const NC_CORETEST_CONFIG_DIR_PATH = `${TMP_PATH}/${config_dir_name}`;
 process.env.DEBUG_MODE = 'true';
-process.env.ACCOUNTS_CACHE_EXPIRY = '1';
+// process.env.ACCOUNTS_CACHE_EXPIRY = '1'; In NC we check if the config file was changed as validation
 process.env.NC_CORETEST = 'true';
 
 require('../../util/dotenv').load();

--- a/src/test/unit_tests/test_nc_with_a_couple_of_forks.js
+++ b/src/test/unit_tests/test_nc_with_a_couple_of_forks.js
@@ -1,19 +1,24 @@
 /* Copyright (C) 2024 NooBaa */
+/* eslint-disable max-statements */
 'use strict';
 
 const path = require('path');
 const _ = require('lodash');
+const fs = require('fs');
 const P = require('../../util/promise');
 const mocha = require('mocha');
 const assert = require('assert');
 const fs_utils = require('../../util/fs_utils');
-const { TMP_PATH, generate_nsfs_account, get_new_buckets_path_by_test_env, generate_s3_client, get_coretest_path } = require('../system_tests/test_utils');
+const { TMP_PATH, generate_nsfs_account, get_new_buckets_path_by_test_env, generate_s3_client,
+    get_coretest_path, exec_manage_cli } = require('../system_tests/test_utils');
+const { TYPES, ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
+const ManageCLIResponse = require('../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 
 const coretest_path = get_coretest_path();
 const coretest = require(coretest_path);
 const setup_options = { forks: 2, debug: 5 };
 coretest.setup(setup_options);
-const { rpc_client, EMAIL, get_current_setup_options, stop_nsfs_process, start_nsfs_process } = coretest;
+const { rpc_client, EMAIL, get_current_setup_options, stop_nsfs_process, start_nsfs_process, config_dir_name } = coretest;
 
 const CORETEST_ENDPOINT = coretest.get_http_address();
 
@@ -73,5 +78,73 @@ mocha.describe('operations with a couple of forks', async function() {
 
         // cleanup
        await s3_admin.deleteBucket({ Bucket: bucket_name });
+    });
+
+    mocha.it('list buckets after regenerate access keys', async function() {
+        // create additional account
+        const account_name = 'James';
+        const account_options_create = { account_name, uid: 5, gid: 5, config_root: config_dir_name };
+        await fs_utils.create_fresh_path(new_bucket_path_param);
+        await fs.promises.chown(new_bucket_path_param, account_options_create.uid, account_options_create.gid);
+        await fs.promises.chmod(new_bucket_path_param, 0o700);
+        const access_details = await generate_nsfs_account(rpc_client, EMAIL, new_bucket_path_param, account_options_create);
+        // check the account status
+        const account_options_status = { config_root: config_dir_name, name: account_name};
+        const res_account_status = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.STATUS, account_options_status);
+        assert.equal(JSON.parse(res_account_status).response.code, ManageCLIResponse.AccountStatus.code);
+        // generate the s3 client
+        const s3_uid5_before_access_keys_update = generate_s3_client(access_details.access_key,
+            access_details.secret_key, CORETEST_ENDPOINT);
+        // check the connection for the new account (can be any of the forks)
+        const res_list_buckets = await s3_uid5_before_access_keys_update.listBuckets({});
+        assert.equal(res_list_buckets.$metadata.httpStatusCode, 200);
+        // create a bucket
+        const bucket_name2 = 'bucket2';
+        const res_bucket_create = await s3_uid5_before_access_keys_update.createBucket({ Bucket: bucket_name2 });
+        assert.equal(res_bucket_create.$metadata.httpStatusCode, 200);
+        // update the account
+        const account_options_update = { config_root: config_dir_name, name: account_name, regenerate: true};
+        const res_account_update = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.UPDATE, account_options_update);
+        const access_key_id_updated = JSON.parse(res_account_update).response.reply.access_keys[0].access_key;
+        const secret_key_updated = JSON.parse(res_account_update).response.reply.access_keys[0].secret_key;
+        const s3_uid5_after_access_keys_update = generate_s3_client(access_key_id_updated,
+            secret_key_updated, CORETEST_ENDPOINT);
+        // check the connection for the updated access keys account (can be any of the forks)
+        const res_list_buckets3 = await s3_uid5_after_access_keys_update.listBuckets({});
+        assert.equal(res_list_buckets3.$metadata.httpStatusCode, 200);
+
+        // a couple of requests with the previous access keys (all should failed)
+        // without checking the stat the expiry is OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS
+        let failed_operations = 0;
+        let successful_operations = 0;
+        const number_of_requests = 5;
+        for (let i = 0; i < number_of_requests; i++) {
+            try {
+                await s3_uid5_before_access_keys_update.listBuckets({});
+                successful_operations += 1;
+            } catch (err) {
+                failed_operations += 1;
+            }
+        }
+        assert.equal(successful_operations, 0);
+        assert.equal(failed_operations, number_of_requests);
+
+        // a couple of requests with the updated access keys (all should success)
+        let failed_operations2 = 0;
+        let successful_operations2 = 0;
+        const number_of_requests2 = 5;
+        for (let i = 0; i < number_of_requests2; i++) {
+            try {
+                await s3_uid5_after_access_keys_update.listBuckets({});
+                successful_operations2 += 1;
+            } catch (err) {
+                failed_operations2 += 1;
+            }
+        }
+        assert.equal(successful_operations2, number_of_requests2);
+        assert.equal(failed_operations2, 0);
+
+        // cleanup
+        await s3_uid5_after_access_keys_update.deleteBucket({ Bucket: bucket_name2 });
     });
 });


### PR DESCRIPTION
### Explain the changes
1. In `account_cache` move the value that we had in `expiry_ms` to the `config.js` (with its comment of "TODO"), and add `_validate_account` function (like in `bucket_namespace_cache` we have the method `_validate_bucket_namespace`).
2. In `read_account_by_access_key` add the property `stat` so we can save the stat of the account config.
3. Rename `check_same_stat` to `check_same_stat_bucket` so we can have 2 methods for buckets and accounts. Also rename `ns_allow_stat_bucket` to `bs_allow_stat_bucket` (as it is implemented in the bucketspace and not in the namespace).
4. Add `stat_account_config_file` in `config_fs`.

### Issues: Fixed #8071
1. Currently, when updating access keys of an account using the noobaa-cli they are validate until the item is expired (in the current config 10 mminutes). With the suggested code change, updating the access keys results in changing the config file, and therefore the stat is changing and the item is no longer valid in the `account_cache`.

GAPS:
1. There are many functions that should move to accountspace and not bucketspace (and also the `account_cache` itself should be in `account_sdk`). Please see [comment1](https://github.com/noobaa/noobaa-core/pull/8585#discussion_r1890212811) [comment2](https://github.com/noobaa/noobaa-core/pull/8585#discussion_r1888280651).
2. We would probably want to do the same on `account_id_cache`.

Note: the idea for the solution was planned as part of issue #8391 

### Testing Instructions:
#### Automatic Test:
Please run: `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_nc_with_a_couple_of_forks.js`

#### Manual Test:
1. Add the line: `dbg.log('SDSD same_stat', same_stat);` after declaring the variable `same_stat`, and restart the server.
##### Regular account (not anonymous)
2. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`
4. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
5. Create the alias for S3 service:`alias nc-user-1-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443’`
6. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-1-s3 s3 ls; echo $?`
6. Change the account configuration, for example: `sudo node src/cmd/manage_nsfs account update --name <account-name> --fs_backend GPFS`
7. List the buckets again (should be empty): `nc-user-1-s3 s3 ls; echo $?` (search in the logs for the added printing with `SDSD same_stat false`

##### Anonymous account
8. Create an anonymous account with the CLI: `sudo node src/cmd/manage_nsfs account add --anonymous --uid <uid> --gid <gid>`
9. Create the alias for S3 service:`alias nc-user-anon-s3='aws --no-verify-ssl --endpoint-url https://localhost:6443 --no-sign-request' #anonymous`
10. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-anon-s3 s3 ls; echo $?`
11. Change the account configuration, for example: `sudo node src/cmd/manage_nsfs account update --anonymous --uid 3333`
12. List the buckets again (should be empty): `nc-user-anon-s3 s3 ls; echo $?` (search in the logs for the added printing with `SDSD same_stat false`

- [ ] Doc added/updated
- [X] Tests added
