### PR TITLE
NC Health | add dedicated servers for each forks for health checks

### DIFF
--- a/config.js
+++ b/config.js
@@ -1006,6 +1006,8 @@ config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
 // Remove the NSFS condition when NSFS starts to support STS.
 config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || (process.env.NC_NSFS_NO_DB_ENV === 'true' ? -1 : 7443);
 config.ENDPOINT_SSL_IAM_PORT = Number(process.env.ENDPOINT_SSL_IAM_PORT) || -1;
+// each fork will get port in range [ENDPOINT_FORK_PORT_BASE, ENDPOINT_FORK_PORT_BASE + number of forks - 1)]
+config.ENDPOINT_FORK_PORT_BASE = Number(process.env.ENDPOINT_FORK_PORT_BASE) || 6002;
 config.ALLOW_HTTP = false;
 config.ALLOW_HTTP_METRICS = true;
 config.ALLOW_HTTPS_METRICS = true;
@@ -1018,6 +1020,8 @@ config.VIRTUAL_HOSTS = process.env.VIRTUAL_HOSTS || '';
 
 config.NC_HEALTH_ENDPOINT_RETRY_COUNT = 3;
 config.NC_HEALTH_ENDPOINT_RETRY_DELAY = 10;
+config.NC_FORK_SERVER_TIMEOUT = 5; // 5 minutes
+config.NC_FORK_SERVER_RETRIES = 10;
 
 
 /** @type {'file' | 'executable'} */

--- a/src/nc/nc_utils.js
+++ b/src/nc/nc_utils.js
@@ -24,7 +24,15 @@ function check_root_account_owns_user(root_account, account) {
     return root_account._id === account.owner;
 }
 
+/**
+ * @returns {boolean} true if the current environment is a NooBaa non containerized environment
+ */
+function is_nc_environment() {
+    return process.env.NC_NSFS_NO_DB_ENV && process.env.NC_NSFS_NO_DB_ENV === 'true';
+}
+
 // EXPORTS
 exports.generate_id = generate_id;
 exports.check_root_account_owns_user = check_root_account_owns_user;
+exports.is_nc_environment = is_nc_environment;
 

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -16,6 +16,7 @@ const nb_native = require('../../util/nb_native');
 const { CONFIG_TYPES } = require('../../sdk/config_fs');
 const native_fs_utils = require('../../util/native_fs_utils');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
+const sinon = require('sinon');
 
 const GPFS_ROOT_PATH = process.env.GPFS_ROOT_PATH;
 const IS_GPFS = !_.isUndefined(GPFS_ROOT_PATH);
