### PR TITLE
NC | supplemental groups - getpwuid concurrency issue

### DIFF
--- a/src/native/util/os.h
+++ b/src/native/util/os.h
@@ -41,6 +41,20 @@ public:
         change_user();
     }
 
+    static void init_passwd_buf_size()
+    {
+        long passwd_bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+        if (passwd_bufsize == -1) {
+            passwd_bufsize = 16384;
+        }
+        passwd_buf_size = passwd_bufsize;
+    }
+
+    static long get_passwd_buf_size()
+    {
+        return passwd_buf_size;
+    }
+
     int add_thread_capabilities();
 
     const static uid_t orig_uid;
@@ -55,6 +69,8 @@ private:
     uid_t _uid;
     gid_t _gid;
     std::vector<gid_t> _groups;
+
+    static long passwd_buf_size;
 };
 
 } // namespace noobaa

--- a/src/native/util/os_linux.cpp
+++ b/src/native/util/os_linux.cpp
@@ -27,17 +27,21 @@ get_current_uid()
 
 const uid_t ThreadScope::orig_uid = getuid();
 const gid_t ThreadScope::orig_gid = getgid();
+long ThreadScope::passwd_buf_size = -1;
 
 const std::vector<gid_t> ThreadScope::orig_groups = get_process_groups();
 
 static int
 get_supplemental_groups_by_uid(uid_t uid, std::vector<gid_t>& groups)
 {
-    // getpwuid will only indicate if an error happened by setting errno. set it to 0, so will know if there is a change
-    errno = 0;
-    struct passwd* pw = getpwuid(uid);
+    const long passwd_buf_size = ThreadScope::get_passwd_buf_size();
+    std::unique_ptr<char[]> buf(new char[passwd_buf_size]);
+    struct passwd pwd;
+    struct passwd *pw = NULL;
+
+    const int res = getpwuid_r(uid, &pwd, buf.get(), passwd_buf_size, &pw);
     if (pw == NULL) {
-        if (errno == 0) {
+        if (res == 0) {
             // LOG("get_supplemental_groups_by_uid: no record for uid " << uid);
         } else {
             LOG("WARNING: get_supplemental_groups_by_uid: getpwuid failed: " << strerror(errno));


### PR DESCRIPTION
### Describe the Problem
as noted in #8982 : getpwuid function is not thread safe. so need to replace with thread safe getpwuid_r

### Explain the Changes
1. create a static variable for password buffer size in ThreadScope scope. initialize it from buffer length we got in fs_napi CTOR
2. replace getpwuid in both dynamic supplemental group usage for both linux and darwin.

### Issues: Fixed #8985 

### Testing Instructions:
1. for general supplemental groups tests run:
`sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_nsfs_access.js`


- [ ] Doc added/updated
- [x] Tests added
