### PR TITLE
change defalut http server listen ip from 0.0.0.0 to nodes default configuration

### DIFF
--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -958,7 +958,7 @@ function listen_port(port, server, server_type) {
         if (server_type !== 'METRICS' && server_type !== 'FORK_HEALTH') {
             setup_endpoint_server(server);
         }
-        const local_ip = process.env.LOCAL_IP || '0.0.0.0';
+        const local_ip = process.env.LOCAL_IP || undefined;
         server.listen(port, local_ip, err => {
             if (err) {
                 dbg.error('ENDPOINT FAILED to listen', err);


### PR DESCRIPTION
### Describe the Problem
The default address used for HTTP servers was 0.0.0.0. This does not work in IPv6-only environments because 0.0.0.0 accepts only IPv4 connections and does not support IPv6.

### Explain the Changes
According to the Node.js documentation, when no host is provided:

`If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.` see https://nodejs.org/api/net.html#serverlisten

To align with this behavior, this change passes undefined when no IP address is explicitly provided.
In IPv6-enabled environments, Node.js will bind to ::, which supports both IPv6 and IPv4 connections.
In IPv4-only environments, Node.js will fall back to 0.0.0.0.
This ensures compatibility across IPv4-only and IPv6-only environments without requiring explicit configuration.

this is how we used to do it. changed to default to 0.0.0.0 as part of #9438 

### Issues: Fixed https://issues.redhat.com/browse/DFBUGS-5765
1. 

### Testing Instructions:
1. deploy noobaa on ipv6 only environment
2. noobaa endpoint pod should load properly no startup errors 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the default network interface binding for HTTP/HTTPS endpoints. The server will now allow the operating system to select the appropriate interface instead of binding to all interfaces by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->