### PR TITLE
Mongo | Fix mongo_pool issues

### DIFF
--- a/src/upgrade/upgrade_scripts/5.20.0/remove_mongo_pool.js
+++ b/src/upgrade/upgrade_scripts/5.20.0/remove_mongo_pool.js
@@ -1,0 +1,27 @@
+/* Copyright (C) 2025 NooBaa */
+"use strict";
+
+const config = require('../../../../config.js');
+
+async function run({ dbg, system_store }) {
+    try {
+        dbg.log0(`Starting monogo pool delete...`);
+        const internal_mongo_pool = `${config.INTERNAL_STORAGE_POOL_NAME}-${system_store.data.systems[0]._id}`;
+        dbg.log0(`Internal mongo pool id is : ${internal_mongo_pool}`);
+        const pool_ids = system_store.data.pools.filter(pool => pool.name === internal_mongo_pool);
+        if (pool_ids.length > 0) {
+            dbg.log0(`Removing default mongo pool: ${pool_ids[0]._id}`);
+            await system_store.make_changes({ remove: { pools: [pool_ids[0]._id] }});
+        } else {
+            dbg.log0('Removing mongo pool: Could not find the mongo pool...');
+        }
+    } catch (err) {
+        dbg.error('Got error while removing mongo pool:', err);
+        throw err;
+    }
+}
+
+module.exports = {
+    run,
+    description: 'Noobaa no longer support mongo_pool backingstore, Remove mongo pool',
+};


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes

1. Added upgrade script to delete the mongo_pool entry from the pools
2. updated update_all_buckets_default_pool() method, where all the bucket get updated with default backingstore once default backingstore added to the system(after deplyment success)

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-3749

### Testing Instructions:
1. Run ODF upgrade CI : [test CI ](https://jenkins-csb-storage-ceph-downstream.dno.corp.redhat.com/view/Simple/job/odf-konflux-4.20/140/)


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk-update to migrate buckets from internal storage to a chosen default pool.

* **Improvements**
  * Pool selection now avoids internal/backing-store pools.
  * Safer pool name resolution to prevent lookup errors.

* **Upgrade**
  * Add 5.20.0 upgrade script to remove deprecated Mongo backing-store pools.

* **Tests**
  * New integration test validating removal of Mongo backing-store pool during upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->