### PR TITLE
NC | lifecycle | add notifications for lifecycle expire

### DIFF
--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -11,7 +11,7 @@ const system_store = require('../system_services/system_store').get_instance();
 const auth_server = require('../common_services/auth_server');
 const config = require('../../../config');
 const { get_notification_logger, check_notif_relevant,
-    OP_TO_EVENT, compose_notification_lifecycle } = require('../../util/notifications_util');
+    OP_TO_EVENT, compose_notification_lifecycle, should_notify_on_event } = require('../../util/notifications_util');
 
 function get_expiration_timestamp(expiration) {
     if (!expiration) {
@@ -49,9 +49,7 @@ async function handle_bucket_rule(system, rule, j, bucket) {
     //3.2. notification is for LifecycleExpiration event
     //if so, we need the metadata of the deleted objects from the object server
     // TODO - should move to the upper for, looks like it's per bucket and not per rule
-    const reply_objects = config.NOTIFICATION_LOG_DIR && bucket.notifications &&
-         _.some(bucket.notifications, notif =>
-            (!notif.Events || _.some(notif.Events, event => event.includes(OP_TO_EVENT.lifecycle_delete.name))));
+    const reply_objects = should_notify_on_event(bucket, OP_TO_EVENT.lifecycle_delete.name);
 
     const res = await server_rpc.client.object.delete_multiple_objects_by_filter({
         bucket: bucket.name,

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -16,6 +16,7 @@ const http_utils = require('../util/http_utils');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 const {ConfigFS} = require('../sdk/config_fs');
+const _ = require('lodash');
 
 const OP_TO_EVENT = Object.freeze({
     put_object: { name: 'ObjectCreated' },
@@ -469,9 +470,9 @@ function compose_notification_req(req, res, bucket, notif_conf) {
     return compose_meta(notif, notif_conf, bucket);
 }
 
-function compose_notification_lifecycle(deleted_obj, notif_conf, bucket) {
+function compose_notification_lifecycle(deleted_obj, notif_conf, bucket, object_sdk) {
 
-    const notif = compose_notification_base(notif_conf, bucket);
+    const notif = compose_notification_base(notif_conf, bucket, {object_sdk});
 
     notif.eventName = OP_TO_EVENT.lifecycle_delete.name + ':' +
         (deleted_obj.created_delete_marker ? 'DeleteMarkerCreated' : 'Delete');
@@ -650,6 +651,17 @@ async function encrypt_connect_file(data) {
     }
 }
 
+/**
+ * @param {Object} bucket
+ * @param {String} event_name
+ * @returns {Boolean}
+ */
+function should_notify_on_event(bucket, event_name) {
+    return config.NOTIFICATION_LOG_DIR && bucket.notifications &&
+    _.some(bucket.notifications, notif =>
+    (!notif.Events || _.some(notif.Events, event => event.includes(event_name))));
+}
+
 exports.Notificator = Notificator;
 exports.test_notifications = test_notifications;
 exports.compose_notification_req = compose_notification_req;
@@ -660,4 +672,5 @@ exports.add_connect_file = add_connect_file;
 exports.update_connect_file = update_connect_file;
 exports.check_free_space = check_free_space;
 exports.check_free_space_if_needed = check_free_space_if_needed;
+exports.should_notify_on_event = should_notify_on_event;
 exports.OP_TO_EVENT = OP_TO_EVENT;


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. add notifications handling for nc lifecycle based on containerized lifecycle notifications handling
2. merged some of the notifications for lifecycle into notifications_util

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
manual testing:
1. create new bucket: `s3api create-bucket --bucket test_bucket`
2. create a new connection `nb connection add --name conn --notification_protocol http`
3. create notifications json:
```
{
    "TopicConfigurations": [
        {
            "Id": "notifications",
            "TopicArn": "conn",
            "Events": [
                "s3:LifecycleExpiration:Delete",
                "s3:LifecycleExpiration:DeleteMarkerCreated"
            ]
        }
    ]
}
```
4. add notifications configuration to the bucket: `s3api put-bucket-notification-configuration --bucket test-bucket --notification-configuration file://notifications.json`
5. create lifecycle policy. for example this policy delete all objects:
```
{
    "Rules": [
        {
            "ID": "Transition and Expiration Rule",
            "Status": "Enabled",
            "Filter": {
                "Prefix": ""
            },
            "Expiration": {
                "Date": "2022-07-12"
            }
        }
    ]
}
```
6. apply lifecycle policy to the bucket: `s3api put-bucket-lifecycle-configuration --bucket test-bucket --lifecycle-configuration file://lifecycle.json`
7. add objects to the bucket
8. run lifecycle cli: `sudo node src/cmd/manage_nsfs lifecycle  --disable_service_validation true --disable_runtime_validation true`
9. delete notifications should be in the permanent log file. can be configured as env variable `NOTIFICATION_LOG_DIR` or set `NOTIFICATION_LOG_DIR` in config.js
10. to check notifications for delete marker, enable versioning on the bucket: `s3api put-bucket-versioning --bucket test-bucket --versioning-configuration Status=Enabled`, before running lifecycle

- [ ] Doc added/updated
- [ ] Tests added
