### PR TITLE
system store - endpoints load from core instead of db

### DIFF
--- a/config.js
+++ b/config.js
@@ -255,7 +255,9 @@ config.INTERNAL_STORAGE_POOL_NAME = 'system-internal-storage-pool';
 config.ALLOW_BUCKET_CREATE_ON_INTERNAL = true;
 config.BUCKET_AUTOCONF_TIER2_ENABLED = false;
 config.SYSTEM_STORE_LOAD_CONCURRENCY = parseInt(process.env.SYSTEM_STORE_LOAD_CONCURRENCY, 10) || 5;
-config.SYSTEM_STORE_SOURCE = process.env.SYSTEM_STORE_SOURCE || "DB";
+// SYSTEM_STORE_SOURCE determines the preffered source for loading system_store data
+// This can be either "DB" to load from the DB or "CORE" to load from the system_server in noobaa-core
+config.SYSTEM_STORE_SOURCE = process.env.SYSTEM_STORE_SOURCE?.toUpperCase() || "DB";
 //////////////////////////
 // MD AGGREGATOR CONFIG //
 //////////////////////////

--- a/config.js
+++ b/config.js
@@ -255,7 +255,7 @@ config.INTERNAL_STORAGE_POOL_NAME = 'system-internal-storage-pool';
 config.ALLOW_BUCKET_CREATE_ON_INTERNAL = true;
 config.BUCKET_AUTOCONF_TIER2_ENABLED = false;
 config.SYSTEM_STORE_LOAD_CONCURRENCY = parseInt(process.env.SYSTEM_STORE_LOAD_CONCURRENCY, 10) || 5;
-
+config.SYSTEM_STORE_SOURCE = process.env.SYSTEM_STORE_SOURCE || "db";
 //////////////////////////
 // MD AGGREGATOR CONFIG //
 //////////////////////////

--- a/config.js
+++ b/config.js
@@ -255,7 +255,7 @@ config.INTERNAL_STORAGE_POOL_NAME = 'system-internal-storage-pool';
 config.ALLOW_BUCKET_CREATE_ON_INTERNAL = true;
 config.BUCKET_AUTOCONF_TIER2_ENABLED = false;
 config.SYSTEM_STORE_LOAD_CONCURRENCY = parseInt(process.env.SYSTEM_STORE_LOAD_CONCURRENCY, 10) || 5;
-config.SYSTEM_STORE_SOURCE = process.env.SYSTEM_STORE_SOURCE || "db";
+config.SYSTEM_STORE_SOURCE = process.env.SYSTEM_STORE_SOURCE || "DB";
 //////////////////////////
 // MD AGGREGATOR CONFIG //
 //////////////////////////

--- a/src/api/server_inter_process_api.js
+++ b/src/api/server_inter_process_api.js
@@ -19,7 +19,8 @@ module.exports = {
                 properties: {
                     since: { idate: true },
                     load_from_core_step: {
-                        type: 'string'
+                        type: 'string',
+                        enum: ['CORE', 'ENDPOINT']
                     }
                 }
             },

