### PR TITLE
Fixing few issues with sdkv3

### DIFF
--- a/src/sdk/noobaa_s3_client/noobaa_s3_client.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client.js
@@ -53,6 +53,9 @@ function change_s3_client_params_to_v2_structure(params) {
     // v2: s3ForcePathStyle, v3: forcePathStyle
     replace_field(params, 'forcePathStyle', 's3ForcePathStyle');
 
+    // v2: s3DisableBodySigning, v3: applyChecksum
+    replace_field(params, 'applyChecksum', 's3DisableBodySigning');
+
     // v2: sslEnabled, v3: tls
     replace_field(params, 'tls', 'sslEnabled');
 

--- a/src/test/unit_tests/internal/test_noobaa_s3_client.test.js
+++ b/src/test/unit_tests/internal/test_noobaa_s3_client.test.js
@@ -85,18 +85,27 @@ describe('noobaa_s3_client change_s3_client_params_to_v2_structure', () => {
         expect(params.bucketEndpoint).toBeUndefined();
     });
 
-        it('v2: httpOptions, v3: requestHandler', () => {
-            const params = {
-                endpoint: 'http://127.0.0.1:8080',
-                requestHandler: new NodeHttpHandler({
-                    httpAgent: new Agent({
-                        /*Agent params*/
-                    }),
-                })
-            };
-            noobaa_s3_client.change_s3_client_params_to_v2_structure(params);
-            expect(params).toHaveProperty('httpOptions');
-            expect(params.requestHandler).toBeUndefined();
-        });
+    it('v2: httpOptions, v3: requestHandler', () => {
+        const params = {
+            endpoint: 'http://127.0.0.1:8080',
+            requestHandler: new NodeHttpHandler({
+                httpAgent: new Agent({
+                    /*Agent params*/
+                }),
+            })
+        };
+        noobaa_s3_client.change_s3_client_params_to_v2_structure(params);
+        expect(params).toHaveProperty('httpOptions');
+        expect(params.requestHandler).toBeUndefined();
+    });
+
+    it('v2: s3DisableBodySigning, v3: applyChecksum', () => {
+        const params = {
+            applyChecksum: false,
+        };
+        noobaa_s3_client.change_s3_client_params_to_v2_structure(params);
+        expect(params.s3DisableBodySigning).toBe(false);
+        expect(params.applyChecksum).toBeUndefined();
+    });
 
 });

--- a/src/tools/s3cat.js
+++ b/src/tools/s3cat.js
@@ -40,6 +40,7 @@ async function main() {
         s3BucketEndpoint: argv.vhost || false,
         signatureVersion: argv.sig, // s3 or v4
         computeChecksums: argv.checksum || false, // disabled by default for performance
+        // IMPORTANT - we had issues with applyChecksum - when migrating to sdkv3 check if works as expected.
         s3DisableBodySigning: !argv.signing || true, // disabled by default for performance
         region: argv.region || 'us-east-1',
     });

--- a/src/tools/s3perf.js
+++ b/src/tools/s3perf.js
@@ -95,6 +95,7 @@ const s3 = new AWS.S3({
     s3ForcePathStyle: true,
     signatureVersion: argv.sig, // s3 or v4
     computeChecksums: argv.checksum || false, // disabled by default for performance
+    // IMPORTANT - we had issues with applyChecksum - when migrating to sdkv3 check if works as expected.
     s3DisableBodySigning: !argv.signing || true, // disabled by default for performance
     region: argv.region || 'us-east-1',
 });

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -76,6 +76,7 @@ function get_signed_url(params, expiry = 604800, custom_operation = 'getObject')
         s3ForcePathStyle: true,
         sslEnabled: false,
         signatureVersion: get_s3_endpoint_signature_ver(params.endpoint),
+        // IMPORATANT - we had issues with applyChecksum - when migrating to sdkv3 check if this option is needed.
         s3DisableBodySigning: disable_s3_compatible_bodysigning(params.endpoint),
         region: params.region || config.DEFAULT_REGION,
         httpOptions: {


### PR DESCRIPTION
### Describe the Problem
The main issue here is we can't just set s3DisableBodySigning to false in sdkv3. 
Setting his replacement applyChecksum - will stop calculating the checksum and will leave x-amz-content-sha256
to be empty and not UNSIGNED-PAYLOAD like it was in sdkv2.
So if we do want to set applyChecksum to false - we will need to patch this headr ourselves like this:
```
params.applyChecksum = cloud_utils.disable_s3_compatible_bodysigning(endpoint);
const client = noobaa_s3_client.get_s3_client_v3_params(params);
client.middlewareStack.add(
  (next) => (args) => {
    // Only add if missing to avoid double-hashing
    if (!args.request.headers["x-amz-content-sha256"]) {
      args.request.headers["x-amz-content-sha256"] = "UNSIGNED-PAYLOAD";
    }
    return next(args);
  },
  { step: "build" }
);
```
So, we won't use it as the default for now

### Explain the Changes
1. Fixed the main issue - removing applyChecksum
2. returning the signatureVersion part - for cases we will revert to sdkv2
3. fixing putObject in blockstore_s3 to use empty string instead of undefined: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutObjectCommand/
4. Adding an auto translate from applyChecksum to s3DisableBodySigning for sdkv2, which was missing. 

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://issues.redhat.com/browse/DFBUGS-4461
2. Opened an issue with AWS SDK about this issue: https://github.com/aws/aws-sdk-js-v3/issues/7740

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 signature version handling for better compatibility with various storage endpoints.
  * Corrected checksum/body-signing mapping for non-AWS endpoints and ensured consistent behavior when metadata is disabled.

* **Tests**
  * Added unit test verifying body-signing/applyChecksum mapping between client parameter formats.

* **Chores**
  * Clarifying comments added around S3 client options to aid future SDK migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->