### PR TITLE
NC | lifecycle | Add Tests in POSIX Integration Tests - Part 1

### DIFF
--- a/docs/NooBaaNonContainerized/CI&Tests.md
+++ b/docs/NooBaaNonContainerized/CI&Tests.md
@@ -115,6 +115,8 @@ The following is a list of `NC jest tests` files -
 18. `test_cli_upgrade.test.js` - Tests of the upgrade CLI commands.
 19. `test_nc_online_upgrade_cli_integrations.test.js` - Tests CLI commands during mocked config directory upgrade.
 20. `test_nc_connection_cli.test.js` - Tests NooBaa CLI connection commands.
+21. `test_nc_lifecycle_posix_integration.test` - Tests NC lifecycle POSIX related configuration.
+(Note: in this layer we do not test the validation related to lifecycle configuration and it is done in `test_lifecycle.js` - which currently is running only in containerized deployment, but it is mutual code)
 
 #### nc_index.js File
 * The `nc_index.js` is a file that runs several NC and NSFS mocha related tests.  


### PR DESCRIPTION
### Describe the Problem
We want to expand our test coverage in the NC lifecycle test.

### Explain the Changes
1. Create an enum for the status for easier reuse.
2. Fix the description mismatch (`id`) in the rule `lifecycle_rule_delete_all`.
3. Rename the file: remove the suffix `cli` and replace it with `posix_integration`, also inside the test titles, remove the `cli` and replace it with `nc`.
4. Separate with additional `describe` parts.
5. Remove the test "abort mpu by tags" as according to the [docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html):

> When you use the ExpiredObjectDeleteMarker S3 Lifecycle action, the rule cannot specify a tag-based filter.

Note: We added a validation for this - see issue #8870

7. Add cases where the status is `Disabled` and the rule doesn't run (in partially picked cases).
8. In versioning:
  - `DISABLED`, add the test cases for nested key and content dir
  - `ENABLED` only for nested key (as content dir is an unsupported case - see our [design doc of versioning](https://github.com/noobaa/noobaa-core/blob/master/docs/design/NsfsVersioning.md#out-of-scope)).
using Jest feature `it.each` (see [Jest docs](https://jestjs.io/docs/api#each) - we used array of objects and in the title we used the placeholder of `$description` to add information in the title).
Note: The tests were picked (we didn't want to run them on all the existing tests, although we can).
9. Add a warning to the JSDoc function `update_file_mtime`.
10. Format document.
11. Add the name test in our docs with a short explanation.

### Issues:
1. GAPS - we still have more tests that we plan to add to improve our coverage.

### Testing Instructions:
#### Automatic Tests
1. Please run: `sudo npx jest test_nc_lifecycle_posix_integration.test`


- [X] Doc added/updated
- [X] Tests added
