### PR TITLE
vectors - indices ops, schema for db

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1,6 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+const SensitiveString = require('../util/sensitive_string');
+
 /**
  *
  * BUCKET API
@@ -979,7 +981,7 @@ module.exports = {
                 type: 'object',
                 required: ['name'],
                 properties: {
-                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    name: { wrapper: SensitiveString },
                 }
             },
             reply: {
@@ -996,7 +998,7 @@ module.exports = {
                 type: 'object',
                 required: ['name'],
                 properties: {
-                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    name: { wrapper: SensitiveString },
                 }
             },
             auth: {
@@ -1011,14 +1013,117 @@ module.exports = {
                 required: [],
                 properties: {
                     max_results: { type: 'integer' },
-                    prefix: { $ref: 'common_api#/definitions/bucket_name' },
+                    prefix: { wrapper: SensitiveString },
+                    next_token: {type: 'string'},
                 }
             },
             reply: {
-                type: 'array',
-                items: {
-                    $ref: '#/definitions/vector_bucket_info'
+                type: 'object',
+                properties: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/definitions/vector_bucket_info'
+                        }
+                    },
+                    next_token: {type: 'string'},
                 }
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
+
+        create_vector_index: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['vector_index_name', 'vector_bucket_name', 'distance_metric', 'dimension'],
+                properties: {
+                    vector_index_name: { wrapper: SensitiveString },
+                    vector_bucket_name: { wrapper: SensitiveString },
+                    distance_metric: {
+                        type: 'string',
+                        enum: ['cosine', 'euclidean']
+                    },
+                    dimension: {
+                        type: 'integer',
+                        minimum: 1,
+                    }
+                    //TODO - non filterable MD keys
+                }
+            },
+            reply: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: { wrapper: SensitiveString }
+                }
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
+
+        get_vector_index: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['vector_index_name', 'vector_bucket_name'],
+                properties: {
+                    vector_index_name: { wrapper: SensitiveString },
+                    vector_bucket_name: { wrapper: SensitiveString },
+                }
+            },
+            reply: {
+                $ref: '#/definitions/vector_index_info',
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
+
+        list_vector_indices: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['vector_bucket_name'],
+                properties: {
+                    vector_bucket_name: { wrapper: SensitiveString },
+                    max_results: { type: 'integer' },
+                    prefix: { wrapper: SensitiveString },
+                    next_token: {type: 'string'},
+                }
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/definitions/vector_index_info'
+                        }
+                    },
+                    next_token: {type: 'string'},
+                }
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
+
+        delete_vector_index: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['vector_index_name', 'vector_bucket_name'],
+                properties: {
+                    vector_index_name: { wrapper: SensitiveString },
+                    vector_bucket_name: { wrapper: SensitiveString },
+                }
+            },
+            reply: {
+                $ref: '#/definitions/vector_index_info',
             },
             auth: {
                 system: ['admin', 'user']
@@ -1034,7 +1139,7 @@ module.exports = {
                     'name',
                 ],
                 properties: {
-                    name: { $ref: 'common_api#/definitions/bucket_name' },
+                    name: { wrapper: SensitiveString },
                     policy: {
                         $ref: 'common_api#/definitions/bucket_policy'
                     }
@@ -1087,6 +1192,15 @@ module.exports = {
     },
 
     definitions: {
+        owner_account: {
+            type: 'object',
+            required: ['email', 'id'],
+            properties: {
+                email: { $ref: 'common_api#/definitions/email' },
+                id: { objectid: true }
+            }
+        },
+
         log_replication_endpoint_type: {
             type: 'string',
             enum: ['AWS', 'AZURE'],
@@ -1101,14 +1215,7 @@ module.exports = {
                     enum: ['REGULAR', 'NAMESPACE'],
                     type: 'string',
                 },
-                owner_account: {
-                    type: 'object',
-                    required: ['email', 'id'],
-                    properties: {
-                        email: { $ref: 'common_api#/definitions/email' },
-                        id: { objectid: true }
-                    }
-                },
+                owner_account: {$ref: '#/definitions/owner_account'},
                 versioning: { $ref: 'common_api#/definitions/versioning' },
                 namespace: { $ref: '#/definitions/namespace_bucket_config' },
                 bucket_claim: { $ref: '#/definitions/bucket_claim' },
@@ -1292,19 +1399,36 @@ module.exports = {
             type: 'object',
             required: ['name'],
             properties: {
-                name: { $ref: 'common_api#/definitions/bucket_name' },
+                name: { wrapper: SensitiveString },
                 bucket_backendtype: {
                     enum: ['lance', 'davinci'],
                     type: 'string',
                 },
-                owner_account: {
-                    type: 'object',
-                    required: ['email', 'id'],
-                    properties: {
-                        email: { $ref: 'common_api#/definitions/email' },
-                        id: { objectid: true },
-                    }
+                owner_account: {$ref: '#/definitions/owner_account'},
+                creation_time: {type: 'integer'},
+            }
+        },
+
+        vector_index_info: {
+            type: 'object',
+            required: ['name', 'dimension', 'distance_metric', 'vector_bucket'],
+            properties: {
+                name: { wrapper: SensitiveString },
+                vector_bucket: { wrapper: SensitiveString },
+                distance_metric: {
+                    type: 'string',
+                    enum: ['cosine', 'euclidean']
                 },
+                dimension: {
+                    type: 'integer',
+                    minimum: 1,
+                },
+                data_type: {
+                    type: 'string',
+                    enum: ['float32'],
+                },
+                metadata_configuration: { $ref: 'common_api#/definitions/metadata_configuration' },
+                owner_account: {$ref: '#/definitions/owner_account'},
                 creation_time: {type: 'integer'},
             }
         },

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1638,5 +1638,18 @@ module.exports = {
                 }
             }
         },
+
+        metadata_configuration: {
+            type: 'object',
+            required: ['non_filterable_metadata_keys'],
+            properties: {
+                non_filterable_metadata_keys: {
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    },
+                }
+            }
+        },
     }
 };

--- a/src/endpoint/vector/ops/vector_delete_vectors.js
+++ b/src/endpoint/vector/ops/vector_delete_vectors.js
@@ -12,6 +12,7 @@ async function post_delete_vectors(req, res) {
 
     await req.vector_sdk.delete_vectors({
         vector_bucket_name: req.body.vectorBucketName,
+        vector_index_name: req.body.indexName,
         keys: req.body.keys,
     });
 }

--- a/src/endpoint/vector/ops/vector_index_create.js
+++ b/src/endpoint/vector/ops/vector_index_create.js
@@ -1,0 +1,27 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+//const config = require('../../../../config');
+const dbg = require('../../../util/debug_module')(__filename);
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_CreateIndex.html
+ */
+async function post_create_index(req, res) {
+
+    dbg.log0("post_create_index body =", req.body);
+
+    const vector_index_name = req.body.indexName;
+    const vector_bucket_name = req.body.vectorBucketName;
+    const dimension = req.body.dimension;
+    const distance_metric = req.body.distanceMetric;
+
+    await req.vector_sdk.create_vector_index({
+        vector_index_name,
+        vector_bucket_name,
+        dimension,
+        distance_metric
+    });
+}
+
+exports.handler = post_create_index;
+

