### PR TITLE
Fix id parse for s3_put_bucket_cors

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_cors.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_cors.js
@@ -13,7 +13,7 @@ async function put_bucket_cors(req) {
             allowed_methods: rule.AllowedMethod,
             allowed_origins: rule.AllowedOrigin,
             expose_headers: rule.ExposeHeader,
-            id: rule.ID,
+            id: rule.ID?.[0],
             max_age_seconds: rule.MaxAgeSeconds && parseInt(rule.MaxAgeSeconds, 10),
         }, _.isUndefined)
     );

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -461,6 +461,59 @@ mocha.describe('s3_ops', function() {
         });
     });
 
+    mocha.describe('bucket-cors', function() {
+
+        mocha.before(async function() {
+            await s3.createBucket({ Bucket: "cors-bucket" });
+        });
+
+        mocha.it('should put and get bucket cors with ID', async function() {
+
+            // put bucket cors
+            const params = {
+                Bucket: "cors-bucket",
+                CORSConfiguration: {
+                    CORSRules: [{
+                        ID: 'rule1',
+                        AllowedOrigins: ["http://www.example.com"],
+                        AllowedHeaders: ["*"],
+                        AllowedMethods: ["PUT", "POST", "DELETE"],
+                        ExposeHeaders: ["x-amz-server-side-encryption"]
+                    }]
+                }
+            };
+            await s3.putBucketCors(params);
+
+            // get bucket CORS
+            const res = await s3.getBucketCors({ Bucket: "cors-bucket" });
+            assert.deepEqual(res.CORSRules, params.CORSConfiguration.CORSRules);
+        });
+
+        mocha.it('should put and get bucket cors with max age seconds', async function() {
+
+            // put bucket cors
+            const params = {
+                Bucket: "cors-bucket",
+                CORSConfiguration: {
+                    CORSRules: [{
+                        AllowedOrigins: ["http://www.example.com"],
+                        AllowedMethods: ["PUT", "POST", "DELETE"],
+                        MaxAgeSeconds: 1500,
+                    }]
+                }
+            };
+            await s3.putBucketCors(params);
+
+            // get bucket CORS
+            const res = await s3.getBucketCors({ Bucket: "cors-bucket" });
+            assert.deepEqual(res.CORSRules, params.CORSConfiguration.CORSRules);
+        });
+
+        mocha.after(async function() {
+            await s3.deleteBucket({ Bucket: "cors-bucket" });
+        });
+    });
+
     async function test_object_ops(bucket_name, bucket_type, caching, remote_endpoint_options) {
 
         const is_azure_namespace = is_namespace_blob_bucket(bucket_type, remote_endpoint_options && remote_endpoint_options.endpoint_type);


### PR DESCRIPTION
### Describe the Problem
Issue while running put-bucket-cors with id - we expected string and got array - now we will support array of single ID

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. run put-bucket-core with id
for example:
```
cors.json:
{
  "CORSRules": [
    {
      "ID": "rule-1",
      "AllowedOrigins": ["http://www.example.com"],
      "AllowedHeaders": ["*"],
      "AllowedMethods": ["PUT", "POST", "DELETE"],
      "MaxAgeSeconds": 3000,
      "ExposeHeaders": ["x-amz-server-side-encryption"]
    },
  ]
}
aws s3api put-bucket-cors --bucket cors-bucket --cors-configuration file://cors.json
```


- [ ] Doc added/updated
- [x] Tests added
