### PR TITLE
[NC | NSFS | GLACIER] Add disk usage info to nsfs metrics

### DIFF
--- a/config.js
+++ b/config.js
@@ -966,6 +966,11 @@ config.NSFS_GLACIER_FORCE_EXPIRE_ON_GET = false;
 // interval
 config.NSFS_GLACIER_MIGRATE_LOG_THRESHOLD = 50 * 1024;
 
+// NSFS_GLACIER_METRICS_STAT_PATHS if set NooBaa will start reporting the statfs info of that
+// path as part of its metrics report
+config.NSFS_GLACIER_METRICS_STATFS_PATHS = [];
+config.NSFS_GLACIER_METRICS_STATFS_INTERVAL = 60 * 1000; // Refresh statfs value every minute
+
 /** 
  * NSFS_GLACIER_RESERVED_BUCKET_TAGS defines an object of bucket tags which will be reserved
  * by the system and PUT operations for them via S3 API would be limited - as in they would be


### PR DESCRIPTION
### Explain the Changes
This PR adds support for NooBaa reporting `disk_usage` as part of NSFS stats if enabled. This feature was requested by a customer.

Example:
```javascript
// config-local.js
config.NSFS_GLACIER_METRICS_STATFS_PATHS = ['/Users/usrivast'];
```
```
{"nsfs_counters":{"noobaa_nsfs_io_read_count":0,"noobaa_nsfs_io_write_count":0,"noobaa_nsfs_io_read_bytes":0,"noobaa_nsfs_io_write_bytes":0},"op_stats_counters":{},"fs_worker_stats_counters":{},"disk_usage":{"/Users/usrivast":85.42}}
```

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Periodic reporting of filesystem disk-usage metrics for configurable NSFS Glacier paths.
  * New configuration options to specify monitored paths and the refresh interval for disk-usage sampling.
  * Disk-usage statistics are included in NSFS Prometheus metrics endpoints when monitoring is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->