### PR TITLE
bucket logging - adapt s3 conn to aws sdk v3 (dfs 3887)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-s3": "3.864.0",
         "@aws-sdk/client-sts": "3.864.0",
         "@aws-sdk/credential-providers": "3.864.0",
+        "@aws-sdk/lib-storage": "3.864.0",
         "@aws-sdk/s3-request-presigner": "3.864.0",
         "@azure/identity": "4.10.2",
         "@azure/monitor-query": "1.3.2",
@@ -67,7 +68,6 @@
       },
       "devDependencies": {
         "@aws-sdk/client-iam": "3.864.0",
-        "@aws-sdk/lib-storage": "3.864.0",
         "@stylistic/eslint-plugin-js": "1.8.1",
         "@types/jest": "30.0.0",
         "@types/lodash": "4.17.20",
@@ -882,7 +882,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.864.0.tgz",
       "integrity": "sha512-Me/HlMXXPv3tStPQufdwnYGholY14JmmzCdOjhnG7gnaClBEnroZKcHuQhrgMm+KyfbzCQ2+9YHsULOfFrg7Mw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.5",
@@ -5410,7 +5409,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
       "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
@@ -12145,7 +12143,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
       "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.4",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@aws-sdk/client-sts": "3.864.0",
     "@aws-sdk/credential-providers": "3.864.0",
     "@aws-sdk/s3-request-presigner": "3.864.0",
+    "@aws-sdk/lib-storage": "3.864.0",
     "@azure/identity": "4.10.2",
     "@azure/monitor-query": "1.3.2",
     "@azure/storage-blob": "12.27.0",
@@ -126,7 +127,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-iam": "3.864.0",
-    "@aws-sdk/lib-storage": "3.864.0",
     "@stylistic/eslint-plugin-js": "1.8.1",
     "@types/jest": "30.0.0",
     "@types/lodash": "4.17.20",

--- a/src/server/bg_services/bucket_logs_upload.js
+++ b/src/server/bg_services/bucket_logs_upload.js
@@ -40,7 +40,7 @@ class BucketLogUploader {
         }
         if (config.BUCKET_LOG_TYPE === 'PERSISTENT') {
             const fs_context = get_process_fs_context();
-            const success = await export_logs_to_target(fs_context, this.noobaa_connection, this.get_bucket_owner_keys);
+            const success = await export_logs_to_target(fs_context, () => this.noobaa_connection, this.get_bucket_owner_keys);
             if (success) {
                 dbg.log0('Logs were uploaded succesfully to their target buckets');
             } else {
@@ -148,7 +148,7 @@ class BucketLogUploader {
         };
 
         try {
-            await noobaa_con.putObject(params).promise();
+            await noobaa_con.putObject(params);
         } catch (err) {
             dbg.error('Failed to upload bucket log object: ', log_object.log_object_name, ' to bucket: ', log_object.log_bucket_name, ' :', err);
         }

--- a/src/util/bucket_logs_utils.js
+++ b/src/util/bucket_logs_utils.js
@@ -9,12 +9,12 @@ const path = require('path');
 const { PersistentLogger } = require('../util/persistent_logger');
 const { format_aws_date } = require('../util/time_utils');
 const nsfs_schema_utils = require('../manage_nsfs/nsfs_schema_utils');
-const semaphore = require('../util/semaphore');
 const P = require('../util/promise');
 const nb_native = require('../util/nb_native');
-const AWS = require('aws-sdk');
+const { Upload } = require("@aws-sdk/lib-storage");
+const { once } = require('events');
 
-const sem = new semaphore.Semaphore(config.BUCKET_LOG_CONCURRENCY);
+//const sem = new semaphore.Semaphore(config.BUCKET_LOG_CONCURRENCY);
 
 // delimiter between bucket name and log object name.
 // Assuming noobaa bucket name follows the s3 bucket
@@ -27,16 +27,16 @@ const BUCKET_NAME_DEL = "_";
  * This function will process the persistent log of bucket logging
  * and will upload the log files in using provided noobaa connection
  * @param {nb.NativeFSContext} fs_context
- * @param {AWS.S3} s3_connection
+ * @param {function(Object): import("@aws-sdk/client-s3").S3} s3_conn_func
  * @param {function} bucket_to_owner_keys_func
  */
-async function export_logs_to_target(fs_context, s3_connection, bucket_to_owner_keys_func) {
+async function export_logs_to_target(fs_context, s3_conn_func, bucket_to_owner_keys_func) {
     const entries = await nb_native().fs.readdir(fs_context, config.PERSISTENT_BUCKET_LOG_DIR);
     const results = await P.map_with_concurrency(5, entries, async entry => {
         if (!entry.name.endsWith('.log')) return;
         const log = new PersistentLogger(config.PERSISTENT_BUCKET_LOG_DIR, path.parse(entry.name).name, { locking: 'EXCLUSIVE' });
         try {
-            return log.process(async file => _upload_to_targets(s3_connection, file, bucket_to_owner_keys_func));
+            return log.process(async file => _upload_to_targets(file, s3_conn_func, bucket_to_owner_keys_func));
         } catch (err) {
             dbg.error('processing log file failed', log.file);
             throw err;
@@ -51,12 +51,12 @@ async function export_logs_to_target(fs_context, s3_connection, bucket_to_owner_
  * This function gets a persistent log file, will go over it's entries one by one,
  * and will upload the entry to the target_bucket using the provided s3 connection
  * in order to know which user to use to upload to each bucket we will need to provide bucket_to_owner_keys_func
- * @param {AWS.S3} s3_connection
+ * @param {function(Object): import("@aws-sdk/client-s3").S3} s3_conn_func
  * @param {import('../util/persistent_logger').LogFile} log_file
  * @param {function} bucket_to_owner_keys_func
  * @returns {Promise<Boolean>}
  */
-async function _upload_to_targets(s3_connection, log_file, bucket_to_owner_keys_func) {
+async function _upload_to_targets(log_file, s3_conn_func, bucket_to_owner_keys_func) {
     const bucket_streams = {};
     const promises = [];
     try {
@@ -67,11 +67,12 @@ async function _upload_to_targets(s3_connection, log_file, bucket_to_owner_keys_
             const target_bucket = log_entry.log_bucket;
             const log_prefix = log_entry.log_prefix;
             const source_bucket = log_entry.source_bucket;
-            if (!bucket_streams[source_bucket + BUCKET_NAME_DEL + target_bucket]) {
+            let upload_stream = bucket_streams[source_bucket + BUCKET_NAME_DEL + target_bucket];
+            if (!upload_stream) {
                 /* new stream is needed for each target bucket, but also for each source bucket
                            - as mulitple buckets can't be written to the same object */
                 const date = new Date();
-                const upload_stream = new stream.PassThrough();
+                upload_stream = new stream.PassThrough();
                 let access_keys;
                 try {
                     access_keys = await bucket_to_owner_keys_func(target_bucket);
@@ -79,21 +80,31 @@ async function _upload_to_targets(s3_connection, log_file, bucket_to_owner_keys_
                     dbg.warn('Error when trying to resolve bucket keys', err);
                     if (err.rpc_code === 'NO_SUCH_BUCKET') return; // If the log_bucket doesn't exist any more - nowhere to upload - just skip
                 }
-                s3_connection.config.credentials = new AWS.Credentials(access_keys[0].access_key, access_keys[0].secret_key);
+                //target bucket can be in either cloud or an NC noobaa bucket
+                //use the s3_conn_func CB to get suitable connection
+                const s3_connection = s3_conn_func(access_keys);
                 const sha = crypto.createHash('sha512').update(target_bucket + date.getTime()).digest('hex');
-                promises.push(sem.surround(() => P.retry({
-                    attempts: 3,
-                    delay_ms: 1000,
-                    func: () => s3_connection.upload({
+
+                const upload = new Upload({
+                    client: s3_connection,
+                    params: {
                         Bucket: target_bucket,
                         Key: `${log_prefix}${format_aws_date(date)}-${sha.slice(0, 16).toUpperCase()}`,
-                        Body: upload_stream,
-                    }).promise()
-                })));
+                        Body: upload_stream
+                    },
+                    queueSize: 1,
+                });
+
                 bucket_streams[source_bucket + BUCKET_NAME_DEL + target_bucket] = upload_stream;
+                promises.push(upload.done());
             }
             dbg.log2(`uploading entry: ${entry} to target bucket: ${target_bucket}`);
-            bucket_streams[source_bucket + BUCKET_NAME_DEL + target_bucket].write(entry + '\n');
+            const can_write = upload_stream.write(entry + '\n');
+            if (!can_write) {
+                dbg.warn(`waiting for target bucket: ${target_bucket} to drain`);
+                await once(upload_stream, 'drain');
+                dbg.warn(`target bucket: ${target_bucket} drained, resume writing`);
+            }
         });
         Object.values(bucket_streams).forEach(st => st.end());
         await Promise.all(promises);


### PR DESCRIPTION
### Describe the Problem
cloud_utils.js was adapted to use s3client from aws sdk v3.
However, bucket_logs_utils.js was not.
This commit adapts bucket_logs_utils.js to use new v3 s3client.

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-3887

### Testing Instructions:
1. src/test/integration_tests/nc/cli/test_nc_bucket_logging.js


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Migrated S3 upload flow to the AWS SDK v3 Upload-based approach with per-target/per-credential connections, improving streaming, upload completion handling, and stability.
  - Reworked log export to obtain connections on demand, simplifying concurrency and error handling during uploads.

- Chores
  - Promoted the storage library from dev-only to a runtime dependency to support the new upload flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->