### PR TITLE
NC |  don't stat directories in list_object

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -737,16 +737,18 @@ class NamespaceFS {
                     if (!delimiter && r.common_prefix) {
                         await process_dir(r.key);
                     } else {
-                        const entry_path = path.join(this.bucket_path, r.key);
-                        // If entry is outside of bucket, returns stat of symbolic link
-                        const use_lstat = !(await this._is_path_in_bucket_boundaries(fs_context, entry_path));
-                        const stat = await native_fs_utils.stat_if_exists(fs_context, entry_path,
-                            use_lstat, config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES);
-                        // TODO - GAP of .folder files - we return stat of the directory for the 
-                        // xattr, but the creation time should be of the .folder files (and maybe more )
-                        if (stat) {
-                            r.stat = stat;
-                            // add the result only if we have the stat information
+                        if (!r.common_prefix) {
+                            const entry_path = path.join(this.bucket_path, r.key);
+                            // If entry is outside of bucket, returns stat of symbolic link
+                            const use_lstat = !(await this._is_path_in_bucket_boundaries(fs_context, entry_path));
+                            const stat = await native_fs_utils.stat_if_exists(fs_context, entry_path,
+                                use_lstat, config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES);
+                            // TODO - GAP of .folder files - we return stat of the directory for the 
+                            // xattr, but the creation time should be of the .folder files (and maybe more )
+                            if (stat) r.stat = stat;
+                        }
+                        // add the result only if we have the stat information or a directory
+                        if (r.stat || r.common_prefix) {
                             if (pos < results.length) {
                                 results.splice(pos, 0, r);
                             } else {


### PR DESCRIPTION
### Describe the Problem
PR #8809 starts stating sub-directories inside the bucket - this draft PR will revert it to only stating the files.
The problem is some sub-directories, like .snapshot fail to stat as the GPFS library returns 'Invalid argument' when trying to list their attributes

### Explain the Changes
1. stat only objects and skip directories
2. If the record has a successful stat - push it in the results, and also add the directories as it was before the fix.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object listing to include folder-like entries even when detailed metadata isn’t available, preventing missing directories in some views.
  * Reduced unnecessary metadata lookups for directory-like entries, improving responsiveness when browsing large namespaces.
  * Ensures more consistent and complete results when listing objects without impacting existing behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->