### PR TITLE
IAM | Block OBC Accounts From IAM API

### DIFF
--- a/src/endpoint/iam/iam_rest.js
+++ b/src/endpoint/iam/iam_rest.js
@@ -223,6 +223,12 @@ function authenticate_request(req) {
 async function authorize_request(req) {
     await req.account_sdk.load_requesting_account(req);
     req.account_sdk.authorize_request_account(req);
+    // we want to block OBC accounts from IAM API related to user management
+    // bucket_claim_owner is a property that we have only in OBC account in containerized deployments
+    if (req.account_sdk.requesting_account.bucket_claim_owner) {
+        dbg.error('OBC accounts are not allowed to perform IAM API actions');
+        throw new IamError(IamError.AccessDeniedException);
+    }
 }
 
 function parse_op_name(req, action) {


### PR DESCRIPTION
### Describe the Problem
Currently all accounts in the system can perform IAM API, we decided at this point that accounts that are related to the OBC cannot perform IAM API operations (have the property `bucket_claim_owner` in the DB is it the bucket ID of the OBC).

### Explain the Changes
1. Block the IAM requests in the step of `authorize_request`.

### Issues: 
List of GAPs:
1. The tests are only manual at this point; there is a plan to add automated tests after we have the design change.

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
3. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
4. Create the OBC: `nb obc create shira-obc1 -n test1 --show-secrets`
5. Create the alias for the OBC account:
- `alias account-obc-s3='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:12443'`
- `alias account-obc-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
7. Check the connection to the endpoint:
- try to list the buckets: `account-obc-s3 s3 ls; echo $?` (should see the OBC bucket).
- try to list the users (should throw an error): `account-obc-iam iam list-users; echo $?`
In the logs:
```
Nov-24 11:44:33.281 [Endpoint/13] [ERROR] core.endpoint.iam.iam_rest:: OBC accounts cannot are not allowed to perform IAM API actions
Nov-24 11:44:33.281 [Endpoint/13] [ERROR] core.endpoint.iam.iam_rest:: IAM ERROR <?xml version="1.0" encoding="UTF-8"?><ErrorResponse><Error><Type>Sender</Type><Code>AccessDeniedException</Code><Message>You do not have sufficient access to perform this action.</Message></Error><RequestId>mid2xgxs-9ib675-5kd</RequestId></ErrorResponse> POST / {"host":"localhost:14443","accept-encoding":"identity","content-type":"application/x-www-form-urlencoded; charset=utf-8","user-agent":"aws-cli/2.27.7 md/awscrt#0.26.1 ua/2.1 os/macos#25.0.0 md/arch#arm64 lang/python#3.13.5 md/pyimpl#CPython m/C,N cfg/retry-mode#standard md/installer#source md/prompt#off md/command#iam.list-users","x-amz-date":"20251124T114434Z","authorization":"AWS4-HMAC-SHA256 Credential=Pymzf04ynwvJxeuXXroC/20251124/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=fde997baf8abee3b19ab171c11c8ef3118728fecd8d46627483c04e10fa30756","content-length":"35"} Error: You do not have sufficient access to perform this action.
    at authorize_request (/root/node_modules/noobaa-core/src/endpoint/iam/iam_rest.js:230:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async handle_request (/root/node_modules/noobaa-core/src/endpoint/iam/iam_rest.js:196:5)
    at async iam_rest (/root/node_modules/noobaa-core/src/endpoint/iam/iam_rest.js:142:9)
```

Code changes for testing:
1. To see the account (of a user) in the cache after changes, `src/sdk/object_sdk.js` uses cache expiry of 1 millisecond.
```diff
const account_cache = new LRUCache({
    name: 'AccountCache',
-    expiry_ms: config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS,
+   expiry_ms: 1, //SDSD 
```

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IAM API now blocks requests from OBC (bucket-claim owner) accounts for user-management actions. Such attempts are logged as errors and return an access-denied response, improving authorization handling and security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->