### PR TITLE
bucket notifications - lifecycle - ignore failures (issue #8884)

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1166,9 +1166,23 @@ module.exports = {
                     deleted_objects: {
                         type: 'array',
                         items: {
-                            $ref: '#/definitions/object_info'
+                            oneOf: [
+                                {
+                                    $ref: '#/definitions/object_info',
+                                },
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        err_code: {
+                                            type: 'string',
+                                            enum: ['AccessDenied', 'InternalError']
+                                        },
+                                        err_message: { type: 'string' }
+                                    }
+                                }
+                            ]
                         }
-                    }
+                    },
                 }
             },
             auth: { system: 'admin' }

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -68,13 +68,13 @@ async function handle_bucket_rule(system, rule, j, bucket) {
         })
     });
 
-    //dbg.log0("LIFECYCLE PROCESSING res =", res);
-
     if (res.deleted_objects) {
 
         const writes = [];
 
         for (const deleted_obj of res.deleted_objects) {
+            //if deletion has failed, don't send a notification
+            if (deleted_obj.err_code) continue;
             for (const notif of bucket.notifications) {
                 if (check_notif_relevant(notif, {
                     op_name: 'lifecycle_delete',

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -986,7 +986,7 @@ async function delete_multiple_objects_by_filter(req) {
 
     const { objects } = await MDStore.instance().find_objects(query);
 
-    await delete_multiple_objects(_.assign(req, {
+    const delete_results = await delete_multiple_objects(_.assign(req, {
         rpc_params: {
             bucket: req.bucket.name,
             objects: _.map(objects, obj => ({
@@ -1000,8 +1000,19 @@ async function delete_multiple_objects_by_filter(req) {
     if (reply_objects) {
         //reply needs to include deleted objects
         //(this is used for LifecycleExpiratoin event notifications)
-        //so map the md into (api friendly) object info
-        reply.deleted_objects = _.map(objects, get_object_info);
+        //so map the md into (api friendly) object info,
+        //or incude the error if deletion failed
+        reply.deleted_objects = [];
+        for (let i = 0; i < objects.length; ++i) {
+             if (delete_results[i].err_code) {
+                reply.deleted_objects[i] = {
+                    err_code: delete_results[i].err_code,
+                    err_message: delete_results[i].err_message
+                };
+             } else {
+                reply.deleted_objects[i] = get_object_info(objects[i]);
+             }
+        }
     }
 
     return reply;


### PR DESCRIPTION
### Describe the Problem
Lifecycle notification sends a notification for failed deletions.

### Explain the Changes
1. For each deletion, include the result.
2. If deletion result is failure, don't send a notification.

### Issues: Fixed #xxx / Gap #xxx
[1. ](https://github.com/noobaa/noobaa-core/issues/8884)

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
