### PR TITLE
NC | Health | Connection test is invalid because of additional .json

### DIFF
--- a/docs/bucket-notifications.md
+++ b/docs/bucket-notifications.md
@@ -10,7 +10,7 @@ A notification json has these fields:
           If not specified, the notification is relevant for all events.
 - TopicArn: The connection file (see below). (To specify a Kafka target topic, see "Kafka Connection Fields" below).
 
-Example for a bucket's notification configuration, in a file:
+Example for a bucket's notification configuration on containerized environment, in a file:
 {
     "TopicConfigurations": [
         {
@@ -23,6 +23,18 @@ Example for a bucket's notification configuration, in a file:
     ]
 }
 
+Example for a bucket's notification configuration on Non-containerized environment, in a file:
+{
+    "TopicConfigurations": [
+        {
+	    "Id": "created_from_s3op",
+            "TopicArn": "secret-name/connect",
+            "Events": [
+                "s3:ObjectCreated:*"
+            ]
+        }
+    ]
+}
 
 ## Connection File
 A connection file contains some fields that specify the target notification server.

--- a/src/manage_nsfs/health.js
+++ b/src/manage_nsfs/health.js
@@ -418,7 +418,7 @@ class NSFSHealth {
                 const connection_file_path = this.config_fs.get_connection_path_by_name(config_file_name);
                 const test_notif_err = await notifications_util.test_notifications([{
                     name: config_data.name,
-                    topic: [this.config_fs.json(config_file_name)]
+                    topic: [config_file_name]
                 }], this.config_fs.config_root);
                 if (test_notif_err) {
                     res = get_invalid_object(config_data.name, connection_file_path, undefined, test_notif_err.code);


### PR DESCRIPTION
### Describe the Problem
The following 2 fixes got merged around the same time, they have a logical conflict - 
1. https://github.com/noobaa/noobaa-core/pull/8833 - added a health test to a connection file, in which .json was added to the file name.
2. https://github.com/noobaa/noobaa-core/pull/8806 - removed a config dir check that if a file already has .json in it won't add.
get_connection_by_name() already adds .json, therefore, the health CLI tried to search for conn.json.json and failed because it doesn't exist.
### Explain the Changes
1. Removed the additional `.json` suffix.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. create an account - `noobaa-cli account add --name account1 --user=root  --new_buckets_path=/private/tmp/nb_storage1`
2. create a bucket - `noobaa-cli bucket add --name buck1 --owner account1  --path=/private/tmp/nb_storage1`
3. create a dummy connection - `noobaa-cli connection add --name conn --notification_protocol http`
4. Run noobaa service - `sudo node noobaa-core/src/cmd/nsfs.js --debug 5`
5. create notification configuration file - 
```
> vi notif.json
{
"TopicConfigurations": [ { "Id": "notify_event", "TopicArn": "conn", "Events": [ "s3:ObjectCreated:*" ] }
]
}
```
6. Run health script and check that the connection is valid/invalid - 
```
{
  "response": {
    "code": "HealthStatus",
    "message": "Health status retrieved successfully",
    "reply": {
      "service_name": "noobaa",
....
       },
        "connections_status": {
          "invalid_storages": [],
          "valid_storages": [
            {
              "name": "conn",
              "config_path": "/private/tmp/custom_conf_dir/connections/conn.json"
            }
          ]
        }
      }
    }
  }
}
```
- [ ] Doc added/updated
- [ ] Tests added
