### PR TITLE
NC | CLI | Fix for unsettable flags issues

### DIFF
--- a/docs/NooBaaNonContainerized/CI&Tests.md
+++ b/docs/NooBaaNonContainerized/CI&Tests.md
@@ -87,7 +87,7 @@ Run `NC mocha tests` with root permissions -
 
 #### NC mocha tests 
 The following is a list of `NC mocha test` files -   
-1. `test_nc_nsfs_cli.js` - Tests NooBaa CLI.  
+1. `test_nc_cli.js` - Tests NooBaa CLI.  
 2. `test_nc_health` - Tests NooBaa Health CLI.  
 3. `test_nsfs_glacier_backend.js` - Tests NooBaa Glacier Backend.  
 4. `test_nc_with_a_couple_of_forks.js` - Tests the `bucket_namespace_cache` when running with a couple of forks. Please notice that it uses `nc_coretest` with setup that includes a couple of forks.
@@ -99,7 +99,7 @@ The following is a list of `NC jest tests` files -
 2. `test_nc_master_keys.test.js` - Tests NC master key manager (store type = file).  
 3. `test_nc_master_keys_exec.test.js` - Tests NC master key manager (store type = executable).  
 4. `test_nc_nsfs_bucket_cli.test.js` - Tests NooBaa CLI bucket commands.  
-5. `test_nc_nsfs_account_cli.test.js` - Tests NooBaa CLI account commands.  
+5. `test_nc_account_cli.test.js` - Tests NooBaa CLI account commands.  
 6. `test_nc_nsfs_anonymous_cli.test.js` - Tests NooBaa CLI anonymous account commands.  
 7. `test_nc_nsfs_config_schema_validation.test.js` - Tests NC config.json schema validation.  
 8. `test_nc_nsfs_bucket_schema_validation.test.js` - Tests NC bucket schema validation.  

--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -168,11 +168,11 @@ noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--use
 
 - `supplemental_groups`
     - Type: String
-    - Description: Specifies additional FS groups (GID) a user can be a part of. Allows access to directories/files having one or more of the provided groups. A String of GIDs separated by commas. unset with ''
+    - Description: Specifies additional FS groups (GID) a user can be a part of. Allows access to directories/files having one or more of the provided groups. A String of GIDs separated by commas. Unset with ''.
 
 - `new_buckets_path` 
     - Type: String
-    - Description: Specifies a file system directory to be used for creating underlying directories that represent buckets created by an account using the S3 API.
+    - Description: Specifies a file system directory to be used for creating underlying directories that represent buckets created by an account using the S3 API. Unset with ''.
 
 - `regenerate`
     - Type: Boolean
@@ -189,7 +189,7 @@ noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--use
 - `fs_backend`
     - Type: String
     - Enum: none | GPFS | CEPH_FS | NFSv4
-    - Description: Specifies the file system of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND).
+    - Description: Specifies the file system of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND). Unset with ''.
 
 - `allow_bucket_creation`
     - Type: Boolean
@@ -197,7 +197,7 @@ noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--use
 
 - `force_md5_etag`
     - Type: Boolean
-    - Description: Set the account to force md5 ETag calculation.
+    - Description: Set the account to force md5 ETag calculation. Unset with ''.
 
 - `anonymous`
     - Type: Boolean
@@ -365,16 +365,16 @@ noobaa-cli bucket update --name <bucket_name> [--new_name] [--owner]
 
 - `bucket_policy`
     - Type: String
-    - Description: Set the bucket policy, type is a string of valid JSON policy.
+    - Description: Set the bucket policy, type is a string of valid JSON policy. Unset with ''.
 
 - `fs_backend`
     - Type: String
     - Enum: none | GPFS | CEPH_FS | NFSv4
-    - Description: Specifies the file system of the bucket (default config.NSFS_NC_STORAGE_BACKEND), unset with ''.
+    - Description: Specifies the file system of the bucket (default config.NSFS_NC_STORAGE_BACKEND), Unset with ''.
 
 - `force_md5_etag`
     - Type: Boolean
-    - Description: Set the bucket to force md5 ETag calculation.
+    - Description: Set the bucket to force md5 ETag calculation. Unset with ''.
 
 
 ### Bucket Status
