### PR TITLE
IAM | Doc | Update file `docs/design/AWS_API_Compatibility.md`

### DIFF
--- a/docs/design/AWS_API_Compatibility.md
+++ b/docs/design/AWS_API_Compatibility.md
@@ -1,10 +1,13 @@
 [NooBaa Core](../../README.md) /
 
 # AWS APIs Compatibility Table
-The chart below strives to provide an up-to-date overview of which AWS API calls are supported by NooBaa, and to what extent.
-Actions that are absent from the table are entirely unsupported*.
-The table is split into categories, each containing a list of features and their corresponding API actions.
-NooBaa utilizes different implementations of API calls for different storage providers, so the table is split into columns for each provider to indicate whether it's supported or not.
+The chart below strives to provide an up-to-date overview of which AWS API calls are supported by NooBaa, and to what extent.  
+Actions that are absent from the table are entirely *unsupported*.  
+
+## S3 API
+The table is split into categories, each containing a list of features and their corresponding API actions.  
+NooBaa utilizes different implementations of API calls for different storage providers, so the table is split into columns for each provider to indicate whether it's supported or not.  
+
 The store types currently included in the table are backingstore (regardless of storage provider), namespace filesystem (NSFS), namespace for Amazon Web Services, and namespace for Microsoft Azure.
 For more information, see [S3 Compatibility](https://github.com/noobaa/noobaa-operator/tree/master/doc/s3-compatibility.md), [Bucket Types](https://github.com/noobaa/noobaa-operator/tree/master/doc/bucket-types.md), [Backingstore CRD](https://github.com/noobaa/noobaa-operator/blob/master/doc/backing-store-crd.md) and [Namespacestore CRD](https://github.com/noobaa/noobaa-operator/blob/master/doc/namespace-store-crd.md).
 
@@ -71,16 +74,34 @@ _* Note that it is also possible for actions to be supported but absent because 
 | **Security**          | Encryption                      | GetBucketEncryption               | ✅            | ✅    | ❌      | ❌        |                                                                         |
 |                       | Encryption                      | PutBucketEncryption               | ✅            | ✅*   | ❌      | ❌        | *Additional automation setup is needed (NooBaa only verifies that the FS encryption matches the bucket configuration |
 |                       | Encryption                      | DeleteBucketEncryption            | ✅            | ✅    | ❌      | ❌        |                                                                         |
-| **STS API**           | Session Tokens                  | AssumeRole                        | ✅            | ✅    | ❌      | ❌        |                                                                         |
-| **IAM API***           | Users                          | GetUser                           | ❌            | ✅    | ❌      | ❌        |                                                                         |
-|                       | Users                           | CreateUser                        | ❌            | ✅    | ❌      | ❌        |                                                                         |
-|                       | Users                           | UpdateUser                        | ❌            | ✅    | ❌      | ❌        |                                                                         |
-|                       | Users                           | DeleteUser                        | ❌            | ✅    | ❌      | ❌        |                                                                         |
-|                       | Users                           | ListUsers                         | ❌            | ✅*   | ❌      | ❌        | *No pagination support                                                  |
-|                       | Access Keys                     | GetAccessKeyLastUsed              | ❌            | ✅*   | ❌      | ❌        | *Partially implemented                                                  |
-|                       | Access Keys                     | CreateAccessKey                   | ❌            | ✅    | ❌      | ❌        |                                                                         |
-|                       | Access Keys                     | UpdateAccessKey                   | ❌            | ✅    | ❌      | ❌        |                                                                         |
-|                       | Access Keys                     | DeleteAccessKey                   | ❌            | ✅    | ❌      | ❌        |                                                                         |
-|                       | Access Keys                     | ListAccessKeys                    | ❌            | ✅*   | ❌      | ❌        | *No pagination support                                                  |
 
-_* IAM API uses a different port than the S3 API, and needs to be manually enabled prior to use._
+
+## IAM and STS API
+The following table compares the actions of managing entities between NooBaa deployments:
+1. NooBaa non-containerized deployment (NC)
+2. Containerized deployment
+
+| Category              | Feature                         | API Action                        | Containerized  | NC   | Comments                                                                |
+|:---------------------:|:-------------------------------:|:---------------------------------:|:-------------:|:------:|-------------------------------------------------------------------------|
+| **STS API** | Session Tokens | AssumeRole           | ✅ | ❌ | |
+| **IAM API** | Users          | CreateUser           | ✅ | ✅ | |
+|             | Users          | GetUser              | ✅ | ✅ | |
+|             | Users          | UpdateUser           | ✅ | ✅ | |
+|             | Users          | DeleteUser           | ✅ | ✅ | |
+|             | Users          | ListUsers            | ✅ | ✅ | *No pagination support|
+|             | Access Keys    | CreateAccessKey      | ✅ | ✅ | |
+|             | Access Keys    | GetAccessKeyLastUsed | ✅ | ✅ | *Partially implemented|
+|             | Access Keys    | UpdateAccessKey      | ✅ | ✅ | |
+|             | Access Keys    | DeleteAccessKey      | ✅ | ✅ | |
+|             | Access Keys    | ListAccessKeys       | ✅ | ✅ | *No pagination support|
+|             | Tag User       | TagUser              | ✅ | ❌ | |
+|             | Tag User       | UntagUser            | ✅ | ❌ | |
+|             | Tag User       | ListUserTags         | ✅ | ❌ | *No pagination support|
+|             | IAM Policy     | PutUserPolicy        | ✅ | ❌ | |
+|             | IAM Policy     | GetUserPolicy        | ✅ | ❌ | |
+|             | IAM Policy     | DeleteUserPolicy     | ✅ | ❌ | |
+|             | IAM Policy     | ListUserPolicies     | ✅ | ❌ | *No pagination support|
+
+Notes:
+- IAM API uses a different port than the S3 API (and needs to be manually enabled before use in NC deployments).
+- The specific supported request parameters in IAM are detailed in the [IAM Design](./iam.md#supported-actions-and-their-request-parameters).


### PR DESCRIPTION
### Describe the Problem
Update the `docs/design/AWS_API_Compatibility.md` and take the IAM and STS to a different table where the comparison is between deployments instead of namespacestore/backingstore types.

### Explain the Changes
1. Move the STS API to the deployment comparison - change the NC column to not implemented.
2. Move the IAM API to the deployment comparison.
3. Add new actions that were implemented in Containerized deployment.

### Issues:
1. none

### Testing Instructions:
1. none


- [X] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized AWS API compatibility guide with a new "IAM and STS API" section and added "S3 API" subsection for clearer discovery.
  * Consolidated IAM and STS action listings into a single, reformatted table showing per-deployment support (containerized vs non-containerized), including pagination and partial-implementation notes.
  * Clarified deployment port differences, manual enablement for non-containerized deployments, headings, footnotes, and overall readability.
  * No changes to public API behavior or capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->