### PR TITLE
node-ip removal - Phase 5

### DIFF
--- a/src/rpc/ice.js
+++ b/src/rpc/ice.js
@@ -20,6 +20,7 @@ const dbg = require('../util/debug_module')(__filename);
 const stun = require('./stun');
 const config = require('../../config');
 const js_utils = require('../util/js_utils');
+const net_utils = require('../util/net_utils');
 const url_utils = require('../util/url_utils');
 const FrameStream = require('../util/frame_stream');
 const buffer_utils = require('../util/buffer_utils');
@@ -1311,7 +1312,7 @@ Ice.prototype.close = function() {
 function IceCandidate(cand) {
     const is_private_no_throw = address => {
         try {
-            return ip_module.isPrivate(address);
+            return net_utils.is_private(address);
         } catch (err) {
             return false;
         }

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -432,7 +432,7 @@ function should_proxy(hostname) {
     for (const { kind, addr } of no_proxy_list) {
         dbg.log3(`should_proxy: an item from no_proxy_list: kind ${kind} addr ${addr}`);
         if (isIp) {
-            if (kind === 'IP' && ip_module.isEqual(addr, hostname)) {
+            if (kind === 'IP' && net_utils.is_equal(addr, hostname)) {
                 return false;
             }
             if (kind === 'CIDR' && ip_module.cidrSubnet(addr).contains(hostname)) {


### PR DESCRIPTION
### Explain the Changes
Adding functions to net_utils.js | nope-ip removal - Phase 5 

`net_utils.js`

- Updating `is_private` to capture more cases
- Adding `ip_to_buffer_safe` that will allocate a buffer for the given IP address
- Adding `is_ipv6_loopback_buffer` that will ensure that an IPv6 buffer is a loopback
- Adding `is_equal` that will check if two addresses are equal

`ice.js`

- Calling the native `is_private` from `net_utils`

`http_utils`
- Calling the native `is_equal` from `net_utils`

- Adding jest tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader IPv4/IPv6 handling including IPv4‑mapped IPv6 recognition and safer address parsing and comparison.

* **Bug Fixes**
  * More accurate detection of private, loopback, link-local, and unspecified addresses.
  * Improved no-proxy matching for IP addresses, reducing proxy/bypass errors.
  * More reliable connection prioritization in mixed network environments.

* **Tests**
  * Expanded unit tests covering classification, equality, buffer conversion, CIDR and invalid-address cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->