### PR TITLE
Removing mongo_upgrade field from system schema

### DIFF
--- a/src/api/system_api.js
+++ b/src/api/system_api.js
@@ -895,9 +895,6 @@ module.exports = {
                         path: {
                             type: 'string'
                         },
-                        mongo_upgrade: {
-                            type: 'boolean'
-                        },
                         status: {
                             type: 'string',
                             enum: [

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -177,17 +177,6 @@ module.exports = {
             idate: true
         },
 
-        mongo_upgrade: {
-            type: 'object',
-            // required: [],
-            properties: {
-                blocks_to_buckets: {
-                    type: 'boolean'
-                }
-            }
-        },
-
-
         current_version: {
             type: 'string'
         },

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -155,9 +155,6 @@ function new_system_defaults(name, owner_account_id) {
             udp_port: true,
         },
         debug_level: 0,
-        mongo_upgrade: {
-            blocks_to_buckets: true
-        },
         last_stats_report: 0,
         freemium_cap: {
             phone_home_upgraded: false,
@@ -872,21 +869,6 @@ async function _ensure_internal_structure(system_id) {
 
     const support_account = _.find(system_store.data.accounts, account => account.is_support);
     if (!support_account) throw new Error('SUPPORT ACCOUNT DOES NOT EXIST');
-    // Skip creation of agent on PostgreSQL
-    if (config.DB_TYPE !== 'mongodb') return;
-    try {
-        server_rpc.client.hosted_agents.create_pool_agent({
-            pool_name: `${config.INTERNAL_STORAGE_POOL_NAME}-${system_id}`
-        }, {
-            auth_token: auth_server.make_auth_token({
-                system_id,
-                role: 'admin',
-                account_id: support_account._id
-            })
-        });
-    } catch (err) {
-        throw new Error('MONGO POOL CREATION FAILURE:' + err);
-    }
 }
 
 async function get_join_cluster_yaml(req) {

--- a/src/upgrade/upgrade_scripts/5.22.0/remove_mongo_upgrade.js
+++ b/src/upgrade/upgrade_scripts/5.22.0/remove_mongo_upgrade.js
@@ -1,0 +1,28 @@
+/* Copyright (C) 2025 NooBaa */
+"use strict";
+
+async function run({ dbg, system_store }) {
+    try {
+        dbg.log0('starting remove mongo_upgrade from systems...');
+        const systems = system_store.data.systems
+            .map(s => Object.hasOwn(s, 'mongo_upgrade') && ({
+                _id: s._id,
+                $unset: { mongo_upgrade: true }
+            }))
+            .filter(Boolean);
+        if (systems.length > 0) {
+            dbg.log0(`removing "mongo_upgrade" from systems: ${systems.map(s => s._id).join(', ')}`);
+            await system_store.make_changes({ update: { systems } });
+        } else {
+            dbg.log0('remove mongo_upgrade: no upgrade needed...');
+        }
+    } catch (err) {
+        dbg.error('got error while removing mongo_upgrade from systems:', err);
+        throw err;
+    }
+}
+
+module.exports = {
+    run,
+    description: 'Remove mongo_upgrade field from systems'
+};


### PR DESCRIPTION
### Explain the Changes
- Removing mongo_upgrade field from system schema
- Removing mongo_upgrade field from system api
- Removing mongo_upgrade field from system server
- writing upgrade script to update the removal of  mongo_upgrade field from system schema

### Testing Instructions:
1. See that system schema no longer have mongo_upgrade field after first install and after upgrades



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed obsolete MongoDB upgrade property from system configuration, public API schema, and server defaults
  * Removed legacy internal logic that created a DB-specific pool agent and its PostgreSQL workaround

* **Chores**
  * Added an automated migration to unset the removed MongoDB upgrade field on existing systems
<!-- end of auto-generated comment: release notes by coderabbit.ai -->