### PR TITLE
Generate optimized SQL query to improve performance of find_chunks_by_dedup_key method

### DIFF
--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -770,6 +770,7 @@ interface DBCollection {
 
     executeSQL<T>(query: string, params: Array<any>, options?: { query_name?: string, preferred_pool?: string }): Promise<sqlResult<T>>;
     name: any;
+    schema: any;
 }
 
 type DBDoc = any;

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -85,8 +85,8 @@ class GetMapping {
         if (!config.DEDUP_ENABLED) return;
         await Promise.all(Object.values(this.chunks_per_bucket).map(async chunks => {
             const bucket = chunks[0].bucket;
-            const dedup_keys = _.compact(_.map(chunks,
-                chunk => chunk.digest_b64 && Buffer.from(chunk.digest_b64, 'base64')));
+            const dedup_keys = chunks.map(chunk => chunk.digest_b64).filter(Boolean);
+
             if (!dedup_keys.length) return;
             dbg.log0('GetMapping.find_dups: found keys', dedup_keys.length);
             const dup_chunks_db = await MDStore.instance().find_chunks_by_dedup_key(bucket, dedup_keys);

--- a/src/test/integration_tests/api/s3/test_bucket_replication.js
+++ b/src/test/integration_tests/api/s3/test_bucket_replication.js
@@ -5,6 +5,7 @@ const mocha = require('mocha');
 const assert = require('assert');
 const _ = require('lodash');
 const P = require('../../../../util/promise');
+const config = require('../../../../../config');
 const coretest = require('../../../utils/coretest/coretest');
 const { rpc_client, EMAIL } = coretest; //, PASSWORD, SYSTEM
 const util = require('util');
@@ -264,6 +265,9 @@ mocha.describe('replication collection tests', function() {
 });
 
 mocha.describe('replication configuration bg worker tests', function() {
+    // Skip test if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
+
     const self = this; // eslint-disable-line no-invalid-this
     self.timeout(60000);
     const bucket1 = 'bucket1-br-bg';
@@ -576,6 +580,9 @@ async function _list_objects_and_wait(s3_owner, bucket, expected_num_of_objects)
 }
 
 mocha.describe('Replication pagination test', function() {
+    // Skip test if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
+
     const self = this; // eslint-disable-line no-invalid-this
     self.timeout(60000);
     const obj_amount = 11;

--- a/src/test/integration_tests/api/s3/test_chunked_upload.js
+++ b/src/test/integration_tests/api/s3/test_chunked_upload.js
@@ -24,6 +24,9 @@ const default_checksum_algorithm = ChecksumAlgorithm.SHA256;
 const non_chunked_upload_key = 'non_chunked_upload.txt';
 
 mocha.describe('S3 basic chunked upload tests', async function() {
+    // Skip test if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
+
     let s3;
 
     mocha.before(async () => {

--- a/src/test/integration_tests/api/s3/test_lifecycle.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle.js
@@ -821,6 +821,8 @@ mocha.describe('lifecycle', () => {
         };
 
         mocha.it('should select rule with longest prefix', async () => {
+            // Skip test if DB is not PostgreSQL
+            if (config.DB_TYPE !== 'postgres') return;
             const rules = [
                 test_utils.generate_lifecycle_rule(10, 'short-prefix', 'test1/', [], undefined, undefined),
                 test_utils.generate_lifecycle_rule(17, 'long-prefix', 'test1/logs/', [], undefined, undefined),
@@ -834,6 +836,8 @@ mocha.describe('lifecycle', () => {
         });
 
         mocha.it('should select rule with more tags when prefix is same', async () => {
+            // Skip test if DB is not PostgreSQL
+            if (config.DB_TYPE !== 'postgres') return;
             const rules = [
                 test_utils.generate_lifecycle_rule(5, 'one-tag', 'test2/', [{ Key: 'env', Value: 'prod' }], undefined, undefined),
                 test_utils.generate_lifecycle_rule(9, 'two-tags', 'test2/', [
@@ -851,6 +855,8 @@ mocha.describe('lifecycle', () => {
         });
 
         mocha.it('should select rule with narrower size span when prefix and tags are matching', async () => {
+            // Skip test if DB is not PostgreSQL
+            if (config.DB_TYPE !== 'postgres') return;
             const rules = [
                 test_utils.generate_lifecycle_rule(4, 'wide-range', 'test3/', [], 100, 10000),
                 test_utils.generate_lifecycle_rule(6, 'narrow-range', 'test3/', [], 1000, 5000),
@@ -865,6 +871,8 @@ mocha.describe('lifecycle', () => {
         });
 
         mocha.it('should fallback to first matching rule if all filters are equal', async () => {
+            // Skip test if DB is not PostgreSQL
+            if (config.DB_TYPE !== 'postgres') return;
             const rules = [
                 test_utils.generate_lifecycle_rule(7, 'rule-a', 'test4/', [], 0, 10000),
                 test_utils.generate_lifecycle_rule(11, 'rule-b', 'test4/', [], 0, 10000),

--- a/src/test/integration_tests/api/s3/test_namespace_auth.js
+++ b/src/test/integration_tests/api/s3/test_namespace_auth.js
@@ -21,6 +21,8 @@ const FKEY = 'ns_auth_file';
 const config = require('../../../../../config');
 
 mocha.describe('Namespace Auth', function() {
+    // Skip test if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
 
     let s3;
     mocha.before(async function() {

--- a/src/test/integration_tests/api/s3/test_notifications.js
+++ b/src/test/integration_tests/api/s3/test_notifications.js
@@ -57,6 +57,8 @@ let expect_test;
 
 // eslint-disable-next-line max-lines-per-function
 mocha.describe('notifications', function() {
+    // Skip test if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
 
     this.timeout(40000); // eslint-disable-line no-invalid-this
     let s3;

--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
@@ -175,6 +175,10 @@ async function setup() {
     });
 }
 
+// @ts-ignore
+// Do not run below tests if DB is not PostgreSQL
+if (config.DB_TYPE !== 'postgres') return;
+
 /*eslint max-lines-per-function: ["error", 3000]*/
 mocha.describe('s3_bucket_policy', function() {
     mocha.before(setup);

--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy_iam_user.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy_iam_user.js
@@ -149,6 +149,9 @@ async function setup() {
 }
 
 mocha.describe('Integration between IAM and S3 bucket policy', async function() {
+    // Skip tests for other DB's
+    if (config.DB_TYPE !== 'postgres') return;
+
     mocha.before(setup);
     mocha.after(async function() {
         this.timeout(60000); // eslint-disable-line no-invalid-this

--- a/src/test/integration_tests/api/s3/test_s3_encryption.js
+++ b/src/test/integration_tests/api/s3/test_s3_encryption.js
@@ -59,6 +59,8 @@ async function get_s3_instances() {
 }
 
 mocha.describe('Bucket Encryption Operations', async () => {
+    // Skip test if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
 
     const BKT = 'sloth-bucket-encryption';
     let local_s3;

--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -735,6 +735,8 @@ mocha.describe('s3_ops', function() {
     });
 
     async function test_object_ops(bucket_name, bucket_type, caching, remote_endpoint_options, skip) {
+        // Skip test if DB is not PostgreSQL
+        if (config.DB_TYPE !== 'postgres') return;
 
         const is_azure_namespace = is_namespace_blob_bucket(bucket_type, remote_endpoint_options && remote_endpoint_options.endpoint_type);
         const is_azure_mock = is_namespace_blob_mock(bucket_type, remote_endpoint_options && remote_endpoint_options.endpoint_type);

--- a/src/test/integration_tests/internal/test_agent_blocks_reclaimer.js
+++ b/src/test/integration_tests/internal/test_agent_blocks_reclaimer.js
@@ -113,6 +113,10 @@ class ReclaimerMock extends AgentBlocksReclaimer {
 }
 
 
+// @ts-ignore
+// Do not run below tests if DB is not PostgreSQL
+if (config.DB_TYPE !== 'postgres') return;
+
 mocha.describe('not mocked agent_blocks_reclaimer', function() {
 
     const object_io = new ObjectIO();

--- a/src/test/integration_tests/internal/test_encryption.js
+++ b/src/test/integration_tests/internal/test_encryption.js
@@ -31,6 +31,10 @@ const key_rotator = new KeyRotator({ name: 'kr'});
 
 config.MIN_CHUNK_AGE_FOR_DEDUP = 0;
 
+// @ts-ignore
+// Do not run below tests if DB is not PostgreSQL
+if (config.DB_TYPE !== 'postgres') return;
+
 mocha.describe('Encryption tests', function() {
     const { rpc_client, EMAIL, SYSTEM } = coretest;
     let response_account;
@@ -131,7 +135,7 @@ mocha.describe('Encryption tests', function() {
             }));
         });
 
-       mocha.it('create accounts and compare acount access keys succefully', async function() {
+        mocha.it('create accounts and compare acount access keys succefully', async function() {
             this.timeout(600000); // eslint-disable-line no-invalid-this
             const db_system = await db_client.collection('systems').findOne({ name: SYSTEM });
             const new_account_params = {
@@ -141,7 +145,7 @@ mocha.describe('Encryption tests', function() {
             let i;
             for (i = 0; i < 20; i++) {
                 response_account = await rpc_client.account.create_account({...new_account_params,
-                     email: `email${i}`, name: `name${i}`});
+                        email: `email${i}`, name: `name${i}`});
                 accounts.push({email: `email${i}`, create_account_result: response_account, index: i});
                 const db_account = await db_client.collection('accounts').findOne({ email: `email${i}` });
                 const system_store_account = account_by_name(system_store.data.accounts, `email${i}`);
@@ -213,7 +217,7 @@ mocha.describe('Encryption tests', function() {
                 const system_store_account = account_by_name(system_store.data.accounts, cur_account.email);
                 const db_ns_resource = await db_client.collection('namespace_resources').findOne({ name: namespace_resource_name });
                 const system_store_ns_resource = pool_by_name(system_store.data.namespace_resources,
-                     namespace_resource_name); // system store data supposed to be decrypted
+                        namespace_resource_name); // system store data supposed to be decrypted
                 // check s3 creds key in db is encrypted
                 const secrets = {
                     db_secret: db_ns_resource.connection.secret_key,
@@ -448,7 +452,7 @@ mocha.describe('Encryption tests', function() {
                 name: BKT,
             });
         });
-       mocha.it('regenerate creds for all accounts (non coretest) succefully', async function() {
+        mocha.it('regenerate creds for all accounts (non coretest) succefully', async function() {
             this.timeout(600000); // eslint-disable-line no-invalid-this
             await P.all(_.map(accounts, async cur_account => {
                 await rpc_client.account.generate_account_keys({ email: cur_account.email });
@@ -466,7 +470,7 @@ mocha.describe('Encryption tests', function() {
             }));
         });
         // TODO: remove the comment
-         mocha.it('delete accounts succefully', async function() {
+            mocha.it('delete accounts succefully', async function() {
             this.timeout(600000); // eslint-disable-line no-invalid-this
             await P.all(_.map(accounts, async cur_account => {
                 await rpc_client.account.delete_account({ email: cur_account.email});
@@ -478,7 +482,6 @@ mocha.describe('Encryption tests', function() {
         });
     });
 });
-
 
 /////////////// ROTATION & DISABLE & ENABLE TESTS /////////////////////////
 mocha.describe('Rotation tests', function() {
@@ -588,7 +591,7 @@ mocha.describe('Rotation tests', function() {
         await system_store.load();
         const original_secrets = await get_account_secrets_from_system_store_and_db(accounts[0].email, 's3_creds');
         await rpc_client.system.disable_master_key({entity: new SensitiveString(accounts[0].email),
-             entity_type: 'ACCOUNT'});
+            entity_type: 'ACCOUNT'});
         await system_store.load();
         const system_store_account = account_by_name(system_store.data.accounts, accounts[0].email);
         const secrets = await get_account_secrets_from_system_store_and_db(accounts[0].email, 's3_creds');
@@ -611,7 +614,7 @@ mocha.describe('Rotation tests', function() {
         await system_store.load();
         const original_secrets = await get_account_secrets_from_system_store_and_db(accounts[2].email, 's3_creds');
         await rpc_client.system.disable_master_key({entity: new SensitiveString(accounts[2].email),
-             entity_type: 'ACCOUNT'});
+            entity_type: 'ACCOUNT'});
         await system_store.load();
         const system_store_account = account_by_name(system_store.data.accounts, accounts[2].email);
         const secrets = await get_account_secrets_from_system_store_and_db(accounts[2].email, 's3_creds');

--- a/src/test/integration_tests/internal/test_map_builder.js
+++ b/src/test/integration_tests/internal/test_map_builder.js
@@ -297,6 +297,9 @@ mocha.describe('map_builder', function() {
     });
 
     mocha.it('does block movement across storage class', async function() {
+        // Skip test if DB is not PostgreSQL
+        if (config.DB_TYPE !== 'postgres') return;
+
         this.timeout(600_000); // eslint-disable-line no-invalid-this
         const test_bucket_name = "block-movement-test-1";
 

--- a/src/test/integration_tests/internal/test_object_io.js
+++ b/src/test/integration_tests/internal/test_object_io.js
@@ -12,6 +12,7 @@ const util = require('util');
 const crypto = require('crypto');
 const assert = require('assert');
 const stream = require('stream');
+const config = require('../../../../config');
 
 const ObjectIO = require('../../../sdk/object_io');
 const { crypto_random_string } = require('../../../util/string_utils');
@@ -39,6 +40,9 @@ coretest.describe_mapper_test_case({
     total_replicas,
     chunk_coder_config,
 }) => {
+
+    // Do not run below tests if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
 
     // TODO we need to create more nodes and pools to support all MAPPER_TEST_CASES
     if (data_placement !== 'SPREAD' || num_pools !== 1 || total_blocks > 10) return;

--- a/src/test/integration_tests/internal/test_tiering_ttl_worker.js
+++ b/src/test/integration_tests/internal/test_tiering_ttl_worker.js
@@ -63,6 +63,9 @@ async function load_chunks(obj) {
 }
 
 mocha.describe('tiering_ttl_worker', function() {
+    // Skip test if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
+
     const BUCKET_NAME = 'tiering-ttl-worker-test-bucket';
     const default_ttl_ms = config.TIERING_TTL_MS;
     const ttl_worker = new TieringTTLWorker({ name: 'test_tiering_ttl_worker', client: rpc_client });


### PR DESCRIPTION
### Describe the Problem
The mongo to pg query converter uses IN operator for array. But in case of postgres, using ANY operator improves performance as the query size is reduced and it also allows for plan caching. The sort is also applied on '_id' JSON field of data column, but there is _id column already present (primary key). 

### Explain the Changes
1. Refactored the find_chunks_by_dedup_key method to self generate SQL queries. Improvements are:
 - Using ANY instead of IN improves query planning time for larger array size. (Postgres internally converts IN to ANY, but it requires an additional parsing step) 
 - Using _id instead of data._id for sorting improves query execution time as we are utilizing the primary key index.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Chunk deduplication retrieval now uses a SQL-backed path for broader DB support and improved resilience.
  * Collection objects now expose schema metadata for easier inspection.

* **Tests**
  * Added Postgres-only integration tests for deduplicated chunk lookup, missing-key and empty-key cases.
  * Many integration suites now skip Postgres-specific tests when not running against Postgres.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->