### PR TITLE
CI | push base and builder builds as part of the images to quay

### DIFF
--- a/.github/workflows/manual-full-build.yaml
+++ b/.github/workflows/manual-full-build.yaml
@@ -68,6 +68,10 @@ jobs:
         env:
           DOCKERHUB_OWNER: ${{ secrets.GHACTIONQUAYNAME }}
         run: |
+            docker tag ${{ steps.prep.outputs.basetags }} quay.io/${{ steps.prep.outputs.basetags }}
+            docker push quay.io/${{ steps.prep.outputs.basetags }}
+            docker tag ${{ steps.prep.outputs.buildertags }} quay.io/${{ steps.prep.outputs.buildertags }}
+            docker push quay.io/${{ steps.prep.outputs.buildertags }}
             docker tag ${{ steps.prep.outputs.coretags }} quay.io/${{ steps.prep.outputs.coretags }}
             docker push quay.io/${{ steps.prep.outputs.coretags }}
 


### PR DESCRIPTION
### Describe the Problem
part of the CI changes to use ready base and builder builds.
push base and builder images to quei as part of the manul-full-build-script

### Explain the Changes
1. push base and builder images to quei

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build process to also push the base and builder Docker images to the Quay registry, in addition to the core image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->