### PR TITLE
NSFS | FS Napi | getpwnam concurrency issue

### DIFF
--- a/src/test/unit_tests/jest_tests/test_fs_napi_concurrency.test.js
+++ b/src/test/unit_tests/jest_tests/test_fs_napi_concurrency.test.js
@@ -1,0 +1,55 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const P = require('../../../util/promise');
+const nb_native = require('../../../util/nb_native');
+const test_utils = require('../../system_tests/test_utils');
+const { TEST_TIMEOUT } = require('../../system_tests/test_utils');
+const { get_process_fs_context } = require('../../../util/native_fs_utils');
+
+const DEFAULT_FS_CONFIG = get_process_fs_context();
+
+describe('fs napi concurrency tests', function() {
+
+    describe('getpwnam concurrency tests', function() {
+
+        const users = [];
+        beforeAll(async () => {
+            for (let i = 0; i < 20; i++) {
+                const username = `user-${i}`;
+                const expected_config = { uid: 7000 + i, gid: 7000 + i };
+                await test_utils.create_fs_user_by_platform(username, username, expected_config.uid, expected_config.gid);
+                users.push({ username, expected_config });
+            }
+        }, TEST_TIMEOUT);
+
+        afterAll(async () => {
+            for (let i = 0; i < users.length; i++) {
+                await test_utils.delete_fs_user_by_platform(users[i].username);
+            }
+        }, TEST_TIMEOUT);
+
+        it('getpwnam concurrency tests', async function() {
+            for (let i = 0; i < users.length; i++) {
+                nb_native().fs.getpwname(
+                    DEFAULT_FS_CONFIG,
+                    users[i].username
+                )
+                .catch(err => {
+                    console.log('getpwname error - ', err);
+                    throw err;
+                }).then(res => {
+                    console.log('getpwname res', res);
+                    users[i].actual_config = res;
+                });
+            }
+            await P.delay(5000);
+            for (let i = 0; i < users.length; i++) {
+                const actual = users[i].actual_config;
+                const expected = users[i].expected_config;
+                expect(actual.uid).toBe(expected.uid);
+                expect(actual.gid).toBe(expected.gid);
+            }
+            }, TEST_TIMEOUT);
+    });
+});

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -502,7 +502,7 @@ async function get_user_by_distinguished_name({ distinguished_name }) {
         const user = await nb_native().fs.getpwname(context, distinguished_name);
         return user;
     } catch (err) {
-        dbg.error('native_fs_utils.get_user_by_distinguished_name: failed with error', err, distinguished_name);
+        dbg.error('native_fs_utils.get_user_by_distinguished_name: failed with error', err, err.code, distinguished_name);
         if (err.code !== undefined) throw err;
         throw new RpcError('NO_SUCH_USER', 'User with distinguished_name not found', err);
     }


