### PR TITLE
IAM | Change bucket owner for IAM user to account and more

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -241,9 +241,14 @@ async function create_bucket(req) {
 
         validate_non_nsfs_bucket_creation(req);
         validate_nsfs_bucket(req);
-
+        // Buckets created by IAM users are owned by the IAM account the user belongs to.
+        let account_id = req.account._id;
+        // Only IAM user will have owner.
+        if (req.account.owner) {
+            account_id = req.account.owner._id;
+        }
         const bucket = new_bucket_defaults(req.rpc_params.name, req.system._id,
-            tiering_policy && tiering_policy._id, req.account._id, req.rpc_params.tag, req.rpc_params.lock_enabled);
+            tiering_policy && tiering_policy._id, account_id, req.rpc_params.tag, req.rpc_params.lock_enabled);
 
         const bucket_m_key = system_store.master_key_manager.new_master_key({
             description: `master key of ${bucket._id} bucket`,

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -31,7 +31,6 @@ module.exports = {
         tagging: {
             $ref: 'common_api#/definitions/tagging',
         },
-        iam_arn: { type: 'string' },
         iam_path: { type: 'string' },
         iam_user_policies: {
             type: 'array',

--- a/src/server/system_services/schemas/role_schema.js
+++ b/src/server/system_services/schemas/role_schema.js
@@ -25,7 +25,7 @@ module.exports = {
         },
         role: {
             type: 'string',
-            enum: ['admin', 'user', 'operator', 'iam_user']
+            enum: ['admin', 'user', 'operator']
         },
     }
 };


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. Change bucket owner for IAM user to account
2. Remove ARN from account
3. name:rootaccount_id not name:rootaccount_name
4. Remove roles schema changes
5. Delete access keys before deleting user

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Accounts with active access keys can no longer be deleted.

* **Breaking Changes**
  * Removed the 'iam_user' role; roles are now: 'admin', 'user', 'operator'.
  * Removed the 'iam_arn' field from account objects.
  * Bucket ownership assignment updated for accounts with IAM associations.

* **Improvements**
  * Usernames, ARNs and IAM paths are now derived from account IDs, affecting user and access-key listings, and ARN/path generation.
  * Pre-delete validation for accounts with access keys made consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->