### PR TITLE
NC | NSFS | Fix the `get_bucket_encryption` to Return Object

### DIFF
--- a/docs/dev_guide/run_coretest_locally.md
+++ b/docs/dev_guide/run_coretest_locally.md
@@ -58,6 +58,13 @@ Another option, which is less recommended, is to connect to postgres container a
 Notes:
 * For running `psql` commands you would need to install it on your machine (better with the matching version of postgres).
 * In case you already run postgres on your machine (not the mentioned container) it might raise some issues, better remove it (in MacOs using the Activity Monitor and search for postgres).
+Example: you stopped the docker run, and you tried to connect to postgres, but got an error (probably password authentication failed). As it expected to see the following message when we don't have a postgres container:
+
+```
+psql: error: connection to server at "127.0.0.1", port 5432 failed: Connection refused
+	Is the server running on that host and accepting TCP/IP connections?
+```
+
 * In case a test failed with "error: database "coretest" already exists" it means that you probably forgot to drop the DB table, and you can stop (ctrl + c) and rerun the `docker run` command mentioned above and then run the test again.
 * If you want to run the test with higher debug level you can add the `NOOBAA_LOG_LEVEL=all`, for example: `NOOBAA_LOG_LEVEL=all ./node_modules/mocha/bin/mocha.js src/test/unit_tests/test_s3_bucket_policy.js` (notice that you can printings that are not only from `LOG`, `L0`, `WARN` and `ERROR`, for example: `L1`, `L2`, `L3`, etc.)
 

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -594,7 +594,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             const { name } = params;
             dbg.log0('BucketSpaceFS.get_bucket_encryption: Bucket name', name);
             const bucket = await this.config_fs.get_bucket_by_name(name);
-            return bucket.encryption;
+            return { encryption: bucket.encryption };
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }

--- a/src/test/unit_tests/test_bucketspace_fs.js
+++ b/src/test/unit_tests/test_bucketspace_fs.js
@@ -722,6 +722,11 @@ mocha.describe('bucketspace_fs', function() {
     });
 
     mocha.describe('bucket encryption operations', function() {
+        mocha.it('get_bucket_encryption (return empty encryption)', async function() {
+            const param = { name: test_bucket };
+            const empty_encryption = await bucketspace_fs.get_bucket_encryption(param);
+            assert.ok(empty_encryption.encryption === undefined);
+        });
         mocha.it('put_bucket_encryption ', async function() {
             const encryption = {
                 algorithm: 'AES256',
@@ -731,19 +736,19 @@ mocha.describe('bucketspace_fs', function() {
             await bucketspace_fs.put_bucket_encryption(param);
 
             const output_encryption = await bucketspace_fs.get_bucket_encryption(param);
-            assert.deepEqual(output_encryption, encryption);
+            assert.deepEqual(output_encryption.encryption, encryption);
         });
-        mocha.it('delete_bucket_encryption ', async function() {
+        mocha.it('delete_bucket_encryption', async function() {
             const encryption = {
                 algorithm: 'AES256',
                 kms_key_id: 'kms-123'
             };
             const param = { name: test_bucket };
             const output_encryption = await bucketspace_fs.get_bucket_encryption(param);
-            assert.deepEqual(output_encryption, encryption);
+            assert.deepEqual(output_encryption.encryption, encryption);
             await bucketspace_fs.delete_bucket_encryption(param);
             const empty_encryption = await bucketspace_fs.get_bucket_encryption(param);
-            assert.ok(empty_encryption === undefined);
+            assert.ok(empty_encryption.encryption === undefined);
         });
     });
 

--- a/src/test/unit_tests/test_nsfs_integration.js
+++ b/src/test/unit_tests/test_nsfs_integration.js
@@ -795,6 +795,14 @@ mocha.describe('bucket operations - namespace_fs', function() {
         const expected_payer = 'BucketOwner'; // this is the mock that we use
         assert.equal(res.Payer, expected_payer);
     });
+    mocha.it('get bucket encryption (before put bucket encryption) - throws an error', async function() {
+        try {
+            await s3_correct_uid_default_nsr.getBucketEncryption({ Bucket: bucket_name});
+            assert.fail('get bucket encryption when encryption not set should fail');
+        } catch (err) {
+            assert.strictEqual(err.Code, 'ServerSideEncryptionConfigurationNotFoundError');
+        }
+    });
 
     mocha.it('delete multiple non existing objects without failing', async function() {
         const keys_to_delete = [

--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -116,6 +116,22 @@ mocha.describe('s3_ops', function() {
             const expected_payer = 'BucketOwner'; // this is the mock that we use
             assert.equal(res.Payer, expected_payer);
         });
+        mocha.it('should allow get_bucket_encryption (no put before the get)', async function() {
+            const res = await s3.getBucketEncryption({ Bucket: BKT1 });
+            const expected_response = {
+                ServerSideEncryptionConfiguration: {
+                    Rules: [{
+                        ApplyServerSideEncryptionByDefault: {
+                            SSEAlgorithm: 'AES256'
+                        },
+                        BucketKeyEnabled: false
+                    }]
+                }
+            };
+            assert.equal(res.$metadata.httpStatusCode, 200);
+            const res_without_metadata = _.omit(res, '$metadata');
+            assert.deepEqual(res_without_metadata, expected_response);
+        });
         mocha.it('should enable bucket logging', async function() {
             await s3.createBucket({ Bucket: BKT2 });
             await s3.putBucketLogging({


### PR DESCRIPTION
### Describe the Problem
In NC, the request of `get-bucket-encryption` will fail on `TypeError: Cannot read properties of undefined (reading 'encryption')` if we didn't `put-bucket-encryption` before.

### Explain the Changes
1. By default, we will fail the request with `ServerSideEncryptionConfigurationNotFoundError`, aligned with PR #8716 . 
2. Edit existing unit tests in `test_bucketspace_fs.js`.
3. Not related to NC changes:
  - Add a test (only runs in containerized).
  - Improve docs related to running `core_tests` locally.


### Issues:
1. Currently, when a client tries to use the API of `get-bucket-encryption` in NC it fails with `InternalError` and in the logs, we can see that `TypeError: Cannot read properties of undefined (reading 'encryption')`.

### Testing Instructions:
#### Unit Test:
Please run:
`sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_bucketspace_fs.js`

Note: I also added a test in containerized (although the changes are not related to it):
Use this [guide](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/run_coretest_locally.md) for local run and run: `./node_modules/mocha/bin/mocha.js src/test/unit_tests/test_s3_ops.js NOOBAA_LOG_LEVEL=all`

#### Manual Testing Instructions
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`
2. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5`
3. Create the alias for S3 service:`alias nc-user-1-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6443’`
4. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-1-s3 s3 ls; echo $?`
5. Add bucket to the account using AWS CLI: `nc-user-1-s3 s3 mb s3://bucket-01-04` (`bucket-01-04` is the bucket name in this example)
6. Get bucket encryption: `nc-user-1-s3 s3api get-bucket-encryption --bucket bucket-01-04` (should throw `ServerSideEncryptionConfigurationNotFoundError`).

- [X] Doc added/updated
- [X] Tests added
