### PR TITLE
[Backport into 5.21] Include common directory in RPM build

### DIFF
--- a/src/deploy/RPM_build/RPM.Dockerfile
+++ b/src/deploy/RPM_build/RPM.Dockerfile
@@ -15,6 +15,7 @@ ARG GYP_DEFINES
 # Install GCC11 toolchain on Centos8 to match the default toolchain of Centos9
 RUN if [ "$CENTOS_VER" == "8" ]; then dnf install -y -q gcc-toolset-11; fi
 
+COPY ./src/common ./src/common
 COPY ./src/agent ./src/agent
 COPY ./src/api ./src/api
 COPY ./src/cmd ./src/cmd


### PR DESCRIPTION
### Explain the Changes
Include the common directory in the RPM build
(cherry picked from commit cf431b72c96ea637dc11ee5926f0e3c5951ed352)

### Issues: Fixed #xxx / Gap #xxx
1. [DFBUGS-5572](https://issues.redhat.com/browse/DFBUGS-5572)

