### PR TITLE
node-ip removal - Phase 6

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -7,7 +7,6 @@ const path = require('path');
 const http = require('http');
 const https = require('https');
 const assert = require('assert');
-const ip_module = require('ip');
 const os = require('os');
 const util = require('util');
 
@@ -747,7 +746,7 @@ class Agent {
             return res.info.address;
         }
 
-        const ip = ip_module.address();
+        const ip = net_utils.get_local_address();
         dbg.log0(`get_node_ip: using fallback node ip`, ip);
         return ip;
     }

--- a/src/rpc/ice.js
+++ b/src/rpc/ice.js
@@ -14,7 +14,6 @@ const util = require('util');
 const crypto = require('crypto');
 const chance = require('chance')();
 const events = require('events');
-const ip_module = require('ip');
 
 const dbg = require('../util/debug_module')(__filename);
 const stun = require('./stun');
@@ -146,7 +145,7 @@ function Ice(connid, n2n_config, signal_target) {
             n.ifcname = name;
             self.networks.push(n);
             // for the nodes internal ip - add public_ips as another network interface. take same parameters as internal ip
-            if (n.address === ip_module.address() &&
+            if (n.address === net_utils.get_local_address() &&
                 self.config.public_ips.length) {
                 self.config.public_ips.forEach(ip => {
                     if (ip === n.address) return;

--- a/src/server/system_services/system_server.js
+++ b/src/server/system_services/system_server.js
@@ -5,7 +5,6 @@ require('../../util/dotenv').load();
 
 const _ = require('lodash');
 const net = require('net');
-const ip_module = require('ip');
 const moment = require('moment');
 const util = require('util');
 
@@ -18,6 +17,7 @@ const cutil = require('../utils/clustering_utils');
 const config = require('../../../config');
 const { BucketStatsStore } = require('../analytic_services/bucket_stats_store');
 const { EndpointStatsStore } = require('../analytic_services/endpoint_stats_store');
+const net_utils = require('../../util/net_utils');
 const os_utils = require('../../util/os_utils');
 const { RpcError, RPC_BUFFERS } = require('../../rpc');
 const nb_native = require('../../util/nb_native');
@@ -537,7 +537,7 @@ async function read_system(req) {
             (bucket.storage_stats && bucket.storage_stats.objects_count) || 0
         );
     });
-    const ip_address = ip_module.address();
+    const ip_address = net_utils.get_local_address();
     const n2n_config = system.n2n_config;
     const debug_time = system.debug_mode ?
         Math.max(0, config.DEBUG_MODE_PERIOD - (Date.now() - system.debug_mode)) :

--- a/src/test/unit_tests/util_functions_tests/test_net_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_net_utils.test.js
@@ -5,6 +5,10 @@ const os = require('os');
 const net_utils = require('../../../util/net_utils');
 
 describe('IP Utils', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it('is_ip should correctly identify IP addresses', () => {
         expect(net_utils.is_ip('192.168.1.1')).toBe(true);
         expect(net_utils.is_ip('::1')).toBe(true);
@@ -55,18 +59,63 @@ describe('IP Utils', () => {
     });
 
     it('find_ifc_containing_address should find interface containing the address', () => {
-        const networkInterfacesMock = {
+        const networkInterfacesMock = /** @type {ReturnType<typeof os.networkInterfaces>} */ ({
             eth0: [
-                { family: 'IPv4', cidr: '192.168.1.0/24', address: '192.168.1.2' },
-                { family: 'IPv6', cidr: 'fe80::/64', address: 'fe80::1' },
+                { family: 'IPv4', cidr: '192.168.1.0/24', address: '192.168.1.2', netmask: '255.255.255.0', mac: '00:00:00:00:00:00', internal: false },
+                { family: 'IPv6', cidr: 'fe80::/64', address: 'fe80::1', netmask: 'ffff:ffff:ffff:ffff::', mac: '00:00:00:00:00:00', internal: false, scopeid: 0 },
             ],
-            lo: [{ family: 'IPv4', cidr: '127.0.0.0/8', address: '127.0.0.1' }],
-        };
-        jest.spyOn(os, 'networkInterfaces').mockReturnValue(networkInterfacesMock);
+            lo: [{ family: 'IPv4', cidr: '127.0.0.0/8', address: '127.0.0.1', netmask: '255.0.0.0', mac: '00:00:00:00:00:00', internal: true }],
+        });
+        jest.spyOn(os, 'networkInterfaces').mockReturnValue(/** @type {ReturnType<typeof os.networkInterfaces>} */ (/** @type {unknown} */ (networkInterfacesMock)));
 
         expect(net_utils.find_ifc_containing_address('192.168.1.5')).toEqual({ ifc: 'eth0', info: networkInterfacesMock.eth0[0] });
         expect(net_utils.find_ifc_containing_address('127.0.0.1')).toEqual({ ifc: 'lo', info: networkInterfacesMock.lo[0] });
         expect(net_utils.find_ifc_containing_address('8.8.8.8')).toBeUndefined();
+    });
+
+    it('get_local_address should return the first non-internal IPv4 address', () => {
+        const networkInterfacesMock = /** @type {ReturnType<typeof os.networkInterfaces>} */ (/** @type {unknown} */ ({
+            lo: [{ family: 'IPv4', address: '127.0.0.1', netmask: '255.0.0.0', mac: '00:00:00:00:00:00', internal: true }],
+            eth0: [
+                { family: 'IPv4', address: '192.168.1.10', netmask: '255.255.255.0', mac: '00:00:00:00:00:00', internal: false },
+                { family: 'IPv6', address: 'fe80::1', netmask: 'ffff:ffff:ffff:ffff::', mac: '00:00:00:00:00:00', internal: false, scopeid: 0 },
+            ],
+        }));
+        jest.spyOn(os, 'networkInterfaces').mockReturnValue(networkInterfacesMock);
+        expect(net_utils.get_local_address()).toBe('192.168.1.10');
+    });
+
+    it('get_local_address should skip internal interfaces and return first external IPv4', () => {
+        const networkInterfacesMock = /** @type {ReturnType<typeof os.networkInterfaces>} */ (/** @type {unknown} */ ({
+            lo: [{ family: 'IPv4', address: '127.0.0.1', netmask: '255.0.0.0', mac: '00:00:00:00:00:00', internal: true }],
+            eth1: [{ family: 'IPv4', address: '10.0.0.5', netmask: '255.0.0.0', mac: '00:00:00:00:00:00', internal: false }],
+        }));
+        jest.spyOn(os, 'networkInterfaces').mockReturnValue(networkInterfacesMock);
+        expect(net_utils.get_local_address()).toBe('10.0.0.5');
+    });
+
+    it('get_local_address should return 127.0.0.1 when no non-internal IPv4 interface exists', () => {
+        const networkInterfacesMock = /** @type {ReturnType<typeof os.networkInterfaces>} */ (/** @type {unknown} */ ({
+            lo: [{ family: 'IPv4', address: '127.0.0.1', netmask: '255.0.0.0', mac: '00:00:00:00:00:00', internal: true }],
+            eth0: [{ family: 'IPv6', address: 'fe80::1', netmask: 'ffff:ffff:ffff:ffff::', mac: '00:00:00:00:00:00', internal: false, scopeid: 0 }],
+        }));
+        jest.spyOn(os, 'networkInterfaces').mockReturnValue(networkInterfacesMock);
+        expect(net_utils.get_local_address()).toBe('127.0.0.1');
+    });
+
+    it('get_local_address should return 127.0.0.1 when networkInterfaces returns empty', () => {
+        jest.spyOn(os, 'networkInterfaces').mockReturnValue({});
+        expect(net_utils.get_local_address()).toBe('127.0.0.1');
+    });
+
+    it('get_local_address should return first external IPv4 when multiple interfaces exist', () => {
+        const networkInterfacesMock = /** @type {ReturnType<typeof os.networkInterfaces>} */ (/** @type {unknown} */ ({
+            eth1: [{ family: 'IPv4', address: '10.0.0.2', netmask: '255.0.0.0', mac: '00:00:00:00:00:00', internal: false }],
+            eth0: [{ family: 'IPv4', address: '192.168.1.1', netmask: '255.255.255.0', mac: '00:00:00:00:00:00', internal: false }],
+        }));
+        jest.spyOn(os, 'networkInterfaces').mockReturnValue(networkInterfacesMock);
+        const result = net_utils.get_local_address();
+        expect(['10.0.0.2', '192.168.1.1']).toContain(result);
     });
 
     it('ip_toString should convert buffers to IP strings', () => {
@@ -104,7 +153,7 @@ describe('IP Utils', () => {
             Buffer.from([32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
         );
         expect(() => net_utils.ip_toBuffer('invalid_ip', Buffer.alloc(16), 0)).toThrow('Invalid IP address: invalid_ip');
-        expect(() => net_utils.ip_toBuffer('10.0.0.1')).toThrow('Offset is required');
+        expect(() => net_utils.ip_toBuffer('10.0.0.1', Buffer.alloc(4), undefined)).toThrow('Offset is required');
     });
 
     it('normalize_family should return the proper family', () => {

--- a/src/util/addr_utils.js
+++ b/src/util/addr_utils.js
@@ -1,8 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const ip_module = require('ip');
 const url = require('url');
+const net_utils = require('./net_utils');
 const { construct_url } = require('./url_utils');
 
 const default_base_port = parseInt(process.env.SSL_PORT, 10) || 5443;
@@ -60,8 +60,8 @@ function get_base_address(address_list, options = {}) {
     }
 
     if (hint === 'SERVER_IP') {
-        // ip_module.address() returns loopback if no iterface is active.
-        const hostname = ip_module.address();
+        // get_local_address() returns loopback if no interface is active.
+        const hostname = net_utils.get_local_address();
         const port = default_port;
         return construct_url({ protocol, hostname, port });
     }

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -265,6 +265,23 @@ function is_ip(address) {
     return net.isIPv4(address) || net.isIPv6(address);
 }
 
+/**
+ * get_local_address will return the first non-internal IPv4 address of the machine.
+ * returns loopback if no external interface is found.
+ * @returns {string}
+ */
+function get_local_address() {
+    const ifaces = os.networkInterfaces();
+    for (const address of Object.values(ifaces)) {
+        for (const info of address) {
+            if (info.family === 'IPv4' && !info.internal) {
+                return info.address;
+            }
+        }
+    }
+    return '127.0.0.1';
+}
+
 function find_ifc_containing_address(address) {
     const family =
         (net.isIPv4(address) && 'IPv4') ||
@@ -332,6 +349,7 @@ exports.ip_toString = ip_toString;
 exports.ip_toBuffer = ip_toBuffer;
 exports.ip_to_long = ip_to_long;
 exports.find_ifc_containing_address = find_ifc_containing_address;
+exports.get_local_address = get_local_address;
 exports.is_equal = is_equal;
 
 /// EXPORTS FOR TESTING:


### PR DESCRIPTION
### Explain the Changes
node-ip removal - Phase 6

- Adding `get_local_address`
- Replacing `ip_module.address()` with `net_utils.get_local_address()`
- Adding tests to `test_net_utils.test.js`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized local IP resolution across the app for more consistent network interface handling and reliable host address selection.

* **Tests**
  * Expanded and hardened tests for IP/address utilities, covering multiple interface scenarios and fallback behavior to ensure stable local-address resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->