### PR TITLE
Fixes for S3A Hadoop tests gh action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,10 @@ MINT_NOOBAA_HTTP_ENDPOINT_PORT=6001
 # HADOOP S3A VARIABLES #
 #######################
 
-HADOOP_S3A_IMAGE?="maven:3.9.6-eclipse-temurin-11"
+# HADOOP_S3A_IMAGE?="maven:3.9.6-eclipse-temurin-11"
+HADOOP_S3A_IMAGE?="quay.io/noobaa/s3a-tester:v1"
 HADOOP_S3A_ENDPOINT_PORT?=6001
+HADOOP_S3A_NC_CONTAINER:=noobaa-s3a-$(GIT_COMMIT)
 HADOOP_S3A_SCRIPT?="$(REPO_ROOT)/src/test/external_tests/hadoop_s3a_tests/run_hadoop_s3a_tests.sh"
 
 ###############
@@ -385,10 +387,10 @@ run-nc-tests: tester
 hadoop-s3a-nc-tests: tester
 	@$(call create_docker_network)
 	@echo "\033[1;34mRunning Hadoop S3A NC tests\033[0m"
-	@$(call run_nc_endpoint)
-	@$(call wait_nc_endpoint)
+	@$(call run_s3a_nc_endpoint)
+	@$(call wait_s3a_nc_endpoint)
 	@$(call run_hadoop_s3a_tests)
-	@$(call stop_nc_endpoint)
+	@$(call stop_s3a_nc_endpoint)
 	@$(call remove_docker_network)
 .PHONY: hadoop-s3a-nc-tests
 
@@ -569,8 +571,8 @@ endef
 
 define run_s3a_nc_endpoint
 	@echo "\033[1;34mStarting NC endpoint container\033[0m"
-	$(CONTAINER_ENGINE) rm -f noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) >/dev/null 2>&1 || true
-	$(CONTAINER_ENGINE) run -d --name noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) --network noobaa-net \
+	$(CONTAINER_ENGINE) rm -f $(HADOOP_S3A_NC_CONTAINER) >/dev/null 2>&1 || true
+	$(CONTAINER_ENGINE) run -d --name $(HADOOP_S3A_NC_CONTAINER) --network noobaa-net \
 		--network-alias noobaa-s3a \
 		--privileged --user root $(TESTER_TAG) \
 		bash -c "./src/test/external_tests/hadoop_s3a_tests/run_s3a_on_test_container.sh; tail -f /dev/null"
@@ -579,26 +581,26 @@ endef
 
 define stop_s3a_nc_endpoint
 	@echo "\033[1;34mStopping NC endpoint container\033[0m"
-	$(CONTAINER_ENGINE) rm -f noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) >/dev/null 2>&1 || true
+	$(CONTAINER_ENGINE) rm -f $(HADOOP_S3A_NC_CONTAINER) >/dev/null 2>&1 || true
 	@echo "\033[1;32mNC endpoint container removed.\033[0m"
 endef
 
-define wait_nc_endpoint
+define wait_s3a_nc_endpoint
 	@echo "\033[1;34mWaiting for NC endpoint to be ready\033[0m"
-	@set -euo pipefail; \
+	@set -eu; \
 	for _ in $$(seq 1 60); do \
-		if $(CONTAINER_ENGINE) exec noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) bash -lc "nc -z localhost $(HADOOP_S3A_ENDPOINT_PORT)"; then \
+		if $(CONTAINER_ENGINE) exec $(HADOOP_S3A_NC_CONTAINER) bash -lc "nc -z localhost $(HADOOP_S3A_ENDPOINT_PORT)"; then \
 			exit 0; \
 		fi; \
 		sleep 2; \
 	done; \
 	echo "NooBaa endpoint did not start in time" >&2; \
-	$(CONTAINER_ENGINE) logs noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) || true; \
+	$(CONTAINER_ENGINE) logs $(HADOOP_S3A_NC_CONTAINER) || true; \
 	exit 1
 endef
 
 define run_hadoop_s3a_tests
-	@set -euo pipefail; \
+	@set -eu; \
 	test -f $(HADOOP_S3A_SCRIPT); \
 	set +e; \
 	$(CONTAINER_ENGINE) run --rm --network noobaa-net \
@@ -610,7 +612,7 @@ define run_hadoop_s3a_tests
 	set -e; \
 	if [ "$${status}" -ne 0 ]; then \
 		echo "\033[1;31mHadoop S3A tests failed (exit $${status}).\033[0m"; \
-		$(CONTAINER_ENGINE) logs noobaa_$(GIT_COMMIT)_$(NAME_POSTFIX) || true; \
+		$(CONTAINER_ENGINE) logs $(HADOOP_S3A_NC_CONTAINER) || true; \
 	fi; \
 	exit "$${status}"
 endef

