### PR TITLE
[NC | GLACIER] Fix migration retries of deleted files

### DIFF
--- a/src/sdk/glacier_tapecloud.js
+++ b/src/sdk/glacier_tapecloud.js
@@ -14,6 +14,7 @@ const { get_process_fs_context } = require("../util/native_fs_utils");
 const dbg = require('../util/debug_module')(__filename);
 
 const ERROR_DUPLICATE_TASK = "GLESM431E";
+const ERROR_FILE_NOT_FOUND = "GLESL400E";
 
 /** @import {LogFile} from "../util/persistent_logger" */
 
@@ -27,6 +28,11 @@ class TapeCloudUtils {
     static TASK_SHOW_SCRIPT = 'task_show';
     static PROCESS_EXPIRED_SCRIPT = 'process_expired';
     static LOW_FREE_SPACE_SCRIPT = 'low_free_space';
+
+    static ERROR_IGNORE_LIST = [
+        ERROR_DUPLICATE_TASK,
+        ERROR_FILE_NOT_FOUND,
+    ];
 
     /**
      * @param {*} task_id
@@ -78,7 +84,7 @@ class TapeCloudUtils {
 
                 if (failure_case) {
                     const failure_code = parsed_meta[1];
-                    if (failure_code !== ERROR_DUPLICATE_TASK) {
+                    if (!TapeCloudUtils.ERROR_IGNORE_LIST.includes(failure_code)) {
                         dbg.warn('failed to migrate', filename, 'will record in failure/retry log');
                         await failure_recorder(filename);
                     }

--- a/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
@@ -684,6 +684,7 @@ Result    Failure Code  Failed time               Node -- File name
 Fail      GLESM451W     2023/11/08T02:38:47          1 -- /ibm/gpfs/NoobaaTest/file.aaai
 Fail      GLESM451W     2023/11/08T02:38:47          1 -- /ibm/gpfs/NoobaaTest/file.aaaj
 Fail      GLESL401E     2023/11/08T02:38:44          1 -- /ibm/gpfs/NoobaaTest/noobaadata
+Fail      GLESL400E     2023/11/08T02:38:44          1 -- /ibm/gpfs/NoobaaTest/noobaadata2
 Success   -             -                            - -- /ibm/gpfs/NoobaaTest/testingdata/file.aaaa
 Success   -             -                            - -- /ibm/gpfs/NoobaaTest/testingdata/file.aaab
 Success   -             -                            - -- /ibm/gpfs/NoobaaTest/testingdata/file.aaaj`;
@@ -708,6 +709,8 @@ EOF`;
         });
 
         mocha.it('record_task_status', async function() {
+            // /ibm/gpfs/NoobaaTest/noobaadata2 would not be part of failed case however wouldn't
+            // be part of success case either as it must be ignored
             const expected_failed_records = [
                 '/ibm/gpfs/NoobaaTest/file.aaai',
                 '/ibm/gpfs/NoobaaTest/file.aaaj',


### PR DESCRIPTION
### Describe the Problem
NooBaa processes logs is 2 stages, in second stage noobaa does not check whether a file exists or not and directly hands over the log file to eeadm. If a file doesn't exist, noobaa takes that as a failure and queue it for retry which leads to an infinite retry situation.

### Explain the Changes
This PR adds the error code [GLESL400E](https://www.ibm.com/docs/en/SSJ4VJ_1.3.4/EE_messages/GLESL400E.html) to a ignore list which prevents queuing up the entry for retry.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `./node_modules/.bin/mocha src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error handling to ignore an additional non-critical error when recording failures, reducing noise in failure records and improving visibility into genuine issues.
  * Updated unit tests to account for the ignored entry so test expectations match the new failure-record behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->