### PR TITLE
Update md_blow.js to support root key

### DIFF
--- a/src/tools/md_blow.js
+++ b/src/tools/md_blow.js
@@ -29,6 +29,8 @@ main();
 
 async function main() {
     try {
+        const mkm = system_store.master_key_manager;
+        await mkm.load_root_keys_from_mount();
         await system_store.load();
         await client.create_auth_token({
             email: argv.email,


### PR DESCRIPTION
### Describe the Problem
md_blow complains about no rook-key. This way, we will first load the key before the test starts.
User still needs to have in his env the root key value, like:
NOOBAA_ROOT_SECRET=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved initialization by explicitly loading root keys before loading the system store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->