### PR TITLE
Add nightly IBM VM provision and cleanup tools

### DIFF
--- a/.github/workflows/ibm-daily-leftover-cleanup.yaml
+++ b/.github/workflows/ibm-daily-leftover-cleanup.yaml
@@ -1,0 +1,97 @@
+name: Daily IBM leftover cleanup
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Run daily at 6AM UTC
+  workflow_dispatch: # Allow manual triggering for on-demand cleanup
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup-nb-nightly-resources:
+    name: Clean up nb-nightly IBM resources
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash -euo pipefail {0}
+
+    steps:
+      - name: Install IBM Cloud CLI + VPC plugin
+        run: |
+          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh >/dev/null
+          ibmcloud plugin install vpc-infrastructure -f >/dev/null
+          ibmcloud --version
+
+      - name: Authenticate with IBM Cloud
+        env:
+          IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
+        run: |
+          ibmcloud login --apikey "${IBM_CLOUD_API_KEY}" -r eu-de >/dev/null
+
+      - name: Clean up nb-nightly floating IPs
+        run: |
+          echo "🔍 Looking for floating IPs with 'nb-nightly' in the name"
+          
+          # Get all floating IPs and filter by name containing 'nb-nightly'
+          FLOATING_IPS=$(ibmcloud is floating-ips --output JSON 2>/dev/null || echo "[]")
+          MATCHING_IPS=$(echo "${FLOATING_IPS}" | jq -r '.[] | select(.name | contains("nb-nightly")) | .id' 2>/dev/null || echo "")
+          
+          if [ -n "${MATCHING_IPS}" ]
+          then
+            echo "🗑️ Releasing floating IP(s) with 'nb-nightly' in name"
+            for IP_ID in ${MATCHING_IPS}
+            do
+              IP_NAME=$(echo "${FLOATING_IPS}" | jq -r ".[] | select(.id == \"${IP_ID}\") | .name")
+              ibmcloud is floating-ip-release "${IP_ID}" --force >/dev/null
+              echo "IP released successfully"
+            done
+            echo "✅ All nb-nightly floating IPs released successfully"
+          else
+            echo "ℹ️  No floating IPs found with 'nb-nightly' in name"
+          fi
+
+      - name: Clean up nb-nightly IBM VMs
+        run: |
+          echo "🔍 Looking for IBM VMs with 'nb-nightly' in the name"
+          
+          # Get all instances and filter by name containing 'nb-nightly'
+          INSTANCES=$(ibmcloud is instances --output JSON 2>/dev/null || echo "[]")
+          MATCHING_INSTANCES=$(echo "${INSTANCES}" | jq -r '.[] | select(.name | contains("nb-nightly")) | .id' 2>/dev/null || echo "")
+          
+          if [ -z "${MATCHING_INSTANCES}" ]
+          then
+            echo "ℹ️  No VMs found with 'nb-nightly' in name"
+            echo "This might be expected if the VMs were already deleted or never created."
+            exit 0
+          fi
+          
+          echo "🔎 Found VM(s) with 'nb-nightly' in name"
+          echo "🗑️ Deleting IBM VM(s)..."
+          for INSTANCE_ID in ${MATCHING_INSTANCES}
+          do
+            INSTANCE_NAME=$(echo "${INSTANCES}" | jq -r ".[] | select(.id == \"${INSTANCE_ID}\") | .name")
+            ibmcloud is instance-delete "${INSTANCE_ID}" --force >/dev/null
+            echo "VM deleted successfully"
+          done
+          echo "✅ All nb-nightly IBM VMs deletion initiated"
+          
+          # Wait up to 2 minutes for deletion to complete
+          echo "⏳ Waiting for deletion to complete..."
+          for i in {1..24}
+          do
+            sleep 5
+            REMAINING_INSTANCES=$(ibmcloud is instances --output JSON 2>/dev/null | jq -r '.[] | select(.name | contains("nb-nightly")) | .id' 2>/dev/null || echo "")
+            if [ -z "${REMAINING_INSTANCES}" ]
+            then
+              echo "✅ All nb-nightly VMs deleted successfully"
+              break
+            fi
+            if [ $i -eq 24 ]
+            then
+              echo "⚠️  Some VMs may still be deleting (timeout reached)"
+              REMAINING_COUNT=$(echo "${REMAINING_INSTANCES}" | wc -w)
+              echo "   ${REMAINING_COUNT} VM(s) still in deletion process"
+            fi
+          done

