### PR TITLE
CI | Mint Integration with NooBaa

### DIFF
--- a/.github/workflows/mint-nc-tests.yaml
+++ b/.github/workflows/mint-nc-tests.yaml
@@ -1,0 +1,41 @@
+
+name: Mint NC Tests
+on: [workflow_call]
+
+jobs:
+  mint-nc-tests:
+    name: Mint NC Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
+    steps:
+      - name: Checkout noobaa-core
+        uses: actions/checkout@v4
+        with:
+          repository: 'noobaa/noobaa-core'
+          path: 'noobaa-core'
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
+
+      - name: Create Mint logs directory
+        run: |
+          set -x
+          cd ./noobaa-core
+          mkdir -p logs/mint-nc-test-logs
+          chmod 777 logs/mint-nc-test-logs
+    
+      - name: Run NC Mint tests
+        run: |
+          set -x
+          cd ./noobaa-core
+          make test-nc-mint -o tester
+

--- a/.github/workflows/mint-tests.yaml
+++ b/.github/workflows/mint-tests.yaml
@@ -1,0 +1,41 @@
+name: Mint Tests
+on: [workflow_call]
+
+jobs:
+  mint-tests:
+    name: Mint Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      actions: read         # download-artifact
+      contents: read        # required for actions/checkout
+    steps:
+      - name: Checkout noobaa-core
+        uses: actions/checkout@v4
+        with:
+          repository: 'noobaa/noobaa-core'
+          path: 'noobaa-core'
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: noobaa-tester
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/noobaa-tester.tar
+    
+      - name: Create Mint logs directory
+        run: |
+          set -x
+          cd ./noobaa-core
+          mkdir -p logs/mint-test-logs
+          chmod 777 logs/mint-test-logs
+        
+      - name: Run Mint tests
+        run: |
+          set -x
+          cd ./noobaa-core
+          make test-mint -o tester
+
+

--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -41,6 +41,14 @@ jobs:
     needs: build-noobaa-image
     uses: ./.github/workflows/warp-nc-tests.yaml
 
+  mint-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/mint-tests.yaml
+
+  mint-nc-tests:
+    needs: build-noobaa-image
+    uses: ./.github/workflows/mint-nc-tests.yaml
+
   build-noobaa-image:
     name: Build Noobaa Image
     runs-on: ubuntu-latest

