### PR TITLE
Noobaa/Quota: Provide correct error message

### DIFF
--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -164,6 +164,11 @@ S3Error.InvalidBucketState = Object.freeze({
     message: 'The request is not valid with the current state of the bucket.',
     http_code: 409,
 });
+S3Error.ObjectQuotaExceeded = Object.freeze({
+    code: 'ObjectQuotaExceeded',
+    message: 'Object quota exceeded for the bucket.',
+    http_code: 409,
+});
 S3Error.InvalidDigest = Object.freeze({
     code: 'InvalidDigest',
     message: 'The Content-MD5 you specified is not valid.',
@@ -613,6 +618,7 @@ S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     INVALID_PORT_ORDER: S3Error.InvalidPartOrder,
     INVALID_BUCKET_STATE: S3Error.InvalidBucketState,
     NOT_ENOUGH_SPACE: S3Error.InvalidBucketState,
+    OBJECT_QUOTA_EXCEEDED: S3Error.ObjectQuotaExceeded,
     MALFORMED_POLICY: S3Error.MalformedPolicy,
     NO_SUCH_OBJECT_LOCK_CONFIGURATION: S3Error.NoSuchObjectLockConfiguration,
     OBJECT_LOCK_CONFIGURATION_NOT_FOUND_ERROR: S3Error.ObjectLockConfigurationNotFoundError,

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1700,7 +1700,7 @@ function check_quota(bucket) {
     if (major_messages.length > 0) {
         const message = major_messages.join();
         dbg.error(message);
-        throw new RpcError('INVALID_BUCKET_STATE', message);
+        throw new RpcError('OBJECT_QUOTA_EXCEEDED', message);
     }
 }
 


### PR DESCRIPTION
When we exceed the object quota for a bucket,
we should provide an error message which can
convey the clear problem.

https://issues.redhat.com/browse/DFBUGS-242

Testing - 
1 - Create noobaa bucket
_nb bucket create test.bucket_
2 - Set object quota on test.bucket
_nb bucket update test.bucket --max-objects=1_
3 - Copy one object on this bucket
_s3 cp ../test.file s3://test.bucket_

4 - Check status of bucket -
_date; nb bucket status test.bucket_
You might see that everything is fine. At this point you can upload more object but there will not be any issue.
It is because the number of objects has not been update on database.

Keep checking the status.  After 2 minutes or so, you will see following status -
Bucket status:
  Bucket                 : test.bucket
  Type                   : REGULAR
  Mode                   : EXCEEDING_QUOTA
  ResiliencyStatus       : OPTIMAL
  QuotaStatus            : EXCEEDING_QUOTA
  Num Objects            : 1
  Data Size              : 32.620 KB
  Data Size Reduced      : 11.995 KB
  Data Space Avail       : 6.243 GB
  Num Objects Avail      : 0


After this any more object upload  will fail.
_s3 cp ../system.go s3://test.bucket_

You will see following error  message - 
upload failed: ../test.file to s3://test.bucket/test.file An error occurred (ObjectQuotaExceeded) when calling the PutObject operation: Object quota exceeded for the bucket.
