### PR TITLE
NC | `generate_entropy` Using `lsblk` Command

### DIFF
--- a/config.js
+++ b/config.js
@@ -1009,6 +1009,9 @@ config.NC_DISABLE_HEALTH_ACCESS_CHECK = false;
 config.NC_DISABLE_POSIX_MODE_ACCESS_CHECK = true;
 config.NC_DISABLE_SCHEMA_CHECK = false;
 
+config.ENTROPY_DISK_SIZE_THRESHOLD = 100 * 1024 * 1024;
+config.ENTROPY_MIN_THRESHOLD = 512;
+
 ////////// NC LIFECYLE  //////////
 
 config.NC_LIFECYCLE_LOGS_DIR = '/var/log/noobaa/lifecycle';

--- a/src/test/unit_tests/jest_tests/test_entropy_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_entropy_utils.test.js
@@ -1,0 +1,80 @@
+/* Copyright (C) 2025 NooBaa */
+'use strict';
+
+const config = require('../../../../config');
+const entropy_utils = require('../../../util/entropy_utils');
+
+describe('entropy_utils', () => {
+
+    describe('get_block_device_disk_info', () => {
+
+        it('(on Linux) should return array of disk devices that their names starts with ' +
+            '/dev/, and their size it a number in bytes ' +
+            '(else) empty array', async () => {
+            const res = await entropy_utils.get_block_device_disk_info();
+            expect(Array.isArray(res)).toBe(true);
+            const is_linux = process.platform === 'linux';
+            console.log('is_linux', is_linux, ' entropy_utils.get_block_device_disk_info res', res);
+            if (is_linux) {
+                res.forEach(item => {
+                    expect(item.name.startsWith('/dev/')).toBe(true);
+                    expect(typeof(item.size)).toBe('number');
+                });
+            } else {
+                expect(res.length).toBe(0);
+            }
+        });
+
+    });
+
+    describe('pick_a_disk', () => {
+
+        it('should return sd disk with size greater than 100 MiB', async () => {
+            const mock_arr = [
+                { name: '/dev/sda', size: config.ENTROPY_DISK_SIZE_THRESHOLD + 1 },
+                { name: '/dev/vda', size: 5 } // size too small
+            ];
+            const res = await entropy_utils.pick_a_disk(mock_arr);
+            expect(res.name.startsWith('/dev/sd')).toBe(true);
+            expect(res.size).toBeGreaterThan(config.ENTROPY_DISK_SIZE_THRESHOLD);
+        });
+
+        it('should return vd disk with size greater than 100 MiB', async () => {
+            const mock_arr = [
+                 {name: '/dev/sda', size: 5 }, // size too small
+                { name: '/dev/vda', size: config.ENTROPY_DISK_SIZE_THRESHOLD + 1 }];
+            const res = await entropy_utils.pick_a_disk(mock_arr);
+            expect(res.name.startsWith('/dev/vd')).toBe(true);
+            expect(res.size).toBeGreaterThan(config.ENTROPY_DISK_SIZE_THRESHOLD);
+        });
+
+        it('should return nvme disk with size greater than 100 MiB', async () => {
+            const mock_arr = [
+                { name: '/dev/nvme1n1', size: config.ENTROPY_DISK_SIZE_THRESHOLD + 1 },
+                { name: '/dev/some_disk', size: config.ENTROPY_DISK_SIZE_THRESHOLD + 1 } // name is not in whitelist
+            ];
+            const res = await entropy_utils.pick_a_disk(mock_arr);
+            expect(res.name.startsWith('/dev/nvme')).toBe(true);
+            expect(res.size).toBeGreaterThan(config.ENTROPY_DISK_SIZE_THRESHOLD);
+        });
+
+        it('should return undefined', async () => {
+            const mock_arr = [
+                { name: '/dev/sda', size: config.ENTROPY_DISK_SIZE_THRESHOLD - 1 }, // size too small
+                { name: '/dev/vda', size: config.ENTROPY_DISK_SIZE_THRESHOLD - 1 } // size too small
+            ];
+            const res = await entropy_utils.pick_a_disk(mock_arr);
+            expect(res).toBeUndefined();
+        });
+
+        it('should return vd disk with size greater than 100 MiB', async () => {
+            const mock_arr = [
+                { name: '/dev/vda', size: config.ENTROPY_DISK_SIZE_THRESHOLD + 1 },
+                { name: '/dev/nvme1n1', size: config.ENTROPY_DISK_SIZE_THRESHOLD + 1 }
+            ];
+            const res = await entropy_utils.pick_a_disk(mock_arr);
+            expect(res.name.startsWith('/dev/vda')).toBe(true); // vd in higher priority than nvme
+            expect(res.size).toBeGreaterThan(config.ENTROPY_DISK_SIZE_THRESHOLD);
+        });
+    });
+});

