### PR TITLE
Added a fix for S3 namespace bucket caching while upload

### DIFF
--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -664,7 +664,7 @@ class NamespaceCache {
                 source_stream: cache_stream,
                 async_get_last_modified_time: async () => {
                     const upload_res = await hub_promise;
-                    const last_modified_time = (new Date(upload_res.last_modified_time)).getTime();
+                    const last_modified_time = (new Date(upload_res.date)).getTime();
                     if (isNaN(last_modified_time)) {
                         throw new Error('Invalid last_modified_time returned from hub_promise, Expected a valid date or timestamp.');
                     }

--- a/src/test/unit_tests/internal/test_namespace_cache.js
+++ b/src/test/unit_tests/internal/test_namespace_cache.js
@@ -276,7 +276,7 @@ class MockNamespace {
                 if (this._write_err) {
                     // Simulate success in the case that the error is caused by other stream
                     console.log(`${this.type} mock: write err bucket ${params.bucket} key ${params.key}`);
-                    resolve({ etag, last_modified_time: create_time });
+                    resolve({ etag, date: create_time });
                     return;
                 }
 
@@ -296,7 +296,7 @@ class MockNamespace {
                         buf: this._buf,
                         size: params.size,
                     });
-                resolve({ etag, last_modified_time: create_time });
+                resolve({ etag, date: create_time });
             });
             params.source_stream.on('finish', async () => {
                 console.log(`${this.type} mock: got finish in upload_object: bucket ${params.bucket} key ${params.key}`, recv_buf);
@@ -434,7 +434,7 @@ mocha.describe('namespace caching: upload scenarios', () => {
             return !_.isUndefined(cache_obj_create_time);
         }, 5000);
         const cache_obj = cache.get_obj(bucket, key);
-        assert(cache_obj.create_time === ret.last_modified_time);
+        assert(cache_obj.create_time === ret.date);
     });
 
     mocha.it('hub upload failure: object not cached', async () => {


### PR DESCRIPTION
### Describe the Problem
Cache bucket uploads were failing with error "Invalid last_modified_time returned from hub_promise" when using S3 namespace as the hub. The cache upload would abort even though the hub upload succeeded, preventing objects from being cached locally.

### Explain the Changes
1. Fixed field name mismatch in `namespace_cache.js` changed `upload_res.last_modified_time` to `upload_res.date` to match the field name returned by `namespace_s3.js` hub upload response.

### Issues: Fixed #xxx / Gap #xxx
1. Bug fixed: https://issues.redhat.com/browse/DFBUGS-4148
2. PR (GAP): #9163 

### Testing Instructions:
1. Create aws namespacestore bucket with caching upload some object to the bucket and verify if the objects are available in the cache using list_objects noobaa api.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp retrieval during cache uploads so the stored modification time now comes from the correct response field.
* **Tests**
  * Updated unit tests to reflect the revised upload response format and ensure cache timestamps are validated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->