### PR TITLE
[Backport into 5.17] nsfs nsr monitoring - fix last_monitoring when calculating mode 

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1133,10 +1133,12 @@ function calc_namespace_resource_mode(namespace_resource) {
     if (!map_issues_and_monitoring_report.has(namespace_resource_id)) {
         map_issues_and_monitoring_report.set(namespace_resource_id, { last_monitoring: undefined, issues: [] });
     }
-    const issues_report = map_issues_and_monitoring_report.get(namespace_resource_id).issues;
+
+    const nsr_report = map_issues_and_monitoring_report.get(namespace_resource_id);
+    const issues_report = nsr_report.issues;
     const errors_count = _.reduce(issues_report, (acc, issue) => {
         // skip if error timestamp is before of the latest monitoring
-        if (issue.time < namespace_resource.last_monitoring) {
+        if (issue.time < nsr_report.last_monitoring) {
             return acc;
         }
         const err_type = map_err_to_type_count[issue.error_code] || 'io_errors';


### PR DESCRIPTION
### Explain the Changes
[Backport into 5.17] nsfs nsr monitoring - fix last_monitoring when calculating mode 

(cherry picked from commit aa860440e541ad4a9964874fa2e5162786627ebd)


### Fixes:
1. [DFBUGS-3593](https://issues.redhat.com/browse/DFBUGS-3593)


