### PR TITLE
NC | object lock - implement object lock configuration function

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -26,7 +26,7 @@ module.exports = {
                     chunk_split_config: { $ref: 'common_api#/definitions/chunk_split_config' },
                     chunk_coder_config: { $ref: 'common_api#/definitions/chunk_coder_config' },
                     tag: { type: 'string' },
-                    object_lock_configuration: { $ref: '#/definitions/object_lock_configuration' },
+                    object_lock_configuration: { $ref: 'common_api#/definitions/object_lock_configuration' },
                     namespace: { $ref: '#/definitions/namespace_bucket_config' },
                     lock_enabled: {
                         type: 'boolean'
@@ -710,7 +710,7 @@ module.exports = {
                 required: ['name', 'object_lock_configuration'],
                 properties: {
                     name: { $ref: 'common_api#/definitions/bucket_name' },
-                    object_lock_configuration: { $ref: '#/definitions/object_lock_configuration' },
+                    object_lock_configuration: { $ref: 'common_api#/definitions/object_lock_configuration' },
                 },
             },
             auth: {
@@ -728,7 +728,7 @@ module.exports = {
                 },
             },
             reply: {
-                $ref: '#/definitions/object_lock_configuration'
+                $ref: 'common_api#/definitions/object_lock_configuration'
             },
             auth: {
                 system: 'admin'
@@ -1010,7 +1010,7 @@ module.exports = {
                 spillover: {
                     type: 'string'
                 },
-                object_lock_configuration: { $ref: '#/definitions/object_lock_configuration' },
+                object_lock_configuration: { $ref: 'common_api#/definitions/object_lock_configuration' },
                 storage: {
                     type: 'object',
                     properties: {
@@ -1348,40 +1348,6 @@ module.exports = {
         undeletable_bucket_reason: {
             enum: ['NOT_EMPTY'],
             type: 'string',
-        },
-        object_lock_configuration: {
-            type: 'object',
-            properties: {
-                object_lock_enabled: { type: 'string' },
-                rule: {
-                    type: 'object',
-                    properties: {
-                        default_retention: {
-                            oneOf: [{
-                                    type: 'object',
-                                    properties: {
-                                        years: { type: 'integer' },
-                                        mode: {
-                                            type: 'string',
-                                            enum: ['GOVERNANCE', 'COMPLIANCE']
-                                        }
-                                    }
-                                },
-                                {
-                                    type: 'object',
-                                    properties: {
-                                        days: { type: 'integer' },
-                                        mode: {
-                                            type: 'string',
-                                            enum: ['GOVERNANCE', 'COMPLIANCE']
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                }
-            }
         },
 
         // namespace bucket configuration

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1589,6 +1589,47 @@ module.exports = {
                 block_public_policy: { type: 'boolean' },
                 restrict_public_buckets: { type: 'boolean' },
             },
-        }
+        },
+        object_lock_configuration: {
+            type: 'object',
+            properties: {
+                object_lock_enabled: {
+                    type: 'string',
+                    enum: ['Enabled']
+                },
+                rule: {
+                    type: 'object',
+                    properties: {
+                        default_retention: {
+                            oneOf: [{
+                                    type: 'object',
+                                    required: ['years', 'mode'],
+                                    additionalProperties: false,
+                                    properties: {
+                                        years: { type: 'integer' },
+                                        mode: {
+                                            type: 'string',
+                                            enum: ['GOVERNANCE', 'COMPLIANCE']
+                                        }
+                                    }
+                                },
+                                {
+                                    type: 'object',
+                                    required: ['days', 'mode'],
+                                    additionalProperties: false,
+                                    properties: {
+                                        days: { type: 'integer' },
+                                        mode: {
+                                            type: 'string',
+                                            enum: ['GOVERNANCE', 'COMPLIANCE']
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
     }
 };

--- a/src/server/system_services/schemas/nsfs_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_bucket_schema.js
@@ -89,6 +89,9 @@ module.exports = {
         },
         public_access_block: {
             $ref: 'common_api#/definitions/public_access_block',
-        }
+        },
+        object_lock_configuration: {
+            $ref: 'common_api#/definitions/object_lock_configuration',
+        },
     }
 };

--- a/src/test/utils/coretest/nc_coretest.js
+++ b/src/test/utils/coretest/nc_coretest.js
@@ -215,6 +215,7 @@ async function config_dir_setup() {
         // DO NOT CHANGE - setting VACCUM_ANALYZER_INTERVAL=1 needed for failing the tests
         // in case where vaccumAnalyzer is being called before setting process.env.NC_NSFS_NO_DB_ENV = 'true' on nsfs.js
         VACCUM_ANALYZER_INTERVAL: 1,
+        WORM_ENABLED: true,
     }));
     await fs.promises.mkdir(FIRST_BUCKET_PATH, { recursive: true });
 }

--- a/src/test/utils/index/nc_index.js
+++ b/src/test/utils/index/nc_index.js
@@ -23,6 +23,7 @@ require('../../integration_tests/nc/cli/test_nc_online_upgrade_s3_integrations')
 require('../../integration_tests/api/s3/test_public_access_block');
 require('../../integration_tests/nc/lifecycle/test_nc_lifecycle_expiration');
 require('../../integration_tests/api/s3/test_chunked_upload');
+require('../../integration_tests/api/s3/test_s3_worm.js');
 
 // running with iam port
 require('../../integration_tests/api/iam/test_iam_basic_integration'); // please notice that we use a different setup

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -11,6 +11,7 @@ const config = require('../../config');
 const RpcError = require('../rpc/rpc_error');
 const nb_native = require('../util/nb_native');
 const error_utils = require('../util/error_utils');
+const { S3Error } = require('../endpoint/s3/s3_errors');
 
 const gpfs_link_unlink_retry_err = 'EEXIST';
 const gpfs_unlink_retry_catch = 'GPFS_UNLINK_RETRY';
@@ -759,7 +760,7 @@ function get_bucket_tmpdir_full_path(bucket_path, bucket_id) {
  * @param {('OBJECT'|'BUCKET'|'USER'|'ACCESS_KEY')} entity
  */
 function translate_error_codes(err, entity) {
-    if (err.rpc_code) return err;
+    if (err.rpc_code || err instanceof S3Error) return err;
     if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
         err.rpc_code = `NO_SUCH_${entity}`;
     }


### PR DESCRIPTION
### Explain the Changes
1. implement the following functions to set object locking configuration in nsfs:
  - `get_object_legal_hold`
  -  `put_object_legal_hold`
  - `get_object_retention` 
  - `put_object_retention`
  - `get_object_lock_configuration`
  - `put_object_lock_configuration`
2. move object lock schema to common_api and add it to nsfs_bucket schema
3. add `lock_status` data to head object (`get_object_info` function) so locking information will be available in GET and HEAD object functions
4. don't allow to set object lock configuration when versioning is not enabled
5. don't allow to set versioning when object lock is enabled
6. modify `test_s3_worm` to work in non containerized environment and add it to the nc tests list
7. fix tests and disable tests that test features that are not yet implemented 

### Gaps:
1. don't allow to suspend versioning if object lock configuration is enabled
2. we currently don't allow to set bucket object locking configuration without a default lock. aws does not make this restriction
3. more robust testings  

### Testing Instructions:
1. run `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/integration_tests/api/s3/test_s3_worm.js`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Object Lock: bucket-level configuration, get/put configuration endpoints, legal-hold and retention operations; lock settings now appear in object metadata and listings.

* **Behavior Changes**
  * Stricter defaults for Object Lock enablement; preventing disabling of versioning when Object Lock is configured.

* **API**
  * Object Lock schema centralized and standardized across related endpoints; removed duplicated inline schema.

* **Tests**
  * Added/updated integration tests and test config to cover Object Lock and environment-specific differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->