### PR TITLE
[Backport into 5.20] Added a fix for namespace bucket caching while upload

### DIFF
--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -664,7 +664,7 @@ class NamespaceCache {
                 source_stream: cache_stream,
                 async_get_last_modified_time: async () => {
                     const upload_res = await hub_promise;
-                    const last_modified_time = (new Date(upload_res.last_modified_time)).getTime();
+                    const last_modified_time = (new Date(upload_res.date)).getTime();
                     if (isNaN(last_modified_time)) {
                         throw new Error('Invalid last_modified_time returned from hub_promise, Expected a valid date or timestamp.');
                     }

--- a/src/test/unit_tests/internal/test_namespace_cache.js
+++ b/src/test/unit_tests/internal/test_namespace_cache.js
@@ -276,7 +276,7 @@ class MockNamespace {
                 if (this._write_err) {
                     // Simulate success in the case that the error is caused by other stream
                     console.log(`${this.type} mock: write err bucket ${params.bucket} key ${params.key}`);
-                    resolve({ etag, last_modified_time: create_time });
+                    resolve({ etag, date: create_time });
                     return;
                 }
 
@@ -296,7 +296,7 @@ class MockNamespace {
                         buf: this._buf,
                         size: params.size,
                     });
-                resolve({ etag, last_modified_time: create_time });
+                resolve({ etag, date: create_time });
             });
             params.source_stream.on('finish', async () => {
                 console.log(`${this.type} mock: got finish in upload_object: bucket ${params.bucket} key ${params.key}`, recv_buf);
@@ -434,7 +434,7 @@ mocha.describe('namespace caching: upload scenarios', () => {
             return !_.isUndefined(cache_obj_create_time);
         }, 5000);
         const cache_obj = cache.get_obj(bucket, key);
-        assert(cache_obj.create_time === ret.last_modified_time);
+        assert(cache_obj.create_time === ret.date);
     });
 
     mocha.it('hub upload failure: object not cached', async () => {


### PR DESCRIPTION
### Explain the Changes

Added a fix for namespace bucket caching while upload
(cherry picked from commit 18d685973ef8a582afe1da7a44555c475ab5192d)

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-4148
