### PR TITLE
Added a fix to not include the temp dir in list objects

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -767,7 +767,7 @@ class NamespaceFS {
                     // dbg.log0('process_entry', dir_key, ent.name);
                     if (!ent.name.startsWith(prefix_ent) ||
                         ent.name < marker_curr ||
-                        ent.name === this.get_bucket_tmpdir_name() ||
+                        ent.name.startsWith(config.NSFS_TEMP_DIR_NAME) ||
                         (ent.name === config.NSFS_FOLDER_OBJECT_NAME && is_disabled_dir_content) ||
                         this._is_hidden_version_path(ent.name)) {
                         return;


### PR DESCRIPTION
### Describe the Problem
Currently, when we do `list_objects` for a bucket then for non versioned bucket in the response it will print the temp/hidden dir (starts with `.noobaa-nsfs`) that is already present inside the directory but for versioned bucket the tmp/hidden dir cannot be printed in the response and we can found the `Version dir not found` logs.

### Explain the Changes
1.  Added a fix to exclude temp dir (starts with `.noobaa-nsfs`) from the object listing response.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed: #8908 

### Testing Instructions:
1. To run test: `sudo node node_modules/mocha/bin/mocha src/test/unit_tests/test_namespace_fs.js`
- [X] Tests added