--- a/src/api/server_inter_process_api.js
+++ b/src/api/server_inter_process_api.js
@@ -17,7 +17,10 @@ module.exports = {
             params: {
                 type: 'object',
                 properties: {
-                    since: { idate: true }
+                    since: { idate: true },
+                    load_from_core_step: {
+                        type: 'string'
+                    }
                 }
             },
             auth: {

--- a/src/api/server_inter_process_api.js
+++ b/src/api/server_inter_process_api.js
@@ -20,7 +20,7 @@ module.exports = {
                     since: { idate: true },
                     load_from_core_step: {
                         type: 'string',
-                        enum: ['CORE', 'ENDPOINT']
+                        enum: ['DB', 'CORE']
                     }
                 }
             },

--- a/src/api/server_inter_process_api.js
+++ b/src/api/server_inter_process_api.js
@@ -18,7 +18,7 @@ module.exports = {
                 type: 'object',
                 properties: {
                     since: { idate: true },
-                    load_from_core_step: {
+                    load_source: {
                         type: 'string',
                         enum: ['DB', 'CORE']
                     }

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -459,6 +459,13 @@ module.exports = {
             auth: {
                 system: 'admin'
             }
+        },
+
+        get_system_store: {
+            method: 'GET',
+            auth: {
+                system: false
+            }
         }
     },
 

--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -463,6 +463,12 @@ module.exports = {
 
         get_system_store: {
             method: 'GET',
+            reply: {
+                type: 'object',
+                properties: {
+                    // [RPC_BUFFERS].data
+                },
+            },
             auth: {
                 system: false
             }

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -173,7 +173,7 @@ async function main(options = {}) {
                 // Load a system store instance for the current process and register for changes.
                 // We do not wait for it in becasue the result or errors are not relevent at
                 // this point (and should not kill the process);
-                system_store.get_instance().load();
+                system_store.get_instance({source: system_store.SOURCE.CORE}).load();
                 // Register the process as an md_server.
                 await md_server.register_rpc();
             }

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -173,7 +173,7 @@ async function main(options = {}) {
                 // Load a system store instance for the current process and register for changes.
                 // We do not wait for it in becasue the result or errors are not relevent at
                 // this point (and should not kill the process);
-                system_store.get_instance({source: system_store.SOURCE.CORE}).load();
+                system_store.get_instance().load();
                 // Register the process as an md_server.
                 await md_server.register_rpc();
             }

--- a/src/server/common_services/server_inter_process.js
+++ b/src/server/common_services/server_inter_process.js
@@ -18,7 +18,8 @@ const server_rpc = require('../server_rpc');
  */
 async function load_system_store(req) {
     await system_store.load(
-        req && req.rpc_params && req.rpc_params.since, req?.rpc_params?.load_from_core_step.toUpperCase()
+        req?.rpc_params?.since,
+        req?.rpc_params?.load_from_core_step.toUpperCase()
     );
 }
 

--- a/src/server/common_services/server_inter_process.js
+++ b/src/server/common_services/server_inter_process.js
@@ -17,18 +17,8 @@ const server_rpc = require('../server_rpc');
  *
  */
 async function load_system_store(req) {
-    //if endpoints load from core, and this load is for core
-    //(ie, the first load_system_store() out of two),
-    //then endpoints skip it.
-    //endpoints will be updated in the next load_system_store()
-    //once core's in memory system store is updated.
-    const is_endpoint = process.env.HOSTNAME && process.env.HOSTNAME.indexOf("endpoint") !== -1;
-    if (is_endpoint && req?.rpc_params?.load_from_core_step === 'core') {
-        return;
-    }
-
     await system_store.load(
-        req && req.rpc_params && req.rpc_params.since
+        req && req.rpc_params && req.rpc_params.since, req?.rpc_params?.load_from_core_step.toUpperCase()
     );
 }
 

--- a/src/server/common_services/server_inter_process.js
+++ b/src/server/common_services/server_inter_process.js
@@ -13,11 +13,20 @@ const dbg = require('../../util/debug_module')(__filename);
 const system_store = require('../system_services/system_store').get_instance();
 const server_rpc = require('../server_rpc');
 
-
 /**
  *
  */
 async function load_system_store(req) {
+    //if endpoints load from core, and this load is for core
+    //(ie, the first load_system_store() out of two),
+    //then endpoints skip it.
+    //endpoints will be updated in the next load_system_store()
+    //once core's in memory system store is updated.
+    const is_endpoint = process.env.HOSTNAME && process.env.HOSTNAME.indexOf("endpoint") !== -1;
+    if (is_endpoint && req?.rpc_params?.load_from_core_step === 'core') {
+        return;
+    }
+
     await system_store.load(
         req && req.rpc_params && req.rpc_params.since
     );

--- a/src/server/common_services/server_inter_process.js
+++ b/src/server/common_services/server_inter_process.js
@@ -19,7 +19,7 @@ const server_rpc = require('../server_rpc');
 async function load_system_store(req) {
     await system_store.load(
         req?.rpc_params?.since,
-        req?.rpc_params?.load_from_core_step.toUpperCase()
+        req?.rpc_params?.load_source.toUpperCase()
     );
 }
 

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -19,7 +19,7 @@ const config = require('../../../config');
 const { BucketStatsStore } = require('../analytic_services/bucket_stats_store');
 const { EndpointStatsStore } = require('../analytic_services/endpoint_stats_store');
 const os_utils = require('../../util/os_utils');
-const { RpcError } = require('../../rpc');
+const { RpcError, RPC_BUFFERS } = require('../../rpc');
 const nb_native = require('../../util/nb_native');
 const Dispatcher = require('../notifications/dispatcher');
 const size_utils = require('../../util/size_utils');
@@ -298,6 +298,11 @@ function get_system_status(req) {
     };
 }
 
+async function get_system_store() {
+    return {
+        [RPC_BUFFERS]: {data: Buffer.from(JSON.stringify(await system_store.recent_db_data()))},
+    };
+}
 
 async function _update_system_state(system_id, mode) {
     const update = {
@@ -1595,3 +1600,5 @@ exports.rotate_master_key = rotate_master_key;
 exports.disable_master_key = disable_master_key;
 exports.enable_master_key = enable_master_key;
 exports.upgrade_master_keys = upgrade_master_keys;
+
+exports.get_system_store = get_system_store;

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -299,9 +299,13 @@ function get_system_status(req) {
 }
 
 async function get_system_store() {
-    return {
-        [RPC_BUFFERS]: {data: Buffer.from(JSON.stringify(await system_store.recent_db_data()))},
-    };
+    try {
+        return {
+            [RPC_BUFFERS]: {data: Buffer.from(JSON.stringify(await system_store.recent_db_data()))},
+        };
+    } catch (e) {
+        dbg.error("Failed getting system store", e);
+    }
 }
 
 async function _update_system_state(system_id, mode) {

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -417,13 +417,13 @@ class SystemStore extends EventEmitter {
         }
     }
 
-    async load(since, load_from_core_step) {
+    async load(since, load_source) {
         //if endpoints load from core, and this load is for core
-        //(ie, the first load_system_store() out of two with load_from_core_step === 'CORE'),
+        //(ie, the first load_system_store() out of two with load_source === 'CORE'),
         //then endpoints skip it.
         //endpoints will be updated in the next load_system_store()
         //once core's in memory system store is updated.
-        if (load_from_core_step && (this.source !== load_from_core_step)) {
+        if (load_source && (this.source !== load_source)) {
             return;
         }
 
@@ -431,7 +431,7 @@ class SystemStore extends EventEmitter {
         // because it might not see the latest changes if we don't reload right after make_changes.
         return this._load_serial.surround(async () => {
             try {
-                dbg.log3('SystemStore: loading ... this.last_update_time  =', this.last_update_time, ", since =", since, "load_from_core_step =", load_from_core_step);
+                dbg.log3('SystemStore: loading ... this.last_update_time  =', this.last_update_time, ", since =", since, "load_source =", load_source);
 
                 // If we get a load request with an timestamp older then our last update time
                 // we ensure we load everyting from that timestamp by updating our last_update_time.
@@ -687,7 +687,7 @@ class SystemStore extends EventEmitter {
                     method_api: 'server_inter_process_api',
                     method_name: 'load_system_store',
                     target: '',
-                    request_params: { since: last_update, load_from_core_step: SOURCE.DB }
+                    request_params: { since: last_update, load_source: SOURCE.DB }
                 });
 
                 //if endpoints are loading system store from core, we need to wait until
@@ -699,7 +699,7 @@ class SystemStore extends EventEmitter {
                     method_api: 'server_inter_process_api',
                     method_name: 'load_system_store',
                     target: '',
-                    request_params: { since: last_update, load_from_core_step: SOURCE.CORE }
+                    request_params: { since: last_update, load_source: SOURCE.CORE }
                 });
             }
         }

--- a/src/test/integration_tests/db/test_system_store.js
+++ b/src/test/integration_tests/db/test_system_store.js
@@ -5,6 +5,7 @@ const mocha = require('mocha');
 const assert = require('assert');
 const coretest = require('../../utils/coretest/coretest');
 const db_client = require('../../../util/db_client');
+const { SystemStore } = require('../../../server/system_services/system_store');
 
 // setup coretest first to prepare the env
 coretest.setup();
@@ -136,6 +137,19 @@ mocha.describe('system_store', function() {
         const data2 = await system_store.load();
         console.log('new_data_store', data2.systems.length);
         assert.strictEqual(data2.systems[0].name, 'new_name');
+    });
+
+    mocha.it("Load from core", async function() {
+
+        const system_store_from_core = new SystemStore({
+            source: 'CORE'
+        });
+
+        const from_db = await system_store.load();
+        const from_core = await system_store_from_core.load(undefined, 'ENDPOINT');
+
+        assert.deepStrictEqual(from_db, from_core);
+
     });
 
 });

--- a/src/test/integration_tests/db/test_system_store.js
+++ b/src/test/integration_tests/db/test_system_store.js
@@ -5,7 +5,7 @@ const mocha = require('mocha');
 const assert = require('assert');
 const coretest = require('../../utils/coretest/coretest');
 const db_client = require('../../../util/db_client');
-const { SystemStore } = require('../../../server/system_services/system_store');
+const { SystemStore, SOURCE } = require('../../../server/system_services/system_store');
 
 // setup coretest first to prepare the env
 coretest.setup();
@@ -142,12 +142,12 @@ mocha.describe('system_store', function() {
     mocha.it("Load from core", async function() {
 
         const system_store_from_core = new SystemStore({
-            source: 'CORE',
+            source: SOURCE.CORE,
             skip_define_for_tests: true
         });
 
         const from_db = await system_store.load();
-        const from_core = await system_store_from_core.load(undefined, 'CORE');
+        const from_core = await system_store_from_core.load(undefined, SOURCE.CORE);
 
         assert.deepStrictEqual(from_db.data, from_core.data);
 

--- a/src/test/integration_tests/db/test_system_store.js
+++ b/src/test/integration_tests/db/test_system_store.js
@@ -142,13 +142,14 @@ mocha.describe('system_store', function() {
     mocha.it("Load from core", async function() {
 
         const system_store_from_core = new SystemStore({
-            source: 'CORE'
+            source: 'CORE',
+            skip_define_for_tests: true
         });
 
         const from_db = await system_store.load();
-        const from_core = await system_store_from_core.load(undefined, 'ENDPOINT');
+        const from_core = await system_store_from_core.load(undefined, 'CORE');
 
-        assert.deepStrictEqual(from_db, from_core);
+        assert.deepStrictEqual(from_db.data, from_core.data);
 
     });
 

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1951,3 +1951,4 @@ PostgresClient._instance = undefined;
 // EXPORTS
 exports.PostgresClient = PostgresClient;
 exports.instance = PostgresClient.instance;
+exports.decode_json = decode_json;


### PR DESCRIPTION
### Describe the Problem
Reduce db load spikes when all endpoints load from db simultaneously by having only core load from db and endpoints load from core instead.

### Explain the Changes
1. Introduce new RPC that allows endpoints to get system store from core.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public GET endpoint to retrieve the system store without system-level auth and to obtain the latest in-memory DB snapshot.

* **Configuration**
  * New SYSTEM_STORE_SOURCE setting (defaults to "DB") to choose data source (DB or CORE).

* **Behavior Changes**
  * System store can load from CORE with automatic fallback to DB and a two-phase publish flow; load accepts an explicit load_source (DB or CORE).

* **Tests**
  * Integration test added to verify CORE vs DB load parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->