### PR TITLE
Read postgres connection details from a file

### DIFF
--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -134,6 +134,22 @@ async function disk_usage(root) {
     return { size, count };
 }
 
+// try to read a file synchronously. If the file does not exist, return undefined
+// if the file exists but is not readable, throw an error
+// if the file exists and is readable, return the content
+function try_read_file_sync(file_name) {
+    if (!file_name) return;
+    try {
+        return fs.readFileSync(file_name, 'utf8');
+    } catch (err) {
+        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+            // file does not exist or is not a directory
+            return;
+        }
+        throw err;
+    }
+}
+
 
 // returns the first line in the file that contains the substring
 async function find_line_in_file(file_name, line_sub_string) {
@@ -356,3 +372,4 @@ exports.ignore_enoent = ignore_enoent;
 exports.PRIVATE_DIR_PERMISSIONS = PRIVATE_DIR_PERMISSIONS;
 exports.file_exists = file_exists;
 exports.file_not_exists = file_not_exists;
+exports.try_read_file_sync = try_read_file_sync;


### PR DESCRIPTION
### Explain the Changes
- Reading the DB connection details from a file. This supports passing the secret data from the operator in a more secure way, by volume mount instead of an env
- The existing environment variables are still inspected, allowing overrides if needed.
- The operator should be updated to use a volume mount following this PR.

### Issues: Fixed #xxx / Gap #xxx
1. Partial fix to https://issues.redhat.com/browse/DFBUGS-1466. 


### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
