### PR TITLE
Fix to break semaphore circular dependency

### DIFF
--- a/src/agent/agent_cli.js
+++ b/src/agent/agent_cli.js
@@ -20,7 +20,7 @@ const dbg = require('../util/debug_module')(__filename);
 const Agent = require('./agent');
 const fs_utils = require('../util/fs_utils');
 const os_utils = require('../util/os_utils');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const json_utils = require('../util/json_utils');
 const addr_utils = require('../util/addr_utils');
 const debug_config = require('../util/debug_config');
@@ -494,7 +494,7 @@ class AgentCLI {
         if (n === 0) {
             return self.create(0, paths_to_work_on);
         } else {
-            const sem = new Semaphore(5);
+            const sem = new semaphore.Semaphore(5);
             return P.all(_.times(n, function() {
                 return sem.surround(function() {
                     return self.create(n, paths_to_work_on);

--- a/src/agent/block_store_services/block_store_mongo.js
+++ b/src/agent/block_store_services/block_store_mongo.js
@@ -9,15 +9,15 @@ const size_utils = require('../../util/size_utils');
 const mongo_client = require('../../util/mongo_client');
 const buffer_utils = require('../../util/buffer_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 
 // limiting the IO concurrency on mongo
 // we use a very low limit since this is used only for temporary internal storage
 // which is meant for quick onboarding, and not for performance/production.
-const sem_head = new Semaphore(3);
-const sem_read = new Semaphore(1);
-const sem_write = new Semaphore(1);
-const sem_delete = new Semaphore(1);
+const sem_head = new semaphore.Semaphore(3);
+const sem_read = new semaphore.Semaphore(1);
+const sem_write = new semaphore.Semaphore(1);
+const sem_delete = new semaphore.Semaphore(1);
 
 const GRID_FS_BUCKET_NAME = 'mongo_internal_agent';
 const GRID_FS_BUCKET_NAME_FILES = `${GRID_FS_BUCKET_NAME}.files`;

--- a/src/agent/func_services/func_node.js
+++ b/src/agent/func_services/func_node.js
@@ -9,7 +9,7 @@ const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const { RpcError, RPC_BUFFERS } = require('../../rpc');
 const fs_utils = require('../../util/fs_utils');
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 const zip_utils = require('../../util/zip_utils');
 
 const FUNC_PROC_PATH = path.resolve(__dirname, 'func_proc.js');
@@ -22,7 +22,7 @@ class FuncNode {
         this.storage_path = params.storage_path || '.';
         this.functions_path = path.join(this.storage_path, 'functions');
         this.functions_loading_path = path.join(this.storage_path, 'functions_loading');
-        this.loading_serial = new Semaphore(1);
+        this.loading_serial = new semaphore.Semaphore(1);
     }
 
     async invoke_func(req) {

--- a/src/rpc/ice.js
+++ b/src/rpc/ice.js
@@ -6,6 +6,7 @@ module.exports = Ice;
 
 const _ = require('lodash');
 const P = require('../util/promise');
+const Defer = require('../util/defer');
 const os = require('os');
 const net = require('net');
 const tls = require('tls');
@@ -1341,7 +1342,7 @@ function IceSession(local, remote, packet, udp) {
     self.state = 'init';
     js_utils.self_bind(self, 'run_udp_request_loop');
     js_utils.self_bind(self, 'run_udp_indication_loop');
-    self.defer = new P.Defer();
+    self.defer = new Defer();
     self.defer.promise.catch(_.noop); // to ignore 'Unhandled rejection' printouts
     // set session timeout
     self.ready_timeout = setTimeout(function() {

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -11,6 +11,7 @@ const assert = require('assert');
 const EventEmitter = require('events').EventEmitter;
 
 const P = require('../util/promise');
+const Defer = require('../util/defer');
 const js_utils = require('../util/js_utils');
 const dbg = require('../util/debug_module')(__filename);
 const config = require('../../config');
@@ -191,7 +192,7 @@ class RPC extends EventEmitter {
 
             // initialize the request
             req._new_request(api, method_api, params, options.auth_token);
-            req._response_defer = new P.Defer();
+            req._response_defer = new Defer();
             req._response_defer.promise.catch(_.noop); // to prevent error log of unhandled rejection
 
             if (options.tracker) {

--- a/src/rpc/rpc_base_conn.js
+++ b/src/rpc/rpc_base_conn.js
@@ -7,6 +7,8 @@ const _ = require('lodash');
 const events = require('events');
 
 const P = require('../util/promise');
+const Defer = require('../util/defer');
+
 const dbg = require('../util/debug_module')(__filename);
 const config = require('../../config');
 const time_utils = require('../util/time_utils');
@@ -38,7 +40,7 @@ class RpcBaseConnection extends events.EventEmitter {
         this._state = STATE_INIT;
 
         // the connecting_defer is used by connect() to wait for the connected event
-        this.connecting_defer = new P.Defer();
+        this.connecting_defer = new Defer();
         this._connect_promise = events.once(this, 'connect');
         this._connect_promise.catch(_.noop); // to prevent error log of unhandled rejection
 

--- a/src/rpc/rpc_http.js
+++ b/src/rpc/rpc_http.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const http = require('http');
 const https = require('https');
 
-const P = require('../util/promise');
+const Defer = require('../util/defer');
 const dbg = require('../util/debug_module')(__filename);
 const buffer_utils = require('../util/buffer_utils');
 const http_utils = require('../util/http_utils');
@@ -145,7 +145,7 @@ class RpcHttpConnection extends RpcBaseConnection {
 
         dbg.log3('HTTP request', http_req.method, http_req.path, http_req._headers);
 
-        const send_defer = new P.Defer();
+        const send_defer = new Defer();
 
         // reject on send errors
         http_req.on('error', send_defer.reject);

--- a/src/rpc/rpc_request.js
+++ b/src/rpc/rpc_request.js
@@ -2,7 +2,7 @@
 'use strict';
 
 /** @typedef {import('./rpc_base_conn')} RpcBaseConnection */
-/** @typedef {import('../util/promise').Defer} Defer */
+/** @typedef {import('../util/defer')} Defer */
 
 const _ = require('lodash');
 const RpcMessage = require('./rpc_message');

--- a/src/sdk/map_client.js
+++ b/src/sdk/map_client.js
@@ -16,7 +16,7 @@ const LRUCache = require('../util/lru_cache');
 const s3_utils = require('../endpoint/s3/s3_utils');
 const db_client = require('../util/db_client');
 const nb_native = require('../util/nb_native');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const KeysSemaphore = require('../util/keys_semaphore');
 const block_store_client = require('../agent/block_store_services/block_store_client').instance();
 const system_store = require('../server/system_services/system_store').get_instance();
@@ -25,9 +25,9 @@ const { ChunkAPI } = require('./map_api_types');
 const { RpcError, RPC_BUFFERS } = require('../rpc');
 
 // semphores global to the client
-const block_write_sem_global = new Semaphore(config.IO_WRITE_CONCURRENCY_GLOBAL);
-const block_replicate_sem_global = new Semaphore(config.IO_REPLICATE_CONCURRENCY_GLOBAL);
-const block_read_sem_global = new Semaphore(config.IO_READ_CONCURRENCY_GLOBAL);
+const block_write_sem_global = new semaphore.Semaphore(config.IO_WRITE_CONCURRENCY_GLOBAL);
+const block_replicate_sem_global = new semaphore.Semaphore(config.IO_REPLICATE_CONCURRENCY_GLOBAL);
+const block_read_sem_global = new semaphore.Semaphore(config.IO_READ_CONCURRENCY_GLOBAL);
 
 // semphores specific to an agent
 const block_write_sem_agent = new KeysSemaphore(config.IO_WRITE_CONCURRENCY_AGENT);
@@ -652,7 +652,7 @@ class MapClient {
                 });
                 dbg.log1('MapClient: move_blocks_to_storage_class SUCCEEDED', 'ADDR:', agent_address, 'MOVED:', moved);
             } catch (err) {
-                dbg.error('MapClient: move_blocks_to_storage_class FAILED', 'ADDR:', agent_address, 'ERROR', err,);
+                dbg.error('MapClient: move_blocks_to_storage_class FAILED', 'ADDR:', agent_address, 'ERROR', err);
             }
         });
     }

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -11,13 +11,13 @@ const RangeStream = require('../util/range_stream');
 const P = require('../util/promise');
 const buffer_utils = require('../util/buffer_utils');
 const stream_utils = require('../util/stream_utils');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 const s3_utils = require('../endpoint/s3/s3_utils');
 const config = require('../../config');
 const size_utils = require('../util/size_utils');
 
-const _global_cache_uploader = new Semaphore(cache_config.UPLOAD_SEMAPHORE_CAP, {
+const _global_cache_uploader = new semaphore.Semaphore(cache_config.UPLOAD_SEMAPHORE_CAP, {
     timeout: cache_config.UPLOAD_SEMAPHORE_TIMEOUT,
     timeout_error_code: 'NAMESPACE_CACHE_UPLOAD_TIMEOUT'
 });
@@ -36,7 +36,7 @@ class NamespaceCache {
      *      stats: import('./endpoint_stats_collector').EndpointStatsCollector,
      * }} params
      */
-   constructor({ namespace_hub, namespace_nb, caching, active_triggers, stats }) {
+    constructor({ namespace_hub, namespace_nb, caching, active_triggers, stats }) {
         this.namespace_hub = namespace_hub;
         this.namespace_nb = namespace_nb;
         this.active_triggers = active_triggers;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -7,7 +7,7 @@ import { Readable, Writable } from 'stream';
 import { IncomingMessage, ServerResponse } from 'http';
 import { ObjectPart, Checksum} from '@aws-sdk/client-s3';
 
-type Semaphore = import('../util/semaphore');
+type Semaphore = import('../util/semaphore').Semaphore;
 type KeysSemaphore = import('../util/keys_semaphore');
 type SensitiveString = import('../util/sensitive_string');
 

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -7,7 +7,7 @@ const stream = require('stream');
 
 const dbg = require('../util/debug_module')(__filename);
 const config = require('../../config');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const ChunkCoder = require('../util/chunk_coder');
 const range_utils = require('../util/range_utils');
 const buffer_utils = require('../util/buffer_utils');
@@ -122,7 +122,7 @@ class ObjectIO {
         this._last_io_bottleneck_report = 0;
         this.location_info = location_info;
 
-        this._io_buffers_sem = new Semaphore(config.IO_SEMAPHORE_CAP, {
+        this._io_buffers_sem = new semaphore.Semaphore(config.IO_SEMAPHORE_CAP, {
             timeout: config.IO_STREAM_SEMAPHORE_TIMEOUT,
             timeout_error_code: 'IO_STREAM_ITEM_TIMEOUT'
         });

--- a/src/server/bg_services/log_replication_scanner.js
+++ b/src/server/bg_services/log_replication_scanner.js
@@ -7,7 +7,7 @@ const dbg = require('../../util/debug_module')(__filename);
 const system_utils = require('../utils/system_utils');
 const config = require('../../../config');
 const P = require('../../util/promise');
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 const replication_store = require('../system_services/replication_store').instance();
 const cloud_utils = require('../../util/cloud_utils');
 const log_parser = require('./replication_log_parser');
@@ -25,7 +25,7 @@ class LogReplicationScanner {
     constructor({ name, client }) {
         this.name = name;
         this.client = client;
-        this._scanner_sem = new Semaphore(config.REPLICATION_SEMAPHORE_CAP, {
+        this._scanner_sem = new semaphore.Semaphore(config.REPLICATION_SEMAPHORE_CAP, {
             timeout: config.REPLICATION_SEMAPHORE_TIMEOUT,
             timeout_error_code: 'LOG_REPLICATION_ITEM_TIMEOUT',
             verbose: true

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -7,7 +7,7 @@ const dbg = require('../../util/debug_module')(__filename);
 const system_utils = require('../utils/system_utils');
 const config = require('../../../config');
 const P = require('../../util/promise');
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 const replication_store = require('../system_services/replication_store').instance();
 const cloud_utils = require('../../util/cloud_utils');
 const replication_utils = require('../utils/replication_utils');
@@ -24,7 +24,7 @@ class ReplicationScanner {
     constructor({ name, client }) {
         this.name = name;
         this.client = client;
-        this.scanner_semaphore = new Semaphore(config.REPLICATION_SEMAPHORE_CAP, {
+        this.scanner_semaphore = new semaphore.Semaphore(config.REPLICATION_SEMAPHORE_CAP, {
             timeout: config.REPLICATION_SEMAPHORE_TIMEOUT,
             timeout_error_code: 'REPLICATION_ITEM_TIMEOUT',
             verbose: true

--- a/src/server/license_info.js
+++ b/src/server/license_info.js
@@ -8,12 +8,12 @@ const minimist = require('minimist');
 
 const P = require('../util/promise');
 const pkg = require('../../package.json');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const os_utils = require('../util/os_utils');
 const license_utils = require('../util/license_utils');
 
 const LICENSE_INFO_JSON_PATH = path.resolve('license_info.json');
-const serial = new Semaphore(1);
+const serial = new semaphore.Semaphore(1);
 
 /**
  * Handle the license info http request

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -15,7 +15,7 @@ const dbg = require('../../util/debug_module')(__filename);
 const config = require('../../../config');
 const js_utils = require('../../util/js_utils');
 const MDStore = require('../object_services/md_store').MDStore;
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 const NodesStore = require('./nodes_store').NodesStore;
 const IoStatsStore = require('../analytic_services/io_stats_store').IoStatsStore;
 const size_utils = require('../../util/size_utils');
@@ -187,8 +187,8 @@ class NodesMonitor extends EventEmitter {
         this._started = false;
         this._loaded = false;
         this._num_running_rebuilds = 0;
-        this._run_serial = new Semaphore(1);
-        this._update_nodes_store_serial = new Semaphore(1);
+        this._run_serial = new semaphore.Semaphore(1);
+        this._update_nodes_store_serial = new semaphore.Semaphore(1);
 
         // This is used in order to test n2n connection from node_monitor to agents
         this.n2n_rpc = api.new_rpc();
@@ -851,7 +851,7 @@ class NodesMonitor extends EventEmitter {
 
     _run_node(item) {
         if (!this._started) return P.reject(new Error('monitor has not started'));
-        item._run_node_serial = item._run_node_serial || new Semaphore(1);
+        item._run_node_serial = item._run_node_serial || new semaphore.Semaphore(1);
         if (item.node.deleted) return P.reject(new Error(`node ${item.node.name} is deleted`));
         return item._run_node_serial.surround(() =>
             P.resolve()

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -31,7 +31,7 @@ const agent_config_indexes = require('./schemas/agent_config_indexes');
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const js_utils = require('../../util/js_utils');
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 const server_rpc = require('../server_rpc');
 const time_utils = require('../../util/time_utils');
 const size_utils = require('../../util/size_utils');
@@ -351,7 +351,7 @@ class SystemStore extends EventEmitter {
         this.is_finished_initial_load = false;
         this.START_REFRESH_THRESHOLD = 10 * 60 * 1000;
         this.FORCE_REFRESH_THRESHOLD = 60 * 60 * 1000;
-        this._load_serial = new Semaphore(1, { warning_timeout: this.START_REFRESH_THRESHOLD });
+        this._load_serial = new semaphore.Semaphore(1, { warning_timeout: this.START_REFRESH_THRESHOLD });
         for (const col of COLLECTIONS) {
             db_client.instance().define_collection(col);
         }
@@ -813,9 +813,9 @@ class SystemStore extends EventEmitter {
     get_accounts_by_nsfs_account_config(nsfs_account_config) {
         if (this.data && !_.isEmpty(this.data.accounts)) {
             return this.data.accounts.filter(account => account.nsfs_account_config &&
-                    _.isEqual(account.nsfs_account_config.distinguished_name, nsfs_account_config.distinguished_name) &&
-                    account.nsfs_account_config.uid === nsfs_account_config.uid &&
-                    account.nsfs_account_config.gid === nsfs_account_config.gid);
+                _.isEqual(account.nsfs_account_config.distinguished_name, nsfs_account_config.distinguished_name) &&
+                account.nsfs_account_config.uid === nsfs_account_config.uid &&
+                account.nsfs_account_config.gid === nsfs_account_config.gid);
         }
     }
 

--- a/src/test/system_tests/test_files_ul.js
+++ b/src/test/system_tests/test_files_ul.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const argv = require('minimist')(process.argv);
 const AWS = require('aws-sdk');
 const P = require('../../util/promise');
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 const os_utils = require('../../util/os_utils');
 
 const UL_TEST = {
@@ -97,7 +97,7 @@ function upload_test() {
         Bucket: UL_TEST.bucket_name
     });
 
-    const upload_semaphore = new Semaphore(UL_TEST.num_threads);
+    const upload_semaphore = new semaphore.Semaphore(UL_TEST.num_threads);
     return P.all(_.map(UL_TEST.files, function(f) {
         return upload_semaphore.surround(function() {
             return upload_file(f);

--- a/src/test/unit_tests/test_buffer_pool.js
+++ b/src/test/unit_tests/test_buffer_pool.js
@@ -3,7 +3,7 @@
 const mocha = require('mocha');
 const assert = require('assert');
 const buffer_utils = require('../../util/buffer_utils');
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 
 mocha.describe('Test buffers pool', function() {
 
@@ -12,7 +12,7 @@ mocha.describe('Test buffers pool', function() {
         const BUF_LIMIT = 8 * 1024 * 1024;
         const MAX_POOL_ALLOWED = SEM_LIMIT / BUF_LIMIT;
         const SLEEP_BEFORE_RELEASE = 264;
-        const buffers_pool_sem = new Semaphore(SEM_LIMIT);
+        const buffers_pool_sem = new semaphore.Semaphore(SEM_LIMIT);
         const buffers_pool = new buffer_utils.BuffersPool({
             buf_size: BUF_LIMIT,
             sem: buffers_pool_sem,
@@ -54,18 +54,16 @@ mocha.describe('Test buffers pool', function() {
         const MAX_POOL_ALLOWED1 = SEM_LIMIT1 / BUF_LIMIT1;
         const SLEEP_BEFORE_RELEASE = 264;
         const multi_buffer_pool = new buffer_utils.MultiSizeBuffersPool({
-            sorted_buf_sizes: [
-                {
-                    size: BUF_LIMIT1,
-                    sem_size: SEM_LIMIT1,
-                }, {
-                    size: BUF_LIMIT2,
-                    sem_size: SEM_LIMIT2,
-                }, {
-                    size: BUF_LIMIT3,
-                    sem_size: SEM_LIMIT3,
-                },
-            ],
+            sorted_buf_sizes: [{
+                size: BUF_LIMIT1,
+                sem_size: SEM_LIMIT1,
+            }, {
+                size: BUF_LIMIT2,
+                sem_size: SEM_LIMIT2,
+            }, {
+                size: BUF_LIMIT3,
+                sem_size: SEM_LIMIT3,
+            }, ],
             warning_timeout: 0,
         });
         const lazy_fill = new Array(MAX_POOL_ALLOWED1 + 2).fill(0);
@@ -79,7 +77,7 @@ mocha.describe('Test buffers pool', function() {
         });
         let buf = await multi_buffer_pool.get_buffers_pool(BUF_LIMIT1 + 500).get_buffer();
         console.log('From pool allocations', buf.buffer.length,
-                multi_buffer_pool.pools[1].buffers.length, multi_buffer_pool.pools[1].sem.value);
+            multi_buffer_pool.pools[1].buffers.length, multi_buffer_pool.pools[1].sem.value);
         buf.callback();
         assert(buf.buffer.length === BUF_LIMIT2, 'Allocated different buffer size than expected');
         const from_pool_buffers = await Promise.all(from_pool_allocation);
@@ -89,7 +87,7 @@ mocha.describe('Test buffers pool', function() {
         assert(multi_buffer_pool.pools[0].sem.value === SEM_LIMIT1, 'Sempahore did not deallocate after buffers release');
         buf = await multi_buffer_pool.get_buffers_pool(BUF_LIMIT2 + 500).get_buffer();
         console.log('From pool allocations', buf.buffer.length,
-                multi_buffer_pool.pools[2].buffers.length, multi_buffer_pool.pools[2].sem.value);
+            multi_buffer_pool.pools[2].buffers.length, multi_buffer_pool.pools[2].sem.value);
         buf.callback();
         assert(buf.buffer.length === BUF_LIMIT3, 'Allocated different buffer size than expected');
         buf = await multi_buffer_pool.get_buffers_pool(0).get_buffer();

--- a/src/test/unit_tests/test_promise_utils.js
+++ b/src/test/unit_tests/test_promise_utils.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const P = require('../../util/promise');
+const Defer = require('../../util/defer');
 const mocha = require('mocha');
 const assert = require('assert');
 
@@ -91,22 +92,22 @@ mocha.describe('promise utils', function() {
 
     mocha.describe('P.defer', function() {
         mocha.it('resolves immediately', /** @this {Mocha.Context} */ async function() {
-            const defer = new P.Defer();
+            const defer = new Defer();
             defer.resolve(this.test.title);
             assert.strictEqual(await defer.promise, this.test.title);
         });
         mocha.it('resolves later', /** @this {Mocha.Context} */ async function() {
-            const defer = new P.Defer();
+            const defer = new Defer();
             setTimeout(() => defer.resolve(this.test.title), 12);
             assert.strictEqual(await defer.promise, this.test.title);
         });
         mocha.it('rejects immediately', /** @this {Mocha.Context} */ async function() {
-            const defer = new P.Defer();
+            const defer = new Defer();
             defer.reject(new Error(this.test.title));
             assert.rejects(defer.promise);
         });
         mocha.it('rejects later', /** @this {Mocha.Context} */ async function() {
-            const defer = new P.Defer();
+            const defer = new Defer();
             setTimeout(() => defer.reject(new Error(this.test.title)), 12);
             assert.rejects(defer.promise);
         });

--- a/src/test/unit_tests/test_semaphore.js
+++ b/src/test/unit_tests/test_semaphore.js
@@ -4,14 +4,14 @@
 const util = require('util');
 const mocha = require('mocha');
 const assert = require('assert');
-const Semaphore = require('../../util/semaphore');
+const semaphore = require('../../util/semaphore');
 
 const setImmediateAsync = util.promisify(setImmediate);
 
 mocha.describe('semaphore', function() {
 
     mocha.it('should create ok', function() {
-        const sem = new Semaphore(0);
+        const sem = new semaphore.Semaphore(0);
         assert.strictEqual(sem.length, 0);
         assert.strictEqual(sem.value, 0);
     });
@@ -23,7 +23,7 @@ mocha.describe('semaphore', function() {
             woke += 1;
         }
 
-        const sem = new Semaphore(10);
+        const sem = new semaphore.Semaphore(10);
         assert.strictEqual(sem.length, 0);
         assert.strictEqual(sem.value, 10);
 
@@ -75,7 +75,7 @@ mocha.describe('semaphore', function() {
 
     mocha.it('should surround', async function() {
         const throw_err = new Error();
-        const sem = new Semaphore(10);
+        const sem = new semaphore.Semaphore(10);
         assert.strictEqual(sem.length, 0);
         assert.strictEqual(sem.value, 10);
 
@@ -112,7 +112,7 @@ mocha.describe('semaphore', function() {
     });
 
     mocha.it('should fail on timeout in surround', async function() {
-        const sem = new Semaphore(1, {
+        const sem = new semaphore.Semaphore(1, {
             // Just using the minimum timeout without any place inside the semaphore
             // This means that we are just interested in failing as quickly as we can
             // With the item inside the waiting queue
@@ -135,7 +135,7 @@ mocha.describe('semaphore', function() {
     });
 
     mocha.it('should release value on non settled worker', async function() {
-        const sem = new Semaphore(1, {
+        const sem = new semaphore.Semaphore(1, {
             work_timeout: 1,
             work_timeout_error_code: 'MAJESTIC_SLOTH_TIMEOUT'
         });

--- a/src/tools/http_speed.js
+++ b/src/tools/http_speed.js
@@ -8,7 +8,7 @@ const stream = require('stream');
 const crypto = require('crypto');
 const cluster = require('cluster');
 const ssl_utils = require('../util/ssl_utils');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const Speedometer = require('../util/speedometer');
 const buffer_utils = require('../util/buffer_utils');
 
@@ -42,7 +42,7 @@ const http_agent = argv.ssl ?
     new https.Agent({ keepAlive: true }) :
     new http.Agent({ keepAlive: true });
 
-const buffers_pool_sem = new Semaphore(1024 * 1024 * 1024, {
+const buffers_pool_sem = new semaphore.Semaphore(1024 * 1024 * 1024, {
     timeout: 2 * 60 * 1000,
     timeout_error_code: 'HTTP_SPEED_BUFFER_POOL_TIMEOUT',
     warning_timeout: 10 * 60 * 1000,

--- a/src/tools/tcp_speed.js
+++ b/src/tools/tcp_speed.js
@@ -7,7 +7,7 @@ const argv = require('minimist')(process.argv);
 const crypto = require('crypto');
 const cluster = require('cluster');
 const ssl_utils = require('../util/ssl_utils');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const Speedometer = require('../util/speedometer');
 const buffer_utils = require('../util/buffer_utils');
 
@@ -24,7 +24,7 @@ argv.concur = argv.concur || 1;
 // server
 argv.hash = argv.hash ? String(argv.hash) : '';
 
-const buffers_pool_sem = new Semaphore(1024 * 1024 * 1024, {
+const buffers_pool_sem = new semaphore.Semaphore(1024 * 1024 * 1024, {
     timeout: 2 * 60 * 1000,
     timeout_error_code: 'HTTP_SPEED_BUFFER_POOL_TIMEOUT',
     warning_timeout: 10 * 60 * 1000,

--- a/src/util/barrier.js
+++ b/src/util/barrier.js
@@ -3,6 +3,7 @@
 
 const _ = require('lodash');
 const P = require('../util/promise');
+const Defer = require('../util/defer');
 
 module.exports = Barrier;
 
@@ -49,7 +50,7 @@ Barrier.prototype.call = function(item) {
 
         // add the item to the pending barrier and assign a defer
         // that will be resolved/rejected per this item.
-        const defer = new P.Defer();
+        const defer = new Defer();
         self.barrier.items.push(item);
         self.barrier.defers.push(defer);
 

--- a/src/util/bucket_logs_utils.js
+++ b/src/util/bucket_logs_utils.js
@@ -9,12 +9,12 @@ const path = require('path');
 const { PersistentLogger, LogFile } = require('../util/persistent_logger');
 const { format_aws_date } = require('../util/time_utils');
 const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const P = require('../util/promise');
 const nb_native = require('../util/nb_native');
 const AWS = require('aws-sdk');
 
-const sem = new Semaphore(config.BUCKET_LOG_CONCURRENCY);
+const sem = new semaphore.Semaphore(config.BUCKET_LOG_CONCURRENCY);
 
 // delimiter between bucket name and log object name.
 // Assuming noobaa bucket name follows the s3 bucket
@@ -69,8 +69,9 @@ async function _upload_to_targets(fs_context, s3_connection, log_file, bucket_to
             const target_bucket = log_entry.log_bucket;
             const log_prefix = log_entry.log_prefix;
             const source_bucket = log_entry.source_bucket;
-            if (!bucket_streams[source_bucket + BUCKET_NAME_DEL + target_bucket]) { /* new stream is needed for each target bucket, but also for each source bucket
-            - as mulitple buckets can't be written to the same object */
+            if (!bucket_streams[source_bucket + BUCKET_NAME_DEL + target_bucket]) {
+                /* new stream is needed for each target bucket, but also for each source bucket
+                           - as mulitple buckets can't be written to the same object */
                 const date = new Date();
                 const upload_stream = new stream.PassThrough();
                 let access_keys;

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const stream = require('stream');
-const Semaphore = require('./semaphore');
+const semaphore = require('./semaphore');
 const dbg = require('./debug_module')(__filename);
 const util = require('util');
 
@@ -182,7 +182,7 @@ class BuffersPool {
     /**
      * @param {{
      *      buf_size: number;
-     *      sem: import('./semaphore');
+     *      sem: import('./semaphore').Semaphore;
      *      warning_timeout: number;
      *      buffer_alloc?: (size: number) => Buffer;
      * }} params
@@ -239,34 +239,34 @@ class BuffersPool {
 class MultiSizeBuffersPool {
     /**
      * @param {{
-    *      sorted_buf_sizes: Array<{
-    *           size: number;
-    *           sem_size: number;
-    *      }>;
-    *      warning_timeout?: number;
-    *      sem_timeout?: number,
-    *      sem_timeout_error_code?: string;
-    *      sem_warning_timeout?: number;
-    *      buffer_alloc?: (size: number) => Buffer;
-    * }} params
-    */
-    constructor({ sorted_buf_sizes, warning_timeout, sem_timeout, sem_timeout_error_code, sem_warning_timeout, buffer_alloc}) {
+     *      sorted_buf_sizes: Array<{
+     *           size: number;
+     *           sem_size: number;
+     *      }>;
+     *      warning_timeout?: number;
+     *      sem_timeout?: number,
+     *      sem_timeout_error_code?: string;
+     *      sem_warning_timeout?: number;
+     *      buffer_alloc?: (size: number) => Buffer;
+     * }} params
+     */
+    constructor({ sorted_buf_sizes, warning_timeout, sem_timeout, sem_timeout_error_code, sem_warning_timeout, buffer_alloc }) {
         this.pools = sorted_buf_sizes.map(({ size, sem_size }) =>
             new BuffersPool({
                 buf_size: size,
-                sem: new Semaphore(sem_size, {
+                sem: new semaphore.Semaphore(sem_size, {
                     timeout: sem_timeout,
                     timeout_error_code: sem_timeout_error_code,
                     warning_timeout: sem_warning_timeout,
                 }),
                 warning_timeout: warning_timeout,
                 buffer_alloc
-        }));
+            }));
     }
 
     /**
      * @returns {BuffersPool}
-    */
+     */
     get_buffers_pool(size) {
         const largest = this.pools[this.pools.length - 1];
         if (typeof size !== 'number' || size < 0) {

--- a/src/util/chunk_coder.js
+++ b/src/util/chunk_coder.js
@@ -4,7 +4,7 @@
 const stream = require('stream');
 
 const P = require('./promise');
-const Semaphore = require('./semaphore');
+const semaphore = require('./semaphore');
 const nb_native = require('./nb_native');
 
 /**
@@ -19,14 +19,14 @@ class ChunkCoder extends stream.Transform {
 
     /**
      * @param {{
-    *      watermark?: number,
-    *      concurrency?: number,
-    *      coder?: string,
-    *      chunk_coder_config?: object,
-    *      cipher_key_b64?: string,
-    * }} args 
-    */
-   constructor({ watermark, concurrency, coder, chunk_coder_config, cipher_key_b64 }) {
+     *      watermark?: number,
+     *      concurrency?: number,
+     *      coder?: string,
+     *      chunk_coder_config?: object,
+     *      cipher_key_b64?: string,
+     * }} args 
+     */
+    constructor({ watermark, concurrency, coder, chunk_coder_config, cipher_key_b64 }) {
         super({
             objectMode: true,
             allowHalfOpen: false,
@@ -37,8 +37,8 @@ class ChunkCoder extends stream.Transform {
         this.chunk_coder_config = chunk_coder_config;
         this.stream_promise = P.resolve();
         // using both local and global semaphore to avoid one stream overwhelming the global sem
-        this.stream_sem = new Semaphore(concurrency);
-        ChunkCoder.global_sem = ChunkCoder.global_sem || new Semaphore(concurrency);
+        this.stream_sem = new semaphore.Semaphore(concurrency);
+        ChunkCoder.global_sem = ChunkCoder.global_sem || new semaphore.Semaphore(concurrency);
     }
 
     // Our goal here is to process chunks in concurrency.

--- a/src/util/defer.js
+++ b/src/util/defer.js
@@ -1,0 +1,54 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+/**
+ * @deprecated LEGACY PROMISE UTILS - DEPRECATED IN FAVOR OF ASYNC-AWAIT
+ */
+class Defer {
+
+    constructor() {
+        this.isPending = true;
+        this.isResolved = false;
+        this.isRejected = false;
+        this.promise = new Promise((resolve, reject) => {
+            this._promise_resolve = resolve;
+            this._promise_reject = reject;
+        });
+        Object.seal(this);
+    }
+
+    // setting resolve and reject to assert that the current code assumes 
+    // the Promise ctor is calling the callback synchronously and not deferring it,
+    // otherwise we might have weird cases that we miss the caller's resolve/reject
+    // events, so we throw to assert 
+
+    /**
+     * @param {any} [res]
+     * @returns {void}
+     */
+    resolve(res) {
+        if (!this.isPending) {
+            return;
+        }
+        this.isPending = false;
+        this.isResolved = true;
+        Object.freeze(this);
+        this._promise_resolve(res);
+    }
+
+    /**
+     * @param {Error} err
+     * @returns {void}
+     */
+    reject(err) {
+        if (!this.isPending) {
+            return;
+        }
+        this.isPending = false;
+        this.isRejected = true;
+        Object.freeze(this);
+        this._promise_reject(err);
+    }
+}
+
+module.exports = Defer; // 13 occurrences

--- a/src/util/delayed_trigger.js
+++ b/src/util/delayed_trigger.js
@@ -1,7 +1,7 @@
 /* Copyright (C) 2023 NooBaa */
 'use strict';
 
-const Semaphore = require('./semaphore');
+const semaphore = require('./semaphore');
 
 /**
  * DelayedTrigger is used to invoke a batch handling from smaller triggers.
@@ -22,7 +22,7 @@ class DelayedTrigger {
         this._max_retries = max_retries;
         this._num_retries = 0;
         this._timer = null;
-        this._sem = new Semaphore(1);
+        this._sem = new semaphore.Semaphore(1);
     }
 
     trigger() {

--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -8,7 +8,7 @@ const { rimraf } = require('rimraf');
 const crypto = require('crypto');
 
 const P = require('./promise');
-const Semaphore = require('./semaphore');
+const semaphore = require('./semaphore');
 const os_utils = require('../util/os_utils');
 
 const PRIVATE_DIR_PERMISSIONS = 0o700; // octal 700
@@ -62,9 +62,9 @@ async function read_dir_recursive(options) {
     const root = options.root || '.';
     const depth = options.depth || Infinity;
     const level = options.level || 0;
-    const dir_sem = options.dir_semaphore || new Semaphore(32);
+    const dir_sem = options.dir_semaphore || new semaphore.Semaphore(32);
     options.dir_semaphore = dir_sem;
-    const stat_sem = options.stat_semaphore || new Semaphore(128);
+    const stat_sem = options.stat_semaphore || new semaphore.Semaphore(128);
     options.stat_semaphore = stat_sem;
     const sub_dirs = [];
 
@@ -281,7 +281,7 @@ function replace_file(file_path, data) {
     const tmp_name = `${file_path}.${unique_suffix}`;
     const lock_key = path.resolve(file_path);
     if (!process_file_locks.has(lock_key)) {
-        process_file_locks.set(lock_key, new Semaphore(1));
+        process_file_locks.set(lock_key, new semaphore.Semaphore(1));
     }
     const lock = process_file_locks.get(lock_key);
     return lock.surround(() =>

--- a/src/util/json_utils.js
+++ b/src/util/json_utils.js
@@ -7,13 +7,13 @@ const fs = require('fs');
 const P = require('./promise');
 const dbg = require('./debug_module')(__filename);
 const fs_utils = require('./fs_utils');
-const Semaphore = require('./semaphore');
+const semaphore = require('./semaphore');
 
 class JsonFileWrapper {
 
     constructor(json_path) {
         this.json_path = json_path;
-        this.json_sem = new Semaphore(1);
+        this.json_sem = new semaphore.Semaphore(1);
     }
 
     read() {

--- a/src/util/keys_lock.js
+++ b/src/util/keys_lock.js
@@ -3,6 +3,7 @@
 
 const _ = require('lodash');
 const P = require('../util/promise');
+const Defer = require('../util/defer');
 const LinkedList = require('./linked_list');
 
 class KeysLock {
@@ -43,7 +44,7 @@ class KeysLock {
             return P.resolve();
         }
 
-        const defer = new P.Defer();
+        const defer = new Defer();
         lock_item.defer = defer;
         this._wait_list.push_back(lock_item);
         return defer.promise;

--- a/src/util/keys_semaphore.js
+++ b/src/util/keys_semaphore.js
@@ -1,7 +1,7 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const Semaphore = require('./semaphore');
+const semaphore = require('./semaphore');
 
 
 class KeysSemaphore {
@@ -21,7 +21,7 @@ class KeysSemaphore {
     async surround_key(key, func) {
         let sem = this._keys_map.get(key);
         if (!sem) {
-            sem = new Semaphore(this._initial, this._params);
+            sem = new semaphore.Semaphore(this._initial, this._params);
             this._keys_map.set(key, sem);
         }
         try {

--- a/src/util/persistent_logger.js
+++ b/src/util/persistent_logger.js
@@ -5,7 +5,7 @@ const path = require('path');
 const nb_native = require('./nb_native');
 const native_fs_utils = require('./native_fs_utils');
 const P = require('./promise');
-const Semaphore = require('./semaphore');
+const semaphore = require('./semaphore');
 const { NewlineReader } = require('./file_reader');
 const dbg = require('./debug_module')(__filename);
 
@@ -41,7 +41,7 @@ class PersistentLogger {
         this.fh_stat = null;
         this.local_size = 0;
 
-        this.init_lock = new Semaphore(1);
+        this.init_lock = new semaphore.Semaphore(1);
 
         if (cfg.poll_interval) this._poll_active_file_change(cfg.poll_interval);
     }
@@ -178,8 +178,7 @@ class PersistentLogger {
             // This logger is getting opened only so that we can process all the process the entries
             failure_log = new PersistentLogger(
                 this.dir,
-                `${this.namespace}.failure`,
-                { locking: 'EXCLUSIVE' },
+                `${this.namespace}.failure`, { locking: 'EXCLUSIVE' },
             );
 
             try {
@@ -284,14 +283,12 @@ class LogFile {
         try {
             filtered_log = new PersistentLogger(
                 path.dirname(this.log_path),
-                `tmp_consume_${Date.now().toString()}`,
-                { locking: 'EXCLUSIVE'}
+                `tmp_consume_${Date.now().toString()}`, { locking: 'EXCLUSIVE' }
             );
 
             log_reader = new NewlineReader(
                 this.fs_context,
-                this.log_path,
-                { lock: 'EXCLUSIVE', skip_overflow_lines: true, skip_leftover_line: true },
+                this.log_path, { lock: 'EXCLUSIVE', skip_overflow_lines: true, skip_leftover_line: true },
             );
             await log_reader.forEach(async entry => {
                 await collect(entry, filtered_log.append.bind(filtered_log));

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -3,7 +3,7 @@
 
 const _ = require('lodash');
 const util = require('util');
-const Semaphore = require('./semaphore');
+const semaphore = require('./semaphore');
 
 require('setimmediate'); // shim for the browser
 
@@ -50,7 +50,7 @@ async function map(arr, func) {
  * @returns {Promise<Array<V>>}
  */
 async function map_with_concurrency(concurrency, arr, func) {
-    const sem = new Semaphore(concurrency);
+    const sem = new semaphore.Semaphore(concurrency);
     return Promise.all(arr.map(async (key, index) => sem.surround(async () => func(key, index))));
 }
 

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -210,56 +210,6 @@ async function retry({ attempts, delay_ms, func, error_logger }) {
 /////////////////////////////////////
 
 /**
- * @deprecated LEGACY PROMISE UTILS - DEPRECATED IN FAVOR OF ASYNC-AWAIT
- */
-class Defer {
-
-    constructor() {
-        this.isPending = true;
-        this.isResolved = false;
-        this.isRejected = false;
-        this.promise = new Promise((resolve, reject) => {
-            this._promise_resolve = resolve;
-            this._promise_reject = reject;
-        });
-        Object.seal(this);
-    }
-
-    // setting resolve and reject to assert that the current code assumes 
-    // the Promise ctor is calling the callback synchronously and not deferring it,
-    // otherwise we might have weird cases that we miss the caller's resolve/reject
-    // events, so we throw to assert 
-
-    /**
-     * @param {any} [res]
-     * @returns {void}
-     */
-    resolve(res) {
-        if (!this.isPending) {
-            return;
-        }
-        this.isPending = false;
-        this.isResolved = true;
-        Object.freeze(this);
-        this._promise_resolve(res);
-    }
-
-    /**
-     * @param {Error} err
-     * @returns {void}
-     */
-    reject(err) {
-        if (!this.isPending) {
-            return;
-        }
-        this.isPending = false;
-        this.isRejected = true;
-        Object.freeze(this);
-        this._promise_reject(err);
-    }
-}
-
-/**
  * Callback is a template typedef to help propagate types correctly
  * when using nodejs callback functions.
  * @template T
@@ -366,5 +316,4 @@ exports.fromCallback = fromCallback; // 44 occurrences
 exports.fcall = fcall; // 59 occurrences
 exports.ninvoke = ninvoke; // 30 occurrences
 exports.wait_until = wait_until; // 20 occurrences
-exports.Defer = Defer; // 13 occurrences
 exports.pwhile = pwhile; // 15 occurrences

--- a/src/util/semaphore.js
+++ b/src/util/semaphore.js
@@ -275,4 +275,4 @@ function to_sem_count(count) {
     return (typeof(count) === 'number' && count >= 0) ? Math.floor(count) : 1;
 }
 
-module.exports = Semaphore;
+exports.Semaphore = Semaphore;

--- a/src/util/ssl_utils.js
+++ b/src/util/ssl_utils.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const tls = require('tls');
 const path = require('path');
 const https = require('https');
-const Semaphore = require('../util/semaphore');
+const semaphore = require('../util/semaphore');
 const dbg = require('./debug_module')(__filename);
 const nb_native = require('./nb_native');
 const { EventEmitter } = require('events');
@@ -19,7 +19,7 @@ class CertInfo extends EventEmitter {
         this.cert = null;
         this.is_loaded = false;
         this.is_generated = false;
-        this.sem = new Semaphore(1);
+        this.sem = new semaphore.Semaphore(1);
     }
 
     async file_notification(event, filename) {
@@ -168,7 +168,7 @@ function run_https_test_server() {
 
 // An internal function to prevent code duplication
 async function create_https_server(ssl_cert_info, honorCipherOrder, endpoint_handler) {
-    const ssl_options = {...ssl_cert_info.cert, honorCipherOrder: honorCipherOrder};
+    const ssl_options = { ...ssl_cert_info.cert, honorCipherOrder: honorCipherOrder };
     return https.createServer(ssl_options, endpoint_handler);
 }
 

--- a/src/util/wait_queue.js
+++ b/src/util/wait_queue.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // const _ = require('lodash');
-const P = require('../util/promise');
+const Defer = require('../util/defer');
 const LinkedList = require('./linked_list');
 
 class WaitQueue {
@@ -20,7 +20,7 @@ class WaitQueue {
      */
     wait(item) {
         item = item || {};
-        const defer = new P.Defer();
+        const defer = new Defer();
         item[this._name] = defer;
         this._q.push_back(item);
         return defer.promise;


### PR DESCRIPTION
### Explain the changes
1. We found a circular dependency in our code between: promise -> semaphore -> wait_queue -> promise
2. We want to handle in 2 ways:
2.1 We wont import the whole promise module into wait_queue - we will take defer out and create new class to be imported
2.2 As semaphore was create as empty object due to this issue - we won't import dircectly semaphore object in our code but will import its parent file which will allow the object to be loaded in case of future circular dependencies involving this module.  

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-1471

### Testing Instructions:
1. Ensure you don't see any "Semaphore is not a constructor" in our logs.


- [ ] Doc added/updated
- [ ] Tests added
