### PR TITLE
CI | pull noobaa-base image instead building it

### DIFF
--- a/.github/workflows/ceph-nsfs-s3-tests.yaml
+++ b/.github/workflows/ceph-nsfs-s3-tests.yaml
@@ -3,6 +3,7 @@ on: [workflow_call]
 
 jobs:
   nsfs-ceph-s3-tests:
+    name: NSFS Ceph S3 Tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -3,6 +3,7 @@ on: [workflow_call]
 
 jobs:
   ceph-s3-tests:
+    name: Ceph S3 Tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/nc_unit.yml
+++ b/.github/workflows/nc_unit.yml
@@ -3,6 +3,7 @@ on: [workflow_call]
 
 jobs:
   run-nc-unit-tests:
+    name: Non Containerized Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/postgres-unit-tests.yaml
+++ b/.github/workflows/postgres-unit-tests.yaml
@@ -3,6 +3,7 @@ on: [workflow_call]
 
 jobs:
   run-unit-tests-postgres:
+    name: Unit Tests with Postgres
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -42,28 +42,112 @@ jobs:
     uses: ./.github/workflows/warp-nc-tests.yaml
 
   build-noobaa-image:
+    name: Build Noobaa Image
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: make noobaa image
-        run: make tester
+      - name: Prepare Tags
+        id: prep
+        run: |
+          DOCKER_BUILDER_IMAGE=noobaa/noobaa-builder
+          DOCKER_BASE_IMAGE=noobaa/noobaa-base
+          if [[ -n ${{github.base_ref}} ]]; then
+            #on pull request, use target branch
+            BRANCH=${{github.base_ref}}
+          else
+            #on push, use the pushed branch
+            BRANCH=${{github.ref_name}}
+          fi
+          BUILDER_TAGS="${DOCKER_BUILDER_IMAGE}:${BRANCH}-"
+          BASE_TAGS="${DOCKER_BASE_IMAGE}:${BRANCH}-"
+          EARLIEST_VERSION_PAST=20
+          echo "basetags=${BASE_TAGS}" >> $GITHUB_OUTPUT
+          echo "buildertags=${BUILDER_TAGS}" >> $GITHUB_OUTPUT
+          echo "pull_tries=${EARLIEST_VERSION_PAST}" >> $GITHUB_OUTPUT
+
+      - name: Check changed files
+        id: changed_files
+        uses: tj-actions/changed-files@v44
+
+      - name: Should build noobaa base image
+        id: should_build_base
+        run: |
+          base_files=("package.json" "base.dockerfile" ".nvmrc")
+          output=false
+          for file in ${{ steps.changed_files.outputs.all_changed_files }}; do
+            if printf '%s\n' "${base_files[@]}" | grep -x -q "$file"; then
+              echo "File ${file} has changed, building base image."
+              output=true
+              break;
+            fi
+          done
+          echo "should_build=${output}" >> $GITHUB_OUTPUT
+
+      - name: Pull noobaa-base image
+        id: pull_base_image
+        if: ${{ steps.should_build_base.outputs.should_build == 'false' }}
+        run: |
+          output=false
+          for i in $(seq 0 ${{ steps.prep.outputs.pull_tries }})
+          do
+            date=$(date -d "${i} days ago" +'%Y%m%d')
+            base_tag="quay.io/${{ steps.prep.outputs.basetags }}${date}"
+            echo "Trying to pull ${base_tag}"
+            docker pull ${base_tag} || continue
+            echo "Successfully pulled ${base_tag} from quay.io"
+            docker tag ${base_tag} noobaa-base
+            output=true
+            break
+          done
+          echo "pull_succeed=${output}" >> $GITHUB_OUTPUT
+
+      - name: Pull noobaa-builder image
+        id: should_build_builder
+        if: ${{steps.should_build_base.outputs.should_build == 'true' ||
+          steps.pull_base_image.outputs.pull_succeed == 'false'}}
+        run: |
+          output=true
+          for i in $(seq 0 ${{ steps.prep.outputs.pull_tries }})
+          do
+            date=$(date -d "${i} days ago" +'%Y%m%d')
+            builder_tag="quay.io/${{ steps.prep.outputs.buildertags }}${date}"
+            echo "Trying to pull ${builder_tag}"
+            docker pull ${builder_tag} || continue
+            echo "Successfully pulled ${builder_tag} from quay.io"
+            docker tag ${builder_tag} noobaa-builder
+            output=false
+            break
+          done
+          echo "should_build=${output}" >> $GITHUB_OUTPUT 
+
+      - name: Build noobaa-base image
+        if: ${{steps.should_build_base.outputs.should_build == 'true' ||
+          steps.pull_base_image.outputs.pull_succeed == 'false'}}
+        run: |
+          if [ "${{ steps.should_build_builder.outputs.should_build }}" = 'false' ]; then
+            flags="-o builder"
+          fi
+          make base ${flags}
+
+      - name: Build noobaa and tester images
+        run: make tester -o base
 
       - name: create docker artifact
         run: |
           docker save --output noobaa.tar noobaa
           docker save --output noobaa-tester.tar noobaa-tester
 
