### PR TITLE
IAM | Account Server - Block Account Deletion in Case the Account Has Users

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1179,6 +1179,17 @@ function _verify_can_delete_account(req, account_to_delete) {
             throw new RpcError('FORBIDDEN', 'Cannot delete account that is owner of buckets');
         }
     }
+    if (account_to_delete.owner === undefined) {
+        const has_iam_users = _.some(system_store.data.accounts, function(account) {
+            const owner_account_id = account_util.get_owner_account_id(account);
+            // Check IAM user owner is same as account_to_delete id
+            return owner_account_id === account_to_delete._id.toString();
+        });
+        if (has_iam_users) {
+            dbg.log2('account', account_to_delete.name.unwrap(), 'account has users');
+            throw new RpcError('FORBIDDEN', 'Cannot delete account that is owner of IAM users');
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
### Describe the Problem
Add a restriction for deleting an account that has users, so we will not have "dangling" users in the system.

### Explain the Changes
1. Add additional condition to check if the account has users (based on the check that we do that an account does not have buckets and the filtering that we have in list_users).

### Issues: 
1. none

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
3. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
4. Set the debug level to see the added log message: `nb system set-debug-level 2 -n test1`
5. Create the account: `nb account create shira-acc01 -n test1 --show-secrets`
6. Create the alias for the account:
- `alias account-1-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
7. Check the connection to the endpoint:
- try to list the users (should throw an error): `account-1-iam iam list-users; echo $?`
8. Create a user: `account-1-iam iam create-user --user-name Robert`
9. OPen the logs of the operator and core pods:
- `kubectl logs noobaa-operator-6f7b579656-mz9wp -n test1 --tail 0 -f`
- `kubectl logs noobaa-core-0 -n test1 --tail 0 -f`
10. Delete the account: `nb account delete shira-acc01 -n test1` - see that it is not finished.
12. See in the logs:

operator logs:
```
time="2025-11-27T12:46:09Z" level=info msg="✈️  RPC: account.delete_account() Request: {Email:shira-acc01}"
time="2025-11-27T12:46:09Z" level=error msg="⚠️  RPC: account.delete_account() Response Error: Code=FORBIDDEN Message=Cannot delete account that is owner of users"
time="2025-11-27T12:46:09Z" level=info msg="SetPhase: temporary error during phase \"Deleting\"" noobaaaccount=test1/shira-acc01
time="2025-11-27T12:46:09Z" level=warning msg="⏳ Temporary Error: failed to delete account \"shira-acc01\". got error: Cannot delete account that is owner of users" noobaaaccount=test1/shira-acc01
time="2025-11-27T12:46:09Z" level=info msg="UpdateStatus: Done" noobaaaccount=test1/shira-acc0
```

core logs:
```
Nov-27 12:46:09.195 [WebServer/33] [ERROR] CONSOLE:: RPC._on_request: ERROR srv account_api.delete_account reqid wss://noobaa-mgmt.test1.svc.cluster.local:443/rpc/-795 connid ws://[::ffff:10.42.0.213]:46292/(8wpljk3) Error: Cannot delete account that is owner of users
```

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents deletion of accounts that would orphan IAM users by blocking deletions when account ownership of users is detected.
  * Returns a forbidden response with a clear message when such a deletion is attempted.
  * Ensures existing protections for special/system accounts and owned resources remain enforced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->