### PR TITLE
CI | Nightly RPM Build - Master Branch - Fails (Arch ppc64le)

### DIFF
--- a/.github/workflows/nightly-rpm-master-build.yaml
+++ b/.github/workflows/nightly-rpm-master-build.yaml
@@ -1,7 +1,7 @@
 name: Nightly RPM Build - Master Branch
 on: 
   schedule:
-    - cron: '0 23 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   call-master-rpm-build-and-upload:

--- a/.github/workflows/nightly-rpm-stage-5.15.yaml
+++ b/.github/workflows/nightly-rpm-stage-5.15.yaml
@@ -1,7 +1,7 @@
 name: Nightly RPM Build - 5.15 Branch
 on: 
   schedule:
-    - cron: '0 23 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   call-stage-5-15-4-rpm-build-and-upload:


### PR DESCRIPTION
### Explain the changes
1. Nightly RPM Build will start at midnight every day, It was at 11pm before.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8575

### Testing Instructions:
1. check Nightly RPM Build in Github actions


- [ ] Doc added/updated
- [ ] Tests added
