### PR TITLE
NC | CLI | InvalidType Error | Replaced hard coded command types list with a dynamic list

### DIFF
--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -3,6 +3,7 @@
 
 const config = require('../../config');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
+const { TYPES } = require('../manage_nsfs/manage_nsfs_constants');
 
 // by default NC_DISABLE_POSIX_MODE_ACCESS_CHECK=true, therefore CLI access check of account/bucket will be based on stat (open file)
 // which checks only read permissions. 
@@ -100,7 +101,7 @@ ManageCLIError.UnsetArgumentIsInvalid = Object.freeze({
 
 ManageCLIError.InvalidType = Object.freeze({
     code: 'InvalidType',
-    message: 'Invalid type, available types are account, bucket, logging, whitelist, upgrade, notification or connection.',
+    message: `Invalid type, valid types are ${Object.values(TYPES).join(', ')}.`,
     http_code: 400,
 });
 


### PR DESCRIPTION
### Describe the Problem
While adding a new CLI command, we want to always add the new type to the list mentioned in CLI invalidType error message.

### Explain the Changes
1. Replaced the hard coded CLI types list to be dynamic so we won't need to add it to the list manually.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-2080

### Testing Instructions:
1. Run 
```
% noobaa-cli
{
  "error": {
    "code": "InvalidType",
    "message": "Invalid type, valid types are account, bucket, whitelist, glacier, logging, diagnose, upgrade, notification, connection, lifecycle."
  }
}
```


- [ ] Doc added/updated
- [ ] Tests added
