### PR TITLE
NC | lifecycle | Small GPFS flow fixes

### DIFF
--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -1236,7 +1236,7 @@ class NCLifecycle {
         const { bucket_rule_id, in_bucket_path, in_bucket_internal_dir } = ilm_policy_helpers;
         const mod_age_definition = `define( mod_age, (DAYS(CURRENT_TIMESTAMP) - DAYS(MODIFICATION_TIME)) )\n`;
         const change_age_definition = `define( change_age, (DAYS(CURRENT_TIMESTAMP) - DAYS(CHANGE_TIME)) )\n`;
-        const rule_id_definition = `RULE ${bucket_rule_id} LIST ${bucket_rule_id}\n`;
+        const rule_id_definition = `RULE '${bucket_rule_id}' LIST '${bucket_rule_id}'\n`;
         const policy_path_base = `WHERE PATH_NAME LIKE '${in_bucket_path}'\n` +
             `AND PATH_NAME NOT LIKE '${in_bucket_internal_dir}'\n`;
 
@@ -1285,8 +1285,8 @@ class NCLifecycle {
             const { object_size_greater_than = undefined, object_size_less_than = undefined, tags = undefined } = filter;
             const rule_prefix = prefix || filter.prefix;
             filter_policy += rule_prefix ? `AND PATH_NAME LIKE '${path.join(bucket_path, rule_prefix)}%'\n` : '';
-            filter_policy += object_size_greater_than ? `AND FILE_SIZE > ${object_size_greater_than}\n` : '';
-            filter_policy += object_size_less_than ? `AND FILE_SIZE < ${object_size_less_than}\n` : '';
+            filter_policy += object_size_greater_than === undefined ? '' : `AND FILE_SIZE > ${object_size_greater_than}\n`;
+            filter_policy += object_size_less_than === undefined ? '' : `AND FILE_SIZE < ${object_size_less_than}\n`;
             filter_policy += tags ? tags.map(tag => `AND XATTR('user.noobaa.tag.${tag.key}') LIKE ${tag.value}\n`).join('') : '';
         }
         return filter_policy;
@@ -1434,7 +1434,7 @@ class NCLifecycle {
             if (err.code === 'ENOENT') {
                 dbg.log2(`parse_candidates_from_gpfs_ilm_policy ilm_candidates_file_exists does not exist, no candidates to delete`);
                 this._set_rule_state(bucket_json, lifecycle_rule, finished_state);
-                return;
+                return [];
             }
             dbg.error('parse_candidates_from_gpfs_ilm_policy: error', err);
             throw err;

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_gpfs_ilm_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_gpfs_ilm_integration.test.js
@@ -477,7 +477,7 @@ function get_mock_base_ilm_policy(bucket_storage_path, rule_id, lifecycle_run_st
         `define( change_age, (DAYS(CURRENT_TIMESTAMP) - DAYS(CHANGE_TIME)) )\n`;
 
     const policy_rule_id = `${bucket_name}_${rule_id}_${lifecycle_run_status.lifecycle_run_times.run_lifecycle_start_time}`;
-    const policy_base = `RULE ${policy_rule_id} LIST ${policy_rule_id}\n` +
+    const policy_base = `RULE '${policy_rule_id}' LIST '${policy_rule_id}'\n` +
     `WHERE PATH_NAME LIKE '${bucket_storage_path}/%'\n` +
     `AND PATH_NAME NOT LIKE '${bucket_storage_path}/.noobaa_nsfs%/%'\n`;
 


### PR DESCRIPTION
### Describe the Problem
This PR aims to fix some small issues found while working on manual tests of lifecycle GPFS flow.

### Explain the Changes
1. size is a number - can be 0 - therefore we should check if it's undefined and not if truthy.
2. bucket name having dots/dash or others caused mmapply policy issues without ''.
3. parse_candidates_from_gpfs_ilm_policy() - if there were no candidates we accidently returned undefined instead of an empty array. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
