### PR TITLE
NC | Removing root check for manage_nsfs

### DIFF
--- a/src/cmd/manage_nsfs.js
+++ b/src/cmd/manage_nsfs.js
@@ -51,9 +51,6 @@ let config_fs;
 async function main(argv = minimist(process.argv.slice(2))) {
     try {
         config.EVENT_LOGGING_ENABLED = true;
-        if (process.getuid() !== 0 || process.getgid() !== 0) {
-            throw new Error('Root permissions required for Manage NSFS execution.');
-        }
         const type = argv._[0] || '';
         const action = argv._[1] || '';
         if (argv.help || argv.h) {


### PR DESCRIPTION

### Describe the Problem
As a new check for allowed running users will be in scale CLIs, we will remove the check from our side 

### Explain the Changes
1. won't check for root

### Issues: Fixed #xxx / Gap #xxx
1. Part of the efforts needed in https://issues.redhat.com/browse/RHSTOR-6713

### Testing Instructions:
1. try and run manage_nsfs with out using sudo - see it doesn't fail


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the root-permission requirement, allowing the application to execute with any user privilege level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->