### PR TITLE
NC | list_objects skip another case of stat failure on EINVAL

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -808,6 +808,10 @@ class NamespaceFS {
                         dbg.log0('NamespaceFS: no keys for non existing dir', dir_path);
                         return;
                     }
+                    if (err.code === 'EINVAL' && config.NSFS_LIST_IGNORE_ENTRY_ON_EINVAL) {
+                        dbg.log0('NamespaceFS: can\'t stat directory (probably internal gpfs directory)', dir_path);
+                        return;
+                    }
                     throw err;
                 }
 


### PR DESCRIPTION
### Describe the Problem
In continue to #9247 We missed another case of stat, for the dir cache - now both fixed

### Explain the Changes
1.  add a skip for EINVAL

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during namespace listing: when a specific configuration flag is enabled, certain invalid-entry errors are ignored rather than causing the operation to fail, reducing unexpected crashes and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->