### PR TITLE
CI | seperate noobaa image build to different action

### DIFF
--- a/.github/workflows/ceph-nsfs-s3-tests.yaml
+++ b/.github/workflows/ceph-nsfs-s3-tests.yaml
@@ -1,13 +1,13 @@
 name: NSFS Ceph S3 Tests
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call]
 
 jobs:
   nsfs-ceph-s3-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
         uses: actions/checkout@v4
@@ -15,10 +15,19 @@ jobs:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
+
       - name: Run NSFS Ceph s3-tests
         run: |
           set -x
           cd ./noobaa-core
           mkdir -p logs/ceph-nsfs-test-logs
           chmod 777 logs/ceph-nsfs-test-logs
-          make test-nsfs-cephs3
+          make test-nsfs-cephs3 -o tester

--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -1,13 +1,13 @@
 name: Ceph S3 Tests
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call]
 
 jobs:
   ceph-s3-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
         uses: actions/checkout@v4
@@ -15,10 +15,19 @@ jobs:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
+
       - name: Run Ceph s3-tests
         run: |
           set -x
           cd ./noobaa-core
           mkdir -p logs/ceph-test-logs
           chmod 777 logs/ceph-test-logs
-          make test-cephs3
+          make test-cephs3 -o tester

--- a/.github/workflows/nc_unit.yml
+++ b/.github/workflows/nc_unit.yml
@@ -1,17 +1,26 @@
 name: Non Containerized Unit Tests
-on: [push, pull_request]
+on: [workflow_call]
 
 jobs:
   run-nc-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
+
       - name: Run Non Containerized Test
         run: |
-          make run-nc-tests
+          make run-nc-tests -o tester

--- a/.github/workflows/postgres-unit-tests.yaml
+++ b/.github/workflows/postgres-unit-tests.yaml
@@ -1,16 +1,25 @@
 name: Unit Tests with Postgres
-on: [push, pull_request]
+on: [workflow_call]
 
 jobs:
   run-unit-tests-postgres:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
+
       - name: Run Unit Tests with Postgres
-        run: make test-postgres
+        run: make test-postgres -o tester

--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -1,0 +1,71 @@
+name: Run PR Tests
+on: [push, pull_request, workflow_dispatch]
+concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+jobs:
+
+  run-sanity-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/sanity.yaml
+
+  run-sanity-ssl-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/sanity-ssl.yaml
+
+  run-unit-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/unit.yaml
+
+  run-unit-tests-postgres:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/postgres-unit-tests.yaml
+
+  run-nc-unit-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/nc_unit.yml
+
+  ceph-s3-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/ceph-s3-tests.yaml
+
+  ceph-nsfs-s3-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/ceph-nsfs-s3-tests.yaml
+
+  warp-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/warp-tests.yaml
+
+  warp-nc-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/warp-nc-tests.yaml
+
+  build-noobaa-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: make noobaa image
+        run: make tester
+
+      - name: create docker artifact
+        run: |
+          docker save --output noobaa.tar noobaa
+          docker save --output noobaa-tester.tar noobaa-tester
+
+      - name: upload noobaa docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: noobaa-image
+          path: noobaa.tar
+          retention-days: "1"
+
+      - name: upload noobaa-tester docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: noobaa-tester
+          path: noobaa-tester.tar
+          retention-days: "1"

--- a/.github/workflows/sanity-ssl.yaml
+++ b/.github/workflows/sanity-ssl.yaml
@@ -1,20 +1,29 @@
 name: Build & Sanity SSL
-on: [push, pull_request]
+on: [workflow_call]
 
 jobs:
   run-sanity-ssl-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
 
       - name: Run Build & SSL Sanity Tests
         run: |
           set -x
           mkdir -p logs/sanity-test-logs
           chmod 777 logs/sanity-test-logs
-          make test-external-pg-sanity
+          make test-external-pg-sanity -o tester

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,20 +1,29 @@
 name: Build & Sanity
-on: [push, pull_request]
+on: [workflow_call]
 
 jobs:
   run-sanity-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
 
       - name: Run Build & Sanity Tests
         run: |
           set -x
           mkdir -p logs/sanity-test-logs
           chmod 777 logs/sanity-test-logs
-          make test-sanity
+          make test-sanity -o tester

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,18 +1,28 @@
 name: Unit Tests
-on: [push, pull_request]
+on: [workflow_call]
 
 jobs:
   run-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+      
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
+
       - name: Run Test
         run: |
-          make test
-          make root-perm-test
+          make test -o tester
+          make root-perm-test -o tester
+

--- a/.github/workflows/warp-nc-tests.yaml
+++ b/.github/workflows/warp-nc-tests.yaml
@@ -1,20 +1,29 @@
 
 name: Warp NC Tests
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call]
 
 jobs:
   warp-nc-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
         uses: actions/checkout@v4
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
 
       - name: Create Warp logs directory
         run: |
@@ -27,5 +36,5 @@ jobs:
         run: |
           set -x
           cd ./noobaa-core
-          make test-nc-warp
+          make test-nc-warp -o tester
 

--- a/.github/workflows/warp-tests.yaml
+++ b/.github/workflows/warp-tests.yaml
@@ -1,19 +1,28 @@
 name: Warp Tests
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call]
 
 jobs:
   warp-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
         uses: actions/checkout@v4
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
 
       - name: Create Warp logs directory
         run: |
@@ -26,5 +35,5 @@ jobs:
         run: |
           set -x
           cd ./noobaa-core
-          make test-warp
+          make test-warp -o tester
 


### PR DESCRIPTION
### Describe the Problem
currently noobaa and tester image are built for each task separately. causing extra load on the CI resources

### Explain the Changes
1. create a new action build-noobaa to build noobaa and tester images. download load the needed image from each action instead of building it.
2. run the tests using the loaded image, while skipping tester make steps
 
###Gaps
1. building tar from image and uploading downloading take extra time. causing the entire testing process to take extra time. there is a container storeon github we might be able to use to skip this step 
2. should probably remove old noobaa images when rerunning the build-noobaa action within the same PR
3. minimum time for artifact retention is 1 day. there is an [open issue](https://github.com/actions/upload-artifact/issues/290) in github to allow for retention days 0, which retains only for workflow run. should replace once it is available

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new workflow to automate building and testing for pull requests, including artifact creation and test orchestration across multiple suites.

- **Chores**
  - Updated existing workflows to improve artifact handling and Docker image usage during test execution.
  - Standardized workflow triggers to use reusable workflows for greater consistency.
  - Enhanced workflow permissions and simplified checkout steps.
  - Modified test commands to include an additional option for improved test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->