### PR TITLE
Upgrade utils | change variables, errors and log prints to be general to both Containerized and NC environments

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
@@ -795,7 +795,7 @@ describe('nc upgrade manager - upgrade config directory', () => {
             const expected_version = pkg.version;
             const hosts_list = [hostname];
             await config_fs.create_system_config_file(JSON.stringify(system_data));
-            const expected_err_msg = 'attempt to run old container version with newer server version';
+            const expected_err_msg = 'attempt to upgrade to an older version while server\'s version is newer';
             await expect(nc_upgrade_manager.upgrade_config_dir(expected_version, hosts_list))
                 .rejects.toThrow(expected_err_msg);
         });


### PR DESCRIPTION
### Explain the changes
1. Converted `Container`/`Server` terms usage from upgrade_utils.js should_upgrade() and load_required_scripts() and instead used `current_version` and `existing_version` since it's being used by both Containerized and NC environments and `Container` can't be used in NC env. 

### Issues: Fixed #xxx / Gap #xxx
1. Fixed bullet 12 of https://github.com/noobaa/noobaa-core/issues/8586

### Testing Instructions:
Manual tests - 
1. Nothing to upgrade - 
a. Run `sudo node noobaa-core/src/cmd/nsfs.js --debug 5`, CTRL + C
b. Run `noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts hostname1`
Check the logs and see that container term was removed - 
`Jan-16 11:11:04.197 [/13595]    [L0] core.upgrade.upgrade_utils:: the versions of the new_version and the current_version match. no need to upgrade`

2. Upgrade is needed - 
a. git checkout 5.17, Run `sudo node noobaa-core/src/cmd/nsfs.js --debug 5`, CTRL + C
b. git checkout 5.18.0, Run `sudo node noobaa-core/src/cmd/nsfs.js --debug 5`, CTRL + C
c. Run `noobaa-cli upgrade start --expected_version 5.18.0 --expected_hosts hostname1`
Check the logs and see that container term was removed - 
`Jan-16 11:15:28.699 [/15525]    [L0] core.upgrade.upgrade_utils:: new_version is 1.0.0 and current server version is 0.0.0. will upgrade`

3. Downgrade (artificial because 5.17 does not contain these changes) - 
a. change package.json version to 5.19, Run `sudo node noobaa-core/src/cmd/nsfs.js --debug 5`, CTRL + C
b. git checkout 5.18.0, Run `sudo node noobaa-core/src/cmd/nsfs.js --debug 5`, CTRL + C
Check the logs and see that container term was removed - 
```
an-16 11:18:49.191 [nsfs/16419] [ERROR] core.upgrade.upgrade_utils:: the new_version (5.18.0) appears to be older than the current server version (5.19.0). cannot downgrade
Jan-16 11:18:49.191 [nsfs/16419] [ERROR] CONSOLE:: nsfs: exit on error Error: attempt to upgrade to an older version while server's version is newer
    at should_upgrade (noobaa-core/src/upgrade/upgrade_utils.js:57:15)
    at NCUpgradeManager.update_rpm_upgrade (noobaa-core/src/upgrade/nc_upgrade_manager.js:72:14)
    at async main (noobaa-core/src/cmd/nsfs.js:331:17)
```

- [ ] Doc added/updated
- [ ] Tests added
