### PR TITLE
bucket notification - move kafka options into object. Also add missing call to destroy()

### DIFF
--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -569,6 +569,16 @@ noobaa-cli connection add --from_file
    - Type: Object
    - Description: An object given as options to node http(s) request. If "auth" field is specified, it's value is encrypted.
 
+- `kafka_options_object`
+   - Type: Object
+   - Description: An object given as options to kafka client.
+     Options are listed in https://github.com/edenhill/librdkafka/blob/v2.8.0/CONFIGURATION.md.
+     Specifically, 'metadata.broker.list' is used to specify the external kafka server.
+
+- `topic`
+   - Type: String
+   - Description - Topic for kafka messages.
+
 - `from_file`
     - Type: String
     - Description: Path to a JSON file which includes connection properties. When using `from_file` flag the connection details must only appear inside the options JSON file. See example below.

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -89,7 +89,7 @@ const VALID_OPTIONS_UPGRADE = {
 const VALID_OPTIONS_NOTIFICATION = {};
 
 const VALID_OPTIONS_CONNECTION = {
-    'add': new Set(['name', 'notification_protocol', 'agent_request_object', 'request_options_object', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
+    'add': new Set(['name', 'notification_protocol', 'agent_request_object', 'request_options_object', 'topic', 'kafka_options_object', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
     'update': new Set(['name', 'key', 'value', 'remove_key', ...CLI_MUTUAL_OPTIONS]),
     'delete': new Set(['name', ...CLI_MUTUAL_OPTIONS]),
     'list': new Set(CLI_MUTUAL_OPTIONS),
@@ -163,6 +163,8 @@ const OPTION_TYPE = {
     notification_protocol: 'string',
     agent_request_object: 'string',
     request_options_object: 'string',
+    kafka_options_object: 'string',
+    topic: 'string',
     decrypt: 'boolean',
     key: 'string',
     value: 'string',

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -104,6 +104,9 @@ class Notificator {
             } finally {
                 await log.close();
                 this.notif_to_connect.clear();
+                for (const conn of this.connect_str_to_connection.values()) {
+                    conn.destroy();
+                }
             }
         }
     }
@@ -255,13 +258,7 @@ class KafkaNotificator {
     }
 
     async connect() {
-        //kafka client doens't like options it's not familiar with
-        //so delete them before connecting
-        const connect_for_kafka = structuredClone(this.connect_obj);
-        delete connect_for_kafka.topic;
-        delete connect_for_kafka.notification_protocol;
-        delete connect_for_kafka.name;
-        this.connection = new Kafka.HighLevelProducer(connect_for_kafka);
+        this.connection = new Kafka.HighLevelProducer(this.connect_obj.kafka_options_object);
         await new Promise((res, rej) => {
             this.connection.on('ready', () => {
                 res();


### PR DESCRIPTION
### Describe the Problem
Connect file to kafka could not be created by cli add connection.
Now that all kafka options are in a single object, there's no need to add all possible kafka client options to cli.

### Explain the Changes
1. Add kafka_options_object param to connection add cli. Use this new field when creating a kafka client.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. manage_nsfs.js connection add --name ko --notification_protocol kafka --kafka_options_object '{"metadata.broker.list": "localhost:9092"}' --topic mytopic


- [x] Doc added/updated
- [x] Tests added
