### PR TITLE
NSFS | content dir, ignore failure to delete xattr from latest, if already deleted

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2438,8 +2438,8 @@ class NamespaceFS {
         try {
             await this.set_fs_xattr_op(fs_context, file_path, undefined, prefix);
         } catch (err) {
-            if (err.code !== 'ENOENT') throw err;
-            dbg.log0(`NamespaceFS._clear_user_xattr: dir ${file_path} was already deleted`);
+            if (err.code !== 'ENOENT' && err.code !== 'ENODATA') throw err;
+            dbg.log0(`NamespaceFS._clear_user_xattr: dir ${file_path} or xattr was already deleted`);
         }
     }
 


### PR DESCRIPTION
### Describe the Problem
when adding to content dir at the same time after enabling versioning. both of them might try to remove the xattr from the directory. one of them will fail with ENODATA (The named attribute does not exist). ignore this error because attribute already deleted. see [removexattr](https://man7.org/linux/man-pages/man2/removexattr.2.html)

### Explain the Changes
1. ignore xattr clear error for data already deleted

### Issues: Fixed #8846 
NOTE - issue doesn't replicate on my environment. ran jest tests on CI 15 times without test failing but since it is a concurrency test, there may be other problems that didn't happen by chance

### Testing Instructions:
1. run `sudo npx jest test_versioning_concurrency -t "content dir multiple puts of the same key"`


- [ ] Doc added/updated
- [ ] Tests added
