### PR TITLE
NC | Update noobaa.spec python requirement in order to support RHEL 10

### DIFF
--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -26,13 +26,17 @@ URL:  https://www.noobaa.io/
 Source0:  %{noobaatar}
 
 BuildRequires:  systemd
-BuildRequires:  python3.9
 BuildRequires:  make
 BuildRequires:  gcc-c++
 BuildRequires:  boost-devel
 BuildRequires:  libcap-devel
 %if 0%{?rhel} == 8
 BuildRequires:  gcc-toolset-11
+%endif
+%if 0%{?rhel} > 8
+BuildRequires:  python3 # We can use default version in RHEL 9+
+%else
+BuildRequires:  python3.9 # We need at least 3.9 in RHEL 8
 %endif
 
 Recommends:     jemalloc


### PR DESCRIPTION
### Describe the Problem
We don't have Python 3.9 in RHEL 10. So we will use 3.12 instead.

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed https://issues.redhat.com/browse/DFBUGS-3868

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * RPM packaging updated to select the system Python on RHEL 9+ and retain Python 3.9 on RHEL 8 and earlier during builds.
  * Preserves existing build tools and runtime behavior; no user-facing changes or upgrade impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->