### PR TITLE
NSFS | close stream when getting empty content dir

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1022,7 +1022,12 @@ class NamespaceFS {
                     // NOTE: don't move this code after the open
                     // this can lead to ENOENT failures due to file not exists when content size is 0
                     // if entry is a directory object and its content size = 0 - return empty response
-                    if (await this._is_empty_directory_content(file_path, fs_context, params)) return null;
+                    if (await this._is_empty_directory_content(file_path, fs_context, params)) {
+                        res.end();
+                        // since we don't write anything to the stream wait_finished might not be needed. added just in case there is a delay
+                        await stream_utils.wait_finished(res, { signal: object_sdk.abort_controller.signal });
+                        return null;
+                    }
 
                     file = await nb_native().fs.open(
                         fs_context,

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -547,6 +547,7 @@ mocha.describe('namespace_fs', function() {
         const dir_2 = '/a/b/';
         const upload_key_1 = dir_1 + 'upload_key_1/';
         const upload_key_2 = dir_2 + 'upload_key_2/';
+        const upload_key_empty = 'empty_key/';
         const data = crypto.randomBytes(100);
 
         mocha.before(async function() {
@@ -556,6 +557,22 @@ mocha.describe('namespace_fs', function() {
                 source_stream: buffer_utils.buffer_to_read_stream(data)
             }, dummy_object_sdk);
             console.log('upload_object with trailing / response', inspect(upload_res));
+        });
+
+        mocha.it('get empty content dir', async function() {
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: upload_key_empty,
+                source_stream: buffer_utils.buffer_to_read_stream(crypto.randomBytes(0)),
+                size: 0
+            }, dummy_object_sdk);
+
+            const read_res = buffer_utils.write_stream();
+            await ns_tmp.read_object_stream({
+                bucket: upload_bkt,
+                key: upload_key_empty,
+            }, dummy_object_sdk, read_res);
+            assert(read_res.writableEnded);
         });
 
         mocha.it(`delete the path - stop when not empty and key with trailing /`, async function() {
@@ -574,11 +591,17 @@ mocha.describe('namespace_fs', function() {
         });
 
         mocha.after(async function() {
-            const delete_res = await ns_tmp.delete_object({
+            let delete_res = await ns_tmp.delete_object({
                 bucket: upload_bkt,
                 key: upload_key_2,
             }, dummy_object_sdk);
             console.log('delete_object with trailing / (key 2) response', inspect(delete_res));
+
+            delete_res = await ns_tmp.delete_object({
+                bucket: upload_bkt,
+                key: upload_key_empty,
+            }, dummy_object_sdk);
+            console.log('delete_object with trailing / (empty content dir) response', inspect(delete_res));
         });
     });
 


### PR DESCRIPTION
### Explain the changes
1. currently we don't close the write stream before returning from read_object_md for empty content dir case. this causes the client to wait for the stream to close until it times out. added closing of the stream in that case

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
manual:
1. put empty content dir object: `s3api put-object --bucket test-bucket --key key5/`
2. get the new object: 's3api get-object --bucket test-bucket --key key5 outfile`
3. get should succeed with empty file

automatic:
`sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_namespace_fs.js`


- [ ] Doc added/updated
- [x] Tests added
