### PR TITLE
NSFS | enable content_encoding header

### DIFF
--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -652,6 +652,7 @@ class ObjectSDK {
         if (params.xattr_copy) {
             params.xattr = source_md.xattr;
             params.content_type = source_md.content_type;
+            params.content_encoding = source_md.content_encoding;
         }
         try {
             //omitBy iterates all xattr calling startsWith on them. this can include symbols such as XATTR_SORT_SYMBOL.

--- a/src/test/unit_tests/nsfs/test_namespace_fs.js
+++ b/src/test/unit_tests/nsfs/test_namespace_fs.js
@@ -899,6 +899,57 @@ mocha.describe('namespace_fs', function() {
         });
     });
 
+    mocha.describe('content encoding', function() {
+
+        const upload_key = 'upload_key_content_encoding';
+        const upload_key_dir = 'upload_key_content_encoding1/';
+        const data = crypto.randomBytes(100);
+
+        mocha.it('upload and read object without content encoding', async function() {
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: upload_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data)
+            }, dummy_object_sdk);
+
+            const md = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: upload_key,
+            }, dummy_object_sdk);
+            assert.strictEqual(md.content_encoding, undefined);
+        });
+
+        mocha.it('upload and read object with content encoding', async function() {
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: upload_key,
+                content_encoding: 'gzip',
+                source_stream: buffer_utils.buffer_to_read_stream(data)
+            }, dummy_object_sdk);
+
+            const md = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: upload_key,
+            }, dummy_object_sdk);
+            assert.strictEqual(md.content_encoding, 'gzip');
+        });
+
+        mocha.it('upload and read empty content dir with content encoding', async function() {
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: upload_key_dir,
+                content_encoding: 'gzip',
+                size: 0
+            }, dummy_object_sdk);
+
+            const md = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: upload_key_dir,
+            }, dummy_object_sdk);
+            assert.strictEqual(md.content_encoding, 'gzip');
+        });
+    });
+
     mocha.describe('restore_object', function() {
         const restore_key = 'restore_key_1';
         const data = crypto.randomBytes(100);


### PR DESCRIPTION
### Describe the Problem
enable content type header

### Explain the Changes
1. enable content type header
2. add tests

### Issues: part of #9362  

### Testing Instructions:
1. run `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/unit_tests/nsfs/test_namespace_fs.js`

#### hadoop tests
s3a hadoop aws tests ITestS3AContractMultipartUploader:

1. `clone hadoop repository: git clone git@github.com:apache/hadoop.git`
2. `cd hadoop/hadoop-tools/hadoop-aws`
3. `mvn verify -Dtest=ITestS3AContentEncoding -Dit.test=ITestS3AContentEncoding`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Objects (including empty-directory objects) now persist, expose, and validate content-encoding metadata so it is preserved across uploads, listings, retrievals, and server-side copies.

* **Tests**
  * Added unit tests verifying content-encoding is absent when not set, preserved when set, and applied to empty-directory objects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->