### PR TITLE
Removed counters queries from md_store find_objects

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -901,25 +901,6 @@ module.exports = {
                 type: 'object',
                 required: ['objects'],
                 properties: {
-                    counters: {
-                        type: 'object',
-                        properties: {
-                            by_mode: {
-                                type: 'object',
-                                properties: {
-                                    completed: {
-                                        type: 'integer'
-                                    },
-                                    uploading: {
-                                        type: 'integer'
-                                    },
-                                }
-                            },
-                            non_paginated: {
-                                type: 'integer'
-                            },
-                        }
-                    },
                     objects: {
                         type: 'array',
                         items: {
@@ -1152,8 +1133,7 @@ module.exports = {
                     deleted_objects: {
                         type: 'array',
                         items: {
-                            oneOf: [
-                                {
+                            oneOf: [{
                                     $ref: '#/definitions/object_info',
                                 },
                                 {
@@ -1586,8 +1566,7 @@ module.exports = {
                 // currently no properties for the object as there is no implementation
                 object_owner: {
                     type: 'object',
-                    properties: {
-                    }
+                    properties: {}
                 },
             }
         },


### PR DESCRIPTION
### Describe the Problem
- `md_store.find_objects` performed additional count queries to support the old ui `list_objects_admin` function
- These queries can be very expensive for certain operations, specifically in lifecycle and obc deletion flows.


### Explain the Changes
- Removed the counters that are returned from find_objects and are not used anywhere in the code.

### Issues: Fixed #xxx / Gap #xxx
1.  https://issues.redhat.com/browse/DFBUGS-2232

### Testing Instructions:
1. Create an OBC bucket and upload millions of objects
2. Delete the OBC to trigger `delete_multiple_objects_unordered` that calls `find_objects`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed display of object counters in the admin object list view.

* **Refactor**
  * Simplified object listing to show only the list of objects without additional counters.
  * Minor formatting and code cleanup for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->