### PR TITLE
[Backport to 5.14] Added an index for deleted unreclaimed blocks

### DIFF
--- a/src/server/object_services/schemas/data_block_indexes.js
+++ b/src/server/object_services/schemas/data_block_indexes.js
@@ -16,6 +16,22 @@ module.exports = [{
         }
     },
     {
+        fields: {
+            _id: 1,
+        },
+        options: {
+            unique: false,
+            // mongo does not support partial indexes on _id field
+            // This is a workaround to exclude it for mongo for tests purposes
+            postgres_only: true,
+            name: "deleted_not_reclaimed",
+            partialFilterExpression: {
+                deleted: { $exists: true },
+                reclaimed: { $exists: false }
+            }
+        }
+    },
+    {
         // iterate_node_chunks()
         // count_blocks_of_node()
         fields: {

--- a/src/util/mongo_client.js
+++ b/src/util/mongo_client.js
@@ -33,9 +33,8 @@ class MongoCollection {
         MongoCollection.implements_interface(this);
         this.schema = col.schema;
         this.name = col.name;
-        this.db_indexes = col.db_indexes;
+        this.db_indexes = col.db_indexes?.filter(index => !index?.options?.postgres_only);
         this.mongo_client = mongo_client;
-
     }
 
     /**
@@ -46,9 +45,9 @@ class MongoCollection {
     }
 
     /**
-     * 
-     * @param {object} doc 
-     * @param {'warn'} [warn] 
+     *
+     * @param {object} doc
+     * @param {'warn'} [warn]
      */
     validate(doc, warn) {
         if (this.schema) {
@@ -553,7 +552,7 @@ class MongoClient extends EventEmitter {
     }
 
     /**
-     * 
+     *
      * @returns {nb.DBCollection}
      */
     define_collection(col) {
@@ -585,7 +584,7 @@ class MongoClient extends EventEmitter {
     }
 
     /**
-     * 
+     *
      * @returns {nb.DBCollection}
      */
     collection(col_name) {


### PR DESCRIPTION
- agent_blocks_reclaimer looks for deleted unreclaimed blocks.
- This query can take a long time for large tables.
- This index is usually small, and is only updated for deleted blocks and not for new blocks inserts

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>
(cherry picked from commit 983d5f23336bbf19ea905b87b6b64ae81582a150)

Fixes https://issues.redhat.com/browse/DFBUGS-1844
