### PR TITLE
NC | generate_entropy() - remove /dev/nvme0 from the supported devices list

### DIFF
--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -120,7 +120,7 @@ async function generate_entropy(loop_cond) {
                 const count = 32;
                 let disk;
                 let disk_size;
-                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda', '/dev/nvme0']) {
+                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda']) {
                     try {
                         const res = await async_exec(`blockdev --getsize64 ${disk}`);
                         disk_size = res.stdout;


### PR DESCRIPTION
### Explain the changes
1. Removed /dev/nvme0 from the supported devices list in generate_entropy(), revert of https://github.com/noobaa/noobaa-core/pull/8600

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1.



- [ ] Doc added/updated
- [ ] Tests added
