### PR TITLE
in try_read_file_sync - treat ENOTDIR as ENOENT

### DIFF
--- a/src/util/fs_utils.js
+++ b/src/util/fs_utils.js
@@ -142,7 +142,7 @@ function try_read_file_sync(file_name) {
     try {
         return fs.readFileSync(file_name, 'utf8');
     } catch (err) {
-        if (err.code === 'ENOENT') {
+        if (is_not_exist_err_code(err)) {
             // file does not exist
             return;
         }
@@ -150,6 +150,11 @@ function try_read_file_sync(file_name) {
     }
 }
 
+// returns true if the error is ENOENT or ENOTDIR
+// ENOTDIR is relevant for cases where a directory in the middle of the path is a file and not a directory
+function is_not_exist_err_code(err) {
+    return err && (err.code === 'ENOENT' || err.code === 'ENOTDIR');
+}
 
 // returns the first line in the file that contains the substring
 async function find_line_in_file(file_name, line_sub_string) {
@@ -373,3 +378,4 @@ exports.PRIVATE_DIR_PERMISSIONS = PRIVATE_DIR_PERMISSIONS;
 exports.file_exists = file_exists;
 exports.file_not_exists = file_not_exists;
 exports.try_read_file_sync = try_read_file_sync;
+exports.is_not_exist_err_code = is_not_exist_err_code;


### PR DESCRIPTION
### Describe the Problem
- Following a discussion with @guymguym, reverting the change in #9030 
- `ENOTDIR` can be returned by `fs.readFile` and `fs.readFileSync` if part of the path is a regular file and not a directory.

### Explain the Changes
1. Added a function in fs_utils `is_not_exist_err_code` that checks if the error code is `ENOTDIR` or `ENOTDIR`

### Issues: Fixed #xxx / Gap #xxx
1. related to https://issues.redhat.com/browse/DFBUGS-1466 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
