### PR TITLE
NC | IAM metrics

### DIFF
--- a/docs/NooBaaNonContainerized/Monitoring.md
+++ b/docs/NooBaaNonContainerized/Monitoring.md
@@ -122,6 +122,44 @@ The Per-Operation Metrics table details the performance and count of specific op
 | noobaa_nsfs_op_complete_object_upload_count    | Number of complete object upload operations | operations |
 | noobaa_nsfs_op_complete_object_upload_error_count | Number of errors in completing object upload | errors   |
 
+### IAM Per-Operation Metrics
+
+The Per-Operation Metrics table details the performance and count of specific operations related to IAM management. It includes metrics such as the minimum, maximum, and average time taken for creating, deleting and listing both users and access-keys. Additionally, it tracks the total number of operations and any errors encountered. These metrics are essential for analyzing the efficiency and reliability of different operations within the system.
+
+
+| Metric Name                                      | Description                              | Unit          |
+|--------------------------------------------------|------------------------------------------|---------------|
+| noobaa_nsfs_iam_op_create_user_min_time          | Minimum time to create a user            | milliseconds  |
+| noobaa_nsfs_iam_op_create_user_max_time          | Maximum time to create a user            | milliseconds  |
+| noobaa_nsfs_iam_op_create_user_avg_time          | Average time to create a user            | milliseconds  |
+| noobaa_nsfs_iam_op_create_user_count             | Number of create user operations         | operations    |
+| noobaa_nsfs_iam_op_create_user_error_count       | Number of errors in creating users       | errors        |
+| noobaa_nsfs_iam_op_delete_user_min_time          | Minimum time to delete a user            | milliseconds  |
+| noobaa_nsfs_iam_op_delete_user_max_time          | Maximum time to delete a user            | milliseconds  |
+| noobaa_nsfs_iam_op_delete_user_avg_time          | Average time to delete a user            | milliseconds  |
+| noobaa_nsfs_iam_op_delete_user_count             | Number of delete user operations         | operations    |
+| noobaa_nsfs_iam_op_delete_user_error_count       | Number of errors in deleting users       | errors        |
+| noobaa_nsfs_iam_op_list_users_min_time           | Minimum time to list users               | milliseconds  |
+| noobaa_nsfs_iam_op_list_users_max_time           | Maximum time to list users               | milliseconds  |
+| noobaa_nsfs_iam_op_list_users_avg_time           | Average time to list users               | milliseconds  |
+| noobaa_nsfs_iam_op_list_users_count              | Number of list users operations          | operations    |
+| noobaa_nsfs_iam_op_list_users_error_count        | Number of errors in listing users        | errors        |
+| noobaa_nsfs_iam_op_create_access_key_min_time    | Minimum time to create an access key     | milliseconds  |
+| noobaa_nsfs_iam_op_create_access_key_max_time    | Maximum time to create an access key     | milliseconds  |
+| noobaa_nsfs_iam_op_create_access_key_avg_time    | Average time to create an access key     | milliseconds  |
+| noobaa_nsfs_iam_op_create_access_key_count       | Number of create access key operations   | operations    |
+| noobaa_nsfs_iam_op_create_access_key_error_count | Number of errors in creating access keys | errors        |
+| noobaa_nsfs_iam_op_delete_access_key_min_time    | Minimum time to delete an access key     | milliseconds  |
+| noobaa_nsfs_iam_op_delete_access_key_max_time    | Maximum time to delete an access key     | milliseconds  |
+| noobaa_nsfs_iam_op_delete_access_key_avg_time    | Average time to delete an access key     | milliseconds  |
+| noobaa_nsfs_iam_op_delete_access_key_count       | Number of delete access key operations   | operations    |
+| noobaa_nsfs_iam_op_delete_access_key_error_count | Number of errors in deleting access keys | errors        |
+| noobaa_nsfs_iam_op_list_access_keys_min_time     | Minimum time to list access keys         | milliseconds  |
+| noobaa_nsfs_iam_op_list_access_keys_max_time     | Maximum time to list access keys         | milliseconds  |
+| noobaa_nsfs_iam_op_list_access_keys_avg_time     | Average time to list access keys         | milliseconds  |
+| noobaa_nsfs_iam_op_list_access_keys_count        | Number of list access keys operations    | operations    |
+| noobaa_nsfs_iam_op_list_access_keys_error_count  | Number of errors in listing access keys  | errors        |
+
 
 ## Getting Started
 
