### PR TITLE
Remove OPTIONS from default CORS rule

### DIFF
--- a/config.js
+++ b/config.js
@@ -172,7 +172,6 @@ config.S3_CORS_ALLOW_METHODS = [
     'POST',
     'PUT',
     'DELETE',
-    'OPTIONS'
 ];
 config.S3_CORS_ALLOW_HEADERS = [
     'Content-Type',


### PR DESCRIPTION
### Describe the Problem
As we want to work in the same way as AWS, also in our default CORS rule, we won't have OPTIONS anymore

### Explain the Changes
1. We removed options from the list of allowed methods in the default CORS rule

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-2273

### Testing Instructions:
1. Create a new bucket, or check the CORS rule of an existing bucket - see that you don't get OPTIONS in allowed methods anymore.


- [ ] Doc added/updated
- [ ] Tests added
