### PR TITLE
IAM | User Without IAM User Policy Improve Error Message

### DIFF
--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -674,7 +674,7 @@ class AccountSpaceFS {
         const full_action_name = get_action_message_title(action);
         const account_id_for_arn = this._get_account_owner_id_for_arn(requesting_account);
         const arn_for_requesting_account = create_arn_for_user(account_id_for_arn,
-            requesting_account.name.unwrap(), requesting_account.path);
+            requesting_account.name.unwrap(), requesting_account.iam_path);
         const basic_message = `User: ${arn_for_requesting_account} is not authorized to perform:` +
         `${full_action_name} on resource: `;
         let message_with_details;

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -441,7 +441,7 @@ function _throw_access_denied_error(action, requesting_account, details, entity)
     const full_action_name = get_action_message_title(action);
     const account_id_for_arn = _get_account_owner_id_for_arn(requesting_account).toString();
     const arn_for_requesting_account = create_arn_for_user(account_id_for_arn, get_iam_username(requesting_account.name.unwrap()),
-                                        requesting_account.path || IAM_DEFAULT_PATH);
+                                        requesting_account.iam_path || IAM_DEFAULT_PATH);
     const basic_message = `User: ${arn_for_requesting_account} is not authorized to perform:` +
     `${full_action_name} on resource: `;
     let message_with_details;


### PR DESCRIPTION
### Describe the Problem
Currently, in Containerised NooBaa deployment, when a user is created under an account (and has access keys), they must have a matching IAM policy to perform any S3 operations.

### Explain the Changes
1. Edit the error message when a user tries to perform an S3 operation to match what it tries to do and have a proper message when executing `authorize_request_iam_policy`.
2. Add log messages when there is no IAM user policy for better experience.
3. Fix a minor bug when I read the code so I changed the `path` to be `iam_path` according to the account schemas in NC and Containerised deployment.
4. Fix the `resource_arn` in the IAM policy for the list buckets operation.

### Issues: 
List of GAPs:
1. The tests are only manual at this point; there is a plan to add automated tests after we have the design change.
2. I might want to refactor the code so that `s3_bucket_policy_utils.js` so the terms will be policy in general and can be used for bucket policy and IAM policy.
3. I might want to move the created function somewhere else.

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
3. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
5. Create the alias for the admin - first, need to get the credentials: `nb status --show-secrets -n test1` and then:
`alias admin-s3='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
`alias admin-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
6. Check the connection to the endpoint:
- try to list the users (should be an empty list): `admin-iam iam list-users; echo $?`
- try to list the buckets (should be `first.bucket`): `admin-s3 s3 ls; echo $?`
7. Create a user: `admin-iam iam create-user --user-name Robert`
Note: To validate user creation, you can rerun `admin-iam iam list-users` and expect 1 user in the list
8. Create access keys: `admin-iam iam create-access-keys --user-name Robert`
9. Create the alias for the user (like in step 4 with alias `user-1-s3`): `alias user-1-s3='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
10. The case with no bucket policy, no IAM policy - the user would be restricted from S3 operation, for example:
- The user lists objects in a bucket: `user-1-s3 s3 ls s3://first.bucket` (should not work - should throw `AccessDenied` error - look at the error). Example:
```
An error occurred (AccessDenied) when calling the ListObjectsV2 operation: User: arn:aws:iam::6922dfb199663d002117094e:user/Robert is not authorized to perform: s3:ListBucket on resource: arn:aws:s3:::first.bucket because no identity-based policy allows the s3:ListBucket action
```
11. The admin adds an inline policy so the user can list objects in the bucket.
policy_allow_list_bucket.json
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:ListBucket"
            ],
            "Resource": "*"
        }
    ]
}
```
12. `admin-iam iam put-user-policy --user-name Robert --policy-name policy_allow_list_bucket --policy-document file://policy_allow_list_bucket.json`
13. Repeat step 9:
- The user lists objects in a bucket: `user-1-s3 s3 ls s3://first.bucket` (should work - bucket is empty, no error was thrown).

Code changes for testing:
1. To see the account (of a user) in the cache after changes, `src/sdk/object_sdk.js` uses cache expiry of 1 millisecond.
```diff
const account_cache = new LRUCache({
    name: 'AccountCache',
-    expiry_ms: config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS,
+   expiry_ms: 1, //SDSD 
```

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).
- I used the admin account, but for IAM operations, there is no difference between a created account and an admin account. I tested with the admin only because it saves steps (I have the admin account upon system creation and a bucket `first.bucket`).


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More detailed "Access Denied" messages for S3 operations with clearer account and resource context.
  * Consistent account-path formatting in authorization error messages for clearer diagnostics.
  * Improved handling when the resource/bucket is unspecified (e.g., list-all-buckets), producing accurate denial messages.
  * Unified error logging and reporting when inline policies deny or no policies match.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->