### PR TITLE
notificatoins - fixes for lifecycle dfbugs 4469

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -986,7 +986,7 @@ async function delete_multiple_objects_by_filter(req) {
     let delete_results;
     let objects;
     // TODO: Add support to delete_objects_by_query also for versioning or add another function to support versioning.
-    if (req.bucket.versioning === 'DISABLED' && config.DB_TYPE !== 'mongodb') /* only for postgres */ {
+    if (req.bucket.versioning === 'DISABLED' && config.DB_TYPE !== 'mongodb' && reply_objects !== true) /* only for postgres */ {
         query.return_results = true; // we want to return the objects that were deleted
         objects = await MDStore.instance().delete_objects_by_query(query);
     } else {
@@ -1019,6 +1019,7 @@ async function delete_multiple_objects_by_filter(req) {
                 };
             } else {
                 reply.deleted_objects[i] = get_object_info(objects[i]);
+                reply.deleted_objects[i].delete_marker = delete_results && delete_results[i] && delete_results[i].created_delete_marker;
             }
         }
     }

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -498,7 +498,7 @@ function compose_notification_lifecycle(deleted_obj, notif_conf, bucket, object_
     const notif = compose_notification_base(notif_conf, bucket, {object_sdk});
 
     notif.eventName = OP_TO_EVENT.lifecycle_delete.name + ':' +
-        (deleted_obj.created_delete_marker ? 'DeleteMarkerCreated' : 'Delete');
+        ((deleted_obj.created_delete_marker || deleted_obj.delete_marker) ? 'DeleteMarkerCreated' : 'Delete');
     notif.s3.object.key = deleted_obj.key;
     notif.s3.object.size = deleted_obj.size;
     notif.s3.object.eTag = deleted_obj.etag;


### PR DESCRIPTION
### Describe the Problem
1. No notification for lifecycle deletion.
2. Versioned objects deleted by lifecycle has wrong event.

### Explain the Changes
1. Don't use faster option for lifecycle with notification - we need the MD for the notification.
2. Use correct event DeleteMarkerCreated when lifecycle deletes a versioned object.


### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-4469

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deletion flow when versioning is disabled so reply paths no longer return object details.
  * Delete responses now include delete-marker metadata for each deleted object.
  * Improved deletion event/notification classification to recognize delete markers for more accurate event types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->