### PR TITLE
bucket notifications - fix TopicConfiguration array for get (github issue 8647)

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_notification.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_notification.js
@@ -14,6 +14,8 @@ async function get_bucket_notification(req) {
 
     result = _.cloneDeep(result);
 
+    const TopicConfiguration = [];
+
     //adapt to aws cli structure
     if (result && result.length > 0) {
         for (const conf of result) {
@@ -23,19 +25,19 @@ async function get_bucket_notification(req) {
             delete conf.event;
             delete conf.topic;
             delete conf.id;
+
+            TopicConfiguration.push({TopicConfiguration: conf});
         }
     }
 
     const reply = result && result.length > 0 ?
         {
             //return result inside TopicConfiguration tag
-            NotificationConfiguration: {
-                TopicConfiguration: result
-            }
+            NotificationConfiguration:
+                TopicConfiguration
         } :
         //if there's no notification, return empty NotificationConfiguration tag
         { NotificationConfiguration: {} };
-
 
     return reply;
 }


### PR DESCRIPTION
### Explain the changes
1. The TopicConfiguration array was not being converted to proper xml when bucket has more than one notification confs.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8647

### Testing Instructions:
1. Add several bucket notifications to a bucket.
2. Perform get bucket notification s3op on bucket.


- [ ] Doc added/updated
- [ ] Tests added
