### PR TITLE
bucket notifications - use node name in eventSource

### DIFF
--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -513,10 +513,11 @@ function compose_notification_test(req) {
 
 function _get_system_name(req) {
 
+    //in NC case - return node name
     if (req && req.object_sdk && req.object_sdk.nsfs_system) {
-        const name = Object.keys(req.object_sdk.nsfs_system)[0];
+        const name = process.env.NODE_NAME || os.hostname();
         return name;
-    } else {
+    } else { //in containerized - return system's name
         //see comment on Notificator._can_run() for the require here
         const system_store = require('../server/system_services/system_store').get_instance();
         return system_store.data.systems[0].name;


### PR DESCRIPTION
### Describe the Problem
Ramya from scale asked that eventSource will have the node's name (not system's name).

### Explain the Changes
1. Use correct node's name in eventSource instead of first key in system.json.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2088

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
