### PR TITLE
node-ip removal - Phase 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "heapdump": "0.3.15",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "ip": "2.0.1",
         "jsonwebtoken": "9.0.3",
         "ldapts": "8.1.6",
         "linux-blockutils": "0.2.0",
@@ -397,6 +396,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.993.0.tgz",
       "integrity": "sha512-0slCxdbo9O3rfzqD7/PsBOrZ6vcwFzPAvGeUu5NZApI5WyjEfMLLi2T9QW8R9N9TQeUfiUQiHkg/NV0LPS61/g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1354,6 +1354,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -1415,6 +1416,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
       "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -1633,6 +1635,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4803,6 +4806,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5351,6 +5355,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6401,6 +6406,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7890,12 +7896,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "license": "MIT"
-    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -8292,6 +8292,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -10296,6 +10297,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -12581,6 +12583,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12740,6 +12743,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "heapdump": "0.3.15",
     "http-proxy-agent": "7.0.2",
     "https-proxy-agent": "7.0.6",
-    "ip": "2.0.1",
     "jsonwebtoken": "9.0.3",
     "ldapts": "8.1.6",
     "linux-blockutils": "0.2.0",

--- a/src/test/unit_tests/util_functions_tests/test_net_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_net_utils.test.js
@@ -23,17 +23,6 @@ describe('IP Utils', () => {
         expect(net_utils.is_fqdn('invalid_domain-.com')).toBe(false);
     });
 
