### PR TITLE
Added `x-amz-expiration` missing HTTP header in the response of object operations

### DIFF
--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -49,6 +49,7 @@ async function get_object(req, res) {
         }
     }
     http_utils.set_response_headers_from_request(req, res);
+    if (!version_id) await http_utils.set_expiration_header(req, res, object_md); // setting expiration header for bucket lifecycle
     const obj_size = object_md.size;
     const params = {
         object_md,

--- a/src/endpoint/s3/ops/s3_head_object.js
+++ b/src/endpoint/s3/ops/s3_head_object.js
@@ -29,6 +29,7 @@ async function head_object(req, res) {
     s3_utils.set_response_object_md(res, object_md);
     s3_utils.set_encryption_response_headers(req, res, object_md.encryption);
     http_utils.set_response_headers_from_request(req, res);
+    if (!params.version_id) await http_utils.set_expiration_header(req, res, object_md); // setting expiration header for bucket lifecycle
 }
 
 module.exports = {

--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -81,6 +81,14 @@ async function put_object(req, res) {
     }
     res.setHeader('ETag', `"${reply.etag}"`);
 
+    const object_info = {
+        key: req.params.key,
+        create_time: new Date().getTime(),
+        size: size,
+        tagging: tagging,
+    };
+    await http_utils.set_expiration_header(req, res, object_info); // setting expiration header for bucket lifecycle
+
     if (reply.seq) {
         res.seq = reply.seq;
         delete reply.seq;

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle.test.js
@@ -9,10 +9,9 @@ const path = require('path');
 const crypto = require('crypto');
 const config = require('../../../../config');
 const fs_utils = require('../../../util/fs_utils');
-const { ConfigFS } = require('../../../sdk/config_fs');
 const NamespaceFS = require('../../../sdk/namespace_fs');
 const buffer_utils = require('../../../util/buffer_utils');
-const { NCLifecycle } = require('../../../manage_nsfs/nc_lifecycle');
+const lifecycle_utils = require('../../../../src/util/lifecycle_utils');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
 const { TMP_PATH, set_nc_config_dir_in_config, TEST_TIMEOUT } = require('../../system_tests/test_utils');
 
@@ -21,9 +20,7 @@ const config_root = path.join(TMP_PATH, 'config_root_nc_lifecycle');
 const root_path = path.join(TMP_PATH, 'root_path_nc_lifecycle/');
 const bucket_name = 'lifecycle_bucket';
 const bucket_path = path.join(root_path, bucket_name);
-const config_fs = new ConfigFS(config_root);
 const dummy_object_sdk = make_dummy_object_sdk();
-const nc_lifecycle = new NCLifecycle(config_fs);
 const key = 'obj1.txt';
 const data = crypto.randomBytes(100);
 
@@ -90,7 +87,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should fail on wrong prefix - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -98,7 +95,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should fail on wrong object_size_less_than - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -106,7 +103,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should fail on wrong object_size_greater_than - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -114,7 +111,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should fail on wrong tags - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -122,7 +119,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should fail on expiration - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 5 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -133,7 +130,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should pass on wrong prefix - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
         });
@@ -141,7 +138,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should pass on wrong object_size_less_than - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
         });
@@ -149,7 +146,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should pass on wrong object_size_greater_than - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
         });
@@ -158,7 +155,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const tagging = [{ key: 'a', value: 'b' }];
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer, tagging }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
         });
@@ -166,7 +163,7 @@ describe('delete_multiple_objects + filter', () => {
         it('delete_multiple_objects - filter should pass on expiration - versioning DISABLED bucket', async () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
         });
@@ -178,7 +175,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -187,7 +184,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -196,7 +193,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -205,7 +202,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -214,7 +211,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 5 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
         });
@@ -226,7 +223,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
         });
@@ -235,7 +232,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
         });
@@ -244,7 +241,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
         });
@@ -254,7 +251,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const tagging = [{ key: 'a', value: 'b' }];
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer, tagging }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
         });
@@ -263,7 +260,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 0 });
             const delete_res = await nsfs.delete_multiple_objects({ objects: [{ key }], filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { should_create_a_delete_marker: true });
         });
