### PR TITLE
CORS - Fixing max_age_seconds to number and not string

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_cors.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_cors.js
@@ -14,7 +14,7 @@ async function put_bucket_cors(req) {
             allowed_origins: rule.AllowedOrigin,
             expose_headers: rule.ExposeHeader,
             id: rule.ID,
-            max_age_seconds: rule.MaxAgeSeconds,
+            max_age_seconds: rule.MaxAgeSeconds && parseInt(rule.MaxAgeSeconds, 10),
         }, _.isUndefined)
     );
     await req.object_sdk.put_bucket_cors({

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -673,6 +673,7 @@ function set_cors_headers_s3(req, res, cors_rules) {
         }));
     if (matched_rule) {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
+        dbg.log0('set_cors_headers_s3: found matching CORS rule:', matched_rule);
         set_cors_headers(req, res, {
             allow_origin: matched_rule.allowed_origins.includes('*') ? '*' : req.headers.origin,
             allow_methods: matched_rule.allowed_methods.join(','),


### PR DESCRIPTION
### Explain the changes
1. fix max_age_seconds to be a number and not a string
2. add a print of the matched rule

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
