### PR TITLE
NC | Fix for NooBaa CLI not creating events

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -33,6 +33,7 @@ let config_fs;
 
 async function main(argv = minimist(process.argv.slice(2))) {
     try {
+        config.EVENT_LOGGING_ENABLED = true;
         if (process.getuid() !== 0 || process.getgid() !== 0) {
             throw new Error('Root permissions required for Manage NSFS execution.');
         }


### PR DESCRIPTION
### Explain the changes
1. A new config called `EVENT_LOGGING_ENABLED` was introduced on https://github.com/noobaa/noobaa-core/pull/8518.
As mentioned in the declaration of this configuration, `config.EVENT_LOGGING_ENABLED = false; // should be changed in NC NSFS configuration` - we need to enable it on Non-containerized environment, there was a bug that it was enabled only in nsfs.js and not in the CLI, therefore I enabled it on the CLI as well since no cli events were created due to this issue.

### Issues: Fixed #xxx / Gap #xxx
1. consider backport it to 5.17.

### Testing Instructions:
1. Run CLI and expect to see events. 
Example - 
`noobaa-cli account add --name=account1 --new_buckets_path=/private/tmp/dir2/ --user=root`
expect to see in the logs the following event - 
```
Jan-9 10:26:07.836 [/25144] [EVENT]{"timestamp":"2025-01-09T08:26:07.836Z","host":"hostname1","event":{"code":"noobaa_account_created","message":"Account created","description":"Noobaa Account created","entity_type":"NODE","event_type":"INFO","scope":"NODE","severity":"INFO","state":"HEALTHY","arguments":{"account":"account1"},"pid":25144}}
```
- [ ] Doc added/updated
- [ ] Tests added
