### PR TITLE
IAM | Change Default Behavior of Users Without IAM User Policy

### DIFF
--- a/docs/design/IamUserInlinePolicy.md
+++ b/docs/design/IamUserInlinePolicy.md
@@ -4,7 +4,7 @@ When used, it adds a layer of permission to the users under the account.
 We decided that IAM user inline policies are checked for authorization only in S3 operations (`src/endpoint/s3/s3_rest.js`).
 
 ## User Without IAM User Policy
-We decided that when a user is created under the account (and has access keys), it can operate all S3 operations (unless there is a bucket policy which do not authorize it).
+User must have IAM policy to be authorized for S3 operations.
 
 ## User With IAM User Policy
 The user’s inline policy is embedded in the user.  
@@ -29,8 +29,8 @@ If a user has a user policy, the ability to perform an S3 operation is based on 
 For every S3 request, authorization (`authorize_request` in `src/endpoint/s3/s3_rest.js`) is performed.
 The authorization now will have:
 1. Authorization handle for signed request and anonymous requests.  
-2. Authorization handle according to bucket policy.  
-3. Authorization handle according to the user IAM policy (the new added layer - only for IAM users).  
+2. Authorization handle according to the user IAM policy (the new added layer - only for IAM users).  
+3. Authorization handle according to bucket policy.  
 
 If one of the layers does not permit it would result in `AccessDenied` error.
 


### PR DESCRIPTION
### Describe the Problem
Currently in Containerised NooBaa deployment, when a user is created under an account (and has access keys), they can perform all S3 operations. Since we added the IAM User Policy APIs, we want to change the default so the user must have a policy for any S3 operations.

### Explain the Changes
1. Change `authorize_request` in  `s3_rest.js` so that the IAM policy check will be after `authorize_request_account` and before `authorize_request_policy`.
2. Check for IAM user policy in case it is not NC deployment.

### Issues: 
List of GAPs:
1. The tests are only manual at this point; there is a plan to add automated tests after we have the design change.
2. I might want to refactor the code so that `s3_bucket_policy_utils.js` so the terms will be policy in general and can be used for bucket policy and IAM policy.
3. I might want to move the created function somewhere else (perhaps `iam_rest`) so the thrown error will be `amError.AccessDeniedException` instead of `S3Error.AccessDenied`

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
3. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
4. Create the alias for the admin - first, need to get the credentials: `nb status --show-secrets -n test1` and then:
`alias admin-s3='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
`alias admin-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
5. Check the connection to the endpoint:
- try to list the users (should be an empty list): `admin-iam iam list-users; echo $?`
- try to list the buckets (should be `first.bucket`): `admin-iam s3 ls; echo $?`
6. Create a user: `admin-iam iam create-user --user-name Robert`
Note: To validate user creation, you can rerun `admin-iam iam list-users` and expect 1 user in the list
7. Create access keys: `admin-iam iam create-access-keys --user-name Robert`
8. Create the alias for the user (like in step 4 with alias `user-1-s3`): `alias user-1-s3='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
9. The case with no bucket policy, no IAM policy - the user would be restricted from S3 operation, for example:
- The user lists objects in a bucket: `user-1-s3 s3 ls s3://first.bucket` (should not work - should throw `AccessDenied` error).
12. The admin adds an inline policy so the user can list objects in the bucket.
policy_allow_list_bucket.json
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:ListBucket"
            ],
            "Resource": "*"
        }
    ]
}
```
13. `admin-iam iam put-user-policy --user-name Robert --policy-name policy_allow_list_bucket --policy-document file://policy_allow_list_bucketjson`
14. Repeat step 9:
- The user lists objects in a bucket: `user-1-s3 s3 ls s3://first.bucket` (should work).

Code changes for testing:
1. To see the account (of a user) in the cache after changes, `src/sdk/object_sdk.js` uses cache expiry of 1 millisecond.
```diff
const account_cache = new LRUCache({
    name: 'AccountCache',
-    expiry_ms: config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS,
+   expiry_ms: 1, //SDSD 
```

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).
- I used the admin account, but for IAM operations, there is no difference between a created account and an admin account. I tested with the admin only because it saves steps (I have the admin account upon system creation and a bucket `first.bucket`).


- [X] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that an IAM user policy is required for S3 operations and updated ordering to show the IAM user policy evaluated before the bucket policy; minor wording tweaks.

* **Refactor**
  * Authorization checks now run sequentially rather than in parallel, changing control flow and error timing.
  * Tightened conditions under which IAM policy validation may be bypassed for specific deployments and added notes for future IAM handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->