### PR TITLE
NSFS | fix key, key/ collition problem

### DIFF
--- a/config.js
+++ b/config.js
@@ -794,6 +794,7 @@ config.NSFS_DEFAULT_IOV_MAX = 1024; // see IOV_MAX in https://man7.org/linux/man
 config.NSFS_TEMP_DIR_NAME = '.noobaa-nsfs';
 
 config.NSFS_FOLDER_OBJECT_NAME = '.folder';
+config.NSFS_COLLITION_OBJECT_NAME = '.object';
 
 config.NSFS_DIR_CACHE_MAX_DIR_SIZE = 64 * 1024 * 1024;
 config.NSFS_DIR_CACHE_MIN_DIR_SIZE = 64;

--- a/src/test/unit_tests/test_bucketspace_versioning.js
+++ b/src/test/unit_tests/test_bucketspace_versioning.js
@@ -742,7 +742,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
             const list_res = await s3_uid6.listObjectVersions({ Bucket: content_dir_bucket_name });
             const key_list_versions = list_res.Versions.filter(v => v.Key === key);
             assert.equal(key_list_versions.length, 3);
-            assert.equal(list_res.DeleteMarkers.length, 3); // 2 previous delete markers + 1 new delete marker 
+            assert.equal(list_res.DeleteMarkers.length, 3); // 2 previous delete markers + 1 new delete marker
             let is_delete_marker_present = false;
             for (const delete_marker of list_res.DeleteMarkers) {
                 if (delete_marker.versionId === delete_res.created_version_id) {
@@ -3658,8 +3658,8 @@ async function create_empty_content_dir(fs_context, bucket_path, key) {
 
 /**
  * check_non_current_xattr_exists checks that the XATTR_NON_CURRENT_TIMESTASMP xattr exists
- * @param {String} full_path 
- * @param {String} [key] 
+ * @param {String} full_path
+ * @param {String} [key]
  * @returns {Promise<Void>}
  */
 async function check_non_current_xattr_exists(full_path, key = '') {
@@ -3669,8 +3669,8 @@ async function check_non_current_xattr_exists(full_path, key = '') {
 
 /**
  * check_non_current_xattr_does_not_exist checks that the XATTR_NON_CURRENT_TIMESTASMP xattr does not exist
- * @param {String} full_path 
- * @param {String} [key] 
+ * @param {String} full_path
+ * @param {String} [key]
  * @returns {Promise<Void>}
  */
 async function check_non_current_xattr_does_not_exist(full_path, key = '') {

--- a/src/test/unit_tests/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/test_nsfs_glacier_backend.js
@@ -259,8 +259,8 @@ mocha.describe('nsfs_glacier', function() {
                 source_stream: buffer_utils.buffer_to_read_stream(data)
             };
 
-            const failed_file_path = glacier_ns._get_file_path(failed_params);
-            const success_file_path = glacier_ns._get_file_path(success_params);
+            const failed_file_path = await glacier_ns._get_file_path(dummy_object_sdk, failed_params);
+            const success_file_path = await glacier_ns._get_file_path(dummy_object_sdk, success_params);
 
             const failure_backend = new TapeCloudGlacier();
             failure_backend._migrate = async () => true;
@@ -435,7 +435,7 @@ mocha.describe('nsfs_glacier', function() {
                 objs.map(async obj => {
                     // obj.Key will be the same as original key for as long as
                     // no custom encoding is provided
-                    const file_path = glacier_ns._get_file_path({ key: obj.Contents.Key });
+                    const file_path = await glacier_ns._get_file_path(fs_context, { key: obj.Contents.Key });
                     const stat = await nb_native().fs.stat(fs_context, file_path);
 
                     // @ts-ignore


### PR DESCRIPTION
### Describe the Problem
for content directory objects we create a directory with the name of the object without the '/' in the end. this can cause a collision if there is already an object with the same key just without the '/' at the end. in that case we will instead have an object named ".object" inside the directory for that object. versioning still works the same, the versions will be in the .version directory where it would have also been if there was no collision

### Explain the Changes
1. in case there is a collision, move the key to inside the directory as `.object` key
2. change _get_file_path to account for this new location possibility
3. add case for list object that if there is a directory object we should check for this .object file as well
4. add tests

### Issues: Fixed #8320

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added
