### PR TITLE
bucket notifications - fix diagnose's test notifs (broken after 8951)

### DIFF
--- a/src/manage_nsfs/health.js
+++ b/src/manage_nsfs/health.js
@@ -417,9 +417,11 @@ class NSFSHealth {
             } else {
                 const connection_file_path = this.config_fs.get_connection_path_by_name(config_file_name);
                 const test_notif_err = await notifications_util.test_notifications([{
-                    name: config_data.name,
+                    id: [config_data.name],
                     topic: [config_file_name]
-                }], this.config_fs.config_root);
+                }], this.config_fs.config_root, {
+                    params: {bucket: 'test_notif_bucket'}
+                });
                 if (test_notif_err) {
                     res = get_invalid_object(config_data.name, connection_file_path, undefined, test_notif_err.code);
                 } else {


### PR DESCRIPTION
### Describe the Problem
diagnose health --all_connection_details incorrectly reports all connections as invalid.

### Explain the Changes
PR 8951 changed test notification to have a json format.
Diagnose flow needs to be adjusted.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2658

### Testing Instructions:
1. Add a connection
2. run above health diagnose command


- [ ] Doc added/updated
- [ ] Tests added
