### PR TITLE
[NC | GLACIER] Fix no progress in processing Glacier logs when multiple processes are involved

### DIFF
--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Should build noobaa base image
         id: should_build_base
         run: |
-          base_files=("package.json" "base.dockerfile" ".nvmrc")
+          base_files=("package.json" "src/deploy/NVA_build/Base.Dockerfile" ".nvmrc" "src/native/fs/fs_napi.cpp")
           output=false
           for file in ${{ steps.changed_files.outputs.all_changed_files }}; do
             if printf '%s\n' "${base_files[@]}" | grep -x -q "$file"; then

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -1471,6 +1471,7 @@ struct FileWrap : public Napi::ObjectWrap<FileWrap>
                 InstanceMethod<&FileWrap::fsync>("fsync"),
                 InstanceMethod<&FileWrap::flock>("flock"),
                 InstanceMethod<&FileWrap::fcntllock>("fcntllock"),
+                InstanceMethod<&FileWrap::fcntlgetlock>("fcntlgetlock"),
                 InstanceAccessor<&FileWrap::getfd>("fd"),
             }));
         constructor.SuppressDestruct();
@@ -1503,6 +1504,7 @@ struct FileWrap : public Napi::ObjectWrap<FileWrap>
     Napi::Value getfd(const Napi::CallbackInfo& info);
     Napi::Value flock(const Napi::CallbackInfo& info);
     Napi::Value fcntllock(const Napi::CallbackInfo& info);
+    Napi::Value fcntlgetlock(const Napi::CallbackInfo& info);
 };
 
 Napi::FunctionReference FileWrap::constructor;
@@ -2011,6 +2013,51 @@ struct FileFcntlLock : public FSWrapWorker<FileWrap>
     }
 };
 
+// NOTE: This function in most cases must NOT be called from the
+// same fd from which a lock was acquired earlier as the locks
+// are associated with the FD itself and the result of this
+// function in those cases would be meaningless.
+struct FileFcntlGetLock : public FSWrapWorker<FileWrap>
+{
+    struct flock fl;
+    FileFcntlGetLock(const Napi::CallbackInfo& info)
+        : FSWrapWorker<FileWrap>(info)
+        , fl()
+    {
+        fl.l_whence = SEEK_SET;
+        fl.l_start = 0;
+        fl.l_len = 0;
+        fl.l_pid = 0;
+        // F_UNLCK is a trick, by default GETLK doesn't report
+        // lock status rather checks for conflicts.
+        // However, if F_UNLCK is used then conflict detection
+        // acts similar lock status fetching.
+        fl.l_type = F_UNLCK;
+
+        Begin(XSTR() << "FileFcntlGetLock" << DVAL(_wrap->_path));
+    }
+    virtual void Work()
+    {
+        int fd = _wrap->_fd;
+        CHECK_WRAP_FD(fd);
+        if (fcntl(fd, F_OFD_GETLK, &fl) == -1) {
+            SetSyscallError();
+        };
+    }
+    virtual void OnOK() {
+        DBG1("FS::FileFcntlGetLock::OnOK: " << DVAL(fl.l_type));
+        Napi::Env env = Env();
+
+        if (fl.l_type == F_UNLCK) {
+            _deferred.Resolve(env.Null());
+        } else if (fl.l_type == F_RDLCK) {
+            _deferred.Resolve(Napi::String::New(env, "SHARED"));
+        } else {
+            _deferred.Resolve(Napi::String::New(env, "EXCLUSIVE"));
+        }
+    }
+};
+
 struct RealPath : public FSWorker
 {
     std::string _path;
@@ -2179,6 +2226,12 @@ Napi::Value
 FileWrap::fcntllock(const Napi::CallbackInfo& info)
 {
     return api<FileFcntlLock>(info);
+}
+
+Napi::Value
+FileWrap::fcntlgetlock(const Napi::CallbackInfo& info)
+{
+    return api<FileFcntlGetLock>(info);
 }
 
 /**

--- a/src/sdk/glacier_tapecloud.js
+++ b/src/sdk/glacier_tapecloud.js
@@ -257,7 +257,7 @@ class TapeCloudGlacier extends Glacier {
                     // is being done there
                     await encoded_failure_recorder(entry);
                 } finally {
-                    entry_fh?.close(fs_context);
+                    await entry_fh?.close(fs_context);
                 }
             });
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -1041,6 +1041,7 @@ interface NativeFile {
     fd: number;
     flock(fs_context: NativeFSContext, operation: "EXCLUSIVE" | "SHARED" | "UNLOCK"): Promise<void>;
     fcntllock(fs_context: NativeFSContext, operation: "EXCLUSIVE" | "SHARED" | "UNLOCK"): Promise<void>;
+    fcntlgetlock(fs_context: NativeFSContext): Promise<"EXCLUSIVE" | "SHARED" | null>;
 }
 
 interface NativeDir {


### PR DESCRIPTION
### Describe the Problem
When for any reason (most common when and tested one is `glacier migrate` taking too long), there are a lot of processes trying to acquire the lock to process the log files, they tend to get stuck. 


### Explain the Changes
This PR removes the locks completely and simply adds a test by checking whether the lock is placed or not. If it is placed all the processes would SKIP processing that log file assuming that there MUST be another process already consuming the log file and hence they all would move forward to attempt to process other log files.

This not only ensures that migrate doesn't gets stuck but also ensures that we can keep processing new migrate requests that are coming while the older ones are getting processed.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an asynchronous file-lock query API (returns EXCLUSIVE, SHARED, or null) and updated types.

* **Bug Fixes**
  * Log processing now skips files that are exclusively locked.
  * File close is now awaited to ensure consistent async behavior.

* **Refactor**
  * Removed per-stage locking; simplified to cluster-wide lock handling.

* **Chores**
  * Build trigger updated to consider native filesystem changes for base-image rebuilds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->