### PR TITLE
NC | NSFS | Add `stat` to `account_id_cache`

### DIFF
--- a/config.js
+++ b/config.js
@@ -635,16 +635,24 @@ config.REMOTE_NOOAA_NAMESPACE = `remote-${config.KUBE_APP_LABEL}`;
 ///////////////////////////////
 config.INLINE_MAX_SIZE = 4096;
 
+///////////////////////////////
+// CACHE (ACCOUNT, BUCKET)   //
+///////////////////////////////
+
 // Object SDK bucket cache expiration time
 config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS = 60000;
 // Object SDK account cache expiration time
 config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS = Number(process.env.ACCOUNTS_CACHE_EXPIRY) || 10 * 60 * 1000; // TODO: Decide on a time that we want to invalidate
+// Accountspace_fs account id cache expiration time
+config.ACCOUNTS_ID_CACHE_EXPIRY = 3 * 60 * 1000; // TODO: Decide on a time that we want to invalidate
 
 
 // Object SDK bucket_namespace_cache allow stat of the config file
 config.NC_ENABLE_BUCKET_NS_CACHE_STAT_VALIDATION = true;
 // Object SDK account_cache allow stat of the config file
 config.NC_ENABLE_ACCOUNT_CACHE_STAT_VALIDATION = true;
+// accountspace_fs allow stat of the config file
+config.NC_ENABLE_ACCOUNT_ID_CACHE_STAT_VALIDATION = true;
 
 //////////////////////////////
 // OPERATOR RELATED         //
@@ -932,7 +940,6 @@ config.NC_DISABLE_HEALTH_ACCESS_CHECK = false;
 config.NC_DISABLE_POSIX_MODE_ACCESS_CHECK = true;
 config.NC_DISABLE_SCHEMA_CHECK = false;
 
-config.ACCOUNTS_ID_CACHE_EXPIRY = 3 * 60 * 1000;
 ////////// GPFS //////////
 config.GPFS_DOWN_DELAY = 1000;
 

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -27,6 +27,7 @@ const BucketSpaceNB = require('./bucketspace_nb');
 const { RpcError } = require('../rpc');
 
 const anonymous_access_key = Symbol('anonymous_access_key');
