### PR TITLE
5.18.7 Backport | NC | Manual fix for 5.18.7 - NSFS_LIST_IGNORE_ENTRY_ON_EACCES should be set to true

### DIFF
--- a/config.js
+++ b/config.js
@@ -984,7 +984,7 @@ config.ANONYMOUS_ACCOUNT_NAME = 'anonymous';
 config.NFSF_UPLOAD_STREAM_MEM_THRESHOLD = 8 * 1024 * 1024;
 
 // we want to change our handling related to EACCESS error
-config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES = false;
+config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES = true;
 
 ////////////////////////////
 // NSFS NON CONTAINERIZED //


### PR DESCRIPTION
### Describe the Problem
Per a request coming from CES, we need to change the default of NSFS_LIST_IGNORE_ENTRY_ON_EACCES configuration to true.
On master (5.20) branch it's already set to true but originally we backported it as false
https://github.com/noobaa/noobaa-core/pull/8809#issuecomment-2703166652 due to incompatibility with AWS / performance issues that might arise due to this change.

### Explain the Changes
1. Changed NSFS_LIST_IGNORE_ENTRY_ON_EACCES default configuration to true.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
