### PR TITLE
improve performance by introducing composite index for datachunks

### DIFF
--- a/src/server/object_services/schemas/data_chunk_indexes.js
+++ b/src/server/object_services/schemas/data_chunk_indexes.js
@@ -17,6 +17,8 @@ module.exports = [{
     {
         fields: {
             dedup_key: 1,
+            system: 1,
+            bucket: 1
         },
         options: {
             unique: false,

--- a/src/upgrade/upgrade_scripts/5.21.0/remove_datachunks_index.js
+++ b/src/upgrade/upgrade_scripts/5.21.0/remove_datachunks_index.js
@@ -1,0 +1,23 @@
+/* Copyright (C) 2025 NooBaa */
+"use strict";
+
+async function run({ dbg, db_client }) {
+  /* After the index is dropped, a new composite index (system, bucket, dedup_key) 
+    will be created during bootstrap */
+  const indexName = 'idx_btree_datachunks_dedup_key';
+
+  try {
+    const pool = db_client.instance().get_pool();
+    await pool.query(`DROP INDEX IF EXISTS ${indexName};`);
+
+    dbg.log0("Executed upgrade script for dropping index ", indexName);
+  } catch (err) {
+    dbg.error('An error ocurred in the upgrade process:', err);
+    throw err;
+  }
+}
+
+module.exports = {
+  run,
+  description: 'Delete the "idx_btree_datachunks_dedup_key" index'
+};


### PR DESCRIPTION
### Describe the Problem
When dedup checks for existing chunks in the system, the query filters by system, dedup_key and bucket. When the table size is large, the index is not being used by the pg planner.

### Explain the Changes
1. Added an upgrade script which deletes the index 'idx_btree_datachunks_dedup_key'.
2. New composite index (dedup_key, system, bucket) is created during bootstrapping.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Upgrade noobaa from 4.20 to 4.21. 
2. After successful upgrade compare the time taken by upload with dedup enabled.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a database index to a composite index by including additional fields to improve query targeting and performance.
  * Added an upgrade script for v5.21.0 to remove a deprecated index during migration, ensuring smoother upgrades and index replacement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->