### PR TITLE
Clear connection map on clean up. (dfs 2834)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "morgan": "1.10.0",
         "nan": "2.22.2",
         "node-addon-api": "8.3.1",
-        "node-rdkafka": "3.4.0",
+        "node-rdkafka": "3.4.1",
         "performance-now": "2.1.0",
         "pg": "8.16.0",
         "ping": "0.4.4",
@@ -9824,9 +9824,9 @@
       "license": "MIT"
     },
     "node_modules/node-rdkafka": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.4.0.tgz",
-      "integrity": "sha512-jLFIsGzlAq8hHMY+c0B7e8vEZs9qs65tr95GTUqgSc95qCNE97Nk9f1kor2isXdLC3diILKqzk+oKqmRYO64MA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.4.1.tgz",
+      "integrity": "sha512-qWEjyeZmCNtc7MVUucl9xRsSSXdmMS3lQOiQU15fXIFaLK0K3OZr5T6VTjAAIgz+yoATvaCBDXmMc4RiK65eTg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "morgan": "1.10.0",
     "nan": "2.22.2",
     "node-addon-api": "8.3.1",
-    "node-rdkafka": "3.4.0",
+    "node-rdkafka": "3.4.1",
     "performance-now": "2.1.0",
     "pg": "8.16.0",
     "ping": "0.4.4",


### PR DESCRIPTION
### Describe the Problem
When Notificator is done, it should clean the map containing the connections established during it's run.
Otherwise these stale connection would be used in the next run.
This scenario is relevant only to containerized (ie, does not affect NC).

Also-
-add more logs
-bump version 3.4.0 -> 3.4.1

### Explain the Changes
1. Clear connection's map on Notificator's cleanup.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2834

### Testing Instructions:


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved connection handling to prevent disconnect attempts on inactive connections.
	- Fixed clearing of connection mappings to ensure proper resource cleanup.

- **Chores**
	- Updated the "node-rdkafka" dependency to version 3.4.1.

- **Style**
	- Enhanced debug logging for Kafka notifications to provide clearer connection and error tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->