### PR TITLE
IAM | Remove Unneeded `system_store` Calls - Part 1

### DIFF
--- a/src/sdk/accountspace_nb.js
+++ b/src/sdk/accountspace_nb.js
@@ -1,17 +1,8 @@
-/* Copyright (C) 2024 NooBaa */
+/* Copyright (C) 2025 NooBaa */
 'use strict';
 
 const account_util = require('../util/account_util');
-const system_store = require('..//server/system_services/system_store').get_instance();
 const { IAM_DEFAULT_PATH} = require('../endpoint/iam/iam_constants');
-
-/* 
-    TODO: DISCUSS: 
-    1. IAM API only for account created using IAM API and OBC accounts not from admin, support, 
-       operator and account created using noobaa.
-    2. Do we need to have two access keys
-    3. get_access_key_last_used() API call could return dummy values?
-*/
 
 /**
  * @implements {nb.AccountSpace}
@@ -30,27 +21,24 @@ class AccountSpaceNB {
         this.stats = stats;
     }
 
-    //////////////////////
-    // ACCOUNT METHODS  //
-    //////////////////////
+    ////////////////////
+    // USER METHODS  //
+    ///////////////////
 
     async create_user(params, account_sdk) {
-
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        const account_email_wrapped = account_util.get_account_email_from_username(params.username, requesting_account._id.toString());
+        const requesting_account = account_sdk.requesting_account;
+        const account_email_wrapped = account_util.get_account_email_from_username(params.username, requesting_account._id);
         const req = {
                 name: params.username, // actual username saved
                 email: account_email_wrapped, // unique email generated from username lowercase and root account id
                 has_login: false,
                 s3_access: true,
                 allow_bucket_creation: true,
-                owner: requesting_account._id.toString(),
+                owner: requesting_account._id,
                 iam_path: params.iam_path,
                 roles: ['admin'],
-                // TODO: default_resource remove
-                default_resource: requesting_account.default_resource.name,
             };
-        const iam_account = await account_sdk.rpc_client.account.create_user(req, requesting_account);
+        const iam_account = await account_sdk.rpc_client.account.create_user(req);
         // TODO : Clean account cache
         // TODO : Send Event
         return {
@@ -63,110 +51,86 @@ class AccountSpaceNB {
     }
 
     async get_user(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.get_user(params, requesting_account);
+        return account_sdk.rpc_client.account.get_user(params);
     }
 
     async update_user(params, account_sdk) {
-
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.update_user(params, requesting_account);
+        return account_sdk.rpc_client.account.update_user(params);
         // TODO : Clean account cache
         // TODO : Send Event
     }
 
     async delete_user(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.delete_user(params, requesting_account);
+        return account_sdk.rpc_client.account.delete_user(params);
         // TODO : clean account cache
 
     }
 
     async list_users(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.list_users(params, requesting_account);
+        return account_sdk.rpc_client.account.list_users(params);
 
     }
 
-    /////////////////////////////////
-    // ACCOUNT ACCESS KEY METHODS  //
-    /////////////////////////////////
+    ///////////////////////////////
+    // USER ACCESS KEY METHODS  //
+    //////////////////////////////
 
     async create_access_key(params, account_sdk) {
-
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.create_access_key(params, requesting_account);
+        return account_sdk.rpc_client.account.create_access_key(params);
     }
 
     async get_access_key_last_used(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.get_access_key_last_used(params, requesting_account);
+        return account_sdk.rpc_client.account.get_access_key_last_used(params);
     }
 
     async update_access_key(params, account_sdk) {
-
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.update_access_key(params, requesting_account);
+        return account_sdk.rpc_client.account.update_access_key(params);
         // TODO : clean account cache
     }
 
     async delete_access_key(params, account_sdk) {
-
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.delete_access_key(params, requesting_account);
+        return account_sdk.rpc_client.account.delete_access_key(params);
         // TODO : clean account cache
     }
 
     async list_access_keys(params, account_sdk) {
-
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.list_access_keys(params, requesting_account);
+        return account_sdk.rpc_client.account.list_access_keys(params);
     }
 
-    ///////////////////////////
-    // ACCOUNT TAGS METHODS  //
-    ///////////////////////////
+    ////////////////////////
+    // USER TAGS METHODS  //
+    ////////////////////////
 
     async tag_user(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.tag_user(params, requesting_account);
+        return account_sdk.rpc_client.account.tag_user(params);
     }
 
     async untag_user(params, account_sdk) {
-
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.untag_user(params, requesting_account);
+        return account_sdk.rpc_client.account.untag_user(params);
     }
 
     async list_user_tags(params, account_sdk) {
-
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.list_user_tags(params, requesting_account);
-
+        return account_sdk.rpc_client.account.list_user_tags(params);
     }
 
-    ////////////////////
-    // POLICY METHODS //
-    ////////////////////
+    /////////////////////
+    // POLICY METHODS  //
+    /////////////////////
 
     async put_user_policy(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.put_user_policy(params, requesting_account);
+        return account_sdk.rpc_client.account.put_user_policy(params);
     }
 
     async get_user_policy(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.get_user_policy(params, requesting_account);
+        return account_sdk.rpc_client.account.get_user_policy(params);
     }
 
     async delete_user_policy(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.delete_user_policy(params, requesting_account);
+        return account_sdk.rpc_client.account.delete_user_policy(params);
     }
 
     async list_user_policies(params, account_sdk) {
-        const requesting_account = system_store.get_account_by_email(account_sdk.requesting_account.email);
-        return await account_sdk.rpc_client.account.list_user_policies(params, requesting_account);
+        return account_sdk.rpc_client.account.list_user_policies(params);
     }
 }
 


### PR DESCRIPTION
### Describe the Problem
Currently, there are many calls to `system_store` in functions related to IAM.

### Explain the Changes
1. Reduce the calls to `system_store`, mainly where it was to get the `requesting_account` in the file `accountspace_nb.js`.

### Issues:
List of GAPs:
- I think we need to move the `create_user` inside the `account_server` so we would have the `req.account` access and keep this file with small functionality.
- Planned to work on the files: `account_server` and `account_utils` as well.
- There is code duplication that I found; probably we can reduce more in the future.

### Testing Instructions:
I rerun the API tests to make sure it doesn't break.

#### Automatic test
Containerized
1. Use the guide "Run Tests From coretest Locally" ([link](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/run_coretest_locally.md)) for running the core tests.
4. Run first tab: `docker run -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=noobaa  quay.io/sclorg/postgresql-15-c9s`
5. Run second tab: `NOOBAA_LOG_LEVEL=all ./node_modules/.bin/mocha src/test/integration_tests/api/iam/test_iam_basic_integration.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal account/user handling and streamlined backend request flow by removing redundant internal argument passing.
  * Consolidated ownership/resource resolution and cleaned up related labels and comments.
  * No changes to public APIs, method signatures, or any user-visible behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->