### PR TITLE
NC | allow non-continuous uploads complete multipart upload

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1864,6 +1864,8 @@ class NamespaceFS {
             let prev_part_size = 0;
             let should_copy_file_prefix = true;
             let total_size = 0;
+            const last_multipart_num = multiparts[multiparts.length - 1]?.num || 0;
+            const is_non_continuous_upload = last_multipart_num !== multiparts.length;
             for (const { num, etag } of multiparts) {
                 const md_part_path = this._get_part_md_path({ ...params, num });
                 const md_part_stat = await nb_native().fs.stat(fs_context, md_part_path);
@@ -1883,7 +1885,7 @@ class NamespaceFS {
                 }
 
                 // 1
-                if (part_size_to_fd_map.size === 1) {
+                if (part_size_to_fd_map.size === 1 && !is_non_continuous_upload) {
                     if (num === multiparts.length) {
                         await nb_native().fs.link(fs_context, data_part_path, upload_path);
                         break;
@@ -1892,7 +1894,7 @@ class NamespaceFS {
                         total_size += part_size;
                         continue;
                     }
-                } else if (part_size_to_fd_map.size === 2 && should_copy_file_prefix) { // 2
+                } else if (part_size_to_fd_map.size === 2 && should_copy_file_prefix && !is_non_continuous_upload) { // 2
                     if (num === multiparts.length) {
                         const prev_data_part_path = this._get_part_data_path({ ...params, size: prev_part_size });
                         await nb_native().fs.link(fs_context, prev_data_part_path, upload_path);


### PR DESCRIPTION
### Describe the Problem
The current implementation of Complete Multipart Upload assumes that all uploaded parts are present and ordered sequentially from `1` to `N` (the total number of parts).
If the part numbers are not ordered as expected, we may fail to detect that the upload has completed.

Additionally, when all parts have the same size, this assumption can cause incorrect behavior: the system may copy data from parts that are not actually included in the upload, including placeholder data for missing parts.

### Explain the Changes

When the number of uploaded parts does not match the highest part number (i.e., there are gaps in the part numbering), the implementation now falls back to copying the parts one by one instead of relying on the fixed-order optimization.

This ensures that only the explicitly provided parts are copied and prevents unintended data from being included in the final object.
### Issues: part of #9362

### Gaps
This change does not handle the case where only the initial subset of parts is used (e.g., parts 1–3 out of 5). In this scenario, the remaining data within the part-size file will be copied. we should probably copy only part of this file.

### Testing Instructions:
1. run `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/nsfs/test_namespace_fs.js` 

#### hadoop tests
s3a hadoop aws tests `ITestS3AContractMultipartUploader`:
1. clone hadoop repository: `git clone git@github.com:apache/hadoop.git`
2. `cd hadoop/hadoop-tools/hadoop-aws`
3. `mvn verify -Dtest=ITestS3AContractMultipartUploader -Dit.test=ITestS3AContractMultipartUploader`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multipart uploads with non-contiguous parts: when gaps are detected, optimized assembly shortcuts are skipped and the system reliably falls back to an explicit assembly/copy path to ensure correct final object data.

* **Tests**
  * Added unit test coverage for non-continuous multipart upload scenarios to verify data integrity and assembly behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->