-    it('is_cidr should correctly identify CIDR notation', () => {
-        expect(net_utils.is_cidr('192.168.1.0/24')).toBe(true);
-        expect(net_utils.is_cidr('10.0.0.0/8')).toBe(true);
-        expect(net_utils.is_cidr('2001:db8::/32')).toBe(true);
-        expect(net_utils.is_cidr('192.168.1.300/24')).toBe(false);
-        expect(net_utils.is_cidr('invalid_cidr')).toBe(false);
-        expect(net_utils.is_cidr('192.168.1.1')).toBe(false);
-        expect(net_utils.is_cidr('282.150.0.0/12')).toBe(false);
-        expect(net_utils.is_cidr('192.168.0.0/35')).toBe(false);
-    });
-
     it('is_localhost should correctly identify localhost addresses', () => {
         expect(net_utils.is_localhost('127.0.0.1')).toBe(true);
         expect(net_utils.is_localhost('::1')).toBe(true);
@@ -71,6 +60,22 @@ describe('IP Utils', () => {
         expect(net_utils.find_ifc_containing_address('192.168.1.5')).toEqual({ ifc: 'eth0', info: networkInterfacesMock.eth0[0] });
         expect(net_utils.find_ifc_containing_address('127.0.0.1')).toEqual({ ifc: 'lo', info: networkInterfacesMock.lo[0] });
         expect(net_utils.find_ifc_containing_address('8.8.8.8')).toBeUndefined();
+    });
+
+    it('find_ifc_containing_address should find interface for IPv6 via os.networkInterfaces()', () => {
+        const ipv6_info = { family: 'IPv6', cidr: '2001:db8::/32', address: '2001:db8::1', netmask: 'ffff:ffff::', mac: '00:00:00:00:00:00', internal: false, scopeid: 0 };
+        const network_interfaces_mock = /** @type {ReturnType<typeof os.networkInterfaces>} */ ({
+            eth0: [
+                { family: 'IPv4', cidr: '192.168.1.0/24', address: '192.168.1.2', netmask: '255.255.255.0', mac: '00:00:00:00:00:00', internal: false },
+                ipv6_info,
+            ],
+            lo: [{ family: 'IPv4', cidr: '127.0.0.0/8', address: '127.0.0.1', netmask: '255.0.0.0', mac: '00:00:00:00:00:00', internal: true }],
+        });
+        jest.spyOn(os, 'networkInterfaces').mockReturnValue(/** @type {ReturnType<typeof os.networkInterfaces>} */ (/** @type {unknown} */ (network_interfaces_mock)));
+
+        expect(net_utils.find_ifc_containing_address('2001:db8::1')).toEqual({ ifc: 'eth0', info: ipv6_info });
+        expect(net_utils.find_ifc_containing_address('2001:db8::ff00:42:8329')).toEqual({ ifc: 'eth0', info: ipv6_info });
+        expect(net_utils.find_ifc_containing_address('2001:db9::1')).toBeUndefined();
     });
 
     it('get_local_address should return the first non-internal IPv4 address', () => {
@@ -375,4 +380,128 @@ describe('IP Utils', () => {
         expect(net_utils.is_equal('192.168.1.1', '::1')).toBe(false);
     });
 
+});
+
+describe('IP Utils - CIDR', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('is_cidr', () => {
+        it('should correctly identify CIDR notation', () => {
+            expect(net_utils.is_cidr('192.168.1.0/24')).toBe(true);
+            expect(net_utils.is_cidr('10.0.0.0/8')).toBe(true);
+            expect(net_utils.is_cidr('2001:db8::/32')).toBe(true);
+            expect(net_utils.is_cidr('192.168.1.300/24')).toBe(false);
+            expect(net_utils.is_cidr('invalid_cidr')).toBe(false);
+            expect(net_utils.is_cidr('192.168.1.1')).toBe(false);
+            expect(net_utils.is_cidr('282.150.0.0/12')).toBe(false);
+            expect(net_utils.is_cidr('192.168.0.0/35')).toBe(false);
+        });
+    });
+
+    describe('cidr_subnet_contains', () => {
+        it('returns false for invalid or non-CIDR input', () => {
+            expect(net_utils.cidr_subnet_contains('invalid', '192.168.1.1')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('192.168.1.1', '192.168.1.1')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('', '192.168.1.1')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('192.168.0.0/24', 'not-an-ip')).toBe(false);
+        });
+
+        it('returns false when address family does not match CIDR (IPv4 CIDR vs IPv6 and vice versa)', () => {
+            expect(net_utils.cidr_subnet_contains('192.168.0.0/24', '2001:db8::1')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('2001:db8::/32', '192.168.1.1')).toBe(false);
+        });
+
+        it('matches IPv4 addresses inside and outside the range', () => {
+            expect(net_utils.cidr_subnet_contains('192.168.1.0/24', '192.168.1.0')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.1.0/24', '192.168.1.5')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.1.0/24', '192.168.1.255')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.1.0/24', '192.168.2.0')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('192.168.1.0/24', '192.168.0.255')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('10.0.0.0/8', '10.1.2.3')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('10.0.0.0/8', '11.0.0.1')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('127.0.0.0/8', '127.0.0.1')).toBe(true);
+        });
+
+        it('matches IPv4 with non-byte prefix lengths (partial-byte path)', () => {
+            // /26 = 64 addresses per subnet; 192.168.1.0/26 covers .0–.63
+            expect(net_utils.cidr_subnet_contains('192.168.1.0/26', '192.168.1.0')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.1.0/26', '192.168.1.63')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.1.0/26', '192.168.1.64')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('192.168.1.128/26', '192.168.1.128')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.1.128/26', '192.168.1.191')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.1.128/26', '192.168.1.192')).toBe(false);
+            // /30 = 4 addresses; 10.0.0.0/30 covers .0–.3
+            expect(net_utils.cidr_subnet_contains('10.0.0.0/30', '10.0.0.2')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('10.0.0.0/30', '10.0.0.4')).toBe(false);
+        });
+
+        it('handles IPv4 /32 (single host) and /0 (whole space)', () => {
+            expect(net_utils.cidr_subnet_contains('192.168.1.5/32', '192.168.1.5')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.1.5/32', '192.168.1.6')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('0.0.0.0/0', '0.0.0.0')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('0.0.0.0/0', '255.255.255.255')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('0.0.0.0/0', '8.8.8.8')).toBe(true);
+        });
+
+        it('treats IPv4-mapped IPv6 address as IPv4 when CIDR is IPv4', () => {
+            expect(net_utils.cidr_subnet_contains('192.168.0.0/24', '::ffff:192.168.0.1')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('10.0.0.0/8', '::ffff:10.1.2.3')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('192.168.0.0/24', '::ffff:192.168.1.1')).toBe(false);
+        });
+
+        it('matches IPv6 addresses inside and outside the range', () => {
+            expect(net_utils.cidr_subnet_contains('2001:db8::/32', '2001:db8::1')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('2001:db8::/32', '2001:db8:0:0:0:0:0:1')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('2001:db8::/32', '2001:db8::')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('2001:db8::/32', '2001:db9::1')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('2001:db8::/32', '2001:db7:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(false);
+        });
+
+        it('matches IPv6 with non-byte prefix length (partial-byte path)', () => {
+            // /36: first 36 bits must match
+            expect(net_utils.cidr_subnet_contains('2001:db8::/36', '2001:db8:0::1')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('2001:db8::/36', '2001:db8:f::1')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('2001:db8::/36', '2001:db9::1')).toBe(false);
+        });
+
+        it('handles IPv6 /128 (single host) and /0', () => {
+            expect(net_utils.cidr_subnet_contains('2001:db8::1/128', '2001:db8::1')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('2001:db8::1/128', '2001:db8::2')).toBe(false);
+            expect(net_utils.cidr_subnet_contains('::/0', '2001:db8::1')).toBe(true);
+            expect(net_utils.cidr_subnet_contains('::/0', '::1')).toBe(true);
+        });
+    });
+
+    describe('cidr_subnet', () => {
+        it('returns an object with a contains method', () => {
+            const subnet = net_utils.cidr_subnet('192.168.1.0/24');
+            expect(subnet).toEqual(expect.objectContaining({ contains: expect.any(Function) }));
+            expect(typeof subnet.contains).toBe('function');
+        });
+
+        it('contains() returns true for addresses in the subnet and false otherwise', () => {
+            const subnet = net_utils.cidr_subnet('192.168.1.0/24');
+            expect(subnet.contains('192.168.1.0')).toBe(true);
+            expect(subnet.contains('192.168.1.100')).toBe(true);
+            expect(subnet.contains('192.168.1.255')).toBe(true);
+            expect(subnet.contains('192.168.2.0')).toBe(false);
+        });
+
+        it('subnet object can be reused for multiple contains() calls', () => {
+            const subnet = net_utils.cidr_subnet('10.0.0.0/8');
+            expect(subnet.contains('10.0.0.1')).toBe(true);
+            expect(subnet.contains('10.255.255.255')).toBe(true);
+            expect(subnet.contains('11.0.0.0')).toBe(false);
+            expect(subnet.contains('9.255.255.255')).toBe(false);
+        });
+
+        it('works for IPv6 CIDR', () => {
+            const subnet = net_utils.cidr_subnet('2001:db8::/32');
+            expect(subnet.contains('2001:db8::1')).toBe(true);
+            expect(subnet.contains('2001:db8:0:0:0:0:0:1')).toBe(true);
+            expect(subnet.contains('2001:db9::1')).toBe(false);
+        });
+    });
 });

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -4,7 +4,6 @@
 
 const _ = require('lodash');
 const util = require('util');
-const ip_module = require('ip');
 const net = require('net');
 const url = require('url');
 const http = require('http');
@@ -492,7 +491,7 @@ function should_proxy(hostname) {
             if (kind === 'IP' && net_utils.is_equal(addr, hostname)) {
                 return false;
             }
-            if (kind === 'CIDR' && ip_module.cidrSubnet(addr).contains(hostname)) {
+            if (kind === 'CIDR' && net_utils.cidr_subnet(addr).contains(hostname)) {
                 return false;
             }
 

--- a/src/util/net_utils.js
+++ b/src/util/net_utils.js
@@ -3,7 +3,6 @@
 
 const os = require('os');
 const net = require('net');
-const ip_module = require('ip');
 
 const fqdn_regexp = /^(?=^.{1,253}$)(^(((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9])|((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63})$)/;
 
@@ -26,6 +25,83 @@ function is_cidr(ip) {
     const address = ip.split("/")[0];
     if (!net.isIP(address)) return false;
     return true;
+}
+
+/**
+ * Returns true if the first `prefix` bits of baseBuf and addrBuf match (byte-based, no bitwise).
+ * @param {Buffer} base_buf
+ * @param {Buffer} addr_buf
+ * @param {number} prefix - number of bits to match (e.g. 24 for /24)
+ * @returns {boolean}
+ */
+function buffer_prefix_match(base_buf, addr_buf, prefix) {
+    // CIDR match: the first `prefix` bits of base and address must be identical.
+    // We do this in two steps: full bytes, then a possible partial byte.
+
+    const full_bytes = Math.floor(prefix / 8);
+    // Compare entire bytes for the first full_bytes (e.g. prefix 24 => 3 bytes for IPv4).
+    for (let i = 0; i < full_bytes; i++) {
+        if (base_buf[i] !== addr_buf[i]) return false;
+    }
+
+    // If prefix is not a multiple of 8, the next byte is only partly significant.
+    // E.g. prefix 26: we care only about the top 2 bits of the 4th byte.
+    // Dividing by 2^shift keeps those high bits and drops the rest (no bitwise ops).
+    if (prefix % 8 !== 0) {
+        const shift = 8 - (prefix % 8);
+        const divisor = 2 ** shift;
+        if (Math.floor(base_buf[full_bytes] / divisor) !== Math.floor(addr_buf[full_bytes] / divisor)) return false;
+    }
+    return true;
+}
+
+/**
+ * cidr_subnet_contains returns true if the given address is inside the CIDR subnet.
+ * Drop-in logic for the "ip" module's cidrSubnet(cidr).contains(address).
+ * @param {string} cidr - CIDR string (e.g. '192.168.0.0/24' or '2001:db8::/32')
+ * @param {string} address - IP address to test
+ * @returns {boolean}
+ */
+function cidr_subnet_contains(cidr, address) {
+    if (!is_cidr(cidr)) return false;
+    const idx = cidr.indexOf('/');
+    const base_str = cidr.slice(0, idx);
+    const prefix = parseInt(cidr.slice(idx + 1), 10);
+
+    if (net.isIPv4(base_str)) {
+        const addr = unwrap_ipv6(address);
+        if (!net.isIPv4(addr)) return false;
+        const base_buf = ip_to_buffer_safe(base_str);
+        const addr_buf = ip_to_buffer_safe(addr);
+        if (!base_buf || !addr_buf || base_buf.length !== 4 || addr_buf.length !== 4) return false;
+        return buffer_prefix_match(base_buf, addr_buf, Math.min(prefix, 32));
+    }
+
+    if (net.isIPv6(base_str)) {
+        if (!net.isIPv6(address)) return false;
+        const base_buf = ip_to_buffer_safe(base_str);
+        const addr_buf = ip_to_buffer_safe(address);
+        if (!base_buf || !addr_buf || base_buf.length !== 16 || addr_buf.length !== 16) return false;
+        return buffer_prefix_match(base_buf, addr_buf, Math.min(prefix, 128));
+    }
+
+    return false;
+}
+
+/**
+ * cidr_subnet returns a contains-only wrapper around cidr_subnet_contains.
+ * Not full API-compatible with the "ip" module's cidrSubnet(cidr); the following
+ * properties are not provided: networkAddress, firstAddress, lastAddress,
+ * broadcastAddress, subnetMask, subnetMaskLength, numHosts, length.
+ * @param {string} cidr - CIDR string (e.g. '192.168.0.0/24' or '2001:db8::/32')
+ * @returns {{ contains: (address: string) => boolean }}
+ */
+function cidr_subnet(cidr) {
+    return {
+        contains(address) {
+            return cidr_subnet_contains(cidr, address);
+        },
+    };
 }
 
 /**
@@ -290,7 +366,7 @@ function find_ifc_containing_address(address) {
     if (!family) return;
     for (const [ifc, arr] of Object.entries(os.networkInterfaces())) {
         for (const info of arr) {
-            if (info.family === family && ip_module.cidrSubnet(info.cidr).contains(address)) {
+            if (info.family === family && cidr_subnet(info.cidr).contains(address)) {
                 return { ifc, info };
             }
         }
@@ -342,6 +418,8 @@ function is_equal(address1, address2) {
 exports.is_ip = is_ip;
 exports.is_fqdn = is_fqdn;
 exports.is_cidr = is_cidr;
+exports.cidr_subnet = cidr_subnet;
+exports.cidr_subnet_contains = cidr_subnet_contains;
 exports.is_localhost = is_localhost;
 exports.unwrap_ipv6 = unwrap_ipv6;
 exports.ip_toLong = ip_toLong;


### PR DESCRIPTION
### Explain the Changes
node-ip removal - Phase 7

- Adding `buffer_prefix_match`, `cidr_subnet_contains`, and `cidr_subnet` as a drop-in replacement for "ip" module's cidrSubnet(cidr).
- Replacing `ip_module.cidrSubnet()` with `net_utils.cidr_subnet()`
- Adding tests to `test_net_utils.test.js`
- Removing the npm module ip (node-ip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an external IP dependency and replaced it with built-in CIDR handling across the codebase.

* **Tests**
  * Expanded CIDR/subnet tests with broad IPv4/IPv6 coverage, edge cases (/0, /128, non-byte prefixes), IPv4-mapped IPv6 and cross-family checks; a duplicated test-suite insertion was noted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->