### PR TITLE
[GLACIER | NSFS | NC] Replace GLACIER_DA with DEEP_ARCHIVE

### DIFF
--- a/config.js
+++ b/config.js
@@ -197,12 +197,12 @@ config.STS_CORS_EXPOSE_HEADERS = 'ETag';
 config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD = false;
 
 /**
- * NSFS_GLACIER_FORCE_STORAGE_CLASS when set to true
- * will force `GLACIER` storage class if no storage class
- * is provided and if `STANDARD` storage class is provided
- * @type {boolean}
+ * NSFS_GLACIER_FORCE_STORAGE_CLASS controls which storage
+ * class to be used if no storage class or `STANDARD` storage
+ * class is provided.
+ * @type {nb.StorageClass}
  */
-config.NSFS_GLACIER_FORCE_STORAGE_CLASS = false;
+config.NSFS_GLACIER_FORCE_STORAGE_CLASS = undefined;
 
 // S3_RESTORE_MAX_DAYS controls that for how many maximum number
 // of days an object can be restored using `restore-object` call.

--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -41,7 +41,7 @@ async function get_object(req, res) {
 
     s3_utils.set_response_object_md(res, object_md);
     s3_utils.set_encryption_response_headers(req, res, object_md.encryption);
-    if (object_md.storage_class === s3_utils.STORAGE_CLASS_GLACIER) {
+    if (s3_utils.GLACIER_STORAGE_CLASSES.includes(object_md.storage_class)) {
         if (object_md.restore_status?.ongoing || !object_md.restore_status?.expiry_time) {
             // Don't try to read the object if it's not restored yet
             dbg.warn('Object is not restored yet', req.path, object_md.restore_status);

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -107,9 +107,6 @@ async function handle_request(req, res) {
     }
     http_utils.check_headers(req, headers_options);
 
-    // Will override the storage class if configured
-    s3_utils.override_storage_class(req);
-
     const redirect = await populate_request_additional_info_or_redirect(req);
     if (redirect) {
         res.setHeader('Location', redirect);

--- a/src/sdk/glacier.js
+++ b/src/sdk/glacier.js
@@ -339,7 +339,7 @@ class Glacier {
      */
     static get_restore_status(xattr, now, file_path) {
         const storage_class = Glacier.storage_class_from_xattr(xattr);
-        if (storage_class !== s3_utils.STORAGE_CLASS_GLACIER) {
+        if (!s3_utils.GLACIER_STORAGE_CLASSES.includes(storage_class)) {
             return;
         }
 

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1077,7 +1077,7 @@ class NamespaceFS {
                     // Disallow read if the object is in Glacier storage class and isn't restored
                     const obj_storage_class = Glacier.storage_class_from_xattr(stat.xattr);
                     const obj_restore_status = Glacier.get_restore_status(stat.xattr, new Date(), file_path);
-                    if (obj_storage_class === s3_utils.STORAGE_CLASS_GLACIER) {
+                    if (s3_utils.GLACIER_STORAGE_CLASSES.includes(obj_storage_class)) {
                         if (obj_restore_status?.ongoing || !obj_restore_status?.expiry_time) {
                             dbg.warn('read_object_stream: object is not restored yet', obj_restore_status);
                             throw new S3Error(S3Error.InvalidObjectState);
@@ -1307,7 +1307,7 @@ class NamespaceFS {
             const src_storage_class = Glacier.storage_class_from_xattr(stat.xattr);
             const src_restore_status = Glacier.get_restore_status(stat.xattr, new Date(), src_file_path);
 
-            if (src_storage_class === s3_utils.STORAGE_CLASS_GLACIER) {
+            if (s3_utils.GLACIER_STORAGE_CLASSES.includes(src_storage_class)) {
                 if (src_restore_status?.ongoing || !src_restore_status?.expiry_time) {
                     dbg.warn('_validate_upload: object is not restored yet', src_restore_status);
                     throw new S3Error(S3Error.InvalidObjectState);
@@ -1317,7 +1317,7 @@ class NamespaceFS {
             }
         }
 
-        return params.copy_source && params.storage_class === s3_utils.STORAGE_CLASS_GLACIER;
+        return params.copy_source && s3_utils.GLACIER_STORAGE_CLASSES.includes(params.storage_class);
     }
 
     // on put part - file path is equal to upload path
@@ -1363,7 +1363,7 @@ class NamespaceFS {
                 [Glacier.STORAGE_CLASS_XATTR]: params.storage_class
             });
 
-            if (params.storage_class === s3_utils.STORAGE_CLASS_GLACIER) {
+            if (s3_utils.GLACIER_STORAGE_CLASSES.includes(params.storage_class)) {
                 await this.append_to_migrate_wal(file_path);
             }
         }
@@ -2297,7 +2297,7 @@ class NamespaceFS {
                 return {
                     accepted: false,
                     expires_on,
-                    storage_class: s3_utils.STORAGE_CLASS_GLACIER
+                    storage_class: Glacier.storage_class_from_xattr(stat.xattr)
                 };
             }
         } catch (error) {
@@ -3539,15 +3539,9 @@ class NamespaceFS {
     }
 
     async _is_storage_class_supported(storage_class) {
-        const glacier_storage_classes = [
-            s3_utils.STORAGE_CLASS_GLACIER,
-            s3_utils.STORAGE_CLASS_GLACIER_DA,
-            s3_utils.STORAGE_CLASS_GLACIER_IR,
-        ];
-
         if (!storage_class || storage_class === s3_utils.STORAGE_CLASS_STANDARD) return true;
 
-        if (glacier_storage_classes.includes(storage_class)) {
+        if (s3_utils.GLACIER_STORAGE_CLASSES.includes(storage_class)) {
             return config.NSFS_GLACIER_ENABLED || false;
         }
 
@@ -3619,7 +3613,7 @@ class NamespaceFS {
         if (!config.NSFS_GLACIER_FORCE_EXPIRE_ON_GET) return;
 
         const storage_class = s3_utils.parse_storage_class(stat.xattr[Glacier.STORAGE_CLASS_XATTR]);
-        if (storage_class !== s3_utils.STORAGE_CLASS_GLACIER) return;
+        if (!s3_utils.GLACIER_STORAGE_CLASSES.includes(storage_class)) return;
 
         // Remove all the restore related xattrs
         await file.replacexattr(fs_context, {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -17,7 +17,7 @@ type DigestType = 'sha1' | 'sha256' | 'sha384' | 'sha512';
 type CompressType = 'snappy' | 'zlib';
 type CipherType = 'aes-256-gcm';
 type ParityType = 'isa-c1' | 'isa-rs' | 'cm256';
-type StorageClass = 'STANDARD' | 'GLACIER' | 'GLACIER_IR' | 'GLACIER_DA';
+type StorageClass = 'STANDARD' | 'GLACIER' | 'GLACIER_IR' | 'DEEP_ARCHIVE';
 type ResourceType = 'HOSTS' | 'CLOUD' | 'INTERNAL';
 type NodeType =
     'BLOCK_STORE_S3' |


### PR DESCRIPTION
### Describe the Problem
This PR replaces GLACIER_DA with DEEP_ARCHIVE and changes the way we override the storage class without overwriting the storage class HTTP header.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Broadened Glacier handling so restore/read flows consider multiple Glacier-related storage classes.
  - Removed the pre-redirect automatic storage-class override step.

* **Refactor**
  - Renamed storage class option from GLACIER_DA to DEEP_ARCHIVE and exposed a grouped Glacier storage-classes list.

* **SDK**
  - Public type updated: DEEP_ARCHIVE replaces GLACIER_DA as a valid storage-class option.

* **Chores**
  - Config entry for NSFS_GLACIER_FORCE_STORAGE_CLASS changed from boolean to optional storage-class selector.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->