### PR TITLE
NC | Online Upgrade events

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -520,6 +520,7 @@ const NSFS_CLI_ERROR_EVENT_MAP = {
     BucketSetForbiddenBucketOwnerNotExists: NoobaaEvent.UNAUTHORIZED, // GAP - add event
     BucketSetForbiddenBucketOwnerIsIAMAccount: NoobaaEvent.UNAUTHORIZED, // // GAP - add event
     LoggingExportFailed: NoobaaEvent.LOGGING_FAILED,
+    UpgradeFailed: NoobaaEvent.CONFIG_DIR_UPGRADE_FAILED
 };
 
 exports.ManageCLIError = ManageCLIError;

--- a/src/manage_nsfs/manage_nsfs_cli_responses.js
+++ b/src/manage_nsfs/manage_nsfs_cli_responses.js
@@ -155,6 +155,8 @@ const NSFS_CLI_SUCCESS_EVENT_MAP = {
     BucketDeleted: NoobaaEvent.BUCKET_DELETE,
     WhiteListIPUpdated: NoobaaEvent.WHITELIST_UPDATED,
     LoggingExported: NoobaaEvent.LOGGING_EXPORTED,
+    UpgradeStarted: NoobaaEvent.CONFIG_DIR_UPGRADE_STARTED,
+    UpgradeSuccessful: NoobaaEvent.CONFIG_DIR_UPGRADE_SUCCESSFUL
 };
 
 exports.ManageCLIResponse = ManageCLIResponse;

--- a/src/manage_nsfs/manage_nsfs_events_utils.js
+++ b/src/manage_nsfs/manage_nsfs_events_utils.js
@@ -347,4 +347,41 @@ NoobaaEvent.LOGGING_FAILED = Object.freeze({
     state: 'DEGRADED',
 });
 
+/////////////////////////////////////
+// CONFIG DIRECTORY UPGRADE EVENTS //
+/////////////////////////////////////
+
+NoobaaEvent.CONFIG_DIR_UPGRADE_STARTED = Object.freeze({
+    event_code: 'config_dir_upgrade_started',
+    entity_type: 'NODE',
+    event_type: 'INFO',
+    message: 'Config directory upgrade started.',
+    description: 'Config directory upgrade started.',
+    scope: 'NODE',
+    severity: 'INFO',
+    state: 'HEALTHY',
+});
+
+NoobaaEvent.CONFIG_DIR_UPGRADE_SUCCESSFUL = Object.freeze({
+    event_code: 'config_dir_upgrade_successful',
+    entity_type: 'NODE',
+    event_type: 'INFO',
+    message: 'Config directory upgrade finished successfully.',
+    description: 'Config directory upgrade finished successfully.',
+    scope: 'NODE',
+    severity: 'INFO',
+    state: 'HEALTHY',
+});
+
+NoobaaEvent.CONFIG_DIR_UPGRADE_FAILED = Object.freeze({
+    event_code: 'config_dir_upgrade_failed',
+    entity_type: 'NODE',
+    event_type: 'ERROR',
+    message: 'Config directory upgrade failed.',
+    description: 'Config directory upgrade failed due to an error',
+    scope: 'NODE',
+    severity: 'ERROR',
+    state: 'DEGRADED',
+});
+
 exports.NoobaaEvent = NoobaaEvent;


### PR DESCRIPTION
### Explain the changes
Added online upgrade events on **start, success and failure** of the config directory upgrade.
For example - 
While running the command - `noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts hostname1` the following events will be created on success/failure.

**1. Start event -** 
```
Jan-9 10:15:34.509 [/22415] [EVENT]{"timestamp":"2025-01-09T08:15:34.509Z","host":"hostname1","event":{"code":"config_dir_upgrade_started","message":"Config directory upgrade started.","description":"Config directory upgrade started.","entity_type":"NODE","event_type":"INFO","scope":"NODE","severity":"INFO","state":"HEALTHY","arguments":{"expected_version":"5.18.0","expected_hosts":["hostname1"]},"pid":22415}}
```

**2. Failure event -** 
```
Jan-9 10:15:34.512 [/22415] [EVENT]{"timestamp":"2025-01-09T08:15:34.512Z","host":"hostname1","event":{"code":"config_dir_upgrade_failed","message":"Config directory upgrade failed.","description":"Config directory upgrade failed due to an error","entity_type":"NODE","event_type":"ERROR","scope":"NODE","severity":"ERROR","state":"DEGRADED","arguments":{"error":"Error: system does not exist\n    at NCUpgradeManager.upgrade_config_dir (noobaa-core/src/upgrade/nc_upgrade_manager.js:102:33)\n    at async start_config_dir_upgrade (noobaa-core/src/manage_nsfs/upgrade.js:55:29)\n    at async Object.manage_upgrade_operations (noobaa-core/src/manage_nsfs/upgrade.js:23:13)\n    at async main (noobaa-core/src/cmd/manage_nsfs.js:74:13)"},"pid":22415}}
```

**3. Success event -** 
```
Jan-9 10:16:48.482 [/23116] [EVENT]{"timestamp":"2025-01-09T08:16:48.482Z","host":"hostname1","event":{"code":"config_dir_upgrade_successful","message":"Config directory upgrade finished successfully.","description":"Config directory upgrade finished successfully.","entity_type":"NODE","event_type":"INFO","scope":"NODE","severity":"INFO","state":"HEALTHY","arguments":{"expected_version":"5.18.0","expected_hosts":["hostname1"]},"pid":23116}}
```

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Run `noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts hostname1` when upgrade is valid/invalid.


- [ ] Doc added/updated
- [ ] Tests added
