### PR TITLE
[NSFS | NC | Glacier] Fix migrate hang under race condition

### DIFF
--- a/src/util/persistent_logger.js
+++ b/src/util/persistent_logger.js
@@ -59,6 +59,8 @@ class PersistentLogger {
                 undefined,
                 { lock: this.locking, retries: 10, backoff: 5 }
             );
+            this.fh_stat = await this.fh.stat(this.fs_context);
+            this.local_size = 0;
 
             return this.fh;
         });


### PR DESCRIPTION
### Describe the Problem
Tape team discovered that sometimes, `noobaa-cli glacier migrate` `noobaa-cli glacier restore` would hang indefinitely. Upon investigation it was found that it was the migrate process which was hanging but due to acquiring a cluster wide lock, it was blocking the restore command as well.

The migrate process was hanging because it was trying to acquire an `EXCLUSIVE` lock on the migration lock but one of the NooBaa server process was not releasing the lock. We have a detection mechanism in persistent_logger which must release the lock eventually however this detection was failing. The root cause of the failure was that in an earlier PR of mine ([#9183](https://github.com/noobaa/noobaa-core/pull/9183)), I missed updating the `fh_stat` information which is used by a part of this detection mechanism,

### Explain the Changes
This PR updates the code to ensure that the `fh_stat` value is updated correctly.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.ibm.com/Tier2/Test-Issue/issues/159

### Testing Instructions:
1. Set `NOOBAA_LOG_LEVEL="all"` in config
2. Start the NooBaa server
3. Put an object (to ensure that the process is holding the lock on the migration log)
4. Run `rm -rf <LOG_DIR>/migrate.log && touch <LOG_DIR>/migrate.log`
5. Ensure that NooBaa emits `active file changed, closing for namespace: migrate`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly initializes log metadata and in-memory size counters when opening active logs, reducing inconsistencies.
  * Improves accuracy of log size tracking and stability during logging sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->