### PR TITLE
persistent logger (for bucket notifications) - don't log rename ENOENT if there were no failures

### DIFF
--- a/src/util/persistent_logger.js
+++ b/src/util/persistent_logger.js
@@ -198,7 +198,7 @@ class PersistentLogger {
 
             try {
                 // Finally replace the current active so as to consume them in the next iteration
-                await failure_log._replace_active();
+                await failure_log._replace_active(!result);
             } catch (error) {
                 dbg.error('failed to replace active failure log:', error, 'log_namespace:', this.namespace);
             }
@@ -208,14 +208,16 @@ class PersistentLogger {
         }
     }
 
-    async _replace_active() {
+    async _replace_active(log_noent) {
         const inactive_file = `${this.namespace}.${Date.now()}.log`;
         const inactive_file_path = path.join(this.dir, inactive_file);
 
         try {
             await nb_native().fs.rename(this.fs_context, this.active_path, inactive_file_path);
         } catch (error) {
-            dbg.warn('failed to rename active file:', error);
+            if (log_noent || error.code !== 'ENOENT') {
+                dbg.warn('failed to rename active file:', error);
+            }
         }
     }
 


### PR DESCRIPTION
### Explain the changes
1. If there were no failures during active persistent logger processing, the rename for the active failure file fails (because it's not there). Scale have opened a bug for this log.
This PR changes the rename to not log ENOENT in case there were no failures.
Let me know if you have other ideas.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8762

### Testing Instructions:
1. Run notifications with one successful notifications. No WARN for renaming of active failure log file should be logged.


- [ ] Doc added/updated
- [ ] Tests added
