### PR TITLE
Added a fix for AWS/Azure S3 namespace bucket caching while upload

### DIFF
--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -664,7 +664,7 @@ class NamespaceCache {
                 source_stream: cache_stream,
                 async_get_last_modified_time: async () => {
                     const upload_res = await hub_promise;
-                    const last_modified_time = (new Date(upload_res.date)).getTime();
+                    const last_modified_time = (new Date(upload_res.last_modified_time)).getTime();
                     if (isNaN(last_modified_time)) {
                         throw new Error('Invalid last_modified_time returned from hub_promise, Expected a valid date or timestamp.');
                     }

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -376,7 +376,7 @@ class NamespaceS3 {
         }
         dbg.log0('NamespaceS3.upload_object:', this.bucket, inspect(params), 'res', inspect(res), 'Date', date);
         const etag = s3_utils.parse_etag(res.ETag || res.CopyObjectResult?.ETag);
-        return { etag, version_id: res.VersionId, date };
+        return { etag, version_id: res.VersionId, last_modified_time: date };
     }
 
     ////////////////////////

--- a/src/test/unit_tests/internal/test_namespace_cache.js
+++ b/src/test/unit_tests/internal/test_namespace_cache.js
@@ -276,7 +276,7 @@ class MockNamespace {
                 if (this._write_err) {
                     // Simulate success in the case that the error is caused by other stream
                     console.log(`${this.type} mock: write err bucket ${params.bucket} key ${params.key}`);
-                    resolve({ etag, date: create_time });
+                    resolve({ etag, last_modified_time: create_time });
                     return;
                 }
 
@@ -296,7 +296,7 @@ class MockNamespace {
                         buf: this._buf,
                         size: params.size,
                     });
-                resolve({ etag, date: create_time });
+                resolve({ etag, last_modified_time: create_time });
             });
             params.source_stream.on('finish', async () => {
                 console.log(`${this.type} mock: got finish in upload_object: bucket ${params.bucket} key ${params.key}`, recv_buf);
@@ -434,7 +434,7 @@ mocha.describe('namespace caching: upload scenarios', () => {
             return !_.isUndefined(cache_obj_create_time);
         }, 5000);
         const cache_obj = cache.get_obj(bucket, key);
-        assert(cache_obj.create_time === ret.date);
+        assert(cache_obj.create_time === ret.last_modified_time);
     });
 
     mocha.it('hub upload failure: object not cached', async () => {


### PR DESCRIPTION
### Describe the Problem

Cache bucket uploads were failing with error "Invalid last_modified_time returned from hub_promise" when using S3 namespace as the hub. The cache upload would abort even though the hub upload succeeded, preventing objects from being cached locally for AWS and Azure bucket.

Replication is failing for AWS and Azure namespace cached buckets

### Explain the Changes
1. Fetch last modified time for AWS from `upload_res.last_modified_time`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Create two namespacestore cache buckets, one with AWS and second with Azure
2. Add bidirectional replication on the two buckets

```
kubectl  patch obc my-bucket-aws -p '{"spec": {"additionalConfig": {"replicationPolicy": "{\"rules\": [{\"rule_id\": \"basic-replication-rule-2\", \"destination_bucket\": \"azure-bucket-ab8311e3-e6b6-4349-b6c2-daf0329e954c\", \"filter\": {\"prefix\": \"bidi_1\"}}]}"}}}' --type merge

kubectl  patch obc azure-bucket -p '{"spec": {"additionalConfig": {"replicationPolicy": "{\"rules\": [{\"rule_id\": \"basic-replication-rule-3\", \"destination_bucket\": \"my-bucket-aws-db83d155-55bc-4963-96dc-0b49c0b0dcd2\", \"filter\": {\"prefix\": \"log\"}}]}"}}}' --type merge
```

3. Verify the Replication.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent handling of object last-modified timestamps during uploads, with improved validation and conversion to a unified timestamp.
  * API response now exposes the timestamp as last_modified_time (replacing the previous date field), so integrations should read last_modified_time for upload results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->