### PR TITLE
pool server - don't issue MANY_STORAGE_ISSUES after scaling up (dfbgus 4152)

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1190,8 +1190,11 @@ function calc_hosts_pool_mode(pool_info, storage_by_mode, s3_by_mode) {
     const storage_count = hosts.by_service.STORAGE;
     const storage_offline = storage_by_mode.OFFLINE || 0;
     const storage_optimal = storage_by_mode.OPTIMAL || 0;
+    const storage_low_capacity = storage_by_mode.LOW_CAPACITY || 0;
     const storage_offline_ratio = (storage_offline / host_count) * 100;
-    const storage_issues_ratio = ((storage_count - storage_optimal) / storage_count) * 100;
+    //don't count individual storage with low capacity as having issues.
+    //low capacity is handled for the entire BS by free_ratio check below
+    const storage_issues_ratio = ((storage_count - storage_optimal - storage_low_capacity) / storage_count) * 100;
     const hosts_initializing = hosts.by_mode.INITIALIZING || 0;
     const hosts_migrating = (hosts.by_mode.INITIALIZING || 0) + (hosts.by_mode.MIGRATING || 0);
     const s3_count = hosts.by_service.GATEWAY;


### PR DESCRIPTION
### Describe the Problem
Customer has 1 host in BS.
This host reaches less than 20% free capacity, so we issue a LOW_CAPACITY state.
CU adds a host to BS, system is writable and has a lot of free space.
BS state is now MANY_STORAGE_ISSUES, despite being functional and having lots of space on new host.

### Explain the Changes
1. Don't count hosts with low_capacity when calculating MANY_STORAGE_ISSUES.
(Low capacity state is handled by "free_ratio" and "free" checks)

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-4152

### Testing Instructions:
1. Create BS with one host.
2. Let host reach LOW_CAPACITY status (manually upload or by altering nodes_monitor._filter_hosts() result)
3. Add new host to BS (ie scale out the BS).
4. BS status after scale out should be OPTIMAL.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage health calculation so low-capacity storage is excluded from issue counts, reducing false alerts and stabilizing status reporting.

* **Documentation**
  * Added a clarifying note describing how low-capacity storage is accounted for in overall free-space checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->