### PR TITLE
Added a check for duplicate Id in bucket lifecycle rules

### DIFF
--- a/src/test/system_tests/test_lifecycle.js
+++ b/src/test/system_tests/test_lifecycle.js
@@ -55,6 +55,7 @@ async function main() {
     await commonTests.test_filter_size(Bucket, s3);
     await commonTests.test_and_prefix_size(Bucket, Key, s3);
     await commonTests.test_rule_id_length(Bucket, Key, s3);
+    await commonTests.test_rule_duplicate_id(Bucket, Key, s3);
 
     const getObjectParams = {
         Bucket,


### PR DESCRIPTION
### Explain the changes
1. Added a check for duplicate Id in bucket lifecycle rules.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: #8550 

### Testing Instructions:
1. create s3 backingstore>bucketclass>obc
2. Apply below lifecycle configuration on the bucket created by obc:
`AWS_ACCESS_KEY_ID=<access-id> AWS_SECRET_ACCESS_KEY=<secret-key> aws s3api --no-verify-ssl --endpoint-url <endpoint-url> put-bucket-lifecycle-configuration --bucket <bucket-name> --lifecycle-configuration '{
  "Rules": [
    {
      "ID": "rule_id",
      "Status": "enabled",
      "Filter": {
        "Prefix": "test/"
      },
      "Expiration": {
        "Date": "2020-01-02T00:00:00.000Z"
      }
    },
   {
      "ID": "rule_id",
      "Status": "enabled",
      "Filter": {
        "Prefix": "hello/"
      },
      "Expiration": {
        "Date": "2024-01-02T00:00:00.000Z"
      }
    }
  ]
}'`
3. Check for the similar error as aws, we should get an error for duplicate ID found in rules.
- [X] Tests added
