### PR TITLE
IAM | Add `Tags` to `GetUser` Reply

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -1305,6 +1305,17 @@ module.exports = {
                         $ref: 'common_api#/definitions/access_keys'
                     }
                 },
+                tags: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            member: {
+                                $ref: '#/definitions/tag'
+                            },
+                        },
+                    },
+                },
             }
         },
         user_accesskey_info: {

--- a/src/endpoint/iam/ops/iam_get_user.js
+++ b/src/endpoint/iam/ops/iam_get_user.js
@@ -29,6 +29,7 @@ async function get_user(req, res) {
                     Arn: reply.arn,
                     CreateDate: iam_utils.format_iam_xml_date(reply.create_date),
                     PasswordLastUsed: iam_utils.format_iam_xml_date(reply.password_last_used),
+                    Tags: reply.tags && reply.tags.length === 0 ? undefined : reply.tags
                 }
             },
             ResponseMetadata: {

--- a/src/test/integration_tests/api/iam/test_iam_basic_integration.js
+++ b/src/test/integration_tests/api/iam/test_iam_basic_integration.js
@@ -423,6 +423,16 @@ mocha.describe('IAM basic integration tests - happy path', async function() {
             assert.equal(response2.Tags.length, 2);
             const sorted = arr => _.sortBy(arr, 'Key');
             assert.deepEqual(sorted(response2.Tags), sorted(user_tags));
+
+            // verify it with get user (Tags are included in the User object)
+            const input3 = {
+                UserName: username4
+            };
+            const command3 = new GetUserCommand(input3);
+            const response3 = await iam_account.send(command3);
+            _check_status_code_ok(response3);
+            assert.equal(response3.User.Tags.length, 2);
+            assert.deepEqual(sorted(response3.User.Tags), sorted(user_tags));
         });
 
         mocha.it('untag user', async function() {

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -730,6 +730,19 @@ function return_list_member(iam_user, iam_path, iam_username) {
     };
 }
 
+function get_sorted_list_tags_for_user(user_tagging) {
+    if (!user_tagging || user_tagging.length === 0) {
+        return [];
+    }
+    const sorted_tags = user_tagging.sort((a, b) => a.key.localeCompare(b.key));
+    return sorted_tags.map(tag => ({
+        member: {
+            Key: tag.key,
+            Value: tag.value
+        }
+    }));
+}
+
 
 exports.delete_account = delete_account;
 exports.create_account = create_account;
@@ -757,3 +770,4 @@ exports.validate_and_return_requested_account = validate_and_return_requested_ac
 exports.get_iam_username = get_iam_username;
 exports.return_list_member = return_list_member;
 exports.get_owner_account_id = get_owner_account_id;
+exports.get_sorted_list_tags_for_user = get_sorted_list_tags_for_user;


### PR DESCRIPTION
### Describe the Problem
Currently, we haven't returned the Tags on the `GetUser` Reply.

### Explain the Changes
1. Move the part related to listing the tags to a function and reuse it also in `GetUser`.
2. Add `tags` in the `user_info`.
3. Change the existing debug log level from 0 to 1.
4. Add verification in the test case of `TagUser`.

### Issues: 
none

### Testing Instructions:
#### Automatic test
Containerized
1. Use the guide "Run Tests From coretest Locally" ([link](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/run_coretest_locally.md)) for running the core tests.
4. Run first tab: `docker run -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=noobaa  quay.io/sclorg/postgresql-15-c9s`
5. Run second tab: `NOOBAA_LOG_LEVEL=all ./node_modules/.bin/mocha src/test/integration_tests/api/iam/test_iam_basic_integration.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User accounts now include a Tags field in profile and GetUser responses, so tags are returned and visible when retrieving user info.

* **Behavior Changes**
  * Tags are consistently sorted and presented in a stable order when listed.

* **Tests**
  * Added integration checks to verify tags are correctly applied and returned.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->