### PR TITLE
Notif backports

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_notification.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_notification.js
@@ -30,12 +30,6 @@ async function get_bucket_notification(req) {
         }
     }
 
-    if (result && result.length > 0) {
-        for (const conf of result) {
-            TopicConfiguration.push({TopicConfiguration: conf});
-        }
-    }
-
     const reply = result && result.length > 0 ?
         {
             //return result inside TopicConfiguration tag

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -364,9 +364,9 @@ async function test_notifications(notifs, nc_config_dir) {
             connect = await notificator.parse_connect_file(notif.topic[0]);
             connection = get_connection(connect);
             await connection.connect();
-            await connection.promise_notify({notif: "test notification"}, async (notif_cb, err_cb) => {
+            await connection.promise_notify({notif: "test notification"}, async (notif_cb, err_cb, err) => {
                 failure = true;
-                notif_failure = err_cb;
+                notif_failure = err;
             });
             if (failure) {
                 if (notif_failure) {


### PR DESCRIPTION
https://github.com/noobaa/noobaa-core/pull/8745
https://github.com/noobaa/noobaa-core/pull/8764

Also contains a fix to wrong merge that causes double output for get-bucket-notif.

Fixes:
https://issues.redhat.com/browse/DFBUGS-1507
https://github.com/noobaa/noobaa-core/issues/8759
https://github.com/noobaa/noobaa-core/issues/8760
https://github.com/noobaa/noobaa-core/issues/8761