@@ -195,6 +233,13 @@ The following is an example of the JSON output containing system metrics -
             "noobaa_nsfs_op_read_object_avg_time_milisec":12,
             "noobaa_nsfs_op_read_object_count":1,
             "noobaa_nsfs_op_read_object_error_count":0
+        },
+        "iam_op_stats_counters": {
+            "noobaa_nsfs_iam_op_list_users_min_time_milisec": 0,
+            "noobaa_nsfs_iam_op_list_users_max_time_milisec": 1,
+            "noobaa_nsfs_iam_op_list_users_avg_time_milisec": 0,
+            "noobaa_nsfs_iam_op_list_users_count": 2,
+            "noobaa_nsfs_iam_op_list_users_error_count": 0
         }
     }
 }
@@ -235,6 +280,13 @@ The following is an example of the JSON output containing system metrics -
         "noobaa_nsfs_op_read_object_avg_time_milisec":12,
         "noobaa_nsfs_op_read_object_count":1,
         "noobaa_nsfs_op_read_object_error_count":0
+    },
+    "iam_op_stats_counters": {
+        "noobaa_nsfs_iam_op_list_users_min_time_milisec": 0,
+        "noobaa_nsfs_iam_op_list_users_max_time_milisec": 1,
+        "noobaa_nsfs_iam_op_list_users_avg_time_milisec": 0,
+        "noobaa_nsfs_iam_op_list_users_count": 2,
+        "noobaa_nsfs_iam_op_list_users_error_count": 0
     }
 }
 ```

--- a/docs/design/NSFSMetrics.md
+++ b/docs/design/NSFSMetrics.md
@@ -6,11 +6,12 @@
     * Provides S3 Operations Metrics
     * I/O Count Metrics 
     * FS Operations Metrics
+    * Provides IAM Operations Metrics
  * Provide the Admin the ability to get the metrics from an exposed route. 
 
 ## SOLUTION
 
- * For S3 and FS Operations Metric we will collect min time, max time, average time, count, and error count
+ * For S3, IAM and FS Operations Metric we will collect min time, max time, average time, count, and error count
  * For I/O Count Metrics we will collect read/write count and bytes.
  * We will collect the metrics per endpoint, send them to the core, and aggregate all the endpoint values.
  * The metrics will not be persistent. on pod restart, we will lose the metrics collected to this point.
@@ -23,8 +24,8 @@
 
  ## The Metrics Flow
 
- * The client address the Endpoint with an S3 operation
- * Reaching the `object_sdk`, the operation will get timed. time, name and if it is an error will be sent to the endpoint stat collector per op.
+ * The client address the Endpoint with an S3 or IAM operation
+ * Reaching the `object_sdk`(S3) or `account_sdk`(IAM), the operation will get timed. time, name and if it is an error will be sent to the endpoint stat collector per op.
  * The s3 operation timing will be collected for all types of namespaces, as it is being collected inside the object_sdk.
  * On read and write op, we will count the I/O (as we do today), and instead of sending it to the DB, we will collect it in memory.
  * If the namespace type is NSFS we will reach the `fs_napi` via `namespace_fs` and there on the `FSworker` we will time the `Work` function.
@@ -39,8 +40,9 @@
 
 
 ### Updating the nsfs stat in the stat aggregator (Core) - API
- * The nsfs stats will be an object with 3 fields one per each metric type:
+ * The nsfs stats will be an object with 4 fields one per each metric type:
     * op_stats - S3 Operations Metrics
+    * iam_stats - IAM Operations Metrics
     * io_stats - I/O Count Metrics
     * fs_workers_stats - FS Operations Metric
 
@@ -61,6 +63,9 @@
                            $ref: 'common_api#/definitions/io_stats'
                         },
                         op_stats: {
+                           $ref: 'common_api#/definitions/op_stats'
+                        },
+                        iam_stats: {
                            $ref: 'common_api#/definitions/op_stats'
                         },
                         fs_workers_stats: {

--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -160,6 +160,9 @@ module.exports = {
                             op_stats: {
                                 $ref: 'common_api#/definitions/op_stats'
                             },
+                            iam_stats: {
+                                $ref: 'common_api#/definitions/op_stats'
+                            },
                             fs_workers_stats: {
                                 $ref: 'common_api#/definitions/fs_workers_stats'
                             }

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -138,6 +138,7 @@ class NsfsAccountSDK extends AccountSDK {
             internal_rpc_client: null,
             bucketspace: bucketspace,
             accountspace: accountspace,
+            stats: endpoint_stats_collector && endpoint_stats_collector.instance(),
         });
         this.nsfs_config_root = nsfs_config_root;
         this.nsfs_fs_root = fs_root;

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -437,7 +437,7 @@ function create_init_request_sdk(rpc, internal_rpc_client, object_io) {
         req.account_sdk = new NBAccountSDK({
             rpc_client,
             internal_rpc_client,
-            //stats: endpoint_stats_collector.instance(),
+            stats: endpoint_stats_collector.instance(),
         });
     };
     return init_request_sdk;

--- a/src/sdk/account_sdk.js
+++ b/src/sdk/account_sdk.js
@@ -16,9 +16,10 @@ class AccountSDK {
      *      internal_rpc_client: nb.APIClient;
      *      bucketspace?: nb.BucketSpace;
      *      accountspace?: nb.AccountSpace;
+     *      stats?: import('./endpoint_stats_collector').EndpointStatsCollector;
      * }} args
      */
-    constructor({ rpc_client, internal_rpc_client, bucketspace, accountspace }) {
+    constructor({ rpc_client, internal_rpc_client, bucketspace, accountspace, stats }) {
         this.rpc_client = rpc_client;
         this.internal_rpc_client = internal_rpc_client;
         this.requesting_account = undefined;
@@ -27,6 +28,7 @@ class AccountSDK {
         this.bucketspace = bucketspace || new BucketSpaceNB({ rpc_client, internal_rpc_client });
         const config_root = config.NSFS_NC_DEFAULT_CONF_DIR;
         this.accountspace = accountspace || new AccountSpaceFS({ config_root });
+        this.stats = stats;
     }
 
     set_auth_token(auth_token) {
@@ -93,28 +95,68 @@ class AccountSDK {
     ////////////
 
     async create_user(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.create_user(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.create_user(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'create_user',
+            op_func,
+        });
     }
 
     async get_user(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.get_user(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.get_user(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'get_user',
+            op_func,
+        });
     }
 
     async update_user(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.update_user(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.update_user(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'update_user',
+            op_func,
+        });
     }
 
     async delete_user(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.delete_user(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.delete_user(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'delete_user',
+            op_func,
+        });
     }
 
     async list_users(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.list_users(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.list_users(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'list_users',
+            op_func,
+        });
     }
 
     ////////////
@@ -141,28 +183,68 @@ class AccountSDK {
     ////////////////
 
     async create_access_key(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.create_access_key(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.create_access_key(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'create_access_key',
+            op_func,
+        });
     }
 
     async get_access_key_last_used(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.get_access_key_last_used(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.get_access_key_last_used(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'get_access_key_last_used',
+            op_func,
+        });
     }
 
     async update_access_key(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.update_access_key(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.update_access_key(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'update_access_key',
+            op_func,
+        });
     }
 
     async delete_access_key(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.delete_access_key(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.delete_access_key(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'delete_access_key',
+            op_func,
+        });
     }
 
     async list_access_keys(params) {
-        const accountspace = this._get_accountspace();
-        return accountspace.list_access_keys(params, this);
+        const op_func = () => {
+            const accountspace = this._get_accountspace();
+            return accountspace.list_access_keys(params, this);
+        };
+        if (!this.stats) return op_func();
+        return this.stats.call_op_and_update_stats({
+            service: 'iam',
+            op_name: 'list_access_keys',
+            op_func,
+        });
     }
 
     /////////////////

--- a/src/sdk/nb_account_sdk.js
+++ b/src/sdk/nb_account_sdk.js
@@ -11,9 +11,10 @@ class NBAccountSDK extends AccountSDK {
      * @param {{
      *      rpc_client: nb.APIClient;
      *      internal_rpc_client: nb.APIClient;
+     *      stats: import("../sdk/endpoint_stats_collector").EndpointStatsCollector;
      * }} args
      */
-    constructor({rpc_client, internal_rpc_client}) {
+    constructor({rpc_client, internal_rpc_client, stats}) {
         const bucketspace = new BucketSpaceNB({ rpc_client, internal_rpc_client });
         const accountspace = new AccountSpaceNB({ rpc_client, internal_rpc_client });
 
@@ -22,6 +23,7 @@ class NBAccountSDK extends AccountSDK {
             internal_rpc_client: internal_rpc_client,
             bucketspace: bucketspace,
             accountspace: accountspace,
+            stats
         });
     }
 }

--- a/src/test/integration_tests/nc/cli/test_nc_account_cli.test.js
+++ b/src/test/integration_tests/nc/cli/test_nc_account_cli.test.js
@@ -19,7 +19,7 @@ const ManageCLIError = require('../../../../manage_nsfs/manage_nsfs_cli_errors')
 const ManageCLIResponse = require('../../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 
 const tmp_fs_path = path.join(TMP_PATH, 'test_nc_account_cli');
-const timeout = 50000;
+const timeout = 60000;
 const config = require('../../../../../config');
 const config_fs_account_options = { show_secrets: true, decrypt_secret_key: true };
 

--- a/src/util/fork_utils.js
+++ b/src/util/fork_utils.js
@@ -21,6 +21,7 @@ const io_stats = {
 };
 
 const op_stats = {};
+const iam_stats = {};
 
 const fs_workers_stats = {};
 /**
@@ -130,6 +131,10 @@ function create_worker_message_handler(params) {
             _update_ops_stats(msg.op_stats);
             prom_reporting.set_ops_stats(op_stats);
         }
+        if (msg.iam_stats) {
+            _update_iam_ops_stats(msg.iam_stats);
+            prom_reporting.set_iam_ops_stats(iam_stats);
+        }
         if (msg.fs_workers_stats) {
             _update_fs_stats(msg.fs_workers_stats);
             prom_reporting.set_fs_worker_stats(fs_workers_stats);
@@ -165,6 +170,15 @@ function _update_ops_stats(stats) {
     for (const op_name of stats_collector_utils.op_names) {
         if (op_name in stats) {
             stats_collector_utils.update_nsfs_stats(op_name, op_stats, stats[op_name]);
+        }
+    }
+}
+
+function _update_iam_ops_stats(stats) {
+    //Go over the op_stats
+    for (const op_name of stats_collector_utils.iam_op_names) {
+        if (op_name in stats) {
+            stats_collector_utils.update_nsfs_stats(op_name, iam_stats, stats[op_name]);
         }
     }
 }

--- a/src/util/stats_collector_utils.js
+++ b/src/util/stats_collector_utils.js
@@ -16,6 +16,20 @@ const op_names = [
     `complete_object_upload`,
 ];
 
+// Predefined iam_op_names
+const iam_op_names = [
+    `create_user`,
+    `get_user`,
+    `update_user`,
+    `delete_user`,
+    `list_users`,
+    `create_access_key`,
+    `get_access_key_last_used`,
+    `update_access_key`,
+    `delete_access_key`,
+    `list_access_keys`,
+];
+
 function update_nsfs_stats(op_name, stats, new_data) {
     //In the event of all of the same ops are failing (count = error_count) we will not masseur the op times
     // As this is intended as a timing masseur and not a counter.
@@ -49,4 +63,5 @@ function update_nsfs_stats(op_name, stats, new_data) {
 }
 
 exports.op_names = op_names;
+exports.iam_op_names = iam_op_names;
 exports.update_nsfs_stats = update_nsfs_stats;


### PR DESCRIPTION
### Describe the Problem
We want to add IAM ops counters to noobaa's NC/NSFS metrics

### Explain the Changes
1. We will collect same metrics we collect for S3 ops also for the following IAM ops: <add/get/update/delete/list>_<user/access_key>(s)

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [x] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IAM per-operation metrics (counts, errors, min/max/avg timings) and end-to-end reporting through collectors and Prometheus paths.

* **Documentation**
  * Monitoring docs updated with an IAM Per-Operation Metrics section and JSON examples showing iam_op_stats_counters.

* **API**
  * NSFS metrics payload/schema and runtime metrics endpoints extended to include iam_stats; new getters/setters for IAM stats.

* **Bug Fixes**
  * Fixed metrics propagation so IAM counters are reliably aggregated and exposed.

* **Tests**
  * Integration test timeout increased to accommodate account operation timing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->