### PR TITLE
Remove huge blob result print from logs

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -232,8 +232,7 @@ class NamespaceBlob {
                 dbg.log0('NamespaceBlob.read_object_stream:',
                     this.container,
                     inspect(_.omit(params, 'object_md.ns')),
-                    'callback res', inspect(res)
-                );
+                    'callback res');
                 if (!res.readableStreamBody) throw new Error('NamespaceBlob.read_object_stream: download response is invalid');
                 return resolve(res.readableStreamBody.pipe(count_stream));
             }).catch(err => {


### PR DESCRIPTION
### Describe the Problem
When inspecting blob's download result it takes around 300 lines of prints. As we don't get any real value from this print we will just simply remove it.

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal logging adjustments made to improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->