### PR TITLE
NSFS | Fix Bug | Race Between List Object and Delete Object

### DIFF
--- a/config.js
+++ b/config.js
@@ -913,6 +913,9 @@ config.ANONYMOUS_ACCOUNT_NAME = 'anonymous';
 
 config.NFSF_UPLOAD_STREAM_MEM_THRESHOLD = 8 * 1024 * 1024;
 
+// we want to change our handling related to EACCESS error
+config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES = true;
+
 ////////////////////////////
 // NSFS NON CONTAINERIZED //
 ////////////////////////////

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -752,6 +752,11 @@ struct FSWrapWorker : public FSWorker
 
 /**
  * Stat is an fs op
+ * 
+ * Note: this stat operation contains the system call of open.
+ *       Currently, we use it in list objects, but might want to create a different stat call
+ *       (or add changes inside this) to avoid permission check during list objects
+ *       while we stat each file (to avoid EACCES error)
  */
 struct Stat : public FSWorker
 {

--- a/src/test/unit_tests/jest_tests/test_nsfs_concurrency.test.js
+++ b/src/test/unit_tests/jest_tests/test_nsfs_concurrency.test.js
@@ -6,7 +6,7 @@ const P = require('../../../util/promise');
 const fs_utils = require('../../../util/fs_utils');
 const NamespaceFS = require('../../../sdk/namespace_fs');
 const buffer_utils = require('../../../util/buffer_utils');
-const { TMP_PATH } = require('../../system_tests/test_utils');
+const { TMP_PATH, TEST_TIMEOUT } = require('../../system_tests/test_utils');
 const { crypto_random_string } = require('../../../util/string_utils');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
 
@@ -27,18 +27,20 @@ function make_dummy_object_sdk(nsfs_config, uid, gid) {
 }
 
 const DUMMY_OBJECT_SDK = make_dummy_object_sdk(true);
-describe('test nsfs concurrency', () => {
-    const tmp_fs_path = path.join(TMP_PATH, 'test_nsfs_concurrency');
 
-    const nsfs = new NamespaceFS({
-        bucket_path: tmp_fs_path,
-        bucket_id: '1',
-        namespace_resource_id: undefined,
-        access_mode: undefined,
-        versioning: 'DISABLED',
-        force_md5_etag: false,
-        stats: endpoint_stats_collector.instance(),
-    });
+const tmp_fs_path = path.join(TMP_PATH, 'test_nsfs_concurrency');
+
+const nsfs = new NamespaceFS({
+    bucket_path: tmp_fs_path,
+    bucket_id: '1',
+    namespace_resource_id: undefined,
+    access_mode: undefined,
+    versioning: 'DISABLED',
+    force_md5_etag: false,
+    stats: endpoint_stats_collector.instance(),
+});
+
+describe('test nsfs concurrency', () => {
 
     beforeEach(async () => {
         await fs_utils.create_fresh_path(tmp_fs_path);
@@ -68,5 +70,101 @@ describe('test nsfs concurrency', () => {
         }
         await P.delay(5000);
         expect(res_etags).toHaveLength(15);
-    }, 6000);
+    }, TEST_TIMEOUT);
+
+    test_list_and_delete({
+        test_name: 'list objects and delete an object during it - random deletion',
+        bucket_name: 'bucket1',
+        num_of_objects_to_upload: 5,
+        expected_num_of_object_in_list: 4,
+        key_to_delete: `my-key-${random_integer(1, 5)}`,
+        iterations: 5,
+    });
+
+    test_list_and_delete({
+        test_name: 'list objects and delete an object during it - delete the last object',
+        bucket_name: 'bucket2',
+        num_of_objects_to_upload: 1000,
+        expected_num_of_object_in_list: 999,
+        key_to_delete: `my-key-1000`,
+        iterations: 1
+    });
 });
+
+    /**
+     * @param {{
+    *      test_name: string,
+    *      bucket_name: string,
+    *      num_of_objects_to_upload: number,
+    *      expected_num_of_object_in_list: number,
+    *      key_to_delete?: string,
+    *      iterations?: number,
+    * }} params
+    */
+   function test_list_and_delete({
+       test_name,
+       bucket_name,
+       num_of_objects_to_upload,
+       expected_num_of_object_in_list,
+       key_to_delete,
+       iterations = 1
+   }) {
+
+    it(test_name, async () => {
+        await _upload_objects(bucket_name, num_of_objects_to_upload);
+        if (key_to_delete === undefined) {
+            key_to_delete = `my-key-${random_integer(1, expected_num_of_object_in_list)}`;
+            console.log('test_list_and_delete: key_to_delete', key_to_delete);
+        }
+
+        console.log(`test_list_and_delete: ${test_name} ${bucket_name} num_of_objects_to_upload: ${num_of_objects_to_upload},
+            expected_num_of_object_in_list ${expected_num_of_object_in_list} key_to_delete ${key_to_delete}`);
+
+        for (let i = 0; i < iterations; ++i) {
+                nsfs.list_objects({ bucket: bucket_name }, DUMMY_OBJECT_SDK)
+                .catch(err => {
+                    console.log('error during list_objects', err);
+                    throw err;
+                }).then(res => {
+                    console.log('list was successful');
+                });
+            nsfs.delete_object({ bucket: bucket_name, key: key_to_delete }, DUMMY_OBJECT_SDK)
+                .catch(err => {
+                    console.log('delete_object got an error', err);
+                    throw err;
+                }).then(res => {
+                    console.log('delete_object during list objects was successful');
+                });
+            await P.delay(5000);
+            // up to this point if it was successful, the race between the delete object and list object went fine.
+        }
+    }, TEST_TIMEOUT);
+}
+
+/**
+ * _upload_objects uploads number_of_versions of objects in bucket
+ * note: this function is not concurrent, it's a helper function for preparing a bucket with a couple of objects
+ * @param {string} bucket
+ * @param {number} number_of_objects
+ */
+async function _upload_objects(bucket, number_of_objects) {
+    const keys_names = [];
+    for (let i = 0; i < number_of_objects; i++) {
+        const key_name = `my-key-${i + 1}`;
+        const random_data = Buffer.from(String(crypto_random_string(7)));
+        const body = buffer_utils.buffer_to_read_stream(random_data);
+        await nsfs.upload_object({ bucket: bucket, key: key_name, source_stream: body }, DUMMY_OBJECT_SDK);
+        keys_names.push(key_name);
+    }
+    return keys_names;
+}
+
+/**
+ * randomInteger between min (included) and max (included)
+ * // copied from: https://stackoverflow.com/questions/4959975/generate-random-number-between-two-numbers-in-javascript
+ * @param {number} min
+ * @param {number} max
+ */
+function random_integer(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }


### PR DESCRIPTION
### Explain the changes
1. Replace the function `stat_ignore_eacces` with `stat_if_exists` and add ignore of `ENOENT` and `ENOTDIR` (in addition to `EACCES` with a flag of `config.EACCES_IGNORE_ENTRY`).
2. Call `stat` on the `entry_path` one time and save is instead of calling it in concurrency so that we can be sure that the value was not deleted from the result array. Move the `stat` call before `results.push(r)` and `results.splice(pos, 0, r)` as they both add a result to the array.
3. Add a comment before the `check_access`, see also in PR description of #6576.

This change is continuing PR #8751 by adding a case to ignore a `stat` failure entry.

### Issues: Fixed [DFBUGS-1582](https://issues.redhat.com/browse/DFBUGS-1582)
1. Currently, during a list object operation there is a call to stat on the `entry_path` (which is the path of the key in the bucket in the FS). If a concurrent delete happens, this `stat` will return an error (`ENOENT` as the object was deleted). In this fix, we suggest that the `stat` would not return any value and, as a result, would not appear in the list object result.

GAPs - are mentioned in issue #8845 (discussions were documented [here](https://docs.google.com/document/d/1WpfNBLzcZQvT4DThm70xUYGRRaIF4ymw80Rpy8sk-OI/edit?usp=sharing)).

### Testing Instructions:
#### Automatic Test:
Please run: `sudo npx jest test_nsfs_concurrency.test.js`

For example we could see the lines:
```
Mar-3 14:10:13.679 [/69906]    [L0] core.util.native_fs_utils:: stat_if_exists: Could not access file entry_path /private/tmp/test_nsfs_concurrency/my-key-2 error code ENOENT , skipping...
```

```
Mar-3 14:10:43.534 [/69906]    [L0] core.util.native_fs_utils:: stat_if_exists: Could not access file entry_path /private/tmp/test_nsfs_concurrency/my-key-1000 error code ENOENT , skipping...
```

#### Manual Testing instructions:
We will add code changes to simulate the problem:
Add the sleep function:
```js
sleep(ms) {
    return new Promise(resolve => {
        setTimeout(resolve, ms);
    });
}
```
we will add the following lines:
```js
console.log('SDSD before stat', this.bucket_path, r.key, fs_context);
console.log('SDSD sleep 8000');
await this.sleep(8000);
stat = await nb_native().fs.stat(fs_context, entry_path, { use_lstat });
```

1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`
5. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
6. Create the alias for S3 service:`alias nc-user-1-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443’`
7. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-1-s3 s3 ls; echo $?`
8. Add bucket to the account using AWS CLI: `nc-user-1-s3 s3 mb s3://bucket-race` (`bucket-race` is the bucket name in this example)
9. Put objects in the bucket: `echo 'hello_world' | nc-user-1-s3 s3 cp - s3://bucket-race/hello_world1.txt` (repeat this and change the key name to `hello_world2.txt`, `hello_world3.txt`, `hello_world4.txt`
10. Tab1: Start the list objects: `nc-user-1-s3 s3api list-objects-v2 --bucket bucket-race`
    Tab2: Delete an object while you see the "SDSD before stat" on the key: `nc-user-1-s3 s3api delete-object --bucket bucket-race --key hello_world3.txt` (for example)
Expect to see the list without the deleted key, and also to see in the logs printings.

##### Before the change
It was: `An error occurred (NoSuchKey) when calling the ListObjectsV2 operation: The specified key does not exist.`
and in the logs:
```
Feb-19 9:03:11.560 [nsfs/22301] [ERROR] core.endpoint.s3.s3_rest:: S3 ERROR <?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Resource>/bucket-race?list-type=2&amp;encoding-type=url</Resource><RequestId>m7bkghze-8fc8b7-e0y</RequestId></Error> GET /bucket-race?list-type=2&encoding-type=url {"host":"localhost:6443","accept-encoding":"identity","user-agent":"aws-cli/2.17.11 md/awscrt#0.20.11 ua/2.0 os/macos#24.2.0 md/arch#arm64 lang/python#3.11.10 md/pyimpl#CPython cfg/retry-mode#standard md/installer#source md/prompt#off md/command#s3api.list-objects-v2","x-amz-date":"20250219T070256Z","x-amz-content-sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","authorization":"AWS4-HMAC-SHA256 Credential=Dwertyuiopasdfg11001/20250219/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=98e78f14c8a60ea9c1442face8f569e040bab077beeff61a124b07349e8eaa29"} Error: No such file or directory - context: Stat _path=/Users/buckets/bucket-race/hello_world3.txt
```
[Logs before the change](https://github.com/user-attachments/files/18864153/local_reproduce_logs_before.txt)

- [ ] Doc added/updated
- [X] Tests added
