### PR TITLE
SDK | Upgrade AWS SDK to v3 - NamespaceS3

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -666,18 +666,6 @@ function parse_body_logging_xml(req) {
     return logging;
 }
 
-function get_http_response_date(res) {
-    const r = get_http_response_from_resp(res);
-    if (!r.httpResponse.headers.date) throw new Error("date not found in response header");
-    return r.httpResponse.headers.date;
-}
-
-function get_http_response_from_resp(res) {
-    const r = res.$response;
-    if (!r) throw new Error("no $response in s3 returned object");
-    return r;
-}
-
 function get_response_field_encoder(req) {
     const encoding_type = req.query['encoding-type'];
     if ((typeof encoding_type === 'undefined') || (encoding_type === null)) return response_field_encoder_none;
@@ -861,8 +849,6 @@ exports.parse_lock_header = parse_lock_header;
 exports.parse_body_object_lock_conf_xml = parse_body_object_lock_conf_xml;
 exports.parse_to_camel_case = parse_to_camel_case;
 exports._is_valid_retention = _is_valid_retention;
-exports.get_http_response_from_resp = get_http_response_from_resp;
-exports.get_http_response_date = get_http_response_date;
 exports.XATTR_SORT_SYMBOL = XATTR_SORT_SYMBOL;
 exports.get_response_field_encoder = get_response_field_encoder;
 exports.response_field_encoder_url = response_field_encoder_url;

--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -71,7 +71,6 @@ mocha.describe('s3_ops', function() {
     mocha.before(async function() {
         const self = this;
         self.timeout(60000);
-
         const account_info = await rpc_client.account.read_account({ email: EMAIL, });
         s3_client_params = {
             endpoint: coretest.get_http_address(),

--- a/src/test/unit_tests/util_functions_tests/test_cloud_utils.js
+++ b/src/test/unit_tests/util_functions_tests/test_cloud_utils.js
@@ -4,7 +4,6 @@
 const mocha = require('mocha');
 const assert = require('assert');
 const sinon = require('sinon');
-const AWS = require('aws-sdk');
 const cloud_utils = require('../../../util/cloud_utils');
 const dbg = require('../../../util/debug_module')(__filename);
 const { STSClient } = require('@aws-sdk/client-sts');
@@ -15,71 +14,7 @@ const fakeAccessKeyId = "fakeAccessKeyId";
 const fakeSecretAccessKey = "fakeSecretAccessKey";
 const fakeSessionToken = "fakeSessionToken";
 const roleArn = "arn:aws:iam::261532230807:role/noobaa_s3_sts";
-const defaultSTSCredsValidity = 3600;
 const REGION = "us-east-1";
-const expectedParams = [{
-    RoleArn: roleArn,
-    RoleSessionName: 'testSession',
-    WebIdentityToken: 'web-identity-token',
-    DurationSeconds: defaultSTSCredsValidity,
-}];
-
-mocha.describe('AWS STS tests', function() {
-    let STSStub;
-    let stsFake;
-    mocha.before('Creating STS stub', function() {
-
-        sinon.stub(fs.promises, "readFile")
-            .withArgs(projectedServiceAccountToken)
-            .returns("web-identity-token");
-
-        stsFake = {
-            assumeRoleWithWebIdentity: sinon.stub().returnsThis(),
-            promise: sinon.stub()
-            .resolves({
-                Credentials: {
-                    AccessKeyId: fakeAccessKeyId,
-                    SecretAccessKey: fakeSecretAccessKey,
-                    SessionToken: fakeSessionToken
-                }
-            }),
-        };
-        STSStub = sinon.stub(AWS, 'STS')
-            .callsFake(() => stsFake);
-    });
-    mocha.after('Restoring STS stub', function() {
-        STSStub.restore();
-        fs.promises.readFile.restore?.();
-    });
-    mocha.it('should generate aws sts creds', async function() {
-        const params = {
-            aws_sts_arn: roleArn
-        };
-        const roleSessionName = "testSession";
-        const json = await cloud_utils.generate_aws_sts_creds(params, roleSessionName);
-        sinon.assert.calledOnce(STSStub);
-        sinon.assert.calledWith(stsFake.assumeRoleWithWebIdentity, ...expectedParams);
-        assert.equal(json.accessKeyId, fakeAccessKeyId);
-        assert.equal(json.secretAccessKey, fakeSecretAccessKey);
-        assert.equal(json.sessionToken, fakeSessionToken);
-        dbg.log0('test.aws.sts.assumeRoleWithWebIdentity: ', json);
-    });
-    mocha.it('should generate an STS S3 client', async function() {
-        const params = {
-            aws_sts_arn: roleArn,
-            region: 'us-east-1'
-        };
-        const additionalParams = {
-            RoleSessionName: 'testSession'
-        };
-        const s3 = await cloud_utils.createSTSS3Client(params, additionalParams);
-        dbg.log0('test.aws.sts.createSTSS3Client: ', s3);
-        assert.equal(s3.config.credentials.accessKeyId, fakeAccessKeyId);
-        assert.equal(s3.config.credentials.secretAccessKey, fakeSecretAccessKey);
-        assert.equal(s3.config.credentials.sessionToken, fakeSessionToken);
-        assert.equal(s3.config.region, 'us-east-1');
-    });
-});
 
 mocha.describe('AWS STS SDK V3 tests', function() {
     let sts_v3_stub;

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -31,38 +31,6 @@ function find_cloud_connection(account, conn_name) {
     return conn;
 }
 
-async function createSTSS3Client(params, additionalParams) {
-    const creds = await generate_aws_sts_creds(params, additionalParams.RoleSessionName);
-    return new AWS.S3({
-        credentials: creds,
-        region: params.region,
-        endpoint: additionalParams.endpoint,
-        signatureVersion: additionalParams.signatureVersion,
-        s3DisableBodySigning: additionalParams.s3DisableBodySigning,
-        httpOptions: additionalParams.httpOptions,
-        s3ForcePathStyle: additionalParams.s3ForcePathStyle
-    });
-}
-
-async function generate_aws_sts_creds(params, roleSessionName) {
-    const sts = new AWS.STS();
-    const creds = await (sts.assumeRoleWithWebIdentity({
-        RoleArn: params.aws_sts_arn,
-        RoleSessionName: roleSessionName || defaultRoleSessionName,
-        WebIdentityToken: (await fs.promises.readFile(projectedServiceAccountToken)).toString(),
-        DurationSeconds: defaultSTSCredsValidity
-    }).promise());
-    if (_.isEmpty(creds.Credentials)) {
-        dbg.error(`AWS STS empty creds ${params.RoleArn}, RolesessionName: ${params.RoleSessionName},Projected service Account Token Path : ${projectedServiceAccountToken}`);
-        throw new RpcError('AWS_STS_ERROR', 'Empty AWS STS creds retrieved for Role "' + params.RoleArn + '"');
-    }
-    return new AWS.Credentials(
-        creds.Credentials.AccessKeyId,
-        creds.Credentials.SecretAccessKey,
-        creds.Credentials.SessionToken
-    );
-}
-
 async function createSTSS3SDKv3Client(params, additionalParams) {
     const creds = await generate_aws_sdkv3_sts_creds(params, additionalParams.RoleSessionName);
     return new S3({
@@ -247,8 +215,6 @@ exports.get_s3_endpoint_signature_ver = get_s3_endpoint_signature_ver;
 exports.is_aws_endpoint = is_aws_endpoint;
 exports.disable_s3_compatible_bodysigning = disable_s3_compatible_bodysigning;
 exports.set_noobaa_s3_connection = set_noobaa_s3_connection;
-exports.createSTSS3Client = createSTSS3Client;
-exports.generate_aws_sts_creds = generate_aws_sts_creds;
 exports.generate_access_keys = generate_access_keys;
 exports.createSTSS3SDKv3Client = createSTSS3SDKv3Client;
 exports.generate_aws_sdkv3_sts_creds = generate_aws_sdkv3_sts_creds;


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. Upgrade AWS SDK to v3 - NamespaceS3 
2. Remove AWS SDK V2 cloud util changes

### Issues: Fixed #xxx / Gap #xxx
1. Remove deprecated AWS SDKv3 for NamespaceS3.

### Testing Instructions:
1. Run namespaces3 flows


- [ ] Doc added/updated
- [ ] Tests added

Reference: https://mattsumme.rs/2025/aws-sdk-v3-put-object-stream-regression/
https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/migrating/notable-changes/
https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/Interface/PutObjectOutput/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated S3 integration to AWS SDK v3-style: improved streaming, multipart uploads, request handling, richer object metadata and operation-date capture, and stricter bucket requirement.

* **Chores**
  * Removed legacy v2 credential/client paths and deprecated public helpers; consolidated on STS v3 and v3-style S3 client configuration.

* **Tests**
  * Updated tests to exercise SDK v3 flows and removed obsolete v2-specific coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->