### PR TITLE
NC | Lifecycle | GPFS | Skip bucket processing if mount point has errors and add to the bucket status

### DIFF
--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -90,6 +90,9 @@ class NCLifecycle {
         this.disable_service_validation = options.disable_service_validation || false;
         this.disable_runtime_validation = options.disable_runtime_validation || false;
         this.should_continue_last_run = options.should_continue_last_run || false;
+        // used for GPFS optimization - maps bucket names to their mount points
+        // example - { 'bucket1': '/gpfs/mount/point1', 'bucket2': '/gpfs/mount/point2' }
+        this.bucket_to_mount_point_map = {};
     }
 
     /**
@@ -183,13 +186,19 @@ class NCLifecycle {
         }
 
         while (!this.lifecycle_run_status.state.is_finished) {
-            await P.map_with_concurrency(buckets_concurrency, bucket_names, async bucket_name =>
-                await this._call_op_and_update_status({
-                    bucket_name,
-                    op_name: TIMED_OPS.PROCESS_BUCKET,
-                    op_func: async () => this.process_bucket(bucket_name, system_json)
-                })
-            );
+            await P.map_with_concurrency(buckets_concurrency, bucket_names, async bucket_name => {
+                try {
+                    await this._call_op_and_update_status({
+                        bucket_name,
+                        op_name: TIMED_OPS.PROCESS_BUCKET,
+                        op_func: async () => this.process_bucket(bucket_name, system_json)
+                    });
+                } catch (err) {
+                    dbg.error('process_bucket failed with error', err, err.code, err.message);
+                    if (!this.lifecycle_run_status.buckets_statuses[bucket_name]) this.init_bucket_status(bucket_name);
+                    this.lifecycle_run_status.buckets_statuses[bucket_name].state.is_finished = true;
+                }
+            });
             this.lifecycle_run_status.state.is_finished = Object.values(this.lifecycle_run_status.buckets_statuses).reduce(
                 (acc, bucket) => acc && (bucket.state?.is_finished),
                 true
@@ -214,7 +223,7 @@ class NCLifecycle {
         await object_sdk._simple_load_requesting_account();
         const should_notify = notifications_util.should_notify_on_event(bucket_json, notifications_util.OP_TO_EVENT.lifecycle_delete.name);
         if (!bucket_json.lifecycle_configuration_rules) {
-            this.lifecycle_run_status.buckets_statuses[bucket_json.name].state = { is_finished: true };
+            this.lifecycle_run_status.buckets_statuses[bucket_name].state = { is_finished: true };
             return;
         }
         await this.process_rules(bucket_json, object_sdk, should_notify);
@@ -226,14 +235,20 @@ class NCLifecycle {
      * @param {nb.ObjectSDK} object_sdk
      */
     async process_rules(bucket_json, object_sdk, should_notify) {
-        try {
-            const bucket_state = this.lifecycle_run_status.buckets_statuses[bucket_json.name].state;
-            bucket_state.num_processed_objects = 0;
-            while (!bucket_state.is_finished && bucket_state.num_processed_objects < config.NC_LIFECYCLE_BUCKET_BATCH_SIZE) {
-                await P.all(_.map(bucket_json.lifecycle_configuration_rules,
+        const bucket_name = bucket_json.name;
+        const bucket_state = this.lifecycle_run_status.buckets_statuses[bucket_name].state;
+        bucket_state.num_processed_objects = 0;
+        while (!bucket_state.is_finished && bucket_state.num_processed_objects < config.NC_LIFECYCLE_BUCKET_BATCH_SIZE) {
+            if (this._should_use_gpfs_optimization()) {
+                const bucket_mount_point = this.bucket_to_mount_point_map[bucket_name];
+                if (this.lifecycle_run_status.mount_points_statuses[bucket_mount_point]?.errors?.length > 0) {
+                    throw new Error(`Lifecycle run failed for bucket ${bucket_name} on mount point ${bucket_mount_point} due to errors: ${this.lifecycle_run_status.mount_points_statuses[bucket_mount_point].errors}`);
+                }
+            }
+            await P.all(_.map(bucket_json.lifecycle_configuration_rules,
                     async (lifecycle_rule, index) =>
                         await this._call_op_and_update_status({
-                            bucket_name: bucket_json.name,
+                            bucket_name,
                             rule_id: lifecycle_rule.id,
                             op_name: TIMED_OPS.PROCESS_RULE,
                             op_func: async () => this.process_rule(
@@ -245,15 +260,12 @@ class NCLifecycle {
                             )
                         })
                     )
-                );
-                bucket_state.is_finished = Object.values(this.lifecycle_run_status.buckets_statuses[bucket_json.name].rules_statuses)
-                    .reduce(
-                    (acc, rule) => acc && (_.isEmpty(rule.state) || rule.state.is_finished),
-                    true
-                );
-            }
-        } catch (err) {
-            dbg.error('process_rules failed with error', err, err.code, err.message);
+            );
+            bucket_state.is_finished = Object.values(this.lifecycle_run_status.buckets_statuses[bucket_name].rules_statuses)
+                .reduce(
+                (acc, rule) => acc && (_.isEmpty(rule.state) || rule.state.is_finished),
+                true
+            );
         }
     }
 
@@ -1199,7 +1211,9 @@ class NCLifecycle {
         for (const bucket_name of bucket_names) {
             const bucket_json = await this.config_fs.get_bucket_by_name(bucket_name, config_fs_options);
             const bucket_mount_point = this.find_mount_point_by_bucket_path(mount_point_to_policy_map, bucket_json.path);
+            this.bucket_to_mount_point_map[bucket_name] = bucket_mount_point;
             if (!bucket_json.lifecycle_configuration_rules?.length) continue;
+
             for (const lifecycle_rule of bucket_json.lifecycle_configuration_rules) {
                 // currently we support expiration (current version) only
                 if (lifecycle_rule.expiration) {


### PR DESCRIPTION
### Describe the Problem
Currently, mount point errors are externalized on the mount point status, it could benefit to have this also on the bucket status level.

### Explain the Changes
1. In process_bucket() - in GPFS flow -  if bucket's mount point has any errors it will skip its processing and add throw an error for the bucket.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-2729

### Testing Instructions:

1. Manual testing - mentioned in the bug.
2. Manual + artificial test - 
a. Add to line 1222 the following error throw - `if (mount_point === '/mnt/gpfs0') throw new Error('ROMY Mount point /mnt/gpfs0 is not supported for lifecycle ILM policies');`
b. create 2 buckets, one on /mnt/gpfs0/romy_storage1/ and one on /mnt/cesSharedRoot/romy_storage1/ and add files 10 days old under the directories.
```
noobaa-cli bucket add --name bucket.ces.mount --path /mnt/cesSharedRoot/romy_storage1/ --owner account1
noobaa-cli bucket add --name bucket.gpfs.mount --path /mnt/gpfs0/romy_storage1/ --owner account1
for i in {1..10} ; do touch -d  "10 days ago"  /mnt/cesSharedRoot/romy_storage1/file${i}.txt ; done
for i in {1..10} ; do touch -d  "10 days ago"  /mnt/gpfs0/romy_storage1/file${i}.txt ; done
```
c. Attach a lifecycle policy with filter/prefix: "" to both of the buckets.
```
cat ~/demo/policies/delete_all_policy.js
{
    "Rules": [
        {
            "Expiration":{ "Days": 1},
            "ID": "expire-data",
            "Filter":{ "Prefix": ""},
            "Status": "Enabled"
        }
    ]
}
s3-account-demo1 put-bucket-lifecycle-configuration --bucket bucket.ces.mount --lifecycle-configuration file://~/demo/policies/delete_all_policy.js
```
d. run lifecycle worker - `noobaa-cli lifecycle --disable_runtime_validation --debug 5 &> lifecycle.logs`
e. check that the objects under /mnt/cesSharedRoot/romy_storage1/ were deleted and under /mnt/gpfs0/romy_storage1/  the objects still exist.
check the logs of the latest run and see it was completed 
```
ls -la  /mnt/cesSharedRoot/romy_storage1/  // -should be empty
ls -la /mnt/gpfs0/romy_storage1/ // should still contain all objects
cat lifecycle.logs |  less -R
```


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an early error check to prevent processing of buckets with mount point errors when GPFS optimization is enabled.

- **Bug Fixes**
  - Improved reliability by ensuring lifecycle processing is aborted for buckets with problematic mount points.
  - Enhanced error handling to prevent retries on buckets that encounter processing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->