### PR TITLE
NC | NSFS | Add Module (`dev-dependency`) `iam-client` For Integration Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "noobaa-core": "src/cmd/index.js"
       },
       "devDependencies": {
+        "@aws-sdk/client-iam": "3.726.1",
         "@aws-sdk/lib-storage": "3.717.0",
         "@stylistic/eslint-plugin-js": "1.8.1",
         "@types/jest": "29.5.14",
@@ -300,6 +301,1192 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam": {
+      "version": "3.726.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.726.1.tgz",
+      "integrity": "sha512-ht2eTRtFpE5P56d694tCLCQWOwTTb94jyuiyNnTkGF37kblboRelJ2B4ySu/f3kJ28l5r/i9n36+mV9ggYdzvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.726.0",
+        "@aws-sdk/client-sts": "3.726.1",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/credential-provider-node": "3.726.0",
+        "@aws-sdk/middleware-host-header": "3.723.0",
+        "@aws-sdk/middleware-logger": "3.723.0",
+        "@aws-sdk/middleware-recursion-detection": "3.723.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/region-config-resolver": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@aws-sdk/util-user-agent-browser": "3.723.0",
+        "@aws-sdk/util-user-agent-node": "3.726.0",
+        "@smithy/config-resolver": "^4.0.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/hash-node": "^4.0.0",
+        "@smithy/invalid-dependency": "^4.0.0",
+        "@smithy/middleware-content-length": "^4.0.0",
+        "@smithy/middleware-endpoint": "^4.0.0",
+        "@smithy/middleware-retry": "^4.0.0",
+        "@smithy/middleware-serde": "^4.0.0",
+        "@smithy/middleware-stack": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/url-parser": "^4.0.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.0",
+        "@smithy/util-defaults-mode-node": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/util-retry": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sso": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.726.0.tgz",
+      "integrity": "sha512-NM5pjv2qglEc4XN3nnDqtqGsSGv1k5YTmzDo3W3pObItHmpS8grSeNfX9zSH+aVl0Q8hE4ZIgvTPNZ+GzwVlqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/middleware-host-header": "3.723.0",
+        "@aws-sdk/middleware-logger": "3.723.0",
+        "@aws-sdk/middleware-recursion-detection": "3.723.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/region-config-resolver": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@aws-sdk/util-user-agent-browser": "3.723.0",
+        "@aws-sdk/util-user-agent-node": "3.726.0",
+        "@smithy/config-resolver": "^4.0.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/hash-node": "^4.0.0",
+        "@smithy/invalid-dependency": "^4.0.0",
+        "@smithy/middleware-content-length": "^4.0.0",
+        "@smithy/middleware-endpoint": "^4.0.0",
+        "@smithy/middleware-retry": "^4.0.0",
+        "@smithy/middleware-serde": "^4.0.0",
+        "@smithy/middleware-stack": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/url-parser": "^4.0.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.0",
+        "@smithy/util-defaults-mode-node": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/util-retry": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.726.0.tgz",
+      "integrity": "sha512-5JzTX9jwev7+y2Jkzjz0pd1wobB5JQfPOQF3N2DrJ5Pao0/k6uRYwE4NqB0p0HlGrMTDm7xNq7OSPPIPG575Jw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/credential-provider-node": "3.726.0",
+        "@aws-sdk/middleware-host-header": "3.723.0",
+        "@aws-sdk/middleware-logger": "3.723.0",
+        "@aws-sdk/middleware-recursion-detection": "3.723.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/region-config-resolver": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@aws-sdk/util-user-agent-browser": "3.723.0",
+        "@aws-sdk/util-user-agent-node": "3.726.0",
+        "@smithy/config-resolver": "^4.0.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/hash-node": "^4.0.0",
+        "@smithy/invalid-dependency": "^4.0.0",
+        "@smithy/middleware-content-length": "^4.0.0",
+        "@smithy/middleware-endpoint": "^4.0.0",
+        "@smithy/middleware-retry": "^4.0.0",
+        "@smithy/middleware-serde": "^4.0.0",
+        "@smithy/middleware-stack": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/url-parser": "^4.0.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.0",
+        "@smithy/util-defaults-mode-node": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/util-retry": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.726.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sts": {
+      "version": "3.726.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.726.1.tgz",
+      "integrity": "sha512-qh9Q9Vu1hrM/wMBOBIaskwnE4GTFaZu26Q6WHwyWNfj7J8a40vBxpW16c2vYXHLBtwRKM1be8uRLkmDwghpiNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.726.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/credential-provider-node": "3.726.0",
+        "@aws-sdk/middleware-host-header": "3.723.0",
+        "@aws-sdk/middleware-logger": "3.723.0",
+        "@aws-sdk/middleware-recursion-detection": "3.723.0",
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/region-config-resolver": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@aws-sdk/util-user-agent-browser": "3.723.0",
+        "@aws-sdk/util-user-agent-node": "3.726.0",
+        "@smithy/config-resolver": "^4.0.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/hash-node": "^4.0.0",
+        "@smithy/invalid-dependency": "^4.0.0",
+        "@smithy/middleware-content-length": "^4.0.0",
+        "@smithy/middleware-endpoint": "^4.0.0",
+        "@smithy/middleware-retry": "^4.0.0",
+        "@smithy/middleware-serde": "^4.0.0",
+        "@smithy/middleware-stack": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/url-parser": "^4.0.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.0",
+        "@smithy/util-defaults-mode-node": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/util-retry": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/core": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
+      "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/signature-v4": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.723.0.tgz",
+      "integrity": "sha512-OuH2yULYUHTVDUotBoP/9AEUIJPn81GQ/YBtZLoo2QyezRJ2QiO/1epVtbJlhNZRwXrToLEDmQGA2QfC8c7pbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.723.0.tgz",
+      "integrity": "sha512-DTsKC6xo/kz/ZSs1IcdbQMTgiYbpGTGEd83kngFc1bzmw7AmK92DBZKNZpumf8R/UfSpTcj9zzUUmrWz1kD0eQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/fetch-http-handler": "^5.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/smithy-client": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/util-stream": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.726.0.tgz",
+      "integrity": "sha512-seTtcKL2+gZX6yK1QRPr5mDJIBOatrpoyrO8D5b8plYtV/PDbDW3mtDJSWFHet29G61ZmlNElyXRqQCXn9WX+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/credential-provider-env": "3.723.0",
+        "@aws-sdk/credential-provider-http": "3.723.0",
+        "@aws-sdk/credential-provider-process": "3.723.0",
+        "@aws-sdk/credential-provider-sso": "3.726.0",
+        "@aws-sdk/credential-provider-web-identity": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/credential-provider-imds": "^4.0.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.726.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.726.0.tgz",
+      "integrity": "sha512-jjsewBcw/uLi24x8JbnuDjJad4VA9ROCE94uVRbEnGmUEsds75FWOKp3fWZLQlmjLtzsIbJOZLALkZP86liPaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.723.0",
+        "@aws-sdk/credential-provider-http": "3.723.0",
+        "@aws-sdk/credential-provider-ini": "3.726.0",
+        "@aws-sdk/credential-provider-process": "3.723.0",
+        "@aws-sdk/credential-provider-sso": "3.726.0",
+        "@aws-sdk/credential-provider-web-identity": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/credential-provider-imds": "^4.0.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.723.0.tgz",
+      "integrity": "sha512-fgupvUjz1+jeoCBA7GMv0L6xEk92IN6VdF4YcFhsgRHlHvNgm7ayaoKQg7pz2JAAhG/3jPX6fp0ASNy+xOhmPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.726.0.tgz",
+      "integrity": "sha512-WxkN76WeB08j2yw7jUH9yCMPxmT9eBFd9ZA/aACG7yzOIlsz7gvG3P2FQ0tVg25GHM0E4PdU3p/ByTOawzcOAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.726.0",
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/token-providers": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.723.0.tgz",
+      "integrity": "sha512-tl7pojbFbr3qLcOE6xWaNCf1zEfZrIdSJtOPeSXfV/thFMMAvIjgf3YN6Zo1a6cxGee8zrV/C8PgOH33n+Ev/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.723.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
+      "integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
+      "integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
+      "integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.726.0.tgz",
+      "integrity": "sha512-hZvzuE5S0JmFie1r68K2wQvJbzyxJFdzltj9skgnnwdvLe8F/tz7MqLkm28uV0m4jeHk0LpiBo6eZaPkQiwsZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.723.0",
+        "@aws-sdk/types": "3.723.0",
+        "@aws-sdk/util-endpoints": "3.726.0",
+        "@smithy/core": "^3.0.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
+      "integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/token-providers": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.723.0.tgz",
+      "integrity": "sha512-hniWi1x4JHVwKElANh9afKIMUhAutHVBRD8zo6usr0PAoj+Waf220+1ULS74GXtLXAPCiNXl5Og+PHA7xT8ElQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/property-provider": "^4.0.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.723.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/types": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
+      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.726.0.tgz",
+      "integrity": "sha512-sLd30ASsPMoPn3XBK50oe/bkpJ4N8Bpb7SbhoxcY3Lk+fSASaWxbbXE81nbvCnkxrZCvkPOiDHzJCp1E2im71A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/types": "^4.0.0",
+        "@smithy/util-endpoints": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
+      "integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/types": "^4.0.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.726.0.tgz",
+      "integrity": "sha512-iEj6KX9o6IQf23oziorveRqyzyclWai95oZHDJtYav3fvLJKStwSjygO4xSF7ycHcTYeCHSLO1FFOHgGVs4Viw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.726.0",
+        "@aws-sdk/types": "3.723.0",
+        "@smithy/node-config-provider": "^4.0.0",
+        "@smithy/types": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/abort-controller": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/config-resolver": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+      "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-swFv0wQiK7TGHeuAp6lfF5Kw1dHWsTrCuc+yh4Kh05gEShjsE2RUxHucEerR9ih9JITNtaHcSpUThn5Y/vDw0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-stream": "^4.0.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+      "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/url-parser": "^4.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+      "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/querystring-builder": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-base64": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/hash-node": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+      "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/invalid-dependency": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+      "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/is-array-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-content-length": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+      "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-endpoint": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.1.tgz",
+      "integrity": "sha512-hCCOPu9+sRI7Wj0rZKKnGylKXBEd9cQJetzjQqe8cT4PWvtQAbvNVa6cgAONiZg9m8LaXtP9/waxm3C3eO4hiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.1.0",
+        "@smithy/middleware-serde": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/shared-ini-file-loader": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/url-parser": "^4.0.1",
+        "@smithy/util-middleware": "^4.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-retry": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.1.tgz",
+      "integrity": "sha512-n3g2zZFgOWaz2ZYCy8+4wxSmq+HSTD8QKkRhFDv+nkxY1o7gzyp4PDz/+tOdcNPMPZ/A6Mt4aVECYNjQNiaHJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/service-error-classification": "^4.0.1",
+        "@smithy/smithy-client": "^4.1.0",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-retry": "^4.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-serde": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.1.tgz",
+      "integrity": "sha512-Fh0E2SOF+S+P1+CsgKyiBInAt3o2b6Qk7YOp2W0Qx2XnfTdfMuSDKUEcnrtpxCzgKJnqXeLUZYqtThaP0VGqtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-stack": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+      "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/node-config-provider": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+      "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/shared-ini-file-loader": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/node-http-handler": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.1.tgz",
+      "integrity": "sha512-ddQc7tvXiVLC5c3QKraGWde761KSk+mboCheZoWtuqnXh5l0WKyFy3NfDIM/dsKrI9HlLVH/21pi9wWK2gUFFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/querystring-builder": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/property-provider": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+      "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/protocol-http": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+      "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/querystring-builder": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+      "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/querystring-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+      "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/service-error-classification": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+      "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+      "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/signature-v4": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+      "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/smithy-client": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.0.tgz",
+      "integrity": "sha512-NiboZnrsrZY+Cy5hQNbYi+nVNssXVi2I+yL4CIKNIanOhH8kpC5PKQ2jx/MQpwVr21a3XcVoQBArlpRF36OeEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.1.0",
+        "@smithy/middleware-endpoint": "^4.0.1",
+        "@smithy/middleware-stack": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-stream": "^4.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/url-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+      "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-base64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-body-length-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-body-length-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-config-provider": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.1.tgz",
+      "integrity": "sha512-nkQifWzWUHw/D0aLPgyKut+QnJ5X+5E8wBvGfvrYLLZ86xPfVO6MoqfQo/9s4bF3Xscefua1M6KLZtobHMWrBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/smithy-client": "^4.1.0",
+        "@smithy/types": "^4.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.1.tgz",
+      "integrity": "sha512-LeAx2faB83litC9vaOdwFaldtto2gczUHxfFf8yoRwDU3cwL4/pDm7i0hxsuBCRk5mzHsrVGw+3EVCj32UZMdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.0.1",
+        "@smithy/credential-provider-imds": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/smithy-client": "^4.1.0",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-endpoints": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+      "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-middleware": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+      "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-retry": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+      "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.1.tgz",
+      "integrity": "sha512-Js16gOgU6Qht6qTPfuJgb+1YD4AEO+5Y1UPGWKSp3BNo8ONl/qhXSYDhFKJtwybRJynlCqvP5IeiaBsUmkSPTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.0.1",
+        "@smithy/node-http-handler": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-uri-escape": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-utf8": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-waiter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.2.tgz",
+      "integrity": "sha512-piUTHyp2Axx3p/kc2CIJkYSv0BAaheBQmbACZgQSSfWUumWNW+R1lL+H9PDBxKJkvOeEX+hKYEFiwO8xagL8AQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-s3": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "yazl": "3.3.1"
   },
   "devDependencies": {
+    "@aws-sdk/client-iam": "3.726.1",
     "@aws-sdk/lib-storage": "3.717.0",
     "@stylistic/eslint-plugin-js": "1.8.1",
     "@types/jest": "29.5.14",


### PR DESCRIPTION
### Explain the changes
1. Add the `iam-client` for integration tests by running: `npm install --save-dev @aws-sdk/client-iam`.

### Issues: 
1. I would need this merged for PR #8661.

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added
