### PR TITLE
Fix key and bucket length checks

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -13,6 +13,7 @@ const time_utils = require('../../util/time_utils');
 const http_utils = require('../../util/http_utils');
 const signature_utils = require('../../util/signature_utils');
 const config = require('../../../config');
+const s3_utils = require('./s3_utils');
 
 const S3_MAX_BODY_LEN = 4 * 1024 * 1024;
 
@@ -384,10 +385,10 @@ function get_bucket_and_key(req) {
         }
     }
 
-    if (key?.length > config.S3_MAX_KEY_LENGTH) {
+    if (key?.length && !s3_utils.verify_string_byte_length(key, config.S3_MAX_KEY_LENGTH)) {
         throw new S3Error(S3Error.KeyTooLongError);
     }
-    if (bucket?.length > config.S3_MAX_BUCKET_NAME_LENGTH) {
+    if (bucket?.length && !s3_utils.verify_string_byte_length(bucket, config.S3_MAX_BUCKET_NAME_LENGTH)) {
         throw new S3Error(S3Error.InvalidBucketName);
     }
 

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -785,6 +785,24 @@ function key_marker_to_cont_tok(key_marker, objects_arr, is_truncated) {
     return Buffer.from(j).toString('base64');
 }
 
+/**
+ * Returns true if the byte length of the key
+ * is within the range [0, max_length]
+ * @param {string} key 
+ * @param {number} max_length 
+ * @returns 
+ */
+function verify_string_byte_length(key, max_length) {
+    // Fast path
+    const MAX_UTF8_WIDTH = 4;
+    if (key.length * MAX_UTF8_WIDTH <= max_length) {
+        return true;
+    }
+
+    // Slow path
+    return Buffer.byteLength(key, 'utf8') <= max_length;
+}
+
 exports.STORAGE_CLASS_STANDARD = STORAGE_CLASS_STANDARD;
 exports.STORAGE_CLASS_GLACIER = STORAGE_CLASS_GLACIER;
 exports.STORAGE_CLASS_GLACIER_IR = STORAGE_CLASS_GLACIER_IR;
@@ -828,5 +846,6 @@ exports.set_response_supported_storage_classes = set_response_supported_storage_
 exports.cont_tok_to_key_marker = cont_tok_to_key_marker;
 exports.key_marker_to_cont_tok = key_marker_to_cont_tok;
 exports.parse_sse_c = parse_sse_c;
+exports.verify_string_byte_length = verify_string_byte_length;
 exports.OBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES;
 exports.OBJECT_ATTRIBUTES_UNSUPPORTED = OBJECT_ATTRIBUTES_UNSUPPORTED;


### PR DESCRIPTION
### Explain the changes
This PR fixes the key and bucket length checks by using the byte length instead of UTF8 character length.

### Issues: Fixed #xxx / Gap #xxx
1. An issue found by DBS3 folks

### Testing Instructions:


- [ ] Doc added/updated
- [ ] Tests added
