### PR TITLE
CI | Add Validate package-lock.json Tests

### DIFF
--- a/.github/workflows/Validate-package-lock.yaml
+++ b/.github/workflows/Validate-package-lock.yaml
@@ -1,0 +1,79 @@
+name: Validate package-lock.json Tests
+on: [push, pull_request]
+
+jobs:
+  run-package-lock-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Backup the current package-lock.json
+        run: | 
+            # Backup the current package-lock.json
+            mv package-lock.json package-lock-backup.json
+            
+            # Generate a new package-lock.json
+            npm install
+
+      - name: Validate top-level versions in package-lock.json
+        run: | 
+            # Validate the main version field
+            top_version_backup=$(jq -r '.version' package-lock-backup.json)
+            top_version_new=$(jq -r '.version' package-lock.json)
+  
+            # Define the ANSI escape code for red
+            RED='\033[0;31m'
+            NC='\033[0m' # No Color (resets the color)
+
+            if [ "$top_version_backup" != "$top_version_new" ]; then
+              echo "The top-level version in package-lock.json is inconsistent."
+            echo -e "${RED}Original version: $top_version_backup${NC}"
+            echo -e "${RED}Generated version: $top_version_new${NC}"
+              exit 1
+            fi
+
+      - name: Validate dependencies top-level versions in package-lock.json
+        run: |
+            # Extract and validate top-level module versions
+            jq '.packages[""].dependencies' package-lock-backup.json > top-level-versions-backup.json
+            jq '.packages[""].dependencies' package-lock.json > top-level-versions-new.json
+  
+            if ! diff -q top-level-versions-backup.json top-level-versions-new.json > /dev/null; then
+              echo -e "${RED}Top-level module versions in package-lock.json are inconsistent.${NC}"
+              echo -e "${RED}Differences:${NC}"
+              diff top-level-versions-backup.json top-level-versions-new.json || true
+              exit 1
+            else
+              echo "Top-level module versions are consistent. Validation passed."
+            fi
+
+      - name: Validate devDependencies top-level versions in package-lock.json
+        run: |
+            # Extract and validate top-level module versions
+            jq '.packages[""].devDependencies' package-lock-backup.json > top-level-versions-backup.json
+            jq '.packages[""].devDependencies' package-lock.json > top-level-versions-new.json
+  
+
+            # Define the ANSI escape code for red
+            RED='\033[0;31m'
+            NC='\033[0m' # No Color (resets the color)
+
+            if ! diff -q top-level-versions-backup.json top-level-versions-new.json > /dev/null; then
+              echo -e "${RED}Top-level module versions in package-lock.json are inconsistent.${NC}"
+              echo -e "${RED}Differences:${NC}"
+              diff top-level-versions-backup.json top-level-versions-new.json || true
+              exit 1
+            else
+              echo "Top-level module versions are consistent. Validation passed."
+            fi
+            


### PR DESCRIPTION
### Explain the changes
- Adding Validate package-lock.json Tests to ensure that npm install ran before committing the changes.

