### PR TITLE
Endpoint TLS configurations support

### DIFF
--- a/config.js
+++ b/config.js
@@ -78,6 +78,18 @@ config.VECTOR_SERVICE_CERT_PATH = '/etc/vector-secret';
 config.MGMT_SERVICE_CERT_PATH = '/etc/mgmt-secret';
 config.EXTERNAL_DB_SERVICE_CERT_PATH = '/etc/external-db-secret';
 
+// add noobaa-mgmt or others in the future if needed ?
+config.TLS_CONFIGURABLE_SERVERS = [
+    'S3',
+    'STS',
+    'IAM',
+    'METRICS',
+    'VECTOR'
+];
+config.TLS_MIN_VERSION = process.env.TLS_MIN_VERSION || '';
+config.TLS_CIPHERS = process.env.TLS_CIPHERS || '';
+config.TLS_CURVES = process.env.TLS_CURVES || '';
+
 /////////////////
 // LDAP CONFIG //
 /////////////////

--- a/src/test/unit_tests/util_functions_tests/test_ssl_utils.js
+++ b/src/test/unit_tests/util_functions_tests/test_ssl_utils.js
@@ -1,13 +1,13 @@
 /* Copyright (C) 2016 NooBaa */
+/* eslint-disable max-lines-per-function */
 'use strict';
 
-// const _ = require('lodash');
-// const tls = require('tls');
 const mocha = require('mocha');
 const assert = require('assert');
 const https = require('https');
+const tls = require('tls');
 
-// const P = require('../../util/promise');
+const config = require('../../../../config');
 const ssl_utils = require('../../../util/ssl_utils');
 const nb_native = require('../../../util/nb_native');
 
@@ -182,4 +182,295 @@ mocha.describe('ssl_utils', function() {
         }
     }
 
