### PR TITLE
Rejecting wildcard('*') in expose headers - like AWS

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_cors.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_cors.js
@@ -17,6 +17,13 @@ async function put_bucket_cors(req) {
                 message: `Found unsupported HTTP method in CORS config. Unsupported method is ${unsupported_method}`
             });
         }
+        const wildcard_expose_header = rule.ExposeHeader?.find(item => item.includes('*'));
+        if (wildcard_expose_header) {
+            throw new S3Error({
+                ...S3Error.InvalidRequest,
+                message: `ExposeHeader "${wildcard_expose_header}" contains wildcard. We currently do not support wildcard for ExposeHeader.`
+            });
+        }
         return _.omitBy({
             allowed_headers: rule.AllowedHeader,
             allowed_methods: rule.AllowedMethod,


### PR DESCRIPTION
### Describe the Problem
We accepted wildcards in expose headers, but AWS rejected them.

### Explain the Changes
1. we will now reject as well

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-2081

### Testing Instructions:
1. See the steps in the above issue.


- [ ] Doc added/updated
- [ ] Tests added
