### PR TITLE
bucket notifications - facilitate notif conf to override connection

### DIFF
--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -75,7 +75,7 @@ The `account add` command is used to create a new account with customizable opti
 ```sh
 noobaa-cli account add --name <account_name> --uid <uid> --gid <gid> [--user]
 [--new_buckets_path][--access_key][--secret_key][--fs_backend]
-[--allow_bucket_creation][--force_md5_etag][--anonymous][--from_file][--iam_operate_on_root_account]
+[--allow_bucket_creation][--force_md5_etag][--anonymous][--from_file][--iam_operate_on_root_account][--default_connection]
 ```
 #### Flags -
 - `name` (Required)
@@ -135,6 +135,10 @@ noobaa-cli account add --name <account_name> --uid <uid> --gid <gid> [--user]
     - Type: Boolean
     - Description: Specifies if the account allowed to create root accounts using the IAM API (the default behavior is to create of IAM accounts). See - [IAM - Root Accounts Manager](./../design/iam.md#root-accounts-manager).
 
+- `default_connection`
+    - Type: String
+    - Description: A default account for Kafka external servers. See bucket-notifications.md.
+
 ### Update Account
 
 The `account update` command is used to update an existing account with customizable options.
@@ -143,7 +147,7 @@ The `account update` command is used to update an existing account with customiz
 ```sh
 noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--user]
 [--new_buckets_path][--access_key][--secret_key][--regenerate][--fs_backend]
-[--allow_bucket_creation][--force_md5_etag][--anonymous][--iam_operate_on_root_account]
+[--allow_bucket_creation][--force_md5_etag][--anonymous][--iam_operate_on_root_account][--default_connection]
 ```
 #### Flags -
 - `name` (Required)
@@ -206,6 +210,10 @@ noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--use
 - `iam_operate_on_root_account`
     - Type: Boolean
     - Description: Specifies if the account allowed to create root accounts using the IAM API (the default behavior is to create of IAM accounts). See - [IAM - Root Accounts Manager](./../design/iam.md#root-accounts-manager).
+
+- `default_connection`
+    - Type: String
+    - Description: A default account for Kafka external servers. See bucket-notifications.md.
 
 ### Account Status
 

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -484,7 +484,8 @@ async function fetch_account_data(action, user_input) {
             gid: user_input.user ? undefined : user_input.gid,
             new_buckets_path: user_input.new_buckets_path,
             fs_backend: user_input.fs_backend ? String(user_input.fs_backend) : config.NSFS_NC_STORAGE_BACKEND
-        }
+        },
+        default_connection: user_input.default_connection === undefined ? undefined : String(user_input.default_connection)
     };
     if (action === ACTIONS.UPDATE || action === ACTIONS.DELETE) {
         // @ts-ignore

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -46,8 +46,8 @@ const FROM_FILE = 'from_file';
 const ANONYMOUS = 'anonymous';
 
 const VALID_OPTIONS_ACCOUNT = {
-    'add': new Set(['name', 'uid', 'gid', 'supplemental_groups', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
-    'update': new Set(['name', 'uid', 'gid', 'supplemental_groups', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', ...CLI_MUTUAL_OPTIONS]),
+    'add': new Set(['name', 'uid', 'gid', 'supplemental_groups', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'default_connection', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
+    'update': new Set(['name', 'uid', 'gid', 'supplemental_groups', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', 'default_connection', ...CLI_MUTUAL_OPTIONS]),
     'delete': new Set(['name', ...CLI_MUTUAL_OPTIONS]),
     'list': new Set(['wide', 'show_secrets', 'gid', 'uid', 'user', 'name', 'access_key', ...CLI_MUTUAL_OPTIONS]),
     'status': new Set(['name', 'access_key', 'show_secrets', ...CLI_MUTUAL_OPTIONS]),
@@ -142,6 +142,7 @@ const OPTION_TYPE = {
     ips: 'string',
     force: 'boolean',
     anonymous: 'boolean',
+    default_connection: 'string',
     // health options
     deployment_type: 'string',
     all_account_details: 'boolean',

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -101,5 +101,8 @@ module.exports = {
                 }
             }]
         },
+        default_connection: {
+            type: 'string'
+        }
     }
 };

--- a/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js
@@ -643,6 +643,20 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res_list).response.reply.map(item => item.name))
                 .toEqual(expect.arrayContaining([name]));
         });
+
+        it('cli account add - default connection', async function() {
+            const action = ACTIONS.ADD;
+            const { type, name, new_buckets_path, uid, gid } = defaults;
+            const default_connection = 'defcon';
+            const account_options = { config_root, name, new_buckets_path, uid, gid, default_connection };
+            await fs_utils.create_fresh_path(new_buckets_path);
+            await fs_utils.file_must_exist(new_buckets_path);
+            await set_path_permissions_and_owner(new_buckets_path, account_options, 0o700);
+            await exec_manage_cli(type, action, account_options);
+            const account = await config_fs.get_account_by_name(name, config_fs_account_options);
+            assert_account(account, account_options, false);
+            expect(account.default_connection).toBe(default_connection);
+        });
     });
 
     describe('cli update account', () => {

--- a/src/test/unit_tests/test_notifications.js
+++ b/src/test/unit_tests/test_notifications.js
@@ -55,7 +55,6 @@ let expected_event_name;
 let expected_key;
 let expected_eTag;
 let expect_test;
-let expected_url;
 
 // eslint-disable-next-line max-lines-per-function
 mocha.describe('notifications', function() {
@@ -96,7 +95,6 @@ mocha.describe('notifications', function() {
                     assert.strictEqual(notif.Records[0].Event, "s3:TestEvent", 'wrong event name in notification');
                     expect_test = false;
                 } else {
-                    assert.strictEqual(req.url, expected_url);
                     assert.strictEqual(notif.Records[0].s3.bucket.name, expected_bucket, 'wrong bucket name in notification');
                     assert.strictEqual(notif.Records[0].eventName, expected_event_name, 'wrong event name in notification');
                     assert.strictEqual(notif.Records[0].s3.object.key, expected_key, 'wrong key in notification');
@@ -237,34 +235,6 @@ mocha.describe('notifications', function() {
             });
         });
 
-        mocha.it('override connection', async () => {
-            await s3.putBucketNotificationConfiguration({
-                Bucket: bucket,
-                NotificationConfiguration: {
-                    TopicConfigurations: [{
-                        "Id": "system_test_http_no_event_override",
-                        "TopicArn": http_connect_filename + "?" + JSON.stringify({
-                            request_options_object: {path: "/override"}
-                        }),
-                    }],
-                },
-            });
-
-            const res = await s3.putObject({
-                Bucket: bucket,
-                Key: 'f1',
-                Body: 'this is the body',
-            });
-
-            await notify_await_result({
-                bucket_name: bucket,
-                event_name: 'ObjectCreated:Put',
-                key: "f1",
-                etag: res.ETag,
-                url: "/override"
-            });
-        });
-
     });
 
 });
