### PR TITLE
CI | Increase Timeouts

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1196,7 +1196,7 @@ describe('manage nsfs cli account flow', () => {
                 await set_path_permissions_and_owner(account_options.new_buckets_path, account_options, 0o700);
                 await exec_manage_cli(type, action, account_options);
             }
-        });
+        }, timeout);
 
         afterAll(async () => {
             await fs_utils.folder_delete(`${config_root}`);


### PR DESCRIPTION
### Explain the changes
1. Continuing PR #8446, I noticed that sometimes Jest tests are failing. The failing tests were coming from the `beforeAll` function inside `cli list account` part, therefore suggesting to extend the timeout.

### Issues: Fixed #xxx / Gap #xxx
1. From this file that I downloaded in the past (which re-run solved the failure) I noticed 
[0_run-unit-tests.txt](https://github.com/user-attachments/files/18488460/0_run-unit-tests.txt)
Printing example:

> 2025-01-09T10:33:59.3629422Z   ● manage nsfs cli account flow › cli list account › cli list wide and show_secrets
> 2025-01-09T10:33:59.3629898Z
> 2025-01-09T10:33:59.3630257Z     thrown: "Exceeded timeout of 5000 ms for a hook.
> 2025-01-09T10:33:59.3634321Z     Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
> 2025-01-09T10:33:59.3635252Z
> 2025-01-09T10:33:59.3635380Z       1184 |         }];
> 2025-01-09T10:33:59.3635556Z       1185 |
> 2025-01-09T10:33:59.3635832Z     > 1186 |         beforeAll(async () => {
> 2025-01-09T10:33:59.3636200Z            |         ^
> 2025-01-09T10:33:59.3638142Z       1187 |             await fs_utils.create_fresh_path(root_path);
> 2025-01-09T10:33:59.3639586Z       1188 |             set_nc_config_dir_in_config(config_root);
> 2025-01-09T10:33:59.3640511Z       1189 |             // Creating the account
> 2025-01-09T10:33:59.3640792Z
> 2025-01-09T10:33:59.3643078Z       at beforeAll (src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js:1186:9)
> 2025-01-09T10:33:59.3645156Z       at describe (src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js:1152:5)
> 2025-01-09T10:33:59.3647461Z       at Object.describe (src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js:27:1)


### Testing Instructions:
1. `sudo npx jest test_nc_nsfs_account_cli.test.js`


- [ ] Doc added/updated
- [ ] Tests added
