### PR TITLE
Add no error for cast issue with macos

### DIFF
--- a/src/native/common.gypi
+++ b/src/native/common.gypi
@@ -69,6 +69,7 @@
                     'CLANG_CXX_LANGUAGE_STANDARD': 'c++2a', # -std=c++2a
                     'GCC_C_LANGUAGE_STANDARD': 'c99', # -std=c99
                     'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                    'OTHER_CFLAGS': ['-Wno-error=cast-function-type-mismatch'],
                 },
             }],
 


### PR DESCRIPTION
### Describe the Problem
When building native code on macos we get this issue: 
```
error: cast from 'typename WeakCallbackInfo<ObjectWrap>::Callback' (aka 'void (*)(const WeakCallbackInfo<ObjectWrap> &)') to 'Callback' (aka 'void (*)(const WeakCallbackInfo<void> &)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
```
This will resolve this issue

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build reliability by relaxing a macOS compiler check that previously caused build failures; users building on macOS should see fewer interruptions and smoother installations. No functional or behavioral changes to the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->