### PR TITLE
rdkafka change to optional npm dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "morgan": "1.10.1",
         "nan": "2.23.1",
         "node-addon-api": "8.5.0",
-        "node-rdkafka": "3.6.0",
         "performance-now": "2.1.0",
         "pg": "8.16.3",
         "ping": "1.0.0",
@@ -84,6 +83,9 @@
         "pkg-fetch": "3.5.2",
         "sinon": "21.0.0",
         "wtfnode": "0.10.1"
+      },
+      "optionalDependencies": {
+        "node-rdkafka": "3.6.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -9923,6 +9925,7 @@
       "integrity": "sha512-FntdqNV+Q6D7Yb54xn2IuQIBGr/cT+MjFo/4JTXKRikSP0rRkEMY7vZoNd0HJY334b/oaY7dv3+OnY7DGsSbiQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bindings": "^1.3.1",
         "nan": "^2.22.0"

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "morgan": "1.10.1",
     "nan": "2.23.1",
     "node-addon-api": "8.5.0",
-    "node-rdkafka": "3.6.0",
     "performance-now": "2.1.0",
     "pg": "8.16.3",
     "ping": "1.0.0",
@@ -124,6 +123,9 @@
     "yaml": "2.8.1",
     "yauzl": "3.2.0",
     "yazl": "3.3.1"
+  },
+  "optionalDependencies": {
+    "node-rdkafka": "3.6.0"
   },
   "devDependencies": {
     "@aws-sdk/client-iam": "3.936.0",

--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -1,5 +1,8 @@
 FROM noobaa-builder AS noobaa-base
 
+# By default we build the image with rdkafka support, but can be overridden
+ARG USE_RDKAFKA=1
+
 ######################################################################
 # Layers:
 #   Title: npm install (using package.json)
@@ -11,6 +14,13 @@ RUN npm install --omit=dev && \
     npm cache clean --force
 RUN rm -rf node_modules/node-rdkafka/deps/librdkafka/examples/
 RUN rm -rf node_modules/node-rdkafka/deps/librdkafka/src/
+
+# Build time check that rdkafka was installed by npm in the image.
+# It was added to optionalDependencies because it's not available 
+# on all platforms, so we check explicitly.
+RUN if [ "$USE_RDKAFKA" = "1" ]; then \
+        node -p 'require("node-rdkafka").librdkafkaVersion'; \
+    fi
 
 ##############################################################
 # Layers:

--- a/src/util/js_utils.js
+++ b/src/util/js_utils.js
@@ -237,6 +237,22 @@ function omit_symbol(maybe_obj, sym) {
     return _.omit(obj, sym);
 }
 
+/**
+ * For optional modules that may not be installed in the environment.
+ * @param  {string} module_name 
+ * @returns {any|null}
+ */
+function require_optional(module_name) {
+    try {
+        return require(module_name);
+    } catch (err) {
+        if (err.code === 'MODULE_NOT_FOUND') {
+            return null;
+        }
+        throw err;
+    }
+}
+
 exports.self_bind = self_bind;
 exports.array_push_all = array_push_all;
 exports.array_push_keep_latest = array_push_keep_latest;
@@ -250,3 +266,4 @@ exports.inspect_lazy = inspect_lazy;
 exports.make_array = make_array;
 exports.map_get_or_create = map_get_or_create;
 exports.omit_symbol = omit_symbol;
+exports.require_optional = require_optional;

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -4,7 +4,8 @@
 const dbg = require('../util/debug_module')(__filename);
 const config = require('../../config');
 const { PersistentLogger } = require('../util/persistent_logger');
-const Kafka = require('node-rdkafka');
+const { require_optional } = require('../util/js_utils');
+const Kafka = require_optional('node-rdkafka');
 const os = require('os');
 const fs = require('fs');
 const http = require('http');
@@ -267,6 +268,9 @@ class HttpNotificator {
 class KafkaNotificator {
 
     constructor(connect_obj) {
+        if (!Kafka) {
+            throw new Error('Kafka module is not available, cannot use Kafka notifications');
+        }
         this.connect_obj = connect_obj;
     }
 


### PR DESCRIPTION
### Describe the Problem

npm install fails on Mac because node-rdkafka fails to build.
Current solution - https://github.com/noobaa/noobaa-core/wiki/Installing-node%E2%80%90rdkafka-on-M1-mac

Another option is to use `BUILD_RDKAFKA=0 BUILD_LIBRDKAFKA=0 npm install` - not sure what is the runtime result in that case ? @alphaprinz  do you know?

This PR changes node-rdkafka to optionalDependencies and detects if it's missing on runtime.

A concern with this approach is that it might accidentally get skipped in release builds due to some other error, and could create a bad build - but this can be easily solved with a build time check.

### Explain the Changes
1. Changed node-rdkafka to optionalDependencies

### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. Revert your previously applied solutions on mac, and run `make`.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made Kafka support optional by moving the Kafka package to optional dependencies and adding a build-time flag to enable validation.
* **Bug Fixes**
  * Graceful failure when Kafka is absent: attempting to use Kafka now raises a clear error and prevents creating Kafka-dependent components.
* **New Features**
  * Added a runtime helper to optionally load modules, enabling safer optional integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->