### PR TITLE
Read only uses

### DIFF
--- a/config.js
+++ b/config.js
@@ -251,6 +251,10 @@ config.DB_TYPE = /** @type {nb.DBType} */ (process.env.DB_TYPE || 'postgres');
 config.POSTGRES_DEFAULT_MAX_CLIENTS = 10;
 config.POSTGRES_MD_MAX_CLIENTS = (process.env.LOCAL_MD_SERVER === 'true') ? 70 : 10;
 
+//whether to use read-only postgres replica cluster
+//ro host is set by operator in process.env.POSTGRES_HOST_RO
+config.POSTGRES_USE_READ_ONLY = true;
+
 ///////////////////
 // SYSTEM CONFIG //
 ///////////////////

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -766,7 +766,7 @@ interface DBCollection {
 
     validate(doc: object, warn?: 'warn'): object;
 
-    executeSQL<T>(query: string, params: Array<any>, options?: { query_name?: string }): Promise<sqlResult<T>>;
+    executeSQL<T>(query: string, params: Array<any>, options?: { query_name?: string, preferred_pool?: string }): Promise<sqlResult<T>>;
     name: any;
 }
 

--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -62,19 +62,19 @@ async function clean_md_store(last_date_to_remove) {
     }
     dbg.log0('DB_CLEANER: checking md-store for documents deleted before', new Date(last_date_to_remove));
     const objects_to_remove = await MDStore.instance().find_deleted_objects(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
-    dbg.log2('DB_CLEANER: list objects:', objects_to_remove);
+    dbg.log0('DB_CLEANER: list objects:', objects_to_remove);
     if (objects_to_remove.length) {
         await P.map_with_concurrency(10, objects_to_remove, obj => db_delete_object_parts(obj));
         await MDStore.instance().db_delete_objects(objects_to_remove);
     }
     const blocks_to_remove = await MDStore.instance().find_deleted_blocks(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
-    dbg.log2('DB_CLEANER: list blocks:', blocks_to_remove);
+    dbg.log0('DB_CLEANER: list blocks:', blocks_to_remove);
     if (blocks_to_remove.length) await MDStore.instance().db_delete_blocks(blocks_to_remove);
     const chunks_to_remove = await MDStore.instance().find_deleted_chunks(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
     const filtered_chunks = chunks_to_remove.filter(async chunk =>
         !(await MDStore.instance().has_any_blocks_for_chunk(chunk)) &&
         !(await MDStore.instance().has_any_parts_for_chunk(chunk)));
-    dbg.log2('DB_CLEANER: list chunks with no blocks and no parts to be removed from DB', filtered_chunks);
+    dbg.log0('DB_CLEANER: list chunks with no blocks and no parts to be removed from DB', filtered_chunks);
     if (filtered_chunks.length) await MDStore.instance().db_delete_chunks(filtered_chunks);
     dbg.log0(`DB_CLEANER: removed ${objects_to_remove.length + blocks_to_remove.length + filtered_chunks.length} documents from md-store`);
 }

--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -62,19 +62,19 @@ async function clean_md_store(last_date_to_remove) {
     }
     dbg.log0('DB_CLEANER: checking md-store for documents deleted before', new Date(last_date_to_remove));
     const objects_to_remove = await MDStore.instance().find_deleted_objects(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
-    dbg.log0('DB_CLEANER: list objects:', objects_to_remove);
+    dbg.log2('DB_CLEANER: list objects:', objects_to_remove);
     if (objects_to_remove.length) {
         await P.map_with_concurrency(10, objects_to_remove, obj => db_delete_object_parts(obj));
         await MDStore.instance().db_delete_objects(objects_to_remove);
     }
     const blocks_to_remove = await MDStore.instance().find_deleted_blocks(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
-    dbg.log0('DB_CLEANER: list blocks:', blocks_to_remove);
+    dbg.log2('DB_CLEANER: list blocks:', blocks_to_remove);
     if (blocks_to_remove.length) await MDStore.instance().db_delete_blocks(blocks_to_remove);
     const chunks_to_remove = await MDStore.instance().find_deleted_chunks(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
     const filtered_chunks = chunks_to_remove.filter(async chunk =>
         !(await MDStore.instance().has_any_blocks_for_chunk(chunk)) &&
         !(await MDStore.instance().has_any_parts_for_chunk(chunk)));
-    dbg.log0('DB_CLEANER: list chunks with no blocks and no parts to be removed from DB', filtered_chunks);
+    dbg.log2('DB_CLEANER: list chunks with no blocks and no parts to be removed from DB', filtered_chunks);
     if (filtered_chunks.length) await MDStore.instance().db_delete_chunks(filtered_chunks);
     dbg.log0(`DB_CLEANER: removed ${objects_to_remove.length + blocks_to_remove.length + filtered_chunks.length} documents from md-store`);
 }

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1123,7 +1123,7 @@ class MDStore {
         FROM ${this._objects.name}
         WHERE (to_ts(data->>'deleted')<to_ts($1) and data ? 'deleted' and data ? 'reclaimed') 
         LIMIT ${query_limit};`;
-        const result = await this._objects.executeSQL(query, [new Date(max_delete_time).toISOString()]);
+        const result = await this._objects.executeSQL(query, [new Date(max_delete_time).toISOString()], {preferred_pool: 'read_only'});
         return db_client.instance().uniq_ids(result.rows, '_id');
     }
 
@@ -1773,7 +1773,8 @@ class MDStore {
                 projection: {
                     _id: 1,
                     deleted: 1
-                }
+                },
+                preferred_pool: 'read_only'
             })
             .then(objects => db_client.instance().uniq_ids(objects, '_id'));
     }
@@ -1781,6 +1782,8 @@ class MDStore {
     has_any_blocks_for_chunk(chunk_id) {
         return this._blocks.findOne({
                 chunk: { $eq: chunk_id, $exists: true },
+            }, {
+                preferred_pool: 'read_only'
             })
             .then(obj => Boolean(obj));
     }
@@ -1788,6 +1791,8 @@ class MDStore {
     has_any_parts_for_chunk(chunk_id) {
         return this._parts.findOne({
                 chunk: { $eq: chunk_id, $exists: true },
+            }, {
+                preferred_pool: 'read_only'
             })
             .then(obj => Boolean(obj));
     }
@@ -2029,7 +2034,8 @@ class MDStore {
                 projection: {
                     _id: 1,
                     deleted: 1
-                }
+                },
+                preferred_pool: 'read_only'
             })
             .then(objects => db_client.instance().uniq_ids(objects, '_id'));
     }

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1600,6 +1600,7 @@ class MDStore {
                     _id: -1
                 },
                 limit: limit,
+                preferred_pool: 'read_only',
             })
 
             .then(chunks => ({

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -776,6 +776,7 @@ class MDStore {
         }, {
             limit: Math.min(limit, 1000),
             hint: 'deleted_unreclaimed_index',
+            preferred_pool: 'read_only',
         });
         return results;
     }

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1525,7 +1525,11 @@ class PostgresClient extends EventEmitter {
             // get the connection configuration. first from env, then from file, then default
             const host = process.env.POSTGRES_HOST || fs_utils.try_read_file_sync(process.env.POSTGRES_HOST_PATH) || '127.0.0.1';
             //optional read-only host. if not present defaults to general pg host
-            const host_ro = process.env.POSTGRES_HOST_RO || fs_utils.try_read_file_sync(process.env.POSTGRES_HOST_RO_PATH) || host;
+            let host_ro = process.env.POSTGRES_HOST_RO || fs_utils.try_read_file_sync(process.env.POSTGRES_HOST_RO_PATH) || host;
+            //if POSTGRES_USE_READ_ONLY is off, switch to regular host
+            if (!config.POSTGRES_USE_READ_ONLY) {
+                host_ro = host;
+            }
             const user = process.env.POSTGRES_USER || fs_utils.try_read_file_sync(process.env.POSTGRES_USER_PATH) || 'postgres';
             const password = process.env.POSTGRES_PASSWORD || fs_utils.try_read_file_sync(process.env.POSTGRES_PASSWORD_PATH) || 'noobaa';
             const database = process.env.POSTGRES_DBNAME || fs_utils.try_read_file_sync(process.env.POSTGRES_DBNAME_PATH) || 'nbcore';

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -632,7 +632,7 @@ class PostgresTable {
     get_pool(key = this.pool_key) {
         const pool = this.client.get_pool(key);
         if (!pool) {
-            //if original get_pool was no for the default this.pool_key, try also this.pool_key
+            //if original get_pool was not for the default this.pool_key, try also this.pool_key
             if (key && key !== this.pool_key) {
                 return this.get_pool();
             }


### PR DESCRIPTION
### Describe the Problem
Use new 'read only' pool (connected to cnpg replicated read-only cluster) in order to alleviate load from main, writable pg cluster.

### Explain the Changes
1. Move some background queries to read-only pool:
-db cleancer
-object reclaimer's first find
-scrubber's first find

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query API accepts an optional preferred-pool parameter to route individual queries to a specific database pool.
  * New config flag POSTGRES_USE_READ_ONLY to toggle use of read-only replicas (defaults to true).

* **Improvements**
  * Read operations prefer read-only replicas to distribute load.
  * Queries fall back and retry on the primary pool when a preferred pool is unavailable.

* **Observability**
  * Added debug logging for query host selection and retry behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->