### PR TITLE
NC | Online Upgrade | add host config dir version to system.json | Health - add blocked hosts check

### DIFF
--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -330,7 +330,7 @@ async function main(argv = minimist(process.argv.slice(2))) {
                 const nc_upgrade_manager = new NCUpgradeManager(config_fs);
                 await nc_upgrade_manager.update_rpm_upgrade();
             } else {
-                system_data = await config_fs.init_nc_system();
+                system_data = await config_fs.register_hostname_in_system_json();
             }
         }
 

--- a/src/test/unit_tests/jest_tests/test_config_fs.test.js
+++ b/src/test/unit_tests/jest_tests/test_config_fs.test.js
@@ -1,8 +1,10 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
+const os = require('os');
 const path = require('path');
 const config = require('../../../../config');
+const pkg = require('../../../../package.json');
 const { TMP_PATH } = require('../../system_tests/test_utils');
 const { get_process_fs_context } = require('../../../util/native_fs_utils');
 const { ConfigFS } = require('../../../sdk/config_fs');
@@ -27,5 +29,45 @@ describe('adjust_bucket_with_schema_updates', () => {
         expect(bucket).toBeDefined();
         expect(bucket).not.toHaveProperty('system_owner');
         expect(bucket).not.toHaveProperty('bucket_owner');
+    });
+});
+
+describe('_get_new_hostname_data', () => {
+    it('_get_new_hostname_data - happy path', () => {
+        const new_hostname_data = config_fs._get_new_hostname_data();
+        expect(new_hostname_data).toStrictEqual({
+            [os.hostname()]: {
+                current_version: pkg.version,
+                config_dir_version: config_fs.config_dir_version,
+                upgrade_history: {
+                    successful_upgrades: []
+                },
+            }
+        });
+    });
+});
+
+describe('compare_host_and_config_dir_version', () => {
+    it('running code config_dir_version equals to system.json config_dir_version', () => {
+        const running_code_config_dir_version = '0.0.0';
+        const system_config_dir_version = '0.0.0';
+        const ver_compare_err = config_fs.compare_host_and_config_dir_version(running_code_config_dir_version, system_config_dir_version);
+        expect(ver_compare_err).toBeUndefined();
+    });
+
+    it('running code config_dir_version higher than system.json config_dir_version', () => {
+        const running_code_config_dir_version = '1.0.0';
+        const system_config_dir_version = '0.0.0';
+        const ver_compare_err = config_fs.compare_host_and_config_dir_version(running_code_config_dir_version, system_config_dir_version);
+        expect(ver_compare_err).toBe(`running code config_dir_version=${running_code_config_dir_version} is higher than the config dir version ` +
+                `mentioned in system.json=${system_config_dir_version}, any updates to the config directory are blocked until the config dir upgrade`);
+    });
+
+    it('running code config_dir_version lower than system.json config_dir_version', () => {
+        const running_code_config_dir_version = '0.0.0';
+        const system_config_dir_version = '1.0.0';
+        const ver_compare_err = config_fs.compare_host_and_config_dir_version(running_code_config_dir_version, system_config_dir_version);
+        expect(ver_compare_err).toBe(`running code config_dir_version=${running_code_config_dir_version} is lower than the config dir version ` +
+                `mentioned in system.json=${system_config_dir_version}, any updates to the config directory are blocked until the source code upgrade`);
     });
 });

