### PR TITLE
CI | fix Run PR Tests to respect changes in `.nvmrc` and `builder.dockerfile` for the builder image

### DIFF
--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -1,13 +1,12 @@
 name: Run PR Tests
 on: [pull_request, workflow_dispatch]
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
-    actions: read         # download-artifact
-    contents: read        # required for actions/checkout
+  actions: read # download-artifact
+  contents: read # required for actions/checkout
 jobs:
-
   run-sanity-tests:
     needs: build-noobaa-image
     uses: ./.github/workflows/sanity.yaml
@@ -121,18 +120,31 @@ jobs:
           steps.pull_base_image.outputs.pull_succeed == 'false'}}
         run: |
           output=true
-          for i in $(seq 0 ${{ steps.prep.outputs.pull_tries }})
-          do
-            date=$(date -d "${i} days ago" +'%Y%m%d')
-            builder_tag="quay.io/${{ steps.prep.outputs.buildertags }}${date}"
-            echo "Trying to pull ${builder_tag}"
-            docker pull ${builder_tag} || continue
-            echo "Successfully pulled ${builder_tag} from quay.io"
-            docker tag ${builder_tag} noobaa-builder
-            output=false
-            break
+          should_pull=true
+          # Check if we need to build the builder image
+          builder_files=("builder.dockerfile" ".nvmrc")
+          for file in ${{ steps.changed_files.outputs.all_changed_files }}; do
+            if printf '%s\n' "${builder_files[@]}" | grep -x -q "$file"; then
+              echo "File ${file} has changed, building builder image."
+              should_pull=false
+              break;
+            fi
           done
-          echo "should_build=${output}" >> $GITHUB_OUTPUT 
+          # If not changed, try to pull
+          if [ "$should_pull" = true ]; then
+            for i in $(seq 0 ${{ steps.prep.outputs.pull_tries }})
+            do
+              date=$(date -d "${i} days ago" +'%Y%m%d')
+              builder_tag="quay.io/${{ steps.prep.outputs.buildertags }}${date}"
+              echo "Trying to pull ${builder_tag}"
+              docker pull ${builder_tag} || continue
+              echo "Successfully pulled ${builder_tag} from quay.io"
+              docker tag ${builder_tag} noobaa-builder
+              output=false
+              break
+            done
+          fi
+          echo "should_build=${output}" >> $GITHUB_OUTPUT
 
       - name: Build noobaa-base image
         if: ${{steps.should_build_base.outputs.should_build == 'true' ||


### PR DESCRIPTION
### Explain the Changes

- Fix Run PR Tests to respect changes in `.nvmrc` and `builder.dockerfile` for the builder image

### Describe the Problem
Changes in the `.nvmrc` did not affect the builder image pulling, and as a result, the image was pulled with an older node version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now detects whether builder images should be rebuilt or pulled based on which files changed, reducing unnecessary rebuilds.
  * Replaced unconditional pull loop with a files-driven decision while preserving pull/retry behavior and image tagging.
  * Build/pull signaling and gating were synchronized so downstream steps reliably follow the updated build-or-pull decision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->