### PR TITLE
SDK | Update aws sts cred method

### DIFF
--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -298,7 +298,7 @@ class BlockStoreClient {
                     agent: http_utils.get_unsecured_agent(s3_params.endpoint)
                 };
                 if (bs_info.connection_params.aws_sts_arn) {
-                    const creds = await cloud_utils.generate_aws_sts_creds(s3_params, "_delegate_write_block_s3_session");
+                    const creds = await cloud_utils.generate_aws_sdkv3_sts_creds(s3_params, "_delegate_write_block_s3_session");
                     s3_params.accessKeyId = creds.accessKeyId;
                     s3_params.secretAccessKey = creds.secretAccessKey;
                     s3_params.sessionToken = creds.sessionToken;
@@ -351,7 +351,7 @@ class BlockStoreClient {
                     agent: http_utils.get_unsecured_agent(s3_params.endpoint)
                 };
                 if (bs_info.connection_params.aws_sts_arn) {
-                    const creds = await cloud_utils.generate_aws_sts_creds(s3_params, "_delegate_read_block_s3_session");
+                    const creds = await cloud_utils.generate_aws_sdkv3_sts_creds(s3_params, "_delegate_read_block_s3_session");
                     s3_params.accessKeyId = creds.accessKeyId;
                     s3_params.secretAccessKey = creds.secretAccessKey;
                     s3_params.sessionToken = creds.sessionToken;

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -71,7 +71,7 @@ class NamespaceS3 {
             const additionalParams = {
                 RoleSessionName: 'block_store_operations',
             };
-            this.s3 = await cloud_utils.createSTSS3Client(this.s3_params, additionalParams);
+            this.s3 = await cloud_utils.createSTSS3SDKv3Client(this.s3_params, additionalParams);
         }
     }
 

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1051,7 +1051,7 @@ async function check_google_connection(params) {
 }
 
 async function check_aws_sts_connection(params) {
-    const creds = await cloud_utils.generate_aws_sts_creds(params, "check_aws_sts_sessions");
+    const creds = await cloud_utils.generate_aws_sdkv3_sts_creds(params, "check_aws_sts_sessions");
     params.identity = new SensitiveString(creds.accessKeyId);
     params.secret = new SensitiveString(creds.secretAccessKey);
     params.sessionToken = creds.sessionToken;

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -2037,7 +2037,7 @@ async function _get_s3_client(connection) {
     let access_key;
     let secret_key;
     if (connection.aws_sts_arn) {
-        const creds = await cloud_utils.generate_aws_sts_creds(connection, "get_cloud_buckets_session");
+        const creds = await cloud_utils.generate_aws_sdkv3_sts_creds(connection, "get_cloud_buckets_session");
         access_key = creds.accessKeyId;
         secret_key = creds.secretAccessKey;
         connection.sessionToken = creds.sessionToken;


### PR DESCRIPTION
### Describe the Problem

account_server and bucket_server still using old AWS s2 sts cred generating code

### Explain the Changes
1. Update account_server and bucket_server replace `generate_aws_sts_creds()` with `generate_aws_sdkv3_sts_creds()`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Migrated AWS STS credential handling to AWS SDK v3 across S3 operations (read/write delegation, namespace setup, account checks, and bucket client creation).
  - Improves compatibility and stability when using temporary credentials or assumed roles for S3 access.
  - No user action required; behavior remains the same with enhanced reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->