### PR TITLE
IAM | Upgrade from 4.20 to 4.21 failed when configuring an single account in bucket policy

### DIFF
--- a/src/test/integration_tests/internal/test_upgrade_scripts.js
+++ b/src/test/integration_tests/internal/test_upgrade_scripts.js
@@ -222,6 +222,50 @@ mocha.describe('test upgrade scripts', async function() {
                     Action: ['s3:PutObject'],
                     Resource: [`arn:aws:s3:::*`]
                 },
+                {
+                    Effect: 'Allow',
+                    Principal: {
+                        "AWS": new SensitiveString(iam_username),
+                    },
+                    Action: ['s3:PutObject'],
+                    Resource: [`arn:aws:s3:::*`]
+                },
+                {
+                    Effect: 'Allow',
+                    Principal: {
+                        "AWS": [
+                            '*',
+                            new SensitiveString(iam_username),
+                            new SensitiveString(iam_username)
+                        ],
+                    },
+                    Action: ['s3:PutObject'],
+                    Resource: [`arn:aws:s3:::*`]
+                },
+                {
+                    Effect: 'Allow',
+                    Principal: {
+                        "AWS": '*',
+                    },
+                    Action: ['s3:PutObject'],
+                    Resource: [`arn:aws:s3:::*`]
+                },
+                {
+                    Effect: 'Allow',
+                    Principal: {
+                        "AWS": [new SensitiveString('invalid')],
+                    },
+                    Action: ['s3:PutObject'],
+                    Resource: [`arn:aws:s3:::*`]
+                },
+                {
+                    Effect: 'Allow',
+                    Principal: {
+                        "AWS": new SensitiveString('invalid_second'),
+                    },
+                    Action: ['s3:PutObject'],
+                    Resource: [`arn:aws:s3:::*`]
+                },
             ]
         };
         // clean all leftover bucket policies as upgrade script doesn't work on updated policies 
@@ -273,6 +317,13 @@ mocha.describe('test upgrade scripts', async function() {
 
         assert.strictEqual(new_policy.Statement[0].Principal.AWS[0], `arn:aws:iam::${account._id.toString()}:root`);
         assert.strictEqual(new_policy.Statement[1].Principal.AWS[0], `arn:aws:iam::${iam_account._id.toString()}:user/${iam_account.email.unwrap()}`);
+        assert.strictEqual(new_policy.Statement[2].Principal.AWS, `arn:aws:iam::${iam_account._id.toString()}:user/${iam_account.email.unwrap()}`);
+        assert.strictEqual(new_policy.Statement[3].Principal.AWS[0], '*');
+        assert.strictEqual(new_policy.Statement[3].Principal.AWS[1], `arn:aws:iam::${iam_account._id.toString()}:user/${iam_account.email.unwrap()}`);
+        assert.strictEqual(new_policy.Statement[3].Principal.AWS[2], `arn:aws:iam::${iam_account._id.toString()}:user/${iam_account.email.unwrap()}`);
+        assert.strictEqual(new_policy.Statement[4].Principal.AWS, '*');
+        assert.strictEqual(new_policy.Statement[5].Principal.AWS[0], 'invalid');
+        assert.strictEqual(new_policy.Statement[6].Principal.AWS, 'invalid_second');
     });
 
     mocha.after(async function() {


### PR DESCRIPTION
### Describe the Problem
Upgrade from 4.20 to 4.21 failed when configuring an account in bucket policy prior to upgrade 

### Explain the Changes
1. Previously principals.AWS only upgraded type of array, this code change also consider string type principle.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-5592

### Testing Instructions:
1. On one tab I have docker run -it --rm --network host -v $(pwd):/noobaa -v noobaa_node_modules:/noobaa/node_modules/ -v noobaa_build:/noobaa/build/ -e container=docker -u root noobaa-base bash. Then on the very first install you must do npm ci; npm run build. This will save these assets in a docker volume, whenever you would run the docker command next time, you won't have to do anything, source code is mapped locally so local changes are reflected immediately without any slow image creation.

2. On another tab I have docker run -it --rm -v noobaapg:/var/lib/postgresql --network host -e POSTGRES_PASSWORD=noobaa -e POSTGRES_DB=nbcore postgres:16 .

3. On third tab I simply have docker exec -u postgres -it $(docker ps | awk 'NR>1' | fzf | awk '{print $1}') psql -d nbcore (where I select the pg container - this is fancier you can trim down the command). I keep this tab on to inspect the database post run- the db is called coretest.

4. run ./node_modules/.bin/mocha src/test/integration_tests/internal/test_upgrade_scripts.js in fouth tab.

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket policy upgrade to more reliably resolve IAM principals, preserve wildcard entries, and retain unresolved/invalid principals so access settings are not lost across upgrades.
  * Better handles both single and multiple principal formats to prevent misconfiguration during policy migration.

* **Tests**
  * Updated integration tests to validate expanded policy shapes, wildcard preservation, arrays vs single principals, and handling of unresolved principal values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->