### PR TITLE
Remove root key mentions from the core YAML

### DIFF
--- a/src/deploy/NVA_build/noobaa_core.yaml
+++ b/src/deploy/NVA_build/noobaa_core.yaml
@@ -186,11 +186,6 @@ spec:
                 secretKeyRef:
                   name: noobaa-secrets
                   key: server_secret
-            - name: NOOBAA_ROOT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: noobaa-secrets
-                  key: noobaa_root_secret
             - name: AGENT_PROFILE
               valueFrom:
                 configMapKeyRef:
@@ -256,11 +251,6 @@ spec:
                 secretKeyRef:
                   name: noobaa-secrets
                   key: jwt
-            - name: NOOBAA_ROOT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: noobaa-secrets
-                  key: noobaa_root_secret
             - name: LOCAL_MD_SERVER
               value: "true"
           # - name: MGMT_URL


### PR DESCRIPTION
### Describe the Problem
In continuation to https://github.com/noobaa/noobaa-operator/pull/1533 (which also contains a more elaborate explanation), this PR removes the references to the env var in the core YAMLs.

### Issues:
Fixes:
1. [DFBUGS-1608](https://issues.redhat.com/browse/DFBUGS-1608)

### Testing Instructions:
1. Deploy NooBaa
2. Perform some day 1 operations (bucket creation, bucket IO)

- [ ] Doc added/updated
- [ ] Tests added
