### PR TITLE
SDK | Upgrade AWS SDK to v3 - Block Store S3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       "dependencies": {
         "@aws-sdk/client-s3": "3.840.0",
         "@aws-sdk/client-sts": "3.840.0",
+        "@aws-sdk/credential-providers": "3.840.0",
+        "@aws-sdk/s3-request-presigner": "3.840.0",
         "@azure/identity": "4.10.1",
         "@azure/monitor-query": "1.3.2",
         "@azure/storage-blob": "12.27.0",
@@ -298,6 +300,72 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.840.0.tgz",
+      "integrity": "sha512-0sn/X63Xqqh5D1FYmdSHiS9SkDzTitoGO++/8IFik4xf/jpn4ZQkIoDPvpxFZcLvebMuUa6jAQs4ap4RusKGkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/credential-provider-node": "3.840.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.6.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.21",
+        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-http-handler": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
+      "integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-iam": {
@@ -611,6 +679,22 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.840.0.tgz",
+      "integrity": "sha512-p1RaMVd6+6ruYjKsWRCZT/jWhrYfDKbXY+/ScIYTvcaOOf9ArMtVnhFk3egewrC7kPXFGRYhg2GPmxRotNYMng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.840.0.tgz",
@@ -756,6 +840,36 @@
         "@aws-sdk/core": "3.840.0",
         "@aws-sdk/nested-clients": "3.840.0",
         "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.840.0.tgz",
+      "integrity": "sha512-+CxYdGd+uM4NZ9VUvFTU1c/H61qhDB4q362k8xKU+bz24g//LDQ5Mpwksv8OUD1en44v4fUwgZ4SthPZMs+eFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.840.0",
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.840.0",
+        "@aws-sdk/credential-provider-env": "3.840.0",
+        "@aws-sdk/credential-provider-http": "3.840.0",
+        "@aws-sdk/credential-provider-ini": "3.840.0",
+        "@aws-sdk/credential-provider-node": "3.840.0",
+        "@aws-sdk/credential-provider-process": "3.840.0",
+        "@aws-sdk/credential-provider-sso": "3.840.0",
+        "@aws-sdk/credential-provider-web-identity": "3.840.0",
+        "@aws-sdk/nested-clients": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.6.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -1040,6 +1154,25 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.840.0.tgz",
+      "integrity": "sha512-1jcrhVoSZjiAQJGNswI0RGR36/+OG6yTV42wQamHdNHk+/68dn9MGTUVr+58AEFOyEAPE/EvkiYRD6n5WkUjMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-format-url": "3.840.0",
+        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.840.0.tgz",
@@ -1109,6 +1242,21 @@
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
         "@smithy/util-endpoints": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.840.0.tgz",
+      "integrity": "sha512-VB1PWyI1TQPiPvg4w7tgUGGQER1xxXPNUqfh3baxUSFi1Oh8wHrDnFywkxLm3NMmgDmnLnSZ5Q326qAoyqKLSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.840.0",
     "@aws-sdk/client-sts": "3.840.0",
+    "@aws-sdk/credential-providers": "3.840.0",
+    "@aws-sdk/s3-request-presigner": "3.840.0",
     "@azure/identity": "4.10.1",
     "@azure/monitor-query": "1.3.2",
     "@azure/storage-blob": "12.27.0",

--- a/src/test/unit_tests/util_functions_tests/test_cloud_utils.js
+++ b/src/test/unit_tests/util_functions_tests/test_cloud_utils.js
@@ -7,42 +7,49 @@ const sinon = require('sinon');
 const AWS = require('aws-sdk');
 const cloud_utils = require('../../../util/cloud_utils');
 const dbg = require('../../../util/debug_module')(__filename);
-const fs = require("fs");
+const { STSClient } = require('@aws-sdk/client-sts');
+const fs = require('fs');
+
 const projectedServiceAccountToken = "/var/run/secrets/openshift/serviceaccount/token";
 const fakeAccessKeyId = "fakeAccessKeyId";
 const fakeSecretAccessKey = "fakeSecretAccessKey";
 const fakeSessionToken = "fakeSessionToken";
 const roleArn = "arn:aws:iam::261532230807:role/noobaa_s3_sts";
 const defaultSTSCredsValidity = 3600;
+const REGION = "us-east-1";
 const expectedParams = [{
     RoleArn: roleArn,
     RoleSessionName: 'testSession',
     WebIdentityToken: 'web-identity-token',
     DurationSeconds: defaultSTSCredsValidity,
 }];
+
 mocha.describe('AWS STS tests', function() {
     let STSStub;
     let stsFake;
     mocha.before('Creating STS stub', function() {
+
         sinon.stub(fs.promises, "readFile")
             .withArgs(projectedServiceAccountToken)
             .returns("web-identity-token");
+
         stsFake = {
-        assumeRoleWithWebIdentity: sinon.stub().returnsThis(),
-        promise: sinon.stub()
-        .resolves({
-            Credentials: {
-                AccessKeyId: fakeAccessKeyId,
-                SecretAccessKey: fakeSecretAccessKey,
-                SessionToken: fakeSessionToken
-            }
-        }),
-    };
+            assumeRoleWithWebIdentity: sinon.stub().returnsThis(),
+            promise: sinon.stub()
+            .resolves({
+                Credentials: {
+                    AccessKeyId: fakeAccessKeyId,
+                    SecretAccessKey: fakeSecretAccessKey,
+                    SessionToken: fakeSessionToken
+                }
+            }),
+        };
         STSStub = sinon.stub(AWS, 'STS')
             .callsFake(() => stsFake);
     });
     mocha.after('Restoring STS stub', function() {
         STSStub.restore();
+        fs.promises.readFile.restore?.();
     });
     mocha.it('should generate aws sts creds', async function() {
         const params = {
@@ -71,5 +78,55 @@ mocha.describe('AWS STS tests', function() {
         assert.equal(s3.config.credentials.secretAccessKey, fakeSecretAccessKey);
         assert.equal(s3.config.credentials.sessionToken, fakeSessionToken);
         assert.equal(s3.config.region, 'us-east-1');
+    });
+});
+
+mocha.describe('AWS STS SDK V3 tests', function() {
+    let sts_v3_stub;
+    mocha.before('Creating STS stub', function() {
+        sinon.stub(fs.promises, "readFile")
+            .withArgs(projectedServiceAccountToken)
+            .returns("web-identity-token");
+        sts_v3_stub = sinon.stub(STSClient.prototype, 'send')
+            .callsFake(() => Promise.resolve({
+                Credentials: {
+                    AccessKeyId: fakeAccessKeyId,
+                    SecretAccessKey: fakeSecretAccessKey,
+                    SessionToken: fakeSessionToken
+                }
+            }));
+    });
+    mocha.after('Restoring STS v3 stub', function() {
+        sts_v3_stub.restore();
+        fs.promises.readFile.restore?.();
+   });
+    mocha.it('should generate aws sts creds', async function() {
+        const params = {
+            aws_sts_arn: roleArn,
+            region: REGION,
+        };
+        const roleSessionName = "testSession";
+        const json = await cloud_utils.generate_aws_sdkv3_sts_creds(params, roleSessionName);
+        sinon.assert.calledOnce(sts_v3_stub);
+        assert.equal(json.accessKeyId, fakeAccessKeyId);
+        assert.equal(json.secretAccessKey, fakeSecretAccessKey);
+        assert.equal(json.sessionToken, fakeSessionToken);
+        dbg.log0('test.aws.sts.assumeRoleWithWebIdentity: ', json);
+    });
+
+    mocha.it('should generate an STS S3 client', async function() {
+        const params = {
+            aws_sts_arn: roleArn,
+            region: 'us-east-1'
+        };
+        const additionalParams = {
+            RoleSessionName: 'testSession'
+        };
+        const s3 = await cloud_utils.createSTSS3SDKv3Client(params, additionalParams);
+        dbg.log0('test.aws.sts.createSTSS3Client: ', (await s3.config.credentials()));
+        assert.equal((await s3.config.credentials()).accessKeyId, fakeAccessKeyId);
+        assert.equal((await s3.config.credentials()).secretAccessKey, fakeSecretAccessKey);
+        assert.equal((await s3.config.credentials()).sessionToken, fakeSessionToken);
+        assert.equal((await s3.config.region()), 'us-east-1');
     });
 });


### PR DESCRIPTION
### Describe the Problem

Upgrade AWS SDK to v3 - Block Store S3

### Explain the Changes
1. update SDK version to V3 for block_store_s3.js
2. STS flow updated with new SDK v3.

### Issues: Fixed #xxx / Gap #xxx
1. remove deprecated SDK v2 from block store s3 flow.

### Testing Instructions:
1. Test bulk storage flow


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AWS SDK v3 for S3 interactions, including new methods for creating S3 clients and generating STS credentials.

* **Chores**
  * Updated dependencies to include AWS SDK v3 packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->