### PR TITLE
NC | Lifecycle | Status, Events, Timeout

### DIFF
--- a/config.js
+++ b/config.js
@@ -1011,7 +1011,8 @@ config.NC_DISABLE_SCHEMA_CHECK = false;
 
 ////////// NC LIFECYLE  //////////
 
-config.LIFECYCLE_LOGS_DIR = '/var/log/noobaa/lifecycle';
+config.NC_LIFECYCLE_LOGS_DIR = '/var/log/noobaa/lifecycle';
+config.NC_LIFECYCLE_TIMEOUT_MS = 6 * 60 * 60 * 1000;
 
 // NC_LIFECYCLE_RUN_TIME must be of the format hh:mm which specifies
 // when NooBaa should allow running nc lifecycle process

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -883,7 +883,8 @@ async function list_connections() {
 async function lifecycle_management(args) {
     const disable_service_validation = get_boolean_or_string_value(args.disable_service_validation);
     const disable_runtime_validation = get_boolean_or_string_value(args.disable_runtime_validation);
-    await noobaa_cli_lifecycle.run_lifecycle_under_lock(config_fs, disable_service_validation, disable_runtime_validation);
+    const short = get_boolean_or_string_value(args.short);
+    await noobaa_cli_lifecycle.run_lifecycle_under_lock(config_fs, { disable_service_validation, disable_runtime_validation, short });
 }
 
 exports.main = main;

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -534,6 +534,18 @@ ManageCLIError.NooBaaServiceIsNotActive = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.LifecycleFailed = Object.freeze({
+    code: 'LifecycleFailed',
+    message: 'Lifecycle worker run failed.',
+    http_code: 400,
+});
+
+ManageCLIError.LifecycleWorkerReachedTimeout = Object.freeze({
+    code: 'LifecycleWorkerReachedTimeout',
+    message: `Lifecycle worker reached timeout - configured timeout is ${config.NC_LIFECYCLE_TIMEOUT_MS} ms`,
+    http_code: 400,
+});
+
 ///////////////////////////////
 //       ERRORS MAPPING      //
 ///////////////////////////////
@@ -556,7 +568,8 @@ ManageCLIError.RPC_ERROR_TO_MANAGE = Object.freeze({
     NO_SUCH_USER: ManageCLIError.InvalidAccountDistinguishedName,
     INVALID_MASTER_KEY: ManageCLIError.InvalidMasterKey,
     INVALID_BUCKET_NAME: ManageCLIError.InvalidBucketName,
-    CONFIG_DIR_VERSION_MISMATCH: ManageCLIError.ConfigDirUpdateBlocked
+    CONFIG_DIR_VERSION_MISMATCH: ManageCLIError.ConfigDirUpdateBlocked,
+    LIFECYCLE_WORKER_TIMEOUT: ManageCLIError.LifecycleWorkerReachedTimeout
 });
 
 const NSFS_CLI_ERROR_EVENT_MAP = {
@@ -569,7 +582,9 @@ const NSFS_CLI_ERROR_EVENT_MAP = {
     BucketSetForbiddenBucketOwnerNotExists: NoobaaEvent.UNAUTHORIZED, // GAP - add event
     BucketSetForbiddenBucketOwnerIsIAMAccount: NoobaaEvent.UNAUTHORIZED, // // GAP - add event
     LoggingExportFailed: NoobaaEvent.LOGGING_FAILED,
-    UpgradeFailed: NoobaaEvent.CONFIG_DIR_UPGRADE_FAILED
+    UpgradeFailed: NoobaaEvent.CONFIG_DIR_UPGRADE_FAILED,
+    LifecycleFailed: NoobaaEvent.LIFECYCLE_FAILED,
+    LifecycleWorkerReachedTimeout: NoobaaEvent.LIFECYCLE_TIMEOUT
 };
 
 exports.ManageCLIError = ManageCLIError;

--- a/src/manage_nsfs/manage_nsfs_cli_responses.js
+++ b/src/manage_nsfs/manage_nsfs_cli_responses.js
@@ -1,6 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const config = require('../../config');
+
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 
 // TODO : define list & status types
@@ -198,6 +200,24 @@ ManageCLIResponse.ConnectionList = Object.freeze({
 });
 
 ///////////////////////////////
+//    LIFECYCLE RESPONSES    //
+///////////////////////////////
+
+ManageCLIResponse.LifecycleSuccessful = Object.freeze({
+    code: 'LifecycleSuccessful',
+    message: 'Lifecycle worker run finished successfully',
+    status: {}
+});
+
+ManageCLIResponse.LifecycleWorkerNotRunning = Object.freeze({
+    code: 'LifecycleWorkerNotRunning',
+    message: `Lifecycle worker must run at ${config.NC_LIFECYCLE_RUN_TIME} ` +
+        `with delay of ${config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS} minutes ` +
+        `in timezone ${config.NC_LIFECYCLE_TZ}`,
+    status: {}
+});
+
+///////////////////////////////
 //  RESPONSES-EVENT MAPPING  //
 ///////////////////////////////
 
@@ -209,7 +229,8 @@ const NSFS_CLI_SUCCESS_EVENT_MAP = {
     WhiteListIPUpdated: NoobaaEvent.WHITELIST_UPDATED,
     LoggingExported: NoobaaEvent.LOGGING_EXPORTED,
     UpgradeStarted: NoobaaEvent.CONFIG_DIR_UPGRADE_STARTED,
-    UpgradeSuccessful: NoobaaEvent.CONFIG_DIR_UPGRADE_SUCCESSFUL
+    UpgradeSuccessful: NoobaaEvent.CONFIG_DIR_UPGRADE_SUCCESSFUL,
+    LifecycleSuccessful: NoobaaEvent.LIFECYCLE_SUCCESSFUL
 };
 
 exports.ManageCLIResponse = ManageCLIResponse;

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -96,7 +96,7 @@ const VALID_OPTIONS_CONNECTION = {
     'status': new Set(['name', 'decrypt', ...CLI_MUTUAL_OPTIONS]),
 };
 
-const VALID_OPTIONS_LIFECYCLE = new Set(['disable_service_validation', 'disable_runtime_validation', ...CLI_MUTUAL_OPTIONS]);
+const VALID_OPTIONS_LIFECYCLE = new Set(['disable_service_validation', 'disable_runtime_validation', 'short', ...CLI_MUTUAL_OPTIONS]);
 
 const VALID_OPTIONS_WHITELIST = new Set(['ips', ...CLI_MUTUAL_OPTIONS]);
 
@@ -158,6 +158,7 @@ const OPTION_TYPE = {
     // lifecycle options
     disable_service_validation: 'boolean',
     disable_runtime_validation: 'boolean',
+    short: 'boolean',
     //connection
     notification_protocol: 'string',
     agent_request_object: 'string',
@@ -170,7 +171,7 @@ const OPTION_TYPE = {
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];
 const BOOLEAN_STRING_OPTIONS = new Set(['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force',
-    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous', 'disable_service_validation', 'disable_runtime_validation']);
+    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous', 'disable_service_validation', 'disable_runtime_validation', 'short']);
 
 // CLI UNSET VALUES
 const CLI_EMPTY_STRING = '';

--- a/src/manage_nsfs/manage_nsfs_events_utils.js
+++ b/src/manage_nsfs/manage_nsfs_events_utils.js
@@ -410,4 +410,52 @@ NoobaaEvent.NOTIFICATION_FAILED = Object.freeze({
     state: 'HEALTHY',
 });
 
+////////////////////////////
+//   LIFECYCLE EVENTS     //
+////////////////////////////
+
+NoobaaEvent.LIFECYCLE_STARTED = Object.freeze({
+    event_code: 'noobaa_lifecycle_worker_started',
+    entity_type: 'NODE',
+    event_type: 'INFO',
+    message: 'NooBaa Lifecycle worker run started.',
+    description: 'NooBaa Lifecycle worker run started.',
+    scope: 'NODE',
+    severity: 'INFO',
+    state: 'HEALTHY',
+});
+
+NoobaaEvent.LIFECYCLE_SUCCESSFUL = Object.freeze({
+    event_code: 'noobaa_lifecycle_worker_finished_successfully',
+    entity_type: 'NODE',
+    event_type: 'INFO',
+    message: 'NooBaa Lifecycle worker run finished successfully.',
+    description: 'NooBaa Lifecycle worker finished successfully.',
+    scope: 'NODE',
+    severity: 'INFO',
+    state: 'HEALTHY',
+});
+
+NoobaaEvent.LIFECYCLE_FAILED = Object.freeze({
+    event_code: 'noobaa_lifecycle_worker_failed',
+    message: 'NooBaa Failed to run lifecycle worker.',
+    description: 'NooBaa Lifecycle worker run failed due to an error.',
+    entity_type: 'NODE',
+    event_type: 'ERROR',
+    scope: 'NODE',
+    severity: 'ERROR',
+    state: 'DEGRADED',
+});
+
+NoobaaEvent.LIFECYCLE_TIMEOUT = Object.freeze({
+    event_code: 'noobaa_lifecycle_worker_timeout',
+    message: 'NooBaa lifecycle worker run timed out.',
+    description: 'NooBaa Lifecycle worker run timed out.',
+    entity_type: 'NODE',
+    event_type: 'ERROR',
+    scope: 'NODE',
+    severity: 'ERROR',
+    state: 'DEGRADED',
+});
+
 exports.NoobaaEvent = NoobaaEvent;

--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const dbg = require('../util/debug_module')(__filename);
+const os = require('os');
 const _ = require('lodash');
 const path = require('path');
 const util = require('util');
@@ -10,49 +11,94 @@ const config = require('../../config');
 const nb_native = require('../util/nb_native');
 const NsfsObjectSDK = require('../sdk/nsfs_object_sdk');
 const native_fs_utils = require('../util/native_fs_utils');
+const { NoobaaEvent } = require('./manage_nsfs_events_utils');
 const ManageCLIError = require('./manage_nsfs_cli_errors').ManageCLIError;
-const { throw_cli_error, get_service_status, NOOBAA_SERVICE_NAME } = require('./manage_nsfs_cli_utils');
-const { is_desired_time, record_current_time } = require('./manage_nsfs_cli_utils');
+const ManageCLIResponse = require('../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
+const { write_stdout_response, throw_cli_error, get_service_status, NOOBAA_SERVICE_NAME,
+    is_desired_time, record_current_time } = require('./manage_nsfs_cli_utils');
 
 // TODO:
 // implement 
 // 1. notifications
 // 2. POSIX scanning and filtering per rule
 // 3. GPFS ILM policy and apply for scanning and filtering optimization
+// TODO - we will filter during the scan except for get_candidates_by_expiration_rule on GPFS that does the filter on the file system
 
 const CLUSTER_LOCK = 'cluster.lock';
 const LIFECYLE_TIMESTAMP_FILE = 'lifecycle.timestamp';
+const config_fs_options = { silent_if_missing: true };
+
+const lifecycle_run_status = {
+    running_host: os.hostname(), lifecycle_run_times: {},
+    total_stats: _get_default_stats(), buckets_statuses: {}
+};
+
+let short_status = false;
+
+const TIMED_OPS = Object.freeze({
+    RUN_LIFECYLE: 'run_lifecycle',
+    LIST_BUCKETS: 'list_buckets',
+    PROCESS_BUCKETS: 'process_buckets',
+    PROCESS_BUCKET: 'process_bucket',
+    PROCESS_RULE: 'process_rule',
+    GET_CANDIDATES: 'get_candidates',
+    ABORT_MPUS: 'abort_mpus',
+    DELETE_MULTIPLE_OBJECTS: 'delete_multiple_objects'
+});
 
 /**
  * run_lifecycle_under_lock runs the lifecycle workflow under a file system lock
  * lifecycle workflow is being locked to prevent multiple instances from running the lifecycle workflow
  * @param {import('../sdk/config_fs').ConfigFS} config_fs 
- * @param {boolean} disable_service_validation 
- * @param {boolean} disable_runtime_validation
+ * @param {{disable_service_validation?: boolean, disable_runtime_validation?: boolean, short?: boolean}} flags
  */
-async function run_lifecycle_under_lock(config_fs, disable_service_validation, disable_runtime_validation) {
-    const lifecyle_logs_dir_path = config.LIFECYCLE_LOGS_DIR;
-    await config_fs.create_dir_if_missing(lifecyle_logs_dir_path);
-    const lock_path = path.join(lifecyle_logs_dir_path, CLUSTER_LOCK);
+async function run_lifecycle_under_lock(config_fs, flags) {
+    const { disable_service_validation = false, disable_runtime_validation = false, short = false } = flags;
+    short_status = short;
     const fs_context = config_fs.fs_context;
+    const lifecyle_logs_dir_path = config.NC_LIFECYCLE_LOGS_DIR;
+    const lock_path = path.join(lifecyle_logs_dir_path, CLUSTER_LOCK);
+    const lifecycle_timestamp_file_path = path.join(lifecyle_logs_dir_path, LIFECYLE_TIMESTAMP_FILE);
+    await config_fs.create_dir_if_missing(lifecyle_logs_dir_path);
 
     await native_fs_utils.lock_and_run(fs_context, lock_path, async () => {
         dbg.log0('run_lifecycle_under_lock acquired lock - start lifecycle');
-        const lifecycle_timestamp_file_path = path.join(lifecyle_logs_dir_path, LIFECYLE_TIMESTAMP_FILE);
-        const should_run = disable_runtime_validation ? true :
-            await is_desired_time(
-                fs_context,
-                new Date(),
-                config.NC_LIFECYCLE_RUN_TIME,
-                config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS,
-                lifecycle_timestamp_file_path,
-                config.NC_LIFECYCLE_TZ);
-        dbg.log0('run_lifecycle_under_lock should_run', should_run);
-        if (should_run) {
-            await run_lifecycle(config_fs, disable_service_validation);
+        const should_run = await _should_lifecycle_run(fs_context, lifecycle_timestamp_file_path, disable_runtime_validation);
+        if (!should_run) write_stdout_response(ManageCLIResponse.LifecycleWorkerNotRunning);
+
+        try {
+            dbg.log0('run_lifecycle_under_lock acquired lock - start lifecycle');
+            new NoobaaEvent(NoobaaEvent.LIFECYCLE_STARTED).create_event();
+            await run_lifecycle_or_timeout(config_fs, disable_service_validation);
+            write_stdout_response(ManageCLIResponse.LifecycleSuccessful, lifecycle_run_status);
+        } catch (err) {
+            dbg.error('run_lifecycle_under_lock failed with error', err, err.code, err.message);
+            throw_cli_error(err);
+        } finally {
             await record_current_time(fs_context, lifecycle_timestamp_file_path);
+            await write_lifecycle_log_file(config_fs.fs_context, lifecyle_logs_dir_path);
+            dbg.log0('run_lifecycle_under_lock done lifecycle - released lock');
         }
-        dbg.log0('run_lifecycle_under_lock done lifecycle - released lock');
+    });
+}
+
+/**
+ * run_lifecycle_or_timeout runs the lifecycle workflow or times out while calculating 
+ * and saving times and stats of the run on the global lifecycle status
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs 
+ * @param {boolean} disable_service_validation
+ * @returns {Promise<Void>}
+ */
+async function run_lifecycle_or_timeout(config_fs, disable_service_validation) {
+    await _call_op_and_update_status({
+        op_name: TIMED_OPS.RUN_LIFECYLE,
+        op_func: async () => {
+            await P.timeout(
+                config.NC_LIFECYCLE_TIMEOUT_MS,
+                run_lifecycle(config_fs, disable_service_validation),
+                () => ManageCLIError.LifecycleWorkerReachedTimeout
+            );
+        }
     });
 }
 
@@ -63,25 +109,177 @@ async function run_lifecycle_under_lock(config_fs, disable_service_validation, d
  * @returns {Promise<Void>}
  */
 async function run_lifecycle(config_fs, disable_service_validation) {
-    const options = { silent_if_missing: true };
-    const system_json = await config_fs.get_system_config_file(options);
+    const system_json = await config_fs.get_system_config_file(config_fs_options);
     if (!disable_service_validation) await throw_if_noobaa_not_active(config_fs, system_json);
 
-    const bucket_names = await config_fs.list_buckets();
-    const concurrency = 10; // TODO - think about it
-    await P.map_with_concurrency(concurrency, bucket_names, async bucket_name => {
-        const bucket_json = await config_fs.get_bucket_by_name(bucket_name, options);
-        const account = { email: '', nsfs_account_config: config_fs.fs_context, access_keys: [] };
-        const object_sdk = new NsfsObjectSDK('', config_fs, account, bucket_json.versioning, config_fs.config_root, system_json);
-        //TODO temporary - need to check if we want to use a real account
-        object_sdk._simple_load_requesting_account();
-        await P.all(_.map(bucket_json.lifecycle_configuration_rules,
-            async (lifecycle_rule, j) => {
-                dbg.log0('NC LIFECYCLE READ BUCKETS configuration handle_bucket_rule bucket name:', bucket_json.name, 'rule', lifecycle_rule, 'j', j);
-                return await handle_bucket_rule(config_fs, lifecycle_rule, j, bucket_json, object_sdk);
-            }
-        ));
+    const bucket_names = await _call_op_and_update_status({
+        op_name: TIMED_OPS.LIST_BUCKETS,
+        op_func: async () => config_fs.list_buckets()
     });
+
+    await _call_op_and_update_status({
+        op_name: TIMED_OPS.PROCESS_BUCKETS,
+        op_func: async () => process_buckets(config_fs, bucket_names, system_json)
+    });
+}
+
+/**
+ * process_buckets iterates over buckets and handles their rules
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs 
+ * @param {String[]} bucket_names 
+ * @param {Object} system_json
+ * @returns {Promise<Void>}
+ */
+async function process_buckets(config_fs, bucket_names, system_json) {
+    const buckets_concurrency = 10; // TODO - think about it 
+    await P.map_with_concurrency(buckets_concurrency, bucket_names, async bucket_name =>
+        await _call_op_and_update_status({
+            bucket_name,
+            op_name: TIMED_OPS.PROCESS_BUCKET,
+            op_func: async () => process_bucket(config_fs, bucket_name, system_json)
+        })
+    );
+}
+
+/**
+ * process_bucket processes the lifecycle rules for a bucket
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @param {string} bucket_name
+ * @param {Object} system_json
+ */
+async function process_bucket(config_fs, bucket_name, system_json) {
+    const bucket_json = await config_fs.get_bucket_by_name(bucket_name, config_fs_options);
+    const account = { email: '', nsfs_account_config: config_fs.fs_context, access_keys: [] };
+    const object_sdk = new NsfsObjectSDK('', config_fs, account, bucket_json.versioning, config_fs.config_root, system_json);
+    await object_sdk._simple_load_requesting_account();
+    if (!bucket_json.lifecycle_configuration_rules) return {};
+    await process_rules(config_fs, bucket_json, object_sdk);
+}
+
+/**
+ * process_rules processes the lifecycle rules for a bucket
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @param {Object} bucket_json
+ * @param {nb.ObjectSDK} object_sdk
+ */
+async function process_rules(config_fs, bucket_json, object_sdk) {
+    try {
+        await P.all(_.map(bucket_json.lifecycle_configuration_rules,
+            async (lifecycle_rule, index) =>
+                await _call_op_and_update_status({
+                    bucket_name: bucket_json.name,
+                    rule_id: lifecycle_rule.id,
+                    op_name: TIMED_OPS.PROCESS_RULE,
+                    op_func: async () => process_rule(config_fs, lifecycle_rule, index, bucket_json, object_sdk)
+                })
+            )
+        );
+    } catch (err) {
+        dbg.error('process_rules failed with error', err, err.code, err.message);
+    }
+}
+
+/**
+ * process_rule processes the lifecycle rule for a bucket
+ * TODO - implement notifications for the deleted objects (check if needed for abort mpus as well)
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs 
+ * @param {Object} lifecycle_rule 
+ * @param {number} index 
+ * @param {Object} bucket_json 
+ * @param {nb.ObjectSDK} object_sdk
+ * @returns {Promise<Void>}
+ */
+async function process_rule(config_fs, lifecycle_rule, index, bucket_json, object_sdk) {
+    dbg.log0('nc_lifecycle.process_rule: start bucket name:', bucket_json.name, 'rule', lifecycle_rule, 'index', index);
+    const bucket_name = bucket_json.name;
+    const rule_id = lifecycle_rule.id;
+    const should_process_lifecycle_rule = validate_rule_enabled(lifecycle_rule, bucket_json);
+    if (!should_process_lifecycle_rule) return;
+
+    dbg.log0('nc_lifecycle.process_rule: processing rule:', bucket_name, '(bucket id:', bucket_json._id, ') rule', util.inspect(lifecycle_rule));
+    try {
+        const candidates = await _call_op_and_update_status({
+            bucket_name,
+            rule_id,
+            op_name: TIMED_OPS.GET_CANDIDATES,
+            op_func: async () => get_candidates(bucket_json, lifecycle_rule, object_sdk, config_fs.fs_context)
+        });
+
+        if (candidates.delete_candidates?.length > 0) {
+            await _call_op_and_update_status({
+                bucket_name,
+                rule_id,
+                op_name: TIMED_OPS.DELETE_MULTIPLE_OBJECTS,
+                op_func: async () => object_sdk.delete_multiple_objects({
+                    bucket: bucket_json.name,
+                    objects: candidates.delete_candidates
+                })
+            });
+        }
+
+        if (candidates.abort_mpu_candidates?.length > 0) {
+            await _call_op_and_update_status({
+                bucket_name,
+                rule_id,
+                op_name: TIMED_OPS.ABORT_MPUS,
+                op_func: async () => abort_mpus(candidates, object_sdk)
+            });
+        }
+        await update_lifecycle_rules_last_sync(config_fs, bucket_json, rule_id, index);
+    } catch (err) {
+        dbg.error('process_rule failed with error', err, err.code, err.message);
+    }
+}
+
+/**
+ * abort_mpus iterates over the abort mpu candidates and calls abort_object_upload
+ * since abort_object_upload is not returning anything, we catch it in case of an error and assign err_code 
+ * so it can be translated to error on stats
+ * @param {*} candidates
+ * @param {nb.ObjectSDK} object_sdk  
+ * @returns {Promise<Object[]>}
+ */
+async function abort_mpus(candidates, object_sdk) {
+    const aborts_concurrency = 10; // TODO - think about it 
+    const abort_mpus_reply = await P.map_with_concurrency(aborts_concurrency, candidates.abort_mpu_candidates,
+        async candidate => {
+            const candidate_info = { key: candidate.key, upload_id: candidate.obj_id };
+            try {
+                await object_sdk.abort_object_upload(candidate);
+            } catch (err) {
+                candidate_info.err_code = err.code || err.message;
+                dbg.log0('process_rule: abort_mpu_failed candidate_info', candidate_info);
+            }
+            return candidate_info;
+        }
+    );
+    return abort_mpus_reply;
+}
+
+/////////////////////////////////
+//////// GENERAL HELPERS ////////
+/////////////////////////////////
+
+/**
+ * _should_lifecycle_run checks if lifecycle worker should run based on the followings - 
+ * 1. lifecycle workrer can be disabled 
+ * 2. lifecycle worker might run at time that does not match config.NC_LIFECYCLE_RUN_TIME
+ * 3. previous run was in the delay time frame
+ * @param {nb.NativeFSContext} fs_context 
+ * @param {String} lifecycle_timestamp_file_path 
+ * @param {Boolean} disable_runtime_validation 
+ * @returns {Promise<Boolean>}
+ */
+async function _should_lifecycle_run(fs_context, lifecycle_timestamp_file_path, disable_runtime_validation) {
+    const should_run = disable_runtime_validation ? true : await is_desired_time(
+        fs_context,
+        new Date(),
+        config.NC_LIFECYCLE_RUN_TIME,
+        config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS,
+        lifecycle_timestamp_file_path,
+        config.NC_LIFECYCLE_TZ);
+    dbg.log0('_should_lifecycle_run should_run', should_run);
+    return should_run;
 }
 
 /**
@@ -100,6 +298,206 @@ async function throw_if_noobaa_not_active(config_fs, system_json) {
         dbg.error('throw_if_noobaa_not_active: noobaa service is not active');
         throw_cli_error(ManageCLIError.NooBaaServiceIsNotActive);
     }
+}
+
+/**
+ * get_candidates gets the delete and abort candidates for the lifecycle rule
+ * @param {Object} bucket_json
+ * @param {*} lifecycle_rule
+ */
+async function get_candidates(bucket_json, lifecycle_rule, object_sdk, fs_context) {
+    const candidates = { abort_mpu_candidates: [], delete_candidates: [] };
+    if (lifecycle_rule.expiration) {
+        candidates.delete_candidates = await get_candidates_by_expiration_rule(lifecycle_rule, bucket_json);
+        if (lifecycle_rule.expiration.days || lifecycle_rule.expiration.expired_object_delete_marker) {
+            const dm_candidates = await get_candidates_by_expiration_delete_marker_rule(lifecycle_rule, bucket_json);
+            candidates.delete_candidates = candidates.delete_candidates.concat(dm_candidates);
+        }
+    }
+    if (lifecycle_rule.noncurrent_version_expiration) {
+        const non_current_candidates = await get_candidates_by_noncurrent_version_expiration_rule(lifecycle_rule, bucket_json);
+        candidates.delete_candidates = candidates.delete_candidates.concat(non_current_candidates);
+    }
+    if (lifecycle_rule.abort_incomplete_multipart_upload) {
+        candidates.abort_mpu_candidates = await get_candidates_by_abort_incomplete_multipart_upload_rule(
+            lifecycle_rule, bucket_json, object_sdk, fs_context);
+    }
+    return candidates;
+}
+
+/**
+ * validate_rule_enabled checks if the rule is enabled and should be processed
+ * @param {*} rule 
+ * @param {Object} bucket 
+ * @returns {boolean}
+ */
+function validate_rule_enabled(rule, bucket) {
+    const now = Date.now();
+    if (rule.status !== 'Enabled') {
+        dbg.log0('validate_rule_enabled: SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'not Enabled');
+        return false;
+    }
+    if (rule.last_sync && now - rule.last_sync < config.LIFECYCLE_SCHEDULE_MIN) {
+        dbg.log0('validate_rule_enabled: SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'schedule min', config.LIFECYCLE_SCHEDULE_MIN);
+        return false;
+    }
+    return true;
+}
+
+////////////////////////////////////
+//////// EXPIRATION HELPERS ////////
+////////////////////////////////////
+
+/**
+ * get_candidates_by_expiration_rule processes the expiration rule
+ * @param {*} lifecycle_rule 
+ * @param {Object} bucket_json 
+ * @returns {Promise<Object[]>}
+ */
+async function get_candidates_by_expiration_rule(lifecycle_rule, bucket_json) {
+    const is_gpfs = nb_native().fs.gpfs;
+    if (is_gpfs) {
+        return get_candidates_by_expiration_rule_gpfs(lifecycle_rule, bucket_json);
+    } else {
+        return get_candidates_by_expiration_rule_posix(lifecycle_rule, bucket_json);
+    }
+}
+
+/**
+ * 
+ * @param {*} lifecycle_rule 
+ * @param {Object} bucket_json 
+ * @returns {Promise<Object[]>}
+ */
+async function get_candidates_by_expiration_rule_gpfs(lifecycle_rule, bucket_json) {
+    // TODO - implement
+    return [];
+}
+
+/**
+ * 
+ * @param {*} lifecycle_rule 
+ * @param {Object} bucket_json
+ * @returns {Promise<Object[]>} 
+ */
+async function get_candidates_by_expiration_rule_posix(lifecycle_rule, bucket_json) {
+    // TODO - implement
+    return [];
+}
+
+/**
+ * get_candidates_by_expiration_delete_marker_rule processes the expiration delete marker rule
+ * @param {*} lifecycle_rule 
+ * @param {Object} bucket_json 
+ * @returns {Promise<Object[]>}
+ */
+async function get_candidates_by_expiration_delete_marker_rule(lifecycle_rule, bucket_json) {
+    // TODO - implement
+    return [];
+}
+
+/////////////////////////////////////////////
+//////// NON CURRENT VERSION HELPERS ////////
+/////////////////////////////////////////////
+
+/**
+ * get_candidates_by_noncurrent_version_expiration_rule processes the noncurrent version expiration rule
+ * TODO:
+ * POSIX - need to support both noncurrent_days and newer_noncurrent_versions
+ * GPFS - implement noncurrent_days using GPFS ILM policy as an optimization
+ * @param {*} lifecycle_rule
+ * @param {Object} bucket_json
+ * @returns {Promise<Object[]>}
+ */
+async function get_candidates_by_noncurrent_version_expiration_rule(lifecycle_rule, bucket_json) {
+    // TODO - implement
+    return [];
+}
+
+////////////////////////////////////
+///////// ABORT MPU HELPERS ////////
+////////////////////////////////////
+
+/**
+ * get_candidates_by_abort_incomplete_multipart_upload_rule processes the abort incomplete multipart upload rule
+ * @param {*} lifecycle_rule
+ * @param {Object} bucket_json
+ * @returns {Promise<Object[]>}
+ */
+async function get_candidates_by_abort_incomplete_multipart_upload_rule(lifecycle_rule, bucket_json, object_sdk, fs_context) {
+    const nsfs = await object_sdk._get_bucket_namespace(bucket_json.name);
+    const mpu_path = nsfs._mpu_root_path();
+    const filter = lifecycle_rule.filter;
+    const expiration = lifecycle_rule.abort_incomplete_multipart_upload.days_after_initiation;
+    const res = [];
+
+    const filter_func = _build_lifecycle_filter({filter, expiration});
+    let dir_handle;
+    //TODO this is almost identical to list_uploads except for error handling and support for pagination. should modify list-upload and use it in here instead
+    try {
+        dir_handle = await nb_native().fs.opendir(fs_context, mpu_path);
+    } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+        return;
+    }
+    for (;;) {
+        try {
+            const dir_entry = await dir_handle.read(fs_context);
+            if (!dir_entry) break;
+            const create_path = path.join(mpu_path, dir_entry.name, 'create_object_upload');
+            const { data: create_params_buffer } = await nb_native().fs.readFile(fs_context, create_path);
+            const create_params_parsed = JSON.parse(create_params_buffer.toString());
+            const stat = await nb_native().fs.stat(fs_context, path.join(mpu_path, dir_entry.name));
+            const object_lifecycle_info = _get_lifecycle_object_info_for_mpu(create_params_parsed, stat);
+            if (filter_func(object_lifecycle_info)) {
+                res.push({ obj_id: dir_entry.name, key: create_params_parsed.key, bucket: bucket_json.name});
+            }
+        } catch (err) {
+            if (err.code !== 'ENOENT' || err.code !== 'ENOTDIR') throw err;
+        }
+    }
+    await dir_handle.close(fs_context);
+    dir_handle = null;
+    return res;
+}
+
+/**
+ * @param {*} create_params_parsed
+ * @param {nb.NativeFSStats} stat
+ */
+function _get_lifecycle_object_info_for_mpu(create_params_parsed, stat) {
+    return {
+        key: create_params_parsed.key,
+        age: _get_file_age_days(stat),
+        tags: create_params_parsed.tagging,
+    };
+}
+
+////////////////////////////////////
+/////////   FILTER HELPERS  ////////
+////////////////////////////////////
+
+/**
+ * @typedef {{
+ *     filter: Object
+ *     expiration: Number
+ * }} filter_params
+ *
+ * @param {filter_params} params
+ * @returns
+ */
+function _build_lifecycle_filter(params) {
+    /**
+     * @param {Object} object_info
+     */
+    return function(object_info) {
+        if (params.filter?.prefix && !object_info.key.startsWith(params.filter.prefix)) return false;
+        if (params.expiration && object_info.age < params.expiration) return false;
+        if (params.filter?.tags && !_file_contain_tags(object_info, params.filter.tags)) return false;
+        if (params.filter?.object_size_greater_than && object_info.size < params.filter.object_size_greater_than) return false;
+        if (params.filter?.object_size_less_than && object_info.size > params.filter.object_size_less_than) return false;
+        return true;
+    };
 }
 
 /**
@@ -139,222 +537,209 @@ function _file_contain_tags(object_info, filter_tags) {
     return true;
 }
 
-/**
- * @param {*} create_params_parsed
- * @param {nb.NativeFSStats} stat
- */
-function _get_lifecycle_object_info_for_mpu(create_params_parsed, stat) {
-    return {
-        key: create_params_parsed.key,
-        age: _get_file_age_days(stat),
-        tags: create_params_parsed.tagging,
-    };
-}
-
-
-/**
- * @typedef {{
- *     filter: Object
- *     expiration: Number
- * }} filter_params
- *
- * @param {filter_params} params
- * @returns
- */
-function _build_lifecycle_filter(params) {
-    /**
-     * @param {Object} object_info
-     */
-    return function(object_info) {
-        if (params.filter?.prefix && !object_info.key.startsWith(params.filter.prefix)) return false;
-        if (params.expiration && object_info.age < params.expiration) return false;
-        if (params.filter?.tags && !_file_contain_tags(object_info, params.filter.tags)) return false;
-        if (params.filter?.object_size_greater_than && object_info.size < params.filter.object_size_greater_than) return false;
-        if (params.filter?.object_size_less_than && object_info.size > params.filter.object_size_less_than) return false;
-        return true;
-    };
-}
-
-/**
- * handle_bucket_rule processes the lifecycle rule for a bucket
- * @param {*} lifecycle_rule
- * @param {*} j
- * @param {Object} bucket_json
- * @param {Object} object_sdk
- */
-async function handle_bucket_rule(config_fs, lifecycle_rule, j, bucket_json, object_sdk) {
-    // TODO - implement notifications
-    const now = Date.now();
-    const should_process_lifecycle_rule = validate_rule_enabled(lifecycle_rule, bucket_json, now);
-    if (!should_process_lifecycle_rule) return;
-    dbg.log0('LIFECYCLE PROCESSING bucket:', bucket_json.name, '(bucket id:', bucket_json._id, ') rule', util.inspect(lifecycle_rule));
-    const candidates = await get_delete_candidates(bucket_json, lifecycle_rule, object_sdk, config_fs.fs_context);
-    const delete_objects_reply = await object_sdk.delete_multiple_objects({
-        bucket: bucket_json.name,
-        objects: candidates.delete_candidates // probably need to convert to the format expected by delete_multiple_objects
-    });
-    await candidates.abort_mpus?.forEach(async element => {
-        await object_sdk.abort_object_upload(element);
-    });
-    // TODO - implement notifications for the deleted objects
-    await update_lifecycle_rules_last_sync(config_fs, bucket_json, j, delete_objects_reply.num_objects_deleted);
-}
-
-/**
- * get_delete_candidates gets the delete candidates for the lifecycle rule
- * @param {Object} bucket_json
- * @param {*} lifecycle_rule
- */
-async function get_delete_candidates(bucket_json, lifecycle_rule, object_sdk, fs_context) {
-    // let reply_objects = []; // TODO: needed for the notification log file
-    const candidates = {delete_candidates: []};
-    if (lifecycle_rule.expiration) {
-        await get_candidates_by_expiration_rule(lifecycle_rule, bucket_json);
-        if (lifecycle_rule.expiration.days || lifecycle_rule.expiration.expired_object_delete_marker) {
-            await get_candidates_by_expiration_delete_marker_rule(lifecycle_rule, bucket_json);
-        }
-    }
-    if (lifecycle_rule.noncurrent_version_expiration) {
-        await get_candidates_by_noncurrent_version_expiration_rule(lifecycle_rule, bucket_json);
-    }
-    if (lifecycle_rule.abort_incomplete_multipart_upload) {
-        candidates.abort_mpus = await get_candidates_by_abort_incomplete_multipart_upload_rule(
-            lifecycle_rule, bucket_json, object_sdk, fs_context);
-    }
-    return candidates;
-}
-
-/**
- * validate_rule_enabled checks if the rule is enabled and should be processed
- * @param {*} rule 
- * @param {Object} bucket 
- * @param {*} now 
- * @returns {boolean}
- */
-function validate_rule_enabled(rule, bucket, now) {
-    if (rule.status !== 'Enabled') {
-        dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'not Enabled');
-        return false;
-    }
-    if (rule.last_sync && now - rule.last_sync < config.LIFECYCLE_SCHEDULE_MIN) {
-        dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'schedule min', config.LIFECYCLE_SCHEDULE_MIN);
-        return false;
-    }
-    return true;
-}
-
-// TODO - we will filter during the scan except for get_candidates_by_expiration_rule on GPFS that does the filter on the file system
-
-/**
- * get_candidates_by_expiration_rule processes the expiration rule
- * @param {*} lifecycle_rule 
- * @param {Object} bucket_json 
- */
-async function get_candidates_by_expiration_rule(lifecycle_rule, bucket_json) {
-    const is_gpfs = nb_native().fs.gpfs;
-    if (is_gpfs) {
-        await get_candidates_by_expiration_rule_gpfs(lifecycle_rule, bucket_json);
-    } else {
-        await get_candidates_by_expiration_rule_posix(lifecycle_rule, bucket_json);
-    }
-}
-
-/**
- * 
- * @param {*} lifecycle_rule 
- * @param {Object} bucket_json 
- */
-async function get_candidates_by_expiration_rule_gpfs(lifecycle_rule, bucket_json) {
-    // TODO - implement
-}
-
-/**
- * 
- * @param {*} lifecycle_rule 
- * @param {Object} bucket_json 
- */
-async function get_candidates_by_expiration_rule_posix(lifecycle_rule, bucket_json) {
-    // TODO - implement
-}
-
-/**
- * get_candidates_by_expiration_delete_marker_rule processes the expiration delete marker rule
- * @param {*} lifecycle_rule 
- * @param {Object} bucket_json 
- */
-async function get_candidates_by_expiration_delete_marker_rule(lifecycle_rule, bucket_json) {
-    // TODO - implement
-}
-
-/**
- * get_candidates_by_noncurrent_version_expiration_rule processes the noncurrent version expiration rule
- * TODO:
- * POSIX - need to support both noncurrent_days and newer_noncurrent_versions
- * GPFS - implement noncurrent_days using GPFS ILM policy as an optimization
- * @param {*} lifecycle_rule
- * @param {Object} bucket_json
- */
-async function get_candidates_by_noncurrent_version_expiration_rule(lifecycle_rule, bucket_json) {
-    // TODO - implement
-}
-
-/**
- * get_candidates_by_abort_incomplete_multipart_upload_rule processes the abort incomplete multipart upload rule
- * @param {*} lifecycle_rule
- * @param {Object} bucket_json
- */
-async function get_candidates_by_abort_incomplete_multipart_upload_rule(lifecycle_rule, bucket_json, object_sdk, fs_context) {
-    const nsfs = await object_sdk._get_bucket_namespace(bucket_json.name);
-    const mpu_path = nsfs._mpu_root_path();
-    const filter = lifecycle_rule.filter;
-    const expiration = lifecycle_rule.abort_incomplete_multipart_upload.days_after_initiation;
-    const res = [];
-
-    const filter_func = _build_lifecycle_filter({filter, expiration});
-    let dir_handle;
-    //TODO this is almost identical to list_uploads except for error handling and support for pagination. should modify list-upload and use it in here instead
-    try {
-        dir_handle = await nb_native().fs.opendir(fs_context, mpu_path);
-    } catch (err) {
-        if (err.code !== 'ENOENT') throw err;
-        return;
-    }
-    for (;;) {
-        try {
-            const dir_entry = await dir_handle.read(fs_context);
-            if (!dir_entry) break;
-            const create_path = path.join(mpu_path, dir_entry.name, 'create_object_upload');
-            const { data: create_params_buffer } = await nb_native().fs.readFile(fs_context, create_path);
-            const create_params_parsed = JSON.parse(create_params_buffer.toString());
-            const stat = await nb_native().fs.stat(fs_context, path.join(mpu_path, dir_entry.name));
-            const object_lifecycle_info = _get_lifecycle_object_info_for_mpu(create_params_parsed, stat);
-            if (filter_func(object_lifecycle_info)) {
-                res.push({obj_id: dir_entry.name, key: create_params_parsed.key, bucket: bucket_json.name});
-            }
-        } catch (err) {
-            if (err.code !== 'ENOENT' || err.code !== 'ENOTDIR') throw err;
-        }
-    }
-    await dir_handle.close(fs_context);
-    dir_handle = null;
-    return res;
-}
+/////////////////////////////////
+//////// STATUS HELPERS ////////
+/////////////////////////////////
 
 /**
  * update_lifecycle_rules_last_sync updates the last sync time of the lifecycle rule
  * @param {import('../sdk/config_fs').ConfigFS} config_fs
  * @param {Object} bucket_json
- * @param {number} j
- * @param {number} num_objects_deleted
+ * @param {String} rule_id 
+ * @param {number} index
+ * @returns {Promise<Void>}
  */
-async function update_lifecycle_rules_last_sync(config_fs, bucket_json, j, num_objects_deleted) {
-    bucket_json.lifecycle_configuration_rules[j].last_sync = Date.now();
-    // if (res.num_objects_deleted >= config.LIFECYCLE_BATCH_SIZE) should_rerun = true; // TODO - think if needed
-    dbg.log0('LIFECYCLE Done bucket:', bucket_json.name, '(bucket id:', bucket_json._id, ') done deletion of objects per rule',
-        bucket_json.lifecycle_configuration_rules[j],
-        'time:', bucket_json.lifecycle_configuration_rules[j].last_sync,
-        'objects deleted:', num_objects_deleted);
+async function update_lifecycle_rules_last_sync(config_fs, bucket_json, rule_id, index) {
+    bucket_json.lifecycle_configuration_rules[index].last_sync = Date.now();
+    const { num_objects_deleted = 0, num_mpu_aborted = 0 } =
+    lifecycle_run_status.buckets_statuses[bucket_json.name].rules_statuses[rule_id].rule_stats;
+    // if (res.num_objects_deleted >= config.LIFECYCLE_BATCH_SIZE) should_rerun = true; // TODO - think if needed and add something about mpu abort
+    dbg.log0('nc_lifecycle.update_lifecycle_rules_last_sync Done bucket:', bucket_json.name, '(bucket id:', bucket_json._id, ') done deletion of objects per rule',
+        bucket_json.lifecycle_configuration_rules[index],
+        'time:', bucket_json.lifecycle_configuration_rules[index].last_sync,
+        'num_objects_deleted:', num_objects_deleted, 'num_mpu_aborted:', num_mpu_aborted);
     await config_fs.update_bucket_config_file(bucket_json);
+}
+
+/**
+ * _call_op_and_update_status calls the op and report time and error to the lifecycle status.
+ *
+ * @template T
+ * @param {{
+*      op_name: string;
+*      op_func: () => Promise<T>;
+*      bucket_name?: string,
+*      rule_id?: string
+* }} params
+* @returns {Promise<T>}
+*/
+async function _call_op_and_update_status({ bucket_name = undefined, rule_id = undefined, op_name, op_func }) {
+    const start_time = Date.now();
+    const update_options = { op_name, bucket_name, rule_id };
+    let end_time;
+    let took_ms;
+    let error;
+    let reply;
+    try {
+        if (!short_status) update_status({ ...update_options, op_times: { start_time } });
+        reply = await op_func();
+        return reply;
+    } catch (e) {
+        error = e;
+        throw e;
+    } finally {
+        end_time = Date.now();
+        took_ms = end_time - start_time;
+        const op_times = short_status ? { took_ms } : { end_time, took_ms };
+        update_status({ ...update_options, op_times, reply, error });
+    }
+}
+
+/**
+ * update_status updates rule/bucket/global based on the given parameters
+ * 1. initalize statuses/times/stats per level
+ * 2. update times
+ * 3. update errors
+ * 4. update stats if the op is at rule level
+ * @param {{ 
+ * op_name: string,
+ * bucket_name?: string,
+ * rule_id?: string, 
+ * op_times: { start_time?: number, end_time?: number, took_ms?: number },
+ * reply?: Object[],
+ * error?: Error}
+ * } params 
+ * @returns {Void}
+*/
+function update_status({ bucket_name, rule_id, op_name, op_times, reply = [], error = undefined }) {
+    // TODO - check errors
+    if (op_times.start_time) {
+        if (op_name === TIMED_OPS.PROCESS_RULE) {
+            lifecycle_run_status.buckets_statuses[bucket_name].rules_statuses[rule_id] = { rule_process_times: {}, rule_stats: {} };
+        } else if (op_name === TIMED_OPS.PROCESS_BUCKET) {
+            lifecycle_run_status.buckets_statuses[bucket_name] = { bucket_process_times: {}, bucket_stats: {}, rules_statuses: {} };
+        }
+    }
+    _update_times_on_status({ op_name, op_times, bucket_name, rule_id });
+    _update_error_on_status({ error, bucket_name, rule_id });
+    if (bucket_name && rule_id) {
+        update_stats_on_status({ bucket_name, rule_id, op_name, op_times, reply });
+    }
+}
+
+/**
+ * _calc_stats accumulates stats for global/bucket stats
+ * @param {Object} stats_acc 
+ * @param {Object} [cur_op_stats]
+ * @returns {Object}
+ */
+function _acc_stats(stats_acc, cur_op_stats = {}) {
+    const stats_res = stats_acc;
+
+    for (const [stat_key, stat_value] of Object.entries(cur_op_stats)) {
+        if (typeof stat_value === 'number') {
+            stats_res[stat_key] += stat_value;
+        }
+        if (Array.isArray(stat_value)) {
+            stats_res[stat_key].concat(stat_value);
+        }
+    }
+    return stats_res;
+}
+
+/**
+ * update_stats_on_status updates stats on rule context status and adds the rule status to the summarized bucket/global context stats
+ * @param {{ 
+ * op_name: string, 
+ * bucket_name: string, 
+ * rule_id: string, 
+ * op_times: { 
+ *  start_time?: number, 
+ *  end_time?: number, 
+ *  took_ms?: number 
+ * },
+ * reply?: Object[],
+ * }} params 
+ * @returns {Void}
+ */
+function update_stats_on_status({ bucket_name, rule_id, op_name, op_times, reply = [] }) {
+    if (op_times.end_time === undefined || ![TIMED_OPS.DELETE_MULTIPLE_OBJECTS, TIMED_OPS.ABORT_MPUS].includes(op_name)) return;
+
+    const rule_stats_acc = lifecycle_run_status.buckets_statuses[bucket_name].rules_statuses[rule_id].rule_stats || _get_default_stats();
+    const bucket_stats_acc = lifecycle_run_status.buckets_statuses[bucket_name].bucket_stats || _get_default_stats();
+    const lifecycle_stats_acc = lifecycle_run_status.total_stats || _get_default_stats();
+
+    let cur_op_stats;
+    if (op_name === TIMED_OPS.DELETE_MULTIPLE_OBJECTS) {
+        const objects_delete_errors = reply.filter(obj => obj.err_code);
+        const num_objects_delete_failed = objects_delete_errors.length;
+        const num_objects_deleted = reply.length - num_objects_delete_failed;
+        cur_op_stats = { num_objects_deleted, num_objects_delete_failed, objects_delete_errors };
+    }
+    if (op_name === TIMED_OPS.ABORT_MPUS) {
+        const mpu_abort_errors = reply.filter(obj => obj.err_code);
+        const num_mpu_abort_failed = mpu_abort_errors.length;
+        const num_mpu_aborted = reply.length - num_mpu_abort_failed;
+        cur_op_stats = { num_mpu_aborted, num_mpu_abort_failed, mpu_abort_errors };
+    }
+    lifecycle_run_status.buckets_statuses[bucket_name].rules_statuses[rule_id].rule_stats = { ...rule_stats_acc, ...cur_op_stats };
+    lifecycle_run_status.buckets_statuses[bucket_name].bucket_stats = _acc_stats({ stats_acc: bucket_stats_acc, cur_op_stats });
+    lifecycle_run_status.total_stats = _acc_stats({ stats_acc: lifecycle_stats_acc, cur_op_stats });
+}
+
+/**
+ * _update_times_on_status updates start/end & took times in lifecycle status
+ * @param {{op_name: String, op_times: {start_time?: number, end_time?: number, took_ms?: number }, 
+ * bucket_name?: String, rule_id?: String}} params
+ * @returns 
+ */
+function _update_times_on_status({ op_name, op_times, bucket_name = undefined, rule_id = undefined }) {
+    for (const [key, value] of Object.entries(op_times)) {
+        const status_key = op_name + '_' + key;
+        if (bucket_name && rule_id) {
+            lifecycle_run_status.buckets_statuses[bucket_name].rules_statuses[rule_id].rule_process_times[status_key] = value;
+        } else if (bucket_name) {
+            lifecycle_run_status.buckets_statuses[bucket_name].bucket_process_times[status_key] = value;
+        } else {
+            lifecycle_run_status.lifecycle_run_times[status_key] = value;
+        }
+    }
+}
+
+/**
+ * _update_error_on_status updates an error occured in lifecycle status
+ * @param {{error: Error, bucket_name?: string, rule_id?: string}} params
+ * @returns 
+ */
+function _update_error_on_status({ error, bucket_name = undefined, rule_id = undefined }) {
+    if (!error) return;
+    if (bucket_name && rule_id) {
+        (lifecycle_run_status.buckets_statuses[bucket_name].rules_statuses[rule_id].errors ??= []).push(error.message);
+    } else if (bucket_name) {
+        (lifecycle_run_status.buckets_statuses[bucket_name].errors ??= []).push(error.message);
+    } else {
+        (lifecycle_run_status.errors ??= []).push(error.message);
+    }
+}
+
+function _get_default_stats() {
+    return {
+        num_objects_deleted: 0, num_objects_delete_failed: 0, objects_delete_errors: [],
+        num_mpu_aborted: 0, num_mpu_abort_failed: 0, mpu_abort_errors: []
+    };
+}
+
+/**
+ * write_lifecycle_log_file
+ */
+async function write_lifecycle_log_file(fs_context, lifecyle_logs_dir_path) {
+    const log_file_name = `lifecycle_run_${lifecycle_run_status.lifecycle_run_times.run_lifecycle_start_time}.json`;
+    await nb_native().fs.writeFile(
+        fs_context,
+        path.join(lifecyle_logs_dir_path, log_file_name),
+        Buffer.from(JSON.stringify(lifecycle_run_status)),
+        { mode: native_fs_utils.get_umasked_mode(config.BASE_MODE_FILE) }
+    );
 }
 
 // EXPORTS

--- a/src/server/system_services/schemas/nsfs_config_schema.js
+++ b/src/server/system_services/schemas/nsfs_config_schema.js
@@ -149,6 +149,27 @@ const nsfs_node_config_schema = {
         NOTIFICATION_SPACE_CHECK_THRESHOLD: {
             type: 'number',
             doc: 'Fraction (more than 0, less than 1) of free blocks in, below which free space check creates an event.'
+        },
+        NC_LIFECYCLE_TIMEOUT_MS: {
+            type: 'number',
+            doc: 'The timeout of NC lifecycle worker in milliseconds.'
+        },
+        NC_LIFECYCLE_LOGS_DIR: {
+            type: 'string',
+            doc: 'The directory in which NC lifecycle worker writes logs'
+        },
+        NC_LIFECYCLE_RUN_TIME: {
+            type: 'string',
+            doc: 'NC lifecycle worker run time, worker running on different time will not be able to start, format "HH:MM"'
+        },
+        NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS: {
+            type: 'number',
+            doc: 'Configures the delay tolerance in minutes. Default is 2 minutes.'
+        },
+        NC_LIFECYCLE_TZ: {
+            type: 'string',
+            enum: ['UTC', 'LOCAL'],
+            doc: 'The timezone used for calculating NC lifecycle worker run time. Default is LOCAL.'
         }
     }
 };


### PR DESCRIPTION
### Describe the Problem
The NC lifecycle process should -
1. Write lifecycle run status in a log file on finish/fail.
2. Write events on start, finish, failure.
3. Have configurable timeout that is by default 6 hours.

### Explain the Changes
1. Added config.NC_LIFECYLE_TIMEOUT_MS configuration that is set by default to be 6 hours, added P.race[lifecyle_run(), lifecycle_timeout()] in lifecycle_run_under_lock().
2. Added 3 new events - LIFECYCLE_STARTED, LIFECYCLE_SUCCESSFUL and LIFECYCLE_FAILED that will be logged to events.log.
3. Added lifecycle run status capture in nc_lifecycle, per run, bucket and rule. After every run a JSON file will be written under `/var/log/noobaa/lifecycle/`.
The name of the file will be lifecycle_run_1741525171954.json while 1741525171954 is the lifecycle run start timestamp.
The following is an example of the times other statuses captured in a lifecycle run status.
```JSON
{
   "running_host": "my-hostname1",
    "lifecycle_run_times": {
      "start_time": 1741529394579,
      "end_time": 1741529394597,
      "took_ms": 18,
      "buckets_list_start_time": 1741529394584,
      "buckets_list_end_time": 1741529394584,
      "buckets_list_took_ms": 0,
      "buckets_process_took_ms": 13
    },
    "errors": [],
    "buckets_statuses": [
      {
        "bucket_name": "bucket1",
        "bucket_process_times": {
          "start_time": 1741529394585,
          "end_time": 1741529394597,
          "took_ms": 12
          "error": { "code": "", "message": "", "stack": ""}
        },
        "rules_statuses": [
          {
            "lifecycle_rule": "rule1",
            "rule_process_times": {
              "start_time": 1741529394587,
              "end_time": 1741529394597,
              "took_ms": 10,
              "list_candidates_start_time": 1741529394589,
              "list_candidates_took_ms": 0,
              "delete_candidates_start_time": 1741529394589,
              "delete_candidates_took_ms": 0,
              "update_last_sync_time": 1741529394589,
              "update_last_sync_took_ms": 8
            },
            "num_objects_deleted": 0,
            "num_objects_delete_failed": 0,
            "objects_delete_errors": []
            "error": { "code": "", "message": "", "stack": ""} 
          }
        ]
      }
    ]
  }
}
```

### Issues: Fixed #xxx / Gap #xxx
1. Add automatic tests.
2. Add docs.

### Testing Instructions:
**Status manual test -** 
1. create an account, a bucket and set lifecycle configuration on the bucket.
3. start nsfs process - `sudo node noobaa-core/src/cmd/nsfs.js --debug 5`
4. run `noobaa-cli lifecycle` and check for the status of the rule processing.

**Events manual test -** 
Happy path - 
1. start nsfs process - `sudo node noobaa-core/src/cmd/nsfs.js --debug 5`
1. run `noobaa-cli lifecycle` and check in the stderr logs (if locally) or in events.log the following - 
```
Mar-9 16:09:54.583 [noobaa-cli/91017] [EVENT]{"timestamp":"2025-03-09T14:09:54.580Z","host":"hostname1","event":{"code":"noobaa_lifecycle_worker_started","message":"NooBaa Lifecycle worker run started.","description":"NooBaa Lifecycle worker run started.","entity_type":"NODE","event_type":"INFO","scope":"NODE","severity":"INFO","state":"HEALTHY","pid":91017}}
Mar-9 16:09:54.597 [noobaa-cli/91017] [EVENT]{"timestamp":"2025-03-09T14:09:54.597Z","host":"hostname1","event":{"code":"noobaa_lifecycle_worker_finished_successfully","message":"NooBaa Lifecycle worker run finished successfully.","description":"NooBaa Lifecycle worker finished successfully.","entity_type":"NODE","event_type":"INFO","scope":"NODE","severity":"INFO","state":"HEALTHY","pid":91017}}
``` 
Sad path - 
1. don't start nsfs process 
2. run `noobaa-cli lifecycle` and check in the stderr logs (if locally) or in events.log the following - 
```
Mar-9 16:48:22.733 [noobaa-cli/97456] [EVENT]{"timestamp":"2025-03-09T14:48:22.732Z","host":"hostname1","event":{"code":"noobaa_lifecycle_worker_started","message":"NooBaa Lifecycle worker run started.","description":"NooBaa Lifecycle worker run started.","entity_type":"NODE","event_type":"INFO","scope":"NODE","severity":"INFO","state":"HEALTHY","pid":97456}}
Mar-9 16:48:22.773 [noobaa-cli/97456] [EVENT]{"timestamp":"2025-03-09T14:48:22.773Z","host":"hostname1","event":{"code":"noobaa_lifecycle_worker_failed","message":"NooBaa Failed to run lifecycle worker.","description":"NooBaa Lifecycle worker run failed due to an error.","entity_type":"NODE","event_type":"ERROR","scope":"NODE","severity":"ERROR","state":"DEGRADED","pid":97456}
```

**Timeout manual test -** 
1. sudo sh -c "echo '{\"NC_LIFECYCLE_TIMEOUT_MS\":2}' > /etc/noobaa.conf.d/config.json"
2. run `noobaa-cli lifecycle` and expect the following error - 
```
{
  "error": {
    "code": "LifecycleWorkerReachedTimeout",
    "message": "Lifecycle worker reached timeout - configured timeout is 1 ms"
  }
}
```
3. check that a new status file was created under /var/log/noobaa/lifecycle and it contains the error and the current status - 
```
sudo tree  /var/log/noobaa/lifecycle/
/var/log/noobaa/lifecycle/
├── cluster.lock
├── lifecycle.timestamp
├── lifecycle_run_1742125850575.json
└── lifecycle_run_1742126160821.json

sudo cat  /var/log/noobaa/lifecycle/lifecycle_run_1742126160821.json | jq
{
  "running_host": "hostname1",
  "lifecycle_run_times": {
    "run_lifecycle_start_time": 1742126160821,
    "list_buckets_start_time": 1742126160821,
    "list_buckets_end_time": 1742126160822,
    "list_buckets_took_ms": 1,
    "process_buckets_start_time": 1742126160822,
    "run_lifecycle_end_time": 1742126160823,
    "run_lifecycle_took_ms": 2,
    "process_buckets_end_time": 1742126160827,
    "process_buckets_took_ms": 5
  },
  "total_stats": {
    "num_objects_deleted": 0,
    "num_objects_delete_failed": 0,
    "objects_delete_errors": [],
    "num_mpu_aborted": 0,
    "num_mpu_abort_failed": 0,
    "mpu_abort_errors": []
  },
  "buckets_statuses": {
    ...
    }
  },
  "errors": [
    "Lifecycle worker reached timeout - configured timeout is 2 ms"
  ]
}
```

- [ ] Doc added/updated
- [ ] Tests added