+    mocha.describe('apply_tls_config', function() {
+
+        const saved_min_version = config.TLS_MIN_VERSION;
+        const saved_ciphers = config.TLS_CIPHERS;
+        const saved_curves = config.TLS_CURVES;
+        const saved_enabled_services = config.TLS_CONFIGURABLE_SERVERS;
+
+        mocha.beforeEach(function() {
+            config.TLS_MIN_VERSION = '';
+            config.TLS_CIPHERS = '';
+            config.TLS_CURVES = '';
+            config.TLS_CONFIGURABLE_SERVERS = ['S3', 'STS', 'IAM'];
+        });
+
+        mocha.afterEach(function() {
+            config.TLS_MIN_VERSION = saved_min_version;
+            config.TLS_CIPHERS = saved_ciphers;
+            config.TLS_CURVES = saved_curves;
+            config.TLS_CONFIGURABLE_SERVERS = saved_enabled_services;
+        });
+
+        mocha.it('should not modify options when config is empty', function() {
+            const options = { key: 'k', cert: 'c' };
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = { minVersion: undefined, ciphers: undefined, ecdhCurve: undefined };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+        });
+
+        mocha.it('should not modify options when config values are undefined', function() {
+            config.TLS_MIN_VERSION = undefined;
+            config.TLS_CIPHERS = undefined;
+            config.TLS_CURVES = undefined;
+            const options = { key: 'k', cert: 'c' };
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = { minVersion: undefined, ciphers: undefined, ecdhCurve: undefined };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+        });
+
+        mocha.it('should set minVersion TLSv1.2', function() {
+            config.TLS_MIN_VERSION = 'TLSv1.2';
+            const options = {};
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = {
+                minVersion: config.TLS_MIN_VERSION,
+                ciphers: undefined,
+                ecdhCurve: undefined
+            };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+        });
+
+        mocha.it('should set minVersion TLSv1.3', function() {
+            config.TLS_MIN_VERSION = 'TLSv1.3';
+            const options = {};
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = {
+                minVersion: config.TLS_MIN_VERSION,
+                ciphers: undefined,
+                ecdhCurve: undefined
+            };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+
+        });
+
+        mocha.it('should set a single cipher', function() {
+            config.TLS_CIPHERS = 'TLS_AES_256_GCM_SHA384';
+            const options = {};
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = {
+                minVersion: undefined,
+                ciphers: config.TLS_CIPHERS,
+                ecdhCurve: undefined
+            };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+        });
+
+        mocha.it('should set multiple ciphers', function() {
+            config.TLS_CIPHERS = 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384';
+            const options = {};
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = {
+                minVersion: undefined,
+                ciphers: config.TLS_CIPHERS,
+                ecdhCurve: undefined
+            };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+
+        });
+
+        mocha.it('should set a single ecdhCurve', function() {
+            config.TLS_CURVES = 'P-256';
+            const options = {};
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = {
+                minVersion: undefined,
+                ciphers: undefined,
+                ecdhCurve: config.TLS_CURVES
+            };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+        });
+
+        mocha.it('should set multiple ecdhCurves', function() {
+            config.TLS_CURVES = 'X25519:P-256:P-384';
+            const options = {};
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = {
+                minVersion: undefined,
+                ciphers: undefined,
+                ecdhCurve: config.TLS_CURVES
+            };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+        });
+
+        mocha.it('should set ecdhCurve as-is including PQC curve names', function() {
+            config.TLS_CURVES = 'X25519MLKEM768:X25519:P-256';
+            const options = {};
+            ssl_utils.apply_tls_config(options, 'S3');
+            const expected_configurable_tls_config = {
+                minVersion: undefined,
+                ciphers: undefined,
+                ecdhCurve: config.TLS_CURVES
+            };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+        });
+
+        mocha.it('should set all TLS options together', function() {
+            config.TLS_MIN_VERSION = 'TLSv1.2';
+            config.TLS_CIPHERS = 'ECDHE-RSA-AES128-GCM-SHA256';
+            config.TLS_CURVES = 'X25519:P-256:X25519MLKEM768';
+            const s3_options = {};
+            ssl_utils.apply_tls_config(s3_options, 'S3');
+            const sts_options = {};
+            ssl_utils.apply_tls_config(sts_options, 'STS');
+            const iam_options = {};
+            ssl_utils.apply_tls_config(iam_options, 'IAM');
+
+            const expected_configurable_tls_config = {
+                minVersion: config.TLS_MIN_VERSION,
+                ciphers: config.TLS_CIPHERS,
+                ecdhCurve: config.TLS_CURVES
+            };
+            validate_configurable_tls_option_fields(s3_options, expected_configurable_tls_config);
+            validate_configurable_tls_option_fields(sts_options, expected_configurable_tls_config);
+            validate_configurable_tls_option_fields(iam_options, expected_configurable_tls_config);
+        });
+
+        mocha.it('should preserve existing ssl_options properties', function() {
+            config.TLS_MIN_VERSION = 'TLSv1.3';
+            config.TLS_CIPHERS = 'TLS_AES_128_GCM_SHA256';
+            config.TLS_CURVES = 'X25519';
+            const options = { key: 'my-key', cert: 'my-cert', honorCipherOrder: true };
+            ssl_utils.apply_tls_config(options, 'S3');
+            assert.strictEqual(options.key, 'my-key');
+            assert.strictEqual(options.cert, 'my-cert');
+            assert.strictEqual(options.honorCipherOrder, true);
+            const expected_configurable_tls_config = {
+                minVersion: config.TLS_MIN_VERSION,
+                ciphers: config.TLS_CIPHERS,
+                ecdhCurve: config.TLS_CURVES
+            };
+            validate_configurable_tls_option_fields(options, expected_configurable_tls_config);
+
+        });
+
+        mocha.it('should skip TLS config for non-enabled service (MGMT)', function() {
+            config.TLS_MIN_VERSION = 'TLSv1.3';
+            const options = {};
+            ssl_utils.apply_tls_config(options, 'MGMT');
+            assert.strictEqual(options.minVersion, undefined);
+        });
+    });
+
+    mocha.describe('create_https_server with TLS config', function() {
+
+        const saved_min_version = config.TLS_MIN_VERSION;
+        const saved_ciphers = config.TLS_CIPHERS;
+        const saved_curves = config.TLS_CURVES;
+
+        mocha.beforeEach(function() {
+            config.TLS_MIN_VERSION = '';
+            config.TLS_CIPHERS = '';
+            config.TLS_CURVES = '';
+        });
+
+        mocha.afterEach(function() {
+            config.TLS_MIN_VERSION = saved_min_version;
+            config.TLS_CIPHERS = saved_ciphers;
+            config.TLS_CURVES = saved_curves;
+        });
+
+        async function create_tls_server_and_connect(client_options, cert_options) {
+            const ssl_cert = nb_native().x509({ dns: 'localhost', ...cert_options });
+            const server = await ssl_utils.create_https_server(
+                { cert: ssl_cert }, true, (req, res) => res.end('ok'), 'S3'
+            );
+            try {
+                await new Promise((resolve, reject) => {
+                    server.on('error', reject);
+                    server.listen(resolve);
+                });
+                const { port } = server.address();
+                return await new Promise((resolve, reject) => {
+                    const req = https.request({
+                        method: 'GET',
+                        port,
+                        ca: ssl_cert.cert,
+                        rejectUnauthorized: true,
+                        timeout: 1000,
+                        ...client_options,
+                    });
+                    req.on('error', reject);
+                    req.on('response', res => {
+                        resolve({
+                            protocol: res.socket.getProtocol(),
+                            cipher: res.socket.getCipher(),
+                            ephemeral: res.socket.getEphemeralKeyInfo(),
+                        });
+                        res.on('data', d => d);
+                        res.on('end', resolve);
+                    });
+                    req.end();
+                });
+            } finally {
+                server.close();
+            }
+        }
+
+        mocha.it('should negotiate TLS 1.3 when minVersion is TLSv1.3', async function() {
+            if (tls.DEFAULT_MAX_VERSION !== 'TLSv1.3') return;
+            config.TLS_MIN_VERSION = 'TLSv1.3';
+            const result = await create_tls_server_and_connect({ minVersion: 'TLSv1.3' });
+            assert.strictEqual(result.protocol, 'TLSv1.3');
+        });
+
+        mocha.it('should reject TLS 1.2 client when server minimum is TLS 1.3', async function() {
+            if (tls.DEFAULT_MAX_VERSION !== 'TLSv1.3') return;
+            config.TLS_MIN_VERSION = 'TLSv1.3';
+            await assert.rejects(
+                () => create_tls_server_and_connect({ maxVersion: 'TLSv1.2' }),
+                /TLSV1_ALERT_PROTOCOL_VERSION|ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION|tlsv1 alert protocol version|handshake failure/i
+            );
+        });
+
+        mocha.it('should enforce specific cipher suite', async function() {
+            config.TLS_CIPHERS = 'ECDHE-RSA-AES128-GCM-SHA256';
+            const result = await create_tls_server_and_connect({ maxVersion: 'TLSv1.2' });
+            assert.strictEqual(result.cipher.name, 'ECDHE-RSA-AES128-GCM-SHA256');
+        });
+
+        mocha.it('should enforce ecdhCurve P-256', async function() {
+            config.TLS_CURVES = 'P-256';
+            const result = await create_tls_server_and_connect({});
+            console.log('Negotiated cipher:', result);
+            assert.strictEqual(result.ephemeral.type, 'ECDH');
+            assert.strictEqual(result.ephemeral.name, 'prime256v1');
+        });
+
+        /*TODO - re-enable once node supports KEM ephermal keys in tls.getEphemeralKeyInfo() - see
+        https://nodejs.org/api/tls.html#tlssocketgetephemeralkeyinfo
+        mocha.it('should enforce ecdhCurve X25519MLKEM768', async function() {
+            config.TLS_CURVES = 'X25519MLKEM768';
+            const result = await create_tls_server_and_connect({});
+            assert.strictEqual(result.protocol, 'TLSv1.3');
+            console.log('Negotiated cipher:', result);
+            if (result.ephemeral.type) {
+                assert.strictEqual(result.ephemeral.type, 'KEM');
+                assert.strictEqual(result.ephemeral.name, 'x25519mlkem768');
+            }
+        });*/
+
+        mocha.it('should enforce all TLS options combined', async function() {
+            if (tls.DEFAULT_MAX_VERSION !== 'TLSv1.3') return;
+            config.TLS_MIN_VERSION = 'TLSv1.3';
+            config.TLS_CIPHERS = 'TLS_AES_256_GCM_SHA384';
+            config.TLS_CURVES = 'X25519';
+            const result = await create_tls_server_and_connect({ minVersion: 'TLSv1.3' });
+            assert.strictEqual(result.protocol, 'TLSv1.3');
+            assert.strictEqual(result.cipher.name, 'TLS_AES_256_GCM_SHA384');
+        });
+    });
+
 });
