### PR TITLE
Added a fix for bucket lifecycle having tagging as an empty array in filter

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -669,7 +669,7 @@ class MDStore {
                 $lt: new Date(moment.unix(max_create_time).toISOString()),
                 $exists: true
             } : undefined,
-            tagging: tagging ? {
+            tagging: (tagging?.length > 0) ? {
                 $all: tagging,
             } : undefined,
             size: (max_size || min_size) ?


### PR DESCRIPTION
### Describe the Problem
While debugging a failing test, it was found that bucket lifecycle incorrectly include `tagging: []` (as an empty array) when tagging is not provided.

Below lifecycle rule doesn't work correctly, here tagging is an empty array:

`{ bucket_id: 67efcc4869121b0008c9ea14, key: /^/, max_create_time: 1743724800, tagging: [], latest_versions: true, filter_delete_markers: true, max_size: 3, min_size: 1, limit: 1000 }`

### Explain the Changes
1. Added a fix to handle the edge case where tagging is defined as an empty array in the lifecycle filter.
2. The fix ensures that if tagging is not provided or is an empty array, it is set to undefined, so it is excluded from the final query.

### Issues: Fixed #xxx / Gap #xxx
1. Gap: #8914 

### Testing Instructions:
1. Tests covered in the above PR where the gap is found.
