### PR TITLE
Fix RPM build on RHEL8 & friends

### DIFF
--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -32,6 +32,7 @@ RUN ./src/deploy/NVA_build/clone_s3select_submodules.sh
 RUN ln -s /lib64/libboost_thread.so.1.66.0 /lib64/libboost_thread.so.1.75.0 || true
 #Pass BUILD_S3SELECT down to GYP native build.
 #S3Select will be built only if this parameter is equal to "1".
+#Next step would fail for RHEL8 and derivatives
 RUN GYP_DEFINES="BUILD_S3SELECT=$BUILD_S3SELECT BUILD_S3SELECT_PARQUET=$BUILD_S3SELECT_PARQUET" npm run build
 
 ##############################################################

--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -38,6 +38,9 @@ COPY ./src/deploy/standalone/noobaa-logrotate ./src/deploy/standalone/noobaa-log
 COPY ./src/manage_nsfs ./src/manage_nsfs
 COPY ./src/nc ./src/nc
 
+# Install GCC11 toolchain on Centos8 to match the default toolchain of Centos9
+RUN if [ "$CENTOS_VER" == "8" ];then dnf install -y -q gcc-toolset-11; fi
+
 WORKDIR /build
 
 COPY ./src/deploy/RPM_build/* ./
@@ -54,4 +57,5 @@ ENV BUILD_S3SELECT_PARQUET=${BUILD_S3SELECT_PARQUET}
 ENV CENTOS_VER=${CENTOS_VER}
 ENV SRPM_ONLY=${SRPM_ONLY}
 RUN mkdir -p /export
-CMD ./packagerpm.sh /export /build
+# Set GCC Toolset in path - won't exist in RHEL9 but that's OK
+CMD PATH=/opt/rh/gcc-toolset-11/root/bin:$PATH ./packagerpm.sh /export /build

--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -31,6 +31,9 @@ BuildRequires:  make
 BuildRequires:  gcc-c++
 BuildRequires:  boost-devel
 BuildRequires:  libcap-devel
+%if 0%{?rhel} == 8
+BuildRequires:  gcc-toolset-11
+%endif
 
 Recommends:     jemalloc
 
@@ -43,6 +46,7 @@ NooBaa is a data service for cloud environments, providing S3 object-store inter
 %setup -n noobaa -q
 
 %build
+PATH=/opt/rh/gcc-toolset-11/root/bin:$PATH
 NODEJS_VERSION="%{nodever}"
 SKIP_NODE_INSTALL=1 source src/deploy/NVA_build/install_nodejs.sh $NODEJS_VERSION
 

--- a/src/native/s3select/s3select.gyp
+++ b/src/native/s3select/s3select.gyp
@@ -4,6 +4,7 @@
         'target_name': 's3select',
         'type': 'static_library',
         'cflags_cc!': ['-fno-rtti'],
+        'cflags_cc': ['-std=c++17'],
         'include_dirs': [
             '<@(napi_include_dirs)',
             '../../../submodules/s3select/include',


### PR DESCRIPTION
### Explain the changes
This PR attempts to fix the broken builds of NooBaa RPM on RHEL8.

### Testing Instructions:
1. `make rpm CENTOS_VER=8` should work.
2. `make rpm CENTOS_VER=9` should also work.


- [ ] Doc added/updated
- [ ] Tests added
