### PR TITLE
Fix anonymous user access with public_access defined and fix public_access tests

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1321,6 +1321,9 @@ module.exports = {
                 },
                 cors_configuration_rules: {
                     $ref: 'common_api#/definitions/bucket_cors_configuration',
+                },
+                public_access_block: {
+                    $ref: 'common_api#/definitions/public_access_block',
                 }
             }
         },

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -219,6 +219,7 @@ class ObjectSDK {
             system_owner: bucket.system_owner, // note that bucketspace_fs currently doesn't return system_owner
             bucket_owner: bucket.bucket_owner,
             owner_account: bucket.owner_account, // in NC NSFS this is the account id that owns the bucket
+            public_access_block: bucket.public_access_block,
         };
         return policy_info;
     }

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -716,6 +716,7 @@ async function read_bucket_sdk_info(req) {
             .then(get_bucket_info),
         notifications: bucket.notifications,
         cors_configuration_rules: bucket.cors_configuration_rules,
+        public_access_block: bucket.public_access_block,
     };
 
     if (bucket.namespace) {


### PR DESCRIPTION
### Describe the Problem
The problem was noticed by the QE while verifying PublicAccessBlock (PAB) feature for ODF. It was noticed that although the feature worked fine for the noobaa users but failed to work when anonymous user was used. That is, when a public policy was used and the `RestrictPublicAccess` was applied to it, the anonymous user could still access the data which is undesirable.

### Explain the Changes
There was missing `RestrictPublicAccess` check in the anonymous auth flow which this PR adds. Also, the tests were badly written by me or else our CI would have caught the issue. I have fixed those tests now.

### Issues: Fixed #xxx / Gap #xxx
Feature Epic:  https://issues.redhat.com/browse/RHSTOR-6623
Reported Issue: https://issues.redhat.com/browse/DFBUGS-2382

### Testing Instructions:
1. `./node_modules/.bin/jest src/test/unit_tests/jest_tests/test_s3_utils.test.js`
2. `./node_modules/.bin/mocha src/test/unit_tests/test_public_access_block.js`
3. `NC_CORETEST=true NC_NSFS_NO_DB_ENV=true ./node_modules/.bin/mocha src/test/unit_tests/test_public_access_block.js`


- [ ] Doc added/updated
- [x] Tests added
