### PR TITLE
Mongo | Mongo pool upgrade

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -486,7 +486,7 @@ class NodesMonitor extends EventEmitter {
         const pool =
             agent_config.pool ||
             system.pools_by_name[pool_name] ||
-            _.filter(system.pools_by_name, p => (!_.get(p, 'cloud_pool_info')))[0]; // default - the 1st host pool in the system
+            _.filter(system.pools_by_name, p => (!p.is_default_pool && !_.get(p, 'cloud_pool_info')))[0]; // default - the 1st host pool in the system
         // system_store.get_account_by_email(system.owner.email).default_resource; //This should not happen, but if it does, use owner's default
 
         if (!pool) {

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -16,6 +16,7 @@ const SensitiveString = require('../../util/sensitive_string');
 const cloud_utils = require('../../util/cloud_utils');
 const auth_server = require('../common_services/auth_server');
 const system_store = require('../system_services/system_store').get_instance();
+const pool_server = require('../system_services/pool_server');
 const azure_storage = require('../../util/azure_storage_wrap');
 const NetStorage = require('../../util/NetStorageKit-Node-master/lib/netstorage');
 const usage_aggregator = require('../bg_services/usage_aggregator');
@@ -83,8 +84,8 @@ async function create_account(req) {
             const resource = req.rpc_params.default_resource ?
             req.system.pools_by_name[req.rpc_params.default_resource] ||
                 (req.system.namespace_resources_by_name && req.system.namespace_resources_by_name[req.rpc_params.default_resource]) :
-                req.system.pools_by_name.backingstores;
-                if (!resource) throw new RpcError('BAD_REQUEST', 'default resource doesn\'t exist');
+                pool_server.get_default_pool(req.system);
+            if (!resource) throw new RpcError('BAD_REQUEST', 'default resource doesn\'t exist');
             if (resource.nsfs_config && resource.nsfs_config.fs_root_path && !req.rpc_params.nsfs_account_config) {
                 throw new RpcError('Invalid account configuration - must specify nsfs_account_config when default resource is a namespace resource');
             }
@@ -370,7 +371,7 @@ function update_account_s3_access(req) {
     //If s3_access is on, update allowed buckets, default_resource and force_md5_etag
     if (req.rpc_params.s3_access) {
         if (!req.rpc_params.default_resource) {
-            const pools = _.filter(req.system.pools_by_name);
+            const pools = _.filter(req.system.pools_by_name, p => !p.is_default_pool);
             if (pools.length) { // has resources which is not internal - must supply resource
                 throw new RpcError('BAD_REQUEST', 'Enabling S3 requires providing default_resource');
             }
@@ -1310,7 +1311,7 @@ function validate_create_account_permissions(req) {
 function validate_create_account_params(req) {
     // find none-internal pools
     const has_non_internal_resources = (req.system && req.system.pools_by_name) ?
-        Object.values(req.system.pools_by_name).some(p => p.name !== 'backingstores') :
+        Object.values(req.system.pools_by_name).some(p => !p.is_default_pool) :
         false;
 
     if (req.rpc_params.name.unwrap() !== req.rpc_params.name.unwrap().trim()) {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1323,7 +1323,7 @@ async function update_all_buckets_default_pool(req) {
     const pool_name = req.rpc_params.pool_name;
     const pool = req.system.pools_by_name[pool_name];
     if (!pool) throw new RpcError('INVALID_POOL_NAME');
-    const internal_pool = pool_server.get_optimal_non_default_pool_id(pool.system);
+    const internal_pool = pool_server.get_default_pool(pool.system);
     if (!internal_pool || !internal_pool._id) return;
     if (String(pool._id) === String(internal_pool._id)) return;
     const buckets_with_internal_pool = _.filter(req.system.buckets_by_name, bucket =>

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1301,18 +1301,14 @@ function _is_cloud_pool(pool) {
     return Boolean(pool.cloud_pool_info);
 }
 
-function _is_optimal_non_default_pool_id(pool) {
-    return Boolean(pool.name === config.DEFAULT_POOL_NAME);
-}
-
-function get_optimal_non_default_pool_id(system) {
+function get_default_pool(system) {
     return system.pools_by_name[config.DEFAULT_POOL_NAME];
 }
 
-async function get_optimal_non_mongo_pool_id() {
+async function get_optimal_non_default_pool_id() {
     for (const pool of system_store.data.pools) {
         // skip backingstore_pool.
-        if (_is_optimal_non_default_pool_id(pool)) {
+        if (pool.is_default_pool) {
             continue;
         }
         const aggr_nodes = await nodes_client.instance().aggregate_nodes_by_pool([pool.name], pool.system._id);
@@ -1329,7 +1325,7 @@ async function update_account_default_resource() {
         try {
             const system = system_store.data.systems[0];
             if (system) {
-                const optimal_pool_id = await get_optimal_non_mongo_pool_id();
+                const optimal_pool_id = await get_optimal_non_default_pool_id();
 
                 if (optimal_pool_id) {
                     const updates = system_store.data.accounts
@@ -1423,10 +1419,9 @@ exports.assign_pool_to_region = assign_pool_to_region;
 exports.scale_hosts_pool = scale_hosts_pool;
 exports.update_hosts_pool = update_hosts_pool;
 exports.update_cloud_pool = update_cloud_pool;
-exports.get_optimal_non_mongo_pool_id = get_optimal_non_mongo_pool_id;
 exports.get_hosts_pool_agent_config = get_hosts_pool_agent_config;
 exports.update_issues_report = update_issues_report;
 exports.update_last_monitoring = update_last_monitoring;
 exports.calc_namespace_resource_mode = calc_namespace_resource_mode;
 exports.check_deletion_ownership = check_deletion_ownership;
-exports.get_optimal_non_default_pool_id = get_optimal_non_default_pool_id;
+exports.get_default_pool = get_default_pool;

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -138,6 +138,9 @@ module.exports = {
                 },
             }
         },
+        is_default_pool: {
+            type: 'boolean',
+        },
         hosts_pool_info: {
             type: 'object',
             required: [

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -310,6 +310,7 @@ async function get_partial_providers_stats(req) {
                 // TODO: Handle deleted pools
                 if (!pool) continue;
                 let type = 'KUBERNETES';
+                if (pool.is_default_pool) continue;
                 if (pool.cloud_pool_info) {
                     type = (supported_cloud_types.includes(pool.cloud_pool_info.endpoint_type)) ?
                         pool.cloud_pool_info.endpoint_type : 'OTHERS';
@@ -710,6 +711,7 @@ async function get_cloud_pool_stats(req) {
     ];
     //Per each system fill out the needed info
     for (const pool of system_store.data.pools) {
+        if (pool.is_default_pool) continue;
         const pool_info = await server_rpc.client.pool.read_pool({ name: pool.name }, {
             auth_token: req.auth_token
         });

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -191,6 +191,7 @@ function new_system_changes(req, name, owner_account_id) {
     if (config.DEFAULT_POOL_TYPE === 'HOSTS') {
         const pool_name = config.DEFAULT_POOL_NAME;
         const fs_pool = pool_server.new_pool_defaults(pool_name, system._id, 'HOSTS', 'BLOCK_STORE_FS', owner_account_id);
+        fs_pool.is_default_pool = true;
         fs_pool.hosts_pool_info = { is_managed: false, host_count: 0 };
         default_pool = fs_pool;
     } else {

--- a/src/upgrade/upgrade_scripts/5.20.0/remove_mongo_pool.js
+++ b/src/upgrade/upgrade_scripts/5.20.0/remove_mongo_pool.js
@@ -1,24 +1,103 @@
 /* Copyright (C) 2025 NooBaa */
 "use strict";
+const _ = require('lodash');
 
 const config = require('../../../../config.js');
+const SensitiveString = require('../../../util/sensitive_string');
+const pool_server = require('../../../server/system_services/pool_server.js');
+
 
 async function run({ dbg, system_store }) {
     try {
-        dbg.log0(`Starting monogo pool delete...`);
+        dbg.log0(`Start: Mongo pool upgrade script...`);
         const internal_mongo_pool = `${config.INTERNAL_STORAGE_POOL_NAME}-${system_store.data.systems[0]._id}`;
         dbg.log0(`Internal mongo pool id is : ${internal_mongo_pool}`);
-        const pool_ids = system_store.data.pools.filter(pool => pool.name === internal_mongo_pool);
-        if (pool_ids.length > 0) {
-            dbg.log0(`Removing default mongo pool: ${pool_ids[0]._id}`);
-            await system_store.make_changes({ remove: { pools: [pool_ids[0]._id] }});
-        } else {
-            dbg.log0('Removing mongo pool: Could not find the mongo pool...');
+        const mongo_pools = system_store.data.pools.filter(pool => (pool.mongo_info || pool.resource_type === 'INTERNAL'));
+        if (mongo_pools.length === 0) {
+             dbg.log0(`Missing mongo pool: ${mongo_pools[0]._id}`);
+            return;
         }
+
+        dbg.log0(`Start: Create new default pool...`);
+        const pool_name = config.DEFAULT_POOL_NAME;
+        const default_pool = system_store.data.systems[0].pools_by_name[pool_name];
+        if (!default_pool) {
+            await create_new_default_pool(dbg, pool_name, system_store);
+            dbg.log0(`End: Create new default pool Created...`);
+        }
+
+        dbg.log0(`Start: Update bucket default bucket pool with new default pool...`);
+        await update_buckets_default_pool(dbg, pool_name, mongo_pools[0], system_store);
+        dbg.log0(`End: Updated bucket default bucket pool with new default pool...`);
+
+        await system_store.make_changes({ remove: { pools: [mongo_pools[0]._id] }});
+        dbg.log0(`End: Mongo pool upgrade script...`);
     } catch (err) {
         dbg.error('Got error while removing mongo pool:', err);
         throw err;
     }
+}
+
+async function update_buckets_default_pool(dbg, pool_name, mongo_pool, system_store) {
+    const pool = system_store.data.systems[0].pools_by_name[pool_name];
+    if (!pool) {
+        dbg.error('INVALID_POOL_NAME:');
+         throw new Error('INVALID_POOL_NAME');
+    }
+    if (!mongo_pool || !mongo_pool._id) return;
+    if (String(pool._id) === String(mongo_pool._id)) return;
+    const buckets_with_internal_pool = _.filter(system_store.data.systems[0].buckets_by_name, bucket =>
+        is_using_internal_storage(bucket, mongo_pool));
+    if (!buckets_with_internal_pool.length) return;
+
+    // The loop pushes one update per bucket
+    const updates = _.uniqBy([], '_id');
+    for (const bucket of buckets_with_internal_pool) {
+        updates.push({
+            _id: bucket.tiering.tiers[0].tier._id,
+            mirrors: [{
+                _id: system_store.new_system_store_id(),
+                spread_pools: [pool._id]
+            }]
+        });
+    }
+    dbg.log0(`Updating ${buckets_with_internal_pool.length} buckets to use ${pool_name} as default resource`);
+    await system_store.make_changes({
+        update: {
+            tiers: updates
+        }
+    });
+}
+
+async function create_new_default_pool(dbg, pool_name, system_store) {
+    // TODO: UPDATE EMAIL
+    let account = system_store.get_account_by_email(new SensitiveString('admin@noobaa.io'));
+    if (!account) {
+        dbg.error('NO_SUCH_ACCOUNT', 'No such account email: admin@noobaa.io');
+        // For testing
+        account = system_store.get_account_by_email(new SensitiveString(config.OPERATOR_ACCOUNT_EMAIL));
+    }
+    const fs_pool = pool_server.new_pool_defaults(pool_name, system_store.data.systems[0]._id, 'HOSTS', 'BLOCK_STORE_FS', account._id);
+    fs_pool.hosts_pool_info = { is_managed: false, host_count: 0 };
+    fs_pool.is_default_pool = true;
+    const default_pool = fs_pool;
+    await system_store.make_changes({
+        insert: {
+            pools: [default_pool]
+        }
+    });
+}
+
+function is_using_internal_storage(bucket, internal_pool) {
+    if (!internal_pool || !internal_pool._id) return false;
+    const tiers = bucket.tiering && bucket.tiering.tiers;
+    if (!tiers || tiers.length !== 1) return false;
+    const mirrors = tiers[0].tier.mirrors;
+    if (mirrors.length !== 1) return false;
+    const spread_pools = mirrors[0].spread_pools;
+    if (spread_pools.length !== 1) return false;
+
+    return String(spread_pools[0]._id) === String(internal_pool._id);
 }
 
 module.exports = {


### PR DESCRIPTION
### Describe the Problem
backing store in upgrade scenario
Replace bucket with tier with new backingstore

### Explain the Changes
1. Upgrade Script
  - Create a new Backingstore pool in upgrade scenario
  - Replace bucket with tier with new backingstore
  - Delete eisting mongo_pool internal poool
2. Update pool schema with new property `is_default_pool`


### Issues: Fixed #xxx / Gap #xxx
1. 4.20 upgrade issues

### Testing Instructions:
1. Deploy 4.19 and run `remove_mongo_pool.js` upgrade script
2. Or run `test remove mongo_pool to version 5.20.0` test in `test_upgrade_scripts.js` file with 4.19 code

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a system "default" storage pool and a public API to reference it.

- Upgrade
  - Upgrade now creates or reuses a default pool, migrates buckets to it, and removes legacy internal/mongo pools.

- Behavior Changes
  - Account default-resource resolution now prefers the default pool; S3 enablement validation adjusted.
  - Node placement skips the default pool.
  - Provider/cloud stats now exclude the default pool.

- Chores
  - Schema adds an is_default_pool flag.

- Tests
  - Integration tests updated to verify pool migration and upgrade behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->