### PR TITLE
IAM | Add Creation Date for IAM Users

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1213,8 +1213,7 @@ async function get_user(req) {
         iam_path: requested_account.iam_path || IAM_DEFAULT_PATH,
         username: username,
         arn: iam_arn,
-        // TODO: GAP Need to save created date
-        create_date: Date.now(),
+        create_date: requested_account.creation_date,
         // TODO: Dates missing : GAP
         password_last_used: Date.now(),
         tags: tags

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -38,6 +38,7 @@ module.exports = {
                 $ref: 'common_api#/definitions/iam_user_policy',
             }
         },
+        creation_date: { idate: true },
         // default policy for new buckets
         default_resource: { objectid: true },
         default_chunk_config: { objectid: true },

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -113,6 +113,7 @@ async function create_account(req) {
     if (req.rpc_params.owner) {
         account.owner = req.rpc_params.owner;
         account.iam_path = req.rpc_params.iam_path;
+        account.creation_date = Date.now();
     }
 
     await system_store.make_changes({
@@ -141,7 +142,7 @@ async function create_account(req) {
         token: auth_server.make_auth_token(auth),
         access_keys: account_access_info.decrypted_access_keys,
         id: created_account._id.toString(),
-        create_date: req.rpc_params.owner ? Date.now() : undefined, // GAP: Do not save account creation date
+        create_date: req.rpc_params.owner ? account.creation_date : undefined, // GAP: Do not save account creation date
     };
 }
 
@@ -753,8 +754,7 @@ function return_list_member(iam_user, iam_path, iam_username) {
         iam_path: iam_path,
         username: iam_username,
         arn: create_arn_for_user(owner_account_id, iam_username, iam_path),
-        // TODO: GAP Need to save created date
-        create_date: Date.now(),
+        create_date: iam_user.creation_date,
         // TODO: GAP missing password_last_used
         password_last_used: Date.now(), // GAP
     };


### PR DESCRIPTION
### Describe the Problem
Currently, on the APIs of `GetUser` and `ListUsers` we returned the `Date().now` since we didn't store that information.

### Explain the Changes
1. Save the `creation_date` in the DB.
2. Return this value in `GetUser` and `ListUsers`.

### Issues: 
1. none

### Testing Instructions:
#### Manual Test
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
3. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
4. Create the alias for the admin - first, need to get the credentials: `nb status --show-secrets -n test1` and then:
`alias admin-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
5. Check the connection to the endpoint:
- try to list the users (should be an empty list): `admin-iam iam list-users; echo $?`
6. Create a user: `admin-iam iam create-user --user-name Robert`
output:
> {
>     “User”: {
>         “Path”: “/”,
>         “UserName”: “Robert”,
>         “UserId”: “6937f6c15d5cde0022ff0b81”,
>         “Arn”: “arn:aws:iam::6937ef775d5cde0022ff0b63:user/Robert”,
>         “CreateDate”: “2025-12-09T10:15:29+00:00”
>     }
> }

See, the `CreateDate` is on 10:15
7. (wait a minute) List users: `admin-iam iam list-users` 
output:
> {
>     “Users”: [
>         {
>             “Path”: “/”,
>             “UserName”: “Robert”,
>             “UserId”: “6937f6c15d5cde0022ff0b81",
>             “Arn”: “arn:aws:iam::6937ef775d5cde0022ff0b63:user/Robert”,
>             “CreateDate”: “2025-12-09T10:15:29+00:00",
>             “PasswordLastUsed”: “2025-12-09T10:16:04+00:00"
>         }
>     ]
> }

See, the `CreateDate` is still 10:15 (`PasswordLastUsed` is still a mock 10:16)
9. (wait a minute) Get a user: `admin-iam iam get-user --user-name Robert`
output:

> {
>     “User”: {
>         “Path”: “/”,
>         “UserName”: “Robert”,
>         “UserId”: “6937f6c15d5cde0022ff0b81”,
>         “Arn”: “arn:aws:iam::6937ef775d5cde0022ff0b63:user/Robert”,
>         “CreateDate”: “2025-12-09T10:15:29+00:00”,
>         “PasswordLastUsed”: “2025-12-09T10:17:04+00:00”
>     }
> }

See, the `CreateDate` is still 10:15 (`PasswordLastUsed` is still a mock 10:17)
10. In the DB I checked the field: `"creation_date": 1765275329703,` I used [online Epoch Converter](https://www.epochconverter.com/) and saw it is GMT: Tuesday, December 9, 2025 10:15:29.703 AM)

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).
- I used the admin account, but for IAM operations, there is no difference between a created account and an admin account. I tested with the admin only because it saves steps (I have the admin account upon system creation).


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account creation timestamps are now consistently preserved and displayed across creation, token responses, and member listings (no longer replaced with the current time).

* **New Features**
  * Account records now include an explicit creation date field so original creation timestamps are retained and visible where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->