### PR TITLE
NSFS | versioning | add direcory content versioning PUT action

### DIFF
--- a/config.js
+++ b/config.js
@@ -818,6 +818,7 @@ config.NSFS_RANDOM_DELAY_BASE = 70;
 
 config.NSFS_VERSIONING_ENABLED = true;
 config.NSFS_UPDATE_ISSUES_REPORT_ENABLED = true;
+config.NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED = false;
 
 config.NSFS_EXIT_EVENTS_TIME_FRAME_MIN = 24 * 60; // per day
 config.NSFS_MAX_EXIT_EVENTS_PER_TIME_FRAME = 10; // allow max 10 failed forks per day

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -27,6 +27,7 @@ config.test_mode = true;
 config.NODES_FREE_SPACE_RESERVE = 10 * 1024 * 1024;
 config.NSFS_VERSIONING_ENABLED = true;
 config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS = 1;
+config.NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED = true;
 
 config.ROOT_KEY_MOUNT = '/tmp/noobaa-server/root_keys';
 

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -204,7 +204,8 @@ async function config_dir_setup() {
         NC_RELOAD_CONFIG_INTERVAL: 1,
         // DO NOT CHANGE - setting VACCUM_ANALYZER_INTERVAL=1 needed for failing the tests
         // in case where vaccumAnalyzer is being called before setting process.env.NC_NSFS_NO_DB_ENV = 'true' on nsfs.js
-        VACCUM_ANALYZER_INTERVAL: 1
+        VACCUM_ANALYZER_INTERVAL: 1,
+        NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED: true
     }));
     await fs.promises.mkdir(FIRST_BUCKET_PATH, { recursive: true });
 }

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -289,6 +289,20 @@ function should_retry_link_unlink(err) {
     return should_retry_general || should_retry_gpfs || should_retry_posix;
 }
 
+/**
+ * stat_ignore_enoent unlinks a file and if recieved an ENOENT error it'll not fail
+ * @param {nb.NativeFSContext} fs_context
+ * @param {string} file_path
+ * @returns {Promise<nb.NativeFSStats>}
+ */
+async function stat_ignore_enoent(fs_context, file_path) {
+    try {
+        return await nb_native().fs.stat(fs_context, file_path);
+    } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+    }
+}
+
 ////////////////////////
 /// NON CONTAINERIZED //
 ////////////////////////
@@ -691,6 +705,7 @@ exports.copy_bytes = copy_bytes;
 exports.finally_close_files = finally_close_files;
 exports.get_user_by_distinguished_name = get_user_by_distinguished_name;
 exports.get_config_files_tmpdir = get_config_files_tmpdir;
+exports.stat_ignore_enoent = stat_ignore_enoent;
 
 exports._is_gpfs = _is_gpfs;
 exports.safe_move = safe_move;


### PR DESCRIPTION
### Explain the changes
1. part of the effort to enable versioning to content directory objects. enable PUT commend for versioned directory objects both with and without a body. when versioning is disabled directory objects work the same as before. after enabling versioning, always create .folder object (even for directory objects without a body). save xattr on .folder instead of directory itself. put object works the same as with other keys only that the .folder is treated as the file
2. if there was already directory content for this key in the old format: move the .folder(if it exist, if it doesn't create a new one) to the .version dir and move the noobaa external attributes to the file.
3. having the directory content external attribute on the directory is used to check if directory keys with the old format existed. for this reason after moving the old key to the .versions directory, remove the noobaa xattr from the directory 
4.  in case there was a key in the old format and a new object was created in suspended mode. override the old .folder and remove the old external attributes from the directory
5. added a configuration value to enable versioning for directory objects. should be false by default
6. added tests

### Issues: 
####GAPS
implement other commends

### Testing Instructions:
automatic:
`sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_bucketspace_versioning.js`

manual:
1. create new bucket
2. add directory objects with alternating versioning status
3. new objects should be in the bucket directory. old versions should be in the .versions directory under the bucket


- [ ] Doc added/updated
- [x] Tests added
