### PR TITLE
Added cnpg services to system_schema

### DIFF
--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -78,7 +78,17 @@ module.exports = {
                 properties: {
                     service: {
                         type: 'string',
-                        enum: ['noobaa-mgmt', 's3', 'sts', 'noobaa-db', 'noobaa-db-pg', 'noobaa-syslog']
+                        enum: [
+                            'noobaa-mgmt',
+                            's3',
+                            'sts',
+                            'noobaa-db',
+                            'noobaa-db-pg',
+                            'noobaa-db-pg-cluster-rw',
+                            'noobaa-db-pg-cluster-ro',
+                            'noobaa-db-pg-cluster-r',
+                            'noobaa-syslog'
+                        ]
                     },
                     kind: {
                         type: 'string',


### PR DESCRIPTION
Signed-off-by: Danny Zaken <dannyzaken@gmail.com>

### Describe the Problem
- on startup, the system server updates the system in the DB with k8s services that has the label `app=noobaa`
- new cnpg services were not defined in the schema, which caused `INVALID_SCHEMA` messages to the log

### Explain the Changes
1. added to `system_schema.js` the new cnpg services: `noobaa-db-pg-cluster-rw`, `noobaa-db-pg-cluster-ro`, `noobaa-db-pg-cluster-r` 

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2138

### Testing Instructions:
1. deploy noobaa with a cnpg cluster and check the logs


- [ ] Doc added/updated
- [ ] Tests added
