### PR TITLE
CI | Update Ceph S3 Tests Days (Temporary Solution)

### DIFF
--- a/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
+++ b/src/test/system_tests/ceph_s3_tests/test_ceph_s3_deploy.sh
@@ -38,7 +38,7 @@ commit_epoch=$(git show -s --format=%ci ${CEPH_TESTS_VERSION} | awk '{print $1}'
 commit_date=$(date -d ${commit_epoch} +%s)
 current_date=$(date +%s)
 
-max_days="450"
+max_days="600"
 if [ $((current_date-commit_date)) -gt $((3600*24*${max_days})) ]
 then
     echo "ceph tests were not updated for ${max_days} days, Exiting"


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. Updated the number of days as a temporary solution.

### Issues: Fixed #xxx / Gap #xxx
continuation of PR #8392 
this is a known issue. see [MCGI-254](https://issues.redhat.com/browse/MCGI-254)

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the allowed age threshold for Ceph S3 tests from 450 days to 600 days before they are considered outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->