### PR TITLE
[backport into 18] notification - nc test - don't assume test vm has enough fs free

### DIFF
--- a/src/test/unit_tests/test_nc_health.js
+++ b/src/test/unit_tests/test_nc_health.js
@@ -240,7 +240,9 @@ mocha.describe('nsfs nc health', function() {
             const health_status = await Health.nc_nsfs_health();
             Health.notif_storage_limit = false;
 
-            assert.strictEqual(health_status.checks.notif_storage_threshold_details.result, 'above threshold');
+            console.log("PSA fs stats =", fs.statfsSync(config.NOTIFICATION_LOG_DIR));
+
+            assert(health_status.checks.notif_storage_threshold_details.result.indexOf(' threshold') > -1);
             assert.strictEqual(health_status.checks.notif_storage_threshold_details.threshold, config.NOTIFICATION_SPACE_CHECK_THRESHOLD);
         });
 


### PR DESCRIPTION
backport for https://github.com/noobaa/noobaa-core/pull/9292

NB tests fail on old Cept s3 tests