--- a/src/endpoint/vector/ops/vector_index_delete.js
+++ b/src/endpoint/vector/ops/vector_index_delete.js
@@ -1,0 +1,23 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+//const config = require('../../../../config');
+const dbg = require('../../../util/debug_module')(__filename);
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_DeleteIndex.html
+ */
+async function post_delete_index(req, res) {
+
+    dbg.log0("post_delete_index body =", req.body);
+
+    const vector_index_name = req.body.indexName;
+    const vector_bucket_name = req.body.vectorBucketName;
+
+    await req.vector_sdk.delete_vector_index({
+        vector_index_name,
+        vector_bucket_name,
+    });
+}
+
+exports.handler = post_delete_index;
+

--- a/src/endpoint/vector/ops/vector_index_get.js
+++ b/src/endpoint/vector/ops/vector_index_get.js
@@ -1,0 +1,34 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+//const config = require('../../../../config');
+const dbg = require('../../../util/debug_module')(__filename);
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_GetIndex.html
+ */
+async function post_get_index(req, res) {
+
+    dbg.log0("post_get_index body =", req.body);
+
+    const vector_index_name = req.body.indexName;
+    const vector_bucket_name = req.body.vectorBucketName;
+
+    const vector_index_info = await req.vector_sdk.get_vector_index({
+        vector_index_name,
+        vector_bucket_name
+    });
+
+    return {
+        index: {
+            indexName: vector_index_info.name,
+            vectorBucketName: vector_index_info.vector_bucket,
+            dimension: vector_index_info.dimension,
+            dataType: vector_index_info.data_type,
+            distanceMetric: vector_index_info.distance_metric,
+            creationTime: vector_index_info.creation_time / 1000,
+        }
+    };
+}
+
+exports.handler = post_get_index;
+

--- a/src/endpoint/vector/ops/vector_index_list.js
+++ b/src/endpoint/vector/ops/vector_index_list.js
@@ -1,0 +1,36 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+//const config = require('../../../../config');
+const dbg = require('../../../util/debug_module')(__filename);
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_ListIndexes.html
+ */
+async function post_list_index(req, res) {
+
+    dbg.log0("post_list_index body =", req.body);
+
+    const max_results = req.body.maxResults || 500;
+    const prefix = req.body.prefix;
+    const vector_bucket_name = req.body.vectorBucketName;
+    const next_token = req.body.nextToken;
+
+    const list_res = await req.vector_sdk.list_vector_indices({
+        vector_bucket_name,
+        max_results,
+        prefix,
+        next_token
+    });
+
+    return {
+        indexes: list_res.items.map(vi => ({
+                creationTime: vi.creation_time / 1000,
+                indexName: vi.name,
+                vectorBucketName: vi.vector_bucket
+            })
+        ),
+        nextToken: list_res.next_token
+    };
+}
+
+exports.handler = post_list_index;

