### PR TITLE
NC | fix anonymous user delete test

### DIFF
--- a/src/test/integration_tests/nc/cli/test_nc_account_cli.test.js
+++ b/src/test/integration_tests/nc/cli/test_nc_account_cli.test.js
@@ -1783,24 +1783,6 @@ describe('manage nsfs cli account flow', () => {
             expect(JSON.parse(res.stdout).error.code).toBe(ManageCLIError.AccountDeleteForbiddenHasIAMAccounts.code);
         });
 
-        it('should fail when deleting anonymous account with option (name), and succeed with option (anonymous)', async function() {
-            const { type } = defaults;
-            const user = 'test-user';
-            const account_options1 = { user: user };
-            const command = create_command(type, ACTIONS.ADD, account_options1);
-            const flag = ANONYMOUS;
-            await exec_manage_cli_add_empty_option(command, flag);
-
-            const account_options2 = { name: ANONYMOUS };
-            const res = await exec_manage_cli(type, ACTIONS.DELETE, account_options2);
-            expect(JSON.parse(res.stdout).error.message).toBe(ManageCLIError.InvalidAccountName.message);
-
-            const command2 = create_command(type, ACTIONS.DELETE);
-            const res2 = await exec_manage_cli_add_empty_option(command2, flag);
-            const res_json = JSON.parse(res2.trim());
-            expect(res_json.response.code).toBe(ManageCLIResponse.AccountDeleted.code);
-        });
-
     });
 
     describe('cli status account', () => {

--- a/src/test/integration_tests/nc/cli/test_nc_anonymous_cli.test.js
+++ b/src/test/integration_tests/nc/cli/test_nc_anonymous_cli.test.js
@@ -9,7 +9,7 @@ const os_util = require('../../../../util/os_utils');
 const fs_utils = require('../../../../util/fs_utils');
 const { ConfigFS } = require('../../../../sdk/config_fs');
 const { TMP_PATH, set_nc_config_dir_in_config } = require('../../../system_tests/test_utils');
-const { TYPES, ACTIONS } = require('../../../../manage_nsfs/manage_nsfs_constants');
+const { TYPES, ACTIONS, ANONYMOUS } = require('../../../../manage_nsfs/manage_nsfs_constants');
 const ManageCLIError = require('../../../../manage_nsfs/manage_nsfs_cli_errors').ManageCLIError;
 const ManageCLIResponse = require('../../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
 
@@ -270,22 +270,33 @@ describe('manage nsfs cli anonymous account flow', () => {
             await fs_utils.create_fresh_path(root_path);
             set_nc_config_dir_in_config(config_root);
             config.NSFS_NC_CONF_DIR = config_root;
-        });
 
-        beforeAll(async () => {
-            await fs_utils.folder_delete(`${config_root}`);
-            await fs_utils.folder_delete(`${root_path}`);
-        });
-
-        it('cli delete anonymous account', async () => {
-            let action = ACTIONS.ADD;
+            //create the anonymous account
+            const action = ACTIONS.ADD;
             const { type, uid, gid, anonymous } = defaults;
             const account_options = { anonymous, config_root, uid, gid };
             await exec_manage_cli(type, action, account_options);
             const account = await config_fs.get_account_by_name(config.ANONYMOUS_ACCOUNT_NAME);
             assert_account(account, account_options);
 
-            action = ACTIONS.DELETE;
+        });
+
+        afterAll(async () => {
+            await fs_utils.folder_delete(`${config_root}`);
+            await fs_utils.folder_delete(`${root_path}`);
+        });
+
+        it('should fail - cli delete anonymous account with "anonymous" name', async () => {
+            const action = ACTIONS.DELETE;
+            const { type } = defaults;
+            const account_delete_options = { name: ANONYMOUS, config_root };
+            const resp = await exec_manage_cli(type, action, account_delete_options);
+            expect(JSON.parse(resp.stdout).error.message).toBe(ManageCLIError.InvalidAccountName.message);
+        });
+
+        it('cli delete anonymous account', async () => {
+            const action = ACTIONS.DELETE;
+            const { type, anonymous } = defaults;
             const account_delete_options = { anonymous, config_root };
             const resp = await exec_manage_cli(type, action, account_delete_options);
             const res_json = JSON.parse(resp.trim());


### PR DESCRIPTION
### Describe the Problem
There were a few issues with the test added in #9023:
1. `config_root` was not passed to the CLI command. This occasionally caused failures in CI when the default config root was modified by other test suites.
2. The test used a fixed name instead of `uid`/`gid`. While this may not always cause issues, it could fail in certain environments where these values differ (e.g., when modified by other test suites).
3. The test was placed in the wrong location. It should be in `test_nc_anonymous_cli.js` alongside the other anonymous user CLI tests.

### Explain the Changes
1. Added a new test in `test_nc_anonymous_cli.js` with the correct CLI parameters.
2. changed second `before_all` to be `after_all` as it should have been

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `sudo npx jest src/test/integration_tests/nc/cli/test_nc_anonymous_cli.test.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined anonymous-account test suite: removed a redundant case, added explicit failure and success scenarios for anonymous-account deletion, and retained nickname-based deletion checks.
  * Improved test isolation by moving account setup into individual tests and adding global cleanup to ensure reliable teardown and lifecycle separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->