### PR TITLE
NC | LIFECYLE | GPFS | add external binary directory and --allow-scan-on-remote flag

### DIFF
--- a/config.js
+++ b/config.js
@@ -1064,6 +1064,9 @@ config.NC_LIFECYCLE_LIST_BATCH_SIZE = 1000;
 config.NC_LIFECYCLE_BUCKET_BATCH_SIZE = 10000;
 
 config.NC_LIFECYCLE_GPFS_ILM_ENABLED = true;
+config.NC_LIFECYCLE_GPFS_ALLOW_SCAN_ON_REMOTE = true;
+config.NC_GPFS_BIN_DIR = '/usr/lpp/mmfs/bin/';
+
 ////////// GPFS //////////
 config.GPFS_DOWN_DELAY = 1000;
 

--- a/src/nc/nc_constants.js
+++ b/src/nc/nc_constants.js
@@ -1,0 +1,10 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const GPFS_EXTERNAL_BINS = Object.freeze({
+    MMAPPLYPOLICY: 'mmapplypolicy',
+    MMLSFS: 'mmlsfs'
+});
+
+// EXPORTS
+exports.GPFS_EXTERNAL_BINS = GPFS_EXTERNAL_BINS;


### PR DESCRIPTION
### Describe the Problem
On remote FS/remote GPFS clusters the GPFS ILM will not work without passing --allow-scan-on-remote-flag.
We would like to allow the CES to set a custom binary directory where CES can setup and change the external binary usage without NooBaa code changes.

### Explain the Changes
1. `config.js` - Added 2 new configs for enable/disable allow-scan-on-remote flag (it won't fail if passed on local clusters)
and added a configuration for NC_GPFS_BIN_DIR, by default it's the default GPFS binary directory.
```
NC_LIFECYCLE_GPFS_ALLOW_SCAN_ON_REMOTE = true;
NC_GPFS_BIN_DIR = '/usr/lpp/mmfs/bin/';
```
2. moved `get_bin_path()` function from Glacier to `external_bin_util.js` file and passed also the directory so it can be used by regular NC as well and applied the relevant changed to glacier as well.
3. `nc_lifecycle.js` -
- instead of calling mmapplypolicy/mmlsfs directly, changed the code to use their binary paths.
- Added `--allow-scan-on-remote` if `NC_LIFECYCLE_GPFS_ALLOW_SCAN_ON_REMOTE` configuration is set to true.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
Manual - 
**Pre-reqs**- 
1. Create 10 days old files under a bucket that is configured with an expiration policy of 4 days - 
```
mkdir {mount_point_path}/bucket1/logs/
for i in {1..10} ; do touch -d  "10 days ago"  {mount_point_path}/bucket1/logs/file${i}.txt ; done
```

**Default `NC_GPFS_BIN_DIR = '/usr/lpp/mmfs/bin/';` flow (local cluster)** -

1. Run lifecycle CLI - `noobaa-cli lifecycle --disable_runtime_validation --debug 5 &> lifecycle_1.logs`, check in the logs that the expected files where deleted and search for mmlsfs and mmapplypolicy and check that they ran from the default path - `/usr/lpp/mmfs/bin/mmapplypolicy` and `/usr/lpp/mmfs/bin/mmlsfs`.
Check in the logs that `--allow-scan-on-remote` flag appears in the mmapplypolicy command.

**Custom `NC_GPFS_BIN_DIR = 'path/to/custom/bin/dir/';` flow (local cluster)** -
1. Edit config.json and add the following configuration - `"NC_GPFS_BIN_DIR": "path/to/custom/bin/dir/"`
2. Create custom binary dir and mmapplypolicy/mmlsfs wrapper files - 
```
mkdir {path/to/custom/bin/dir}/

cat <<EOF > {path/to/custom/bin/dir}/mmlsfs
#!/bin/bash
mmlsfs "\$@"
EOF

cat <<EOF > {path/to/custom/bin/dir}/mmapplypolicy
#!/bin/bash
mmapplypolicy "\$@"
EOF

chmod +x {path/to/custom/bin/dir}/mmlsfs
chmod +x {path/to/custom/bin/dir}/mmapplypolicy
```
4. Run lifecycle CLI - `noobaa-cli lifecycle --disable_runtime_validation --debug 5 &> lifecycle_1.logs`, check in the logs that the expected files where deleted and search for mmlsfs and mmapplypolicy and check that they ran from the custom path - `path/to/custom/bin/dir/mmapplypolicy` and `path/to/custom/bin/dir/mmlsfs`.
Check in the logs that `--allow-scan-on-remote` flag appears in the mmapplypolicy command.


- [ ] Doc added/updated
- [ ] Tests added