--- a/.github/workflows/ibm-nightly-cleanup-dispatcher.yaml
+++ b/.github/workflows/ibm-nightly-cleanup-dispatcher.yaml
@@ -1,0 +1,14 @@
+name: Nightly IBM VM Cleanup Dispatcher
+
+on:
+    schedule:
+        # Run daily at 4 AM UTC (4 hours after the nightly provisioning at midnight)
+        - cron: '0 4 * * *'
+    workflow_dispatch: # Allow manual triggering for on-demand cleanup
+
+jobs:
+  cleanup-warp-vm:
+    uses: ./.github/workflows/ibm-nightly-vm-cleanup.yaml
+    secrets:
+      VM_CONFIG: ${{ secrets.IBM_WARP_VM_CONFIG }}
+      IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}

--- a/.github/workflows/ibm-nightly-provision-dispatcher.yaml
+++ b/.github/workflows/ibm-nightly-provision-dispatcher.yaml
@@ -1,0 +1,18 @@
+name: Nightly IBM VM Provision Dispatcher
+
+on:
+    schedule:
+        # Run daily at midnight UTC
+        - cron: '0 0 * * *'
+    workflow_dispatch: # Allow manual triggering for on-demand provisioning
+
+jobs:
+  provision-warp-vm:
+    uses: ./.github/workflows/ibm-nightly-vm-provision.yaml
+    with:
+        VM_CLOUD_INIT_CONFIG_LOCATION: ".github/ibm-warp-runner-config.yaml"
+    secrets:
+      VM_CONFIG: ${{ secrets.IBM_WARP_VM_CONFIG }}
+      IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
+      IBM_COS_WRITER_CREDENTIALS: ${{ secrets.IBM_COS_WRITER_CREDENTIALS }}
+      SLACK_NIGHTLY_RESULTS_URL: ${{ secrets.SLACK_NIGHTLY_RESULTS_URL }}

--- a/.github/workflows/ibm-nightly-vm-cleanup.yaml
+++ b/.github/workflows/ibm-nightly-vm-cleanup.yaml
@@ -1,0 +1,91 @@
+name: Nightly IBM VM Cleanup
+
+on:
+  workflow_call:
+    secrets:
+      VM_CONFIG:
+        required: true
+      IBM_CLOUD_API_KEY:
+        required: true
+  workflow_dispatch: # Allow manual triggering for on-demand cleanup
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup-ibm-vm:
+    name: Clean up IBM VM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash -euo pipefail {0}
+
+    steps:
+      - name: Install IBM Cloud CLI + VPC plugin
+        run: |
+          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh >/dev/null
+          ibmcloud plugin install vpc-infrastructure -f >/dev/null
+          ibmcloud --version
+
+      - name: Mask and export VM config from JSON secret
+        env:
+          VM_CONFIG: ${{ secrets.VM_CONFIG }}
+        run: |
+          # Mask non-empty values
+          jq -r 'to_entries[] | select(.value != "") | "::add-mask::\(.value)"' <<<"${VM_CONFIG}"
+          # Append KEY=VALUE lines to GITHUB_ENV
+          jq -r 'to_entries[] | "\(.key)=\(.value)"' <<<"${VM_CONFIG}" >>"${GITHUB_ENV}"
+
+
+      - name: Authenticate with IBM Cloud
+        env:
+          IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
+        run: |
+          ibmcloud login --apikey "${IBM_CLOUD_API_KEY}" -r "${REGION}" >/dev/null
+
+      - name: Clean up floating IPs
+        run: |
+          echo "🔍 Looking for floating IPs with the resource tag"
+          FLOATING_IP_IDS=$(ibmcloud resource search "tags:\"${RESOURCE_TAG}\" AND type:floating-ip" --output JSON | jq -r '.items[].resource_id' 2>/dev/null || echo "")
+          
+          if [ -n "${FLOATING_IP_IDS}" ]
+          then
+            echo "🗑️ Releasing floating IP(s)"
+            for IP_ID in ${FLOATING_IP_IDS}
+            do
+              ibmcloud is floating-ip-release "${IP_ID}" --force >/dev/null
+            done
+            echo "✅ All tagged floating IPs released successfully"
+          else
+            echo "ℹ️  No floating IPs found"
+          fi
+
+      - name: Clean up IBM VMs
+        run: |
+          echo "🔍 Looking for IBM VMs with the resource tag"
+          INSTANCE_IDS=$(ibmcloud resource search "tags:\"${RESOURCE_TAG}\" AND type:instance" --output JSON | jq -r '.items[].resource_id' 2>/dev/null || echo "")
+          
+          if [ -z "${INSTANCE_IDS}" ]
+          then
+            echo "ℹ️  No VMs found with the resource tag"
+            echo "This might be expected if the VMs were already deleted or never created."
+            exit 0
+          fi
+          
+          echo "🔎 Found VM(s) with the resource tag"
+          echo "🗑️ Deleting IBM VM(s)..."
+          for INSTANCE_ID in ${INSTANCE_IDS}
+          do
+            ibmcloud is instance-delete "${INSTANCE_ID}" --force >/dev/null
+          done
+          echo "✅ All tagged IBM VMs deleted successfully"
+          
+          # Wait up to 1 minute for deletion to complete
+          for i in {1..12}
+          do
+            sleep 5
+            REMAINING=$(ibmcloud resource search "tags:\"${RESOURCE_TAG}\" AND type:instance" --output JSON | jq -r '.items[].resource_id' 2>/dev/null || echo "")
+            [ -z "${REMAINING}" ] && echo "✅ Deletion verified" && break
+            [ $i -eq 12 ] && echo "⚠️  Some VMs may still be deleting"
+          done

