### PR TITLE
SDK | Upgrade AWS SDK to v3 - Unit tests

### DIFF
--- a/src/server/bg_services/replication_server.js
+++ b/src/server/bg_services/replication_server.js
@@ -52,7 +52,7 @@ async function delete_objects(req) {
                 Delete: {
                     Objects: batch.map(key => ({ Key: key }))
                 }
-            }).promise();
+            });
 
             res.Deleted?.forEach(obj => delete_done_list.push(obj.Key));
         } catch (err) {
@@ -83,7 +83,7 @@ async function copy_objects_mixed_types(req) {
                 Key: key
             };
             try {
-                await noobaa_con.copyObject(params).promise();
+                await noobaa_con.copyObject(params);
                 copy_res.num_of_objects += 1;
                 // The size of the object can be in either Size or ContentLength, depending on whether
                 // the request was ListObjectVersions or HeadObject
@@ -100,7 +100,7 @@ async function copy_objects_mixed_types(req) {
                     Key: key
                 };
                 try {
-                    await noobaa_con.copyObject(params).promise();
+                    await noobaa_con.copyObject(params);
                     copy_res.num_of_objects += 1;
                     copy_res.size_of_objects += keys_diff_map[key][i].Size;
                 } catch (err) {

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -77,7 +77,7 @@ function update_replication_prom_report(bucket_name, replication_policy_id, repl
 /**
  * @param {any} bucket_name
  * @param {string} key
- * @param {AWS.S3} s3
+ * @param {import('@aws-sdk/client-s3').S3} s3
  * @param {string} version_id
  */
 async function get_object_md(bucket_name, key, s3, version_id) {
@@ -90,7 +90,7 @@ async function get_object_md(bucket_name, key, s3, version_id) {
 
     dbg.log1('get_object_md params:', params);
     try {
-        const head = await s3.headObject(params).promise();
+        const head = await s3.headObject(params);
         //for namespace s3 we are omitting the 'noobaa-namespace-s3-bucket' as it will be defer between buckets
         if (head?.Metadata) head.Metadata = _.omit(head.Metadata, 'noobaa-namespace-s3-bucket');
         dbg.log1('get_object_md: finished successfully', head);

--- a/src/test/system_tests/test_build_chunks.js
+++ b/src/test/system_tests/test_build_chunks.js
@@ -10,7 +10,7 @@ dbg.set_process_name('test_build_chunks');
 
 const _ = require('lodash');
 const fs = require('fs');
-const AWS = require('aws-sdk');
+const { S3 } = require('@aws-sdk/client-s3');
 // const util = require('util');
 // const crypto = require('crypto');
 
@@ -112,23 +112,17 @@ async function setup_case(
 
 async function upload_random_file(size_mb, bucket_name, extension, content_type) {
     const filename = await ops.generate_random_file(size_mb, extension);
-    const s3bucket = new AWS.S3({
+    const s3bucket = new S3({
         endpoint: TEST_CTX.s3_endpoint,
         credentials: {
             accessKeyId: '123',
             secretAccessKey: 'abc'
         },
-        s3ForcePathStyle: true,
-        sslEnabled: false
+        forcePathStyle: true,
+        tls: false
     });
-
-    await P.ninvoke(s3bucket, 'upload', {
-        Bucket: bucket_name,
-        Key: filename,
-        Body: fs.createReadStream(filename),
-        ContentType: content_type
-    });
-
+    await s3bucket.putObject({Bucket: bucket_name, Key: filename,
+        Body: fs.createReadStream(filename), ContentType: content_type});
     return filename;
 }
 

--- a/src/test/system_tests/test_cloud_pools.js
+++ b/src/test/system_tests/test_cloud_pools.js
@@ -5,7 +5,7 @@ const api = require('../../api');
 const rpc = api.new_rpc();
 const util = require('util');
 const _ = require('lodash');
-const AWS = require('aws-sdk');
+const { S3 } = require('@aws-sdk/client-s3');
 const argv = require('minimist')(process.argv);
 const P = require('../../util/promise');
 const basic_server_ops = require('../utils/basic_server_ops');
@@ -13,15 +13,16 @@ const dotenv = require('../../util/dotenv');
 dotenv.load();
 const test_utils = require('./test_utils');
 
-const s3 = new AWS.S3({
+const s3 = new S3({
     // endpoint: 'https://s3.amazonaws.com',
     credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
     },
-    s3ForcePathStyle: true,
-    sslEnabled: false,
-    signatureVersion: 'v4',
+    forcePathStyle: true,
+    tls: false,
+    // signatureVersion is Deprecated in SDK v3
+    //signatureVersion: 'v4',
     // region: 'eu-central-1'
 });
 
@@ -295,15 +296,16 @@ function run_test() {
                 .then(() => block_ids);
         })
         .then(function(block_ids) {
-            return P.ninvoke(new AWS.S3({
+            return P.ninvoke(new S3({
                     endpoint: 'http://' + TEST_CTX.source_ip,
                     credentials: {
                         accessKeyId: argv.access_key || '123',
                         secretAccessKey: argv.secret_key || 'abc'
                     },
-                    s3ForcePathStyle: true,
-                    sslEnabled: false,
-                    signatureVersion: 'v4',
+                    forcePathStyle: true,
+                    tls: false,
+                    // signatureVersion is Deprecated in SDK v3
+                    //signatureVersion: 'v4',
                     // region: 'eu-central-1'
                 }), 'deleteObject', {
                     Bucket: TEST_CTX.source_bucket,

--- a/src/test/system_tests/test_lifecycle.js
+++ b/src/test/system_tests/test_lifecycle.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const assert = require('assert');
-const AWS = require('aws-sdk');
+const { S3 } = require('@aws-sdk/client-s3');
 const crypto = require('crypto');
 const commonTests = require('../lifecycle/common');
 
@@ -12,14 +12,16 @@ assert(process.env.AWS_ENDPOINT, "Please set AWS_ENDPOINT env. variable, example
 assert(process.env.AWS_ACCESS_KEY_ID, "Please set AWS_ACCESS_KEY_ID env. variable, example 'XXXXXXXXXXXXXXXXXXXX'");
 assert(process.env.AWS_SECRET_ACCESS_KEY, "Please set AWS_SECRET_ACCESS_KEY env. variable, example 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'");
 
-const s3 = new AWS.S3({
+const s3 = new S3({
     endpoint: process.env.AWS_ENDPOINT, // 'https://s3.amazonaws.com/',
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+    credentials: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
 });
 
 async function main() {
-    const buckets = await s3.listBuckets().promise();
+    const buckets = await s3.listBuckets();
     console.log('buckets', buckets);
     assert(buckets.Buckets);
     const Bucket = process.env.AWS_BUCKET;
@@ -38,7 +40,7 @@ async function main() {
         Body,
     };
 
-    const putObjectResult = await s3.putObject(putObjectParams).promise();
+    const putObjectResult = await s3.putObject(putObjectParams);
     console.log('put object params:', putObjectParams, 'result', putObjectResult);
     assert(putObjectResult.ETag);
 
@@ -59,7 +61,7 @@ async function main() {
         Bucket,
         Key,
     };
-    const getObjectResult = await s3.getObject(getObjectParams).promise();
+    const getObjectResult = await s3.getObject(getObjectParams);
     const getObjectEtag = getObjectResult.ETag;
     console.log("get object result", getObjectResult, "ETag", getObjectEtag);
 
@@ -67,7 +69,7 @@ async function main() {
     await s3.deleteObject({
         Bucket,
         Key
-    }).promise();
+    });
     console.log('delete test object key', Key);
     console.log('✅ The test was completed successfully');
 }

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -48,12 +48,12 @@ function get_tmp_path() {
 const is_nc_coretest = process.env.NC_CORETEST === 'true';
 
 /**
- *
- * @param {*} need_to_exist
- * @param {*} pool_id
- * @param {*} bucket_name
- * @param {*} blocks
- * @param {AWS.S3} s3
+ * 
+ * @param {*} need_to_exist 
+ * @param {*} pool_id 
+ * @param {*} bucket_name 
+ * @param {*} blocks 
+ * @param {S3} s3 
  */
 async function blocks_exist_on_cloud(need_to_exist, pool_id, bucket_name, blocks, s3) {
     console.log('blocks_exist_on_cloud::', need_to_exist, pool_id, bucket_name);
@@ -70,7 +70,7 @@ async function blocks_exist_on_cloud(need_to_exist, pool_id, bucket_name, blocks
                 return s3.headObject({
                     Bucket: bucket_name,
                     Key: `noobaa_blocks/${pool_id}/blocks_tree/${block.slice(block.length - 3)}.blocks/${block}`
-                }).promise();
+                });
             }));
 
             let condition_correct;
@@ -885,6 +885,27 @@ function set_health_mock_functions(Health, mock_function_responses) {
 }
 
 
+/**
+ * return the response body and metadata
+ * 
+ * @param {import('@aws-sdk/client-s3').S3} s3_client
+ * @param {any} bucket_name
+ * @param {string} key
+ * 
+ * */
+async function get_object(s3_client, bucket_name, key) {
+    try {
+        const res = await s3_client.getObject({ Bucket: bucket_name, Key: key });
+        const metadata = res.Metadata;
+        const body = await res.Body.transformToString('utf-8');
+        return { body, metadata };
+    } catch (err) {
+      console.error("Error while getting object for bucket: ", bucket_name, " Key: ", key, err);
+      throw err;
+    }
+}
+
+
 exports.update_file_mtime = update_file_mtime;
 exports.generate_lifecycle_rule = generate_lifecycle_rule;
 exports.validate_expiration_header = validate_expiration_header;
@@ -929,3 +950,4 @@ exports.create_config_dir = create_config_dir;
 exports.clean_config_dir = clean_config_dir;
 exports.CLI_UNSET_EMPTY_STRING = CLI_UNSET_EMPTY_STRING;
 exports.set_health_mock_functions = set_health_mock_functions;
+exports.get_object = get_object;

--- a/src/test/unit_tests/jest_tests/test_bucket_diff.test.js
+++ b/src/test/unit_tests/jest_tests/test_bucket_diff.test.js
@@ -11,6 +11,7 @@ const replication_utils = require('../../../server/utils/replication_utils');
 const mock_fn = jest.fn();
 const mock_fn2 = jest.fn();
 
+
 describe('fail on improper constructor call', () => {
     it('should fail when there is no connection and no s3_params', () => {
         const params = {
@@ -32,8 +33,10 @@ describe('BucketDiff', () => {
             let expected;
             beforeEach(() => {
                 const s3_params = {
-                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                    credentials: {
+                        accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                        secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                    },
                 };
                 bucketDiff = new BucketDiff({
                     first_bucket: 'first-bucket',
@@ -136,8 +139,10 @@ describe('BucketDiff', () => {
             let expected;
             beforeEach(() => {
                 const s3_params = {
-                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                    credentials: {
+                        accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                        secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                    },
                 };
                 bucketDiff = new BucketDiff({
                     first_bucket: 'first-bucket',
@@ -238,8 +243,10 @@ describe('BucketDiff', () => {
             let expected;
             beforeEach(() => {
                 const s3_params = {
-                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                    credentials: {
+                        accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                        secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                    },
                 };
                 bucketDiff = new BucketDiff({
                     first_bucket: 'first-bucket',
@@ -292,8 +299,10 @@ describe('BucketDiff', () => {
                 keep_listing_second_bucket: false,
             };
             const s3_params = {
-                accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                credentials: {
+                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                },
             };
             bucketDiff = new BucketDiff({
                 first_bucket: 'first-bucket',
@@ -369,15 +378,15 @@ describe('BucketDiff', () => {
 
 describe('_process_keys_in_range with version', () => {
     let ans;
-    let s3_params;
     let bucketDiff;
     let second_bucket_cont_token;
     beforeEach(() => {
-        s3_params = {
-            accessKeyId: 'YOUR_ACCESS_KEY_ID',
-            secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+        const s3_params = {
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
         };
-
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -668,6 +677,12 @@ describe('_process_keys_in_range with version', () => {
     });
 
     it('case 3: should update keys_diff_map and keys_contents_left when LastModified in the first bucket is newer', async () => {
+        const s3_params = {
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
+        };
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -703,6 +718,12 @@ describe('_process_keys_in_range with version', () => {
     });
 
     it('case 3: should update only keys_contents_left when LastModified in the second bucket is newer', async () => {
+        const s3_params = {
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
+        };
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -737,15 +758,15 @@ describe('_process_keys_in_range with version', () => {
 
 describe('_process_keys_in_range with version for for_deletion enabled', () => {
     let ans;
-    let s3_params;
     let bucketDiff;
     let second_bucket_cont_token;
     beforeEach(() => {
-        s3_params = {
-            accessKeyId: 'YOUR_ACCESS_KEY_ID',
-            secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+        const s3_params = {
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
         };
-
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -828,14 +849,14 @@ describe('_process_keys_in_range with version for for_deletion enabled', () => {
 describe('_process_keys_in_range without version', () => {
     let ans;
     let bucketDiff;
-    let s3_params;
     let second_bucket_cont_token;
     beforeEach(() => {
-        s3_params = {
-            accessKeyId: 'YOUR_ACCESS_KEY_ID',
-            secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+        const s3_params = {
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
         };
-
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -959,6 +980,12 @@ describe('_process_keys_in_range without version', () => {
     });
 
     it('case 3: should update keys_diff_map and keys_contents_left when LastModified in the first bucket is newer', async () => {
+        const s3_params = {
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
+        };
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -981,6 +1008,12 @@ describe('_process_keys_in_range without version', () => {
     });
 
     it('case 3: should update only keys_contents_left when LastModified in the second bucket is newer', async () => {
+        const s3_params = {
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
+        };
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -1012,10 +1045,11 @@ describe('BucketDiff aiding functions', () => {
             let bucketDiff;
             beforeEach(() => {
                 const s3_params = {
-                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                    credentials: {
+                        accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                        secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                    },
                 };
-
                 bucketDiff = new BucketDiff({
                     first_bucket: 'first-bucket',
                     second_bucket: 'second-bucket',
@@ -1100,8 +1134,10 @@ describe('BucketDiff aiding functions', () => {
             let bucketDiff;
             beforeEach(() => {
                 const s3_params = {
-                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                    credentials: {
+                        accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                        secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                    },
                 };
                 bucketDiff = new BucketDiff({
                     first_bucket: 'first-bucket',
@@ -1140,8 +1176,10 @@ describe('BucketDiff aiding functions', () => {
             let bucketDiff;
             beforeEach(() => {
                 const s3_params = {
-                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                    credentials: {
+                        accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                        secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                    },
                 };
                 bucketDiff = new BucketDiff({
                     first_bucket: 'first-bucket',
@@ -1169,10 +1207,12 @@ describe('BucketDiff aiding functions', () => {
         });
         describe('_get_next_key_marker without version', () => {
             let bucketDiff;
-            beforeEach(() => {
+             beforeEach(() => {
                 const s3_params = {
-                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                    credentials: {
+                        accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                        secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                    },
                 };
                 bucketDiff = new BucketDiff({
                     first_bucket: 'first-bucket',
@@ -1195,8 +1235,10 @@ describe('BucketDiff aiding functions', () => {
         let bucketDiff;
         beforeEach(() => {
             const s3_params = {
-                accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                credentials: {
+                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                },
             };
             bucketDiff = new BucketDiff({
                 first_bucket: 'first-bucket',
@@ -1256,8 +1298,10 @@ describe('BucketDiff aiding functions', () => {
         const second_bucket_curr_obj = {};
         beforeEach(() => {
             const s3_params = {
-                accessKeyId: 'YOUR_ACCESS_KEY_ID',
-                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+                credentials: {
+                    accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                    secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                },
             };
             bucketDiff = new BucketDiff({
                 first_bucket: 'first-bucket',
@@ -1352,10 +1396,11 @@ describe('BucketDiff get_keys_diff case 3 with version', () => {
     let second_bucket_cont_token;
     beforeEach(() => {
         const s3_params = {
-            accessKeyId: 'YOUR_ACCESS_KEY_ID',
-            secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
         };
-
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -1632,10 +1677,11 @@ describe('BucketDiff get_keys_diff', () => {
     let second_bucket_cont_token;
     beforeEach(() => {
         const s3_params = {
-            accessKeyId: 'YOUR_ACCESS_KEY_ID',
-            secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
         };
-
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',
@@ -1774,10 +1820,11 @@ describe('BucketDiff get_buckets_diff', () => {
     let bucketDiff;
     beforeEach(() => {
         const s3_params = {
-            accessKeyId: 'YOUR_ACCESS_KEY_ID',
-            secretAccessKey: 'YOUR_SECRET_ACCESS_KEY'
+            credentials: {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+            },
         };
-
         bucketDiff = new BucketDiff({
             first_bucket: 'first-bucket',
             second_bucket: 'second-bucket',

--- a/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_account_cli.test.js
@@ -823,7 +823,7 @@ describe('manage nsfs cli account flow', () => {
                 await exec_manage_cli(type, action, account_options);
                 new_account_details = await config_fs.get_account_by_name(new_name, config_fs_account_options);
                 expect(new_account_details.name).toBe(new_name);
-            });
+            }, timeout);
 
             it('cli account update access key, secret_key & new_name by name', async function() {
                 const { name } = defaults;

--- a/src/test/unit_tests/test_s3_worm.js
+++ b/src/test/unit_tests/test_s3_worm.js
@@ -4,7 +4,8 @@
 // setup coretest first to prepare the env
 const coretest = require('./coretest');
 coretest.setup({ pools_to_create: coretest.POOL_LIST });
-const AWS = require('aws-sdk');
+const { S3 } = require('@aws-sdk/client-s3');
+const { NodeHttpHandler } = require("@smithy/node-http-handler");
 const http = require('http');
 const mocha = require('mocha');
 const assert = require('assert');
@@ -22,6 +23,7 @@ async function assert_throws_async(promise, expected_code = 'AccessDenied', expe
         if (err.message !== expected_message || err.code !== expected_code) throw err;
     }
 }
+// eslint-disable-next-line max-lines-per-function
 mocha.describe('s3 worm', function() {
     const { rpc_client, EMAIL } = coretest;
     const BKT = 'wormbucket';
@@ -44,98 +46,103 @@ mocha.describe('s3 worm', function() {
         self.timeout(60000);
         const s3_creds = {
             endpoint: coretest.get_http_address(),
-            s3ForcePathStyle: true,
-            signatureVersion: 'v4',
-            computeChecksums: true,
+            forcePathStyle: true,
+            // signatureVersion is Deprecated in SDK v3
+            //signatureVersion: 'v4',
+            // automatically compute the MD5 checksums for of the request payload in SDKV3
+            //computeChecksums: true,
+            //  s3DisableBodySigning renamed to applyChecksum but can be assigned in S3 object but cant find
             s3DisableBodySigning: false,
             region: 'us-east-1',
-            httpOptions: { agent: new http.Agent({ keepAlive: false }) },
+            requestHandler: new NodeHttpHandler({
+                    httpsAgent: new http.Agent({ keepAlive: false })
+                })
         };
         const account = { has_login: false, s3_access: true };
         const admin_keys = (await rpc_client.account.read_account({ email: EMAIL, })).access_keys;
         account.name = user_a;
         account.email = user_a;
         const user_a_keys = (await rpc_client.account.create_account(account)).access_keys;
-        s3_creds.accessKeyId = user_a_keys[0].access_key.unwrap();
-        s3_creds.secretAccessKey = user_a_keys[0].secret_key.unwrap();
+        s3_creds.credentials.accessKeyId = user_a_keys[0].access_key.unwrap();
+        s3_creds.credentials.secretAccessKey = user_a_keys[0].secret_key.unwrap();
         //s3_a = new AWS.S3(s3_creds);
-        s3_creds.accessKeyId = admin_keys[0].access_key.unwrap();
-        s3_creds.secretAccessKey = admin_keys[0].secret_key.unwrap();
-        s3_owner = new AWS.S3(s3_creds);
+        s3_creds.credentials.accessKeyId = admin_keys[0].access_key.unwrap();
+        s3_creds.credentials.secretAccessKey = admin_keys[0].secret_key.unwrap();
+        s3_owner = new S3(s3_creds);
     });
     mocha.describe('buckets creation', function() {
         mocha.it('create bucket BKT & enable lock', async function() {
-            const res = await s3_owner.createBucket({ Bucket: BKT, ObjectLockEnabledForBucket: true }).promise();
+            const res = await s3_owner.createBucket({ Bucket: BKT, ObjectLockEnabledForBucket: true });
             assert.equal(res.Location, `/${BKT}`);
         });
         mocha.it('create bucket BKT1 & enable lock', async function() {
-            const res = await s3_owner.createBucket({ Bucket: BKT1, ObjectLockEnabledForBucket: true }).promise();
+            const res = await s3_owner.createBucket({ Bucket: BKT1, ObjectLockEnabledForBucket: true });
             assert.equal(res.Location, `/${BKT1}`);
         });
         mocha.it('list buckets with BKT & BKT1', async function() {
-            const res = await s3_owner.listBuckets().promise();
+            const res = await s3_owner.listBuckets();
             assert(res.Buckets.find(bucket => bucket.Name === BKT));
             assert(res.Buckets.find(bucket => bucket.Name === BKT1));
         });
         mocha.it('should fail suspend versioning on locked bucket', async function() {
-            await assert_throws_async(s3_owner.putBucketVersioning({
+            await assert_throws_async(await s3_owner.putBucketVersioning({
                 Bucket: BKT,
                 VersioningConfiguration: { MFADelete: 'Disabled', Status: 'Suspended' }
-            }).promise(), 'InvalidBucketState', 'The request is not valid with the current state of the bucket.');
+            }), 'InvalidBucketState', 'The request is not valid with the current state of the bucket.');
         });
     });
     mocha.describe('object OBJ1 creation before having lock config on BKT', function() {
         mocha.it('create object OBJ1 in BKT', async function() {
-            const put_object_res = await s3_owner.putObject({ Bucket: BKT, Key: OBJ1, Body: file_body, ContentType: 'text/plain' }).promise();
+            const put_object_res = await s3_owner.putObject({ Bucket: BKT, Key: OBJ1, Body: file_body, ContentType: 'text/plain' });
             version_id1 = put_object_res.VersionId;
             assert.ok(put_object_res.VersionId);
         });
         mocha.it('IT6. should list objects in BKT', async function() {
-            const res = await s3_owner.listObjects({ Bucket: BKT }).promise();
+            const res = await s3_owner.listObjects({ Bucket: BKT });
             assert(res.Contents.find(object => object.Key === OBJ1));
         });
     });
     mocha.describe('bucket object lock configuration on BKT', function() {
         mocha.it('should fail put lock configuration with boch days and years', async function() {
-            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+            await assert_throws_async(await s3_owner.putObjectLockConfiguration({
                 Bucket: BKT,
                 ObjectLockConfiguration: {
                     ObjectLockEnabled: 'Enabled',
                     Rule: { DefaultRetention: { Years: 1, Days: 15, Mode: 'COMPLIANCE' } }
                 }
-            }).promise(), 'MalformedXML', malformedXML_message);
+            }), 'MalformedXML', malformedXML_message);
         });
         mocha.it('should fail put lock configuration with 0 years', async function() {
-            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+            await assert_throws_async(await s3_owner.putObjectLockConfiguration({
                 Bucket: BKT,
                 ObjectLockConfiguration: {
                     ObjectLockEnabled: 'Enabled',
                     Rule: { DefaultRetention: { Years: 0, Mode: 'GOVERNANCE' } }
                 }
-            }).promise(), 'InvalidArgument', 'Default retention period must be a positive integer value');
+            }), 'InvalidArgument', 'Default retention period must be a positive integer value');
         });
         mocha.it('should fail put faulty lock configuration', async function() {
-            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+            await assert_throws_async(await s3_owner.putObjectLockConfiguration({
                 Bucket: BKT,
                 ObjectLockConfiguration: {
                     ObjectLockEnabled: 'Enabled',
                     Rule: { DefaultRetention: { Days: 1, Mode: 'GOVERNANCE1' } }
                 }
-            }).promise(), 'MalformedXML', malformedXML_message);
+            }), 'MalformedXML', malformedXML_message);
         });
         mocha.it('should get empty lock configuration', async function() {
-            const conf = await s3_owner.getObjectLockConfiguration({ Bucket: BKT }).promise();
+            const conf = await s3_owner.getObjectLockConfiguration({ Bucket: BKT });
             assert.equal(conf.ObjectLockEnabled, 'Enabled');
             assert.strictEqual(conf.ObjectLockConfiguration.Rule, undefined);
         });
         mocha.it('should fail put lock configuration with disabled lock', async function() {
-            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+            await assert_throws_async(await s3_owner.putObjectLockConfiguration({
                 Bucket: BKT,
                 ObjectLockConfiguration: {
                     ObjectLockEnabled: 'Disabled',
                     Rule: { DefaultRetention: { Days: 15, Mode: 'COMPLIANCE' } }
                 }
-            }).promise(), 'MalformedXML', malformedXML_message);
+            }), 'MalformedXML', malformedXML_message);
         });
         mocha.it('should put lock configuration', async function() {
             const conf = await s3_owner.putObjectLockConfiguration({
@@ -144,11 +151,11 @@ mocha.describe('s3 worm', function() {
                     ObjectLockEnabled: 'Enabled',
                     Rule: { DefaultRetention: { Days: 15, Mode: 'COMPLIANCE' } }
                 }
-            }).promise();
+            });
             assert.deepEqual(conf, {});
         });
         mocha.it('should get non empty lock configuration', async function() {
-            const conf = await s3_owner.getObjectLockConfiguration({ Bucket: BKT }).promise();
+            const conf = await s3_owner.getObjectLockConfiguration({ Bucket: BKT });
             assert.ok(conf.ObjectLockConfiguration.Rule.DefaultRetention);
             assert.strictEqual(conf.ObjectLockConfiguration.Rule.DefaultRetention.Mode, 'COMPLIANCE');
             assert.strictEqual(conf.ObjectLockConfiguration.Rule.DefaultRetention.Days, 15);
@@ -156,7 +163,7 @@ mocha.describe('s3 worm', function() {
     });
     mocha.describe('OBJ1 checks', function() {
         mocha.it('should head object without default values of the BKT conf', async function() {
-            const conf = await s3_owner.headObject({ Bucket: BKT, Key: OBJ1 }).promise();
+            const conf = await s3_owner.headObject({ Bucket: BKT, Key: OBJ1 });
             assert.ok(!conf.ObjectLockLegalHoldStatus && !conf.ObjectLockRetainUntilDate && !conf.ObjectLockMode);
         });
         mocha.it('should put legal hold', async function() {
@@ -167,18 +174,18 @@ mocha.describe('s3 worm', function() {
                     Status: 'ON'
                 },
                 VersionId: version_id1,
-            }).promise();
+            });
             assert.deepEqual(conf, {});
         });
         mocha.it('should get object with legal hold', async function() {
-            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 });
             assert.equal(conf.LegalHold.Status, 'ON');
         });
         const today2 = new Date();
         const MinusOneMin = new Date(today2);
         MinusOneMin.setMinutes(MinusOneMin.getMinutes() - 1);
         mocha.it('should fail put retention at the past', async function() {
-            await assert_throws_async(s3_owner.putObjectRetention({
+            await assert_throws_async(await s3_owner.putObjectRetention({
                 Bucket: BKT,
                 Key: OBJ1,
                 BypassGovernanceRetention: true,
@@ -187,7 +194,7 @@ mocha.describe('s3 worm', function() {
                     RetainUntilDate: MinusOneMin,
                 },
                 VersionId: version_id1
-            }).promise(), 'InvalidArgument', 'The retain until date must be in the future!');
+            }), 'InvalidArgument', 'The retain until date must be in the future!');
         });
         mocha.it('should put retention', async function() {
             const today1 = new Date();
@@ -199,11 +206,11 @@ mocha.describe('s3 worm', function() {
                 BypassGovernanceRetention: true,
                 Retention: { Mode: 'GOVERNANCE', RetainUntilDate: oneSec },
                 VersionId: version_id1
-            }).promise();
+            });
             assert.deepEqual(conf, {});
         });
         mocha.it('should get retention 1', async function() {
-            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 });
             assert.ok(conf.Retention.RetainUntilDate);
             assert.equal(conf.Retention.Mode, 'GOVERNANCE');
         });
@@ -214,96 +221,96 @@ mocha.describe('s3 worm', function() {
                 BypassGovernanceRetention: true,
                 Retention: { Mode: 'GOVERNANCE', RetainUntilDate: tomorrow },
                 VersionId: version_id1
-            }).promise();
+            });
             assert.deepEqual(conf, {});
         });
         mocha.it('should get retention 2', async function() {
-            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 });
             assert.ok(conf.Retention.RetainUntilDate);
             assert.equal(conf.Retention.Mode, 'GOVERNANCE');
         });
         mocha.it('should get legal hold (check if legal hold overridden)', async function() {
-            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 });
             assert.equal(conf.LegalHold.Status, 'ON');
         });
         mocha.it('should put retention (compliance mode)', async function() {
             const today3 = new Date();
             const oneSec3 = new Date(today3);
             oneSec3.setSeconds(oneSec3.getSeconds() + 30);
-            await assert_throws_async(s3_owner.putObjectRetention({
+            await assert_throws_async(await s3_owner.putObjectRetention({
                 Bucket: BKT,
                 Key: OBJ1,
                 BypassGovernanceRetention: false,
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: oneSec3 },
                 VersionId: version_id1
-            }).promise(), 'AccessDenied', 'Access Denied');
+            }), 'AccessDenied', 'Access Denied');
             const conf = await s3_owner.putObjectRetention({
                 Bucket: BKT,
                 Key: OBJ1,
                 BypassGovernanceRetention: true,
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: oneSec3 },
                 VersionId: version_id1
-            }).promise();
+            });
             assert.deepEqual(conf, {});
         });
         mocha.it('IT25. should get object with retention (compliance mode)', async function() {
-            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 }).promise();
+            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 });
             assert.ok(conf.Retention.RetainUntilDate);
             assert.equal(conf.Retention.Mode, 'COMPLIANCE');
         });
         mocha.it('fail delete object with retention COMPLIANCE', async function() {
-            await assert_throws_async(s3_owner.deleteObject({
+            await assert_throws_async(await s3_owner.deleteObject({
                 Bucket: BKT,
                 Key: OBJ1,
                 BypassGovernanceRetention: true,
                 VersionId: version_id1,
-            }).promise(), 'AccessDenied', 'Access Denied');
+            }), 'AccessDenied', 'Access Denied');
         });
         mocha.it('put object with retention mode and without date', async function() {
             const params = { Bucket: BKT, Key: OBJ1, Body: file_body, ContentType: 'text/plain', ObjectLockMode: 'GOVERNANCE' };
-            await assert_throws_async(s3_owner.putObject(params).promise(), 'InvalidArgument',
+            await assert_throws_async(await s3_owner.putObject(params), 'InvalidArgument',
                 'x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied');
         });
     });
     mocha.describe('put object OBJ3 after bucket configuration exist', function() {
         mocha.it('should create object OBJ3 in BKT', async function() {
-            const conf = await s3_owner.putObject({ Bucket: BKT, Key: OBJ3, Body: file_body, ContentType: 'text/plain' }).promise();
+            const conf = await s3_owner.putObject({ Bucket: BKT, Key: OBJ3, Body: file_body, ContentType: 'text/plain' });
             assert.ok(conf.VersionId);
             version_id3 = conf.VersionId;
         });
         mocha.it('should list objects in BKT contains OBJ3', async function() {
-            const res = await s3_owner.listObjects({ Bucket: BKT }).promise();
+            const res = await s3_owner.listObjects({ Bucket: BKT });
             assert(res.Contents.find(object => object.Key === OBJ3));
         });
         mocha.it('should fail get slegal hold', async function() {
-            await assert_throws_async(s3_owner.getObjectLegalHold({
+            await assert_throws_async(await s3_owner.getObjectLegalHold({
                 Bucket: BKT,
                 Key: OBJ3,
                 VersionId: version_id3
-            }).promise(), 'InvalidRequest', 'SOAP requests must be made over an HTTPS connection.');
+            }), 'InvalidRequest', 'SOAP requests must be made over an HTTPS connection.');
         });
         mocha.it('should put legal hold on OBJ3', async function() {
-            const conf = await s3_owner.putObjectLegalHold({ Bucket: BKT, Key: OBJ3, LegalHold: { Status: 'OFF' } }).promise();
+            const conf = await s3_owner.putObjectLegalHold({ Bucket: BKT, Key: OBJ3, LegalHold: { Status: 'OFF' } });
             assert.deepEqual(conf, {});
         });
         mocha.it('should get object', async function() {
-            const conf = await s3_owner.getObject({ Bucket: BKT, Key: OBJ3 }).promise();
+            const conf = await s3_owner.getObject({ Bucket: BKT, Key: OBJ3 });
             assert.ok(conf.ObjectLockRetainUntilDate);
             assert.strictEqual(conf.ObjectLockMode, 'COMPLIANCE');
         });
         mocha.it('should head object', async function() {
-            const conf = await s3_owner.headObject({ Bucket: BKT, Key: OBJ3 }).promise();
+            const conf = await s3_owner.headObject({ Bucket: BKT, Key: OBJ3 });
             assert.equal(conf.ObjectLockLegalHoldStatus, 'OFF');
             assert.ok(conf.ObjectLockRetainUntilDate);
             assert.strictEqual(conf.ObjectLockMode, 'COMPLIANCE');
         });
         mocha.it('should fail put retention (compliance mode)', async function() {
-            await assert_throws_async(s3_owner.putObjectRetention({
+            await assert_throws_async(await s3_owner.putObjectRetention({
                 Bucket: BKT,
                 Key: OBJ3,
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: tomorrow },
                 VersionId: version_id3,
-            }).promise(), 'AccessDenied', 'Access Denied');
+            }), 'AccessDenied', 'Access Denied');
         });
     });
     mocha.describe('put object', function() {
@@ -316,30 +323,30 @@ mocha.describe('s3 worm', function() {
                 ObjectLockLegalHoldStatus: 'OFF',
                 ObjectLockMode: 'GOVERNANCE',
                 ObjectLockRetainUntilDate: tomorrow,
-            }).promise();
+            });
             version_id4 = put_object_res.VersionId;
             assert.ok(put_object_res.VersionId);
         });
         mocha.it('should list objects in BKT contains OBJ4', async function() {
-            const res = await s3_owner.listObjects({ Bucket: BKT }).promise();
+            const res = await s3_owner.listObjects({ Bucket: BKT });
             assert(res.Contents.find(object => object.Key === OBJ4));
         });
         mocha.it('should get retention', async function() {
-            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ4, VersionId: version_id4 }).promise();
+            const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ4, VersionId: version_id4 });
             assert.ok(conf.Retention.RetainUntilDate);
             assert.equal(conf.Retention.Mode, 'GOVERNANCE');
         });
         mocha.it('should get LegalHold', async function() {
-            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ4, VersionId: version_id4 }).promise();
+            const conf = await s3_owner.getObjectLegalHold({ Bucket: BKT, Key: OBJ4, VersionId: version_id4 });
             assert.equal(conf.LegalHold.Status, 'OFF');
         });
         mocha.it('should fail delete object with retention (governanceBypass=false)', async function() {
-            await assert_throws_async(s3_owner.deleteObject({
+            await assert_throws_async(await s3_owner.deleteObject({
                 Bucket: BKT,
                 Key: OBJ4,
                 BypassGovernanceRetention: false,
                 VersionId: version_id4,
-            }).promise(), 'AccessDenied', 'Access Denied');
+            }), 'AccessDenied', 'Access Denied');
         });
         mocha.it('should delete object with retention (governanceBypass=trues)', async function() {
             const deleted = await s3_owner.deleteObject({
@@ -347,18 +354,18 @@ mocha.describe('s3 worm', function() {
                 Key: OBJ4,
                 BypassGovernanceRetention: true,
                 VersionId: version_id4,
-            }).promise();
+            });
             assert.ok(deleted.VersionId);
         });
     });
     mocha.describe('overwrite versions and check', function() {
         mocha.it('should create object OBJs in BKT', async function() {
-            const conf = await s3_owner.putObject({ Bucket: BKT1, Key: OBJ2, Body: file_body, ContentType: 'text/plain' }).promise();
+            const conf = await s3_owner.putObject({ Bucket: BKT1, Key: OBJ2, Body: file_body, ContentType: 'text/plain' });
             assert.ok(conf.VersionId);
             version_id2 = conf.VersionId;
         });
         mocha.it('should head object', async function() { //get object version2 = latest
-            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 }).promise();
+            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 });
             assert.ok(!conf.ObjectLockLegalHoldStatus && !conf.ObjectLockRetainUntilDate && !conf.ObjectLockMode);
         });
         mocha.it('IT29. should not overwrite object with retention', async function() {
@@ -367,41 +374,41 @@ mocha.describe('s3 worm', function() {
                 Key: OBJ2,
                 Body: file_body2,
                 ContentType: 'text/plain',
-            }).promise();
+            });
             assert.ok(put_object_res.VersionId);
         });
         mocha.it('should put legal hold on OBJ2', async function() {
-            await s3_owner.putObjectLegalHold({ Bucket: BKT1, Key: OBJ2, LegalHold: { Status: 'ON' } }).promise();
+            await s3_owner.putObjectLegalHold({ Bucket: BKT1, Key: OBJ2, LegalHold: { Status: 'ON' } });
         });
         mocha.it('should put retention', async function() {
             await s3_owner.putObjectRetention({
                 Bucket: BKT1,
                 Key: OBJ2,
                 Retention: { Mode: 'GOVERNANCE', RetainUntilDate: tomorrow },
-            }).promise();
+            });
         });
         mocha.it('should head object', async function() { //get object version5 = latest
-            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 }).promise();
+            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 });
             assert.ok(conf.ObjectLockLegalHoldStatus);
             assert.ok(conf.ObjectLockRetainUntilDate);
             assert.strictEqual(conf.ObjectLockMode, 'GOVERNANCE');
         });
         mocha.it('should get legal hold on OBJ2', async function() {
-            await assert_throws_async(s3_owner.getObjectLegalHold({
+            await assert_throws_async(await s3_owner.getObjectLegalHold({
                 Bucket: BKT1,
                 Key: OBJ2,
                 VersionId: version_id2
-            }).promise(), 'InvalidRequest', 'SOAP requests must be made over an HTTPS connection.');
+            }), 'InvalidRequest', 'SOAP requests must be made over an HTTPS connection.');
         });
         mocha.it('should get retention on OBJ2', async function() {
-            await assert_throws_async(s3_owner.getObjectRetention({
+            await assert_throws_async(await s3_owner.getObjectRetention({
                 Bucket: BKT1,
                 Key: OBJ2,
                 VersionId: version_id2
-            }).promise(), 'NoSuchObjectLockConfiguration', 'The specified object does not have a ObjectLock configuration');
+            }), 'NoSuchObjectLockConfiguration', 'The specified object does not have a ObjectLock configuration');
         });
         mocha.it('should put legal hold on OBJ2 version_id', async function() {
-            await s3_owner.putObjectLegalHold({ Bucket: BKT1, Key: OBJ2, LegalHold: { Status: 'OFF' }, VersionId: version_id2 }).promise();
+            await s3_owner.putObjectLegalHold({ Bucket: BKT1, Key: OBJ2, LegalHold: { Status: 'OFF' }, VersionId: version_id2 });
         });
         mocha.it('should put retention (compliance mode) version_id', async function() {
             await s3_owner.putObjectRetention({
@@ -409,10 +416,10 @@ mocha.describe('s3 worm', function() {
                 Key: OBJ2,
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: tomorrow },
                 VersionId: version_id2
-            }).promise();
+            });
         });
         mocha.it('should head object', async function() { //get object version5 = latest
-            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 }).promise();
+            const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 });
             assert.strictEqual(conf.ObjectLockLegalHoldStatus, 'ON');
             assert.strictEqual(conf.ObjectLockMode, 'GOVERNANCE');
         });


### PR DESCRIPTION
### Describe the Problem

Replace AWS SDK v2 with SDK v3 in unit test.

### Explain the Changes
1. Replace AWS SDK v2 with SDK v3 in unit test and update respective properties and methoeds, Also remove deprecated SDK v2 properties such as `signatureVersion`, `computeChecksums`, `s3DisableBodySigning` etc
2. Updated SDK version to V3 in replication flow, `set_noobaa_s3_connection()` will send SDKv3 for replication Noobaa connection. 

### Issues: Fixed #xxx / Gap #xxx
1. end-of-support for AWS SDK for JavaScript v2.

### Testing Instructions:
1. run complete unit test cases and validete scenarios in manuelly


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Migrated all S3-related test scripts and server utilities from AWS SDK v2 to AWS SDK v3, updating client initialization, method calls, and configuration options.
	- Modernized test code to use async/await patterns for improved readability and error handling.
	- Updated test setup and client configuration to align with new SDK credential structures and removed deprecated options.
	- Refactored server and utility code to remove explicit `.promise()` calls, adapting to SDK v3’s native promise support.
	- Updated S3 connection setup to use explicit endpoint URLs, region settings, and custom request handlers.

- **Tests**
	- Added a timeout to a specific asynchronous CLI account update test.
	- Introduced a new helper function for S3 object retrieval in test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->