### PR TITLE
Added a fix for handling invalid_schema_error returning with invalid status value for bucket lifecycle configuration rule

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
@@ -108,9 +108,10 @@ async function put_bucket_lifecycle(req) {
         }
         id_set.add(current_rule.id);
 
-        if (rule.Status?.length !== 1) {
-            dbg.error('Rule should have status', rule);
-            throw new S3Error(S3Error.InvalidArgument);
+        if (!rule.Status || rule.Status.length !== 1 ||
+            (rule.Status[0] !== s3_const.LIFECYCLE_STATUS.STAT_ENABLED && rule.Status[0] !== s3_const.LIFECYCLE_STATUS.STAT_DISABLED)) {
+            dbg.error(`Rule should have a status value of "${s3_const.LIFECYCLE_STATUS.STAT_ENABLED}" or "${s3_const.LIFECYCLE_STATUS.STAT_DISABLED}".`, rule);
+            throw new S3Error(S3Error.MalformedXML);
         }
         current_rule.status = rule.Status[0];
 

--- a/src/endpoint/s3/s3_constants.js
+++ b/src/endpoint/s3/s3_constants.js
@@ -10,3 +10,7 @@ const s3_const = exports;
 ///////////////
 
 s3_const.MAX_RULE_ID_LENGTH = 255;
+s3_const.LIFECYCLE_STATUS = Object.freeze({
+    STAT_ENABLED: 'Enabled',
+    STAT_DISABLED: 'Disabled'
+});

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -271,7 +271,8 @@ S3Error.MalformedPOSTRequest = Object.freeze({
 });
 S3Error.MalformedXML = Object.freeze({
     code: 'MalformedXML',
-    message: 'This happens when the user sends malformed xml (xml that doesn\'t conform to the published xsd) for the configuration. The error message is, "The XML you provided was not well-formed or did not validate against our published schema."',
+    // This happens when the user sends malformed xml (xml that doesn't conform to the published xsd) for the configuration.
+    message: 'The XML you provided was not well-formed or did not validate against our published schema.',
     http_code: 400,
 });
 S3Error.InvalidTag = Object.freeze({

--- a/src/test/lifecycle/common.js
+++ b/src/test/lifecycle/common.js
@@ -569,3 +569,17 @@ exports.test_rule_duplicate_id = async function(Bucket, Key, s3) {
         assert(error.code === 'InvalidArgument', 'Expected InvalidArgument: duplicate ID found in the rules');
     }
 };
+
+exports.test_rule_status_value = async function(Bucket, Key, s3) {
+    const putLifecycleParams = id_lifecycle_configuration(Bucket, Key);
+
+    // set the status value to an invalid value - other than 'Enabled' and 'Disabled'
+    putLifecycleParams.LifecycleConfiguration.Rules[0].Status = 'enabled';
+
+    try {
+        await s3.putBucketLifecycleConfiguration(putLifecycleParams);
+        assert.fail('Expected MalformedXML error due to wrong status value, but received a different response');
+    } catch (error) {
+        assert(error.code === 'MalformedXML', `Expected MalformedXML error: due to invalid status value`);
+    }
+};

--- a/src/test/system_tests/test_lifecycle.js
+++ b/src/test/system_tests/test_lifecycle.js
@@ -56,6 +56,7 @@ async function main() {
     await commonTests.test_and_prefix_size(Bucket, Key, s3);
     await commonTests.test_rule_id_length(Bucket, Key, s3);
     await commonTests.test_rule_duplicate_id(Bucket, Key, s3);
+    await commonTests.test_rule_status_value(Bucket, Key, s3);
 
     const getObjectParams = {
         Bucket,


### PR DESCRIPTION
### Explain the changes
1. This fix ensures that when an INVALID_SCHEMA_PARAMS error occurs due to an incorrect Status value (other than "Enabled" or "Disabled") in a bucket lifecycle configuration rule, the appropriate AWS S3 error (MalformedXML) is returned.

Below is the aws output:
![Screenshot from 2025-01-08 19-12-26](https://github.com/user-attachments/assets/d170c099-bf4f-40d4-8a83-55be7b05f075)

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: #8553 

### Testing Instructions:
1. create s3 backingstore>bucketclass>obc.
2. Apply below policy on the bucket created with obc:
`$ AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws s3api --no-verify-ssl --endpoint-url <endpoint-url> put-bucket-lifecycle-configuration --bucket <bucket-name> --lifecycle-configuration '{
  "Rules": [
    {
      "ID": "rule_id",
      "Status": "enabled",
      "Filter": {
        "Prefix": "test/"
      },
      "Expiration": {
        "Date": "2020-01-02T00:00:00.000Z"
      }
    }
  ]
}'
`
3. Check for the similar error as AWS S3:
`An error occurred (MalformedXML) when calling the PutBucketLifecycleConfiguration operation: The XML you provided was not well-formed or did not validate against our published schema`

- [X] Tests added
