### PR TITLE
NC | Lifecycle | Health

### DIFF
--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -75,7 +75,7 @@ const VALID_OPTIONS_GLACIER = {
 };
 
 const VALID_OPTIONS_DIAGNOSE = {
-    'health': new Set([ 'https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', 'all_connection_details', 'notif_storage_threshold', ...CLI_MUTUAL_OPTIONS]),
+    'health': new Set([ 'https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', 'all_connection_details', 'notif_storage_threshold', 'lifecycle', ...CLI_MUTUAL_OPTIONS]),
     'gather-logs': new Set([ CONFIG_ROOT_FLAG]),
     'metrics': new Set([CONFIG_ROOT_FLAG])
 };
@@ -150,6 +150,7 @@ const OPTION_TYPE = {
     notif_storage_threshold: 'boolean',
     https_port: 'number',
     debug: 'number',
+    lifecycle: 'boolean',
     // upgrade options
     expected_version: 'string',
     expected_hosts: 'string',

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -371,6 +371,7 @@ Flags:
     --all_account_details    <boolean>       (optional)          Set a flag for returning all account details.
     --all_bucket_details     <boolean>       (optional)          Set a flag for returning all bucket details.
     --all_connection_details <boolean>       (optional)          Set a flag for returning all connection details.
+    --lifecycle              <boolean>       (optional)          Set a flag for returning lifecycle details on the current host.
     --debug                  <number>        (optional)          Use for increasing the log verbosity of health cli commands.
     --config_root            <string>        (optional)          Set Configuration files path for Noobaa standalon NSFS. (default config.NSFS_NC_DEFAULT_CONF_DIR)
 


### PR DESCRIPTION
### Describe the Problem
The NC health CLI should report on the latest lifecycle worker run.

### Explain the Changes
1. health.js - Added get_lifecycle_health_status() and get_latest_lifecycle_run_status() functions that return the status of the latest lifecycle run **on the current host**.
2. manage_nsfs_constants - added --lifecycle flag to health options
3. manage_nsfs_help_utils - added --lifecycle help.
4. test_nc_health.js - added unit tests

### Issues: Fixed #xxx / Gap #xxx
1. Gap - Open question - do we need to trigger an event with Degraded/Healthy status? 

### Testing Instructions:
1. Auto -
```
sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_nc_health.js  --g "health - lifecycle"
```
2. Manual - 
a. Empty scenario - run `noobaa-cli diagnose health --lifecycle`
b. valid scenario - 
    b.1. run `noobaa-cli lifecycle` 3 times.
    b.2. run `noobaa-cli diagnose health --lifecycle` and expect to have the latest run information. 
c. error scenario = 
   c.1. Edit config.json and set NC_LIFECYLE_TIMEOUT_MS to be 1.
   c.2.  run `noobaa-cli diagnose health --lifecycle` and expect to have the latest run information including the timeout error.
- [ ] Doc added/updated
- [x] Tests added