--- a/src/deploy/NVA_build/S3ATester.Dockerfile
+++ b/src/deploy/NVA_build/S3ATester.Dockerfile
@@ -1,0 +1,20 @@
+# This Dockerfile contains the image specification of the Hadoop S3A NC tester
+# It is based on the maven image, and it clones the hadoop repository and pre-downloads the dependencies of the hadoop-aws module.
+# This Dockerfile images will be stored in Quay.io under quay.io/noobaa/s3a-tester and used in the CI pipeline of the S3A NC tester.
+FROM maven:3.9.6-eclipse-temurin-11
+
+# Install git to pull the source
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# 1. Clone only the specific tag (shallow clone to save space/time)
+RUN git clone --depth 1 --branch rel/release-3.3.6 https://github.com/apache/hadoop.git .
+
+# 2. Pre-download the "Big" AWS JAR and S3A dependencies
+# This layer is cached unless you change this command
+RUN mvn dependency:go-offline -pl :hadoop-aws -am
+
+# Default to the AWS tool directory
+WORKDIR /app/hadoop-tools/hadoop-aws
+CMD ["/bin/bash"]

--- a/src/test/external_tests/hadoop_s3a_tests/run_hadoop_s3a_tests.sh
+++ b/src/test/external_tests/hadoop_s3a_tests/run_hadoop_s3a_tests.sh
@@ -5,14 +5,15 @@ set -euo pipefail
 
 AWS_ACCESS_KEY_ID="hadoopS3aAccessKey01"
 AWS_SECRET_ACCESS_KEY="hadoopS3aSecretKey0000000000000000000000"
-HADOOP_S3A_BRANCH="rel/release-3.3.6"
 HADOOP_S3A_BUCKET="s3a-test"
 
-apt-get update -y
-apt-get install -y git
-git clone --depth 1 --branch "${HADOOP_S3A_BRANCH}" https://github.com/apache/hadoop.git /tmp/hadoop
-mkdir -p /tmp/hadoop/hadoop-tools/hadoop-aws/src/test/resources
-cat <<EOF > /tmp/hadoop/hadoop-tools/hadoop-aws/src/test/resources/auth-keys.xml
+# As downloading the hadoop repository and pre-downloading the dependencies takes a long time, we do it in a separate step in the Dockerfile, and then we just run the tests in this script.
+# This way, we can take advantage of Docker caching and avoid re-downloading the dependencies every time we want to run the tests.
+# apt-get update -y
+# apt-get install -y git
+# git clone --depth 1 --branch "${HADOOP_S3A_BRANCH}" https://github.com/apache/hadoop.git /tmp/hadoop
+# mkdir -p /tmp/hadoop/hadoop-tools/hadoop-aws/src/test/resources
+cat <<EOF > src/test/resources/auth-keys.xml
 <configuration>
   <property>
     <name>fs.s3a.endpoint</name>
@@ -62,9 +63,35 @@ cat <<EOF > /tmp/hadoop/hadoop-tools/hadoop-aws/src/test/resources/auth-keys.xml
     <name>test.fs.s3a.encryption.enabled</name>
     <value>false</value>
   </property>
+   <property>
+    <name>test.fs.s3a.create.storage.class.enabled</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>test.fs.s3a.sts.enabled</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>test.fs.s3a.create.acl.enabled</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>test.fs.s3a.performance.enabled</name>
+    <value>false</value>
+  </property>
+  <!--
+   If the store reports errors when trying to list/abort completed multipart uploads,
+   expect failures in ITestUploadRecovery and ITestS3AContractMultipartUploader.
+   The tests can be reconfigured to expect failure.
+   Note how this can be set as a per-bucket option.
+  -->
+  <property>
+    <name>fs.s3a.ext.test.multipart.commit.consumes.upload.id</name>
+    <value>true</value>
+  </property>
 </configuration>
 EOF
 
-cd /tmp/hadoop
-echo "Running: mvn -pl hadoop-tools/hadoop-aws -DskipTests=false -DskipITs=false -Dit.test=ITestS3A* -Dtest=TestS3A* verify"
-mvn -pl hadoop-tools/hadoop-aws -DskipTests=false -DskipITs=false -Dit.test=ITestS3A* -Dtest=TestS3A* verify
+EXCLUDED_ITESTS="${EXCLUDED_ITESTS:-ITestS3AContractMultipartUploader}" # TODO: remove exclusion after CI resource fix
+echo "Running: mvn -pl :hadoop-aws -am -DskipTests=false -DskipITs=false -Dit.test='ITestS3A*,!${EXCLUDED_ITESTS}' -Dtest=TestS3A* verify"
+mvn -pl :hadoop-aws -am -DskipTests=false -DskipITs=false "-Dit.test=ITestS3A*,!${EXCLUDED_ITESTS}" -Dtest=TestS3A* verify


### PR DESCRIPTION
### Describe the Problem
GitHub Actions have very weak runners, so I had to add some more fixes to make the action run in an acceptable time

### Explain the Changes
1. perbuilt s3a-tester image - so we won't need to re-download the test dependencies for hours for every run. the image is now in quay.io -  quay.io/jalbo/s3a-tester:latest
2. Skipping this test ITestS3AContractMultipartUploader - as it hangs due to very low resources for the run
3. Added some fixes of naming conventions 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized NC container naming and improved lifecycle handling for consistent start/stop/wait behavior and clearer logs.
  * Switched to a purpose-built S3A tester image and moved Hadoop dependency setup into that image to speed and stabilize test runs.
  * Updated test scripts and XML config, added new S3A test properties and an exclusion mechanism to streamline which tests execute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->