### PR TITLE
Changing get bucket encryption defaults

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -105,7 +105,10 @@ module.exports = {
                 },
                 kms_key_id: {
                     type: 'string'
-                }
+                },
+                bucket_key_enabled: {
+                    type: 'boolean'
+                },
             }
         },
 

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv3.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv3.js
@@ -28,7 +28,7 @@ class S3ClientAutoRegion extends S3 {
             const region = err.$response?.headers?.['x-amz-bucket-region'];
             if (!region) throw err;
             dbg.log0(`Updating region to new region ${region} in bucket ${args[0].input.Bucket}, will call ${args[0].constructor.name} again with the new region`);
-            this.config.region = region;
+            this.config.region = async () => region;
             const res = await super.send(...args);
             return res;
         }

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -141,3 +141,7 @@ s3tests_boto3/functional/test_s3.py::test_object_lock_delete_multipart_object_wi
 s3tests_boto3/functional/test_s3.py::test_object_lock_delete_multipart_object_with_legal_hold_on
 s3tests_boto3/functional/test_s3.py::test_get_undefined_public_block
 s3tests_boto3/functional/test_s3.py::test_get_public_block_deny_bucket_policy
+s3tests_boto3/functional/test_s3.py::test_get_bucket_encryption_s3
+s3tests_boto3/functional/test_s3.py::test_get_bucket_encryption_kms
+s3tests_boto3/functional/test_s3.py::test_delete_bucket_encryption_s3
+s3tests_boto3/functional/test_s3.py::test_delete_bucket_encryption_kms

--- a/src/test/unit_tests/test_s3_encryption.js
+++ b/src/test/unit_tests/test_s3_encryption.js
@@ -3,7 +3,7 @@
 
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
-coretest.setup({ pools_to_create: [coretest.POOL_LIST[0]] });
+coretest.setup({ pools_to_create: [coretest.POOL_LIST[1]] });
 const { rpc_client, EMAIL } = coretest;
 
 const _ = require('lodash');
@@ -71,15 +71,20 @@ mocha.describe('Bucket Encryption Operations', async () => {
         await local_s3.createBucket({ Bucket: BKT });
     });
 
-    mocha.it('should get bucket encryption error without encryption configured', async () => {
-        try {
-            const res = await local_s3.getBucketEncryption({ Bucket: BKT });
-            throw new Error(`Expected to get error with unconfigured bucket encryption ${res}`);
-        } catch (error) {
-            assert(error.message === 'The server side encryption configuration was not found.', `Error message does not match got: ${error.message}`);
-            assert(error.Code === 'ServerSideEncryptionConfigurationNotFoundError', `Error code does not match got: ${error.Code}`);
-            assert(error.$metadata.httpStatusCode === 404, `Error status code does not match got: ${error.$metadata.httpStatusCode}`);
-        }
+    mocha.it('should get default bucket encryption without encryption configured', async () => {
+        const res = await local_s3.getBucketEncryption({ Bucket: BKT });
+        const expected_response = {
+            ServerSideEncryptionConfiguration: {
+                Rules: [{
+                    ApplyServerSideEncryptionByDefault: {
+                        SSEAlgorithm: 'AES256'
+                    },
+                    BucketKeyEnabled: false
+                }]
+            }
+        };
+        const res_without_metadata = _.omit(res, '$metadata');
+        assert.deepEqual(res_without_metadata, expected_response);
     });
 
     mocha.it('should configure bucket encryption', async () => {
@@ -90,7 +95,8 @@ mocha.describe('Bucket Encryption Operations', async () => {
                     ApplyServerSideEncryptionByDefault: {
                         SSEAlgorithm: 'AES256',
                         // KMSMasterKeyID: 'Sloth'
-                    }
+                    },
+                    BucketKeyEnabled: false
                 }, ]
             },
         };
@@ -104,7 +110,8 @@ mocha.describe('Bucket Encryption Operations', async () => {
                 Rules: [{
                     ApplyServerSideEncryptionByDefault: {
                         SSEAlgorithm: 'AES256'
-                    }
+                    },
+                    BucketKeyEnabled: false
                 }]
             }
         };
@@ -116,15 +123,20 @@ mocha.describe('Bucket Encryption Operations', async () => {
         await local_s3.deleteBucketEncryption({ Bucket: BKT });
     });
 