@@ -47,12 +48,12 @@ function get_tmp_path() {
 const is_nc_coretest = process.env.NC_CORETEST === 'true';
 
 /**
- * 
- * @param {*} need_to_exist 
- * @param {*} pool_id 
- * @param {*} bucket_name 
- * @param {*} blocks 
- * @param {AWS.S3} s3 
+ *
+ * @param {*} need_to_exist
+ * @param {*} pool_id
+ * @param {*} bucket_name
+ * @param {*} blocks
+ * @param {AWS.S3} s3
  */
 async function blocks_exist_on_cloud(need_to_exist, pool_id, bucket_name, blocks, s3) {
     console.log('blocks_exist_on_cloud::', need_to_exist, pool_id, bucket_name);
@@ -207,13 +208,13 @@ async function disable_accounts_s3_access(rpc_client, accounts_emails) {
 
 /**
  * generate_s3_policy generates S3 buket policy for the given principal
- * 
+ *
  * @param {string} principal - The principal to grant access to.
  * @param {string} bucket - The bucket to grant access to.
  * @param {Array<string>} action - The action to grant access to.
- * @returns {{ 
+ * @returns {{
  *  policy: Record<string, any>,
- *  params: { bucket: string, action: Array<string>, principal: string } 
+ *  params: { bucket: string, action: Array<string>, principal: string }
  * }}
  */
 function generate_s3_policy(principal, bucket, action) {
@@ -248,7 +249,7 @@ function invalid_nsfs_root_permissions() {
 
 /**
  * get_coretest_path returns coretest path according to process.env.NC_CORETEST value
- * @returns {string} 
+ * @returns {string}
  */
 function get_coretest_path() {
     return process.env.NC_CORETEST ? './nc_coretest' : './coretest';
@@ -402,7 +403,7 @@ async function set_path_permissions_and_owner(p, owner_options, permissions = 0o
     await fs.promises.chmod(p, permissions);
 }
 
-/** 
+/**
  * set_nc_config_dir_in_config sets given config_root to be config.NSFS_NC_CONF_DIR
  * @param {string} config_root
  */
@@ -482,12 +483,12 @@ function generate_iam_client(access_key, secret_key, endpoint) {
 
 /**
  * generate_nsfs_account generate an nsfs account and returns its credentials
- * if the admin flag is received (in the options object) the function will not create 
+ * if the admin flag is received (in the options object) the function will not create
  * the account (it was already created in the system) and only return the credentials.
- * @param {nb.APIClient} rpc_client 
- * @param {String} EMAIL 
- * @param {String} default_new_buckets_path 
- * @param {Object} options 
+ * @param {nb.APIClient} rpc_client
+ * @param {String} EMAIL
+ * @param {String} default_new_buckets_path
+ * @param {Object} options
  * @returns {Promise<Object>}
  */
 async function generate_nsfs_account(rpc_client, EMAIL, default_new_buckets_path, options = {}) {
@@ -528,11 +529,11 @@ async function generate_nsfs_account(rpc_client, EMAIL, default_new_buckets_path
  * get_new_buckets_path_by_test_env returns new_buckets_path value
  * on NC - new_buckets_path is full absolute path
  * on Containerized - new_buckets_path is the directory
- * Example - 
+ * Example -
  * On NC - /private/tmp/new_buckets_path/
  * On Continerized - new_buckets_path/
- * @param {string} new_buckets_full_path 
- * @param {string} new_buckets_dir 
+ * @param {string} new_buckets_full_path
+ * @param {string} new_buckets_dir
  * @returns {string}
  */
 function get_new_buckets_path_by_test_env(new_buckets_full_path, new_buckets_dir) {
@@ -542,16 +543,16 @@ function get_new_buckets_path_by_test_env(new_buckets_full_path, new_buckets_dir
 /**
  * write_manual_config_file writes config file directly to the file system without using config FS
  * used for creating backward compatibility tests, invalid config files etc
- * 1. if it's account - 
+ * 1. if it's account -
  *    1.1. create identity directory /{config_dir_path}/identities/{id}/
- * 2. create the config file - 
+ * 2. create the config file -
  *    2.1. if it's a bucket - create it in /{config_dir_path}/buckets/{bucket_name}.json
  *    2.2. if it's an account - create it in /{config_dir_path}/identities/{id}/identity.json
  * 3. if it's an account and symlink_name is true - create /{config_dir_path}/accounts_by_name/{account_name}.symlink -> /{config_dir_path}/identities/{id}/identity.json
  * 4. if it's an account and symlink_access_key is true and there is access key in the account config - create /{config_dir_path}/access_keys/{access_key}.symlink -> /{config_dir_path}/identities/{id}/identity.json
- * @param {String} type 
+ * @param {String} type
  * @param {import('../../sdk/config_fs').ConfigFS} config_fs
- * @param {Object} config_data 
+ * @param {Object} config_data
  * @param {String} [invalid_str]
  * @param {{symlink_name?: Boolean, symlink_access_key?: Boolean}} [options]
  * @returns {Promise<Void>}
@@ -586,8 +587,8 @@ async function write_manual_config_file(type, config_fs, config_data, invalid_st
  * symlink_account_name symlinks the account's name path to the target link path
  * used for manual creation of the account name symlink
  * @param {import('../../sdk/config_fs').ConfigFS} config_fs
- * @param {String} account_name 
- * @param {String} link_target 
+ * @param {String} account_name
+ * @param {String} link_target
  */
 async function symlink_account_name(config_fs, account_name, link_target) {
     const name_symlink_path = config_fs.get_account_or_user_path_by_name(account_name);
@@ -599,7 +600,7 @@ async function symlink_account_name(config_fs, account_name, link_target) {
  * used for manual creation of the account access key symlink
  * @param {import('../../sdk/config_fs').ConfigFS} config_fs
  * @param {Object} access_keys
- * @param {String} link_target 
+ * @param {String} link_target
  */
 async function symlink_account_access_keys(config_fs, access_keys, link_target) {
     for (const { access_key } of access_keys) {
@@ -611,7 +612,7 @@ async function symlink_account_access_keys(config_fs, access_keys, link_target) 
 /**
  * create_identity_dir_if_missing created the identity directory if missing
  * @param {import('../../sdk/config_fs').ConfigFS} config_fs
- * @param {String} _id 
+ * @param {String} _id
  * @returns {Promise<Void>}
  */
 async function create_identity_dir_if_missing(config_fs, _id) {
@@ -628,7 +629,7 @@ async function create_identity_dir_if_missing(config_fs, _id) {
  * 1. create old json file in /config_dir_path/accounts/account.json
  * 2. if symlink_access_key is true - create old access key symlink /config_dir_path/access_keys/{access_key}.symlink -> /config_dir_path/accounts/account.json
  * @param {import('../../sdk/config_fs').ConfigFS} config_fs
- * @param {Object} config_data 
+ * @param {Object} config_data
  * @param {{symlink_access_key?: Boolean}} [options]
  * @returns {Promise<Void>}
  */
@@ -652,9 +653,9 @@ async function write_manual_old_account_config_file(config_fs, config_data, { sy
 /**
  * delete_manual_config_file deletes config file directly from the file system without using config FS
  * used for deleting invalid config files etc
- * @param {String} type 
+ * @param {String} type
  * @param {import('../../sdk/config_fs').ConfigFS} config_fs
- * @param {Object} config_data 
+ * @param {Object} config_data
  * @returns {Promise<Void>}
  */
 async function delete_manual_config_file(type, config_fs, config_data) {
@@ -695,7 +696,7 @@ async function fail_test_if_default_config_dir_exists(test_name, config_fs) {
 
 /**
  * create_config_dir will create the config directory on the file system
- * @param {String} config_dir 
+ * @param {String} config_dir
  * @returns {Promise<Void>}
  */
 async function create_config_dir(config_dir) {
@@ -734,10 +735,10 @@ async function clean_config_dir(config_fs, custom_config_dir_path) {
 
 /**
  * create_file creates a file in the file system
- * @param {nb.NativeFSContext} fs_context 
- * @param {String} file_path 
- * @param {Object} file_data 
- * @param {{stringify_json?: Boolean}} [options={}] 
+ * @param {nb.NativeFSContext} fs_context
+ * @param {String} file_path
+ * @param {Object} file_data
+ * @param {{stringify_json?: Boolean}} [options={}]
  */
 async function create_file(fs_context, file_path, file_data, options = {}) {
     const buf = Buffer.from(options?.stringify_json ? JSON.stringify(file_data) : file_data);
@@ -755,7 +756,7 @@ async function create_file(fs_context, file_path, file_data, options = {}) {
  * create_system_json creates the system.json file
  * if mock_config_dir_version it sets it before creating the file
  * @param {import('../../sdk/config_fs').ConfigFS} config_fs
- * @param {String} [mock_config_dir_version] 
+ * @param {String} [mock_config_dir_version]
  * @returns {Promise<Void>}
  */
 async function create_system_json(config_fs, mock_config_dir_version) {
@@ -768,7 +769,7 @@ async function create_system_json(config_fs, mock_config_dir_version) {
  * update_system_json updates the system.json file
  * if mock_config_dir_version it sets it before creating the file
  * @param {import('../../sdk/config_fs').ConfigFS} config_fs
- * @param {String} [mock_config_dir_version] 
+ * @param {String} [mock_config_dir_version]
  * @returns {Promise<Void>}
  */
 async function update_system_json(config_fs, mock_config_dir_version) {
@@ -780,8 +781,8 @@ async function update_system_json(config_fs, mock_config_dir_version) {
 /**
  * run_or_skip_test checks -
  * 1. if cond condition evaluated to true - run test
- * 2. else - skip test 
- * @param {*} cond 
+ * 2. else - skip test
+ * @param {*} cond
  * @returns {*}
  */
 const run_or_skip_test = cond => {
@@ -861,6 +862,29 @@ function validate_expiration_header(expiration_header, start_time, expected_rule
     return days_diff === delta_days && rule_id === expected_rule_id;
 }
 
+/**
+ * set_mock_functions sets mock functions used by the health script
+ * the second param is an object having the name of the mock functions as the keys and
+ * the value is an array of responses by the order of their call
+ * @param {Object} Health
+ * @param {{get_endpoint_response?: Object[], get_service_state?: Object[],
+ * get_system_config_file?: Object[], get_service_memory_usage?: Object[],
+ * get_lifecycle_health_status?: Object, get_latest_lifecycle_run_status?: Object}} mock_function_responses
+ */
+function set_health_mock_functions(Health, mock_function_responses) {
+    for (const mock_function_name of Object.keys(mock_function_responses)) {
+        const mock_function_responses_arr = mock_function_responses[mock_function_name];
+        const obj_to_stub = mock_function_name === 'get_system_config_file' ? Health.config_fs : Health;
+
+        if (obj_to_stub[mock_function_name]?.restore) obj_to_stub[mock_function_name]?.restore();
+        const stub = sinon.stub(obj_to_stub, mock_function_name);
+        for (let i = 0; i < mock_function_responses_arr.length; i++) {
+            stub.onCall(i).returns(Promise.resolve(mock_function_responses_arr[i]));
+        }
+    }
+}
+
+
 exports.update_file_mtime = update_file_mtime;
 exports.generate_lifecycle_rule = generate_lifecycle_rule;
 exports.validate_expiration_header = validate_expiration_header;
@@ -904,3 +928,4 @@ exports.fail_test_if_default_config_dir_exists = fail_test_if_default_config_dir
 exports.create_config_dir = create_config_dir;
 exports.clean_config_dir = clean_config_dir;
 exports.CLI_UNSET_EMPTY_STRING = CLI_UNSET_EMPTY_STRING;
+exports.set_health_mock_functions = set_health_mock_functions;

--- a/src/test/unit_tests/nc_coretest.js
+++ b/src/test/unit_tests/nc_coretest.js
@@ -11,6 +11,7 @@ const SensitiveString = require('../../util/sensitive_string');
 const { exec_manage_cli, TMP_PATH, create_redirect_file, delete_redirect_file } = require('../system_tests/test_utils');
 const { TYPES, ACTIONS } = require('../../manage_nsfs/manage_nsfs_constants');
 const { ConfigFS } = require('../../sdk/config_fs');
+const os_utils = require('../../util/os_utils');
 
 // keep me first - this is setting envs that should be set before other modules are required.
 const NC_CORETEST = 'nc_coretest';
@@ -162,6 +163,11 @@ async function stop_nsfs_process() {
     _nsfs_process = false;
     await announce('stop nsfs script');
     if (nsfs_process) nsfs_process.kill('SIGKILL');
+}
+
+async function get_nsfs_fork_pids() {
+    const res = await os_utils.exec(`ps -o pid --ppid ${nsfs_process.pid}`, { return_stdout: true, trim_stdout: true });
+    return res.split('\n').slice(1).map(pid => parseInt(pid, 10));
 }
 
 /**
@@ -538,6 +544,7 @@ exports.setup = setup;
 exports.get_current_setup_options = get_current_setup_options;
 exports.stop_nsfs_process = stop_nsfs_process;
 exports.start_nsfs_process = start_nsfs_process;
+exports.get_nsfs_fork_pids = get_nsfs_fork_pids;
 exports.no_setup = _.noop;
 exports.log = log;
 exports.SYSTEM = SYSTEM;

--- a/src/test/unit_tests/test_nc_health.js
+++ b/src/test/unit_tests/test_nc_health.js
@@ -6,7 +6,6 @@
 const path = require('path');
 const _ = require('lodash');
 const mocha = require('mocha');
-const sinon = require('sinon');
 const assert = require('assert');
 const config = require('../../../config');
 const pkg = require('../../../package.json');
@@ -175,7 +174,7 @@ mocha.describe('nsfs nc health', function() {
             await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, {config_root, ...account1_options});
             await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, {config_root, ...bucket1_options});
             await fs_utils.file_must_exist(path.join(config_root, 'master_keys.json'));
-            set_mock_functions(Health, { get_service_memory_usage: [100]});
+            test_utils.set_health_mock_functions(Health, { get_service_memory_usage: [100]});
             for (const user of Object.values(fs_users)) {
                 await create_fs_user_by_platform(user.distinguished_name, user.distinguished_name, user.uid, user.gid);
             }
@@ -207,7 +206,7 @@ mocha.describe('nsfs nc health', function() {
             };
             valid_system_json[hostname].config_dir_version = config_fs.config_dir_version;
             await Health.config_fs.create_system_config_file(JSON.stringify(valid_system_json));
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
             });
@@ -246,7 +245,7 @@ mocha.describe('nsfs nc health', function() {
         });
 
         mocha.it('NooBaa service is inactive', async function() {
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: [{ service_status: 'inactive', pid: 0 }],
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -257,7 +256,7 @@ mocha.describe('nsfs nc health', function() {
         });
 
         mocha.it('NooBaa endpoint return error response is inactive', async function() {
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: [{ response: { response_code: 'MISSING_FORKS', total_fork_count: 3, running_workers: ['1', '3'] } }],
                 get_system_config_file: get_system_config_mock_default_response
@@ -271,7 +270,7 @@ mocha.describe('nsfs nc health', function() {
             // create it manually because we can not skip invalid storage path check on the CLI
             const account_invalid_options = { _id: mongo_utils.mongoObjectId(), name: 'account_invalid', nsfs_account_config: { new_buckets_path: path.join(new_buckets_path, '/invalid') } };
             await test_utils.write_manual_config_file(TYPES.ACCOUNT, config_fs, account_invalid_options);
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -290,7 +289,7 @@ mocha.describe('nsfs nc health', function() {
             // create it manually because we can not skip invalid storage path check on the CLI
             const bucket_invalid = { _id: mongo_utils.mongoObjectId(), name: 'bucket_invalid', path: new_buckets_path + '/bucket1/invalid', owner_account: parsed_res._id };
             await test_utils.write_manual_config_file(TYPES.BUCKET, config_fs, bucket_invalid);
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -312,7 +311,7 @@ mocha.describe('nsfs nc health', function() {
             await config_fs.delete_config_json_file();
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -337,7 +336,7 @@ mocha.describe('nsfs nc health', function() {
             await test_utils.write_manual_config_file(TYPES.BUCKET, config_fs, bucket_invalid_owner);
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -357,7 +356,7 @@ mocha.describe('nsfs nc health', function() {
             await test_utils.write_manual_config_file(TYPES.BUCKET, config_fs, bucket_invalid_owner);
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -374,7 +373,7 @@ mocha.describe('nsfs nc health', function() {
             // create it manually because we can not skip json schema check on the CLI
             const bucket_invalid_schema = { _id: mongo_utils.mongoObjectId(), name: 'bucket_invalid_schema', path: new_buckets_path };
             await test_utils.write_manual_config_file(TYPES.BUCKET, config_fs, bucket_invalid_schema, 'invalid');
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -391,7 +390,7 @@ mocha.describe('nsfs nc health', function() {
             // create it manually because we can not skip json schema check on the CLI
             const account_invalid_schema = { _id: mongo_utils.mongoObjectId(), name: 'account_invalid_schema', path: new_buckets_path, bla: 5 };
             await test_utils.write_manual_config_file(TYPES.ACCOUNT, config_fs, account_invalid_schema, 'invalid');
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -407,7 +406,7 @@ mocha.describe('nsfs nc health', function() {
         mocha.it('Health all condition is success, all_account_details is false', async function() {
             Health.all_account_details = false;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -423,7 +422,7 @@ mocha.describe('nsfs nc health', function() {
         mocha.it('Health all condition is success, all_bucket_details is false', async function() {
             Health.all_account_details = true;
             Health.all_bucket_details = false;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -442,7 +441,7 @@ mocha.describe('nsfs nc health', function() {
             Health.config_root = config_root_invalid;
             const old_config_fs = Health.config_fs;
             Health.config_fs = new ConfigFS(config_root_invalid);
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -464,7 +463,7 @@ mocha.describe('nsfs nc health', function() {
             await config_fs.delete_config_json_file();
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -484,7 +483,7 @@ mocha.describe('nsfs nc health', function() {
             await config_fs.delete_config_json_file();
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -507,7 +506,7 @@ mocha.describe('nsfs nc health', function() {
             await config_fs.delete_config_json_file();
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -529,7 +528,7 @@ mocha.describe('nsfs nc health', function() {
             await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_inaccessible_dn_options });
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -548,7 +547,7 @@ mocha.describe('nsfs nc health', function() {
             await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_inaccessible_dn_options });
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -570,7 +569,7 @@ mocha.describe('nsfs nc health', function() {
             await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_inaccessible_dn_options });
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -592,7 +591,7 @@ mocha.describe('nsfs nc health', function() {
             await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...invalid_account_dn_options });
             Health.all_account_details = true;
             Health.all_bucket_details = true;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -613,7 +612,7 @@ mocha.describe('nsfs nc health', function() {
             await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_valid });
             Health.all_account_details = true;
             Health.all_bucket_details = false;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -630,7 +629,7 @@ mocha.describe('nsfs nc health', function() {
             await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account_invalid });
             Health.all_account_details = true;
             Health.all_bucket_details = false;
-            set_mock_functions(Health, {
+            test_utils.set_health_mock_functions(Health, {
                 get_service_state: get_service_state_mock_default_response,
                 get_endpoint_response: get_endpoint_response_mock_default_response,
                 get_system_config_file: get_system_config_mock_default_response
@@ -828,26 +827,4 @@ function restore_health_if_needed(health_obj) {
     if (health_obj?.get_endpoint_response?.restore) health_obj.get_endpoint_response.restore();
     if (health_obj?.config_fs?.get_system_config_file?.restore) health_obj.config_fs.get_system_config_file.restore();
     if (health_obj?.get_service_memory_usage?.restore) health_obj.get_service_memory_usage.restore();
-}
-
-/**
- * set_mock_functions sets mock functions used by the health script
- * the second param is an object having the name of the mock functions as the keys and 
- * the value is an array of responses by the order of their call
- * @param {Object} Health 
- * @param {{get_endpoint_response?: Object[], get_service_state?: Object[], 
- * get_system_config_file?: Object[], get_service_memory_usage?: Object[],
- * get_lifecycle_health_status?: Object, get_latest_lifecycle_run_status?: Object}} mock_function_responses 
- */
-function set_mock_functions(Health, mock_function_responses) {
-    for (const mock_function_name of Object.keys(mock_function_responses)) {
-        const mock_function_responses_arr = mock_function_responses[mock_function_name];
-        const obj_to_stub = mock_function_name === 'get_system_config_file' ? Health.config_fs : Health;
-
-        if (obj_to_stub[mock_function_name]?.restore) obj_to_stub[mock_function_name]?.restore();
-        const stub = sinon.stub(obj_to_stub, mock_function_name);
-        for (let i = 0; i < mock_function_responses_arr.length; i++) {
-            stub.onCall(i).returns(Promise.resolve(mock_function_responses_arr[i]));
-        }
-    }
 }

--- a/src/util/fork_utils.js
+++ b/src/util/fork_utils.js
@@ -10,6 +10,7 @@ const prom_reporting = require('../server/analytic_services/prometheus_reporting
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 const config = require('../../config');
 const stats_collector_utils = require('./stats_collector_utils');
+const { is_nc_environment } = require('../nc/nc_utils');
 
 
 const io_stats = {
@@ -27,7 +28,7 @@ const fs_workers_stats = {};
  * When count > 0 the primary process will fork worker processes to process incoming http requests.
  * In case of any worker exit, also the entire process group will exit.
  * @see https://nodejs.org/api/cluster.html
- * 
+ *
  * @param {number} [metrics_port]
  * @param {number} [https_metrics_port]
  * @param {string} [nsfs_config_root] nsfs configuration path
@@ -36,10 +37,12 @@ const fs_workers_stats = {};
  */
 async function start_workers(metrics_port, https_metrics_port, nsfs_config_root, count = 0) {
     const exit_events = [];
+    const fork_port_offsets = [];
     if (cluster.isPrimary && count > 0) {
         for (let i = 0; i < count; ++i) {
             const worker = cluster.fork();
             console.warn('WORKER started', { id: worker.id, pid: worker.process.pid });
+            fork_port_offsets.push(worker.id);
         }
 
         // We don't want to leave the process with a partial set of workers,
@@ -66,11 +69,26 @@ async function start_workers(metrics_port, https_metrics_port, nsfs_config_root,
             console.warn(`${exit_events.length} exit events in the last ${config.NSFS_EXIT_EVENTS_TIME_FRAME_MIN} minutes,` +
                 ` max allowed are: ${config.NSFS_MAX_EXIT_EVENTS_PER_TIME_FRAME}`);
             const new_worker = cluster.fork();
-            console.warn('WORKER re-started', { id: new_worker.id, pid: new_worker.process.pid });
+            const offset = fork_port_offsets.findIndex(id => id === worker.id);
+            const listener = create_worker_message_handler({
+                worker: new_worker,
+                offset: offset,
+                nsfs_config_root: nsfs_config_root
+            });
+            new_worker.on('message', listener);
+            fork_port_offsets[offset] = new_worker.id;
+            const port = is_nc_environment() ? {port: config.ENDPOINT_FORK_PORT_BASE + offset} : {};
+            console.warn('WORKER re-started', { id: new_worker.id, pid: new_worker.process.pid, ...port});
         });
         for (const id in cluster.workers) {
             if (id) {
-                cluster.workers[id].on('message', nsfs_io_stats_handler);
+                const offset = fork_port_offsets.findIndex(worker_id => worker_id === cluster.workers[id].id);
+                const listener = create_worker_message_handler({
+                    worker: cluster.workers[id],
+                    offset: offset,
+                    nsfs_config_root: nsfs_config_root
+                });
+                cluster.workers[id].on('message', listener);
             }
         }
         if (metrics_port > 0 || https_metrics_port > 0) {
@@ -84,20 +102,58 @@ async function start_workers(metrics_port, https_metrics_port, nsfs_config_root,
     return false;
 }
 
-function nsfs_io_stats_handler(msg) {
-    if (msg.io_stats) {
+//global variable as it is shared between all workers
+let fork_server_retries = config.NC_FORK_SERVER_RETRIES;
+function create_worker_message_handler(params) {
+    let fork_server_timer;
+    if (is_nc_environment() && fork_server_retries > 0) {
+        fork_server_timer = setTimeout(async () => {
+            dbg.error(`Timeout: It took more than ${config.NC_FORK_SERVER_TIMEOUT} minutes to get a ready message from worker ${params.worker.id}, killing the worker`);
+            fork_server_retries -= 1;
+            await params.worker.kill();
+            if (fork_server_retries <= 0) {
+                dbg.error(`ERROR: fork health server failed to start for ${config.NC_FORK_SERVER_RETRIES} attempts stop retrying to reload the worker`);
+            }
+        }, config.NC_FORK_SERVER_TIMEOUT * 60 * 1000);
+    }
+    return function(msg) {
+        if (msg.io_stats) {
         for (const [key, value] of Object.entries(msg.io_stats)) {
             io_stats[key] += value;
         }
         prom_reporting.set_io_stats(io_stats);
-    }
-    if (msg.op_stats) {
-        _update_ops_stats(msg.op_stats);
-        prom_reporting.set_ops_stats(op_stats);
-    }
-    if (msg.fs_workers_stats) {
-        _update_fs_stats(msg.fs_workers_stats);
-        prom_reporting.set_fs_worker_stats(fs_workers_stats);
+        }
+        if (msg.op_stats) {
+            _update_ops_stats(msg.op_stats);
+            prom_reporting.set_ops_stats(op_stats);
+        }
+        if (msg.fs_workers_stats) {
+            _update_fs_stats(msg.fs_workers_stats);
+            prom_reporting.set_fs_worker_stats(fs_workers_stats);
+        }
+        if (msg.ready_to_start_fork_server) {
+            clearTimeout(fork_server_timer);
+            _send_fork_server_message(params);
+        }
+    };
+}
+
+/**
+ * Sends a message to the worker to start the fork server with the giver port
+ * NOTE - currently runs only on non containerized enviorment
+ */
+function _send_fork_server_message({worker, offset, nsfs_config_root}) {
+    const is_nc = is_nc_environment();
+    if (is_nc && offset >= 0) {
+        //wait for the worker to be ready to receive messages
+        try {
+            worker.send({
+                nsfs_config_root: nsfs_config_root,
+                health_port: config.ENDPOINT_FORK_PORT_BASE + offset
+            });
+        } catch (err) {
+            dbg.warn(`Timeout: It took more than 5 minute to get a message from worker ${worker.id} do not send start server message`);
+        }
     }
 }
 

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -821,8 +821,8 @@ function http_get(uri, options) {
 /**
  * start_https_server starts the secure https server by type and options and creates a certificate if required
  * @param {number} https_port
- * @param {('S3'|'IAM'|'STS'|'METRICS')} server_type 
- * @param {Object} request_handler 
+ * @param {('S3'|'IAM'|'STS'|'METRICS'|'FORK_HEALTH')} server_type
+ * @param {Object} request_handler
  */
 async function start_https_server(https_port, server_type, request_handler, nsfs_config_root) {
     const ssl_cert_info = await ssl_utils.get_ssl_cert_info(server_type, nsfs_config_root);
@@ -840,8 +840,8 @@ async function start_https_server(https_port, server_type, request_handler, nsfs
 /**
  * start_http_server starts the non-secure http server by type
  * @param {number} http_port
- * @param {('S3'|'IAM'|'STS'|'METRICS')} server_type 
- * @param {Object} request_handler 
+ * @param {('S3'|'IAM'|'STS'|'METRICS'|'FORK_HEALTH')} server_type
+ * @param {Object} request_handler
  */
 async function start_http_server(http_port, server_type, request_handler) {
     const http_server = http.createServer(request_handler);
@@ -856,11 +856,11 @@ async function start_http_server(http_port, server_type, request_handler) {
  * Listen server for http/https ports
  * @param {number} port
  * @param {http.Server} server
- * @param {('S3'|'IAM'|'STS'|'METRICS')} server_type 
+ * @param {('S3'|'IAM'|'STS'|'METRICS'|'FORK_HEALTH')} server_type
  */
 function listen_port(port, server, server_type) {
     return new Promise((resolve, reject) => {
-        if (server_type !== 'METRICS') {
+        if (server_type !== 'METRICS' && server_type !== 'FORK_HEALTH') {
             setup_endpoint_server(server);
         }
         server.listen(port, err => {

--- a/src/util/ssl_utils.js
+++ b/src/util/ssl_utils.js
@@ -47,7 +47,8 @@ const certs = {
     EXTERNAL_DB: new CertInfo(config.EXTERNAL_DB_SERVICE_CERT_PATH),
     STS: new CertInfo(config.STS_SERVICE_CERT_PATH),
     IAM: new CertInfo(config.IAM_SERVICE_CERT_PATH),
-    METRICS: new CertInfo(config.S3_SERVICE_CERT_PATH) // metric server will use the S3 cert.
+    METRICS: new CertInfo(config.S3_SERVICE_CERT_PATH), // metric server will use the S3 cert.
+    FORK_HEALTH: new CertInfo(config.S3_SERVICE_CERT_PATH) // fork health server will use the S3 cert.
 };
 
 function generate_ssl_certificate() {
@@ -66,7 +67,7 @@ function verify_ssl_certificate(certificate) {
 // Get SSL certificate (load once then serve from cache)
 async function get_ssl_cert_info(service, nsfs_config_root) {
     let cert_info;
-    if ((service === 'S3' || service === 'METRICS') && nsfs_config_root) {
+    if ((service === 'S3' || service === 'METRICS' || service === 'FORK_HEALTH') && nsfs_config_root) {
         const nsfs_ssl_cert_dir = path.join(nsfs_config_root, 'certificates/');
         cert_info = new CertInfo(nsfs_ssl_cert_dir);
     } else {


### PR DESCRIPTION
### Describe the Problem
since we can't predict node forwarding of connections, we can't make sure health requests gets to all forks. currently a retry mechanism is used. this is unreliable, and might fail in certain cases. also under heavy system loads health requests can timeout. both those cases cause health to detect the system as being down and as a result causing a failover in CES systems. add a dedicated server for each fork for health requests

### Explain the Changes
1. add a new server for each fork for health requests. the port for each server will be in range between a defined base port and port + number of forks
2. add a value in config ENDPOINT_FORK_PORT_BASE that define the base for the dedicated ports for each fork
3. change health script to use the new dedicated servers instead of the endpoint main server to detect forks health
4. add a list of port offsets in the master fork. if fork is replaced, give his server the port of the replaced fork
5. add an argument for the health script to disable server validation - `disable_service_validation`. this value is to enable the use for testing both lacal and on CI

how the mechanism for distributing the different ports to each fork works:
Each fork is assigned a unique port based on its index offset from a base port. To allow a new fork to reuse the same port as a dead one, the primary process maintains a list of port offsets. When spawning a fork, the primary first waits for a "ready" message from the fork (indicating it's ready to receive instructions). Only then does the primary send the assigned port. This ensures the fork doesn't miss the port assignment message. The fork then starts its server on the received port. It's crucial that the primary starts listening for the "ready" message immediately after spawning to avoid missing it.


### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2284

### Testing Instructions:
1. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/test_nc_with_a_couple_of_forks.js`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated health server for forked processes in non-containerized environments, improving health check reliability and visibility.
  - Added new configuration options for fork server port base, timeout, and retry attempts.
  - Health checks now query each fork individually, providing more accurate status reporting.

- **Bug Fixes**
  - Improved handling of worker process restarts to maintain consistent port assignments and robust server startup.

- **Tests**
  - Added comprehensive tests for fork health server behavior, including concurrency and fork restart scenarios.
  - Centralized and enhanced test utilities for mocking health check functions.

- **Chores**
  - Updated documentation and parameter types for server-related functions to reflect new health server support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->