### PR TITLE
Fix - updated stats_api for schema validation failure

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -758,7 +758,7 @@ module.exports = {
                     type: 'array',
                     items: {
                         type: 'object',
-                        required: ['bucket_name', 'quota_size_precent', 'quota_quantity_percent', 'capacity_precent', 'is_healthy', 'tagging', 'bucket_used_bytes'],
+                        required: ['bucket_name', 'quota_size_precent', 'quota_quantity_percent', 'capacity_precent', 'is_healthy', 'tagging', 'bucket_used_bytes', 'object_count', 'quota_max_objects', 'quota_max_bytes'],
                         properties: {
                             bucket_name: {
                                 type: 'string'
@@ -776,6 +776,15 @@ module.exports = {
                                 type: 'boolean'
                             },
                             bucket_used_bytes: {
+                                type: 'number'
+                            },
+                            object_count: {
+                                type: 'number'
+                            },
+                            quota_max_objects: {
+                                type: 'number'
+                            },
+                            quota_max_bytes: {
                                 type: 'number'
                             },
                             tagging: {


### PR DESCRIPTION
### Describe the Problem
The schema validation was failing because stats_api.js was missing three recently added bucket metrics: object_count, quota_max_objects, and quota_max_bytes.

### Explain the Changes
1.  Update the stats_api for the metrics.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - #9205 

### Testing Instructions:
1.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added additional numeric statistics for buckets, including object count, maximum object quota, and maximum byte quota.
* **Improvements**
  * Enhanced bucket statistics to provide more comprehensive information about storage resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->