--- a/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
@@ -59,12 +59,12 @@ module.exports = {
 `;
 const old_expected_system_json = {
     [hostname]: {
-        'current_version': '5.17.0',
-        'upgrade_history': {
-            'successful_upgrades': [{
-                'timestamp': 1724687496424,
-                'from_version': '5.16.0',
-                'to_version': '5.17.0'
+        current_version: '5.17.0',
+        upgrade_history: {
+            successful_upgrades: [{
+                timestamp: 1724687496424,
+                from_version: '5.16.0',
+                to_version: '5.17.0'
             }]
         },
     }
@@ -72,25 +72,25 @@ const old_expected_system_json = {
 
 const old_expected_system_json_has_config_directory = {
     [hostname]: {
-        'current_version': '5.18.1',
-        'upgrade_history': {
-            'successful_upgrades': [{
-                'timestamp': 1724687496424,
-                'from_version': '5.18.0',
-                'to_version': '5.18.1'
+        current_version: '5.18.1',
+        upgrade_history: {
+            successful_upgrades: [{
+                timestamp: 1724687496424,
+                from_version: '5.18.0',
+                to_version: '5.18.1'
             }]
         },
     },
     config_directory: {
-        'config_dir_version': '1.0.0',
-        'upgrade_package_version': '5.18.0',
-        'phase': CONFIG_DIR_PHASES.CONFIG_DIR_UNLOCKED,
-        'upgrade_history': {
-            'successful_upgrades': [{
-                'timestamp': 1724687496424,
-                'completed_scripts': [],
-                'package_from_version': '5.17.0',
-                'package_to_version': '5.18.0'
+        config_dir_version: '1.0.0',
+        upgrade_package_version: '5.18.0',
+        phase: CONFIG_DIR_PHASES.CONFIG_DIR_UNLOCKED,
+        upgrade_history: {
+            successful_upgrades: [{
+                timestamp: 1724687496424,
+                completed_scripts: [],
+                package_from_version: '5.17.0',
+                package_to_version: '5.18.0'
             }]
         }
     }
@@ -98,21 +98,22 @@ const old_expected_system_json_has_config_directory = {
 
 const old_expected_system_json_no_successful_upgrades = {
     [hostname]: {
-        'current_version': '5.17.0',
-        'upgrade_history': {
-            'successful_upgrades': []
+        current_version: '5.17.0',
+        upgrade_history: {
+            successful_upgrades: []
         },
     }
 };
 
 const current_expected_system_json = {
     [hostname]: {
-        'current_version': pkg.version,
-        'upgrade_history': {
-            'successful_upgrades': [{
-                'timestamp': 1724687496424,
-                'from_version': '5.17.0',
-                'to_version': pkg.version
+        current_version: pkg.version,
+        config_dir_version: config_fs.config_dir_version,
+        upgrade_history: {
+            successful_upgrades: [{
+                timestamp: 1724687496424,
+                from_version: '5.17.0',
+                to_version: pkg.version
             }]
         },
     }
@@ -121,9 +122,10 @@ const current_expected_system_json = {
 
 const current_expected_system_json_no_successful_upgrades = {
     [hostname]: {
-        'current_version': pkg.version,
-        'upgrade_history': {
-            'successful_upgrades': []
+        current_version: pkg.version,
+        config_dir_version: config_fs.config_dir_version,
+        upgrade_history: {
+            successful_upgrades: []
         },
     }
 };
@@ -207,8 +209,10 @@ describe('nc upgrade manager - upgrade RPM', () => {
         await nc_upgrade_manager.update_rpm_upgrade(config_fs);
         const system_data_after_upgrade_run = await config_fs.get_system_config_file();
         const new_version = pkg.version;
+        const new_config_dir_version = config_fs.config_dir_version;
         const host_data_after_upgrade = system_data_after_upgrade_run[hostname];
         expect(host_data_after_upgrade.current_version).toStrictEqual(new_version);
+        expect(host_data_after_upgrade.config_dir_version).toStrictEqual(new_config_dir_version);
         expect(host_data_after_upgrade.upgrade_history.successful_upgrades[0].from_version).toStrictEqual(
             old_expected_system_json[hostname].current_version);
         expect(host_data_after_upgrade.upgrade_history.successful_upgrades[0].to_version).toStrictEqual(new_version);
@@ -219,8 +223,10 @@ describe('nc upgrade manager - upgrade RPM', () => {
         await nc_upgrade_manager.update_rpm_upgrade(config_fs);
         const system_data_after_upgrade_run = await config_fs.get_system_config_file();
         const new_version = pkg.version;
+        const new_config_dir_version = config_fs.config_dir_version;
         const host_data_after_upgrade = system_data_after_upgrade_run[hostname];
         expect(host_data_after_upgrade.current_version).toStrictEqual(new_version);
+        expect(host_data_after_upgrade.config_dir_version).toStrictEqual(new_config_dir_version);
         expect(host_data_after_upgrade.upgrade_history.successful_upgrades[0].from_version).toStrictEqual(
             old_expected_system_json_no_successful_upgrades[hostname].current_version);
         expect(host_data_after_upgrade.upgrade_history.successful_upgrades[0].to_version).toStrictEqual(new_version);

--- a/src/upgrade/nc_upgrade_manager.js
+++ b/src/upgrade/nc_upgrade_manager.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const os = require('os');
-const _ = require('lodash');
 const path = require('path');
 const util = require('util');
 const pkg = require('../../package.json');
@@ -74,6 +73,7 @@ class NCUpgradeManager {
 
         const this_upgrade = { timestamp: Date.now(), from_version, to_version };
         system_data[hostname].current_version = to_version;
+        system_data[hostname].config_dir_version = this.config_fs.config_dir_version;
         system_data[hostname]?.upgrade_history?.successful_upgrades.unshift(this_upgrade);
         await this.config_fs.update_system_json_with_retries(JSON.stringify(system_data));
     }
@@ -164,7 +164,7 @@ class NCUpgradeManager {
      */
     async _verify_config_dir_upgrade(system_data, expected_version, expected_hosts) {
         const new_version = this.package_version;
-        const hosts_data = _.omit(system_data, 'config_directory');
+        const hosts_data = this.config_fs.get_hosts_data(system_data);
         let err_message;
         if (expected_version !== new_version) {
             err_message = `config dir upgrade can not be started - the host's package version=${new_version} does not match the user's expected version=${expected_version}`;


### PR DESCRIPTION
### Explain the changes
1. Added config_dir_version info per host in system.json.
```bash
> sudo cat /etc/noobaa.conf.d/system.json | jq .
{
  "config_directory": {
    "config_dir_version": "1.0.0",
    "upgrade_package_version": "5.18.0",
    "phase": "CONFIG_DIR_UNLOCKED",
    "upgrade_history": {
      "successful_upgrades": []
    }
  },
  "hostname1": {
    "current_version": "5.20.0",
    "config_dir_version": "3.0.0", // <- this is the new added property
    "upgrade_history": {
      "successful_upgrades": [
        {
          "timestamp": 1735114113164,
          "from_version": "5.18.0",
          "to_version": "5.20.0"
        }
      ]
    }
  }
}
```
3. Health script - added a check that reports on hosts that are blocked for config directory updates based on the comparison of the new property config_dir_version per hosts and the config_directory.config_dir_version. Both compared items are read from system.json
```bash
> noobaa-cli diagnose health 2>/dev/null
{
  "response": {
    "code": "HealthStatus",
    "reply": {
      "service_name": "noobaa",
      "status": "NOTOK",
      ......
        },
        "config_directory_status": {
          "phase": "CONFIG_DIR_UNLOCKED",
          "config_dir_version": "1.0.0",
          "upgrade_package_version": "5.18.0",
          "upgrade_status": {
            "message": "there is no in-progress upgrade"
          },
          "blocked_hosts": { // <- this is the new check
            "hostaname1": {
              "host_version": "5.20.0",
              "host_config_dir_version": "3.0.0",
              "error": "running code config_dir_version=3.0.0 is higher than the config dir version mentioned in system.json=1.0.0, any updates to the config directory are blocked until the config dir upgrade"
            }
          }
        }
      }
    }
  }
