### PR TITLE
[NC | Glacier] Fix migrate.log stat issue

### DIFF
--- a/src/manage_nsfs/manage_nsfs_glacier.js
+++ b/src/manage_nsfs/manage_nsfs_glacier.js
@@ -124,10 +124,17 @@ async function time_exceeded(fs_context, interval, timestamp_file) {
  */
 async function migrate_log_exceeds_threshold(threshold = config.NSFS_GLACIER_MIGRATE_LOG_THRESHOLD) {
     const log = new PersistentLogger(config.NSFS_GLACIER_LOGS_DIR, Glacier.MIGRATE_WAL_NAME, { locking: null });
-    await log._open();
+    let log_size = Number.MAX_SAFE_INTEGER;
+    try {
+        const fh = await log._open();
 
-    const { size } = await log.fh.stat(log.fs_context);
-    return size > threshold;
+        const { size } = await fh.stat(log.fs_context);
+        log_size = size;
+    } catch (error) {
+        console.error("failed to get size of", Glacier.MIGRATE_WAL_NAME, error);
+    }
+
+    return log_size > threshold;
 }
 
 /**


### PR DESCRIPTION
### Describe the Problem
This PR fixes the stat bug which was preventing `migrate` calls from running.

### Explain the Changes
Rely on the `fh` from the open call instead of the internal `fh` and add a try catch to ensure no crashes.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
