### PR TITLE
NC | GPFS | ILM policy special chars and tagging fixes

### DIFF
--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -34,7 +34,11 @@ const LIFECYLE_TIMESTAMP_FILE = 'lifecycle.timestamp';
 const config_fs_options = { silent_if_missing: true };
 const ILM_POLICIES_TMP_DIR = path.join(config.NC_LIFECYCLE_LOGS_DIR, 'lifecycle_ilm_policies');
 const ILM_CANDIDATES_TMP_DIR = path.join(config.NC_LIFECYCLE_LOGS_DIR, 'lifecycle_ilm_candidates');
-
+const escape_backslash_str = "ESCAPE '\\'";
+const underscore_wildcard_regex = /_/g;
+const precentage_wildcard_regex = /%/g;
+const single_quote_regex = /'/g;
+const backslash_regex = /\\/g;
 
 const TIMED_OPS = Object.freeze({
     RUN_LIFECYLE: 'run_lifecycle',
@@ -1257,16 +1261,17 @@ class NCLifecycle {
     convert_lifecycle_policy_to_gpfs_ilm_policy(lifecycle_rule, bucket_json) {
         const bucket_path = bucket_json.path;
         const bucket_rule_id = this.get_lifecycle_ilm_candidate_file_suffix(bucket_json.name, lifecycle_rule);
-        const in_bucket_path = path.join(bucket_path, '/%');
-        const in_bucket_internal_dir = path.join(bucket_path, `/${config.NSFS_TEMP_DIR_NAME}%/%`);
-        const in_versions_dir = path.join(bucket_path, '/.versions/%');
-        const in_nested_versions_dir = path.join(bucket_path, '/%/.versions/%');
+        const escaped_bucket_path = this._escape_like_clause_ilm_policy(bucket_path);
+        const in_bucket_path = path.join(escaped_bucket_path, '/%');
+        const in_bucket_internal_dir = path.join(escaped_bucket_path, `/${config.NSFS_TEMP_DIR_NAME}%/%`);
+        const in_versions_dir = path.join(escaped_bucket_path, '/.versions/%');
+        const in_nested_versions_dir = path.join(escaped_bucket_path, '/%/.versions/%');
         const ilm_policy_helpers = { bucket_rule_id, in_bucket_path, in_bucket_internal_dir, in_versions_dir, in_nested_versions_dir };
 
         const policy_base = this._get_gpfs_ilm_policy_base(ilm_policy_helpers);
         const expiry_string = this.convert_expiry_rule_to_gpfs_ilm_policy(lifecycle_rule, ilm_policy_helpers);
         const non_current_days_string = this.convert_noncurrent_version_by_days_to_gpfs_ilm_policy(lifecycle_rule, ilm_policy_helpers);
-        const filter_policy = this.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, bucket_json);
+        const filter_policy = this.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         return policy_base + non_current_days_string + expiry_string + filter_policy;
     }
 
@@ -1280,10 +1285,27 @@ class NCLifecycle {
         const mod_age_definition = `define( mod_age, (DAYS(CURRENT_TIMESTAMP) - DAYS(MODIFICATION_TIME)) )\n`;
         const change_age_definition = `define( change_age, (DAYS(CURRENT_TIMESTAMP) - DAYS(CHANGE_TIME)) )\n`;
         const rule_id_definition = `RULE '${bucket_rule_id}' LIST '${bucket_rule_id}'\n`;
-        const policy_path_base = `WHERE PATH_NAME LIKE '${in_bucket_path}'\n` +
-            `AND PATH_NAME NOT LIKE '${in_bucket_internal_dir}'\n`;
+        const policy_path_base = `WHERE PATH_NAME LIKE '${in_bucket_path}' ${escape_backslash_str}\n` +
+            `AND PATH_NAME NOT LIKE '${in_bucket_internal_dir}' ${escape_backslash_str}\n`;
 
         return mod_age_definition + change_age_definition + rule_id_definition + policy_path_base;
+    }
+
+    /**
+     * escape_like_clause_ilm_policy escapes the \ _ % and ' characters in the ILM policy string
+     * this is needed because GPFS ILM policies use _ and % as wildcards
+     * and we need to escape them to use them as normal characters
+     * since we are escaping using backslash we also need to escape the backslash itself
+     * IMPORTANT - escaping of the backslash must be done before escaping of the underscore and percentage
+     * @param {String} ilm_policy_string 
+     * @returns String 
+     */
+    _escape_like_clause_ilm_policy(ilm_policy_string) {
+        return ilm_policy_string
+            .replace(backslash_regex, '\\\\')
+            .replace(underscore_wildcard_regex, '\\_')
+            .replace(precentage_wildcard_regex, '\\%')
+            .replace(single_quote_regex, `''`);
     }
 
     /**
@@ -1296,8 +1318,8 @@ class NCLifecycle {
     convert_expiry_rule_to_gpfs_ilm_policy(lifecycle_rule, { in_versions_dir, in_nested_versions_dir }) {
         const { expiration = undefined } = lifecycle_rule;
         if (!expiration) return '';
-        const current_path_policy = `AND PATH_NAME NOT LIKE '${in_versions_dir}'\n` +
-            `AND PATH_NAME NOT LIKE '${in_nested_versions_dir}'\n`;
+        const current_path_policy = `AND PATH_NAME NOT LIKE '${in_versions_dir}' ${escape_backslash_str}\n` +
+            `AND PATH_NAME NOT LIKE '${in_nested_versions_dir}' ${escape_backslash_str}\n`;
 
         const expiry_policy = expiration.days ? `AND mod_age > ${expiration.days}\n` : '';
         return current_path_policy + expiry_policy;
@@ -1317,20 +1339,23 @@ class NCLifecycle {
     /**
      * convert_filter_to_gpfs_ilm_policy converts the filter to GPFS ILM policy
      * @param {*} lifecycle_rule
-     * @param {Object} bucket_json
+     * @param {String} escaped_bucket_path
      * @returns {String}
      */
-    convert_filter_to_gpfs_ilm_policy(lifecycle_rule, bucket_json) {
+    convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path) {
         const { prefix = undefined, filter = {} } = lifecycle_rule;
-        const bucket_path = bucket_json.path;
         let filter_policy = '';
         if (prefix || Object.keys(filter).length > 0) {
             const { object_size_greater_than = undefined, object_size_less_than = undefined, tags = undefined } = filter;
             const rule_prefix = prefix || filter.prefix;
-            filter_policy += rule_prefix ? `AND PATH_NAME LIKE '${path.join(bucket_path, rule_prefix)}%'\n` : '';
+            const escaped_prefix = this._escape_like_clause_ilm_policy(rule_prefix || '');
+            filter_policy += rule_prefix ? `AND PATH_NAME LIKE '${path.join(escaped_bucket_path, escaped_prefix)}%' ${escape_backslash_str}\n` : '';
             filter_policy += object_size_greater_than === undefined ? '' : `AND FILE_SIZE > ${object_size_greater_than}\n`;
             filter_policy += object_size_less_than === undefined ? '' : `AND FILE_SIZE < ${object_size_less_than}\n`;
-            filter_policy += tags ? tags.map(tag => `AND XATTR('user.noobaa.tag.${tag.key}') LIKE ${tag.value}\n`).join('') : '';
+            filter_policy += tags ? tags.map(tag => {
+                const escaped_tag_value = this._escape_like_clause_ilm_policy(tag.value);
+                return `AND XATTR('user.noobaa.tag.${tag.key}') LIKE '${escaped_tag_value}' ${escape_backslash_str}\n`;
+            }).join('') : '';
         }
         return filter_policy;
     }
@@ -1493,16 +1518,21 @@ class NCLifecycle {
      * example -
      * 17460 1316236366 0   -- /mnt/gpfs0/account1_new_buckets_path/bucket1_storage/key1.txt
      * if file is .folder (directory object) we need to return its parent directory
-     * @param {*} entry
+     * Notice that trim() is not used here because if used will remove whitespaces from the end of the line and might delete 
+     * spaces at the end of the file name that might be part of the file name, file reader should trim the line before passing it to this function
+     * @param {Object} entry - entry from the candidates file
+     * @param {Object} bucket_json
      */
     _parse_key_from_line(entry, bucket_json) {
-        const line_array = entry.path.split(' ');
-        const file_path = line_array[line_array.length - 1];
+        dbg.log1(`_parse_key_from_line entry=${util.inspect(entry)}, bucket_json=${util.inspect(bucket_json)}`);
+        const path_start_index = entry.path.indexOf(bucket_json.path);
+        const file_path = entry.path.slice(path_start_index);
         let file_key = file_path.replace(path.join(bucket_json.path, '/'), '');
         const basename = path.basename(file_key);
         if (basename.startsWith(config.NSFS_FOLDER_OBJECT_NAME)) {
             file_key = path.join(path.dirname(file_key), '/');
         }
+        dbg.log1(`_parse_key_from_line file_path=${util.inspect(file_path)}, file_key=${util.inspect(file_key)}`);
         return file_key;
     }
 }

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_gpfs_ilm_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_gpfs_ilm_integration.test.js
@@ -34,6 +34,7 @@ const bucket_path = path.join(TMP_PATH, 'mock_bucket_path');
 const prefix = 'mock_prefix';
 const mock_content = `mock_content`;
 const mock_bucket_json = { _id: 'mock_bucket_id', name: bucket_name, path: bucket_path };
+const escape_backslash_str = "ESCAPE '\\'";
 
 const days = 3;
 const default_lifecycle_rule = {
@@ -53,9 +54,10 @@ describe('convert_expiry_rule_to_gpfs_ilm_policy unit tests', () => {
         ...default_lifecycle_rule,
         filter: { 'prefix': '' }
     };
+    const escaped_bucket_path = get_escaped_string(bucket_path);
     const convertion_helpers = {
-        in_versions_dir: path.join(bucket_path, '/.versions/%'),
-        in_nested_versions_dir: path.join(bucket_path, '/%/.versions/%')
+        in_versions_dir: path.join(escaped_bucket_path, '/.versions/%'),
+        in_nested_versions_dir: path.join(escaped_bucket_path, '/%/.versions/%')
     };
     it('convert_expiry_rule_to_gpfs_ilm_policy - expiry days', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, expiration: { days: days } };
@@ -86,45 +88,46 @@ describe('convert_filter_to_gpfs_ilm_policy unit tests', () => {
         expiration: { days: days }
     };
 
+    const escaped_bucket_path = get_escaped_string(bucket_path);
     it('convert_filter_to_gpfs_ilm_policy - filter empty', () => {
         const lifecycle_rule = lifecycle_rule_base;
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         expect(ilm_policy).toBe('');
     });
 
     it('convert_filter_to_gpfs_ilm_policy - inline prefix', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, prefix };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         expect(ilm_policy).toBe(get_expected_ilm_prefix(bucket_path, prefix));
     });
 
     it('convert_filter_to_gpfs_ilm_policy - filter with prefix', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { prefix } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         expect(ilm_policy).toBe(get_expected_ilm_prefix(bucket_path, prefix));
     });
 
     it('convert_filter_to_gpfs_ilm_policy - filter with size gt', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { object_size_greater_than } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         expect(ilm_policy).toBe(get_expected_ilm_size_greater_than(object_size_greater_than));
     });
 
     it('convert_filter_to_gpfs_ilm_policy - filter with size lt', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { object_size_less_than } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         expect(ilm_policy).toBe(get_expected_ilm_size_less_than(object_size_less_than));
     });
 
     it('convert_filter_to_gpfs_ilm_policy - filter with tags', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { tags } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         expect(ilm_policy).toBe(get_expected_ilm_tags(tags));
     });
 
     it('convert_filter_to_gpfs_ilm_policy - filter with prefix + size gt', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { prefix, object_size_greater_than } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_prefix(bucket_path, prefix) +
             get_expected_ilm_size_greater_than(object_size_greater_than);
         expect(ilm_policy).toBe(expected_ilm_filter);
@@ -132,21 +135,21 @@ describe('convert_filter_to_gpfs_ilm_policy unit tests', () => {
 
     it('convert_filter_to_gpfs_ilm_policy - filter with prefix + size lt', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { prefix, object_size_less_than } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_prefix(bucket_path, prefix) + get_expected_ilm_size_less_than(object_size_less_than);
         expect(ilm_policy).toBe(expected_ilm_filter);
     });
 
     it('convert_filter_to_gpfs_ilm_policy - filter with prefix + tags', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { prefix, tags } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_prefix(bucket_path, prefix) + get_expected_ilm_tags(tags);
         expect(ilm_policy).toBe(expected_ilm_filter);
     });
 
     it('convert_filter_to_gpfs_ilm_policy - filter with size gt + size lt', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { object_size_less_than, object_size_greater_than } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_size_greater_than(object_size_greater_than) +
             get_expected_ilm_size_less_than(object_size_less_than);
         expect(ilm_policy).toBe(expected_ilm_filter);
@@ -154,7 +157,7 @@ describe('convert_filter_to_gpfs_ilm_policy unit tests', () => {
 
     it('convert_filter_to_gpfs_ilm_policy - filter with size gt + tags', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { object_size_greater_than, tags } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_size_greater_than(object_size_greater_than) +
             get_expected_ilm_tags(tags);
         expect(ilm_policy).toBe(expected_ilm_filter);
@@ -162,7 +165,7 @@ describe('convert_filter_to_gpfs_ilm_policy unit tests', () => {
 
     it('convert_filter_to_gpfs_ilm_policy - filter with size lt + tags', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { object_size_less_than, tags } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_size_less_than(object_size_less_than) +
             get_expected_ilm_tags(tags);
         expect(ilm_policy).toBe(expected_ilm_filter);
@@ -170,7 +173,7 @@ describe('convert_filter_to_gpfs_ilm_policy unit tests', () => {
 
     it('convert_filter_to_gpfs_ilm_policy - filter with prefix + size gt + size lt', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { prefix, object_size_greater_than, object_size_less_than } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_prefix(bucket_path, prefix) +
             get_expected_ilm_size_greater_than(object_size_greater_than) +
             get_expected_ilm_size_less_than(object_size_less_than);
@@ -179,7 +182,7 @@ describe('convert_filter_to_gpfs_ilm_policy unit tests', () => {
 
     it('convert_filter_to_gpfs_ilm_policy - filter with prefix + size lt + tags', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { prefix, object_size_less_than, tags } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_prefix(bucket_path, prefix) +
             get_expected_ilm_size_less_than(object_size_less_than) +
             get_expected_ilm_tags(tags);
@@ -188,7 +191,7 @@ describe('convert_filter_to_gpfs_ilm_policy unit tests', () => {
 
     it('convert_filter_to_gpfs_ilm_policy - filter with size gt + size lt + tags', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { object_size_greater_than, object_size_less_than, tags } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_size_greater_than(object_size_greater_than) +
             get_expected_ilm_size_less_than(object_size_less_than) +
             get_expected_ilm_tags(tags);
@@ -197,7 +200,7 @@ describe('convert_filter_to_gpfs_ilm_policy unit tests', () => {
 
     it('convert_filter_to_gpfs_ilm_policy - filter with prefix + size gt + size lt + tags', () => {
         const lifecycle_rule = { ...lifecycle_rule_base, filter: { prefix, object_size_greater_than, object_size_less_than, tags } };
-        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, mock_bucket_json);
+        const ilm_policy = nc_lifecycle.convert_filter_to_gpfs_ilm_policy(lifecycle_rule, escaped_bucket_path);
         const expected_ilm_filter = get_expected_ilm_prefix(bucket_path, prefix) +
             get_expected_ilm_size_greater_than(object_size_greater_than) +
             get_expected_ilm_size_less_than(object_size_less_than) +
@@ -476,11 +479,11 @@ async function create_mock_candidates_file(candidates_path, file_prefix, num_of_
 function get_mock_base_ilm_policy(bucket_storage_path, rule_id, lifecycle_run_status) {
     const definitions_base = `define( mod_age, (DAYS(CURRENT_TIMESTAMP) - DAYS(MODIFICATION_TIME)) )\n` +
         `define( change_age, (DAYS(CURRENT_TIMESTAMP) - DAYS(CHANGE_TIME)) )\n`;
-
+    const escaped_bucket_storage_path = get_escaped_string(bucket_storage_path);
     const policy_rule_id = `${bucket_name}_${rule_id}_${lifecycle_run_status.lifecycle_run_times.run_lifecycle_start_time}`;
     const policy_base = `RULE '${policy_rule_id}' LIST '${policy_rule_id}'\n` +
-    `WHERE PATH_NAME LIKE '${bucket_storage_path}/%'\n` +
-    `AND PATH_NAME NOT LIKE '${bucket_storage_path}/${config.NSFS_TEMP_DIR_NAME}%/%'\n`;
+    `WHERE PATH_NAME LIKE '${escaped_bucket_storage_path}/%' ${escape_backslash_str}\n` +
+    `AND PATH_NAME NOT LIKE '${escaped_bucket_storage_path}/${config.NSFS_TEMP_DIR_NAME}%/%' ${escape_backslash_str}\n`;
 
     return definitions_base + policy_base;
 }
@@ -492,8 +495,9 @@ function get_mock_base_ilm_policy(bucket_storage_path, rule_id, lifecycle_run_st
  * @returns {String}
  */
 function get_expected_ilm_expiry(expiry_days, bucket_storage_path) {
-    const path_policy = `AND PATH_NAME NOT LIKE '${bucket_storage_path}/.versions/%'\n` +
-        `AND PATH_NAME NOT LIKE '${bucket_storage_path}/%/.versions/%'\n`;
+    const escaped_bucket_storage_path = get_escaped_string(bucket_storage_path);
+    const path_policy = `AND PATH_NAME NOT LIKE '${escaped_bucket_storage_path}/.versions/%' ${escape_backslash_str}\n` +
+        `AND PATH_NAME NOT LIKE '${escaped_bucket_storage_path}/%/.versions/%' ${escape_backslash_str}\n`;
     const expiration_policy = expiry_days ? `AND mod_age > ${expiry_days}\n` : '';
     return path_policy + expiration_policy;
 }
@@ -505,7 +509,13 @@ function get_expected_ilm_expiry(expiry_days, bucket_storage_path) {
  * @returns {String}
  */
 function get_expected_ilm_prefix(bucket_storage_path, obj_prefix) {
-    return `AND PATH_NAME LIKE '${bucket_storage_path}/${obj_prefix}%'\n`;
+    const escaped_bucket_storage_path = get_escaped_string(bucket_storage_path);
+    const escaped_obj_prefix = get_escaped_string(obj_prefix);
+    return `AND PATH_NAME LIKE '${escaped_bucket_storage_path}/${escaped_obj_prefix}%' ${escape_backslash_str}\n`;
+}
+
+function get_escaped_string(str) {
+    return str.replace(/_/g, '\\_').replace(/%/g, '\\%').replace(/'/g, "''");
 }
 
 /**
@@ -532,7 +542,10 @@ function get_expected_ilm_size_less_than(size) {
  * @returns {String}
  */
 function get_expected_ilm_tags(tags) {
-    return tags.map(tag => `AND XATTR('user.noobaa.tag.${tag.key}') LIKE ${tag.value}\n`).join('');
+    return tags.map(tag => {
+        const escaped_tag_val = get_escaped_string(tag.value);
+        return `AND XATTR('user.noobaa.tag.${tag.key}') LIKE '${escaped_tag_val}' ${escape_backslash_str}\n`;
+    }).join('');
 }
 
 /**


### PR DESCRIPTION
### Describe the Problem
Per the GPFS ILM policy documentation - https://www.ibm.com/docs/en/storage-scale/5.2.2?topic=management-policy-rules-examples-tips
We should escape % and _ characters - 
```
Where:
- A percent % wildcard in the name represents zero or more characters.
- An underscore (_) wildcard in the name represents 1 byte.

Use the optional ESCAPE clause to establish an escape character, when you need to match '_' or '%' exactly.
```

Also, there are existing bugs in tags and in bucket path that contain spaces.
 
### Explain the Changes
1. Converted `%` to `\%` and `_` to `\_` in every LIKE clause of ILM policy.
2. Added `ESCAPE "\\"` at the end of every LIKE clause.
3. Added double quote when a single quote is given in bucket path, prefix or tag value. 
4. Added missing quotes on tag.value causing bug 2722.
5. Fixed _parse_key_from_line() issue with bucket paths that contain spaces.
 
### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-2722
2. Gap - Add auto tests.

### Testing Instructions:
1. Tagging issue - as mentioned in the fixed bug.
2. Special chars on ILM - create a bucket path/lifecycle policy prefix/tag value that has a special character and run lifecycle worker.


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of special characters in bucket paths, prefixes, and tag values to ensure accurate pattern matching in GPFS ILM policies.
	- Enhanced parsing of file paths to preserve trailing spaces and improve robustness.

- **Tests**
	- Updated tests to verify correct escaping of special characters in generated ILM policy strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->