@@ -275,7 +272,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -285,7 +282,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -295,7 +292,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -305,7 +302,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -315,7 +312,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 5 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -329,7 +326,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
@@ -339,7 +336,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
@@ -349,7 +346,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
@@ -361,7 +358,7 @@ describe('delete_multiple_objects + filter', () => {
             const tagging = [{ key: 'a', value: 'b' }];
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer, tagging },
                 dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
@@ -371,7 +368,7 @@ describe('delete_multiple_objects + filter', () => {
             nsfs.versioning = 'ENABLED';
             const data_buffer = buffer_utils.buffer_to_read_stream(data);
             const upload_res = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res);
@@ -386,7 +383,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -398,7 +395,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_less_than: 99 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -410,7 +407,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -422,7 +419,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b'}] }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -434,7 +431,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 5 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res);
@@ -449,7 +446,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'ob' }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
@@ -461,7 +458,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_less_than: 101 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
@@ -473,7 +470,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 1 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
@@ -486,7 +483,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: tagging }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
@@ -498,7 +495,7 @@ describe('delete_multiple_objects + filter', () => {
             const data_buffer2 = buffer_utils.buffer_to_read_stream(data);
             const upload_res1 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const upload_res2 = await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer2 }, dummy_object_sdk);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 0 });
             const objects_to_delete = [{ key, version_id: upload_res1.version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deleted(delete_res, { new_latest_version: upload_res2.version_id});
@@ -513,7 +510,7 @@ describe('delete_multiple_objects + filter', () => {
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const delete_res1 = await nsfs.delete_object({ bucket: bucket_name, key: key }, dummy_object_sdk);
             expect(delete_res1.created_delete_marker).toBe(true);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { prefix: 'd' }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: delete_res1.created_version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res, { latest_delete_marker: true });
@@ -525,7 +522,7 @@ describe('delete_multiple_objects + filter', () => {
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const delete_res1 = await nsfs.delete_object({ bucket: bucket_name, key: key }, dummy_object_sdk);
             expect(delete_res1.created_delete_marker).toBe(true);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { object_size_greater_than: 101 }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: delete_res1.created_version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res, { latest_delete_marker: true });
@@ -537,7 +534,7 @@ describe('delete_multiple_objects + filter', () => {
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const delete_res1 = await nsfs.delete_object({ bucket: bucket_name, key: key }, dummy_object_sdk);
             expect(delete_res1.created_delete_marker).toBe(true);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b' }] }, expiration: 0 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ filter: { tags: [{ key: 'a', value: 'b' }] }, expiration: 0 });
             const objects_to_delete = [{ key, version_id: delete_res1.created_version_id }];
             const delete_res = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res, { latest_delete_marker: true });
@@ -549,7 +546,7 @@ describe('delete_multiple_objects + filter', () => {
             await nsfs.upload_object({ bucket: bucket_name, key: key, source_stream: data_buffer1 }, dummy_object_sdk);
             const delete_res1 = await nsfs.delete_object({ bucket: bucket_name, key: key }, dummy_object_sdk);
             expect(delete_res1.created_delete_marker).toBe(true);
-            const filter_func = nc_lifecycle._build_lifecycle_filter({ expiration: 5 });
+            const filter_func = lifecycle_utils.build_lifecycle_filter({ expiration: 5 });
             const objects_to_delete = [{ key, version_id: delete_res1.created_version_id }];
             const delete_res2 = await nsfs.delete_multiple_objects({ objects: objects_to_delete, filter_func }, dummy_object_sdk);
             await assert_object_deletion_failed(delete_res2, { latest_delete_marker: true });

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
@@ -11,11 +11,10 @@ const fs = require('fs');
 const config = require('../../../../config');
 const fs_utils = require('../../../util/fs_utils');
 const { ConfigFS } = require('../../../sdk/config_fs');
-const { TMP_PATH, set_nc_config_dir_in_config, TEST_TIMEOUT, exec_manage_cli, create_system_json } = require('../../system_tests/test_utils');
+const { TMP_PATH, set_nc_config_dir_in_config, TEST_TIMEOUT, exec_manage_cli, create_system_json, update_file_mtime } = require('../../system_tests/test_utils');
 const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const NamespaceFS = require('../../../sdk/namespace_fs');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
-const os_utils = require('../../../util/os_utils');
 const { ManageCLIResponse } = require('../../../manage_nsfs/manage_nsfs_cli_responses');
 const { ManageCLIError } = require('../../../manage_nsfs/manage_nsfs_cli_errors');
 const buffer_utils = require('../../../util/buffer_utils');
@@ -2185,19 +2184,6 @@ async function create_object(object_sdk, bucket, key, size, is_old, tagging) {
         }
     }
     return res;
-}
-
-/**
- * update_file_mtime updates the mtime of the target path
- * Warnings:
- *  - This operation would change the mtime of the file to 5 days ago - which means that it changes the etag / obj_id of the object
- *  - Please do not use on versioned objects (version_id will not be changed, but the mtime will be changed) - might cause issues.
- * @param {String} target_path
- * @returns {Promise<Void>}
- */
-async function update_file_mtime(target_path) {
-    const update_file_mtime_cmp = os_utils.IS_MAC ? `touch -t $(date -v -5d +"%Y%m%d%H%M.%S") ${target_path}` : `touch -d "5 days ago" ${target_path}`;
-    await os_utils.exec(update_file_mtime_cmp, { return_stdout: true });
 }
 
 /**

--- a/src/test/unit_tests/nc_index.js
+++ b/src/test/unit_tests/nc_index.js
@@ -21,6 +21,7 @@ require('./test_bucketspace_versioning');
 require('./test_nc_bucket_logging');
 require('./test_nc_online_upgrade_s3_integrations');
 require('./test_public_access_block');
+require('./test_nc_lifecycle_expiration');
 
 // running with iam port
 require('./test_nc_iam_basic_integration.js'); // please notice that we use a different setup

--- a/src/test/unit_tests/test_nc_lifecycle_expiration.js
+++ b/src/test/unit_tests/test_nc_lifecycle_expiration.js
@@ -1,0 +1,150 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const path = require('path');
+const mocha = require('mocha');
+const assert = require('assert');
+const fs_utils = require('../../util/fs_utils');
+const { TYPES, ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
+const { TMP_PATH, set_path_permissions_and_owner, invalid_nsfs_root_permissions, generate_s3_client, get_coretest_path,
+    generate_lifecycle_rule, validate_expiration_header, update_file_mtime, exec_manage_cli } = require('../system_tests/test_utils');
+
+const coretest_path = get_coretest_path();
+const coretest = require(coretest_path);
+const { rpc_client, EMAIL, get_admin_mock_account_details } = coretest;
+coretest.setup({});
+
+let s3_admin;
+
+const tmp_fs_root = path.join(TMP_PATH, 'test_nc_lifecycle_expiration/');
+
+/**
+ * is_nc_coretest returns true when the test runs on NC env
+ */
+const is_nc_coretest = process.env.NC_CORETEST === 'true';
+
+mocha.describe('nc lifecycle - check expiration header', async function() {
+    const bucket_path = path.join(tmp_fs_root, 'test-bucket/');
+    const bucket_name = 'test-bucket';
+
+    mocha.before(async function() {
+        this.timeout(0); // eslint-disable-line no-invalid-this
+        if (invalid_nsfs_root_permissions()) this.skip(); // eslint-disable-line no-invalid-this
+        // create paths
+        await fs_utils.create_fresh_path(tmp_fs_root, 0o777);
+        await fs_utils.create_fresh_path(bucket_path, 0o770);
+        await fs_utils.file_must_exist(bucket_path);
+
+        // set permissions
+        if (is_nc_coretest) {
+            const { uid, gid } = get_admin_mock_account_details();
+            await set_path_permissions_and_owner(bucket_path, { uid, gid }, 0o700);
+        }
+
+        // create s3_admin client
+        const admin = (await rpc_client.account.read_account({ email: EMAIL, }));
+        const admin_keys = admin.access_keys;
+        s3_admin = generate_s3_client(admin_keys[0].access_key.unwrap(),
+                        admin_keys[0].secret_key.unwrap(),
+                        coretest.get_http_address());
+
+        // create test bucket
+        const cli_bucket_options = {
+            name: bucket_name,
+            owner: admin.name,
+            path: bucket_path,
+        };
+        await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, cli_bucket_options);
+    });
+
+    mocha.after(async function() {
+        this.timeout(0); // eslint-disable-line no-invalid-this
+        fs_utils.folder_delete(tmp_fs_root);
+    });
+
+    const run_expiration_test = async ({ rules, expected_id, expected_days, key, tagging = undefined, size = 1000}) => {
+        const putLifecycleParams = {
+            Bucket: bucket_name,
+            LifecycleConfiguration: { Rules: rules }
+        };
+        await s3_admin.putBucketLifecycleConfiguration(putLifecycleParams);
+
+        const putObjectParams = {
+            Bucket: bucket_name,
+            Key: key,
+            Body: 'x'.repeat(size) // default 1KB if size not specified
+        };
+        if (tagging) {
+            putObjectParams.Tagging = tagging;
+        }
+        const start_time = new Date();
+        let res = await s3_admin.putObject(putObjectParams);
+        assert.ok(res.Expiration, 'expiration header missing in putObject response');
+
+        // update file mtime to simulate a 5-days old object
+        await update_file_mtime(path.join(bucket_path, key));
+
+        res = await s3_admin.headObject({ Bucket: bucket_name, Key: key });
+        assert.ok(res.Expiration, 'expiration header missing in headObject response');
+
+        const valid = validate_expiration_header(res.Expiration, start_time, expected_id, expected_days - 5);
+        assert.ok(valid, `expected rule ${expected_id} to match`);
+    };
+
+    mocha.it('should select rule with longest prefix', async () => {
+        const rules = [
+            generate_lifecycle_rule(10, 'short-prefix', 'lifecycle-test1/', [], undefined, undefined),
+            generate_lifecycle_rule(17, 'long-prefix', 'lifecycle-test1/logs/', [], undefined, undefined),
+        ];
+        await run_expiration_test({
+            rules,
+            key: 'lifecycle-test1/logs//file.txt',
+            expected_id: 'long-prefix',
+            expected_days: 17
+        });
+    });
+
+    mocha.it('should select rule with more tags when prefix is same', async () => {
+        const rules = [
+            generate_lifecycle_rule(5, 'one-tag', 'lifecycle-test2/', [{ Key: 'env', Value: 'prod' }], undefined, undefined),
+            generate_lifecycle_rule(9, 'two-tags', 'lifecycle-test2/', [
+                { Key: 'env', Value: 'prod' },
+                { Key: 'team', Value: 'backend' }
+            ], undefined, undefined),
+        ];
+        await run_expiration_test({
+            rules,
+            key: 'lifecycle-test2/file2.txt',
+            tagging: 'env=prod&team=backend',
+            expected_id: 'two-tags',
+            expected_days: 9
+        });
+    });
+
+    mocha.it('should select rule with narrower size span when prefix and tags are matching', async () => {
+        const rules = [
+            generate_lifecycle_rule(4, 'wide-range', 'lifecycle-test3/', [], 100, 10000),
+            generate_lifecycle_rule(6, 'narrow-range', 'lifecycle-test3/', [], 1000, 5000),
+        ];
+        await run_expiration_test({
+            rules,
+            key: 'lifecycle-test3/file3.txt',
+            size: 1500,
+            expected_id: 'narrow-range',
+            expected_days: 6
+        });
+    });
+
+    mocha.it('should fallback to first matching rule if all filters are equal', async () => {
+        const rules = [
+            generate_lifecycle_rule(7, 'rule-a', 'lifecycle/test4/', [], 0, 10000),
+            generate_lifecycle_rule(11, 'rule-b', 'lifecycle/test4/', [], 0, 10000),
+        ];
+        await run_expiration_test({
+            rules,
+            key: 'lifecycle/test4/file4.txt',
+            expected_id: 'rule-a',
+            expected_days: 7
+        });
+    });
+});


### PR DESCRIPTION
### Describe the Problem
S3-compatible clients expect the `x-amz-expiration` response header when an object is subject to a lifecycle expiration rule. However, NooBaa was not setting this header in GET, PUT, or HEAD responses, even when valid expiration rules were configured.

### Explain the Changes
1. Added `set_expiration_header()` function to include the `x-amz-expiration` header in GET, PUT, and HEAD object responses.
2. Implemented `parse_expiration_header()` to convert lifecycle expiration rules (days or date) into proper s3 style header format.

Below is the output for header of putObject, headObject and getObject (after the fix):

![Screenshot from 2025-04-30 18-30-45](https://github.com/user-attachments/assets/b86fc772-4992-4cd0-9688-a0dfa42f266c)


### Issues: Fixed #xxx / Gap #xxx
1.  Partially Fixed: #8554 
2.  Ceph-s3 tests are failing because in ceph tests they are calculating number of days without converting `start_time` to midnigt UTC (inside check_expiration_header() function) which is causing error and returning wrong no. of expiration days.
[ceph-s3 tests issue](https://github.com/ceph/s3-tests/issues/652) has been created for the same.

### Testing Instructions:
1. Ceph-s3 tests are failing.
3. Added unit tests.
- [X] Tests added
