### PR TITLE
bucket notifications - missing await in failure handling, default topic_configuration in put

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_notification.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_notification.js
@@ -6,7 +6,7 @@
  */
 async function put_bucket_notification(req) {
 
-    const topic_configuration = req.body.NotificationConfiguration?.TopicConfiguration;
+    let topic_configuration = req.body.NotificationConfiguration?.TopicConfiguration;
 
     //adapt to db shcema
     if (topic_configuration) {
@@ -18,6 +18,8 @@ async function put_bucket_notification(req) {
             delete conf.Event;
             delete conf.Topic;
         }
+    } else {
+        topic_configuration = [];
     }
 
     const reply = await req.object_sdk.put_bucket_notification({

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -142,7 +142,9 @@ class Notificator {
             } catch (err) {
                 dbg.error("Failed to notify. err = ", err, ", str =", str);
                 //re-write the failed notification if it's still configured on the bucket
-                this.handle_failed_notification(notif, failure_append, err);
+                if (notif) {
+                    await this.handle_failed_notification(notif, failure_append, err);
+                }
             }
         });
         //note we can't reject promises here, since Promise.all() is rejected on


### PR DESCRIPTION
### Explain the changes
1. The error handling in notification_utils.Notificator._notify() was missing an await.
2. Default for empty TopicConfiguration was missing in put notification.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
