### PR TITLE
NSFS | content dir versioning LIST and tagging operations

### DIFF
--- a/config.js
+++ b/config.js
@@ -823,7 +823,6 @@ config.NSFS_RANDOM_DELAY_BASE = 70;
 
 config.NSFS_VERSIONING_ENABLED = true;
 config.NSFS_UPDATE_ISSUES_REPORT_ENABLED = true;
-config.NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED = false;
 
 config.NSFS_EXIT_EVENTS_TIME_FRAME_MIN = 24 * 60; // per day
 config.NSFS_MAX_EXIT_EVENTS_PER_TIME_FRAME = 10; // allow max 10 failed forks per day

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -763,12 +763,12 @@ class NamespaceFS {
                 /**
                  * @param {fs.Dirent} ent
                  */
-                const process_entry = async ent => {
+                const process_entry = async (ent, is_disabled_dir_content) => {
                     // dbg.log0('process_entry', dir_key, ent.name);
-                    if ((!ent.name.startsWith(prefix_ent) ||
+                    if (!ent.name.startsWith(prefix_ent) ||
                         ent.name < marker_curr ||
                         ent.name === this.get_bucket_tmpdir_name() ||
-                        ent.name === config.NSFS_FOLDER_OBJECT_NAME) ||
+                        (ent.name === config.NSFS_FOLDER_OBJECT_NAME && is_disabled_dir_content) ||
                         this._is_hidden_version_path(ent.name)) {
                         return;
                     }
@@ -783,7 +783,7 @@ class NamespaceFS {
                         };
                     } else {
                         r = {
-                            key: this._get_entry_key(dir_key, ent, isDir),
+                            key: this._get_entry_key(dir_key, ent, isDir, is_disabled_dir_content),
                             common_prefix: isDir,
                             is_latest: true
                         };
@@ -813,8 +813,8 @@ class NamespaceFS {
 
                 // insert dir object to objects list if its key is lexicographicly bigger than the key marker &&
                 // no delimiter OR prefix is the current directory entry
-                const is_dir_content = cached_dir.stat.xattr && cached_dir.stat.xattr[XATTR_DIR_CONTENT];
-                if (is_dir_content && dir_key > key_marker && (!delimiter || dir_key === prefix)) {
+                const is_disabled_dir_content = cached_dir.stat.xattr && cached_dir.stat.xattr[XATTR_DIR_CONTENT];
+                if (is_disabled_dir_content && dir_key > key_marker && (!delimiter || dir_key === prefix)) {
                     const r = { key: dir_key, common_prefix: false };
                     await insert_entry_to_results_arr(r);
                 }
@@ -867,7 +867,7 @@ class NamespaceFS {
                         if (ent.name === config.NSFS_FOLDER_OBJECT_NAME && dir_key === marker_dir) {
                             continue;
                         }
-                        await process_entry(ent);
+                        await process_entry(ent, is_disabled_dir_content);
                         // since we traverse entries in sorted order,
                         // we can break as soon as enough keys are collected.
                         if (is_truncated) break;
@@ -915,6 +915,16 @@ class NamespaceFS {
                 }
             };
 
+            const format_key_name = obj_info => {
+                if (this._is_hidden_version_path(obj_info.key)) {
+                    obj_info.key = path.normalize(obj_info.key.replace(HIDDEN_VERSIONS_PATH + '/', ''));
+                    obj_info.key = _get_filename(obj_info.key);
+                }
+                if (obj_info.key.endsWith(config.NSFS_FOLDER_OBJECT_NAME)) {
+                    obj_info.key = obj_info.key.slice(0, -config.NSFS_FOLDER_OBJECT_NAME.length);
+                }
+            };
+
             const prefix_dir_key = prefix.slice(0, prefix.lastIndexOf('/') + 1);
             await process_dir(prefix_dir_key);
             const res = {
@@ -933,11 +943,8 @@ class NamespaceFS {
                     if (!list_versions && obj_info.delete_marker) {
                         continue;
                     }
-                    if (this._is_hidden_version_path(obj_info.key)) {
-                        obj_info.key = path.normalize(obj_info.key.replace(HIDDEN_VERSIONS_PATH + '/', ''));
-                        obj_info.key = _get_filename(obj_info.key);
-                        set_latest_delete_marker(obj_info);
-                    }
+                    format_key_name(obj_info);
+                    set_latest_delete_marker(obj_info);
                     res.objects.push(obj_info);
                     previous_key = obj_info.key;
                 }
@@ -1247,7 +1254,7 @@ class NamespaceFS {
         try {
             await this._check_path_in_bucket_boundaries(fs_context, file_path);
 
-            if (this.should_use_empty_content_dir_optimization() && this.empty_dir_content_flow(file_path, params)) {
+            if (this._is_versioning_disabled() && this.empty_dir_content_flow(file_path, params)) {
                 const content_dir_info = await this._create_empty_dir_content(fs_context, params, file_path);
                 return content_dir_info;
             }
@@ -1344,14 +1351,14 @@ class NamespaceFS {
 
     /**
      * _check_copy_storage_class returns true if a copy is needed to be forced.
-     * 
+     *
      * This might be needed if we need to manage xattr separately on the source
      * object and target object (eg. GLACIER objects).
-     * 
+     *
      * NOTE: The function will throw S3 error if source object storage class is
      * "GLACIER" but it is not in restored state (AWS behaviour).
-     * @param {nb.NativeFSContext} fs_context 
-     * @param {Record<any, any>} params 
+     * @param {nb.NativeFSContext} fs_context
+     * @param {Record<any, any>} params
      * @returns {Promise<boolean>}
      */
     async _check_copy_storage_class(fs_context, params) {
@@ -1385,8 +1392,7 @@ class NamespaceFS {
         const part_upload = file_path === upload_path;
         const same_inode = params.copy_source && copy_res === COPY_STATUS_ENUM.SAME_INODE;
         const should_replace_xattr = params.copy_source ? copy_res === COPY_STATUS_ENUM.FALLBACK : true;
-        const is_dir_content_optimized_flow = this._is_directory_content(file_path, params.key) &&
-            this.should_use_empty_content_dir_optimization();
+        const is_disabled_dir_content = this._is_directory_content(file_path, params.key) && this._is_versioning_disabled();
 
         const stat = await target_file.stat(fs_context);
         this._verify_encryption(params.encryption, this._get_encryption_info(stat));
@@ -1429,7 +1435,7 @@ class NamespaceFS {
                 });
             }
         }
-        if (fs_xattr && !is_dir_content_optimized_flow && should_replace_xattr) {
+        if (fs_xattr && !is_disabled_dir_content && should_replace_xattr) {
             await target_file.replacexattr(fs_context, fs_xattr);
         }
         // fsync
@@ -1437,13 +1443,12 @@ class NamespaceFS {
         dbg.log1('NamespaceFS._finish_upload:', open_mode, file_path, upload_path, fs_xattr);
 
         if (!same_inode && !part_upload) {
-            await this._move_to_dest(fs_context, upload_path, file_path, target_file, open_mode, params.key,
-                is_dir_content_optimized_flow);
+            await this._move_to_dest(fs_context, upload_path, file_path, target_file, open_mode, params.key);
         }
 
         // when object is a dir, xattr are set on the folder itself and the content is in .folder file
         // we still should put the xattr if copy is link/same inode because we put the xattr on the directory
-        if (is_dir_content_optimized_flow) {
+        if (is_disabled_dir_content) {
             await this._assign_dir_content_to_xattr(fs_context, fs_xattr, { ...params, size: stat.size }, copy_xattr);
         }
         stat.xattr = { ...stat.xattr, ...fs_xattr };
@@ -1471,13 +1476,13 @@ class NamespaceFS {
     }
 
     // move to dest GPFS (wt) / POSIX (w / undefined) - non part upload
-    async _move_to_dest(fs_context, source_path, dest_path, target_file, open_mode, key, is_dir_content_optimized_flow) {
-        dbg.log2('_move_to_dest', fs_context, source_path, dest_path, target_file, open_mode, key, is_dir_content_optimized_flow);
+    async _move_to_dest(fs_context, source_path, dest_path, target_file, open_mode, key) {
+        dbg.log2('_move_to_dest', fs_context, source_path, dest_path, target_file, open_mode, key);
         let retries = config.NSFS_RENAME_RETRIES;
         // will retry renaming a file in case of parallel deleting of the destination path
         for (;;) {
             try {
-                if (this._is_versioning_disabled() || is_dir_content_optimized_flow) {
+                if (this._is_versioning_disabled()) {
                     await native_fs_utils._make_path_dirs(dest_path, fs_context);
                     if (open_mode === 'wt') {
                         await target_file.linkfileat(fs_context, dest_path);
@@ -1504,7 +1509,7 @@ class NamespaceFS {
 
     // 1. get latest version_id
     // 2. if versioning is suspended -
-    //     2.1 if version ID of the latest version is null - 
+    //     2.1 if version ID of the latest version is null -
     //       2.1.1. if it's POSIX backend - unlink the null version
     //       2.1.2. if it's GPFS backend - nothing to do, the linkatif will override it
     //     2.2 else (version ID of the latest version is unique or there is no latest version) -
@@ -1722,7 +1727,7 @@ class NamespaceFS {
                 const delimiter_idx = create_params_parsed.key.indexOf(params.delimiter, start_idx);
                 if (delimiter_idx > 0) {
                     common_prefixes_set.add(create_params_parsed.key.substring(0, delimiter_idx + 1));
-                    // if key has common prefix it should not be returned as an upload object 
+                    // if key has common prefix it should not be returned as an upload object
                     return undefined;
                 }
             }
@@ -2028,7 +2033,7 @@ class NamespaceFS {
             if (is_key_dir_path && !params.key.endsWith('/')) {
                 return {};
             }
-            if (this._is_versioning_disabled() || (is_key_dir_path && this.should_use_empty_content_dir_optimization())) {
+            if (this._is_versioning_disabled()) {
                 // TODO- Directory object (key/) is currently can't co-exist while key (without slash) exists. see -https://github.com/noobaa/noobaa-core/issues/8320
                 await this._delete_single_object(fs_context, file_path, params);
             } else {
@@ -2166,13 +2171,8 @@ class NamespaceFS {
 
     async delete_object_tagging(params, object_sdk) {
         dbg.log0('NamespaceFS.delete_object_tagging:', params);
-        let file_path;
-        if (params.version_id && this._is_versioning_enabled()) {
-            file_path = this._get_version_path(params.key, params.version_id);
-        } else {
-            file_path = this._get_file_path(params);
-        }
         const fs_context = this.prepare_fs_context(object_sdk);
+        const file_path = await this._find_version_path(fs_context, params, true);
         try {
             await this._clear_user_xattr(fs_context, file_path, XATTR_TAG);
         } catch (err) {
@@ -2188,13 +2188,8 @@ class NamespaceFS {
         for (const [xattr_key, xattr_value] of Object.entries(tagging)) {
               fs_xattr[XATTR_TAG + xattr_key] = xattr_value;
         }
-        let file_path;
-        if (params.version_id && this._is_versioning_enabled()) {
-            file_path = this._get_version_path(params.key, params.version_id);
-        } else {
-            file_path = this._get_file_path(params);
-        }
         const fs_context = this.prepare_fs_context(object_sdk);
+        const file_path = await this._find_version_path(fs_context, params, true);
         dbg.log0('NamespaceFS.put_object_tagging: fs_xattr ', fs_xattr, 'file_path :', file_path);
         try {
             // remove existng tag before putting new tags
@@ -2268,8 +2263,8 @@ class NamespaceFS {
      * restore_object internally relies on 2 xattrs:
      * - XATTR_RESTORE_REQUEST
      * - XATTR_RESTORE_EXPIRY
-     * @param {*} params 
-     * @param {nb.ObjectSDK} object_sdk 
+     * @param {*} params
+     * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<Object>}
      */
     async restore_object(params, object_sdk) {
@@ -2575,8 +2570,8 @@ class NamespaceFS {
      * @param {fs.Dirent} ent
      * @returns {string}
      */
-    _get_entry_key(dir_key, ent, isDir) {
-        if (ent.name === config.NSFS_FOLDER_OBJECT_NAME) return dir_key;
+    _get_entry_key(dir_key, ent, isDir, is_disabled_dir_content) {
+        if (ent.name === config.NSFS_FOLDER_OBJECT_NAME && is_disabled_dir_content) return dir_key;
         return dir_key + ent.name + (isDir ? '/' : '');
     }
 
@@ -2586,7 +2581,6 @@ class NamespaceFS {
      * @returns {string}
      */
      _get_version_entry_key(dir_key, ent) {
-        if (ent.name === config.NSFS_FOLDER_OBJECT_NAME) return dir_key;
         return dir_key + HIDDEN_VERSIONS_PATH + '/' + ent.name;
     }
 
@@ -2753,14 +2747,14 @@ class NamespaceFS {
 
     /**
      * _delete_path_dirs deletes all the paths in the hierarchy that are empty after a successful delete
-     * if the original file_path to be deleted is a regular object which means file_path is not a directory and it's not a directory object path - 
-     * before deletion of the parent directory  - 
+     * if the original file_path to be deleted is a regular object which means file_path is not a directory and it's not a directory object path -
+     * before deletion of the parent directory  -
      * if the parent directory is a directory object (has CONTENT_DIR xattr) - stop the deletion loop
      * else - delete the directory - if dir is not empty it will stop at the first non empty dir
      * NOTE - the directory object check is needed because when object size is zero we won't create a .folder file and the dir will be empty
      * therefore the deletion will succeed although we shouldn't delete the directory object
-     * @param {String} file_path 
-     * @param {nb.NativeFSContext} fs_context 
+     * @param {String} file_path
+     * @param {nb.NativeFSContext} fs_context
      */
     async _delete_path_dirs(file_path, fs_context) {
         try {
@@ -2867,7 +2861,7 @@ class NamespaceFS {
         }
         try {
             // Returns the real path of the entry.
-            // The entry path may point to regular file or directory, but can have symbolic links  
+            // The entry path may point to regular file or directory, but can have symbolic links
             const full_path = await nb_native().fs.realpath(fs_context, entry_path);
             if (!full_path.startsWith(this.bucket_path)) {
                 dbg.log0('check_bucket_boundaries: the path', entry_path, 'is not in the bucket', this.bucket_path, 'boundaries');
@@ -2925,9 +2919,6 @@ class NamespaceFS {
         return is_dir_content && params.size === 0;
     }
 
-    should_use_empty_content_dir_optimization() {
-        return this._is_versioning_disabled() || !config.NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED;
-    }
     /**
      * returns if should force md5 calculation for the bucket/account.
      * first check if defined for bucket / account, if not use global default
@@ -3248,15 +3239,15 @@ class NamespaceFS {
     }
 
     /**
-     * delete version_id does the following - 
+     * delete version_id does the following -
      * 1. get version info, if it's empty - return
      * 2. unlink key
      * 3. if version is latest version - promote second latest -> latest
      * 4. if it's the latest version - delete the directory hirerachy of the key if it's empty
      *    if it's a past version - delete .versions/ and the directory hirerachy if it's empty
-     * @param {nb.NativeFSContext} fs_context 
-     * @param {String} file_path 
-     * @param {Object} params 
+     * @param {nb.NativeFSContext} fs_context
+     * @param {String} file_path
+     * @param {Object} params
      * @returns {Promise<{deleted_delete_marker?: string, version_id?: string}>}
      */
     async _delete_version_id(fs_context, file_path, params) {
@@ -3582,9 +3573,9 @@ class NamespaceFS {
     /**
      * _check_version_moved recieves key and version_id and checks if the version still exists in one of the optional locations
      * latest version location or .versions/ directory
-     * @param {import('./nb').NativeFSContext} fs_context 
-     * @param {string} key 
-     * @param {string} version_id 
+     * @param {import('./nb').NativeFSContext} fs_context
+     * @param {string} key
+     * @param {string} version_id
      */
     async _check_version_moved(fs_context, key, version_id) {
         const latest_version_path = this._get_file_path({ key });
@@ -3674,8 +3665,8 @@ class NamespaceFS {
      * class set to GLACIER and NooBaa is configured for forced get based
      * eviction
      * @param {nb.NativeFSContext} fs_context
-     * @param {string} file_path 
-     * @param {nb.NativeFile} file 
+     * @param {string} file_path
+     * @param {nb.NativeFile} file
      * @param {nb.NativeFSStats} stat
      */
     async _glacier_force_expire_on_get(fs_context, file_path, file, stat) {

--- a/src/test/unit_tests/coretest.js
+++ b/src/test/unit_tests/coretest.js
@@ -27,7 +27,6 @@ config.test_mode = true;
 config.NODES_FREE_SPACE_RESERVE = 10 * 1024 * 1024;
 config.NSFS_VERSIONING_ENABLED = true;
 config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS = 1;
-config.NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED = true;
 
 config.ROOT_KEY_MOUNT = '/tmp/noobaa-server/root_keys';
 

--- a/src/test/unit_tests/jest_tests/test_versioning_concurrency.test.js
+++ b/src/test/unit_tests/jest_tests/test_versioning_concurrency.test.js
@@ -10,8 +10,6 @@ const buffer_utils = require('../../../util/buffer_utils');
 const { TMP_PATH, IS_GPFS, TEST_TIMEOUT } = require('../../system_tests/test_utils');
 const { crypto_random_string } = require('../../../util/string_utils');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
-const config = require('../../../../config');
-config.NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED = true;
 
 function make_dummy_object_sdk(nsfs_config, uid, gid) {
     return {
@@ -635,8 +633,7 @@ describe('test versioning concurrency', () => {
         expect(successful_operations).toHaveLength(num_of_concurrency);
         expect(failed_operations).toHaveLength(0);
         const versions = await nsfs.list_object_versions({ bucket: bucket }, DUMMY_OBJECT_SDK);
-        //TODO should be num_of_concurrency + 1 (the null version). list-object-version currently ignores the latest .folder file
-        expect(versions.objects.length).toBe(num_of_concurrency);
+        expect(versions.objects.length).toBe(num_of_concurrency + 1);
     }, TEST_TIMEOUT);
 });
 

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -205,7 +205,6 @@ async function config_dir_setup() {
         // DO NOT CHANGE - setting VACCUM_ANALYZER_INTERVAL=1 needed for failing the tests
         // in case where vaccumAnalyzer is being called before setting process.env.NC_NSFS_NO_DB_ENV = 'true' on nsfs.js
         VACCUM_ANALYZER_INTERVAL: 1,
-        NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED: true
     }));
     await fs.promises.mkdir(FIRST_BUCKET_PATH, { recursive: true });
 }

--- a/src/test/unit_tests/test_namespace_fs.js
+++ b/src/test/unit_tests/test_namespace_fs.js
@@ -42,8 +42,6 @@ const DEFAULT_FS_CONFIG = get_process_fs_context();
 const empty_data = crypto.randomBytes(0);
 const empty_stream = () => buffer_utils.buffer_to_read_stream(empty_data);
 
-config.NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED = true;
-
 function make_dummy_object_sdk(config_root) {
     return {
         requesting_account: {


### PR DESCRIPTION
### Explain the changes
1. change list-object-versions to work with content directory objects
2. change tagging functions to use _find_version_path in order to get the correct path
3. remove configuration variable to enable content dir versioning, as it should be completed
4. add documentation about content dir versioning
5. add unit test

### Issues: Fixed #xxx / Gap #xxx
Content-dir versioning issue: #8531 
continuation of #8773 

####GAPS

### Testing Instructions:
1. 


- [x] Doc added/updated
- [x] Tests added
