### PR TITLE
NC | Fix node warning: Accessing non-existent property 'key' of module exports inside circular dependency

### DIFF
--- a/config.js
+++ b/config.js
@@ -829,6 +829,7 @@ config.NSFS_CONTENT_DIRECTORY_VERSIONING_ENABLED = false;
 config.NSFS_EXIT_EVENTS_TIME_FRAME_MIN = 24 * 60; // per day
 config.NSFS_MAX_EXIT_EVENTS_PER_TIME_FRAME = 10; // allow max 10 failed forks per day
 
+config.GPFS_DL_PATH = '/usr/lpp/mmfs/lib/libgpfs.so';
 config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = 'true';
 
 config.NSFS_GLACIER_LOGS_DIR = '/var/run/noobaa-nsfs/wal';
@@ -1119,11 +1120,12 @@ function _get_config_root() {
 */
 function _set_nc_config_to_env() {
     const config_to_env = ['NOOBAA_LOG_LEVEL', 'UV_THREADPOOL_SIZE', 'GPFS_DL_PATH', 'NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS'];
-    Object.values(config_to_env).forEach(function(key) {
-        if (config[key] !== undefined) {
-            process.env[key] = config[key];
+    for (const configuration_key of config_to_env) {
+        if (config && Object.keys(config).includes(configuration_key) && config[configuration_key] !== undefined) {
+            console.warn('setting configuration_key as env var', configuration_key, config[configuration_key]);
+            process.env[configuration_key] = config[configuration_key];
         }
-    });
+    }
 }
 
 /**
@@ -1181,7 +1183,7 @@ function load_nsfs_nc_config() {
         console.warn(`nsfs: config.json= ${util.inspect(config_data)}`);
         console.warn(`nsfs: merged config.json= ${util.inspect(merged_config)}`);
         validate_nc_master_keys_config(config);
-        config.event_emitter.emit("config_updated");
+        config.event_emitter.emit('config_updated');
     } catch (err) {
         if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ENOENT') throw err;
         console.warn('config.load_nsfs_nc_config could not find config.json... skipping');

--- a/docs/NooBaaNonContainerized/ConfigFileCustomizations.md
+++ b/docs/NooBaaNonContainerized/ConfigFileCustomizations.md
@@ -112,7 +112,7 @@ The following list consists of supported optional developer customization -
 ### 7. GPFS library path -
 * <u>Key</u>: `GPFS_DL_PATH`  
 * <u>Type</u>: String  
-* <u>Default</u>: ''   
+* <u>Default</u>: '/usr/lpp/mmfs/lib/libgpfs.so'  
 * <u>Description</u>: Set GPFS library path location.  
 * <u>Steps</u>:  
     ```


### PR DESCRIPTION
### Explain the changes
1. A new node dependency warning started showing after merging [PR](https://github.com/noobaa/noobaa-core/pull/8769) when running NC nsfs/CLI - 
```
(node:30731) Warning: Accessing non-existent property 'NOOBAA_LOG_LEVEL' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
2025-03-02 18:51:49.362704 [PID-30731/TID-8963] [L1] FS::FSWorker::Execute: Readfile 
(node:30731) Warning: Accessing non-existent property 'UV_THREADPOOL_SIZE' of module exports inside circular dependency
(node:30731) Warning: Accessing non-existent property 'GPFS_DL_PATH' of module exports inside circular dependency
```
Attaching logs when running with --node-trace-warnings at the additional details section. 
The fix added in this PR avoids accessing non existing properties in config but it won't fix the circular dependency.

2. Added a default of gpfs lib location.


Additional Details - 
```
(node:31086) Warning: Accessing non-existent property 'NOOBAA_LOG_LEVEL' of module exports inside circular dependency
    at emitCircularRequireWarning (node:internal/modules/cjs/loader:937:11)
    at Object.get (node:internal/modules/cjs/loader:953:5)
    at noobaa-core/config.js:1123:19
    at Array.forEach (<anonymous>)
    at _set_nc_config_to_env (noobaa-core/config.js:1122:34)
    at load_nsfs_nc_config (noobaa-core/config.js:1189:5)
    at Object.<anonymous> (noobaa-core/config.js:1238:1)
    at Module._compile (node:internal/modules/cjs/loader:1467:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1551:10)
    at Module.load (node:internal/modules/cjs/loader:1282:32)
(node:31086) Warning: Accessing non-existent property 'UV_THREADPOOL_SIZE' of module exports inside circular dependency
    at emitCircularRequireWarning (node:internal/modules/cjs/loader:937:11)
    at Object.get (node:internal/modules/cjs/loader:953:5)
    at noobaa-core/config.js:1123:19
    at Array.forEach (<anonymous>)
    at _set_nc_config_to_env (noobaa-core/config.js:1122:34)
    at load_nsfs_nc_config (noobaa-core/config.js:1189:5)
    at Object.<anonymous> (noobaa-core/config.js:1238:1)
    at Module._compile (node:internal/modules/cjs/loader:1467:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1551:10)
    at Module.load (node:internal/modules/cjs/loader:1282:32)
(node:31086) Warning: Accessing non-existent property 'GPFS_DL_PATH' of module exports inside circular dependency
    at emitCircularRequireWarning (node:internal/modules/cjs/loader:937:11)
    at Object.get (node:internal/modules/cjs/loader:953:5)
    at noobaa-core/config.js:1123:19
    at Array.forEach (<anonymous>)
    at _set_nc_config_to_env (noobaa-core/config.js:1122:34)
    at load_nsfs_nc_config (noobaa-core/config.js:1189:5)
    at Object.<anonymous> (noobaa-core/config.js:1238:1)
    at Module._compile (node:internal/modules/cjs/loader:1467:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1551:10)
    at Module.load (node:internal/modules/cjs/loader:1282:32)
```


### Issues: Fixed #xxx / Gap #xxx
1. Open a gap about the circular dependencies found in this file.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
