### PR TITLE
bucket notifications - go on to next event when checking event filters (gh issue 8652)

### DIFF
--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -445,7 +445,7 @@ function check_notif_relevant(notif, req) {
         const notif_event_elems = notif_event.split(':');
         const notif_event_name = notif_event_elems[1];
         const notif_event_method = notif_event_elems[2];
-        if (notif_event_name.toLowerCase() !== op_event.name.toLowerCase()) return false;
+        if (notif_event_name.toLowerCase() !== op_event.name.toLowerCase()) continue;
         //is there filter by method?
         if (notif_event_method === '*') {
             //no filtering on method. we've passed the filter and need to send a notification


### PR DESCRIPTION
### Explain the changes
1. Continue to next possible event if several events filters are present in a notification configuration.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8652

### Testing Instructions:
1. See gh issue.


- [ ] Doc added/updated
- [ ] Tests added
