### PR TITLE
NC | lifecycle | continue last run

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -889,8 +889,9 @@ async function lifecycle_management(args) {
     const disable_service_validation = get_boolean_or_string_value(args.disable_service_validation);
     const disable_runtime_validation = get_boolean_or_string_value(args.disable_runtime_validation);
     const short_status = get_boolean_or_string_value(args.short_status);
+    const should_continue_last_run = get_boolean_or_string_value(args.continue);
     try {
-        const options = { disable_service_validation, disable_runtime_validation, short_status };
+        const options = { disable_service_validation, disable_runtime_validation, short_status, should_continue_last_run };
         const { should_run, lifecycle_run_status } = await noobaa_cli_lifecycle.run_lifecycle_under_lock(config_fs, options);
         if (should_run) {
             write_stdout_response(ManageCLIResponse.LifecycleSuccessful, lifecycle_run_status);

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -96,7 +96,7 @@ const VALID_OPTIONS_CONNECTION = {
     'status': new Set(['name', 'decrypt', ...CLI_MUTUAL_OPTIONS]),
 };
 
-const VALID_OPTIONS_LIFECYCLE = new Set(['disable_service_validation', 'disable_runtime_validation', 'short_status', ...CLI_MUTUAL_OPTIONS]);
+const VALID_OPTIONS_LIFECYCLE = new Set(['disable_service_validation', 'disable_runtime_validation', 'short_status', 'continue', ...CLI_MUTUAL_OPTIONS]);
 
 const VALID_OPTIONS_WHITELIST = new Set(['ips', ...CLI_MUTUAL_OPTIONS]);
 
@@ -159,7 +159,8 @@ const OPTION_TYPE = {
     // lifecycle options
     disable_service_validation: 'boolean',
     disable_runtime_validation: 'boolean',
-    short: 'boolean',
+    short_status: 'boolean',
+    continue: 'boolean',
     //connection
     notification_protocol: 'string',
     agent_request_object: 'string',
@@ -175,7 +176,7 @@ const OPTION_TYPE = {
 const BOOLEAN_STRING_VALUES = ['true', 'false'];
 const BOOLEAN_STRING_OPTIONS = new Set(['allow_bucket_creation', 'regenerate', 'wide', 'show_secrets', 'force',
     'force_md5_etag', 'iam_operate_on_root_account', 'all_account_details', 'all_bucket_details', 'anonymous',
-    'disable_service_validation', 'disable_runtime_validation', 'short_status', 'skip_verification']);
+    'disable_service_validation', 'disable_runtime_validation', 'short_status', 'skip_verification', 'continue']);
 
 // CLI UNSET VALUES
 const CLI_EMPTY_STRING = '';

--- a/src/util/lifecycle_utils.js
+++ b/src/util/lifecycle_utils.js
@@ -1,0 +1,33 @@
+/* Copyright (C) 2025 NooBaa */
+'use strict';
+
+const _ = require("lodash");
+const nb_native = require("./nb_native");
+const path = require("path");
+const config = require("../../config");
+
+/**
+ * get_latest_nc_lifecycle_run_status returns the latest lifecycle run status
+ * latest run can be found by maxing the lifecycle log entry names, log entry name is the lifecycle_run_{timestamp}.json of the run
+ * @param {Object} config_fs
+ * @param {{silent_if_missing: boolean}} options
+ * @returns {Promise<object | undefined >}
+ */
+async function get_latest_nc_lifecycle_run_status(config_fs, options) {
+    const { silent_if_missing = false } = options;
+    try {
+        const lifecycle_log_entries = await nb_native().fs.readdir(config_fs.fs_context, config.NC_LIFECYCLE_LOGS_DIR);
+        const latest_lifecycle_run = _.maxBy(lifecycle_log_entries, entry => entry.name);
+        const latest_lifecycle_run_status_path = path.join(config.NC_LIFECYCLE_LOGS_DIR, latest_lifecycle_run.name);
+        const latest_lifecycle_run_status = await config_fs.get_config_data(latest_lifecycle_run_status_path, options);
+        return latest_lifecycle_run_status;
+    } catch (err) {
+        if (err.code === 'ENOENT' && silent_if_missing) {
+            return;
+        }
+        throw err;
+    }
+}
+
+
+exports.get_latest_nc_lifecycle_run_status = get_latest_nc_lifecycle_run_status;


### PR DESCRIPTION
### Describe the Problem
lifecycle run might fail or timeout before all the objects were processed. add a flag to continue the ran from where it last stopped

### Explain the Changes
1. add new flag continue to resume the last run. in case last run finished. this will end the ran. in case there was no last run. start a new run
2. move function to load previous run status to a new file lifecycle_utils and use it both in nc_lifecycle and health scripts
3. create init function for bucket and rule status, and init objects if they don't exist
4. in case we run with continue. load the previous run states to this run status object 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
automatic tests:
`sudo npx jest test_nc_lifecycle_cli`
manual test:
1. set timeout less then run time, but more then a single cycle
2. keep starting new runs with continue flag, until a lifecycle finishes successfully
3. all new lifecycle runs with continue should pass without doing anything


- [ ] Doc added/updated
- [x] Tests added
