### PR TITLE
Add more validation for lifecycle

### DIFF
--- a/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
@@ -141,6 +141,16 @@ async function put_bucket_lifecycle(req) {
                 days_after_initiation: parse_lifecycle_field(rule.AbortIncompleteMultipartUpload[0].DaysAfterInitiation),
             }, _.isUndefined);
             reject_empty_field(current_rule.abort_incomplete_multipart_upload);
+
+            if (current_rule.abort_incomplete_multipart_upload?.days_after_initiation === undefined) {
+                throw new S3Error(S3Error.InvalidArgument);
+            }
+            if (current_rule.abort_incomplete_multipart_upload?.days_after_initiation < 1) {
+                throw new S3Error({
+                    ...S3Error.InvalidArgument,
+                    detail: 'when calling the PutBucketLifecycleConfiguration operation: \'DaysAfterInitiation\' for AbortIncompleteMultipartUpload action must be a positive integer',
+                });
+            }
         }
 
         if (rule.Transition?.length === 1) {
@@ -158,6 +168,16 @@ async function put_bucket_lifecycle(req) {
                 newer_noncurrent_versions: parse_lifecycle_field(rule.NoncurrentVersionExpiration[0].NewerNoncurrentVersions),
             }, _.isUndefined);
             reject_empty_field(current_rule.noncurrent_version_expiration);
+
+            if (current_rule.noncurrent_version_expiration?.noncurrent_days === undefined) {
+                throw new S3Error(S3Error.InvalidArgument);
+            }
+            if (current_rule.noncurrent_version_expiration?.noncurrent_days < 1) {
+                throw new S3Error({
+                    ...S3Error.InvalidArgument,
+                    detail: 'when calling the PutBucketLifecycleConfiguration operation: \'NoncurrentDays\' for NoncurrentVersionExpiration action must be a positive integer',
+                });
+            }
         }
 
         if (rule.NoncurrentVersionTransition?.length === 1) {

--- a/src/test/unit_tests/test_lifecycle.js
+++ b/src/test/unit_tests/test_lifecycle.js
@@ -254,7 +254,7 @@ mocha.describe('lifecycle', () => {
         mocha.it('basic test cleanup abandoned multipart upload', async function() {
             const bucket = multipart_bucket;
             const key = 'test-lifecycle-multipart-basic-0';
-            const parts_age = 3;
+            const parts_age = 30;
             const parts_count = 7;
             const part_size = 45;
 
@@ -296,7 +296,7 @@ mocha.describe('lifecycle', () => {
         mocha.it('test cleanup abandoned multipart upload with prefix', async function() {
             const bucket = multipart_bucket;
             const prefix = 'test-lifecycle-multipart-with-prefix-';
-            const parts_age = 3;
+            const parts_age = 30;
             const parts_count = 7;
             const part_size = 45;
 


### PR DESCRIPTION
### Describe the Problem
Right now NooBaa validates a bunch of lifecycle policy but misses on the following 2:
1. Does not throw error if `DaysAfterInitiation` is empty in the `AbortIncompleteMultipartUpload` rule.
2. Does not throw error if `DaysAfterInitiation` is 0 in the `AbortIncompleteMultipartUpload` rule.
3. Does not throw error if `NoncurrentDays` is empty in the `NoncurrentVersionExpiration` rule.
4. Does not throw error if `NoncurrentDays` is 0 in the `NoncurrentVersionExpiration` rule.

### Explain the Changes
Added more rules in the `put-bucket-lifecycle-configuration`.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2141

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
