### PR TITLE
Added lifecycle-configuration-rules in bucket SDK cache for x-amz-expiration header

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1214,6 +1214,9 @@ module.exports = {
                 website: {
                     $ref: 'common_api#/definitions/bucket_website'
                 },
+                lifecycle_configuration_rules: {
+                    $ref: 'common_api#/definitions/bucket_lifecycle_configuration'
+                },
                 namespace: {
                     type: 'object',
                     required: [

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -244,6 +244,11 @@ class ObjectSDK {
         }
     }
 
+    async read_bucket_sdk_lifecycle_rules(name) {
+        const { bucket } = await bucket_namespace_cache.get_with_cache({ sdk: this, name });
+        return bucket?.lifecycle_configuration_rules;
+    }
+
     async load_requesting_account(req) {
         try {
             const token = this.get_auth_token();

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -769,6 +769,7 @@ async function read_bucket_sdk_info(req) {
         cors_configuration_rules: bucket.cors_configuration_rules,
         public_access_block: bucket.public_access_block,
     };
+    if (Array.isArray(bucket.lifecycle_configuration_rules)) reply.lifecycle_configuration_rules = bucket.lifecycle_configuration_rules;
 
     if (bucket.namespace) {
         reply.namespace = {

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -745,7 +745,11 @@ function set_amz_headers(req, res) {
 async function set_expiration_header(req, res, object_info) {
     if (!config.S3_LIFECYCLE_EXPIRATION_HEADER_ENABLED) return;
 
-    const rules = req.params.bucket && await req.object_sdk.get_bucket_lifecycle_configuration_rules({ name: req.params.bucket });
+    const bucket_name = req.params?.bucket;
+    if (!bucket_name) return;
+
+    const rules = await req.object_sdk.read_bucket_sdk_lifecycle_rules(bucket_name);
+    if (!Array.isArray(rules) || !rules.length) return;
 
     const matched_rule = lifecycle_utils.get_lifecycle_rule_for_object(rules, object_info);
     if (matched_rule) {


### PR DESCRIPTION
### Describe the Problem
`set_expiration_header()` was loading bucket lifecycle rules on every GET/HEAD/PUT, which is expensive on NC/NSFS (it re-reads bucket config), for small objects this is noticeable and should be avoided.

### Explain the Changes
1. `set_expiration_header()` now fetches lifecycle rules via object_sdk.read_bucket_sdk_lifecycle_rules(), which uses the existing bucket SDK cache and returns early when no rules exist.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed: #9418
2.  Related PR: #8958 

### Testing Instructions:
1.  Tests not required, its a small fix and the tests were already added in the above mentioned related PR.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bucket info now exposes lifecycle configuration rules so clients can view lifecycle settings.
  * Added API to retrieve bucket lifecycle rules for use when evaluating expirations.

* **Bug Fixes**
  * Tightened validation for expiration header processing to avoid setting headers without matching rules.
  * Improved handling when lifecycle rules are missing, empty, or invalid to ensure consistent responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->