### PR TITLE
NC | lifecycle | remove key_marker and version_marker from state when finished

### DIFF
--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -458,6 +458,7 @@ class NCLifecycle {
             expire_state.key_marker = objects_list.next_marker;
             expire_state.is_finished = false;
         } else {
+            expire_state.key_marker = undefined;
             expire_state.is_finished = true;
         }
         const bucket_state = this.lifecycle_run_status.buckets_statuses[bucket_json.name].state;
@@ -579,6 +580,8 @@ class NCLifecycle {
             noncurrent_state.key_marker_versioned = list_versions.next_marker;
             noncurrent_state.version_id_marker = list_versions.next_version_id_marker;
         } else {
+            noncurrent_state.key_marker_versioned = undefined;
+            noncurrent_state.version_id_marker = undefined;
             noncurrent_state.is_finished = true;
         }
         const bucket_state = this.lifecycle_run_status.buckets_statuses[bucket_json.name].state;


### PR DESCRIPTION
set key_marker and version_marker to be undefined when list_object is is finished. do it so it wouldn't be confusing when looking at the status after the run has finished
 
### Describe the Problem


### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:

manual tests:
1. run lifecycle with batches
2. check status of the rules. should only have is_finished set to true


- [ ] Doc added/updated
- [ ] Tests added
