### PR TITLE
Optimize bulk delete operation for non versioned buckets

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,0 +1,14 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const COMMON_CONSTANTS = {
+  S3: {
+    VERSIONING: {
+      ENABLED: 'ENABLED',
+      SUSPENDED: 'SUSPENDED',
+      DISABLED: "DISABLED"
+    }
+  }
+};
+
+module.exports = COMMON_CONSTANTS;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -2068,6 +2068,10 @@ class MDStore {
     estimated_total_objects() {
         return this._objects.estimatedDocumentCount();
     }
+
+    get_unordered_bulk_op_on_objects() {
+        return this._objects.initializeUnorderedBulkOp();
+    }
 }
 
 MDStore._instance = undefined;


### PR DESCRIPTION
### Describe the Problem
For delete-objects S3 API, the internal implementation performs separate DB update queries (soft-delete in objectmds) for each object. This introduces additional round trip delay between the endpoint and PostgreSQL. It can be avoided by performing single update for all objects (Non versioned bucket only).

### Explain the Changes
1. Created a new function to perform bulk update for all the objects to be deleted.
2. Added checks in appropriate places in code to skip individual updates.

NOTE: This improvement is only for non versioned buckets. Buckets with versioning suspended are not part of this improvement.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-5137

### Testing Instructions:
1. Create a json file with all the objects to be deleted.
2. Use the S3 delete-objects API with the json file.
3. There is a limit of upto 1000 objects in a single request.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized bulk-delete path for buckets with versioning disabled to improve throughput and ensure consistent per-item results.

* **New Features**
  * Added unordered bulk update support to accelerate large-scale object deletions.

* **Infrastructure**
  * Introduced a centralized constants module to standardize common configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->