### PR TITLE
NC | CLI | List Accounts When Decrypt Access Keys Fails

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -597,6 +597,10 @@ async function list_account_config_files(wide, show_secrets, filters = {}) {
     const options = {
         show_secrets: show_secrets || should_filter,
         decrypt_secret_key: show_secrets,
+        // in case we have an error on secret_key decryption 
+        // we will neither return the secret_key nor the encrypted_secret_key
+        // and add the property of decryption_err with the error we had
+        return_on_decryption_error: true,
         silent_if_missing: true
     };
 

--- a/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_invalid_mkm_integration.test.js
@@ -11,19 +11,29 @@ const { exec_manage_cli, set_path_permissions_and_owner, TMP_PATH, set_nc_config
 const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const ManageCLIError = require('../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
+const { get_process_fs_context } = require('../../../util/native_fs_utils');
+const nb_native = require('../../../util/nb_native');
 
 const tmp_fs_path = path.join(TMP_PATH, 'test_nc_invalid_mkm_integration');
 const config_root = path.join(tmp_fs_path, 'config_root_account_mkm_integration');
 const root_path = path.join(tmp_fs_path, 'root_path_account_mkm_integration/');
-const defaults = {
-    _id: 'account1',
+const defaults_account1 = {
     type: TYPES.ACCOUNT,
     name: 'account1',
-    new_buckets_path: `${root_path}new_buckets_path_mkm_integration/`,
-    uid: 999,
-    gid: 999,
+    new_buckets_path: `${root_path}new_buckets_path_mkm_integration_account1/`,
+    uid: 1001,
+    gid: 1001,
     access_key: 'GIGiFAnjaaE7OKD5N7hA',
     secret_key: 'U2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
+};
+const defaults_account2 = {
+    type: TYPES.ACCOUNT,
+    name: 'account2',
+    new_buckets_path: `${root_path}new_buckets_path_mkm_integration_account2/`,
+    uid: 1002,
+    gid: 1002,
+    access_key: 'HIHiFAnjaaE7OKD5N7hA',
+    secret_key: 'U3BYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
 };
 
 describe('manage nsfs cli account flow + fauly master key flow', () => {
@@ -49,13 +59,13 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
         });
 
         it('cli account list', async () => {
-            const { name } = defaults;
+            const { name } = defaults_account1;
             const list_res = await list_account_flow();
             expect(list_res.response.reply[0].name).toBe(name);
         });
 
         it('cli account status', async () => {
-            const { name, uid, gid, new_buckets_path } = defaults;
+            const { name, uid, gid, new_buckets_path } = defaults_account1;
             const status_res = await status_account();
             expect(status_res.response.reply.name).toBe(name);
             expect(status_res.response.reply.email).toBe(name);
@@ -99,7 +109,7 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
 
         it('should fail | cli create account', async () => {
             try {
-                await create_account({ ...defaults, name: 'account_corrupted_mk' });
+                await create_account({ ...defaults_account1, name: 'account_corrupted_mk' });
                 fail('should have failed with InvalidMasterKey');
             } catch (err) {
                 expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
@@ -116,13 +126,13 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
         });
 
         it('cli account list', async () => {
-            const { name } = defaults;
+            const { name } = defaults_account1;
             const list_res = await list_account_flow();
             expect(list_res.response.reply[0].name).toBe(name);
         });
 
         it('cli account status', async () => {
-            const { name, uid, gid, new_buckets_path } = defaults;
+            const { name, uid, gid, new_buckets_path } = defaults_account1;
             const status_res = await status_account();
             expect(status_res.response.reply.name).toBe(name);
             expect(status_res.response.reply.email).toBe(name);
@@ -165,7 +175,7 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
 
         it('should fail | cli create account', async () => {
             try {
-                await create_account({ ...defaults, name: 'account_corrupted_mk' });
+                await create_account({ ...defaults_account1, name: 'account_corrupted_mk' });
                 fail('should have failed with InvalidMasterKey');
             } catch (err) {
                 expect(JSON.parse(err.stdout).error.code).toBe(ManageCLIError.InvalidMasterKey.code);
@@ -182,13 +192,13 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
         });
 
         it('cli account list', async () => {
-            const { name } = defaults;
+            const { name } = defaults_account1;
             const list_res = await list_account_flow();
             expect(list_res.response.reply[0].name).toBe(name);
         });
 
         it('cli account status', async () => {
-            const { name, uid, gid, new_buckets_path } = defaults;
+            const { name, uid, gid, new_buckets_path } = defaults_account1;
             const status_res = await status_account();
             expect(status_res.response.reply.name).toBe(name);
             expect(status_res.response.reply.email).toBe(name);
@@ -211,6 +221,34 @@ describe('manage nsfs cli account flow + fauly master key flow', () => {
             expect(delete_res.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
         });
     });
+
+    describe('cli with renamed master key file (invalid)', () => {
+        const type = TYPES.ACCOUNT;
+
+        beforeEach(async () => {
+            await setup_nc_system_and_first_account();
+            await setup_account(defaults_account2);
+            await master_key_file_rename(true);
+        });
+
+        afterEach(async () => {
+            await master_key_file_rename(false);
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('cli list with wide and show_secrets flags (will show encrypted_secret_key and warning property)', async () => {
+            const action = ACTIONS.LIST;
+            const account_options = { config_root, wide: true, show_secrets: true };
+            const res = await exec_manage_cli(type, action, account_options);
+            const account_array_res = JSON.parse(res).response.reply;
+            for (const account_res of account_array_res) {
+                expect(account_res.access_keys[0].encrypted_secret_key).toBeUndefined();
+                expect(account_res.access_keys[0].secret_key).toBeUndefined();
+                expect(account_res.decryption_err).toBeDefined();
+            }
+        });
+    });
 });
 
 async function create_account(account_options) {
@@ -224,7 +262,7 @@ async function create_account(account_options) {
 
 async function update_account() {
     const action = ACTIONS.UPDATE;
-    const { type, name, new_buckets_path } = defaults;
+    const { type, name, new_buckets_path } = defaults_account1;
     const new_uid = '1111';
     const account_options = { config_root, name, new_buckets_path, uid: new_uid };
     const res = await exec_manage_cli(type, action, account_options);
@@ -234,7 +272,7 @@ async function update_account() {
 
 async function status_account(show_secrets) {
     const action = ACTIONS.STATUS;
-    const { type, name } = defaults;
+    const { type, name } = defaults_account1;
     const account_options = { config_root, name, show_secrets };
     const res = await exec_manage_cli(type, action, account_options);
     const parsed_res = JSON.parse(res);
@@ -243,7 +281,7 @@ async function status_account(show_secrets) {
 
 async function list_account_flow() {
     const action = ACTIONS.LIST;
-    const { type } = defaults;
+    const { type } = defaults_account1;
     const account_options = { config_root };
     const res = await exec_manage_cli(type, action, account_options);
     const parsed_res = JSON.parse(res);
@@ -252,7 +290,7 @@ async function list_account_flow() {
 
 async function delete_account_flow() {
     const action = ACTIONS.DELETE;
-    const { type, name } = defaults;
+    const { type, name } = defaults_account1;
     const account_options = { config_root, name };
     const res = await exec_manage_cli(type, action, account_options);
     const parsed_res = JSON.parse(res);
@@ -269,11 +307,34 @@ function fail(reason) {
 async function setup_nc_system_and_first_account() {
     await fs_utils.create_fresh_path(root_path);
     set_nc_config_dir_in_config(config_root);
+    await setup_account(defaults_account1);
+}
+
+async function setup_account(account_defaults) {
     const action = ACTIONS.ADD;
-    const { type, name, new_buckets_path, uid, gid } = defaults;
+    const { type, name, new_buckets_path, uid, gid } = account_defaults;
     const account_options = { config_root, name, new_buckets_path, uid, gid };
     await fs_utils.create_fresh_path(new_buckets_path);
     await fs_utils.file_must_exist(new_buckets_path);
     await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
     await exec_manage_cli(type, action, account_options);
+}
+
+
+/**
+ * master_key_file_rename will rename the master_keys.json file
+ * to mock a situation where master_key_id points to a missing master key
+ * use the to_rename_temp false to rename it back (after the test)
+ * @param {boolean} to_rename_temp
+ */
+async function master_key_file_rename(to_rename_temp) {
+    const default_fs_config = get_process_fs_context();
+    const source_path = path.join(config_root, 'master_keys.json');
+    const dest_path = path.join(config_root, 'temp_master_keys.json');
+    // eliminate the master key file by renaming it
+    if (to_rename_temp) {
+        await nb_native().fs.rename(default_fs_config, source_path, dest_path);
+    } else {
+        await nb_native().fs.rename(default_fs_config, dest_path, source_path);
+    }
 }


### PR DESCRIPTION
### Explain the changes
1. In account list add additional option of `return_encrypted_on_decryption_error` and we will neither return the `secret_key` nor the `encrypted_secret_key` in case of failure of access keys decryption.
2. In the function `get_identity_config_data` add a case in  try-catch clause for the decryption failure and add the property of `decryption_err` in case there was failure of access keys decryption that is related to `INVALID_MASTER_KEY` and remove the `encrypted_secret_key` property (added a helper function for that).
3. Small refactors in file `test_nc_account_invalid_mkm_integration.test.js` so we can add additional account and rename the file `master_keys.json` for the test.

### Issues:
1. It is a partial fix related to issue #8104 - this fix only handles the list account CLI with decrypt issue.

### Testing Instructions:
#### Automatic Tests:
Please run:
- `sudo npx jest test_nc_account_invalid_mkm_integration.test.js -t 'cli with renamed master key file'`
- `npx jest test_config_fs.test.js -t 'remove_encrypted_secret_key'`

#### Manual Tests
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`.
3. Make the master key invalid by renaming the file `master_key.json`: `sudo mv /etc/noobaa.conf.d/master_keys.json /etc/noobaa.conf.d/temp_master_keys.json`
4. Account list with decryption: `sudo node src/cmd/manage_nsfs account list --wide --show_secrets` (should not fail, but you will see the property `encrypted_secret_key` and `decryption_err`).
5. Account status with decryption: `sudo node src/cmd/manage_nsfs account status --name <account-name> --show_secrets` (will fail - we didn't handle this case).

Before this fix we had this error (added partial output):
```
  "error": {
    "code": "InvalidMasterKey",
    "message": "Master key manager had issues loading master key, can not decrypt/encrypt secrets.",
    "cause": "Error: master key id is missing in master_keys_by_id\n    at NCMasterKeysManager._validate_master_key_manager ...
...
  }
```

- [ ] Doc added/updated
- [X] Tests added
