### PR TITLE
[Backport to 5.21] Optimize bulk delete operation for non versioned buckets

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,0 +1,14 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const COMMON_CONSTANTS = {
+  S3: {
+    VERSIONING: {
+      ENABLED: 'ENABLED',
+      SUSPENDED: 'SUSPENDED',
+      DISABLED: "DISABLED"
+    }
+  }
+};
+
+module.exports = COMMON_CONSTANTS;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -2068,6 +2068,10 @@ class MDStore {
     estimated_total_objects() {
         return this._objects.estimatedDocumentCount();
     }
+
+    get_unordered_bulk_op_on_objects() {
+        return this._objects.initializeUnorderedBulkOp();
+    }
 }
 
 MDStore._instance = undefined;


### PR DESCRIPTION
### Explain the Changes
[Backport to 5.21] Optimize bulk delete operation for non versioned buckets
Cherry picked from commit [853fe58c1](https://github.com/noobaa/noobaa-core/pull/9389/changes/853fe58c186e21315b9d200844e0906a79426e2d)

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-5137

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
