### PR TITLE
Fix python version to 3.9 to fix builds on RHEL 8

### DIFF
--- a/src/deploy/NVA_build/builder.Dockerfile
+++ b/src/deploy/NVA_build/builder.Dockerfile
@@ -21,9 +21,13 @@ RUN dnf update -y -q --nobest && \
 COPY ./src/deploy/NVA_build/install_arrow_build.sh ./src/deploy/NVA_build/install_arrow_build.sh
 ARG BUILD_S3SELECT_PARQUET=0
 RUN ./src/deploy/NVA_build/install_arrow_build.sh $BUILD_S3SELECT_PARQUET
-RUN dnf install -y -q wget unzip which vim python3 boost-devel libcap-devel && \
+RUN dnf install -y -q wget unzip which vim python3.9 boost-devel libcap-devel && \
     dnf group install -y -q "Development Tools" && \
     dnf clean all
+
+# It's not important to report this failure (fails for Centos9)
+RUN alternatives --auto python3 || exit 0
+
 RUN version="2.15.05" && \
     wget -q -O nasm-${version}.tar.gz https://github.com/netwide-assembler/nasm/archive/nasm-${version}.tar.gz && \
     tar -xf nasm-${version}.tar.gz && \

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -26,7 +26,7 @@ URL:  https://www.noobaa.io/
 Source0:  %{noobaatar}
 
 BuildRequires:  systemd
-BuildRequires:  python3
+BuildRequires:  python3.9
 BuildRequires:  make
 BuildRequires:  gcc-c++
 BuildRequires:  boost-devel


### PR DESCRIPTION
### Explain the changes
This PR fixes the python version to 3.9 to fix the buids on RHEL 8. Node Gyps seems to now require python version >= 3.8 and RHEL9 default is 3.9 hence the choice of moving to python 3.9.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
