### PR TITLE
Added bucket_mode as labels in metrics - bucket_status and namespace_bucket_status

### DIFF
--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -262,7 +262,7 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
         name: 'bucket_status',
         configuration: {
             help: 'Bucket Health',
-            labelNames: ['bucket_name']
+            labelNames: ['bucket_name', 'bucket_mode']
         }
     },
     {
@@ -270,7 +270,7 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
         name: 'namespace_bucket_status',
         configuration: {
             help: 'Namespace Bucket Health',
-            labelNames: ['bucket_name'],
+            labelNames: ['bucket_name', 'bucket_mode'],
         },
     }, {
         type: 'Gauge',
@@ -603,10 +603,11 @@ class NooBaaCoreReport extends BasePrometheusReport {
         this._metrics.bucket_max_objects_quota.reset();
         this._metrics.bucket_max_bytes_quota.reset();
         buckets_info.forEach(bucket_info => {
-            const bucket_labels = { bucket_name: bucket_info.bucket_name };
+            const bucket_labels = { bucket_name: bucket_info.bucket_name, bucket_mode: bucket_info.mode };
+            const bucket_tagging_labels = { bucket_name: bucket_info.bucket_name };
             if (bucket_info.tagging && bucket_info.tagging.length) {
                 const tagging = bucket_info.tagging.map(tag => `{ ${tag.key} : ${tag.value} }`);
-                this._metrics.bucket_tagging.set({ ...bucket_labels, tagging }, Date.now());
+                this._metrics.bucket_tagging.set({ ...bucket_tagging_labels, tagging }, Date.now());
             }
             this._metrics.bucket_status.set(bucket_labels, Number(bucket_info.is_healthy));
             this._metrics.bucket_size_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_size_precent);
@@ -624,10 +625,11 @@ class NooBaaCoreReport extends BasePrometheusReport {
         this._metrics.namespace_bucket_status.reset();
         this._metrics.namespace_bucket_tagging.reset();
         buckets_info.forEach(bucket_info => {
-            const bucket_labels = { bucket_name: bucket_info.bucket_name };
+            const bucket_labels = { bucket_name: bucket_info.bucket_name, bucket_mode: bucket_info.mode };
+            const bucket_tagging_labels = { bucket_name: bucket_info.bucket_name };
             if (bucket_info.tagging && bucket_info.tagging.length) {
                 const tagging = bucket_info.tagging.map(tag => `{ ${tag.key} : ${tag.value} }`);
-                this._metrics.namespace_bucket_tagging.set({ ...bucket_labels, tagging }, Date.now());
+                this._metrics.namespace_bucket_tagging.set({ ...bucket_tagging_labels, tagging }, Date.now());
             }
             this._metrics.namespace_bucket_status.set(bucket_labels, Number(bucket_info.is_healthy));
         });

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -491,6 +491,7 @@ async function _partial_buckets_info(req) {
                 const ns_bucket_mode_optimal = bucket_info.mode === 'OPTIMAL';
                 namespace_buckets_stats.namespace_buckets.push({
                     bucket_name: bucket_info.name.unwrap(),
+                    mode: bucket_info.mode,
                     is_healthy: ns_bucket_mode_optimal,
                     tagging: bucket_info.tagging || []
                 });
@@ -534,6 +535,7 @@ async function _partial_buckets_info(req) {
 
             buckets_stats.buckets.push({
                 bucket_name: bucket_info.name.unwrap(),
+                mode: bucket_info.mode,
                 quota_size_precent: size_used_percent,
                 quota_quantity_percent: quantity_used_percent,
                 capacity_precent: (is_capacity_relevant && bucket_total > 0) ? size_utils.bigint_to_json(bucket_used.multiply(100)


### PR DESCRIPTION
### Describe the Problem
`NooBaaBucketErrorState` was not showing the complete error why the bucket is in error state, it can be because of other resources as well. 

### Explain the Changes
1. Added `bucket_mode` label to bucket/namespace status metrics and populated it from bucket stats. This mode describe the actual state/error of the bucket in the alerts.

<img width="1868" height="777" alt="Screenshot from 2026-01-21 21-14-36" src="https://github.com/user-attachments/assets/02a51ab8-5d84-4f07-96ff-094f0df827b7" />


### Issues: Fixed #xxx / Gap #xxx
1. JIRA: https://issues.redhat.com/browse/RHSTOR-7732
2.  Operator PR: https://github.com/noobaa/noobaa-operator/pull/1781

### Testing Instructions:
1. Check operator PR.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Metrics and status tracking now include bucket mode, providing more detailed monitoring.
  * Tagging metrics now use separate tagging labels that omit bucket mode, preventing mode from being treated as a tag.
  * Aggregated bucket summaries now include bucket mode for both regular and namespaced buckets, enriching reported bucket metadata.
  * No changes to public API signatures or external interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->