### PR TITLE
CI | Fix PR dispatch flow for PR tests workflow

### DIFF
--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -1,8 +1,11 @@
 name: Run PR Tests
 on: [pull_request, workflow_dispatch]
 concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+permissions:
+    actions: read         # download-artifact
+    contents: read        # required for actions/checkout
 jobs:
 
   run-sanity-tests:
@@ -62,7 +65,7 @@ jobs:
         run: |
           DOCKER_BUILDER_IMAGE=noobaa/noobaa-builder
           DOCKER_BASE_IMAGE=noobaa/noobaa-base
-          if [[ -n ${{github.base_ref}} ]]; then
+          if [[ -n "${{github.base_ref}}" ]]; then
             #on pull request, use target branch
             BRANCH=${{github.base_ref}}
           else


### PR DESCRIPTION
### Describe the Problem
When triggering the PR workflow via a `workflow_dispatch` event, the run fails. This prevents us from manually dispatching the workflow from a specific branch.

The failures are caused by two main issues:

1. Some jobs require read permissions for `actions` and `contents`, but the main job doesn't explicitly declare them—causing permission errors during dispatch.
2. A check for `github.base_ref` fails when the value is empty due to missing quotes around the variable, resulting in a syntax error.

### Explain the Changes
1. Explicitly add `read` permissions for `actions` and `contents` to the main job.
2. Wrap `github.base_ref` in quotes to safely handle cases where it may be empty.
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to clarify and restrict access.
  * Improved shell script robustness in workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->