### PR TITLE
NC | Online Upgrade | Replace failure if system.json contains hosts that do not exist in --expected_hosts with a warning

### DIFF
--- a/src/test/unit_tests/jest_tests/test_cli_upgrade.test.js
+++ b/src/test/unit_tests/jest_tests/test_cli_upgrade.test.js
@@ -282,23 +282,22 @@ describe('noobaa cli - upgrade', () => {
         const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version: pkg.version, expected_hosts: `${hostname},bla1,bla2` }, true);
         const parsed_res = JSON.parse(res.stdout);
         expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
-        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started - expected_hosts missing one or more hosts specified in system.json  hosts_data=');
+        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started - expected_hosts contains one or more hosts that are not specified in system.json hosts_data=');
     });
 
-    it('upgrade start - should fail on missing system.json hosts in expected_hosts', async () => {
+    it('upgrade start - should succeed although system.json contains extra hosts than specified in expected_hosts', async () => {
         await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(invalid_hostname_system_json));
         const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version: pkg.version, expected_hosts: `${hostname}` }, true);
-        const parsed_res = JSON.parse(res.stdout);
-        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
-        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started - system.json missing one or more hosts info specified in expected_hosts hosts_data');
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeSuccessful.code);
     });
 
-    it('upgrade start - should fail on missing system.json hosts in expected_hosts1', async () => {
+    it('upgrade start - should succeed although on missing system.json hosts in expected_hosts with comma', async () => {
+        // we set intentionally comma at the end so we will test we know how to parse it
         await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(invalid_hostname_system_json));
         const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version: pkg.version, expected_hosts: `${hostname},` }, true);
-        const parsed_res = JSON.parse(res.stdout);
-        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
-        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started - system.json missing one or more hosts info specified in expected_hosts hosts_data');
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeSuccessful.code);
     });
 
     it('upgrade start - should fail expected_version invalid', async () => {
@@ -316,7 +315,7 @@ describe('noobaa cli - upgrade', () => {
         const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
         const parsed_res = JSON.parse(res.stdout);
         expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
-        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started until all nodes have the expected version');
+        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started until all expected hosts have the expected version');
     });
 
     it('upgrade start - should fail - RPM version is higher than source code version', async () => {
@@ -326,7 +325,7 @@ describe('noobaa cli - upgrade', () => {
         const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, options, true);
         const parsed_res = JSON.parse(res.stdout);
         expect(parsed_res.error.code).toBe(ManageCLIError.UpgradeFailed.code);
-        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started until all nodes have the expected');
+        expect(parsed_res.error.cause).toContain('config dir upgrade can not be started until all expected hosts have the expected');
         const system_data_after_upgrade = await config_fs.get_system_config_file();
         // check that in the hostname section nothing changed
         expect(system_data_before_upgrade[hostname]).toStrictEqual(system_data_after_upgrade[hostname]);

--- a/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
@@ -282,7 +282,7 @@ describe('nc upgrade manager - upgrade config directory', () => {
 
         it('_verify_config_dir_upgrade - empty host current_version', async () => {
             const system_data = { [hostname]: []};
-            const expected_err_msg = `config dir upgrade can not be started until all nodes have the expected version=${pkg.version}, host=${hostname} host's current_version=undefined`;
+            const expected_err_msg = `config dir upgrade can not be started until all expected hosts have the expected version=${pkg.version}, host=${hostname} host's current_version=undefined`;
             await expect(nc_upgrade_manager._verify_config_dir_upgrade(system_data, pkg.version, [hostname]))
                 .rejects.toThrow(expected_err_msg);
         });
@@ -290,7 +290,7 @@ describe('nc upgrade manager - upgrade config directory', () => {
         it('_verify_config_dir_upgrade - host current_version < new_version should upgrade RPM', async () => {
             const old_version = '5.16.0';
             const system_data = { [hostname]: { current_version: old_version }, other_hostname: { current_version: pkg.version } };
-            const expected_err_msg = `config dir upgrade can not be started until all nodes have the expected version=${pkg.version}, host=${hostname} host's current_version=${old_version}`;
+            const expected_err_msg = `config dir upgrade can not be started until all expected hosts have the expected version=${pkg.version}, host=${hostname} host's current_version=${old_version}`;
             await expect(nc_upgrade_manager._verify_config_dir_upgrade(system_data, pkg.version, [hostname, 'other_hostname']))
                 .rejects.toThrow(expected_err_msg);
         });
@@ -298,7 +298,7 @@ describe('nc upgrade manager - upgrade config directory', () => {
         it('_verify_config_dir_upgrade - host current_version > new_version should upgrade RPM', async () => {
             const newer_version = pkg.version + '.1';
             const system_data = { [hostname]: { current_version: newer_version }, other_hostname: { current_version: pkg.version } };
-            const expected_err_msg = `config dir upgrade can not be started until all nodes have the expected version=${pkg.version}, host=${hostname} host's current_version=${newer_version}`;
+            const expected_err_msg = `config dir upgrade can not be started until all expected hosts have the expected version=${pkg.version}, host=${hostname} host's current_version=${newer_version}`;
             await expect(nc_upgrade_manager._verify_config_dir_upgrade(system_data, pkg.version, [hostname, 'other_hostname']))
                 .rejects.toThrow(expected_err_msg);
         });


### PR DESCRIPTION
### Explain the changes
1. Replaced the error coming from the condition for failing config dir upgrade if the --expected_hosts list does not match the hosts registered in system.json with a warning in the logs. This change is needed because NooBaa is not cluster aware and we can not take system.json as the source of truth of the current hosts status in the cluster, therefore we will rely on CES to send us the expected hosts list that should contain only hosts the upgraded their noobaa RPM.
2. Note - we still verify that the hosts in the expected hosts list have upgraded noobaa version and that we have information in system.json about the NooBaa version of the host.
3. Changed tests that tested this condition to expect a successful upgrade.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
Automatic tests - 
`sudo  jest --testRegex=jest_tests/test_cli_upgrade`

Manual tests - 
1. Check that upgrade won't fail if system.json contains a host that doesn't exist in expected_hosts (Artificially)- 
a. sudo mkdir /etc/noobaa.conf.d/
b. checkout to 5.16
c. start noobaa - `sudo node src/cmd/nsfs.js --debug 5`, stop noobaa CTRL+C
d. checkout to 5.18 
e. start noobaa - `sudo node src/cmd/nsfs.js --debug 5`, stop noobaa CTRL+C
f. edit system.json and add another hostname object with key that doesn't exist, for example - 
`vi cat /etc/noobaa.conf.d/system.json`
```diff
{"existing_hostname":{"current_version":"5.18.0","upgrade_history":{"successful_upgrades":[{"timestamp":1734620619190,"from_version":"5.16.5","to_version":"5.18.0"}]}}
+ "non_existing_hostname":{"current_version":"5.18.0","upgrade_history":{"successful_upgrades":[{"timestamp":1734620619190,"from_version":"5.16.5","to_version":"5.18.0"}]}}
}
```
g. run config dir upgrade start with expected_hosts having non only the existing_host - 
`noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts existing_host_name`
and expect a successful upgrade
```bash
{
  "response": {
    "code": "UpgradeSuccessful",
    ....
```
Inside the logs you can see a warning about it but no failure - 
```
[WARN] core.upgrade.nc_upgrade_manager:: _verify_config_dir_upgrade - system.json contains one or more hosts info that are not specified in expected_hosts hosts_data...
```
2. Check that upgrade still fails if expected_hosts contains a host that doesn't exist in system.json - 
a. sudo mkdir /etc/noobaa.conf.d/
b. checkout to 5.16
c. start noobaa - `sudo node src/cmd/nsfs.js --debug 5`, stop noobaa CTRL+C
d. checkout to 5.18 
e. start noobaa - `sudo node src/cmd/nsfs.js --debug 5`, stop noobaa CTRL+C
f. run config dir upgrade start with expected_hosts having non existing host - 
`noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts existing_host_name,non_existing_hostname`
and expect a failure - 
```bash
{
  "error": {
    "code": "UpgradeFailed",
    "message": "Upgrade request failed",
    "cause": "Error: config dir upgrade can not be started - expected_hosts contains one or more hosts that are not specified in system.json hosts_data=...."
  }
}
```
- [ ] Doc added/updated
- [x] Tests added
