### PR TITLE
Auto-label new PRs with the 'Enable-Auto-Rebase' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,2 @@
 Enable-Auto-Rebase:
-  any:
-    head-branch: ['.*']  # matches all head branches
+  - head-branch: '.*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+Enable-Auto-Rebase:
+  any:
+    head-branch: ['.*']  # matches all head branches

--- a/.github/workflows/autolabel-prs.yml
+++ b/.github/workflows/autolabel-prs.yml
@@ -1,0 +1,23 @@
+name: Label new PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Add label to new PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Enable-Auto-Rebase']
+            })

--- a/.github/workflows/autolabel-prs.yml
+++ b/.github/workflows/autolabel-prs.yml
@@ -1,7 +1,6 @@
 name: PR Labeler
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  - pull_request_target
 
 jobs:
   label:

--- a/.github/workflows/autolabel-prs.yml
+++ b/.github/workflows/autolabel-prs.yml
@@ -1,6 +1,7 @@
 name: PR Labeler
 on:
-  - pull_request_target
+  pull_request_target:
+    types: [opened]
 
 jobs:
   label:
@@ -10,7 +11,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run Labeler
         uses: actions/labeler@v5
         with:

--- a/.github/workflows/autolabel-prs.yml
+++ b/.github/workflows/autolabel-prs.yml
@@ -1,6 +1,6 @@
 name: PR Labeler
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 jobs:

--- a/.github/workflows/autolabel-prs.yml
+++ b/.github/workflows/autolabel-prs.yml
@@ -1,23 +1,18 @@
-name: Label new PRs
-
+name: PR Labeler
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened, synchronize]
 
 jobs:
-  add-label:
+  label:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
 
     steps:
-      - name: Add label to new PR
-        uses: actions/github-script@v7
+      - uses: actions/checkout@v3
+      - name: Run Labeler
+        uses: actions/labeler@v5
         with:
-          script: |
-            github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['Enable-Auto-Rebase']
-            })
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Describe the Problem
This workflow will add the `Enable-Auto-Rebase` label to any new PR, to mark it as a candidate for auto-rebase.
It's possible to opt-out of auto rebase by removing the label - the workflow only runs when a PR is opened, so removing the label from the PR means it'll stay removed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic labeling for pull requests to streamline workflow and organization. Labels are now applied based on branch patterns for all pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->