### PR TITLE
Exporting threshold values as metrics from env vars

### DIFF
--- a/config.js
+++ b/config.js
@@ -621,6 +621,10 @@ config.HA_METRICS_SERVER_PORT = 7003;
 config.EP_METRICS_SERVER_PORT = 7004;
 config.EP_METRICS_SERVER_SSL_PORT = 9443;
 
+// Bucket capacity thresholds (percentage)
+config.BUCKET_LOW_CAPACITY_THRESHOLD = parseInt(process.env.BUCKET_LOW_CAPACITY_THRESHOLD, 10) || 80;
+config.BUCKET_NO_CAPACITY_THRESHOLD = parseInt(process.env.BUCKET_NO_CAPACITY_THRESHOLD, 10) || 95;
+
 //////////////////////////////
 // OAUTH RELATES            //
 //////////////////////////////
@@ -1118,6 +1122,7 @@ config.GPFS_DOWN_DELAY = 1000;
 
 //Quota
 config.QUOTA_LOW_THRESHOLD = 80;
+
 config.QUOTA_MAX_OBJECTS = Number.MAX_SAFE_INTEGER;
 
 //////////////////////////

--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -431,6 +431,20 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
             help: 'Object Bucket Used Bytes',
             labelNames: ['bucket_name']
         }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_low_capacity_threshold',
+        generate_default_set: true,
+        configuration: {
+            help: 'Bucket Low Capacity Threshold Percentage'
+        }
+    }, {
+        type: 'Gauge',
+        name: 'bucket_no_capacity_threshold',
+        generate_default_set: true,
+        configuration: {
+            help: 'Bucket No Capacity Threshold Percentage'
+        }
     }
 ]);
 

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -1065,6 +1065,9 @@ function partial_cycle_parse_prometheus_metrics(payload) {
     // TODO: Currently mock data, update with the relevant values.
     core_report.set_rebuild_progress(100);
     core_report.set_rebuild_time(0);
+    // set bucket capacity thresholds from config (env vars with defaults)
+    core_report.set_bucket_low_capacity_threshold(config.BUCKET_LOW_CAPACITY_THRESHOLD);
+    core_report.set_bucket_no_capacity_threshold(config.BUCKET_NO_CAPACITY_THRESHOLD);
 }
 
 /*


### PR DESCRIPTION
### Describe the Problem
Currently, bucket capacity alert thresholds (80% and 95%) are hardcoded in PrometheusRule (in noobaa-operator). So, we made them configurable from noobaa CR and set the env vars which can be exported as metrics from noobaa core. 

### Explain the Changes
1. Exported two metrics: `bucket_low_capacity_threshold` and `bucket_no_capacity_threshold`

### Issues: Fixed #xxx / Gap #xxx
1. JIRA: https://issues.redhat.com/browse/RHSTOR-7492
2. Operator PR: https://github.com/noobaa/noobaa-operator/pull/1750

### Testing Instructions:
1. See instructions in the operator PR.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable bucket capacity threshold settings to monitor low and no capacity states, customizable via environment variables with preset defaults (80% and 95%)
  * Added quota configuration option to define maximum objects limit with safe integer boundary protection
  * Expanded system monitoring and analytics capabilities with new Prometheus metrics for real-time bucket capacity threshold tracking and reporting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->