### PR TITLE
[S3Vectors] Supporting  bucket policies - Part I - NB APIs

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1024,6 +1024,66 @@ module.exports = {
                 system: ['admin', 'user']
             }
         },
+
+        put_vector_bucket_policy: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: [
+                    'policy',
+                    'name',
+                ],
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    policy: {
+                        $ref: 'common_api#/definitions/bucket_policy'
+                    }
+                }
+            },
+            auth: {
+                system: ['admin', 'user'],
+            }
+        },
+
+        get_vector_bucket_policy: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: [
+                    'name'
+                ],
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                }
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    policy: {
+                        $ref: 'common_api#/definitions/bucket_policy'
+                    },
+                },
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
+
+        delete_vector_bucket_policy: {
+            method: 'DELETE',
+            params: {
+                type: 'object',
+                required: [
+                    'name'
+                ],
+                properties: {
+                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                }
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
     },
 
     definitions: {

--- a/src/endpoint/vector/ops/vector_delete_vector_bucket_policy.js
+++ b/src/endpoint/vector/ops/vector_delete_vector_bucket_policy.js
@@ -1,0 +1,23 @@
+/* Copyright (C) 2025 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const VectorError = require('../vector_errors').VectorError;
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_DeleteVectorBucketPolicy.html
+ */
+async function delete_vector_bucket_policy(req, res) {
+    dbg.log1("delete_vector_bucket_policy body =", req.body);
+
+    const vector_bucket_name = req.body.vectorBucketName;
+    if (!vector_bucket_name) {
+        throw new VectorError(VectorError.ValidationException);
+    }
+
+    await req.vector_sdk.delete_vector_bucket_policy({
+        name: vector_bucket_name,
+    });
+}
+
+exports.handler = delete_vector_bucket_policy;

--- a/src/endpoint/vector/ops/vector_get_vector_bucket_policy.js
+++ b/src/endpoint/vector/ops/vector_get_vector_bucket_policy.js
@@ -1,0 +1,27 @@
+/* Copyright (C) 2025 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const VectorError = require('../vector_errors').VectorError;
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_GetVectorBucketPolicy.html
+ */
+async function get_vector_bucket_policy(req, res) {
+    dbg.log1("get_vector_bucket_policy body =", req.body);
+
+    const vector_bucket_name = req.body.vectorBucketName;
+    if (!vector_bucket_name) {
+        throw new VectorError(VectorError.ValidationException);
+    }
+
+    const reply = await req.vector_sdk.get_vector_bucket_policy({
+        name: vector_bucket_name,
+    });
+    if (!reply.policy) {
+        throw new VectorError(VectorError.NoSuchVectorBucketPolicy);
+    }
+    return { policy: JSON.stringify(reply.policy) };
+}
+
+exports.handler = get_vector_bucket_policy;

--- a/src/endpoint/vector/ops/vector_put_vector_bucket_policy.js
+++ b/src/endpoint/vector/ops/vector_put_vector_bucket_policy.js
@@ -1,0 +1,55 @@
+/* Copyright (C) 2025 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const VectorError = require('../vector_errors').VectorError;
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_PutVectorBucketPolicy.html
+ */
+async function put_vector_bucket_policy(req, res) {
+    dbg.log1("put_vector_bucket_policy body =", req.body);
+
+    const vector_bucket_name = req.body.vectorBucketName;
+    if (!vector_bucket_name) {
+        throw new VectorError(VectorError.ValidationException);
+    }
+
+    let policy;
+    try {
+        policy = JSON.parse(req.body.policy);
+    } catch (error) {
+        dbg.error('put_vector_bucket_policy: Invalid policy JSON', error);
+        throw new VectorError(VectorError.ValidationException);
+    }
+
+    try {
+        await req.vector_sdk.put_vector_bucket_policy({
+            name: vector_bucket_name,
+            policy,
+        });
+    } catch (error) {
+        if (error.rpc_code === 'MALFORMED_POLICY') {
+            const err = new VectorError(VectorError.ValidationException);
+            err.message = error.message || 'Policy was not well formed or did not validate against the published schema';
+            const detail = error.rpc_data && error.rpc_data.detail;
+            err.fieldList = [{
+                path: 'policy',
+                message: error.message + (detail ? ': ' + detail : ''),
+            }];
+            throw err;
+        }
+        if (error.rpc_code === 'INVALID_SCHEMA' || error.rpc_code === 'INVALID_SCHEMA_PARAMS') {
+            const err = new VectorError(VectorError.ValidationException);
+            err.message = 'Policy was not well formed or did not validate against the published schema';
+            err.fieldList = [{
+                path: 'policy',
+                message: 'Policy was not well formed or did not validate against the published schema',
+            }];
+            throw err;
+        }
+        throw error;
+    }
+}
+
+exports.handler = put_vector_bucket_policy;

--- a/src/endpoint/vector/vector_errors.js
+++ b/src/endpoint/vector/vector_errors.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2025 NooBaa */
 'use strict';
-const xml_utils = require('../../util/xml_utils');
 
 const error_type_enum = {
     SENDER: 'Sender',
@@ -27,20 +26,19 @@ class VectorError extends Error {
         this.code = code;
         this.http_code = http_code;
         this.type = type;
+        /** @type {Array<{path: string, message: string}>|undefined} */
+        this.fieldList = undefined;
     }
 
-    reply(request_id) {
-        const xml = {
-            ErrorResponse: {
-                Error: {
-                    Type: this.type,
-                    Code: this.code,
-                    Message: this.message,
-                },
-                RequestId: request_id || '',
-            }
+    reply() {
+        const body = {
+            __type: this.code,
+            message: this.message,
         };
-        return xml_utils.encode_xml(xml);
+        if (this.fieldList) {
+            body.fieldList = this.fieldList;
+        }
+        return JSON.stringify(body);
     }
 
 }
@@ -111,8 +109,8 @@ VectorError.ThrottlingException = Object.freeze({
     http_code: 400,
     type: error_type_enum.SENDER,
 });
-VectorError.ValidationError = Object.freeze({
-    code: 'ValidationError',
+VectorError.ValidationException = Object.freeze({
+    code: 'ValidationException',
     message: 'The input fails to satisfy the constraints specified by an AWS service.',
     http_code: 400,
     type: error_type_enum.SENDER,
@@ -132,6 +130,18 @@ VectorError.InvalidParameterValue = Object.freeze({
 VectorError.ExpiredToken = Object.freeze({
     code: 'ExpiredToken',
     message: 'The security token included in the request is expired',
+    http_code: 400,
+    type: error_type_enum.SENDER,
+});
+VectorError.NoSuchVectorBucketPolicy = Object.freeze({
+    code: 'NoSuchVectorBucketPolicy',
+    message: 'The vector bucket policy does not exist.',
+    http_code: 404,
+    type: error_type_enum.SENDER,
+});
+VectorError.MalformedPolicy = Object.freeze({
+    code: 'MalformedPolicy',
+    message: 'Policy was not well formed or did not validate against the published schema.',
     http_code: 400,
     type: error_type_enum.SENDER,
 });

--- a/src/endpoint/vector/vector_rest.js
+++ b/src/endpoint/vector/vector_rest.js
@@ -17,7 +17,7 @@ const RPC_ERRORS_TO_VECTOR = Object.freeze({ //TODO - validate
     DEACTIVATED_ACCESS_KEY_ID: VectorError.InvalidClientTokenIdInactiveAccessKey,
     NO_SUCH_ACCOUNT: VectorError.AccessDeniedException,
     NO_SUCH_ROLE: VectorError.AccessDeniedException,
-    VALIDATION_ERROR: VectorError.ValidationError,
+    VALIDATION_ERROR: VectorError.ValidationException,
     /*INVALID_INPUT: VectorError.InvalidInput,
     MALFORMED_POLICY_DOCUMENT: VectorError.MalformedPolicyDocument,
     ENTITY_ALREADY_EXISTS: VectorError.EntityAlreadyExists,
@@ -32,6 +32,7 @@ const RPC_ERRORS_TO_VECTOR = Object.freeze({ //TODO - validate
     ACCESS_DENIED_EXCEPTION: VectorError.AccessDeniedException,
     NOT_AUTHORIZED: VectorError.NotAuthorized,
     INTERNAL_FAILURE: VectorError.InternalFailure,
+    NO_SUCH_BUCKET: VectorError.ValidationException,
 });
 
 const VECTOR_OPS = js_utils.deep_freeze({
@@ -42,6 +43,9 @@ const VECTOR_OPS = js_utils.deep_freeze({
     QueryVectors: require('./ops/vector_query_vectors'),
     ListVectorBuckets: require('./ops/vector_list_vector_buckets'),
     DeleteVectors: require('./ops/vector_delete_vectors'),
+    PutVectorBucketPolicy: require('./ops/vector_put_vector_bucket_policy'),
+    GetVectorBucketPolicy: require('./ops/vector_get_vector_bucket_policy'),
+    DeleteVectorBucketPolicy: require('./ops/vector_delete_vector_bucket_policy'),
 });
 
 async function vector_rest(req, res) {
@@ -138,19 +142,20 @@ function handle_error(req, res, err) {
     const vector_err =
         ((err instanceof VectorError) && err) ||
         new VectorError(RPC_ERRORS_TO_VECTOR[err.rpc_code] || VectorError.InternalFailure);
-    if (!req.object_sdk.nsfs_config_root) {
+    if (req.object_sdk && !req.object_sdk.nsfs_config_root) {
         vector_err.message = err.message;
     }
-    const reply = vector_err.reply(req.request_id);
+    const reply = vector_err.reply();
     dbg.error('VECTOR ERROR', reply,
         req.method, req.originalUrl,
         JSON.stringify(req.headers),
         err.stack || err);
     if (res.headersSent) {
-        dbg.log0('Sending error xml in body, but too late for headers...');
+        dbg.log0('Sending error in body, but too late for headers...');
     } else {
         res.statusCode = vector_err.http_code;
-        res.setHeader('Content-Type', 'text/xml'); // based on actual header seen in AWS CLI
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('x-amzn-ErrorType', vector_err.code);
         res.setHeader('Content-Length', Buffer.byteLength(reply));
     }
     res.end(reply);

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -350,6 +350,29 @@ class BucketSpaceNB {
         await vectors_utils.delete_vector_bucket(params);
         return resp;
     }
+
+    //////////////////////////////
+    // VECTOR BUCKET POLICY     //
+    //////////////////////////////
+
+    async put_vector_bucket_policy(params) {
+        return this.rpc_client.bucket.put_vector_bucket_policy({
+            name: params.name,
+            policy: params.policy
+        });
+    }
+
+    async delete_vector_bucket_policy(params) {
+        return this.rpc_client.bucket.delete_vector_bucket_policy({
+            name: params.name
+        });
+    }
+
+    async get_vector_bucket_policy(params) {
+        return this.rpc_client.bucket.get_vector_bucket_policy({
+            name: params.name
+        });
+    }
 }
 
 module.exports = BucketSpaceNB;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -889,6 +889,10 @@ interface BucketSpace {
     delete_bucket_policy(params: object): Promise<any>;
     get_bucket_policy(params: object, object_sdk: ObjectSDK): Promise<any>;
 
+    put_vector_bucket_policy(params: object): Promise<any>;
+    delete_vector_bucket_policy(params: object): Promise<any>;
+    get_vector_bucket_policy(params: object): Promise<any>;
+
     put_bucket_notification(params: object): Promise<any>;
     get_bucket_notification(params: object): Promise<any>;
 

--- a/src/sdk/vector_sdk.js
+++ b/src/sdk/vector_sdk.js
@@ -61,6 +61,25 @@ class VectorSDK {
         return res;
     }
 
+    //////////////////////////////
+    // VECTOR BUCKET POLICY     //
+    //////////////////////////////
+
+    async put_vector_bucket_policy(params) {
+        const bs = this._get_bucketspace();
+        return await bs.put_vector_bucket_policy(params);
+    }
+
+    async get_vector_bucket_policy(params) {
+        const bs = this._get_bucketspace();
+        return await bs.get_vector_bucket_policy(params);
+    }
+
+    async delete_vector_bucket_policy(params) {
+        const bs = this._get_bucketspace();
+        return await bs.delete_vector_bucket_policy(params);
+    }
+
 }
 
 module.exports = VectorSDK;

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -2258,6 +2258,43 @@ function get_vector_bucket_info(vector_bucket) {
     return info;
 }
 
+async function get_vector_bucket_policy(req) {
+    dbg.log0('get_vector_bucket_policy:', req.rpc_params);
+    const vector_bucket = find_vector_bucket(req, req.rpc_params.name);
+    return {
+        policy: vector_bucket.vector_policy,
+    };
+}
+
+async function put_vector_bucket_policy(req) {
+    dbg.log0('put_vector_bucket_policy:', req.rpc_params);
+    const vector_bucket = find_vector_bucket(req, req.rpc_params.name);
+    await access_policy_utils.validate_vector_bucket_policy(req.rpc_params.policy, vector_bucket.name,
+        principal => get_account_by_principal(principal));
+
+    await system_store.make_changes({
+        update: {
+            vector_buckets: [{
+                _id: vector_bucket._id,
+                vector_policy: req.rpc_params.policy
+            }]
+        }
+    });
+}
+
+async function delete_vector_bucket_policy(req) {
+    dbg.log0('delete_vector_bucket_policy:', req.rpc_params);
+    const vector_bucket = find_vector_bucket(req, req.rpc_params.name);
+    await system_store.make_changes({
+        update: {
+            vector_buckets: [{
+                _id: vector_bucket._id,
+                $unset: { vector_policy: 1 }
+            }]
+        }
+    });
+}
+
 // EXPORTS
 exports.new_bucket_defaults = new_bucket_defaults;
 exports.get_bucket_info = get_bucket_info;
@@ -2319,7 +2356,12 @@ exports.get_public_access_block = get_public_access_block;
 exports.put_public_access_block = put_public_access_block;
 exports.delete_public_access_block = delete_public_access_block;
 
-//vecor buckets
+//vector buckets
 exports.create_vector_bucket = create_vector_bucket;
 exports.delete_vector_bucket = delete_vector_bucket;
 exports.list_vector_buckets = list_vector_buckets;
+
+// vector bucket policy
+exports.put_vector_bucket_policy = put_vector_bucket_policy;
+exports.get_vector_bucket_policy = get_vector_bucket_policy;
+exports.delete_vector_bucket_policy = delete_vector_bucket_policy;

--- a/src/server/system_services/schemas/vector_bucket_schema.js
+++ b/src/server/system_services/schemas/vector_bucket_schema.js
@@ -30,5 +30,8 @@ module.exports = {
         deleted: {
             date: true
         },
+        vector_policy: {
+            $ref: 'common_api#/definitions/bucket_policy'
+        },
     }
 };

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -216,6 +216,116 @@ mocha.describe('vectors_ops', function() {
             compare_vectors(response.vectors, vectors, false);
         });
 
+        mocha.it('should put a vector bucket policy', async function() {
+            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+
+            const policy = {
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: '*',
+                    Action: 's3vectors:*',
+                    Resource: `arn:aws:s3vectors:::${vector_bucket_name1}`,
+                }]
+            };
+
+            const put_cmd = new s3vectors.PutVectorBucketPolicyCommand({
+                vectorBucketName: vector_bucket_name1,
+                policy: JSON.stringify(policy),
+            });
+            await send(s3_vectors_client, put_cmd);
+        });
+
+        mocha.it('should get a vector bucket policy', async function() {
+            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+
+            const policy = {
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: '*',
+                    Action: 's3vectors:GetVectorBucket',
+                    Resource: `arn:aws:s3vectors:::${vector_bucket_name1}`,
+                }]
+            };
+
+            const put_cmd = new s3vectors.PutVectorBucketPolicyCommand({
+                vectorBucketName: vector_bucket_name1,
+                policy: JSON.stringify(policy),
+            });
+            await send(s3_vectors_client, put_cmd);
+
+            const get_cmd = new s3vectors.GetVectorBucketPolicyCommand({
+                vectorBucketName: vector_bucket_name1,
+            });
+            const response = await send(s3_vectors_client, get_cmd);
+            const returned_policy = JSON.parse(response.policy);
+            assert.deepStrictEqual(returned_policy, policy);
+        });
+
+        mocha.it('should reject a malformed vector bucket policy', async function() {
+            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+
+            const malformed_policy = {
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: '*',
+                    Action: 's3:GetObject',
+                    Resource: `arn:aws:s3:::${vector_bucket_name1}`,
+                }]
+            };
+
+            const put_cmd = new s3vectors.PutVectorBucketPolicyCommand({
+                vectorBucketName: vector_bucket_name1,
+                policy: JSON.stringify(malformed_policy),
+            });
+            try {
+                await s3_vectors_client.send(put_cmd);
+                assert.fail('Expected error for malformed policy');
+            } catch (err) {
+                console.error('Received expected error for malformed policy:', err);
+                assert.strictEqual(err.name, 'ValidationException');
+                assert.ok(err.fieldList, 'Expected fieldList in validation error');
+                assert.ok(err.fieldList.length > 0, 'Expected at least one entry in fieldList');
+                assert.strictEqual(err.fieldList[0].path, 'policy');
+            }
+        });
+
+        mocha.it('should delete a vector bucket policy', async function() {
+            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+
+            const policy = {
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: '*',
+                    Action: 's3vectors:*',
+                    Resource: `arn:aws:s3vectors:::${vector_bucket_name1}`,
+                }]
+            };
+
+            const put_cmd = new s3vectors.PutVectorBucketPolicyCommand({
+                vectorBucketName: vector_bucket_name1,
+                policy: JSON.stringify(policy),
+            });
+            await send(s3_vectors_client, put_cmd);
+
+            const del_cmd = new s3vectors.DeleteVectorBucketPolicyCommand({
+                vectorBucketName: vector_bucket_name1,
+            });
+            await send(s3_vectors_client, del_cmd);
+
+            const get_cmd = new s3vectors.GetVectorBucketPolicyCommand({
+                vectorBucketName: vector_bucket_name1,
+            });
+            try {
+                await s3_vectors_client.send(get_cmd);
+                assert.fail('Expected error for missing policy');
+            } catch (err) {
+                assert.strictEqual(err.name, 'NoSuchVectorBucketPolicy');
+            }
+        });
 
     });
 });

--- a/src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js
@@ -1,0 +1,506 @@
+/* Copyright (C) 2026 NooBaa */
+/* eslint-disable max-lines-per-function */
+'use strict';
+
+const access_policy_utils = require('../../../util/access_policy_utils');
+const RpcError = require('../../../rpc/rpc_error');
+
+const BUCKET_NAME = 'test-bucket';
+const VECTOR_BUCKET_NAME = 'test-vector-bucket';
+
+const account_handler_allow_all = async () => ({ _id: '123' });
+const account_handler_deny_all = async () => null;
+
+/**
+ * @param {Object} [params]
+ * @param {'Allow'|'Deny'} [params.effect='Allow']
+ * @param {string|{AWS: string|string[]}} [params.principal='*']
+ * @param {string|string[]} [params.action]
+ * @param {string|string[]} [params.resource]
+ * @param {Object} [params.condition]
+ * @returns {{ Statement: Object[] }}
+ */
+function make_policy({ effect = 'Allow', principal = '*', action, resource, condition } = {}) {
+    const statement = { Effect: effect };
+    statement.Principal = principal;
+    if (action) statement.Action = action;
+    if (resource) statement.Resource = resource;
+    if (condition) statement.Condition = condition;
+    return { Statement: [statement] };
+}
+
+async function expect_malformed_policy(fn) {
+    try {
+        await fn();
+        throw new Error('Expected MALFORMED_POLICY error but none was thrown');
+    } catch (err) {
+        expect(err).toBeInstanceOf(RpcError);
+        expect(err.rpc_code).toBe('MALFORMED_POLICY');
+    }
+}
+
+describe('access_policy_utils', () => {
+
+    describe('validate_bucket_policy', () => {
+
+        describe('valid policies', () => {
+            it('should accept a policy with wildcard principal and s3:* action', async () => {
+                const policy = make_policy({
+                    action: 's3:*',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}`,
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a policy with a specific valid s3 action', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a policy with multiple valid actions', async () => {
+                const policy = make_policy({
+                    action: ['s3:GetObject', 's3:PutObject'],
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a Deny statement with NotPrincipal', async () => {
+                const policy = make_policy({
+                    effect: 'Deny',
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                });
+                policy.Statement[0].NotPrincipal = { AWS: '*' };
+                delete policy.Statement[0].Principal;
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a valid s3 condition key', async () => {
+                const policy = make_policy({
+                    action: 's3:PutObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { StringEquals: { 's3:x-amz-server-side-encryption': 'AES256' } },
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a condition key with sub-key (split on /)', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { StringEquals: { 's3:ExistingObjectTag/environment': 'production' } },
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a resource with wildcard matching the bucket', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::test-*`,
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+        });
+
+        describe('invalid actions', () => {
+            it('should reject an s3vectors action in an s3 bucket policy', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:PutVectors',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a completely invalid action', async () => {
+                const policy = make_policy({
+                    action: 'ec2:RunInstances',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject s3vectors:* wildcard in an s3 bucket policy', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:*',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+        });
+
+        describe('invalid resources', () => {
+            it('should reject a resource that does not match the bucket name', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: 'arn:aws:s3:::other-bucket/*',
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a malformed resource with brackets', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}[bad]`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+        });
+
+        describe('invalid principals', () => {
+            it('should reject an Allow statement with NotPrincipal', async () => {
+                const policy = make_policy({
+                    effect: 'Allow',
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                });
+                policy.Statement[0].NotPrincipal = { AWS: '*' };
+                delete policy.Statement[0].Principal;
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a non-wildcard principal that does not exist', async () => {
+                const policy = make_policy({
+                    principal: { AWS: 'arn:aws:iam::123456789:root' },
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_deny_all)
+                );
+            });
+
+            it('should reject a non-wildcard bare string principal', async () => {
+                const policy = make_policy({
+                    principal: 'arn:aws:iam::123456789:root',
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+        });
+
+        describe('invalid conditions', () => {
+            it('should reject an unsupported condition key', async () => {
+                const policy = make_policy({
+                    action: 's3:PutObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { StringEquals: { 'aws:SourceIp': '10.0.0.0/8' } },
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a vector condition key in an s3 bucket policy', async () => {
+                const policy = make_policy({
+                    action: 's3:PutObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { StringEquals: { 's3vectors:sseType': 'AES256' } },
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+        });
+    });
+
+    describe('validate_vector_bucket_policy', () => {
+
+        describe('valid policies', () => {
+            it('should accept a policy with wildcard principal and s3vectors:* action', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:*',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect(
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a policy with a specific valid vector action', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:PutVectors',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect(
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a policy with multiple valid vector actions', async () => {
+                const policy = make_policy({
+                    action: ['s3vectors:PutVectors', 's3vectors:QueryVectors', 's3vectors:GetVectors'],
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect(
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept all individual vector actions', async () => {
+                const all_actions = [
+                    's3vectors:CreateVectorBucket', 's3vectors:GetVectorBucket',
+                    's3vectors:DeleteVectorBucket', 's3vectors:ListVectorBuckets',
+                    's3vectors:ListIndexes', 's3vectors:PutVectorBucketPolicy',
+                    's3vectors:GetVectorBucketPolicy', 's3vectors:DeleteVectorBucketPolicy',
+                    's3vectors:CreateIndex', 's3vectors:GetIndex',
+                    's3vectors:DeleteIndex', 's3vectors:QueryVectors',
+                    's3vectors:PutVectors', 's3vectors:GetVectors',
+                    's3vectors:ListVectors', 's3vectors:DeleteVectors',
+                ];
+                for (const action of all_actions) {
+                    const policy = make_policy({
+                        action,
+                        resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                    });
+                    await expect(
+                        access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                    ).resolves.toBeUndefined();
+                }
+            });
+
+            it('should accept a Deny statement with NotPrincipal', async () => {
+                const policy = make_policy({
+                    effect: 'Deny',
+                    action: 's3vectors:PutVectors',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                policy.Statement[0].NotPrincipal = { AWS: '*' };
+                delete policy.Statement[0].Principal;
+                await expect(
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a valid vector condition key', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:CreateVectorBucket',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                    condition: { StringEquals: { 's3vectors:sseType': 'AES256' } },
+                });
+                await expect(
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept the kmsKeyArn condition key', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:CreateVectorBucket',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                    condition: { StringEquals: { 's3vectors:kmsKeyArn': 'arn:aws:kms:us-east-1:123456789:key/abc' } },
+                });
+                await expect(
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept a resource with wildcard matching the vector bucket', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:PutVectors',
+                    resource: 'arn:aws:s3vectors:::test-*',
+                });
+                await expect(
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+        });
+
+        describe('invalid actions', () => {
+            it('should reject an s3 action in a vector bucket policy', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject s3:* wildcard in a vector bucket policy', async () => {
+                const policy = make_policy({
+                    action: 's3:*',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a completely invalid action', async () => {
+                const policy = make_policy({
+                    action: 'ec2:RunInstances',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a made-up s3vectors action', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:FooBar',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+        });
+
+        describe('invalid resources', () => {
+            it('should reject a resource that does not match the vector bucket name', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:PutVectors',
+                    resource: 'arn:aws:s3vectors:::other-bucket',
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject an s3 ARN resource in a vector bucket policy', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:PutVectors',
+                    resource: `arn:aws:s3:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a malformed resource with brackets', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:PutVectors',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}[bad]`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+        });
+
+        describe('invalid principals', () => {
+            it('should reject an Allow statement with NotPrincipal', async () => {
+                const policy = make_policy({
+                    effect: 'Allow',
+                    action: 's3vectors:PutVectors',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                policy.Statement[0].NotPrincipal = { AWS: '*' };
+                delete policy.Statement[0].Principal;
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a non-wildcard principal that does not exist', async () => {
+                const policy = make_policy({
+                    principal: { AWS: 'arn:aws:iam::123456789:root' },
+                    action: 's3vectors:PutVectors',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_deny_all)
+                );
+            });
+        });
+
+        describe('invalid conditions', () => {
+            it('should reject an s3 condition key in a vector bucket policy', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:CreateVectorBucket',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                    condition: { StringEquals: { 's3:x-amz-server-side-encryption': 'AES256' } },
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject an unsupported condition key', async () => {
+                const policy = make_policy({
+                    action: 's3vectors:CreateVectorBucket',
+                    resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+                    condition: { StringEquals: { 'aws:SourceIp': '10.0.0.0/8' } },
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+        });
+    });
+
+    describe('cross-validation (s3 vs s3vectors boundaries)', () => {
+        it('should not accept s3vectors actions in s3 bucket policy', async () => {
+            const policy = make_policy({
+                action: ['s3:GetObject', 's3vectors:PutVectors'],
+                resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+            });
+            await expect_malformed_policy(() =>
+                access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+            );
+        });
+
+        it('should not accept s3 actions in vector bucket policy', async () => {
+            const policy = make_policy({
+                action: ['s3vectors:PutVectors', 's3:GetObject'],
+                resource: `arn:aws:s3vectors:::${VECTOR_BUCKET_NAME}`,
+            });
+            await expect_malformed_policy(() =>
+                access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+            );
+        });
+
+        it('s3 resource ARN should not be valid for vector policy', async () => {
+            const policy = make_policy({
+                action: 's3vectors:PutVectors',
+                resource: `arn:aws:s3:::${VECTOR_BUCKET_NAME}`,
+            });
+            await expect_malformed_policy(() =>
+                access_policy_utils.validate_vector_bucket_policy(policy, VECTOR_BUCKET_NAME, account_handler_allow_all)
+            );
+        });
+
+        it('s3vectors resource ARN should not be valid for s3 policy', async () => {
+            const policy = make_policy({
+                action: 's3:GetObject',
+                resource: `arn:aws:s3vectors:::${BUCKET_NAME}`,
+            });
+            await expect_malformed_policy(() =>
+                access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+            );
+        });
+    });
+});

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -303,8 +303,21 @@ function _parse_condition_keys(condition_statement) {
     }
 }
 
-async function validate_bucket_policy(policy, bucket_name, get_account_handler) {
-    const all_op_names = _.flatten(_.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned])));
+/**
+ * _validate_policy is the shared validation logic for both S3 bucket policies and vector bucket policies.
+ * @param {Object} policy - the policy document to validate
+ * @param {string} bucket_name - the bucket name to validate resources against
+ * @param {Function} get_account_handler - async function to look up an account by principal
+ * @param {Object} options
+ * @param {string} options.resource_arn_prefix - ARN prefix for resource validation (e.g. 'arn:aws:s3:::' or 'arn:aws:s3vectors:::')
+ * @param {string} options.action_wildcard - wildcard action string (e.g. 's3:*' or 's3vectors:*')
+ * @param {readonly string[]} options.valid_actions - list of valid action strings
+ * @param {readonly string[]} options.supported_condition_keys - list of supported condition key prefixes
+ * @param {boolean} [options.split_condition_key=false] - whether to split condition keys on '/' before matching
+ */
+async function _validate_policy(policy, bucket_name, get_account_handler, options) {
+    const { resource_arn_prefix, action_wildcard, valid_actions, supported_condition_keys,
+        split_condition_key = false } = options;
     for (const statement of policy.Statement) {
         if (statement.NotPrincipal && statement.Effect !== 'Deny') {
             throw new RpcError('MALFORMED_POLICY', 'Allow with NotPrincipal is not allowed.', {});
@@ -336,29 +349,37 @@ async function validate_bucket_policy(policy, bucket_name, get_account_handler) 
                 .replace(esc_regex, '\\$&')
                 .replace(qm_regex, '.?')
                 .replace(ar_regex, '.*')}$`);
-            if (!resource_regex.test('arn:aws:s3:::' + bucket_name)) {
+            if (!resource_regex.test(resource_arn_prefix + bucket_name)) {
                 throw new RpcError('MALFORMED_POLICY', 'Policy has invalid resource', { detail: resource });
             }
         }
         for (const action of _.flatten([statement.Action || statement.NotAction])) {
-            if (action !== 's3:*' && !all_op_names.includes(action)) {
+            if (action !== action_wildcard && !valid_actions.includes(action)) {
                 throw new RpcError('MALFORMED_POLICY', 'Policy has invalid action', { detail: action });
             }
         }
         if (statement.Condition) {
             for (const condition of Object.values(statement.Condition)) {
                 for (const condition_key of Object.keys(condition)) {
-                    // some condition keys have arguments in their names.(e.g. s3:ExistingObjectTag/<key>)
-                    // parse to get only the condition key itself
-                    const key_parts = condition_key.split("/");
-                    if (!SUPPORTED_BUCKET_POLICY_CONDITIONS.includes(key_parts[0])) {
+                    const key_to_check = split_condition_key ? condition_key.split("/")[0] : condition_key;
+                    if (!supported_condition_keys.includes(key_to_check)) {
                         throw new RpcError('MALFORMED_POLICY', 'Policy has invalid condition key or unsupported condition key', { detail: condition_key });
                     }
                 }
             }
         }
-        // TODO: Need to validate that the resource comply with the action
     }
+}
+
+async function validate_bucket_policy(policy, bucket_name, get_account_handler) {
+    const all_op_names = _.flatten(_.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned])));
+    return _validate_policy(policy, bucket_name, get_account_handler, {
+        resource_arn_prefix: 'arn:aws:s3:::',
+        action_wildcard: 's3:*',
+        valid_actions: all_op_names,
+        supported_condition_keys: SUPPORTED_BUCKET_POLICY_CONDITIONS,
+        split_condition_key: true,
+    });
 }
 
 /**
@@ -447,9 +468,44 @@ function check_iam_path_was_set(iam_path) {
     return iam_path && iam_path !== IAM_DEFAULT_PATH;
 }
 
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-access-management.html
+const VECTOR_BUCKET_POLICY_ACTIONS = Object.freeze([
+    's3vectors:CreateVectorBucket',
+    's3vectors:GetVectorBucket',
+    's3vectors:DeleteVectorBucket',
+    's3vectors:ListVectorBuckets',
+    's3vectors:ListIndexes',
+    's3vectors:PutVectorBucketPolicy',
+    's3vectors:GetVectorBucketPolicy',
+    's3vectors:DeleteVectorBucketPolicy',
+    's3vectors:CreateIndex',
+    's3vectors:GetIndex',
+    's3vectors:DeleteIndex',
+    's3vectors:QueryVectors',
+    's3vectors:PutVectors',
+    's3vectors:GetVectors',
+    's3vectors:ListVectors',
+    's3vectors:DeleteVectors',
+]);
+
+const SUPPORTED_VECTOR_BUCKET_POLICY_CONDITIONS = Object.freeze([
+    's3vectors:sseType',
+    's3vectors:kmsKeyArn',
+]);
+
+async function validate_vector_bucket_policy(policy, bucket_name, get_account_handler) {
+    return _validate_policy(policy, bucket_name, get_account_handler, {
+        resource_arn_prefix: 'arn:aws:s3vectors:::',
+        action_wildcard: 's3vectors:*',
+        valid_actions: VECTOR_BUCKET_POLICY_ACTIONS,
+        supported_condition_keys: SUPPORTED_VECTOR_BUCKET_POLICY_CONDITIONS,
+    });
+}
+
 exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;
 exports.has_access_policy_permission = has_access_policy_permission;
 exports.validate_bucket_policy = validate_bucket_policy;
+exports.validate_vector_bucket_policy = validate_vector_bucket_policy;
 exports.allows_public_access = allows_public_access;
 exports.get_bucket_policy_principal_arn = get_bucket_policy_principal_arn;
 exports.create_arn_for_root = create_arn_for_root;

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -184,7 +184,7 @@ function get_lance_opts_s3() {
 
 let lanceConn;
 
-async function getVecorConn(vectorConnId) {
+async function getVectorConn(vectorConnId) {
 
     const lance_s3_opts = get_lance_opts_s3();
 
@@ -207,7 +207,7 @@ async function create_fs_db(path = '/tmp/lance') {
 
 async function create_vector_bucket({name}) {
     dbg.log0("create_vector_bucket name = ", name);
-    const vc = await getVecorConn();
+    const vc = await getVectorConn();
     await vc.create_vector_bucket();
     dbg.log0("create_vector_bucket done");
 }
@@ -215,33 +215,33 @@ async function create_vector_bucket({name}) {
 async function delete_vector_bucket({name}) {
     const unwrapped = name.unwrap ? name.unwrap() : name;
     dbg.log0("delete_vector_bucket name = ", unwrapped);
-    const vc = await getVecorConn();
+    const vc = await getVectorConn();
     await vc.delete_vector_bucket(unwrapped);
     dbg.log0("delete_vector_bucket done");
 }
 
 async function put_vectors({vector_bucket_name, vectors}) {
     dbg.log0("put_vectors =", vector_bucket_name, ", vectors =", vectors);
-    const vc = await getVecorConn();
+    const vc = await getVectorConn();
     await vc.put_vectors(vector_bucket_name, vectors);
     dbg.log0("put_vectors done");
 }
 
 async function list_vectors({vector_bucket_name, max_results}) {
     dbg.log0("list_vectors =", vector_bucket_name, ", max_results =", max_results);
-    const vc = await getVecorConn();
+    const vc = await getVectorConn();
     return await vc.list_vectors(vector_bucket_name, max_results);
 }
 
 async function query_vectors({vector_bucket_name, query_vector, topk, return_metadata, return_distance}) {
     dbg.log0("query_vectors =", vector_bucket_name, ", query_vector =", query_vector);
-    const vc = await getVecorConn();
+    const vc = await getVectorConn();
     return await vc.query_vectors(vector_bucket_name, query_vector.float32, topk, return_metadata, return_distance);
 }
 
 async function delete_vectors({vector_bucket_name, keys}) {
     dbg.log0("delete_vectors =", vector_bucket_name, ", keys =", keys);
-    const vc = await getVecorConn();
+    const vc = await getVectorConn();
     return await vc.delete_vectors(vector_bucket_name, keys);
 }
 


### PR DESCRIPTION
### Describe the Problem
We will support vector bucket polices - this is the first PR supporting only the APIs

### Explain the Changes
1. Adding just API support - no real authorization yet
2. Adding just bucketspace_nb support
3. Adding support for add/get/delete vector bucket policy 
4. Sharing same verification logic for the policy as in bucket policies 
5. Updating/Adding tests

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector bucket policy management: create, update, retrieve, and delete per-vector-bucket access policies.
  * New validation API for vector bucket policies and an exported helper to inspect account identifiers.

* **Behavior Changes**
  * Vector API error responses now use JSON with clearer error types, headers, and updated error variants.
  * Vector bucket schemas now include a vector_policy field.

* **Tests**
  * Comprehensive integration and unit tests covering policy operations, validation, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->