### PR TITLE
[5.17 backport][DB-Cleaner] fixing find_deleted_objects to hit index

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -865,20 +865,21 @@ class MDStore {
         return buckets;
     }
 
+    /**
+     * Find deleted objects that were deleted before max_delete_time and are reclaimed.
+     *
+     * @param {number} max_delete_time - timestamp in milliseconds
+     * @param {number} limit
+     * @returns {Promise<nb.ID[]>}
+     */
     async find_deleted_objects(max_delete_time, limit) {
-        const objects = await this._objects.find({
-            deleted: {
-                $lt: new Date(max_delete_time),
-                $exists: true // This forces the index to be used
-            },
-        }, {
-            limit: Math.min(limit, 1000),
-            projection: {
-                _id: 1,
-                deleted: 1
-            }
-        });
-        return db_client.instance().uniq_ids(objects, '_id');
+        const query_limit = limit || 1000;
+        const query = `SELECT _id 
+        FROM ${this._objects.name}
+        WHERE (to_ts(data->>'deleted')<to_ts($1) and data ? 'deleted' and data ? 'reclaimed') 
+        LIMIT ${query_limit};`;
+        const result = await this._objects.executeSQL(query, [new Date(max_delete_time).toISOString()]);
+        return db_client.instance().uniq_ids(result.rows, '_id');
     }
 
     async db_delete_objects(object_ids) {


### PR DESCRIPTION
(cherry picked from commit a0cc0403b10b30ae279cf56876c02427d26c8dd8) (cherry picked from commit 661a635bb76bb797c22510877d4f0e896c204c4f) (cherry picked from commit 59ede619cfe9615a7f58973f64e46b1f6d4b75ae)

### Describe the Problem


### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
