### PR TITLE
NC | GPFS | Config Files | Create Config Files Size 0 Bug Fix

### DIFF
--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -319,10 +319,9 @@ function get_config_files_tmpdir() {
  * @param {string} config_data 
  */
 async function create_config_file(fs_context, schema_dir, config_path, config_data) {
-    const is_gpfs = _is_gpfs(fs_context);
-    const open_mode = is_gpfs ? 'wt' : 'w';
+    const open_mode = 'w';
+    let open_path;
     let upload_tmp_file;
-    let gpfs_dst_file;
     try {
         // validate config file doesn't exist
         try {
@@ -336,37 +335,30 @@ async function create_config_file(fs_context, schema_dir, config_path, config_da
         dbg.log1('create_config_file:: config_path:', config_path, 'config_data:', config_data, 'is_gpfs:', open_mode);
         // create config dir if it does not exist
         await _create_path(schema_dir, fs_context, config.BASE_MODE_CONFIG_DIR);
-        // when using GPFS open dst file as soon as possible for later linkat validation
-        if (is_gpfs) gpfs_dst_file = await open_file(fs_context, schema_dir, config_path, 'w*', config.BASE_MODE_CONFIG_FILE);
 
         // open tmp file (in GPFS we open the parent dir using wt open mode)
         const tmp_dir_path = path.join(schema_dir, get_config_files_tmpdir());
-        let open_path = is_gpfs ? config_path : await _generate_unique_path(fs_context, tmp_dir_path);
+        open_path = await _generate_unique_path(fs_context, tmp_dir_path);
         upload_tmp_file = await open_file(fs_context, schema_dir, open_path, open_mode, config.BASE_MODE_CONFIG_FILE);
 
         // write tmp file data
         await upload_tmp_file.writev(fs_context, [Buffer.from(config_data)], 0);
 
-        // moving tmp file to config path atomically
-        let src_stat;
-        let gpfs_options;
-        if (is_gpfs) {
-            gpfs_options = { dst_file: gpfs_dst_file, dir_file: upload_tmp_file };
-            // open path in GPFS is the parent dir 
-            open_path = schema_dir;
-        } else {
-            src_stat = await nb_native().fs.stat(fs_context, open_path);
-        }
-        dbg.log1('create_config_file:: moving from:', open_path, 'to:', config_path, 'is_gpfs=', is_gpfs);
+        dbg.log1('create_config_file:: moving from:', open_path, 'to:', config_path);
 
-        await safe_move(fs_context, open_path, config_path, src_stat, gpfs_options, tmp_dir_path);
+        await nb_native().fs.link(fs_context, open_path, config_path);
 
         dbg.log1('create_config_file:: done', config_path);
     } catch (err) {
         dbg.error('create_config_file:: error', err);
         throw err;
     } finally {
-        await finally_close_files(fs_context, [upload_tmp_file, gpfs_dst_file]);
+        await finally_close_files(fs_context, [upload_tmp_file]);
+        try {
+            await nb_native().fs.unlink(fs_context, open_path);
+        } catch (error) {
+            dbg.log0(`create_config_file:: unlink tmp file failed with error ${error}, skipping`);
+        }
     }
 }
 


### PR DESCRIPTION
### Explain the changes
Background to the bug - 
In the current create_config_file() function logic, due to small files rename() low performance we have tried to use GPFS linkat(), GPFS linkat() overrides the link target. Due to this GPFS linkat() optimization, we used the safe_move() mechanism for making the config file creation atomic, before using GPFS safe_move() the destination file should be open (size 0).
In a customer bug we found that when there is an error thrown from one of the steps in the function, we are not cleaning the destination file.

Changes - 
1. On first creation of a file, we will remove the creation of the destination file and the linkat() usage since on GPFS linkat() overrides the link target and will use POSIX link(), link() on race condition will fail if target already exists. By doing this change we will get atomic creation without leaving destination files.

### Issues: Fixed #xxx / Gap #xxx
1. [DFBUGS-1522](https://issues.redhat.com/browse/DFBUGS-1522)

### Testing Instructions:
Manual and Artificial reproduction on GPFS - 

a. Add to `/usr/local/noobaa-core/src/util/native_fs_utils.js` the following artificial error throw - 
`throw new Error('Error test');`
Notice that you need to write that error after this line - 
`if (is_gpfs) gpfs_dst_file = await open_file(fs_context, schema_dir, config_path, 'w*', config.BASE_MODE_CONFIG_FILE);`

b. Create a bucket/account using the CLI/S3 - 
`noobaa-cli bucket add --name=bucket1 --path=/path/to/bucket/storage/path --owner account1`

c. List buckets directory and check for buckets size 0 - 
`sudo ls -la /{config-dir-path}/buckets/`

- [ ] Doc added/updated
- [ ] Tests added
