### PR TITLE
NC | dynamic supplemental groups add user cache

### DIFF
--- a/config.js
+++ b/config.js
@@ -856,6 +856,8 @@ config.NSFS_MAX_EXIT_EVENTS_PER_TIME_FRAME = 10; // allow max 10 failed forks pe
 
 config.GPFS_DL_PATH = '/usr/lpp/mmfs/lib/libgpfs.so';
 config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = false;
+// Cache expiry for supplemental groups by uid, default 1 minute
+config.NSFS_SUPPLEMENTAL_GROUPS_CACHE_EXPIRY_MS = 1 * 60 * 1000;
 
 config.NSFS_GLACIER_LOGS_DIR = '/var/run/noobaa-nsfs/wal';
 config.NSFS_GLACIER_LOGS_POLL_INTERVAL = 10 * 1000;
@@ -1323,7 +1325,7 @@ function _get_config_root() {
  * go over the config object and set the relevant configurations as environment variables
  */
 function _set_nc_config_to_env() {
-    const config_to_env = ['NOOBAA_LOG_LEVEL', 'UV_THREADPOOL_SIZE', 'GPFS_DL_PATH', 'NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS'];
+    const config_to_env = ['NOOBAA_LOG_LEVEL', 'UV_THREADPOOL_SIZE', 'GPFS_DL_PATH'];
     for (const configuration_key of config_to_env) {
         if (config && Object.keys(config).includes(configuration_key) && config[configuration_key] !== undefined) {
             console.warn('setting configuration_key as env var', configuration_key, config[configuration_key]);

--- a/src/native/fs/fs_napi.cpp
+++ b/src/native/fs/fs_napi.cpp
@@ -19,6 +19,7 @@
 #include <limits.h>
 #include <map>
 #include <math.h>
+#include <grp.h>
 #include <pwd.h>
 #include <stdlib.h>
 #include <sys/fcntl.h>
@@ -415,6 +416,14 @@ set_getpwnam_res(Napi::Env env, Napi::Object getpwnam_res, struct passwd& _getpw
     getpwnam_res["name"] = Napi::String::New(env, _getpwnam_res.pw_name);
     getpwnam_res["uid"] = Napi::Number::New(env, _getpwnam_res.pw_uid);
     getpwnam_res["gid"] = Napi::Number::New(env, _getpwnam_res.pw_gid);
+}
+
+static void
+set_supplemental_groups_result(Napi::Env env,Napi::Array& groups_res, std::vector<gid_t>& groups)
+{
+    for (size_t i = 0; i < groups.size(); ++i) {
+        groups_res.Set(i, Napi::Number::New(env, groups[i]));
+    }
 }
 
 static bool
@@ -1444,6 +1453,112 @@ struct GetPwName : public FSWorker
         auto res = Napi::Object::New(env);
         set_getpwnam_res(env, res, *_getpwnam_res);
         _deferred.Resolve(res);
+    }
+};
+
+/**
+ * Helper: get supplemental groups via getgrouplist.
+ * Returns 0 on success, -1 on failure. Populates groups_res on success.
+ */
+static int
+get_supplemental_groups(const char* user, gid_t gid, std::vector<gid_t>& groups_res)
+{
+    int ngroups = NGROUPS_MAX;
+#ifdef __APPLE__
+    //for some reason on mac getgrouplist accepts an array of int instead of gid_t. so need to create a vector of int and then insert it into groups
+    std::vector<int> tmp_groups(ngroups);
+    if (getgrouplist(user, gid, &tmp_groups[0], &ngroups) < 0) {
+        return -1;
+    }
+    groups_res.assign(tmp_groups.begin(), tmp_groups.begin() + ngroups);
+#else
+    groups_res.resize(ngroups);
+    if (getgrouplist(user, gid, &groups_res[0], &ngroups) < 0) {
+        return -1;
+    }
+    groups_res.resize(ngroups);
+#endif
+    return 0;
+}
+
+/**
+ * GetSupplementalGroupsByUid gets the supplemental groups for a user by uid using getpwuid_r and getgrouplist.
+ */
+struct GetSupplementalGroupsByUid : public FSWorker
+{
+    uid_t _uid;
+    std::vector<gid_t> _groups;
+    GetSupplementalGroupsByUid(const Napi::CallbackInfo& info)
+        : FSWorker(info)
+        , _uid(0)
+    {
+        _uid = info[1].As<Napi::Number>().Uint32Value();
+        Begin(XSTR() << "GetSupplementalGroupsByUid " << DVAL(_uid));
+    }
+    virtual void Work()
+    {
+        const long passwd_buf_size = ThreadScope::get_passwd_buf_size();
+        std::unique_ptr<char[]> buf(new char[passwd_buf_size]);
+        struct passwd pwd;
+        struct passwd* pw = NULL;
+
+        const int res = getpwuid_r(_uid, &pwd, buf.get(), passwd_buf_size, &pw);
+        if (pw == NULL) {
+            if (res != 0) {
+                errno = res; // getpwuid_r returns errno in retval, does not set errno
+                SetSyscallError();
+            } else {
+                SetError("NO_SUCH_USER");
+            }
+            return;
+        }
+        if (get_supplemental_groups(pw->pw_name, pw->pw_gid, _groups) < 0) {
+            if (errno == 0) errno = EIO; // getgrouplist may not set errno
+            SetSyscallError();
+        }
+    }
+    virtual void OnOK()
+    {
+        DBG1("FS::GetSupplementalGroupsByUid::OnOK: " << DVAL(_uid) << DVAL(_groups.size()));
+        Napi::Env env = Env();
+        auto groups_res = Napi::Array::New(env, _groups.size());
+        set_supplemental_groups_result(env, groups_res, _groups);
+        _deferred.Resolve(groups_res);
+    }
+};
+
+/**
+ * GetSupplementalGroupsByUserName gets supplemental groups using getgrouplist with username and primary gid.
+ * Optimization: when user data is already available (e.g. from getpwnam for distinguished_name),
+ * avoids redundant getpwuid_r lookup.
+ */
+struct GetSupplementalGroupsByUserName : public FSWorker
+{
+    std::string _user;
+    gid_t _gid;
+    std::vector<gid_t> _groups;
+    GetSupplementalGroupsByUserName(const Napi::CallbackInfo& info)
+        : FSWorker(info)
+        , _gid(0)
+    {
+        _user = info[1].As<Napi::String>();
+        _gid = info[2].As<Napi::Number>().Uint32Value();
+        Begin(XSTR() << "GetSupplementalGroupsByUserName " << DVAL(_user) << DVAL(_gid));
+    }
+    virtual void Work()
+    {
+        if (get_supplemental_groups(_user.c_str(), _gid, _groups) < 0) {
+            if (errno == 0) errno = EIO; // getgrouplist may not set errno
+            SetSyscallError();
+        }
+    }
+    virtual void OnOK()
+    {
+        DBG1("FS::GetSupplementalGroupsByUserName::OnOK: " << DVAL(_user) << DVAL(_groups.size()));
+        Napi::Env env = Env();
+        auto groups_res = Napi::Array::New(env, _groups.size());
+        set_supplemental_groups_result(env, groups_res, _groups);
+        _deferred.Resolve(groups_res);
     }
 };
 
@@ -2704,6 +2819,8 @@ fs_napi(Napi::Env env, Napi::Object exports)
     exports_fs["realpath"] = Napi::Function::New(env, api<RealPath>);
     exports_fs["getsinglexattr"] = Napi::Function::New(env, api<GetSingleXattr>);
     exports_fs["getpwname"] = Napi::Function::New(env, api<GetPwName>);
+    exports_fs["getSupplementalGroupsByUid"] = Napi::Function::New(env, api<GetSupplementalGroupsByUid>);
+    exports_fs["getSupplementalGroupsByUserName"] = Napi::Function::New(env, api<GetSupplementalGroupsByUserName>);
     exports_fs["symlink"] = Napi::Function::New(env, api<Symlink>);
     exports_fs["fcntlgetlock"] = Napi::Function::New(env, api<FcntlGetLock>);
 

--- a/src/native/util/os_darwin.cpp
+++ b/src/native/util/os_darwin.cpp
@@ -45,54 +45,22 @@ const gid_t ThreadScope::orig_gid = getgid();
 const std::vector<gid_t> ThreadScope::orig_groups = get_process_groups();
 long ThreadScope::passwd_buf_size = -1;
 
-static int
-get_supplemental_groups_by_uid(uid_t uid, std::vector<gid_t>& groups)
-{
-    const long passwd_buf_size = ThreadScope::get_passwd_buf_size();
-    std::unique_ptr<char[]> buf(new char[passwd_buf_size]);
-    struct passwd pwd;
-    struct passwd *pw = NULL;
-
-    const int res = getpwuid_r(uid, &pwd, buf.get(), passwd_buf_size, &pw);
-    if (pw == NULL) {
-        if (res == 0) {
-            // LOG("get_supplemental_groups_by_uid: no record for uid " << uid);
-        } else {
-            LOG("WARNING: get_supplemental_groups_by_uid: getpwuid failed: " << strerror(errno));
-        }
-        return -1;
-    }
-    int ngroups = NGROUPS_MAX;
-    //for some reason on mac getgrouplist accepts an array of int instead of gid_t. so need to create a vector of int and then insert it into groups
-    std::vector<int> tmp_groups(ngroups);
-    if (getgrouplist(pw->pw_name, pw->pw_gid, &tmp_groups[0], &ngroups) < 0) {
-        LOG("get_supplemental_groups_by_uid: getgrouplist failed: ngroups too small " << ngroups);
-        return -1;
-    }
-    groups.insert(groups.begin(), tmp_groups.begin(), tmp_groups.begin() + ngroups);
-    return 0;
-}
-
 /**
- * set supplemental groups of the thread according to the following:
- * 1. if groups were defined in the account configuration, set the groups list to the one defined
- * 2. try to get the list of groups corresponding to the user in the system recods, and set it to it
- * 3. if supplemental groups were not defined for the account and getting it from system record failed (either because record doesn't exist ot because of an error)
- *    keep it as an empty set
+ * set supplemental groups of the thread.
+ * Groups are resolved in JavaScript (get_fs_context) with cache - similar to distinguished_name.
+ * Logic: if supplemental_groups defined in account CLI use those; else if
+ * NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS get from filesystem via SupplementalGroupsCache.
+ * Native just applies the pre-resolved groups.
  */
 static void
-set_supplemental_groups(uid_t uid, gid_t gid, std::vector<gid_t>& groups) {
-    //first check if groups were defined in the account configuration
+set_supplemental_groups(gid_t gid, std::vector<gid_t>& groups) {
     if (groups.empty()) {
-        const char* is_enabled = getenv("NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS");
-        if ((is_enabled == NULL) || (strcmp(is_enabled, "true") != 0) || get_supplemental_groups_by_uid(uid, groups) < 0) {
-            //aready unset by _mac_thread_setugid
-            return;
-        }
+        // already unset by _mac_thread_setugid
+        return;
     }
-    /*accourding to BSD Manual https://man.freebsd.org/cgi/man.cgi?query=setgroups
+    /* according to BSD Manual https://man.freebsd.org/cgi/man.cgi?query=setgroups
     which darwin is occasionally compliant to setgroups changes the effective gid according to
-    the first element on the list. add the effective gid as the first element to prevent issues*/
+    the first element on the list. add the effective gid as the first element to prevent issues */
     groups.push_back(gid);
     std::swap(groups.front(), groups.back());
     MUST_SYS(setgroups(groups.size(), &groups[0]));
@@ -116,7 +84,7 @@ ThreadScope::change_user()
 {
     if (_uid != orig_uid || _gid != orig_gid) {
         MUST_SYS(_mac_thread_setugid(_uid, _gid));
-        set_supplemental_groups(_uid, _gid, _groups);
+        set_supplemental_groups(_gid, _groups);
     }
 }
 

--- a/src/native/util/os_linux.cpp
+++ b/src/native/util/os_linux.cpp
@@ -31,50 +31,18 @@ long ThreadScope::passwd_buf_size = -1;
 
 const std::vector<gid_t> ThreadScope::orig_groups = get_process_groups();
 
-static int
-get_supplemental_groups_by_uid(uid_t uid, std::vector<gid_t>& groups)
-{
-    const long passwd_buf_size = ThreadScope::get_passwd_buf_size();
-    std::unique_ptr<char[]> buf(new char[passwd_buf_size]);
-    struct passwd pwd;
-    struct passwd *pw = NULL;
-
-    const int res = getpwuid_r(uid, &pwd, buf.get(), passwd_buf_size, &pw);
-    if (pw == NULL) {
-        if (res == 0) {
-            // LOG("get_supplemental_groups_by_uid: no record for uid " << uid);
-        } else {
-            LOG("WARNING: get_supplemental_groups_by_uid: getpwuid failed: " << strerror(errno));
-        }
-        return -1;
-    }
-    int ngroups = NGROUPS_MAX;
-    groups.resize(ngroups);
-    if (getgrouplist(pw->pw_name, pw->pw_gid, &groups[0], &ngroups) < 0) {
-        LOG("get_supplemental_groups_by_uid: getgrouplist failed: ngroups too small " << ngroups);
-        return -1;
-    }
-    groups.resize(ngroups);
-    return 0;
-}
-
 /**
- * set supplemental groups of the thread according to the following:
- * 1. if groups were defined in the account configuration, set the groups list to the one defined
- * 2. try to get the list of groups corresponding to the user in the system recods, and set it to it
- * 3. if supplemental groups were not defined for the account and getting it from system record failed (either because record doesn't exist ot because of an error)
- *    set it to be an empty set
+ * set supplemental groups of the thread.
+ * Groups are resolved in JavaScript (get_fs_context) with cache - similar to distinguished_name.
+ * Logic: if supplemental_groups defined in account CLI use those; else if
+ * NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS get from filesystem via SupplementalGroupsCache.
+ * Native just applies the pre-resolved groups.
  */
 static void
-set_supplemental_groups(uid_t uid, std::vector<gid_t>& groups) {
-    //first check if groups were defined in the account configuration
+set_supplemental_groups(std::vector<gid_t>& groups) {
     if (groups.empty()) {
-        const char* is_enabled = getenv("NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS");
-        if ((is_enabled == NULL) || (strcmp(is_enabled, "true") != 0) || get_supplemental_groups_by_uid(uid, groups) < 0) {
-            //couldn't get supplemental groups dynamically. set it to be an empty set
-            MUST_SYS(syscall(SYS_setgroups, 0, NULL));
-            return;
-        }
+        MUST_SYS(syscall(SYS_setgroups, 0, NULL));
+        return;
     }
     MUST_SYS(syscall(SYS_setgroups, groups.size(), &groups[0]));
 }
@@ -88,7 +56,7 @@ void
 ThreadScope::change_user()
 {
     if (_uid != orig_uid || _gid != orig_gid) {
-        set_supplemental_groups(_uid, _groups);
+        set_supplemental_groups(_groups);
         // must change gid first otherwise will fail on permission
         MUST_SYS(syscall(SYS_setresgid, -1, _gid, -1));
         MUST_SYS(syscall(SYS_setresuid, -1, _uid, -1));

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -1009,6 +1009,8 @@ interface NativeFS {
     checkAccess(fs_context: NativeFSContext, path: string): Promise<void>;
     getsinglexattr(fs_context: NativeFSContext, path: string, key: string): Promise<string>;
     getpwname(fs_context: NativeFSContext, user: string): Promise<NativeFSUserObject>;
+    getSupplementalGroupsByUid(fs_context: NativeFSContext, uid: number): Promise<number[]>;
+    getSupplementalGroupsByUserName(fs_context: NativeFSContext, username: string, primaryGid: number): Promise<number[]>;
 
     readFile(
         fs_context: NativeFSContext,

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -77,6 +77,25 @@ const dn_cache = new LRUCache({
     load: async ({ distinguished_name }) => native_fs_utils.get_user_by_distinguished_name({ distinguished_name }),
 });
 
+const supplemental_groups_cache = new LRUCache({
+    name: 'SupplementalGroupsCache',
+    expiry_ms: config.NSFS_SUPPLEMENTAL_GROUPS_CACHE_EXPIRY_MS,
+    /**
+     * @param {{ uid: number; name?: string; gid?: number }} params
+     */
+    make_key: ({ uid }) => uid,
+    /**
+     * When user_from_dn provides name/gid, use get_supplemental_groups_by_user to avoid redundant getpwuid_r.
+     * @param {{ uid: number; name?: string; gid?: number }} params
+     */
+    load: async ({ uid, name, gid }) => {
+        if (name !== undefined && gid !== undefined) {
+            return native_fs_utils.get_supplemental_groups_by_user({ name, gid });
+        }
+        return native_fs_utils.get_supplemental_groups_by_uid({ uid });
+    },
+});
+
 const MULTIPART_NAMESPACES = [
     'NET_STORAGE'
 ];
@@ -257,14 +276,35 @@ class ObjectSDK {
                 bucketspace: this._get_bucketspace(),
                 access_key: token ? token.access_key : anonymous_access_key,
             });
+            let distinguished_name;
             if (this.requesting_account?.nsfs_account_config?.distinguished_name) {
-                const distinguished_name = this.requesting_account.nsfs_account_config.distinguished_name.unwrap();
+                distinguished_name = this.requesting_account.nsfs_account_config.distinguished_name.unwrap();
                 const user = await dn_cache.get_with_cache({
                     bucketspace: this._get_bucketspace(),
                     distinguished_name,
                 });
                 this.requesting_account.nsfs_account_config.uid = user.uid;
                 this.requesting_account.nsfs_account_config.gid = user.gid;
+            }
+            const cfg = this.requesting_account?.nsfs_account_config;
+            const enable_dynamic = cfg && config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+            if (enable_dynamic && !cfg.supplemental_groups) {
+                const groups = await supplemental_groups_cache.get_with_cache({
+                    uid: this.requesting_account.nsfs_account_config.uid,
+                    name: distinguished_name,
+                    gid: this.requesting_account.nsfs_account_config.gid
+                });
+                // Copy instead of mutating: this.requesting_account points at the shared account_cache
+                // entry (from get_with_cache above). Mutating it would persist supplemental_groups
+                // onto the cache, causing future requests to skip supplemental_groups_cache and
+                // serve stale groups until account_cache expires.
+                this.requesting_account = {
+                    ...this.requesting_account,
+                    nsfs_account_config: {
+                        ...this.requesting_account.nsfs_account_config,
+                        supplemental_groups: groups
+                    }
+                };
             }
         } catch (error) {
             dbg.error('load_requesting_account error:', error);
@@ -1221,3 +1261,4 @@ module.exports = ObjectSDK;
 module.exports.anonymous_access_key = anonymous_access_key;
 module.exports.account_cache = account_cache;
 module.exports.dn_cache = dn_cache;
+module.exports.supplemental_groups_cache = supplemental_groups_cache;

--- a/src/test/unit_tests/nsfs/test_nsfs_access.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_access.js
@@ -5,8 +5,11 @@
 const path = require('path');
 const mocha = require('mocha');
 const assert = require('assert');
+const config = require('../../../../config');
 const fs_utils = require('../../../util/fs_utils');
+const native_fs_utils = require('../../../util/native_fs_utils');
 const nb_native = require('../../../util/nb_native');
+const ObjectSDK = require('../../../sdk/object_sdk');
 const test_utils = require('../../system_tests/test_utils');
 const fs = require('fs');
 const { TMP_PATH } = require('../../system_tests/test_utils');
@@ -14,6 +17,7 @@ const NamespaceFS = require('../../../sdk/namespace_fs');
 const buffer_utils = require('../../../util/buffer_utils');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
 const SensitiveString = require('../../../util/sensitive_string');
+const { RpcError } = require('../../../rpc');
 
 const new_umask = process.env.NOOBAA_ENDPOINT_UMASK || 0o000;
 const old_umask = process.umask(new_umask);
@@ -25,8 +29,6 @@ mocha.describe('new tests check', async function() {
     const root_dir = 'root_dir';
     const non_root_dir = 'non_root_dir';
     const non_root_dir2 = 'non_root_dir2';
-    const test_user_name = 'test_user';
-    const test_group_name = 'test_group';
     const full_path_root = path.join(p, root_dir);
     const full_path_non_root = path.join(full_path_root, non_root_dir);
     const full_path_non_root1 = path.join(p, non_root_dir);
@@ -60,27 +62,17 @@ mocha.describe('new tests check', async function() {
         warn_threshold_ms: 100,
     };
 
-    const NON_ROOT4_FS_CONFIG = {
-        uid: 1575,
-        gid: 1575,
-        backend: '',
-        warn_threshold_ms: 100,
-    };
     mocha.before(async function() {
         if (test_utils.invalid_nsfs_root_permissions()) this.skip(); // eslint-disable-line no-invalid-this
         await fs_utils.create_fresh_path(p, 0o777);
         await fs_utils.file_must_exist(p);
         await fs_utils.create_fresh_path(full_path_root, 0o770);
         await fs_utils.file_must_exist(full_path_root);
-        await test_utils.create_fs_user_by_platform(test_user_name, test_user_name, NON_ROOT4_FS_CONFIG.uid, NON_ROOT4_FS_CONFIG.gid); //non root 4
-        await test_utils.create_fs_group_by_platform(test_group_name, NON_ROOT1_FS_CONFIG.gid, test_user_name); //non root 1 group
     });
 
     mocha.after(async function() {
         this.timeout(60000); // eslint-disable-line no-invalid-this
         await fs_utils.folder_delete(p);
-        await test_utils.delete_fs_user_by_platform(test_user_name);
-        await test_utils.delete_fs_group_by_platform(test_group_name);
     });
 
     mocha.it('ROOT readdir - sucsses', async function() {
@@ -133,7 +125,7 @@ mocha.describe('new tests check', async function() {
     mocha.it('NON ROOT 3 with suplemental group - success', async function() {
         await nb_native().fs.mkdir(NON_ROOT1_FS_CONFIG, full_path_non_root1, 0o770);
         //TODO on mac new directories are created with the parents directory GID and not with the process GID. manually change the gid
-        fs.promises.chown(full_path_non_root1, NON_ROOT1_FS_CONFIG.uid, NON_ROOT1_FS_CONFIG.gid);
+        await fs.promises.chown(full_path_non_root1, NON_ROOT1_FS_CONFIG.uid, NON_ROOT1_FS_CONFIG.gid);
         //non root3 has non-root1 group as supplemental group, so it should succeed
         const non_root_entries = await nb_native().fs.readdir(NON_ROOT3_FS_CONFIG, full_path_non_root1);
         assert.equal(non_root_entries && non_root_entries.length, 0);
@@ -142,7 +134,7 @@ mocha.describe('new tests check', async function() {
     mocha.it('NON ROOT 3 suplemental group without the files gid - failure', async function() {
         await nb_native().fs.mkdir(NON_ROOT2_FS_CONFIG, full_path_non_root2, 0o770);
         //TODO on mac new directories are created with the parents directory GID and not with the process GID. manually change the gid
-        fs.promises.chown(full_path_non_root2, NON_ROOT2_FS_CONFIG.uid, NON_ROOT2_FS_CONFIG.gid);
+        await fs.promises.chown(full_path_non_root2, NON_ROOT2_FS_CONFIG.uid, NON_ROOT2_FS_CONFIG.gid);
         try {
             //non root3 doesn't have non-root2 group as supplemental group, so it should fail
             const non_root_entries = await nb_native().fs.readdir(NON_ROOT3_FS_CONFIG, full_path_non_root2);
@@ -152,59 +144,250 @@ mocha.describe('new tests check', async function() {
         }
     });
 
-    mocha.it('NON ROOT 4 with dynamicly allocated suplemental groups - success', async function() {
-        const saved = process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
-        try {
-            process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = 'true';
-            //non root4 has non-root1 group as supplemental group, so it should succeed
-            const non_root_entries = await nb_native().fs.readdir(NON_ROOT4_FS_CONFIG, full_path_non_root1);
-            assert.equal(non_root_entries && non_root_entries.length, 0);
-        } finally {
-            if (saved === undefined) {
-                delete process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
-            } else {
-                process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = saved;
-            }
-        }
+});
+
+mocha.describe('dynamic supplemental groups - get_fs_context flow', function() {
+    const dynamic_supplemental_groups_enabled_backup = config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+    const p = '/tmp/dir_dynamic_sg/';
+    const full_path_non_root1 = path.join(p, 'non_root_dir1');
+    const full_path_non_root2 = path.join(p, 'non_root_dir2');
+    const test_user_name = 'test_user_dyn_sg';
+    const test_group_name = 'test_group_dyn_sg';
+    const NON_ROOT4_UID = 1575;
+    const NON_ROOT4_GID = 1575;
+    const NON_ROOT1_GID = 1572;
+    const NON_ROOT2_GID = 1573;
+
+    mocha.before(async function() {
+        config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = true;
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        if (test_utils.invalid_nsfs_root_permissions()) this.skip(); // eslint-disable-line no-invalid-this
+        await fs_utils.create_fresh_path(p, 0o777);
+        await test_utils.create_fs_user_by_platform(test_user_name, test_user_name, NON_ROOT4_UID, NON_ROOT4_GID);
+        await test_utils.create_fs_group_by_platform(test_group_name, NON_ROOT1_GID, test_user_name);
+        await nb_native().fs.mkdir({ uid: 1572, gid: 1572, backend: '', warn_threshold_ms: 100 }, full_path_non_root1, 0o770);
+        await fs.promises.chown(full_path_non_root1, 1572, 1572);
+        await nb_native().fs.mkdir({ uid: 1573, gid: 1573, backend: '', warn_threshold_ms: 100 }, full_path_non_root2, 0o770);
+        await fs.promises.chown(full_path_non_root2, 1573, 1573);
     });
 
-    mocha.it('NON ROOT 4 with default dynamic supplemental groups (false) - failure', async function() {
-        const saved = process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+    mocha.after(async function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        await fs_utils.folder_delete(p);
+        await test_utils.delete_fs_user_by_platform(test_user_name).catch(() => { /* ignore cleanup */ });
+        await test_utils.delete_fs_group_by_platform(test_group_name).catch(() => { /* ignore cleanup */ });
+        config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = dynamic_supplemental_groups_enabled_backup;
+    });
+
+    mocha.it('get_fs_context with uid/gid and dynamic enabled - supplemental groups resolved, readdir succeeds', async function() {
+        const nsfs_account_config = { uid: NON_ROOT4_UID, gid: NON_ROOT4_GID };
+        const fs_context = await native_fs_utils.get_fs_context(nsfs_account_config, '');
+        assert.ok(fs_context.supplemental_groups, 'should have supplemental groups from OS');
+        assert.ok(fs_context.supplemental_groups.includes(NON_ROOT1_GID), 'should include test_group gid');
+        const entries = await nb_native().fs.readdir(fs_context, full_path_non_root1);
+        assert.equal(entries && entries.length, 0);
+    });
+
+    mocha.it('get_fs_context with uid/gid and dynamic disabled - no supplemental groups, readdir fails with EACCES', async function() {
         try {
-            process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = 'false';
-            //non root4 has non-root1 group as supplemental group, but it should fail because dynamic supplemental groups are disabled
-            const non_root_entries = await nb_native().fs.readdir(NON_ROOT4_FS_CONFIG, full_path_non_root1);
-            assert.fail(`non root 4 has access to a folder created by user with gid not in supplemental groups - ${p} ${non_root_entries}`);
+            config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = false;
+            const nsfs_account_config = { uid: NON_ROOT4_UID, gid: NON_ROOT4_GID };
+            const fs_context = await native_fs_utils.get_fs_context(nsfs_account_config, '');
+            assert.ok(!fs_context.supplemental_groups || fs_context.supplemental_groups.length === 0);
+            await nb_native().fs.readdir(fs_context, full_path_non_root1);
+            assert.fail('readdir should fail with EACCES');
         } catch (err) {
             assert.equal(err.code, 'EACCES');
         } finally {
-            if (saved === undefined) {
-                delete process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
-            } else {
-                process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = saved;
-            }
+            config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = true;
         }
     });
 
-    mocha.it('NON ROOT 4 with dynamicly allocated suplemental groups that dont contains the files gid - failure', async function() {
+    mocha.it('get_fs_context with supplemental_groups defined - uses account config, readdir succeeds', async function() {
+        const nsfs_account_config = {
+            uid: NON_ROOT4_UID,
+            gid: NON_ROOT4_GID,
+            supplemental_groups: [NON_ROOT1_GID]
+        };
+        const fs_context = await native_fs_utils.get_fs_context(nsfs_account_config, '');
+        assert.deepStrictEqual(fs_context.supplemental_groups, [NON_ROOT1_GID]);
+        const entries = await nb_native().fs.readdir(fs_context, full_path_non_root1);
+        assert.equal(entries && entries.length, 0);
+    });
+
+    mocha.it('get_fs_context with distinguished_name - resolves uid/gid and supplemental groups, readdir succeeds', async function() {
+        const nsfs_account_config = { distinguished_name: test_user_name };
+        const fs_context = await native_fs_utils.get_fs_context(nsfs_account_config, '');
+        assert.strictEqual(fs_context.uid, NON_ROOT4_UID);
+        assert.strictEqual(fs_context.gid, NON_ROOT4_GID);
+        assert.ok(fs_context.supplemental_groups && fs_context.supplemental_groups.includes(NON_ROOT1_GID));
+        const entries = await nb_native().fs.readdir(fs_context, full_path_non_root1);
+        assert.equal(entries && entries.length, 0);
+    });
+
+    mocha.it('get_fs_context dynamic groups do not contain file gid - readdir fails with EACCES', async function() {
         try {
-            //non root4 doesn't have non-root2 group as supplemental group, so it should fail
-            const non_root_entries = await nb_native().fs.readdir(NON_ROOT4_FS_CONFIG, full_path_non_root2);
-            assert.fail(`non root 4 has access to a folder created by user with gid not in supplemental groups - ${p} ${non_root_entries}`);
+            const nsfs_account_config = { uid: NON_ROOT4_UID, gid: NON_ROOT4_GID };
+            const fs_context = await native_fs_utils.get_fs_context(nsfs_account_config, '');
+            assert.ok(fs_context.supplemental_groups);
+            assert.ok(!fs_context.supplemental_groups.includes(NON_ROOT2_GID), 'should not have non_root2 group');
+            await nb_native().fs.readdir(fs_context, full_path_non_root2);
+            assert.fail('readdir should fail with EACCES');
         } catch (err) {
             assert.equal(err.code, 'EACCES');
         }
     });
+});
 
-    mocha.it('NON ROOT 4 with disabled dynamicly suplemental groups - failure', async function() {
+mocha.describe('dynamic supplemental groups - load_requesting_account flow', function() {
+    const dynamic_supplemental_groups_enabled_backup = config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+    const test_access_key = 'a-test-dynamic-sg-key';
+    const NON_ROOT4_UID = 1575;
+    const NON_ROOT4_GID = 1575;
+    const DYNAMIC_GROUPS_GID = 1572;
+    const CLI_SET_GID = 1573;
+    const test_user_name = 'test_user_dyn_sg';
+    const test_group_name = 'test_group_dyn_sg';
+    const p_load = '/tmp/dir_dynamic_sg_load/';
+    const full_path_sg_read = path.join(p_load, 'sg_read');
+
+    mocha.before(async function() {
+        if (test_utils.invalid_nsfs_root_permissions()) this.skip(); // eslint-disable-line no-invalid-this
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = true;
+        await test_utils.create_fs_user_by_platform(test_user_name, test_user_name, NON_ROOT4_UID, NON_ROOT4_GID)
+            .catch(() => { /* ignore if exists */ });
+        await test_utils.create_fs_group_by_platform(test_group_name, DYNAMIC_GROUPS_GID, test_user_name)
+            .catch(() => { /* ignore if exists */ });
+        await fs_utils.create_fresh_path(p_load, 0o777);
+        await nb_native().fs.mkdir({ uid: 1572, gid: DYNAMIC_GROUPS_GID, backend: '', warn_threshold_ms: 100 }, full_path_sg_read, 0o770);
+        await fs.promises.chown(full_path_sg_read, 1572, DYNAMIC_GROUPS_GID);
+    });
+
+    mocha.after(async function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        await fs_utils.folder_delete(p_load);
+        await test_utils.delete_fs_user_by_platform(test_user_name).catch(() => { /* ignore cleanup */ });
+        await test_utils.delete_fs_group_by_platform(test_group_name).catch(() => { /* ignore cleanup */ });
+        config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = dynamic_supplemental_groups_enabled_backup;
+    });
+
+    mocha.it('load_requesting_account with uid/gid and dynamic enabled - populates supplemental_groups on account', async function() {
+        const account = {
+            nsfs_account_config: { uid: NON_ROOT4_UID, gid: NON_ROOT4_GID },
+            access_keys: [{ access_key: test_access_key }]
+        };
+        const mock_bucketspace = {
+            read_account_by_access_key: async ({ access_key }) => {
+                if (access_key === test_access_key) return account;
+                throw new RpcError('NO_SUCH_ACCOUNT', 'Account not found');
+            },
+            is_nsfs_containerized_user_anonymous: () => false
+        };
+        const object_sdk = new ObjectSDK({ rpc_client: { options: {} }, internal_rpc_client: {} });
+        object_sdk.bucketspace = mock_bucketspace;
+        object_sdk.set_auth_token({ access_key: test_access_key });
+        await object_sdk.load_requesting_account({});
+        assert.ok(object_sdk.requesting_account.nsfs_account_config.supplemental_groups);
+        assert.ok(object_sdk.requesting_account.nsfs_account_config.supplemental_groups.includes(DYNAMIC_GROUPS_GID));
+    });
+
+    mocha.it('load_requesting_account with uid/gid and dynamic disabled - no supplemental_groups on account', async function() {
         try {
-            process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = 'false';
-            const non_root_entries = await nb_native().fs.readdir(NON_ROOT4_FS_CONFIG, full_path_non_root1);
-            assert.fail(`non root 4 has access to a folder with disabled supplemental groups - ${p} ${non_root_entries}`);
-        } catch (err) {
-            assert.equal(err.code, 'EACCES');
+            config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = false;
+            const account = {
+                nsfs_account_config: { uid: NON_ROOT4_UID, gid: NON_ROOT4_GID },
+                access_keys: [{ access_key: test_access_key + '_disabled' }]
+            };
+            const mock_bucketspace = {
+                read_account_by_access_key: async ({ access_key }) => {
+                    if (access_key === test_access_key + '_disabled') return account;
+                    throw new RpcError('NO_SUCH_ACCOUNT', 'Account not found');
+                },
+                is_nsfs_containerized_user_anonymous: () => false
+            };
+            const object_sdk = new ObjectSDK({ rpc_client: { options: {} }, internal_rpc_client: {} });
+            object_sdk.bucketspace = mock_bucketspace;
+            object_sdk.set_auth_token({ access_key: test_access_key + '_disabled' });
+            await object_sdk.load_requesting_account({});
+            assert.ok(!object_sdk.requesting_account.nsfs_account_config.supplemental_groups ||
+                object_sdk.requesting_account.nsfs_account_config.supplemental_groups.length === 0);
+        } finally {
+            config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = true;
         }
-        process.env.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = 'true';
+    });
+
+    mocha.it('load_requesting_account with distinguished_name - populates supplemental_groups via optimized path', async function() {
+        const account = {
+            nsfs_account_config: {
+                distinguished_name: new SensitiveString(test_user_name)
+            },
+            access_keys: [{ access_key: test_access_key + '_dn' }]
+        };
+        const mock_bucketspace = {
+            read_account_by_access_key: async ({ access_key }) => {
+                if (access_key === test_access_key + '_dn') return account;
+                throw new RpcError('NO_SUCH_ACCOUNT', 'Account not found');
+            },
+            is_nsfs_containerized_user_anonymous: () => false
+        };
+        const object_sdk = new ObjectSDK({ rpc_client: { options: {} }, internal_rpc_client: {} });
+        object_sdk.bucketspace = mock_bucketspace;
+        object_sdk.set_auth_token({ access_key: test_access_key + '_dn' });
+        await object_sdk.load_requesting_account({});
+        assert.strictEqual(object_sdk.requesting_account.nsfs_account_config.uid, NON_ROOT4_UID);
+        assert.strictEqual(object_sdk.requesting_account.nsfs_account_config.gid, NON_ROOT4_GID);
+        assert.ok(object_sdk.requesting_account.nsfs_account_config.supplemental_groups);
+        assert.ok(object_sdk.requesting_account.nsfs_account_config.supplemental_groups.includes(DYNAMIC_GROUPS_GID));
+    });
+
+    mocha.it('load_requesting_account with supplemental_groups on account - overrides dynamic allocation', async function() {
+        const account = {
+            nsfs_account_config: {
+                uid: NON_ROOT4_UID,
+                gid: NON_ROOT4_GID,
+                supplemental_groups: [CLI_SET_GID]
+            },
+            access_keys: [{ access_key: test_access_key + '_override' }]
+        };
+        const mock_bucketspace = {
+            read_account_by_access_key: async ({ access_key }) => {
+                if (access_key === test_access_key + '_override') return account;
+                throw new RpcError('NO_SUCH_ACCOUNT', 'Account not found');
+            },
+            is_nsfs_containerized_user_anonymous: () => false
+        };
+        const object_sdk = new ObjectSDK({ rpc_client: { options: {} }, internal_rpc_client: {} });
+        object_sdk.bucketspace = mock_bucketspace;
+        object_sdk.set_auth_token({ access_key: test_access_key + '_override' });
+        await object_sdk.load_requesting_account({});
+        assert.deepStrictEqual(
+            object_sdk.requesting_account.nsfs_account_config.supplemental_groups,
+            [CLI_SET_GID],
+            'should use account config, not dynamic lookup'
+        );
+    });
+
+    mocha.it('load_requesting_account - user can read dir with supplemental_groups access', async function() {
+        const account = {
+            nsfs_account_config: { uid: NON_ROOT4_UID, gid: NON_ROOT4_GID },
+            access_keys: [{ access_key: test_access_key + '_read' }]
+        };
+        const mock_bucketspace = {
+            read_account_by_access_key: async ({ access_key }) => {
+                if (access_key === test_access_key + '_read') return account;
+                throw new RpcError('NO_SUCH_ACCOUNT', 'Account not found');
+            },
+            is_nsfs_containerized_user_anonymous: () => false
+        };
+        const object_sdk = new ObjectSDK({ rpc_client: { options: {} }, internal_rpc_client: {} });
+        object_sdk.bucketspace = mock_bucketspace;
+        object_sdk.set_auth_token({ access_key: test_access_key + '_read' });
+        await object_sdk.load_requesting_account({});
+        const fs_context = await native_fs_utils.get_fs_context(
+            object_sdk.requesting_account.nsfs_account_config, '');
+        const entries = await nb_native().fs.readdir(fs_context, full_path_sg_read);
+        assert.equal(entries && entries.length, 0);
     });
 });
 

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -565,6 +565,37 @@ async function get_user_by_distinguished_name({ distinguished_name }) {
     }
 }
 
+/**
+ * get_supplemental_groups_by_uid - gets supplemental groups by uid via getpwuid_r + getgrouplist.
+ * Used by supplemental_groups_cache load when user data is not already available.
+ */
+async function get_supplemental_groups_by_uid({ uid }) {
+    try {
+        const context = get_process_fs_context();
+        const groups = await nb_native().fs.getSupplementalGroupsByUid(context, uid);
+        return groups;
+    } catch (err) {
+        dbg.error('native_fs_utils.get_supplemental_groups_by_uid: failed with error', err, err.code, uid);
+        throw err;
+    }
+}
+
+/**
+ * get_supplemental_groups_by_user - gets supplemental groups by username and primary gid.
+ * Optimization: when user data is already available (e.g. from getpwnam for distinguished_name),
+ * avoids redundant getpwuid_r lookup.
+ */
+async function get_supplemental_groups_by_user({ name, gid }) {
+    try {
+        const context = get_process_fs_context();
+        const groups = await nb_native().fs.getSupplementalGroupsByUserName(context, name, gid);
+        return groups;
+    } catch (err) {
+        dbg.error('native_fs_utils.get_supplemental_groups_by_user: failed with error', err, err.code, name);
+        throw err;
+    }
+}
+
 function isDirectory(ent) {
     if (!ent) throw new Error('isDirectory: ent is empty');
     if (ent.mode) {
@@ -594,6 +625,32 @@ function get_process_fs_context(backend = '', warn_threshold_ms = config.NSFS_WA
 }
 
 /**
+ * get_supplemental_groups_for_account - gets supplemental groups for NSFS account.
+ * Logic: if defined in account CLI use those; else if NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS get via cache.
+ * When account_ids_by_dn is provided (from distinguished_name resolution), uses optimized path avoiding getpwuid_r.
+ * @param {Object} nsfs_account_config
+ * @param {nb.NativeFSContext} fs_context
+ * @returns {Promise<number[] | undefined>}
+ */
+async function _get_supplemental_groups_for_account(nsfs_account_config, fs_context) {
+    if (Array.isArray(nsfs_account_config.supplemental_groups)) {
+        return nsfs_account_config.supplemental_groups;
+    }
+    if (!config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS || fs_context.uid === undefined) {
+        return undefined;
+    }
+    try {
+        if (nsfs_account_config.distinguished_name) {
+            return await get_supplemental_groups_by_user({ name: nsfs_account_config.distinguished_name, gid: fs_context.gid });
+        }
+        return await get_supplemental_groups_by_uid({ uid: fs_context.uid });
+    } catch (err) {
+        dbg.warn('get_supplemental_groups_for_account: failed to get supplemental groups', fs_context.uid, err);
+        return undefined;
+    }
+}
+
+/**
  * @param {Object} nsfs_account_config
  * @param {string} [fs_backend]
  * @returns {Promise<nb.NativeFSContext>}
@@ -610,9 +667,9 @@ async function get_fs_context(nsfs_account_config, fs_backend) {
         backend: fs_backend
     };
 
-    //napi does not accepts undefined value for an array. if supplemental_groups is undefined don't include this property at all
-    if (nsfs_account_config.supplemental_groups) {
-        fs_context.supplemental_groups = nsfs_account_config.supplemental_groups;
+    const supplemental_groups = await _get_supplemental_groups_for_account(nsfs_account_config, fs_context);
+    if (supplemental_groups && supplemental_groups.length > 0) {
+        fs_context.supplemental_groups = supplemental_groups;
     }
     return fs_context;
 }
@@ -662,7 +719,8 @@ async function is_dir_accessible(fs_context, dir_path) {
     if (config.NC_DISABLE_POSIX_MODE_ACCESS_CHECK) return true;
 
     const is_owner = fs_context.uid === stat.uid;
-    const is_group = fs_context.gid === stat.gid;
+    const is_group = fs_context.gid === stat.gid ||
+        (fs_context.supplemental_groups && fs_context.supplemental_groups.includes(stat.gid));
 
     const read_access_owner = stat.mode & fs.constants.S_IRUSR;
     const read_access_group = stat.mode & fs.constants.S_IRGRP;
@@ -916,6 +974,8 @@ exports.use_file = use_file;
 exports.copy_bytes = copy_bytes;
 exports.finally_close_files = finally_close_files;
 exports.get_user_by_distinguished_name = get_user_by_distinguished_name;
+exports.get_supplemental_groups_by_uid = get_supplemental_groups_by_uid;
+exports.get_supplemental_groups_by_user = get_supplemental_groups_by_user;
 exports.get_config_files_tmpdir = get_config_files_tmpdir;
 exports.stat_ignore_enoent = stat_ignore_enoent;
 exports.stat_if_exists = stat_if_exists;


### PR DESCRIPTION
### Describe the Problem
we check FS user supplemental groups in OS for each file system command. this causes a major performance hit for NSFS systems 

### Explain the Changes
1. create a new supplemental groups cache. and get the groups from it instead of getting them from the filesystem every time
2. add config variable NSFS_SUPPLEMENTAL_GROUPS_CACHE_EXPIRY_MS that sets when the cache gets invalidated (default to 1 minute)
3. modify get_fs_context function to get the correct supplemental groups after the change
4. added new tests 

warp performance results:

### GAPS
1. I made limited performance testing for this feature. only using warp on a small system. need more thorough performance testing

**feature disabled:**
```                                                                              
Reqs: 148593, Errs:0, Objs:148593, Bytes: 141.7MiB                                                   
 -       GET Average: 497 Obj/s, 485.0KiB/s; Current 521 Obj/s, 508.9KiB/s, 39.9 ms/req, TTFB: 39.9ms
 
 Report: GET. Concurrency: 20. Ran: 4m57s
 * Average: 0.47 MiB/s, 496.38 obj/s
 * Reqs: Avg: 40.5ms, 50%: 39.8ms, 90%: 45.4ms, 99%: 58.7ms, Fastest: 21.4ms, Slowest: 149.9ms, StdDev: 4.7ms
 * TTFB: Avg: 41ms, Best: 21ms, 25th: 38ms, Median: 40ms, 75th: 42ms, 90th: 45ms, 99th: 59ms, Worst: 150ms StdDev: 5ms

Throughput, split into 297 x 1s:
 * Fastest: 767.4KiB/s, 785.80 obj/s
 * 50% Median: 506.8KiB/s, 518.94 obj/s
 * Slowest: 265.9KiB/s, 272.29 obj/s
 ```
 
 **feature enabled before changes:**
 ```
 Reqs: 85898, Errs:0, Objs:85898, Bytes: 81.9MiB                                                      
 -       GET Average: 286 Obj/s, 279.8KiB/s; Current 282 Obj/s, 275.0KiB/s, 77.0 ms/req, TTFB: 76.9ms
                                                                                                     

Report: GET. Concurrency: 20. Ran: 4m57s
 * Average: 0.27 MiB/s, 286.54 obj/s
 * Reqs: Avg: 69.7ms, 50%: 67.5ms, 90%: 80.0ms, 99%: 102.6ms, Fastest: 36.6ms, Slowest: 259.9ms, StdDev: 8.8ms
 * TTFB: Avg: 70ms, Best: 37ms, 25th: 64ms, Median: 67ms, 75th: 72ms, 90th: 80ms, 99th: 103ms, Worst: 260ms StdDev: 9ms

Throughput, split into 297 x 1s:
 * Fastest: 315.8KiB/s, 323.35 obj/s
 * 50% Median: 289.1KiB/s, 296.03 obj/s
 * Slowest: 148.6KiB/s, 152.15 obj/s
 ```
 
 **feature enabled after changes:**
 ```
 Reqs: 148742, Errs:0, Objs:148742, Bytes: 141.9MiB                                                   
 -       GET Average: 495 Obj/s, 483.1KiB/s; Current 514 Obj/s, 501.9KiB/s, 47.9 ms/req, TTFB: 47.9ms
                                                                                                     

Report: GET. Concurrency: 20. Ran: 4m57s
 * Average: 0.47 MiB/s, 494.77 obj/s
 * Reqs: Avg: 40.6ms, 50%: 39.4ms, 90%: 47.7ms, 99%: 61.2ms, Fastest: 22.5ms, Slowest: 139.4ms, StdDev: 5.9ms
 * TTFB: Avg: 41ms, Best: 23ms, 25th: 36ms, Median: 39ms, 75th: 43ms, 90th: 48ms, 99th: 61ms, Worst: 139ms StdDev: 6ms

Throughput, split into 297 x 1s:
 * Fastest: 540.1KiB/s, 553.08 obj/s
 * 50% Median: 501.3KiB/s, 513.34 obj/s
 * Slowest: 226.9KiB/s, 232.33 obj/s
 ```
 

### Issues: Fixed #9459 

### Testing Instructions:
functionality tests:
`sudo node ./node_modules/mocha/bin/mocha src/test/unit_tests/nsfs/test_nsfs_access.js`
performance tests:
`warp get --access-key <access_key> --secret-key <secret_key> --host 127.0.0.1:6001 --bucket warp-bucket --obj.size 1000`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FS API: retrieve supplemental groups by UID or username.
  * Exposed supplemental-groups cache with configurable expiry.

* **Improvements**
  * Dynamic supplemental-group resolution integrated into account loading and access checks, improving permission accuracy.
  * Native behavior simplified to apply pre-resolved group lists.

* **Configuration**
  * Added cache-expiry setting (default 1 minute); removed one config key from env propagation.

* **Tests**
  * New unit tests covering dynamic supplemental-group flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->