--- a/docs/CI & Tests/Mint.md
+++ b/docs/CI & Tests/Mint.md
@@ -1,0 +1,107 @@
+# Mint Github Action, Tests and Tool
+
+1. [Introduction](#introduction)
+2. [Mint GitHub actions](#mint-github-actions)
+3. [Mint Makefile Targets](#mint-makefile-targets)
+4. [Manual Mint Installation](#manual-mint-installation)
+
+
+
+## Introduction
+
+[Mint](https://github.com/minio/mint) is a testing framework for S3-compatible object storage systems, NooBaa CI runs Mint as correctness/benchmarking and stress tests for the NooBaa system on both containerized and Non Containerized flavors.
+Following are the SDKs/tools used in correctness tests.
+
+- awscli
+- aws-sdk-go
+- aws-sdk-java
+- aws-sdk-java-v2
+- aws-sdk-php
+- aws-sdk-ruby
+- healthcheck
+- mc
+- minio-go
+- minio-java
+- minio-js
+- minio-py
+- s3cmd
+- s3select
+- versioning
+
+## Mint GitHub actions
+
+NooBaa CI contains 2 Github actions that build, configure and run Mint. These Github actions run automatically on every PR and on every push, and can run by workflow dispatch manually.
+* [Mint Tests](../../.github/workflows/mint-tests.yaml) - Based on NooBaa Tester image, runs Mint on standard NooBaa (db configuration).
+* [Mint NC Tests](../../.github/workflows/mint-nc-tests.yaml) - Based on NooBaa Tester image, runs Mint on non-containerized NooBaa (ConfigFS configuration).
+
+Our next goal is to add longer Mint runs as part of NooBaa's nightly CI process.
+
+## Mint Makefile Targets
+
+One can run Mint tests on NooBaa using Mint Makefile targets - 
+* `make test-mint` - Based on NooBaa Tester image, runs Mint on standard NooBaa (db configuration).
+* `make test-nc-mint` - Based on NooBaa Tester image, runs Mint on non-containerized NooBaa (ConfigFS configuration).
+
+The above makefile targets, build NooBaa tester image, and later deploy NooBaa (DB/ConfigFS deployments), create default account and runs the supported sdks on Mint per the deployment type.
+
+Currently, the supported mint test frameworks are:
+1. s3cmd
+2. minio-go
+
+## Manual Mint Installation
+
+NC deployment - 
+1. Tab 1 - Install NooBaa
+2. Tab 2 - Create a NooBaa account.
+2. Tab 2 - Run Mint pointing to NooBaa endpoint -  
+```
+docker run -e SERVER_ENDPOINT=<noobaa-endpoint-address>:<noobaa-endpoint-http-port> -e ACCESS_KEY=<pre-existing-account-access-key> -e SECRET_KEY=<pre-existing-account-secret-key> -e ENABLE_HTTPS=0 minio/mint <sdk-or-tool-name>
+```
+
+Developer notes -
+
+
+To manually run a MinIO Mint container that connects to a noobaa-tester container, ensure both containers are on the same Docker network (noobaa-net).
+
+
+If the noobaa-tester is already connected to noobaa-net, your Mint run command should look like this:
+```
+docker run -e SERVER_ENDPOINT=<noobaa-tester-container-id-or-name>:<noobaa-http-endpoint-port> -e ACCESS_KEY=<pre-existing-account-access-key> -e SECRET_KEY=<pre-existing-account-secret-key> -e ENABLE_HTTPS=0 --network noobaa-net minio/mint <sdk-or-tool-name>
+```
+
+Replace <sdk-or-tool-name> with the specific SDK or tool you want to test (e.g., aws-sdk-java, minio-go, s3cmd, etc.).
+
+## Debugging Mint on NooBaa locally - 
+Running `make test-mint` will generate the following debug log files - 
+
+```bash
+noobaa-core % tree logs/mint-test-logs
+logs/mint-test-logs
+├── log.json                     // contains the Mint run results
+├── minio-go
+│   └── error.log                // contains errors coming from minio-go run
+├── mint-test-logs
+│   ├── backingstore1.log        // contains noobaa backingstore logs
+│   ├── bg.log                   // contains noobaa BG workers logs
+│   ├── hosted_agents.log        // contains noobaa hosted agents logs
+│   ├── s3.log                   // contains noobaa endpoint logs
+│   └── web.log                  // contains noobaa webserver logs
+└── s3cmd
+    └── error.log                // contains errors coming from s3-cmd run
+
+```
+
+Running `make test-nc-mint` will generate the following debug log files - 
+
+```bash
+noobaa-core % tree /mint-nc-test-logs
+logs/mint-nc-test-logs
+    ├── log.json                 // contains the Mint run results
+    ├── minio-go
+    │   └── error.log            // contains errors coming from minio-go run
+    ├── mint-nc-test-logs
+    │   └── nsfs.log             // contains NC noobaa endpoint logs
+    └── s3cmd 
+        └── error.log            // contains errors coming from s3-cmd run
+
+```

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -332,7 +332,7 @@ S3Error.NoLoggingStatusForKey = Object.freeze({
 });
 S3Error.NoSuchBucket = Object.freeze({
     code: 'NoSuchBucket',
-    message: 'The specified bucket does not exist.',
+    message: 'The specified bucket does not exist',
     http_code: 404,
 });
 S3Error.NoSuchKey = Object.freeze({

--- a/src/test/system_tests/mint/configure_mint.js
+++ b/src/test/system_tests/mint/configure_mint.js
@@ -1,0 +1,31 @@
+/* Copyright (C) 2016 NooBaa */
+"use strict";
+
+const dbg = require('../../../util/debug_module')(__filename);
+dbg.set_process_name('test_mint_s3');
+
+const { MINT_TEST } = require('./mint_constants');
+const { is_containerized_deployment, create_system_test_account } = require('../external_tests_utils.js');
+
+async function main() {
+    try {
+        await mint_test_setup();
+    } catch (err) {
+        console.error(`Mint Setup Failed: ${err}`);
+        process.exit(1);
+    }
+    process.exit(0);
+}
+
+async function mint_test_setup() {
+    console.info('MINT TEST CONFIGURATION:', JSON.stringify(MINT_TEST));
+    const is_containerized = is_containerized_deployment();
+    const account_options = is_containerized ? MINT_TEST.mint_account_params : MINT_TEST.nc_mint_account_params;
+    await create_system_test_account(account_options);
+    console.info('MINT TEST SETUP DONE');
+}
+
+if (require.main === module) {
+    main();
+}
+

--- a/src/test/system_tests/mint/mint_constants.js
+++ b/src/test/system_tests/mint/mint_constants.js
@@ -1,0 +1,47 @@
+/* Copyright (C) 2022 NooBaa */
+'use strict';
+
+const SensitiveString = require('../../../util/sensitive_string');
+
+const mint_account_name = 'mint_account';
+
+// NC mint tests paths for bucket creation
+const FS_ROOT_1 = '/tmp/nsfs_root1/';
+const FS_ROOT_2 = '/tmp/nsfs_root2/';
+const MINT_MOCK_ACCESS_KEY = 'aaaaaaaaaaaaaEXAMPLE';
+const MINT_MOCK_SECRET_KEY = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaEXAMPLE';
+
+const MINT_TEST = {
+    s3_test_dir: 's3-tests/',
+    mint_logs_dir_path: '/logs/mint-test-logs',
+    mint_account_params: {
+        name: mint_account_name,
+        email: 'mint_account@noobaa.com',
+        has_login: true,
+        password: 'mint_pass123_example',
+        s3_access: true,
+        allow_bucket_creation: true,
+        access_keys: [{
+            access_key: new SensitiveString(MINT_MOCK_ACCESS_KEY),
+            secret_key: new SensitiveString(MINT_MOCK_SECRET_KEY)
+        }]
+    },
+    nc_mint_account_params: {
+        name: mint_account_name,
+        uid: 1000,
+        gid: 1000,
+        new_buckets_path: FS_ROOT_1,
+        access_key: MINT_MOCK_ACCESS_KEY,
+        secret_key: MINT_MOCK_SECRET_KEY
+    },
+    nc_anonymous_account_params: {
+        anonymous: true,
+        uid: process.getuid(),
+        gid: process.getgid()
+    }
+};
+
+exports.MINT_TEST = MINT_TEST;
+exports.FS_ROOT_1 = FS_ROOT_1;
+exports.FS_ROOT_2 = FS_ROOT_2;
+

--- a/src/test/system_tests/mint/run_mint_on_test_container.sh
+++ b/src/test/system_tests/mint/run_mint_on_test_container.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} \e[0m'
+
+set -e
+
+# ====================================================================================
+# Set the environment variables
+export email='admin@noobaa.io'
+export password=123456789
+
+export PORT=8080
+export SSL_PORT=5443
+export ENDPOINT_PORT=6001
+export ENDPOINT_SSL_PORT=6443
+export NOOBAA_MGMT_SERVICE_HOST=localhost
+export NOOBAA_MGMT_SERVICE_PORT=${SSL_PORT}
+export NOOBAA_MGMT_SERVICE_PROTO=wss
+export S3_SERVICE_HOST=localhost
+
+export CREATE_SYS_NAME=noobaa
+export CREATE_SYS_EMAIL=${email}
+export CREATE_SYS_PASSWD=${password}
+export JWT_SECRET=123456789
+export NOOBAA_ROOT_SECRET='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+export LOCAL_MD_SERVER=true
+
+#The default max connections for postgres is 100. limit max clients to 10 per pool (per process). 
+export CONFIG_JS_POSTGRES_MD_MAX_CLIENTS=10
+export CONFIG_JS_POSTGRES_DEFAULT_MAX_CLIENTS=10
+
+export POSTGRES_HOST=${POSTGRES_HOST:-localhost}
+export MGMT_ADDR=wss://${NOOBAA_MGMT_SERVICE_HOST:-localhost}:${NOOBAA_MGMT_SERVICE_PORT:-5443}
+export BG_ADDR=wss://localhost:5445
+export HOSTED_AGENTS_ADDR=wss://localhost:5446
+export CEPH_TEST_LOGS_DIR=/logs/mint-test-logs
+
+# ====================================================================================
+
+# Create the logs directory
+mkdir -p ${CEPH_TEST_LOGS_DIR}
+
+# ====================================================================================
+
+# Deploy standalone NooBaa on the test container
+./src/deploy/NVA_build/standalone_deploy.sh
+
+# ====================================================================================
+
+cd /root/node_modules/noobaa-core/
+
+# Configure the mint test 
+node ./src/test/system_tests/mint/configure_mint.js

--- a/src/test/system_tests/mint/run_nc_mint_on_test_container.sh
+++ b/src/test/system_tests/mint/run_nc_mint_on_test_container.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+export PS4='\e[36m+ ${FUNCNAME:-main}\e[0m@\e[32m${BASH_SOURCE}:\e[35m${LINENO} \e[0m'
+
+set -e
+# It will add to the logs every line that we run
+set -x
+
+# ====================================================================================
+# Set the environment variables
+export email='admin@noobaa.io'
+export password=123456789
+
+export SERVER_ADDRESS=localhost
+export ENDPOINT_PORT=6001
+export ENDPOINT_SSL_PORT=6443
+export S3_SERVICE_HOST=localhost
+
+export CEPH_TEST_LOGS_DIR=/logs/mint-nc-test-logs
+export CONFIG_DIR=/etc/noobaa.conf.d/
+export FS_ROOT_1=/tmp/nsfs_root1/
+export FS_ROOT_2=/tmp/nsfs_root2/
+export CONFIG_JS_allow_anonymous_access_in_test=true # Needed for allowing anon access for tests using ACL='public-read-write'
+
+# ====================================================================================
+
+# 1. Create configuration directory
+# 2. Create config.json file
+mkdir -p ${CONFIG_DIR}
+config='{"ALLOW_HTTP":true, "ENDPOINT_FORKS":2, "NSFS_CALCULATE_MD5": true}'
+echo "$config" > ${CONFIG_DIR}/config.json
+
+# 1. Create root directory for bucket creation
+# 2. Add permission to all users
+# this will allow the new accounts to create directories (buckets),
+# else we would see [Error: Permission denied] { code: 'EACCES' }
+mkdir -p ${FS_ROOT_1}
+mkdir -p ${FS_ROOT_2}
+chmod 777 ${FS_ROOT_1}
+chmod 777 ${FS_ROOT_2}
+
+# Create the logs directory
+mkdir -p ${CEPH_TEST_LOGS_DIR}
+chmod 777 ${CEPH_TEST_LOGS_DIR}
+
+# ====================================================================================
+
+# Deploy standalone NooBaa on the test container
+# And create the accounts needed for the Ceph tests
+./src/deploy/NVA_build/standalone_deploy_nsfs.sh
+
+# ====================================================================================
+
+cd /root/node_modules/noobaa-core/
+
+# Configure the mint test 
+node ./src/test/system_tests/mint/configure_mint.js

--- a/src/test/system_tests/warp/configure_warp.js
+++ b/src/test/system_tests/warp/configure_warp.js
@@ -5,7 +5,7 @@ const dbg = require('../../../util/debug_module')(__filename);
 dbg.set_process_name('test_warp_s3');
 
 const { WARP_TEST } = require('./warp_constants.js');
-const { create_warp_account, create_warp_bucket } = require('./warp_utils.js');
+const { is_containerized_deployment, create_system_test_account, create_system_test_bucket } = require('../external_tests_utils.js');
 
 async function main() {
     try {
@@ -19,8 +19,11 @@ async function main() {
 
 async function warp_test_setup() {
     console.info('WARP TEST CONFIGURATION:', JSON.stringify(WARP_TEST));
-    await create_warp_account();
-    await create_warp_bucket();
+    const is_containerized = is_containerized_deployment();
+    const account_options = is_containerized ? WARP_TEST.warp_account_params : WARP_TEST.nc_warp_account_params;
+    const bucket_options = is_containerized ? WARP_TEST.warp_bucket_params : WARP_TEST.nc_warp_bucket_params;
+    await create_system_test_account(account_options);
+    await create_system_test_bucket(account_options, bucket_options);
     console.info('WARP TEST SETUP DONE');
 }
 

--- a/src/test/system_tests/warp/run_warp.js
+++ b/src/test/system_tests/warp/run_warp.js
@@ -8,7 +8,7 @@ delete argv._;
 
 const config = require('../../../../config');
 const os_utils = require('../../../util/os_utils');
-const { get_warp_access_keys } = require('./warp_utils');
+const { get_account_access_keys } = require('../external_tests_utils');
 const { DEFAULT_NUMBER_OF_WORKERS, WARP_TEST } = require('./warp_constants.js');
 
 const usage = `
@@ -81,7 +81,7 @@ async function run_warp() {
     }
 
     if (account_name && !access_key && !secret_key) {
-        ({ access_key, secret_key } = await get_warp_access_keys(account_name));
+        ({ access_key, secret_key } = await get_account_access_keys(account_name));
     }
 
     // TODO - add --benchdata so that the result csv will be saved in logs


### PR DESCRIPTION
### Describe the Problem
[Mint](https://github.com/minio/mint) is a tool used for S3 correctentss and benchmarking tests that runs different S3 sdks, we would like to run it as part of NooBaa CI actions.

### Explain the Changes
1. Created 2 new github actions that run make-mint and make-nc-mint targets.
2. Created 2 new makefile targets called make-mint and make-nc-mint that build noobaa tester image and run mint on  Containerized/Non Containerized setups.
3. Added Containerized/Non Containerized setups, configurations mint runs.
5. Added documentation.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/MCGI-248

### Testing Instructions:
1. 


- [x] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated workflows for running Mint tests in both standard and non-containerized environments.
  * Introduced Makefile targets to simplify running Mint tests locally and in CI.
  * Added scripts and configuration files to streamline Mint test setup and execution.
  * Provided documentation for integrating and running Mint tests within the CI environment.

* **Bug Fixes**
  * Updated an error message for S3 bucket errors to improve clarity.

* **Refactor**
  * Generalized and renamed system test utility functions for broader test support.
  * Improved flexibility and maintainability in Makefile helper functions.

* **Style**
  * Updated logging and naming conventions for better clarity in test scripts and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->