### PR TITLE
IAM | Basic Interrogation Tests Add User Inline Policy Test Cases

### DIFF
--- a/docs/design/IamUserInlinePolicy.md
+++ b/docs/design/IamUserInlinePolicy.md
@@ -93,3 +93,10 @@ Check the ability of the user to perform S3 operations according to the IAM poli
 
 ### Notes:
 The IAM policy (like bucket policy) is read from the account info, which is saved in the endpoint cache. Currently, the cache does not invalidate those changes immediately. For local testing, you may temporarily reduce the cache expiry in `src/sdk/object_sdk.js` by setting `expiry_ms: 1`, but this should never be committed to the repository.
+
+We enforce the policy document to have an array in the field of `Statement` even though there are cases of a single item in the array (same behavior as bucket policy document in NooBaa).
+Although this IAM policy is legal in AWS:  
+`{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`.  
+In NooBaa system it should be used with:  
+`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`.  
+(notice the array in `Statement` field).


### PR DESCRIPTION
### Describe the Problem
Currently, we do not have test cases for user inline policy in our basic IAM interrogation tests, as it is not implemented in NC yet.

### Explain the Changes
1. Add test cases for the user inline policy (will not run in NC)
2. Add clarification in our doc, as it is something that I found during testing - Statement as an array in the policy document.
3. Fix `mocha.after` to run only in NC deployment.

### Issues: 
1. none

### Testing Instructions:
#### Automatic test
Containerized
1. Use the guide "Run Tests From coretest Locally" ([link](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/run_coretest_locally.md)) for running the core tests.
2. Run first tab: `docker run -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=noobaa  quay.io/sclorg/postgresql-15-c9s`
3. Run second tab: `NOOBAA_LOG_LEVEL=all ./node_modules/.bin/mocha src/test/integration_tests/api/iam/test_iam_basic_integration.js`

NC:
`sudo NC_CORETEST=true ./node_modules/.bin/mocha src/test/integration_tests/api/iam/test_iam_basic_integration.js`


- [X] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified IAM policy guidance: Statement must be an array, added canonical example, contrasted single-item vs array usage, and aligned behavior with AWS expectations.

* **Tests**
  * Added end-to-end IAM User Policy integration tests covering list/put/get/delete flows, validation of policy content, error handling for missing users, and conditional test execution for specific environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->