### PR TITLE
NC | disable dynamic supplemental groups by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -853,7 +853,7 @@ config.NSFS_EXIT_EVENTS_TIME_FRAME_MIN = 24 * 60; // per day
 config.NSFS_MAX_EXIT_EVENTS_PER_TIME_FRAME = 10; // allow max 10 failed forks per day
 
 config.GPFS_DL_PATH = '/usr/lpp/mmfs/lib/libgpfs.so';
-config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = 'true';
+config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = false;
 
 config.NSFS_GLACIER_LOGS_DIR = '/var/run/noobaa-nsfs/wal';
 config.NSFS_GLACIER_LOGS_POLL_INTERVAL = 10 * 1000;

--- a/src/test/unit_tests/nsfs/test_nsfs_access.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_access.js
@@ -153,9 +153,37 @@ mocha.describe('new tests check', async function() {
     });
 
     mocha.it('NON ROOT 4 with dynamicly allocated suplemental groups - success', async function() {
-        //non root4 has non-root1 group as supplemental group, so it should succeed
-        const non_root_entries = await nb_native().fs.readdir(NON_ROOT4_FS_CONFIG, full_path_non_root1);
-        assert.equal(non_root_entries && non_root_entries.length, 0);
+        const saved = process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+        try {
+            process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = 'true';
+            //non root4 has non-root1 group as supplemental group, so it should succeed
+            const non_root_entries = await nb_native().fs.readdir(NON_ROOT4_FS_CONFIG, full_path_non_root1);
+            assert.equal(non_root_entries && non_root_entries.length, 0);
+        } finally {
+            if (saved === undefined) {
+                delete process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+            } else {
+                process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = saved;
+            }
+        }
+    });
+
+    mocha.it('NON ROOT 4 with default dynamic supplemental groups (false) - failure', async function() {
+        const saved = process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+        try {
+            process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = 'false';
+            //non root4 has non-root1 group as supplemental group, but it should fail because dynamic supplemental groups are disabled
+            const non_root_entries = await nb_native().fs.readdir(NON_ROOT4_FS_CONFIG, full_path_non_root1);
+            assert.fail(`non root 4 has access to a folder created by user with gid not in supplemental groups - ${p} ${non_root_entries}`);
+        } catch (err) {
+            assert.equal(err.code, 'EACCES');
+        } finally {
+            if (saved === undefined) {
+                delete process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+            } else {
+                process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = saved;
+            }
+        }
     });
 
     mocha.it('NON ROOT 4 with dynamicly allocated suplemental groups that dont contains the files gid - failure', async function() {


### PR DESCRIPTION
### Describe the Problem
dynamic supplemental groups causes a serious performance drop on nsfs systems. disable it by default
see #9459 

### Explain the Changes
1. set NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS to `false`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled dynamic supplemental groups by changing the public configuration flag from a string to boolean false.
* **Tests**
  * Updated unit tests to cover both enabled and disabled scenarios, temporarily enable the flag for specific success paths, add a failing-case when disabled, and ensure the original configuration is reliably restored after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->