### PR TITLE
NC | Lifecycle | An internal file/folder should be blocked for deletion by the lifecycle worker

### DIFF
--- a/src/test/unit_tests/test_s3_ops.js
+++ b/src/test/unit_tests/test_s3_ops.js
@@ -604,7 +604,6 @@ mocha.describe('s3_ops', function() {
 
             // make an OPTIONS request without the allowed header
             const url = new URL(coretest.get_https_address());
-            console.log('ROMY DEBUG: url', url, url.hostname, url.port, url.pathname);
             const response = await http_utils.make_https_request({
                 hostname: url.hostname,
                 port: url.port,

--- a/src/util/lifecycle_utils.js
+++ b/src/util/lifecycle_utils.js
@@ -148,6 +148,11 @@ function build_lifecycle_filter(params) {
      * @param {Object} object_info
      */
     return function(object_info) {
+        // fail if object is a temp file/part or a folder object or a versioned object
+        if (object_info.key.startsWith(config.NSFS_TEMP_DIR_NAME)) return false;
+        if (object_info.key.includes(config.NSFS_FOLDER_OBJECT_NAME)) return false;
+        if (object_info.key.includes('.versions/')) return false;
+
         if (params.filter?.prefix && !object_info.key.startsWith(params.filter.prefix)) return false;
         if (params.expiration && object_info.age < params.expiration) return false;
         if (params.filter?.tags && !file_contain_tags(object_info, params.filter.tags)) return false;


### PR DESCRIPTION
### Describe the Problem
An internal file/folder should be blocked for deletion by the lifecycle worker, we are not supposed to see an issue due to the whole flow but I added it in order to be extra safe on the filter func as well.

1. POSIX flow - we shouldn't see this issue at all because list_objects() is used and should not be return an internal file.
2. GPFS flow  - also shouldn't happen because on the ILM policy we avoid internal directory/past versions and when seeing .folder file we convert the key to be the directory name.

### Explain the Changes
1. lifecycle_utils.build_lifecycle_filter() - returned false if the object key is inside the bucket temp uploads dir / any .versions/ dir or directory object (.folder).


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `sudo jest --testRegex=jest_tests/test_nc_lifecycle.test`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lifecycle filtering to prevent deletion of temporary files, folder marker objects, and versioned objects.
- **Tests**
  - Added new test cases to verify deletion fails for internal and special system files and directories.
  - Enhanced test assertions for more flexible error checking.
- **Chores**
  - Removed unnecessary debug logging from a CORS test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->