### PR TITLE
bucket notifications - events for scale

### DIFF
--- a/config.js
+++ b/config.js
@@ -714,6 +714,8 @@ config.BUCKET_LOG_CONCURRENCY = 10;
 config.NOTIFICATION_LOG_NS = 'notification_logging';
 config.NOTIFICATION_LOG_DIR = process.env.NOTIFICATION_LOG_DIR;
 config.NOTIFICATION_BATCH = process.env.BATCH || 10;
+config.NOTIFICATION_REQ_PER_SPACE_CHECK = process.env.NOTIFICATION_REQ_PER_SPACE_CHECK || 0;
+config.NOTIFICATION_SPACE_CHECK_THRESHOLD = parseInt(process.env.NOTIFICATION_SPACE_CHECK_THRESHOLD, 10) || 0.1;
 
 ///////////////////////////
 //      KEY ROTATOR      //

--- a/docs/NooBaaNonContainerized/ConfigFileCustomizations.md
+++ b/docs/NooBaaNonContainerized/ConfigFileCustomizations.md
@@ -478,6 +478,34 @@ Warning: After setting this configuration, NooBaa will skip schema validations a
     3. systemctl restart noobaa
     ```
 
+### 33. Notification space monitor frequency flag -
+* <u>Key</u>: `NOTIFICATION_REQ_PER_SPACE_CHECK`
+* <u>Type</u>: Positive integer
+* <u>Default</u>: 0
+* <u>Description</u>: Free space check will run per this many notifications (per node). 0 to disable.
+* <u>Steps</u>:
+    ```
+    1. Open /path/to/config_dir/config.json file.
+    2. Set the config key to run free space check each 1000 notifications -
+    Example:
+    "NOTIFICATION_REQ_PER_SPACE_CHECK": 1000
+    3. systemctl restart noobaa
+    ```
+
+### 34. Notification space monitor threshold flag -
+* <u>Key</u>: `NOTIFICATION_SPACE_CHECK_THRESHOLD`
+* <u>Type</u>: Number
+* <u>Default</u>: 0.1
+* <u>Description</u>: Fraction (more than zero, less than 1) of availble block, below which event is logged.
+* <u>Steps</u>:
+    ```
+    1. Open /path/to/config_dir/config.json file.
+    2. Set the config key -
+    Example:
+    "NOTIFICATION_SPACE_CHECK_THRESHOLD": 0.1
+    3. systemctl restart noobaa
+    ```
+
 ## Config.json File Examples
 The following is an example of a config.json file - 
 

--- a/docs/NooBaaNonContainerized/Events.md
+++ b/docs/NooBaaNonContainerized/Events.md
@@ -204,3 +204,19 @@ The following list includes events that indicate on some sort of malfunction or 
     - Bucket is in invalid state. Bucket schema missing required property or invalid property gets added.  
 - Resolutions:
     - Check the bucket schema definition and make sure the required property is missing and the invalid property gets added in the config root path.
+
+#### 18. `noobaa_notification_failed`
+- Arguments
+    - `name`
+- Reasons:
+    - No connectivity to external server.
+- Resolutions:
+    - Check if external server is reachable.
+
+#### 19. `noobaa_notification_low_space`
+- Arguments
+    - `fs_stat`
+- Reasons:
+    - Free space in notification log dir FS is below threshold.
+- Resolutions:
+    - Free up space is FS.

--- a/src/endpoint/s3/s3_bucket_logging.js
+++ b/src/endpoint/s3/s3_bucket_logging.js
@@ -6,7 +6,7 @@ const http_utils = require('../../util/http_utils');
 const dgram = require('node:dgram');
 const { Buffer } = require('node:buffer');
 const config = require('../../../config');
-const {compose_notification_req, check_notif_relevant} = require('../../util/notifications_util');
+const {compose_notification_req, check_notif_relevant, check_free_space} = require('../../util/notifications_util');
 
 async function send_bucket_op_logs(req, res) {
     if (req.params && req.params.bucket &&
@@ -43,6 +43,8 @@ async function send_bucket_op_logs(req, res) {
                         file: req.notification_logger,
                         buffer: JSON.stringify(notif)
                     });
+
+                    check_free_space(req);
                 }
             }
         }

--- a/src/manage_nsfs/manage_nsfs_events_utils.js
+++ b/src/manage_nsfs/manage_nsfs_events_utils.js
@@ -384,4 +384,30 @@ NoobaaEvent.CONFIG_DIR_UPGRADE_FAILED = Object.freeze({
     state: 'DEGRADED',
 });
 
+///////////////////////////////
+//   NOTIFICATION EVENTS     //
+///////////////////////////////
+
+NoobaaEvent.NOTIFICATION_LOW_SPACE = Object.freeze({
+    event_code: 'noobaa_notification_low_space',
+    message: 'Pending notification log dir low on space',
+    description: 'Low space',
+    entity_type: 'NODE',
+    event_type: 'WARN',
+    scope: 'NODE',
+    severity: 'WARN',
+    state: 'HEALTHY',
+});
+
+NoobaaEvent.NOTIFICATION_FAILED = Object.freeze({
+    event_code: 'noobaa_notification_failed',
+    message: 'Failed to send notification.',
+    description: 'Notification failed.',
+    entity_type: 'NODE',
+    event_type: 'WARN',
+    scope: 'NODE',
+    severity: 'WARN',
+    state: 'HEALTHY',
+});
+
 exports.NoobaaEvent = NoobaaEvent;

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -142,6 +142,14 @@ const nsfs_node_config_schema = {
             type: 'boolean',
             doc: 'This flag will decide whether need to push logs to the console or not.'
         },
+        NOTIFICATION_REQ_PER_SPACE_CHECK: {
+            type: 'number',
+            doc: 'Number of pending notifications per node in between of free space check. 0 to disable.'
+        },
+        NOTIFICATION_SPACE_CHECK_THRESHOLD: {
+            type: 'number',
+            doc: 'Fraction (more than 0, less than 1) of free blocks in, below which free space check creates an event.'
+        }
     }
 };
 

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_config_schema_validation.test.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2024 NooBaa */
+/* eslint-disable max-lines-per-function */
 
 'use strict';
 
@@ -290,6 +291,47 @@ describe('schema validation NC NSFS config', () => {
                 "ENDPOINT_PROCESS_TITLE": '',
             };
             nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('nsfs_config valid NOTIFICATION_REQ_PER_SPACE_CHECK', () => {
+            const config_data = {
+                NOTIFICATION_REQ_PER_SPACE_CHECK: 300
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('nsfs_config valid NOTIFICATION_REQ_PER_SPACE_CHECK', () => {
+            const config_data = {
+                NOTIFICATION_REQ_PER_SPACE_CHECK: 0
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('nsfs_config valid NOTIFICATION_SPACE_CHECK_THRESHOLD', () => {
+            const config_data = {
+                NOTIFICATION_SPACE_CHECK_THRESHOLD: 0.11
+            };
+            nsfs_schema_utils.validate_nsfs_config_schema(config_data);
+        });
+
+        it('nsfs_config check invalid NOTIFICATION_REQ_PER_SPACE_CHECK', () => {
+            const config_data = {
+                "NOTIFICATION_REQ_PER_SPACE_CHECK": 'asd',
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'NOTIFICATION_REQ_PER_SPACE_CHECK with string (instead of number)';
+            const message = 'must be number';
+            assert_validation(config_data, reason, message);
+        });
+
+        it('nsfs_config check invalid NOTIFICATION_SPACE_CHECK_THRESHOLD', () => {
+            const config_data = {
+                "NOTIFICATION_SPACE_CHECK_THRESHOLD": 'asd',
+            };
+            const reason = 'Test should have failed because of wrong type ' +
+            'NOTIFICATION_SPACE_CHECK_THRESHOLD with string (instead of number)';
+            const message = 'must be number';
+            assert_validation(config_data, reason, message);
         });
     });
 


### PR DESCRIPTION
### Explain the changes
1. Adds events to scenarios the scale wishes to monitor.
2. New event for a failed notification.
3. New event for low space in monitoring logs FS.

Free space below threshold sample:
Jan-26 10:56:06.747 [nsfs/573237] [EVENT]{"timestamp":"2025-01-26T18:56:06.746Z","host":"li-56a4e0cc-353c-11b2-a85c-9bc45442ed4b.ibm.com","event":{"code":"noobaa_notification_low_space","message":"Pending notification log dir low on space","description":"Low space","entity_type":"NODE","event_type":"WARN","scope":"NODE","severity":"WARN","state":"HEALTHY","arguments":{"fs_stat":{"type":1481003842,"bsize":4096,"blocks":483087906,"bfree":411722363,"bavail":411722363,"files":193329536,"ffree":185506484}},"pid":573237}}

Failed notification sample:
Jan-26 11:05:28.657 [/576243] [EVENT]{"timestamp":"2025-01-26T19:05:28.657Z","host":"li-56a4e0cc-353c-11b2-a85c-9bc45442ed4b.ibm.com","event":{"code":"noobaa_notification_failed","message":"Failed to send notification., value: first","description":"Notification failed., error: Error: No such file or directory","entity_type":"NODE","event_type":"WARN","scope":"NODE","severity":"WARN","state":"HEALTHY","arguments":{"code":"ENOENT","context":"Readfile _path=/etc/noobaa.conf.d/connections/connect_http.json "},"pid":576243}}

### Issues: Fixed #xxx / Gap #xxx
1. -

### Testing Instructions:
1. Achieve or simulate low FS space. Alternatively, set a high threshold for event (eg NOTIFICATION_SPACE_CHECK_THRESHOLD = 0.99)
2. Set NOTIFICATION_REQ_PER_SPACE_CHECK to a low value, but more than 0 (eg 1).
3. Setup notification, send a notification
5. Event should appear in logs.


- [ ] Doc added/updated
- [ ] Tests added
