### PR TITLE
NC | Lifecycle | Small configuration adjustments/ fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -1012,20 +1012,21 @@ config.NC_DISABLE_SCHEMA_CHECK = false;
 ////////// NC LIFECYLE  //////////
 
 config.NC_LIFECYCLE_LOGS_DIR = '/var/log/noobaa/lifecycle';
-config.NC_LIFECYCLE_TIMEOUT_MS = 6 * 60 * 60 * 1000;
+config.NC_LIFECYCLE_CONFIG_DIR_NAME = 'lifecycle';
+config.NC_LIFECYCLE_TIMEOUT_MS = 8 * 60 * 60 * 1000;
 
 // NC_LIFECYCLE_RUN_TIME must be of the format hh:mm which specifies
 // when NooBaa should allow running nc lifecycle process
 // NOTE: This will also be in the same timezone as specified in
 // NC_LIFECYCLE_TZ
-config.NC_LIFECYCLE_RUN_TIME = '01:00';
+config.NC_LIFECYCLE_RUN_TIME = '00:00';
 
 // NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS configures the delay
 // tolerance in minutes.
 //
-// eg. If the expiry run time is set to 01:00 and the tolerance is
-// set to be 2 mins then the expiry can trigger till 01:02 (unless
-// already triggered between 01:00 - 01:02
+// eg. If the expiry run time is set to 00:00 and the tolerance is
+// set to be 2 mins then the expiry can trigger till 00:02 (unless
+// already triggered between 00:00 - 00:02
 config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS = 2;
 
 /** @type {'UTC' | 'LOCAL'} */

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -96,7 +96,7 @@ const VALID_OPTIONS_CONNECTION = {
     'status': new Set(['name', 'decrypt', ...CLI_MUTUAL_OPTIONS]),
 };
 
-const VALID_OPTIONS_LIFECYCLE = new Set(['disable_service_validation', 'disable_runtime_validation', 'short', ...CLI_MUTUAL_OPTIONS]);
+const VALID_OPTIONS_LIFECYCLE = new Set(['disable_service_validation', 'disable_runtime_validation', 'short_status', ...CLI_MUTUAL_OPTIONS]);
 
 const VALID_OPTIONS_WHITELIST = new Set(['ips', ...CLI_MUTUAL_OPTIONS]);
 
@@ -171,7 +171,7 @@ const OPTION_TYPE = {
 
 const BOOLEAN_STRING_VALUES = ['true', 'false'];
 const BOOLEAN_STRING_OPTIONS = new Set(['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force',
-    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous', 'disable_service_validation', 'disable_runtime_validation', 'short']);
+    'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous', 'disable_service_validation', 'disable_runtime_validation', 'short_status']);
 
 // CLI UNSET VALUES
 const CLI_EMPTY_STRING = '';

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_cli.test.js
@@ -47,6 +47,7 @@ describe('noobaa cli - lifecycle - lock check', () => {
         config.NC_LIFECYCLE_RUN_TIME = original_lifecycle_run_time;
         config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS = original_lifecycle_run_delay;
         await fs_utils.folder_delete(config.NC_LIFECYCLE_LOGS_DIR);
+        await fs_utils.folder_delete(config_root);
     });
 
     afterAll(async () => {
@@ -104,7 +105,7 @@ describe('noobaa cli - lifecycle - lock check', () => {
         expect(parsed_res.message).toBe(ManageCLIResponse.LifecycleSuccessful.message);
     });
 
-    it('lifecycle_cli - change run time to 1 minutes ago - should fail ', async () => {
+    it('lifecycle_cli - change run time to 1 minute in the future - should fail ', async () => {
         const lifecyle_run_date = new Date();
         lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() + 1);
         await config_fs.create_config_json_file(JSON.stringify({


### PR DESCRIPTION
### Describe the Problem
Per feedback received in a design meeting adding some changes + tiny CLI fix.
 
### Explain the Changes
1. Changed the following configurations - 
```
config.NC_LIFECYCLE_TIMEOUT_MS = 8 * 60 * 60;
config.NC_LIFECYCLE_RUN_TIME = 00:00;
config.NC_LIFECYCLE_CONFIG_DIR_NAME = 'lifecycle';
```
2. Moved back the lifecycle cluster lock and the timestamp file to be inside a directory in the config directory which is shared between all the nodes - `/etc/noobaa.conf.d/lifecycle/`. Initially was the case in [8858](https://github.com/noobaa/noobaa-core/pull/8858) but changed it mistakenly on [8860](https://github.com/noobaa/noobaa-core/pull/8860).
3. Renamed cluster.lock to be lifecycle_cluster.lock.
4. Moved the write_stdout_response/throw_cli_error to manage_nsfs because it was wrongly under the lock and these functions do process.exit(). So changed the order to first release the lock and then write the response to stdout.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Run `noobaa-cli lifecycle` and expect to see successful + status
2. Run `sudo cat /{path_to_config_path}/lifecycle/lifecycle.timestamp` - should contain last lifecycle run timestamp 
3. Run `sudo cat /{path_to_config_path}/lifecycle/lifecycle_cluster.lock` - should be empty
4. Run `sudo cat /var/log/noobaa/lifecycle/lifecycle_run_{lifecycle_run_timestamp}.json | jq` - should have the status

- [ ] Doc added/updated
- [ ] Tests added
