### PR TITLE
5.18 Backport | online upgrade | make hosts verification optional

### DIFF
--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -483,7 +483,7 @@ The `upgrade start` command is used to start a config directory upgrade run.
 
 #### Usage
 ```sh
-noobaa-cli upgrade start --expected_version <expected-version> --expected_hosts <expected-hosts> [--skip-verification] [--custom_upgrade_scripts_dir]
+noobaa-cli upgrade start --expected_version <expected-version> [--expected_hosts] <expected-hosts> [--skip-verification] [--custom_upgrade_scripts_dir]
 ```
 
 #### Flags -
@@ -492,7 +492,7 @@ noobaa-cli upgrade start --expected_version <expected-version> --expected_hosts 
     - Description: Specifies the upgrade's expected target version.
     - Example - `--expected_version 5.18.0`
 
-- `expected_hosts` (Required)
+- `expected_hosts`
     - Type: String
     - Description: Specifies the upgrade's expected hosts. String of hostnames separated by comma (,). 
     - Example - `--expected_hosts hostname1,hostname2,hostname3`

--- a/docs/NooBaaNonContainerized/Upgrade.md
+++ b/docs/NooBaaNonContainerized/Upgrade.md
@@ -103,7 +103,9 @@ Online Upgrade Algorithm commands examples -
 2. Stop NooBaa service - `systemctl stop noobaa`
 3. RPM upgrade on a specific node - `rpm -Uvh /path/to/new_noobaa_rpm_version.rpm`
 4. Restart NooBaa service - `systemctl restart noobaa`
-5. `noobaa-cli upgrade start --expected_version=5.18.0 --expected_hosts=hostname1,hostname2,hostname3` 
+5. Check that each node has NooBaa service running with the new code - `curl -k https://localhost:6443/_/version` or `curl http://${host_address}:6001/_/version`
+6. `noobaa-cli upgrade start --expected_version=5.18.0`
+
 
 ### Additional Upgrade Properties of `system.json`
 

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -437,7 +437,7 @@ Usage:
 Flags:
 
     --expected_version              <string>                            The expected target version of the upgrade
-    --expected_hosts                <string>                            The expected hosts running NooBaa NC, a string of hosts separated by ,
+    --expected_hosts                <string>         (optional)         The expected hosts running NooBaa NC, a string of hosts separated by ,
     --skip_verification             <boolean>        (optional)         skip upgrade verification
                                                                         WARNING: can cause corrupted config dir files created by hosts running old code.
                                                                         this should generally not be used and is intended exclusively for NooBaa team support. 

--- a/src/manage_nsfs/upgrade.js
+++ b/src/manage_nsfs/upgrade.js
@@ -49,7 +49,7 @@ async function start_config_dir_upgrade(user_input, config_fs) {
         new NoobaaEvent(NoobaaEvent.CONFIG_DIR_UPGRADE_STARTED).create_event(undefined, { expected_version, expected_hosts }, undefined);
 
         if (!expected_version) throw new Error('expected_version flag is required');
-        if (!expected_hosts) throw new Error('expected_hosts flag is required');
+        if (!expected_hosts) dbg.warn('expected_hosts flag is empty, config dir upgrade will be performed without hosts version verification');
 
         const nc_upgrade_manager = new NCUpgradeManager(config_fs, { custom_upgrade_scripts_dir });
         const upgrade_res = await nc_upgrade_manager.upgrade_config_dir(expected_version, expected_hosts, { skip_verification });

--- a/src/test/unit_tests/jest_tests/test_cli_upgrade.test.js
+++ b/src/test/unit_tests/jest_tests/test_cli_upgrade.test.js
@@ -270,12 +270,11 @@ describe('noobaa cli - upgrade', () => {
         expect(parsed_res.error.cause).toContain('expected_version flag is required');
     });
 
-    it('upgrade start - should fail on no expected_hosts', async () => {
+    it('upgrade start - should succeed although missing expected hosts', async () => {
         await fs_utils.replace_file(config_fs.system_json_path, JSON.stringify(old_rpm_expected_system_json));
         const res = await exec_manage_cli(TYPES.UPGRADE, UPGRADE_ACTIONS.START, { config_root, expected_version: pkg.version }, true);
-        const parsed_res = JSON.parse(res.stdout);
-        expect(parsed_res.error.message).toBe(ManageCLIError.UpgradeFailed.message);
-        expect(parsed_res.error.cause).toContain('expected_hosts flag is required');
+        const parsed_res = JSON.parse(res);
+        expect(parsed_res.response.code).toBe(ManageCLIResponse.UpgradeSuccessful.code);
     });
 
     it('upgrade start - should fail on missing expected_hosts in system.json', async () => {


### PR DESCRIPTION
### Explain the changes
Backports to 5.18 of - 
1. https://github.com/noobaa/noobaa-core/pull/8786
2. https://github.com/noobaa/noobaa-core/pull/8790

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