--- a/src/util/entropy_utils.js
+++ b/src/util/entropy_utils.js
@@ -1,0 +1,138 @@
+/* Copyright (C) 2025 NooBaa */
+'use strict';
+
+const fs = require('fs');
+const util = require('util');
+const chance = require('chance')();
+const child_process = require('child_process');
+const config = require('../../config');
+const blockutils = require('linux-blockutils');
+
+const DEVICE_TYPE_DISK = 'disk';
+
+const async_delay = util.promisify(setTimeout);
+const async_exec = util.promisify(child_process.exec);
+const get_block_info_async = util.promisify(blockutils.getBlockInfo);
+
+/**
+ * generate_entropy will create randomness by changing the MD5
+ * using information from the device (disk)
+ * it will run as long as the callback it true
+ * @param {() => Boolean} loop_cond
+ */
+async function generate_entropy(loop_cond) {
+    if (process.platform !== 'linux' || process.env.container === 'docker') return;
+    while (loop_cond()) {
+        try {
+            await async_delay(1000);
+
+            // most likely we will read from the disk for no reason at all as the caller
+            // already finished initializing its randomness
+            if (loop_cond()) break;
+
+            const ENTROPY_AVAIL_PATH = '/proc/sys/kernel/random/entropy_avail';
+            const entropy_avail = parseInt(await fs.promises.readFile(ENTROPY_AVAIL_PATH, 'utf8'), 10);
+            console.log(`generate_entropy: entropy_avail ${entropy_avail}`);
+            if (entropy_avail >= config.ENTROPY_MIN_THRESHOLD) return;
+            const available_disks = await get_block_device_disk_info();
+            const disk_details = pick_a_disk(available_disks);
+            if (disk_details) {
+                await generate_entropy_from_disk(disk_details.name, disk_details.size);
+            } else {
+                throw new Error('No disk candidates found');
+            }
+        } catch (err) {
+            // we intentionally don't print the error
+            // as console.err/warm and the error with stack trace
+            // as the generate_entropy is our best effort to generate entropy
+            // until Linux will finally do it
+            console.log('generate_entropy: retrying');
+        }
+    }
+}
+
+/**
+ * get_block_device_disk_info
+ * (on Linux) will return array of disk devices
+ *            that their names starts with /dev/
+ *            and their size it a number in bytes
+ * (else) will return an empty array
+ * Note: under the hood it uses blockutils.getBlockInfo which calls lsblk command
+ *       we used the option onlyStandard for parsing "disk" and "part" entries
+ *       reference: https://github.com/mw-white/node-linux-blockutils
+ * @returns {Promise<object[]>}
+ */
+async function get_block_device_disk_info() {
+    const is_linux = process.platform === 'linux';
+    if (!is_linux) return [];
+
+    const block_devices = await get_block_info_async({ onlyStandard: true });
+    if (!block_devices) return [];
+
+    const available_disks = [];
+    for (const block_device of block_devices) {
+        if (block_device.TYPE === DEVICE_TYPE_DISK) {
+            available_disks.push({
+                name: `/dev/${block_device.NAME}`,
+                size: Number(block_device.SIZE),
+            });
+        }
+    }
+    return available_disks;
+}
+
+/**
+ * pick_a_disk will pick a disk that:
+ *  - The disk name is in the disk_order_by_priority array - the lower index in the array the higher priority
+ *  - Its size is higher than config.ENTROPY_DISK_SIZE_THRESHOLD
+ * 
+ * The item that is returned is an object with properties: name, size and priority
+ * (we could delete the priority property as it is used only inside this function)
+ * 
+ * if none matches then it would return undefined
+ * @param {object[]} available_disks
+ * @returns {object | undefined}
+ */
+function pick_a_disk(available_disks) {
+    // the disk_order_by_priority array is the whitelist and also sets the priority
+    // (0 index highest priority, n-1 index lowest priority)
+    // note: we decided on the order according to previous implantation we had in the past
+    // as it added in patches we might want to reconsider it
+    const disk_order_by_priority = ['/dev/sd', '/dev/vd', '/dev/xvd', 'dev/dasd', '/dev/nvme'];
+    const priority_disk_array = [];
+    for (const disk of available_disks) {
+        if (disk.size > config.ENTROPY_DISK_SIZE_THRESHOLD) {
+            for (let index = 0; index < disk_order_by_priority.length; index++) {
+                const prefix = disk_order_by_priority[index];
+                if (disk.name.startsWith(prefix)) {
+                    disk.priority = index;
+                    priority_disk_array.push(disk);
+                }
+            }
+        }
+    }
+    // sort the array based on the priority
+    const sorted_priority_disk_array = priority_disk_array.sort((item1, item2) => item1.priority - item2.priority);
+    const first_element = sorted_priority_disk_array.length > 0 ? sorted_priority_disk_array[0] : undefined;
+    return first_element;
+}
+
+/**
+ * generate_entropy_from_disk will execute dd command which pipes to md5sum
+ * in order to get the MD5 hash to change
+ * @param {string} disk_name
+ * @param {number} disk_size
+ */
+async function generate_entropy_from_disk(disk_name, disk_size) {
+    const bs = 1024 * 1024;
+    const count = 32;
+    const disk_size_in_blocks = disk_size / bs;
+    const skip = chance.integer({ min: 0, max: disk_size_in_blocks - 1}); // reduce 1 from the max because the range is inclusive in chance.integer()
+    console.log(`generate_entropy_from_disk: adding entropy: dd if=${disk_name} bs=${bs} count=${count} skip=${skip} | md5sum`);
+    await async_exec(`dd if=${disk_name} bs=${bs} count=${count} skip=${skip} | md5sum`);
+}
+
+exports.generate_entropy = generate_entropy;
+exports.get_block_device_disk_info = get_block_device_disk_info;
+exports.pick_a_disk = pick_a_disk;
+exports.generate_entropy_from_disk = generate_entropy_from_disk;


