### PR TITLE
STS | Azure backingstore support and schema changes

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -113,7 +113,8 @@ class Agent {
                     params.cloud_info.endpoint_type === 'IBM_COS') {
                     this.node_type = 'BLOCK_STORE_S3';
                     this.block_store = new BlockStoreS3(block_store_options);
-                } else if (params.cloud_info.endpoint_type === 'AZURE') {
+                } else if (params.cloud_info.endpoint_type === 'AZURE' ||
+                    params.cloud_info.endpoint_type === 'AZURESTS') {
                     const connection_string = cloud_utils.get_azure_new_connection_string({
                         endpoint: params.cloud_info.endpoint,
                         access_key: params.cloud_info.access_keys.access_key,

--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -195,7 +195,14 @@ class BlockStoreClient {
                 const azure_params = bs_info.connection_params;
                 const block_id = block_md.id;
                 const block_dir = get_block_internal_dir(block_id);
-                const blob = azure_storage.BlobServiceClient.fromConnectionString(azure_params.connection_string);
+                /** @type {import('../../util/azure_storage_wrap').BlobServiceClient} */
+                const blob = cloud_utils.create_azure_blob_client({
+                    endpoint: azure_params.endpoint,
+                    connection_string: azure_params.connection_string,
+                    access_key: azure_params.access_key,
+                    azure_client_id: azure_params.azure_client_id,
+                    azure_tenant_id: azure_params.azure_tenant_id,
+                });
                 const container = bs_info.target_bucket;
                 const block_key = `${bs_info.blocks_path}/${block_dir}/${block_id}`;
                 const encoded_md = Buffer.from(JSON.stringify(block_md)).toString('base64');
@@ -243,7 +250,14 @@ class BlockStoreClient {
                 const azure_params = bs_info.connection_params;
                 const block_id = block_md.id;
                 const block_dir = get_block_internal_dir(block_id);
-                const blob = azure_storage.BlobServiceClient.fromConnectionString(azure_params.connection_string);
+                /** @type {import('../../util/azure_storage_wrap').BlobServiceClient} */
+                const blob = cloud_utils.create_azure_blob_client({
+                    endpoint: azure_params.endpoint,
+                    connection_string: azure_params.connection_string,
+                    access_key: azure_params.access_key,
+                    azure_client_id: azure_params.azure_client_id,
+                    azure_tenant_id: azure_params.azure_tenant_id,
+                });
                 const container = bs_info.target_bucket;
                 const block_key = `${bs_info.blocks_path}/${block_dir}/${block_id}`;
                 const container_client = blob.getContainerClient(container);

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -243,7 +243,7 @@ module.exports = {
                     properties: {
                         service: {
                             type: 'string',
-                            enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                         },
                         read_count: {
                             type: 'integer'

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -159,6 +159,7 @@ class HostedAgents {
                 access_key: pool.cloud_pool_info.access_keys.access_key,
                 secret_key: pool.cloud_pool_info.access_keys.secret_key
             },
+            azure_sts_credentials: pool.cloud_pool_info.azure_sts_credentials,
             aws_sts_arn: pool.cloud_pool_info.aws_sts_arn,
             region: pool.cloud_pool_info.region,
             pool_name: pool.name
@@ -178,6 +179,9 @@ class HostedAgents {
         agent_params[pool_info_property] = pool_info;
         if (pool.cloud_pool_info && pool.cloud_pool_info.storage_limit) agent_params.storage_limit = pool.cloud_pool_info.storage_limit;
         if (pool.cloud_pool_info && pool.cloud_pool_info.aws_sts_arn) agent_params.aws_sts_arn = pool.cloud_pool_info.aws_sts_arn;
+        if (pool.cloud_pool_info && pool.cloud_pool_info.azure_sts_credentials) {
+            agent_params.azure_sts_credentials = pool.cloud_pool_info.azure_sts_credentials;
+        }
         dbg.log0(`running agent with params ${util.inspect(agent_params)}`);
         const agent = new Agent(agent_params);
         this._started_agents[node_name] = {

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -373,6 +373,7 @@ async function create_cloud_pool(req) {
         backingstore: req.rpc_params.backingstore,
         available_capacity: req.rpc_params.available_capacity,
         storage_limit: req.rpc_params.storage_limit,
+        azure_sts_credentials: connection.azure_sts_credentials,
     }, _.isUndefined);
 
     const cloud_buckets = await server_rpc.client.bucket.get_cloud_buckets({
@@ -415,6 +416,7 @@ async function create_cloud_pool(req) {
         FLASHBLADE: 'BLOCK_STORE_S3',
         IBM_COS: 'BLOCK_STORE_S3',
         AZURE: 'BLOCK_STORE_AZURE',
+        AZURESTS: 'BLOCK_STORE_AZURE',
         GOOGLE: 'BLOCK_STORE_GOOGLE'
     };
 

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -96,7 +96,7 @@ module.exports = {
                     cp_code: { type: 'string' },
                     endpoint_type: {
                         type: 'string',
-                        enum: ['AWSSTS', 'AWS', 'AZURESTS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                        enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                     },
                 }
             }

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -762,6 +762,7 @@ async function get_cloud_pool_stats(req) {
                         cloud_pool_stats.unhealthy_pool_target.amazon_unhealthy += 1;
                     }
                     break;
+                case 'AZURESTS':
                 case 'AZURE':
                     cloud_pool_stats.pool_target.azure += 1;
                     if (!_.includes(OPTIMAL_MODES, pool_info.mode)) {


### PR DESCRIPTION
### Describe the Problem

Add Azure STS support to backingstore

### Explain the Changes
1. Update `Accounts` and `Pools` schema with azure sts credentials `tenant_id` and `client_id`.
2. Create BlobServiceClient depending the deployment
     STS deployment: Create BlobServiceClient using tenant id, client id and federated token
     Normql deployment: Create BlobServiceClient connection string(storage account name and key)

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/RHSTOR-5085

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Azure Secure Token Service (AZURESTS) for Azure storage access.
  * STS-based Azure credentials can be used alongside connection-string authentication for pools and agents.
  * Bucket listing and storage operations now work with AZURESTS endpoints.
  * Cloud pool creation and monitoring now include AZURESTS credentials and are tracked in stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->