### PR TITLE
IAM | Account Schema Changes for Supporting Inline User Policy

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -487,6 +487,90 @@ module.exports = {
             }
         },
 
+        // based on bucket policy without Principal and NotPrincipal since are not used in inline policies
+        // removed the Condition as we don't support it yet
+        iam_user_policy_document: {
+            type: 'object',
+            required: ['Statement'],
+            properties: {
+                Version: { type: 'string' },
+                Statement: {
+                    type: 'array',
+                    items: {
+                        allOf: [{
+                                type: 'object',
+                                required: ['Effect'],
+                                properties: {
+                                    Sid: {
+                                        type: 'string'
+                                    },
+                                    Action: {
+                                        $ref: '#/definitions/string_or_string_array'
+                                    },
+                                    NotAction: {
+                                        $ref: '#/definitions/string_or_string_array'
+                                    },
+                                    Resource: {
+                                        $ref: '#/definitions/string_or_string_array'
+                                    },
+                                    NotResource: {
+                                        $ref: '#/definitions/string_or_string_array'
+                                    },
+                                    Effect: {
+                                        enum: ['Allow', 'Deny'],
+                                        type: 'string'
+                                    },
+                                }
+                            },
+                            // see the comment in bucket_policy about these schemas
+                            // here we removed the Principal / NotPrincipal schemas
+                            {
+                                oneOf: [{
+                                        type: 'object',
+                                        required: ["Action"],
+                                        additionalProperties: true,
+                                        properties: {}
+                                    },
+                                    {
+                                        type: 'object',
+                                        required: ["NotAction"],
+                                        additionalProperties: true,
+                                        properties: {}
+                                    }
+                                ],
+                            },
+                            {
+                                oneOf: [{
+                                        type: 'object',
+                                        required: ["Resource"],
+                                        additionalProperties: true,
+                                        properties: {}
+                                    },
+                                    {
+                                        type: 'object',
+                                        required: ["NotResource"],
+                                        additionalProperties: true,
+                                        properties: {}
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                },
+            }
+        },
+
+        iam_user_policy: {
+            type: 'object',
+            required: ['policy_name', 'policy_document'],
+            properties: {
+                policy_name: { type: 'string' },
+                policy_document: {
+                    $ref: 'common_api#/definitions/iam_user_policy_document',
+                }
+            }
+        },
+
         object_encryption: {
             type: 'object',
             properties: {

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -33,6 +33,12 @@ module.exports = {
         },
         iam_arn: { type: 'string' },
         iam_path: { type: 'string' },
+        iam_user_policies: {
+            type: 'array',
+            items: {
+                $ref: 'common_api#/definitions/iam_user_policy',
+            }
+        },
         // default policy for new buckets
         default_resource: { objectid: true },
         default_chunk_config: { objectid: true },


### PR DESCRIPTION
### Describe the Problem
Adding the schema for IAM User Policy inline policy.
The API implementation would be in a separate PR.

### Explain the Changes
1. Define in `common_api` `iam_user_policy_document` based on `bucket_policy` structure without `Principal` and `NotPrincipal` (and `Condition`), and create `iam_user_policy`.
2. Add the property `iam_user_policies` in `account` schema (which also serves for IAM users).

Note: the explanation why I could not just `ref` `bucket_policy` in the comments ([link](https://github.com/noobaa/noobaa-core/pull/9269#discussion_r2495179110)).

### Issues:
1. none

### Testing Instructions:
1. none


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IAM user policies are now supported, enabling inline policy definition and validation for individual users.
  * Account profiles can store and reference multiple user policies, extending per-user access control options.
  * User policies include configurable statements with action and resource specifications and a simplified schema for common inline policy use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->