### PR TITLE
bucket notifications - validate notifications on change (gh issue 8649)

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_notification.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_notification.js
@@ -1,6 +1,9 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const S3Error = require('../s3_errors').S3Error;
+const notif_util = require('../../../util/notifications_util');
+
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTnotification.html
  */
@@ -20,6 +23,19 @@ async function put_bucket_notification(req) {
         }
     } else {
         topic_configuration = [];
+    }
+
+    //test new notifications.
+    //if test notification fails, fail the put op
+    const err = await notif_util.test_notifications(topic_configuration,
+        req.object_sdk.nsfs_config_root);
+    if (err) {
+        throw new S3Error({
+            code: 'InvalidArgument',
+            message: JSON.stringify(err.message),
+            http_code: 400,
+            detail: err.toString()
+        });
     }
 
     const reply = await req.object_sdk.put_bucket_notification({


### PR DESCRIPTION
### Explain the changes
1. As per aws spec, when bucket's notification change, all of the bucket's notification configuration are validated.
If one of them fails, the user's request is failed.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8649

### Testing Instructions:
1. Create a new bucket with a non-existing connect file or with a wrong connect info.
2. Bucket creation should fail.

- [ ] Doc added/updated
- [ ] Tests added
