### PR TITLE
NC | RPM build and install github action

### DIFF
--- a/.github/workflows/manual-rpm-build-and-install-test.yaml
+++ b/.github/workflows/manual-rpm-build-and-install-test.yaml
@@ -1,0 +1,22 @@
+name: Manual RPM Build and Install Test Dispatch
+on: 
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to RPM Build and Install From'
+        required: true
+      centos_ver:
+        type: choice
+        description: 'Centos Base image (options: 8/9) - Optional, default is 9'
+        default: '9'
+        options: 
+          - '8'
+          - '9'
+
+# Currently the only supported arch is linux/amd64 (x86_64)
+jobs:
+  manual-build-rpm-and-install:
+    uses: ./.github/workflows/rpm-build-and-install-test-base.yaml
+    with:
+      branch: ${{ github.event.inputs.branch }}
+      centos_ver: ${{ github.event.inputs.centos_ver }}

--- a/.github/workflows/nightly-rpm-build-and-install-test.yaml
+++ b/.github/workflows/nightly-rpm-build-and-install-test.yaml
@@ -1,0 +1,20 @@
+name: Nightly RPM Build and Install Test
+on: 
+  schedule:
+    - cron: '0 0 * * *'
+      
+# Currently the only supported arch is linux/amd64 (x86_64)
+jobs:
+  call-master-rpm-build-and-install-test-centos9:
+    uses: ./.github/workflows/rpm-build-and-install-test-base.yaml
+    secrets: inherit
+    with:
+      branch: 'master'
+      centos_ver: '9'
+  
+  # call-master-rpm-build-and-install-test-centos8:
+  #   uses: ./.github/workflows/rpm-build-and-install-test-base.yaml
+  #   secrets: inherit
+  #   with:
+  #     branch: 'master'
+  #     centos_ver: '8'

--- a/.github/workflows/rpm-build-and-install-test-base.yaml
+++ b/.github/workflows/rpm-build-and-install-test-base.yaml
@@ -1,0 +1,27 @@
+name: RPM Build and Install Test Workflow
+on: 
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        description: 'Branch to Build RPM From'
+        required: true
+      centos_ver:
+        type: string
+        description: 'Centos Base image (options: 8/9) - Optional, default is 9'
+        default: '9'
+  
+jobs:
+  rpm-build-and-and-install-test-base:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+     
+      - name: Run Non Containerized RPM Build And Install Test
+        run: |
+            make rpm-build-and-install-test BUILD_S3SELECT=0 CENTOS_VER=${{ inputs.centos_ver }} CONTAINER_PLATFORM=linux/amd64
+


### PR DESCRIPTION
### Explain the changes
1. Makefile - added `rpm-build-and-install-test` target that will build rpm, and install it and its dependencies in a `redhat/ubi9-init` ( or `redhat/ubi8-init` which is currently not working, due to the python upgrade missing fix).
notice that due to `redhat/ubi9-init` limitation we currently support only `linux/amd64` architecture.
3. Github actions - Added 3 new actions - 
- `rpm-build-and-install-test-base.yaml` - calls make rpm-build-and-install-test.
- `manual-rpm-build-and-install-test.yaml` - calls rpm-build-and-install-test-base action based on the executer's **branch** and centos/rhel version choice. 
- `nightly-rpm-build-and-install-test.yaml` -  runs rpm-build-and-install-test-base action based on master branch and centos/rhel 9 (RHEL8 is commented because it's currently not working, due to the python upgrade missing fix) every night.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - when building RPM on centos/RHEL 8 fixed, remove the comment from the nightly test.

### Testing Instructions:
1. Makefile changes - Run `make rpm-build-and-install-test BUILD_S3SELECT=0 CENTOS_VER=9 CONTAINER_PLATFORM=linux/amd64`
2. Manual github action - Dispatch the `manual-rpm-build-and-install-test.yaml` action.
3. Nightly github action - Check in actions section in noobaa/noobaa-core repo if the `nightly-rpm-build-and-install-test.yaml` action ran without any failures.

- [ ] Doc added/updated
- [ ] Tests added
