### PR TITLE
NC | CLI | Updated the CLI response to have more info when account/bucket has been deleted

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -259,7 +259,7 @@ async function delete_bucket(data, force) {
         }
         await native_fs_utils.folder_delete(bucket_temp_dir_path, fs_context_fs_backend, true);
         await config_fs.delete_bucket_config_file(data.name);
-        return { code: ManageCLIResponse.BucketDeleted, detail: '', event_arg: { bucket: data.name } };
+        return { code: ManageCLIResponse.BucketDeleted, detail: { name: data.name }, event_arg: { bucket: data.name } };
     } catch (err) {
         if (err.code === 'ENOENT') throw_cli_error(ManageCLIError.NoSuchBucket, data.name);
         throw err;
@@ -528,7 +528,7 @@ async function update_account(data) {
  */
 async function delete_account(data) {
     await config_fs.delete_account_config_file(data);
-    return { code: ManageCLIResponse.AccountDeleted, detail: '', event_arg: { account: data.name } };
+    return { code: ManageCLIResponse.AccountDeleted, detail: { name: data.name }, event_arg: { account: data.name } };
 }
 
 /**
@@ -791,12 +791,12 @@ async function connection_management(action, user_input) {
             break;
         case ACTIONS.DELETE:
             await config_fs.delete_connection_config_file(user_input.name);
-            response = { code: ManageCLIResponse.ConnectionDeleted };
+            response = { code: ManageCLIResponse.ConnectionDeleted, detail: {name: user_input.name} };
             break;
         case ACTIONS.UPDATE:
             await notifications_util.update_connect_file(user_input.name, user_input.key,
                 user_input.value, user_input.remove_key, config_fs);
-            response = { code: ManageCLIResponse.ConnectionUpdated };
+            response = { code: ManageCLIResponse.ConnectionUpdated, detail: {name: user_input.name} };
             break;
         case ACTIONS.STATUS:
             data = await new notifications_util.Notificator({

--- a/src/manage_nsfs/manage_nsfs_cli_responses.js
+++ b/src/manage_nsfs/manage_nsfs_cli_responses.js
@@ -7,9 +7,10 @@ const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEve
 /**
  * @typedef {{
  *      code?: string, 
+ *      message?: string,
  *      http_code: number,
  *      list?: object,
- *      status?: object,  
+ *      status?: object
  * }} ManageCLIResponseSpec
  */
 
@@ -18,17 +19,19 @@ class ManageCLIResponse {
     /**
      * @param {ManageCLIResponseSpec} response_spec 
      */
-    constructor({ code, status, list }) {
+    constructor({ code, status, list, message }) {
         this.code = code;
         this.http_code = 200;
         this.status = status;
         this.list = list;
+        this.message = message;
     }
 
     to_string(detail) {
         const json = {
             response: {
                 code: this.code,
+                message: detail?.name ? `${this.message}: ${detail.name}` : this.message,
             }
         };
         if (this.list || this.status) json.response.reply = typeof detail === 'string' ? JSON.parse(detail) : detail;
@@ -44,11 +47,13 @@ class ManageCLIResponse {
 
 ManageCLIResponse.HealthStatus = Object.freeze({
     code: 'HealthStatus',
+    message: 'Health status retrieved successfully',
     status: {}
 });
 
 ManageCLIResponse.MetricsStatus = Object.freeze({
     code: 'MetricsStatus',
+    message: 'Metrics status retrieved successfully',
     status: {}
 });
 
@@ -57,6 +62,7 @@ ManageCLIResponse.MetricsStatus = Object.freeze({
 ///////////////////////////////
 ManageCLIResponse.WhiteListIPUpdated = Object.freeze({
     code: 'WhiteListIPUpdated',
+    message: 'WhiteListIP has been updated successfully',
     status: {}
 });
 
@@ -66,25 +72,30 @@ ManageCLIResponse.WhiteListIPUpdated = Object.freeze({
 
 ManageCLIResponse.AccountCreated = Object.freeze({
     code: 'AccountCreated',
+    message: 'Account has been created successfully',
     status: {}
 });
 
 ManageCLIResponse.AccountDeleted = Object.freeze({
     code: 'AccountDeleted',
+    message: 'Account has been deleted successfully'
 });
 
 ManageCLIResponse.AccountUpdated = Object.freeze({
     code: 'AccountUpdated',
+    message: 'Account has been updated successfully',
     status: {}
 });
 
 ManageCLIResponse.AccountStatus = Object.freeze({
     code: 'AccountStatus',
+    message: 'Account status retrieved successfully',
     status: {}
 });
 
 ManageCLIResponse.AccountList = Object.freeze({
     code: 'AccountList',
+    message: 'Account list retrieved successfully',
     list: {}
 });
 
@@ -94,25 +105,30 @@ ManageCLIResponse.AccountList = Object.freeze({
 
 ManageCLIResponse.BucketCreated = Object.freeze({
     code: 'BucketCreated',
+    message: 'Bucket has been created successfully',
     status: {}
 });
 
 ManageCLIResponse.BucketDeleted = Object.freeze({
     code: 'BucketDeleted',
+    message: 'Bucket has been deleted successfully'
 });
 
 ManageCLIResponse.BucketUpdated = Object.freeze({
     code: 'BucketUpdated',
+    message: 'Bucket has been updated successfully',
     status: {}
 });
 
 ManageCLIResponse.BucketStatus = Object.freeze({
     code: 'BucketStatus',
+    message: 'Bucket status retrieved successfully',
     status: {}
 });
 
 ManageCLIResponse.BucketList = Object.freeze({
     code: 'BucketList',
+    message: 'Bucket list retrieved successfully',
     list: {}
 });
 
@@ -122,6 +138,7 @@ ManageCLIResponse.BucketList = Object.freeze({
 
 ManageCLIResponse.LoggingExported = Object.freeze({
     code: 'LoggingExported',
+    message: 'Logging data exported successfully',
     status: {}
 });
 
@@ -131,16 +148,19 @@ ManageCLIResponse.LoggingExported = Object.freeze({
 
 ManageCLIResponse.UpgradeSuccessful = Object.freeze({
     code: 'UpgradeSuccessful',
+    message: 'Config directory upgrade completed successfully',
     status: {}
 });
 
 ManageCLIResponse.UpgradeStatus = Object.freeze({
     code: 'UpgradeStatus',
+    message: 'Config directory upgrade status retrieved successfully',
     status: {}
 });
 
 ManageCLIResponse.UpgradeHistory = Object.freeze({
     code: 'UpgradeHistory',
+    message: 'Config directory upgrade history retrieved successfully',
     status: {}
 });
 
@@ -150,25 +170,30 @@ ManageCLIResponse.UpgradeHistory = Object.freeze({
 
 ManageCLIResponse.ConnectionCreated = Object.freeze({
     code: 'ConnectionCreated',
+    message: 'Notification connection has been created successfully',
     status: {}
 });
 
 ManageCLIResponse.ConnectionDeleted = Object.freeze({
     code: 'ConnectionDeleted',
+    message: 'Notification connection has been deleted successfully'
 });
 
 ManageCLIResponse.ConnectionUpdated = Object.freeze({
     code: 'ConnectionUpdated',
+    message: 'Notification connection has been updated successfully',
     status: {}
 });
 
 ManageCLIResponse.ConnectionStatus = Object.freeze({
     code: 'ConnectionStatus',
+    message: 'Notification connection status retrieved successfully',
     status: {}
 });
 
 ManageCLIResponse.ConnectionList = Object.freeze({
     code: 'ConnectionList',
+    message: 'Notification connection list retrieved successfully',
     list: {}
 });
 

--- a/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js
@@ -1518,6 +1518,8 @@ describe('manage nsfs cli account flow', () => {
             const res = await exec_manage_cli(type, action, account_options);
             const res_json = JSON.parse(res.trim());
             expect(res_json.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
+            const message = `Account has been deleted successfully: ${name}`;
+            expect(res_json.response.message).toBe(message);
             const account_by_name_exists = await config_fs.is_account_exists_by_name(name);
             expect(account_by_name_exists).toBe(false);
             const account_by_access_key_exists = await config_fs.is_account_exists_by_access_key(defaults.access_key);

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -731,6 +731,8 @@ describe('manage nsfs cli bucket flow', () => {
             const delete_bucket_options = { config_root, name: bucket_defaults.name, force: true};
             const resp = await exec_manage_cli(TYPES.BUCKET, ACTIONS.DELETE, delete_bucket_options);
             expect(JSON.parse(resp.trim()).response.code).toBe(ManageCLIResponse.BucketDeleted.code);
+            const message = `Bucket has been deleted successfully: ${bucket_defaults.name}`;
+            expect(JSON.parse(resp.trim()).response.message).toBe(message);
             const is_bucket_exists = await config_fs.is_bucket_exists(bucket_defaults.name);
             expect(is_bucket_exists).toBe(false);
         });


### PR DESCRIPTION
### Explain the changes
1.  Improved the response to provide a clearer message about the operations.
2.  Now, the name of the object would also be printed in the response message for more info.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: #8200 

### Testing Instructions:
1. Try creating/deleting(or any other operation) on objects(account, bucket, etc.) using noobaa-cli and check the response returned.

- [X] Tests added
