### PR TITLE
[NSFS | GLACIER] Add support for parallel recall and migrate

### DIFF
--- a/config.js
+++ b/config.js
@@ -916,6 +916,11 @@ config.NSFS_GLACIER_DMAPI_TPS_HTTP_HEADER = 'x-tape-meta-copy';
 // but can be overridden to any numberical value
 config.NSFS_GLACIER_DMAPI_PMIG_DAYS = config.S3_RESTORE_REQUEST_MAX_DAYS;
 
+// NSFS_GLACIER_DMAPI_FINALIZE_RESTORE_ENABLE if enabled will force NooBaa to
+// examine the DMAPI xattr of the file before finalizing the restore to prevent
+// accidental blocking reads from happening.
+config.NSFS_GLACIER_DMAPI_FINALIZE_RESTORE_ENABLE = false;
+
 config.NSFS_STATFS_CACHE_SIZE = 10000;
 config.NSFS_STATFS_CACHE_EXPIRY_MS = 1 * 1000;
 

--- a/src/manage_nsfs/manage_nsfs_glacier.js
+++ b/src/manage_nsfs/manage_nsfs_glacier.js
@@ -9,86 +9,53 @@ const { Glacier } = require('../sdk/glacier');
 const native_fs_utils = require('../util/native_fs_utils');
 const { is_desired_time, record_current_time } = require('./manage_nsfs_cli_utils');
 
-const CLUSTER_LOCK = 'cluster.lock';
-const SCAN_LOCK = 'scan.lock';
-
 async function process_migrations() {
     const fs_context = native_fs_utils.get_process_fs_context();
-    const lock_path = path.join(config.NSFS_GLACIER_LOGS_DIR, CLUSTER_LOCK);
-    await native_fs_utils.lock_and_run(fs_context, lock_path, async () => {
-        const backend = Glacier.getBackend();
+    const backend = Glacier.getBackend();
 
-        if (
-            await backend.low_free_space() ||
-            await time_exceeded(fs_context, config.NSFS_GLACIER_MIGRATE_INTERVAL, Glacier.MIGRATE_TIMESTAMP_FILE) ||
-            await migrate_log_exceeds_threshold()
-        ) {
-            await run_glacier_migrations(fs_context, backend);
-            const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.MIGRATE_TIMESTAMP_FILE);
-            await record_current_time(fs_context, timestamp_file_path);
-        }
-    });
-}
-
-/**
- * run_tape_migrations reads the migration WALs and attempts to migrate the
- * files mentioned in the WAL.
- * @param {nb.NativeFSContext} fs_context
- * @param {import('../sdk/glacier').Glacier} backend
- */
-async function run_glacier_migrations(fs_context, backend) {
-    await run_glacier_operation(fs_context, Glacier.MIGRATE_WAL_NAME, backend.migrate.bind(backend));
+    if (
+        await backend.low_free_space() ||
+        await time_exceeded(fs_context, config.NSFS_GLACIER_MIGRATE_INTERVAL, Glacier.MIGRATE_TIMESTAMP_FILE) ||
+        await migrate_log_exceeds_threshold()
+    ) {
+        await backend.perform(prepare_galcier_fs_context(fs_context), "MIGRATION");
+        const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.MIGRATE_TIMESTAMP_FILE);
+        await record_current_time(fs_context, timestamp_file_path);
+    }
 }
 
 async function process_restores() {
     const fs_context = native_fs_utils.get_process_fs_context();
-    const lock_path = path.join(config.NSFS_GLACIER_LOGS_DIR, CLUSTER_LOCK);
-    await native_fs_utils.lock_and_run(fs_context, lock_path, async () => {
-        const backend = Glacier.getBackend();
+    const backend = Glacier.getBackend();
 
-        if (
-            await backend.low_free_space() ||
-            !(await time_exceeded(fs_context, config.NSFS_GLACIER_RESTORE_INTERVAL, Glacier.RESTORE_TIMESTAMP_FILE))
-        ) return;
+    if (
+        await backend.low_free_space() ||
+        !(await time_exceeded(fs_context, config.NSFS_GLACIER_RESTORE_INTERVAL, Glacier.RESTORE_TIMESTAMP_FILE))
+    ) return;
 
-
-        await run_glacier_restore(fs_context, backend);
-        const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.RESTORE_TIMESTAMP_FILE);
-        await record_current_time(fs_context, timestamp_file_path);
-    });
-}
-
-/**
- * run_tape_restore reads the restore WALs and attempts to restore the
- * files mentioned in the WAL.
- * @param {nb.NativeFSContext} fs_context
- * @param {import('../sdk/glacier').Glacier} backend
- */
-async function run_glacier_restore(fs_context, backend) {
-    await run_glacier_operation(fs_context, Glacier.RESTORE_WAL_NAME, backend.restore.bind(backend));
+    await backend.perform(prepare_galcier_fs_context(fs_context), "RESTORE");
+    const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.RESTORE_TIMESTAMP_FILE);
+    await record_current_time(fs_context, timestamp_file_path);
 }
 
 async function process_expiry() {
     const fs_context = native_fs_utils.get_process_fs_context();
-    const lock_path = path.join(config.NSFS_GLACIER_LOGS_DIR, SCAN_LOCK);
-    await native_fs_utils.lock_and_run(fs_context, lock_path, async () => {
-        const backend = Glacier.getBackend();
-        const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.EXPIRY_TIMESTAMP_FILE);
-        if (
-            await backend.low_free_space() ||
-            await is_desired_time(
-                fs_context,
-                new Date(),
-                config.NSFS_GLACIER_EXPIRY_RUN_TIME,
-                config.NSFS_GLACIER_EXPIRY_RUN_DELAY_LIMIT_MINS,
-                timestamp_file_path,
-                config.NSFS_GLACIER_EXPIRY_TZ
-            )
-        ) {
-            await backend.expiry(fs_context);
-            await record_current_time(fs_context, timestamp_file_path);
-        }
-    });
+    const backend = Glacier.getBackend();
+    const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.EXPIRY_TIMESTAMP_FILE);
+    if (
+        await backend.low_free_space() ||
+        await is_desired_time(
+            fs_context,
+            new Date(),
+            config.NSFS_GLACIER_EXPIRY_RUN_TIME,
+            config.NSFS_GLACIER_EXPIRY_RUN_DELAY_LIMIT_MINS,
+            timestamp_file_path,
+            config.NSFS_GLACIER_EXPIRY_TZ
+        )
+    ) {
+        await backend.perform(prepare_galcier_fs_context(fs_context), "EXPIRY");
+        await record_current_time(fs_context, timestamp_file_path);
+    }
 }
 
 
