### PR TITLE
remove push directive so we will not run tests on merge

### DIFF
--- a/.github/workflows/Validate-package-lock.yaml
+++ b/.github/workflows/Validate-package-lock.yaml
@@ -1,5 +1,5 @@
 name: Validate package-lock.json Tests
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run-package-lock-validation:

--- a/.github/workflows/jest-unit-tests.yaml
+++ b/.github/workflows/jest-unit-tests.yaml
@@ -1,5 +1,5 @@
 name: Jest Unit Tests
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   run-jest-unit-tests:

--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -1,5 +1,5 @@
 name: Run PR Tests
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -66,7 +66,7 @@ jobs:
             #on pull request, use target branch
             BRANCH=${{github.base_ref}}
           else
-            #on push, use the pushed branch
+            #on dispach, use the current branch
             BRANCH=${{github.ref_name}}
           fi
           BUILDER_TAGS="${DOCKER_BUILDER_IMAGE}:${BRANCH}-"


### PR DESCRIPTION
### Describe the Problem
We currently run GitHub Actions for pull request (PR) tests on both `push` and `pull_request` events. However, since we push changes to a forked branch, the `push` event triggers a workflow run on the forked branch, and again on the target branch (e.g., `noobaa`) when the PR is merged—because the merge itself is treated as a push to the target branch.

This results in redundant test executions. Additionally, the workflows triggered by the push event often fail, making these runs both unnecessary and noisy.


### Explain the Changes
1. remove the push event. since only pull request is used

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test workflows to run only on pull request and manual dispatch events, no longer triggering on push events.
  * Clarified comments in workflow configuration regarding branch selection for manual dispatch events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->