### PR TITLE
IAM | User ID for principal is not supported

### DIFF
--- a/src/endpoint/s3/s3_bucket_policy_utils.js
+++ b/src/endpoint/s3/s3_bucket_policy_utils.js
@@ -378,6 +378,19 @@ function get_bucket_policy_principal_arn(account) {
 }
 
 /**
+ *  Both NSFS NC and containerized will validate bucket policy against acccount id 
+ *  but in containerized deplyment not against IAM user ID.
+ * 
+ * @param {boolean} is_nc_deployment
+ * @param {object} account
+ */
+function get_account_identifier_id(is_nc_deployment, account) {
+    if (is_nc_deployment || account.owner === undefined) {
+        return account._id;
+    }
+}
+
+/**
  * create_arn_for_root creates the AWS ARN for root account user
  * see: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns
  * @param {nb.ID} account_id (the root user account id)
@@ -416,3 +429,4 @@ exports.validate_s3_policy = validate_s3_policy;
 exports.allows_public_access = allows_public_access;
 exports.get_bucket_policy_principal_arn = get_bucket_policy_principal_arn;
 exports.create_arn_for_root = create_arn_for_root;
+exports.get_account_identifier_id = get_account_identifier_id;

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -252,10 +252,10 @@ async function authorize_request_policy(req) {
     const account = req.object_sdk.requesting_account;
     const is_nc_deployment = Boolean(req.object_sdk.nsfs_config_root);
     const account_identifier_name = is_nc_deployment ? account.name.unwrap() : account.email.unwrap();
-    // Both NSFS NC and containerized will validate bucket policy against acccount id.
-    const account_identifier_id = account._id;
+    // Both NSFS NC and containerized will validate bucket policy against acccount id 
+    // but in containerized deplyment not against IAM user ID.
+    const account_identifier_id = s3_bucket_policy_utils.get_account_identifier_id(is_nc_deployment, account);
     const account_identifier_arn = s3_bucket_policy_utils.get_bucket_policy_principal_arn(account);
-
     // deny delete_bucket permissions from bucket_claim_owner accounts (accounts that were created by OBC from openshift\k8s)
     // the OBC bucket can still be delete by normal accounts according to the access policy which is checked below
     if (req.op_name === 'delete_bucket' && account.bucket_claim_owner) {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -559,7 +559,11 @@ async function get_account_by_principal(principal) {
         if (principal_by_arn) return true;
     } else {
         const account = system_store.data.accounts.find(acc => acc._id.toString() === principal_as_string);
-        const principal_by_id = account !== undefined;
+       if (account && account.owner) {
+            dbg.log3('get_account_by_principal: principal_by_id not supported for IAM users');
+            return false;
+        }
+        const principal_by_id = Boolean(account);
         dbg.log3('get_account_by_principal: principal_by_id', principal_by_id);
         if (principal_by_id) return true;
     }


### PR DESCRIPTION
### Describe the Problem

User ID for principal is not supported

### Explain the Changes
1. Block put pucket policy if the principal is IAM user ID

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

GAP: Missing integration test for IAM users, Will add in upcoming PRs

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deployment-aware helper to determine when an account identifier should be used for bucket policy evaluation.

* **Bug Fixes**
  * Improved bucket policy principal resolution: IAM users are no longer treated as valid principals when looked up by account ID, reducing unintended principal matches.
  * Policy evaluation now respects deployment-specific account identification rules for more accurate access control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->