### PR TITLE
NC | NSFS | CLI | Separate Bucket and Account List Functions

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -858,8 +858,9 @@ describe('manage nsfs cli bucket flow', () => {
             secret_key: 'G2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
         };
 
+        const bucket_name = 'bucket1';
         const bucket_defaults = {
-            name: 'bucket1',
+            name: bucket_name,
             owner: account_name,
             path: bucket_storage_path,
         };
@@ -901,11 +902,37 @@ describe('manage nsfs cli bucket flow', () => {
         });
 
         it('cli list filter by name (bucket1)', async () => {
-            const bucket_options = { config_root, name: 'bucket1' };
+            const bucket_options = { config_root, name: bucket_name };
             const action = ACTIONS.LIST;
             const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             expect(JSON.parse(res).response.reply.map(item => item.name))
-                .toEqual(expect.arrayContaining(['bucket1']));
+                .toEqual(expect.arrayContaining([bucket_name]));
+        });
+
+        it('cli list no flags - expect to see bucket1 only', async () => {
+            const bucket_options = { config_root };
+            const action = ACTIONS.LIST;
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            const buckets_arr = JSON.parse(res).response.reply.map(item => item.name);
+            expect(buckets_arr.length).toBe(1);
+            expect(buckets_arr[0]).toEqual(bucket_name);
+        });
+
+        it('cli list with flag wide - expect to see bucket1 with additional properties', async () => {
+            const bucket_options = { config_root, wide: true};
+            const action = ACTIONS.LIST;
+            const res = await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
+            const buckets_arr = JSON.parse(res).response.reply;
+            expect(buckets_arr.length).toBe(1);
+            expect(buckets_arr[0].name).toEqual(bucket_name);
+            // check additional properties in the output that we expect to see when using wide flag
+            expect(buckets_arr[0]._id).toBeDefined();
+            expect(buckets_arr[0].owner_account).toBeDefined();
+            expect(buckets_arr[0].versioning).toBeDefined();
+            expect(buckets_arr[0].creation_date).toBeDefined();
+            expect(buckets_arr[0].path).toBeDefined();
+            expect(buckets_arr[0].should_create_underlying_storage).toBeDefined();
+            expect(buckets_arr[0].bucket_owner).toBeDefined();
         });
 
     });


### PR DESCRIPTION
### Explain the changes
1. Separate the list function - from `list_config_files` to `list_bucket_config_files` and `list_account_config_files`.
2. Organize the file and add titles to the parts (buckets, accounts, etc.).
3. Move the functions `filter_bucket` and `list_bucket_config_files` under the buckets part, and move `list_connections` to the notifications part.
4. Remove the function `filter_list_item` as we use the functions `filter_account` and `filter_bucket` directly.
5. Added 2 cases in the file `test_nc_nsfs_bucket_cli.test.js` (after adding them I saw that we had them in the file `test_nc_nsfs_cli.js` but decided to keep them).
6. Fix a typo in a comment ("initialization").

### Issues:
1. It is a partial fix as a part of #8264 "In manage_nsfs: split the implementation of list config file to a function for accounts and a function for buckets.", and was done as step in #8104 that part of the solution would be to avoid decryption when there are issues related to the master key.

Gaps:
1. Rename CLI test files in Jest - I added in issue #8056 (was raised in [this comment](https://github.com/noobaa/noobaa-core/pull/8747#discussion_r1948108358)).

### Testing Instructions:
#### Automatic tests
Please run:
1. `sudo npx jest test_nc_nsfs_account_cli.test.js`
3. `sudo npx jest test_nc_nsfs_bucket_cli.test.js` (here 2 cases were added)
4. `sudo NC_CORETEST=true node node_modules/mocha/bin/mocha src/test/unit_tests/test_nc_nsfs_cli.js`

- [ ] Doc added/updated
- [X] Tests added