+
+/**
+ * validate_configurable_tls_option_fields is a helper function to validate that the actual TLS config options match the expected TLS config options.
+ * @param {*} actual_tls_config 
+ * @param {*} expected_tls_config 
+ */
+function validate_configurable_tls_option_fields(actual_tls_config, expected_tls_config) {
+    assert.strictEqual(actual_tls_config.minVersion, expected_tls_config.minVersion);
+    assert.strictEqual(actual_tls_config.ciphers, expected_tls_config.ciphers);
+    assert.strictEqual(actual_tls_config.ecdhCurve, expected_tls_config.ecdhCurve);
+}

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -918,11 +918,12 @@ function http_server_connections_logger(conn) {
  */
 async function start_https_server(https_port, server_type, request_handler, nsfs_config_root) {
     const ssl_cert_info = await ssl_utils.get_ssl_cert_info(server_type, nsfs_config_root);
-    const https_server = await ssl_utils.create_https_server(ssl_cert_info, true, request_handler);
+    const https_server = await ssl_utils.create_https_server(ssl_cert_info, true, request_handler, server_type);
     https_server.on('connection', http_server_connections_logger);
     ssl_cert_info.on('update', updated_ssl_cert_info => {
         dbg.log0(`Setting updated ${server_type} ssl certs for endpoint.`);
         const updated_ssl_options = { ...updated_ssl_cert_info.cert, honorCipherOrder: true };
+        ssl_utils.apply_tls_config(updated_ssl_options, server_type);
         https_server.setSecureContext(updated_ssl_options);
     });
     dbg.log0(`Starting ${server_type} server on HTTPS port ${https_port}`);

--- a/src/util/ssl_utils.js
+++ b/src/util/ssl_utils.js
@@ -169,9 +169,28 @@ function run_https_test_server() {
 }
 
 // An internal function to prevent code duplication
-async function create_https_server(ssl_cert_info, honorCipherOrder, endpoint_handler) {
+async function create_https_server(ssl_cert_info, honorCipherOrder, endpoint_handler, service) {
     const ssl_options = { ...ssl_cert_info.cert, honorCipherOrder: honorCipherOrder };
+    apply_tls_config(ssl_options, service);
+    dbg.log0(`Creating HTTPS server for service ${service} with TLS options: minVersion=${ssl_options.minVersion} ciphers=${ssl_options.ciphers} ecdhCurve=${ssl_options.ecdhCurve}`);
     return https.createServer(ssl_options, endpoint_handler);
+}
+
+function apply_tls_config(ssl_options, service) {
+    if (!service || !config.TLS_CONFIGURABLE_SERVERS.includes(service)) {
+        dbg.log0(`TLS config skipped for service ${service} (not in TLS_CONFIGURABLE_SERVERS)`);
+        return;
+    }
+    dbg.log0(`Updating TLS config for service ${service} config.TLS_MIN_VERSION=${config.TLS_MIN_VERSION}, config.TLS_CIPHERS=${config.TLS_CIPHERS} config.TLS_CURVES=${config.TLS_CURVES}`);
+    if (config.TLS_MIN_VERSION) {
+        ssl_options.minVersion = config.TLS_MIN_VERSION;
+    }
+    if (config.TLS_CIPHERS) {
+        ssl_options.ciphers = config.TLS_CIPHERS;
+    }
+    if (config.TLS_CURVES) {
+        ssl_options.ecdhCurve = config.TLS_CURVES;
+    }
 }
 
 exports.generate_ssl_certificate = generate_ssl_certificate;
@@ -180,5 +199,6 @@ exports.get_ssl_cert_info = get_ssl_cert_info;
 exports.is_using_generated_certs = is_using_generated_certs;
 exports.get_cert_dir = get_cert_dir;
 exports.create_https_server = create_https_server;
+exports.apply_tls_config = apply_tls_config;
 
 if (require.main === module) run_https_test_server();


### PR DESCRIPTION
### Describe the Problem
Currently, NooBaa uses default TLS min_version, ciphers and curve_preferences, we would like to have it configurable.

### Explain the Changes
1. The following PR applies TLS configurations for S3, IAM and STS servers only. This is the noobaa-core PR that handles the actual creation of the server while allowing admin to change the following TLS configurations - 
1. TLS_MIN_VERSION
2. TLS_CIPHERS
3. TLS_CURVES

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-service TLS controls for S3, STS, IAM, METRICS, and VECTOR: configurable minimum TLS version, cipher suites, and key-exchange curves via environment/settings; applied when starting or updating HTTPS servers and preserves pre-existing TLS options.
* **Tests**
  * Added coverage validating TLS negotiation (version, ciphers, curves), enforcement of minimum versions/ciphers, preservation of existing options, and skipping of non-enabled services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->