### PR TITLE
IAM | Add Events

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1261,6 +1261,16 @@ async function update_user(req) {
         }
     });
 
+    const sys_id = account_util.get_system_id_for_events(req);
+    Dispatcher.instance().activity({
+        event: 'account.update',
+        level: 'info',
+        system: sys_id,
+        actor: requesting_account._id,
+        account: requested_account._id,
+        desc: `${requested_account.email.unwrap()} was updated by ${requesting_account.email.unwrap()}`,
+    });
+
     return {
         iam_path: iam_path || IAM_DEFAULT_PATH,
         username: user_name,
@@ -1279,11 +1289,7 @@ async function delete_user(req) {
     account_util._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
     account_util._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
     account_util._check_if_user_does_not_have_resources_before_deletion(action, requested_account);
-    const delete_user_info = {
-        system: system_store.data.systems[0],
-        account: requested_account,
-    };
-    return account_util.delete_account(delete_user_info, requested_account);
+    return account_util.delete_account(req, requested_account);
 }
 
 async function list_users(req) {
@@ -1384,6 +1390,16 @@ async function update_access_key(req) {
             }]
         }
     });
+
+    const sys_id = account_util.get_system_id_for_events(req);
+    Dispatcher.instance().activity({
+        event: 'account.update_credentials',
+        level: 'info',
+        system: sys_id,
+        actor: requesting_account._id,
+        account: requested_account._id,
+        desc: `Credentials for ${requested_account.email.unwrap()} were updated by ${requesting_account.email.unwrap()}`,
+    });
 }
 
 async function get_access_key_last_used(req) {
@@ -1422,6 +1438,16 @@ async function delete_access_key(req) {
                 $set: _.omitBy(updates, _.isUndefined),
             }]
         }
+    });
+
+    const sys_id = account_util.get_system_id_for_events(req);
+    Dispatcher.instance().activity({
+        event: 'account.delete_credentials',
+        level: 'info',
+        system: sys_id,
+        actor: requesting_account._id,
+        account: requested_account._id,
+        desc: `Credentials for ${requested_account.email.unwrap()} were deleted by ${requesting_account.email.unwrap()}`,
     });
 }
 

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -773,6 +773,12 @@ function get_sorted_list_tags_for_user(user_tagging) {
     }));
 }
 
+function get_system_id_for_events(req) {
+        const sys_id = req.rpc_params.new_system_parameters ?
+        system_store.parse_system_store_id(req.rpc_params.new_system_parameters.new_system_id) :
+        req.system && req.system._id;
+        return sys_id;
+}
 
 exports.delete_account = delete_account;
 exports.create_account = create_account;
@@ -801,3 +807,4 @@ exports.return_list_member = return_list_member;
 exports.get_owner_account_id = get_owner_account_id;
 exports.get_sorted_list_tags_for_user = get_sorted_list_tags_for_user;
 exports._check_if_iam_user_belongs_to_account_owner_by_access_key = _check_if_iam_user_belongs_to_account_owner_by_access_key;
+exports.get_system_id_for_events = get_system_id_for_events;


### PR DESCRIPTION
### Describe the Problem
Currently, we have events for user creation and user deletion (with an issue).
In this PR, we are adding the events so we will have events on: 
1. Create user (reusing account creation)
2. Delete user(reusing account deletion)
3. Update user
4. Add access key (reusing account generate credentials) 
5. Delete access key
6. Update access key

### Explain the Changes
1. Fix the arguments that were passed to `delete_account` in `delete_user`.
2. Add events for: Update user, Delete access key and Update access key.

Note: Since there are some cases that use the same function for account and IAM user:
- create user - reusing account creation
- delete user - reusing account deletion
- add access key - reusing account generate credentials)
I wanted to use the same style, and hence, the events are with a prefix of 'account` and not IAM user. The assumption is that it's all saved in the `activitylogs`, and can filter by `account`, which is the ID (can be user or account).

### Issues: 
1. none

### Testing Instructions:
#### Manual Test
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Wait for the default backing store pod to be in state Ready before starting the tests: `kubectl wait --for=condition=available backingstore/noobaa-default-backing-store --timeout=6m -n test1`
4. I'm using port-forward (in a different tab):
- S3 `kubectl port-forward -n test1 service/s3 12443:443`
- IAM `kubectl port-forward -n test1 service/iam 14443:443`
5. Create the alias for the admin - first, need to get the credentials: `nb status --show-secrets -n test1` and then:
`alias admin-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:14443'`
6. Check the connection to the endpoint:
- try to list the users (should be an empty list): `admin-iam iam list-users; echo $?`
7. Start running actions that create events, for example:
- Create a user: `admin-iam iam create-user --user-name Robert`
- Create access key: `admin-iam iam create-access-key --user-name Robert`
- Update user: `admin-iam iam update-user --user-name Robert --new-path /div/sub/`
- Create additional access key: `admin-iam iam create-access-key --user-name Robert`
8. Create the alias for the the user:  `alias user-1-iam='AWS_ACCESS_KEY=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url https://localhost:1414443'`
9. Continue running actions that create events, for example:
- Update the access key from the user: `user-1-iam iam update-access-key --access-key-id <access-key-id> --status Inactive`
- Delete access key: `user-1-iam iam delete-access-key --access-key-id <access-key-id>`
10. In the DB you will see the following (I copied the line of desc only):

> “desc”: “robert:693824bf2b88180021f0b950 was created by [admin@noobaa.io](mailto:admin@noobaa.io)”
> “desc”: “Credentials for robert:693824bf2b88180021f0b950 were regenerated by [admin@noobaa.io](mailto:admin@noobaa.io)”,
> “desc”: “robert:693824bf2b88180021f0b950 was updated by [admin@noobaa.io](mailto:admin@noobaa.io)”,
> “desc”: “Credentials for robert:693824bf2b88180021f0b950 were regenerated by [admin@noobaa.io](mailto:admin@noobaa.io)”,
> “desc”: “Credentials for robert:693824bf2b88180021f0b950 were updated by robert:693824bf2b88180021f0b950",
> “desc”: “Credentials for robert:693824bf2b88180021f0b950 were deleted by robert:693824bf2b88180021f0b950",

Notes:
- In step 1 - deploying the system, I used `--use-standalone-db` for simplicity (fewer steps for the system in Ready status).
- I used the admin account, but for IAM operations, there is no difference between a created account and an admin account. I tested with the admin only because it saves steps (I have the admin account upon system creation).
- To see the full table use: `select jsonb_pretty(data) from activitylogs;` from the DB pod.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system-scoped activity logging for account updates, credential updates, and credential deletions, capturing system context and actor details.
  * Added a helper to resolve system context used by event logging.

* **Refactor**
  * Simplified the user delete flow and aligned IAM-related logging with other account operations for consistent activity records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->