### PR TITLE
Disable dedup indexer by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -421,7 +421,7 @@ config.MIN_CHUNK_AGE_FOR_DEDUP = 60 * 60 * 1000; // 1 hour
 //////////////////////////
 // DEDUP INDEXER CONFIG //
 //////////////////////////
-config.DEDUP_INDEXER_ENABLED = true;
+config.DEDUP_INDEXER_ENABLED = false;
 config.DEDUP_INDEXER_BATCH_SIZE = 200;
 config.DEDUP_INDEXER_BATCH_DELAY = 1000;
 config.DEDUP_INDEXER_ERROR_DELAY = 10 * 1000;


### PR DESCRIPTION
### Describe the Problem
- The BG worker is taking a lot of CPU time in Postgres.
- We should fix this bg_worker to better work with Postgres. until then, disabling it by default.


### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-1765#

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
