### PR TITLE
[Backport into 5.19] improve performance of find_chunks_by_dedup_key by introducing composite index

### DIFF
--- a/src/server/object_services/schemas/data_chunk_indexes.js
+++ b/src/server/object_services/schemas/data_chunk_indexes.js
@@ -17,6 +17,8 @@ module.exports = [{
     {
         fields: {
             dedup_key: 1,
+            system: 1,
+            bucket: 1
         },
         options: {
             unique: false,

--- a/src/upgrade/upgrade_scripts/5.21.0/remove_datachunks_index.js
+++ b/src/upgrade/upgrade_scripts/5.21.0/remove_datachunks_index.js
@@ -1,0 +1,23 @@
+/* Copyright (C) 2025 NooBaa */
+"use strict";
+
+async function run({ dbg, db_client }) {
+  /* After the index is dropped, a new composite index (system, bucket, dedup_key) 
+    will be created during bootstrap */
+  const indexName = 'idx_btree_datachunks_dedup_key';
+
+  try {
+    const pool = db_client.instance().get_pool();
+    await pool.query(`DROP INDEX IF EXISTS ${indexName};`);
+
+    dbg.log0("Executed upgrade script for dropping index ", indexName);
+  } catch (err) {
+    dbg.error('An error ocurred in the upgrade process:', err);
+    throw err;
+  }
+}
+
+module.exports = {
+  run,
+  description: 'Delete the "idx_btree_datachunks_dedup_key" index'
+};


### PR DESCRIPTION
### Explain the Changes
[Backport into 5.19] improve performance of find_chunks_by_dedup_key by introducing composite index

(cherry picked from commit a2075586d1966620974d36d482c5e70b9f3c922c) (cherry picked from commit e01e8ec147bf0de22d8aed8469904979773ad6fb)

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-4833
