### PR TITLE
SSL | Secure service for Noobaa metric

### DIFF
--- a/config.js
+++ b/config.js
@@ -594,6 +594,7 @@ config.WS_METRICS_SERVER_PORT = 7001;
 config.BG_METRICS_SERVER_PORT = 7002;
 config.HA_METRICS_SERVER_PORT = 7003;
 config.EP_METRICS_SERVER_PORT = 7004;
+config.EP_METRICS_SERVER_SSL_PORT = 9443;
 
 //////////////////////////////
 // OAUTH RELATES            //
@@ -916,6 +917,8 @@ config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
 config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || (process.env.NC_NSFS_NO_DB_ENV === 'true' ? -1 : 7443);
 config.ENDPOINT_SSL_IAM_PORT = Number(process.env.ENDPOINT_SSL_IAM_PORT) || -1;
 config.ALLOW_HTTP = false;
+config.ALLOW_HTTP_METRICS = true;
+config.ALLOW_HTTPS_METRICS = true;
 // config files should allow access to the owner of the files
 config.BASE_MODE_CONFIG_FILE = 0o600;
 config.BASE_MODE_CONFIG_DIR = 0o700;

--- a/docs/NooBaaNonContainerized/ConfigFileCustomizations.md
+++ b/docs/NooBaaNonContainerized/ConfigFileCustomizations.md
@@ -450,6 +450,34 @@ Warning: After setting this configuration, NooBaa will skip schema validations a
     3. systemctl restart noobaa
     ```
 
+### 31. Prometheus HTTP enable flag -
+* <u>Key</u>: `ALLOW_HTTP_METRICS`  
+* <u>Type</u>: Boolean  
+* <u>Default</u>: true  
+* <u>Description</u>: This flag will decide whether to enable HTTP service for Prometheus metrics.
+* <u>Steps</u>:  
+    ```
+    1. Open /path/to/config_dir/config.json file.
+    2. Set the config key -
+    Example:
+    "ALLOW_HTTP_METRICS": true
+    3. systemctl restart noobaa
+    ```
+
+### 32. Prometheus HTTPS enable flag -
+* <u>Key</u>: `ALLOW_HTTPS_METRICS`  
+* <u>Type</u>: Boolean  
+* <u>Default</u>: true  
+* <u>Description</u>: This flag will decide whether to enable HTTPS service for Prometheus metrics.
+* <u>Steps</u>:  
+    ```
+    1. Open /path/to/config_dir/config.json file.
+    2. Set the config key -
+    Example:
+    "ALLOW_HTTPS_METRICS": true
+    3. systemctl restart noobaa
+    ```
+
 ## Config.json File Examples
 The following is an example of a config.json file - 
 

--- a/docs/NooBaaNonContainerized/Monitoring.md
+++ b/docs/NooBaaNonContainerized/Monitoring.md
@@ -16,12 +16,27 @@ Read more about NSFS metrics at - [NSFS metrics design](./../design/NSFSMetrics.
 
 This section provides details about the metrics URL and port configuration necessary for accessing and monitoring system metrics.
 
-#### Prometheus Metrics URL - </br>
-- NooBaa exports the system statistics via the following URL - </br> `http://{host}:{metrics_port}/metrics/nsfs_stats`
+#### Prometheus Metrics HTTP URL - </br>
+- NooBaa exports the system statistics via the following URL - </br> `http://{host}:{http_metrics_port}/metrics/nsfs_stats`
 
 - Default port - 7004
 
 - Prometheus metrics port configuration -  </br> Changing Prometheus metrics port can be done by changing EP_METRICS_SERVER_PORT in config.json.  </br>