@@ -135,27 +102,6 @@ async function migrate_log_exceeds_threshold(threshold = config.NSFS_GLACIER_MIG
     }
 
     return log_size > threshold;
-}
-
-/**
- * run_glacier_operations takes a log_namespace and a callback and executes the
- * callback on each log file in that namespace. It will also generate a failure
- * log file and persist the failures in that log file.
- * @param {nb.NativeFSContext} fs_context 
- * @param {string} log_namespace 
- * @param {Function} cb 
- */
-async function run_glacier_operation(fs_context, log_namespace, cb) {
-    const log = new PersistentLogger(config.NSFS_GLACIER_LOGS_DIR, log_namespace, { locking: 'EXCLUSIVE' });
-
-    fs_context = prepare_galcier_fs_context(fs_context);
-    try {
-        await log.process(async (entry, failure_recorder) => cb(fs_context, entry, failure_recorder));
-    } catch (error) {
-        console.error('failed to process log in namespace:', log_namespace);
-    } finally {
-        await log.close();
-    }
 }
 
 /**

--- a/src/util/file_reader.js
+++ b/src/util/file_reader.js
@@ -199,8 +199,18 @@ class NewlineReader {
         }
     }
 
+    /**
+     * close will close the file descriptor and will
+     * set the internaly file handler to `null`. HOWEVER,
+     * the reader can still be used after close is called
+     * as the reader will initiialize the file handler
+     * again if a read is attempted.
+     */
     async close() {
-        if (this.fh) await this.fh.close(this.fs_context);
+        const fh = this.fh;
+        this.fh = null;
+
+        if (fh) await fh.close(this.fs_context);
     }
 }
 


### PR DESCRIPTION
### Describe the Problem
Currently NooBaa allows to run only one glacier operation at a time. Either a migration can be running or a restore operation can be running. This was done to avoid several kinds of race cases. This doesn't create any "correctness" problem however it means that we don't completely utilize the underlying tape drives.

Another problem this PR tries to address is that the `PersistentLogger.process` would delete the file after the callback would return. This can potentially create a race situation because the file gets "moved" outside of lock.

### Explain the Changes
This PR addresses the parallel processing of migration and recall by splitting the processing into 2 different stages:
1. Stage 1 - "stages" the files that needs to be processed. This stage still requires a cluster wide lock. This is done to ensure that all the processes get a consistent view of the system state. This stage involves reading each log file line-by-line, opening it, stat-ting it, xattr modification. These steps should take negligible amount of time when compared to the time taken by actual tape migration and recall.
2. Stage 2 - This stage doesn't acquire any cluster wide lock however it still acquires a lock to ensure only 1 restore/migrate is running at a time (i.e a migrate and a restore at max). This is done to ensure that in case of a multi-node cluster we don't end up in situation where multiple nodes are trying to consume the same file. As a future improvement in this stage, I would want to use `Promise.all([this._migrate...])` to run multiple migrations concurrently within the same process which could potentially improve the drive utilization further.

To address the race in delete scenario - This PR acquires a lock on the file before handing it over to the callback and releases the lock once the callback returns. This has some implications:
1. The callback needs to make sure that it doesn't try to acquire lock on the file again.
2. It needs to make sure that it doesn't `deinit` the LogFile as that would close the file leading to losing the lock.
3. Notice that the callback no longer receives the filename in its parameter rather the `LogFile` object.

### Issues: Fixed #xxx / Gap #xxx


### Testing Instructions:
1. `./node_modules/.bin/mocha src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a staging phase for migration and restore flows and a config flag to enable DMAPI checks before finalizing restores (disabled by default).

* **Refactor**
  * Centralized orchestration for migration/restore/expiry and unified operation execution.
  * Introduced a log-file abstraction and shared open-with-lock utilities to simplify log handling.

* **Bug Fixes**
  * Improved error reporting, cleanup, and restore finalization handling.

* **Tests**
  * Simplified and centralized backend test helpers and updated migration/restore tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->