### PR TITLE
Fix (NC | NSFS) - list_buckets allowing unauthorized bucket access

### DIFF
--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -63,6 +63,7 @@ interface System extends Base {
 
 interface Account extends Base {
     _id: ID;
+    owner?: ID;
     name: string;
     system: System;
     email: SensitiveString;
@@ -179,6 +180,7 @@ interface MirrorStatus {
 
 interface Bucket extends Base {
     _id: ID;
+    owner_account?: ID;
     deleted?: Date;
     name: SensitiveString;
     system: System;


### PR DESCRIPTION
### Describe the Problem
Currently, bucket policy interfere with the list buckets which is not aws complaint.

### Explain the Changes
1. Handled `list_buckets()` with proper permissions and make it aws complaint.

NOTE: We do not support inline policy for iam users in NC and NSFS, after we support it we need to put iam policy to user to list the root account buckets.
`AWS_ACCESS_KEY_ID=<root-account-id> AWS_SECRET_ACCESS_KEY=<root-account-key> aws --no-verify-ssl --endpoint-url https://localhost:13443 iam put-user-policy   --user-name iam-aayush   --policy-name S3ListBucketsPolicy   --policy-document '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Action": [ "s3:ListAllMyBuckets", "s3:ListBucket", "s3:GetObject", "s3:PutObject" ], "Resource": "*" } ]}'
`

### Issues: Fixed #xxx / Gap #xxx
1. Issue: https://issues.redhat.com/browse/DFBUGS-4449
2. Related PR: #9272 

### Testing Instructions:
(NC | NSFS)
1.  Create account
2.  Create bucket using the above account credentials
3.  Try listing bucket --> it should list the owned buckets for the user
4.  Create iam user under above account and create access key
5.  Using iam user credentials try listing buckets --> it should list the above root account buckets (currently we do not support inline policy for NC/NSFS, after we support it `s3:ListAllMyBuckets` permission is required with inline policy to list root account buckets)


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket listing and access now use ownership-aware checks (including IAM root inheritance) to gate visibility and actions.

* **New Features**
  * Account and bucket metadata include owner identifiers in the SDK/API.
  * NSFS directory access validation added to enforce filesystem-based access rules.

* **Refactor**
  * Permission logic consolidated into reusable ownership-first checks, with clearer ownership vs policy flow.

* **Tests**
  * Removed two bucket-listing policy tests; added/updated bucket-tagging tests with cross-account scenarios and setup/cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->