### PR TITLE
STS | Azure Identity flow support in Namespacestore

### DIFF
--- a/config.js
+++ b/config.js
@@ -512,7 +512,7 @@ config.STATISTICS_COLLECTOR_EXPIRATION = 31 * 24 * 60 * 60 * 1000; // 1 month
 ///////////////////
 // USAGE REPORTS //
 ///////////////////
-config.SERVICES_TYPES = Object.freeze(['AWS', 'AWSSTS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'IBM_COS']);
+config.SERVICES_TYPES = Object.freeze(['AWS', 'AWSSTS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'IBM_COS']);
 config.USAGE_AGGREGATOR_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
 
 config.BLOCK_STORE_USAGE_INTERVAL = 1 * 60 * 1000; // 1 minute

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -175,7 +175,7 @@ module.exports = {
                     properties: {
                         service: {
                             type: 'string',
-                            enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                         },
                         read_count: {
                             type: 'integer'

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -627,6 +627,9 @@ module.exports = {
                 region: {
                     type: 'string'
                 },
+                azure_sts_credentials: {
+                    $ref: 'common_api#/definitions/azure_sts_credentials'
+                },
             }
         },
 

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -17,6 +17,7 @@ const invalid_azure_md_regex = /[^a-zA-Z0-9_]/g;
 const invalid_azure_tag_regex = /[^a-zA-Z0-9 +-.:=_/]/g;
 const XATTR_RENAME_PREFIX = 'rename_';
 const XATTR_RENAME_KEY_PREFIX = 'rename_key_';
+const cloud_utils = require('../util/cloud_utils');
 
 /**
  * @implements {nb.Namespace}
@@ -31,6 +32,10 @@ class NamespaceBlob {
      *      account_name: string,
      *      account_key: string,
      *      access_mode: string,
+     *      endpoint: string,
+     *      endpoint_type: string,
+     *      azure_client_id: string,
+     *      azure_tenant_id: string,
      *      stats: import('./endpoint_stats_collector').EndpointStatsCollector,
      * }} params
      */
@@ -41,14 +46,24 @@ class NamespaceBlob {
         account_name,
         account_key,
         access_mode,
+        endpoint,
+        endpoint_type,
+        azure_client_id,
+        azure_tenant_id,
         stats,
     }) {
         this.namespace_resource_id = namespace_resource_id;
         this.connection_string = connection_string;
         this.container = container;
-        this.blob = azure_storage.BlobServiceClient.fromConnectionString(connection_string);
         this.account_name = account_name;
         this.account_key = account_key;
+        this.blob = cloud_utils.create_azure_blob_client({
+            endpoint: endpoint,
+            connection_string: this.connection_string,
+            access_key: this.account_name,
+            azure_client_id: azure_client_id,
+            azure_tenant_id: azure_tenant_id,
+        });
         this.container_client = azure_storage.get_container_client(this.blob, this.container);
         this.access_mode = access_mode;
         this.stats = stats;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -483,7 +483,7 @@ class ObjectSDK {
                 stats: this.stats,
             });
         }
-        if (r.endpoint_type === 'AZURE') {
+        if (r.endpoint_type === 'AZURE' || r.endpoint_type === 'AZURESTS') {
             return new NamespaceBlob({
                 namespace_resource_id: r.id,
                 container: r.target_bucket,
@@ -492,6 +492,10 @@ class ObjectSDK {
                 account_name: r.access_key.unwrap(),
                 account_key: r.secret_key.unwrap(),
                 access_mode: r.access_mode,
+                endpoint: r.endpoint,
+                endpoint_type: r.endpoint_type,
+                azure_client_id: r.azure_sts_credentials?.azure_client_id?.unwrap(),
+                azure_tenant_id: r.azure_sts_credentials?.azure_tenant_id?.unwrap(),
                 stats: this.stats,
             });
         }

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -4,7 +4,6 @@
 const system_store = require('../system_services/system_store').get_instance();
 //TODO: why do we what to use the wrap and not directly @google-cloud/storage ? 
 const GoogleCloudStorage = require('../../util/google_storage_wrap');
-const azure_storage = require('../../util/azure_storage_wrap');
 const auth_server = require('../common_services/auth_server');
 const dbg = require('../../util/debug_module')(__filename);
 const system_utils = require('../utils/system_utils');
@@ -66,7 +65,7 @@ class NamespaceMonitor {
                     await this.test_nsfs_resource(nsr);
                 } else if (['AWS', 'AWSSTS', 'S3_COMPATIBLE', 'IBM_COS'].includes(endpoint_type)) {
                     await this.test_s3_resource(nsr);
-                } else if (endpoint_type === 'AZURE') {
+                } else if (['AZURE', 'AZURESTS' ].includes(endpoint_type)) {
                     await this.test_blob_resource(nsr);
                 } else if (endpoint_type === 'GOOGLE') {
                     await this.test_gcs_resource(nsr);
@@ -157,11 +156,17 @@ class NamespaceMonitor {
         if (!conn) {
             const { endpoint, access_key, secret_key } = nsr.connection;
             const conn_string = cloud_utils.get_azure_new_connection_string({
-                endpoint,
-                access_key: access_key,
-                secret_key: secret_key
+                        endpoint,
+                        access_key: access_key,
+                        secret_key: secret_key
+                    });
+            conn = cloud_utils.create_azure_blob_client({
+                endpoint: nsr.connection.endpoint,
+                connection_string: conn_string,
+                access_key: nsr.connection.access_key,
+                azure_client_id: nsr.connection.azure_sts_credentials?.azure_client_id.unwrap(),
+                azure_tenant_id: nsr.connection.azure_sts_credentials?.azure_tenant_id.unwrap(),
             });
-            conn = azure_storage.BlobServiceClient.fromConnectionString(conn_string);
             if (conn) this.nsr_connections_obj[nsr._id] = conn;
         }
         const { target_bucket } = nsr.connection;

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -298,7 +298,13 @@ async function create_namespace_resource(req) {
                 azure_logs_analytics_workspace_id: connection.azure_log_access_keys.azure_logs_analytics_workspace_id
             };
         }
-
+        let azure_sts_credentials;
+        if (connection.azure_sts_credentials) {
+            azure_sts_credentials = {
+                azure_tenant_id: connection.azure_sts_credentials.azure_tenant_id,
+                azure_client_id: connection.azure_sts_credentials.azure_client_id,
+        };
+        }
         namespace_resource = new_namespace_resource_defaults(name, req.system._id, req.account._id, _.omitBy({
             aws_sts_arn: connection.aws_sts_arn,
             endpoint: connection.endpoint,
@@ -310,6 +316,7 @@ async function create_namespace_resource(req) {
             endpoint_type: connection.endpoint_type || 'AWS',
             region: connection.region,
             azure_log_access_keys,
+            azure_sts_credentials
         }, _.isUndefined), undefined, req.rpc_params.access_mode);
 
         const cloud_buckets = await server_rpc.client.bucket.get_cloud_buckets({
@@ -1158,6 +1165,7 @@ function get_namespace_resource_extended_info(namespace_resource) {
         secret_key: namespace_resource.connection.secret_key,
         access_mode: namespace_resource.access_mode,
         aws_sts_arn: namespace_resource.connection.aws_sts_arn || undefined,
+        azure_sts_credentials: namespace_resource.connection.azure_sts_credentials || undefined,
     };
     const nsfs_info = namespace_resource.nsfs_config && {
         fs_root_path: namespace_resource.nsfs_config.fs_root_path,

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -86,7 +86,9 @@ module.exports = {
                     aws_sts_arn: {
                         type: 'string'
                     },
-                   azure_sts_credentials: {$ref: 'common_api#/definitions/azure_sts_credentials' },
+                    azure_sts_credentials: {
+                        $ref: 'common_api#/definitions/azure_sts_credentials'
+                    },
                     auth_method: {
                         type: 'string',
                         enum: ['AWS_V2', 'AWS_V4']

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -35,7 +35,7 @@ module.exports = {
                 },
                 endpoint_type: {
                     type: 'string',
-                    enum: ['AWSSTS', 'AWS', 'AZURE', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                    enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                 },
                 auth_method: {
                     type: 'string',
@@ -55,7 +55,10 @@ module.exports = {
                 azure_log_access_keys: { $ref: 'common_api#/definitions/azure_log_access_keys' },
                 cp_code: {
                     type: 'string'
-                }
+                },
+                azure_sts_credentials: {
+                    $ref: 'common_api#/definitions/azure_sts_credentials'
+                },
             }
         },
         nsfs_config: {

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -298,6 +298,7 @@ async function get_partial_providers_stats(req) {
         'AWS',
         'AWSSTS',
         'AZURE',
+        'AZURESTS',
         'S3_COMPATIBLE',
         'GOOGLE',
     ];


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. Update namespace resourse schema to include Azure STS creds
2. Update object I/O flow to validate the Azure STS for namespacestore based buckets
3. 

### Issues: Fixed #xxx / Gap #xxx
1. https://issues.redhat.com/browse/RHSTOR-8534

### Testing Instructions:

### Testing Instructions:
1. OPENID_BUCKET_URL=https://{storageaccountname}.blob.core.windows.net/{blob_name}
2. minikube start --extra-config=apiserver.service-account-issuer=${OPENID_BUCKET_URL}
3.  Create signed public and private key for OIDC JWT validation
minikube ssh sudo cat /var/lib/minikube/certs/sa.pub > sa-signer.pubBuild an OIDC configuration
4. https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_aws_sts_setup_on_minikube.md#build-an-oidc-configuration: Do steps 7 and 8
5. Upload to OIDC container and make the container publicaly available.
6. Created managed Identity(same resource group as storage)
    1. Add Kubernates Federated credentials, 
    2. Cluster Issuer URL is OIDC file stored container path(here `https://{storageaccountname}.blob.core.windows.net/oidc-azure-sts`)
7. Give access to created managed identity
Storage account -> IAM -> Grant access to this resource -> 
    1. select Storage Account Contributor and Storage Blob Data Contributor ->
    2. Managed identity -> Select previously created managed Identity
8. kubectl edit sa default:   azure.workload.identity/client-id: {client id of managed identity }
9. Create nginx pod
10. WEB_IDENTITY_TOKEN=$(kubectl exec nginx -- cat /var/run/secrets/tokens/oidc-token)

 Now have the web identity token, and this token is valid for already created managed identity
We will be mouth this token inside our operator and core pods in path `/var/run/secrets/openshift/serviceaccount`
10. Create a configmap `bound-sa-token-config`
```
 kind: ConfigMap
apiVersion: v1
metadata:
  name: bound-sa-token-config
  namespace: {ns}
data:
  token: eyJhbGciOi****bTpn7fLImykDez8Q
```
11. Mount this configMap in `/var/run/secrets/openshift/serviceaccount` instead of `serviceAccountToken` for both operator and core

```
volumes:
- name: bound-sa-token-from-config
        configMap:
          name: bound-sa-token-config
          items:
          - key: token
            path: token
          optional: true
```

```
volumeMounts:
    - name: bound-sa-token-from-config
      mountPath: /var/run/secrets/openshift/serviceaccount
      readOnly: true
```

Now default and other backingstores will use the token from `bound-sa-token-config` for webIdentity validation.
12. Create NS using YAML file verify NS is `ready` state
```
apiVersion: noobaa.io/v1alpha1
kind: NamespaceStore
metadata:
  finalizers:
  - noobaa.io/finalizer
  name: <>
  namespace: <>
spec:
  azureBlob:
    secret:
      name: <>
      namespace: <>
    targetBlobContainer: <>
    clientId: <>
  type: azure-blob
```


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Azure STS as a new cloud service/endpoint type.
  * Enabled Azure STS credential handling (client ID and tenant ID) for namespace configuration and blob access.
  * Exposed Azure STS credential info in namespace metadata and relevant API responses.
  * Updated monitoring and stats to recognize and treat Azure STS endpoints alongside existing Azure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->