### PR TITLE
Add a pre-commit ESLint hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Get list of staged files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(js|jsx|ts|tsx)$' | sed 's| |\\ |g')
+
+# If there are no staged files, exit successfully
+if [ -z "$STAGED_FILES" ]; then
+  exit 0
+fi
+
+# Run ESLint on staged files and capture both output and exit code
+echo "Running ESLint on staged files..."
+ESLINT_OUTPUT=$(npx eslint $STAGED_FILES 2>&1)
+ESLINT_EXIT_CODE=$?
+
+# If ESLint found errors, show them and exit with error
+if [ $ESLINT_EXIT_CODE -ne 0 ]; then
+  echo "❌ ESLint found errors in staged files:"
+  echo "$ESLINT_OUTPUT"
+  echo "Please fix the errors above before committing."
+  exit 1
+fi
+
+echo "✅ ESLint passed!"
+exit 0

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "src/api/index.js",
   "bin": "src/cmd/index.js",
   "scripts": {
+    "preinstall": "if [ -d .git ]; then git config core.hooksPath .githooks; fi",
     "install": "echo install hook override to avoid npm default hook calling node-gyp",
     "build": "npm run build:native",
     "build:native": "node-gyp configure && node-gyp build",


### PR DESCRIPTION
### Describe the Problem
Currently, there's no automated way to ensure code quality through ESLint checks before commits. This can lead to inconsistent code style and potential issues being committed to the repository.

### Explain the Changes
1. Added a pre-commit hook in `.githooks/pre-commit` that runs ESLint on staged JavaScript/TypeScript files
2. Added a `preinstall` script in `package.json` that automatically configures git to use the hooks from `.githooks` directory
3. The hook will:
   - Check only staged JavaScript/TypeScript files (`.js`, `.jsx`, `.ts`, `.tsx`)
   - Run ESLint on these files
   - Block the commit if any ESLint errors are found
   - Show the specific ESLint errors that need to be fixed

### Testing Instructions:
Fresh repo clone:
1. Clone the repository
2. Run `npm install` - this will automatically set up the git hooks. 
4. Make a change to any JavaScript/TypeScript file that violates ESLint rules (e.g., add an unused variable)
5. Try to commit the change - the commit should be blocked with ESLint error messages
6. Fix the ESLint errors and try to commit again - the commit should succeed

Existing repo clone:
1. `cd` into the repo directory
2. Run `git config core.hooksPath .githooks`
3. Follow step 4 onwards above