### PR TITLE
Fixing issue with allowed methods

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_cors.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_cors.js
@@ -2,21 +2,30 @@
 'use strict';
 
 const _ = require('lodash');
+const { S3Error } = require('../s3_errors');
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTcors.html
  */
 async function put_bucket_cors(req) {
-    const cors_rules = req.body.CORSConfiguration.CORSRule.map(rule =>
-        _.omitBy({
+    const allowedList = ['GET', 'PUT', 'POST', 'DELETE', 'HEAD'];
+    const cors_rules = req.body.CORSConfiguration.CORSRule.map(rule => {
+        const unsupported_method = rule.AllowedMethod.find(item => !allowedList.includes(item));
+        if (unsupported_method) {
+            throw new S3Error({
+                ...S3Error.InvalidRequest,
+                message: `Found unsupported HTTP method in CORS config. Unsupported method is ${unsupported_method}`
+            });
+        }
+        return _.omitBy({
             allowed_headers: rule.AllowedHeader,
             allowed_methods: rule.AllowedMethod,
             allowed_origins: rule.AllowedOrigin,
             expose_headers: rule.ExposeHeader,
             id: rule.ID?.[0],
             max_age_seconds: rule.MaxAgeSeconds && parseInt(rule.MaxAgeSeconds, 10),
-        }, _.isUndefined)
-    );
+        }, _.isUndefined);
+    });
     await req.object_sdk.put_bucket_cors({
         name: req.params.bucket,
         cors_rules


### PR DESCRIPTION
### Describe the Problem
We used to support any string as an allowed method in a provided CORS rule - AWS supports only limited HTTP methods: GET, PUT, POST, DELETE, HEAD

### Explain the Changes
1. if we now get a CORS rule that is not one of the above methods - we will fail the request
2. in the error we will provide the first not allowed method - like AWS is doing.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-1923

### Testing Instructions:
1. follow steps in https://issues.redhat.com/browse/DFBUGS-1923


- [ ] Doc added/updated
- [x] Tests added
