### PR TITLE
[GLACIER | NC] Fix fcntlgetlock INVAL issue

### DIFF
--- a/config.js
+++ b/config.js
@@ -1013,6 +1013,8 @@ config.NSFS_GLACIER_METRICS_STATFS_INTERVAL = 60 * 1000; // Refresh statfs value
  */
 config.NSFS_GLACIER_RESERVED_BUCKET_TAGS = {};
 
+config.NSFS_LOGGER_LOCK_CHECK_INTERVAL = process.env.NODE_ENV === 'test' ? 10 : 1000;
+
 // anonymous account name
 config.ANONYMOUS_ACCOUNT_NAME = 'anonymous';
 

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -1447,6 +1447,43 @@ struct GetPwName : public FSWorker
     }
 };
 
+struct FcntlGetLock: public FSWorker
+{
+    std::string _path;
+    struct flock fl;
+    FcntlGetLock(const Napi::CallbackInfo& info)
+        : FSWorker(info)
+        , fl()
+    {
+        fl.l_whence = SEEK_SET;
+        fl.l_start = 0;
+        fl.l_len = 0;
+        fl.l_pid = 0;
+        fl.l_type = F_WRLCK;
+
+        _path = info[1].As<Napi::String>();
+        Begin(XSTR() << "FcntlGetLock" << DVAL(_path));
+    }
+    virtual void Work()
+    {
+        int fd = open(_path.c_str(), 0);
+        CHECK_OPEN_FD(fd);
+        SYSCALL_OR_RETURN(fcntl(fd, F_OFD_GETLK, &fl));
+    }
+    virtual void OnOK() {
+        DBG1("FS::FileFcntlGetLock::OnOK: " << DVAL(fl.l_type));
+        Napi::Env env = Env();
+
+        if (fl.l_type == F_UNLCK) {
+            _deferred.Resolve(env.Undefined());
+        } else if (fl.l_type == F_RDLCK) {
+            _deferred.Resolve(Napi::String::New(env, "SHARED"));
+        } else {
+            _deferred.Resolve(Napi::String::New(env, "EXCLUSIVE"));
+        }
+    }
+};
+
 struct FileWrap : public Napi::ObjectWrap<FileWrap>
 {
     std::string _path;
@@ -2013,10 +2050,6 @@ struct FileFcntlLock : public FSWrapWorker<FileWrap>
     }
 };
 
-// NOTE: This function in most cases must NOT be called from the
-// same fd from which a lock was acquired earlier as the locks
-// are associated with the FD itself and the result of this
-// function in those cases would be meaningless.
 struct FileFcntlGetLock : public FSWrapWorker<FileWrap>
 {
     struct flock fl;
@@ -2028,11 +2061,7 @@ struct FileFcntlGetLock : public FSWrapWorker<FileWrap>
         fl.l_start = 0;
         fl.l_len = 0;
         fl.l_pid = 0;
-        // F_UNLCK is a trick, by default GETLK doesn't report
-        // lock status rather checks for conflicts.
-        // However, if F_UNLCK is used then conflict detection
-        // acts similar lock status fetching.
-        fl.l_type = F_UNLCK;
+        fl.l_type = F_WRLCK;
 
         Begin(XSTR() << "FileFcntlGetLock" << DVAL(_wrap->_path));
     }
@@ -2040,16 +2069,14 @@ struct FileFcntlGetLock : public FSWrapWorker<FileWrap>
     {
         int fd = _wrap->_fd;
         CHECK_WRAP_FD(fd);
-        if (fcntl(fd, F_OFD_GETLK, &fl) == -1) {
-            SetSyscallError();
-        };
+        SYSCALL_OR_RETURN(fcntl(fd, F_OFD_GETLK, &fl));
     }
     virtual void OnOK() {
         DBG1("FS::FileFcntlGetLock::OnOK: " << DVAL(fl.l_type));
         Napi::Env env = Env();
 
         if (fl.l_type == F_UNLCK) {
-            _deferred.Resolve(env.Null());
+            _deferred.Resolve(env.Undefined());
         } else if (fl.l_type == F_RDLCK) {
             _deferred.Resolve(Napi::String::New(env, "SHARED"));
         } else {
@@ -2613,6 +2640,7 @@ fs_napi(Napi::Env env, Napi::Object exports)
     exports_fs["getsinglexattr"] = Napi::Function::New(env, api<GetSingleXattr>);
     exports_fs["getpwname"] = Napi::Function::New(env, api<GetPwName>);
     exports_fs["symlink"] = Napi::Function::New(env, api<Symlink>);
+    exports_fs["fcntlgetlock"] = Napi::Function::New(env, api<FcntlGetLock>);
 
     FileWrap::init(env);
     exports_fs["open"] = Napi::Function::New(env, api<FileOpen>);

--- a/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
@@ -336,6 +336,9 @@ mocha.describe('nsfs_glacier', function() {
         });
 
         mocha.it('restore-object should successfully restore objects with special characters', async function() {
+            // eslint-disable-next-line no-invalid-this
+            this.timeout(5000);
+
             const now = Date.now();
             const data = crypto.randomBytes(100);
             const all_params = [


### PR DESCRIPTION
### Describe the Problem
GPFS doesn't support `flock.l_type` value to be `F_UNLCK` which caused fcntlgetlock to throw exception when run on GPFS.

### Explain the Changes
This PR replaces `F_UNLCK` with `F_WRLCK` which has the same result as `F_UNLCK`. This PR also adds `nb_native().fs.fcntlgetlock` which is safer than the previous `fcntlgetlock` as the previous one was easy to incorrectly use by acquiring the lock from an file handler and then accidentally reusing the same handler to check for lock which would always result in `F_UNLCK`. The new API eliminates that possibility by managing the lifecycle of the FD internally.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `./node_modules/.bin/mocha src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public lock-query API added to check file lock state (undefined/unlocked, SHARED, EXCLUSIVE) from file objects and top-level FS.

* **Bug Fixes**
  * Standardized unlocked reporting and improved lock-detection semantics.
  * Background logger now queries lock state directly, simplifying retries and removing explicit handle management.

* **Documentation**
  * Added LockType and JSDoc clarifying lock semantics and return values.

* **Tests**
  * Increased timeout for a restore-object test to improve reliability.

* **Chores**
  * New configurable logger lock-check interval option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->