### PR TITLE
IAM | Refactor `src/endpoint/s3/s3_bucket_policy_utils.js` (Used in Bucket Policy and IAM User Inline Policy)

### DIFF
--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -9,7 +9,7 @@ const P = require('../util/promise');
 const string_utils = require('../util/string_utils');
 const native_fs_utils = require('../util/native_fs_utils');
 const ManageCLIError = require('../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
-const bucket_policy_utils = require('../endpoint/s3/s3_bucket_policy_utils');
+const access_policy_utils = require('../util/access_policy_utils');
 const { throw_cli_error, get_options_from_file, get_boolean_or_string_value, get_bucket_owner_account_by_id,
     is_name_update, is_access_key_update } = require('../manage_nsfs/manage_nsfs_cli_utils');
 const { TYPES, ACTIONS, VALID_OPTIONS, OPTION_TYPE, FROM_FILE, BOOLEAN_STRING_VALUES, BOOLEAN_STRING_OPTIONS,
@@ -487,7 +487,7 @@ async function validate_bucket_args(config_fs, data, action) {
         }
         if (data.s3_policy) {
             try {
-                await bucket_policy_utils.validate_s3_policy(data.s3_policy, data.name,
+                await access_policy_utils.validate_bucket_policy(data.s3_policy, data.name,
                     async principal => config_fs.is_account_exists_by_principal(principal, { silent_if_missing: true })
                 );
             } catch (err) {

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -33,7 +33,7 @@ const azure_storage = require('../../util/azure_storage_wrap');
 const usage_aggregator = require('../bg_services/usage_aggregator');
 const chunk_config_utils = require('../utils/chunk_config_utils');
 const NetStorage = require('../../util/NetStorageKit-Node-master/lib/netstorage');
-const bucket_policy_utils = require('../../endpoint/s3/s3_bucket_policy_utils');
+const access_policy_utils = require('../../util/access_policy_utils');
 const path = require('path');
 const KeysSemaphore = require('../../util/keys_semaphore');
 const bucket_semaphore = new KeysSemaphore(1);
@@ -573,12 +573,12 @@ async function get_account_by_principal(principal) {
 async function put_bucket_policy(req) {
     dbg.log0('put_bucket_policy:', req.rpc_params);
     const bucket = find_bucket(req, req.rpc_params.name);
-    await bucket_policy_utils.validate_s3_policy(req.rpc_params.policy, bucket.name,
+    await access_policy_utils.validate_bucket_policy(req.rpc_params.policy, bucket.name,
         principal => get_account_by_principal(principal));
 
     if (
         bucket.public_access_block?.block_public_policy &&
-        bucket_policy_utils.allows_public_access(req.rpc_params.policy)
+        access_policy_utils.allows_public_access(req.rpc_params.policy)
     ) {
             // Should result in AccessDenied error
             throw new RpcError('UNAUTHORIZED');

--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
@@ -12,7 +12,7 @@ coretest.setup({ pools_to_create: process.env.NC_CORETEST ? undefined : [POOL_LI
 const path = require('path');
 const _ = require('lodash');
 const fs_utils = require('../../../../util/fs_utils');
-const s3_bucket_policy_utils = require('../../../../endpoint/s3/s3_bucket_policy_utils');
+const access_policy_utils = require('../../../../util/access_policy_utils');
 
 const { S3 } = require('@aws-sdk/client-s3');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
@@ -152,9 +152,9 @@ async function setup() {
         For coretest nc, principal will have account name and
         for containerized deployment principal is ARN
     */
-    admin_principal = is_nc_coretest ? EMAIL : s3_bucket_policy_utils.create_arn_for_root(admin_info._id.toString());
-    a_principal = is_nc_coretest ? user_a : s3_bucket_policy_utils.create_arn_for_root(user_a_account_details.id.toString());
-    b_principal = is_nc_coretest ? user_b : s3_bucket_policy_utils.create_arn_for_root(user_b_account_details.id.toString());
+    admin_principal = is_nc_coretest ? EMAIL : access_policy_utils.create_arn_for_root(admin_info._id.toString());
+    a_principal = is_nc_coretest ? user_a : access_policy_utils.create_arn_for_root(user_a_account_details.id.toString());
+    b_principal = is_nc_coretest ? user_b : access_policy_utils.create_arn_for_root(user_b_account_details.id.toString());
 
     s3_owner = new S3(s3_creds);
     await s3_owner.createBucket({ Bucket: BKT });
@@ -394,7 +394,7 @@ mocha.describe('s3_bucket_policy', function() {
             };
         }
         // Losing this value in-between, assigning it again
-        a_principal = is_nc_coretest ? user_a : s3_bucket_policy_utils.create_arn_for_root(user_a_account_id.toString());
+        a_principal = is_nc_coretest ? user_a : access_policy_utils.create_arn_for_root(user_a_account_id.toString());
         const deny_account_by_name_all_s3_actions_statement = {
             Sid: `Do not allow user ${user_a} any s3 action`,
             Effect: 'Deny',
@@ -2221,7 +2221,7 @@ mocha.describe('s3_bucket_policy', function() {
         mocha.it('should fail : Bucket policy with valid principal account ARN, try to putObject with different account', async function() {
             if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             this.timeout(5000); // eslint-disable-line no-invalid-this
-            const valid_arn_b = s3_bucket_policy_utils.create_arn_for_root(user_b_account_id);
+            const valid_arn_b = access_policy_utils.create_arn_for_root(user_b_account_id);
             const s3_policy = {
                 Version: '2012-10-17',
                 Statement: [
@@ -2251,7 +2251,7 @@ mocha.describe('s3_bucket_policy', function() {
         mocha.it('Bucket policy with valid principal account ARN', async function() {
             if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             this.timeout(5000); // eslint-disable-line no-invalid-this
-            const valid_arn = s3_bucket_policy_utils.create_arn_for_root(user_b_account_id);
+            const valid_arn = access_policy_utils.create_arn_for_root(user_b_account_id);
             const s3_policy = {
                 Version: '2012-10-17',
                 Statement: [
@@ -2276,7 +2276,7 @@ mocha.describe('s3_bucket_policy', function() {
         mocha.it('Bucket policy with valid principal ARN, and PutObject', async function() {
             if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             this.timeout(5000); // eslint-disable-line no-invalid-this
-            const valid_arn = s3_bucket_policy_utils.create_arn_for_root(user_b_account_id);
+            const valid_arn = access_policy_utils.create_arn_for_root(user_b_account_id);
             const s3_policy = {
                 Version: '2012-10-17',
                 Statement: [

--- a/src/upgrade/upgrade_scripts/5.15.6/upgrade_bucket_policy.js
+++ b/src/upgrade/upgrade_scripts/5.15.6/upgrade_bucket_policy.js
@@ -2,7 +2,7 @@
 "use strict";
 
 const util = require('util');
-const { OP_NAME_TO_ACTION } = require('../../../endpoint/s3/s3_bucket_policy_utils');
+const { OP_NAME_TO_ACTION } = require('../../../util/access_policy_utils');
 const _ = require('lodash');
 
 


### PR DESCRIPTION
### Describe the Problem
Currently, our `src/endpoint/s3/s3_bucket_policy_utils.js` is used for bucket policy in several places, and not all of them are in the endpoint S3 stack (for example, NC CLI). In addition, when I added the IAM user inline policy, I reused those functions.

### Explain the Changes
1. Renaming:
- In the logs: `bucket_policy -> access_policy`
- The function: `has_bucket_policy_permission -> has_access_policy_permission`
2.  Move `s3_bucket_policy_utils.js` from `src/endpoint/s3/` to `src/util/`.
3.  Renaming:
- The file: `s3_bucket_policy_utils.js` to `access_policy_utils.js`
- The variable name: `s3_bucket_policy_utils` to `acess_policy_utils`

### Issues: 
List of GAPs:
- We'd better also move the `const s3_utils = require('../endpoint/s3/s3_utils');` as it is in the endpoint S3 stack.

### Testing Instructions:
1. Tested in the CI.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and renamed internal policy utilities across the system to consolidate policy validation and permission checks; public APIs and user-facing behavior unchanged.

* **Tests**
  * Updated tests to reference the consolidated policy utilities; test behavior and outcomes remain the same.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->