### PR TITLE
[Backport into 5.18] generate_entropy() - Add Disks

### DIFF
--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -120,7 +120,9 @@ async function generate_entropy(loop_cond) {
                 const count = 32;
                 let disk;
                 let disk_size;
-                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda']) {
+                // this is as a temporary and partial solution -
+                // adding the NVMe disk with namespace
+                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda', '/dev/nvme0n1', '/dev/nvme1n1']) {
                     try {
                         const res = await async_exec(`blockdev --getsize64 ${disk}`);
                         disk_size = res.stdout;


### PR DESCRIPTION
### Explain the changes
1. [Backport into 5.18] generate_entropy() - Add Disks (see PR #8734)
