### PR TITLE
Include common directory in RPM docker file

### DIFF
--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -15,6 +15,7 @@ ARG GYP_DEFINES
 # Install GCC11 toolchain on Centos8 to match the default toolchain of Centos9
 RUN if [ "$CENTOS_VER" == "8" ]; then dnf install -y -q gcc-toolset-11; fi
 
+COPY ./src/common ./src/common
 COPY ./src/agent ./src/agent
 COPY ./src/api ./src/api
 COPY ./src/cmd ./src/cmd


### PR DESCRIPTION
### Describe the Problem
The common/constants.js is not included in the DockerFile for RPM builds

### Explain the Changes
1. Include the common directory in the image filesystem.

### Issues: Fixed #xxx / Gap #xxx
1. [DFBUGS-5572](https://issues.redhat.com/browse/DFBUGS-5572)

### Testing Instructions:
1. Run `make RPM`
2. Inspect the rpm file using `rpm -qlp <rpm> | grep src/common`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include additional resources in the build image, improving build process consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->