-    mocha.it('should get bucket encryption error without encryption configured', async () => {
-        try {
-            const res = await local_s3.getBucketEncryption({ Bucket: BKT });
-            throw new Error(`Expected to get an error with unconfigured bucket encryption ${res}`);
-        } catch (error) {
-            assert(error.message === 'The server side encryption configuration was not found.', `Error message does not match got: ${error.message}`);
-            assert(error.Code === 'ServerSideEncryptionConfigurationNotFoundError', `Error code does not match got: ${error.Code}`);
-            assert(error.$metadata.httpStatusCode === 404, `Error status code does not match got: ${error.$metadata.httpStatusCode}`);
-        }
+    mocha.it('should get default bucket encryption without encryption configured', async () => {
+        const res = await local_s3.getBucketEncryption({ Bucket: BKT });
+        const expected_response = {
+            ServerSideEncryptionConfiguration: {
+                Rules: [{
+                    ApplyServerSideEncryptionByDefault: {
+                        SSEAlgorithm: 'AES256'
+                    },
+                    BucketKeyEnabled: false
+                }]
+            }
+        };
+        const res_without_metadata = _.omit(res, '$metadata');
+        assert.deepEqual(res_without_metadata, expected_response);
     });
 
     mocha.it('should put encrypted object and copy with different encryption', async function() {
@@ -181,15 +193,20 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
         await rpc_client.bucket.create_bucket({ name: BKT, namespace: { read_resources, write_resource } });
     });
 
-    mocha.it('should get bucket encryption error without encryption configured', async () => {
-        try {
-            const res = await local_s3.getBucketEncryption({ Bucket: BKT });
-            throw new Error(`Expected to get error with unconfigured bucket encryption ${res}`);
-        } catch (error) {
-            assert(error.message === 'The server side encryption configuration was not found.', `Error message does not match got: ${error.message}`);
-            assert(error.Code === 'ServerSideEncryptionConfigurationNotFoundError', `Error code does not match got: ${error.Code}`);
-            assert(error.$metadata.httpStatusCode === 404, `Error status code does not match got: ${error.$metadata.httpStatusCode}`);
-        }
+    mocha.it('should get default bucket encryption without encryption configured', async () => {
+        const res = await local_s3.getBucketEncryption({ Bucket: BKT });
+        const expected_response = {
+            ServerSideEncryptionConfiguration: {
+                Rules: [{
+                    ApplyServerSideEncryptionByDefault: {
+                        SSEAlgorithm: 'AES256'
+                    },
+                    BucketKeyEnabled: false
+                }]
+            }
+        };
+        const res_without_metadata = _.omit(res, '$metadata');
+        assert.deepEqual(res_without_metadata, expected_response);
     });
 
     mocha.it('should configure bucket encryption', async () => {
@@ -200,7 +217,8 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
                     ApplyServerSideEncryptionByDefault: {
                         SSEAlgorithm: 'AES256',
                         // KMSMasterKeyID: 'Sloth'
-                    }
+                    },
+                    BucketKeyEnabled: false
                 }, ]
             },
         };
@@ -214,26 +232,33 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
                 Rules: [{
                     ApplyServerSideEncryptionByDefault: {
                         SSEAlgorithm: 'AES256'
-                    }
+                    },
+                    BucketKeyEnabled: false
                 }]
             }
         };
-        assert.deepEqual(res, expected_response);
+        const res_without_metadata = _.omit(res, '$metadata');
+        assert.deepEqual(res_without_metadata, expected_response);
     });
 
     mocha.it('should delete bucket encryption', async () => {
         await local_s3.deleteBucketEncryption({ Bucket: BKT });
     });
 
-    mocha.it('should get bucket encryption error without encryption configured', async () => {
-        try {
-            const res = await local_s3.getBucketEncryption({ Bucket: BKT });
-            throw new Error(`Expected to get error with unconfigured bucket encryption ${res}`);
-        } catch (error) {
-            assert(error.message === 'The server side encryption configuration was not found.', `Error message does not match got: ${error.message}`);
-            assert(error.Code === 'ServerSideEncryptionConfigurationNotFoundError', `Error code does not match got: ${error.Code}`);
-            assert(error.$metadata.httpStatusCode === 404, `Error status code does not match got: ${error.$metadata.httpStatusCode}`);
-        }
+    mocha.it('should get default bucket encryption without encryption configured', async () => {
+        const res = await local_s3.getBucketEncryption({ Bucket: BKT });
+        const expected_response = {
+            ServerSideEncryptionConfiguration: {
+                Rules: [{
+                    ApplyServerSideEncryptionByDefault: {
+                        SSEAlgorithm: 'AES256'
+                    },
+                    BucketKeyEnabled: false
+                }]
+            }
+        };
+        const res_without_metadata = _.omit(res, '$metadata');
+        assert.deepEqual(res_without_metadata, expected_response);
     });
 
     mocha.it('should put encrypted object and copy with different encryption', async function() {


### PR DESCRIPTION
### Explain the changes
1.  In case of data buckets - returning AES256 by default in case of none configured bucket encryption - like AWS is doing
2. In case of data buckets - Returning BucketKeyEnabled=False as the default as we don't support it yet
3. In case of a namespace where AWS/S3compatible is the write resource - we will get the encryption from the bucket and forward it to the client
4. In case of any other namespace (or error while trying to get the encryption from AWS), we will return the error of ServerSideEncryptionConfigurationNotFoundError

Also in this PR as a 2nd commit - a fix to an issue we had as part of testing this feature
It seems AWS changed the region under config to be a function instead of string - so it is now fix

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. updated the test_s3_encryption test

For the region issue mentioned above, in order to validate, run this:
1. Create a bucket in AWS with region other than us-east-1(our default)
`aws s3 mb s3://west-bucket --region us-west-1`
3. Create namespacestore:
`nb namespacestore create aws-s3  <namespace-store-name>`(don't provide the region so we will default to us-east-1)
4. Run analyze resource (It creates the log files and then deletes the created job):
`nb diagnostics analyze namespacestore <namespace-store-name>`
5. make sure the test doesn't fail(fail result for example: `Analyze Resource Tests Result west-ns: 0 passed, 2 failed, ...)`

- [ ] Doc added/updated
- [x] Tests added
