### PR TITLE
IAM | Authorize Requests for IAM Users According to IAM User Inline Policy

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -749,6 +749,15 @@ module.exports = {
                 },
                 nsfs_account_config: {
                     $ref: 'common_api#/definitions/nsfs_account_config'
+                },
+                iam_user_policies: {
+                    type: 'array',
+                    items: {
+                        $ref: 'common_api#/definitions/iam_user_policy',
+                    }
+                },
+                owner: {
+                    type: 'string'
                 }
             },
         },

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -951,7 +951,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             action,
             `arn:aws:s3:::${bucket.name.unwrap()}${bucket_path}`,
             undefined,
-            bucket.public_access_block?.restrict_public_buckets,
+            { disallow_public_access: bucket.public_access_block?.restrict_public_buckets }
         );
         if (permission_by_id === "DENY") return false;
         // we (currently) allow account identified to be both id and name,
@@ -963,7 +963,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 action,
                 `arn:aws:s3:::${bucket.name.unwrap()}${bucket_path}`,
                 undefined,
-                bucket.public_access_block?.restrict_public_buckets,
+                { disallow_public_access: bucket.public_access_block?.restrict_public_buckets }
             );
         }
         if (permission_by_name === 'DENY') return false;

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1049,6 +1049,14 @@ function get_account_info(account, include_connection_cache) {
     };
     info.role_config = account.role_config;
     info.force_md5_etag = account.force_md5_etag;
+
+    if (account.iam_user_policies) {
+        info.iam_user_policies = account.iam_user_policies;
+    }
+    if (account.owner) {
+        info.owner = account.owner._id.toString();
+    }
+
     return info;
 }
 


### PR DESCRIPTION
### Describe the Problem
Add a step in `s3_rest` to authorize requests for IAM users according to the IAM user inline policy.

### Explain the Changes
1. Add the function `authorize_request_iam_policy` and call it from `authorize_request`.
2. Add properties that I need for this step in `account_info` (`owner` and `iam_user_policies`).

### Issues:
List of GAPs:
1. The tests are only manual at this point; there is a plan to add automated tests after we have the design change.
2. I might want to refactor the code so that `s3_bucket_policy_utils.js` so the terms will be policy in general and can be used for bucket policy and IAM policy.
3. I might want to move the created function somewhere else (perhaps `iam_rest`) so the thrown error will be `IamError.AccessDeniedException` instead of `S3Error.AccessDenied`

Design Decisions:
- When there is no IAM user policy, it is authorized for this step (didn't want to change default behavior).
- The IAM policy authorization is done in **parallel** - I had the option to do it **sequentially**, meaning policy after policy - get the resolved promise answer and work on it (`DENY` throws an error), but I decided to do it in parallel, assuming that the total user policy is limited. If I were to do it sequentially, I would need to wait for every policy check, instead of running all the checks and waiting for all the promises to be resolved and work on the result (`DENY`, `ALLOW`, `IMPLICIT_DENY`). I also decided to check in parallel to the bucket policy, and I had the option to do it after, as in the case where there is an IAM user policy with `DENY`, we would like it to be thrown as part of the calculation.

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
4. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
5. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
6. Create the alias for the admin - first, need to get the credentials: `nb status --show-secrets -n test1` and then:
`alias admin-s3='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
`alias admin-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
7. Check the connection to the endpoint:
- try to list the users (should be an empty list): `admin-iam iam list-users; echo $?`
- try to list the buckets (should be `first.bucket`): `admin-iam s3 ls; echo $?`
8. Create a user: `admin-iam iam create-user --user-name Robert`
Note: To validate user creation, you can rerun `admin-iam iam list-users` and expect 1 user in the list
9. Create access keys: `admin-iam iam create-access-keys --user-name Robert`
10. Create the alias for the user (like in step 4 with alias `user-2-s3`).
11. The case with no bucket policy, no IAM policy - the user will not be restricted from S3 operation, for example:
- The user creates a bucket: `user-2-s3 s3 mb s3://mybucket` (should work).
- The user put an object in that bucket: `echo 'test_data' | user-2-s3 s3 cp - s3://first.bucket/test_object.txt` (should work).
12. The admin adds an inline policy so the user cannot create a bucket, but can put an object.
policy_deny_create_bucket_allow_put_object.json
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Deny",
            "Action": [
                "s3:CreateBucket"
            ],
            "Resource": "*"
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:PutObject"
            ],
            "Resource": "*"
        }
    ]
}
```
13. `admin-iam iam put-user-policy --user-name Robert --policy-name policy_deny_create_bucket_allow_put_object --policy-document file://policy_deny_create_bucket_allow_put_object.json`
14. Repeat step 10:
- The user put an object in that bucket: `echo 'test_data' | user-2-s3 s3 cp - s3://first.bucket/test_object2.txt` (should work).
- The user creates a bucket: `user-2-s3 mb mybucket2` (should throw `AccessDenied` error).

Code changes for testing:
1. To see the account (of a user) in the cache after changes, `src/sdk/object_sdk.js` uses cache expiry of 1 millisecond.
```diff
const account_cache = new LRUCache({
    name: 'AccountCache',
-    expiry_ms: config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS,
+   expiry_ms: 1, //SDSD 
```
2. (temporarily) Not to be blocked on authorization by bucket policy `src/endpoint/s3/s3_rest.js` in the `if (!s3_policy) {` remove the error thrown as currently `owner_account` in NC deployment and is undefined. rest of the code in `else` condition.

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).
- I used the admin account, but for IAM operations, there is no difference between a created account and an admin account. I tested with the admin only because it saves steps (I have the admin account upon system creation and a bucket).

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accounts can include an owner field and associated IAM user policies surfaced in account info.
  * S3 authorization now evaluates IAM user inline policies in parallel with existing bucket/account policies.
  * Bucket permission checks honor public-access restrictions when evaluating permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->