### PR TITLE
Mongo | Remove mongo_pool code(1/2)

### DIFF
--- a/config.js
+++ b/config.js
@@ -84,7 +84,6 @@ config.EXTERNAL_DB_SERVICE_CERT_PATH = '/etc/external-db-secret';
 // TODO take nodes min and free space reserve from system/pool config
 config.NODES_MIN_COUNT = 3;
 config.NODES_PER_CLOUD_POOL = 1;
-config.NODES_PER_MONGO_POOL = 1;
 // in kubernetes use reserve of 100MB instead of 10GB
 config.NODES_FREE_SPACE_RESERVE = 100 * (1024 ** 2);
 
@@ -243,7 +242,7 @@ config.POSTGRES_MD_MAX_CLIENTS = (process.env.LOCAL_MD_SERVER === 'true') ? 70 :
 // SYSTEM CONFIG //
 ///////////////////
 
-config.DEFAULT_POOL_TYPE = 'INTERNAL'; // use 'HOSTS' for setting up a pool of FS backingstores instead
+config.DEFAULT_POOL_TYPE = 'HOSTS'; // use 'HOSTS' for setting up a pool of FS backingstores instead
 config.DEFAULT_POOL_NAME = 'backingstores'; // only used when config.DEFAULT_POOL_TYPE = 'HOSTS'
 config.DEFAULT_BUCKET_NAME = 'first.bucket';
 config.INTERNAL_STORAGE_POOL_NAME = 'system-internal-storage-pool';

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -480,8 +480,8 @@ class Agent {
                         dbg.error('This agent appears to be using an old token.',
                             'cleaning this agent noobaa_storage directory', this.storage_path);
                         if (this.cloud_info || this.mongo_info) {
-                            dbg.error(`shouldn't be here. node not found for cloud pool or mongo pool!!`);
-                            throw new Error('node not found cloud or mongo node');
+                            dbg.error(`shouldn't be here. node not found for cloud pool pool!!`);
+                            throw new Error('node not found cloud node');
                         } else {
                             // We don't exit the process in order to keep the underlaying pod alive until
                             // the pool statefulset will scale this pod out of existence.

--- a/src/api/hosted_agents_api.js
+++ b/src/api/hosted_agents_api.js
@@ -59,7 +59,7 @@ module.exports = {
                         },
                     },
 
-                    mongo_info: {
+                     mongo_info: {
                         type: 'object',
                         additionalProperties: true,
                         properties: {}

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1665,7 +1665,6 @@ module.exports = {
                         mount: { type: 'string' },
                         online: { type: 'boolean' },
                         in_cloud_pool: { type: 'boolean' },
-                        in_mongo_pool: { type: 'boolean' },
                     }
                 }
             }

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -128,23 +128,6 @@ module.exports = {
             }
         },
 
