### PR TITLE
Added restriction to limit the ID length to 255 characters in bucket lifecycle rules

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const _ = require('lodash');
+const s3_const = require('../s3_constants');
 const { v4: uuid } = require('uuid');
 const dbg = require('../../../util/debug_module')(__filename);
 const S3Error = require('../s3_errors').S3Error;
@@ -88,7 +89,12 @@ async function put_bucket_lifecycle(req) {
         };
 
         if (rule.ID?.length === 1) {
-            current_rule.id = rule.ID[0];
+            if (rule.ID[0].length > s3_const.MAX_RULE_ID_LENGTH) {
+                dbg.error('Rule should not have ID length exceed allowed limit of ', s3_const.MAX_RULE_ID_LENGTH, ' characters', rule);
+                throw new S3Error({ ...S3Error.InvalidArgument, message: `ID length should not exceed allowed limit of ${s3_const.MAX_RULE_ID_LENGTH}` });
+            } else {
+                current_rule.id = rule.ID[0];
+            }
         } else {
             // Generate a random ID if missing
             current_rule.id = uuid();

--- a/src/endpoint/s3/s3_constants.js
+++ b/src/endpoint/s3/s3_constants.js
@@ -1,0 +1,12 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// `s3_const` serves as an alias for `exports` which expose constants related to s3 operations
+//  keeping name referencing consistent to s3_const.NAME for easier imports and searches
+const s3_const = exports;
+
+///////////////
+// LIFECYCLE //
+///////////////
+
+s3_const.MAX_RULE_ID_LENGTH = 255;

--- a/src/test/system_tests/test_lifecycle.js
+++ b/src/test/system_tests/test_lifecycle.js
@@ -54,6 +54,7 @@ async function main() {
     await commonTests.test_rule_id(Bucket, Key, s3);
     await commonTests.test_filter_size(Bucket, s3);
     await commonTests.test_and_prefix_size(Bucket, Key, s3);
+    await commonTests.test_rule_id_length(Bucket, Key, s3);
 
     const getObjectParams = {
         Bucket,


### PR DESCRIPTION
### Explain the changes
1.  Currently, any length of ID can be accepted, as a fix we have added restriction to limit the length of ID to 255 characters only in bucket lifecycle rules.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: #8549 

### Testing Instructions:
1. create s3 backingstore>bucketclass>obc
2. Apply below lifecycle configuration on the bucket created by obc:
`AWS_ACCESS_KEY_ID=<access-id> AWS_SECRET_ACCESS_KEY=<secret-key> aws s3api --no-verify-ssl --endpoint-url <endpoint-url> put-bucket-lifecycle-configuration --bucket <bucket-name> --lifecycle-configuration '{
  "Rules": [
    {
      "ID": "JiLekqcxZ6q0W0kKmiCLtVUYgyurIKmmUixcgHrkVKHyo6MfRU3EwPDD4NFBNWfA1Ej4qnuqSwS1NPRBvIn2x11aEf5kCK1GOjwp6SdTi17wivc9f7Zt44vaXkf73mME0PG1HwI8vGhzHfo9EptdWwdqG9J7mUYcGTbh63aUShPbjRAtLgIHYs2MyTTocohssHQ2cSnQiZjtLXi1j8h4AzFNFx5PzaPInmWqCiMrQPY6npbnbZrNKv7scXcLd0zkszxktHmgoPLLimJYHwaH0a2GRZqw6icnXUmSY4oXMzU1XAYBSJwQ3S3n42RlrVQK11JnZvKYYpKcB1cHz5oYNrGyRczopsgRvn6vPZ8TK9JfxTrDkwMB5o7vfQoXynZPkjeH4uX0N3TLqmEBUUcFGBPJND6vOMgfTiZDtMsBQPTtAepimZCbcRAmJ8F5GPj4ZQtjaXPgEFrEHWRpeEXknZBaBKZYaf8CQpi8WF3fHbnFbZK1G6x1oYG2gtn1MgHU",
      "Status": "enabled",
      "Filter": {
        "Prefix": "test/"
      },
      "Expiration": {
        "Date": "2020-01-02T00:00:00.000Z"
      }
    }
  ]
}'`
3. Check for the similar error as aws, we should get an error for ID having length exeeding 255 characters.
- [X] Tests added
