### PR TITLE
prometheus alerts - replace bucket capacity with BS capacity DF3671

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -450,6 +450,9 @@ module.exports = {
                             },
                             is_healthy: {
                                 type: 'boolean'
+                            },
+                            is_low_capacity: {
+                                type: 'boolean'
                             }
                         }
                     }

--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -296,6 +296,13 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
         }
     }, {
         type: 'Gauge',
+        name: 'backing_store_low_capacity',
+        configuration: {
+            help: 'Backing Store Low Capacity Status (0=normal, 1=low capacity)',
+            labelNames: ['backing_store_name']
+        }
+    }, {
+        type: 'Gauge',
         name: 'bucket_size_quota',
         configuration: {
             help: 'Bucket Size Quota Precent',
@@ -630,8 +637,12 @@ class NooBaaCoreReport extends BasePrometheusReport {
         if (!this._metrics) return;
 
         this._metrics.resource_status.reset();
+        this._metrics.backing_store_low_capacity.reset();
         resources_info.forEach(resource_info => {
             this._metrics.resource_status.set({ resource_name: resource_info.resource_name }, Number(resource_info.is_healthy));
+            this._metrics.backing_store_low_capacity.set(
+                { backing_store_name: resource_info.resource_name },
+                Number(resource_info.is_low_capacity));
         });
     }
 

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -728,6 +728,10 @@ async function get_cloud_pool_stats(req) {
         'TIER_LOW_CAPACITY',
         'LOW_CAPACITY',
     ];
+    const LOW_CAPACITY_MODES = [
+        'TIER_LOW_CAPACITY',
+        'LOW_CAPACITY',
+    ];
     //Per each system fill out the needed info
     for (const pool of system_store.data.pools) {
         if (pool.is_default_pool) continue;
@@ -796,6 +800,7 @@ async function get_cloud_pool_stats(req) {
         cloud_pool_stats.resources.push({
             resource_name: pool_info.name,
             is_healthy: _.includes(OPTIMAL_MODES, pool_info.mode),
+            is_low_capacity: _.includes(LOW_CAPACITY_MODES, pool_info.mode),
         });
     }
 


### PR DESCRIPTION
### Describe the Problem
The bucket's capacity doesn't take into account data reduction, which is confusing.

### Explain the Changes
We opted to remove the per-bucket capacity check and replace with backing store-level check (physical).

### Issues: Fixed
https://issues.redhat.com/browse/DFBUGS-3671

### Testing Instructions:
1. Create a BS, preferably a small one..
2. Fill BS to 80% capacity (possible with enough "s3 cp")
3. An alert is triggered on the BS.

Note corresponding PR in operator for the rules change:
https://github.com/noobaa/noobaa-operator/pull/1747

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backing-store capacity metrics to improve visibility of storage capacity across resources and pools, enabling better monitoring and alerting for low-capacity conditions.
  * Exposed an optional is_low_capacity flag in cloud pool stats so monitoring systems and UIs can mark and surface resources operating in low-capacity modes for operators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->