@@ -441,7 +441,7 @@ noobaa-cli whitelist --ips <ips>
 #### Flags -
 - `ips` (Required)
     - Type: String
-    - Description: Specifies the white list of server IPs for S3 access. Example - '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]'
+    - Description: Specifies the white list of server IPs for S3 access. Example - '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]'. Unset with '[]'.
 
 
 ## Managing Glacier

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -92,6 +92,12 @@ ManageCLIError.InvalidArgumentType = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.UnsetArgumentIsInvalid = Object.freeze({
+    code: 'UnsetArgumentIsInvalid',
+    message: 'Argument can not be unset or it was unset incorrectly, its value must be set or unset correctly or check there are no leading spaces',
+    http_code: 400,
+});
+
 ManageCLIError.InvalidType = Object.freeze({
     code: 'InvalidType',
     message: 'Invalid type, available types are account, bucket, logging, whitelist, upgrade, notification or connection.',

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -164,8 +164,21 @@ const BOOLEAN_STRING_VALUES = ['true', 'false'];
 const BOOLEAN_STRING_OPTIONS = new Set(['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force',
     'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous']);
 
-//options that can be unset using ''
-const LIST_UNSETABLE_OPTIONS = ['fs_backend', 's3_policy', 'force_md5_etag'];
+// CLI UNSET VALUES
+const CLI_EMPTY_STRING = '';
+const CLI_EMPTY_STRING_ARRAY = '[]';
+
+const CLI_EMPTY_VALUES = new Set([CLI_EMPTY_STRING, CLI_EMPTY_STRING_ARRAY]);
+
+// options that can be unset using '' / '[]'
+const UNSETTABLE_OPTIONS_OBJ = Object.freeze({
+    'fs_backend': CLI_EMPTY_STRING,
+    'bucket_policy': CLI_EMPTY_STRING,
+    'force_md5_etag': CLI_EMPTY_STRING,
+    'supplemental_groups': CLI_EMPTY_STRING,
+    'new_buckets_path': CLI_EMPTY_STRING,
+    'ips': CLI_EMPTY_STRING_ARRAY,
+});
 
 const LIST_ACCOUNT_FILTERS = ['uid', 'gid', 'user', 'name', 'access_key'];
 const LIST_BUCKET_FILTERS = ['name'];
@@ -181,7 +194,10 @@ exports.OPTION_TYPE = OPTION_TYPE;
 exports.FROM_FILE = FROM_FILE;
 exports.BOOLEAN_STRING_VALUES = BOOLEAN_STRING_VALUES;
 exports.BOOLEAN_STRING_OPTIONS = BOOLEAN_STRING_OPTIONS;
-exports.LIST_UNSETABLE_OPTIONS = LIST_UNSETABLE_OPTIONS;
+exports.UNSETTABLE_OPTIONS_OBJ = UNSETTABLE_OPTIONS_OBJ;
+exports.CLI_EMPTY_VALUES = CLI_EMPTY_VALUES;
+exports.CLI_EMPTY_STRING = CLI_EMPTY_STRING;
+exports.CLI_EMPTY_STRING_ARRAY = CLI_EMPTY_STRING_ARRAY;
 
 exports.LIST_ACCOUNT_FILTERS = LIST_ACCOUNT_FILTERS;
 exports.LIST_BUCKET_FILTERS = LIST_BUCKET_FILTERS;

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -98,7 +98,7 @@ Usage:
 
 Flags:
 
-    --ips <string>                                          Set configuring for allowed IP addresses; format: '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]'
+    --ips <string>                                          Set configuring for allowed IP addresses; format: '["127.0.0.1", "192.0.10.0", "3002:0bd6:0000:0000:0000:ee00:0033:6778"]', unset using '[]'
 
 `;
 
@@ -161,12 +161,12 @@ Flags:
     --uid <number>                                        (optional)        Update the User Identifier (UID)
     --gid <number>                                        (optional)        Update the Group Identifier (GID)
     --supplemental_groups <string>                        (optional)        Update the list of supplemental groups (List of GID) seperated by comma(,) example: 211,202,23 - it will override existing list (unset with '')
-    --new_buckets_path <string>                           (optional)        Update the filesystem's root path where each subdirectory is a bucket
+    --new_buckets_path <string>                           (optional)        Update the filesystem's root path where each subdirectory is a bucket (unset with '')
     --user <string>                                       (optional)        Update the OS user name (instead of uid and gid)
     --regenerate                                          (optional)        Update automatically generated access key and secret key
     --access_key <string>                                 (optional)        Update the access key
     --secret_key <string>                                 (optional)        Update the secret key
-    --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND)
+    --fs_backend <none | GPFS | CEPH_FS | NFSv4>          (optional)        Update the filesystem type of new_buckets_path (default config.NSFS_NC_STORAGE_BACKEND), (unset with '')
     --allow_bucket_creation <true | false>                (optional)        Update the account to explicitly allow or block bucket creation
     --force_md5_etag <true | false>                       (optional)        Update the account to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
     --iam_operate_on_root_account <true | false>          (optional)        Update the account to create root accounts instead of IAM users in IAM API requests.

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -22,6 +22,9 @@ const IS_GPFS = !_.isUndefined(GPFS_ROOT_PATH);
 const TMP_PATH = get_tmp_path();
 const TEST_TIMEOUT = 60 * 1000;
 
+// NC CLI Constants
+const CLI_UNSET_EMPTY_STRING = "''";
+
 /**
  * TMP_PATH is a path to the tmp path based on the process platform
  * in contrast to linux, /tmp/ path on mac is a symlink to /private/tmp/
@@ -814,3 +817,4 @@ exports.update_system_json = update_system_json;
 exports.fail_test_if_default_config_dir_exists = fail_test_if_default_config_dir_exists;
 exports.create_config_dir = create_config_dir;
 exports.clean_config_dir = clean_config_dir;
+exports.CLI_UNSET_EMPTY_STRING = CLI_UNSET_EMPTY_STRING;

--- a/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_nsfs_bucket_cli.test.js
@@ -9,7 +9,7 @@ const path = require('path');
 const os_util = require('../../../util/os_utils');
 const fs_utils = require('../../../util/fs_utils');
 const { ConfigFS } = require('../../../sdk/config_fs');
-const { set_path_permissions_and_owner, TMP_PATH, generate_s3_policy,
+const { set_path_permissions_and_owner, TMP_PATH, generate_s3_policy, CLI_UNSET_EMPTY_STRING,
     set_nc_config_dir_in_config } = require('../../system_tests/test_utils');
 const { ACTIONS, TYPES } = require('../../../manage_nsfs/manage_nsfs_constants');
 const { get_process_fs_context, is_path_exists, get_bucket_tmpdir_full_path } = require('../../../util/native_fs_utils');
@@ -505,8 +505,7 @@ describe('manage nsfs cli bucket flow', () => {
             expect(bucket_config.force_md5_etag).toBe(true);
 
             // unset force_md5_etag
-            const empty_string = '\'\'';
-            bucket_options.force_md5_etag = empty_string;
+            bucket_options.force_md5_etag = CLI_UNSET_EMPTY_STRING;
             await exec_manage_cli(TYPES.BUCKET, action, bucket_options);
             bucket_config = await config_fs.get_bucket_by_name(bucket_defaults.name);
             expect(bucket_config.force_md5_etag).toBeUndefined();

--- a/src/test/unit_tests/nc_index.js
+++ b/src/test/unit_tests/nc_index.js
@@ -9,7 +9,7 @@ require('./test_namespace_fs');
 require('./test_ns_list_objects');
 require('./test_namespace_fs_mpu');
 require('./test_nb_native_fs');
-require('./test_nc_nsfs_cli');
+require('./test_nc_cli');
 require('./test_nc_health');
 require('./test_nsfs_access');
 require('./test_nsfs_integration');

--- a/src/test/unit_tests/sudo_index.js
+++ b/src/test/unit_tests/sudo_index.js
@@ -20,6 +20,6 @@ require('./test_nsfs_integration');
 require('./test_bucketspace_versioning');
 require('./test_bucketspace_fs');
 require('./test_nsfs_versioning');
-require('./test_nc_nsfs_cli');
+require('./test_nc_cli');
 require('./test_nc_health');
 

--- a/src/test/unit_tests/test_nc_cli.js
+++ b/src/test/unit_tests/test_nc_cli.js
@@ -991,16 +991,25 @@ mocha.describe('manage_nsfs cli', function() {
             assert_whitelist(config_data, config_options);
         });
 
-        mocha.it('cli whitelist ips is empty', async function() {
+        mocha.it('should fail - cli whitelist ips is an empty string', async function() {
             try {
                 await exec_manage_cli(type, '', { config_root, ips: '' });
                 assert.fail('should have failed with whitelist ips should not be empty.');
             } catch (err) {
-                assert_error(err, ManageCLIError.InvalidWhiteListIPFormat);
+                assert_error(err, ManageCLIError.UnsetArgumentIsInvalid);
             }
         });
 
-        mocha.it('cli whitelist formate is invalid', async function() {
+        mocha.it('cli whitelist ips is empty array', async function() {
+            const ips = [];
+            const res = await exec_manage_cli(type, '', { config_root, ips: JSON.stringify(ips) });
+            config_options.S3_SERVER_IP_WHITELIST = ips;
+            const config_data = await config_fs.get_config_json();
+            await assert_response('', type, res, ips);
+            assert_whitelist(config_data, config_options);
+        });
+
+        mocha.it('should fail - cli whitelist format is invalid', async function() {
             try {
                 const ips = ['127.0.0.1'];
                 const ip_list_invalid_format = JSON.stringify(ips) + 'invalid';
@@ -1011,7 +1020,7 @@ mocha.describe('manage_nsfs cli', function() {
             }
         });
 
-        mocha.it('cli whitelist has invalid IP address (one item in the list)', async function() {
+        mocha.it('should fail - cli whitelist has invalid IP address (one item in the list)', async function() {
             const ip_list_with_invalid_ip_address = ['10.1.11']; // missing a class in the IP address
             try {
                 await exec_manage_cli(type, '', { config_root, ips: ip_list_with_invalid_ip_address});
@@ -1021,7 +1030,7 @@ mocha.describe('manage_nsfs cli', function() {
             }
         });
 
-        mocha.it('cli whitelist has invalid IP address (a couple of items in the list)', async function() {
+        mocha.it('should fail - cli whitelist has invalid IP address (a couple of items in the list)', async function() {
             const invalid_ip_address = '10.1.11'; // missing a class in the IP address
             const ips = ['127.0.0.1', '::ffff:7f00:3', '0000:0000:0000:0000:0000:ffff:7f00:0002'];
             ips.push(invalid_ip_address);
@@ -1033,7 +1042,7 @@ mocha.describe('manage_nsfs cli', function() {
             }
         });
 
-        mocha.it('cli whitelist with invalid option', async function() {
+        mocha.it('should fail -  cli whitelist with invalid option', async function() {
             const ips = ['127.0.0.1']; // IPV4 format
             try {
                 await exec_manage_cli(type, '', {


### PR DESCRIPTION
### Explain the changes
This PR fixes 3 issues with CLI unsettable flags and a tiny test rename refactoring - 
1. We checked if a flag can be unsettable only if the expected type of the flag value and the actual type of value didn't match, but this is not the case when the flag type and value's type match - we should always check it.
2. The list `LIST_UNSETABLE_OPTIONS` was missing some flags that were supposed to be included in it and be checked, their check passed because their type was string (See bullet 1).
The missing options were new_buckets_path (was missing also in the help) and supplemental_groups.
3. The list `LIST_UNSETABLE_OPTIONS` consisted s3_policy flag which does not exist, changed it to bucket_policy.
4. Renamed `test_nc_nsfs_account_cli.test.js -> test_nc_account_cli.test.js` and it's references.

** Found this bug during the reviewing of - https://github.com/noobaa/noobaa-core/pull/8722, hopefully it can help @achouhan09 with the comment https://github.com/noobaa/noobaa-core/pull/8722#discussion_r1944544541

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [x] Doc added/updated
- [x] Tests added
