### PR TITLE
Backports to 5.17 

### DIFF
--- a/config.js
+++ b/config.js
@@ -90,7 +90,13 @@ config.NODES_FREE_SPACE_RESERVE = 100 * (1024 ** 2);
 // don't use agents with less than reserve + 5 GB
 config.MINIMUM_AGENT_TOTAL_STORAGE = config.NODES_FREE_SPACE_RESERVE + (5 * (1024 ** 3));
 
-config.NODE_IO_DETENTION_DISABLE = false;
+
+// by default not disconnecting nodes on error. This caused more issues than benefits
+config.NODES_DISCONNECT_ON_ERROR = false;
+
+// by default not detaining nodes on io errors. This caused more issues than benefits
+config.NODE_IO_DETENTION_DISABLE = true;
+
 config.NODE_IO_DETENTION_THRESHOLD = 60 * 1000;
 config.NODE_IO_DETENTION_RECENT_ISSUES = 5;
 // Picked two because minimum of nodes per pool is three

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -248,7 +248,7 @@ class NodesMonitor extends EventEmitter {
         return P.resolve()
             .then(() => this._run())
             .then(() => {
-                // do nothing. 
+                // do nothing.
             });
     }
 
@@ -1016,7 +1016,7 @@ class NodesMonitor extends EventEmitter {
             })
             .then(() => this._update_nodes_store('force'))
             .then(() => {
-                // do nothing. 
+                // do nothing.
             });
     }
 
@@ -1240,7 +1240,7 @@ class NodesMonitor extends EventEmitter {
         if (item.node.deleted) return;
         if (!item.connection) return;
         if (!item.agent_info) return;
-        //The node should be set as enable if it is not decommissioned. 
+        //The node should be set as enable if it is not decommissioned.
         const should_enable = !item.node.decommissioned;
         const item_pool = system_store.data.get_by_id(item.node.pool);
         const location_info = {
@@ -1248,7 +1248,7 @@ class NodesMonitor extends EventEmitter {
             host_id: String(item.node.host_id),
             pool_id: String(item.node.pool),
         };
-        // We should only add region if it is defined. 
+        // We should only add region if it is defined.
         if (item_pool && !_.isUndefined(item_pool.region)) location_info.region = item_pool.region;
         // We should change the service enable field if the field is not equal to the decommissioned decision.
         const service_enabled_not_changed = (item.node.enabled === should_enable);
@@ -3570,12 +3570,16 @@ class NodesMonitor extends EventEmitter {
                 'node', item.node.name,
                 'issues_report', item.node.issues_report,
                 'block_report', block_report);
-            // disconnect from the node to force reconnect
-            // only disconnect if enough time passed since last disconnect to avoid amplification of errors in R\W flows
-            const DISCONNECT_GRACE_PERIOD = 2 * 60 * 1000; // 2 minutes grace before another disconnect
-            if (!item.disconnect_time || item.disconnect_time + DISCONNECT_GRACE_PERIOD < Date.now()) {
-                dbg.log0('disconnecting node to force reconnect. node:', item.node.name);
-                this._disconnect_node(item);
+
+
+            if (config.NODES_DISCONNECT_ON_ERROR) {
+                // disconnect from the node to force reconnect
+                // only disconnect if enough time passed since last disconnect to avoid amplification of errors in R\W flows
+                const DISCONNECT_GRACE_PERIOD = 2 * 60 * 1000; // 2 minutes grace before another disconnect
+                if (!item.disconnect_time || item.disconnect_time + DISCONNECT_GRACE_PERIOD < Date.now()) {
+                    dbg.log0('disconnecting node to force reconnect. node:', item.node.name);
+                    this._disconnect_node(item);
+                }
             }
         }
     }

--- a/src/server/object_services/schemas/data_block_indexes.js
+++ b/src/server/object_services/schemas/data_block_indexes.js
@@ -16,6 +16,22 @@ module.exports = [{
         }
     },
     {
+        fields: {
+            _id: 1,
+        },
+        options: {
+            unique: false,
+            // mongo does not support partial indexes on _id field
+            // This is a workaround to exclude it for mongo for tests purposes
+            postgres_only: true,
+            name: "deleted_not_reclaimed",
+            partialFilterExpression: {
+                deleted: { $exists: true },
+                reclaimed: { $exists: false }
+            }
+        }
+    },
+    {
         // iterate_node_chunks()
         // count_blocks_of_node()
         fields: {

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -33,9 +33,8 @@ class MongoCollection {
         MongoCollection.implements_interface(this);
         this.schema = col.schema;
         this.name = col.name;
-        this.db_indexes = col.db_indexes;
+        this.db_indexes = col.db_indexes?.filter(index => !index?.options?.postgres_only);
         this.mongo_client = mongo_client;
-
     }
 
     /**
@@ -46,9 +45,9 @@ class MongoCollection {
     }
 
     /**
-     * 
-     * @param {object} doc 
-     * @param {'warn'} [warn] 
+     *
+     * @param {object} doc
+     * @param {'warn'} [warn]
      */
     validate(doc, warn) {
         if (this.schema) {
@@ -553,7 +552,7 @@ class MongoClient extends EventEmitter {
     }
 
     /**
-     * 
+     *
      * @returns {nb.DBCollection}
      */
     define_collection(col) {
@@ -585,7 +584,7 @@ class MongoClient extends EventEmitter {
     }
 
     /**
-     * 
+     *
      * @returns {nb.DBCollection}
      */
     collection(col_name) {


### PR DESCRIPTION
### Added an index for deleted unreclaimed blocks
- agent_blocks_reclaimer looks for deleted unreclaimed blocks.
- This query can take a long time for large tables.
- This index is usually small, and is only updated for deleted blocks and not for new blocks inserts

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 983d5f23336bbf19ea905b87b6b64ae81582a150)

### disable node disconnect on error and detention
- Added `config.NODES_DISCONNECT_ON_ERROR` which is false by default.
- In `nodes_monitor. report_error_on_node_blocks`, disconnect the node only if config.NODES_DISCONNECT_ON_ERROR is true.
- Changed the default of NODE_IO_DETENTION_DISABLE to true. Most users usually have a single node in a pool, so putting a node into detention causes many issues.

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit https://github.com/noobaa/noobaa-core/commit/e5754e7c5c75ecea721179942a6450f5b1d6917a)

