### PR TITLE
IAM | Block Accounts From Performing IAM API on Themselves

### DIFF
--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -701,6 +701,10 @@ function validate_and_return_requested_account(params, action, requesting_accoun
             // When accesskeyt API called without specific username, action on the same requesting account.
             // So in that case requesting account and requested account is same.
             requested_account = requesting_account;
+            // we do not allow for AWS account root user to perform IAM action on itself
+            if (requesting_account.owner === undefined) {
+                throw new RpcError('NOT_AUTHORIZED', 'You do not have permission to perform this action.');
+            }
         } else {
             _check_if_requesting_account_is_root_account(action, requesting_account, { username: params.username });
             const account_email = get_account_name_from_username(params.username, requesting_account._id.toString());


### PR DESCRIPTION
### Describe the Problem
Currently, we didn't block accounts from performing the IAM API on themselves, the main issue it creates is that accounts can use the IAM API of access key i and delete their own access key.

### Explain the Changes
1. Throw and error in case account tries to perfrom IAM operation on himself.
Note: decide to leave the message of the error simple.

### Issues:
1. none

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
3. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
4. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
5. Create the alias for the admin account:
- `alias account-1-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
6. Check the connection to the endpoint:
- try to list the users (should throw an error): `account-1-iam iam list-users; echo $?`
7. Try to delete the access key of the admin: `admin-iam iam delete-access-key --access-key-id <access-key-of-admin>` should fail.
output:
```
An error occurred (NotAuthorized) when calling the DeleteAccessKey operation: You do not have permission to perform this action.
```

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).
- I used the admin account, but for IAM operations, there is no difference between a created account and an admin account. I tested with the admin only because it saves steps (I have the admin account upon system creation and a bucket).

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an authorization issue where root accounts could perform certain IAM operations on themselves. These operations are now properly blocked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->