### PR TITLE
NC | LIFECYCLE | Add temporary NC_LIFECYCLE_GPFS_ILM_ENABLED configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -1032,6 +1032,7 @@ config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS = 2;
 /** @type {'UTC' | 'LOCAL'} */
 config.NC_LIFECYCLE_TZ = 'LOCAL';
 
+config.NC_LIFECYCLE_GPFS_ILM_ENABLED = false;
 ////////// GPFS //////////
 config.GPFS_DOWN_DELAY = 1000;
 

--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -372,7 +372,7 @@ function _get_lifecycle_object_info_from_list_object_entry(entry) {
  */
 async function get_candidates_by_expiration_rule(lifecycle_rule, bucket_json, object_sdk) {
     const is_gpfs = nb_native().fs.gpfs;
-    if (is_gpfs) {
+    if (is_gpfs && config.NC_LIFECYCLE_GPFS_ILM_ENABLED) {
         return get_candidates_by_expiration_rule_gpfs(lifecycle_rule, bucket_json);
     } else {
         return get_candidates_by_expiration_rule_posix(lifecycle_rule, bucket_json, object_sdk);


### PR DESCRIPTION
### Describe the Problem
Currently, we always return an empty array if the underlying file system is GPFS.

### Explain the Changes
1. Add NC_LIFECYCLE_GPFS_ILM_ENABLED configuration and set it to false by default so we will fallback to POSIX directory scan.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
