### PR TITLE
[NSFS | Glacier] Add support force expiry based on GET completions and migration log size

### DIFF
--- a/config.js
+++ b/config.js
@@ -946,6 +946,16 @@ config.NSFS_LOW_FREE_SPACE_MB_UNLEASH = 10 * 1024;
 // operations safely.
 config.NSFS_LOW_FREE_SPACE_PERCENT_UNLEASH = 0.10;
 
+// NSFS_GLACIER_GET_FORCE_EXPIRE if set to true then any restored item in the GLACIER
+// storage class will expire as soon as first GET request is received for it or
+// if the previous restore time has exceed, whichever is the earlier.
+config.NSFS_GLACIER_FORCE_EXPIRE_ON_GET = false;
+
+// NSFS_GLACIER_MIGRATE_LOG_THRESHOLD controls that how big the migration log file should be
+// Once this size is exceeded, migrate calls are supposed to kick in regardless of configured
+// interval
+config.NSFS_GLACIER_MIGRATE_LOG_THRESHOLD = 50 * 1024;
+
 // anonymous account name
 config.ANONYMOUS_ACCOUNT_NAME = 'anonymous';
 

--- a/src/util/file_reader.js
+++ b/src/util/file_reader.js
@@ -17,8 +17,12 @@ class NewlineReaderFilePathEntry {
 
 class NewlineReader {
     /**
-     * NewlineReader allows to read a file line by line while at max holding one line + 4096 bytes
-     * in memory.
+     * Newline character code
+     */
+    static NL_CODE = 10;
+
+    /**
+     * NewlineReader allows to read a file line by line.
      * @param {nb.NativeFSContext} fs_context 
      * @param {string} filepath 
      * @param {{
@@ -66,7 +70,7 @@ class NewlineReader {
         while (!this.eof) {
             // extract next line if terminated in current buffer
             if (this.start < this.end) {
-                const term_idx = this.buf.subarray(this.start, this.end).indexOf(10);
+                const term_idx = this.buf.subarray(this.start, this.end).indexOf(NewlineReader.NL_CODE);
                 if (term_idx >= 0) {
                     if (this.overflow_state) {
                         console.warn('line too long finally terminated:', this.info());


### PR DESCRIPTION
### Explain the changes
This PR adds support for :
1. Force expiring Glacier objects upon a successful GET operation.
2. Trigger migration if the migration log/journal size exceeds the `config.NSFS_GLACIER_MIGRATE_LOG_THRESHOLD` value.


- [ ] Doc added/updated
- [ ] Tests added
