### PR TITLE
Updated schema details for implementing Azure STS

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -446,6 +446,7 @@ module.exports = {
                     aws_sts_arn: {
                         type: 'string'
                     },
+                    azure_sts_credentials: {$ref: 'common_api#/definitions/azure_sts_credentials' },
                     region: {
                         type: 'string'
                     },
@@ -507,6 +508,7 @@ module.exports = {
                     aws_sts_arn: {
                         type: 'string'
                     },
+                    azure_sts_credentials: {$ref: 'common_api#/definitions/azure_sts_credentials' },
                     region: {
                         type: 'string'
                     },

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -882,7 +882,7 @@ module.exports = {
 
         endpoint_type: {
             type: 'string',
-            enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
         },
 
         block_md: {
@@ -1036,6 +1036,15 @@ module.exports = {
                 azure_client_id: { $ref: '#/definitions/azure_client_id' },
                 azure_client_secret: { $ref: '#/definitions/azure_client_secret' },
                 azure_logs_analytics_workspace_id: { $ref: '#/definitions/azure_logs_analytics_workspace_id' },
+            }
+        },
+
+        azure_sts_credentials: {
+            type: 'object',
+            required: ['azure_tenant_id', 'azure_client_id' ],
+            properties: {
+                azure_tenant_id: { $ref: '#/definitions/azure_tenant_id' },
+                azure_client_id: { $ref: '#/definitions/azure_client_id' }
             }
         },
 

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -751,7 +751,6 @@ async function check_azure_connection(params) {
 }
 
 async function _check_azure_connection_internal(params) {
-
     const conn_str = cloud_utils.get_azure_new_connection_string({
         endpoint: params.endpoint,
         access_key: params.identity,

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -86,6 +86,7 @@ module.exports = {
                     aws_sts_arn: {
                         type: 'string'
                     },
+                   azure_sts_credentials: {$ref: 'common_api#/definitions/azure_sts_credentials' },
                     auth_method: {
                         type: 'string',
                         enum: ['AWS_V2', 'AWS_V4']
@@ -95,7 +96,7 @@ module.exports = {
                     cp_code: { type: 'string' },
                     endpoint_type: {
                         type: 'string',
-                        enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                        enum: ['AWSSTS', 'AWS', 'AZURESTS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                     },
                 }
             }

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -86,6 +86,7 @@ module.exports = {
                 aws_sts_arn: {
                     type: 'string'
                 },
+               azure_sts_credentials: {$ref: 'common_api#/definitions/azure_sts_credentials' },
                 backingstore: {
                     type: 'object',
                     properties: {
@@ -116,7 +117,7 @@ module.exports = {
                 },
                 endpoint_type: {
                     type: 'string',
-                    enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                    enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                 },
                 agent_info: {
                     type: 'object',


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. Added Azure Security Token Service (STS) credential support across API and server schema definitions. 
2. The azure_sts_credentials field is introduced to multiple API parameter schemas and server cache/pool configurations. 
3. A new AZURESTS endpoint type is added to the supported endpoint types enumeration.

### Issues: Fixed #xxx / Gap #xxx
1.  [RHSTOR-5085](https://issues.redhat.com/browse/RHSTOR-5085)

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure STS credentials field to account and external-connection APIs for Azure STS support.
  * Introduced AZURESTS as a new endpoint type across account and pool schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->