### PR TITLE
Support `AbortIncompleteMultipartUpload` bucket lifecycle rule

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1410,6 +1410,37 @@ module.exports = {
             auth: { system: ['admin', 'user'] }
         },
 
+        delete_incomplete_multiparts: {
+            method: 'DELETE',
+            params: {
+                type: 'object',
+                required: [
+                    'bucket',
+                    'days_after_initiation',
+                ],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    days_after_initiation: {
+                        type: 'integer',
+                    },
+                    prefix: {
+                        type: 'string',
+                    },
+                    reply_objects: {
+                        type: 'boolean'
+                    }
+                },
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    num_objects_deleted: {
+                        type: 'integer'
+                    }
+                }
+            },
+            auth: { system: ['admin', 'user'] }
+        }
     },
 
     definitions: {

--- a/src/deploy/NVA_build/standalone_deploy.sh
+++ b/src/deploy/NVA_build/standalone_deploy.sh
@@ -73,6 +73,8 @@ function main() {
     mkdir -p storage/backingstores/drive1
     execute "npm -- run backingstore storage/backingstores/drive1 --port 9991" backingstore1.log
     sleep 30
+
+    wait
 }
 
 main

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -737,6 +737,11 @@ interface DBSequence {
     nextsequence(): Promise<number>;
 }
 
+interface sqlResult<T> {
+    rows: T[],
+    rowCount: number | null,
+}
+
 interface DBCollection {
     find(query?: object, options?: object): Promise<DBDoc[]>;
     findOne(query?: object, options?: object): Promise<DBDoc>;
@@ -761,6 +766,9 @@ interface DBCollection {
     stats(): Promise<mongodb.CollStats>;
 
     validate(doc: object, warn?: 'warn'): object;
+
+    executeSQL<T>(query: string, params: Array<any>, options?: { query_name?: string }): Promise<sqlResult<T>>;
+    name: any;
 }
 
 type DBDoc = any;

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -23,37 +23,14 @@ function get_expiration_timestamp(expiration) {
     }
 }
 
-async function handle_bucket_rule(system, rule, j, bucket) {
-    const now = Date.now();
-    let should_rerun = false;
-
-    if (rule.status !== 'Enabled') {
-        dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'not Enabled');
-        return;
-    }
-    if (rule.last_sync && now - rule.last_sync < config.LIFECYCLE_SCHEDULE_MIN) {
-        dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'schedule min', config.LIFECYCLE_SCHEDULE_MIN);
-        return;
-    }
-    if (rule.expiration === undefined) {
-        dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'no expiration');
-        return;
-    }
-    dbg.log0('LIFECYCLE PROCESSING bucket:', bucket.name.unwrap(), '(bucket id:', bucket._id, ') rule', util.inspect(rule));
-
-    //we might need to send notifications for deleted objects, if
-    //1. notifications are enabled AND
-    //2. bucket has notifications at all AND
-    //3. bucket has a relevant notification, either
-    //3.1. notification is without event filtering OR
-    //3.2. notification is for LifecycleExpiration event
-    //if so, we need the metadata of the deleted objects from the object server
-    // TODO - should move to the upper for, looks like it's per bucket and not per rule
-    const reply_objects = config.NOTIFICATION_LOG_DIR && bucket.notifications &&
-         _.some(bucket.notifications, notif =>
-            (!notif.Events || _.some(notif.Events, event => event.includes(OP_TO_EVENT.lifecycle_delete.name))));
-
-    const res = await server_rpc.client.object.delete_multiple_objects_by_filter({
+async function delete_expired_objects(system, bucket, rule, reply_objects) {
+    /* 
+    Note that expired delete-markers are also deleted by this query
+    since the lack of filter_delete_markers means the function's internal
+    delete_marker variable remains as undefined, which is then dropped by compact()
+    effectively matching all object_md entries regardless of their delete_marker status
+    */
+    return await server_rpc.client.object.delete_multiple_objects_by_filter({
         bucket: bucket.name,
         create_time: get_expiration_timestamp(rule.expiration),
         prefix: rule.filter.prefix,
@@ -69,46 +46,114 @@ async function handle_bucket_rule(system, rule, j, bucket) {
             role: 'admin'
         })
     });
+}
 
-    //dbg.log0("LIFECYCLE PROCESSING res =", res);
+async function delete_incomplete_multipart_uploads(system, bucket, rule, reply_objects) {
+    return await server_rpc.client.object.delete_incomplete_multiparts({
+        bucket,
+        days_after_initiation: rule.abort_incomplete_multipart_upload.days_after_initiation,
+        prefix: rule.filter?.prefix,
+        reply_objects
+    }, {
+        auth_token: auth_server.make_auth_token({
+            system_id: system._id,
+            account_id: system.owner._id,
+            role: 'admin'
+        })
+    });
+}
 
-    if (res.deleted_objects) {
 
-        const writes = [];
+async function handle_bucket_rule(system, rule, j, bucket) {
+    const now = Date.now();
+    let should_rerun = false;
+    let num_objects_deleted = 0;
 
-        for (const deleted_obj of res.deleted_objects) {
-            for (const notif of bucket.notifications) {
-                if (check_notif_relevant(notif, {
-                    op_name: 'lifecycle_delete',
-                    s3_event_method: deleted_obj.created_delete_marker ? 'DeleteMarkerCreated' : 'Delete',
-                })) {
-                    //remember that this deletion needs a notif for this specific notification conf
-                    writes.push({notif, deleted_obj});
+    if (rule.status !== 'Enabled') {
+        dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'not Enabled');
+        return;
+    }
+    if (rule.last_sync && now - rule.last_sync < config.LIFECYCLE_SCHEDULE_MIN) {
+        dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'schedule min', config.LIFECYCLE_SCHEDULE_MIN);
+        return;
+    }
+    // When creating rules via the AWS web console, they always contain an Expiration key
+    // However, rules applied via the CLI don't have to contain Expiration, and can instead contain
+    // NoncurrentVersionExpiration or AbortIncompleteMultipartUpload
+    if (
+        rule.expiration === undefined &&
+        rule.abort_incomplete_multipart_upload === undefined &&
+        rule.NoncurrentVersionExpiration === undefined
+    ) {
+        dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'rule contains no expiration parameters');
+        return;
+    }
+    dbg.log0('LIFECYCLE PROCESSING bucket:', bucket.name.unwrap(), '(bucket id:', bucket._id, ') rule', util.inspect(rule));
+
+    //we might need to send notifications for deleted objects, if
+    //1. notifications are enabled AND
+    //2. bucket has notifications at all AND
+    //3. bucket has a relevant notification, either
+    //3.1. notification is without event filtering OR
+    //3.2. notification is for LifecycleExpiration event
+    //if so, we need the metadata of the deleted objects from the object server
+    const reply_objects = config.NOTIFICATION_LOG_DIR && bucket.notifications &&
+         _.some(bucket.notifications, notif =>
+            (!notif.Events || _.some(notif.Events, event => event.includes(OP_TO_EVENT.lifecycle_delete.name))));
+
+    // Check if rule.expiration.days/date is set - if it is, delete expired objects and delete markers
+    if (!_.isUndefined(rule.expiration?.days) || !_.isUndefined(rule.expiration?.date)) {
+        dbg.log0('LIFECYCLE PROCESSING rule.expiration.days:', rule.expiration.days);
+        const res = await delete_expired_objects(system, bucket, rule, reply_objects);
+        num_objects_deleted = res.num_objects_deleted;
+        //dbg.log0("LIFECYCLE PROCESSING res =", res);
+        if (res.deleted_objects) {
+            const writes = [];
+            for (const deleted_obj of res.deleted_objects) {
+                for (const notif of bucket.notifications) {
+                    if (check_notif_relevant(notif, {
+                        op_name: 'lifecycle_delete',
+                        s3_event_method: deleted_obj.created_delete_marker ? 'DeleteMarkerCreated' : 'Delete',
+                    })) {
+                        //remember that this deletion needs a notif for this specific notification conf
+                        writes.push({notif, deleted_obj});
+                    }
                 }
             }
-        }
 
-        //if any notifications are needed, write them in notification log file
-        //(otherwise don't do any unnecessary filesystem actions)
-        if (writes.length > 0) {
-            let logger;
-            try {
-                logger = get_notification_logger('SHARED');
-                await P.map_with_concurrency(100, writes, async write => {
-                    const notif = compose_notification_lifecycle(write.deleted_obj, write.notif, bucket);
-                    logger.append(JSON.stringify(notif));
-                });
-            } finally {
-                if (logger) logger.close();
+            //if any notifications are needed, write them in notification log file
+            //(otherwise don't do any unnecessary filesystem actions)
+            if (writes.length > 0) {
+                let logger;
+                try {
+                    logger = get_notification_logger('SHARED');
+                    await P.map_with_concurrency(100, writes, async write => {
+                        const notif = compose_notification_lifecycle(write.deleted_obj, write.notif, bucket);
+                        logger.append(JSON.stringify(notif));
+                    });
+                } finally {
+                    if (logger) logger.close();
+                }
             }
         }
     }
 
+    // Check if rule.AbortIncompleteMultipartUpload exists - 
+    // if it does, delete incomplete parts if DaysAfterInitiation has passed
+    if (rule.abort_incomplete_multipart_upload?.days_after_initiation) {
+        await delete_incomplete_multipart_uploads(
+            system,
+            bucket.name,
+            rule,
+            reply_objects
+        );
+    }
+
     bucket.lifecycle_configuration_rules[j].last_sync = Date.now();
-    if (res.num_objects_deleted >= config.LIFECYCLE_BATCH_SIZE) should_rerun = true;
+    if (num_objects_deleted >= config.LIFECYCLE_BATCH_SIZE) should_rerun = true;
     dbg.log0('LIFECYCLE Done bucket:', bucket.name, '(bucket id:', bucket._id, ') done deletion of objects per rule',
-        rule, 'time:', bucket.lifecycle_configuration_rules[j].last_sync, 'objects deleted:', res.num_objects_deleted,
-        should_rerun ? 'lifecycle should rerun' : '');
+            rule, 'time:', bucket.lifecycle_configuration_rules[j].last_sync, 'objects deleted:', num_objects_deleted,
+            should_rerun ? 'lifecycle should rerun' : '');
     update_lifecycle_rules_last_sync(bucket, bucket.lifecycle_configuration_rules);
     return should_rerun;
 }

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -73,6 +73,17 @@ class MongoCollection {
     async estimatedDocumentCount(options = {}) { return this._get_mongo_col().estimatedDocumentCount(options); }
     async estimatedQueryCount(query) { return this._get_mongo_col().countDocuments(query); }
     async stats() { return this._get_mongo_col().stats(); }
+
+    /**
+     * 
+     * @param {*} query 
+     * @param {*} params 
+     * @param {*} options 
+     * @returns {Promise<any>}
+     */
+    async executeSQL(query, params, options) {
+        throw new Error("NOT SUPPORTED");
+    }
 }
 
 class MongoSequence {
@@ -943,7 +954,6 @@ class MongoClient extends EventEmitter {
         clearTimeout(this.connect_timeout);
         this.connect_timeout = null;
     }
-
 }
 
 MongoClient._instance = undefined;


### PR DESCRIPTION
### Explain the changes
1. Adds support for the [AbortIncompleteMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortIncompleteMultipartUpload.html) bucket lifecycle rule

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/RHSTOR-7034

### Testing Instructions:
1. Set a lifecycle rule that aborts (and effectively deletes) incomplete multipart uploads by utilizing [AbortIncompleteMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortIncompleteMultipartUpload.html)
2. Start a multipart upload
3. Abort the upload before it's completed
4. Verify that the multipart upload was saved in the system (see [list-multipart-uploads](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-multipart-uploads.html))
5. Wait for *DaysAfterInitiation* to pass / modify the database entry under `object_mds` to reflect an older creation date
6. Verify that the multipart upload is no longer present in the system (similarly to step 4)

I still need to add tests; for now, I'm creating the PR to get review in parallel

- [ ] Doc added/updated
- [ ] Tests added