-      - name: upload noobaa docker image
+      - name: Upload noobaa docker image
         uses: actions/upload-artifact@v4
         with:
           name: noobaa-image
           path: noobaa.tar
           retention-days: "1"
 
-      - name: upload noobaa-tester docker image
+      - name: Upload noobaa-tester docker image
         uses: actions/upload-artifact@v4
         with:
           name: noobaa-tester

--- a/.github/workflows/sanity-ssl.yaml
+++ b/.github/workflows/sanity-ssl.yaml
@@ -3,6 +3,7 @@ on: [workflow_call]
 
 jobs:
   run-sanity-ssl-tests:
+    name: Sanity SSL Tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -3,6 +3,7 @@ on: [workflow_call]
 
 jobs:
   run-sanity-tests:
+    name: Sanity Tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -3,6 +3,7 @@ on: [workflow_call]
 
 jobs:
   run-unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/warp-nc-tests.yaml
+++ b/.github/workflows/warp-nc-tests.yaml
@@ -4,6 +4,7 @@ on: [workflow_call]
 
 jobs:
   warp-nc-tests:
+    name: Warp NC Tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/warp-tests.yaml
+++ b/.github/workflows/warp-tests.yaml
@@ -3,6 +3,7 @@ on: [workflow_call]
 
 jobs:
   warp-tests:
+    name: Warp Tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:


### PR DESCRIPTION
### Describe the Problem
Currently, we build the noobaa-base and noobaa-builder images for every commit and pull request. This significantly increases CI workflow time.

### Explain the Changes
We now pull the base image from a Quay repository instead of building it on every run — unless the PR includes changes to files that require a new build:
- package.json
- base.dockerfile
- .nvmrc

**new build noobaa image flow**:
1. check for what files were changed in the PR
2. If no critical files were changed:
        a. Pull the `noobaa-base` image from Quay
3. if critical files were changed or pulling the image failed:
        a. Pull the `noobaa-builder` image from Quay.
        b. Build a new `noobaa-base` image from the builder image.
        c. If pulling the `builder image` also fails, build it locally.
4. build noobaa and tester images based on base image (either pulled or created)
    
**Additional Updates**
Improved the display names of test jobs for better readability in the CI output.

### Issues: Fixed #xxx / Gap #xxx

#### GAPS

### Testing Instructions:
1. create new PR with none of the above files changed: should pull the noobaa-base image from quay, and build core and tester images based of it
2. create a new PR with the above files changed: should pull noobaa-builder image from quay, and build base, core, and tester images based of it
3. in order to test fail to pull scenarios, can change the names of the quay repositories to an invalid names

in all cases build should succeed, and test worfklows should run

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Added descriptive names to multiple jobs in workflow runs for improved clarity in the GitHub Actions UI.
	- Enhanced the build process for Docker images in pull request workflows with more robust logic for building, pulling, and tagging images, as well as artifact creation and upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->