### PR TITLE
IAM | No Bucket Policy Authorization for IAM Users

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1207,6 +1207,9 @@ module.exports = {
                 bucket_owner: {
                     $ref: 'common_api#/definitions/email'
                 },
+                bucket_owner_id: {
+                    type: 'string'
+                },
                 website: {
                     $ref: 'common_api#/definitions/bucket_website'
                 },

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -218,7 +218,8 @@ class ObjectSDK {
             s3_policy: bucket.s3_policy,
             system_owner: bucket.system_owner, // note that bucketspace_fs currently doesn't return system_owner
             bucket_owner: bucket.bucket_owner,
-            owner_account: bucket.owner_account, // in NC NSFS this is the account id that owns the bucket
+            bucket_owner_id: bucket.bucket_owner_id, // in containerized this is the account id that owns the bucket
+            owner_account: bucket.owner_account, // in NC NSFS this is an object of account id and name that owns the bucket
             public_access_block: bucket.public_access_block,
         };
         return policy_info;

--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -545,7 +545,13 @@ async function has_bucket_action_permission(bucket, account, action, req_query, 
         (account.bucket_claim_owner && account.bucket_claim_owner.name.unwrap() === bucket.name.unwrap());
     const bucket_policy = bucket.s3_policy;
 
-    if (!bucket_policy) return is_owner;
+    if (!bucket_policy) {
+        // in case we do not have bucket policy
+        // we allow IAM account to access a bucket that that is owned by their root account
+        const is_iam_and_same_root_account_owner = account.owner !== undefined &&
+            account.owner._id.toString() === bucket.owner_account._id.toString();
+        return is_owner || is_iam_and_same_root_account_owner;
+    }
     if (!action) {
         throw new Error('has_bucket_action_permission: action is required');
     }

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -733,6 +733,7 @@ async function read_bucket_sdk_info(req) {
         s3_policy: bucket.s3_policy,
         system_owner: bucket.system.owner.email,
         bucket_owner: bucket.owner_account.email,
+        bucket_owner_id: bucket.owner_account._id.toString(),
         bucket_info: await P.map_props({
                 bucket,
                 nodes_aggregate_pool: bucket.tiering && nodes_client.instance().aggregate_nodes_by_pool(pool_names, system._id),


### PR DESCRIPTION
### Describe the Problem
In case there is no bucket policy, we want users under the account to be authorized to perform S3 operations.

### Explain the Changes
1. In case there is no bucket policy - permit users under the account for S3 operations.

### Issues: 
List of GAPs:
1. This code does not handle a case where there is a user under an OBC account, in case we decide to add this layer.
2. The tests are only manual at this point; there is a plan to add automated tests after we have the design change.

### Testing Instructions:
1. Build the images and install the NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
3. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
4. Create the alias for the admin - first, need to get the credentials: `nb status --show-secrets -n test1` and then:
`alias admin-s3='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
`alias admin-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
5. Check the connection to the endpoint:
- try to list the users (should be an empty list): `admin-iam iam list-users; echo $?`
- try to list the buckets (should be `first.bucket`): `admin-iam s3 ls; echo $?`
6. Create a user: `admin-iam iam create-user --user-name Robert`
Note: To validate user creation, you can rerun `admin-iam iam list-users` and expect 1 user in the list
7. Create access keys: `admin-iam iam create-access-keys --user-name Robert`
8. Create the alias for the user (like in step 4 with alias `user-2-s3`).
9. The case with no bucket policy, for example:
- The user can put an object in the bucket of the owner:
`echo 'test_data' | user-2-s3 s3 cp - s3://first.bucket/test_object.txt` (should work).
- The user can list objects in the bucket (to check the flow of the RPC call of `has_bucket_action_permission` function that was created in the `auth_server`):
`user-1-s3 s3 ls s3://first.bucket`

Code changes for testing:
1. To see the account (of a user) in the cache after changes, `src/sdk/object_sdk.js` uses cache expiry of 1 millisecond.
```diff
const account_cache = new LRUCache({
    name: 'AccountCache',
-    expiry_ms: config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS,
+   expiry_ms: 1, //SDSD 
```

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).
- I used the admin account, but for IAM operations, there is no difference between a created account and an admin account. I tested with the admin only because it saves steps (I have the admin account upon system creation and a bucket).


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public bucket_owner_id field to bucket info and policy responses.

* **Improvements**
  * Owner info now includes both account id and display name.
  * Authorization expanded so IAM accounts sharing a root owner can access buckets when no policy exists.
  * Ownership checks unified and made aware of containerized vs. non-containerized deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->