### PR TITLE
IAM | Add IAM endpoint port in `config.js`

### DIFF
--- a/config.js
+++ b/config.js
@@ -1032,7 +1032,8 @@ config.ENDPOINT_PORT = Number(process.env.ENDPOINT_PORT) || 6001;
 config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
 // Remove the NSFS condition when NSFS starts to support STS.
 config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || (process.env.NC_NSFS_NO_DB_ENV === 'true' ? -1 : 7443);
-config.ENDPOINT_SSL_IAM_PORT = Number(process.env.ENDPOINT_SSL_IAM_PORT) || -1;
+// Remove the NC NSFS condition when NC NSFS starts to support IAM.
+config.ENDPOINT_SSL_IAM_PORT = Number(process.env.ENDPOINT_SSL_IAM_PORT) || (process.env.NC_NSFS_NO_DB_ENV === 'true' ? -1 : 13443);
 // each fork will get port in range [ENDPOINT_FORK_PORT_BASE, ENDPOINT_FORK_PORT_BASE + number of forks - 1)]
 config.ENDPOINT_FORK_PORT_BASE = Number(process.env.ENDPOINT_FORK_PORT_BASE) || 6002;
 config.ALLOW_HTTP = false;


### PR DESCRIPTION
### Describe the Problem
In noobaa/noobaa-operator#1721 the IAM service and route were created; we need to set the port in the endpoint as well.

### Explain the Changes
1. Update `ENDPOINT_SSL_IAM_PORT` to be the same number as in the mentioned PR.
Note: Currently, it is not open for IAM NC. 

### Issues:
1. None

### Testing Instructions:
1. Mentioned in noobaa/noobaa-operator#1721 ([link](https://github.com/noobaa/noobaa-operator/pull/1721#issuecomment-3450260748)).


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Adjusted the default SSL IAM endpoint port behavior so the fallback port now varies depending on the runtime environment flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->