### PR TITLE
CI | Update Ceph S3 Tests Days (Temporary Solution)

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -38,7 +38,7 @@ commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}'
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
 
-max_days="360"
+max_days="450"
 if [ $((current_date-commit_date)) -gt $((3600*24*${max_days})) ]
 then
     echo "ceph tests were not updated for ${max_days} days, Exiting"


### PR DESCRIPTION
### Describe the Problem
Currently, the CI has failures with "ceph tests were not updated for 360 days, Exiting" to avoid it in the meantime, we will extend the time.

### Explain the Changes
1. Change the number of days from 360 to 450 (3 months extra for update the last commit).

### Issues: Fixed #xxx / Gap #xxx
1. As mentioned in PR #8621 there is an opened a Jira ticket ([MCGI-254](https://issues.redhat.com/browse/MCGI-254)) to investigate it, after updating the commit hash the number of days should be 180 again.
More information in PR #8392.

### Testing Instructions:
1. none (tested through the CI).


- [ ] Doc added/updated
- [ ] Tests added
