### PR TITLE
nsfs nsr monitoring - fix last_monitoring when calculating mode

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1133,10 +1133,12 @@ function calc_namespace_resource_mode(namespace_resource) {
     if (!map_issues_and_monitoring_report.has(namespace_resource_id)) {
         map_issues_and_monitoring_report.set(namespace_resource_id, { last_monitoring: undefined, issues: [] });
     }
-    const issues_report = map_issues_and_monitoring_report.get(namespace_resource_id).issues;
+
+    const nsr_report = map_issues_and_monitoring_report.get(namespace_resource_id);
+    const issues_report = nsr_report.issues;
     const errors_count = _.reduce(issues_report, (acc, issue) => {
         // skip if error timestamp is before of the latest monitoring
-        if (issue.time < namespace_resource.last_monitoring) {
+        if (issue.time < nsr_report.last_monitoring) {
             return acc;
         }
         const err_type = map_err_to_type_count[issue.error_code] || 'io_errors';


### PR DESCRIPTION
;### Describe the Problem
When calculating nsr mode, the wrong object is accessed when reading 'last_monitoring'.

### Explain the Changes
1. Use correct object.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-153

### Testing Instructions:
1. As describe in dfs bug:
The nsr json looks like:
apiVersion: noobaa.io/v1alpha1
kind: NamespaceStore
metadata:
        name: nsfs-nss
        namespace: openshift-storage
        labels:
                app: noobaa
        finalizers:
                - noobaa.io/finalizer
spec:
        type: nsfs
        nsfs:
                pvcName: my-pvc

(Assuming you have an available pcv called 'my-pvc').

Create/delete the nsr several times rapidly using standard kubectl, eg-
kubectl create -f nsfs_nss.yaml
kubectl delete namespacestore nsfs-nss

- [ ] Doc added/updated
- [ ] Tests added
