### PR TITLE
Added a fix for event handling of different errors

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -579,12 +579,13 @@ const NSFS_CLI_ERROR_EVENT_MAP = {
     AccountNameAlreadyExists: NoobaaEvent.ACCOUNT_ALREADY_EXISTS,
     AccountDeleteForbiddenHasBuckets: NoobaaEvent.ACCOUNT_DELETE_FORBIDDEN,
     BucketAlreadyExists: NoobaaEvent.BUCKET_ALREADY_EXISTS,
-    BucketSetForbiddenBucketOwnerNotExists: NoobaaEvent.UNAUTHORIZED, // GAP - add event
-    BucketSetForbiddenBucketOwnerIsIAMAccount: NoobaaEvent.UNAUTHORIZED, // // GAP - add event
+    BucketSetForbiddenBucketOwnerNotExists: NoobaaEvent.BUCKET_OWNER_NOT_EXISTS,
+    BucketSetForbiddenBucketOwnerIsIAMAccount: NoobaaEvent.BUCKET_OWNER_IS_IAM_ACCOUNT,
     LoggingExportFailed: NoobaaEvent.LOGGING_FAILED,
     UpgradeFailed: NoobaaEvent.CONFIG_DIR_UPGRADE_FAILED,
     LifecycleFailed: NoobaaEvent.LIFECYCLE_FAILED,
-    LifecycleWorkerReachedTimeout: NoobaaEvent.LIFECYCLE_TIMEOUT
+    LifecycleWorkerReachedTimeout: NoobaaEvent.LIFECYCLE_TIMEOUT,
+    InternalError: NoobaaEvent.INTERNAL_ERROR
 };
 
 exports.ManageCLIError = ManageCLIError;

--- a/src/manage_nsfs/manage_nsfs_events_utils.js
+++ b/src/manage_nsfs/manage_nsfs_events_utils.js
@@ -292,6 +292,26 @@ NoobaaEvent.BUCKET_ALREADY_EXISTS = Object.freeze({
     severity: 'ERROR',
     state: 'HEALTHY',
 });
+NoobaaEvent.BUCKET_OWNER_NOT_EXISTS = Object.freeze({
+    event_code: 'bucket_owner_not_exists',
+    message: 'Bucket owner does not exist',
+    description: 'The specified bucket owner does not exist in the system',
+    entity_type: 'NODE',
+    event_type: 'ERROR',
+    scope: 'NODE',
+    severity: 'ERROR',
+    state: 'HEALTHY'
+});
+NoobaaEvent.BUCKET_OWNER_IS_IAM_ACCOUNT = Object.freeze({
+    event_code: 'bucket_owner_is_iam_account',
+    message: 'The bucket owner is an IAM account',
+    description: 'The specified bucket owner is an IAM account. Please set a root account as the bucket owner',
+    entity_type: 'NODE',
+    event_type: 'ERROR',
+    scope: 'NODE',
+    severity: 'ERROR',
+    state: 'HEALTHY'
+});
 NoobaaEvent.UNAUTHORIZED = Object.freeze({
     event_code: 'noobaa_bucket_access_unauthorized',
     message: 'Bucket is not accessible with current access rights ',


### PR DESCRIPTION
### Describe the Problem
Previously, when an InternalError occurred during an operation, it was not recorded as an event.

### Explain the Changes
1.  Implemented a fix to ensure that InternalError and other error types are properly recorded as events.

### Issues: Fixed #xxx / Gap #xxx
1. Fix: #8199 

### Testing Instructions:
1.  Manual testing instructions:

- Use command `make rpm`  inside `noobaa-core` to create rpm, which will be found in dir `build/rpm/` after creation.
- Start Redhat UBI9 container and enter the shell using below commands:
`$ docker pull redhat/ubi9:latest`
`$ docker run --privileged -it --user root -d --platform=linux/amd64 redhat/ubi9 /usr/sbin/init`
`$ docker exec -it <container-id> bash`
- Copy rpm created in step 1 to the container from `noobaa-core`(update rpm name):
`$ docker cp build/rpm/noobaa-core-5.19.0-20250326.el9.x86_64.rpm <container-id>:tmp/`
- Install dependencies in the container using below commands:
`$ yum install -y rsyslog wget make initscripts`
`$ systemctl start rsyslog`
`$ wget https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages/boost-system-1.75.0-8.el9.x86_64.rpm`
`$ wget https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages/boost-thread-1.75.0-8.el9.x86_64.rpm`
`$ rpm -i boost-system-1.75.0-8.el9.x86_64.rpm`
`$ rpm -i boost-thread-1.75.0-8.el9.x86_64.rpm`
- Install noobaa rpm inside the container using below command(update rpm name):
`$ rpm -i tmp/noobaa-core-5.19.0-20250326.el9.x86_64.rpm`
`$ rpm -qa | grep noobaa` (check if noobaa installed or not)
- Do something in the noobaa code to throw `InternalError`, for example try adding this `throw ManageCLIError.InternalError;` as first line of function `delete_account()` in `manage_nsfs.js`. After that try creating and then deleting account using noobaa-cli and check the noobaa-events in the below steps --> new event for InternalError should be created.
- Check for noobaa-events using below command:
`$ cat var/log/noobaa_events.log`

> [root@8ccc29c3ce83 /]# cat var/log/noobaa_events.log 
Mar 20 16:09:57 8ccc29c3ce83 node[218]: {"timestamp":"2025-03-20T16:09:57.526Z","host":"8ccc29c3ce83","event":{"code":"noobaa_gpfslib_missing","message":"Noobaa GPFS library file is missing","description":"Noobaa GPFS library file is missing","entity_type":"NODE","event_type":"STATE_CHANGE","scope":"NODE","severity":"ERROR","state":"DEGRADED","arguments":{"gpfs_dl_path":"/usr/lpp/mmfs/lib/libgpfs.so"},"pid":218}}
Mar 20 16:09:58 8ccc29c3ce83 [218]: {"timestamp":"2025-03-20T16:09:58.009Z","host":"8ccc29c3ce83","event":{"code":"noobaa_started","message":"Noobaa started","description":"Noobaa started running","entity_type":"NODE","event_type":"STATE_CHANGE","scope":"NODE","severity":"INFO","state":"HEALTHY","pid":218}}
Mar 20 16:12:30 8ccc29c3ce83 node[274]: {"timestamp":"2025-03-20T16:12:30.399Z","host":"8ccc29c3ce83","event":{"code":"noobaa_account_created","message":"Account created","description":"Noobaa Account created","entity_type":"NODE","event_type":"INFO","scope":"NODE","severity":"INFO","state":"HEALTHY","arguments":{"account":"aayush"},"pid":274}}
Mar 21 14:38:54 8ccc29c3ce83 node[324]: {"timestamp":"2025-03-21T14:38:54.682Z","host":"8ccc29c3ce83","event":{"code":"noobaa_internal_error","message":"Noobaa action failed with internal error","description":"Noobaa action failed with internal error","entity_type":"NODE","event_type":"ERROR","scope":"NODE","severity":"ERROR","state":"HEALTHY","pid":324}}


- [ ] Tests added