-        create_mongo_pool: {
-            doc: 'Create Mongo Pool',
-            method: 'POST',
-            params: {
-                type: 'object',
-                required: ['name'],
-                properties: {
-                    name: {
-                        type: 'string',
-                    }
-                }
-            },
-            auth: {
-                system: 'admin'
-            }
-        },
-
         read_pool: {
             doc: 'Read Pool Information',
             method: 'GET',

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -62,7 +62,7 @@ class HostedAgents {
     reload() {
         // start agents for all existing cloud pools
         const agents_to_start = system_store.data.pools.filter(pool =>
-            (!_.isUndefined(pool.cloud_pool_info) || !_.isUndefined(pool.mongo_pool_info))
+            (!_.isUndefined(pool.cloud_pool_info))
         );
         dbg.log0(`will start agents for these pools: ${util.inspect(agents_to_start)}`);
         return P.map(agents_to_start, pool => this._start_pool_agent(pool));
@@ -114,8 +114,7 @@ class HostedAgents {
 
         const host_id = config.HOSTED_AGENTS_HOST_ID + pool_id;
         const storage_path = path.join(process.cwd(), 'noobaa_storage', node_name);
-        const pool_property_path = pool.resource_type === 'INTERNAL' ?
-            'mongo_pool_info.agent_info.mongo_path' : 'cloud_pool_info.agent_info.cloud_path';
+        const pool_property_path = 'cloud_pool_info.agent_info.cloud_path';
         const pool_path = _.get(pool, pool_property_path, `noobaa_blocks/${pool_id}`);
         const pool_path_property = pool.resource_type === 'INTERNAL' ? 'mongo_path' : 'cloud_path';
         const pool_info_property = pool.resource_type === 'INTERNAL' ? 'mongo_info' : 'cloud_info';
@@ -131,12 +130,10 @@ class HostedAgents {
             role: 'create_node'
         });
         const { token_wrapper, create_node_token_wrapper } = _get_pool_token_wrapper(pool);
-        const info = pool.resource_type === 'INTERNAL' ?
-            pool.mongo_pool_info : pool.cloud_pool_info;
+        const info = pool.cloud_pool_info;
         if (!info.agent_info || !info.agent_info.create_node_token) {
             const existing_token = info.agent_info ? info.agent_info.node_token : null;
-            const pool_agent_path = pool.resource_type === 'INTERNAL' ?
-                'mongo_pool_info' : 'cloud_pool_info';
+            const pool_agent_path = 'cloud_pool_info';
             const update = {
                 pools: [{
                     _id: pool._id,
@@ -377,8 +374,7 @@ function _get_pool_and_path_for_token(token_pool) {
     const sys = system_store.data.systems[0];
     const pool = sys.pools_by_name[token_pool.name];
     if (!pool) throw new Error(`Pool ${token_pool.name}, ${token_pool._id} does not exist`);
-    const pool_property_path = pool.resource_type === 'INTERNAL' ?
-        'mongo_pool_info.agent_info' : 'cloud_pool_info.agent_info';
+    const pool_property_path = 'cloud_pool_info.agent_info';
     return {
         pool_property_path,
         pool

--- a/src/sdk/map_api_types.js
+++ b/src/sdk/map_api_types.js
@@ -357,7 +357,6 @@ class BlockAPI {
             adminfo.mount = node.drive.mount;
             adminfo.online = Boolean(node.online);
             adminfo.in_cloud_pool = Boolean(node.is_cloud_node);
-            adminfo.in_mongo_pool = Boolean(node.is_mongo_node);
         }
     }
 

--- a/src/server/node_services/node_allocator.js
+++ b/src/server/node_services/node_allocator.js
@@ -303,10 +303,6 @@ function _get_tier_pools_status(pools, required_valid_nodes) {
             if (num_nodes !== config.NODES_PER_CLOUD_POOL) {
                 valid_for_allocation = false;
             }
-        } else if (pool.mongo_pool_info) {
-            if (num_nodes !== config.NODES_PER_MONGO_POOL) {
-                valid_for_allocation = false;
-            }
         } else if (num_nodes < required_valid_nodes) {
             valid_for_allocation = false;
         }

--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -612,7 +612,7 @@ class NodesMonitor extends EventEmitter {
         const pool =
             agent_config.pool ||
             system.pools_by_name[pool_name] ||
-            _.filter(system.pools_by_name, p => (!_.get(p, 'mongo_pool_info') && (!_.get(p, 'cloud_pool_info'))))[0]; // default - the 1st host pool in the system
+            _.filter(system.pools_by_name, p => (!_.get(p, 'cloud_pool_info')))[0]; // default - the 1st host pool in the system
         // system_store.get_account_by_email(system.owner.email).default_resource; //This should not happen, but if it does, use owner's default
 
         if (!pool) {
@@ -641,9 +641,6 @@ class NodesMonitor extends EventEmitter {
 
         if (pool.cloud_pool_info) {
             item.node.is_cloud_node = true;
-        }
-        if (pool.mongo_pool_info) {
-            item.node.is_mongo_node = true;
         }
 
         dbg.log0('_add_new_node', item.node);
@@ -1725,7 +1722,7 @@ class NodesMonitor extends EventEmitter {
 
             } catch (err) {
                 // We will just wait another cycle and attempt to delete it fully again
-                dbg.warn('delete_cloud_or_mongo_pool_node ERROR node', item.node, err);
+                dbg.warn('delete_cloud_node ERROR node', item.node, err);
             }
         });
 

--- a/src/server/object_services/map_db_types.js
+++ b/src/server/object_services/map_db_types.js
@@ -351,7 +351,6 @@ class BlockDB {
                 mount: this.node.drive.mount,
                 online: Boolean(this.node.online),
                 in_cloud_pool: Boolean(this.node.is_cloud_node),
-                in_mongo_pool: Boolean(this.node.is_mongo_node),
             };
         }
         return {

--- a/src/server/object_services/mapper.js
+++ b/src/server/object_services/mapper.js
@@ -54,20 +54,17 @@ function select_mirror_for_write(tier, tiering, tiering_status, location_info) {
     for (const mirror of tier.mirrors) {
         const mirror_status = tier_status.mirrors_storage[mirror_index];
         const local_pool = find_local_pool(mirror.spread_pools, location_info);
-        const is_mongo_included = mirror.spread_pools.some(pool => Boolean(pool.mongo_pool_info));
         const is_local_pool_valid = local_pool && tier_status.pools[local_pool._id.toHexString()].valid_for_allocation;
         const is_regular_pools_valid = size_utils.json_to_bigint(mirror_status.regular_free).greater(config.MIN_TIER_FREE_THRESHOLD);
         const is_redundant_pools_valid = size_utils.json_to_bigint(mirror_status.redundant_free).greater(config.MIN_TIER_FREE_THRESHOLD);
 
         let weight = 0;
-        if (is_mongo_included) {
-            weight = 1;
-        } else if (is_local_pool_valid) {
-            weight = 4;
-        } else if (is_regular_pools_valid) {
+        if (is_local_pool_valid) {
             weight = 3;
-        } else if (is_redundant_pools_valid) {
+        } else if (is_regular_pools_valid) {
             weight = 2;
+        } else if (is_redundant_pools_valid) {
+            weight = 1;
         }
 
         if (!selected || weight > selected_weight || (weight === selected_weight && Math.random() > 0.5)) {
@@ -371,7 +368,7 @@ function _block_sort_newer_first(block1, block2) {
  * @returns {boolean}
  */
 function _pool_has_redundancy(pool) {
-    return Boolean(pool.cloud_pool_info || pool.mongo_pool_info);
+    return Boolean(pool.cloud_pool_info);
 }
 
 // /**

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -54,28 +54,6 @@ module.exports = {
             objectid: true
         },
         pool_node_type: node_schema.properties.node_type,
-        mongo_pool_info: {
-            type: 'object',
-            properties: {
-                agent_info: {
-                    type: 'object',
-                    properties: {
-                        create_node_token: {
-                            type: 'string'
-                        },
-                        node_token: {
-                            type: 'string'
-                        },
-                        mongo_path: {
-                            type: 'string'
-                        }
-                    }
-                },
-                pending_delete: {
-                    type: 'boolean'
-                },
-            }
-        },
         storage_stats: {
             type: 'object',
             required: ['blocks_size', 'last_update'],

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -309,7 +309,6 @@ async function get_partial_providers_stats(req) {
                 const pool = system_store.data.pools.find(pool_rec => String(pool_rec._id) === String(key));
                 // TODO: Handle deleted pools
                 if (!pool) continue;
-                if (pool.mongo_pool_info) continue;
                 let type = 'KUBERNETES';
                 if (pool.cloud_pool_info) {
                     type = (supported_cloud_types.includes(pool.cloud_pool_info.endpoint_type)) ?
@@ -711,7 +710,6 @@ async function get_cloud_pool_stats(req) {
     ];
     //Per each system fill out the needed info
     for (const pool of system_store.data.pools) {
-        if (pool.mongo_pool_info) continue;
         const pool_info = await server_rpc.client.pool.read_pool({ name: pool.name }, {
             auth_token: req.auth_token
         });

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -188,12 +188,7 @@ function new_system_changes(req, name, owner_account_id) {
     system.master_key_id = m_key._id;
 
     let default_pool;
-    if (config.DEFAULT_POOL_TYPE === 'INTERNAL') {
-        const pool_name = `${config.INTERNAL_STORAGE_POOL_NAME}-${system._id}`;
-        const mongo_pool = pool_server.new_pool_defaults(pool_name, system._id, 'INTERNAL', 'BLOCK_STORE_MONGO', owner_account_id);
-        mongo_pool.mongo_pool_info = {};
-        default_pool = mongo_pool;
-    } else if (config.DEFAULT_POOL_TYPE === 'HOSTS') {
+    if (config.DEFAULT_POOL_TYPE === 'HOSTS') {
         const pool_name = config.DEFAULT_POOL_NAME;
         const fs_pool = pool_server.new_pool_defaults(pool_name, system._id, 'HOSTS', 'BLOCK_STORE_FS', owner_account_id);
         fs_pool.hosts_pool_info = { is_managed: false, host_count: 0 };
@@ -607,7 +602,7 @@ async function read_system(req) {
         namespace_resources: _.map(system.namespace_resources_by_name,
             ns => pool_server.get_namespace_resource_info(ns)),
         pools: _.filter(system.pools_by_name,
-                pool => (!_.get(pool, 'cloud_pool_info.pending_delete') && !_.get(pool, 'mongo_pool_info.pending_delete')))
+                pool => (!_.get(pool, 'cloud_pool_info.pending_delete')))
             .map(pool => pool_server.get_pool_info(pool, nodes_aggregate_pool_with_cloud_and_mongo, hosts_aggregate_pool)),
         tiers: _.map(system.tiers_by_name,
             tier => tier_server.get_tier_info(tier,


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. remove mongo_pool and use `BLOCK_STORE_FS` based default backingstoire
2. Remove mongo related tools
3. Delete block_store_mongo.js 

### Issues: Fixed #xxx / Gap #xxx
1. MongoDB is not used in the latest version of NooBaa, and any unnecessary MongoDB-related code should be removed from the NooBaa core

### Testing Instructions:
1. Create bucket and put and get object from it
2. All the fuctionalities should work as before 

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The default pool type for new setups is now filesystem-backed ("HOSTS"), with internal MongoDB-backed pools no longer supported.

* **Bug Fixes**
  * Error messages and logs now consistently reference only cloud pools, removing outdated references to Mongo pools.

* **Refactor**
  * All logic, APIs, and schemas related to internal MongoDB-backed pools have been removed, simplifying pool management and related operations.
  * APIs and account/bucket management now exclusively use cloud or hosts pools, with updated validation and resource selection rules.
  * Pool selection, node monitoring, and mirror weight calculations no longer consider Mongo pools.
  * Statistics aggregation now includes all pools without excluding former Mongo pools.

* **Documentation**
  * Comments updated to reflect the new default pool type and removal of Mongo pool references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->