### PR TITLE
NC | Adding support of user bucket path

### DIFF
--- a/config.js
+++ b/config.js
@@ -1022,6 +1022,9 @@ config.NSFS_LIST_IGNORE_ENTRY_ON_EACCES = true;
 // we will for now handle the same way also EINVAL error - for gpfs stat issues on list (.snapshots)
 config.NSFS_LIST_IGNORE_ENTRY_ON_EINVAL = true;
 
+config.NSFS_CUSTOM_BUCKET_PATH_HTTP_HEADER = 'x-noobaa-custom-bucket-path';
+config.NSFS_CUSTOM_BUCKET_PATH_ALLOWED_LIST = ''; // colon separated list of paths prefixes
+
 ////////////////////////////
 // NSFS NON CONTAINERIZED //
 ////////////////////////////

--- a/docs/NooBaaNonContainerized/AccountsAndBuckets.md
+++ b/docs/NooBaaNonContainerized/AccountsAndBuckets.md
@@ -38,6 +38,8 @@ See all available account properties - [NC Account Schema](../../src/server/syst
 
   - `new_buckets_path` - When an account creates a bucket using the S3 protocol, NooBaa will create the underlying file system directory. This directory will be created under new_buckets_path. Note that the account must have read and write access to its `new_buckets_path`.  Must be an absolute path.  
 
+  - `custom_bucket_path_allowed_list` - When an account creates a bucket using the S3 protocol, He can override the default bucket path location (under new_buckets_path) using `x-noobaa-custom-bucket-path` HTTP header. This directory will be created only if this path will be under one of the provided allowed list paths in custom_bucket_path_allowed_list. Must be a list of absolute paths (divided by colons).  
+
 ### Account configuration  
 Currently, an account can be configured via NooBaa CLI, see - [NooBaa CLI](./NooBaaCLI.md).  
 

--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -76,7 +76,7 @@ The `account add` command is used to create a new account with customizable opti
 ```sh
 noobaa-cli account add --name <account_name> --uid <uid> --gid <gid> [--user]
 [--new_buckets_path][--access_key][--secret_key][--fs_backend]
-[--allow_bucket_creation][--force_md5_etag][--anonymous][--from_file][--iam_operate_on_root_account][--default_connection]
+[--allow_bucket_creation][--force_md5_etag][--anonymous][--from_file][--iam_operate_on_root_account][--default_connection][--custom_bucket_path_allowed_list]
 ```
 #### Flags -
 - `name` (Required)
@@ -140,6 +140,11 @@ noobaa-cli account add --name <account_name> --uid <uid> --gid <gid> [--user]
     - Type: String
     - Description: A default account for Kafka external servers. See bucket-notifications.md.
 
+- `custom_bucket_path_allowed_list`
+    - Type: String
+    - Description: Specifies an allowed list where this account can create buckets in using 
+    x-noobaa-custom-bucket-path header in create_bucket
+
 ### Update Account
 
 The `account update` command is used to update an existing account with customizable options.
@@ -149,6 +154,7 @@ The `account update` command is used to update an existing account with customiz
 noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--user]
 [--new_buckets_path][--access_key][--secret_key][--regenerate][--fs_backend]
 [--allow_bucket_creation][--force_md5_etag][--anonymous][--iam_operate_on_root_account][--default_connection]
