### PR TITLE
Added metrices to show the replication status per bucket

### DIFF
--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -384,6 +384,27 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
         }
     }, {
         type: 'Gauge',
+        name: 'bucket_last_cycle_total_objects_num',
+        configuration: {
+            help: 'Total number of objects scanned per bucket in last replication cycle',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_last_cycle_replicated_objects_num',
+        configuration: {
+            help: 'Number of objects replicated per bucket in last replication cycle',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_last_cycle_error_objects_num',
+        configuration: {
+            help: 'Number of objects failed to replicate per bucket in last replication cycle',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
         name: 'bucket_used_bytes',
         configuration: {
             help: 'Object Bucket Used Bytes',
@@ -606,9 +627,12 @@ class NooBaaCoreReport extends BasePrometheusReport {
     set_replication_status(repl_info) {
         if (!this._metrics) return;
         const replication_id = repl_info.replication_id;
+        const bucket_name = repl_info.bucket_name;
         delete this._metrics.replication_status.hashMap[String(repl_info.replication_id)];
         this._metrics.replication_status.set(_.omit(repl_info, ['last_cycle_writes_size',
-            'last_cycle_writes_num', 'last_cycle_error_writes_size', 'last_cycle_error_writes_num'
+            'last_cycle_writes_num', 'last_cycle_error_writes_size', 'last_cycle_error_writes_num',
+            'bucket_last_cycle_total_objects_num', 'bucket_last_cycle_replicated_objects_num',
+            'bucket_last_cycle_error_objects_num'
         ]), Date.now());
 
         delete this._metrics.replication_last_cycle_writes_size.hashMap[String(repl_info.replication_id)];
@@ -622,6 +646,15 @@ class NooBaaCoreReport extends BasePrometheusReport {
 
         delete this._metrics.replication_last_cycle_error_writes_num.hashMap[String(repl_info.replication_id)];
         this._metrics.replication_last_cycle_error_writes_num.set({ replication_id }, repl_info.last_cycle_error_writes_num);
+
+        delete this._metrics.bucket_last_cycle_total_objects_num.hashMap[String(bucket_name)];
+        this._metrics.bucket_last_cycle_total_objects_num.set({ bucket_name }, repl_info.bucket_last_cycle_total_objects_num);
+
+        delete this._metrics.bucket_last_cycle_replicated_objects_num.hashMap[String(bucket_name)];
+        this._metrics.bucket_last_cycle_replicated_objects_num.set({ bucket_name }, repl_info.bucket_last_cycle_replicated_objects_num);
+
+        delete this._metrics.bucket_last_cycle_error_objects_num.hashMap[String(bucket_name)];
+        this._metrics.bucket_last_cycle_error_objects_num.set({ bucket_name }, repl_info.bucket_last_cycle_error_objects_num);
     }
 }
 

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -86,6 +86,7 @@ class ReplicationScanner {
                 for_replication: config.BUCKET_DIFF_FOR_REPLICATION
             });
             dbg.log1(`scan:: cur_src_cont_token: ${cur_src_cont_token},cur_dst_cont_token: ${cur_dst_cont_token}`);
+
             const {
                 keys_diff_map,
                 first_bucket_cont_token: src_cont_token,
@@ -126,9 +127,10 @@ class ReplicationScanner {
 
             // update the prometheus metrics only if we have diff
             if (Object.keys(keys_diff_map).length) {
-                const replication_status = replication_utils.get_rule_status(rule.rule_id, src_cont_token, keys_diff_map, copy_res);
+                const {rule_status, bucket_status} = replication_utils.get_rule_and_bucket_status(
+                    rule.rule_id, src_cont_token, keys_diff_map, copy_res);
 
-                replication_utils.update_replication_prom_report(src_bucket.name, replication_id, replication_status);
+                replication_utils.update_replication_prom_report(src_bucket.name, replication_id, rule_status, bucket_status);
             }
         }));
     }


### PR DESCRIPTION
### Describe the Problem
Previously, there was no metric available to show the replication progress for each individual bucket. As a result, users had no way to monitor how much data had been successfully replicated.

### Explain the Changes
1.  Added new metrices to expose replication per bucket: `bucket_last_cycle_total_objects_num`, `bucket_last_cycle_replicated_objects_num`,  `bucket_last_cycle_error_objects_num`

![Screenshot from 2025-06-25 18-41-29](https://github.com/user-attachments/assets/a476045f-2b32-40fc-87fa-3349e642161f)


### Issues: Fixed #xxx / Gap #xxx
1.  Issue: https://issues.redhat.com/browse/RHSTOR-7208

### Testing Instructions:
1. To view the metrices:

> $ JWT_TOKEN=$(kubectl get secret/noobaa-metrics-auth-secret -o jsonpath={.data.metrics_token} | base64 -d)
$ kubectl exec -it noobaa-core-0 -- curl -k -H "Authorization: Bearer ${JWT_TOKEN}" http://localhost:8080/metrics/bg_workers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced replication metrics to include per-bucket counts for total objects scanned, replicated objects, and replication errors in the last cycle.
- **Improvements**
  - Replication status reporting now distinguishes between rule-level and bucket-level metrics for more detailed insights.
- **Style**
  - Minor formatting improvements for log readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->