### PR TITLE
`ListObjects` `ListObjectVersions` API | Fix encoded url of `undefined` value

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket_versions.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_versions.js
@@ -37,11 +37,11 @@ async function get_bucket_versions(req) {
     return {
         ListVersionsResult: [{
             Name: req.params.bucket,
-            Prefix: field_encoder(req.query.prefix),
+            Prefix: field_encoder(req.query.prefix) || '',
             Delimiter: field_encoder(req.query.delimiter),
             MaxKeys: max_keys_received,
-            KeyMarker: field_encoder(req.query['key-marker']),
-            VersionIdMarker: version_id_marker,
+            KeyMarker: field_encoder(req.query['key-marker']) || '',
+            VersionIdMarker: version_id_marker || '',
             IsTruncated: reply.is_truncated,
             NextKeyMarker: field_encoder(reply.next_marker),
             NextVersionIdMarker: reply.next_version_id_marker,

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -695,6 +695,7 @@ function response_field_encoder_none(value) {
 * with plus (+) instead of spaces (and not %20 as encodeURIComponent() does)
 */
 function response_field_encoder_url(value) {
+    if (value === undefined) return undefined; // else the undefined value will be a string of 'undefined'
     return new URLSearchParams({ 'a': value }).toString().slice(2); // slice the leading 'a='
 }
 
@@ -864,6 +865,7 @@ exports.get_http_response_from_resp = get_http_response_from_resp;
 exports.get_http_response_date = get_http_response_date;
 exports.XATTR_SORT_SYMBOL = XATTR_SORT_SYMBOL;
 exports.get_response_field_encoder = get_response_field_encoder;
+exports.response_field_encoder_url = response_field_encoder_url;
 exports.parse_decimal_int = parse_decimal_int;
 exports.parse_restore_request_days = parse_restore_request_days;
 exports.parse_version_id = parse_version_id;

--- a/src/test/unit_tests/jest_tests/test_s3_utils.test.js
+++ b/src/test/unit_tests/jest_tests/test_s3_utils.test.js
@@ -200,4 +200,32 @@ describe('s3_utils', () => {
             expect(res.restrict_public_buckets).toBe(false);
         });
     });
+
+    describe('response_field_encoder_url', () => {
+        it('should return undefined value', () => {
+            const value = undefined;
+            const field_encoded = s3_utils.response_field_encoder_url(value);
+            expect(field_encoded).toBe(undefined);
+            expect(typeof field_encoded).not.toBe('string');
+
+        });
+        it('should encode value without spaces (no special characters)', () => {
+            const value = 'test';
+            const field_encoded = s3_utils.response_field_encoder_url(value);
+            expect(typeof field_encoded).toBe('string');
+            expect(field_encoded).toBe(value);
+        });
+        it('should encode value without spaces (with special characters)', () => {
+            const value = 'photos/';
+            const field_encoded = s3_utils.response_field_encoder_url(value);
+            expect(typeof field_encoded).toBe('string');
+            expect(field_encoded).toBe('photos%2F');
+        });
+        it('should encode value with spaces', () => {
+            const value = 'my test';
+            const field_encoded = s3_utils.response_field_encoder_url(value);
+            expect(typeof field_encoded).toBe('string');
+            expect(field_encoded).toBe('my+test');
+        });
+    });
 });


### PR DESCRIPTION
### Describe the Problem
When I tried to `ListObjectVersions`, I noticed that the server returns the Prefix as `"undefined"` while in AWS it is `''` (empty string), which was not our behavior in the past.

### Explain the Changes
1. In the function `response_field_encoder_url` do not encode the value if it is `undefined` and export the function for unit tests.
2. In `s3_get_bucket_versions.js` added the `|| ''` (empty string in case of `undefined` value) to match what I saw in AWS, so the field will appear in the response (see [comment](https://github.com/noobaa/noobaa-core/pull/8997#discussion_r2066162075)).

### Issues: 
I suspect that the default value of encoding-url was changed from `undefined` to `'url'`, and that I noticed it because I upgraded my AWS CLI version recently (my current version is `aws-cli/2.27.0 Python/3.13.3 Darwin/24.4.0 source/arm64`). I couldn't find evidence in the AWS CLI change log.

As mentioned, I noticed that we return ` "Prefix": "undefined"` on `list-object-versions` when using AWS CLI.
```
    "RequestCharged": null,
    "Prefix": "undefined"
```
While in AWS it is:
```
    "RequestCharged": null,
    "Prefix": ""
```
Note: In the AWS SDK the `encoding_type` is still `undefined` (the default changed in the AWS CLI to be `url`).
To see that I added the printing `console.log('SDSD encoding-type', encoding_type);` after https://github.com/noobaa/noobaa-core/blob/2e31d10badd3039b2803f6e145556885a0f1cff0/src/endpoint/s3/s3_utils.js#L682
and run the `./node_modules/mocha/bin/mocha.js src/test/unit_tests/test_s3_ops.js` locally (according to [these instructions](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/run_coretest_locally.md)).
I saw: `Apr-29 10:28:40.822 [Endpoint/71804]   [LOG] CONSOLE:: SDSD encoding-type undefined` in all the cases.

### Testing Instructions:
### Automatic Test (Unit Test)
1. Please run: `npx jest test_s3_utils.test.js`

### Manual Test
I tested it on the NC deployment:
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`
3. Start the NSFS server with: `sudo node src/cmd/nsfs --debug 5 --https_port 6442` (the default port is somehow taken on my machine)
4. Create the alias for S3 service:`alias nc-user-1-s3=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:6442’` (edit the `endpoint-url` to match the port that I set).
5. Check the connection to the endpoint and try to list the buckets (should be empty): `nc-user-1-s3 s3 ls; echo $?`
6. Add bucket to the account using AWS CLI: `nc-user-1-s3 s3 mb s3:// bucket-28-04` (`bucket-28-04` is the bucket name in this example)
7. Set the bucket on suspended mode: `nc-user-1-s3 s3api put-bucket-versioning --bucket bucket-28-04 --versioning-configuration Status=Suspended`.
8. Put objects in the bucket:
  - Create a file of 100MB : `dd if=/dev/urandom of=100MB_file bs=1M count=100`
  - `nc-user-1-s3 s3api put-object --bucket bucket-28-04 --key key1 --body ./100MB_file`
  - `nc-user-1-s3 s3api put-object --bucket bucket-28-04 --key test/key1 --body ./100MB_file`
9. ListObject: `nc-user-1-s3 s3api list-object-versions --bucket bucket-28-04` you can with `--debug` flag to see the the encoding-type that was added: `2025-04-29 10:38:23,900 - MainThread - urllib3.connectionpool - DEBUG - https://localhost:6442 "GET /bucket-28-04?versions&encoding-type=url HTTP/1.1" 200 1050`

- [ ] Doc added/updated
- [X] Tests added
