### PR TITLE
NC | NSFS | Add Log Printing Measuring Time Duration (Buffer Allocation)

### DIFF
--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -2240,9 +2240,14 @@ register_gpfs_noobaa(const Napi::CallbackInfo& info)
 static Napi::Value
 dio_buffer_alloc(const Napi::CallbackInfo& info)
 {
+    auto start_time = std::chrono::high_resolution_clock::now();
+    double _took_time;
     int size = info[0].As<Napi::Number>();
     uint8_t* buf = 0;
     int r = posix_memalign((void**)&buf, DIO_BUFFER_MEMALIGN, size);
+    auto end_time = std::chrono::high_resolution_clock::now();
+    _took_time = std::chrono::duration<double, std::milli>(end_time - start_time).count();
+    DBG2("dio_buffer_alloc took: " << _took_time << " ms");
     if (r || (!buf && size > 0)) {
         throw Napi::Error::New(info.Env(), "FS::dio_buffer_alloc: failed to allocate memory");
     }

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -212,7 +212,10 @@ class BuffersPool {
         if (this.buffers.length) {
             buffer = this.buffers.shift();
         } else {
+            const start = performance.now();
             buffer = this.buffer_alloc(this.buf_size);
+            const end = performance.now();
+            dbg.log2(`get_buffer: Time taken to execute buffer_alloc function with buf_size ${this.buf_size} is ${end - start} ms.`);
         }
         if (this.warning_timeout) {
             const err = new Error('Warning stuck buffer_pool buffer');


### PR DESCRIPTION
### Explain the changes
1. Add logging printing (higher than the default level) measuring tome duration inside `get_buffer` and inside `dio_buffer_alloc` (In `fs_napi.cpp `the code lines were copied from other commands in this file).

### Issues:
1. Related to issue #8521 when the buffer gets timeout (after 2 minutes by current configuration) it prints an error in logs, although the operation is not failing, we want to attach time measurements to better understand the duration of the functions (allocation as an example).

### Testing Instructions:
First, since we change a native file, you need to run: `npm run build` (`npm run build:native`)
I followed the instructions I did in the issue (see [comment](https://github.com/noobaa/noobaa-core/issues/8521#issuecomment-2517715583)).


- [ ] Doc added/updated
- [ ] Tests added