+
 const bucket_namespace_cache = new LRUCache({
     name: 'ObjectSDK-Bucket-Namespace-Cache',
     // This is intentional. Cache entry expiration is handled by _validate_bucket_namespace().
@@ -93,7 +94,7 @@ async function _validate_account(data, params) {
     const bs_allow_stat_account = Boolean(bs.check_same_stat_account);
     if (bs_allow_stat_account && config.NC_ENABLE_ACCOUNT_CACHE_STAT_VALIDATION) {
         const same_stat = await bs.check_same_stat_account(params.access_key, data.stat);
-        if (!same_stat) { // config file of bucket was changed
+        if (!same_stat) { // config file of account was changed
             return false;
         }
     }

--- a/src/test/unit_tests/test_nc_with_a_couple_of_forks.js
+++ b/src/test/unit_tests/test_nc_with_a_couple_of_forks.js
@@ -9,8 +9,7 @@ const P = require('../../util/promise');
 const mocha = require('mocha');
 const assert = require('assert');
 const fs_utils = require('../../util/fs_utils');
-const { TMP_PATH, generate_nsfs_account, get_new_buckets_path_by_test_env, generate_s3_client,
-    get_coretest_path, exec_manage_cli } = require('../system_tests/test_utils');
+const { TMP_PATH, generate_nsfs_account, get_new_buckets_path_by_test_env, generate_s3_client, get_coretest_path, exec_manage_cli } = require('../system_tests/test_utils');
 const { TYPES, ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
 const ManageCLIResponse = require('../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 
@@ -18,7 +17,8 @@ const coretest_path = get_coretest_path();
 const coretest = require(coretest_path);
 const setup_options = { forks: 2, debug: 5 };
 coretest.setup(setup_options);
-const { rpc_client, EMAIL, get_current_setup_options, stop_nsfs_process, start_nsfs_process, config_dir_name } = coretest;
+const { rpc_client, EMAIL, get_current_setup_options, stop_nsfs_process, start_nsfs_process,
+    config_dir_name, NC_CORETEST_CONFIG_FS, NC_CORETEST_STORAGE_PATH } = coretest;
 
 const CORETEST_ENDPOINT = coretest.get_http_address();
 
@@ -52,6 +52,7 @@ mocha.describe('operations with a couple of forks', async function() {
 
     mocha.after(async () => {
         fs_utils.folder_delete(`${config_root}`);
+        fs_utils.folder_delete(`${new_bucket_path_param}`);
     });
 
     mocha.it('versioning change with a couple of forks', async function() {
@@ -146,5 +147,80 @@ mocha.describe('operations with a couple of forks', async function() {
 
         // cleanup
         await s3_uid5_after_access_keys_update.deleteBucket({ Bucket: bucket_name2 });
+    });
+
+    mocha.it('head a bucket after account update (change fs_backend)', async function() {
+        // create additional account
+        const account_name = 'Oliver';
+        const account_options_create = { account_name, uid: 6001, gid: 6001, config_root: config_dir_name };
+        await fs_utils.create_fresh_path(new_bucket_path_param);
+        await fs.promises.chown(new_bucket_path_param, account_options_create.uid, account_options_create.gid);
+        await fs.promises.chmod(new_bucket_path_param, 0o700);
+        const access_details = await generate_nsfs_account(rpc_client, EMAIL, new_bucket_path_param, account_options_create);
+        // check the account status
+        const account_options_status = { config_root: config_dir_name, name: account_name};
+        const res_account_status = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.STATUS, account_options_status);
+        assert.equal(JSON.parse(res_account_status).response.code, ManageCLIResponse.AccountStatus.code);
+        // generate the s3 client
+const s3_uid6001 = generate_s3_client(access_details.access_key,
+            access_details.secret_key, CORETEST_ENDPOINT);
+        // check the connection for the new account (can be any of the forks)
+        const res_list_buckets = await s3_uid6001.listBuckets({});
+        assert.equal(res_list_buckets.$metadata.httpStatusCode, 200);
+        // create a bucket
+        const bucket_name3 = 'bucket3';
+        const res_bucket_create = await s3_uid6001.createBucket({ Bucket: bucket_name3 });
+        assert.equal(res_bucket_create.$metadata.httpStatusCode, 200);
+        // head the bucket
+        const res_head_bucket1 = await s3_uid6001.headBucket({Bucket: bucket_name3});
+        assert.equal(res_head_bucket1.$metadata.httpStatusCode, 200);
+        // update the account
+        const account_options_update = { config_root: config_dir_name, name: account_name, fs_backend: 'GPFS'};
+        const res_account_update = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.UPDATE, account_options_update);
+        assert.equal(JSON.parse(res_account_update).response.code, ManageCLIResponse.AccountUpdated.code);
+        // head the bucket (again)
+        const res_head_bucket2 = await s3_uid6001.headBucket({Bucket: bucket_name3});
+        assert.equal(res_head_bucket2.$metadata.httpStatusCode, 200);
+
+        // cleanup
+        await s3_uid6001.deleteBucket({ Bucket: bucket_name3 });
+    });
+
+    mocha.it('create a bucket after account update (change buckets_path)', async function() {
+        // create an additional account
+        const account_name = 'John';
+        const account_options_create = { account_name, uid: 7001, gid: 7001, config_root: config_dir_name };
+        // reuse NC_CORETEST_STORAGE_PATH as new_buckets_path (no need for create fresh path, chmod and chown) 
+        const access_details = await generate_nsfs_account(rpc_client, EMAIL, NC_CORETEST_STORAGE_PATH, account_options_create);
+        // check the account status
+        const account_options_status = { config_root: config_dir_name, name: account_name};
+        const res_account_status = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.STATUS, account_options_status);
+        assert.equal(JSON.parse(res_account_status).response.code, ManageCLIResponse.AccountStatus.code);
+        // generate the s3 client
+        const s3_uid6001 = generate_s3_client(access_details.access_key,
+        access_details.secret_key, CORETEST_ENDPOINT);
+        // check the connection for the new account (can be any of the forks)
+        const res_list_buckets = await s3_uid6001.listBuckets({});
+        assert.equal(res_list_buckets.$metadata.httpStatusCode, 200);
+        // update the account - change its new_bucket_path
+        const new_bucket_path_param2 = path.join(TMP_PATH, 'nc_coretest_storage_root_path2/');
+        await fs_utils.create_fresh_path(new_bucket_path_param2);
+        await fs.promises.chown(new_bucket_path_param2, account_options_create.uid, account_options_create.gid);
+        await fs.promises.chmod(new_bucket_path_param2, 0o700);
+        const account_options_update = { config_root: config_dir_name, name: account_name, new_buckets_path: new_bucket_path_param2};
+        const res_account_update = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.UPDATE, account_options_update);
+        assert.equal(JSON.parse(res_account_update).response.code, ManageCLIResponse.AccountUpdated.code);
+        // create a bucket
+        const bucket_name4 = 'bucket4';
+        const res_bucket_create = await s3_uid6001.createBucket({ Bucket: bucket_name4 });
+        assert.equal(res_bucket_create.$metadata.httpStatusCode, 200);
+        // validate the bucket was created in the updated path
+        const bucket4 = await NC_CORETEST_CONFIG_FS.get_bucket_by_name(bucket_name4);
+        const expected_bucket_path = path.join(new_bucket_path_param2, bucket_name4);
+        assert.equal(bucket4.path, expected_bucket_path);
+
+        // cleanup
+        await s3_uid6001.deleteBucket({ Bucket: bucket_name4 });
+        await fs.promises.rm(new_bucket_path_param2, { recursive: true });
     });
 });


### PR DESCRIPTION
### Explain the changes
1. In `config.js` move the definition of `ACCOUNTS_ID_CACHE_EXPIRY` near the the configurations of `OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS` and `OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS`.
2. In `accountspace_fs.js`:
   - Remove the Number conversion as the value is number (was `Number(config.ACCOUNTS_ID_CACHE_EXPIRY)`).
   - Change the JSDoc of params so it will be easier to read.
   - Change the `load` inside function to be `get_identity_by_id_and_stat_file` so we will have the identity with the `stat` as property inside it.
   - Add the `validate` method, and add the functions `_validate_account_id` and `check_same_stat_account` that were partially copied from object_sdk.
3. In `config_fs` add the function `get_identity_by_id_and_stat_file` and `stat_account_config_file_by_identity ` that would try to stat the account config file (covering the identity, accounts_by_name - new path, accounts - old path).
4. In `object_sdk.js` add a new line between `anonymous_access_key` `bucket_namespace_cache` for easier readability, fix a typo in a comment.

Note: the changes are based on the suggesting written as a [comment](https://github.com/noobaa/noobaa-core/issues/8391#issuecomment-2410609077).

### Issues: 
1. It is a mentioned GAP in #8527 and #8585.

### Testing Instructions:
#### Automatic Test:
Please run: `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_nc_with_a_couple_of_forks.js`

#### Manual Test:
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`.
2. Add the line: `dbg.log0('SDSD same_stat', same_stat);` before `if (!same_stat) { // config file of bucket was changed` and start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
3. Create the alias for S3 service:`alias nc-user-1-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443’`.
4. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-1-s3 s3 ls; echo $?`
5. Add bucket to the account using AWS CLI: `nc-user-1-s3 s3 mb s3://bucket-01` (`bucket-01` is the bucket name in this example)
6. Head the bucket: `nc-user-1-s3 s3api head-bucket --bucket bucket-01` (expect to see "SDSD same_stat true")
7. Edit the account config file, for example: `sudo node src/cmd/manage_nsfs account update --name <account-name> --fs_backend GPFS` (it was '' and we change it to GPFS).
8. Head the bucket again: `nc-user-1-s3 s3api head-bucket --bucket bucket-01` (expect to see "SDSD same_stat false").

- [ ] Doc added/updated
- [X] Tests added
