### PR TITLE
IAM | Principal validation and S3 permission updated with ID

### DIFF
--- a/src/test/integration_tests/api/iam/test_iam_basic_integration.js
+++ b/src/test/integration_tests/api/iam/test_iam_basic_integration.js
@@ -73,7 +73,9 @@ mocha.describe('IAM basic integration tests - happy path', async function() {
     });
 
     mocha.after(async () => {
-        fs_utils.folder_delete(`${config_root}`);
+        if (is_nc_coretest) {
+            fs_utils.folder_delete(`${config_root}`);
+        }
     });
 
     mocha.describe('IAM User API', async function() {

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -342,7 +342,6 @@ function _check_root_account_owns_user(root_account, user_account) {
     return root_account_id === owner_account_id;
 }
 
-
 function _check_if_requesting_account_is_root_account(action, requesting_account, user_details = {}) {
     const is_root_account = _check_root_account(requesting_account);
     dbg.log1(`AccountSpaceNB.${action} requesting_account ID: ${requesting_account._id}` +


### PR DESCRIPTION
### Describe the Problem

1. Bucket policy "Principal" validation was based on the email before and it updated with account/user ID
2. put_bucket_policy validate principal account/user ID
3. Bucket policy ARN related test added

### Explain the Changes

#### Principal validation 
1. Validate account/user ID

#### S3 Rest authorize request policy
1. Account/user ID is added to request policy validation replacing account email. account/user ID based validation for containerized deployments NSFS NC.
2.  Updated test cases(test_s3_bucket_policy.js), previousily these tests where using email for principal for both NSFS non-containerized and acontainerized, With latest changes containerized will use account/user ID and ARN. Enabled account/user ID based test cases also for containerized integration test

GAP: IAM User test cases for ARN and user ID test cases are missing

### Testing Instructions:
Un integration test `test_s3_bucket_policy.js`
1. Create a bucket(test1) from account(account1)
2. Put bucket policy to newly created bucket()
```
s3api put-bucket-policy --bucket test1 --policy '{"Version": "2012-10-17","Statement": [ { "Effect": "Allow", "Principal": { "AWS": [ "${user2_id}" ] }, "Action": [ "s3:*" ], "Resource": [ "arn:aws:s3:::test1/*", "arn:aws:s3:::test1" ] } ]}'
```
`user2_id` could be ID of different account or IAM user ID of IAM user(not belongs to account1)
4. Verify the `user2` have `bucket1` access.

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate bucket policy enforcement: principal matching accepts multiple identifier forms and evaluates denies before allows to reduce incorrect denials.
  * Owner-account access checks added so owner-based permissions are correctly considered.

* **New Features**
  * Improved principal resolution across deployments so policies using root/user identifiers and ARNs are recognized.

* **Tests**
  * Expanded bucket policy tests to cover ARN principals and unified account-ID usage; teardown now conditional for NC core tests.

* **Chores**
  * Minor logging and formatting clarifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->