### PR TITLE
File Reader | Add next_line_file_offset

### DIFF
--- a/src/test/unit_tests/jest_tests/test_newline_reader.test.js
+++ b/src/test/unit_tests/jest_tests/test_newline_reader.test.js
@@ -51,6 +51,26 @@ describe('newline_reader', () => {
 			expect(result).toStrictEqual(UTF8DATA_ARR);
 		});
 
+		it('read_file_offset - can process utf8 characters when termination with newline character', async () => {
+			const UTF8DATA_BUF = Buffer.from(UTF8DATA_ARR.join('\n') + '\n', 'utf8');
+
+			const reader = new NewlineReader({}, '', { skip_leftover_line: true, read_file_offset: 0 });
+			// @ts-ignore
+			reader.fh = mocked_file_handler(UTF8DATA_BUF);
+
+			const result = [];
+			let expected_cur_next_line_file_offset = 0;
+			const [processed] = await reader.forEach(async entry => {
+				result.push(entry);
+				expected_cur_next_line_file_offset += Buffer.byteLength(entry, 'utf8') + 1;
+				expect(reader.next_line_file_offset).toBe(expected_cur_next_line_file_offset);
+				return true;
+			});
+
+			expect(processed).toBe(UTF8DATA_ARR.length);
+			expect(result).toStrictEqual(UTF8DATA_ARR);
+		});
+
 		it('can process utf8 characters when termination not with new line character', async () => {
 			const UTF8DATA_BUF = Buffer.from(UTF8DATA_ARR.join('\n'), 'utf8');
 
@@ -68,7 +88,48 @@ describe('newline_reader', () => {
 			expect(result).toStrictEqual(UTF8DATA_ARR);
 		});
 
-		it('can process utf8 characters when termination not with new line character [bufsize = 4]', async () => {
+		it('read_file_offset - can process utf8 characters when termination not with new line character', async () => {
+			const UTF8DATA_BUF = Buffer.from(UTF8DATA_ARR.join('\n'), 'utf8');
+
+			const reader = new NewlineReader({}, '', { read_file_offset: 0 });
+			// @ts-ignore
+			reader.fh = mocked_file_handler(UTF8DATA_BUF);
+
+			const result = [];
+			let expected_cur_next_line_file_offset = 0;
+			const [processed] = await reader.forEach(async entry => {
+				result.push(entry);
+				expected_cur_next_line_file_offset += Buffer.byteLength(entry, 'utf8') + (reader.eof ? 0 : 1);
+				expect(reader.next_line_file_offset).toBe(expected_cur_next_line_file_offset);
+				return true;
+			});
+
+			expect(processed).toBe(UTF8DATA_ARR.length);
+			expect(result).toStrictEqual(UTF8DATA_ARR);
+		});
+
+		it('read_file_offset starts from the second line - can process utf8 characters when termination not with new line character', async () => {
+			const UTF8DATA_BUF = Buffer.from(UTF8DATA_ARR.join('\n'), 'utf8');
+			const expected_to_be_processed_data_array = UTF8DATA_ARR.slice(1);
+			const initial_next_line_file_offset = Buffer.byteLength(UTF8DATA_ARR[0], 'utf8') + 1;
+			const reader = new NewlineReader({}, '', { read_file_offset: initial_next_line_file_offset});
+			// @ts-ignore
+			reader.fh = mocked_file_handler(UTF8DATA_BUF);
+
+			const result = [];
+			let expected_cur_next_line_file_offset = initial_next_line_file_offset;
+			const [processed] = await reader.forEach(async entry => {
+				result.push(entry);
+				expected_cur_next_line_file_offset += Buffer.byteLength(entry, 'utf8') + (reader.eof ? 0 : 1);
+				expect(reader.next_line_file_offset).toBe(expected_cur_next_line_file_offset);
+				return true;
+			});
+
+			expect(processed).toBe(expected_to_be_processed_data_array.length);
+			expect(result).toStrictEqual(expected_to_be_processed_data_array);
+		});
+
+		it('can process utf8 characters when termination not with new line character [bufsize = 256]', async () => {
 			const expected = "abc";
 			const UTF8DATA_ARR_TEMP = [ ...UTF8DATA_ARR, expected ];
 			const UTF8DATA_BUF = Buffer.from(UTF8DATA_ARR_TEMP.join('\n'), 'utf8');
@@ -85,6 +146,27 @@ describe('newline_reader', () => {
 
 			expect(processed).toBe(1);
 			expect(result).toStrictEqual([expected]);
+		});
+
+		it('read_file_offset - can process utf8 characters when termination not with new line character [bufsize = 256]', async () => {
+			const expected = "abc";
+			const UTF8DATA_ARR_TEMP = [ ...UTF8DATA_ARR, expected ];
+			const UTF8DATA_BUF = Buffer.from(UTF8DATA_ARR_TEMP.join('\n'), 'utf8');
+
+			const reader = new NewlineReader({}, '', { bufsize: 256, skip_overflow_lines: true, read_file_offset: 0 });
+			// @ts-ignore
+			reader.fh = mocked_file_handler(UTF8DATA_BUF);
+
+			const result = [];
+			const [processed] = await reader.forEach(async entry => {
+				result.push(entry);
+				return true;
+			});
+
+			expect(processed).toBe(1);
+			expect(result).toStrictEqual([expected]);
+			const expected_cur_next_line_file_offset = UTF8DATA_BUF.length;
+			expect(reader.next_line_file_offset).toBe(expected_cur_next_line_file_offset);
 		});
 	});
 });


### PR DESCRIPTION
### Describe the Problem
On https://github.com/noobaa/noobaa-core/pull/8923, we would like to preserve the next_line_file_offset in order to start reading in the next iteration from the middle of the file and not read the whole file again.
Moved the fileReader changes from 8923 to a new PR.

### Explain the Changes
1. Added next_line_file_offset to file Reader.
2. Added unit tests.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. sudo jest --testRegex=jest_tests/test_newline_reader --t "next_line_file_offset"


- [ ] Doc added/updated
- [x] Tests added
