### PR TITLE
bucket notifications - get notif should clone result before altering it (dfsbugs 1286)

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_notification.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_notification.js
@@ -1,14 +1,18 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const _ = require('lodash');
+
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETnotification.html
  */
 async function get_bucket_notification(req) {
 
-    const result = await req.object_sdk.get_bucket_notification({
+    let result = await req.object_sdk.get_bucket_notification({
         bucket_name: req.params.bucket,
     });
+
+    result = _.cloneDeep(result);
 
     //adapt to aws cli structure
     if (result && result.length > 0) {
@@ -16,7 +20,7 @@ async function get_bucket_notification(req) {
             conf.Event = conf.event;
             conf.Topic = conf.topic;
             conf.Id = conf.id;
-            delete conf.vent;
+            delete conf.event;
             delete conf.topic;
             delete conf.id;
         }


### PR DESCRIPTION
### Explain the changes
1. s3_get_bucket_notification adapts the names of fields in result to match s3 spec.
This should be done on a clone. 

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-1286

### Testing Instructions:
1. Perform s3_get_bucket_notification on a bucket.
2. Perform event (eg s3 cp) that has notification on the bucket (on the same endpoint as step 1)


- [ ] Doc added/updated
- [ ] Tests added