+
+- Prometheus metrics HTTP service can be enabled/disabled by changing `ALLOW_HTTP_METRICS` in config.json for Non Containerized Noobaa, for containerized deployments HTTP is always enabled.
+
+#### Prometheus Metrics HTTPS URL - </br>
+
+- NooBaa exports the system statistics via the following SSL URL - </br> `https://{host}:{https_metrics_port}/metrics/nsfs_stats`
+
+- Default port - 9443
+
+- Prometheus metrics port configuration -  </br> Changing Prometheus metrics HTTPS port can be done by changing EP_METRICS_SERVER_SSL_PORT in config.json.  </br>
+
+- Prometheus metrics HTTP service can be enabled/disabled by changing `ALLOW_HTTPS_METRICS` in config.json
+
+- Secure Prometheus metrics will reuse the existing S3 certificates from cert path S3_SERVICE_CERT_PATH (`/etc/s3-secret`) for containerized deployments and  `{nsfs_config_root}/certificates/` for non-containerized NSFS deployments. </br> Prometheus metrics SSL cert dir path can be changed by updating S3_SERVICE_CERT_PATH in config.json. for containerized deployments </br>
+
 For more details about configuring metrics port see - [Non Containerized NooBaa Developer Customization](./ConfigFileCustomizations.md)
 
 

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -71,13 +71,14 @@ Arguments:
 const OPTIONS = `
 Options:
 
-    --http_port <port>         (default 6001)   Set the S3 endpoint listening HTTP port to serve.
-    --https_port <port>        (default 6443)   Set the S3 endpoint listening HTTPS port to serve.
-    --https_port_sts <port>    (default -1)     Set the S3 endpoint listening HTTPS port for STS.
-    --https_port_iam <port>    (default -1)     Set the endpoint listening HTTPS port for IAM.
-    --metrics_port <port>      (default -1)     Set the metrics listening port for prometheus.
-    --forks <n>                (default none)   Forks spread incoming requests (config.ENDPOINT_FORKS used if flag is not provided).
-    --debug <level>            (default 0)      Increase debug level.
+    --http_port <port>          (default 6001)      Set the S3 endpoint listening HTTP port to serve.
+    --https_port <port>         (default 6443)      Set the S3 endpoint listening HTTPS port to serve.
+    --https_port_sts <port>     (default -1)        Set the S3 endpoint listening HTTPS port for STS.
+    --https_port_iam <port>     (default -1)        Set the endpoint listening HTTPS port for IAM.
+    --http_metrics_port <port>      (default 7004)    Set the metrics listening HTTP port for prometheus.
+    --https_metrics_port <port>     (default 9443)    Set the metrics listening HTTPS port for prometheus.
+    --forks <n>                     (default none)  Forks spread incoming requests (config.ENDPOINT_FORKS used if flag is not provided).
+    --debug <level>                 (default 0)     Increase debug level.
 
     ## single user mode
 
@@ -265,7 +266,8 @@ async function main(argv = minimist(process.argv.slice(2))) {
         const https_port = Number(argv.https_port) || config.ENDPOINT_SSL_PORT;
         const https_port_sts = Number(argv.https_port_sts) || config.ENDPOINT_SSL_STS_PORT;
         const https_port_iam = Number(argv.https_port_iam) || config.ENDPOINT_SSL_IAM_PORT;
-        const metrics_port = Number(argv.metrics_port) || config.EP_METRICS_SERVER_PORT;
+        const http_metrics_port = Number(argv.http_metrics_port) || config.EP_METRICS_SERVER_PORT;
+        const https_metrics_port = Number(argv.https_metrics_port) || config.EP_METRICS_SERVER_SSL_PORT;
         const forks = Number(argv.forks) || config.ENDPOINT_FORKS;
         if (forks > 0) process.env.ENDPOINT_FORKS = forks.toString(); // used for argv.forks to take effect
         const uid = Number(argv.uid) || process.getuid();
@@ -311,7 +313,8 @@ async function main(argv = minimist(process.argv.slice(2))) {
             https_port,
             https_port_sts,
             https_port_iam,
-            metrics_port,
+            http_metrics_port,
+            https_metrics_port,
             backend,
             forks,
             access_key,
@@ -340,7 +343,8 @@ async function main(argv = minimist(process.argv.slice(2))) {
             https_port,
             https_port_sts,
             https_port_iam,
-            metrics_port,
+            http_metrics_port,
+            https_metrics_port,
             forks,
             nsfs_config_root,
             init_request_sdk: (req, res) => {

--- a/src/util/fork_utils.js
+++ b/src/util/fork_utils.js
@@ -28,11 +28,13 @@ const fs_workers_stats = {};
  * In case of any worker exit, also the entire process group will exit.
  * @see https://nodejs.org/api/cluster.html
  * 
- * @param {number?} count number of workers to start.
- * @param {number?} metrics_port prometheus metris port.
+ * @param {number} [metrics_port]
+ * @param {number} [https_metrics_port]
+ * @param {string} [nsfs_config_root] nsfs configuration path
+ * @param {number} [count] number of workers to start.
  * @returns {Promise<boolean>} true if workers were started.
  */
-async function start_workers(metrics_port, count = 0) {
+async function start_workers(metrics_port, https_metrics_port, nsfs_config_root, count = 0) {
     const exit_events = [];
     if (cluster.isPrimary && count > 0) {
         for (let i = 0; i < count; ++i) {
@@ -71,9 +73,9 @@ async function start_workers(metrics_port, count = 0) {
                 cluster.workers[id].on('message', nsfs_io_stats_handler);
             }
         }
-        if (metrics_port > 0) {
+        if (metrics_port > 0 || https_metrics_port > 0) {
             dbg.log0('Starting metrics server', metrics_port);
-            await prom_reporting.start_server(metrics_port, true);
+            await prom_reporting.start_server(metrics_port, https_metrics_port, true, nsfs_config_root);
             dbg.log0('Started metrics server successfully');
         }
         return true;

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -20,6 +20,7 @@ const xml_utils = require('./xml_utils');
 const jwt_utils = require('./jwt_utils');
 const time_utils = require('./time_utils');
 const cloud_utils = require('./cloud_utils');
+const ssl_utils = require('../util/ssl_utils');
 
 const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
 const STREAMING_PAYLOAD = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';
@@ -750,7 +751,118 @@ function http_get(uri, options) {
         client.get(uri, options, resolve).on('error', reject);
     });
 }
+/**
+ * start_https_server starts the secure https server by type and options and creates a certificate if required
+ * @param {number} https_port
+ * @param {('S3'|'IAM'|'STS'|'METRICS')} server_type 
+ * @param {Object} request_handler 
+*/
+async function start_https_server(https_port, server_type, request_handler, nsfs_config_root) {
+    const ssl_cert_info = await ssl_utils.get_ssl_cert_info(server_type, nsfs_config_root);
+    const https_server = await ssl_utils.create_https_server(ssl_cert_info, true, request_handler);
+    ssl_cert_info.on('update', updated_ssl_cert_info => {
+        dbg.log0(`Setting updated ${server_type} ssl certs for endpoint.`);
+        const updated_ssl_options = { ...updated_ssl_cert_info.cert, honorCipherOrder: true };
+        https_server.setSecureContext(updated_ssl_options);
+    });
+    dbg.log0(`Starting ${server_type} server on HTTPS port ${https_port}`);
+    await listen_port(https_port, https_server, server_type);
+    dbg.log0(`Started ${server_type} HTTPS server successfully`);
+}
 
+/**
+ * start_http_server starts the non-secure http server by type
+ * @param {number} http_port
+ * @param {('S3'|'IAM'|'STS'|'METRICS')} server_type 
+ * @param {Object} request_handler 
+*/
+async function start_http_server(http_port, server_type, request_handler) {
+    const http_server = http.createServer(request_handler);
+    if (http_port > 0) {
+        dbg.log0(`Starting ${server_type} server on HTTP port ${http_port}`);
+        await listen_port(http_port, http_server, server_type);
+        dbg.log0(`Started ${server_type} HTTP server successfully`);
+    }
+}
+
+/**
+ * Listen server for http/https ports
+ * @param {number} port
+ * @param {http.Server} server
+ * @param {('S3'|'IAM'|'STS'|'METRICS')} server_type 
+*/
+function listen_port(port, server, server_type) {
+    return new Promise((resolve, reject) => {
+        if (server_type !== 'METRICS') {
+            setup_endpoint_server(server);
+        }
+        server.listen(port, err => {
+            if (err) {
+                dbg.error('ENDPOINT FAILED to listen', err);
+                reject(err);
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
+/**
+ * Setup endpoint socket and server, Setup is not used for non-endpoint servers.
+ * @param {http.Server} server
+*/
+function setup_endpoint_server(server) {
+    // Handle 'Expect' header different than 100-continue to conform with AWS.
+    // Consider any expect value as if the client is expecting 100-continue.
+    // See https://github.com/ceph/s3-tests/blob/master/s3tests/functional/test_headers.py:
+    // - test_object_create_bad_expect_mismatch()
+    // - test_object_create_bad_expect_empty()
+    // - test_object_create_bad_expect_none()
+    // - test_object_create_bad_expect_unreadable()
+    // See https://nodejs.org/api/http.html#http_event_checkexpectation
+    server.on('checkExpectation', function on_s3_check_expectation(req, res) {
+        res.writeContinue();
+        server.emit('request', req, res);
+    });
+
+    // See https://nodejs.org/api/http.html#http_event_clienterror
+    server.on('clientError', function on_s3_client_error(err, socket) {
+
+        // On parsing errors we reply 400 Bad Request to conform with AWS
+        // These errors come from the nodejs native http parser.
+        if (typeof err.code === 'string' &&
+            err.code.startsWith('HPE_INVALID_') &&
+            err.bytesParsed > 0) {
+            console.error('ENDPOINT CLIENT ERROR - REPLY WITH BAD REQUEST', err);
+            socket.write('HTTP/1.1 400 Bad Request\r\n');
+            socket.write(`Date: ${new Date().toUTCString()}\r\n`);
+            socket.write('Connection: close\r\n');
+            socket.write('Content-Length: 0\r\n');
+            socket.end('\r\n');
+        }
+
+        // in any case we destroy the socket
+        socket.destroy();
+    });
+
+    server.keepAliveTimeout = config.ENDPOINT_HTTP_SERVER_KEEPALIVE_TIMEOUT;
+    server.requestTimeout = config.ENDPOINT_HTTP_SERVER_REQUEST_TIMEOUT;
+    server.maxRequestsPerSocket = config.ENDPOINT_HTTP_MAX_REQUESTS_PER_SOCKET;
+
+    server.on('error', handle_server_error);
+
+    // This was an attempt to read from the socket in large chunks,
+    // but it seems like it has no effect and we still get small chunks
+    // server.on('connection', function on_s3_connection(socket) {
+    // socket._readableState.highWaterMark = 1024 * 1024;
+    // socket.setNoDelay(true);
+    // });
+}
+
+function handle_server_error(err) {
+    dbg.error('ENDPOINT FAILED TO START on error:', err.code, err.message, err.stack || err);
+    process.exit(1);
+}
 
 exports.parse_url_query = parse_url_query;
 exports.parse_client_ip = parse_client_ip;
@@ -780,6 +892,8 @@ exports.authorize_session_token = authorize_session_token;
 exports.get_agent_by_endpoint = get_agent_by_endpoint;
 exports.validate_server_ip_whitelist = validate_server_ip_whitelist;
 exports.http_get = http_get;
+exports.start_http_server = start_http_server;
+exports.start_https_server = start_https_server;
 exports.CONTENT_TYPE_TEXT_PLAIN = CONTENT_TYPE_TEXT_PLAIN;
 exports.CONTENT_TYPE_APP_OCTET_STREAM = CONTENT_TYPE_APP_OCTET_STREAM;
 exports.CONTENT_TYPE_APP_JSON = CONTENT_TYPE_APP_JSON;


### PR DESCRIPTION
### Explain the changes
1. add secure port for promethus service
2. control prometesu http and https service creation with flags.  non-secure service creation can be prevented using flag (ALLOW_HTTP_METRICS) in NC NSFS deployment only, and secure prometheus service will start only if ALLOW_HTTPS_METRICS flag is enabled for all the deployents.
3. Same S3 ssl certs are used by metrics server
4. Metrics https_port added in CLI and config for flexibility.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8198

### Testing Instructions:
1. start nsfs application
2. verify metrics server is started by hitting url https://localhost:9443/
3. try the same with valid local certificate, steps can be found in [doc](https://ibm.ent.box.com/file/1389669232030?s=jj98n81p3tpfan60vuaqbrj7xk0s2ct2)


- [ ] Doc added/updated
- [X] Tests added
