### PR TITLE
NC | generate_entropy() - add /dev/nvme0 disks to the supported devices

### DIFF
--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -120,7 +120,7 @@ async function generate_entropy(loop_cond) {
                 const count = 32;
                 let disk;
                 let disk_size;
-                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda']) {
+                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda', '/dev/nvme0']) {
                     try {
                         const res = await async_exec(`blockdev --getsize64 ${disk}`);
                         disk_size = res.stdout;


### PR DESCRIPTION
### Explain the changes
1. Add /dev/nvme0 disks to the supported devices (as the suggested on the bug) for not failing generate_entropy()

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/8598

### Testing Instructions:
1. Start NooBaa service on a machine with /dev/nvme0 device, check generate_entropy successful


- [ ] Doc added/updated
- [ ] Tests added
