### PR TITLE
Revert objects reclaimer batch and error delays

### DIFF
--- a/config.js
+++ b/config.js
@@ -388,8 +388,8 @@ config.BUCKET_RECLAIMER_ERROR_DELAY = 3000;
 config.OBJECT_RECLAIMER_ENABLED = true;
 config.OBJECT_RECLAIMER_EMPTY_DELAY = 60 * 60 * 1000; // 1 hour delay
 config.OBJECT_RECLAIMER_BATCH_SIZE = 100;
-config.OBJECT_RECLAIMER_BATCH_DELAY = 10 * 60 * 1000; // 10 minutes delay between batches
-config.OBJECT_RECLAIMER_ERROR_DELAY = 10 * 60 * 1000; // 10 minutes delay between batches;
+config.OBJECT_RECLAIMER_BATCH_DELAY = 100;
+config.OBJECT_RECLAIMER_ERROR_DELAY = 3000;
 
 
 //////////////////


### PR DESCRIPTION
### Describe the Problem
When the objects_reclaimer delays are too short, it previously caused load on the db, in an attempt to increase these delays and decrease the load on the db, it caused a situation where the deletion rate of the object_mds/blocks/blocks from the target bucket was too slow and looked as that storage is not being cleared. 

### Explain the Changes
1. Revert the following configurations to their old short values - 
OBJECT_RECLAIMER_BATCH_DELAY = 100 (ms) 
OBJECT_RECLAIMER_ERROR_DELAY = 3000 (3 seconds)

Notice that for now, we decided not to revert OBJECT_RECLAIMER_EMPTY_DELAY and keep it as 1 hour. 

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2916

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal timing settings to improve responsiveness. No visible changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->