### PR DESCRIPTION
### Describe the Problem
While debugging https://issues.redhat.com/browse/DFBUGS-2227, it was found that getpwnam() sometimes return incorrect uid/gid per the username provided. 
After checking the getpwnam https://man7.org/linux/man-pages/man3/getpwnam.3.html man page, I saw that in fs_napi we use an unsafe multi threaded operation getpwnam() instead of the safe operation getpwnam_r().
![image](https://github.com/user-attachments/assets/841d11c0-883f-4f3c-be7b-b061b9744434)

### Explain the Changes
1. Changed fs_napi GetPwName() to use getpwnam_r() instead of getpwnam().
2. Added concurrency getPwName() tests.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2227

### Testing Instructions:
1. Auto tests - sudo jest --testRegex=jest_tests/test_fs_napi_concurrency.test.js
2. Manual tests for reproducing the original bug - 
1. install warp
2. create at least 2 file system users, create 2 noobaa accounts, configured with distinguished names and create bucket for each account.
you can use the following script - 
```
storage_root_path="/nsfs_storage" ;
mkdir $storage_root_path/ -m 777;
for i in {1..2}; do 
groupadd -g 700$i user-$i ; 
useradd -c user-$i -m user-$i -p $(openssl passwd -1 pass-$i) -u 700$i -g 700$i ; 
mkdir $storage_root_path/user-$i-buckets/ -m 770; 
chown user-$i:user-$i $storage_root_path/user-$i-buckets/ ;  
noobaa-cli account add --name user-$i --new_buckets_path=$storage_root_path/user-$i-buckets/ --user=user-$i ;
for j in {1..1} ; do 
    mkdir $storage_root_path/user-$i-buckets/user-$i-bucket-$j/ -m 770 ;
    chown user-$i:user-$i $storage_root_path/user-$i-buckets/user-$i-bucket-$j/ ; 
    noobaa-cli bucket add --name=user.$i.bucket.$j --path=$storage_root_path/user-$i-buckets/user-$i-bucket-$j/ --owner=user-$i ; 
    done
done
```
3. Open 2 tabs, and run from each the following warp command with different accounts - 
4. tab 1 - 
```
warp put --host=localhost:6443 --access-key=<access_key of account 1> --secret-key=<secret_key of account 1>--obj.size=1k --duration=1m --disable-multipart  --bucket=<bucket of account 1> --tls --insecure --noclear --concurrent 1
```
5. Tab 2 - 
```
warp put --host=localhost:6443 --access-key=<access_key of account 2> --secret-key=<secret_key of account 2>--obj.size=1k --duration=1m --disable-multipart  --bucket=<bucket of account 2> --tls --insecure --noclear --concurrent 1
```

If the bug reproduced you will see AccessDenied error and the following logs - 
```
Apr 22 13:53:41 ba2710905f48 node[5245]: Apr-22 13:53:41.544 [nsfs/5245]  [WARN] core.sdk.namespace_fs:: _load_bucket failed, on bucket
_path /nsfs_storage/user-1-buckets/user-1-bucket-1 got error [Error: Permission denied] { code: 'EACCES', context: 'Stat _path=/nsfs_storage/user-1-buckets/user-1-bucket-1 ' }
Apr 22 13:53:41 ba2710905f48 node[5245]: Apr-22 13:53:41.549 [nsfs/5245] [ERROR] core.endpoint.s3.s3_rest:: S3 ERROR <?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code><Message>Access Denied</Message><Resource>/user.1.bucket.1/8gKQygb%28/25.eDq7H8kg5i4n1Hag.rnd</Resource><RequestId>m9skfje4-c1hdxw-dte</RequestId></Error> PUT /user.1.bucket.1/8gKQygb%28/25.eDq7H8kg5i4n1Hag.rnd {"host":"localhost:6443","user-agent":"MinIO (linux; amd64) minio-go/v7.0.90 warp/1.1.2","content-length":"1000","authorization":"AWS4-HMAC-SHA256 Credential=<access_key>/20250422/us-east-1/s3/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=3205a9a0616d7e1dcfdf369e595e7fea686882f85f4b8d1c142086cf3e3f336f","content-type":"application/octet-stream","x-amz-content-sha256":"UNSIGNED-PAYLOAD","x-amz-date":"20250422T135340Z"} Error: Permission denied - context: Stat _path=/nsfs_storage/user-1-buckets/user-1-bucket-1
```

and especially important, you will see a log message saying getpwnam returned wrong uid/gid - 
```
Apr 22 13:53:41 ba2710905f48 node[5245]: 2025-04-22 13:53:41.507139 [PID-5245/TID-5245] [L1] FS::GetPwName::OnOK: _user=user-1 _getpwna
m_res->pw_uid=7002 _getpwnam_res->pw_gid=7002
```
while in passwd file -
```
user-1:x:7001:7001:user-1:/home/user-1:/bin/bash
user-2:x:7002:7002:user-2:/home/user-2:/bin/bash
```
- [ ] Doc added/updated
- [x] Tests added
