### PR TITLE
Added a fix for 'NotPrincipal' bucket policy check

### DIFF
--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -295,6 +295,9 @@ function _parse_condition_keys(condition_statement) {
 async function validate_bucket_policy(policy, bucket_name, get_account_handler) {
     const all_op_names = _.flatten(_.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned])));
     for (const statement of policy.Statement) {
+        if (statement.NotPrincipal && statement.Effect !== 'Deny') {
+            throw new RpcError('MALFORMED_POLICY', 'Allow with NotPrincipal is not allowed.', {});
+        }
 
         const statement_principal = statement.Principal || statement.NotPrincipal;
         if (statement_principal.AWS) {


### PR DESCRIPTION
### Describe the Problem
Bucket policy `NotPrincipal` was not working correctly. When an account was specified in `NotPrincipal`, it was incorrectly denied access because the authorization code checked account identifiers (ID, Name, ARN) separately. If the policy used ID format but the second check used ARN format, the string comparison failed and the account was not excluded from the Deny statement.
`Principal` worked correctly because the code used OR logic for ALLOW (if ANY check returned ALLOW, access was granted), but used short-circuit logic for DENY (throw on first DENY). 
This issue caused `NotPrincipal` to fail when format mismatch occurred in any single check.

### Explain the Changes
1. Combined all account identifiers (ID + Name for NC, ID + ARN for containerized) into a single array and pass them together to `has_access_policy_permission()` instead of making separate calls for each identifier format.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: https://issues.redhat.com/browse/DFBUGS-1519

### Testing Instructions:
1. Create three accounts - test-a, test-b, test-c
2. Create bucket `test-buck` with `test-a` creds.
3. Apply policy to the `test-buck` (using `test-a` creds, also please update command as per your resources) : 

`$ AWS_ACCESS_KEY_ID=<access-key-a> AWS_SECRET_ACCESS_KEY=<secret-key-a> aws --no-verify-ssl --endpoint-url <url> s3api put-bucket-policy --bucket test-buck --policy '{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:*"
            ],
            "Principal": {
                "AWS": ["<test-b>", "<test-c>"]
            },
            "Resource": ["arn:aws:s3:::test-buck", "arn:aws:s3:::test-buck/*"]
        },
        {
            "Effect": "Deny",
            "Action": ["s3:GetObject"],
            "NotPrincipal": { "AWS": "<test-b>"},
            "Resource": ["arn:aws:s3:::test-buck", "arn:aws:s3:::test-buck/*"]
        }
    ]
}'`

4. Upload an object to the bucket (using `test-a` creds).
5. Try copying (GetObject op) that object using creds of all three accounts --> except for `test-b` GetObject op should fail (after the fix)


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DENY rules are now consistently enforced across deployments; owner IAM access is evaluated correctly.
  * Policies using NotPrincipal with Effect Allow are rejected as malformed.

* **Refactor**
  * Consolidated permission evaluation into a single, consistent flow with unified account identifier handling.

* **Tests**
  * Added/activated NotPrincipal Deny tests and adjusted test cleanup to delete buckets before account teardown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->