### PR TITLE
NC | list_mulitpart upload fixes

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1863,6 +1863,9 @@ class NamespaceFS {
                 path.join(params.mpu_path, 'create_object_upload')
             );
             const create_multipart_upload_params = JSON.parse(data.toString());
+            if (create_multipart_upload_params.key !== params.key) {
+                throw new S3Error(S3Error.NoSuchUpload);
+            }
             const entries = await nb_native().fs.readdir(fs_context, params.mpu_path);
             const multiparts = await Promise.all(
                 entries
@@ -1873,7 +1876,7 @@ class NamespaceFS {
                     const stat = await nb_native().fs.stat(fs_context, part_path);
                     return {
                         num,
-                        size: stat.size,
+                        size: Number(stat.xattr[XATTR_PART_SIZE]),
                         etag: this._get_etag(stat),
                         last_modified: new Date(stat.mtime),
                     };


### PR DESCRIPTION
### Describe the Problem
two problems:
1. When we list multiparts we don't check if the key is the correct key for the multipart - so we return the part of the upload ID even if the user asked for a different key.
2. We print the size from stat of the md file for the part which has no data - so we return 0 for all the part sizes

### Explain the Changes
1. We had a check to see if the key we saved in create_object_upload is the key we get in the params - if not, we throw NoSuchUpload
2. We return XATTR_PART_SIZE from the md_part_path attributes, which has the part's real size.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-3678

### Testing Instructions:
1. create a multipart: `s3api create-multipart-upload --bucket b1 --key k1` -> grep upload-id
2. upload a part: `s3api upload-part --bucket b1 --key k1 --upload-id [upload-id] --part-number 1 --body [path-to-file]`
3. list the part using the correct key: `s3api list-parts --bucket b1 --key k1 --upload-id [upload-id]` check size of part is correct
4. list the part using incorrect key: `s3api list-parts --bucket b1 --key k2 --upload-id [upload-id]` make sure you get: `An error occurred (NoSuchUpload) when calling the ListParts operation: The specified multipart upload does not exist. The upload ID might be invalid, or the multipart upload might have been aborted or completed.`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Multipart upload listing now validates the upload key, returning a “NoSuchUpload” error when the requested key doesn’t match the upload’s key.
  - Part sizes in multipart listings now reflect the recorded part size metadata rather than filesystem size, improving accuracy.
  - Last modified timestamps for parts remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->