### PR TITLE
NSFS | versioning | fix nested object concurrency issue

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1445,8 +1445,8 @@ class NamespaceFS {
         // will retry renaming a file in case of parallel deleting of the destination path
         for (;;) {
             try {
-                await native_fs_utils._make_path_dirs(dest_path, fs_context);
                 if (this._is_versioning_disabled() || is_dir_content_optimized_flow) {
+                    await native_fs_utils._make_path_dirs(dest_path, fs_context);
                     if (open_mode === 'wt') {
                         await target_file.linkfileat(fs_context, dest_path);
                     } else {
@@ -1495,6 +1495,8 @@ class NamespaceFS {
             try {
                 let new_ver_info;
                 let latest_ver_info;
+                // dir might be deleted by other thread. will recreacte if missing
+                await native_fs_utils._make_path_dirs(latest_ver_path, fs_context);
                 if (is_gpfs) {
                     const latest_ver_info_exist = await native_fs_utils.is_path_exists(fs_context, latest_ver_path);
                     gpfs_options = await this._open_files_gpfs(fs_context, new_ver_tmp_path, latest_ver_path, upload_file,


### PR DESCRIPTION
### Explain the changes
1. when putting and deleting nested objects at the same time, the delete operation might delete the objects directories inside move_to_dest_versions. in that case we don't recreate the paths if they don't exist. added line to recreate them inside move_to_dest_versions

### Issues: Fixed #8821 

### Testing Instructions:
1. fixes test issues for test that already exists: `content dir multiple puts of the same key - enabled`
2. run `sudo npx jest test_versioning_concurrency.test.js`


- [ ] Doc added/updated
- [ ] Tests added
