### PR TITLE
NC | Add missing default rpc_code for unmapped errors

### DIFF
--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -660,6 +660,7 @@ function get_bucket_tmpdir_full_path(bucket_path, bucket_id) {
 /**
  * translate_error_codes we translate FS error codes to rpc_codes (strings)
  * and add the rpc_code property to the original error object
+ * default rpc_code is internal error
  * @param {object} err
  * @param {('OBJECT'|'BUCKET'|'USER'|'ACCESS_KEY')} entity
  */
@@ -671,7 +672,7 @@ function translate_error_codes(err, entity) {
     if (err.code === 'EEXIST') err.rpc_code = `${entity}_ALREADY_EXISTS`;
     if (err.code === 'EPERM' || err.code === 'EACCES') err.rpc_code = 'UNAUTHORIZED';
     if (err.code === 'IO_STREAM_ITEM_TIMEOUT') err.rpc_code = 'IO_STREAM_ITEM_TIMEOUT';
-    if (err.code === 'INTERNAL_ERROR') err.rpc_code = 'INTERNAL_ERROR';
+    if (err.code === 'INTERNAL_ERROR' || !err.rpc_code) err.rpc_code = 'INTERNAL_ERROR';
     return err;
 }
 


### PR DESCRIPTION
### Explain the changes
1. native_fs_utils.translate_error_codes() is missing a default rpc_code, this causes events based on rpc error code to fail with the following error - 
```
TypeError: Cannot destructure property 'event_code' of 'undefined' as it is undefined.    at new NoobaaEvent (/usr/local/noobaa-core/src/manage_nsfs/manage_nsfs_events_utils.js:24:23)    at BucketSpaceFS.read_bucket_sdk_info (/usr/local/noobaa-core/src/sdk/bucketspace_fs.js:157:13) 
```
Added default rpc_code to be INTERNAL_ERROR.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://github.com/noobaa/noobaa-core/issues/8619
2. GAP - Having a general logging disabled config?

### Testing Instructions:
Manual artificial reproduction - 
1. Add the following code to bucketspace_fs.read_bucket_sdk_info() -
```diff
+ const err = new Error('mock error: Protocol driver not attached');
+ err.code = 'EUNATCH';
+ throw err;
```
3. Tab 1 - start noobaa - `sudo node src/cmd/nsfs.js --debug 5`
4. Tab 2 - 
a. create an account - `noobaa-cli account add --name account1 --user root --new_buckets_path=/private/tmp/dir2/ --debug=5`
b. create an S3 CLI alias using the account credentials - `alias s3-user1='AWS_ACCESS_KEY_ID=<access_key> AWS_SECRET_ACCESS_KEY=<secret_key> aws --endpoint https://localhost:6443 --no-verify-ssl s3'`
c. create a bucket using S3 CLI - `s3-user1 mb s3://buck1`
d. list the bucket using S3 CLI - `s3-user1 ls s3://buck1`
expect to see the following event and successful logging to bucket - 
```
Dec-23 9:49:44.455 [nsfs/4406] [EVENT]{"timestamp":"2024-12-23T07:49:44.455Z","host":"hostname1","event":{"code":"noobaa_internal_error","message":"Noobaa action failed with internal error, value: buck1","description":"Noobaa action failed with internal error, error: Error: mock error: Protocol driver not attached","entity_type":"NODE","event_type":"ERROR","scope":"NODE","severity":"ERROR","state":"HEALTHY","arguments":{"bucket_name":"buck1"},"pid":4406}}
Dec-23 9:49:44.457 [nsfs/4406]  [WARN] core.endpoint.s3.s3_bucket_logging:: send_bucket_op_logs of bucket buck1 got an error: Error: mock error: Protocol driver not attached
...
  code: 'EUNATCH',
  rpc_code: 'INTERNAL_ERROR'
}
```
- [ ] Doc added/updated
- [ ] Tests added
