### PR TITLE
Fix backingstore deletion

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1904,6 +1904,11 @@ class NodesMonitor extends EventEmitter {
             if (item.node.migrating_to_pool) {
                 delete item.node.migrating_to_pool;
             }
+            if (item.node.deleting) {
+                // We mark it in order to remove the agent fully (process and tokens etc)
+                // Only after successfully completing the removal we assign the deleted date
+                item.ready_to_be_deleted = true;
+            }
             act.done = true;
         }
     }


### PR DESCRIPTION
### Describe the Problem
The backingstore deletion was not working because of accidental removal of some code

### Explain the Changes
This PR simply adds back the deleted code which marks the 'deleting` nodes `ready_to_be_deleted`.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nodes marked for deletion are now reliably flagged for final removal immediately after the wipe stage, preventing stalled or lingering items.
  * Improves reliability and consistency of cleanup workflows, reducing residual data after node removal.
  * Shortens the end-to-end deletion process with no action required by users.
  * No changes to public APIs or user-facing behavior otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->