### PR TITLE
SDK | SDKv3Client region missing error

### DIFF
--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const _ = require('lodash');
-const { S3 } = require('@aws-sdk/client-s3');
 
 const config = require('../../../config');
 const P = require('../../util/promise');
@@ -13,9 +12,8 @@ const size_utils = require('../../util/size_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
 const { RpcError } = require('../../rpc');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
+const noobaa_s3_client = require('../../sdk/noobaa_s3_client/noobaa_s3_client');
 
-
-const DEFAULT_REGION = 'us-east-1';
 
 class BlockStoreS3 extends BlockStoreBase {
 
@@ -40,14 +38,14 @@ class BlockStoreS3 extends BlockStoreBase {
                     RoleSessionName: 'block_store_operations'
                 };
             } else {
-                this.s3cloud = new S3({
+                this.s3cloud = noobaa_s3_client.get_s3_client_v3_params({
                     endpoint: endpoint,
                     credentials: {
                         accessKeyId: this.cloud_info.access_keys.access_key.unwrap(),
                         secretAccessKey: this.cloud_info.access_keys.secret_key.unwrap(),
                     },
                     forcePathStyle: true,
-                    region: DEFAULT_REGION,
+                    region: config.DEFAULT_REGION,
                     requestHandler: new NodeHttpHandler({
                         httpsAgent: http_utils.get_default_agent(endpoint)
                     }),
@@ -58,13 +56,14 @@ class BlockStoreS3 extends BlockStoreBase {
                 config.EXPERIMENTAL_DISABLE_S3_COMPATIBLE_DELEGATION.DEFAULT;
             this.disable_metadata = config.EXPERIMENTAL_DISABLE_S3_COMPATIBLE_METADATA[this.cloud_info.endpoint_type] ||
                 config.EXPERIMENTAL_DISABLE_S3_COMPATIBLE_METADATA.DEFAULT;
-            this.s3cloud = new S3({
+            this.s3cloud = noobaa_s3_client.get_s3_client_v3_params({
                 endpoint: endpoint,
                 forcePathStyle: true,
                 credentials: {
                     accessKeyId: this.cloud_info.access_keys.access_key.unwrap(),
                     secretAccessKey: this.cloud_info.access_keys.secret_key.unwrap(),
                 },
+                region: config.DEFAULT_REGION,
                 applyChecksum: cloud_utils.disable_s3_compatible_bodysigning(endpoint),
                 requestHandler: new NodeHttpHandler({
                     httpsAgent: http_utils.get_unsecured_agent(endpoint)

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -6,7 +6,6 @@ const RpcError = require('../rpc/rpc_error');
 const http_utils = require('./http_utils');
 const string_utils = require('./string_utils');
 const AWS = require('aws-sdk');
-const { S3 } = require('@aws-sdk/client-s3');
 const url = require('url');
 const _ = require('lodash');
 const SensitiveString = require('./sensitive_string');
@@ -33,7 +32,7 @@ function find_cloud_connection(account, conn_name) {
 
 async function createSTSS3SDKv3Client(params, additionalParams) {
     const creds = await generate_aws_sdkv3_sts_creds(params, additionalParams.RoleSessionName);
-    return new S3({
+    return noobaa_s3_client.get_s3_client_v3_params({
         credentials: creds,
         region: params.region || config.DEFAULT_REGION,
         endpoint: additionalParams.endpoint,
@@ -78,7 +77,7 @@ function get_signed_url(params, expiry = 604800, custom_operation = 'getObject')
         sslEnabled: false,
         signatureVersion: get_s3_endpoint_signature_ver(params.endpoint),
         s3DisableBodySigning: disable_s3_compatible_bodysigning(params.endpoint),
-        region: 'eu-central-1',
+        region: params.region || config.DEFAULT_REGION,
         httpOptions: {
             // Setting the agent is not mandatory in this case as this s3 client
             // is only used to acquire a signed Url


### PR DESCRIPTION
### Describe the Problem

Noobaa core throwing lots of Region is missing error and its filling log file fast.
```
write_usage ERROR Error: Region is missing
block_store_services.block_store_s3:: _get_blocks_usage: Error: Region is missing
```

### Explain the Changes
1. Update the block store to fetch sdkv3
2. update createSTSS3SDKv3Client code 

### Issues: Fixed #xxx / Gap #xxx
1.
### Testing Instructions:
1. Create AWS bucket 
3. Create Azure bucket
4. Add replication policy to AWS bucket 
```
nb api bucket_api put_bucket_replication '{"name":"my-bucket-claim1-9b6265f2-2d96-4525-bfdf-adbda4995d77","replication_policy":{"rules":[{"rule_id":"rule-1","destination_bucket":"azure-bucket-8e32f9ee-c04e-4a8c-80dc-9700aa49cf5e","filter":{"prefix":"log"},"sync_deletions":true,"sync_versions":false}]}}'
```
5. Check the replication happening or not


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * S3 client creation unified behind a common wrapper to improve compatibility across AWS and S3‑compatible endpoints and simplify connection handling.

* **Bug Fixes**
  * Signed URL generation now respects the requested or configured region instead of a hard-coded value.
  * Improved handling and connectivity for non‑AWS/S3‑compatible endpoints, including more reliable request handling for certain endpoint types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->