### PR TITLE
Added required validations in lifecycle rules

### DIFF
--- a/docs/dev_guide/ceph_s3_tests/ceph_s3_tests_pending_list_status.md
+++ b/docs/dev_guide/ceph_s3_tests/ceph_s3_tests_pending_list_status.md
@@ -50,4 +50,5 @@ Attached a table with tests that where investigated and their status (this table
 | test_get_bucket_encryption_s3 | Faulty Test | [613](https://github.com/ceph/s3-tests/issues/613) | 
 | test_get_bucket_encryption_kms | Faulty Test | [613](https://github.com/ceph/s3-tests/issues/613) | 
 | test_delete_bucket_encryption_s3 | Faulty Test | [613](https://github.com/ceph/s3-tests/issues/613) | 
-| test_delete_bucket_encryption_kms | Faulty Test | [613](https://github.com/ceph/s3-tests/issues/613) | 
+| test_delete_bucket_encryption_kms | Faulty Test | [613](https://github.com/ceph/s3-tests/issues/613) |
+| test_lifecycle_expiration_tags1 | Faulty Test | [638](https://github.com/ceph/s3-tests/issues/638) | There can be more such tests having the same issue (`Filter` is not aligned with aws structure in bucket lifecycle configuration) |

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_pending_list.txt
@@ -154,3 +154,4 @@ s3tests_boto3/functional/test_s3.py::test_versioned_concurrent_object_create_and
 s3tests_boto3/functional/test_s3.py::test_object_presigned_put_object_with_acl_tenant
 s3tests_boto3/functional/test_s3.py::test_get_undefined_public_block
 s3tests_boto3/functional/test_s3.py::test_get_public_block_deny_bucket_policy
+s3tests_boto3/functional/test_s3.py::test_lifecycle_expiration_tags1

--- a/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
+++ b/src/test/system_tests/ceph_s3_tests/s3-tests-lists/s3_tests_pending_list.txt
@@ -143,3 +143,4 @@ s3tests_boto3/functional/test_s3.py::test_get_bucket_encryption_s3
 s3tests_boto3/functional/test_s3.py::test_get_bucket_encryption_kms
 s3tests_boto3/functional/test_s3.py::test_delete_bucket_encryption_s3
 s3tests_boto3/functional/test_s3.py::test_delete_bucket_encryption_kms
+s3tests_boto3/functional/test_s3.py::test_lifecycle_expiration_tags1

--- a/src/test/system_tests/test_lifecycle.js
+++ b/src/test/system_tests/test_lifecycle.js
@@ -54,9 +54,6 @@ async function main() {
     await commonTests.test_rule_id(Bucket, Key, s3);
     await commonTests.test_filter_size(Bucket, s3);
     await commonTests.test_and_prefix_size(Bucket, Key, s3);
-    await commonTests.test_rule_id_length(Bucket, Key, s3);
-    await commonTests.test_rule_duplicate_id(Bucket, Key, s3);
-    await commonTests.test_rule_status_value(Bucket, Key, s3);
 
     const getObjectParams = {
         Bucket,

--- a/src/test/unit_tests/test_lifecycle.js
+++ b/src/test/unit_tests/test_lifecycle.js
@@ -104,6 +104,30 @@ mocha.describe('lifecycle', () => {
         mocha.it('test multipath', async () => {
             await commonTests.test_multipart(Bucket, Key, s3);
         });
+        mocha.it('test rule ID length', async () => {
+            await commonTests.test_rule_id_length(Bucket, Key, s3);
+        });
+        mocha.it('test rule duplicate ID', async () => {
+            await commonTests.test_rule_duplicate_id(Bucket, Key, s3);
+        });
+        mocha.it('test rule status value', async () => {
+            await commonTests.test_rule_status_value(Bucket, Key, s3);
+        });
+        mocha.it('test invalid filter format', async () => {
+            await commonTests.test_invalid_filter_format(Bucket, Key, s3);
+        });
+        mocha.it('test invalid expiration date format', async () => {
+            await commonTests.test_invalid_expiration_date_format(Bucket, Key, s3);
+        });
+        mocha.it('test expiration with multiple fields', async () => {
+            await commonTests.test_expiration_multiple_fields(Bucket, Key, s3);
+        });
+        mocha.it('test AbortIncompleteMultipartUpload with tags', async () => {
+            await commonTests.test_abortincompletemultipartupload_with_tags(Bucket, Key, s3);
+        });
+        mocha.it('test AbortIncompleteMultipartUpload with object sizes', async () => {
+            await commonTests.test_abortincompletemultipartupload_with_sizes(Bucket, Key, s3);
+        });
     });
 
     mocha.describe('bucket-lifecycle-bg-worker', function() {


### PR DESCRIPTION
### Describe the Problem
The following validations are missing from PutBucketLifecycleConfiguration:

- Expiration Date Must Be Midnight UTC
    - `Date` must be exactly 00:00:00 UTC, or AWS rejects it.
- AbortIncompleteMultipartUpload Cannot Be Used with Size/Tags
    - AWS does not allow it with `Tags` or `ObjectSizeGreaterThan/LessThan`.
- Expiration Rule Conflict
     - `Days/Date` cannot be used with `ExpiredObjectDeleteMarker`.
- Multiple Filter Actions Require And
     - AWS requires multiple `Filters` to be inside an `And` block.

### Explain the Changes
1. Added validations for expiration date, AbortIncompleteMultipartUpload, expiration rule conflicts, and multiple filters requiring And.

### Issues: Fixed #xxx / Gap #xxx
1. Fix: #8870 

### Testing Instructions:
1.  run lifecycle tests: `make run-single-test-postgres testname=lifecycle_index.js`
2.  removed the faulty test from ceph s3 tests and created [ceph s3 tests bug](https://github.com/ceph/s3-tests/issues/638)

- [X] Tests added
