### PR TITLE
NSFS | add option to unset supplemental groups using noobaa cli

### DIFF
--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -168,7 +168,7 @@ noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--use
 
 - `supplemental_groups`
     - Type: String
-    - Description: Specifies additional FS groups (GID) a user can be a part of. Allows access to directories/files having one or more of the provided groups. A String of GIDs separated by commas.
+    - Description: Specifies additional FS groups (GID) a user can be a part of. Allows access to directories/files having one or more of the provided groups. A String of GIDs separated by commas. unset with ''
 
 - `new_buckets_path` 
     - Type: String

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -95,7 +95,9 @@ function get_boolean_or_string_value(value) {
  * This function assumes string format was validated before calling the function, wrong string format can
  * lead to unexpected output (usually array of NaN)
  * 1. if the value is a number return array with this number (3 => [3])
- * 2. if the value is a string return an array of numbers ('0,212,111' => [0,212,111])
+ * 2. if the value is a string:
+ *   2.1 if value is an empty string (""). unset the value
+ *   2.2 else return an array of numbers ('0,212,111' => [0,212,111])
  * 3. for all other types (including object and undefined) return the value itself
  */
 function parse_comma_delimited_string(value) {
@@ -103,6 +105,9 @@ function parse_comma_delimited_string(value) {
         return [value];
     }
     if (typeof value === 'string') {
+        if (value === '') {
+            return undefined;
+        }
         return value.split(',').map(val => Number(val));
     }
     return value;

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -160,7 +160,7 @@ Flags:
     --new_name <string>                                   (optional)        Update the account name
     --uid <number>                                        (optional)        Update the User Identifier (UID)
     --gid <number>                                        (optional)        Update the Group Identifier (GID)
-    --supplemental_groups <number[]>                      (optional)        Update the list of supplemental groups (List of GID) seperated by comma(,) example: 211,202,23 - it will override existing list
+    --supplemental_groups <string>                        (optional)        Update the list of supplemental groups (List of GID) seperated by comma(,) example: 211,202,23 - it will override existing list (unset with '')
     --new_buckets_path <string>                           (optional)        Update the filesystem's root path where each subdirectory is a bucket
     --user <string>                                       (optional)        Update the OS user name (instead of uid and gid)
     --regenerate                                          (optional)        Update automatically generated access key and secret key

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_account_cli.test.js
@@ -1100,6 +1100,39 @@ describe('manage nsfs cli account flow', () => {
                 const account = await config_fs.get_account_by_name(name, config_fs_account_options);
                 expect(account.nsfs_account_config.supplemental_groups).toStrictEqual(expected_groups);
             });
+
+            it('cli account update - cli update account with empty supplemental groups (unset)', async function() {
+                const { name } = defaults;
+                const supplemental_groups = '303,211';
+                const expected_groups = [303, 211];
+                const empty_set = '\'\'';
+                const account_options = { config_root, name, supplemental_groups};
+                await exec_manage_cli(type, ACTIONS.UPDATE, account_options);
+                const account = await config_fs.get_account_by_name(name, config_fs_account_options);
+                expect(account.nsfs_account_config.supplemental_groups).toStrictEqual(expected_groups);
+
+                //unset the value
+                account_options.supplemental_groups = empty_set;
+                await exec_manage_cli(type, ACTIONS.UPDATE, account_options);
+                const updated_account = await config_fs.get_account_by_name(name, config_fs_account_options);
+                expect(updated_account.nsfs_account_config.supplemental_groups).toBeUndefined();
+            });
+
+            it('cli account update - cli update account with no supplemental groups - list remains the same', async function() {
+                const { name } = defaults;
+                const supplemental_groups = '303,211';
+                const expected_groups = [303, 211];
+                const account_options = { config_root, name, supplemental_groups};
+                await exec_manage_cli(type, ACTIONS.UPDATE, account_options);
+                const account = await config_fs.get_account_by_name(name, config_fs_account_options);
+                expect(account.nsfs_account_config.supplemental_groups).toStrictEqual(expected_groups);
+
+                //unset the value
+                const new_account_options = {config_root, name};
+                await exec_manage_cli(type, ACTIONS.UPDATE, new_account_options);
+                const updated_account = await config_fs.get_account_by_name(name, config_fs_account_options);
+                expect(updated_account.nsfs_account_config.supplemental_groups).toStrictEqual(expected_groups);
+            });
         });
 
         describe('cli update account (has distinguished name)', () => {


### PR DESCRIPTION
### Explain the changes
1. when setting supplemental groups as empty string (""), unset supplemental groups list for account. this is especially important following   #8687 as when this value is undefined we will fetch the users groups from the os records
2. continuation of #8552 

### Issues: Fixed #8711 

### Testing Instructions:
automatic test:
run `sudo npx jest test_nc_nsfs_account_cli.test.js`
manual test:
1. create new user with supplemental groups list defined:
`sudo node src/cmd/manage_nsfs.js account add --name test --uid 808 --gid 808 --supplemental_groups 101,22`
2. update account with ""  supplemental_groups to unset this value:
`sudo node src/cmd/manage_nsfs.js account update --name test --supplemental_groups ""`
3. get status of the account. there should be no record for `supplemental_groups`:
`sudo node src/cmd/manage_nsfs.js account status --name test`


- [ ] Doc added/updated
- [x] Tests added
