### PR TITLE
IAM | put_bucket_policy Principal validation updated with ARN

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -620,6 +620,7 @@ module.exports = {
             type: 'object',
             required: ['name', 'email', 'has_s3_access'],
             properties: {
+                _id: { type: 'string'},
                 name: { $ref: 'common_api#/definitions/account_name' },
                 email: { $ref: 'common_api#/definitions/email' },
                 is_support: {
@@ -660,6 +661,9 @@ module.exports = {
                 },
                 bucket_claim_owner: {
                     $ref: 'common_api#/definitions/bucket_name',
+                },
+                iam_path: {
+                    type: 'string',
                 },
                 external_connections: {
                     type: 'object',

--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -62,6 +62,10 @@ function check_iam_path_was_set(iam_path) {
     return iam_path && iam_path !== iam_constants.IAM_DEFAULT_PATH;
 }
 
+function get_iam_username(requested_account_name) {
+    return requested_account_name.split(iam_constants.IAM_SPLIT_CHARACTERS)[0];
+}
+
 /**
  * parse_max_items converts the input to the needed type
  * assuming that we've got only sting type
@@ -818,6 +822,7 @@ exports.create_arn_for_user = create_arn_for_user;
 exports.create_arn_for_root = create_arn_for_root;
 exports.get_action_message_title = get_action_message_title;
 exports.check_iam_path_was_set = check_iam_path_was_set;
+exports.get_iam_username = get_iam_username;
 exports.parse_max_items = parse_max_items;
 exports.validate_params = validate_params;
 exports.validate_iam_path = validate_iam_path;

--- a/src/sdk/accountspace_nb.js
+++ b/src/sdk/accountspace_nb.js
@@ -85,7 +85,7 @@ class AccountSpaceNB {
         const action = IAM_ACTIONS.GET_USER;
         const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
         const requested_account = validate_and_return_requested_account(params, action, requesting_account);
-        const username = account_util.get_iam_username(params.username || requested_account.name.unwrap());
+        const username = iam_utils.get_iam_username(params.username || requested_account.name.unwrap());
         const iam_arn = iam_utils.create_arn_for_user(requesting_account._id.toString(), username,
                                     requested_account.iam_path || IAM_DEFAULT_PATH);
         const reply = {
@@ -110,7 +110,7 @@ class AccountSpaceNB {
         account_util._check_if_account_exists(action, old_username);
         const requested_account = system_store.get_account_by_email(old_username);
         let iam_path = requested_account.iam_path;
-        let user_name = account_util.get_iam_username(requested_account.name.unwrap());
+        let user_name = iam_utils.get_iam_username(requested_account.name.unwrap());
         account_util._check_username_already_exists(action, { username: params.new_username }, requesting_account);
         account_util._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
         account_util._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
@@ -173,7 +173,7 @@ class AccountSpaceNB {
             return account.owner?._id.toString() === requesting_account._id.toString();
         });
         let members = _.map(requesting_account_iam_users, function(iam_user) {
-            const iam_username = account_util.get_iam_username(iam_user.name.unwrap());
+            const iam_username = iam_utils.get_iam_username(iam_user.name.unwrap());
             const iam_path = iam_user.iam_path || IAM_DEFAULT_PATH;
             const member = {
                 user_id: iam_user._id.toString(),
@@ -218,7 +218,7 @@ class AccountSpaceNB {
         }
 
         return {
-            username: account_util.get_iam_username(requested_account.name.unwrap()),
+            username: iam_utils.get_iam_username(requested_account.name.unwrap()),
             access_key: iam_access_key.access_key.unwrap(),
             create_date: iam_access_key.creation_date,
             status: ACCESS_KEY_STATUS_ENUM.ACTIVE,
@@ -238,7 +238,7 @@ class AccountSpaceNB {
             region: dummy_region, // GAP
             last_used_date: Date.now(), // GAP
             service_name: dummy_service_name, // GAP
-            username: username ? account_util.get_iam_username(username) : undefined,
+            username: username ? iam_utils.get_iam_username(username) : undefined,
         };
     }
 

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -15,6 +15,7 @@ const addr_utils = require('../../util/addr_utils');
 const kube_utils = require('../../util/kube_utils');
 const jwt_utils = require('../../util/jwt_utils');
 const config = require('../../../config');
+const iam_utils = require('../../endpoint/iam/iam_utils');
 const s3_bucket_policy_utils = require('../../endpoint/s3/s3_bucket_policy_utils');
 
 
@@ -548,10 +549,11 @@ async function has_bucket_action_permission(bucket, account, action, req_query, 
     if (!action) {
         throw new Error('has_bucket_action_permission: action is required');
     }
-
+    const arn = account.owner ? iam_utils.create_arn_for_user(account.owner._id.toString(), account.name.unwrap().split(':')[0], account.iam_path) :
+                                    iam_utils.create_arn_for_root(account._id);
     const result = await s3_bucket_policy_utils.has_bucket_policy_permission(
         bucket_policy,
-        account.email.unwrap(),
+        arn,
         action,
         `arn:aws:s3:::${bucket.name.unwrap()}${bucket_path}`,
         req_query

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -988,7 +988,7 @@ function get_account_info(account, include_connection_cache) {
         'has_login',
         'allowed_ips',
     );
-
+    info._id = account._id.toString();
     if (account.is_support) {
         info.is_support = true;
         info.has_login = true;
@@ -998,7 +998,10 @@ function get_account_info(account, include_connection_cache) {
             secret_key: 'Not Accesible'
         }];
     }
-
+    if (account.owner) {
+        info.owner = account.owner._id.toString();
+    }
+    info.iam_path = account.iam_path;
     if (account.next_password_change) {
         info.next_password_change = account.next_password_change.getTime();
     }

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -13,10 +13,9 @@ const system_store = require('..//server/system_services/system_store').get_inst
 const pool_server = require('../server/system_services/pool_server');
 const { OP_NAME_TO_ACTION } = require('../endpoint/sts/sts_rest');
 const IamError = require('../endpoint/iam/iam_errors').IamError;
-const { create_arn_for_user, get_action_message_title } = require('../endpoint/iam/iam_utils');
-const { IAM_ACTIONS, MAX_NUMBER_OF_ACCESS_KEYS, IAM_DEFAULT_PATH,
-    ACCESS_KEY_STATUS_ENUM, IAM_SPLIT_CHARACTERS, IAM_ACTIONS_USER_INLINE_POLICY,
-    AWS_LIMIT_CHARS_USER_INlINE_POLICY } = require('../endpoint/iam/iam_constants');
+const { create_arn_for_user, get_action_message_title, get_iam_username } = require('../endpoint/iam/iam_utils');
+const { IAM_ACTIONS, MAX_NUMBER_OF_ACCESS_KEYS, IAM_DEFAULT_PATH, ACCESS_KEY_STATUS_ENUM,
+    IAM_ACTIONS_USER_INLINE_POLICY, AWS_LIMIT_CHARS_USER_INlINE_POLICY } = require('../endpoint/iam/iam_constants');
 
 const demo_access_keys = Object.freeze({
     access_key: new SensitiveString('123'),
@@ -321,10 +320,6 @@ function validate_assume_role_policy(policy) {
 // is root account id, This will make the user name uniq accross system.
 function get_account_name_from_username(username, requesting_account_id) {
     return new SensitiveString(`${username}:${requesting_account_id}`);
-}
-
-function get_iam_username(requested_account_name) {
-    return requested_account_name.split(IAM_SPLIT_CHARACTERS)[0];
 }
 
 function _check_if_account_exists(action, email_wrapped) {
@@ -722,7 +717,6 @@ exports.delete_account = delete_account;
 exports.create_account = create_account;
 exports.generate_account_keys = generate_account_keys;
 exports.get_account_name_from_username = get_account_name_from_username;
-exports.get_iam_username = get_iam_username;
 exports.get_non_updating_access_key = get_non_updating_access_key;
 exports._check_if_requesting_account_is_root_account = _check_if_requesting_account_is_root_account;
 exports._check_username_already_exists = _check_username_already_exists;

--- a/src/util/string_utils.js
+++ b/src/util/string_utils.js
@@ -18,6 +18,7 @@ const AWS_IAM_ACCESS_KEY_INPUT_REGEXP = /^[\w]+$/;
 const AWS_IAM_TAG_KEY_AND_VALUE_REGEXP = /^[\p{L}\p{Z}\p{N}_.:/=+\-@]+$/u;
 const AWS_POLICY_NAME_REGEXP = /^[\w+=,.@-]+$/;
 const AWS_POLICY_DOCUMENT_REGEXP = /^[\u0009\u000A\u000D\u0020-\u00FF]+$/;
+const AWS_IAM_ARN_REGEXP = /^arn:aws:iam::\w{10,}:(?:root|user\/[\w\-\.\/]+)$/;
 
 function crypto_random_string(len, charset = ALPHA_NUMERIC_CHARSET) {
     // In order to not favor any specific chars over others we limit the maximum random value
@@ -171,3 +172,4 @@ exports.AWS_IAM_ACCESS_KEY_INPUT_REGEXP = AWS_IAM_ACCESS_KEY_INPUT_REGEXP;
 exports.AWS_IAM_TAG_KEY_AND_VALUE_REGEXP = AWS_IAM_TAG_KEY_AND_VALUE_REGEXP;
 exports.AWS_POLICY_NAME_REGEXP = AWS_POLICY_NAME_REGEXP;
 exports.AWS_POLICY_DOCUMENT_REGEXP = AWS_POLICY_DOCUMENT_REGEXP;
+exports.AWS_IAM_ARN_REGEXP = AWS_IAM_ARN_REGEXP;


### PR DESCRIPTION
### Describe the Problem

1. Bucket policy "Principal" validation was based on the email before and it updated with ARN
2. put_bucket_policy validate principal ARN

### Explain the Changes
#### Principal validation 
1. Validate basic ARN, like arn prefix `arn:aws:iam::`
2. If principal ARN end with `root sufix its a account and get account with id 
eg: `aws:arn:${account_id}:root`
3. If principle ARN contains `user` its a IAM user and get account with username and id 
      eg : `aws:arn:${account_id}:user/${iam_path}/${use_name}`
account email = ${iam_user_name}:${account_id}

#### S3 Rest authorize request policy
1. ARN is added to equest policy validation replacing account email. ARN based validation valid for containerized deployments(not for NSFS).
2.  Updated test cases(test_s3_bucket_policy.js), previousily these tests where using email for principal for both NSFS non-containerized and acontainerized, With latest changes containerized will use ARN

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bucket policies and permission checks now accept IAM-style ARNs and evaluate ARN-based principals when account IDs aren’t available.
  * Account info responses now include account ID, owner reference, and iam_path; IAM username handling unified to support ARN scenarios.
  * New ARN helper utilities and an ARN validation pattern added for consistent principal construction.

* **Tests**
  * Integration tests updated to use account ARNs across S3, STS and NSFS policy/authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->