### PR TITLE
NC | Lifecycle | Validate bucket storage path exists before processing

### DIFF
--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -223,6 +223,8 @@ class NCLifecycle {
             dbg.warn(`process_bucket - bucket owner ${bucket_json.owner_account} does not exist for bucket ${bucket_name}. skipping lifecycle for this bucket`);
             return;
         }
+        const bucket_storage_path_exists = await native_fs_utils.is_path_exists(this.config_fs.fs_context, bucket_json.path);
+        if (!bucket_storage_path_exists) throw new Error(`process_bucket - bucket storage path ${bucket_json.path} does not exist for bucket ${bucket_name}.`);
         const object_sdk = new NsfsObjectSDK('', this.config_fs, account, bucket_json.versioning, this.config_fs.config_root, system_json);
         await object_sdk._simple_load_requesting_account();
         const should_notify = notifications_util.should_notify_on_event(bucket_json, notifications_util.OP_TO_EVENT.lifecycle_delete.name);


### PR DESCRIPTION
### Describe the Problem
Currently, we validate the bucket storage existence on the fly on POSIX, on GPFS we currently do not check that because the file system search is offloaded to mmapplypolicy CLI, if the fileset is unlinked `mmapplypolicy` won't throw an error but just won't create the candidates file. Therefore, in order to skip lifecycle processing if the bucket's storage path does not exist, we will validate it explicitly. 

### Explain the Changes
1. Added an explicit validation of bucket storage path before processing lifecycle rules.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-2799


### Testing Instructions:
1. On a GPFS cluster - run NooBaa service
2. Create a fileset called fset1 -
```
Fileset Creation instructions per the jira ticket - 
Check available filesystem - df -h
Check fileset in the filesystem - mmlsfileset gpfs0 -L , mmlsfileset gpfs0
Create new fileset - mmcrfileset gpfs0 fset1 --inode-space new
Link the fileset - mmlinkfileset gpfs0 fset1 -J /mnt/gpfs0/fset1-dir/
Check fileset in the filesystem - mmlsfileset gpfs0 -L , mmlsfileset gpfs0
Set permission to the fileset path - chmod 775 /mnt/gpfs0/fset1-dir/
```
4. Create an account called account1
5. Create a bucket using a fileset called fset1 - `noobaa-cli bucket add --name bucket1 --path '/mnt/gpfs0/fset1-dir/' --owner account1`
6. Apply a bucket policy to the bucket - 
```bash 
cat expiration_date_empty_filter.json
{
    "Rules": [
        {
            "ID": "expiration_date_empty_filter",
            "Status": "Enabled",
            "Filter": {
                "Prefix": ""
            },
            "Expiration": {
                "Date": "2025-05-05T00:00:00.000Z"
            }
        }
    ]
}

s3-account1 put-bucket-lifecycle-configuration --bucket bucket1 --lifecycle-configuration file://expiration_date_empty_filter.json
```
7. Upload some objects to the bucket - `s3-account1 put-object --bucket bucket1 --key obj1.txt`
8. unlink fileset - `mmunlinkfileset gpfs0 fset1`
9. Check that path isn't available - 
```
ls -la /mnt/gpfs0/fset1-dir/
ls: cannot access '/mnt/gpfs0/fset1-dir/': No such file or directory
```
10. Run the lifecycle worker - ` noobaa-cli lifecycle --disable_runtime_validation  --debug 5 &> lifecycle.log`
If LOG_TO_STDERR is false in config.json you should set it to true in order to see both stdout and stderr in lifecycle.log.
11. Check lifecycle.log and see that bucket1 has the following errors - 
```
{
  "response": {
    "code": "LifecycleSuccessful",
    "message": "Lifecycle worker run finished successfully",
    "reply": {
      "running_host": "hostname1",
      "lifecycle_run_times": {
        "run_lifecycle_start_time": 1752481666822,
        "list_buckets_start_time": 1752481666846,
        "list_buckets_end_time": 1752481666847,
        "list_buckets_took_ms": 1,
        "process_buckets_start_time": 1752481666847,
        "create_gpfs_candidates_files_start_time": 1752481666847,
        "create_gpfs_candidates_files_end_time": 1752481669656,
        "create_gpfs_candidates_files_took_ms": 2809,
        "process_buckets_end_time": 1752481669839,
        "process_buckets_took_ms": 2992,
        "run_lifecycle_end_time": 1752481669839,
        "run_lifecycle_took_ms": 3017
      },
      "total_stats": {
        "num_objects_deleted": 12,
        "num_objects_delete_failed": 0,
        "objects_delete_errors": [],
        "num_mpu_aborted": 0,
        "num_mpu_abort_failed": 0,
        "mpu_abort_errors": []
      },
      "state": {
        "is_finished": true
      },
      "buckets_statuses": {
        "bucket1": {
          "bucket_process_times": {
            "process_bucket_start_time": 1752481669656,
            "process_bucket_end_time": 1752481669671,
            "process_bucket_took_ms": 15
          },
          "bucket_stats": {},
          "state": {
            "is_finished": true
          },
          "rules_statuses": {},
          "errors": [
            "process_bucket - bucket storage path /mnt/gpfs0/fset1-dir/ does not exist for bucket bucket3."
          ]
        },
        "mount_points_statuses": {
        "/mnt/cesSharedRoot": {
          "mount_point_process_times": {
            "create_candidates_file_by_gpfs_ilm_policy_start_time": 1752481667126,
            "create_candidates_file_by_gpfs_ilm_policy_end_time": 1752481668341,
            "create_candidates_file_by_gpfs_ilm_policy_took_ms": 1215
          }
        },
        "/mnt/gpfs0": {
          "mount_point_process_times": {
            "create_candidates_file_by_gpfs_ilm_policy_start_time": 1752481668341,
            "create_candidates_file_by_gpfs_ilm_policy_end_time": 1752481669656,
            "create_candidates_file_by_gpfs_ilm_policy_took_ms": 1315
          }
        }
      }
    }
  }
}
```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by verifying the existence of a bucket's storage path before processing, ensuring clearer error messages if the path is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->