### PR TITLE
5.18 Backport | add nvme disks to generate_entropy()

### DIFF
--- a/src/util/nb_native.js
+++ b/src/util/nb_native.js
@@ -120,7 +120,9 @@ async function generate_entropy(loop_cond) {
                 const count = 32;
                 let disk;
                 let disk_size;
-                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda']) {
+                // this is as a temporary and partial solution -
+                // adding the NVMe disk with namespace
+                for (disk of ['/dev/sda', '/dev/vda', '/dev/xvda', '/dev/dasda', '/dev/nvme0n1', '/dev/nvme1n1']) {
                     try {
                         const res = await async_exec(`blockdev --getsize64 ${disk}`);
                         disk_size = res.stdout;


### PR DESCRIPTION
(cherry picked from commit eabccadc5ec974fcfef1f5abe1b8b4b30bfe1aea)

### Explain the changes
1. Backport to 5.18 of - https://github.com/noobaa/noobaa-core/pull/8734

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
