### PR TITLE
NC | lifecycle | _parse_key_from_line remove redundant / at the beginning of the file key

### DIFF
--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -1459,7 +1459,7 @@ class NCLifecycle {
     _parse_key_from_line(entry, bucket_json) {
         const line_array = entry.path.split(' ');
         const file_path = line_array[line_array.length - 1];
-        let file_key = file_path.replace(bucket_json.path, '');
+        let file_key = file_path.replace(path.join(bucket_json.path, '/'), '');
         const basename = path.basename(file_key);
         if (basename.startsWith(config.NSFS_FOLDER_OBJECT_NAME)) {
             file_key = path.join(path.dirname(file_key), '/');


### PR DESCRIPTION
### Describe the Problem
If bucket path is configured without trailing '/', _parse_key_from_line() return a key that contained starting '/' which caused an error when trying to delete the object due to re-check of the prefix.

### Explain the Changes
1. On _parse_key_from_line()  - Added trailing '/' when removing the bucket path.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - add auto tests

### Testing Instructions:
1. Manual - 
1. create a bucket configured with a path without a trailing /.
``` 
noobaa-cli bucket update --name bucket10 --path /mnt/gpfs0/romy/demo/bucket10
mkdir /mnt/gpfs0/romy/demo/bucket10/data/
for i in {1..10} ; do touch -d  "10 days ago"  /mnt/gpfs0/romy/demo/bucket10/logs/file${i}.txt ; done
noobaa-cli lifecycle --disable_runtime_validation

// if bug was reproduced expect to see the following output - 
"bucket10": {
          "bucket_process_times": {
            "process_bucket_start_time": 1747122262442,
            "process_bucket_end_time": 1747122262691,
            "process_bucket_took_ms": 249
          },
          "bucket_stats": {
            "num_objects_deleted": 0,
            "num_objects_delete_failed": 20,
            "objects_delete_errors": [
              {
                "err_code": "FILTER_MATCH_FAILED",
                "err_message": "file_matches_filter lifecycle - filter on file returned false /logs/file7.txt"
              },
              {
                "err_code": "FILTER_MATCH_FAILED",
                "err_message": "file_matches_filter lifecycle - filter on file returned false /logs/file9.txt"
              },
              {
                "err_code": "FILTER_MATCH_FAILED",
                "err_message": "file_matches_filter lifecycle - filter on file returned false /logs/file6.txt"
              },
              {
                "err_code": "FILTER_MATCH_FAILED",
                "err_message": "file_matches_filter lifecycle - filter on file returned false /logs/file5.txt"
              },
              {
                "err_code": "FILTER_MATCH_FAILED",
                "err_message": "file_matches_filter lifecycle - filter on file returned false /logs/file2.txt"
              },
              {
                "err_code": "FILTER_MATCH_FAILED",
                "err_message": "file_matches_filter lifecycle - filter on file returned false /logs/file4.txt"
              },
              {
                "err_code": "FILTER_MATCH_FAILED",
....
}
```


- [ ] Doc added/updated
- [ ] Tests added
