### PR TITLE
Make node-rdkafka required dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "morgan": "1.10.1",
         "nan": "2.24.0",
         "node-addon-api": "8.5.0",
+        "node-rdkafka": "3.6.1",
         "performance-now": "2.1.0",
         "pg": "8.17.1",
         "ping": "1.0.0",
@@ -83,9 +84,6 @@
         "pkg-fetch": "3.5.2",
         "sinon": "21.0.1",
         "wtfnode": "0.10.1"
-      },
-      "optionalDependencies": {
-        "node-rdkafka": "3.6.1"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -9858,7 +9856,6 @@
       "integrity": "sha512-sfpTbrT35429cs0RE8Yb9avGX9BiRRvpV7aweQsghKTjtrVZP3jBrKOPItWXAqHb8doyh3SkuGuUVBLgig1SRg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bindings": "^1.3.1",
         "nan": "^2.24.0"

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "morgan": "1.10.1",
     "nan": "2.24.0",
     "node-addon-api": "8.5.0",
+    "node-rdkafka": "3.6.1",
     "performance-now": "2.1.0",
     "pg": "8.17.1",
     "ping": "1.0.0",
@@ -123,9 +124,6 @@
     "yaml": "2.8.2",
     "yauzl": "3.2.0",
     "yazl": "3.3.1"
-  },
-  "optionalDependencies": {
-    "node-rdkafka": "3.6.1"
   },
   "devDependencies": {
     "@aws-sdk/client-iam": "3.971.0",

--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -18,13 +18,6 @@ RUN npm install --omit=dev && \
     rm -rf node_modules/node-rdkafka/deps/librdkafka/examples/ && \
     rm -rf node_modules/node-rdkafka/deps/librdkafka/src/
 
-# Build time check that rdkafka was installed by npm in the image.
-# It was added to optionalDependencies because it's not available 
-# on all platforms, so we check explicitly.
-RUN if [ "$USE_RDKAFKA" = "1" ]; then \
-        node -p 'require("node-rdkafka").librdkafkaVersion'; \
-    fi
-
 ##############################################################
 # Layers:
 #   Title: Building the native code

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -4,8 +4,7 @@
 const dbg = require('../util/debug_module')(__filename);
 const config = require('../../config');
 const { PersistentLogger } = require('../util/persistent_logger');
-const { require_optional } = require('../util/js_utils');
-const Kafka = require_optional('node-rdkafka');
+const Kafka = require('node-rdkafka');
 const os = require('os');
 const fs = require('fs');
 const http = require('http');


### PR DESCRIPTION
### Describe the Problem
Downstream builds ignore `optionalDependency` which means new downstream noobaa-core images do not contain node-rdkafka.

### Explain the Changes
This PR makes `node-rdkafka` dependency required.

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/DFBUGS-5554

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made the Kafka client a required dependency instead of optional.
  * Removed the prior build-time validation step for the Kafka client.
  * The Kafka client is now initialized at application startup; this ensures it’s consistently available but may cause startup failures if the native Kafka library is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->