### PR TITLE
Exporting replication_target_status metric to use in prometheus alert

### DIFF
--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -431,6 +431,14 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
             help: 'Object Bucket Used Bytes',
             labelNames: ['bucket_name']
         }
+    },
+    {
+        type: 'Gauge',
+        name: 'replication_target_status',
+        configuration: {
+            help: 'Replication target bucket reachability status (1=reachable, 0=unreachable)',
+            labelNames: ['source_bucket', 'target_bucket']
+        }
     }
 ]);
 
@@ -682,6 +690,11 @@ class NooBaaCoreReport extends BasePrometheusReport {
 
         delete this._metrics.bucket_last_cycle_error_objects_num.hashMap[String(bucket_name)];
         this._metrics.bucket_last_cycle_error_objects_num.set({ bucket_name }, repl_info.bucket_last_cycle_error_objects_num);
+    }
+
+    set_replication_target_status(source_bucket, target_bucket, is_reachable) {
+        if (!this._metrics) return;
+        this._metrics.replication_target_status.set({ source_bucket, target_bucket }, Number(is_reachable));
     }
 }
 

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -86,6 +86,13 @@ function update_replication_prom_report(bucket_name, replication_policy_id, rule
     core_report.set_replication_status(last_cycle_status);
 }
 
+function update_replication_target_status(source_bucket, target_bucket, is_reachable) {
+    const core_report = prom_reporting.get_core_report();
+    const src_name = source_bucket instanceof SensitiveString ? source_bucket.unwrap() : source_bucket;
+    const dst_name = target_bucket instanceof SensitiveString ? target_bucket.unwrap() : target_bucket;
+    core_report.set_replication_target_status(src_name, dst_name, is_reachable);
+}
+
 /**
  * @param {any} bucket_name
  * @param {string} key
@@ -199,6 +206,7 @@ async function delete_objects(scanner_semaphore, client, bucket_name, keys) {
 // EXPORTS
 exports.get_rule_and_bucket_status = get_rule_and_bucket_status;
 exports.update_replication_prom_report = update_replication_prom_report;
+exports.update_replication_target_status = update_replication_target_status;
 exports.get_object_md = get_object_md;
 exports.find_src_and_dst_buckets = find_src_and_dst_buckets;
 exports.get_copy_type = get_copy_type;


### PR DESCRIPTION
### Describe the Problem
Currently, we don't have a metric which shows the status of target bucket reachability.

### Explain the Changes
1. We have exported a metrics `NooBaa_replication_target_status` which can be used by Prometheus alert.

### Issues: Fixed #xxx / Gap #xxx
1. JIRA: https://issues.redhat.com/browse/RHSTOR-8110
2. Operator PR: https://github.com/noobaa/noobaa-operator/pull/1778

### Testing Instructions:
1. Check operator PR.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for replication target reachability, exposing a way to update target status so destinations are tracked as reachable or unreachable.

* **Bug Fixes**
  * Replication scanning and sync flows now update target reachability on success and on errors, improving status accuracy and reliability.
  * Added a utility to programmatically set replication target reachability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->