### PR TITLE
bucket notifications - wrong etag, size

### DIFF
--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -65,6 +65,8 @@ async function put_object(req, res) {
     }
     s3_utils.set_encryption_response_headers(req, res, reply.encryption);
 
+    res.size_for_notif = size || reply.size;
+
     if (copy_source) {
         // TODO: This needs to be checked regarding copy between diff namespaces
         // In that case we do not have the copy_source property and just read and upload the stream

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2540,7 +2540,8 @@ class NamespaceFS {
         return {
             etag,
             encryption,
-            version_id
+            version_id,
+            size: stat.size
         };
     }
 

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -422,7 +422,7 @@ function compose_notification_req(req, res, bucket, notif_conf) {
     let eTag = res.getHeader('ETag');
     //eslint-disable-next-line
     if (eTag && eTag.startsWith('\"') && eTag.endsWith('\"')) {
-        eTag = eTag.substring(2, eTag.length - 2);
+        eTag = eTag.substring(1, eTag.length - 1);
     }
 
     const event = OP_TO_EVENT[req.op_name];
@@ -442,7 +442,7 @@ function compose_notification_req(req, res, bucket, notif_conf) {
             "x-amz-id-2": req.request_id,
     };
     notif.s3.object.key = req.params.key;
-    notif.s3.object.size = res.getHeader('content-length');
+    notif.s3.object.size = res.size_for_notif;
     notif.s3.object.eTag = eTag;
     notif.s3.object.versionId = res.getHeader('x-amz-version-id');
 
@@ -461,6 +461,8 @@ function compose_notification_req(req, res, bucket, notif_conf) {
         //in noobaa-ns we have a sequence from db
         notif.s3.object.sequencer = res.seq;
     }
+
+    delete res.size_for_notif;
 
     return compose_meta(notif, notif_conf, bucket);
 }


### PR DESCRIPTION
### Explain the changes
1. Etag was mistakenly cut off of first and last character.
2. size was wrong.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.com/noobaa/noobaa-core/issues/8816

### Testing Instructions:
1. Upload an object to a bucket with notifications configured.
3. Get its etag and size (eg using head-object).
4. Compare with etag and size field in notification.


- [ ] Doc added/updated
- [ ] Tests added
