### PR TITLE
xml utils (for bucket notifications) - option for including array's key

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_notification.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_notification.js
@@ -49,5 +49,6 @@ module.exports = {
     },
     reply: {
         type: 'xml',
+        repeat_array_tags: true,
     },
 };

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -350,8 +350,8 @@ function send_reply(req, res, reply, options) {
             reply;
         // TODO: Refactor later on to support potential headers response and delayed XML body
         // This is done for the complete since we assign the XML header only in body prior to responding
-        const xml_reply = xml_utils.encode_xml(xml_root, /* ignore_header */ res.headersSent);
-        dbg.log1('HTTP REPLY XML', req.method, req.originalUrl,
+        const xml_reply = xml_utils.encode_xml(xml_root, /* ignore_header */ res.headersSent, options.reply.repeat_array_tags);
+        dbg.log0('HTTP REPLY XML', req.method, req.originalUrl,
             JSON.stringify(req.headers),
             xml_reply.length <= 2000 ?
             xml_reply : xml_reply.slice(0, 1000) + ' ... ' + xml_reply.slice(-1000));


### PR DESCRIPTION
### Explain the changes
1. Currently xml_utils.encode_xml() does not add a key per item in the array.
This causes mangled output for get-bucket-notif when more than once event is configured:
`<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TopicConfiguration><Event>s3:ObjectCreated:*s3:ObjectRemoved:Delete</Event><Topic>notif-secret/connect_http_c.json</Topic><Id>created_from_s3op_secret2</Id></TopicConfiguration></NotificationConfiguration>`

And aws cli output is:
```
{
    "TopicConfigurations": [
        {
            "Id": "created_from_s3op_secret2",
            "TopicArn": "notif-secret/connect_http_c.json",
            "Events": [
                "s3:ObjectCreated:*s3:ObjectRemoved:Delete"
            ]
        }
    ]
}
```


After change xml is with a tag per item in Event array:
`<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TopicConfiguration><Event>s3:ObjectCreated:*</Event><Event>s3:ObjectRemoved:Delete</Event><Topic>notif-secret/connect_http_c.json</Topic><Id>created_from_s3op_secret2</Id></TopicConfiguration></NotificationConfiguration>
`
And aws cli output is:

```
{
    "TopicConfigurations": [
        {
            "Id": "created_from_s3op_secret2",
            "TopicArn": "notif-secret/connect_http_c.json",
            "Events": [
                "s3:ObjectCreated:*
                 s3:ObjectRemoved:Delete"
            ]
        }
    ]
}
```

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-1507

### Testing Instructions:
1. Configure more than one event filtering in bucket notification.
2. Invoke get-bucket-notif.


- [ ] Doc added/updated
- [ ] Tests added
