### PR TITLE
[backport into 5.19] bucket notifications - use node name in eventSource for NC (#8983)

### DIFF
--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -161,7 +161,7 @@ class Notificator {
 
     async handle_failed_notification(notif, failure_append, err) {
         if (this.nc_config_fs) {
-            new NoobaaEvent(NoobaaEvent.NOTIFICATION_FAILED).create_event(notif?.meta?.name, err, err.toString());
+            new NoobaaEvent(NoobaaEvent.NOTIFICATION_FAILED).create_event(notif?.meta?.name, err, err?.toString());
         }
 
         if (notif) {


### PR DESCRIPTION
https://github.com/noobaa/noobaa-core/pull/8996