### PR TITLE
NC | IAM | Return Empty List On Unimplemented Operations (`list-group-for-user`)

### DIFF
--- a/docs/design/iam.md
+++ b/docs/design/iam.md
@@ -126,6 +126,9 @@ Here attached a diagram with all the accounts that we have in our system:
 - IAM DeleteAccessKey: AccessKeyId, UserName
 - IAM ListAccessKeys: UserName (not supported: Marker, MaxItems)
 
+### Other
+- IAM ListGroupsForUser - would always return empty list (to check that the user exists it runs GetUser).
+
 ### Configuration Directory Components With users
 If account creates a user its config file will be created under identities/<user-id>.identity.json and under the account will be created `users/` directory and inside it it will link to the config.
 Example:

--- a/src/endpoint/iam/iam_rest.js
+++ b/src/endpoint/iam/iam_rest.js
@@ -34,6 +34,7 @@ const ACTIONS = Object.freeze({
     'UpdateAccessKey': 'update_access_key',
     'DeleteAccessKey': 'delete_access_key',
     'ListAccessKeys': 'list_access_keys',
+    'ListGroupsForUser': 'list_groups_for_user',
 });
 
 // notice: shows all methods as method post
@@ -50,6 +51,8 @@ const IAM_OPS = js_utils.deep_freeze({
     post_update_access_key: require('./ops/iam_update_access_key'),
     post_delete_access_key: require('./ops/iam_delete_access_key'),
     post_list_access_keys: require('./ops/iam_list_access_keys'),
+    // other (currently ops that return empty just not to fail them)
+    post_list_groups_for_user: require('./ops/iam_list_groups_for_user.js'),
 });
 
 async function iam_rest(req, res) {

--- a/src/endpoint/iam/ops/iam_list_groups_for_user.js
+++ b/src/endpoint/iam/ops/iam_list_groups_for_user.js
@@ -1,0 +1,45 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const { CONTENT_TYPE_APP_FORM_URLENCODED } = require('../../../util/http_utils');
+const iam_utils = require('../iam_utils');
+const iam_constants = require('../iam_constants');
+
+/**
+ * https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListGroupsForUser.html
+ */
+async function list_groups_for_user(req, res) {
+
+    const params = {
+        username: req.body.user_name,
+    };
+
+    dbg.log1('To check that we have the user we will run the IAM GET USER', params);
+    iam_utils.validate_params(iam_constants.IAM_ACTIONS.GET_USER, params);
+    await req.account_sdk.get_user(params);
+
+    dbg.log1('IAM LIST GROUPS FOR USER (returns empty list on every request)', params);
+
+    return {
+        ListGroupsForUserResponse: {
+            ListGroupsForUserResult: {
+                Groups: [],
+                IsTruncated: false,
+            },
+            ResponseMetadata: {
+                RequestId: req.request_id,
+            }
+        },
+    };
+}
+
+module.exports = {
+    handler: list_groups_for_user,
+    body: {
+        type: CONTENT_TYPE_APP_FORM_URLENCODED,
+    },
+    reply: {
+        type: 'xml',
+    },
+};


### PR DESCRIPTION
### Describe the Problem
Currently, we have implemented a couple of operations in IAM that are related to Users and Access keys, but for the rest of the cases, we fail the request with the error `NotImplemented`. There are automated tools that use it and under the hood use the operation `list-group-for-user`.

### Explain the Changes
1. Add the operation `list-group-for-user` to the constants and add a handler that always returns an empty list on existing user.

### Issues:
1. Currently we throw the error `NotImplemented` on `list-group-for-user` (and on every unsupported operation).

GAP - we would like to do this kind of implementation for other list operation in IAM as well (in a separate PR).

### Testing Instructions:
#### Automatic Tests:
Please run: `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_nc_iam_basic_integration.js`

#### Manual Tests
1. Create an account with noobaa CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`.
2. Start the NSFS server (using debug mode and the port for IAM): `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005`
3. Create the alias for IAM service: 
`alias nc-user-1-iam='AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005'`
4. Create a user: `nc-user-1-iam iam create-user --user-name Bob` 
5. Check the `list-group-for-user`: `nc-user-1-iam iam list-groups-for-user --user-name Bob` (and expect to see empty list)
6. Check the `list-group-for-user` on non-exsiting-user: `nc-user-1-iam iam list-groups-for-user --user-name non-existing-user` (and expect to see an error `NoSuchEntity`)

- [X] Doc added/updated
- [X] Tests added
