### PR TITLE
NSFS | NC | whitelist cli create config.json when it doesn't exist

### DIFF
--- a/src/test/unit_tests/test_nc_cli.js
+++ b/src/test/unit_tests/test_nc_cli.js
@@ -1055,6 +1055,21 @@ mocha.describe('manage_nsfs cli', function() {
                 assert_error(err, ManageCLIError.InvalidArgument);
             }
         });
+
+        mocha.it('cli add whitelist config file doesnt exist', async function() {
+            //delete existing config file
+            const config_file_path = config_fs.get_config_json_path();
+            await fs_utils.file_delete(config_file_path);
+
+            const ips = ['127.0.0.1']; // IPV4 format
+            const res = await exec_manage_cli(type, '', { config_root, ips: JSON.stringify(ips) });
+            await assert_response('', type, res, ips);
+            const new_config_options = { S3_SERVER_IP_WHITELIST: ips};
+            const config_data = await config_fs.get_config_json();
+            console.log(config_data);
+            assert_whitelist(config_data, new_config_options);
+        });
+
     });
 
 });


### PR DESCRIPTION
### Explain the changes
1. when we call whitelist in cli and config.json doesn't exist we get ENOENT when trying to update the config file
2. try to get config.json if exist update it, if it doesn't exist create it with the new data

### Issues: Fixed #8775
1. 

### Testing Instructions:
1. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_nc_cli.js`


- [ ] Doc added/updated
- [x] Tests added
