### PR TITLE
`/etc` permissions - allow read and execute for group

### DIFF
--- a/src/deploy/NVA_build/setup_platform.sh
+++ b/src/deploy/NVA_build/setup_platform.sh
@@ -93,29 +93,37 @@ function setup_non_root_user() {
     local NOOBAA_USER=noob
     mkdir -p /home/${NOOBAA_USER}
     cp -f /root/.bashrc /home/${NOOBAA_USER}
-    
-    chgrp -R 0 /home/${NOOBAA_USER} && chmod -R g+rwX /home/${NOOBAA_USER}
+    # give permissions for root group
+    chgrp -R 0 /home/${NOOBAA_USER} && chmod -R g=u /home/${NOOBAA_USER}
 
-    deploy_log "setting file permissions for root group (OpenShift compatible)"
-
-   # allow root group same permissions as root user so it can run supervisord
+    # in openshift the container will run as a random user which belongs to root group
+    # set permissions for group to be same as owner to allow access to necessary files
+    deploy_log "setting file permissions for root group"
+    # allow root group same permissions as root user so it can run supervisord
     chgrp -R 0 /bin/supervisor* && chmod -R g=u /bin/supervisor*
     # supervisord needs to write supervisor.sock file in /var/log
     chgrp -R 0 /var/log && chmod -R g=u /var/log
 
-    # node modules (needs write)
-    chgrp -R 0 /root/node_modules && chmod -R g+rwX /root/node_modules
+    # noobaa code dir - allow same access as user
+    chgrp -R 0 /root/node_modules && chmod -R g=u /root/node_modules
 
-    # data volumes
-    chgrp -R 0 /data /log && chmod -R g+rwX /data /log
+    # when running with docker /data and /log are not external volumes - allow access
+    chgrp -R 0 /data && chmod -R g=u /data
+    chgrp -R 0 /log && chmod -R g=u /log
 
-    # /etc — READ ONLY
+    # /etc permissions - allow read and execute for group
     chgrp -R 0 /etc && chmod -R g+rX /etc
 
-    # logrotate state (needs write)
-    chgrp -R 0 /var/lib/logrotate && chmod -R g+rwX /var/lib/logrotate
-}
+    # give access for logrotate
+    chgrp -R 0 /var/lib/logrotate && chmod -R g=u /var/lib/logrotate
 
+    # setuid for rsyslog so it can run as root
+    chmod u+s /sbin/rsyslogd
+
+    # setuid for crond so it can run as root
+    chmod u+s /sbin/crond
+
+}
 
 deploy_log "Starting setup platform"
 set -e


### PR DESCRIPTION
### Explain the Changes
`/etc` permissions - allow read and execute for group

### Testing Instructions:
1. https://issues.redhat.com/browse/DFBUGS-5376
2. https://issues.redhat.com/browse/DFBUGS-4986



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined file and directory permission handling in platform setup: standardized group access to match owners, adjusted node_modules/data/log directory treatment, and added setuid for select system services to ensure correct runtime privileges; also standardized permission-related log messages and messaging tone.

* **Documentation**
  * Added explanatory comments clarifying permission adjustments and security-related configuration changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->