### PR TITLE
Revert "NC |  don't stat directories in list_object"

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -737,18 +737,16 @@ class NamespaceFS {
                     if (!delimiter && r.common_prefix) {
                         await process_dir(r.key);
                     } else {
-                        if (!r.common_prefix) {
-                            const entry_path = path.join(this.bucket_path, r.key);
-                            // If entry is outside of bucket, returns stat of symbolic link
-                            const use_lstat = !(await this._is_path_in_bucket_boundaries(fs_context, entry_path));
-                            const stat = await native_fs_utils.stat_if_exists(fs_context, entry_path,
-                                use_lstat, config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES);
-                            // TODO - GAP of .folder files - we return stat of the directory for the 
-                            // xattr, but the creation time should be of the .folder files (and maybe more )
-                            if (stat) r.stat = stat;
-                        }
-                        // add the result only if we have the stat information or a directory
-                        if (r.stat || r.common_prefix) {
+                        const entry_path = path.join(this.bucket_path, r.key);
+                        // If entry is outside of bucket, returns stat of symbolic link
+                        const use_lstat = !(await this._is_path_in_bucket_boundaries(fs_context, entry_path));
+                        const stat = await native_fs_utils.stat_if_exists(fs_context, entry_path,
+                            use_lstat, config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES);
+                        // TODO - GAP of .folder files - we return stat of the directory for the 
+                        // xattr, but the creation time should be of the .folder files (and maybe more )
+                        if (stat) {
+                            r.stat = stat;
+                            // add the result only if we have the stat information
                             if (pos < results.length) {
                                 results.splice(pos, 0, r);
                             } else {


### PR DESCRIPTION
This reverts commit 2edaf375d53d3bc35b8b05b6eb4727da8ac8c48d.

### Describe the Problem
As we didn't get the expected result of this fix, we will revert it and go with a different approach.

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined namespace listing logic to exclude entries lacking file system metadata (unless they are common prefix entries). This ensures that only entries with complete information are included in listing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->