### PR TITLE
nope-ip removal - Phase 1

### DIFF
--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -7,7 +7,6 @@
 const _ = require('lodash');
 const util = require('util');
 const assert = require('assert');
-// const ip_module = require('ip');
 const EventEmitter = require('events').EventEmitter;
 
 const P = require('../util/promise');

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -3,7 +3,6 @@
 
 const _ = require('lodash');
 const bcrypt = require('bcrypt');
-const ip_module = require('ip');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -578,10 +577,10 @@ function _prepare_auth_request(req) {
             const client_ip = net_utils.unwrap_ipv6(req.auth.client_ip);
             if (client_ip) {
                 let is_allowed = false;
-                const client_ip_val = ip_module.toLong(client_ip);
+                const client_ip_val = net_utils.ip_toLong(client_ip);
                 for (const ip_range of req.account.allowed_ips) {
-                    const start = ip_module.toLong(ip_range.start);
-                    const end = ip_module.toLong(ip_range.end);
+                    const start = net_utils.ip_toLong(ip_range.start);
+                    const end = net_utils.ip_toLong(ip_range.end);
                     if (client_ip_val >= start && client_ip_val <= end) {
                         is_allowed = true;
                         break;

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -3,7 +3,8 @@
 /* eslint-disable no-control-regex */
 
 const _ = require('lodash');
-const ip = require('ip');
+const ip_module = require('ip');
+const net = require('net');
 const url = require('url');
 const http = require('http');
 const https = require('https');
@@ -44,7 +45,7 @@ const unsecured_https_proxy_agent = HTTPS_PROXY ?
 
 const no_proxy_list =
     (NO_PROXY ? NO_PROXY.split(',') : []).map(addr => {
-        if (ip.isV4Format(addr) || ip.isV6Format(addr)) {
+        if (net.isIPv4(addr) || net.isIPv6(addr)) {
             return {
                 kind: 'IP',
                 addr
@@ -52,7 +53,7 @@ const no_proxy_list =
         }
 
         try {
-            ip.cidr(addr);
+            ip_module.cidr(addr);
             return {
                 kind: 'CIDR',
                 addr
@@ -383,16 +384,16 @@ function send_reply(req, res, reply, options) {
  * Check if a hostname should be proxied or not
  */
 function should_proxy(hostname) {
-    const isIp = ip.isV4Format(hostname) || ip.isV6Format(hostname);
+    const isIp = net.isIPv4(hostname) || net.isIPv6(hostname);
     dbg.log2(`should_proxy: hostname ${hostname} isIp ${isIp}`);
 
     for (const { kind, addr } of no_proxy_list) {
         dbg.log3(`should_proxy: an item from no_proxy_list: kind ${kind} addr ${addr}`);
         if (isIp) {
-            if (kind === 'IP' && ip.isEqual(addr, hostname)) {
+            if (kind === 'IP' && ip_module.isEqual(addr, hostname)) {
                 return false;
             }
-            if (kind === 'CIDR' && ip.cidrSubnet(addr).contains(hostname)) {
+            if (kind === 'CIDR' && ip_module.cidrSubnet(addr).contains(hostname)) {
                 return false;
             }
 


### PR DESCRIPTION
nope-ip removal - Phase 1

# `net_utils`
- Will no longer use the deprecated `url.parse()` and use `new URL()` instead. It is possible because we use it with .hostname, which is equal for both.
- Create ip_toLong to replace the node-ip toLong

# Others
- Replace the use of isV4Format to net.isIPv4
- Replace the use of isV6Format to net.isIPv6
- Calling ip_toLong instead of toLong

### Explain the changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
