### PR TITLE
bucket notification - prevent undefined read on timeout

### DIFF
--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -161,7 +161,7 @@ class Notificator {
 
     async handle_failed_notification(notif, failure_append, err) {
         if (this.nc_config_fs) {
-            new NoobaaEvent(NoobaaEvent.NOTIFICATION_FAILED).create_event(notif?.meta?.name, err, err.toString());
+            new NoobaaEvent(NoobaaEvent.NOTIFICATION_FAILED).create_event(notif?.meta?.name, err, err?.toString());
         }
 
         if (notif) {


### PR DESCRIPTION
### Describe the Problem
On timeout, in NC, notification error handling issues an event.
This caused an undefined read property, which failed the notification persistent log handling.

### Explain the Changes
1. Check if err object is deifined.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2303

### Testing Instructions:
1. Create several notifications.
2. Cause one of the notifications to fail on timeout (eg by adding a timeout to server handling just once).
3. Only the failed notification should remain in persistent notification log file.


- [ ] Doc added/updated
- [ ] Tests added
