### PR TITLE
CI | Publish Nightly Result in Slack - Only When Not Success

### DIFF
--- a/.github/workflows/test-aws-sdk-clients.yaml
+++ b/.github/workflows/test-aws-sdk-clients.yaml
@@ -25,8 +25,7 @@ jobs:
           make test-aws-sdk-clients
 
       - name: Message Slack Webhook
-        # we will uncomment this after we test it in the CI
-        # if: ${{ failure() }}
+        if: ${{ !success() }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACKWEBHOOKURL }}


### PR DESCRIPTION
### Describe the Problem
Continue PR #8998 and #9002, check the message to be sent only if the job did not succeed (failed or cancelled).

### Explain the Changes
1. Add the `if: ${{ !success() }}` in the step `Message Slack Webhook` according to the [GitHub status docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#status-check-functions).

### Issues: 
1. None

### Testing Instructions:
1. None


- [ ] Doc added/updated
- [ ] Tests added
