### PR TITLE
SDK | Fix log replication sdk issue

### DIFF
--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -108,8 +108,8 @@ async function get_object_md(bucket_name, key, s3, version_id) {
         dbg.log1('get_object_md: finished successfully', head);
         return head;
     } catch (err) {
-        dbg.error('get_object_md: error:', err);
-        if (err.code === 'NotFound') return;
+        dbg.error('get_object_md: error.name: ', err?.name, ' error: ', err);
+        if (err?.name === 'NotFound') return;
         throw err;
     }
 }

--- a/src/test/unit_tests/internal/test_bucket_log_based_replication.test.js
+++ b/src/test/unit_tests/internal/test_bucket_log_based_replication.test.js
@@ -19,7 +19,7 @@ describe('AWS S3 server log parsing tests', () => {
     // Pagination test
     it('Test AWS S3 server log parsing for BATCH.DELETE and REST.PUT actions', async () => {
         const logs = [];
-        const example_log = { Body: `
+        const example_log = `
         aaa test.bucket [13/Feb/2023:15:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT test - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
         aaa test.bucket [13/Feb/2023:15:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT test.js - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
         aaa test.bucket [13/Feb/2023:16:08:56 +0000] 0.0.0.0 arn:aws:iam::111:user/user AAA REST.PUT.OBJECT code2 "PUT /test.bucket/code2?X-Amz-Security-Token=AAAAAAAAAAAAAAA=20230213T160856Z&X-Amz-AAAAAA HTTP/1.1" 200 - - 1 1 1 "https://s3.console.aws.amazon.com/s3/upload/test.bucket?region=us-east-2" "AAA/5.0 (AAA 1.1; AAA; AAA) AAA/1.1 (KHTML, like Gecko) AAA/1.1 AAA/1.1" - AAAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 QueryString s3.us-east-2.amazonaws.com TLSv1.2 - -
@@ -27,9 +27,9 @@ describe('AWS S3 server log parsing tests', () => {
         aaa test.bucket [13/Feb/2023:15:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT testfile.js - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
         aaa test.bucket [13/Feb/2023:15:25:00 +0000] 0.0.0.0 arn:aws:iam::111:user/user AAA REST.PUT.OBJECT empty "PUT /test.bucket/empty?X-Amz-Security-Token=AAAAAAAAAAAAAAA=20230213T152500Z&X-Amz-AAAAAA HTTP/1.1" 200 - - 1 1 1 "https://s3.console.aws.amazon.com/s3/upload/test.bucket?region=us-east-2" "AAA/5.0 (AAA 1.1; AAA; AAA) AAA/1.1 (KHTML, like Gecko) AAA/1.1 AAA/1.1" - AAAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 QueryString s3.us-east-2.amazonaws.com TLSv1.2 - -
         aaa test.bucket [13/Feb/2023:15:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT text.txt - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
-        ` };
+        `;
         const action_dictionary = { 'test': 'delete', 'test.js': 'delete', 'code2': 'copy', 'test2': 'delete', 'testfile.js': 'delete', 'empty': 'copy', 'text.txt': 'delete' };
-        log_parser.aws_parse_log_object(logs, example_log, true, '');
+        await log_parser.aws_parse_log_object(logs, example_log, true, '');
         // Make sure the test doesn't pass in case the parsing fails
         expect(logs.length).toEqual(Object.keys(action_dictionary).length);
         // Make sure all expected actions are mapped to the appropriate keys
@@ -38,7 +38,7 @@ describe('AWS S3 server log parsing tests', () => {
         });
         // Test with sync_deletions set to false
         logs.length = 0;
-        log_parser.aws_parse_log_object(logs, example_log, false, '');
+        await log_parser.aws_parse_log_object(logs, example_log, false, '');
         // Delete all action_dictionary keys whose value is delete
         Object.keys(action_dictionary).forEach(key => {
             if (action_dictionary[key] === 'delete') {
@@ -50,12 +50,12 @@ describe('AWS S3 server log parsing tests', () => {
 
     it('Test AWS S3 server log parsing when a DELETE is logged before a PUT, but occurs after it', async () => {
         const logs = [];
-        const example_log = { Body: `
+        const example_log = `
         aaa test.bucket [13/Feb/2023:19:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT test - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
         aaa test.bucket [13/Feb/2023:09:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT other_obj - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
         aaa test.bucket [13/Feb/2023:09:08:56 +0000] 0.0.0.0 arn:aws:iam::111:user/user AAA REST.PUT.OBJECT test "PUT /test.bucket/test?X-Amz-Security-Token=AAAAAAAAAAAAAAA=20230213T160856Z&X-Amz-AAAAAA HTTP/1.1" 200 - - 1 1 1 "https://s3.console.aws.amazon.com/s3/upload/test.bucket?region=us-east-2" "AAA/5.0 (AAA 1.1; AAA; AAA) AAA/1.1 (KHTML, like Gecko) AAA/1.1 AAA/1.1" - AAAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 QueryString s3.us-east-2.amazonaws.com TLSv1.2 - -
-        ` };
-        log_parser.aws_parse_log_object(logs, example_log, true, '');
+        `;
+        await log_parser.aws_parse_log_object(logs, example_log, true, '');
         const candidates = log_parser.create_candidates(logs);
         // DELETE log should be the latest log present inside the candidate, as candidate storing only latest log per key
         expect(candidates.test.action).toEqual('delete');
@@ -246,7 +246,7 @@ describe('AWS S3 server logs parsing/processing tests', () => {
         const logs = [];
         const src_bucket = "src-bucket";
         const dst_bucket = "dst-bucket";
-        const example_log = {Body: `
+        const example_log = `
             aaa test.bucket [13/Feb/2023:19:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT test - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
             aaa test.bucket [13/Feb/2023:09:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT other_obj - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
             aaa test.bucket [13/Feb/2023:19:08:28 +0000] 0.0.0.0 arn:aws:iam::111:user/user AAA REST.PUT.OBJECT test "PUT /test.bucket/code2?X-Amz-Security-Token=AAAAAAAAAAAAAAA=20230213T160856Z&X-Amz-AAAAAA HTTP/1.1" 200 - - 1 1 1 "https://s3.console.aws.amazon.com/s3/upload/test.bucket?region=us-east-2" "AAA/5.0 (AAA 1.1; AAA; AAA) AAA/1.1 (KHTML, like Gecko) AAA/1.1 AAA/1.1" - AAAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 QueryString s3.us-east-2.amazonaws.com TLSv1.2 - -
@@ -261,10 +261,10 @@ describe('AWS S3 server logs parsing/processing tests', () => {
             aaa test.bucket [12/Feb/2023:15:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT test - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
             aaa test.bucket [13/Feb/2023:15:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT test.js - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
             aaa test.bucket [13/Feb/2023:16:08:56 +0000] 0.0.0.0 arn:aws:iam::111:user/user AAA REST.PUT.OBJECT code2 "PUT /test.bucket/code2?X-Amz-Security-Token=AAAAAAAAAAAAAAA=20230213T160856Z&X-Amz-AAAAAA HTTP/1.1" 200 - - 1 1 1 "https://s3.console.aws.amazon.com/s3/upload/test.bucket?region=us-east-2" "AAA/5.0 (AAA 1.1; AAA; AAA) AAA/1.1 (KHTML, like Gecko) AAA/1.1 AAA/1.1" - AAAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 QueryString s3.us-east-2.amazonaws.com TLSv1.2 - -            aaa test.bucket [13/Feb/2023:15:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT testfile.js - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -            aaa test.bucket [13/Feb/2023:15:08:28 +0000] 1.1.1.1 arn:aws:iam::111:user/user AAA BATCH.DELETE.OBJECT text.txt - 204 - - 1 - - - - - AAA SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.us-east-2.amazonaws.com TLSv1.2 - -
-        `};
+        `;
 
 
-        log_parser.aws_parse_log_object(logs, example_log, true);
+        await log_parser.aws_parse_log_object(logs, example_log, true, '');
         // Make sure the test doesn't pass in case the parsing fails
         expect(logs.length).toEqual(14);
 

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -185,7 +185,7 @@ function set_noobaa_s3_connection(sys) {
         dbg.error('set_noobaa_s3_connection: temporary error: invalid noobaa s3 connection details');
         return;
     }
-    const s3_client = new S3({
+    const s3_client = noobaa_s3_client.get_s3_client_v3_params({
         endpoint: endpoint,
         credentials: {
             accessKeyId: access_key,


### PR DESCRIPTION
### Describe the Problem

Log based deletion sync fails between AWS Namespacestore buckets

### Explain the Changes
1. log_object body and error code updated `err?.name`
2. s3_client fetch from `noobaa_s3_client.get_s3_client_v3_params()`

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-3890

### Testing Instructions:
1. Please refere the issue https://issues.redhat.com/browse/DFBUGS-3890


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - More reliable retrieval and parsing of S3 logs; reduced intermittent failures and quieter handling of "NotFound" errors.

- Refactor
  - Replaced underlying S3 client and moved log parsing to asynchronous, string-based processing for improved stability and performance.

- Chores
  - Updated tests and internal configuration to align with the new client and async processing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->