### PR TITLE
NC | Lifecycle | Add lock to lifecycle worker

### DIFF
--- a/config.js
+++ b/config.js
@@ -961,6 +961,27 @@ config.NC_DISABLE_HEALTH_ACCESS_CHECK = false;
 config.NC_DISABLE_POSIX_MODE_ACCESS_CHECK = true;
 config.NC_DISABLE_SCHEMA_CHECK = false;
 
+////////// NC LIFECYLE  //////////
+
+config.LIFECYCLE_LOGS_DIR = '/var/log/noobaa/lifecycle';
+
+// NC_LIFECYCLE_RUN_TIME must be of the format hh:mm which specifies
+// when NooBaa should allow running nc lifecycle process
+// NOTE: This will also be in the same timezone as specified in
+// NC_LIFECYCLE_TZ
+config.NC_LIFECYCLE_RUN_TIME = '01:00';
+
+// NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS configures the delay
+// tolerance in minutes.
+//
+// eg. If the expiry run time is set to 01:00 and the tolerance is
+// set to be 2 mins then the expiry can trigger till 01:02 (unless
+// already triggered between 01:00 - 01:02
+config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS = 2;
+
+/** @type {'UTC' | 'LOCAL'} */
+config.NC_LIFECYCLE_TZ = 'LOCAL';
+
 ////////// GPFS //////////
 config.GPFS_DOWN_DELAY = 1000;
 

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -881,8 +881,9 @@ async function list_connections() {
  * @returns {Promise<void>}
  */
 async function lifecycle_management(args) {
-    const disable_service_validation = args.disable_service_validation === 'true';
-    await noobaa_cli_lifecycle.run_lifecycle(config_fs, disable_service_validation);
+    const disable_service_validation = get_boolean_or_string_value(args.disable_service_validation);
+    const disable_runtime_validation = get_boolean_or_string_value(args.disable_runtime_validation);
+    await noobaa_cli_lifecycle.run_lifecycle_under_lock(config_fs, disable_service_validation, disable_runtime_validation);
 }
 
 exports.main = main;

--- a/src/manage_nsfs/manage_nsfs_cli_utils.js
+++ b/src/manage_nsfs/manage_nsfs_cli_utils.js
@@ -198,6 +198,91 @@ async function get_service_status(service_name) {
     return service_status;
 }
 
+/**
+ * is_desired_time returns true if the given time matches with
+ * the desired time or if 
+ * @param {nb.NativeFSContext} fs_context 
+ * @param {Date} current
+ * @param {string} desire time in format 'hh:mm'
+ * @param {number} delay_limit_mins
+ * @param {string} timestamp_file_path 
+ * @param {"UTC" | "LOCAL"} timezone
+ * @returns {Promise<boolean>}
+ */
+async function is_desired_time(fs_context, current, desire, delay_limit_mins, timestamp_file_path, timezone) {
+    const [desired_hour, desired_min] = desire.split(':').map(Number);
+    if (
+        isNaN(desired_hour) ||
+        isNaN(desired_min) ||
+        (desired_hour < 0 || desired_hour >= 24) ||
+        (desired_min < 0 || desired_min >= 60)
+    ) {
+        throw new Error('invalid desired_time - must be hh:mm');
+    }
+
+    const min_time = get_tz_date(desired_hour, desired_min, 0, timezone);
+    const max_time = get_tz_date(desired_hour, desired_min + delay_limit_mins, 0, timezone);
+
+    if (current >= min_time && current <= max_time) {
+        try {
+            const { data } = await nb_native().fs.readFile(fs_context, timestamp_file_path);
+            const lastrun = new Date(data.toString());
+
+            // Last run should NOT be in this window
+            if (lastrun >= min_time && lastrun <= max_time) return false;
+        } catch (error) {
+            if (error.code === 'ENOENT') return true;
+            console.error('failed to read last run timestamp:', error, 'timestamp_file_path:', timestamp_file_path);
+
+            throw error;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+
+/**
+ * record_current_time stores the current timestamp in ISO format into
+ * the given timestamp file
+ * @param {nb.NativeFSContext} fs_context 
+ * @param {string} timestamp_file_path 
+ */
+async function record_current_time(fs_context, timestamp_file_path) {
+    await nb_native().fs.writeFile(
+        fs_context,
+        timestamp_file_path,
+        Buffer.from(new Date().toISOString()),
+    );
+}
+
+/**
+ * @param {number} hours
+ * @param {number} mins
+ * @param {number} secs
+ * @param {'UTC' | 'LOCAL'} tz
+ * @returns {Date}
+ */
+function get_tz_date(hours, mins, secs, tz) {
+    const date = new Date();
+
+    if (tz === 'UTC') {
+        date.setUTCHours(hours);
+        date.setUTCMinutes(hours);
+        date.setUTCSeconds(secs);
+        date.setUTCMilliseconds(0);
+    } else {
+        date.setHours(hours);
+        date.setMinutes(mins);
+        date.setSeconds(secs);
+        date.setMilliseconds(0);
+    }
+
+    return date;
+}
+
 // EXPORTS
 exports.throw_cli_error = throw_cli_error;
 exports.write_stdout_response = write_stdout_response;
@@ -212,3 +297,6 @@ exports.is_name_update = is_name_update;
 exports.is_access_key_update = is_access_key_update;
 exports.get_service_status = get_service_status;
 exports.NOOBAA_SERVICE_NAME = NOOBAA_SERVICE_NAME;
+exports.is_desired_time = is_desired_time;
+exports.record_current_time = record_current_time;
+exports.get_tz_date = get_tz_date;

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -96,7 +96,7 @@ const VALID_OPTIONS_CONNECTION = {
     'status': new Set(['name', 'decrypt', ...CLI_MUTUAL_OPTIONS]),
 };
 
-const VALID_OPTIONS_LIFECYCLE = new Set(['disable_service_validation', ...CLI_MUTUAL_OPTIONS]);
+const VALID_OPTIONS_LIFECYCLE = new Set(['disable_service_validation', 'disable_runtime_validation', ...CLI_MUTUAL_OPTIONS]);
 
 const VALID_OPTIONS_WHITELIST = new Set(['ips', ...CLI_MUTUAL_OPTIONS]);
 
@@ -155,7 +155,8 @@ const OPTION_TYPE = {
     custom_upgrade_scripts_dir: 'string',
     skip_verification: 'boolean',
     // lifecycle options
-    disable_service_validation: 'string',
+    disable_service_validation: 'boolean',
+    disable_runtime_validation: 'boolean',
     //connection
     notification_protocol: 'string',
     agent_request_object: 'string',
@@ -168,7 +169,7 @@ const OPTION_TYPE = {
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];
 const BOOLEAN_STRING_OPTIONS = new Set(['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force',
-    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous']);
+    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous', 'disable_service_validation', 'disable_runtime_validation']);
 
 // CLI UNSET VALUES
 const CLI_EMPTY_STRING = '';

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -712,6 +712,24 @@ function translate_error_codes(err, entity) {
     return err;
 }
 
+/**
+ * lock_and_run acquires a fcntl and calls the given callback after
+ * acquiring the lock
+ * @param {nb.NativeFSContext} fs_context 
+ * @param {string} lock_path
+ * @param {Function} cb 
+ */
+async function lock_and_run(fs_context, lock_path, cb) {
+    const lockfd = await nb_native().fs.open(fs_context, lock_path, 'w');
+
+    try {
+        await lockfd.fcntllock(fs_context, 'EXCLUSIVE');
+        await cb();
+    } finally {
+        await lockfd.close(fs_context);
+    }
+}
+
 exports.get_umasked_mode = get_umasked_mode;
 exports._make_path_dirs = _make_path_dirs;
 exports._create_path = _create_path;
@@ -754,3 +772,6 @@ exports.get_bucket_tmpdir_full_path = get_bucket_tmpdir_full_path;
 exports.get_bucket_tmpdir_name = get_bucket_tmpdir_name;
 exports.entity_enum = entity_enum;
 exports.translate_error_codes = translate_error_codes;
+
+exports.lock_and_run = lock_and_run;
+


### PR DESCRIPTION
### Describe the Problem
NC lifecycle worker should run by a cron job from multiple nodes - 
Currently, we would like only one process/worker will do the lifecycle worker work.
In the future, the work will split by all the different lifecycle workers.
NooBaa will synchronize the cron jobs running on the different nodes by using a file system lock (like NooBaa does for Glacier).

### Explain the Changes
1. nc_lifecycle - created a wrapper function called run_lifecycle_under_lock() that takes a file system lock before running the lifecycle work, used native_fs_utils.lock_and_run() function.
the lock called cluster.lock (similarly to glacier's terms) but it's stored under the config directory. 
3. moved lock_and_run() from manage_nsfs_glacier to native_fs_utils.
4. manage_nsfs - called run_lifecycle_under_lock() instead of run_lifecycle().

### Issues: Fixed #xxx / Gap #xxx
1. Gap - add automatic unit tests assets - currently added tests but blocked on [8860](https://github.com/noobaa/noobaa-core/pull/8860) for asserting the response.

### Testing Instructions:
Manual & Artificial test without run time validation - 
1. Add `await P.delay(10000);` inside the lock callback.
2. Tab 1 - Run `noobaa-cli lifecycle --disable_runtime_validation`.
3. Tab 2 - Run `noobaa-cli lifecycle --disable_runtime_validation`.
4. Checked that in the logs of tab 1 I see `run_lifecycle_under_lock acquired lock - start lifecycle'` and after 10 seconds I see `run_lifecycle_under_lock done lifecycle - released lock` and only after the release of the lock I see these log messages in Tab 2.
5. Run `ls /etc/noobaa.conf.d/` - check that the lock file called cluster.lock was created.  

Manual & Artificial test without run time validation - 
1. Change in config.json NC_LIFECYLE_RUN_TIME to be the time now in format HH:MM.
2. Add `await P.delay(10000);` inside the lock callback.
3. Tab 1 - Run `noobaa-cli lifecycle --disable_runtime_validation`.
4. Tab 2 - Run `noobaa-cli lifecycle --disable_runtime_validation`.
5. Checked that in the logs of tab 1 I see `run_lifecycle_under_lock acquired lock - start lifecycle'` and after 10 seconds I see `run_lifecycle_under_lock done lifecycle - released lock` and only after the release of the lock I see these log messages in Tab 2.
6. Run `ls /etc/noobaa.conf.d/` - check that the lock file called cluster.lock was created.  
- [ ] Doc added/updated
- [ ] Tests added
