### PR TITLE
Added a fix for POSTGRES_CONNECTION_STRING_PATH handling

### DIFF
--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1500,10 +1500,14 @@ class PostgresClient extends EventEmitter {
 
         if (process.env.POSTGRES_CONNECTION_STRING_PATH) {
             /** @type {import('pg').PoolConfig} */
-            this.new_pool_params = {
-                connectionString: fs.readFileSync(process.env.POSTGRES_CONNECTION_STRING_PATH, "utf8"),
-                ...params,
-            };
+            try {
+                this.new_pool_params = {
+                    connectionString: fs.readFileSync(process.env.POSTGRES_CONNECTION_STRING_PATH, "utf8"),
+                    ...params,
+                };
+            } catch (err) {
+                throw new Error(`Failed to read connection string file '${process.env.POSTGRES_CONNECTION_STRING_PATH}': ${err.message}`);
+            }
         } else {
             // get the connection configuration. first from env, then from file, then default
             const host = process.env.POSTGRES_HOST || fs_utils.try_read_file_sync(process.env.POSTGRES_HOST_PATH) || '127.0.0.1';


### PR DESCRIPTION
### Describe the Problem
The issue is with the NooBaa core code handling of the `POSTGRES_CONNECTION_STRING_PATH` parameter. When the NooBaa operator sets this environment variable but the connection string file doesn't exist or is not readable, the code uses `fs.readFileSync()` directly which throws an unhandled exception. This causes the NooBaa core pod to crash during operator installation, leading to CI job failures with CrashLoopBackOff errors.

### Explain the Changes
1.  Added proper error handling for `POSTGRES_CONNECTION_STRING_PATH` by wrapping `fs.readFileSync()` in a try-catch block.

### Issues: Fixed #xxx / Gap #xxx
1. gap: https://github.com/noobaa/noobaa-operator/pull/1689

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support configuring the database via a single Postgres connection string from an environment variable or a file, with automatic fallback to host/user/password/port/database settings. No breaking changes.

- Bug Fixes
  - Improved error reporting when reading the connection string from a file, providing clearer failure messages to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->