### PR TITLE
IAM | IAM User Policy API (Skeleton Only)

### DIFF
--- a/src/endpoint/iam/iam_constants.js
+++ b/src/endpoint/iam/iam_constants.js
@@ -12,7 +12,11 @@ const IAM_ACTIONS = Object.freeze({
     GET_ACCESS_KEY_LAST_USED: 'get_access_key_last_used',
     UPDATE_ACCESS_KEY: 'update_access_key',
     DELETE_ACCESS_KEY: 'delete_access_key',
-    LIST_ACCESS_KEYS: 'list_access_keys'
+    LIST_ACCESS_KEYS: 'list_access_keys',
+    PUT_USER_POLICY: 'put_user_policy',
+    GET_USER_POLICY: 'get_user_policy',
+    DELETE_USER_POLICY: 'delete_user_policy',
+    LIST_USER_POLICIES: 'list_user_policies',
 });
 
 // key: action - the function name on accountspace_fs (snake case style)
@@ -29,6 +33,10 @@ const ACTION_MESSAGE_TITLE_MAP = Object.freeze({
     'update_access_key': 'UpdateAccessKey',
     'delete_access_key': 'DeleteAccessKey',
     'list_access_keys': 'ListAccessKeys',
+    'put_user_policy': 'PutUserPolicy',
+    'get_user_policy': 'GetUserPolicy',
+    'delete_user_policy': 'DeleteUserPolicy',
+    'list_user_policies': 'ListUserPolicies',
 });
 
 const ACCESS_KEY_STATUS_ENUM = Object.freeze({
@@ -56,6 +64,8 @@ const IAM_PARAMETER_NAME = Object.freeze({
     IAM_PATH_PREFIX: 'PathPrefix',
     USERNAME: 'UserName',
     NEW_USERNAME: 'NewUserName',
+    POLICY_NAME: 'PolicyName',
+    POLICY_DOCUMENT: 'PolicyDocument',
 });
 
 const IAM_SPLIT_CHARACTERS = ':';

--- a/src/endpoint/iam/iam_errors.js
+++ b/src/endpoint/iam/iam_errors.js
@@ -140,6 +140,11 @@ IamError.NotImplemented = Object.freeze({
 // UpdateAccessKey      errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateAccessKey.html
 // DeleteAccessKey      errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteAccessKey.html
 // ListAccessKeys       errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAccessKeys.html
+// user policy
+// PutUserPolicy    errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutUserPolicy.html
+// GetUserPolicy    errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUserPolicy.html
+// DeleteUserPolicy errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteUserPolicy.html
+// ListUserPolicies errors https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUserPolicies.html
 IamError.ConcurrentModification = Object.freeze({
     code: 'ConcurrentModification',
     message: 'The request was rejected because multiple requests to change this object were submitted simultaneously. Wait a few minutes and submit your request again.',
@@ -188,6 +193,13 @@ IamError.EntityTemporarilyUnmodifiable = Object.freeze({
     http_code: 409,
     type: error_type_enum.SENDER,
 });
+IamError.MalformedPolicyDocument = Object.freeze({
+    code: 'MalformedPolicyDocument',
+    message: 'The request was rejected because the policy document was malformed',
+    http_code: 400,
+    type: error_type_enum.SENDER,
+});
+
 
 // These errors were copied from STS errors
 IamError.InvalidParameterValue = Object.freeze({

--- a/src/endpoint/iam/iam_rest.js
+++ b/src/endpoint/iam/iam_rest.js
@@ -21,6 +21,7 @@ const RPC_ERRORS_TO_IAM = Object.freeze({
     NO_SUCH_ACCOUNT: IamError.AccessDeniedException,
     NO_SUCH_ROLE: IamError.AccessDeniedException,
     VALIDATION_ERROR: IamError.ValidationError,
+    MALFORMED_POLICY_DOCUMENT: IamError.MalformedPolicyDocument,
 });
 
 const ACTIONS = Object.freeze({
@@ -34,6 +35,10 @@ const ACTIONS = Object.freeze({
     'UpdateAccessKey': 'update_access_key',
     'DeleteAccessKey': 'delete_access_key',
     'ListAccessKeys': 'list_access_keys',
+    'PutUserPolicy': 'put_user_policy',
+    'GetUserPolicy': 'get_user_policy',
+    'DeleteUserPolicy': 'delete_user_policy',
+    'ListUserPolicies': 'list_user_policies',
     'ListGroupsForUser': 'list_groups_for_user',
     'ListAccountAliases': 'list_account_aliases',
     'ListAttachedGroupPolicies': 'list_attached_group_policies',
@@ -60,7 +65,6 @@ const ACTIONS = Object.freeze({
     'ListServiceSpecificCredentials': 'list_service_specific_credentials',
     'ListSigningCertificates': 'list_signing_certificates',
     'ListSSHPublicKeys': 'list_ssh_public_keys',
-    'ListUserPolicies': 'list_user_policies',
     'ListUserTags': 'list_user_tags',
     'ListVirtualMFADevices': 'list_virtual_mfa_devices',
 });
@@ -79,6 +83,11 @@ const IAM_OPS = js_utils.deep_freeze({
     post_update_access_key: require('./ops/iam_update_access_key'),
     post_delete_access_key: require('./ops/iam_delete_access_key'),
     post_list_access_keys: require('./ops/iam_list_access_keys'),
+    // user policy
+    post_put_user_policy: require('./ops/iam_put_user_policy'),
+    post_get_user_policy: require('./ops/iam_get_user_policy'),
+    post_delete_user_policy: require('./ops/iam_delete_user_policy'),
+    post_list_user_policies: require('./ops/iam_list_user_policies'),
     // other (currently ops that return empty or NoSuchEntity error - just not to fail them)
     post_list_groups_for_user: require('./ops/iam_list_groups_for_user.js'),
     post_list_account_aliases: require('./ops/iam_list_account_aliases.js'),
@@ -106,7 +115,6 @@ const IAM_OPS = js_utils.deep_freeze({
     post_list_service_specific_credentials: require('./ops/iam_list_service_specific_credentials.js'),
     post_list_signing_certificates: require('./ops/iam_list_signing_certificates.js'),
     post_list_ssh_public_keys: require('./ops/iam_list_ssh_public_keys.js'),
-    post_list_user_policies: require('./ops/iam_list_user_policies.js'),
     post_list_user_tags: require('./ops/iam_list_user_tags.js'),
     post_list_virtual_mfa_devices: require('./ops/iam_list_virtual_mfa_devices.js'),
 });

--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -86,7 +86,9 @@ function parse_max_items(input_max_items) {
  * @param {object} params
  */
 function validate_params(action, params) {
-        if (action.includes('user')) {
+        if (action.includes('policy') || action.includes('policies')) {
+            validate_policy_params(action, params);
+        } else if (action.includes('user')) {
             validate_user_params(action, params);
         } else if (action.includes('access_key')) {
             validate_access_keys_params(action, params);
@@ -150,6 +152,30 @@ function validate_access_keys_params(action, params) {
 }
 
 /**
+ * validate_policy_params will call the aquivalent function for each action in user policy API
+ * @param {string} action
+ * @param {object} params
+ */
+function validate_policy_params(action, params) {
+    switch (action) {
+        case iam_constants.IAM_ACTIONS.PUT_USER_POLICY:
+            validate_put_user_policy(params);
+            break;
+        case iam_constants.IAM_ACTIONS.GET_USER_POLICY:
+            validate_get_user_policy(params);
+            break;
+        case iam_constants.IAM_ACTIONS.DELETE_USER_POLICY:
+            validate_delete_user_policy(params);
+            break;
+        case iam_constants.IAM_ACTIONS.LIST_USER_POLICIES:
+            validate_list_user_policies(params);
+            break;
+        default:
+          throw new RpcError('INTERNAL_ERROR', `${action} is not supported`);
+      }
+}
+
+/**
  * check_required_username checks if the username was set
  * @param {object} params
  */
@@ -171,6 +197,22 @@ function check_required_access_key_id(params) {
  */
 function check_required_status(params) {
     check_required_key(params.status, 'status');
+}
+
+/**
+ * check_required_policy_name checks if the policy name was set
+ * @param {object} params
+ */
+function check_required_policy_name(params) {
+    check_required_key(params.policy_name, 'policy-name');
+}
+
+/**
+ * check_required_policy_document checks if the policy document was set
+ * @param {object} params
+ */
+function check_required_policy_document(params) {
+    check_required_key(params.policy_document, 'policy-document');
 }
 
 /**
@@ -318,6 +360,68 @@ function validate_list_access_keys(params) {
     try {
         validate_marker(params.marker);
         validate_max_items(params.max_items);
+        validation_utils.validate_username(params.username, iam_constants.IAM_PARAMETER_NAME.USERNAME);
+    } catch (err) {
+        translate_rpc_error(err);
+    }
+}
+
+/**
+ * validate_put_user_policy checks the params for put_user_policy action
+ * @param {object} params
+ */
+function validate_put_user_policy(params) {
+    try {
+        check_required_username(params);
+        validation_utils.validate_username(params.username, iam_constants.IAM_PARAMETER_NAME.USERNAME);
+        check_required_policy_name(params);
+        validation_utils.validate_policy_name(params.policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+        check_required_policy_document(params);
+        validation_utils.validate_policy_document(params.policy_document, iam_constants.IAM_PARAMETER_NAME.POLICY_DOCUMENT);
+    } catch (err) {
+        translate_rpc_error(err);
+    }
+}
+
+/**
+ * validate_get_user_policy checks the params for get_user_policy action
+ * @param {object} params
+ */
+function validate_get_user_policy(params) {
+    try {
+        check_required_username(params);
+        validation_utils.validate_username(params.username, iam_constants.IAM_PARAMETER_NAME.USERNAME);
+        check_required_policy_name(params);
+        validation_utils.validate_policy_name(params.policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+    } catch (err) {
+        translate_rpc_error(err);
+    }
+}
+
+/**
+ * validate_delete_user_policy checks the params for delete_user_policy action
+ * @param {object} params
+ */
+function validate_delete_user_policy(params) {
+    try {
+        check_required_username(params);
+        validation_utils.validate_username(params.username, iam_constants.IAM_PARAMETER_NAME.USERNAME);
+        check_required_policy_name(params);
+        validation_utils.validate_policy_name(params.policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+    } catch (err) {
+        translate_rpc_error(err);
+    }
+}
+
+/**
+ * validate_list_user_policies checks the params for list_user_policies action
+ * @param {object} params
+ */
+function validate_list_user_policies(params) {
+    try {
+        validate_marker(params.marker);
+        validate_max_items(params.max_items);
+        check_required_username(params);
         validation_utils.validate_username(params.username, iam_constants.IAM_PARAMETER_NAME.USERNAME);
     } catch (err) {
         translate_rpc_error(err);

--- a/src/endpoint/iam/ops/iam_delete_user_policy.js
+++ b/src/endpoint/iam/ops/iam_delete_user_policy.js
@@ -1,0 +1,39 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const iam_utils = require('../iam_utils');
+const iam_constants = require('../iam_constants');
+const { CONTENT_TYPE_APP_FORM_URLENCODED } = require('../../../util/http_utils');
+
+/**
+ * https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteUserPolicy.html
+ */
+async function delete_user_policy(req, res) {
+
+    const params = {
+        username: req.body.user_name,
+        policy_name: req.body.policy_name,
+    };
+    dbg.log1('IAM DELETE USER POLICY', params);
+    iam_utils.validate_params(iam_constants.IAM_ACTIONS.DELETE_USER_POLICY, params);
+    await req.account_sdk.delete_user_policy(params);
+
+    return {
+        DeleteUserPolicyResponse: {
+            ResponseMetadata: {
+                RequestId: req.request_id,
+            }
+        }
+    };
+}
+
+module.exports = {
+    handler: delete_user_policy,
+    body: {
+        type: CONTENT_TYPE_APP_FORM_URLENCODED,
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/endpoint/iam/ops/iam_get_user_policy.js
+++ b/src/endpoint/iam/ops/iam_get_user_policy.js
@@ -1,0 +1,45 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const iam_utils = require('../iam_utils');
+const iam_constants = require('../iam_constants');
+const { CONTENT_TYPE_APP_FORM_URLENCODED } = require('../../../util/http_utils');
+
+/**
+ * https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUserPolicy.html
+ */
+async function get_user_policy(req, res) {
+
+    const params = {
+        username: req.body.user_name,
+        policy_name: req.body.policy_name,
+    };
+    dbg.log1('IAM GET USER POLICY', params);
+    iam_utils.validate_params(iam_constants.IAM_ACTIONS.GET_USER_POLICY, params);
+    const reply = await req.account_sdk.get_user_policy(params);
+    dbg.log2('get_user_policy reply', reply);
+
+    return {
+        GetUserPolicyResponse: {
+            GetUserPolicyResult: {
+                UserName: reply.username,
+                PolicyName: reply.policy_name,
+                PolicyDocument: reply.policy_document,
+            },
+            ResponseMetadata: {
+                RequestId: req.request_id,
+            }
+        },
+    };
+}
+
+module.exports = {
+    handler: get_user_policy,
+    body: {
+        type: CONTENT_TYPE_APP_FORM_URLENCODED,
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/endpoint/iam/ops/iam_list_user_policies.js
+++ b/src/endpoint/iam/ops/iam_list_user_policies.js
@@ -17,17 +17,16 @@ async function list_user_policies(req, res) {
         max_items: iam_utils.parse_max_items(req.body.max_items) ?? iam_constants.DEFAULT_MAX_ITEMS,
     };
 
-    dbg.log1('To check that we have the user we will run the IAM GET USER', params);
-    iam_utils.validate_params(iam_constants.IAM_ACTIONS.GET_USER, params);
-    await req.account_sdk.get_user(params);
-
-    dbg.log1('IAM LIST USER POLICIES (returns empty list on every request)', params);
+    dbg.log1('IAM LIST USER POLICIES', params);
+    iam_utils.validate_params(iam_constants.IAM_ACTIONS.LIST_USER_POLICIES, params);
+    const reply = await req.account_sdk.list_user_policies(params);
+    dbg.log2('list_user_policies reply', reply);
 
     return {
         ListUserPoliciesResponse: {
             ListUserPoliciesResult: {
-                PolicyNames: [],
-                IsTruncated: false,
+                PolicyNames: reply.members,
+                IsTruncated: reply.is_truncated,
             },
             ResponseMetadata: {
                 RequestId: req.request_id,

--- a/src/endpoint/iam/ops/iam_put_user_policy.js
+++ b/src/endpoint/iam/ops/iam_put_user_policy.js
@@ -1,0 +1,54 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const iam_utils = require('../iam_utils');
+const iam_constants = require('../iam_constants');
+const { CONTENT_TYPE_APP_FORM_URLENCODED } = require('../../../util/http_utils');
+const IamError = require('../iam_errors').IamError;
+
+/**
+ * https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutUserPolicy.html
+ */
+async function put_user_policy(req, res) {
+
+    const params = {
+        username: req.body.user_name,
+        policy_name: req.body.policy_name,
+        policy_document: req.body.policy_document,
+    };
+    dbg.log1('IAM PUT USER POLICY', params);
+    iam_utils.validate_params(iam_constants.IAM_ACTIONS.PUT_USER_POLICY, params);
+    params.policy_document = JSON.parse(params.policy_document); // we want this property as JSON for easier handling
+    try {
+        const reply = await req.account_sdk.put_user_policy(params);
+        dbg.log2('put_user_policy reply', reply);
+    } catch (err) {
+        dbg.error(`put_user_policy failed with params`, params, 'error:', err);
+        if (err.rpc_code === "INVALID_SCHEMA" || err.rpc_code === "INVALID_SCHEMA_PARAMS") {
+            const message_with_details = `Syntax errors in policy`;
+            const { code, http_code, type } = IamError.MalformedPolicyDocument;
+            throw new IamError({ code, message: message_with_details, http_code, type });
+        }
+        throw err;
+    }
+
+
+    return {
+        PutUserPolicyResponse: {
+            ResponseMetadata: {
+                RequestId: req.request_id,
+            }
+        }
+    };
+}
+
+module.exports = {
+    handler: put_user_policy,
+    body: {
+        type: CONTENT_TYPE_APP_FORM_URLENCODED,
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/sdk/account_sdk.js
+++ b/src/sdk/account_sdk.js
@@ -145,6 +145,31 @@ class AccountSDK {
         const accountspace = this._get_accountspace();
         return accountspace.list_access_keys(params, this);
     }
+
+    /////////////////
+    // USER POLICY //
+    /////////////////
+
+    async put_user_policy(params) {
+        const accountspace = this._get_accountspace();
+        return accountspace.put_user_policy(params, this);
+    }
+
+    async get_user_policy(params) {
+        const accountspace = this._get_accountspace();
+        return accountspace.get_user_policy(params, this);
+    }
+
+    async delete_user_policy(params) {
+        const accountspace = this._get_accountspace();
+        return accountspace.delete_user_policy(params, this);
+    }
+
+    async list_user_policies(params) {
+        const accountspace = this._get_accountspace();
+        return accountspace.list_user_policies(params, this);
+    }
+
 }
 
 // EXPORTS

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -520,6 +520,44 @@ class AccountSpaceFS {
         }
     }
 
+    /////////////////////
+    // OTHER FUNCTIONS //
+    /////////////////////
+    // The function here are implemented in AccountSpaceNB, but not in AccountSpaceFS
+    // and will throw NotImplemented error, except for the function with list which will return an empty list
+
+    async put_user_policy(params, account_sdk) {
+        const action = IAM_ACTIONS.PUT_USER_POLICY;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
+
+    async get_user_policy(params, account_sdk) {
+        const action = IAM_ACTIONS.GET_USER_POLICY;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
+
+    async delete_user_policy(params, account_sdk) {
+        const action = IAM_ACTIONS.DELETE_USER_POLICY;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
+
+    async list_user_policies(params, account_sdk) {
+        const action = IAM_ACTIONS.LIST_USER_POLICIES;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        dbg.log1('To check that we have the user we will run the IAM GET USER', params);
+        await account_sdk.get_user(params);
+        dbg.log1('IAM LIST USER POLICIES (returns empty list on every request)', params);
+        const is_truncated = false;
+        const members = [];
+        return { members, is_truncated };
+    }
+
     ////////////////////////
     // INTERNAL FUNCTIONS //
     ////////////////////////

--- a/src/sdk/accountspace_nb.js
+++ b/src/sdk/accountspace_nb.js
@@ -250,6 +250,30 @@ class AccountSpaceNB {
     ////////////////////
     // POLICY METHODS //
     ////////////////////
+
+    async put_user_policy(params, account_sdk) {
+        dbg.log0('AccountSpaceNB.put_user_policy:', params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
+
+    async get_user_policy(params, account_sdk) {
+        dbg.log0('AccountSpaceNB.get_user_policy:', params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
+
+    async delete_user_policy(params, account_sdk) {
+        dbg.log0('AccountSpaceNB.delete_user_policy:', params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
+
+    async list_user_policies(params, account_sdk) {
+        dbg.log0('AccountSpaceNB.list_user_policies:', params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
 }
 
 // EXPORTS

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -907,6 +907,11 @@ interface AccountSpace {
     get_access_key_last_used(params: object, account_sdk: AccountSDK): Promise<any>;
     delete_access_key(params: object, account_sdk: AccountSDK): Promise<any>;
     list_access_keys(params: object, account_sdk: AccountSDK): Promise<any>;
+    // inline user policy
+    put_user_policy(params: object, account_sdk: AccountSDK): Promise<any>;
+    get_user_policy(params: object, account_sdk: AccountSDK): Promise<any>;
+    delete_user_policy(params: object, account_sdk: AccountSDK): Promise<any>;
+    list_user_policies(params: object, account_sdk: AccountSDK): Promise<any>;
 }
 
 

--- a/src/test/unit_tests/api/iam/test_validation_utils.test.js
+++ b/src/test/unit_tests/api/iam/test_validation_utils.test.js
@@ -44,7 +44,6 @@ describe('validate_user_input', () => {
             }
         });
 
-
         it('should throw error when username is invalid - internal limitation (anonymous)', () => {
             try {
                 validation_utils.validate_username('anonymous', iam_constants.IAM_PARAMETER_NAME.USERNAME);
@@ -87,7 +86,7 @@ describe('validate_user_input', () => {
             }
         });
 
-        it('should throw error for invalid input types (null)', () => {
+        it('should throw error for invalid input types (null) in username', () => {
             try {
                 // @ts-ignore
                 const invalid_username = null;
@@ -99,7 +98,7 @@ describe('validate_user_input', () => {
             }
         });
 
-        it('should throw error for invalid input types (number)', () => {
+        it('should throw error for invalid input types (number) in username', () => {
             try {
                 const invalid_username = 1;
                 // @ts-ignore
@@ -111,7 +110,7 @@ describe('validate_user_input', () => {
             }
         });
 
-        it('should throw error for invalid input types (object)', () => {
+        it('should throw error for invalid input types (object) in username', () => {
             try {
                 const invalid_username = {};
                 // @ts-ignore
@@ -123,7 +122,7 @@ describe('validate_user_input', () => {
             }
         });
 
-        it('should throw error for invalid input types (boolean)', () => {
+        it('should throw error for invalid input types (boolean) in username', () => {
             try {
                 const invalid_username = false;
                 // @ts-ignore
@@ -132,6 +131,163 @@ describe('validate_user_input', () => {
             } catch (err) {
                 expect(err).toBeInstanceOf(RpcError);
                 expect(err.rpc_code).toBe(RPC_CODE_VALIDATION_ERROR);
+            }
+        });
+    });
+
+    describe('validate_policy_name', () => {
+        const min_length = 1;
+        const max_length = 128;
+        it('should return true when policy_name is undefined', () => {
+            let dummy_policy_name;
+            const res = validation_utils.validate_policy_name(dummy_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+            expect(res).toBeUndefined();
+        });
+
+        it('should return true when policy_name is at the min or max length', () => {
+            expect(validation_utils.validate_policy_name('a', iam_constants.IAM_PARAMETER_NAME.POLICY_NAME)).toBe(true);
+            expect(validation_utils.validate_policy_name('a'.repeat(max_length), iam_constants.IAM_PARAMETER_NAME.POLICY_NAME)).toBe(true);
+        });
+
+        it('should return true when policy_name is within the length constraint', () => {
+            expect(validation_utils.validate_policy_name('a'.repeat(min_length + 1), iam_constants.IAM_PARAMETER_NAME.POLICY_NAME)).toBe(true);
+            expect(validation_utils.validate_policy_name('a'.repeat(max_length - 1), iam_constants.IAM_PARAMETER_NAME.POLICY_NAME)).toBe(true);
+        });
+
+        it('should return true when policy_name is valid CamelCase', () => {
+            const dummy_policy_name = 'CreateBucketPolicy';
+            const res = validation_utils.validate_policy_name(dummy_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+            expect(res).toBe(true);
+        });
+
+        it('should return true when policy_name is valid SnakeCase', () => {
+            const dummy_policy_name = 'create_bucket_policy';
+            const res = validation_utils.validate_policy_name(dummy_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+            expect(res).toBe(true);
+        });
+
+        it('should throw error when policy_name is invalid - contains invalid character', () => {
+            try {
+                validation_utils.validate_policy_name('{}', iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe(RPC_CODE_VALIDATION_ERROR);
+            }
+        });
+
+        it('should throw error when policy_name is too short', () => {
+            try {
+                const dummy_policy_name = '';
+                validation_utils.validate_policy_name(dummy_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe(RPC_CODE_VALIDATION_ERROR);
+            }
+        });
+
+        it('should throw error when dummy_policy_name is too long', () => {
+            try {
+                const dummy_policy_name = 'A'.repeat(max_length + 1);
+                validation_utils.validate_policy_name(dummy_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe(RPC_CODE_VALIDATION_ERROR);
+            }
+        });
+
+        it('should throw error for invalid input types (null) in policy_name', () => {
+            try {
+                // @ts-ignore
+                const invalid_policy_name = null;
+                validation_utils.validate_policy_name(invalid_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe(RPC_CODE_VALIDATION_ERROR);
+            }
+        });
+
+        it('should throw error for invalid input types (number) in policy_name', () => {
+            try {
+                const invalid_policy_name = 1;
+                // @ts-ignore
+                validation_utils.validate_policy_name(invalid_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe(RPC_CODE_VALIDATION_ERROR);
+            }
+        });
+
+        it('should throw error for invalid input types (object) in policy_name', () => {
+            try {
+                const invalid_policy_name = {};
+                // @ts-ignore
+                validation_utils.validate_policy_name(invalid_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe(RPC_CODE_VALIDATION_ERROR);
+            }
+        });
+
+        it('should throw error for invalid input types (boolean) in policy_name', () => {
+            try {
+                const invalid_policy_name = false;
+                // @ts-ignore
+                validation_utils.validate_policy_name(invalid_policy_name, iam_constants.IAM_PARAMETER_NAME.POLICY_NAME);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe(RPC_CODE_VALIDATION_ERROR);
+            }
+        });
+    });
+
+    describe('validate_policy_document', () => {
+        it('should return true when policy_document is undefined', () => {
+            let dummy_policy_document;
+            const res = validation_utils.validate_policy_document(dummy_policy_document, iam_constants.IAM_PARAMETER_NAME.POLICY_DOCUMENT);
+            expect(res).toBeUndefined();
+        });
+
+        it('should return true when policy_document is valid JSON string', () => {
+            const dummy_policy_document = JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Action: 's3:GetBucketLocation',
+                        Resource: '*'
+                    }
+                ]
+            });
+            const res = validation_utils.validate_policy_document(dummy_policy_document, iam_constants.IAM_PARAMETER_NAME.POLICY_DOCUMENT);
+            expect(res).toBe(true);
+        });
+
+        it('should throw error when policy_document is invalid JSON string', () => {
+            try {
+                const invalid_policy_document = 'hello';
+                validation_utils.validate_policy_document(invalid_policy_document, iam_constants.IAM_PARAMETER_NAME.POLICY_DOCUMENT);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe('MALFORMED_POLICY_DOCUMENT');
+            }
+        });
+
+        it('should throw error when policy_document is empty', () => {
+            try {
+                const invalid_policy_document = '';
+                validation_utils.validate_policy_document(invalid_policy_document, iam_constants.IAM_PARAMETER_NAME.POLICY_DOCUMENT);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(RpcError);
+                expect(err.rpc_code).toBe('VALIDATION_ERROR');
             }
         });
     });

--- a/src/test/unit_tests/internal/test_accountspace_nb.test.js
+++ b/src/test/unit_tests/internal/test_accountspace_nb.test.js
@@ -1,0 +1,64 @@
+/* Copyright (C) 2025 NooBaa */
+/* eslint-disable max-lines-per-function */
+/* eslint-disable max-lines */
+'use strict';
+
+
+const AccountSpaceNB = require('../../../sdk/accountspace_nb');
+const { IamError } = require('../../../endpoint/iam/iam_errors');
+
+class NoErrorThrownError extends Error {}
+
+const accountspace_nb = new AccountSpaceNB({ rpc_client: null, internal_rpc_client: null });
+
+describe('Accountspace_NB tests', () => {
+    describe('Accountspace_NB user policy tests', () => {
+        describe('put_user_policy', () => {
+            it('Should return Not Implemented error for put_user_policy', async () => {
+                try {
+                    await accountspace_nb.put_user_policy({}, accountspace_nb);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NotImplemented.code);
+                }
+            });
+        });
+
+        describe('get_user_policy', () => {
+            it('Should return Not Implemented error for get_user_policy', async () => {
+                try {
+                    await accountspace_nb.get_user_policy({}, accountspace_nb);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NotImplemented.code);
+                }
+            });
+        });
+
+        describe('delete_user_policy', () => {
+            it('Should return Not Implemented error for delete_user_policy', async () => {
+                try {
+                    await accountspace_nb.delete_user_policy({}, accountspace_nb);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NotImplemented.code);
+                }
+            });
+        });
+
+        describe('list_user_policies', () => {
+            it('Should return Not Implemented error for list_user_policies', async () => {
+                try {
+                    await accountspace_nb.list_user_policies({}, accountspace_nb);
+                    throw new NoErrorThrownError();
+                } catch (err) {
+                    expect(err).toBeInstanceOf(IamError);
+                    expect(err).toHaveProperty('code', IamError.NotImplemented.code);
+                }
+            });
+        });
+    });
+});

--- a/src/test/unit_tests/util_functions_tests/test_string_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_string_utils.test.js
@@ -69,4 +69,32 @@ describe('test regex', () => {
         });
 
     });
+
+    describe('test regex - policy name', () => {
+
+        it('document name of alphanumeric characters', () => {
+            const valid_document_name = 'mydocument123';
+            const res = iam_utils.AWS_POLICY_NAME_REGEXP.test(valid_document_name);
+            expect(res).toBe(true);
+        });
+
+        it('document name of with chars out of scope at the beginning', () => {
+            const invalid_document_name = '#mydocument123';
+            const res = iam_utils.AWS_POLICY_NAME_REGEXP.test(invalid_document_name);
+            expect(res).toBe(false);
+        });
+
+        it('document name of with chars out of scope at the end', () => {
+            const invalid_document_name = 'mydocument123#';
+            const res = iam_utils.AWS_POLICY_NAME_REGEXP.test(invalid_document_name);
+            expect(res).toBe(false);
+        });
+
+        it('document name of with chars out of scope at the middle', () => {
+            const invalid_document_name = 'mydocument#123';
+            const res = iam_utils.AWS_POLICY_NAME_REGEXP.test(invalid_document_name);
+            expect(res).toBe(false);
+        });
+
+    });
 });

--- a/src/util/string_utils.js
+++ b/src/util/string_utils.js
@@ -15,6 +15,8 @@ const AWS_IAM_PATH_REGEXP = /^(\u002F|\u002F[\u0021-\u007E]+\u002F)$/;
 const AWS_USERNAME_REGEXP = /^[\w+=,.@-]+$/;
 const AWS_IAM_LIST_MARKER = /^[\u0020-\u00FF]+$/;
 const AWS_IAM_ACCESS_KEY_INPUT_REGEXP = /^[\w]+$/;
+const AWS_POLICY_NAME_REGEXP = /^[\w+=,.@-]+$/;
+const AWS_POLICY_DOCUMENT_REGEXP = /^[\u0009\u000A\u000D\u0020-\u00FF]+$/;
 
 function crypto_random_string(len, charset = ALPHA_NUMERIC_CHARSET) {
     // In order to not favor any specific chars over others we limit the maximum random value
@@ -165,3 +167,5 @@ exports.AWS_IAM_PATH_REGEXP = AWS_IAM_PATH_REGEXP;
 exports.AWS_USERNAME_REGEXP = AWS_USERNAME_REGEXP;
 exports.AWS_IAM_LIST_MARKER = AWS_IAM_LIST_MARKER;
 exports.AWS_IAM_ACCESS_KEY_INPUT_REGEXP = AWS_IAM_ACCESS_KEY_INPUT_REGEXP;
+exports.AWS_POLICY_NAME_REGEXP = AWS_POLICY_NAME_REGEXP;
+exports.AWS_POLICY_DOCUMENT_REGEXP = AWS_POLICY_DOCUMENT_REGEXP;


### PR DESCRIPTION
### Describe the Problem
Adding the structure for IAM User Policy API as a skeleton only, no implementation yet.
Note: for accountspace NB we plan to add the implementation in a different PR.

### Explain the Changes
1. Adding the ops and the basic structure for the IAM user policy API.
Note:  In case of the policy document, the validation is basic, and deeper validation will be performed using the schema.

### Issues:
1. None

### Testing Instructions:
#### Automatic Testing:
1. `npx jest test_accountspace_nb.test` (all should not be implemented)
2. `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha ./src/test/unit_tests/test_nc_iam_basic_integration.js` (ensure that we didn’t change NC behavior - list user policy should be the same as it was).
3. `npx jest test_string_utils.test.js`
4. `npx jest test_validation_utils.test.js`

#### Manual Testing:
##### Containerized:
Please use the added IAM service and endpoint port with the code changes in PRs: noobaa/noobaa-operator#1721 and noobaa/noobaa-core#9262. In the following examples, the namespace will be `test1`.
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
3. I'm using port-forward (in a different tab): `kubectl port-forward -n test1 service/iam 12443:443`
4. Create the alias for the admin - first, need to get the credentials: `nb status --show-secrets -n test1` and then `alias user-1-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
5. Check the connection to the endpoint and try to list the users (should be an empty list): `user-1-iam iam list-users; echo $?`
6. Create a user: `user-1-iam iam create-user --user-name Robert`
Note: To validate user creation, you can rerun `user-1-iam iam list-users` and expect 1 user in the list
7. Run user policy API commands using AWS CLI - expect all actions to fail and check in the logs that the error stack comes from accountspace NB, examples:
- `user-1-iam iam put-user-policy --user-name Robert --policy-name mypolicy --policy-document file://policy_01.json`
An example of a policy that was used:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:GetBucketLocation"
            ],
            "Resource": "*"
        }
    ]
}
```
- `user-1-iam iam get-user-policy --user-name Robert --policy-name mypolicy`
- `user-1-iam iam get-user-policy --user-name Robert --policy-name mypolicy`
- `user-1-iam iam list-user-policies --user-name Robert`

##### NC:
We need to make sure that the list operation still returns an empty list
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`
2. Start the NSFS server with IAM port: `sudo node src/cmd/nsfs --debug 5 --https_port_iam 7005 --https_port 6442`
3. Create the alias for IAM service:`alias nc-user-1-iam=‘AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:7005’`
4. Check the connection to the endpoint and try to list the users (should be an empty list): `user-1-iam iam list-users; echo $?`
5. Try to list user policies without a user - `user-1-iam iam list-user-policies --user-name Robert` and expect an error `NoSuchEntity`
6. Create a user and then try to list its user policies: `nc-user-1-iam iam create-user --user-name Bob` and also `nc-user-1-iam iam list-user-policies --user-name Bob` and expect to see an empty list

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full user policy APIs: create, retrieve, delete, and list IAM user policies exposed via endpoints and SDK methods; listing returns policy names and truncation info.

* **Bug Fixes / Validation**
  * Stronger policy validation (name/document regexes, JSON parsing) and new MalformedPolicyDocument error for malformed policies.

* **Tests**
  * Expanded unit tests covering policy name/document validation and policy operation behaviors.

* **Chores**
  * Platform backends: some implementations currently return stubbed NotImplemented responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->