### PR TITLE
Fixed incorrect error message while updating bucket policy

### DIFF
--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
@@ -217,6 +217,23 @@ mocha.describe('s3_bucket_policy', function() {
         }), 'Policy has invalid resource');
     });
 
+    mocha.it('put_bucket_policy - Malformed policy resource list', async function() {
+        const policy = {
+            Version: '2012-10-17',
+            Statement: [{
+                Sid: 'id-22',
+                Effect: 'Allow',
+                Principal: '*',
+                Action: ['s3:*'],
+                Resource: `"arn:aws:s3:::${BKT}, arn:aws:s3:::${BKT}/*]"`
+            }]
+        };
+        await assert_throws_async(s3_owner.putBucketPolicy({
+            Bucket: BKT,
+            Policy: JSON.stringify(policy)
+        }), 'Policy has invalid resource');
+    });
+
     mocha.it('should fail setting bucket policy when action is illeagel', async function() {
         const made_up_action = 's3:GetNoSuchAction';
         const policy = {


### PR DESCRIPTION
### Describe the Problem

Using put-bucket-policy with wrong syntax under Resource results in InternalError instead of MalformedPolicy

### Explain the Changes
1. Square brackets ([ ]) in resource_bucket_part were misinterpreted in regex.
2. Escaped all regex special characters before inserting into RegExp().


### Issues: Fixed #xxx / Gap #xxx
1. [DFBUGS-1517](https://issues.redhat.com/browse/DFBUGS-1517)

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource validation: special regex characters in resource patterns are now escaped, making ARN-like resource matching more robust and rejecting malformed resource entries with a MALFORMED_POLICY error.

* **Tests**
  * Added unit test to ensure bucket policies with incorrectly formatted Resource lists produce a MALFORMED_POLICY error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->