### PR TITLE
[NSFS | NC | GLACIER] Fix `_finalize_restore` ENOTSUP issue

### DIFF
--- a/src/sdk/glacier_tapecloud.js
+++ b/src/sdk/glacier_tapecloud.js
@@ -536,11 +536,9 @@ class TapeCloudGlacier extends Glacier {
                 throw error;
             }
 
-            const xattr_get_keys = [Glacier.XATTR_RESTORE_REQUEST];
-            if (fs_context.use_dmapi) {
-                xattr_get_keys.push(Glacier.GPFS_DMAPI_XATTR_TAPE_PREMIG);
-            }
-            const stat = await fh.stat(fs_context, { xattr_get_keys });
+            // stat will by default read GPFS_DMAPI_XATTR_TAPE_PREMIG and
+            // user.noobaa.restore.request
+            const stat = await fh.stat(fs_context, {});
 
             // This is a hacky solution and would work only if
             // config.NSFS_GLACIER_DMAPI_ENABLE is enabled. This prevents


### PR DESCRIPTION
### Explain the Changes
This PR fixes the `ENOTSUP` issue in the `_finalize_restore`. When the `xattr_get_keys` are provided then fs_napi tries to use `fgetxattr` to read `dmapi.*` xattrs which it cannot resulting in `ENOTSUP` error.

We don't have to provide `xattr_get_keys` to read the concerned attributes (request days and premigrated xattr) as by default NooBaa anyway would read the desired xattrs.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved reliability of Glacier restore finalization by more accurately detecting premigration state, reducing false failures and ensuring correct expiry timing in environments using DMAPI metadata.

- Performance
  - Streamlined metadata reads during restore operations, reducing overhead and improving consistency without changing external behavior or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->