### PR TITLE
IAM | IAM Validation Input Fix to Use Regex with Anchor Start and Anchor End

### DIFF
--- a/src/test/unit_tests/api/iam/test_iam_utils.test.js
+++ b/src/test/unit_tests/api/iam/test_iam_utils.test.js
@@ -181,7 +181,6 @@ describe('parse_max_items', () => {
 
 describe('validate_user_input_iam', () => {
     describe('validate_iam_path', () => {
-        const min_length = 1;
         const max_length = 512;
         it('should return true when path is undefined', () => {
             let dummy_path;
@@ -201,8 +200,8 @@ describe('validate_user_input_iam', () => {
         });
 
         it('should return true when path is within the length constraint', () => {
-            expect(iam_utils.validate_iam_path('/'.repeat(min_length + 1))).toBe(true);
-            expect(iam_utils.validate_iam_path('/'.repeat(max_length - 1))).toBe(true);
+            expect(iam_utils.validate_iam_path('/a/')).toBe(true);
+            expect(iam_utils.validate_iam_path('/' + 'a'.repeat(max_length - 3) + '/')).toBe(true);
         });
 
         it('should return true when path is valid', () => {

--- a/src/test/unit_tests/util_functions_tests/test_string_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_string_utils.test.js
@@ -1,0 +1,72 @@
+/* Copyright (C) 2025 NooBaa */
+'use strict';
+const iam_utils = require('../../../util/string_utils');
+
+describe('test regex', () => {
+    describe('test regex - iam path', () => {
+
+        it('iam path of /', () => {
+            const valid_path = '/';
+            const res = iam_utils.AWS_IAM_PATH_REGEXP.test(valid_path);
+            expect(res).toBe(true);
+        });
+
+        it('iam path with / at the beginning and / at the end', () => {
+            const valid_path = '/division_abc/subdivision_xyz/';
+            const res = iam_utils.AWS_IAM_PATH_REGEXP.test(valid_path);
+            expect(res).toBe(true);
+        });
+
+        it('iam path of //', () => {
+            const invalid_path = '//';
+            const res = iam_utils.AWS_IAM_PATH_REGEXP.test(invalid_path);
+            expect(res).toBe(false);
+        });
+
+        it('iam path without / at the end', () => {
+            const invalid_path = '/division_abc/subdivision_xyz';
+            const res = iam_utils.AWS_IAM_PATH_REGEXP.test(invalid_path);
+            expect(res).toBe(false);
+        });
+
+        it('iam path without / at the beginning', () => {
+            const invalid_path = 'division_abc/subdivision_xyz/';
+            const res = iam_utils.AWS_IAM_PATH_REGEXP.test(invalid_path);
+            expect(res).toBe(false);
+        });
+
+        it('iam path without / at the beginning and / at the end', () => {
+            const invalid_path = 'division_abc';
+            const res = iam_utils.AWS_IAM_PATH_REGEXP.test(invalid_path);
+            expect(res).toBe(false);
+        });
+    });
+
+    describe('test regex - username', () => {
+
+        it('username of alphanumeric characters', () => {
+            const valid_username = 'myuser123';
+            const res = iam_utils.AWS_USERNAME_REGEXP.test(valid_username);
+            expect(res).toBe(true);
+        });
+
+        it('username of with chars out of scope at the beginning', () => {
+            const invalid_username = ':myuser123';
+            const res = iam_utils.AWS_USERNAME_REGEXP.test(invalid_username);
+            expect(res).toBe(false);
+        });
+
+        it('username of with chars out of scope at the end', () => {
+            const invalid_username = 'myuser123:';
+            const res = iam_utils.AWS_USERNAME_REGEXP.test(invalid_username);
+            expect(res).toBe(false);
+        });
+
+        it('username of with chars out of scope at the middle', () => {
+            const invalid_username = 'myuser:123';
+            const res = iam_utils.AWS_USERNAME_REGEXP.test(invalid_username);
+            expect(res).toBe(false);
+        });
+
+    });
+});

--- a/src/util/string_utils.js
+++ b/src/util/string_utils.js
@@ -11,10 +11,10 @@ const escape_regexp = /[\\^$.*+?()[\]{}|]/g;
 const access_key_regexp = /^[a-zA-Z0-9]{20}$/;
 const secret_key_regexp = /^[a-zA-Z0-9+/]{40}$/;
 // regex for IAM service
-const AWS_IAM_PATH_REGEXP = /(\u002F)|(\u002F[\u0021-\u007E]+\u002F)/;
-const AWS_USERNAME_REGEXP = /[\w+=,.@-]+/;
-const AWS_IAM_LIST_MARKER = /[\u0020-\u00FF]+/;
-const AWS_IAM_ACCESS_KEY_INPUT_REGEXP = /[\w]+/;
+const AWS_IAM_PATH_REGEXP = /^(\u002F|\u002F[\u0021-\u007E]+\u002F)$/;
+const AWS_USERNAME_REGEXP = /^[\w+=,.@-]+$/;
+const AWS_IAM_LIST_MARKER = /^[\u0020-\u00FF]+$/;
+const AWS_IAM_ACCESS_KEY_INPUT_REGEXP = /^[\w]+$/;
 
 function crypto_random_string(len, charset = ALPHA_NUMERIC_CHARSET) {
     // In order to not favor any specific chars over others we limit the maximum random value


### PR DESCRIPTION
### Describe the Problem
I noticed that I could use an invalid parameter in the username when I checked IAM CreateUser API.

### Explain the Changes
1. IAM validation input fix to use regex with anchor start and anchor end.
2. Change a test to avoid using an invalid IAM path.

### Issues:
1. none

### Testing Instructions:
#### Unit Tests
1. Please run: `npx jest test_string_utils.test.js`
3. (for the test that was changed, please run: `npx jest test_iam_utils.test`).


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for IAM path and username validation that cover a range of valid and invalid edge cases.

* **Bug Fixes**
  * Strengthened IAM-related input validation so patterns now require full-string matches (not substrings), improving accuracy for paths, usernames, list markers, and access keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->