### PR TITLE
NC | Online Upgrade | Fail config directory upgrade if upgrade is already in progress

### DIFF
--- a/src/upgrade/nc_upgrade_manager.js
+++ b/src/upgrade/nc_upgrade_manager.js
@@ -178,6 +178,7 @@ class NCUpgradeManager {
         }
         const missing_expected_hosts = !(expected_hosts.every(item => hostnames.includes(item)));
         const missing_hostnames = !(hostnames.every(item => expected_hosts.includes(item)));
+
         if (!err_message && missing_expected_hosts) {
             err_message = `config dir upgrade can not be started - expected_hosts missing one or more hosts specified in system.json  hosts_data=${util.inspect(hosts_data)}`;
         }
@@ -192,6 +193,11 @@ class NCUpgradeManager {
                 }
             }
         }
+
+        if (!err_message && system_data.config_directory?.in_progress_upgrade) {
+            err_message = `config dir upgrade can not be started - there is already an ongoing upgrade system_data.config_directory.in_progess_upgrade=${util.inspect(system_data.config_directory.in_progress_upgrade)}`;
+        }
+
         if (err_message) {
             dbg.error(`_verify_config_dir_upgrade: ${err_message}`);
             throw new Error(err_message);


### PR DESCRIPTION
### Explain the changes
1. Add a condition in the verification step of the config dir upgrade that checks if there is already in progress upgrade based on system.json.
2. Added a unit test.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/8586 partially
2. Gap - this check still can have a race condition while running config dir upgrade in parallel, this can be improved by using lock - lockfd.fcntllock().
 
### Testing Instructions:
Automatic tests - `sudo  jest --testRegex=jest_tests/test_nc_upgrade_manager.test.js -t "fail on already in progress upgrade"`

Manual test artificially - 
1. Checkout to old branch like 5.16/5.17
3. run noobaa - `sudo node src/cmd/nsfs.js --debug 5`, stop noobaa Ctrl+C
4. Checkout to 5.18 branch
5. run noobaa - `sudo node src/cmd/nsfs.js --debug 5`, stop noobaa Ctrl+C
6. add a delay in NCUpgradeManager for making the upgrade take 2 minutes - 
```diff
+ const P = require('../util/promise');
....
+ await P.delay(120 * 1000);
   try {
      await this._run_nc_upgrade_scripts(this_upgrade);
```
7. run upgrade config dir on tab 1 - `noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts <hostname>`
8. run immediately upgrade config dir on tab 2 - `noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts <hostname>` and expect a failure with error message -
```
 "error": {
    "code": "UpgradeFailed",
    "message": "Upgrade request failed",
    "cause": "Error: config dir upgrade can not be started - there is already an ongoing upgrade system_data.config_directory.in_progess_upgrade .....
```

- [ ] Doc added/updated
- [x] Tests added
