### PR TITLE
Added support for second access key s3 access

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -132,9 +132,8 @@ function read_account(req) {
 
 function read_account_by_access_key(req) {
     const { access_key } = req.rpc_params;
-    const account = _.find(system_store.data.accounts, acc =>
-        acc.access_keys && acc.access_keys.length > 0 && acc.access_keys[0].access_key.unwrap() === access_key.unwrap()
-    );
+
+    const account = system_store.get_account_by_access_key(access_key);
 
     if (!account) throw new RpcError('NO_SUCH_ACCOUNT', 'No such account with credentials: ' + access_key);
 


### PR DESCRIPTION
### Describe the Problem
Currently, we do not support second access key for s3 access.

### Explain the Changes
1.  Previously, authentication only checked the first access key (`access_keys[0]`), preventing IAM users from using their second access key for S3 operations. This fix updates `auth_server.js`, `account_server.js` and `account_util.js` to iterate through all access keys in the array.

### Issues: Fixed #xxx / Gap #xxx
1. JIRA: https://issues.redhat.com/browse/RHSTOR-8114

### Testing Instructions:
1. Create account: `nb account create <account-name>`
2. Create user under the above account created.
3. Create two access keys for the user.
4. Try accessing s3 apis using the user credentials (first and second both)
5. Also try deactivating the access keys.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now correctly matches the provided access key and uses that key's associated secret, enabling proper per-key secret resolution for accounts with multiple keys.
  * Account lookup by access key is more reliable — read requests now return the correct account information when queried by access key.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->