### PR TITLE
NC | Fix fs_napi syslog facility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         ecmaVersion: 13, // es2022
     },
 
+    ignorePatterns: ['*.d.ts', '**/*.d.ts'],
 
     plugins: [
         // stylistic validates style related rules: https://eslint.style/

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -2286,9 +2286,14 @@ set_log_config(const Napi::CallbackInfo& info)
 {
     bool stderr_enabled = info[0].As<Napi::Boolean>();
     bool syslog_enabled = info[1].As<Napi::Boolean>();
+    std::string syslog_debug_facility = info[2].As<Napi::String>();
     LOG_TO_STDERR_ENABLED = stderr_enabled;
     LOG_TO_SYSLOG_ENABLED = syslog_enabled;
-    DBG1("FS::set_log_config: " <<  DVAL(LOG_TO_STDERR_ENABLED) << DVAL(LOG_TO_SYSLOG_ENABLED));
+    SYSLOG_DEBUG_FACILITY = syslog_debug_facility;
+    DBG1("FS::set_log_config: " 
+        << DVAL(LOG_TO_STDERR_ENABLED) 
+        << DVAL(LOG_TO_SYSLOG_ENABLED)
+        << DVAL(SYSLOG_DEBUG_FACILITY));
     return info.Env().Undefined();
 }
 

--- a/src/native/tools/syslog_napi.cpp
+++ b/src/native/tools/syslog_napi.cpp
@@ -1,5 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 #include "../util/napi.h"
+#include "../util/common.h"
 
 #ifndef WIN32
 #include <syslog.h>
@@ -34,15 +35,7 @@ _syslog(const Napi::CallbackInfo& info)
     int facility = LOG_LOCAL0;
     if (info.Length() == 3) {
         std::string facility_str = info[2].As<Napi::String>().Utf8Value();
-        if (facility_str == "LOG_LOCAL0") {
-            facility = LOG_LOCAL0;
-        } else if (facility_str == "LOG_LOCAL1") {
-            facility = LOG_LOCAL1;
-        } else if (facility_str == "LOG_LOCAL2") {
-            facility = LOG_LOCAL2;
-        } else {
-            throw Napi::Error::New(info.Env(), "Syslog facility not supported");
-        }
+        facility = _convert_facility(facility_str);
     }
     ::syslog(priority | facility, "%s", message.data());
 #endif

--- a/src/native/util/common.cpp
+++ b/src/native/util/common.cpp
@@ -4,4 +4,21 @@ namespace noobaa
 {
 bool LOG_TO_STDERR_ENABLED = true;
 bool LOG_TO_SYSLOG_ENABLED = false;
+std::string SYSLOG_DEBUG_FACILITY = "LOG_LOCAL0";
+
+int 
+_convert_facility(const std::string& facility_str)
+{
+    int facility = LOG_LOCAL0; 
+    if (facility_str == "LOG_LOCAL0") {
+        facility = LOG_LOCAL0;
+    } else if (facility_str == "LOG_LOCAL1") {
+        facility = LOG_LOCAL1;
+    } else if (facility_str == "LOG_LOCAL2") {
+        facility = LOG_LOCAL2;
+    } else {
+        throw Exception("Syslog facility not supported");
+    }
+    return facility;
+}
 }

--- a/src/native/util/common.h
+++ b/src/native/util/common.h
@@ -35,31 +35,33 @@ namespace noobaa
 
 extern bool LOG_TO_STDERR_ENABLED;
 extern bool LOG_TO_SYSLOG_ENABLED;
+extern std::string SYSLOG_DEBUG_FACILITY;
+extern int _convert_facility(const std::string& facility_str);
 
-#define STD_LOG(x)                                      \
-    do {                                                \
-        std::cerr << x << std::endl;                    \
+#define STD_LOG(x)                                                \
+    do {                                                          \
+        std::cerr << x << std::endl;                              \
     } while (0) 
 
-#define SYS_LOG(x)                                      \
-    do {                                                \
-        const char* log_msg = x.c_str();                \
-        int facility = LOG_LOCAL0;                      \
-        int priority = 5;                               \
-        ::syslog(priority | facility, "%s", log_msg);   \
+#define SYS_LOG(x)                                                \
+    do {                                                          \
+        const char* log_msg = x.c_str();                          \
+        int facility = _convert_facility(SYSLOG_DEBUG_FACILITY);  \
+        int priority = 5;                                         \
+        ::syslog(priority | facility, "%s", log_msg);             \
     } while (0)
 
-#define LOG(x)                                          \
-    do {                                                \
-        std::ostringstream oss;                         \
-        oss << "" << LOG_PREFIX() << x;                 \
-        std::string message = oss.str();                \
-        if (LOG_TO_STDERR_ENABLED) {                    \
-            STD_LOG(message);                           \
-        }                                               \
-        if (LOG_TO_SYSLOG_ENABLED) {                    \
-            SYS_LOG(message);                           \
-        }                                               \
+#define LOG(x)                                                    \
+    do {                                                          \
+        std::ostringstream oss;                                   \
+        oss << "" << LOG_PREFIX() << x;                           \
+        std::string message = oss.str();                          \
+        if (LOG_TO_STDERR_ENABLED) {                              \
+            STD_LOG(message);                                     \
+        }                                                         \
+        if (LOG_TO_SYSLOG_ENABLED) {                              \
+            SYS_LOG(message);                                     \
+        }                                                         \
     } while (0)   
 
 // to use DBG the module/file should use either DBG_INIT or DBG_INIT_VAR.

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -1002,7 +1002,7 @@ interface NativeFS {
 
     dio_buffer_alloc(size: number): Buffer;
     set_debug_level(level: number);
-    set_log_config(stderr_enabled: boolean, syslog_enabled: boolean);
+    set_log_config(stderr_enabled: boolean, syslog_enabled: boolean, debug_facility: string);
 
     S_IFMT: number;
     S_IFDIR: number;

--- a/src/util/debug_module.js
+++ b/src/util/debug_module.js
@@ -506,7 +506,7 @@ function log_syslog_builder(syslevel) {
 /* When logging events message should not have any prefix such as time and processes id and 
  *the message should be in json format because of this events are logged directly without using log_builder; 
  * log_builder will format the message with prefix. 
-*/
+ */
 function log_event(event) {
     if (!config.EVENT_LOGGING_ENABLED) {
         return;
@@ -610,7 +610,7 @@ if (console_wrapper) {
 function set_log_config() {
     const dbg_native_conf = debug_config.get_debug_config(process.env.NOOBAA_LOG_LEVEL);
     nb_native().fs.set_debug_level(dbg_native_conf.level);
-    nb_native().fs.set_log_config(config.LOG_TO_STDERR_ENABLED, config.LOG_TO_SYSLOG_ENABLED);
+    nb_native().fs.set_log_config(config.LOG_TO_STDERR_ENABLED, config.LOG_TO_SYSLOG_ENABLED, config.DEBUG_FACILITY);
 }
 
 config.event_emitter.on("config_updated", set_log_config);


### PR DESCRIPTION
### Describe the Problem
fs_napi didn't support changing the facility of the syslog - it was always sending to LOCAL0. 
while for syslog-napi we did support different facilities

### Explain the Changes
1.  Took the facility logic from syslog-napi and moved to common.cpp
2. both syslog-napi and fs-napi will be using the shared facility control logic

### Issues: Fixed #xxx / Gap #xxx
1. Fixed #9165 

### Testing Instructions:
1. Change DEBUG_FACILITY to "LOG_LOCAL1",
2. See that logs are being written to the correct syslog facility `/etc/rsyslog.d/noobaa_syslog.conf` (default is /var/log/client_noobaa.log)


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logging config now supports selecting a syslog facility (e.g., LOG_LOCAL0/1/2) for flexible debug routing.
  * App passes the selected facility to native logging when configuring logs.

* **Breaking Changes**
  * SDK: set_log_config now accepts an additional debug facility string argument.

* **Chores**
  * Linting updated to ignore TypeScript declaration (*.d.ts) files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->