### PR TITLE
NC | implement object lock functionality

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1592,6 +1592,7 @@ module.exports = {
         },
         object_lock_configuration: {
             type: 'object',
+            required: ['object_lock_enabled'],
             properties: {
                 object_lock_enabled: {
                     type: 'string',
@@ -1606,7 +1607,10 @@ module.exports = {
                                     required: ['years', 'mode'],
                                     additionalProperties: false,
                                     properties: {
-                                        years: { type: 'integer' },
+                                        years: {
+                                            type: 'integer',
+                                            "minimum": 1
+                                        },
                                         mode: {
                                             type: 'string',
                                             enum: ['GOVERNANCE', 'COMPLIANCE']
@@ -1618,7 +1622,10 @@ module.exports = {
                                     required: ['days', 'mode'],
                                     additionalProperties: false,
                                     properties: {
-                                        days: { type: 'integer' },
+                                        days: {
+                                            type: 'integer',
+                                            "minimum": 1
+                                        },
                                         mode: {
                                             type: 'string',
                                             enum: ['GOVERNANCE', 'COMPLIANCE']

--- a/src/endpoint/s3/ops/s3_post_object_uploads.js
+++ b/src/endpoint/s3/ops/s3_post_object_uploads.js
@@ -14,6 +14,7 @@ async function post_object_uploads(req, res) {
     const tagging = s3_utils.parse_tagging_header(req);
     const encryption = s3_utils.parse_encryption(req);
     const storage_class = s3_utils.parse_storage_class_header(req);
+    const lock_settings = config.WORM_ENABLED ? s3_utils.parse_lock_header(req) : undefined;
     if (config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD && storage_class === s3_utils.STORAGE_CLASS_STANDARD) {
         throw new S3Error(S3Error.InvalidStorageClass);
     }
@@ -26,7 +27,8 @@ async function post_object_uploads(req, res) {
         xattr: s3_utils.get_request_xattr(req),
         storage_class,
         tagging,
-        encryption
+        encryption,
+        lock_settings
     });
 
     s3_utils.set_encryption_response_headers(req, res, reply.encryption);

--- a/src/endpoint/s3/ops/s3_put_bucket_object_lock.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_object_lock.js
@@ -17,10 +17,19 @@ async function put_bucket_object_lock(req, res) {
     }
     const lock_configuration = s3_utils.parse_body_object_lock_conf_xml(req);
 
-    await req.object_sdk.put_object_lock_configuration({
-        name: req.params.bucket,
-        object_lock_configuration: lock_configuration,
-    });
+    try {
+        await req.object_sdk.put_object_lock_configuration({
+            name: req.params.bucket,
+            object_lock_configuration: lock_configuration,
+        });
+    } catch (err) {
+        let error = err;
+        if (err.rpc_code === 'INVALID_SCHEMA' || err.rpc_code === 'INVALID_SCHEMA_PARAMS') {
+            console.error('put_bucket_object_lock: Invalid schema provided', err);
+            error = new S3Error(S3Error.MalformedXML);
+        }
+        throw error;
+    }
 }
 
 module.exports = {

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -538,35 +538,50 @@ function parse_body_encryption_xml(req) {
 
 function parse_body_object_lock_conf_xml(req) {
     const configuration = req.body.ObjectLockConfiguration;
-    const retention = configuration.Rule[0].DefaultRetention[0];
+    try {
+        const retention = configuration?.Rule?.[0]?.DefaultRetention?.[0];
+        const object_lock_enabled = configuration?.ObjectLockEnabled?.[0];
+        if (object_lock_enabled !== 'Enabled') {
+            dbg.error('invalid object_lock_enabled, can only be Enabled', object_lock_enabled);
+            throw new S3Error(S3Error.MalformedXML);
+        }
+        const conf = {
+            object_lock_enabled,
+        };
 
-    if ((retention.Days && retention.Years) || (!retention.Days && !retention.Years) ||
-        (retention.Mode[0] !== 'GOVERNANCE' && retention.Mode[0] !== 'COMPLIANCE')) throw new S3Error(S3Error.MalformedXML);
-
-    const conf = {
-        object_lock_enabled: configuration.ObjectLockEnabled[0],
-        rule: { default_retention: { mode: retention.Mode[0], } }
-    };
-
-    if (retention.Days) {
-        const days = parseInt(retention.Days[0], 10);
-        if (days <= 0) {
-            const err = new S3Error(S3Error.InvalidArgument);
-            err.message = 'Default retention period must be a positive integer value';
+        if (retention) {
+            conf.rule = { default_retention: { mode: retention.Mode[0] } };
+            if ((!retention.Days && !retention.Years) || (retention.Mode[0] !== 'GOVERNANCE' && retention.Mode[0] !== 'COMPLIANCE')) {
+                dbg.error('invalid object lock confugration retention', retention);
+                throw new S3Error(S3Error.MalformedXML);
+            }
+            if (retention.Days) {
+                const days = parseInt(retention.Days[0], 10);
+                if (!Number.isInteger(days) || days <= 0) {
+                    const err = new S3Error(S3Error.InvalidArgument);
+                    err.message = 'Default retention period must be a positive integer value';
+                    throw err;
+                }
+                conf.rule.default_retention.days = days;
+            }
+            if (retention.Years) {
+                const years = parseInt(retention.Years[0], 10);
+                if (!Number.isInteger(years) || years <= 0) {
+                    const err = new S3Error(S3Error.InvalidArgument);
+                    err.message = 'Default retention period must be a positive integer value';
+                    throw err;
+                }
+                conf.rule.default_retention.years = years;
+            }
+        }
+        return conf;
+    } catch (err) {
+        dbg.error('parse_body_object_lock_conf_xml failed', err);
+        if (err instanceof S3Error) {
             throw err;
         }
-        conf.rule.default_retention.days = days;
+        throw new S3Error(S3Error.MalformedXML);
     }
-    if (retention.Years) {
-        const years = parseInt(retention.Years[0], 10);
-        if (years <= 0) {
-            const err = new S3Error(S3Error.InvalidArgument);
-            err.message = 'Default retention period must be a positive integer value';
-            throw err;
-        }
-        conf.rule.default_retention.years = years;
-    }
-    return conf;
 }
 
 function parse_body_website_xml(req) {

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2020 NooBaa */
-/*eslint max-lines: ["error", 4000]*/
+/*eslint max-lines: ["error", 5000]*/
 /*eslint max-statements: ["error", 80, { "ignoreTopLevelFunctions": true }]*/
 'use strict';
 
@@ -1371,7 +1371,7 @@ class NamespaceFS {
     // xattr_copy = false implies on non server side copy fallback copy (copy status = FALLBACK)
     // target file can be undefined when it's a folder created and size is 0
     async _finish_upload({ fs_context, params, open_mode, target_file, upload_path, file_path, digest = undefined,
-        copy_res = undefined, offset }) {
+        copy_res = undefined, offset, object_sdk }) {
         const part_upload = file_path === upload_path;
         const same_inode = params.copy_source && copy_res === COPY_STATUS_ENUM.SAME_INODE;
         const should_replace_xattr = params.copy_source ? copy_res === COPY_STATUS_ENUM.FALLBACK : true;
@@ -1402,6 +1402,8 @@ class NamespaceFS {
         }
         if (part_upload) {
             fs_xattr = this._assign_part_props_to_fs_xattr(params.size, digest, offset, fs_xattr);
+        } else {
+            fs_xattr = await this._assign_object_lock_to_fs_xattr(params, object_sdk, fs_xattr);
         }
         if (!part_upload && (this._is_versioning_enabled() || this._is_versioning_suspended())) {
             fs_xattr = this._assign_versions_to_fs_xattr(stat, fs_xattr, undefined);
@@ -1994,14 +1996,18 @@ class NamespaceFS {
                 path.join(params.mpu_path, 'create_object_upload')
             );
 
-            const upload_params = { fs_context, upload_path, open_mode, file_path, params, target_file };
+            const upload_params = { fs_context, upload_path, open_mode, file_path, params, target_file, object_sdk };
             const create_params_parsed = JSON.parse(create_params_buffer.toString());
             upload_params.params.xattr = create_params_parsed.xattr;
             upload_params.params.storage_class = create_params_parsed.storage_class;
             upload_params.digest = MD5Async && (((await MD5Async.digest()).toString('hex')) + '-' + multiparts.length);
             upload_params.params.content_type = create_params_parsed.content_type;
             upload_params.params.content_encoding = create_params_parsed.content_encoding;
-
+            upload_params.params.lock_settings = create_params_parsed.lock_settings;
+            if (upload_params.params.lock_settings?.retention?.retain_until_date) {
+                upload_params.params.lock_settings.retention.retain_until_date =
+                    new Date(upload_params.params.lock_settings.retention.retain_until_date);
+            }
             const upload_info = await this._finish_upload(upload_params);
 
             await target_file.close(fs_context);
@@ -2262,7 +2268,62 @@ class NamespaceFS {
     //  OBJECT LOCK  //
     ///////////////////
 
-    _check_object_retention(retention, {bypass_governance}) {
+    /**
+     * assigns object lock settings to fs xattr, if lock_settings is not provided, will try to get default object lock configuration of the bucket and assign it to fs xattr
+     * @param {Object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @param {Object} fs_xattr
+     */
+    async _assign_object_lock_to_fs_xattr(params, object_sdk, fs_xattr) {
+        let lock_settings = params.lock_settings;
+        const { bucket } = await object_sdk.read_bucket_full_info(params.bucket);
+        if (lock_settings) {
+            this._check_bucket_lock_enabled(bucket);
+        } else {
+            lock_settings = this._get_default_object_lock_configuration(bucket);
+        }
+        if (lock_settings) {
+            fs_xattr = fs_xattr || {};
+            if (lock_settings.legal_hold) {
+                fs_xattr[XATTR_LEGAL_HOLD] = lock_settings.legal_hold.status;
+            }
+            if (lock_settings.retention) {
+                fs_xattr[XATTR_RETENTION_MODE] = lock_settings.retention.mode;
+                fs_xattr[XATTR_RETENTION_DATE] = lock_settings.retention.retain_until_date.toISOString();
+            }
+        }
+        return fs_xattr;
+    }
+
+    /**
+     * get default object lock configuration for the bucket. defined using put_object_lock_configuration.
+     * parse the result and return in the lock settings format. if the bucket does not have default object lock configuration, return undefined.
+     * @param {Object} bucket
+     * @returns default object lock configuration, or undefined if not exists.
+     */
+    _get_default_object_lock_configuration(bucket) {
+        const object_lock_configuration = bucket?.object_lock_configuration;
+        if (object_lock_configuration?.object_lock_enabled !== 'Enabled') {
+            return undefined;
+        }
+        const default_retention = object_lock_configuration?.rule?.default_retention;
+        if (!default_retention) {
+            return undefined;
+        }
+        const today = new Date();
+        const retain_until_date = default_retention.days ? new Date(today.setDate(today.getDate() + default_retention.days)) :
+            new Date(today.setFullYear(today.getFullYear() + default_retention.years));
+
+        return { retention: { mode: default_retention.mode, retain_until_date } };
+    }
+
+    /**
+     * check if the object deletion should be blocked by retention lock. if the object is blocked will throw AccessDenied error
+     * @param {Object} retention - object retention lock settings
+     * @param {boolean} bypass_governance - if true, and user has permission to use this flag, will allow to bypass governance mode retention lock. compliance mode retention lock cannot be bypassed.
+     * @throws {S3Error.AccessDenied} if the object is protected by object lock and the user does not have permission to bypass the lock
+     */
+    _check_object_retention(retention, bypass_governance) {
         if (retention) {
             const retain_until_date = new Date(retention.retain_until_date);
             const now = new Date();
@@ -2278,10 +2339,56 @@ class NamespaceFS {
         }
     }
 
-    async _check_bucket_lock_enabled(bucket_name, object_sdk) {
-        const bucketspace = object_sdk._get_bucketspace();
-        const bucket_lock_configuration = await bucketspace.get_object_lock_configuration({name: bucket_name}, object_sdk);
-        if (bucket_lock_configuration?.object_lock_enabled !== 'Enabled') {
+    /**
+     * check if the object retention lock settings can be updated to the new retention settings. if not, will throw AccessDenied error
+     * the rules are:
+     * 1. if the new retention is longer than the current retention, it can be updated (can increase retention time)
+     * 2. if the new retention is shorter than the current retention, it cannot be updated and will throw error, unless the user has bypass_governance permission and the current retention mode is GOVERNANCE
+     * @param {Object} current_retention - current object retention lock settings
+     * @param {Object} new_retention - new object retention lock settings
+     * @param {boolean} bypass_governance - if true, and user has permission to use this flag, will allow to bypass governance mode retention lock. compliance mode retention lock cannot be bypassed.
+     * @throws {S3Error.AccessDenied} if the object is protected by object lock and the user does not have permission to bypass the lock
+     */
+    _compare_object_retention(current_retention, new_retention, bypass_governance) {
+        if (current_retention) {
+            const retain_until_date = new Date(current_retention.retain_until_date);
+            const new_date = new Date(new_retention.retain_until_date);
+            //can always increase retention time
+            if (new_date >= retain_until_date && new_retention.mode === current_retention.mode) return;
+            //TODO should check for bypass_governance permission
+            if (current_retention.mode === 'COMPLIANCE' ||
+                (current_retention.mode === 'GOVERNANCE' && !bypass_governance)) {
+                const err = new S3Error(S3Error.AccessDenied);
+                err.message = 'Access Denied because object protected by object lock.';
+                throw err;
+            }
+        }
+    }
+
+    /**
+     * check if the object is protected by object lock, if it is, will throw AccessDenied error. this method should be called when trying to delete the object
+     * @param {Object} version_id - object version info, contains retention and legal hold settings
+     * @param {Object} params - request params, contains bypass_governance flag
+     * @throws {S3Error.AccessDenied} if the object is protected by object lock and the user does not have permission to bypass the lock
+     */
+    _check_object_lock(version_id, params) {
+        if (version_id.legal_hold === 'ON') {
+            const err = new S3Error(S3Error.AccessDenied);
+            err.message = 'Access Denied because object protected by object lock.';
+            throw err;
+        }
+        this._check_object_retention(version_id.retention, params.bypass_governance);
+    }
+
+
+    /**
+     * check if the bucket has object lock enabled. if not, will throw InvalidRequest error, since object lock operations are not valid for buckets without object lock enabled
+     * @param {Object} bucket_info
+     * @throws {S3Error.InvalidRequest} if the bucket does not have object lock enabled
+     */
+    _check_bucket_lock_enabled(bucket_info) {
+        const object_lock_configuration = bucket_info?.object_lock_configuration;
+        if (object_lock_configuration?.object_lock_enabled !== 'Enabled') {
             const err = new S3Error(S3Error.InvalidRequest);
             err.message = 'Bucket is missing Object Lock Configuration';
             throw err;
@@ -2293,7 +2400,8 @@ class NamespaceFS {
         const fs_context = this.prepare_fs_context(object_sdk);
         const file_path = await this._find_version_path(fs_context, params, true);
         await this._check_path_in_bucket_boundaries(fs_context, file_path);
-        await this._check_bucket_lock_enabled(params.bucket, object_sdk);
+        const { bucket } = await object_sdk.read_bucket_full_info(params.bucket);
+        this._check_bucket_lock_enabled(bucket);
         let stat;
         try {
             stat = await nb_native().fs.stat(fs_context, file_path);
@@ -2309,7 +2417,8 @@ class NamespaceFS {
 
     async put_object_legal_hold(params, object_sdk) {
         dbg.log0('NamespaceFS.put_object_legal_hold:', params);
-        await this._check_bucket_lock_enabled(params.bucket, object_sdk);
+        const { bucket } = await object_sdk.read_bucket_full_info(params.bucket);
+        this._check_bucket_lock_enabled(bucket);
         const fs_context = this.prepare_fs_context(object_sdk);
         const file_path = await this._find_version_path(fs_context, params, true);
         await this._check_path_in_bucket_boundaries(fs_context, file_path);
@@ -2328,7 +2437,8 @@ class NamespaceFS {
         const fs_context = this.prepare_fs_context(object_sdk);
         const file_path = await this._find_version_path(fs_context, params, true);
         await this._check_path_in_bucket_boundaries(fs_context, file_path);
-        await this._check_bucket_lock_enabled(params.bucket, object_sdk);
+        const { bucket } = await object_sdk.read_bucket_full_info(params.bucket);
+        this._check_bucket_lock_enabled(bucket);
         let stat;
         try {
             stat = await nb_native().fs.stat(fs_context, file_path);
@@ -2350,14 +2460,15 @@ class NamespaceFS {
 
     async put_object_retention(params, object_sdk) {
         dbg.log0('NamespaceFS.put_object_retention:', params);
-        await this._check_bucket_lock_enabled(params.bucket, object_sdk);
+        const { bucket } = await object_sdk.read_bucket_full_info(params.bucket);
+        this._check_bucket_lock_enabled(bucket);
         const fs_context = this.prepare_fs_context(object_sdk);
         const file_path = await this._find_version_path(fs_context, params, true);
         await this._check_path_in_bucket_boundaries(fs_context, file_path);
         try {
             const stat = await nb_native().fs.stat(fs_context, file_path);
             const current_retention = this._get_retention_mode_from_xattr(stat.xattr);
-            this._check_object_retention(current_retention, params);
+            this._compare_object_retention(current_retention, params.retention, params.bypass_governance);
             const fs_xattr = {};
             fs_xattr[XATTR_RETENTION_MODE] = params.retention.mode;
             fs_xattr[XATTR_RETENTION_DATE] = params.retention.retain_until_date.toISOString();
@@ -2738,6 +2849,11 @@ class NamespaceFS {
         return res;
     }
 
+    /**
+     * get the object lock settings from fs xattr, if the xattr is empty or does not contain object lock settings, return undefined
+     * @param {Object} xattr 
+     * @returns object lock settings, or undefined if not exists.
+     */
     _lock_settings_from_fs_xattr(xattr) {
         if (_.isEmpty(xattr)) return undefined;
         if (xattr[XATTR_RETENTION_MODE] || xattr[XATTR_LEGAL_HOLD]) {
@@ -3178,7 +3294,9 @@ class NamespaceFS {
                 ...(ver_info_by_xattr || stat),
                 version_id_str,
                 delete_marker: stat.xattr[XATTR_DELETE_MARKER],
-                path: version_path
+                path: version_path,
+                legal_hold: stat.xattr[XATTR_LEGAL_HOLD],
+                retention: this._get_retention_mode_from_xattr(stat.xattr),
             };
         } catch (err) {
             if (err.code !== 'ENOENT') throw err;
@@ -3302,6 +3420,7 @@ class NamespaceFS {
                 await this._check_path_in_bucket_boundaries(fs_context, file_path);
                 const version_info = await this._get_version_info(fs_context, file_path);
                 if (!version_info) return;
+                this._check_object_lock(version_info, params);
 
                 const deleted_latest = file_path === latest_version_path;
                 if (deleted_latest) {

--- a/src/test/integration_tests/api/s3/test_nsfs_versioning_gpfs.js
+++ b/src/test/integration_tests/api/s3/test_nsfs_versioning_gpfs.js
@@ -33,6 +33,9 @@ function make_dummy_object_sdk(nsfs_config, uid, gid) {
         abort_controller: new AbortController(),
         throw_if_aborted() {
             if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        },
+        read_bucket_full_info(name) {
+            return {};
         }
     };
 }

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -162,6 +162,19 @@ mocha.describe('s3 worm', function() {
                 }
             }), 'MalformedXML', malformedXML_message);
         });
+        mocha.it('should put lock configuration with no rule', async function() {
+            const res = await s3_owner.putObjectLockConfiguration({
+                Bucket: BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                }
+            });
+            delete res.$metadata; // sdk returns metadata we dont care about here
+            assert.deepEqual(res, {});
+            const conf = await s3_owner.getObjectLockConfiguration({ Bucket: BKT });
+            assert.equal(conf.ObjectLockConfiguration.ObjectLockEnabled, 'Enabled');
+            assert.strictEqual(conf.ObjectLockConfiguration.Rule, undefined);
+        });
         mocha.it('should put lock configuration', async function() {
             const conf = await s3_owner.putObjectLockConfiguration({
                 Bucket: BKT,
@@ -256,8 +269,6 @@ mocha.describe('s3 worm', function() {
             assert.equal(conf.LegalHold.Status, 'ON');
         });
         mocha.it('should put retention (compliance mode)', async function() {
-            //TODO: nc - not implemented yet - need user flag to allow compliance mode lock override
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             const today3 = new Date();
             const oneSec3 = new Date(today3);
             oneSec3.setSeconds(oneSec3.getSeconds() + 30);
@@ -267,7 +278,7 @@ mocha.describe('s3 worm', function() {
                 BypassGovernanceRetention: false,
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: oneSec3 },
                 VersionId: version_id1
-            }), 'AccessDenied', 'Access Denied');
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
             const conf = await s3_owner.putObjectRetention({
                 Bucket: BKT,
                 Key: OBJ1,
@@ -275,24 +286,21 @@ mocha.describe('s3 worm', function() {
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: oneSec3 },
                 VersionId: version_id1
             });
+            delete conf.$metadata; // sdk returns metadata we dont care about here
             assert.deepEqual(conf, {});
         });
         mocha.it('IT25. should get object with retention (compliance mode)', async function() {
-            //TODO: nc - is implemented but relies on skiped test above
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             const conf = await s3_owner.getObjectRetention({ Bucket: BKT, Key: OBJ1, VersionId: version_id1 });
             assert.ok(conf.Retention.RetainUntilDate);
             assert.equal(conf.Retention.Mode, 'COMPLIANCE');
         });
         mocha.it('fail delete object with retention COMPLIANCE', async function() {
-            //TODO: nc - not implemented yet
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             await assert_throws_async(s3_owner.deleteObject({
                 Bucket: BKT,
                 Key: OBJ1,
                 BypassGovernanceRetention: true,
                 VersionId: version_id1,
-            }), 'AccessDenied', 'Access Denied');
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
         });
         mocha.it('put object with retention mode and without date', async function() {
             const params = { Bucket: BKT, Key: OBJ1, Body: file_body, ContentType: 'text/plain', ObjectLockMode: 'GOVERNANCE' };
@@ -332,37 +340,26 @@ mocha.describe('s3 worm', function() {
             assert.deepEqual(conf, {});
         });
         mocha.it('should get object', async function() {
-            //TODO: nc - apply object lock from bucket configuration not implemented yet
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             const conf = await s3_owner.getObject({ Bucket: BKT, Key: OBJ3 });
             assert.ok(conf.ObjectLockRetainUntilDate);
             assert.strictEqual(conf.ObjectLockMode, 'COMPLIANCE');
         });
         mocha.it('should head object', async function() {
-            //TODO: nc - apply object lock from bucket configuration not implemented yet
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
-
             const conf = await s3_owner.headObject({ Bucket: BKT, Key: OBJ3 });
             assert.equal(conf.ObjectLockLegalHoldStatus, 'OFF');
             assert.ok(conf.ObjectLockRetainUntilDate);
             assert.strictEqual(conf.ObjectLockMode, 'COMPLIANCE');
         });
         mocha.it('should fail put retention (compliance mode)', async function() {
-            //TODO: nc - apply object lock from bucket configuration not implemented yet
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             await assert_throws_async(s3_owner.putObjectRetention({
                 Bucket: BKT,
                 Key: OBJ3,
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: tomorrow },
                 VersionId: version_id3,
-            }), 'AccessDenied', 'Access Denied');
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
         });
     });
-    mocha.describe('put object', function() {
-        mocha.before(function() {
-            //TODO: nc - not implemented yet - object lock in put object
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
-        });
+    mocha.describe('put object OBJ4 with retention - should override default values', function() {
 
         mocha.it('IT26. should put object with retention', async function() {
             const put_object_res = await s3_owner.putObject({
@@ -396,7 +393,7 @@ mocha.describe('s3 worm', function() {
                 Key: OBJ4,
                 BypassGovernanceRetention: false,
                 VersionId: version_id4,
-            }), 'AccessDenied', 'Access Denied');
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
         });
         mocha.it('should delete object with retention (governanceBypass=trues)', async function() {
             const deleted = await s3_owner.deleteObject({
@@ -480,6 +477,504 @@ mocha.describe('s3 worm', function() {
             const conf = await s3_owner.headObject({ Bucket: BKT1, Key: OBJ2 });
             assert.strictEqual(conf.ObjectLockLegalHoldStatus, 'ON');
             assert.strictEqual(conf.ObjectLockMode, 'GOVERNANCE');
+        });
+    });
+
+    mocha.describe('delete marker behavior with Object Lock', function() {
+        const DELETE_MARKER_KEY = 'delete-marker-test-obj';
+
+        mocha.it('should create object for delete marker test', async function() {
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: DELETE_MARKER_KEY,
+                Body: file_body,
+                ContentType: 'text/plain'
+            });
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should create delete marker without version ID (simple delete)', async function() {
+            const res = await s3_owner.deleteObject({
+                Bucket: BKT1,
+                Key: DELETE_MARKER_KEY
+            });
+            assert.ok(res.VersionId);
+            assert.ok(res.DeleteMarker);
+        });
+
+        mocha.it('should list object versions and find delete marker', async function() {
+            const res = await s3_owner.listObjectVersions({ Bucket: BKT1, Prefix: DELETE_MARKER_KEY });
+            const marker = res.DeleteMarkers && res.DeleteMarkers.find(m => m.Key === DELETE_MARKER_KEY);
+            assert.ok(marker);
+        });
+    });
+
+    mocha.describe('extend retention period (governance mode)', function() {
+        const EXTEND_RETENTION_KEY = 'extend-retention-test';
+        let extend_retention_version_id;
+        let longerDate;
+
+        mocha.it('should create object with short retention period', async function() {
+            const shortDate = new Date();
+            shortDate.setDate(shortDate.getDate() + 1);
+
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: EXTEND_RETENTION_KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockMode: 'GOVERNANCE',
+                ObjectLockRetainUntilDate: shortDate
+            });
+            extend_retention_version_id = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should extend retention period to longer date', async function() {
+            longerDate = new Date();
+            longerDate.setDate(longerDate.getDate() + 5);
+
+            const res = await s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: EXTEND_RETENTION_KEY,
+                VersionId: extend_retention_version_id,
+                Retention: {
+                    Mode: 'GOVERNANCE',
+                    RetainUntilDate: longerDate
+                },
+            });
+            delete res.$metadata;
+            assert.deepEqual(res, {});
+        });
+
+        mocha.it('should verify extended retention date', async function() {
+            const res = await s3_owner.getObjectRetention({
+                Bucket: BKT1,
+                Key: EXTEND_RETENTION_KEY,
+                VersionId: extend_retention_version_id
+            });
+            assert.ok(res.Retention.RetainUntilDate);
+            // Compare with second-level precision to avoid ms truncation issues
+            const actual = Math.floor(new Date(res.Retention.RetainUntilDate).getTime() / 1000);
+            const expected = Math.floor(new Date(longerDate).getTime() / 1000);
+            assert.strictEqual(actual, expected);
+        });
+    });
+
+    mocha.describe('legal hold toggle (on/off)', function() {
+        const LEGAL_HOLD_TOGGLE_KEY = 'legal-hold-toggle-test';
+        let legal_hold_toggle_version_id;
+
+        mocha.it('should create object with legal hold ON', async function() {
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: LEGAL_HOLD_TOGGLE_KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockLegalHoldStatus: 'ON'
+            });
+            legal_hold_toggle_version_id = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should verify legal hold is ON', async function() {
+            const res = await s3_owner.getObjectLegalHold({
+                Bucket: BKT1,
+                Key: LEGAL_HOLD_TOGGLE_KEY,
+                VersionId: legal_hold_toggle_version_id
+            });
+            assert.equal(res.LegalHold.Status, 'ON');
+        });
+
+        mocha.it('should verify default retention was not applied', async function() {
+            await assert_throws_async(s3_owner.getObjectRetention({
+                Bucket: BKT1,
+                Key: LEGAL_HOLD_TOGGLE_KEY,
+                VersionId: legal_hold_toggle_version_id
+            }), 'NoSuchObjectLockConfiguration', 'The specified object does not have a ObjectLock configuration');
+        });
+
+        mocha.it('should toggle legal hold to OFF', async function() {
+            const res = await s3_owner.putObjectLegalHold({
+                Bucket: BKT1,
+                Key: LEGAL_HOLD_TOGGLE_KEY,
+                VersionId: legal_hold_toggle_version_id,
+                LegalHold: { Status: 'OFF' }
+            });
+            delete res.$metadata;
+            assert.deepEqual(res, {});
+        });
+
+        mocha.it('should verify legal hold is now OFF', async function() {
+            const res = await s3_owner.getObjectLegalHold({
+                Bucket: BKT1,
+                Key: LEGAL_HOLD_TOGGLE_KEY,
+                VersionId: legal_hold_toggle_version_id
+            });
+            assert.equal(res.LegalHold.Status, 'OFF');
+        });
+
+        mocha.it('should toggle legal hold back to ON', async function() {
+            const res = await s3_owner.putObjectLegalHold({
+                Bucket: BKT1,
+                Key: LEGAL_HOLD_TOGGLE_KEY,
+                VersionId: legal_hold_toggle_version_id,
+                LegalHold: { Status: 'ON' }
+            });
+            delete res.$metadata;
+            assert.deepEqual(res, {});
+        });
+    });
+
+    mocha.describe('list object versions with retention', function() {
+        const LIST_VERSIONS_KEY = 'list-versions-retention-test';
+        let list_versions_id1;
+        let list_versions_id2;
+        let list_versions_id3;
+
+        mocha.it('should create first version without retention', async function() {
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: LIST_VERSIONS_KEY,
+                Body: file_body,
+                ContentType: 'text/plain'
+            });
+            list_versions_id1 = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should create second version with retention', async function() {
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: LIST_VERSIONS_KEY,
+                Body: file_body2,
+                ContentType: 'text/plain',
+                ObjectLockMode: 'GOVERNANCE',
+                ObjectLockRetainUntilDate: tomorrow
+            });
+            list_versions_id2 = res.VersionId;
+            assert.ok(res.VersionId);
+            assert.notEqual(list_versions_id2, list_versions_id1);
+        });
+
+        mocha.it('should create third version with different retention', async function() {
+            const differentDate = new Date();
+            differentDate.setDate(differentDate.getDate() + 30);
+
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: LIST_VERSIONS_KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockMode: 'COMPLIANCE',
+                ObjectLockRetainUntilDate: differentDate
+            });
+            list_versions_id3 = res.VersionId;
+            assert.ok(res.VersionId);
+            assert.notEqual(list_versions_id3, list_versions_id2);
+        });
+
+        mocha.it('should list all versions of the object', async function() {
+            const res = await s3_owner.listObjectVersions({
+                Bucket: BKT1,
+                Prefix: LIST_VERSIONS_KEY
+            });
+            assert.ok(res.Versions);
+            assert(res.Versions.length >= 3);
+            const keys = res.Versions.map(v => v.VersionId);
+            assert(keys.includes(list_versions_id1));
+            assert(keys.includes(list_versions_id2));
+            assert(keys.includes(list_versions_id3));
+        });
+    });
+
+    mocha.describe('compliance mode restrictions', function() {
+        const COMPLIANCE_KEY = 'compliance-mode-test';
+        let compliance_version_id;
+
+        mocha.it('should create object with compliance mode retention', async function() {
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: COMPLIANCE_KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockMode: 'COMPLIANCE',
+                ObjectLockRetainUntilDate: tomorrow
+            });
+            compliance_version_id = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should fail to shorten compliance retention period', async function() {
+            const shorterDate = new Date();
+            shorterDate.setHours(shorterDate.getHours() + 1);
+
+            await assert_throws_async(s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: COMPLIANCE_KEY,
+                VersionId: compliance_version_id,
+                Retention: {
+                    Mode: 'COMPLIANCE',
+                    RetainUntilDate: shorterDate
+                },
+                BypassGovernanceRetention: true
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+        });
+
+        mocha.it('should allow extending compliance retention period', async function() {
+            const longerDate = new Date();
+            longerDate.setDate(longerDate.getDate() + 60);
+
+            const res = await s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: COMPLIANCE_KEY,
+                VersionId: compliance_version_id,
+                Retention: {
+                    Mode: 'COMPLIANCE',
+                    RetainUntilDate: longerDate
+                },
+                BypassGovernanceRetention: true
+            });
+            delete res.$metadata;
+            assert.deepEqual(res, {});
+        });
+
+        mocha.it('should fail to change compliance mode to governance', async function() {
+            const futureDate = new Date();
+            futureDate.setDate(futureDate.getDate() + 30);
+
+            await assert_throws_async(s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: COMPLIANCE_KEY,
+                VersionId: compliance_version_id,
+                Retention: {
+                    Mode: 'GOVERNANCE',
+                    RetainUntilDate: futureDate
+                },
+                BypassGovernanceRetention: true
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+        });
+    });
+
+    mocha.describe('legal hold and retention independence', function() {
+        const INDEPENDENCE_KEY = 'legal-hold-retention-independence-test';
+        let independence_version_id;
+
+        mocha.it('should create object with both legal hold and retention', async function() {
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: INDEPENDENCE_KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockLegalHoldStatus: 'ON',
+                ObjectLockMode: 'GOVERNANCE',
+                ObjectLockRetainUntilDate: tomorrow
+            });
+            independence_version_id = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should remove legal hold while retention still active', async function() {
+            await s3_owner.putObjectLegalHold({
+                Bucket: BKT1,
+                Key: INDEPENDENCE_KEY,
+                VersionId: independence_version_id,
+                LegalHold: { Status: 'OFF' }
+            });
+
+            // Verify legal hold is off but retention is still on
+            const res = await s3_owner.headObject({
+                Bucket: BKT1,
+                Key: INDEPENDENCE_KEY,
+                VersionId: independence_version_id
+            });
+            assert.equal(res.ObjectLockLegalHoldStatus, 'OFF');
+            assert.ok(res.ObjectLockRetainUntilDate);
+        });
+
+        mocha.it('should fail to delete object with active retention even though legal hold is off', async function() {
+            await assert_throws_async(s3_owner.deleteObject({
+                Bucket: BKT1,
+                Key: INDEPENDENCE_KEY,
+                VersionId: independence_version_id,
+                BypassGovernanceRetention: false
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+        });
+    });
+
+    mocha.describe('multipart upload with object lock', function() {
+        const MULTIPART_KEY = 'multipart-upload-lock-test';
+        let uploadId;
+        let part1ETag;
+        let part2ETag;
+        let multipart_version_id;
+
+        mocha.it('should initiate multipart upload', async function() {
+            const res = await s3_owner.createMultipartUpload({
+                Bucket: BKT1,
+                Key: MULTIPART_KEY,
+                ObjectLockMode: 'GOVERNANCE',
+                ObjectLockRetainUntilDate: tomorrow,
+                ObjectLockLegalHoldStatus: 'OFF'
+            });
+            assert.ok(res.UploadId);
+            uploadId = res.UploadId;
+        });
+
+        mocha.it('should upload parts', async function() {
+            const part1 = file_body;
+            const part2 = file_body2;
+
+            const res1 = await s3_owner.uploadPart({
+                Bucket: BKT1,
+                Key: MULTIPART_KEY,
+                UploadId: uploadId,
+                PartNumber: 1,
+                Body: part1
+            });
+            assert.ok(res1.ETag);
+            part1ETag = res1.ETag;
+
+            const res2 = await s3_owner.uploadPart({
+                Bucket: BKT1,
+                Key: MULTIPART_KEY,
+                UploadId: uploadId,
+                PartNumber: 2,
+                Body: part2
+            });
+            assert.ok(res2.ETag);
+            part2ETag = res2.ETag;
+        });
+
+        mocha.it('should complete multipart upload with retention', async function() {
+            const res = await s3_owner.completeMultipartUpload({
+                Bucket: BKT1,
+                Key: MULTIPART_KEY,
+                UploadId: uploadId,
+                MultipartUpload: {
+                    Parts: [
+                        { PartNumber: 1, ETag: part1ETag },
+                        { PartNumber: 2, ETag: part2ETag }
+                    ]
+                }
+            });
+            assert.ok(res.VersionId);
+            multipart_version_id = res.VersionId;
+        });
+
+        mocha.it('should verify completed multipart upload has retention', async function() {
+            const res = await s3_owner.headObject({
+                Bucket: BKT1,
+                Key: MULTIPART_KEY,
+                VersionId: multipart_version_id
+            });
+            assert.ok(res.ObjectLockRetainUntilDate);
+            assert.equal(res.ObjectLockMode, 'GOVERNANCE');
+            assert.equal(res.ObjectLockLegalHoldStatus, 'OFF');
+        });
+    });
+
+    mocha.describe('object lock with different versions', function() {
+        const VERSION_TEST_KEY = 'version-lock-test';
+        let version_test_id1;
+        let version_test_id2;
+        let version_test_id3;
+
+        mocha.it('should create version 1 without lock', async function() {
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: VERSION_TEST_KEY,
+                Body: file_body,
+                ContentType: 'text/plain'
+            });
+            version_test_id1 = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should create version 2 with governance lock', async function() {
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: VERSION_TEST_KEY,
+                Body: file_body2,
+                ContentType: 'text/plain',
+                ObjectLockMode: 'GOVERNANCE',
+                ObjectLockRetainUntilDate: tomorrow
+            });
+            version_test_id2 = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should create version 3 with compliance lock', async function() {
+            const futureDate = new Date();
+            futureDate.setDate(futureDate.getDate() + 30);
+
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: VERSION_TEST_KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockMode: 'COMPLIANCE',
+                ObjectLockRetainUntilDate: futureDate
+            });
+            version_test_id3 = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should allow deleting version 1 (no lock)', async function() {
+            const res = await s3_owner.deleteObject({
+                Bucket: BKT1,
+                Key: VERSION_TEST_KEY,
+                VersionId: version_test_id1
+            });
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should fail to delete version 2 (governance lock)', async function() {
+            await assert_throws_async(s3_owner.deleteObject({
+                Bucket: BKT1,
+                Key: VERSION_TEST_KEY,
+                VersionId: version_test_id2,
+                BypassGovernanceRetention: false
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+        });
+
+        mocha.it('should allow deleting version 2 with bypass governance flag', async function() {
+            const res = await s3_owner.deleteObject({
+                Bucket: BKT1,
+                Key: VERSION_TEST_KEY,
+                VersionId: version_test_id2,
+                BypassGovernanceRetention: true
+            });
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should fail to delete version 3 (compliance lock) even with bypass flag', async function() {
+            await assert_throws_async(s3_owner.deleteObject({
+                Bucket: BKT1,
+                Key: VERSION_TEST_KEY,
+                VersionId: version_test_id3,
+                BypassGovernanceRetention: true
+            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+        });
+    });
+
+    mocha.describe('should put object in a bucket with object lock enabled and no default retention', function() {
+        mocha.it('should create object in bucket', async function() {
+            await s3_owner.putObjectLockConfiguration({
+                Bucket: BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                }
+            });
+            const conf = await s3_owner.putObject({ Bucket: BKT, Key: OBJ1, Body: file_body, ContentType: 'text/plain' });
+            assert.ok(conf.VersionId);
+        });
+
+        mocha.it('should verify no default retention', async function() {
+            await assert_throws_async(s3_owner.getObjectRetention({
+                Bucket: BKT,
+                Key: OBJ1,
+            }), 'NoSuchObjectLockConfiguration', 'The specified object does not have a ObjectLock configuration');
         });
     });
 });

--- a/src/test/integration_tests/nsfs/test_nsfs_concurrency.test.js
+++ b/src/test/integration_tests/nsfs/test_nsfs_concurrency.test.js
@@ -22,6 +22,9 @@ function make_dummy_object_sdk(nsfs_config, uid, gid) {
         abort_controller: new AbortController(),
         throw_if_aborted() {
             if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        },
+        read_bucket_full_info(name) {
+            return {};
         }
     };
 }

--- a/src/test/integration_tests/nsfs/test_versioning_concurrency.test.js
+++ b/src/test/integration_tests/nsfs/test_versioning_concurrency.test.js
@@ -23,6 +23,9 @@ function make_dummy_object_sdk(nsfs_config, uid, gid) {
         abort_controller: new AbortController(),
         throw_if_aborted() {
             if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        },
+        read_bucket_full_info(name) {
+            return {};
         }
     };
 }

--- a/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle.test.js
+++ b/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle.test.js
@@ -41,6 +41,9 @@ function make_dummy_object_sdk() {
         read_bucket_sdk_config_info(name) {
             return undefined;
         },
+        read_bucket_full_info(name) {
+            return {};
+        }
     };
 }
 

--- a/src/test/unit_tests/nsfs/test_namespace_fs.js
+++ b/src/test/unit_tests/nsfs/test_namespace_fs.js
@@ -63,6 +63,9 @@ function make_dummy_object_sdk(config_root) {
                     id: 'dummy-id-123',
                 }
             };
+        },
+        read_bucket_full_info(name) {
+            return {};
         }
     };
 }

--- a/src/test/unit_tests/nsfs/test_namespace_fs_mpu.js
+++ b/src/test/unit_tests/nsfs/test_namespace_fs_mpu.js
@@ -41,6 +41,9 @@ function make_DUMMY_OBJECT_SDK() {
         abort_controller: new AbortController(),
         throw_if_aborted() {
             if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        },
+        read_bucket_full_info(name) {
+            return {};
         }
     };
 }

--- a/src/test/unit_tests/nsfs/test_nsfs_access.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_access.js
@@ -293,6 +293,10 @@ function make_custom_dummy_object_sdk(uid, gid) {
                     id: 'dummy-id-123',
                 }
             };
+        },
+
+        read_bucket_full_info(name) {
+            return {};
         }
     };
 }

--- a/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
@@ -39,6 +39,10 @@ function make_dummy_object_sdk(config_root) {
         read_bucket_sdk_config_info(name) {
             return undefined;
         },
+        read_bucket_full_info(name) {
+            return {};
+        }
+
     };
 }
 

--- a/src/test/unit_tests/nsfs/test_nsfs_versioning.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_versioning.js
@@ -26,6 +26,9 @@ function make_dummy_object_sdk(nsfs_config, uid, gid) {
         abort_controller: new AbortController(),
         throw_if_aborted() {
             if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        },
+        read_bucket_full_info(name) {
+            return {};
         }
     };
 }

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -95,7 +95,7 @@ require('../../unit_tests/util_functions_tests/test_cloud_utils');
 require('../../integration_tests/internal/test_upgrade_scripts.js');
 require('../../integration_tests/internal/test_tiering_ttl_worker');
 // require('./test_tiering_upload');
-//require('./test_s3_worm');
+//require('../../integration_tests/api/s3/test_s3_worm.js');
 require('../../integration_tests/api/s3/test_bucket_logging');
 require('../../integration_tests/api/s3/test_notifications');
 require('../../integration_tests/api/s3/test_chunked_upload');


### PR DESCRIPTION
### Describe the Problem
implement missing object lock functionality

### Explain the Changes
1. implement put object lock when creating new object using the following logic:
    a. if legal_hold or retention flags were specified in the header use the provided values
    b. if the flags were not defined used the default object lock policy in the defined for the bucket
    c. if there are no headers and no default policy don't put any lock
2. check for object lock during delete object version. in case there is a lock and no bypass, throw AcessDenied
3. fix xml parsing for object lock configuration to allow to enable object lock without setting a default policy. also to throw MalformedXml error in case of a malformed policy
4. change put_object_retention to allow to extend the retention time
5. allow to set object lock during create multipart upload
6. enable all tests in `test_s3_worm.js` for nc and add new tests

### Issues: Fixed #xxx / Gap #xxx
1. continuation of #9371 

### Testing Instructions:
1. run `sudo NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/integration_tests/api/s3/test_s3_worm.js`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Object Lock expanded: bucket default lock config exposed; lock settings flow through uploads (including multipart) and are stored with object metadata; enforcement during reads/deletes/versions.

* **Bug Fixes**
  * Validation tightened: retention durations enforce minimums (1 day / 1 year).
  * Improved parsing and error mapping for malformed lock configuration inputs; safer error handling.

* **Tests**
  * Broad new and updated tests covering retention, legal hold, versioning, multipart uploads, and default-bucket behavior.

* **Chores**
  * Minor test comment/reference updates and mock enhancements to support bucket-info reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->