--- a/src/endpoint/vector/ops/vector_list_vector_buckets.js
+++ b/src/endpoint/vector/ops/vector_list_vector_buckets.js
@@ -10,20 +10,26 @@ async function post_list_vector_buckets(req, res) {
 
     dbg.log0("post_list_vectors body = ", req.body);
 
-    const list = await req.vector_sdk.list_vector_buckets({
-        max_results: req.body.maxResults,
-        prefix: req.body.prefix,
+    const max_results = req.body.maxResults || 500;
+    const prefix = req.body.prefix;
+    const next_token = req.body.nextToken;
+
+    const list_res = await req.vector_sdk.list_vector_buckets({
+        max_results,
+        prefix,
+        next_token,
     });
 
-    dbg.log0("post_list_vector_buckets list =", list);
+    dbg.log0("post_list_vector_buckets list =", list_res);
 
     return {
-        vectorBuckets: list.map(vb => ({
+        vectorBuckets: list_res.items.map(vb => ({
                 //creationTime: new Date(vb.creation_time).toISOString(),
                 creationTime: vb.creation_time / 1000,
                 vectorBucketName: vb.name
             })
-        )
+        ),
+        nextToken: list_res.next_token,
     };
 }
 

--- a/src/endpoint/vector/ops/vector_list_vectors.js
+++ b/src/endpoint/vector/ops/vector_list_vectors.js
@@ -12,6 +12,7 @@ async function post_list_vectors(req, res) {
 
     const list = await req.vector_sdk.list_vectors({
         vector_bucket_name: req.body.vectorBucketName,
+        vector_index_name: req.body.indexName,
         max_results: req.body.maxResults,
         return_data: req.body.returnData,
         return_metadata: req.body.returnMetadata,

--- a/src/endpoint/vector/ops/vector_put_vectors.js
+++ b/src/endpoint/vector/ops/vector_put_vectors.js
@@ -12,6 +12,7 @@ async function post_put_vectors(req, res) {
 
     await req.vector_sdk.put_vectors({
         vector_bucket_name: req.body.vectorBucketName,
+        vector_index_name: req.body.indexName,
         vectors: req.body.vectors,
     });
 }

--- a/src/endpoint/vector/ops/vector_query_vectors.js
+++ b/src/endpoint/vector/ops/vector_query_vectors.js
@@ -12,6 +12,7 @@ async function post_query_vectors(req, res) {
 
     const list = await req.vector_sdk.query_vectors({
         vector_bucket_name: req.body.vectorBucketName,
+        vector_index_name: req.body.indexName,
         query_vector: req.body.queryVector,
         filter: req.body.filter,
         topk: req.body.topK,

--- a/src/endpoint/vector/vector_errors.js
+++ b/src/endpoint/vector/vector_errors.js
@@ -145,7 +145,24 @@ VectorError.MalformedPolicy = Object.freeze({
     http_code: 400,
     type: error_type_enum.SENDER,
 });
-
+VectorError.NoSuchBucket = Object.freeze({
+    code: 'NoSuchBucket',
+    message: 'The specified bucket does not exist',
+    http_code: 404,
+    type: error_type_enum.SENDER,
+});
+VectorError.VectorBucketNotEmpty = Object.freeze({
+    code: 'VectorBucketNotEmpty',
+    message: 'The vector bucket you tried to delete is not empty. You must delete all indices in the vector bucket.',
+    http_code: 409,
+    type: error_type_enum.SENDER,
+});
+VectorError.NotFoundException = Object.freeze({
+    code: 'NotFoundException',
+    message: 'The specified resource does not exist.',
+    http_code: 404,
+    type: error_type_enum.SENDER,
+});
 
 // EXPORTS
 exports.VectorError = VectorError;

--- a/src/endpoint/vector/vector_rest.js
+++ b/src/endpoint/vector/vector_rest.js
@@ -16,6 +16,7 @@ const RPC_ERRORS_TO_VECTOR = Object.freeze({ //TODO - validate
     UNAUTHORIZED: VectorError.AccessDeniedException,
     INVALID_ACCESS_KEY_ID: VectorError.InvalidClientTokenId,
     DEACTIVATED_ACCESS_KEY_ID: VectorError.InvalidClientTokenIdInactiveAccessKey,
+    NO_SUCH_BUCKET: VectorError.NotFoundException,
     NO_SUCH_ACCOUNT: VectorError.AccessDeniedException,
     NO_SUCH_ROLE: VectorError.AccessDeniedException,
     VALIDATION_ERROR: VectorError.ValidationException,
@@ -33,12 +34,16 @@ const RPC_ERRORS_TO_VECTOR = Object.freeze({ //TODO - validate
     ACCESS_DENIED_EXCEPTION: VectorError.AccessDeniedException,
     NOT_AUTHORIZED: VectorError.NotAuthorized,
     INTERNAL_FAILURE: VectorError.InternalFailure,
-    NO_SUCH_BUCKET: VectorError.ValidationException,
+    VECTOR_BUCKET_NOT_EMPTY: VectorError.VectorBucketNotEmpty,
 });
 
 const VECTOR_OPS = js_utils.deep_freeze({
     CreateVectorBucket: require('./ops/vector_bucket_create'),
     DeleteVectorBucket: require('./ops/vector_bucket_delete'),
+    CreateIndex: require('./ops/vector_index_create'),
+    GetIndex: require('./ops/vector_index_get'),
+    ListIndexes: require('./ops/vector_index_list'),
+    DeleteIndex: require('./ops/vector_index_delete'),
     PutVectors: require('./ops/vector_put_vectors'),
     ListVectors: require('./ops/vector_list_vectors'),
     QueryVectors: require('./ops/vector_query_vectors'),

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -33,7 +33,6 @@ const access_policy_utils = require('../util/access_policy_utils');
 const nc_mkm = require('../manage_nsfs/nc_master_key_manager').get_instance();
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 const native_fs_utils = require('../util/native_fs_utils');
-const vectors_utils = require('../util/vectors_util');
 
 const dbg = require('../util/debug_module')(__filename);
 const bucket_semaphore = new KeysSemaphore(1);
@@ -1193,7 +1192,6 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
 
     async create_vector_bucket(params) {
         //TODO create a vector bucket object in the system
-        await vectors_utils.create_vector_bucket(params);
     }
 }
 

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -8,7 +8,6 @@ const dbg = require('../util/debug_module')(__filename);
 const path = require('path');
 const config = require('../../config.js');
 const NamespaceFS = require('./namespace_fs');
-const vectors_utils = require('../util/vectors_util');
 
 /**
  * @implements {nb.BucketSpace}
@@ -336,7 +335,6 @@ class BucketSpaceNB {
 
     async create_vector_bucket(params) {
         const resp = await this.rpc_client.bucket.create_vector_bucket(params);
-        await vectors_utils.create_vector_bucket(params);
         return resp;
     }
 
@@ -347,7 +345,26 @@ class BucketSpaceNB {
 
     async delete_vector_bucket(params) {
         const resp = await this.rpc_client.bucket.delete_vector_bucket(params);
-        await vectors_utils.delete_vector_bucket(params);
+        return resp;
+    }
+
+    async create_vector_index(params) {
+         const resp = await this.rpc_client.bucket.create_vector_index(params);
+        return resp;
+    }
+
+    async get_vector_index(params) {
+        const resp = await this.rpc_client.bucket.get_vector_index(params);
+        return resp;
+    }
+
+    async list_vector_indices(params) {
+        const resp = await this.rpc_client.bucket.list_vector_indices(params);
+        return resp;
+    }
+
+    async delete_vector_index(params) {
+        const resp = await this.rpc_client.bucket.delete_vector_index(params);
         return resp;
     }
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -912,7 +912,12 @@ interface BucketSpace {
 
     create_vector_bucket({vector_bucket_name}) : Promise<any>;
     delete_vector_bucket({vector_bucket_name}) : Promise<any>;
-    list_vector_buckets({max_results, prefix}) : Promise<any>;
+    list_vector_buckets({max_results, prefix, next_token}) : Promise<any>;
+
+    create_vector_index(params: object) : Promise<any>;
+    get_vector_index({vector_bucket_name, vector_index_name}) : Promise<any>;
+    list_vector_indices({vector_bucket_name, max_results, prefix, next_token}) : Promise<any>;
+    delete_vector_index({vector_bucket_name, vector_index_name}) : Promise<any>;
 }
 
 /**********************************************************

--- a/src/sdk/vector_sdk.js
+++ b/src/sdk/vector_sdk.js
@@ -3,8 +3,6 @@
 
 const vector_utils = require("../util/vectors_util");
 
-const dbg = require('../util/debug_module')(__filename);
-
 class VectorSDK {
 
 
@@ -25,18 +23,56 @@ class VectorSDK {
     }
 
     //////////////////////////
-    // VECTORS              //
+    // VECTOR BUCKETS       //
     //////////////////////////
 
     async create_vector_bucket(params) {
         const bs = this._get_bucketspace();
-        return await bs.create_vector_bucket(params);
+        await bs.create_vector_bucket(params);
+        await vector_utils.create_vector_bucket(params);
     }
 
     async delete_vector_bucket(params) {
         const bs = this._get_bucketspace();
-        return await bs.delete_vector_bucket(params);
+        await bs.delete_vector_bucket(params);
+        await vector_utils.delete_vector_bucket(params);
     }
+
+    async list_vector_buckets(params) {
+        const bs = this._get_bucketspace();
+        const res = await bs.list_vector_buckets(params);
+        return res;
+    }
+
+    //////////////////////////
+    // VECTOR INDICES       //
+    //////////////////////////
+
+    async create_vector_index(params) {
+        const bs = this._get_bucketspace();
+        await bs.create_vector_index(params);
+        await vector_utils.create_vector_index(params);
+    }
+
+    async get_vector_index(params) {
+        const bs = this._get_bucketspace();
+        return await bs.get_vector_index(params);
+    }
+
+    async list_vector_indices(params) {
+        const bs = this._get_bucketspace();
+        return await bs.list_vector_indices(params);
+    }
+
+    async delete_vector_index(params) {
+        const bs = this._get_bucketspace();
+        await bs.delete_vector_index(params);
+        await vector_utils.delete_vector_index(params);
+    }
+
+    //////////////////////////
+    // VECTORS              //
+    //////////////////////////
 
     async put_vectors(params) {
         return await vector_utils.put_vectors(params);
@@ -52,13 +88,6 @@ class VectorSDK {
 
     async query_vectors(params) {
         return await vector_utils.query_vectors(params);
-    }
-
-    async list_vector_buckets(params) {
-        const bs = this._get_bucketspace();
-        const res = await bs.list_vector_buckets(params);
-        dbg.log0("list_vector_buckets res =", res);
-        return res;
     }
 
     //////////////////////////////
@@ -79,7 +108,6 @@ class VectorSDK {
         const bs = this._get_bucketspace();
         return await bs.delete_vector_bucket_policy(params);
     }
-
 }
 
 module.exports = VectorSDK;

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/* eslint max-lines: ['error', 2500] */
+/* eslint max-lines: ['error', 3000] */
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -88,6 +88,7 @@ function new_vector_bucket_defaults(name, system_id, owner_account_id) {
         system: system_id,
         owner_account: owner_account_id,
         creation_time: Date.now(),
+        tags: []
     };
 }
 
@@ -2192,6 +2193,11 @@ async function delete_vector_bucket(req) {
     return vector_bucket_semaphore.surround_key(String(req.rpc_params.name), async () => {
         req.load_auth();
         const vector_bucket = find_vector_bucket(req);
+        //don't delete a vector bucket that contains an index
+        if (vector_bucket.vector_indices_by_name &&
+            Object.keys(vector_bucket.vector_indices_by_name).length > 0) {
+            throw new RpcError('VECTOR_BUCKET_NOT_EMPTY', 'Cannot delete non-empty vector bucket.');
+        }
 
         if (!req.rpc_params.internal_call) {
             Dispatcher.instance().activity({
@@ -2211,27 +2217,73 @@ async function delete_vector_bucket(req) {
     });
 }
 
-async function list_vector_buckets(req) {
-
-    dbg.log0("list_vector_buckets req.rpc_params =", req.rpc_params);
+async function list_vector_objects(req, unsorted_system_collection, get_info_func) {
+    if (!unsorted_system_collection) {
+        return {
+            items: []
+        };
+    }
 
     const prefix = req.rpc_params.prefix?.unwrap();
     const max_results = req.rpc_params.max_results;
+    const next_token = req.rpc_params.next_token;
 
-    const res = [];
-    _.forEach(req.system.vector_buckets_by_name, vb => {
-        dbg.log0("vb.name =", vb.name);
-
-        if (res.length === max_results) {
-            return false;
+    //filter for ownership
+    const unsorted_owned_collection = [];
+    await _.forEach(unsorted_system_collection, async item => {
+        if (item.deleting ||
+            !(await req.has_bucket_ownership_permission(item)) ||
+            (prefix && !item.name.unwrap().startsWith(prefix))) {
+            return; //item is not relevant, skip it
         }
-        if (prefix && !vb.name.unwrap().startsWith(prefix)) {
-            return;
-        }
-        res.push(get_vector_bucket_info(vb));
+        unsorted_owned_collection.push(item);
     });
 
+    let collection;
+    const sort = next_token || unsorted_owned_collection.length > max_results;
+    if (sort) {
+        //need to sort the list
+        collection = unsorted_owned_collection.sort((item1, item2) =>
+            item1.name.unwrap().localeCompare(item2.name.unwrap()));
+    } else {
+        //all items fit in this single request. no need to sort it
+        collection = unsorted_owned_collection;
+    }
+
+    const items = [];
+    let place_in_list = 0;
+    _.forEach(collection, item => {
+        if (items.length === max_results) {
+            return false;
+        }
+
+        place_in_list += 1;
+
+        //continue (ie, skip items) until we get to name > next_token
+        if (item.name.unwrap() <= next_token) {
+            return;
+        }
+
+        items.push(get_info_func(item));
+    });
+
+    const res = {
+        items,
+    };
+
+    //are there more objects to list?
+    if (place_in_list < collection.length) {
+        res.next_token = items[items.length - 1].name.unwrap();
+    }
+
+    dbg.log2("list vector obj res =", res);
     return res;
+}
+
+async function list_vector_buckets(req) {
+    dbg.log0("list_vector_buckets req.rpc_params =", req.rpc_params);
+
+    return await list_vector_objects(req, system_store.data.vector_buckets, get_vector_bucket_info);
 }
 
 function find_vector_bucket(req, vector_bucket_name = req.rpc_params.name) {
@@ -2241,8 +2293,18 @@ function find_vector_bucket(req, vector_bucket_name = req.rpc_params.name) {
         dbg.error('VECTOR BUCKET NOT FOUND', vector_bucket_name);
         throw new RpcError('NO_SUCH_BUCKET', 'No such vector bucket: ' + vector_bucket_name);
     }
-    // Don't check for permissions - assume successful authn authz in endpoint
     return vector_bucket;
+}
+
+function find_vector_index(req, vector_bucket_name, vector_index_name) {
+    const vector_bucket = find_vector_bucket(req, vector_bucket_name);
+    const vector_index = vector_bucket.vector_indices_by_name &&
+                         vector_bucket.vector_indices_by_name[vector_index_name.unwrap()];
+    if (!vector_index) {
+        dbg.error('VECTOR INDEX NOT FOUND', vector_index_name);
+        throw new RpcError('NO_SUCH_BUCKET', 'No such vector index: ' + vector_index_name);
+    }
+    return vector_index;
 }
 
 function get_vector_bucket_info(vector_bucket) {
@@ -2293,6 +2355,120 @@ async function delete_vector_bucket_policy(req) {
             }]
         }
     });
+}
+
+function validate_vector_index_creation(req, indices_by_name) {
+    if (req.rpc_params.vector_index_name.unwrap().length < 3 ||
+        req.rpc_params.vector_index_name.unwrap().length > 63 ||
+        net.isIP(req.rpc_params.vector_index_name.unwrap()) ||
+        !VALID_BUCKET_NAME_REGEXP.test(req.rpc_params.vector_index_name.unwrap())) {
+        throw new RpcError('INVALID_VECTOR_INDEX_NAME');
+    }
+    const index = indices_by_name && indices_by_name[req.rpc_params.vector_index_name.unwrap()];
+
+    if (index) {
+        if (system_store.has_same_id(index.owner_account, req.account)) {
+            throw new RpcError('VECTOR_INDEX_ALREADY_OWNED_BY_YOU');
+        } else {
+            throw new RpcError('VECTOR_INDEX_ALREADY_EXISTS');
+        }
+    }
+}
+
+async function create_vector_index(req) {
+    //lock on vector bucket
+    return vector_bucket_semaphore.surround_key(String(req.rpc_params.vector_bucket_name), async () => {
+        req.load_auth();
+        //validate vector bucket exists
+        const vector_bucket = find_vector_bucket(req, req.rpc_params.vector_bucket_name);
+        dbg.log0('vector_bucket obj keys = ', Object.keys(vector_bucket));
+        validate_vector_index_creation(req, vector_bucket.vector_indices_by_name);
+
+        const changes = {
+            insert: {},
+            update: {}
+        };
+
+        // Buckets created by IAM users are owned by the IAM account the user belongs to.
+        let account_id = req.account._id;
+        // Only IAM user will have owner.
+        if (req.account.owner) {
+            account_id = req.account.owner._id;
+        }
+        //vector_bucket_defaults are also  good for index
+        const vector_index = new_vector_bucket_defaults(req.rpc_params.vector_index_name, req.system._id, account_id);
+        vector_index.vector_bucket = vector_bucket._id;
+        vector_index.distance_metric = req.rpc_params.distance_metric;
+        vector_index.dimension = req.rpc_params.dimension;
+        vector_index.data_type = 'float32';
+        vector_index.metadata_configuration = req.rpc_params.metadata_configuration;
+
+        changes.insert.vector_indices = [vector_index];
+
+        Dispatcher.instance().activity({
+            event: 'vector_index.create',
+            level: 'info',
+            system: req.system._id,
+            actor: req.account && req.account._id,
+            bucket: vector_index._id,
+            desc: `${vector_index.name.unwrap()} was created by ${req.account && req.account.email.unwrap()}`,
+        });
+
+        await system_store.make_changes(changes);
+        req.load_auth();
+        const created_vector_index = find_vector_index(req, req.rpc_params.vector_bucket_name, req.rpc_params.vector_index_name);
+        return {name: created_vector_index.name};
+    });
+}
+
+function get_vector_index_info(vector_index) {
+    const info = get_vector_bucket_info(vector_index);
+    info.name = vector_index.name;
+    info.vector_bucket = vector_index.vector_bucket.name;
+    info.dimension = vector_index.dimension;
+    info.distance_metric = vector_index.distance_metric;
+    info.data_type = vector_index.data_type;
+
+    return info;
+}
+
+async function get_vector_index(req) {
+    dbg.log0("get_vector_index req.rpc_params =", req.rpc_params);
+    const vector_index = find_vector_index(req, req.rpc_params.vector_bucket_name, req.rpc_params.vector_index_name);
+    const vector_index_info = get_vector_index_info(vector_index);
+    return vector_index_info;
+}
+
+async function list_vector_indices(req) {
+    dbg.log0("list_vector_indices req.rpc_params =", req.rpc_params);
+    const vector_bucket = find_vector_bucket(req, req.rpc_params.vector_bucket_name);
+    const res = await list_vector_objects(req, vector_bucket.vector_indices_by_name, get_vector_index_info);
+    return res;
+}
+
+async function delete_vector_index(req) {
+    dbg.log0("delete_vector_index req.rpc_params =", req.rpc_params);
+    const vector_index = find_vector_index(req, req.rpc_params.vector_bucket_name, req.rpc_params.vector_index_name);
+    const vector_index_info = get_vector_index_info(vector_index);
+
+    if (!req.rpc_params.internal_call) {
+        Dispatcher.instance().activity({
+            event: 'vector_index.delete',
+            level: 'info',
+            system: req.system._id,
+            actor: req.account && req.account._id,
+            bucket: vector_index._id,
+            desc: `${vector_index.name.unwrap()} was deleted by ${req.account && req.account.email.unwrap()}`,
+        });
+    }
+
+    await system_store.make_changes({
+        remove: {
+            vector_indices: [vector_index._id],
+        }
+    });
+
+    return vector_index_info;
 }
 
 // EXPORTS
@@ -2365,3 +2541,12 @@ exports.list_vector_buckets = list_vector_buckets;
 exports.put_vector_bucket_policy = put_vector_bucket_policy;
 exports.get_vector_bucket_policy = get_vector_bucket_policy;
 exports.delete_vector_bucket_policy = delete_vector_bucket_policy;
+
+//vectors
+exports.create_vector_bucket = create_vector_bucket;
+exports.delete_vector_bucket = delete_vector_bucket;
+exports.list_vector_buckets = list_vector_buckets;
+exports.create_vector_index = create_vector_index;
+exports.get_vector_index = get_vector_index;
+exports.list_vector_indices = list_vector_indices;
+exports.delete_vector_index = delete_vector_index;

--- a/src/server/system_services/schemas/vector_index_indexes.js
+++ b/src/server/system_services/schemas/vector_index_indexes.js
@@ -1,0 +1,16 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+module.exports = [{
+    fields: {
+        system: 1,
+        vector_bucket: 1,
+        name: 1,
+    },
+    options: {
+        unique: true,
+        partialFilterExpression: {
+            deleted: null,
+        }
+    }
+}, ];

--- a/src/server/system_services/schemas/vector_index_schema.js
+++ b/src/server/system_services/schemas/vector_index_schema.js
@@ -1,15 +1,18 @@
-/* Copyright (C) 2025 NooBaa */
+/* Copyright (C) 2026 NooBaa */
 'use strict';
 
 const SensitiveString = require('../../../util/sensitive_string');
 
 module.exports = {
-    $id: 'vector_bucket_schema',
+    $id: 'vector_index_schema',
     type: 'object',
     required: [
         '_id',
         'system',
         'name',
+        'vector_bucket',
+        'distance_metric',
+        'dimension'
     ],
     properties: {
         _id: {
@@ -21,6 +24,22 @@ module.exports = {
         name: {
             wrapper: SensitiveString,
         },
+        vector_bucket: {
+            objectid: true,
+        },
+        dimension: {
+            type: 'integer',
+            minimum: 1,
+        },
+        distance_metric: {
+            type: 'string',
+            enum: ['cosine', 'euclidean']
+        },
+        data_type: {
+            type: 'string',
+            enum: ['float32']
+        },
+        metadata_configuration: { $ref: 'common_api#/definitions/metadata_configuration' },
         owner_account: {
             objectid: true
         },
@@ -32,9 +51,6 @@ module.exports = {
         },
         deleted: {
             date: true
-        },
-        vector_policy: {
-            $ref: 'common_api#/definitions/bucket_policy'
         },
     }
 };

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -28,6 +28,8 @@ const tier_indexes = require('./schemas/tier_indexes');
 const pool_indexes = require('./schemas/pool_indexes');
 const agent_config_indexes = require('./schemas/agent_config_indexes');
 const vector_bucket_schema = require('./schemas/vector_bucket_schema');
+const vector_index_schema = require('./schemas/vector_index_schema');
+const vector_index_indexes = require('./schemas/vector_index_indexes');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -157,6 +159,15 @@ const COLLECTIONS = [{
         key: 'name'
     }],
     db_indexes: bucket_indexes,
+}, {
+    name: 'vector_indices',
+    schema: vector_index_schema,
+    mem_indexes: [{
+        name: 'vector_indices_by_name',
+        context: 'vector_bucket',
+        key: 'name'
+    }],
+    db_indexes: vector_index_indexes,
 }];
 
 const COLLECTIONS_BY_NAME = _.keyBy(COLLECTIONS, 'name');

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -23,6 +23,8 @@ mocha.describe('vectors_ops', function() {
     let s3_vectors_client;
     /** @type {import("@aws-sdk/client-s3vectors").S3VectorsClientConfig} */
     let client_params;
+    let created_vector_indices;
+    let created_vector_buckets;
 
     mocha.before(async function() {
         const self = this;
@@ -63,42 +65,53 @@ mocha.describe('vectors_ops', function() {
     mocha.describe('vector-bucket-ops', function() {
 
         const vector_bucket_name1 = 'test-vec-buc1';
+        const vector_index_name1 = 'test-vec-ind1';
 
         mocha.beforeEach(async function() {
             await s3_client.createBucket({ Bucket: 'lance' });
+
+            created_vector_indices = [];
+            created_vector_buckets = [];
         });
 
         mocha.afterEach(async function() {
 
-            const del_vec_buck = new s3vectors.DeleteVectorBucketCommand({
-                vectorBucketName: vector_bucket_name1
-            });
-            await send(s3_vectors_client, del_vec_buck);
+            for (const vector_index of created_vector_indices) {
+                const del_vec_index = new s3vectors.DeleteIndexCommand({
+                    vectorBucketName: vector_index.vector_bucket,
+                    indexName: vector_index.vector_index,
+                });
+                await send(s3_vectors_client, del_vec_index);
+            }
+
+            for (const vector_bucket of created_vector_buckets) {
+                const del_vec_buck = new s3vectors.DeleteVectorBucketCommand({
+                    vectorBucketName: vector_bucket
+                });
+                await send(s3_vectors_client, del_vec_buck);
+            }
 
             await s3_client.deleteBucket({ Bucket: 'lance' });
         });
 
         mocha.it('should create a vector bucket', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
         });
 
         mocha.it('should list vector buckets', async function() {
             const beforeTs = Date.now();
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
             const afterTs = Date.now();
 
             const command = new s3vectors.ListVectorBucketsCommand({});
             const response = await send(s3_vectors_client, command);
 
-            assert.strictEqual(response.vectorBuckets[0].vectorBucketName, vector_bucket_name1);
-            const ts = response.vectorBuckets[0].creationTime.getTime();
-            assert(ts > beforeTs);
-            assert(afterTs > ts);
+            validate_vector_bucket(response.vectorBuckets[0], vector_bucket_name1, beforeTs, afterTs);
         });
 
 
         mocha.it('should delete a vector bucket', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
 
             const list_commnad = new s3vectors.ListVectorBucketsCommand({});
             let response = await send(s3_vectors_client, list_commnad);
@@ -112,12 +125,57 @@ mocha.describe('vectors_ops', function() {
             response = await send(s3_vectors_client, list_commnad);
             assert.strictEqual(response.vectorBuckets.length, 0);
 
-            //to simplfy cleanup just recreate the bucket
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            //manually fixup vector buckets tracking array
+            created_vector_buckets = [];
         });
 
-        mocha.it('should list vectors (on md)', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+        mocha.it('should create a vector index', async function() {
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
+        });
+
+        mocha.it('should get a vector index', async function() {
+            const beforeTs = Date.now();
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
+            const afterTs = Date.now();
+
+            const put_commnad = new s3vectors.GetIndexCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+            });
+            const response = await send(s3_vectors_client, put_commnad);
+
+            validate_vector_index(response.index, vector_bucket_name1, vector_index_name1, beforeTs, afterTs);
+        });
+
+        mocha.it('should delete a vector index', async function() {
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
+
+            const list_commnad = new s3vectors.ListIndexesCommand({
+                vectorBucketName: vector_bucket_name1,
+            });
+            let response = await send(s3_vectors_client, list_commnad);
+            assert.strictEqual(response.indexes[0].vectorBucketName, vector_bucket_name1);
+            assert.strictEqual(response.indexes[0].indexName, vector_index_name1);
+
+            const delete_commnad = new s3vectors.DeleteIndexCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1
+            });
+            await send(s3_vectors_client, delete_commnad);
+
+            response = await send(s3_vectors_client, list_commnad);
+            assert.strictEqual(response.indexes.length, 0);
+
+            //manually fixup vector indices tracking
+            created_vector_indices = [];
+        });
+
+        mocha.it('should list vectors (no md)', async function() {
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
 
             const vectors = [
                 {
@@ -134,12 +192,14 @@ mocha.describe('vectors_ops', function() {
 
             const put_commnad = new s3vectors.PutVectorsCommand({
                 vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
                 vectors
             });
             await send(s3_vectors_client, put_commnad);
 
             const list_commnad = new s3vectors.ListVectorsCommand({
-                vectorBucketName: vector_bucket_name1
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
             });
             const response = await send(s3_vectors_client, list_commnad);
 
@@ -147,7 +207,8 @@ mocha.describe('vectors_ops', function() {
         });
 
         mocha.it('should query vectors (no md, no filter)', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
 
             const vectors = [
                 {
@@ -162,12 +223,14 @@ mocha.describe('vectors_ops', function() {
 
             const put_commnad = new s3vectors.PutVectorsCommand({
                 vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
                 vectors
             });
             await send(s3_vectors_client, put_commnad);
 
             const query_commnad = new s3vectors.QueryVectorsCommand({
                 vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
                 queryVector: {float32: [0.2, 0.4, 0.6]},
                 topK: 10
             });
@@ -178,7 +241,8 @@ mocha.describe('vectors_ops', function() {
         });
 
         mocha.it('should delete vectors', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
 
             const vectors = [
                 {
@@ -193,12 +257,14 @@ mocha.describe('vectors_ops', function() {
 
             const put_commnad = new s3vectors.PutVectorsCommand({
                 vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
                 vectors
             });
             await send(s3_vectors_client, put_commnad);
 
             const list_commnad = new s3vectors.ListVectorsCommand({
-                vectorBucketName: vector_bucket_name1
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
             });
             let response = await send(s3_vectors_client, list_commnad);
 
@@ -206,6 +272,7 @@ mocha.describe('vectors_ops', function() {
 
             const delete_command = new s3vectors.DeleteVectorsCommand({
                 vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
                 keys: ["vector_id_2"]
             });
             await send(s3_vectors_client, delete_command);
@@ -217,7 +284,7 @@ mocha.describe('vectors_ops', function() {
         });
 
         mocha.it('should put a vector bucket policy', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
 
             const policy = {
                 Version: '2012-10-17',
@@ -237,7 +304,7 @@ mocha.describe('vectors_ops', function() {
         });
 
         mocha.it('should get a vector bucket policy', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
 
             const policy = {
                 Version: '2012-10-17',
@@ -264,7 +331,7 @@ mocha.describe('vectors_ops', function() {
         });
 
         mocha.it('should reject a malformed vector bucket policy', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
 
             const malformed_policy = {
                 Version: '2012-10-17',
@@ -293,7 +360,7 @@ mocha.describe('vectors_ops', function() {
         });
 
         mocha.it('should delete a vector bucket policy', async function() {
-            await create_vector_bucket(s3_vectors_client, vector_bucket_name1);
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
 
             const policy = {
                 Version: '2012-10-17',
@@ -330,12 +397,33 @@ mocha.describe('vectors_ops', function() {
     });
 });
 
-async function create_vector_bucket(client, name) {
-            const params = {
-                vectorBucketName: name
-            };
-            const command = new s3vectors.CreateVectorBucketCommand(params);
-            await send(client, command);
+async function create_vector_bucket(client, create_vector_buckets, name) {
+    const params = {
+        vectorBucketName: name
+    };
+    const command = new s3vectors.CreateVectorBucketCommand(params);
+    await send(client, command);
+
+    create_vector_buckets.push(name);
+}
+
+async function create_vector_index(client, create_vector_buckets, created_vector_indices, buc_name, ind_name) {
+    await create_vector_bucket(client, create_vector_buckets, buc_name);
+
+    const params = {
+        vectorBucketName: buc_name,
+        indexName: ind_name,
+        dataType: s3vectors.DataType.FLOAT32,
+        dimension: 3,
+        distanceMetric: s3vectors.DistanceMetric.EUCLIDEAN
+    };
+    const command = new s3vectors.CreateIndexCommand(params);
+    await send(client, command);
+
+    created_vector_indices.push({
+        vector_bucket: buc_name,
+        vector_index: ind_name}
+    );
 }
 
 async function send(client, command) {
@@ -366,4 +454,20 @@ function compare_vectors(actual, expected, expect_data) {
             }
         }
     }
+}
+
+function validate_vector_bucket(response_vb, expected_name, beforeTs, afterTs) {
+    assert.strictEqual(response_vb.vectorBucketName, expected_name);
+    const ts = response_vb.creationTime.getTime();
+    assert(ts > beforeTs);
+    assert(afterTs > ts);
+}
+
+function validate_vector_index(response_index, expected_vb_name, expected_index_name, beforeTs, afterTs) {
+    assert.strictEqual(response_index.indexName, expected_index_name);
+    assert.strictEqual(response_index.dataType, s3vectors.DataType.FLOAT32);
+    assert.strictEqual(response_index.dimension, 3);
+    assert.strictEqual(response_index.distanceMetric, s3vectors.DistanceMetric.EUCLIDEAN);
+
+    validate_vector_bucket(response_index, expected_vb_name, beforeTs, afterTs);
 }

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -26,22 +26,45 @@ class LanceConn extends VectorConn {
     }
 
     create_vector_bucket() {
+        //nothing to do in lance
+    }
+
+    async delete_vector_bucket(table_name) {
+        //nothing to do in lance
+    }
+
+
+    create_vector_index() {
         //lance needs at least one vector in order to create a table,
         //defer to the first insert
     }
 
-    async delete_vector_bucket(table_name) {
-        dbg.log0("delete_vector_bucket table_name =", table_name);
-
-        await this.lance.dropTable(table_name);
-        this.tables.delete(table_name);
-
-        dbg.log0("delete_vector_bucket done table_name =", table_name);
+    get_vector_index() {
+        //nothing to do in lance
     }
 
-    async put_vectors(table_name, vectors, is_retry = false) {
+    async delete_vector_index(vector_bucket, vector_index) {
+        const table_name = vector_bucket + "_" + vector_index;
+        dbg.log0("delete_vector_index table_name =", table_name);
+        try {
+            await this.lance.dropTable(table_name);
+        } catch (e) {
+            dbg.log1("drop table error =", e);
+            //swallow bucket not found errors. it's possible lance table was never created
+            if (e.message.indexOf('bucket does not exist') === -1) {
+                throw e;
+            }
+        }
+        this.tables.delete(table_name);
+        dbg.log0("delete_vector_index done table_name =", table_name);
 
-        dbg.log0("put_vectors table_name =", table_name, ", vectors =", vectors);
+    }
+
+    async put_vectors(vector_bucket, vector_index, vectors, is_retry = false) {
+
+        dbg.log0("put_vectors vector_bucket =", vector_bucket, ", vector_index =", vector_index, ", vectors =", vectors);
+        //note underscore is not allowed in vector bucket name
+        const table_name = vector_bucket + "_" + vector_index;
 
         let lance_vectors;
         if (is_retry) {
@@ -61,7 +84,6 @@ class LanceConn extends VectorConn {
             }
         }
         dbg.log0("put_vectors lance_vectors =", lance_vectors);
-
 
         let table = await this.get_table(table_name);
         if (table) {
@@ -84,8 +106,9 @@ class LanceConn extends VectorConn {
         }
     }
 
-    async list_vectors(table_name, limit) {
-        dbg.log0("list_vectors table_name =", table_name, ", limit =", limit);
+    async list_vectors(vector_bucket, vector_index, limit) {
+        dbg.log0("list_vectors vector_bucket =", vector_bucket, ", vector_index =", vector_index, ", limit =", limit);
+        const table_name = vector_bucket + "_" + vector_index;
 
         const table = await this.get_table(table_name);
         //TODO - check if(!table)
@@ -100,8 +123,9 @@ class LanceConn extends VectorConn {
         return {vectors: aws_vectors};
     }
 
-    async query_vectors(table_name, query_vector, limit, return_metadata, return_distance) {
-        dbg.log0("query_vectors table_name =", table_name, ", limit =", query_vector);
+    async query_vectors(vector_bucket, vector_index, query_vector, limit, return_metadata, return_distance) {
+        dbg.log0("query_vectors vector_bucket =", vector_bucket, ", vector_index =", vector_index, ", query_vector =", query_vector, ", limit =", limit);
+        const table_name = vector_bucket + "_" + vector_index;
 
         const table = await this.get_table(table_name);
         //TODO - check if(!table)
@@ -113,8 +137,9 @@ class LanceConn extends VectorConn {
         return {vectors: aws_vectors}; //TODO - return distance metric?
     }
 
-    async delete_vectors(table_name, ids) {
-        dbg.log0("delete_vectors table_name =", table_name, ", ids =", ids);
+    async delete_vectors(vector_bucket, vector_index, ids) {
+        dbg.log0("delete_vectors vector_bucket =", vector_bucket, ", vector_index =", vector_index, ", ids =", ids);
+        const table_name = vector_bucket + "_" + vector_index;
 
         const table = await this.get_table(table_name);
         //TODO - check !table
@@ -213,36 +238,47 @@ async function create_vector_bucket({name}) {
 }
 
 async function delete_vector_bucket({name}) {
-    const unwrapped = name.unwrap ? name.unwrap() : name;
-    dbg.log0("delete_vector_bucket name = ", unwrapped);
+    dbg.log0("delete_vector_bucket name = ", name);
     const vc = await getVectorConn();
-    await vc.delete_vector_bucket(unwrapped);
+    await vc.delete_vector_bucket(name);
     dbg.log0("delete_vector_bucket done");
 }
 
-async function put_vectors({vector_bucket_name, vectors}) {
-    dbg.log0("put_vectors =", vector_bucket_name, ", vectors =", vectors);
+async function create_vector_index(params) {
+    dbg.log0("create index params =", params);
     const vc = await getVectorConn();
-    await vc.put_vectors(vector_bucket_name, vectors);
+    await vc.create_vector_index(params);
+}
+
+async function delete_vector_index({vector_bucket_name, vector_index_name}) {
+    dbg.log0("delete index vector_bucket_name =", vector_bucket_name, ", vector_index_name =", vector_index_name);
+    const vc = await getVectorConn();
+    await vc.delete_vector_index(vector_bucket_name, vector_index_name);
+}
+
+async function put_vectors({vector_bucket_name, vector_index_name, vectors}) {
+    dbg.log0("put_vectors vector_bucket_name =", vector_bucket_name, ", vector_index_name =", vector_index_name, ", vectors =", vectors);
+    const vc = await getVectorConn();
+    await vc.put_vectors(vector_bucket_name, vector_index_name, vectors);
     dbg.log0("put_vectors done");
 }
 
-async function list_vectors({vector_bucket_name, max_results}) {
-    dbg.log0("list_vectors =", vector_bucket_name, ", max_results =", max_results);
+async function list_vectors({vector_bucket_name, vector_index_name, max_results}) {
+    dbg.log0("list_vectors vector_bucket_name =", vector_bucket_name, ", vector_index_name =", vector_index_name, ", max_results =", max_results);
     const vc = await getVectorConn();
-    return await vc.list_vectors(vector_bucket_name, max_results);
+    return await vc.list_vectors(vector_bucket_name, vector_index_name, max_results);
 }
 
-async function query_vectors({vector_bucket_name, query_vector, topk, return_metadata, return_distance}) {
-    dbg.log0("query_vectors =", vector_bucket_name, ", query_vector =", query_vector);
+async function query_vectors({vector_bucket_name, vector_index_name, query_vector, topk, return_metadata, return_distance}) {
+    dbg.log0("query_vectors vector_bucket_name =", vector_bucket_name, ", vector_index_name =", vector_index_name, ", query_vector =", query_vector);
     const vc = await getVectorConn();
-    return await vc.query_vectors(vector_bucket_name, query_vector.float32, topk, return_metadata, return_distance);
+    return await vc.query_vectors(vector_bucket_name, vector_index_name, query_vector.float32, topk, return_metadata, return_distance);
 }
 
-async function delete_vectors({vector_bucket_name, keys}) {
-    dbg.log0("delete_vectors =", vector_bucket_name, ", keys =", keys);
+async function delete_vectors({vector_bucket_name, vector_index_name, keys}) {
+    dbg.log0("delete_vectors vector_index_name =", vector_index_name, vector_bucket_name, ", keys =", keys);
     const vc = await getVectorConn();
-    return await vc.delete_vectors(vector_bucket_name, keys);
+    return await vc.delete_vectors(vector_bucket_name, vector_index_name, keys);
 }
 
 async function main() {
@@ -269,6 +305,8 @@ async function main() {
 exports.main = main;
 exports.create_vector_bucket = create_vector_bucket;
 exports.delete_vector_bucket = delete_vector_bucket;
+exports.create_vector_index = create_vector_index;
+exports.delete_vector_index = delete_vector_index;
 exports.put_vectors = put_vectors;
 exports.list_vectors = list_vectors;
 exports.query_vectors = query_vectors;


### PR DESCRIPTION
### Describe the Problem
Implement vector index.

### Explain the Changes
1. New S3 ops in vector rest.
2. Propagate op to vector_utils (mostly a NOP because of lance, except for delete).
3. Send create index to server bucket, insert row to new table.

### Issues: Fixed #xxx / Gap #xxx
1. ODF - get, list, delete in bucket server
2. NC
3. Fixup lance table names to include both vector bucket and index.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create, retrieve, list (paginated) and delete vector indices; per-index vector operations (put, list, query, delete) via indexName. Buckets and indices list responses return items + nextToken. Bucket objects now support tags and index metadata (dimension, distance metric, data type).

* **Bug Fixes / Safety**
  * Deleting a vector bucket is blocked if it still contains indices (conflict error).

* **Tests**
  * Integration tests updated for index-aware flows and per-resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->