### PR TITLE
[Backport into 5.21] ThanosRuleHighRuleEvaluationWarnings firing due to sufix

### DIFF
--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -69,28 +69,28 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
         }
     }, {
         type: 'Gauge',
-        name: 'providers_bandwidth_write_size',
+        name: 'providers_bandwidth_write_size_total',
         configuration: {
             help: 'Providers bandwidth write size',
             labelNames: ['type'],
         }
     }, {
         type: 'Gauge',
-        name: 'providers_bandwidth_read_size',
+        name: 'providers_bandwidth_read_size_total',
         configuration: {
             help: 'Providers bandwidth read size',
             labelNames: ['type']
         }
     }, {
         type: 'Gauge',
-        name: 'providers_ops_read_num',
+        name: 'providers_ops_read_count',
         configuration: {
             help: 'Providers number of read operations',
             labelNames: ['type']
         }
     }, {
         type: 'Gauge',
-        name: 'providers_ops_write_num',
+        name: 'providers_ops_write_count',
         configuration: {
             help: 'Providers number of write operations',
             labelNames: ['type']
@@ -540,15 +540,15 @@ class NooBaaCoreReport extends BasePrometheusReport {
     set_providers_bandwidth(type, write_size, read_size) {
         if (!this._metrics) return;
 
-        this._metrics.providers_bandwidth_read_size.set({ type }, read_size);
-        this._metrics.providers_bandwidth_write_size.set({ type }, write_size);
+        this._metrics.providers_bandwidth_read_size_total.set({ type }, read_size);
+        this._metrics.providers_bandwidth_write_size_total.set({ type }, write_size);
     }
 
     set_providers_ops(type, write_num, read_num) {
         if (!this._metrics) return;
 
-        this._metrics.providers_ops_read_num.set({ type }, read_num);
-        this._metrics.providers_ops_write_num.set({ type }, write_num);
+        this._metrics.providers_ops_read_count.set({ type }, read_num);
+        this._metrics.providers_ops_write_count.set({ type }, write_num);
     }
 
     set_providers_physical_logical(providers_stats) {
@@ -640,15 +640,15 @@ class NooBaaCoreReport extends BasePrometheusReport {
     update_providers_bandwidth(type, write_size, read_size) {
         if (!this._metrics) return;
 
-        this._metrics.providers_bandwidth_read_size.inc({ type }, read_size);
-        this._metrics.providers_bandwidth_write_size.inc({ type }, write_size);
+        this._metrics.providers_bandwidth_read_size_total.inc({ type }, read_size);
+        this._metrics.providers_bandwidth_write_size_total.inc({ type }, write_size);
     }
 
     update_providers_ops(type, write_num, read_num) {
         if (!this._metrics) return;
 
-        this._metrics.providers_ops_read_num.inc({ type }, read_num);
-        this._metrics.providers_ops_write_num.inc({ type }, write_num);
+        this._metrics.providers_ops_read_count.inc({ type }, read_num);
+        this._metrics.providers_ops_write_count.inc({ type }, write_num);
     }
 
     set_replication_status(repl_info) {


### PR DESCRIPTION
### Explain the Changes
[Backport into 5.21] ThanosRuleHighRuleEvaluationWarnings firing due to sufix

(cherry picked from commit f008e1a8c334dd7dd3d591db03e1391dea17597e)

### Issues: Fixed #xxx / Gap #xxx
1. [DFBUGS-3822](https://issues.redhat.com/browse/DFBUGS-3822)
