### PR TITLE
CI | Publish Nightly Result in Slack - Update Secret Name

### DIFF
--- a/.github/workflows/test-aws-sdk-clients.yaml
+++ b/.github/workflows/test-aws-sdk-clients.yaml
@@ -29,7 +29,7 @@ jobs:
         # if: ${{ failure() }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACKWEBHOOKURL }}
           webhook-type: incoming-webhook
           payload: |
             text: "AWS SDK Clients Run result: ${{ job.status }}"


### PR DESCRIPTION
### Describe the Problem
Continue PR #8998 - the secret name in the setting was set without underscores.

### Explain the Changes
1. Change the secret name to be without underscores.

### Issues: Fixed #xxx / Gap #xxx
The job from last time was failing with an empty secret - [link](https://github.com/noobaa/noobaa-core/actions/runs/14744754725/job/41389870206).

### Testing Instructions:
1. none - We will monitor the nightly run in the next days manually and check that the message was sent.


- [ ] Doc added/updated
- [ ] Tests added
