### PR TITLE
NC | lifecycle | Add Tests in POSIX Integration Tests - Part 3

### DIFF
--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
@@ -1,5 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 /* eslint-disable max-lines-per-function */
+/* eslint-disable  max-lines */
 'use strict';
 
 // disabling init_rand_seed as it takes longer than the actual test execution
@@ -421,7 +422,7 @@ describe('noobaa nc - lifecycle versioning DISABLED', () => {
     }
 });
 
-describe('noobaa nc - lifecycle versioning ENABLE', () => {
+describe('noobaa nc - lifecycle versioning ENABLED', () => {
     const test_bucket_path = `${root_path}/${test_bucket}`;
     const test_key1_regular = 'test_key1';
     const test_key2_regular = 'test_key2';
@@ -462,8 +463,38 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
         await fs_utils.folder_delete(config_root);
     }, TEST_TIMEOUT);
 
-    describe('noobaa nc - lifecycle versioning ENABLE - noncurrent expiration rule', () => {
-        it.each(test_cases)('nc lifecycle - noncurrent expiration rule - expire older versions - $description', async ({ description, test_key1, test_key2, test_key3, test_prefix_key }) => {
+    it('nc lifecycle - versioning ENABLED - expiration rule - regular key', async () => {
+        const date = new Date();
+        date.setDate(date.getDate() - 1); // yesterday
+        const lifecycle_rule = [{
+            "id": "expiration after 3 days",
+            "status": "Enabled",
+            "filter": {
+                "prefix": prefix,
+            },
+            "expiration": {
+                "date": date.getTime()
+            }
+        }];
+        await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+        await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false);
+        await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false);
+        await create_object(object_sdk, test_bucket, test_key2_regular, 100, false);
+
+        await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+        const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+        expect(object_list.objects.length).toBe(4); //added delete marker
+        let has_delete_marker = false;
+        object_list.objects.forEach(element => {
+            if (element.delete_marker) has_delete_marker = true;
+        });
+        expect(has_delete_marker).toBe(true);
+    });
+
+
+    describe('noobaa nc - lifecycle versioning ENABLED - noncurrent expiration rule', () => {
+        it.each(test_cases)('nc lifecycle - versioning ENABLED - noncurrent expiration rule - expire older versions - $description', async ({ description, test_key1, test_key2, test_key3, test_prefix_key }) => {
             const lifecycle_rule = [{
                 "id": "keep 2 noncurrent versions",
                 "status": "Enabled",
@@ -491,7 +522,7 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             });
         });
 
-        it('nc lifecycle - noncurrent expiration rule - expire older versions with filter - regular key', async () => {
+        it('nc lifecycle - versioning ENABLED - noncurrent expiration rule - expire older versions with filter - regular key', async () => {
             const lifecycle_rule = [{
                 "id": "keep 1 noncurrent version with filter",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
@@ -525,7 +556,7 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             });
         });
 
-        it('nc lifecycle - noncurrent expiration rule - expire older versions only delete markers - regular key', async () => {
+        it('nc lifecycle - versioning ENABLED - noncurrent expiration rule - expire older versions only delete markers - regular key', async () => {
             const lifecycle_rule = [{
                 "id": "keep 1 noncurrent with size filter",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
@@ -558,36 +589,7 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             });
         });
 
-        it('nc lifecycle - noncurrent expiration rule - expire versioning enabled bucket - regular key', async () => {
-            const date = new Date();
-            date.setDate(date.getDate() - 1); // yesterday
-            const lifecycle_rule = [{
-                "id": "expiration after 3 days",
-                "status": "Enabled",
-                "filter": {
-                    "prefix": prefix,
-                },
-                "expiration": {
-                    "date": date.getTime()
-                }
-            }];
-            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
-
-            await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false);
-            await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false);
-            await create_object(object_sdk, test_bucket, test_key2_regular, 100, false);
-
-            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
-            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
-            expect(object_list.objects.length).toBe(4); //added delete marker
-            let has_delete_marker = false;
-            object_list.objects.forEach(element => {
-                if (element.delete_marker) has_delete_marker = true;
-            });
-            expect(has_delete_marker).toBe(true);
-        });
-
-        it('nc lifecycle - noncurrent expiration rule - expire older versions by number of days with filter - regular key', async () => {
+        it('nc lifecycle - versioning ENABLED - noncurrent expiration rule - expire older versions by number of days with filter - regular key', async () => {
             const lifecycle_rule = [{
                 "id": "expire noncurrent versions after 3 days with size ",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
@@ -620,9 +622,9 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             });
         });
 
-        it('nc lifecycle - noncurrent expiration rule - both noncurrent days and older versions', async () => {
+        it('nc lifecycle - versioning ENABLED - noncurrent expiration rule - both noncurrent days and older versions', async () => {
             const lifecycle_rule = [{
-                "id": "expire noncurrent versions after 3 days with size ",
+                "id": "expire noncurrent versions after 3 days",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
                 "filter": {
                     "prefix": '',
@@ -634,12 +636,10 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             }];
             await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
 
-            const expected_res = await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
-            const res = await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
-            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
-            // older than 3 days but no more than one noncurrent version - don't delete
+            const expected_res = await create_object(object_sdk, test_bucket, test_key1_regular, 100, false); // the second newest noncurrent version (will be deleted)
+            const res = await create_object(object_sdk, test_bucket, test_key1_regular, 100, false); // the newest noncurrent version
+            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false); // latest version
             await update_version_xattr(test_bucket, test_key1_regular, expected_res.version_id);
-            // both older than 3 days and more than one noncurrent version - delete
             await update_version_xattr(test_bucket, test_key1_regular, res.version_id);
 
             await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
@@ -650,9 +650,9 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             });
         });
 
-        it('nc lifecycle - noncurrent expiration rule - older versions valid but noncurrent_days not valid', async () => {
+        it('nc lifecycle - versioning ENABLED - noncurrent expiration rule - older versions valid but noncurrent_days not valid', async () => {
             const lifecycle_rule = [{
-                "id": "expire noncurrent versions after 3 days with size ",
+                "id": "expire noncurrent versions after 3 days",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
                 "filter": {
                     "prefix": '',
@@ -675,8 +675,8 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
         });
     });
 
-    describe('noobaa nc - lifecycle versioning ENABLE - expiration rule - delete marker', () => {
-        it.each(test_cases)('nc lifecycle - expiration rule - expire delete marker - $description', async ({ description, test_key1, test_key2, test_key3, test_prefix_key }) => {
+    describe('noobaa nc - lifecycle versioning ENABLED - expiration rule - delete marker', () => {
+        it.each(test_cases)('nc lifecycle - versioning ENABLED - expiration rule - expire delete marker - $description', async ({ description, test_key1, test_key2, test_key3, test_prefix_key }) => {
             const lifecycle_rule = [{
                 "id": "expired_object_delete_marker no filters",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
@@ -696,13 +696,13 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
 
             await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
             const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
-            expect(object_list.objects.length).toBe(2);
+            expect(object_list.objects.length).toBe(2); // test_prefix_key as older version and a delete marker, hence it doesn't considered expired
             object_list.objects.forEach(element => {
                 expect(element.key).toBe(test_prefix_key);
             });
         });
 
-        it('nc lifecycle - expiration rule - expire delete marker with filter - regular key', async () => {
+        it('nc lifecycle - versioning ENABLED - expiration rule - expire delete marker with filter - regular key', async () => {
             const lifecycle_rule = [{
                 "id": "expired_object_delete_marker with filter by prefix and size",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
@@ -714,7 +714,6 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
                     "expired_object_delete_marker": true
                 }
             }];
-            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "ENABLED" });
             await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
 
             await object_sdk.delete_object({ bucket: test_bucket, key: test_key1_regular });
@@ -726,7 +725,7 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             expect(object_list.objects[0].key).toBe(test_key1_regular);
         });
 
-        it('nc lifecycle - expiration rule - expire delete marker last item', async () => {
+        it('nc lifecycle - versioning ENABLED - expiration rule - expire delete marker last item', async () => {
             const lifecycle_rule = [{
                 "id": "expiration of delete marker with filter by size and prefix",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
@@ -738,7 +737,6 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
                     "expired_object_delete_marker": true
                 }
             }];
-            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "ENABLED" });
             await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
 
             await object_sdk.delete_object({ bucket: test_bucket, key: test_key1_regular });
@@ -748,7 +746,7 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             expect(object_list.objects.length).toBe(0);
         });
 
-        it('nc lifecycle - expiration rule - last item in batch is latest delete marker', async () => {
+        it('nc lifecycle - versioning ENABLED - expiration rule - last item in batch is latest delete marker', async () => {
             const lifecycle_rule = [{
                 "id": "filter by size and no filter by prefix with expiration of delete marker",
                 "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
@@ -764,7 +762,6 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
                 NC_LIFECYCLE_LIST_BATCH_SIZE: 3,
                 NC_LIFECYCLE_BUCKET_BATCH_SIZE: 3,
             }));
-            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "ENABLED" });
             await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
 
             await object_sdk.delete_object({ bucket: test_bucket, key: test_key1_regular });
@@ -780,6 +777,337 @@ describe('noobaa nc - lifecycle versioning ENABLE', () => {
             object_list.objects.forEach(element => {
                 expect([test_key1_regular, test_key2_regular]).toContain(element.key);
             });
+        });
+    });
+
+});
+
+describe('noobaa nc - lifecycle versioning SUSPENDED', () => {
+    const test_bucket_path = `${root_path}/${test_bucket}`;
+    const test_key1_regular = 'test_key1';
+    const test_key2_regular = 'test_key2';
+    const test_key3_regular = 'test_key3';
+    const test_key1_nested = 'nested/test_key1';
+    const test_key2_nested = 'nested/test_key2';
+    const test_key3_nested = 'nested/test_key3';
+    const prefix = 'test/';
+    const test_prefix_key_regular = `${prefix}${test_key1_regular}`;
+    const test_prefix_key_nested = `${prefix}${test_key1_nested}`;
+    const test_cases = [
+        { description: 'regular key', test_key1: test_key1_regular, test_key2: test_key2_regular, test_key3: test_key3_regular, test_prefix_key: test_prefix_key_regular },
+        { description: 'nested key', test_key1: test_key1_nested, test_key2: test_key2_nested, test_key3: test_key3_nested, test_prefix_key: test_prefix_key_nested },
+    ];
+    let object_sdk;
+
+    beforeAll(async () => {
+        await fs_utils.create_fresh_path(config_root, 0o777);
+        set_nc_config_dir_in_config(config_root);
+        await fs_utils.create_fresh_path(root_path, 0o777);
+        const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, account_options1);
+        const json_account = JSON.parse(res).response.reply;
+        console.log(json_account);
+        object_sdk = new NsfsObjectSDK('', config_fs, json_account, "DISABLED", config_fs.config_root, undefined);
+        object_sdk.requesting_account = json_account;
+        await object_sdk.create_bucket({ name: test_bucket });
+        await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "SUSPENDED" });
+    });
+
+    afterEach(async () => {
+        await object_sdk.delete_bucket_lifecycle({ name: test_bucket });
+        await fs_utils.create_fresh_path(test_bucket_path);
+    });
+
+    afterAll(async () => {
+        await fs_utils.folder_delete(test_bucket_path);
+        await fs_utils.folder_delete(root_path);
+        await fs_utils.folder_delete(config_root);
+    }, TEST_TIMEOUT);
+
+    it('nc lifecycle - versioning SUSPENDED - expiration rule - regular key', async () => {
+        const date = new Date();
+        date.setDate(date.getDate() - 1); // yesterday
+        const lifecycle_rule = [{
+            "id": "expiration after 3 days",
+            "status": "Enabled",
+            "filter": {
+                "prefix": prefix,
+            },
+            "expiration": {
+                "date": date.getTime()
+            }
+        }];
+        await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+        await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false); // matches prefix filter - will effectively deletes the object
+        await create_object(object_sdk, test_bucket, test_key2_regular, 100, false);
+
+        await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+        const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+        expect(object_list.objects.length).toBe(2); // one that didn't match and a delete marker of the one that matched
+        const matched_filter_object = object_list.objects.find(element => element.key === test_prefix_key_regular);
+        expect(matched_filter_object.version_id).toBe('null');
+        expect(matched_filter_object.delete_marker).toBe(true);
+        const non_matched_filter_object = object_list.objects.find(element => element.key === test_key2_regular);
+        expect(non_matched_filter_object.version_id).toBe('null');
+        expect(non_matched_filter_object.delete_marker).toBe(false);
+    });
+
+    describe('noobaa nc - lifecycle versioning SUSPENDED - noncurrent expiration rule', () => {
+        it.each(test_cases)('nc lifecycle - versioning SUSPENDED - noncurrent expiration rule - expire older versions - $description', async ({ description, test_key1, test_key2, test_prefix_key }) => {
+            const lifecycle_rule = [{
+                "id": "keep 2 noncurrent versions",
+                "status": "Enabled",
+                "filter": {
+                    "prefix": "",
+                },
+                "noncurrent_version_expiration": {
+                    "newer_noncurrent_versions": 2,
+                    "noncurrent_days": 1
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+            for (let i = 0; i < 5; i++) {
+                await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
+            }
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            // in case the versioning is SUSPENDED the number of newer_noncurrent_versions is not relevant and we would have only the latest version (with version_id null)
+            expect(object_list.objects.length).toBe(1);
+            expect(object_list.objects[0].version_id).toBe('null');
+            expect(object_list.objects[0].is_latest).toBe(true);
+        });
+
+        it('nc lifecycle - versioning SUSPENDED - noncurrent expiration rule - expire older versions with filter - regular key', async () => {
+            const lifecycle_rule = [{
+                "id": "keep 1 noncurrent version with filter",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": prefix,
+                    "object_size_greater_than": 80,
+                },
+                "noncurrent_version_expiration": {
+                    "newer_noncurrent_versions": 1,
+                    "noncurrent_days": 1
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "ENABLED" });
+            const version_arr = [];
+            let res = await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false); // filter by prefix + size
+            version_arr.push(res.version_id);
+            for (let i = 0; i < 2; i++) {
+                const prev_res = res;
+                res = await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false); // filter by prefix + size
+                await update_version_xattr(test_bucket, test_prefix_key_regular, prev_res.version_id);
+                version_arr.push(res.version_id);
+            }
+            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "SUSPENDED" });
+            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false); // doesn't match prefix filter
+            await create_object(object_sdk, test_bucket, `${prefix}${test_key2_regular}`, 60, false); // doesn't match size filter
+            await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false); // filter by prefix + size
+
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(4); // 2 of the mismatched keys (1 version) + 2 versions the filtered key 
+
+            const filtered_versions = object_list.objects.filter(element => element.key === test_prefix_key_regular);
+            expect(filtered_versions.length).toBe(2);
+            expect(['null', version_arr[2]]).toContain(filtered_versions[0].version_id);
+            expect(['null', version_arr[2]]).toContain(filtered_versions[1].version_id);
+        });
+
+        it('nc lifecycle - versioning SUSPENDED - noncurrent expiration rule - expire older versions by number of days with filter - regular key', async () => {
+            const lifecycle_rule = [{
+                "id": "expire noncurrent versions after 3 days with size ",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": prefix,
+                    "object_size_greater_than": 80,
+                },
+                "noncurrent_version_expiration": {
+                    "noncurrent_days": 3
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "ENABLED" });
+            let res = await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
+            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
+            await update_version_xattr(test_bucket, test_key1_regular, res.version_id);
+
+            const expected_res = await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false);
+            res = await create_object(object_sdk, test_bucket, test_prefix_key_regular, 60, false);
+            await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false);
+            await create_object(object_sdk, test_bucket, test_prefix_key_regular, 100, false);
+            await update_version_xattr(test_bucket, test_prefix_key_regular, expected_res.version_id);
+            await update_version_xattr(test_bucket, test_prefix_key_regular, res.version_id);
+            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "SUSPENDED" });
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(5);
+            object_list.objects.forEach(element => {
+                expect(element.version_id).not.toBe(expected_res.version_id);
+            });
+        });
+
+        it('nc lifecycle - versioning SUSPENDED - noncurrent expiration rule - both noncurrent days and older versions', async () => {
+            const lifecycle_rule = [{
+                "id": "expire noncurrent versions after 3 days",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": '',
+                },
+                "noncurrent_version_expiration": {
+                    "noncurrent_days": 3,
+                    "newer_noncurrent_versions": 1
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "ENABLED" });
+            const expected_res = await create_object(object_sdk, test_bucket, test_key1_regular, 100, false); // the second newest noncurrent version (will be deleted)
+            const res = await create_object(object_sdk, test_bucket, test_key1_regular, 100, false); // the newest noncurrent version
+            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false); // latest version
+            await update_version_xattr(test_bucket, test_key1_regular, expected_res.version_id);
+            await update_version_xattr(test_bucket, test_key1_regular, res.version_id);
+            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "SUSPENDED" });
+
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(2);
+            object_list.objects.forEach(element => {
+                expect(element.version_id).not.toBe(expected_res.version_id);
+            });
+        });
+
+        it('nc lifecycle - versioning SUSPENDED - noncurrent expiration rule - older versions valid but noncurrent_days not valid', async () => {
+            const lifecycle_rule = [{
+                "id": "expire noncurrent versions after 3 days",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": '',
+                },
+                "noncurrent_version_expiration": {
+                    "noncurrent_days": 3,
+                    "newer_noncurrent_versions": 1
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "ENABLED" });
+            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
+            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
+            // more than one noncurrent version but not older than 3 days - don't delete
+            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
+            await object_sdk.set_bucket_versioning({ name: test_bucket, versioning: "SUSPENDED" });
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(3);
+        });
+
+    });
+
+    describe('noobaa nc - lifecycle versioning SUSPENDED - expiration rule - delete marker', () => {
+        it.each(test_cases)('nc lifecycle - versioning SUSPENDED - expiration rule - expire delete marker - $description', async ({ description, test_key1, test_key2, test_prefix_key }) => {
+            const lifecycle_rule = [{
+                "id": "expired_object_delete_marker no filters",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": '',
+                },
+                "expiration": {
+                    "expired_object_delete_marker": true
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key1 });
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key2 });
+
+            await create_object(object_sdk, test_bucket, test_prefix_key, 100, false);
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_prefix_key }); // in SUSPENDED mode there would be only the delete marker of test_prefix_key with version id id of null
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(0); // all the objects doesn't have an older version and we have only delete markers
+        });
+
+        it('nc lifecycle - versioning SUSPENDED - expiration rule - expire delete marker with filter - regular key', async () => {
+            const lifecycle_rule = [{
+                "id": "expired_object_delete_marker with filter by prefix and size",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": prefix,
+                    "object_size_less_than": 1
+                },
+                "expiration": {
+                    "expired_object_delete_marker": true
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key1_regular });
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_prefix_key_regular });
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(1);
+            expect(object_list.objects[0].key).toBe(test_key1_regular);
+        });
+
+        it('nc lifecycle - versioning SUSPENDED - expiration rule - expire delete marker last item', async () => {
+            const lifecycle_rule = [{
+                "id": "expiration of delete marker with filter by size and prefix",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": '',
+                    "object_size_less_than": 1
+                },
+                "expiration": {
+                    "expired_object_delete_marker": true
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key1_regular });
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(0);
+        });
+
+        it('nc lifecycle - versioning SUSPENDED - expiration rule - last item in batch is latest delete marker', async () => {
+            const lifecycle_rule = [{
+                "id": "filter by size and no filter by prefix with expiration of delete marker",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": '',
+                    "object_size_less_than": 1
+                },
+                "expiration": {
+                    "expired_object_delete_marker": true
+                }
+            }];
+            await config_fs.create_config_json_file(JSON.stringify({
+                NC_LIFECYCLE_LIST_BATCH_SIZE: 3,
+                NC_LIFECYCLE_BUCKET_BATCH_SIZE: 3,
+            }));
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key1_regular });
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key1_regular });
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key2_regular }); // last in batch should not delete
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key2_regular });
+            await object_sdk.delete_object({ bucket: test_bucket, key: test_key3_regular }); // last in batch should delete
+            await object_sdk.delete_object({ bucket: test_bucket, key: 'test_key4' });
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(0);
         });
     });
 });


### PR DESCRIPTION
### Describe the Problem
We want to expand our test coverage in the NC lifecycle.

### Explain the Changes
1. Add tests related to versioning SUSPENDED based on the tests that we had in versioning ENABLED.
2. Rename the titles `versioning ENABLE` to `versioning ENABLED`.
3. Remove redundant `set_bucket_versioning` as it is set in the `beforeAll`.
4. Move the test `nc lifecycle - noncurrent expiration rule - expire versioning enabled bucket - regular key` under the `describe` of `describe noobaa nc - lifecycle versioning ENABLED` directly and rename it to `nc lifecycle - expiration rule - expire versioning ENABLED bucket - regular key`.
5. Copy the new tests that were added in PR #8992 and run them when the bucket is in versioning SUSPENDED, edit the "id" in the rule in those tests to match them, and edit the comments so it would be clearer.
6. Edit the titles of the test to have versioning ENABLED / SUSPENDED in them.

### Issues:
1. GAPS - we still have more tests that we plan to add to improve our coverage.

### Testing Instructions:
#### Automatic Tests
1. Please run: `sudo npx jest test_nc_lifecycle_posix_integration`

- [ ] Doc added/updated
- [ ] Tests added
