### PR TITLE
bucket notifications - allow empty notifications content to facilitate notification conf removal

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_notification.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_notification.js
@@ -1,25 +1,23 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const S3Error = require('../s3_errors').S3Error;
-
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTnotification.html
  */
 async function put_bucket_notification(req) {
 
     const topic_configuration = req.body.NotificationConfiguration?.TopicConfiguration;
-    if (!topic_configuration ||
-        typeof topic_configuration !== 'object') throw new S3Error(S3Error.MalformedXML);
 
     //adapt to db shcema
-    for (const conf of topic_configuration) {
-        conf.id = conf.Id;
-        conf.event = conf.Event;
-        conf.topic = conf.Topic;
-        delete conf.Id;
-        delete conf.Event;
-        delete conf.Topic;
+    if (topic_configuration) {
+        for (const conf of topic_configuration) {
+            conf.id = conf.Id;
+            conf.event = conf.Event;
+            conf.topic = conf.Topic;
+            delete conf.Id;
+            delete conf.Event;
+            delete conf.Topic;
+        }
     }
 
     const reply = await req.object_sdk.put_bucket_notification({

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -306,6 +306,9 @@ function get_connection(connect) {
 
 
 async function test_notifications(bucket, connect_files_dir) {
+    if (!bucket.notifications) {
+        return;
+    }
     const notificator = new Notificator({connect_files_dir});
     for (const notif of bucket.notifications) {
         const connect = await notificator.parse_connect_file(notif.connect);


### PR DESCRIPTION
### Explain the changes
put-bucket-notification rejected requests without TopicConfiguration.
This prevented removing bucket's notification conf.
The change allows requests with empty content.

### Issues: Fixed #xxx / Gap #xxx
1. Bucket notification conf can't be removed.

### Testing Instructions:
1. Configure a bucket with notifications.
2. Invoke put-bucket-notifications with empty json
`s3nsfsapi put-bucket-notification-configuration --bucket notif --notification-configuration file://empty.json`
Where `cat empty.json`:
{
} 


- [ ] Doc added/updated
- [ ] Tests added