```
### Issues: Fixed #xxx / Gap #xxx
1. Fixed partially https://github.com/noobaa/noobaa-core/issues/8586

### Testing Instructions:
- Automatic tests - 
```bash
sudo  jest --testRegex=jest_tests/test_config_fs.test.js
sudo  jest --testRegex=jest_tests/test_nc_upgrade_manager.test.js
sudo node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_nc_health.js
```

- Manual tests -
1. start noobaa 5.17.z - `sudo node noobaa-core/src/cmd/nsfs.js --debug`, stop noobaa by CTRL+C
2. git checkout 5.18.0
3. start noobaa 5.18.0 - `sudo node noobaa-core/src/cmd/nsfs.js --debug`, stop noobaa by CTRL+C
4. run Health CLI - `noobaa-cli diagnose health 2>/dev/null`
5. expect to see the following blocked hosts in the health response - 
```
"config_directory_status": {
          "error": "config directory data is missing, must upgrade config directory",
          "blocked_hosts": {
            "hostname1": {
              "host_version": "5.18.0",
              "host_config_dir_version": "1.0.0",
              "error": "host's config_dir_version is 1.0.0, system's config_dir_version is undefined"
            }
          }
        }
```
6. upgrade the config directory - `noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts hostname1 2>/dev/null`
7. run again Health CLI - `noobaa-cli diagnose health 2>/dev/null`
8. expect to not see the blocked host in the new health response - 
```bash
"config_directory_status": {
    "phase": "CONFIG_DIR_UNLOCKED",
    "config_dir_version": "1.0.0",
    "upgrade_package_version": "5.18.0",
    "upgrade_status": {
      "message": "there is no in-progress upgrade"
    }
}
``` 
- [ ] Doc added/updated
- [x] Tests added
