### PR TITLE
remove librdkafka/examples directory from our image - in order to decrease its size

### DIFF
--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -9,6 +9,8 @@ FROM noobaa-builder AS noobaa-base
 COPY ./package*.json ./
 RUN npm install --omit=dev && \
     npm cache clean --force
+RUN rm -rf node_modules/node-rdkafka/deps/librdkafka/examples/
+RUN rm -rf node_modules/node-rdkafka/deps/librdkafka/src/
 
 ##############################################################
 # Layers:


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/e28ce786-fb4e-4220-8304-4c24bb89ea3c)

### Explain the changes
I tried few options in order to decrease the image size:
1. don't build rekafka locally and download using DNF - 246MB - last option in the image above
2. regular master with no change - 679MB
3. this solution which is kind of a middle way - build rd-kafka but remove just the examples directory - 312MB

### Issues: Fixed #xxx / Gap #xxx
1. Fixes our noobaa-core image size after adding rd-kafka which made it 2x bigger

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