+[--custom_bucket_path_allowed_list]
 ```
 #### Flags -
 - `name` (Required)
@@ -215,6 +221,11 @@ noobaa-cli account update --name <account_name> [--new_name][--uid][--gid][--use
 - `default_connection`
     - Type: String
     - Description: A default account for Kafka external servers. See bucket-notifications.md.
+
+- `custom_bucket_path_allowed_list`
+    - Type: String
+    - Description: Specifies an allowed list where this account can create buckets in using 
+    x-noobaa-custom-bucket-path header in create_bucket
 
 ### Account Status
 

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -308,6 +308,7 @@ module.exports = {
                             supplemental_groups: {
                                 $ref: 'common_api#/definitions/supplemental_groups'
                             },
+                            custom_bucket_path_allowed_list: { type: 'string' },
                         }
                     },
                 },

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -33,6 +33,7 @@ module.exports = {
                     },
                     bucket_claim: { $ref: '#/definitions/bucket_claim' },
                     force_md5_etag: { type: 'boolean' },
+                    custom_bucket_path: { type: 'string' }
                 }
             },
             reply: {

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1454,6 +1454,7 @@ module.exports = {
                     supplemental_groups: {
                         $ref: '#/definitions/supplemental_groups'
                     },
+                    custom_bucket_path_allowed_list: { type: 'string' },
                 }
             }, {
                 type: 'object',
@@ -1461,7 +1462,8 @@ module.exports = {
                 properties: {
                     distinguished_name: { wrapper: SensitiveString },
                     new_buckets_path: { type: 'string' },
-                    nsfs_only: { type: 'boolean' }
+                    nsfs_only: { type: 'boolean' },
+                    custom_bucket_path_allowed_list: { type: 'string' },
                 }
             }]
         },

--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -503,7 +503,8 @@ async function fetch_account_data(action, user_input) {
             uid: user_input.user ? undefined : user_input.uid,
             gid: user_input.user ? undefined : user_input.gid,
             new_buckets_path: user_input.new_buckets_path,
-            fs_backend: user_input.fs_backend ? String(user_input.fs_backend) : config.NSFS_NC_STORAGE_BACKEND
+            fs_backend: user_input.fs_backend ? String(user_input.fs_backend) : config.NSFS_NC_STORAGE_BACKEND,
+            custom_bucket_path_allowed_list: user_input.custom_bucket_path_allowed_list,
         },
         default_connection: user_input.default_connection === undefined ? undefined : String(user_input.default_connection)
     };
@@ -542,6 +543,8 @@ async function fetch_account_data(action, user_input) {
     } else { // string of true or false
         data.allow_bucket_creation = user_input.allow_bucket_creation.toLowerCase() === 'true';
     }
+    // custom_bucket_path_allowed_list deletion specified with empty string ''
+    data.nsfs_account_config.custom_bucket_path_allowed_list = data.nsfs_account_config.custom_bucket_path_allowed_list || undefined;
 
     return data;
 }

--- a/src/endpoint/s3/ops/s3_put_bucket.js
+++ b/src/endpoint/s3/ops/s3_put_bucket.js
@@ -9,7 +9,8 @@ const config = require('../../../../config');
 async function put_bucket(req, res) {
     const lock_enabled = config.WORM_ENABLED ? req.headers['x-amz-bucket-object-lock-enabled'] &&
         req.headers['x-amz-bucket-object-lock-enabled'].toUpperCase() === 'TRUE' : undefined;
-    await req.object_sdk.create_bucket({ name: req.params.bucket, lock_enabled: lock_enabled });
+    const custom_bucket_path = req.headers[config.NSFS_CUSTOM_BUCKET_PATH_HTTP_HEADER];
+    await req.object_sdk.create_bucket({ name: req.params.bucket, lock_enabled, custom_bucket_path });
     if (config.allow_anonymous_access_in_test && req.headers['x-amz-acl'] === 'public-read') { // For now we will enable only for tests
         const policy = {
             Version: '2012-10-17',

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -46,8 +46,8 @@ const FROM_FILE = 'from_file';
 const ANONYMOUS = 'anonymous';
 
 const VALID_OPTIONS_ACCOUNT = {
-    'add': new Set(['name', 'uid', 'gid', 'supplemental_groups', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'default_connection', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
-    'update': new Set(['name', 'uid', 'gid', 'supplemental_groups', 'new_buckets_path', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', 'default_connection', ...CLI_MUTUAL_OPTIONS]),
+    'add': new Set(['name', 'uid', 'gid', 'supplemental_groups', 'new_buckets_path', 'custom_bucket_path_allowed_list', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'default_connection', FROM_FILE, ...CLI_MUTUAL_OPTIONS]),
+    'update': new Set(['name', 'uid', 'gid', 'supplemental_groups', 'new_buckets_path', 'custom_bucket_path_allowed_list', 'user', 'access_key', 'secret_key', 'fs_backend', 'allow_bucket_creation', 'force_md5_etag', 'iam_operate_on_root_account', 'new_name', 'regenerate', 'default_connection', ...CLI_MUTUAL_OPTIONS]),
     'delete': new Set(['name', ...CLI_MUTUAL_OPTIONS]),
     'list': new Set(['wide', 'show_secrets', 'gid', 'uid', 'user', 'name', 'access_key', ...CLI_MUTUAL_OPTIONS]),
     'status': new Set(['name', 'access_key', 'show_secrets', ...CLI_MUTUAL_OPTIONS]),
@@ -123,6 +123,7 @@ const OPTION_TYPE = {
     gid: 'number',
     supplemental_groups: 'string',
     new_buckets_path: 'string',
+    custom_bucket_path_allowed_list: 'string',
     user: 'string',
     access_key: 'string',
     secret_key: 'string',
@@ -196,6 +197,7 @@ const UNSETTABLE_OPTIONS_OBJ = Object.freeze({
     'force_md5_etag': CLI_EMPTY_STRING,
     'supplemental_groups': CLI_EMPTY_STRING,
     'new_buckets_path': CLI_EMPTY_STRING,
+    'custom_bucket_path_allowed_list': CLI_EMPTY_STRING,
     'ips': CLI_EMPTY_STRING_ARRAY,
 });
 

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -143,6 +143,7 @@ Flags:
     --force_md5_etag <true | false>                       (optional)        Set the account to force md5 etag calculation. (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
     --iam_operate_on_root_account <true | false>          (optional)        Set the account to create root accounts instead of IAM users in IAM API requests.
     --from_file <string>                                  (optional)        Use details from the JSON file, there is no need to mention all the properties individually in the CLI
+    --custom_bucket_path_allowed_list <string>            (optional)        Set the list of allowed custom bucket paths, separated by colons (:) example: '/gpfs/data/custom1/:/gpfs/data/custom2/'
 `;
 
 const ACCOUNT_FLAGS_UPDATE = `
@@ -170,6 +171,7 @@ Flags:
     --allow_bucket_creation <true | false>                (optional)        Update the account to explicitly allow or block bucket creation
     --force_md5_etag <true | false>                       (optional)        Update the account to force md5 etag calculation (unset with '') (will override default config.NSFS_NC_STORAGE_BACKEND)
     --iam_operate_on_root_account <true | false>          (optional)        Update the account to create root accounts instead of IAM users in IAM API requests.
+    --custom_bucket_path_allowed_list <string>            (optional)        Update the list of allowed custom bucket paths, separated by colons (:) example: '/gpfs/data/custom1/:/gpfs/data/custom2/' (override;unset with '')
 `;
 
 const ACCOUNT_FLAGS_DELETE = `

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -608,6 +608,7 @@ class AccountSpaceFS {
                 supplemental_groups: requesting_account.nsfs_account_config.supplemental_groups,
                 new_buckets_path: requesting_account.nsfs_account_config.new_buckets_path,
                 fs_backend: requesting_account.nsfs_account_config.fs_backend,
+                custom_bucket_path_allowed_list: requesting_account.nsfs_account_config.custom_bucket_path_allowed_list,
             }
         };
         if (requesting_account.iam_operate_on_root_account) {

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -87,7 +87,8 @@ module.exports = {
                     new_buckets_path: { type: 'string' },
                     fs_backend: {
                         $ref: 'common_api#/definitions/fs_backend'
-                    }
+                    },
+                    custom_bucket_path_allowed_list: { type: 'string' },
                 }
             }, {
                 type: 'object',
@@ -97,7 +98,8 @@ module.exports = {
                     new_buckets_path: { type: 'string' },
                     fs_backend: {
                         $ref: 'common_api#/definitions/fs_backend'
-                    }
+                    },
+                    custom_bucket_path_allowed_list: { type: 'string' },
                 }
             }]
         },

--- a/src/test/utils/coretest/nc_coretest.js
+++ b/src/test/utils/coretest/nc_coretest.js
@@ -337,7 +337,8 @@ async function create_account_manage(options) {
         uid: options.nsfs_account_config.uid,
         gid: options.nsfs_account_config.gid,
         access_key: options.access_key,
-        secret_key: options.secret_key
+        secret_key: options.secret_key,
+        custom_bucket_path_allowed_list: options.nsfs_account_config.custom_bucket_path_allowed_list,
     };
     const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, cli_options);
     const json_account = JSON.parse(res);
@@ -434,6 +435,7 @@ async function update_account_s3_access_manage(options) {
         distinguished_name: options.nsfs_account_config.distinguished_name,
         uid: options.nsfs_account_config.uid,
         gid: options.nsfs_account_config.gid,
+        custom_bucket_path_allowed_list: options.nsfs_account_config.custom_bucket_path_allowed_list,
     };
     await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.UPDATE, cli_options);
 }


### PR DESCRIPTION
### Describe the Problem
Adding support for an out-of-S3 header to let the user control where the bucket is supposed to be created.
x-noobaa-custom-bucket-path - will point to where the user wants their new bucket to be saved in the file system.

### Explain the Changes
1.  Adapting APIs to support x-noobaa-custom-bucket-path http header - once provided, instead of using the account new_bucket_path directory added to the bucket name, the name in the header will be used.
2.  Accounts can define an allow-list for permitted custom bucket paths; CLI options added to set or unset this allow-list.
3. Adding a test to check this scenario.

config.NSFS_CUSTOM_BUCKET_PATH_ALLOWED_LIST = '/ibm1/:/ibm3/'
or as part of the account, nsfs_account_config, for example:

nsfs_account_config: {
        uid: 100,
        gid: 100,
        new_buckets_path: '/gpfs/new_buckets',
        nsfs_only: false,
        custom_bucket_path_allowed_list: `/gpfs1/:/gpfs2/`,
}
If it exists, the account's custom_bucket_path_allowed_list will override the system's one.
If neither does, we will drop the request with 'access denied'.
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Apply `custom_bucket_path_allowed_list` in config.js and/or in your account
2. Send `x-noobaa-custom-bucket-path` header as part of S3 put_bucket request (using account creds)
3. Verify that the bucket was created in the provided path and not under the account's new_buckets_path/bucket_name


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bucket creation can specify a custom storage path via a special HTTP header.
  * Accounts can define an allow-list of permitted custom bucket path prefixes and a CLI flag to set/unset it.
  * Public configuration entries added to expose the header name and the allow-list setting.

* **Tests**
  * Integration tests added for allowed/denied creation, existing-path conflicts, and account-based path scenarios.

* **Documentation**
  * CLI and account docs updated to describe the new flag and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->