### PR TITLE
NC | Delete object filter verification on regular delete object 

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -24,6 +24,7 @@ const LRUCache = require('../util/lru_cache');
 const nb_native = require('../util/nb_native');
 const RpcError = require('../rpc/rpc_error');
 const { S3Error } = require('../endpoint/s3/s3_errors');
+const lifecycle_utils = require('../util/lifecycle_utils');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 const { PersistentLogger } = require('../util/persistent_logger');
 const { Glacier } = require('./glacier');
@@ -298,6 +299,11 @@ function filter_fs_xattr(xattr) {
     return _.pickBy(xattr, (val, key) => key?.startsWith(XATTR_NOOBAA_INTERNAL_PREFIX));
 }
 
+/**
+ * get_tags_from_xattr converts relevant xattr to tags format
+ * @param {Object} xattr 
+ * @returns {Object}
+ */
 function get_tags_from_xattr(xattr) {
     const tag_set = [];
     for (const [xattr_key, xattr_value] of Object.entries(xattr)) {
@@ -736,6 +742,8 @@ class NamespaceFS {
                         const use_lstat = !(await this._is_path_in_bucket_boundaries(fs_context, entry_path));
                         const stat = await native_fs_utils.stat_if_exists(fs_context, entry_path,
                             use_lstat, config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES);
+                        // TODO - GAP of .folder files - we return stat of the directory for the 
+                        // xattr, but the creation time should be of the .folder files (and maybe more )
                         if (stat) {
                             r.stat = stat;
                             // add the result only if we have the stat information
@@ -1523,8 +1531,10 @@ class NamespaceFS {
                 await native_fs_utils._make_path_dirs(latest_ver_path, fs_context);
                 if (is_gpfs) {
                     const latest_ver_info_exist = await native_fs_utils.is_path_exists(fs_context, latest_ver_path);
-                    gpfs_options = await this._open_files_gpfs(fs_context, new_ver_tmp_path, latest_ver_path, upload_file,
-                        latest_ver_info_exist, open_mode, undefined, undefined);
+                    gpfs_options = await this._open_files(fs_context, {
+                        src_path: new_ver_tmp_path, dst_path: latest_ver_path, upload_or_dir_file: upload_file,
+                        dst_ver_exist: latest_ver_info_exist, open_mode
+                    });
 
                     //get latest version if exists
                     const latest_fd = gpfs_options?.move_to_dst?.dst_file;
@@ -1580,7 +1590,7 @@ class NamespaceFS {
                 if (!should_retry || retries <= 0) throw err;
                 await P.delay(get_random_delay(config.NSFS_RANDOM_DELAY_BASE, 0, 50));
             } finally {
-                if (gpfs_options) await this._close_files_gpfs(fs_context, gpfs_options.move_to_dst, open_mode);
+                if (gpfs_options) await this._close_files(fs_context, gpfs_options.move_to_dst, open_mode);
             }
         }
     }
@@ -2048,7 +2058,7 @@ class NamespaceFS {
                         const file_path = this._get_file_path({ key });
                         await this._check_path_in_bucket_boundaries(fs_context, file_path);
                         dbg.log1('NamespaceFS: delete_multiple_objects', file_path);
-                        await this._delete_single_object(fs_context, file_path, { key });
+                        await this._delete_single_object(fs_context, file_path, { key, filter_func: params.filter_func });
                         res.push({ key });
                     } catch (err) {
                         res.push({ err_code: err.code, err_message: err.message });
@@ -2063,7 +2073,7 @@ class NamespaceFS {
                 }
                 dbg.log3('NamespaceFS: versions_by_key_map', versions_by_key_map);
                 for (const key of Object.keys(versions_by_key_map)) {
-                    const key_res = await this._delete_objects_versioned(fs_context, key, versions_by_key_map[key]);
+                    const key_res = await this._delete_objects_versioned(fs_context, key, versions_by_key_map[key], params.filter_func);
                     res = res.concat(key_res);
                 }
             }
@@ -2073,9 +2083,32 @@ class NamespaceFS {
         }
     }
 
-
+    /**
+     * _delete_single_object does the following before deleting the object
+     * 1. if is_lifecycle_deletion - 
+     * 1.1. open dir_file and src_file fd
+     * 1.2. _verify_lifecycle_filter_and_unlink - which means it stats the to be deleted file, validate filter if exists, unlink safely
+     * 2. else - unlink_ignore_enoent
+     * 3. deleted parent directories if they are empty 
+     * 4. clears directory object xattr if relevant
+     * 5. closes file and dir_file
+     */
     async _delete_single_object(fs_context, file_path, params) {
-        await native_fs_utils.unlink_ignore_enoent(fs_context, file_path);
+        const is_lifecycle_deletion = this.is_lifecycle_deletion_flow(params);
+        if (is_lifecycle_deletion) {
+            let files;
+            try {
+                files = await this._open_files(fs_context, { src_path: file_path, delete_version: true });
+                await this._verify_lifecycle_filter_and_unlink(fs_context, params, file_path, files.delete_version);
+            } catch (err) {
+                if (err.code !== 'ENOENT') throw err;
+            } finally {
+                if (files) await this._close_files(fs_context, files.delete_version, undefined, true);
+            }
+        } else {
+            await native_fs_utils.unlink_ignore_enoent(fs_context, file_path);
+        }
+
         await this._delete_path_dirs(file_path, fs_context);
         // when deleting the data of a directory object, we need to remove the directory dir object xattr
         // if the dir still exists - occurs when deleting dir while the dir still has entries in it
@@ -2962,20 +2995,26 @@ class NamespaceFS {
         return path.normalize(path.join(versions_dir_path, key_version));
     }
 
-    // this function returns the following version information -
-    // version_id_str - mtime-{mtimeNsBigint}-ino-{ino} | explicit null
-    // mtimeNsBigint - modified timestmap in bigint - last time the content of the file was modified
-    // ino - refers to the data stored in a particular location
-    // delete_marker - specifies if the version is a delete marker
-    // path - specifies the path to version
-    // if version xattr contains version info - return info by xattr
-    // else - it's a null version - return stat
-    // if fd is passed, will use fd instead of path to stat
-    async _get_version_info(fs_context, version_path, fd) {
+
+    /**
+     * this function returns the following version information -
+     * version_id_str - mtime-{mtimeNsBigint}-ino-{ino} | explicit null
+     * mtimeNsBigint - modified timestmap in bigint - last time the content of the file was modified
+     * ino - refers to the data stored in a particular location
+     * delete_marker - specifies if the version is a delete marker
+     * path - specifies the path to version
+     * if version xattr contains version info - return info by xattr
+     * else - it's a null version - return stat
+     * if file is passed, will use file instead of path to stat
+     * @param {nb.NativeFSContext} fs_context 
+     * @param {String} version_path 
+     * @param {nb.NativeFile} [file] 
+     * @returns {Promise<object>}
+     */
+    async _get_version_info(fs_context, version_path, file = undefined) {
         try {
-            const stat = fd ? await fd.stat(fs_context, { skip_user_xattr: true }) :
-                await nb_native().fs.stat(fs_context, version_path, { skip_user_xattr: true });
-            dbg.log1('NamespaceFS._get_version_info stat ', stat, version_path, fd);
+            const stat = file ? await file.stat(fs_context) : await nb_native().fs.stat(fs_context, version_path);
+            dbg.log1('NamespaceFS._get_version_info stat ', stat, version_path, file);
 
             const version_id_str = this._get_version_id_by_xattr(stat);
             const ver_info_by_xattr = this._extract_version_info_from_xattr(version_id_str);
@@ -3064,8 +3103,15 @@ class NamespaceFS {
         }
     }
 
-    _is_mismatch_version_id(stat, version_id) {
-        return version_id && !this._is_versioning_disabled() && this._get_version_id_by_xattr(stat) !== version_id;
+    /**
+     * _is_mismatch_version_id checks if the expected_version_id equals to the version_id_str received by version_info or by version_id xattr coming from stat
+     * @param {nb.NativeFSStats} stat 
+     * @param {String} expected_version_id 
+     * @returns {Boolean}
+     */
+    _is_mismatch_version_id(stat, expected_version_id) {
+        const actual_version_id = this._get_version_id_by_xattr(stat);
+        return expected_version_id && !this._is_versioning_disabled() && expected_version_id !== actual_version_id;
     }
 
     /**
@@ -3075,8 +3121,7 @@ class NamespaceFS {
      * we call check_version_moved() in case of concurrent puts, the version might move to .versions/
      * if the version moved we will retry
      * @param {nb.NativeFSContext} fs_context
-     * @param {string} key
-     * @param {string} version_id
+     * @param {{key: string, version_id: string, filter_func: function}} params
      * @returns {Promise<{
      *   version_id_str: any;
      *   delete_marker: string;
@@ -3086,35 +3131,48 @@ class NamespaceFS {
      *   latest?: boolean;
      * }>}
      */
-    async _delete_single_object_versioned(fs_context, key, version_id) {
+    async _delete_single_object_versioned(fs_context, params) {
         let retries = config.NSFS_RENAME_RETRIES;
+        const { key, version_id } = params;
         const latest_version_path = this._get_file_path({ key });
+        const is_lifecycle_deletion = this.is_lifecycle_deletion_flow(params);
+        const is_gpfs = native_fs_utils._is_gpfs(fs_context);
+
         for (;;) {
             let file_path;
-            let gpfs_options;
+            let files;
             try {
-                file_path = await this._find_version_path(fs_context, { key, version_id });
+                file_path = await this._find_version_path(fs_context, params);
                 await this._check_path_in_bucket_boundaries(fs_context, file_path);
                 const version_info = await this._get_version_info(fs_context, file_path);
                 if (!version_info) return;
 
                 const deleted_latest = file_path === latest_version_path;
                 if (deleted_latest) {
-                    gpfs_options = await this._open_files_gpfs(fs_context, file_path, undefined, undefined, undefined, undefined, true);
-                    if (gpfs_options) {
-                        const src_stat = await gpfs_options.delete_version.src_file.stat(fs_context);
+                    if (is_gpfs) {
+                        files = await this._open_files(fs_context, { src_path: file_path, delete_version: true });
+                        const src_stat = await files.delete_version.src_file.stat(fs_context);
                         if (this._is_mismatch_version_id(src_stat, version_id)) {
                             dbg.warn('NamespaceFS._delete_single_object_versioned mismatch version_id', file_path, version_id, this._get_version_id_by_xattr(src_stat));
                             throw error_utils.new_error_code('MISMATCH_VERSION', 'file version does not match the version we asked for');
                         }
                     }
                     const bucket_tmp_dir_path = this.get_bucket_tmpdir_full_path();
-                    await native_fs_utils.safe_unlink(fs_context, file_path, version_info,
-                        gpfs_options?.delete_version, bucket_tmp_dir_path);
+                    if (is_lifecycle_deletion) {
+                        files = await this._open_files(fs_context, { src_path: file_path, delete_version: true });
+                        await this._verify_lifecycle_filter_and_unlink(fs_context, params, file_path, files.delete_version);
+                    } else {
+                        await native_fs_utils.safe_unlink(fs_context, file_path, version_info, files?.delete_version, bucket_tmp_dir_path);
+                    }
                     await this._check_version_moved(fs_context, key, version_id);
                     return { ...version_info, latest: true };
                 } else {
-                    await native_fs_utils.unlink_ignore_enoent(fs_context, file_path);
+                    if (is_lifecycle_deletion) {
+                        files = await this._open_files(fs_context, { src_path: file_path, delete_version: true });
+                        await this._verify_lifecycle_filter_and_unlink(fs_context, params, file_path, files.delete_version);
+                    } else {
+                        await native_fs_utils.unlink_ignore_enoent(fs_context, file_path);
+                    }
                     await this._check_version_moved(fs_context, key, version_id);
                 }
                 if (await this._is_disabled_content_dir(fs_context, latest_version_path, key)) {
@@ -3134,7 +3192,7 @@ class NamespaceFS {
                 if (retries <= 0 || !native_fs_utils.should_retry_link_unlink(err)) throw err;
                 await P.delay(get_random_delay(config.NSFS_RANDOM_DELAY_BASE, 0, 50));
             } finally {
-                if (gpfs_options) await this._close_files_gpfs(fs_context, gpfs_options.delete_version, undefined, true);
+                if (files) await this._close_files(fs_context, files.delete_version, undefined, true);
             }
         }
     }
@@ -3143,7 +3201,7 @@ class NamespaceFS {
     //    1.1 if version_id is undefined, delete latest
     //    1.2 if version exists - unlink version
     // 2. try promote second latest to latest if one of the deleted versions is the latest version (with version id specified) or a delete marker
-    async _delete_objects_versioned(fs_context, key, versions) {
+    async _delete_objects_versioned(fs_context, key, versions, filter_func) {
         dbg.log1('NamespaceFS._delete_objects_versioned', key, versions);
         const res = [];
         let deleted_delete_marker;
@@ -3154,7 +3212,7 @@ class NamespaceFS {
         for (const version_id of versions) {
             try {
                 if (version_id) {
-                    const del_ver_info = await this._delete_single_object_versioned(fs_context, key, version_id);
+                    const del_ver_info = await this._delete_single_object_versioned(fs_context, { key, version_id, filter_func });
                     if (!del_ver_info) {
                         res.push({});
                         continue;
@@ -3166,7 +3224,8 @@ class NamespaceFS {
                     }
                     res.push({ deleted_delete_marker: del_ver_info.delete_marker });
                 } else {
-                    const version_res = await this._delete_latest_version(fs_context, latest_version_path, { key, version_id });
+                    const version_res = await this._delete_latest_version(fs_context, latest_version_path,
+                        { key, version_id, filter_func });
                     res.push(version_res);
                     delete_marker_created = true;
                 }
@@ -3199,7 +3258,7 @@ class NamespaceFS {
      */
     async _delete_version_id(fs_context, file_path, params) {
         // TODO optimization - GPFS link overrides, no need to unlink before promoting, but if there is nothing to promote we should unlink
-        const del_obj_version_info = await this._delete_single_object_versioned(fs_context, params.key, params.version_id);
+        const del_obj_version_info = await this._delete_single_object_versioned(fs_context, params);
         if (!del_obj_version_info) return {};
 
         // we try promote only if the latest version was deleted or we deleted a delete marker
@@ -3275,7 +3334,7 @@ class NamespaceFS {
     async _delete_latest_version(fs_context, latest_ver_path, params) {
         dbg.log0('Namespace_fs._delete_latest_version:', latest_ver_path, params);
 
-        let gpfs_options;
+        let files;
         const is_dir_content = this._is_directory_content(latest_ver_path, params.key);
         const is_gpfs = native_fs_utils._is_gpfs(fs_context);
         let retries = config.NSFS_RENAME_RETRIES;
@@ -3283,16 +3342,19 @@ class NamespaceFS {
         let versioned_path;
         for (;;) {
             try {
-                // TODO get latest version from file in POSIX like in GPFS path
                 latest_ver_info = await this._get_version_info(fs_context, latest_ver_path);
                 dbg.log1('Namespace_fs._delete_latest_version:', latest_ver_info);
                 if (latest_ver_info) {
-                    if (is_gpfs) {
-                    gpfs_options = await this._open_files_gpfs(fs_context, latest_ver_path, undefined, undefined, undefined,
-                            undefined, true);
-                        const latest_fd = gpfs_options?.delete_version?.src_file;
-                        latest_ver_info = latest_fd && await this._get_version_info(fs_context, undefined, latest_fd);
+                    const is_lifecycle_deletion = this.is_lifecycle_deletion_flow(params);
+                    if (is_gpfs || is_lifecycle_deletion) {
+                        files = await this._open_files(fs_context, { src_path: latest_ver_path, delete_version: true });
+                        const latest_file = files?.delete_version?.src_file;
+                        latest_ver_info = latest_file && await this._get_version_info(fs_context, undefined, latest_file);
                         if (!latest_ver_info) break;
+                        if (is_lifecycle_deletion) {
+                            const stat = await latest_file.stat(fs_context);
+                            this._check_lifecycle_filter_before_deletion(params, stat);
+                        }
                     }
                     versioned_path = this._get_version_path(params.key, latest_ver_info.version_id_str, is_dir_content);
 
@@ -3312,7 +3374,7 @@ class NamespaceFS {
                         // versioning suspended and version_id is null
                         dbg.log1('NamespaceFS._delete_latest_version: suspended mode version ID of the latest version is null - file will be unlinked');
                         await native_fs_utils.safe_unlink(fs_context, latest_ver_path, latest_ver_info,
-                            gpfs_options?.delete_version, bucket_tmp_dir_path);
+                            files?.delete_version, bucket_tmp_dir_path);
                     }
                 }
                 if (is_dir_content) {
@@ -3325,7 +3387,7 @@ class NamespaceFS {
                 if (retries <= 0 || !native_fs_utils.should_retry_link_unlink(err)) throw err;
                 await P.delay(get_random_delay(config.NSFS_RANDOM_DELAY_BASE, 0, 50));
             } finally {
-                if (gpfs_options) await this._close_files_gpfs(fs_context, gpfs_options.delete_version, undefined, true);
+                if (files) await this._close_files(fs_context, files.delete_version, undefined, true);
             }
         }
         // create delete marker and move it to .versions/key_{delete_marker_version_id}
@@ -3343,15 +3405,17 @@ class NamespaceFS {
         const null_versioned_path = this._get_version_path(key, NULL_VERSION_ID);
         await this._check_path_in_bucket_boundaries(fs_context, null_versioned_path);
         let gpfs_options;
+        const is_gpfs = native_fs_utils._is_gpfs(fs_context);
+
         let retries = config.NSFS_RENAME_RETRIES;
         for (;;) {
             try {
                 const null_versioned_path_info = await this._get_version_info(fs_context, null_versioned_path);
                 dbg.log1('Namespace_fs._delete_null_version_from_versions_directory:', null_versioned_path, null_versioned_path_info);
                 if (!null_versioned_path_info) return;
-
-                gpfs_options = await this._open_files_gpfs(fs_context, null_versioned_path, undefined, undefined, undefined,
-                    undefined, true);
+                gpfs_options = is_gpfs ?
+                    await this._open_files(fs_context, { src_path: null_versioned_path, delete_version: true }) :
+                    undefined;
                 const bucket_tmp_dir_path = this.get_bucket_tmpdir_full_path();
                 await native_fs_utils.safe_unlink(fs_context, null_versioned_path, null_versioned_path_info,
                     gpfs_options?.delete_version, bucket_tmp_dir_path);
@@ -3362,7 +3426,7 @@ class NamespaceFS {
                 if (retries <= 0 || !native_fs_utils.should_retry_link_unlink(err)) throw err;
                 await P.delay(get_random_delay(config.NSFS_RANDOM_DELAY_BASE, 0, 50));
             } finally {
-                if (gpfs_options) await this._close_files_gpfs(fs_context, gpfs_options.delete_version, undefined, true);
+                if (gpfs_options) await this._close_files(fs_context, gpfs_options.delete_version, undefined, true);
             }
         }
     }
@@ -3445,11 +3509,10 @@ class NamespaceFS {
 
     // opens the unopened files involved in the version move during upload/deletion
     // returns an object contains the relevant options for the move/unlink flow
-    // eslint-disable-next-line max-params
-    async _open_files_gpfs(fs_context, src_path, dst_path, upload_or_dir_file, dst_ver_exist, open_mode, delete_version, versioned_info) {
-        dbg.log1('Namespace_fs._open_files_gpfs:', src_path, src_path && path.dirname(src_path), dst_path, upload_or_dir_file, Boolean(dst_ver_exist), open_mode, delete_version, versioned_info);
-        const is_gpfs = native_fs_utils._is_gpfs(fs_context);
-        if (!is_gpfs) return;
+    async _open_files(fs_context, options) {
+        const { src_path = undefined, dst_path = undefined, upload_or_dir_file = undefined,
+            dst_ver_exist = false, open_mode = undefined, delete_version = false, versioned_info = undefined } = options;
+        dbg.log1('Namespace_fs._open_files:', src_path, src_path && path.dirname(src_path), dst_path, upload_or_dir_file, Boolean(dst_ver_exist), open_mode, delete_version, versioned_info);
 
         let src_file;
         let dst_file;
@@ -3474,7 +3537,7 @@ class NamespaceFS {
                 dir_file = await native_fs_utils.open_file(fs_context, this.bucket_path, path.dirname(src_path), 'r');
             }
             if (dst_ver_exist) {
-                dbg.log1('NamespaceFS._open_files_gpfs dst version exist - opening dst version file...');
+                dbg.log1('NamespaceFS._open_files dst version exist - opening dst version file...');
                 dst_file = await native_fs_utils.open_file(fs_context, this.bucket_path, dst_path, 'r');
             }
             return {
@@ -3482,34 +3545,34 @@ class NamespaceFS {
                 move_to_dst: { src_file, dst_file, dir_file}
             };
         } catch (err) {
-            dbg.warn('NamespaceFS._open_files_gpfs couldn\'t open files', err);
-            await this._close_files_gpfs(fs_context, { src_file, dst_file, dir_file, versioned_file }, open_mode, delete_version);
+            dbg.warn('NamespaceFS._open_files couldn\'t open files', err);
+            await this._close_files(fs_context, { src_file, dst_file, dir_file, versioned_file }, open_mode, delete_version);
             throw err;
         }
     }
 
     // closes files opened during gpfs upload / deletion, avoiding closing files that opened sooner in the process
-    async _close_files_gpfs(fs_context, files_to_close, open_mode, delete_version) {
+    async _close_files(fs_context, files_to_close, open_mode, delete_version) {
         const { src_file, dst_file = undefined, dir_file, versioned_file = undefined } = files_to_close;
         try {
             if (src_file && (delete_version || open_mode === 'wt')) await src_file.close(fs_context);
         } catch (err) {
-            dbg.warn('NamespaceFS: _close_files_gpfs src_file error', err);
+            dbg.warn('NamespaceFS: _close_files src_file error', err);
         }
         try {
             if (dst_file) await dst_file.close(fs_context);
         } catch (err) {
-            dbg.warn('NamespaceFS: _close_files_gpfs dst_file error', err);
+            dbg.warn('NamespaceFS: _close_files dst_file error', err);
         }
         try {
             if (dir_file && (delete_version || open_mode !== 'wt')) await dir_file.close(fs_context);
         } catch (err) {
-            dbg.warn('NamespaceFS: _close_files_gpfs dir_file error', err);
+            dbg.warn('NamespaceFS: _close_files dir_file error', err);
         }
         try {
             if (versioned_file) await versioned_file.close(fs_context);
         } catch (err) {
-            dbg.warn('NamespaceFS: _close_files_gpfs versioned_file error', err);
+            dbg.warn('NamespaceFS: _close_files versioned_file error', err);
         }
     }
 
@@ -3528,6 +3591,10 @@ class NamespaceFS {
         const latest_ver_info = await this._get_version_info(fs_context, latest_version_path);
         if (latest_ver_info && latest_ver_info.version_id_str === version_id) throw error_utils.new_error_code('VERSION_MOVED', `version file moved from .versions/ ${versioned_path} to latest ${latest_version_path}, retrying`);
     }
+
+    /////////////////////////
+    //   GLACIER HELPERS   //
+    /////////////////////////
 
     async _throw_if_storage_class_not_supported(storage_class) {
         if (!await this._is_storage_class_supported(storage_class)) {
@@ -3656,6 +3723,71 @@ class NamespaceFS {
 
         return NamespaceFS._restore_wal;
     }
+
+    ////////////////////////////
+    //    LIFECYLE HELPERS    //
+    ////////////////////////////
+
+    /**
+     * _verify_lifecycle_filter_and_unlink does the following - 
+     * 1. stat the to be deleted file
+     * 2. checks that the file should be deleted based on lifecycle filter (if the flow is not lifecycle the check will be skipped)
+     * 3. calls safe_unlink that inside checks that the path to be deleted has the same inode/fd of the file that should be deleted
+     * GAP - in .folder if exists we should take mtime from the file and not from the directory, this is a bug in get_object_info we should fix
+     * @param {nb.NativeFSContext} fs_context 
+     * @param {Object} params 
+     * @param {String} file_path 
+     * @param {{dir_file: nb.NativeFile, src_file: nb.NativeFile }} files 
+     */
+    async _verify_lifecycle_filter_and_unlink(fs_context, params, file_path, { dir_file, src_file }) {
+        try {
+            const is_dir_content = this._is_directory_content(file_path, params.key);
+            const dir_stat = is_dir_content && await dir_file.stat(fs_context);
+            const is_empty_directory_content = dir_stat && dir_stat.xattr && dir_stat.xattr[XATTR_DIR_CONTENT] === '0';
+            const src_stat = !is_empty_directory_content && await src_file.stat(fs_context);
+            const stat = is_empty_directory_content ? dir_stat : is_dir_content && { ...src_stat, xattr: dir_stat.xattr } || src_stat;
+
+            this._check_lifecycle_filter_before_deletion(params, stat);
+            const bucket_tmp_dir_path = this.get_bucket_tmpdir_full_path();
+            await native_fs_utils.safe_unlink(fs_context, file_path, stat, { dir_file, src_file }, bucket_tmp_dir_path);
+        } catch (err) {
+            dbg.log0('_verify_lifecycle_filter_and_unlink err', err.code, err, file_path);
+            if (err.code !== 'ENOENT' && err.code !== 'EISDIR') throw err;
+        }
+    }
+
+    /**
+     * _check_lifecycle_filter_before_deletion checks if filter_func provided that we want to delete the object
+     * @param {Object} params 
+     * @param {nb.NativeFSStats} stat
+     * @returns {Void} 
+     */
+    _check_lifecycle_filter_before_deletion(params, stat) {
+        if (!params.filter_func) return;
+        const obj_info = {
+            key: params.key,
+            create_time: stat.mtime.getTime(),
+            size: stat.size,
+            tagging: get_tags_from_xattr(stat.xattr)
+        };
+        const should_delete = lifecycle_utils.file_matches_filter({ obj_info, filter_func: params.filter_func });
+        if (!should_delete) {
+            const err = new RpcError('FILTER_MATCH_FAILED', `file_matches_filter lifecycle - filter on file returned false ${obj_info.key}`);
+            dbg.error(err.message);
+            err.code = 'FILTER_MATCH_FAILED';
+            throw err;
+        }
+    }
+
+    /**
+     * is_lifecycle_deletion_flow returns true if params contain filter_func which occurs when calling the function 
+     * from lifecycle deletion flow
+     * @param {Object} params 
+     * @returns {Boolean}
+     */
+    is_lifecycle_deletion_flow(params) {
+        return params.filter_func;
+    }
 }
 
 /** @type {PersistentLogger} */
@@ -3666,4 +3798,5 @@ NamespaceFS._restore_wal = null;
 
 module.exports = NamespaceFS;
 module.exports.multi_buffer_pool = multi_buffer_pool;
+
 

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle.test.js
@@ -1,0 +1,613 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+/* eslint-disable max-lines-per-function */
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = 'true';
+
+const path = require('path');
+const crypto = require('crypto');
+const config = require('../../../../config');
+const fs_utils = require('../../../util/fs_utils');
+const { ConfigFS } = require('../../../sdk/config_fs');
+const NamespaceFS = require('../../../sdk/namespace_fs');
+const buffer_utils = require('../../../util/buffer_utils');
+const { NCLifecycle } = require('../../../manage_nsfs/nc_lifecycle');
+const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
+const { TMP_PATH, set_nc_config_dir_in_config, TEST_TIMEOUT } = require('../../system_tests/test_utils');
+
+
+const config_root = path.join(TMP_PATH, 'config_root_nc_lifecycle');
+const root_path = path.join(TMP_PATH, 'root_path_nc_lifecycle/');
+const bucket_name = 'lifecycle_bucket';
+const bucket_path = path.join(root_path, bucket_name);
+const config_fs = new ConfigFS(config_root);
+const dummy_object_sdk = make_dummy_object_sdk();
+const nc_lifecycle = new NCLifecycle(config_fs);
+const key = 'obj1.txt';
+const data = crypto.randomBytes(100);
+
+function make_dummy_object_sdk() {
+    return {
+        requesting_account: {
+            force_md5_etag: false,
+            nsfs_account_config: {
+                uid: process.getuid(),
+                gid: process.getgid(),
+            }
+        },
+        abort_controller: new AbortController(),
+        throw_if_aborted() {
+            if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        },
+
+        read_bucket_sdk_config_info(name) {
+            return undefined;
+        },
+    };
+}
+
+const nsfs = new NamespaceFS({
+    bucket_path: bucket_path,
+    bucket_id: '1',
+    namespace_resource_id: undefined,
+    access_mode: undefined,
+    versioning: undefined,
+    force_md5_etag: false,
+    stats: endpoint_stats_collector.instance(),
+});
+
+describe('delete_multiple_objects + filter', () => {
+    const original_lifecycle_run_time = config.NC_LIFECYCLE_RUN_TIME;
+    const original_lifecycle_run_delay = config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS;
+
+    beforeAll(async () => {
+        await fs_utils.create_fresh_path(config_root, 0o777);
+        set_nc_config_dir_in_config(config_root);
+        await fs_utils.create_fresh_path(root_path, 0o777);
+        await fs_utils.create_fresh_path(bucket_path, 0o777);
+    });
+
+    beforeEach(async () => {
+        await fs_utils.create_fresh_path(root_path, 0o777);
+        await fs_utils.create_fresh_path(bucket_path, 0o777);
+    });
+
+    afterEach(async () => {
+        config.NC_LIFECYCLE_RUN_TIME = original_lifecycle_run_time;
+        config.NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS = original_lifecycle_run_delay;
+        await fs_utils.folder_delete(config.NC_LIFECYCLE_LOGS_DIR);
+        await fs_utils.folder_delete(config_root);
+    });
+
+    afterAll(async () => {
+        await fs_utils.folder_delete(root_path);
+        await fs_utils.folder_delete(config_root);
+    }, TEST_TIMEOUT);
+
+    describe('filter should fail - versioning DISABLED', () => {
+
+        it('delete_multiple_objects - filter should fail on wrong prefix - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should fail on wrong object_size_less_than - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should fail on wrong object_size_greater_than - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should fail on wrong tags - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should fail on expiration - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+    });
+
+    describe('filter should pass - versioning DISABLED', () => {
+
+        it('delete_multiple_objects - filter should pass on wrong prefix - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should pass on wrong object_size_less_than - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should pass on wrong object_size_greater_than - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should pass on wrong tags - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const tagging = [{ key: 'a', value: 'b' }];
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer, tagging }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should pass on expiration - versioning DISABLED bucket', async () => {
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+    });
+
+    describe('filter should fail - versioning ENABLED', () => {
+
+        it('delete_multiple_objects - filter should fail on wrong prefix - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should fail on wrong object_size_less_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should fail on wrong object_size_greater_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should fail on wrong tags - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects - filter should fail on expiration - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+    });
+
+    describe('filter should pass - versioning ENABLED', () => {
+
+        it('delete_multiple_objects - filter should pass on wrong prefix - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
+        });
+
+        it('delete_multiple_objects - filter should pass on wrong object_size_less_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
+        });
+
+        it('delete_multiple_objects - filter should pass on wrong object_size_greater_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
+        });
+
+        it('delete_multiple_objects - filter should pass on wrong tags - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const tagging = [{ key: 'a', value: 'b' }];
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer, tagging }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
+        });
+
+        it('delete_multiple_objects - filter should pass on expiration - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 0 });
+            const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
+        });
+    });
+
+    describe('delete multiple objects + version_id + version is latest - filter should fail - versioning ENABLED', () => {
+
+        it('delete_multiple_objects + version_id + version is latest - filter should fail on wrong prefix - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is latest - filter should fail on wrong object_size_less_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is latest - filter should fail on wrong object_size_greater_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is latest - filter should fail on wrong tags - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is latest - filter should fail on expiration - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+    });
+
+
+    describe('filter should pass + version_id + version is latest - versioning ENABLED', () => {
+
+        it('delete_multiple_objects + version_id + version is latest - filter should pass on prefix - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is latest - filter should pass on object_size_less_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is latest - filter should pass on object_size_greater_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is latest - filter should pass on tags - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const tagging = [{ key: 'a', value: 'b' }];
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer, tagging },
+                dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is latest - filter should pass on expiration - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer = buffer_utils.buffer_to_read_stream(data);
+            const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res);
+        });
+    });
+
+    describe('delete multiple objects + version_id + version is not latest - filter should fail - versioning ENABLED', () => {
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should fail on wrong prefix - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should fail on wrong object_size_less_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should fail on wrong object_size_greater_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should fail on wrong tags - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should fail on expiration - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res);
+        });
+    });
+
+    describe('filter should pass + version_id + version is not latest - versioning ENABLED', () => {
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should pass on prefix - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
+        });
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should pass on object_size_less_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
+        });
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should pass on object_size_greater_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
+        });
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should pass on tags - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const tagging = [{ key: 'a', value: 'b' }];
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
+        });
+
+        it('delete_multiple_objects + version_id + version is not latest - filter should pass on expiration - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
+            const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 0 });
+            const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
+        });
+    });
+
+    describe('delete multiple objects + version_id + version is latest delete_marker - filter should fail - versioning ENABLED', () => {
+
+        it('delete_multiple_objects + version_id + version is latest delete_marker - filter should fail on wrong prefix - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const delete_res1 = await nsfs.delete_object({ bucket: bucket_name, key: key }, dummy_object_sdk);
+            expect(delete_res1.created_delete_marker).toBe(true);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: delete_res1.created_version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res, { latest_delete_marker: true });
+        });
+
+        it('delete_multiple_objects + version_id + version is latest delete_marker - filter should fail on wrong object_size_greater_than - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const delete_res1 = await nsfs.delete_object({ bucket: bucket_name, key: key }, dummy_object_sdk);
+            expect(delete_res1.created_delete_marker).toBe(true);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: delete_res1.created_version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res, { latest_delete_marker: true });
+        });
+
+        it('delete_multiple_objects + version_id + version is latest delete_marker - filter should fail on wrong tags - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const delete_res1 = await nsfs.delete_object({ bucket: bucket_name, key: key }, dummy_object_sdk);
+            expect(delete_res1.created_delete_marker).toBe(true);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b' }] }, expiration: 0 });
+            const objects_to_delete = [{ key, version_id: delete_res1.created_version_id }];
+            const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res, { latest_delete_marker: true });
+        });
+
+        it('delete_multiple_objects + version_id + version is latest delete_marker - filter should fail on expiration - versioning ENABLED bucket', async () => {
+            nsfs.versioning = 'ENABLED';
+            const data_buffer1 = buffer_utils.buffer_to_read_stream(data);
+            await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
+            const delete_res1 = await nsfs.delete_object({ bucket: bucket_name, key: key }, dummy_object_sdk);
+            expect(delete_res1.created_delete_marker).toBe(true);
+            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const objects_to_delete = [{ key, version_id: delete_res1.created_version_id }];
+            const delete_res2 = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
+            await assert_object_deletion_failed(delete_res2, { latest_delete_marker: true });
+        });
+    });
+});
+
+// , { deleted_delete_marker: true, new_latest_version: upload_res1.version_id }
+/**
+ * assert_object_deletion_failed asserts that delete_res contains an error and that the file still exists
+ * @param {Object} delete_res 
+ * @param {{latest_delete_marker?: boolean}} [options]
+ * @returns {Promise<Void>}
+ */
+async function assert_object_deletion_failed(delete_res, { latest_delete_marker = false } = {}) {
+    expect(delete_res.length).toBe(1);
+    expect(delete_res[0].err_code).toBeDefined();
+    expect(delete_res[0].err_message).toBe('file_matches_filter lifecycle - filter on file returned false ' + key);
+    // file was not deleted
+    if (latest_delete_marker) {
+        await expect(nsfs.read_object_md({ bucket: bucket_name, key: key }, dummy_object_sdk)).rejects.toThrow('No such file or directory');
+    } else {
+        const object_metadata = await nsfs.read_object_md({ bucket: bucket_name, key: key }, dummy_object_sdk);
+        expect(object_metadata.key).toBe(key);
+    }
+}
+
+/**
+ * assert_object_deleted asserts that delete_res contains the deleted key and that the file was deleted
+ * @param {Object} delete_res 
+ * @param {{should_create_a_delete_marker?: Boolean, 
+ * should_delete_a_delete_marker?: Boolean,
+ * new_latest_version?: String
+ * }} [options]
+ * @returns {Promise<Void>}
+ */
+async function assert_object_deleted(delete_res, options = {}) {
+    const { should_create_a_delete_marker = false, should_delete_a_delete_marker = false, new_latest_version = undefined } = options;
+    expect(delete_res.length).toBe(1);
+    if (nsfs.versioning === 'ENABLED') {
+        if (should_create_a_delete_marker) {
+            expect(delete_res[0].created_delete_marker).toBe(true);
+            expect(delete_res[0].created_version_id).toBeDefined();
+        } else if (should_delete_a_delete_marker) {
+            expect(delete_res[0].deleted_delete_marker).toBeDefined();
+        } else {
+            expect(delete_res[0].created_delete_marker).toBeUndefined();
+            expect(delete_res[0].deleted_delete_marker).toBeUndefined();
+            expect(delete_res[0].created_version_id).toBeUndefined();
+        }
+    } else {
+        expect(delete_res[0].key).toBe(key);
+    }
+    // file was deleted
+    if (new_latest_version) {
+        const actual_latest_version = await nsfs.read_object_md({ bucket: bucket_name, key: key }, dummy_object_sdk);
+        expect(new_latest_version).toBe(actual_latest_version.version_id);
+    } else {
+        await expect(nsfs.read_object_md({ bucket: bucket_name, key: key }, dummy_object_sdk)).rejects.toThrow('No such file or directory');
+    }
+}

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
@@ -31,8 +31,8 @@ const new_umask = process.env.NOOBAA_ENDPOINT_UMASK || 0o000;
 const old_umask = process.umask(new_umask);
 console.log('test_nc_lifecycle_cli: replacing old umask: ', old_umask.toString(8), 'with new umask: ', new_umask.toString(8));
 
-const config_root = path.join(TMP_PATH, 'config_root_nc_lifecycle');
-const root_path = path.join(TMP_PATH, 'root_path_nc_lifecycle/');
+const config_root = path.join(TMP_PATH, 'config_root_nc_lifecycle_posix_integration');
+const root_path = path.join(TMP_PATH, 'root_path_nc_lifecycle_posix_integration/');
 const config_fs = new ConfigFS(config_root);
 const account_options1 = { uid: 2002, gid: 2002, new_buckets_path: root_path, name: 'user2', config_root, allow_bucket_creation: 'true' };
 const test_bucket = 'test-bucket';
@@ -1698,7 +1698,12 @@ async function create_object(sdk, bucket, key, size, is_old, tagging) {
         size,
         tagging
     });
-    if (is_old) await update_file_mtime(path.join(root_path, bucket, key));
+    if (is_old) {
+        await update_file_mtime(path.join(root_path, bucket, key));
+        if (key.endsWith('/') === true) {
+            await update_file_mtime(path.join(root_path, bucket, key, '.folder'));
+        }
+    }
     return res;
 }
 


### PR DESCRIPTION
### Describe the Problem
On NC lifecycle - getting the deletion candidates might take a lot of time (especially when using GPFS optimization), therefore we should re-check the filter and expiration before deleting the object.

### Explain the Changes
1. NCLifecycle - Since we call delete_multiple_objects per rule - passed the filter func to the delete_multiple_objects function.
2. NamespaceFS - Changed delete_multiple_objects to delete based on file descriptors if the flow is gpfs/lifecycle_deletion + apply the filter func and check if we should still delete the object. if not - throw an error.
3. refactoring - moved some functions to utils so they can be used by both NCLifecycle and NamespaceFS.

### Issues: Fixed #xxx / Gap #xxx
1.  

### Testing Instructions:
1. `sudo jest --testRegex=jest_tests/test_nc_lifecycle_posix`
2.  `sudo jest --testRegex=jest_tests/test_nc_lifecycle`


- [ ] Doc added/updated
- [x] Tests added
