### PR TITLE
lifecycle | Versioned object doesn't leave a delete marker

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1140,6 +1140,9 @@ module.exports = {
                     filter_delete_markers: {
                         type: 'boolean',
                     },
+                    latest_versions: {
+                        type: 'boolean',
+                    },
                     size_less: {
                         type: 'integer'
                     },
@@ -1151,6 +1154,9 @@ module.exports = {
                     },
                     limit: {
                         type: 'integer'
+                    },
+                    delete_version: {
+                        type: 'boolean'
                     },
                     reply_objects: {
                         type: 'boolean'

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -38,6 +38,10 @@ async function delete_expired_objects(system, bucket, rule, reply_objects) {
         size_greater: rule.filter.object_size_greater_than,
         tags: rule.filter.tags,
         limit: config.LIFECYCLE_BATCH_SIZE,
+        filter_delete_markers: true,
+        latest_versions: true,
+        // deleting only the latest verion and creating delete marker for expired objects
+        delete_version: false,
         reply_objects,
     }, {
         auth_token: auth_server.make_auth_token({

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -978,6 +978,7 @@ async function delete_multiple_objects_by_filter(req) {
         key,
         max_create_time: req.rpc_params.create_time,
         tagging: req.rpc_params.tags,
+        latest_versions: req.rpc_params.latest_versions,
         filter_delete_markers: req.rpc_params.filter_delete_markers,
         max_size: req.rpc_params.size_less,
         min_size: req.rpc_params.size_greater,
@@ -991,7 +992,7 @@ async function delete_multiple_objects_by_filter(req) {
             bucket: req.bucket.name,
             objects: _.map(objects, obj => ({
                 key: obj.key,
-                version_id: MDStore.instance().get_object_version_id(obj),
+                version_id: req.rpc_params.delete_version ? MDStore.instance().get_object_version_id(obj) : '',
             }))
         }
     }));

--- a/src/test/lifecycle/common.js
+++ b/src/test/lifecycle/common.js
@@ -188,6 +188,7 @@ function days_lifecycle_configuration(Bucket, Key) {
         },
     };
 }
+exports.days_lifecycle_configuration = days_lifecycle_configuration;
 
 function tags_lifecycle_configuration(Bucket, Key, Value) {
     return {


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. new property `delete_version` added to delete_multiple_objects_by_filter to control version deletion for expired object and expired versions
2. `filter_delete_markers` and  `latest_versions` added to query to get only current version when query objects for deletion.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-1468

### Testing Instructions:
1. Added is ticket[ DFBUGS-1468](https://issues.redhat.com/browse/DFBUGS-1468)


- [ ] Doc added/updated
- [X] Tests added