### PR DESCRIPTION
### Explain the changes
Create the file `entropy_utils.js` and separate functions:
1. Move the `generate_entropy` with changes:
   - change the condition `if (entropy_avail < 512)` to `if (entropy_avail >= 512) return;` (the constant 512 moved to the config) to avoid additional nested layer. 
   - Add the `if (loop_cond()) break;` to avoid redundant disk read (see comment).
   - Change the printing to not have the error stuck (see comment).
 2. `get_block_device_disk_info` which is based on `get_block_device_sizes` from `os_utils` - I couldn't add it there as it would create a circular dependency
 3. `pick_a_disk` instead of using a static array, and get the size with `blockdev --getsize64` we would use `lsblk` command (which is implemented in `blockutils.getBlockInfo`) and create a priority list and minimum size of the disk.
4. `generate_entropy_from_disk` (copied from original code with a change - in `skip` see comment about it).

### Issues: Fixed #8598
1. Currently there is an array of hard-coded disk names. In PR #8734 we added a partial solution and added 2 disk names to the array. Still, it is not enough as there might be a disk that was not in the array, and there might be a situation where the NVMe disk changes its namespace (from 1 to 2 for example), and then it is not in the array of the disk names (we have `/dev/nvme0n1`).
Note: In the past we also had PR #8600 which was replaced by PR #8734.

### Testing Instructions:
#### Automatic Test:
Please run: `npx jest test_entropy_utils.test.js` (notice that `get_block_device_disk_info` should be run on a Linux machine).

For example this is the output in the CI of the added printing in the test:
`is_linux true  entropy_utils.get_block_device_disk_info res [ { name: '/dev/sda', size: 80530636800 }, { name: '/dev/sdb', size: 80530636800 } ]`

#### Manual Test
In case you don't have a Linux machine you can use a noobaa system running on k8s/OCP connect to the pod and test the basic used function:
1. Connect to the pod core: `kubectl exec -it $(kubectl get pods -n <namespace> | grep core | awk '{ print $1}') -n <namespace> -- bash`
2. Move to the directory of the code: `cd /root/node_modules/noobaa-core/`
3. Use node RPL: `node`
4. Run the following:
  - `const blockutils = require('linux-blockutils');`
  - `const get_block_info_async = util.promisify(blockutils.getBlockInfo);`
  - `const block_devices = await get_block_info_async({ onlyStandard: true });`
  - `console.log(block_devices)`

Example output:
```
[
  {
    NAME: 'vda',
    KNAME: 'vda',
    FSTYPE: '',
    LABEL: '',
    UUID: '',
    RO: '1',
    RM: '0',
    MODEL: '',
    SIZE: '246566912',
    STATE: '',
    TYPE: 'disk',
    PARTITIONS: [ [Object], [Object], [Object] ]
  },
  {
    NAME: 'vdb',
    KNAME: 'vdb',
    FSTYPE: '',
    LABEL: '',
    UUID: '',
    RO: '0',
    RM: '0',
    MODEL: '',
    SIZE: '107374182400',
    STATE: '',
    TYPE: 'disk',
    PARTITIONS: [ [Object] ]
  }
]
```

### Useful Links:
1. The library that we used (which uses `lsblk`) - [node-linux-blockutils](https://github.com/mw-white/node-linux-blockutils).
2. `lsblk` [command man](https://man7.org/linux/man-pages/man8/lsblk.8.html) (as we thought at the beginning to use it directly without the mentioned library mentioned above).

- [ ] Doc added/updated
- [X] Tests added