@@ -277,7 +247,6 @@ async function notify_await_result({bucket_name, event_name, etag, key, url = "/
     expected_event_name = event_name;
     expected_eTag = etag;
     expected_key = key;
-    expected_url = url;
     server_done = false;
 
     //busy-sync wait for server

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -186,14 +186,23 @@ class Notificator {
         }
     }
 
-    async parse_connect_file(connect_filename, decrypt = false) {
+    async parse_connect_file(connect_filename_with_overrides, decrypt = false) {
         let connect;
+        const filename_parts = connect_filename_with_overrides.split('?');
+        const connect_filename_no_overrides = filename_parts[0];
+        const overrides_str = filename_parts[1];
+
         if (this.nc_config_fs) {
-            connect = await this.nc_config_fs.get_connection_by_name(connect_filename);
+            connect = await this.nc_config_fs.get_connection_by_name(connect_filename_no_overrides);
         } else {
-            const filepath = path.join(this.connect_files_dir, connect_filename);
+            const filepath = path.join(this.connect_files_dir, connect_filename_no_overrides);
             const connect_str = fs.readFileSync(filepath, 'utf-8');
             connect = JSON.parse(connect_str);
+        }
+        if (overrides_str) {
+            const overrides_obj = JSON.parse(overrides_str);
+            _.merge(connect, overrides_obj);
+            dbg.log2("effective connect =", connect);
         }
 
         //if connect file is encrypted (and decryption is requested),

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -193,7 +193,7 @@ class Notificator {
         if (connection_name.startsWith("kafka:::topic/")) {
             const connection_parts = connection_name.split('/');
             connect_filename = connection_parts[1];
-            kafka_topic_from_connection_name = connection_parts.length > 2 && connection_parts[3];
+            kafka_topic_from_connection_name = connection_parts.length > 1 && connection_parts[2];
         }
 
         if (this.nc_config_fs) {


### PR DESCRIPTION
### Describe the Problem
We want to allow user to describe an external Kafka server in a connection file, but allow to specify to specify Kafka topic per notification conf (instead of in the connection).

### Explain the Changes
TopicConfigurations' TopicArn field can be of this syntax "kafka:::topic/<connection>/<Kafka topic>", where:
-if connection is not specified, the default account's connection is used.
-Kafka topic in TopicArn takes precedence over Kafka topic in connection.
-backward compatible - you can still put just the connection in TopicArn, like now

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Set "default_connection" field in NC user.

2. Create a connection file for kafka (with or without topic field).
{
	"notification_protocol": "kafka",
	"name": "k",
	"topic": "mytopic",
	"kafka_options_object": "{\"metadata.broker.list\":\"localhost:9092\"}"
}

3. Configure a notification with override object:
{
    "TopicConfigurations": [
        {
	    "Id": "first",
            "TopicArn": "kafka:::topic//override",
	    "Events": []
        }
    ]
}
4. Create an event (ie upload object to bucket with notification).
5. The notification will be sent with user's default connection with topic "override".

- [ ] Doc added/updated - TBD
- [ ] Tests added
