### PR TITLE
[GLACIER] Fix task ID regex

### DIFF
--- a/src/sdk/glacier_tapecloud.js
+++ b/src/sdk/glacier_tapecloud.js
@@ -120,13 +120,9 @@ class TapeCloudUtils {
 
         // Find the line in the stdout which has the line 'task ID is, <id>' and extract id
         // ID in latest version must look like 1005:1111:4444
-        let match = stdout.match(/task ID is (\d+:\d+:\d+)/);
-        if (!match || match.length !== 2) {
-            // Fallback to the older task ID extraction in case we fail to extract new one
-            match = stdout.match(/task ID is (\d+)/);
-            if (!match || match.length !== 2) {
-                throw error;
-            }
+        const match = stdout.match(/task ID is ([\w]+(:[\w]+)*)/);
+        if (!match || match.length < 2) {
+            throw error;
         }
 
         const task_id = match[1];
@@ -196,9 +192,9 @@ class TapeCloudUtils {
 
 class TapeCloudGlacier extends Glacier {
     /**
-     * @param {nb.NativeFSContext} fs_context 
-     * @param {LogFile} log_file 
-     * @param {(entry: string) => Promise<void>} failure_recorder 
+     * @param {nb.NativeFSContext} fs_context
+     * @param {LogFile} log_file
+     * @param {(entry: string) => Promise<void>} failure_recorder
      * @returns {Promise<boolean>}
      */
     async stage_migrate(fs_context, log_file, failure_recorder) {
@@ -265,9 +261,9 @@ class TapeCloudGlacier extends Glacier {
     }
 
     /**
-     * @param {nb.NativeFSContext} fs_context 
-     * @param {LogFile} log_file 
-     * @param {(entry: string) => Promise<void>} failure_recorder 
+     * @param {nb.NativeFSContext} fs_context
+     * @param {LogFile} log_file
+     * @param {(entry: string) => Promise<void>} failure_recorder
      * @returns {Promise<boolean>}
      */
     async migrate(fs_context, log_file, failure_recorder) {
@@ -311,9 +307,9 @@ class TapeCloudGlacier extends Glacier {
     }
 
     /**
-     * @param {nb.NativeFSContext} fs_context 
-     * @param {LogFile} log_file 
-     * @param {(entry: string) => Promise<void>} failure_recorder 
+     * @param {nb.NativeFSContext} fs_context
+     * @param {LogFile} log_file
+     * @param {(entry: string) => Promise<void>} failure_recorder
      * @returns {Promise<boolean>}
      */
     async stage_restore(fs_context, log_file, failure_recorder) {
@@ -375,9 +371,9 @@ class TapeCloudGlacier extends Glacier {
     }
 
     /**
-     * @param {nb.NativeFSContext} fs_context 
-     * @param {LogFile} log_file 
-     * @param {(entry: string) => Promise<void>} failure_recorder 
+     * @param {nb.NativeFSContext} fs_context
+     * @param {LogFile} log_file
+     * @param {(entry: string) => Promise<void>} failure_recorder
      * @returns {Promise<boolean>}
      */
     async restore(fs_context, log_file, failure_recorder) {


### PR DESCRIPTION
### Describe the Problem
Previous regex was pretty rigid in what kind of task id it can accept which is not correct. Task ID can be of the following types:
- `task ID is tmp15nwx2vl:1000:1002`
- `task ID is 1000:1002:1003:1004:1005:1006`
- `task ID is 1000`
- `task ID is tmp15nwx2vl`
- `task ID is tmp15nwx2vl_123:tmpn9km_wyx:1001`

### Explain the Changes
PR changes the regex to `task ID is ([\w]+(:[\w]+)*)` (as suggested my Sasaki-san).

### Issues: Fixed #xxx / Gap #xxx
1. https://github.ibm.com/Tier2/Test-Issue/issues/150

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved task ID detection in TapeCloud operations to more reliably extract compound IDs (including colon‑separated segments) and to preserve the original error when the ID format is unexpected.

- Documentation
  - Cleaned up parameter annotations for Glacier-related methods to improve readability and consistency in generated docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->