### PR TITLE
Added metrics - object count, max_objects and max_size for quota

### DIFF
--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -310,6 +310,27 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
         }
     }, {
         type: 'Gauge',
+        name: 'bucket_object_count',
+        configuration: {
+            help: 'Current Number of Objects per Bucket',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_max_objects_quota',
+        configuration: {
+            help: 'Bucket Maximum Objects Quota',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_max_bytes_quota',
+        configuration: {
+            help: 'Bucket Maximum Bytes Quota',
+            labelNames: ['bucket_name']
+        }
+    }, {
+        type: 'Gauge',
         name: 'resource_status',
         configuration: {
             help: 'Resource Health',
@@ -563,6 +584,9 @@ class NooBaaCoreReport extends BasePrometheusReport {
         this._metrics.bucket_capacity.reset();
         this._metrics.bucket_tagging.reset();
         this._metrics.bucket_used_bytes.reset();
+        this._metrics.bucket_object_count.reset();
+        this._metrics.bucket_max_objects_quota.reset();
+        this._metrics.bucket_max_bytes_quota.reset();
         buckets_info.forEach(bucket_info => {
             const bucket_labels = { bucket_name: bucket_info.bucket_name };
             if (bucket_info.tagging && bucket_info.tagging.length) {
@@ -574,6 +598,9 @@ class NooBaaCoreReport extends BasePrometheusReport {
             this._metrics.bucket_quantity_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_quantity_percent);
             this._metrics.bucket_capacity.set({ bucket_name: bucket_info.bucket_name }, bucket_info.capacity_precent);
             this._metrics.bucket_used_bytes.set({ bucket_name: bucket_info.bucket_name }, bucket_info.bucket_used_bytes);
+            this._metrics.bucket_object_count.set({ bucket_name: bucket_info.bucket_name }, bucket_info.object_count || 0);
+            this._metrics.bucket_max_objects_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_max_objects || 0);
+            this._metrics.bucket_max_bytes_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_max_bytes || 0);
         });
     }
 


### PR DESCRIPTION
### Describe the Problem
Currently, we have not exposed any metrics to show current object, max objects and max size set for bucket in quota.

### Explain the Changes
1. We have added metrics - `bucket_object_count`, `bucket_max_objects_quota` and `bucket_max_bytes_quota`.

<img width="1904" height="899" alt="Screenshot from 2025-09-16 15-05-41" src="https://github.com/user-attachments/assets/aa335113-6eda-481d-bba9-8254813b2841" />



### Issues: Fixed #xxx / Gap #xxx
1. Fixed: https://issues.redhat.com/browse/RHSTOR-6943

### Testing Instructions:
1.  Run below commands, and verify the implemented metrics after setting quota in the bucket: 
> $ JWT_TOKEN=$(kubectl get secret/noobaa-metrics-auth-secret -o jsonpath={.data.metrics_token} | base64 -d)  
$ kubectl exec -it noobaa-core-0 -- curl -k -H "Authorization: Bearer ${JWT_TOKEN}" http://localhost:8080/metrics/web_server | grep -E 'bucket_object_count|quota'

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-bucket Prometheus metrics for object count and quota limits (max objects, max bytes) and ensured they are reset and updated per-bucket.
  * Bucket statistics now include object_count plus quota limit fields (max objects, max bytes) in addition to existing usage percentages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->