### PR TITLE
lifecycle improvement for none-versionning buckets

### DIFF
--- a/src/test/integration_tests/api/s3/test_lifecycle.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle.js
@@ -287,18 +287,16 @@ mocha.describe('lifecycle', () => {
             const putLifecycleParams = {
                 Bucket: bucket,
                 LifecycleConfiguration: {
-                    Rules: [
-                        {
-                            AbortIncompleteMultipartUpload: {
-                                // 10 less days have gone by since upload created
-                                DaysAfterInitiation: parts_age + 10,
-                            },
-                            Filter: {
-                                Prefix: ''
-                            },
-                            Status: 'Enabled',
-                        }
-                    ],
+                    Rules: [{
+                        AbortIncompleteMultipartUpload: {
+                            // 10 less days have gone by since upload created
+                            DaysAfterInitiation: parts_age + 10,
+                        },
+                        Filter: {
+                            Prefix: ''
+                        },
+                        Status: 'Enabled',
+                    }],
                 },
             };
 
@@ -329,18 +327,16 @@ mocha.describe('lifecycle', () => {
             const putLifecycleParams = {
                 Bucket: bucket,
                 LifecycleConfiguration: {
-                    Rules: [
-                        {
-                            AbortIncompleteMultipartUpload: {
-                                // 10 less days have gone by since upload created
-                                DaysAfterInitiation: parts_age + 10,
-                            },
-                            Filter: {
-                                Prefix: prefix,
-                            },
-                            Status: 'Enabled',
-                        }
-                    ],
+                    Rules: [{
+                        AbortIncompleteMultipartUpload: {
+                            // 10 less days have gone by since upload created
+                            DaysAfterInitiation: parts_age + 10,
+                        },
+                        Filter: {
+                            Prefix: prefix,
+                        },
+                        Status: 'Enabled',
+                    }],
                 },
             };
 
@@ -407,7 +403,7 @@ mocha.describe('lifecycle', () => {
 
             const mp_list_after = await rpc_client.object.list_multiparts({ obj_id, bucket, key });
             assert.strictEqual(mp_list_after.multiparts.length, num_parts,
-                        `list_multiparts actual ${mp_list_after.multiparts.length} !== ${num_parts}`);
+                `list_multiparts actual ${mp_list_after.multiparts.length} !== ${num_parts}`);
 
             return obj_id;
         }
@@ -495,17 +491,15 @@ mocha.describe('lifecycle', () => {
             const putLifecycleParams = {
                 Bucket: bucket,
                 LifecycleConfiguration: {
-                    Rules: [
-                        {
-                            NoncurrentVersionExpiration: {
-                                NoncurrentDays: age + 10,
-                            },
-                            Filter: {
-                                Prefix: ''
-                            },
-                            Status: 'Enabled',
-                        }
-                    ],
+                    Rules: [{
+                        NoncurrentVersionExpiration: {
+                            NoncurrentDays: age + 10,
+                        },
+                        Filter: {
+                            Prefix: ''
+                        },
+                        Status: 'Enabled',
+                    }],
                 },
             };
 
@@ -535,17 +529,15 @@ mocha.describe('lifecycle', () => {
             const putLifecycleParams = {
                 Bucket: bucket,
                 LifecycleConfiguration: {
-                    Rules: [
-                        {
-                            NoncurrentVersionExpiration: {
-                                NoncurrentDays: age + 10,
-                            },
-                            Filter: {
-                                Prefix: prefix,
-                            },
-                            Status: 'Enabled',
-                        }
-                    ],
+                    Rules: [{
+                        NoncurrentVersionExpiration: {
+                            NoncurrentDays: age + 10,
+                        },
+                        Filter: {
+                            Prefix: prefix,
+                        },
+                        Status: 'Enabled',
+                    }],
                 },
             };
 
@@ -576,20 +568,18 @@ mocha.describe('lifecycle', () => {
             const putLifecycleParams = {
                 Bucket: bucket,
                 LifecycleConfiguration: {
-                    Rules: [
-                        {
-                            NoncurrentVersionExpiration: {
-                                // Age exceeds but newernoncurrent versions doesn't
-                                // so no expiration should happen
-                                NoncurrentDays: age - 10,
-                                NewerNoncurrentVersions: 10
-                            },
-                            Filter: {
-                                Prefix: ''
-                            },
-                            Status: 'Enabled',
-                        }
-                    ],
+                    Rules: [{
+                        NoncurrentVersionExpiration: {
+                            // Age exceeds but newernoncurrent versions doesn't
+                            // so no expiration should happen
+                            NoncurrentDays: age - 10,
+                            NewerNoncurrentVersions: 10
+                        },
+                        Filter: {
+                            Prefix: ''
+                        },
+                        Status: 'Enabled',
+                    }],
                 },
             };
 
@@ -634,7 +624,7 @@ mocha.describe('lifecycle', () => {
             }
         }
 
-        mocha.it('lifecyle - version object expired', async () => {
+        mocha.it('lifecycle - version object expired', async () => {
             const age = 30;
             const version_count = 10;
             const version_bucket_key = 'test-lifecycle-version1-1';
@@ -646,7 +636,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(version_count + 1, version_bucket_key);
         });
 
-        mocha.it('lifecyle - version object not expired', async () => {
+        mocha.it('lifecycle - version object not expired', async () => {
             const age = 5;
             const version_count = 10;
             const version_bucket_key = 'test-lifecycle-version2-0';
@@ -658,7 +648,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(version_count, version_bucket_key);
         });
 
-        mocha.it('lifecyle - version not expiration', async () => {
+        mocha.it('lifecycle - version not expiration', async () => {
             const days = 30;
             const version_count = 10;
             const newnon_current_version = 1;
@@ -667,7 +657,7 @@ mocha.describe('lifecycle', () => {
             // create_time updated to 29 days and expire is 30 days and noncurrent expire in 15
             await create_mock_version(version_bucket_key, version_bucket, days - 1, version_count);
             const putLifecycleParams = commonTests.version_lifecycle_configuration(version_bucket,
-                                            version_bucket_key, days, newnon_current_version, noncurrent_days);
+                version_bucket_key, days, newnon_current_version, noncurrent_days);
 
             await s3.putBucketLifecycleConfiguration(putLifecycleParams);
             await lifecycle.background_worker();
@@ -676,7 +666,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(2, version_bucket_key);
         });
 
-        mocha.it('lifecyle - version expiration - only NewerNoncurrentVersions exceeded', async () => {
+        mocha.it('lifecycle - version expiration - only NewerNoncurrentVersions exceeded', async () => {
             const days = 35;
             const version_count = 10;
             const newnon_current_version = 5;
@@ -685,7 +675,7 @@ mocha.describe('lifecycle', () => {
             // create_time updated to 36 days and expire is 35 days
             await create_mock_version(version_bucket_key, version_bucket, days + 1, version_count, true);
             const putLifecycleParams = commonTests.version_lifecycle_configuration(version_bucket,
-                                            version_bucket_key, days, newnon_current_version, noncurrent_days);
+                version_bucket_key, days, newnon_current_version, noncurrent_days);
 
             await s3.putBucketLifecycleConfiguration(putLifecycleParams);
             await lifecycle.background_worker();
@@ -693,7 +683,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(7, version_bucket_key);
         });
 
-        mocha.it('lifecyle - version expiration - only NoncurrentDays exceeded', async () => {
+        mocha.it('lifecycle - version expiration - only NoncurrentDays exceeded', async () => {
             const days = 45;
             const version_count = 10;
             const newnon_current_version = 100;
@@ -702,7 +692,7 @@ mocha.describe('lifecycle', () => {
             // create_time updated to 45+30+1= 76 days and expire is 45 days
             await create_mock_version(version_bucket_key, version_bucket, days + noncurrent_days + 1, version_count, true);
             const putLifecycleParams = commonTests.version_lifecycle_configuration(version_bucket,
-                                            version_bucket_key, days, newnon_current_version, noncurrent_days);
+                version_bucket_key, days, newnon_current_version, noncurrent_days);
 
             await s3.putBucketLifecycleConfiguration(putLifecycleParams);
             await lifecycle.background_worker();
@@ -711,7 +701,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(11, version_bucket_key);
         });
 
-        mocha.it('lifecyle - version expiration - both NoncurrentDays and NewerNoncurrentVersions exceeded', async () => {
+        mocha.it('lifecycle - version expiration - both NoncurrentDays and NewerNoncurrentVersions exceeded', async () => {
             const days = 30;
             const version_count = 10;
             const newnon_current_version = 1;
@@ -720,7 +710,7 @@ mocha.describe('lifecycle', () => {
             // create_time updated to 46 days and expire is 30 days
             await create_mock_version(version_bucket_key, version_bucket, days + noncurrent_days + 1, version_count);
             const putLifecycleParams = commonTests.version_lifecycle_configuration(version_bucket,
-                                            version_bucket_key, days, newnon_current_version, noncurrent_days);
+                version_bucket_key, days, newnon_current_version, noncurrent_days);
 
             await s3.putBucketLifecycleConfiguration(putLifecycleParams);
             await lifecycle.background_worker();
@@ -728,7 +718,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(2, version_bucket_key);
         });
 
-        mocha.it('lifecyle - version not expiration - delete marker true', async () => {
+        mocha.it('lifecycle - version not expiration - delete marker true', async () => {
             const days = 30;
             const version_count = 10;
             const noncurrent_days = 15;
@@ -736,7 +726,7 @@ mocha.describe('lifecycle', () => {
             // create_time updated to 29 days and expire is 30 days,
             await create_mock_version(version_bucket_key, version_bucket, days - 1, version_count, true);
             const putLifecycleParams = commonTests.version_lifecycle_configuration(version_bucket,
-                                            version_bucket_key, days, undefined, noncurrent_days);
+                version_bucket_key, days, undefined, noncurrent_days);
 
             await s3.putBucketLifecycleConfiguration(putLifecycleParams);
             await lifecycle.background_worker();
@@ -744,14 +734,14 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(1, version_bucket_key);
         });
 
-        mocha.it('lifecyle - version expiration all - delete marker true', async () => {
+        mocha.it('lifecycle - version expiration all - delete marker true', async () => {
             const days = 30;
             const version_count = 10;
             const noncurrent_days = 15;
             const version_bucket_key = 'test-lifecycle-version6';
             await create_mock_version(version_bucket_key, version_bucket, days + noncurrent_days + 1, version_count, true);
             const putLifecycleParams = commonTests.version_lifecycle_configuration(version_bucket,
-                                            version_bucket_key, days, undefined, noncurrent_days);
+                version_bucket_key, days, undefined, noncurrent_days);
             await s3.putBucketLifecycleConfiguration(putLifecycleParams);
             await lifecycle.background_worker();
             await verify_version_deleted(2, version_bucket_key);
@@ -776,7 +766,7 @@ mocha.describe('lifecycle', () => {
                 prefix: key,
             };
             const obj_ids = [];
-            const {objects} = await rpc_client.object.list_object_versions(obj_params);
+            const { objects } = await rpc_client.object.list_object_versions(obj_params);
             for (const object of objects) {
                 obj_ids.push(object.obj_id);
             }
@@ -804,7 +794,7 @@ mocha.describe('lifecycle', () => {
     mocha.describe('bucket-lifecycle-expiration-header', function() {
         const bucket = Bucket;
 
-        const run_expiration_test = async ({ rules, expected_id, expected_days, key, tagging = undefined, size = 1000}) => {
+        const run_expiration_test = async ({ rules, expected_id, expected_days, key, tagging = undefined, size = 1000 }) => {
             const putLifecycleParams = {
                 Bucket: bucket,
                 LifecycleConfiguration: { Rules: rules }


### PR DESCRIPTION
### Describe the Problem
As most of the times when lifecycle is set, the bucket doesn't have versioning enabled, we would like to add a special case for handling deleting the only key in the bucket that fits the lifecycle rule.
Before the change, we would find 1K keys that fit and then go one by one and delete them from the DB. With this fix, it will be replaced with 1 DB query.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixing one issue we found here: https://issues.redhat.com/browse/DFBUGS-2955 before the customer decided to disable lifecycle.
2. Gap - We need to better handle also for versioning - also there - going over the keys one by one doesn't really scale.

after the fix - this is the explain result: 
```
EXPLAIN ANALYZE WITH rows AS (SELECT _id  FROM objectmds WHERE data->>'bucket' = '67ea718f8525bd002640c893' AND data->>'key' ~ '^application' AND data->>'create_time' < '2025-08-12T11:11:34.000Z' AND data->'deleted' IS NULL AND data->'upload_started' IS NULL AND data->'version_enabled' IS NULL LIMIT 1000) UPDATE objectmds SET data = jsonb_set(data, '{deleted}', to_jsonb('2025-08-13T11:11:34.537Z'::text), true) WHERE _id IN (SELECT rows._id FROM rows) RETURNING *;
                                                                                                                                                QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Update on objectmds  (cost=9.16..17.20 rows=1 width=87) (actual time=53.436..833.670 rows=1000 loops=1)
   ->  Nested Loop  (cost=9.16..17.20 rows=1 width=87) (actual time=52.548..168.073 rows=1000 loops=1)
         ->  HashAggregate  (cost=8.60..8.61 rows=1 width=74) (actual time=52.248..52.648 rows=1000 loops=1)
               Group Key: rows._id
               Batches: 1  Memory Usage: 345kB
               ->  Subquery Scan on rows  (cost=0.55..8.60 rows=1 width=74) (actual time=5.835..51.606 rows=1000 loops=1)
                     ->  Limit  (cost=0.55..8.59 rows=1 width=25) (actual time=5.775..51.187 rows=1000 loops=1)
                           ->  Index Scan using idx_btree_objectmds_version_seq_index on objectmds objectmds_1  (cost=0.55..8.59 rows=1 width=25) (actual time=5.772..51.092 rows=1000 loops=1)
                                 Index Cond: (((data ->> 'bucket'::text) = '67ea718f8525bd002640c893'::text) AND ((data ->> 'key'::text) >= 'application'::text) AND ((data ->> 'key'::text) < 'applicatioo'::text))
                                 Filter: (((data -> 'deleted'::text) IS NULL) AND ((data -> 'upload_started'::text) IS NULL) AND ((data -> 'version_enabled'::text) IS NULL) AND ((data ->> 'key'::text) ~ '^application'::text) AND ((data ->> 'create_time'::text) < '2025-08-12T11:11:34.000Z'::text))
         ->  Index Scan using objectmds_pkey on objectmds  (cost=0.56..8.58 rows=1 width=667) (actual time=0.113..0.113 rows=1 loops=1000)
               Index Cond: (_id = rows._id)
 Planning Time: 0.872 ms
 Execution Time: 833.915 ms
(14 rows)
```
### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk-delete objects by flexible query (key patterns, creation time, size, tags) for PostgreSQL-backed buckets without versioning.

* **Bug Fixes**
  * Improved per-object reply construction and error handling when deleting multiple objects by filter.

* **Tests**
  * Added integration tests for bulk-delete-by-query and refined lifecycle/metadata-store test descriptions and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->