### PR TITLE
Fix for not accepting the past dates as expiration for bucket lifecycle rules

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
@@ -64,7 +64,16 @@ function parse_expiration(expiration) {
             throw new S3Error(S3Error.InvalidArgument);
         }
     } else if (expiration.Date?.length === 1) {
-        output_expiration.date = (new Date(expiration.Date[0])).getTime();
+        const parsed_date = (new Date(expiration.Date[0]));
+        if (isNaN(parsed_date.getTime())) {
+            dbg.error('Invalid expiration date provided:', expiration.Date[0]);
+            throw new S3Error(S3Error.InvalidArgument);
+        }
+        if (parsed_date.getTime() <= Date.now()) {
+            dbg.error('Expiration date is in the past or current date:', expiration.Date[0], 'Parsed value:', parsed_date);
+            throw new S3Error(S3Error.InvalidArgument);
+        }
+        output_expiration.date = parsed_date.getTime();
     } else if (expiration.ExpiredObjectDeleteMarker?.length === 1) {
         output_expiration.expired_object_delete_marker = true_regex.test(expiration.ExpiredObjectDeleteMarker[0]);
     }

--- a/src/test/system_tests/test_lifecycle.js
+++ b/src/test/system_tests/test_lifecycle.js
@@ -54,6 +54,7 @@ async function main() {
     await commonTests.test_rule_id(Bucket, Key, s3);
     await commonTests.test_filter_size(Bucket, s3);
     await commonTests.test_and_prefix_size(Bucket, Key, s3);
+    await commonTests.test_expiration_date_in_past(Bucket, Key, s3);
 
     const getObjectParams = {
         Bucket,


### PR DESCRIPTION
### Explain the changes
1. Added a fix for not accepting past dates as expiration for bucket lifecycle rules also will reject if expiration date is not in correct format.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: #8551 

### Testing Instructions:
- [X] Tests added
