### PR TITLE
update single tests variable names and docs to reflect change to path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,10 @@ ifeq ($(USE_HOSTNETWORK), true)
 endif
 
 # running blob mock on - all tests run OR on single test run of test_s3_ops.js
-NAMESPACE_BLOB_TEST?="test_s3_ops.js"
+NAMESPACE_BLOB_TEST?="integration_tests/api/s3/test_s3_ops.js"
 RUN_BLOB_MOCK=true
-ifdef testname
-	ifneq ("$(testname)", $(NAMESPACE_BLOB_TEST))
+ifdef testpath
+	ifneq ("$(testpath)", $(NAMESPACE_BLOB_TEST))
 		RUN_BLOB_MOCK=false
 	endif
 endif
@@ -280,7 +280,7 @@ run-single-test: tester
 	@$(call run_mongo)
 	@$(call run_blob_mock)
 	@echo "\033[1;34mRunning tests\033[0m"
-	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" --env "DB_TYPE=mongodb" --env "MONGODB_URL=mongodb://noobaa:noobaa@coretest-mongo-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "BLOB_HOST=blob-mock-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "NOOBAA_LOG_LEVEL=all" $(TESTER_TAG) ./src/test/framework/run_npm_test_on_test_container.sh -s $(testname)
+	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" --env "DB_TYPE=mongodb" --env "MONGODB_URL=mongodb://noobaa:noobaa@coretest-mongo-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "BLOB_HOST=blob-mock-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "NOOBAA_LOG_LEVEL=all" $(TESTER_TAG) ./src/test/framework/run_npm_test_on_test_container.sh -s $(testpath)
 	@$(call stop_noobaa)
 	@$(call stop_blob_mock)
 	@$(call stop_mongo)
@@ -301,7 +301,7 @@ run-single-test-postgres: tester
 	@$(call run_postgres)
 	@$(call run_blob_mock)
 	@echo "\033[1;34mRunning tests\033[0m"
-	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" --env "POSTGRES_HOST=coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "POSTGRES_USER=noobaa" --env "DB_TYPE=postgres" --env "PG_ENABLE_QUERY_LOG=true" --env "PG_EXPLAIN_QUERIES=true" --env "BLOB_HOST=blob-mock-$(GIT_COMMIT)-$(NAME_POSTFIX)" $(TESTER_TAG)  ./src/test/framework/run_npm_test_on_test_container.sh -s $(testname)
+	$(CONTAINER_ENGINE) run $(CPUSET) --network noobaa-net --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --env "SUPPRESS_LOGS=$(SUPPRESS_LOGS)" --env "POSTGRES_HOST=coretest-postgres-$(GIT_COMMIT)-$(NAME_POSTFIX)" --env "POSTGRES_USER=noobaa" --env "DB_TYPE=postgres" --env "PG_ENABLE_QUERY_LOG=true" --env "PG_EXPLAIN_QUERIES=true" --env "BLOB_HOST=blob-mock-$(GIT_COMMIT)-$(NAME_POSTFIX)" $(TESTER_TAG)  ./src/test/framework/run_npm_test_on_test_container.sh -s $(testpath)
 	@$(call stop_noobaa)
 	@$(call stop_postgres)
 	@$(call stop_blob_mock)

--- a/docs/dev_guide/run_coretest_locally.md
+++ b/docs/dev_guide/run_coretest_locally.md
@@ -10,7 +10,7 @@ Run simply with `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha .src/
 More info can be found in [CI & Tests](#ci--tests).
 
 ### B) Containerized deployment (With DB)
-One way is to run it with: `make run-single-test testname=test_s3_bucket_policy.js`  
+One way is to run it with: `make run-single-test testpath=integration_tests/api/s3/test_s3_bucket_policy.js`
 but it would take time to build the needed images, therefore we will focus on another way.
 
 Another way is to create a postgres container and then run the test with the following steps:

--- a/src/test/framework/run_npm_test_on_test_container.sh
+++ b/src/test/framework/run_npm_test_on_test_container.sh
@@ -22,7 +22,7 @@ function usage() {
     echo -e "Usage:\n\t${0} [options]"
     echo -e "\t-c|--command     -   Replace the unit test command (default: ${command})"
     echo -e "\t-s|--single      -   Get the desired unit test to run and running it,"
-    echo -e "\t                     needs to get the file name for example test_object_io.js"
+    echo -e "\t                     needs to get the relative path from the tests directory for example integration_tests/internal/test_object_io.js"
     exit 0
 }
 


### PR DESCRIPTION
### Describe the Problem
since we changed the tests directory structure, when we run single test we now need to pass the entire path from the tests directory instead of just the filename. need to change the docs and variable names to reflect this change

### Explain the Changes
1. rename `testname` variable in makefile to `testpath`
2. change `NAMESPACE_BLOB_TEST` to the new relative path of `test_s3_ops.js`
3. change examples and documentation of this value in `run_coretest_locally.md` and `run_npm_test_on_test_container.sh`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated instructions and usage messages to specify test files using relative paths instead of just filenames when running single tests.

* **Chores**
  * Standardized variable usage and default values in test-related scripts and commands to use test file paths for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->