### PR TITLE
CORS | Allowed headers regexp check should be case insensitive

### DIFF
--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -731,7 +731,7 @@ function set_cors_headers_s3(req, res, cors_rules) {
     const matched_rule = req.headers.origin && ( // find the first rule with origin and method match
         cors_rules.find(rule => {
             const allowed_origins_regex = rule.allowed_origins.map(r => RegExp(`^${r.replace(/\*/g, '.*')}$`));
-            const allowed_headers_regex = rule.allowed_headers?.map(r => RegExp(`^${r.replace(/\*/g, '.*')}$`));
+            const allowed_headers_regex = rule.allowed_headers?.map(r => RegExp(`^${r.replace(/\*/g, '.*')}$`, 'i'));
             return allowed_origins_regex.some(r => r.test(match_origin)) &&
                 rule.allowed_methods.includes(match_method) &&
                 // we can match if no request headers or if reuqest headers match the rule allowed headers


### PR DESCRIPTION
### Describe the Problem
As for today, if a user provided a request header that is not matching in the case (upper/lower) to the configured CORS allowed headers we fail although headers should be case insensitive.

### Explain the Changes
1. Added 'i' to the allowed headers regexp to allow case insensitivity.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-2621

### Testing Instructions:
1. Auto - `./node_modules/mocha/bin/mocha.js src/test/unit_tests/test_s3_ops.js --g "bucket-cors"`
2. Manual - see reproduction steps mentioned in the bug.


- [ ] Doc added/updated
- [x] Tests added
