### PR TITLE
NC | lifecycle - modify test lock_check times

### DIFF
--- a/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
@@ -115,7 +115,8 @@ describe('noobaa nc - lifecycle - lock check', () => {
         const lifecyle_run_date = new Date();
         lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() - 1);
         await config_fs.create_config_json_file(JSON.stringify({
-            NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date)
+            NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date),
+            NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS: 5
         }));
         const res = await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', config_root }, undefined, undefined);
         await config_fs.delete_config_json_file();
@@ -124,9 +125,9 @@ describe('noobaa nc - lifecycle - lock check', () => {
         expect(parsed_res.message).toBe(ManageCLIResponse.LifecycleSuccessful.message);
     });
 
-    it('nc lifecycle - change run time to 1 minute in the future - should fail ', async () => {
+    it('nc lifecycle - change run time to 10 minute in the future - should fail ', async () => {
         const lifecyle_run_date = new Date();
-        lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() + 1);
+        lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() + 10);
         await config_fs.create_config_json_file(JSON.stringify({
             NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date)
         }));


### PR DESCRIPTION
### Describe the Problem
CI tests can occasionally run slower than expected, causing lifecycle execution to start more than one minute later than the configured NC_LIFECYCLE_RUN_TIME.
As a result, time-sensitive lifecycle lock tests may intermittently fail in CI due to timing drift rather than functional issues.

### Explain the Changes
1. Increase the allowed delay window to tolerate lifecycle execution starting up to one minute after `NC_LIFECYCLE_RUN_TIME`.
2. Update `lifecycle_run_date` to be set 10 minutes in the future (instead of 1 minute) to better accommodate potential CI delays before lifecycle execution begins.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated lifecycle integration test configurations and timing parameters to ensure proper test execution and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->