### PR TITLE
bucket notifications - add action to encrypt connection file

### DIFF
--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -25,8 +25,14 @@
     1. [Upgrade Start](#upgrade-start)
     2. [Upgrade Status](#upgrade-status)
     3. [Upgrade History](#upgrade-history)
-10. [Global Options](#global-options)
-11. [Examples](#examples)
+10. [Connections](#connection)
+    1. [Add Connection](#add-connection)
+    2. [Update Connection](#update-connection)
+    3. [Connection Status](#connection-status)
+    4. [List Connections][#list-connections]
+    5. [Delete Connection](#delete-connection)
+11. [Global Options](#global-options)
+12. [Examples](#examples)
     1. [Bucket Commands Examples](#bucket-commands-examples)
     2. [Account Commands Examples](#account-commands-examples)
     3. [White List Server IP Command Example](#white-list-server-ip-command-example)
@@ -525,6 +531,109 @@ The available history information is an array of upgrade information - upgrade s
 noobaa-cli upgrade history
 ```
 
+## Managing Connections
+
+A connection file holds information needed to send out a notification to an external server.
+The connection files is specified in each notification configuration of the bucket.
+
+- **[Add Connection](#add-connection)**: Create new connections with customizable options.
+- **[Update Connection](#update-connection)**: Modify the settings and configurations of existing connections.
+- **[Connection Status](#connection-status)**: Retrieve the current status and detailed information about a specific connection.
+- **[List Connections](#list-connections)**: Display a list of all existing connections.
+- **[Delete Connection](#delete-connection)**: Remove unwanted or obsolete connections from the system.
+
+### Add Connection
+
+The `connection add` command is used to create a new connection with customizable options.
+
+#### Usage
+```sh
+noobaa-cli connection add --from_file
+```
+#### Flags -
+
+- `name` (Required)
+    - Type: String
+    - Description: A name to identify the connection.
+
+- `notification_protocol` (Required)
+   - Type: String
+   - Enum: http | https | kafka
+   - Description - Target external server's protocol.
+
+- `agent_request_object`
+   - Type: Object
+   - Description: An object given as options to node http(s) agent.
+
+- `request_options_object`
+   - Type: Object
+   - Description: An object given as options to node http(s) request. If "auth" field is specified, it's value is encrypted.
+
+- `from_file`
+    - Type: String
+    - Description: Path to a JSON file which includes connection properties. When using `from_file` flag the connection details must only appear inside the options JSON file. See example below.
+
+### Update Connection
+
+The `connection update` command is used to update an existing bucket with customizable options.
+
+#### Usage
+```sh
+noobaa-cli connection update --name <connection_name> --key [--value] [--remove_key]
+```
+#### Flags -
+- `name` (Required)
+    - Type: String
+    - Description: Specifies the name of the updated connection.
+
+- `key` (Required)
+    - Type: String
+    - Description: Specifies the key to be updated.
+
+- `value`
+    - Type: String
+    - Description: Specifies the new value of the specified key.  
+
+- `remove_key`
+    - Type: Boolean
+    - Description: Specifies that the specified key should be removed.
+
+### Connection Status
+
+The `connection status` command is used to print the status of the connection.
+
+#### Usage
+```sh
+noobaa-cli connection status --name <connection_name>
+```
+#### Flags -
+- `name` (Required)
+    - Type: String
+    - Description: Specifies the name of the connection.
+
+### List Connections
+
+The `connection list` command is used to display a list of all existing connections.
+
+
+#### Usage
+```sh
+noobaa-cli connection list
+```
+
+### Delete Connection
+
+The `connection delete` command is used to delete an existing connection.
+
+#### Usage
+```sh
+noobaa-cli connection delete --name <connection_name>
+```
+#### Flags -
+- `name` (Required)
+    - Type: String
+    - Description: Specifies the name of the connection to be deleted.
+
 ## Global Options
 
 Global options used by the CLI to define the config directory settings. 
@@ -658,7 +767,21 @@ sudo noobaa-cli bucket delete --name bucket1 2>/dev/null
 ```
 
 -----
+### Connection Commands Examples
 
+#### Create Connection in CLI
+
+```sh
+sudo noobaa-cli connection add --name conn1 --notification_protocol http --request_options_object '{"auth": "user:passw"}'
+```
+
+#### Update Connection Field
+
+```sh
+sudo noobaa-cli connection update --name conn1 --key request_options_object --value '{"auth":"user2:pw2"}'
+```
+
+-----
 #### `--from-file` flag usage example
 
 Using `from_file` flag:
@@ -693,6 +816,21 @@ sudo noobaa-cli account add --from_file <options_account_JSON_file_path>
 
 ```bash
 sudo noobaa-cli bucket add --from_file <options_bucket_JSON_file_path>
+```
+
+##### 2. Create JSON file for connection:
+
+```json
+{
+    "name": "http_conn",
+    "notification_protocol": "http",
+    "agent_request_object": {"host": "localhost", "port": 9999, "timeout": 100},
+    "request_options_object": {"auth": "user:passw", "path": "/query"}
+}
+```
+
+```bash
+sudo noobaa-cli connection add --from_file <options_connection_JSON_file_path>
 ```
 
 ------

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -94,7 +94,7 @@ ManageCLIError.InvalidArgumentType = Object.freeze({
 
 ManageCLIError.InvalidType = Object.freeze({
     code: 'InvalidType',
-    message: 'Invalid type, available types are account, bucket, logging, whitelist, upgrade or notification',
+    message: 'Invalid type, available types are account, bucket, logging, whitelist, upgrade, notification or connection.',
     http_code: 400,
 });
 
@@ -488,6 +488,16 @@ ManageCLIError.ConfigDirUpdateBlocked = Object.freeze({
     code: 'ConfigDirUpdateBlocked',
     message: 'Config directory updates are not allowed on mismatch of the config directory version mentioned in system.json and the config directory version of the source code',
     http_code: 500,
+});
+
+///////////////////////////////
+//     CONNECTION ERRORS     //
+///////////////////////////////
+
+ManageCLIError.MissingCliParam = Object.freeze({
+    code: 'MissingCliParam',
+    message: 'Required cli parameter is missing.',
+    http_code: 400,
 });
 
 ///////////////////////////////

--- a/src/manage_nsfs/manage_nsfs_cli_responses.js
+++ b/src/manage_nsfs/manage_nsfs_cli_responses.js
@@ -145,6 +145,34 @@ ManageCLIResponse.UpgradeHistory = Object.freeze({
 });
 
 ///////////////////////////////
+//   CONNECTION RESPONSES    //
+///////////////////////////////
+
+ManageCLIResponse.ConnectionCreated = Object.freeze({
+    code: 'ConnectionCreated',
+    status: {}
+});
+
+ManageCLIResponse.ConnectionDeleted = Object.freeze({
+    code: 'ConnectionDeleted',
+});
+
+ManageCLIResponse.ConnectionUpdated = Object.freeze({
+    code: 'ConnectionUpdated',
+    status: {}
+});
+
+ManageCLIResponse.ConnectionStatus = Object.freeze({
+    code: 'ConnectionStatus',
+    status: {}
+});
+
+ManageCLIResponse.ConnectionList = Object.freeze({
+    code: 'ConnectionList',
+    list: {}
+});
+
+///////////////////////////////
 //  RESPONSES-EVENT MAPPING  //
 ///////////////////////////////
 

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -9,7 +9,8 @@ const TYPES = Object.freeze({
     LOGGING: 'logging',
     DIAGNOSE: 'diagnose',
     UPGRADE: 'upgrade',
-    NOTIFICATION: 'notification'
+    NOTIFICATION: 'notification',
+    CONNECTION: 'connection'
 });
 
 const ACTIONS = Object.freeze({
@@ -84,6 +85,16 @@ const VALID_OPTIONS_UPGRADE = {
     'history': new Set([...CLI_MUTUAL_OPTIONS])
 };
 
+const VALID_OPTIONS_NOTIFICATION = {};
+
+const VALID_OPTIONS_CONNECTION = {
+    'add': new Set(['name', 'notification_protocol', 'agent_request_object', 'request_options_object', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
+    'update': new Set(['name', 'key', 'value', 'remove_key', ...CLI_MUTUAL_OPTIONS]),
+    'delete': new Set(['name', ...CLI_MUTUAL_OPTIONS]),
+    'list': new Set(CLI_MUTUAL_OPTIONS),
+    'status': new Set(['name', 'decrypt', ...CLI_MUTUAL_OPTIONS]),
+};
+
 
 const VALID_OPTIONS_WHITELIST = new Set(['ips', ...CLI_MUTUAL_OPTIONS]);
 
@@ -97,7 +108,9 @@ const VALID_OPTIONS = {
     from_file_options: VALID_OPTIONS_FROM_FILE,
     anonymous_account_options: VALID_OPTIONS_ANONYMOUS_ACCOUNT,
     diagnose_options: VALID_OPTIONS_DIAGNOSE,
-    upgrade_options: VALID_OPTIONS_UPGRADE
+    upgrade_options: VALID_OPTIONS_UPGRADE,
+    notification_options: VALID_OPTIONS_NOTIFICATION,
+    connection_options: VALID_OPTIONS_CONNECTION,
 };
 
 const OPTION_TYPE = {
@@ -137,8 +150,14 @@ const OPTION_TYPE = {
     expected_hosts: 'string',
     custom_upgrade_scripts_dir: 'string',
     skip_verification: 'boolean',
-    //notifications
-    notifications: 'object'
+    //connection
+    notification_protocol: 'string',
+    agent_request_object: 'string',
+    request_options_object: 'string',
+    decrypt: 'boolean',
+    key: 'string',
+    value: 'string',
+    remove_key: 'boolean',
 };
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -68,6 +68,25 @@ List of actions supported:
 
 `;
 
+const CONNECTION_ACTIONS = `
+Help:
+
+    Use this CLI to execute all the connection related actions.
+
+Usage:
+
+    connection <action> [flags]
+
+List of actions supported:
+
+    add
+    update
+    list
+    status
+    delete
+
+`;
+
 const WHITELIST_FLAGS = `
 Help:
 
@@ -458,6 +477,86 @@ Usage:
 `;
 
 
+const CONNECTION_FLAGS_ADD = `
+Help:
+
+    Use this CLI to add a connection.
+
+Usage:
+
+    connection add [flags]
+
+Flags:
+
+    --name <string>                                                         Set the name for the connection
+    --agent_request_object <object>                                         Value of agent request objects, used for http(s) connection, as defined by nodejs http(s) agent options
+    --request_options_object <object>                                       Value of http(s) request option, as defined by nodejs http(s) request option. "auth" field would be encrypted.
+    --notification_protocol <string>                                        One of http, https, kafka.
+    --from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
+
+`;
+
+const CONNECTION_FLAGS_UPDATE = `
+Help:
+
+    Use this CLI to update a connection.
+
+Usage:
+
+    connection update [flags]
+
+Flags:
+
+    --name <string>                                                         The name of the connection to update.
+    --key <string>                                                          Name of field to update
+    --value <string>                                                        Value of the field to update
+    --remove_key <string>                                                   Removes a key from the connection.
+`;
+
+const CONNECTION_FLAGS_DELETE = `
+Help:
+
+    Use this CLI to delete a connection.
+
+Usage:
+
+    connection delete [flags]
+
+Flags:
+
+    --name <string>                                                         The name of the connection to delete.
+
+`;
+
+const CONNECTION_FLAGS_STATUS = `
+Help:
+
+    Use this CLI to get connection status.
+
+Usage:
+
+    connection status [flags]
+
+Flags:
+
+    --name <string>                                                         The name of the connection.
+    --decrypt <boolean>                                                     Wether to decrypt the auth field of the request.
+
+`;
+
+const CONNECTION_FLAGS_LIST = `
+Help:
+
+    Use this CLI to list connections.
+
+Usage:
+
+    connection list [flags]
+
+Flags:
+
+`;
+
 /**
  * print_usage would print the help according to the arguments that were passed
  * @param {string} type
@@ -485,6 +584,9 @@ function print_usage(type, action) {
             break;
         case TYPES.UPGRADE:
             print_help_upgrade(action);
+            break;
+        case TYPES.CONNECTION:
+            print_help_connection(action);
             break;
         default:
             process.stdout.write(HELP + '\n');
@@ -603,6 +705,33 @@ function print_help_upgrade(action) {
         default:
             process.stdout.write(UPGRADE_OPTIONS.trimStart());
     }
+}
+
+/**
+ * print_help_connection would print the help options for connection
+ * @param {string} action
+ */
+function print_help_connection(action) {
+    switch (action) {
+        case ACTIONS.ADD:
+            process.stdout.write(CONNECTION_FLAGS_ADD.trimStart() + CLI_MUTUAL_FLAGS);
+            break;
+        case ACTIONS.UPDATE:
+            process.stdout.write(CONNECTION_FLAGS_UPDATE.trimStart() + CLI_MUTUAL_FLAGS);
+            break;
+        case ACTIONS.DELETE:
+            process.stdout.write(CONNECTION_FLAGS_DELETE.trimStart() + CLI_MUTUAL_FLAGS);
+            break;
+        case ACTIONS.STATUS:
+            process.stdout.write(CONNECTION_FLAGS_STATUS.trimStart() + CLI_MUTUAL_FLAGS);
+            break;
+        case ACTIONS.LIST:
+            process.stdout.write(CONNECTION_FLAGS_LIST.trimStart() + CLI_MUTUAL_FLAGS);
+            break;
+        default:
+            process.stdout.write(CONNECTION_ACTIONS.trimStart());
+    }
+    process.exit(0);
 }
 
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_connection_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_connection_cli.test.js
@@ -1,0 +1,161 @@
+/* Copyright (C) 2025 NooBaa */
+/* eslint-disable max-lines-per-function */
+/* eslint max-lines: ['error', 4000] */
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = "true";
+
+const fs = require('fs');
+const path = require('path');
+const os_util = require('../../../util/os_utils');
+const fs_utils = require('../../../util/fs_utils');
+const { ConfigFS } = require('../../../sdk/config_fs');
+const { TMP_PATH, set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
+const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
+
+const tmp_fs_path = path.join(TMP_PATH, 'test_nc_nsfs_account_cli');
+const timeout = 5000;
+
+// eslint-disable-next-line max-lines-per-function
+describe('manage nsfs cli connection flow', () => {
+    describe('cli create connection', () => {
+        const config_root = path.join(tmp_fs_path, 'config_root_manage_nsfs');
+        const config_fs = new ConfigFS(config_root);
+        const root_path = path.join(tmp_fs_path, 'root_path_manage_nsfs/');
+        const options_file = path.join(TMP_PATH, "conn1.json");
+        const defaults = {
+            name: 'conn1',
+            agent_request_object: {
+                host: "localhost",
+                "port": 9999,
+                "timeout": 100
+            },
+            request_options_object: {auth: "user:passw"},
+            notification_protocol: "http",
+
+        };
+        beforeEach(async () => {
+            await fs_utils.create_fresh_path(root_path);
+            set_nc_config_dir_in_config(config_root);
+
+            fs.writeFileSync(options_file, JSON.stringify(defaults));
+            const action = ACTIONS.ADD;
+            const conn_options = { config_root, from_file: options_file };
+            await exec_manage_cli(TYPES.CONNECTION, action, conn_options);
+        });
+
+        afterEach(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('cli create connection from file', async () => {
+            const connection = await config_fs.get_connection_by_name(defaults.name);
+            assert_connection(connection, defaults, true);
+        }, timeout);
+
+        it('cli create connection from cli', async () => {
+            const conn_options = {...defaults, config_root};
+            conn_options.name = "fromcli";
+            await exec_manage_cli(TYPES.CONNECTION, ACTIONS.ADD, conn_options);
+            const connection = await config_fs.get_connection_by_name(conn_options.name);
+            assert_connection(connection, conn_options, true);
+        }, timeout);
+
+        it('cli delete connection ', async () => {
+            await exec_manage_cli(TYPES.CONNECTION, ACTIONS.DELETE, {config_root, name: defaults.name});
+            expect(fs.readdirSync(config_fs.connections_dir_path).filter(file => file.endsWith(".json")).length).toEqual(0);
+        }, timeout);
+
+        //update notification_protocol field in the connection file.
+        it('cli update connection ', async () => {
+            await exec_manage_cli(TYPES.CONNECTION, ACTIONS.UPDATE, {
+                config_root,
+                name: defaults.name,
+                key: "notification_protocol",
+                value: "https"
+            });
+            const updated = await config_fs.get_connection_by_name(defaults.name);
+            const updated_content = {...defaults};
+            updated_content.notification_protocol = "https";
+            assert_connection(updated, updated_content, true);
+        }, timeout);
+
+        it('cli list connection ', async () => {
+            const res = JSON.parse(await exec_manage_cli(TYPES.CONNECTION, ACTIONS.LIST, {config_root}));
+            expect(res.response.reply[0]).toEqual(defaults.name);
+        }, timeout);
+
+        it('cli status connection ', async () => {
+            const res = JSON.parse(await exec_manage_cli(TYPES.CONNECTION, ACTIONS.STATUS, {
+                config_root,
+                name: defaults.name,
+                decrypt: true
+            }));
+            assert_connection(res.response.reply, defaults, false);
+        }, timeout);
+
+    });
+});
+
+
+/**
+ * assert_connection will verify the fields of the accounts 
+ * @param {object} connection actual
+ * @param {object} connection_options expected
+ * @param {boolean} is_encrypted whether connection's auth field is encrypted
+ */
+function assert_connection(connection, connection_options, is_encrypted) {
+    expect(connection.name).toEqual(connection_options.name);
+    expect(connection.notification_protocol).toEqual(connection_options.notification_protocol);
+    expect(connection.agent_request_object).toStrictEqual(connection_options.agent_request_object);
+    if (is_encrypted) {
+        expect(connection.request_options_object).not.toStrictEqual(connection_options.request_options_object);
+    } else {
+        expect(connection.request_options_object).toStrictEqual(connection_options.request_options_object);
+    }
+}
+
+/**
+ * exec_manage_cli will get the flags for the cli and runs the cli with it's flags
+ * @param {string} type
+ * @param {string} action
+ * @param {object} options
+ */
+async function exec_manage_cli(type, action, options) {
+    const command = create_command(type, action, options);
+    let res;
+    try {
+        res = await os_util.exec(command, { return_stdout: true });
+    } catch (e) {
+        res = e;
+    }
+    return res;
+}
+
+/**
+ * create_command would create the string needed to run the CLI command
+ * @param {string} type
+ * @param {string} action
+ * @param {object} options
+ */
+function create_command(type, action, options) {
+    let account_flags = ``;
+    for (const key in options) {
+        if (Object.hasOwn(options, key)) {
+            if (typeof options[key] === 'boolean') {
+                account_flags += `--${key} `;
+            } else if (typeof options[key] === 'object') {
+                const val = JSON.stringify(options[key]);
+                account_flags += `--${key} '${val}' `;
+            } else {
+                account_flags += `--${key} ${options[key]} `;
+            }
+        }
+    }
+    account_flags = account_flags.trim();
+
+    const command = `node src/cmd/manage_nsfs ${type} ${action} ${account_flags}`;
+    return command;
+}


### PR DESCRIPTION
### Explain the changes
Before this change the connection file was completely plain text, including the http basic authentication header.
This change adds API to manipulate connection files, adding the logic to encrypt this field when a connection file is created.

The new CONNECTION type is introduced, along with standard CRUD actions.
The 'STATUS' action also includes a 'decrypt' flag to decrypt connection file into plain text.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8643

### Testing Instructions:
1. Using manage_nsfs cli, create a connection with the "auth" option under request_options_object.
2. The auth field is encrypted.
3. Notifications work as intended using the connection. IE, auth header is sent in plain text.


- [ ] Doc added/updated
- [ ] Tests added
