### PR TITLE
NC | Lifecycle | GPFS | fix skip of incorrect noobaa uploads internal directory

### DIFF
--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -1210,7 +1210,7 @@ class NCLifecycle {
         const bucket_path = bucket_json.path;
         const bucket_rule_id = this.get_lifecycle_ilm_candidate_file_suffix(bucket_json.name, lifecycle_rule);
         const in_bucket_path = path.join(bucket_path, '/%');
-        const in_bucket_internal_dir = path.join(bucket_path, '/.noobaa_nsfs%/%');
+        const in_bucket_internal_dir = path.join(bucket_path, `/${config.NSFS_TEMP_DIR_NAME}%/%`);
         const in_versions_dir = path.join(bucket_path, '/.versions/%');
         const in_nested_versions_dir = path.join(bucket_path, '/%/.versions/%');
         const ilm_policy_helpers = { bucket_rule_id, in_bucket_path, in_bucket_internal_dir, in_versions_dir, in_nested_versions_dir };

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_gpfs_ilm_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_gpfs_ilm_integration.test.js
@@ -6,6 +6,7 @@ process.env.DISABLE_INIT_RANDOM_SEED = 'true';
 
 const fs = require('fs');
 const path = require('path');
+const config = require('../../../../config');
 const { ConfigFS } = require('../../../sdk/config_fs');
 const { file_delete, create_fresh_path } = require('../../../util/fs_utils');
 const { read_file } = require('../../../util/native_fs_utils');
@@ -479,7 +480,7 @@ function get_mock_base_ilm_policy(bucket_storage_path, rule_id, lifecycle_run_st
     const policy_rule_id = `${bucket_name}_${rule_id}_${lifecycle_run_status.lifecycle_run_times.run_lifecycle_start_time}`;
     const policy_base = `RULE '${policy_rule_id}' LIST '${policy_rule_id}'\n` +
     `WHERE PATH_NAME LIKE '${bucket_storage_path}/%'\n` +
-    `AND PATH_NAME NOT LIKE '${bucket_storage_path}/.noobaa_nsfs%/%'\n`;
+    `AND PATH_NAME NOT LIKE '${bucket_storage_path}/${config.NSFS_TEMP_DIR_NAME}%/%'\n`;
 
     return definitions_base + policy_base;
 }


### PR DESCRIPTION
### Describe the Problem
As part of code reviewing, I noticed we are skipping `.noobaa_nsfs%/%` directory instead of `.noobaa-nsfs%/%` directory during the nc lifecycle on GPFS flow. Although when setting empty prefix filter I couldn't make this directory get deleted using the lifecycle process.

### Explain the Changes
1. changed to skip the correct internal uploads directory.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal directory path construction to use a configurable directory name instead of a hardcoded value for lifecycle policy generation.

- **Tests**
  - Adjusted tests to align with the new configurable directory name for temporary NSFS directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->