### PR TITLE
[NSFS | NC | Glacier] Disable force eviction on partial reads

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1189,7 +1189,11 @@ class NamespaceFS {
                 }
             }
 
-            await this._glacier_force_expire_on_get(fs_context, file_path, file, stat);
+            // Force evict only if the entire object is being read as part
+            // of the same request
+            if (start === 0 && end >= stat.size) {
+                await this._glacier_force_expire_on_get(fs_context, file_path, file, stat);
+            }
 
             await file.close(fs_context);
             file = null;


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
This PR adds minor code addition to ensure that we do not trigger force eviction if the read is partial ranged read. This PR also adds tests for forced eviction.

### Issues: Fixed #xxx / Gap #xxx
Fixes #9240 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Glacier object eviction now occurs only when a read requests the entire object from the start; partial/ranged reads no longer trigger eviction, preventing premature expirations and improving read reliability and performance across read flows.

* **Tests**
  * Added unit tests confirming eviction after a full-object read and confirming no eviction during ranged/partial reads for the relevant read paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->