### PR TITLE
fix(fs_utils):  Ignore only ENOENT in the context of readFileSync

### DIFF
--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -142,8 +142,8 @@ function try_read_file_sync(file_name) {
     try {
         return fs.readFileSync(file_name, 'utf8');
     } catch (err) {
-        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
-            // file does not exist or is not a directory
+        if (err.code === 'ENOENT') {
+            // file does not exist
             return;
         }
         throw err;


### PR DESCRIPTION
### Explain the Changes
 ENOTDIR is not expected to be returned by readFileSync() hence remove it in this context.

### Issues: Fixed #xxx / Gap #xxx

### Testing Instructions:

- [ ] Doc added/updated
- [ ] Tests added
