### PR TITLE
bucket notifications - fixes for CompleteMultipartUploadResult etag and statusCode check

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -176,7 +176,7 @@ async function handle_request(req, res) {
     http_utils.send_reply(req, res, reply, options);
     collect_bucket_usage(op, req, res);
     try {
-        await s3_logging.send_bucket_op_logs(req, res); // logging again with result
+        await s3_logging.send_bucket_op_logs(req, res, reply); // logging again with result
     } catch (err) {
         dbg.error(`Could not log bucket operation (after operation ${req.op_name}):`, err);
     }

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -418,8 +418,9 @@ function compose_notification_base(notif_conf, bucket, req) {
 }
 
 //see https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html
-function compose_notification_req(req, res, bucket, notif_conf) {
-    let eTag = res.getHeader('ETag');
+function compose_notification_req(req, res, bucket, notif_conf, reply) {
+    //most s3 ops put etag in header. CompleteMultipartUploadResult is an exception.
+    let eTag = res.getHeader('ETag') || reply?.CompleteMultipartUploadResult?.ETag;
     //eslint-disable-next-line
     if (eTag && eTag.startsWith('\"') && eTag.endsWith('\"')) {
         eTag = eTag.substring(1, eTag.length - 1);


### PR DESCRIPTION
### Describe the Problem
1. etag is missing from CompleteMultipartUploadResult notification
2. notification are created for failed requests


### Explain the Changes
1. Add reply of CompleteMultipartUploadResult to compose_notification_req so we can take etag.
2. Don't write notification logs is http status code is not OK (ie in the 200s).

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Run multipart req. eg (assuming bucket has notification configured)-
s3 api create-multipart-upload --bucket <bucket> --key <key>
(get multipart id)
s3 api upload-part --bucket <bucket> --key <key> --part-number 1 --body <filename> --upload-id "<upload id>"
(get etag for part1, edit parts.json)
complete-multipart-upload --bucket <bucket> --key <key> --multipart-upload file://parts.json --upload-id  "<upload id>"
(examine notification)
2. Perform failed s3 req. Eg above example with bad etag in parts.json.

- [ ] Doc added/updated
- [ ] Tests added