--- a/.github/workflows/ibm-nightly-vm-provision.yaml
+++ b/.github/workflows/ibm-nightly-vm-provision.yaml
@@ -1,0 +1,142 @@
+name: Nightly IBM VM Provisioning
+
+on:
+  workflow_call:
+    inputs:
+      VM_CLOUD_INIT_CONFIG_LOCATION:
+        required: true
+        type: string
+    secrets:
+      VM_CONFIG:
+        required: true
+      IBM_CLOUD_API_KEY:
+        required: true
+      IBM_COS_WRITER_CREDENTIALS:
+        required: true
+      SLACK_NIGHTLY_RESULTS_URL:
+        required: true
+  workflow_dispatch:
+
+permissions:
+  contents: read # required for actions/checkout
+
+jobs:
+  provision-ibm-vm:
+    name: Provision IBM VM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash -euo pipefail {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install IBM Cloud CLI + VPC plugin
+        run: |
+          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh >/dev/null
+          ibmcloud plugin install vpc-infrastructure -f >/dev/null
+          ibmcloud --version
+
+      - name: Mask and export VM config from JSON secret
+        env:
+          VM_CONFIG: ${{ secrets.VM_CONFIG }}
+        run: |
+          # Mask non-empty values
+          jq -r 'to_entries[] | select(.value != "") | "::add-mask::\(.value)"' <<<"${VM_CONFIG}"
+          # Append KEY=VALUE lines to GITHUB_ENV
+          jq -r 'to_entries[] | "\(.key)=\(.value)"' <<<"${VM_CONFIG}" >>"${GITHUB_ENV}"
+
+
+      - name: Authenticate with IBM Cloud
+        env:
+          IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
+        run: |
+          ibmcloud login --apikey "${IBM_CLOUD_API_KEY}" -r "${REGION}" >/dev/null
+
+      - name: Extract IBM COS credentials from JSON secret
+        env:
+          IBM_COS_WRITER_CREDENTIALS: ${{ secrets.IBM_COS_WRITER_CREDENTIALS }}
+        run: |
+          # Mask non-empty values
+          jq -r 'to_entries[] | select(.value != "") | "::add-mask::\(.value)"' <<<"${IBM_COS_WRITER_CREDENTIALS}"
+          # Append KEY=VALUE lines to GITHUB_ENV
+          jq -r 'to_entries[] | "\(.key)=\(.value)"' <<<"${IBM_COS_WRITER_CREDENTIALS}" >>"${GITHUB_ENV}"
+
+
+      - name: Create user-data with secrets
+        env:
+          SLACK_NIGHTLY_RESULTS_URL: ${{ secrets.SLACK_NIGHTLY_RESULTS_URL }}
+          VM_CLOUD_INIT_CONFIG_LOCATION: ${{ inputs.VM_CLOUD_INIT_CONFIG_LOCATION }}
+        run: |
+          # Mask sensitive values
+          [ -n "${SLACK_NIGHTLY_RESULTS_URL:-}" ] && echo "::add-mask::$SLACK_NIGHTLY_RESULTS_URL"
+          export SLACK_NIGHTLY_RESULTS_URL
+          export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY WARP_LOGS_BUCKET IBM_COS_ENDPOINT
+          
+          # Use envsubst to replace variables in the config
+          envsubst < ${VM_CLOUD_INIT_CONFIG_LOCATION} > /tmp/ibm-vm-runner-config-with-secrets.yaml
+
+      - name: Provision IBM VM
+        run: |
+          TIMESTAMPED_INSTANCE_NAME="${INSTANCE_NAME}-$(date +"%Y-%m-%d-%H-%M-%S")"
+          echo "::add-mask::$TIMESTAMPED_INSTANCE_NAME"
+          echo "TIMESTAMPED_INSTANCE_NAME=$TIMESTAMPED_INSTANCE_NAME" >> "${GITHUB_ENV}"
+
+          if ! ibmcloud is instance-create \
+            "${TIMESTAMPED_INSTANCE_NAME}" \
+            "${VPC_NAME}" \
+            "${ZONE}" \
+            "${INSTANCE_PROFILE}" \
+            "${SUBNET_ID}" \
+            --image "${IMAGE_ID}" \
+            --sgs "${SECURITY_GROUP_ID}" \
+            --user-data @/tmp/ibm-vm-runner-config-with-secrets.yaml \
+            > /dev/null 2>&1
+          then
+            echo "❌ Failed to provision IBM VM"
+            exit 1
+          fi
+          echo "✅ IBM VM provisioned successfully"
+          sleep 10
+
+      - name: Tag IBM VM
+        run: |
+          if ! ibmcloud resource tag-attach --tag-names "${RESOURCE_TAG}" --resource-name "${TIMESTAMPED_INSTANCE_NAME}" >/dev/null 2>&1
+          then
+            echo "❌ Failed to tag VM - cleanup may not work properly"
+            exit 1
+          fi
+          echo "✅ IBM VM tagged successfully"
+
+      - name: Reserve and bind a floating IP
+        run: |
+          VM_JSON=$(ibmcloud is instance "${TIMESTAMPED_INSTANCE_NAME}" --output json)
+          NIC_ID=$(echo "${VM_JSON}" | jq -r '.primary_network_attachment.virtual_network_interface.id')
+          
+          TIMESTAMPED_FLOATING_IP_NAME="${FLOATING_IP_NAME}-$(date +"%Y-%m-%d-%H-%M-%S")"
+          echo "::add-mask::$TIMESTAMPED_FLOATING_IP_NAME"
+          echo "TIMESTAMPED_FLOATING_IP_NAME=$TIMESTAMPED_FLOATING_IP_NAME" >> "${GITHUB_ENV}"
+
+          # Reserve a floating IP in the same zone as the VM
+          if ! ibmcloud is floating-ip-reserve \
+            "${TIMESTAMPED_FLOATING_IP_NAME}" \
+            --nic "${NIC_ID}" \
+            > /dev/null 2>&1
+          then
+            echo "❌ Failed to reserve and bind floating IP"
+            exit 1
+          fi
+          echo "✅ Floating IP reserved and bound successfully"
+          sleep 10
+
+      - name: Tag floating IP
+        run: |
+          if ! ibmcloud resource tag-attach --tag-names "${RESOURCE_TAG}" --resource-name "${TIMESTAMPED_FLOATING_IP_NAME}" >/dev/null 2>&1
+          then
+            echo "❌ Failed to tag floating IP - cleanup may not work properly"
+            # Consider releasing the floating IP here
+            exit 1
+          fi
+          echo "✅ Floating IP tagged successfully"


### PR DESCRIPTION
* This is one-third of a bigger feature, please see #9230 and #9231 for the rest

### Explain the Changes
- Created a nightly provisioning workflow that dynamically spins up an IBM Cloud VM based on a given configuration
- Created a nighly cleanup workflow that runs 4 hours later to automatically delete VMs and release floating IPs
- Added a Warp-specific VM setup config that installs software dependencies, clones the repository, and automatically executes Warp tests

### Issues: 

### Testing Instructions:
- Test VM provisioning workflow: Trigger the "Nightly IBM VM Provision Dispatcher" workflow manually via GitHub Actions and verify VM and floating IP creation in IBM Cloud console
- Test VM cleanup workflow: After provisioning, trigger the "Nightly IBM VM Cleanup Dispatcher" workflow manually and confirm VM and floating IP are properly deleted
- End-to-end test: Let the nightly workflow run completely, verify Slack notifications are sent, and verify logs appear in the IBM COS bucket mentioned in the Slack notification

- [x] Doc added/updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly and daily IBM VM provisioning and cleanup with scheduled runs (00:00, 04:00, 06:00 UTC) and manual trigger support.
  * Automated VM creation (timestamped names), tagging, floating IP allocation/binding, and targeted cleanup with progress reporting.

* **Chores**
  * Added dispatcher workflows to orchestrate reusable nightly jobs and pass required configs/secrets.
  * Reliability improvements: masked sensitive values, explicit timeouts, polling for completion, and clearer status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->