### PR TITLE
NC | Ignore EINVAL in stat for list

### DIFF
--- a/config.js
+++ b/config.js
@@ -1013,6 +1013,8 @@ config.NFSF_UPLOAD_STREAM_MEM_THRESHOLD = 8 * 1024 * 1024;
 
 // we want to change our handling related to EACCESS error
 config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES = true;
+// we will for now handle the same way also EINVAL error - for gpfs stat issues on list (.snapshots)
+config.NSFS_LIST_IGNORE_ENTRY_ON_EINVAL = true;
 
 ////////////////////////////
 // NSFS NON CONTAINERIZED //

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -318,6 +318,8 @@ async function stat_if_exists(fs_context, entry_path, use_lstat, should_ignore_e
         // we might want to expand the error list due to permission/structure
         // change (for example: ELOOP, ENAMETOOLONG) or other reason (EPERM) - need to be decided
         if ((err.code === 'EACCES' && should_ignore_eacces) ||
+            // A fix for GPFS stat issues on list (.snapshots) - ignore EINVAL as well
+            (err.code === 'EINVAL' && config.NSFS_LIST_IGNORE_ENTRY_ON_EINVAL) ||
             err.code === 'ENOENT' || err.code === 'ENOTDIR') {
             dbg.log0('stat_if_exists: Could not access file entry_path',
                 entry_path, 'error code', err.code, ', skipping...');


### PR DESCRIPTION
### Describe the Problem
Reading extended attributes on internal directories on GPFS causes EINVAL and fails to list them.
We will now ignore this error - hopefully until we have a better way in identifying such directories.

### Explain the Changes
1. Skipping EINVAL just on list - so we won't fail the whole command - we will skip and log the issue in the log like we do for EACCESS

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file system listing operations to gracefully handle and ignore additional error conditions, improving system resilience and stability during edge case scenarios.

* **Chores**
  * Added configuration option to control error handling behavior during file system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->