### PR TITLE
IAM | Bucket policy Principal upgrade script

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -237,6 +237,7 @@ async function authorize_request_policy(req) {
         public_access_block,
     } = await req.object_sdk.read_bucket_sdk_policy_info(req.params.bucket);
 
+    dbg.log2('authorize_request_policy:', { bucket_owner, owner_account });
     const auth_token = req.object_sdk.get_auth_token();
     const arn_path = _get_arn_from_req_path(req);
     const method = _get_method_from_req(req);

--- a/src/upgrade/upgrade_scripts/5.21.0/upgrade_bucket_policy_principal.js
+++ b/src/upgrade/upgrade_scripts/5.21.0/upgrade_bucket_policy_principal.js
@@ -1,0 +1,65 @@
+/* Copyright (C) 2023 NooBaa */
+"use strict";
+
+const iam_constants = require('../../../endpoint/iam/iam_constants');
+
+function _create_arn(dbg, principals, system_store) {
+    if (!principals.AWS) return;
+    const principal_arns = [];
+    for (const principal of principals.AWS) {
+        if (principal === '*') continue;
+        const account = system_store.data.accounts.find(acc => acc.email.unwrap() === principal.unwrap());
+        if (!account) {
+            dbg.log0(`Could not find the account with email: ${principal}`);
+            continue;
+        }
+        let arn;
+        if (account.owner) {
+            const iam_path = account.iam_path || iam_constants.IAM_DEFAULT_PATH;
+            arn = `arn:aws:iam::${account._id.toString()}:user${iam_path}${account.email.unwrap()}`;
+        } else {
+            arn = `arn:aws:iam::${account._id.toString()}:root`;
+        }
+        principal_arns.push(arn);
+    }
+    return { AWS: principal_arns };
+}
+
+async function run({ dbg, system_store, system_server }) {
+    try {
+        dbg.log0('Starting bucket policy Principal upgrade...');
+        const buckets = [];
+        for (const bucket of system_store.data.buckets) {
+            // Do not update if there are no bucket policy.
+            if (!bucket.s3_policy) continue;
+            if (bucket.s3_policy.Statement !== undefined) {
+                const new_policy = bucket.s3_policy;
+                new_policy.Statement = bucket.s3_policy.Statement.map(statement => ({
+                    ...statement,
+                    Principal: _create_arn(dbg, statement.Principal, system_store),
+                }));
+                buckets.push({
+                    _id: bucket._id,
+                    s3_policy: new_policy,
+                });
+            }
+        }
+
+        if (buckets.length > 0) {
+            dbg.log0(`Replacing bucket policy Principal for ${buckets.length} buckets.`);
+            await system_store.make_changes({ update: { buckets } });
+        } else {
+            dbg.log0('Upgrading buckets policy Principal: no upgrade needed...');
+        }
+
+    } catch (err) {
+        dbg.error('Got error while upgrading buckets policy Principal:', err);
+        throw err;
+    }
+}
+
+
+module.exports = {
+    run,
+    description: 'Update bucket policy Principal to ARN format'
+};


### PR DESCRIPTION
### Describe the Problem

Update the bucket policy Principal with ARN, not its a email but we will be updating it with ARN, Existing bucket policy also will be replaced by new ARN,

### Explain the Changes
1. Upgrade script will iterate each buckets and replace Statement.Principals.AWS emails with ARN specific values.

```
Account ARN(that include all the admin/OBC accounts/accounts created with CRD) : 
aws:arn:${account_id}:root
IAM User ARN : aws:arn:${account_id}:user/${account_email}
````
### GAP
1. New bucket policies also should follow the same ARN formate when creating bucket policy
2. S3 policy validation should adapt to accept ARN instead of account email.

Will handle in next PR

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/RHSTOR-7561

### Testing Instructions:
1. Deploy 4.20 and run upgrade_bucket_policy_principal.js upgrade script
4. Run `test_upgrade_scripts.js` test and make sure `test upgrade bucket policy to ARN version 5.21.0` is sucess.


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Bucket policies are migrated to ARN format during the 5.21.0 upgrade for consistent principal representation.
  * Added additional debug logging around authorization requests to aid troubleshooting.

* **Testing**
  * New integration tests verify ARN-format principal handling and confirm policy structure and values remain equivalent after upgrade.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->