### PR TITLE
NC | Online Upgrade CLI | Validate `expected_version` on `upgrade start`

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -472,6 +472,12 @@ ManageCLIError.InvalidUpgradeAction = Object.freeze({
     http_code: 400,
 });
 
+ManageCLIError.MissingExpectedVersionFlag = Object.freeze({
+    code: 'MissingExpectedVersionFlag',
+    message: 'Expected version is mandatory, please use the --expected_version flag',
+    http_code: 400,
+});
+
 ManageCLIError.UpgradeFailed = Object.freeze({
     code: 'UpgradeFailed',
     message: 'Upgrade request failed',

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -174,7 +174,8 @@ const OPTION_TYPE = {
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];
 const BOOLEAN_STRING_OPTIONS = new Set(['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force',
-    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous', 'disable_service_validation', 'disable_runtime_validation', 'short_status']);
+    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous',
+    'disable_service_validation', 'disable_runtime_validation', 'short_status', 'skip_verification']);
 
 // CLI UNSET VALUES
 const CLI_EMPTY_STRING = '';

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -16,7 +16,7 @@ const native_fs_utils = require('../util/native_fs_utils');
 const { RpcError } = require('../rpc');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
-const { version_compare } = require('../upgrade/upgrade_utils');
+const { version_compare } = require('../util/versions_utils');
 const { anonymous_access_key } = require('./object_sdk');
 
 /** @typedef {import('fs').Dirent} Dirent */

--- a/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_upgrade_manager.test.js
@@ -785,9 +785,9 @@ describe('nc upgrade manager - upgrade config directory', () => {
             const expected_version = pkg.version;
             const hosts_list = [hostname];
             await config_fs.create_system_config_file(JSON.stringify(system_data));
-            const expected_msg = { "message": "config_dir_version on system.json and config_fs.config_dir_version match, nothing to upgrade" };
-            const res = await nc_upgrade_manager.upgrade_config_dir(expected_version, hosts_list);
-            expect(res).toStrictEqual(expected_msg);
+            const expected_err_msg = 'config_dir_version on system.json and config_fs.config_dir_version match, nothing to upgrade';
+            await expect(nc_upgrade_manager.upgrade_config_dir(expected_version, hosts_list))
+                .rejects.toThrow(expected_err_msg);
         });
 
         it('upgrade_config_dir - config_dir_version in system.json is newer than the hosts current config_dir_version', async () => {

--- a/src/upgrade/nc_upgrade_manager.js
+++ b/src/upgrade/nc_upgrade_manager.js
@@ -7,7 +7,8 @@ const util = require('util');
 const pkg = require('../../package.json');
 const dbg = require('../util/debug_module')(__filename);
 const { CONFIG_DIR_PHASES } = require('../sdk/config_fs');
-const { should_upgrade, run_upgrade_scripts, version_compare } = require('./upgrade_utils');
+const { should_upgrade, run_upgrade_scripts } = require('./upgrade_utils');
+const { version_compare } = require('../util/versions_utils');
 
 const hostname = os.hostname();
 // prior to 5.18.0 - there is no config dir version, the config dir version to be used on the first upgrade is 0.0.0 (5.17.0 -> 5.18.0)
@@ -108,7 +109,11 @@ class NCUpgradeManager {
         const package_to_version = this.package_version;
         const this_upgrade_versions = { config_dir_from_version, config_dir_to_version, package_from_version, package_to_version };
 
-        if (!should_upgrade(config_dir_from_version, config_dir_to_version)) return { message: 'config_dir_version on system.json and config_fs.config_dir_version match, nothing to upgrade' };
+        if (!should_upgrade(config_dir_from_version, config_dir_to_version)) {
+            const err_message = 'config_dir_version on system.json and config_fs.config_dir_version match, nothing to upgrade';
+            dbg.error(`upgrade_config_dir: ${err_message}`);
+            throw new Error(err_message);
+        }
 
         if (!skip_verification) await this._verify_config_dir_upgrade(system_data, expected_version, hosts_list);
 

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -5,34 +5,7 @@ const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
 const dbg = require('../util/debug_module')(__filename);
-
-/**
- * @param {string} ver
- */
-function parse_ver(ver) {
-    const stripped_ver = ver.split('-')[0];
-    return stripped_ver.split('.').map(i => Number.parseInt(i, 10));
-}
-
-
-/**
- * version_compare compares 2 versions. returns positive if ver1 is larger, negative if ver2, 0 if equal
- * @param {string} ver1
- * @param {string} ver2
- */
-function version_compare(ver1, ver2) {
-    const ver1_arr = parse_ver(ver1);
-    const ver2_arr = parse_ver(ver2);
-    const max_length = Math.max(ver1_arr.length, ver2_arr.length);
-    for (let i = 0; i < max_length; ++i) {
-        const comp1 = ver1_arr[i] || 0;
-        const comp2 = ver2_arr[i] || 0;
-        const diff = comp1 - comp2;
-        // if version component is not the same, return the difference
-        if (diff) return diff;
-    }
-    return 0;
-}
+const { version_compare } = require('../util/versions_utils');
 
 /**
  * @param {string} current_version
@@ -137,5 +110,4 @@ async function run_upgrade_scripts(this_upgrade, upgrade_scripts_dir, options) {
 
 exports.should_upgrade = should_upgrade;
 exports.load_required_scripts = load_required_scripts;
-exports.version_compare = version_compare;
 exports.run_upgrade_scripts = run_upgrade_scripts;

--- a/src/util/versions_utils.js
+++ b/src/util/versions_utils.js
@@ -1,0 +1,47 @@
+/* Copyright (C) 2025 NooBaa */
+"use strict";
+
+/**
+ * @param {string} ver
+ */
+function parse_ver(ver) {
+    const stripped_ver = ver.split('-')[0];
+    return stripped_ver.split('.').map(i => Number.parseInt(i, 10));
+}
+
+/**
+ * version_compare compares 2 versions. returns positive if ver1 is larger, negative if ver2, 0 if equal
+ * @param {string} ver1
+ * @param {string} ver2
+ */
+function version_compare(ver1, ver2) {
+    const ver1_arr = parse_ver(ver1);
+    const ver2_arr = parse_ver(ver2);
+    const max_length = Math.max(ver1_arr.length, ver2_arr.length);
+    for (let i = 0; i < max_length; ++i) {
+        const comp1 = ver1_arr[i] || 0;
+        const comp2 = ver2_arr[i] || 0;
+        const diff = comp1 - comp2;
+        // if version component is not the same, return the difference
+        if (diff) return diff;
+    }
+    return 0;
+}
+
+/**
+ * is_valid_semantic_version checks that the version string is a valid sematic version
+ *   1. strips the additional "-<something>" that might be added, for example: -alpha, -beta etc
+ *   2. checks that the version has the sematic version is from the structure of version: major.minor.patch
+ * @param {string} version
+ * @returns {boolean}
+ */
+function is_valid_semantic_version(version) {
+    const stripped_ver = version.split('-')[0];
+    // sematic version is from the structure of version: major.minor.patch
+    const semantic_version_regex = /^\d+\.\d+.\.\d+$/;
+    return semantic_version_regex.test(stripped_ver);
+}
+
+exports.version_compare = version_compare;
+exports.is_valid_semantic_version = is_valid_semantic_version;
+


### PR DESCRIPTION
### Describe the Problem
Currently, we do not validate the value of the argument of `expected_version` in noobaa-cli when using `upgrade start` command.

### Explain the Changes
1. Add the function of `validate_expected_version` that would check that we have the flag of `expected_version` and it is from the supported versions we allow. Also, add specific errors to the CLI (`MissingExpectedVersionFlag` and `InvalidArgumentType`) so that eventually we would not report it as `UpgradeFailed`.
2. Move functions that are related to versions to `versions_utils`, and added a helper function `is_valid_sematic_version` to check the structure of the string.
3. Throw an error instead of the message "config_dir_version on system.json and config_fs.config_dir_version match, nothing to upgrade" and change the tests accordingly.
4. Add the `skip_verification` to `BOOLEAN_STRING_OPTIONS` and use it to in `validate_expected_version`. 

### Issues: Fixed #8852, Fixed #8851
1. In the described issues, the example is of using `upgrade start --expected_version <expected_version>` when `expected_version` is not supported: either lower than expected, or at the same version.

### Testing Instructions:
#### Automatic Testing
Please run:
- `sudo rm -rf /etc/noobaa.conf.d/; sudo npx jest test_cli_upgrade.test` (only in a test environment).
- `sudo npx jest test_nc_upgrade_manager.test.js`

#### Manual Testing
You can recreate the failing flag options, for example:
-  `sudo node src/cmd/manage_nsfs upgrade start #invalid, missing --expected_version`
- `sudo node src/cmd/manage_nsfs upgrade start --expected_version  9  #invalid (number and not string)`
-  `sudo node src/cmd/manage_nsfs upgrade start --expected_version  bla #invalid not semver structure`
- `sudo node src/cmd/manage_nsfs upgrade start --expected_version '6.18.0' #invalid version (higher)`
- `sudo node src/cmd/manage_nsfs upgrade start --expected_version '4.18.0' #invalid version (lower)`
- `sudo node src/cmd/manage_nsfs upgrade start --expected_version '5.19.0' #nothing to upgrade`, for the following case, we need to have `system.json` created, therefore before running it please create an account and start the NSFS server: (1) Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>` - before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`
(2) Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`

- [ ] Doc added/updated
- [X] Tests added
