### PR TITLE
CI | Publish Nightly of "Test AWS SDK Clients" Result in Slack

### DIFF
--- a/.github/workflows/test-aws-sdk-clients.yaml
+++ b/.github/workflows/test-aws-sdk-clients.yaml
@@ -24,4 +24,14 @@ jobs:
           cd ./noobaa-core
           make test-aws-sdk-clients
 
+      - name: Message Slack Webhook
+        # we will uncomment this after we test it in the CI
+        # if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "AWS SDK Clients Run result: ${{ job.status }}"
+
 


### PR DESCRIPTION
### Describe the Problem
Add a step to publish the nightly test results of the job "test-aws-sdk-clients" in the Slack channel.

### Explain the Changes
1. Add a step to message the job status - we temporarily message only success, then we will uncomment the condition and message only failures.

### Issues:
- It was a gap of #8847 and was mentioned as a part of issue #8905
- For more information, see [this comment](https://github.com/noobaa/noobaa-core/pull/8969#issuecomment-2823388311)
- Now we're trying to test after merging and not use the secrets from a forked repo - see [this comment](https://github.com/orgs/community/discussions/157452#discussioncomment-12970670).

### Testing Instructions:
1. We will monitor the nightly run in the next days manually and check that the message was sent.


- [ ] Doc added/updated
- [ ] Tests added
