### PR TITLE
Return 405 for Get/Head Specific Delete-Marker

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1568,6 +1568,12 @@ function get_obj_id(req, rpc_code) {
  * @param {string} rpc_code
  */
 function check_object_mode(req, obj, rpc_code) {
+    if (obj && obj.delete_marker && req.rpc_params.version_id) {
+        throw new RpcError('METHOD_NOT_ALLOWED',
+            'Method not allowed, delete object id of entry delete marker',
+            { last_modified: obj.last_modified_time, delete_marker: true });
+    }
+
     if (!obj || obj.deleted || obj.delete_marker) {
         throw new RpcError(rpc_code,
             `No such object: obj_id ${req.rpc_params.obj_id} bucket ${req.rpc_params.bucket} key ${req.rpc_params.key}`);


### PR DESCRIPTION
If the specified version in the request is a delete marker the returned is 405 Method Not Allowed.

1. Create a versioned bucket and multiple versions of the object by copying the same object multiple times
 ```
   # nb-s3 mb s3://test-16
   # nb-s3 cp Makefile s3://test-16
```

2. delete the object
`nb-s3api delete-object --bucket test-16 --key Makefile`

3. Now head/get object with version id of the delete marker (list-object-versions will give the delete version marker id)

```
# nb-s3api head-object --bucket test-16 --key Makefile --version-id nbver-9
An error occurred (405) when calling the HeadObject operation: Method Not Allowed

```

Output:

Fixes: https://github.com/noobaa/noobaa-core/issues/8369

