### PR TITLE
Added a validation for deletion of anonymous account with --name

### DIFF
--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -350,6 +350,12 @@ function validate_flags_value_combination(type, action, input_options_with_data)
                 throw_cli_error(ManageCLIError.InvalidAccountName, detail);
             }
         }
+        if (action === ACTIONS.DELETE) {
+            if (input_options_with_data.name === ANONYMOUS) {
+                const detail = `Please use --${ANONYMOUS} flag to delete the ${ANONYMOUS} account`;
+                throw_cli_error(ManageCLIError.InvalidAccountName, detail);
+            }
+        }
     }
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js
@@ -1705,6 +1705,24 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.AccountDeleteForbiddenHasIAMAccounts.code);
         });
 
+        it('should fail when deleting anonymous account with option (name), and succeed with option (anonymous)', async function() {
+            const { type } = defaults;
+            const user = 'test-user';
+            const account_options1 = { user: user };
+            const command = create_command(type, ACTIONS.ADD, account_options1);
+            const flag = ANONYMOUS;
+            await exec_manage_cli_add_empty_option(command, flag);
+
+            const account_options2 = { name: ANONYMOUS };
+            const res = await exec_manage_cli(type, ACTIONS.DELETE, account_options2);
+            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidAccountName.message);
+
+            const command2 = create_command(type, ACTIONS.DELETE);
+            const res2 = await exec_manage_cli_add_empty_option(command2, flag);
+            const res_json = JSON.parse(res2.trim());
+            expect(res_json.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
+        });
+
     });
 
     describe('cli status account', () => {


### PR DESCRIPTION
### Describe the Problem
Currently, we are allowing user to delete the anonymous account with below command:
`noobaa-cli account delete --name anonymous`

### Explain the Changes
1. Added a validation to not delete the anonymous account with --name.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: #8856 

### Testing Instructions:
1.  `sudo npx jest noobaa-core/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js`
- [X] Tests added
