### PR TITLE
NSFS check_md_conditions for GET/HEAD (not yet for PUT/DELETE)

### DIFF
--- a/docs/dev_guide/ceph_s3_tests/ceph_s3_tests_pending_list_status.md
+++ b/docs/dev_guide/ceph_s3_tests/ceph_s3_tests_pending_list_status.md
@@ -46,10 +46,6 @@ Attached a table with tests that where investigated and their status (this table
 | test_object_create_bad_date_none_aws2                     | Internal Component | [438](https://github.com/ceph/s3-tests/issues/438)                    | It used to pass in the past (not related to code change in our repo) |
 | test_bucket_create_bad_authorization_invalid_aws2         | Internal Component | [438](https://github.com/ceph/s3-tests/issues/438)                    | It used to pass in the past (not related to code change in our repo) |
 | test_bucket_create_bad_date_none_aws2                     | Internal Component | [438](https://github.com/ceph/s3-tests/issues/438)                    | It used to pass in the past (not related to code change in our repo) |
-| test_get_object_ifnonematch_good                     | Internal Component |                    | It used to pass in the past (not related to code 
-change in our repo) - stopped passing between the update of commit hash 6861c3d81081a6883fb90d66cb60392e1abdf3ca to da91ad8bbf899c72199df35b69e9393c706aabee |
-| test_get_object_ifmodifiedsince_failed                     | Internal Component |                    | It used to pass in the past (not related to code 
-change in our repo) - stopped passing between the update of commit hash 6861c3d81081a6883fb90d66cb60392e1abdf3ca to da91ad8bbf899c72199df35b69e9393c706aabee |
 | test_versioning_concurrent_multi_object_delete | Faulty Test | [588](https://github.com/ceph/s3-tests/issues/588) | 
 | test_get_bucket_encryption_s3 | Faulty Test | [613](https://github.com/ceph/s3-tests/issues/613) | 
 | test_get_bucket_encryption_kms | Faulty Test | [613](https://github.com/ceph/s3-tests/issues/613) | 

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -481,7 +481,8 @@ S3Error.AccessControlListNotSupported = Object.freeze({
 /////////////////////////////////////
 S3Error.NotModified = Object.freeze({
     code: 'NotModified',
-    message: 'The resource was not modified according to the conditions in the provided headers.',
+    // this short undescriptive message is compatible with AWS and is expected by s3-tests
+    message: 'Not Modified',
     http_code: 304,
 });
 S3Error.BadRequest = Object.freeze({

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -450,7 +450,7 @@ function _prepare_error(req, res, err) {
             if (res.headersSent) {
                 dbg.log0('Sent reply in body, bit too late for Etag header');
             } else {
-                res.setHeader('ETag', err.rpc_data.etag);
+                res.setHeader('ETag', '"' + err.rpc_data.etag + '"');
             }
         }
         if (err.rpc_data.last_modified) {

--- a/src/native/util/os_darwin.cpp
+++ b/src/native/util/os_darwin.cpp
@@ -52,7 +52,7 @@ get_supplemental_groups_by_uid(uid_t uid, std::vector<gid_t>& groups)
     struct passwd* pw = getpwuid(uid);
     if (pw == NULL) {
         if (errno == 0) {
-            LOG("get_supplemental_groups_by_uid: no record for uid " << uid);
+            // LOG("get_supplemental_groups_by_uid: no record for uid " << uid);
         } else {
             LOG("WARNING: get_supplemental_groups_by_uid: getpwuid failed: " << strerror(errno));
         }

--- a/src/native/util/os_linux.cpp
+++ b/src/native/util/os_linux.cpp
@@ -38,7 +38,7 @@ get_supplemental_groups_by_uid(uid_t uid, std::vector<gid_t>& groups)
     struct passwd* pw = getpwuid(uid);
     if (pw == NULL) {
         if (errno == 0) {
-            LOG("get_supplemental_groups_by_uid: no record for uid " << uid);
+            // LOG("get_supplemental_groups_by_uid: no record for uid " << uid);
         } else {
             LOG("WARNING: get_supplemental_groups_by_uid: getpwuid failed: " << strerror(errno));
         }

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -18,6 +18,7 @@ const error_utils = require('../util/error_utils');
 const stream_utils = require('../util/stream_utils');
 const buffer_utils = require('../util/buffer_utils');
 const size_utils = require('../util/size_utils');
+const http_utils = require('../util/http_utils');
 const native_fs_utils = require('../util/native_fs_utils');
 const FileWriter = require('../util/file_writer');
 const LRUCache = require('../util/lru_cache');
@@ -970,6 +971,10 @@ class NamespaceFS {
                 }
             }
             this._throw_if_delete_marker(stat, params);
+            http_utils.check_md_conditions(params.md_conditions, {
+                etag: this._get_etag(stat),
+                last_modified_time: stat.mtime,
+            });
             return this._get_object_info(params.bucket, params.key, stat, isDir);
         } catch (err) {
             if (this._should_update_issues_report(params, file_path, err)) {
@@ -1045,6 +1050,10 @@ class NamespaceFS {
             }
             this._throw_if_delete_marker(stat, params);
             // await this._fail_if_archived_or_sparse_file(fs_context, file_path, stat);
+            http_utils.check_md_conditions(params.md_conditions, {
+                etag: this._get_etag(stat),
+                last_modified_time: stat.mtime,
+            });
 
             const start = Number(params.start) || 0;
             const end = isNaN(Number(params.end)) ? Infinity : Number(params.end);

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
@@ -116,10 +116,6 @@ s3tests_boto3/functional/test_s3.py::test_multi_object_delete_key_limit
 s3tests_boto3/functional/test_s3.py::test_multi_objectv2_delete_key_limit
 s3tests_boto3/functional/test_s3.py::test_object_write_check_etag
 s3tests_boto3/functional/test_s3.py::test_object_metadata_replaced_on_put
-s3tests_boto3/functional/test_s3.py::test_get_object_ifmatch_failed
-s3tests_boto3/functional/test_s3.py::test_get_object_ifnonematch_good
-s3tests_boto3/functional/test_s3.py::test_get_object_ifmodifiedsince_failed
-s3tests_boto3/functional/test_s3.py::test_get_object_ifunmodifiedsince_good
 s3tests_boto3/functional/test_s3.py::test_put_object_ifmatch_failed
 s3tests_boto3/functional/test_s3.py::test_put_object_ifnonmatch_failed
 s3tests_boto3/functional/test_s3.py::test_put_object_ifnonmatch_overwrite_existed_failed

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_black_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_black_list.txt
@@ -123,7 +123,6 @@ s3tests_boto3/functional/test_s3.py::test_post_object_missing_content_length_arg
 s3tests_boto3/functional/test_s3.py::test_post_object_invalid_content_length_argument
 s3tests_boto3/functional/test_s3.py::test_post_object_upload_size_below_minimum
 s3tests_boto3/functional/test_s3.py::test_post_object_empty_conditions
-s3tests_boto3/functional/test_s3.py::test_put_object_ifmatch_nonexisted_failed
 s3tests_boto3/functional/test_s3.py::test_object_raw_get_bucket_gone
 s3tests_boto3/functional/test_s3.py::test_object_raw_get
 s3tests_boto3/functional/test_s3.py::test_object_delete_key_bucket_gone

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -129,8 +129,6 @@ s3tests/functional/test_headers.py::test_object_create_bad_authorization_invalid
 s3tests/functional/test_headers.py::test_object_create_bad_date_none_aws2
 s3tests/functional/test_headers.py::test_bucket_create_bad_authorization_invalid_aws2
 s3tests/functional/test_headers.py::test_bucket_create_bad_date_none_aws2
-s3tests_boto3/functional/test_s3.py::test_get_object_ifnonematch_good
-s3tests_boto3/functional/test_s3.py::test_get_object_ifmodifiedsince_failed
 s3tests_boto3/functional/test_s3.py::test_post_object_wrong_bucket
 s3tests_boto3/functional/test_s3.py::test_cors_presigned_put_object_tenant
 s3tests_boto3/functional/test_s3.py::test_object_presigned_put_object_with_acl_tenant


### PR DESCRIPTION
### Explain the changes
1. Support NSFS md conditions for GET/HEAD.
2. Reuse the logic for both nsfs and object_server (backingstores).

Fix two problems that were in existing code and caused some s3-tests cases to fail:
- ETag in error responses was not quoted as it should.
- When checking preconditions for PUT/DELETE the check should be made also for non existing object.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - need to implement conditions for nsfs also for PUT/DELETE by checking against an existing/nonexisting object to be replaced/deleted.

### Testing Instructions:
1. Enabled s3 test cases in CI.