### PR TITLE
IAM | Remove Unneeded `system_store` Calls - Part 2

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1227,13 +1227,12 @@ async function get_user(req) {
 async function update_user(req) {
 
     const action = IAM_ACTIONS.UPDATE_USER;
-    const requesting_account = system_store.get_account_by_email(req.account.email);
+    const requesting_account = req.account;
     const old_account_email_wrapped = account_util.get_account_email_from_username(
         req.rpc_params.username, requesting_account._id.toString());
     account_util._check_if_requesting_account_is_root_account(action, requesting_account,
             { username: req.rpc_params.username, iam_path: req.rpc_params.new_iam_path });
-    account_util._check_if_account_exists(action, old_account_email_wrapped, req.rpc_params.username);
-    const requested_account = system_store.get_account_by_email(old_account_email_wrapped);
+    const requested_account = account_util._check_if_account_exists(action, old_account_email_wrapped, req.rpc_params.username);
     let iam_path = requested_account.iam_path;
     let user_name = req.rpc_params.username;
     // Change to complete user name
@@ -1279,8 +1278,7 @@ async function delete_user(req) {
     const requesting_account = req.account;
     const account_email_wrapped = account_util.get_account_email_from_username(req.rpc_params.username, requesting_account._id.toString());
     account_util._check_if_requesting_account_is_root_account(action, requesting_account, { username: req.rpc_params.username });
-    account_util._check_if_account_exists(action, account_email_wrapped, req.rpc_params.username);
-    const requested_account = system_store.get_account_by_email(account_email_wrapped);
+    const requested_account = account_util._check_if_account_exists(action, account_email_wrapped, req.rpc_params.username);
     account_util._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
     account_util._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
     account_util._check_if_user_does_not_have_resources_before_deletion(action, requested_account);
@@ -1433,15 +1431,7 @@ async function delete_access_key(req) {
 async function tag_user(req) {
     const action = IAM_ACTIONS.TAG_USER;
     const requesting_account = req.account;
-    const account_email_wrapped = account_util.get_account_email_from_username(req.rpc_params.username, requesting_account._id.toString());
-
-    account_util._check_if_requesting_account_is_root_account(action, requesting_account, { username: req.rpc_params.username });
-    account_util._check_if_account_exists(action, account_email_wrapped, req.rpc_params.username);
-
-    const requested_account = system_store.get_account_by_email(account_email_wrapped);
-    account_util._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
-    account_util._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
-
+    const requested_account = account_util.validate_and_return_requested_account(req.rpc_params, action, requesting_account);
     const existing_tags = requested_account.tagging || [];
 
     const tags_map = new Map();
@@ -1475,15 +1465,7 @@ async function tag_user(req) {
 async function untag_user(req) {
     const action = IAM_ACTIONS.UNTAG_USER;
     const requesting_account = req.account;
-    const account_email_wrapped = account_util.get_account_email_from_username(req.rpc_params.username, requesting_account._id.toString());
-
-    account_util._check_if_requesting_account_is_root_account(action, requesting_account, { username: req.rpc_params.username });
-    account_util._check_if_account_exists(action, account_email_wrapped, req.rpc_params.username);
-
-    const requested_account = system_store.get_account_by_email(account_email_wrapped);
-    account_util._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
-    account_util._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
-
+    const requested_account = account_util.validate_and_return_requested_account(req.rpc_params, action, requesting_account);
     const existing_tags = requested_account.tagging || [];
 
     const tag_keys_set = new Set(req.rpc_params.tag_keys);
@@ -1504,15 +1486,7 @@ async function untag_user(req) {
 async function list_user_tags(req) {
     const action = IAM_ACTIONS.LIST_USER_TAGS;
     const requesting_account = req.account;
-    const account_email_wrapped = account_util.get_account_email_from_username(req.rpc_params.username, requesting_account._id.toString());
-
-    account_util._check_if_requesting_account_is_root_account(action, requesting_account, { username: req.rpc_params.username });
-    account_util._check_if_account_exists(action, account_email_wrapped, req.rpc_params.username);
-
-    const requested_account = system_store.get_account_by_email(account_email_wrapped);
-    account_util._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
-    account_util._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
-
+    const requested_account = account_util.validate_and_return_requested_account(req.rpc_params, action, requesting_account);
     // TODO: Pagination not supported - currently returns all tags, ignoring marker and max_items params
     const tags = account_util.get_sorted_list_tags_for_user(requested_account.tagging);
     dbg.log1('AccountSpaceNB.list_user_tags: returning', tags, 'tags for user', req.rpc_params.username);

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -329,6 +329,7 @@ function _check_if_account_exists(action, email_wrapped, username) {
         const message_with_details = `The user with name ${username} cannot be found.`;
         throw new RpcError('NO_SUCH_ENTITY', message_with_details);
     }
+    return account;
 }
 
 function _check_root_account_owns_user(root_account, user_account) {
@@ -738,8 +739,7 @@ function validate_and_return_requested_account(params, action, requesting_accoun
     } else {
         _check_if_requesting_account_is_root_account(action, requesting_account, { username: params.username });
         const account_email = get_account_email_from_username(params.username, requesting_account._id.toString());
-        _check_if_account_exists(action, account_email, params.username);
-        requested_account = system_store.get_account_by_email(account_email);
+        requested_account = _check_if_account_exists(action, account_email, params.username);
         _check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
         _check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
     }


### PR DESCRIPTION
### Describe the Problem
Currently, there are many calls to `system_store` in functions related to IAM.
Note: Part 1 was in PR #9330.

### Explain the Changes
1. Reduce the calls to `system_store`, mainly where it was to get the `requested_account` and the use of the function `_check_if_account_exists`.

### Issues:
List of GAPs:
I think we need to move the create_user inside the account_server so we would have the req.account access and keep this file with small functionality.
Planned to work on the files: account_utils as well.
There is code duplication that I found; probably we can reduce more in the future.

### Testing Instructions:
Containerized
1. Use the guide "Run Tests From coretest Locally" ([link](https://github.com/noobaa/noobaa-core/blob/master/docs/dev_guide/run_coretest_locally.md)) for running the core tests.
4. Run first tab: `docker run -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=noobaa  quay.io/sclorg/postgresql-15-c9s`
5. Run second tab: `NOOBAA_LOG_LEVEL=all ./node_modules/.bin/mocha src/test/integration_tests/api/iam/test_iam_basic_integration.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized account resolution used across user management actions (update, delete, tag/untag, list tags).
  * Account validation helper now returns the resolved account object for downstream use.
  * Validation and error flows for account operations now follow the centralized helper, improving consistency of responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->