### PR TITLE
Add initial vector functions for NC

### DIFF
--- a/src/endpoint/vector/ops/vector_bucket_create.js
+++ b/src/endpoint/vector/ops/vector_bucket_create.js
@@ -17,8 +17,8 @@ async function post_vector_bucket(req, res) {
     const subpath = req.headers[config.NSFS_CUSTOM_BUCKET_PATH_HTTP_HEADER];
     const vector_db_type = req.headers[config.VECTORS_DB_TYPE_HEADER] || 'lance';
 
-    //for now NS header is mandatory
-    if (!ns_name) {
+    // NS header is mandatory for containerized, optional for NC NSFS
+    if (!ns_name && !req.object_sdk.nsfs_config_root) {
         throw new VectorError({
             code: VectorError.ValidationException.code,
             http_code: VectorError.ValidationException.http_code,
@@ -27,10 +27,10 @@ async function post_vector_bucket(req, res) {
         });
     }
 
-    const namespace_resource = {
+    const namespace_resource = ns_name ? {
         resource: ns_name,
         path: subpath //not to be confused with nsr path
-    };
+    } : undefined;
 
     const vector_bucket_name = req.body.vectorBucketName;
     await req.vector_sdk.create_vector_bucket({

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -1190,9 +1190,279 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         }
     }
 
-    async create_vector_bucket(params) {
-        //TODO create a vector bucket object in the system
+    //////////////////////////
+    // VECTOR BUCKETS       //
+    //////////////////////////
+
+    async create_vector_bucket(params, object_sdk) {
+        const { vector_bucket_name, vector_db_type } = params;
+        return bucket_semaphore.surround_key(String(vector_bucket_name), async () => {
+            const account = object_sdk.requesting_account;
+            if (!account.allow_bucket_creation) {
+                throw new RpcError('UNAUTHORIZED', 'Not allowed to create new buckets');
+            }
+            if (!account.nsfs_account_config || !account.nsfs_account_config.new_buckets_path) {
+                throw new RpcError('MISSING_NSFS_ACCOUNT_CONFIGURATION');
+            }
+
+            const exists = await this.config_fs.is_vector_bucket_exists(vector_bucket_name);
+            if (exists) {
+                throw new RpcError('BUCKET_ALREADY_EXISTS', 'Vector bucket already exists: ' + vector_bucket_name);
+            }
+
+            const bucket_storage_path = path.join(account.nsfs_account_config.new_buckets_path, vector_bucket_name);
+            const owner_account_id = account.owner ? account.owner : account._id;
+
+            const vector_bucket = {
+                _id: mongo_utils.mongoObjectId(),
+                name: vector_bucket_name,
+                owner_account: owner_account_id,
+                creation_time: Date.now(),
+                vector_db_type: vector_db_type || 'lance',
+                path: bucket_storage_path,
+            };
+
+            await this.config_fs.create_vector_bucket_config_file(vector_bucket);
+
+            // create underlying storage directory for lance db
+            const fs_context = this.prepare_fs_context(object_sdk);
+            try {
+                await nb_native().fs.mkdir(fs_context, bucket_storage_path, get_umasked_mode(config.BASE_MODE_DIR));
+            } catch (err) {
+                dbg.error('BucketSpaceFS.create_vector_bucket: failed to create storage dir, cleaning up config', err);
+                await this.config_fs.delete_vector_bucket_config_file(vector_bucket_name);
+                throw err;
+            }
+        });
+    }
+
+    async get_vector_bucket(params) {
+        const { vector_bucket_name } = params;
+        try {
+            const vb = await this.config_fs.get_vector_bucket_by_name(vector_bucket_name);
+            if (!vb) throw new RpcError('NO_SUCH_BUCKET', 'No such vector bucket: ' + vector_bucket_name);
+            return {
+                name: new SensitiveString(vb.name),
+                owner_account: { id: vb.owner_account },
+                creation_time: vb.creation_time,
+                vector_db_type: vb.vector_db_type,
+                path: vb.path,
+            };
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                throw new RpcError('NO_SUCH_BUCKET', 'No such vector bucket: ' + vector_bucket_name);
+            }
+            throw err;
+        }
+    }
+
+    async delete_vector_bucket(params, object_sdk) {
+        const { vector_bucket_name } = params;
+        return bucket_semaphore.surround_key(String(vector_bucket_name), async () => {
+            const vb = await this.config_fs.get_vector_bucket_by_name(vector_bucket_name, { silent_if_missing: true });
+            if (!vb) {
+                throw new RpcError('NO_SUCH_BUCKET', 'No such vector bucket: ' + vector_bucket_name);
+            }
+
+            // check bucket is empty (no indices)
+            const indexes = await this.config_fs.list_vector_indexes(vector_bucket_name);
+            if (indexes.length > 0) {
+                throw new RpcError('VECTOR_BUCKET_NOT_EMPTY', 'Cannot delete non-empty vector bucket.');
+            }
+
+            // delete the underlying lance storage directory
+            if (vb.path) {
+                const fs_context = this.prepare_fs_context(object_sdk);
+                try {
+                    await folder_delete(vb.path, fs_context);
+                } catch (err) {
+                    dbg.warn('delete_vector_bucket: failed to delete storage dir', vb.path, err);
+                    if (err.code !== 'ENOENT') throw err;
+                }
+            }
+
+            await this.config_fs.delete_vector_bucket_config_file(vector_bucket_name);
+        });
+    }
+
+    async list_vector_buckets(params, object_sdk) {
+        const { max_results, prefix, next_token } = params;
+        const account = object_sdk.requesting_account;
+
+        let vb_names;
+        try {
+            vb_names = await this.config_fs.list_vector_buckets();
+        } catch (err) {
+            if (err.code === 'ENOENT') return { items: [] };
+            throw err;
+        }
+
+        // read configs, filter by ownership and prefix
+        const owner_id = account.owner ? account.owner : account._id;
+        const filtered = [];
+        for (const name of vb_names) {
+            try {
+                const vb = await this.config_fs.get_vector_bucket_by_name(name, { silent_if_missing: true });
+                if (!vb) continue;
+                if (vb.owner_account !== owner_id) continue;
+                if (prefix && !vb.name.startsWith(prefix)) continue;
+                filtered.push({
+                    name: new SensitiveString(vb.name),
+                    creation_time: vb.creation_time,
+                });
+            } catch (err) {
+                dbg.warn('list_vector_buckets: error reading vector bucket config', name, err);
+            }
+        }
+
+        // sort and paginate
+        filtered.sort((a, b) => a.name.unwrap().localeCompare(b.name.unwrap()));
+
+        const items = [];
+        let has_more = false;
+        for (const vb of filtered) {
+            if (next_token && vb.name.unwrap() <= next_token) continue;
+            if (items.length >= max_results) {
+                has_more = true;
+                break;
+            }
+            items.push(vb);
+        }
+
+        const result = { items };
+        if (has_more) {
+            result.next_token = items[items.length - 1].name.unwrap();
+        }
+        return result;
+    }
+
+    //////////////////////////
+    // VECTOR INDICES       //
+    //////////////////////////
+
+    async create_vector_index(params, object_sdk) {
+        const { vector_index_name, vector_bucket_name, dimension, distance_metric, metadata_configuration } = params;
+        const account = object_sdk.requesting_account;
+
+        return bucket_semaphore.surround_key(String(vector_bucket_name), async () => {
+            const vb = await this.config_fs.get_vector_bucket_by_name(vector_bucket_name, { silent_if_missing: true });
+            if (!vb) {
+                throw new RpcError('NO_SUCH_BUCKET', 'No such vector bucket: ' + vector_bucket_name);
+            }
+
+            // verify the requesting account owns this bucket
+            const owner_id = account.owner ? account.owner : account._id;
+            if (vb.owner_account !== owner_id) {
+                throw new RpcError('UNAUTHORIZED', 'Access denied to vector bucket: ' + vector_bucket_name);
+            }
+
+            // check index doesn't already exist
+            const existing = await this.config_fs.get_vector_index_by_name(
+                vector_bucket_name, vector_index_name, { silent_if_missing: true }
+            );
+            if (existing) {
+                throw new RpcError('BUCKET_ALREADY_EXISTS', 'Vector index already exists: ' + vector_index_name);
+            }
+
+            const owner_account_id = account.owner ? account.owner : account._id;
+            const vector_index = {
+                _id: mongo_utils.mongoObjectId(),
+                name: vector_index_name,
+                vector_bucket: vector_bucket_name,
+                dimension,
+                distance_metric,
+                data_type: 'float32',
+                metadata_configuration,
+                owner_account: owner_account_id,
+                creation_time: Date.now(),
+            };
+
+            await this.config_fs.create_vector_index_config_file(vector_bucket_name, vector_index);
+        });
+    }
+
+    async get_vector_index(params) {
+        const { vector_bucket_name, vector_index_name } = params;
+        try {
+            const vi = await this.config_fs.get_vector_index_by_name(vector_bucket_name, vector_index_name);
+            if (!vi) throw new RpcError('NO_SUCH_BUCKET', 'No such vector index: ' + vector_index_name);
+            return {
+                name: new SensitiveString(vi.name),
+                vector_bucket: vi.vector_bucket,
+                dimension: vi.dimension,
+                distance_metric: vi.distance_metric,
+                data_type: vi.data_type,
+                metadata_configuration: vi.metadata_configuration,
+                owner_account: { id: vi.owner_account },
+                creation_time: vi.creation_time,
+            };
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                throw new RpcError('NO_SUCH_BUCKET', 'No such vector index: ' + vector_index_name);
+            }
+            throw err;
+        }
+    }
+
+    async list_vector_indices(params, object_sdk) {
+        const { vector_bucket_name, max_results, prefix, next_token } = params;
+        const account = object_sdk.requesting_account;
+
+        let index_names;
+        try {
+            index_names = await this.config_fs.list_vector_indexes(vector_bucket_name);
+        } catch (err) {
+            if (err.code === 'ENOENT') return { items: [] };
+            throw err;
+        }
+
+        const owner_id = account.owner ? account.owner : account._id;
+        const filtered = [];
+        for (const name of index_names) {
+            try {
+                const vi = await this.config_fs.get_vector_index_by_name(
+                    vector_bucket_name, name, { silent_if_missing: true }
+                );
+                if (!vi) continue;
+                if (vi.owner_account !== owner_id) continue;
+                if (prefix && !vi.name.startsWith(prefix)) continue;
+                filtered.push({
+                    name: new SensitiveString(vi.name),
+                    vector_bucket: vi.vector_bucket,
+                    creation_time: vi.creation_time,
+                });
+            } catch (err) {
+                dbg.warn('list_vector_indices: error reading vector index config', name, err);
+            }
+        }
+
+        filtered.sort((a, b) => a.name.unwrap().localeCompare(b.name.unwrap()));
+
+        const items = [];
+        let has_more = false;
+        for (const vi of filtered) {
+            if (next_token && vi.name.unwrap() <= next_token) continue;
+            if (items.length >= max_results) {
+                has_more = true;
+                break;
+            }
+            items.push(vi);
+        }
+
+        const result = { items };
+        if (has_more) {
+            result.next_token = items[items.length - 1].name.unwrap();
+        }
+        return result;
+    }
+
+    async delete_vector_index(params) {
+        const { vector_bucket_name, vector_index_name } = params;
+        return bucket_semaphore.surround_key(String(vector_bucket_name), async () => {
+            await this.config_fs.delete_vector_index_config_file(vector_bucket_name, vector_index_name);
+        });
     }
 }
+
 
 module.exports = BucketSpaceFS;

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -47,6 +47,8 @@ const CONFIG_SUBDIRS = Object.freeze({
     ACCOUNTS: 'accounts', // deprecated on 5.18
     USERS: 'users',
     CONNECTIONS: 'connections',
+    VECTOR_BUCKETS: 'vector_buckets',
+    VECTOR_INDEXES: 'vector_indexes',
 });
 
 const CONFIG_TYPES = Object.freeze({
@@ -96,6 +98,8 @@ class ConfigFS {
         this.access_keys_dir_path = path.join(config_root, CONFIG_SUBDIRS.ACCESS_KEYS);
         this.buckets_dir_path = path.join(config_root, CONFIG_SUBDIRS.BUCKETS);
         this.connections_dir_path = path.join(config_root, CONFIG_SUBDIRS.CONNECTIONS);
+        this.vector_buckets_dir_path = path.join(config_root, CONFIG_SUBDIRS.VECTOR_BUCKETS);
+        this.vector_indexes_dir_path = path.join(config_root, CONFIG_SUBDIRS.VECTOR_INDEXES);
         this.system_json_path = path.join(config_root, 'system.json');
         this.config_json_path = path.join(config_root, 'config.json');
         this.fs_context = fs_context || native_fs_utils.get_process_fs_context(this.config_root_backend);
@@ -171,6 +175,8 @@ class ConfigFS {
             this.identities_dir_path,
             this.access_keys_dir_path,
             this.connections_dir_path,
+            this.vector_buckets_dir_path,
+            this.vector_indexes_dir_path,
         ];
 
         if (config.NSFS_GLACIER_LOGS_ENABLED) {
@@ -1111,6 +1117,151 @@ class ConfigFS {
         await this._throw_if_config_dir_locked();
         const bucket_config_path = this.get_bucket_path_by_name(bucket_name);
         await native_fs_utils.delete_config_file(this.fs_context, this.buckets_dir_path, bucket_config_path);
+    }
+
+    /////////////////////////////////////////////
+    ////// VECTOR BUCKET CONFIG DIR FUNCS  //////
+    /////////////////////////////////////////////
+
+    /**
+     * get_vector_bucket_path_by_name returns the full vector bucket config path by name
+     * @param {string} vector_bucket_name
+     * @returns {string}
+     */
+    get_vector_bucket_path_by_name(vector_bucket_name) {
+        return path.join(this.vector_buckets_dir_path, this.json(vector_bucket_name));
+    }
+
+    /**
+     * is_vector_bucket_exists returns true if vector bucket config path exists
+     * @param {string} vector_bucket_name
+     * @returns {Promise<boolean>}
+     */
+    async is_vector_bucket_exists(vector_bucket_name) {
+        const vb_path = this.get_vector_bucket_path_by_name(vector_bucket_name);
+        return native_fs_utils.is_path_exists(this.fs_context, vb_path);
+    }
+
+    /**
+     * get_vector_bucket_by_name returns the vector bucket config data by name
+     * @param {string} vector_bucket_name
+     * @param {{silent_if_missing?: boolean}} [options]
+     * @returns {Promise<Object>}
+     */
+    async get_vector_bucket_by_name(vector_bucket_name, options = {}) {
+        const vb_path = this.get_vector_bucket_path_by_name(vector_bucket_name);
+        return this.get_config_data(vb_path, options);
+    }
+
+    /**
+     * list_vector_buckets returns the array of vector bucket names under the config dir
+     * @returns {Promise<string[]>}
+     */
+    async list_vector_buckets() {
+        const dir_exists = await this.validate_config_dir_exists(this.vector_buckets_dir_path);
+        if (!dir_exists) return [];
+        const entries = await nb_native().fs.readdir(this.fs_context, this.vector_buckets_dir_path);
+        return this._get_config_entries_names(entries, JSON_SUFFIX);
+    }
+
+    /**
+     * create_vector_bucket_config_file creates a vector bucket config file
+     * @param {Object} data
+     * @returns {Promise<void>}
+     */
+    async create_vector_bucket_config_file(data) {
+        await this._throw_if_config_dir_locked();
+        const string_data = JSON.stringify(_.omitBy(data, _.isUndefined));
+        const vb_path = this.get_vector_bucket_path_by_name(data.name);
+        await this.create_dir_if_missing(this.vector_buckets_dir_path);
+        await native_fs_utils.create_config_file(this.fs_context, this.vector_buckets_dir_path, vb_path, string_data);
+    }
+
+    /**
+     * delete_vector_bucket_config_file deletes a vector bucket config file
+     * @param {string} vector_bucket_name
+     * @returns {Promise<void>}
+     */
+    async delete_vector_bucket_config_file(vector_bucket_name) {
+        await this._throw_if_config_dir_locked();
+        const vb_path = this.get_vector_bucket_path_by_name(vector_bucket_name);
+        await native_fs_utils.delete_config_file(this.fs_context, this.vector_buckets_dir_path, vb_path);
+    }
+
+    ////////////////////////////////////////////
+    ////// VECTOR INDEX CONFIG DIR FUNCS  //////
+    ////////////////////////////////////////////
+
+    /**
+     * get_vector_indexes_dir_for_bucket returns the directory path for indexes of a vector bucket
+     * @param {string} vector_bucket_name
+     * @returns {string}
+     */
+    get_vector_indexes_dir_for_bucket(vector_bucket_name) {
+        return path.join(this.vector_indexes_dir_path, vector_bucket_name);
+    }
+
+    /**
+     * get_vector_index_path returns the full path for a vector index config file
+     * @param {string} vector_bucket_name
+     * @param {string} vector_index_name
+     * @returns {string}
+     */
+    get_vector_index_path(vector_bucket_name, vector_index_name) {
+        return path.join(this.get_vector_indexes_dir_for_bucket(vector_bucket_name), this.json(vector_index_name));
+    }
+
+    /**
+     * get_vector_index_by_name returns the vector index config data
+     * @param {string} vector_bucket_name
+     * @param {string} vector_index_name
+     * @param {{silent_if_missing?: boolean}} [options]
+     * @returns {Promise<Object>}
+     */
+    async get_vector_index_by_name(vector_bucket_name, vector_index_name, options = {}) {
+        const vi_path = this.get_vector_index_path(vector_bucket_name, vector_index_name);
+        return this.get_config_data(vi_path, options);
+    }
+
+    /**
+     * list_vector_indexes returns the array of vector index names for a given vector bucket
+     * @param {string} vector_bucket_name
+     * @returns {Promise<string[]>}
+     */
+    async list_vector_indexes(vector_bucket_name) {
+        const dir_path = this.get_vector_indexes_dir_for_bucket(vector_bucket_name);
+        const dir_exists = await this.validate_config_dir_exists(dir_path);
+        if (!dir_exists) return [];
+        const entries = await nb_native().fs.readdir(this.fs_context, dir_path);
+        return this._get_config_entries_names(entries, JSON_SUFFIX);
+    }
+
+    /**
+     * create_vector_index_config_file creates a vector index config file
+     * @param {string} vector_bucket_name
+     * @param {Object} data
+     * @returns {Promise<void>}
+     */
+    async create_vector_index_config_file(vector_bucket_name, data) {
+        await this._throw_if_config_dir_locked();
+        const string_data = JSON.stringify(_.omitBy(data, _.isUndefined));
+        const indexes_dir = this.get_vector_indexes_dir_for_bucket(vector_bucket_name);
+        await this.create_dir_if_missing(indexes_dir);
+        const vi_path = this.get_vector_index_path(vector_bucket_name, data.name);
+        await native_fs_utils.create_config_file(this.fs_context, indexes_dir, vi_path, string_data);
+    }
+
+    /**
+     * delete_vector_index_config_file deletes a vector index config file
+     * @param {string} vector_bucket_name
+     * @param {string} vector_index_name
+     * @returns {Promise<void>}
+     */
+    async delete_vector_index_config_file(vector_bucket_name, vector_index_name) {
+        await this._throw_if_config_dir_locked();
+        const indexes_dir = this.get_vector_indexes_dir_for_bucket(vector_bucket_name);
+        const vi_path = this.get_vector_index_path(vector_bucket_name, vector_index_name);
+        await native_fs_utils.delete_config_file(this.fs_context, indexes_dir, vi_path);
     }
 
     ////////////////////////

--- a/src/sdk/vector_sdk.js
+++ b/src/sdk/vector_sdk.js
@@ -59,17 +59,17 @@ class VectorSDK {
 
     async create_vector_bucket(params) {
         const bs = this._get_bucketspace();
-        await bs.create_vector_bucket(params);
+        await bs.create_vector_bucket(params, this.req.object_sdk);
     }
 
     async get_vector_bucket(params) {
         const bs = this._get_bucketspace();
-        return await bs.get_vector_bucket(params);
+        return await bs.get_vector_bucket(params, this.req.object_sdk);
     }
 
     async delete_vector_bucket(params) {
         const bs = this._get_bucketspace();
-        await bs.delete_vector_bucket(params);
+        await bs.delete_vector_bucket(params, this.req.object_sdk);
         vector_utils.delete_vector_bucket(this.req.vector_bucket);
         vector_bucket_cache.invalidate({
             params,
@@ -79,7 +79,7 @@ class VectorSDK {
 
     async list_vector_buckets(params) {
         const bs = this._get_bucketspace();
-        const res = await bs.list_vector_buckets(params);
+        const res = await bs.list_vector_buckets(params, this.req.object_sdk);
         return res;
     }
 
@@ -89,23 +89,23 @@ class VectorSDK {
 
     async create_vector_index(params) {
         const bs = this._get_bucketspace();
-        await bs.create_vector_index(params);
+        await bs.create_vector_index(params, this.req.object_sdk);
         await vector_utils.create_vector_index(this.req.vector_bucket, this.req.vector_index, params);
     }
 
     async get_vector_index(params) {
         const bs = this._get_bucketspace();
-        return await bs.get_vector_index(params);
+        return await bs.get_vector_index(params, this.req.object_sdk);
     }
 
     async list_vector_indices(params) {
         const bs = this._get_bucketspace();
-        return await bs.list_vector_indices(params);
+        return await bs.list_vector_indices(params, this.req.object_sdk);
     }
 
     async delete_vector_index(params) {
         const bs = this._get_bucketspace();
-        await bs.delete_vector_index(params);
+        await bs.delete_vector_index(params, this.req.object_sdk);
         await vector_utils.delete_vector_index(this.req.vector_bucket, this.req.vector_index);
         vector_index_cache.invalidate({
             params,

--- a/src/test/unit_tests/nsfs/test_bucketspace_fs_vectors.js
+++ b/src/test/unit_tests/nsfs/test_bucketspace_fs_vectors.js
@@ -1,0 +1,757 @@
+/* Copyright (C) 2025 NooBaa */
+/*eslint max-lines-per-function: ['error', 800]*/
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+const mocha = require('mocha');
+const assert = require('assert');
+const { TMP_PATH } = require('../../system_tests/test_utils');
+
+const tmp_fs_path = path.join(TMP_PATH, 'test_bucketspace_fs_vectors');
+const config_root = path.join(tmp_fs_path, 'config_root');
+const new_buckets_path = path.join(tmp_fs_path, 'new_buckets_path', '/');
+
+// set master keys file location before requiring nc_mkm
+const config = require('../../../../config');
+config.NC_MASTER_KEYS_FILE_LOCATION = path.join(config_root, 'master_keys.json');
+
+const P = require('../../../util/promise');
+const fs_utils = require('../../../util/fs_utils');
+const SensitiveString = require('../../../util/sensitive_string');
+const BucketSpaceFS = require('../../../sdk/bucketspace_fs');
+const { CONFIG_SUBDIRS } = require('../../../sdk/config_fs');
+const nc_mkm = require('../../../manage_nsfs/nc_master_key_manager').get_instance();
+
+let vector_utils;
+let lance_available = false;
+try {
+    vector_utils = require('../../../util/vectors_util');
+    lance_available = true;
+} catch (err) {
+    console.log('LanceDB native binding not available, skipping vector data tests');
+}
+
+const bucketspace_fs = new BucketSpaceFS({ config_root }, undefined);
+
+const process_uid = process.getuid();
+const process_gid = process.getgid();
+
+const root_account = {
+    _id: '65a8edc9bc5d5bbf9db71c01',
+    name: 'vec_root_user',
+    email: 'vec_root_user@noobaa.io',
+    allow_bucket_creation: true,
+    access_keys: [{
+        access_key: 'a-vecroot123456789012',
+        secret_key: 's-vecroot123456789012'
+    }],
+    nsfs_account_config: {
+        uid: process_uid,
+        gid: process_gid,
+        new_buckets_path,
+    },
+    creation_date: '2025-01-01T00:00:00.000Z',
+};
+
+const iam_account = {
+    _id: '65a8edc9bc5d5bbf9db71c02',
+    name: 'vec_iam_user',
+    email: 'vec_iam_user@noobaa.io',
+    owner: root_account._id,
+    allow_bucket_creation: true,
+    access_keys: [{
+        access_key: 'a-veciam1234567890123',
+        secret_key: 's-veciam1234567890123'
+    }],
+    nsfs_account_config: {
+        uid: process_uid,
+        gid: process_gid,
+        new_buckets_path,
+    },
+    creation_date: '2025-01-01T00:00:00.000Z',
+};
+
+const other_account = {
+    _id: '65a8edc9bc5d5bbf9db71c03',
+    name: 'vec_other_user',
+    email: 'vec_other_user@noobaa.io',
+    allow_bucket_creation: true,
+    access_keys: [{
+        access_key: 'a-vecother12345678901',
+        secret_key: 's-vecother12345678901'
+    }],
+    nsfs_account_config: {
+        uid: process_uid,
+        gid: process_gid,
+        new_buckets_path,
+    },
+    creation_date: '2025-01-01T00:00:00.000Z',
+};
+
+const no_create_account = {
+    _id: '65a8edc9bc5d5bbf9db71c04',
+    name: 'vec_nocreate_user',
+    email: 'vec_nocreate_user@noobaa.io',
+    allow_bucket_creation: false,
+    access_keys: [{
+        access_key: 'a-vecnocrt12345678901',
+        secret_key: 's-vecnocrt12345678901'
+    }],
+    nsfs_account_config: {
+        uid: process_uid,
+        gid: process_gid,
+        new_buckets_path,
+    },
+    creation_date: '2025-01-01T00:00:00.000Z',
+};
+
+function make_dummy_object_sdk(account) {
+    return {
+        requesting_account: {
+            ...account,
+            name: new SensitiveString(account.name),
+            email: new SensitiveString(account.email),
+        },
+        abort_controller: new AbortController(),
+        throw_if_aborted() {
+            if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        },
+    };
+}
+
+mocha.describe('bucketspace_fs vectors', function() {
+    this.timeout(30000); // eslint-disable-line no-invalid-this
+
+    const root_sdk = make_dummy_object_sdk(root_account);
+    const iam_sdk = make_dummy_object_sdk(iam_account);
+    const other_sdk = make_dummy_object_sdk(other_account);
+    const no_create_sdk = make_dummy_object_sdk(no_create_account);
+
+    mocha.before(async () => {
+        await P.all(_.map([
+            CONFIG_SUBDIRS.IDENTITIES,
+            CONFIG_SUBDIRS.ACCOUNTS_BY_NAME,
+            CONFIG_SUBDIRS.ACCESS_KEYS,
+            CONFIG_SUBDIRS.BUCKETS,
+            CONFIG_SUBDIRS.VECTOR_BUCKETS,
+            CONFIG_SUBDIRS.VECTOR_INDEXES,
+        ], async dir =>
+            fs_utils.create_fresh_path(`${config_root}/${dir}`)
+        ));
+        await fs_utils.create_fresh_path(new_buckets_path);
+        for (let account of [root_account, iam_account, other_account, no_create_account]) {
+            account = await nc_mkm.encrypt_access_keys(account);
+            const account_dir_path = bucketspace_fs.config_fs.get_identity_dir_path_by_id(account._id);
+            const account_path = bucketspace_fs.config_fs.get_identity_path_by_id(account._id);
+            const account_name_path = bucketspace_fs.config_fs.get_account_path_by_name(account.name);
+            const account_access_path = bucketspace_fs.config_fs.get_account_or_user_path_by_access_key(
+                account.access_keys[0].access_key
+            );
+            await fs.promises.mkdir(account_dir_path);
+            await fs.promises.writeFile(account_path, JSON.stringify(account));
+            await fs.promises.symlink(account_path, account_name_path);
+            await fs.promises.symlink(account_path, account_access_path);
+        }
+    });
+
+    mocha.after(async () => {
+        await fs_utils.folder_delete(config_root);
+        await fs_utils.folder_delete(new_buckets_path);
+    });
+
+    //////////////////////////////
+    // VECTOR BUCKETS           //
+    //////////////////////////////
+
+    mocha.describe('create_vector_bucket', function() {
+        mocha.it('should create a vector bucket', async function() {
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: 'testvb1',
+                vector_db_type: 'lance',
+            }, root_sdk);
+
+            const vb = await bucketspace_fs.get_vector_bucket({ vector_bucket_name: 'testvb1' }, root_sdk);
+            assert.strictEqual(vb.name.unwrap(), 'testvb1');
+            assert.strictEqual(vb.vector_db_type, 'lance');
+            assert.strictEqual(vb.owner_account.id, root_account._id);
+            assert.ok(vb.path);
+            assert.ok(vb.creation_time);
+        });
+
+        mocha.it('should fail to create duplicate vector bucket', async function() {
+            try {
+                await bucketspace_fs.create_vector_bucket({
+                    vector_bucket_name: 'testvb1',
+                    vector_db_type: 'lance',
+                }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'BUCKET_ALREADY_EXISTS');
+            }
+        });
+
+        mocha.it('should fail when account not allowed to create buckets', async function() {
+            try {
+                await bucketspace_fs.create_vector_bucket({
+                    vector_bucket_name: 'testvb-nocreate',
+                    vector_db_type: 'lance',
+                }, no_create_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'UNAUTHORIZED');
+            }
+        });
+
+        mocha.it('should default vector_db_type to lance', async function() {
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: 'testvb-default-type',
+            }, root_sdk);
+            const vb = await bucketspace_fs.get_vector_bucket({ vector_bucket_name: 'testvb-default-type' }, root_sdk);
+            assert.strictEqual(vb.vector_db_type, 'lance');
+            // cleanup
+            await bucketspace_fs.delete_vector_bucket({ vector_bucket_name: 'testvb-default-type' }, root_sdk);
+        });
+
+        mocha.it('IAM user creates vector bucket owned by root account', async function() {
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: 'testvb-iam',
+                vector_db_type: 'lance',
+            }, iam_sdk);
+            const vb = await bucketspace_fs.get_vector_bucket({ vector_bucket_name: 'testvb-iam' }, iam_sdk);
+            // owner should be the root account (iam_account.owner), not the IAM user itself
+            assert.strictEqual(vb.owner_account.id, root_account._id);
+        });
+    });
+
+    mocha.describe('get_vector_bucket', function() {
+        mocha.it('should get an existing vector bucket', async function() {
+            const vb = await bucketspace_fs.get_vector_bucket({ vector_bucket_name: 'testvb1' }, root_sdk);
+            assert.strictEqual(vb.name.unwrap(), 'testvb1');
+            assert.strictEqual(vb.vector_db_type, 'lance');
+        });
+
+        mocha.it('should fail to get nonexistent vector bucket', async function() {
+            try {
+                await bucketspace_fs.get_vector_bucket({ vector_bucket_name: 'nonexistent' }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'NO_SUCH_BUCKET');
+            }
+        });
+    });
+
+    mocha.describe('list_vector_buckets', function() {
+        mocha.before(async function() {
+            // create a bucket owned by other_account
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: 'testvb-other',
+                vector_db_type: 'lance',
+            }, other_sdk);
+        });
+
+        mocha.it('should list only owned vector buckets', async function() {
+            const res = await bucketspace_fs.list_vector_buckets({ max_results: 100 }, root_sdk);
+            const names = res.items.map(vb => vb.name.unwrap());
+            assert.ok(names.includes('testvb1'));
+            assert.ok(names.includes('testvb-iam'));
+            // other_account's bucket should NOT appear
+            assert.ok(!names.includes('testvb-other'));
+        });
+
+        mocha.it('IAM user should see root account buckets', async function() {
+            const res = await bucketspace_fs.list_vector_buckets({ max_results: 100 }, iam_sdk);
+            const names = res.items.map(vb => vb.name.unwrap());
+            assert.ok(names.includes('testvb1'));
+            assert.ok(names.includes('testvb-iam'));
+        });
+
+        mocha.it('should filter by prefix', async function() {
+            const res = await bucketspace_fs.list_vector_buckets({
+                max_results: 100,
+                prefix: 'testvb-i'
+            }, root_sdk);
+            assert.strictEqual(res.items.length, 1);
+            assert.strictEqual(res.items[0].name.unwrap(), 'testvb-iam');
+        });
+
+        mocha.it('should paginate with max_results and next_token', async function() {
+            const res1 = await bucketspace_fs.list_vector_buckets({ max_results: 1 }, root_sdk);
+            assert.strictEqual(res1.items.length, 1);
+            assert.ok(res1.next_token);
+
+            const res2 = await bucketspace_fs.list_vector_buckets({
+                max_results: 100,
+                next_token: res1.next_token
+            }, root_sdk);
+            assert.ok(res2.items.length >= 1);
+            // no overlap
+            assert.ok(!res2.items.some(vb => vb.name.unwrap() === res1.items[0].name.unwrap()));
+        });
+
+        mocha.it('should return empty items for account with no buckets', async function() {
+            const lonely_sdk = make_dummy_object_sdk({
+                _id: '65a8edc9bc5d5bbf9db71c99',
+                name: 'lonely_user',
+                email: 'lonely@noobaa.io',
+                allow_bucket_creation: true,
+                access_keys: [{ access_key: 'a-lonely12345678901234', secret_key: 's-lonely12345678901234' }],
+                nsfs_account_config: { uid: 0, gid: 0, new_buckets_path },
+            });
+            const res = await bucketspace_fs.list_vector_buckets({ max_results: 100 }, lonely_sdk);
+            assert.strictEqual(res.items.length, 0);
+        });
+    });
+
+    mocha.describe('delete_vector_bucket', function() {
+        mocha.it('should fail to delete nonexistent vector bucket', async function() {
+            try {
+                await bucketspace_fs.delete_vector_bucket({ vector_bucket_name: 'nonexistent' }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'NO_SUCH_BUCKET');
+            }
+        });
+
+        mocha.it('should delete an empty vector bucket', async function() {
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: 'testvb-to-delete',
+                vector_db_type: 'lance',
+            }, root_sdk);
+
+            await bucketspace_fs.delete_vector_bucket({ vector_bucket_name: 'testvb-to-delete' }, root_sdk);
+
+            try {
+                await bucketspace_fs.get_vector_bucket({ vector_bucket_name: 'testvb-to-delete' }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'NO_SUCH_BUCKET');
+            }
+        });
+
+        mocha.it('should fail to delete non-empty vector bucket (has indices)', async function() {
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: 'testvb-notempty',
+                vector_db_type: 'lance',
+            }, root_sdk);
+
+            await bucketspace_fs.create_vector_index({
+                vector_bucket_name: 'testvb-notempty',
+                vector_index_name: 'idx1',
+                dimension: 128,
+                distance_metric: 'cosine',
+            }, root_sdk);
+
+            try {
+                await bucketspace_fs.delete_vector_bucket({ vector_bucket_name: 'testvb-notempty' }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'VECTOR_BUCKET_NOT_EMPTY');
+            }
+
+            // cleanup: delete index then bucket
+            await bucketspace_fs.delete_vector_index({
+                vector_bucket_name: 'testvb-notempty',
+                vector_index_name: 'idx1',
+            }, root_sdk);
+            await bucketspace_fs.delete_vector_bucket({ vector_bucket_name: 'testvb-notempty' }, root_sdk);
+        });
+    });
+
+    //////////////////////////////
+    // VECTOR INDICES           //
+    //////////////////////////////
+
+    mocha.describe('create_vector_index', function() {
+        mocha.it('should create a vector index', async function() {
+            await bucketspace_fs.create_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx1',
+                dimension: 256,
+                distance_metric: 'cosine',
+            }, root_sdk);
+
+            const vi = await bucketspace_fs.get_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx1',
+            }, root_sdk);
+            assert.strictEqual(vi.name.unwrap(), 'testidx1');
+            assert.strictEqual(vi.vector_bucket, 'testvb1');
+            assert.strictEqual(vi.dimension, 256);
+            assert.strictEqual(vi.distance_metric, 'cosine');
+            assert.strictEqual(vi.data_type, 'float32');
+            assert.strictEqual(vi.owner_account.id, root_account._id);
+            assert.ok(vi.creation_time);
+        });
+
+        mocha.it('should fail to create duplicate vector index', async function() {
+            try {
+                await bucketspace_fs.create_vector_index({
+                    vector_bucket_name: 'testvb1',
+                    vector_index_name: 'testidx1',
+                    dimension: 256,
+                    distance_metric: 'cosine',
+                }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'BUCKET_ALREADY_EXISTS');
+            }
+        });
+
+        mocha.it('should fail to create index on nonexistent bucket', async function() {
+            try {
+                await bucketspace_fs.create_vector_index({
+                    vector_bucket_name: 'nonexistent',
+                    vector_index_name: 'testidx1',
+                    dimension: 256,
+                    distance_metric: 'cosine',
+                }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'NO_SUCH_BUCKET');
+            }
+        });
+
+        mocha.it('should create index with metadata_configuration', async function() {
+            await bucketspace_fs.create_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx-meta',
+                dimension: 128,
+                distance_metric: 'euclidean',
+                metadata_configuration: {
+                    non_filterable_metadata_keys: ['raw_text'],
+                },
+            }, root_sdk);
+
+            const vi = await bucketspace_fs.get_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx-meta',
+            }, root_sdk);
+            assert.deepStrictEqual(vi.metadata_configuration, {
+                non_filterable_metadata_keys: ['raw_text'],
+            });
+
+            // cleanup
+            await bucketspace_fs.delete_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx-meta',
+            }, root_sdk);
+        });
+
+        mocha.it('should fail when other account creates index on bucket it does not own', async function() {
+            try {
+                await bucketspace_fs.create_vector_index({
+                    vector_bucket_name: 'testvb1',
+                    vector_index_name: 'cross-acct-idx',
+                    dimension: 64,
+                    distance_metric: 'cosine',
+                }, other_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'UNAUTHORIZED');
+            }
+        });
+
+        mocha.it('IAM user creates index owned by root account', async function() {
+            await bucketspace_fs.create_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx-iam',
+                dimension: 64,
+                distance_metric: 'cosine',
+            }, iam_sdk);
+
+            const vi = await bucketspace_fs.get_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx-iam',
+            }, iam_sdk);
+            assert.strictEqual(vi.owner_account.id, root_account._id);
+        });
+    });
+
+    mocha.describe('get_vector_index', function() {
+        mocha.it('should get an existing vector index', async function() {
+            const vi = await bucketspace_fs.get_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx1',
+            }, root_sdk);
+            assert.strictEqual(vi.name.unwrap(), 'testidx1');
+            assert.strictEqual(vi.dimension, 256);
+        });
+
+        mocha.it('should fail to get nonexistent vector index', async function() {
+            try {
+                await bucketspace_fs.get_vector_index({
+                    vector_bucket_name: 'testvb1',
+                    vector_index_name: 'nonexistent',
+                }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'NO_SUCH_BUCKET');
+            }
+        });
+    });
+
+    mocha.describe('list_vector_indices', function() {
+        mocha.before(async function() {
+            // create an index owned by other_account on a separate bucket
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: 'testvb-other-idx',
+                vector_db_type: 'lance',
+            }, other_sdk);
+            await bucketspace_fs.create_vector_index({
+                vector_bucket_name: 'testvb-other-idx',
+                vector_index_name: 'other-idx1',
+                dimension: 128,
+                distance_metric: 'cosine',
+            }, other_sdk);
+        });
+
+        mocha.it('should list indices for a vector bucket', async function() {
+            const res = await bucketspace_fs.list_vector_indices({
+                vector_bucket_name: 'testvb1',
+                max_results: 100,
+            }, root_sdk);
+            const names = res.items.map(vi => vi.name.unwrap());
+            assert.ok(names.includes('testidx1'));
+            assert.ok(names.includes('testidx-iam'));
+        });
+
+        mocha.it('should filter indices by ownership', async function() {
+            // other_account's indices should not be visible to root_sdk
+            const res = await bucketspace_fs.list_vector_indices({
+                vector_bucket_name: 'testvb-other-idx',
+                max_results: 100,
+            }, root_sdk);
+            assert.strictEqual(res.items.length, 0);
+        });
+
+        mocha.it('IAM user should see root account indices', async function() {
+            const res = await bucketspace_fs.list_vector_indices({
+                vector_bucket_name: 'testvb1',
+                max_results: 100,
+            }, iam_sdk);
+            const names = res.items.map(vi => vi.name.unwrap());
+            assert.ok(names.includes('testidx1'));
+            assert.ok(names.includes('testidx-iam'));
+        });
+
+        mocha.it('should filter by prefix', async function() {
+            const res = await bucketspace_fs.list_vector_indices({
+                vector_bucket_name: 'testvb1',
+                max_results: 100,
+                prefix: 'testidx-i',
+            }, root_sdk);
+            assert.strictEqual(res.items.length, 1);
+            assert.strictEqual(res.items[0].name.unwrap(), 'testidx-iam');
+        });
+
+        mocha.it('should paginate with max_results and next_token', async function() {
+            const res1 = await bucketspace_fs.list_vector_indices({
+                vector_bucket_name: 'testvb1',
+                max_results: 1,
+            }, root_sdk);
+            assert.strictEqual(res1.items.length, 1);
+            assert.ok(res1.next_token);
+
+            const res2 = await bucketspace_fs.list_vector_indices({
+                vector_bucket_name: 'testvb1',
+                max_results: 100,
+                next_token: res1.next_token,
+            }, root_sdk);
+            assert.ok(res2.items.length >= 1);
+            assert.ok(!res2.items.some(vi => vi.name.unwrap() === res1.items[0].name.unwrap()));
+        });
+
+        mocha.it('should return empty items for bucket with no indices', async function() {
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: 'testvb-empty-idx',
+                vector_db_type: 'lance',
+            }, root_sdk);
+            const res = await bucketspace_fs.list_vector_indices({
+                vector_bucket_name: 'testvb-empty-idx',
+                max_results: 100,
+            }, root_sdk);
+            assert.strictEqual(res.items.length, 0);
+            // cleanup
+            await bucketspace_fs.delete_vector_bucket({ vector_bucket_name: 'testvb-empty-idx' }, root_sdk);
+        });
+    });
+
+    mocha.describe('delete_vector_index', function() {
+        mocha.it('should delete an existing vector index', async function() {
+            await bucketspace_fs.create_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx-to-delete',
+                dimension: 64,
+                distance_metric: 'cosine',
+            }, root_sdk);
+
+            await bucketspace_fs.delete_vector_index({
+                vector_bucket_name: 'testvb1',
+                vector_index_name: 'testidx-to-delete',
+            }, root_sdk);
+
+            try {
+                await bucketspace_fs.get_vector_index({
+                    vector_bucket_name: 'testvb1',
+                    vector_index_name: 'testidx-to-delete',
+                }, root_sdk);
+                assert.fail('should have thrown');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'NO_SUCH_BUCKET');
+            }
+        });
+    });
+
+    //////////////////////////////
+    // VECTOR DATA OPERATIONS   //
+    //////////////////////////////
+
+    // vector data operations require LanceDB native binding
+    const describe_lance = lance_available ? mocha.describe : mocha.describe.skip;
+    describe_lance('vector data operations (put, query, list, delete)', function() {
+        const vb_name = 'testvb-data';
+        const idx_name = 'dataidx';
+        const dimension = 4;
+        let vector_bucket;
+        let vector_index;
+
+        mocha.before(async function() {
+            await bucketspace_fs.create_vector_bucket({
+                vector_bucket_name: vb_name,
+                vector_db_type: 'lance',
+            }, root_sdk);
+            await bucketspace_fs.create_vector_index({
+                vector_bucket_name: vb_name,
+                vector_index_name: idx_name,
+                dimension,
+                distance_metric: 'cosine',
+            }, root_sdk);
+            vector_bucket = await bucketspace_fs.get_vector_bucket({ vector_bucket_name: vb_name }, root_sdk);
+            vector_index = await bucketspace_fs.get_vector_index({
+                vector_bucket_name: vb_name,
+                vector_index_name: idx_name,
+            }, root_sdk);
+        });
+
+        mocha.it('should put vectors', async function() {
+            const vectors = [
+                { key: 'vec1', data: { float32: [1.0, 0.0, 0.0, 0.0] } },
+                { key: 'vec2', data: { float32: [0.0, 1.0, 0.0, 0.0] } },
+                { key: 'vec3', data: { float32: [0.0, 0.0, 1.0, 0.0] } },
+                { key: 'vec4', data: { float32: [0.0, 0.0, 0.0, 1.0] } },
+            ];
+            await vector_utils.put_vectors(vector_bucket, vector_index, vectors);
+        });
+
+        mocha.it('should list vectors', async function() {
+            const res = await vector_utils.list_vectors(vector_bucket, vector_index, { max_results: 100 });
+            assert.ok(res.vectors);
+            assert.strictEqual(res.vectors.length, 4);
+            const keys = res.vectors.map(v => v.key);
+            assert.ok(keys.includes('vec1'));
+            assert.ok(keys.includes('vec2'));
+            assert.ok(keys.includes('vec3'));
+            assert.ok(keys.includes('vec4'));
+        });
+
+        mocha.it('should query vectors and return nearest match', async function() {
+            const res = await vector_utils.query_vectors(vector_bucket, vector_index, {
+                query_vector: { float32: [1.0, 0.0, 0.0, 0.0] },
+                topk: 2,
+                return_metadata: false,
+                return_distance: true,
+            });
+            assert.ok(res.vectors);
+            assert.strictEqual(res.vectors.length, 2);
+            // the closest vector to [1,0,0,0] should be vec1
+            assert.strictEqual(res.vectors[0].key, 'vec1');
+            // distance should be returned
+            assert.ok(res.vectors[0].distance !== undefined);
+        });
+
+        mocha.it('should query vectors with return_metadata', async function() {
+            // insert vectors with metadata
+            const vectors_with_meta = [
+                { key: 'vmeta1', data: { float32: [0.5, 0.5, 0.0, 0.0] }, metadata: { category: 'test' } },
+            ];
+            await vector_utils.put_vectors(vector_bucket, vector_index, vectors_with_meta);
+
+            const res = await vector_utils.query_vectors(vector_bucket, vector_index, {
+                query_vector: { float32: [0.5, 0.5, 0.0, 0.0] },
+                topk: 1,
+                return_metadata: true,
+                return_distance: false,
+            });
+            assert.ok(res.vectors);
+            assert.strictEqual(res.vectors.length, 1);
+            assert.strictEqual(res.vectors[0].key, 'vmeta1');
+            assert.ok(res.vectors[0].metadata);
+            assert.strictEqual(res.vectors[0].metadata.category, 'test');
+        });
+
+        mocha.it('should query vectors without return_distance', async function() {
+            const res = await vector_utils.query_vectors(vector_bucket, vector_index, {
+                query_vector: { float32: [0.0, 1.0, 0.0, 0.0] },
+                topk: 1,
+                return_metadata: false,
+                return_distance: false,
+            });
+            assert.ok(res.vectors);
+            assert.strictEqual(res.vectors.length, 1);
+            assert.strictEqual(res.vectors[0].key, 'vec2');
+            assert.strictEqual(res.vectors[0].distance, undefined);
+            assert.strictEqual(res.vectors[0].metadata, undefined);
+        });
+
+        mocha.it('should delete vectors by key', async function() {
+            await vector_utils.delete_vectors(vector_bucket, vector_index, ['vec3', 'vec4']);
+            const res = await vector_utils.list_vectors(vector_bucket, vector_index, { max_results: 100 });
+            const keys = res.vectors.map(v => v.key);
+            assert.ok(!keys.includes('vec3'));
+            assert.ok(!keys.includes('vec4'));
+        });
+
+        mocha.after(async function() {
+            await vector_utils.delete_vector_index(vector_bucket, vector_index);
+            vector_utils.delete_vector_bucket(vector_bucket);
+            await bucketspace_fs.delete_vector_index({
+                vector_bucket_name: vb_name,
+                vector_index_name: idx_name,
+            }, root_sdk);
+            await bucketspace_fs.delete_vector_bucket({ vector_bucket_name: vb_name }, root_sdk);
+        });
+    });
+
+    //////////////////////////////
+    // CLEANUP                  //
+    //////////////////////////////
+
+    mocha.describe('cleanup', function() {
+        mocha.it('should clean up test vector indices and buckets', async function() {
+            // delete indices created during tests
+            const indices_to_delete = [
+                { vector_bucket_name: 'testvb1', vector_index_name: 'testidx1' },
+                { vector_bucket_name: 'testvb1', vector_index_name: 'testidx-iam' },
+                { vector_bucket_name: 'testvb-other-idx', vector_index_name: 'other-idx1' },
+            ];
+            for (const params of indices_to_delete) {
+                try {
+                    await bucketspace_fs.delete_vector_index(params, root_sdk);
+                } catch (err) {
+                    // ignore if already deleted
+                }
+            }
+            // delete buckets
+            const buckets_to_delete = ['testvb1', 'testvb-iam', 'testvb-other', 'testvb-other-idx'];
+            for (const vector_bucket_name of buckets_to_delete) {
+                try {
+                    await bucketspace_fs.delete_vector_bucket({ vector_bucket_name }, root_sdk);
+                } catch (err) {
+                    // ignore if already deleted
+                }
+            }
+        });
+    });
+});

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -251,15 +251,21 @@ class LanceConn extends VectorConn {
 async function new_vector_conn(vector_bucket) {
     dbg.log0("Creating a new vector conn for", vector_bucket.name, ", db type =", vector_bucket.vector_db_type);
 
-    const nsr = system_store.data.systems[0].namespace_resources_by_name[vector_bucket.namespace_resource.resource];
     let lance_path;
 
     switch (vector_bucket.vector_db_type) {
         case 'lance':
-            dbg.log0("vector_bucket.namespace_resource =", vector_bucket.namespace_resource);
-            lance_path = nsr.nsfs_config.fs_root_path;
-            if (vector_bucket.namespace_resource.path) {
-                lance_path = path.join(lance_path, vector_bucket.namespace_resource.path);
+            if (vector_bucket.path) {
+                // NC NSFS - path is directly available in the vector bucket config
+                lance_path = vector_bucket.path;
+            } else {
+                // Containerized - resolve via system_store namespace resource
+                dbg.log0("vector_bucket.namespace_resource =", vector_bucket.namespace_resource);
+                const nsr = system_store.data.systems[0].namespace_resources_by_name[vector_bucket.namespace_resource.resource];
+                lance_path = nsr.nsfs_config.fs_root_path;
+                if (vector_bucket.namespace_resource.path) {
+                    lance_path = path.join(lance_path, vector_bucket.namespace_resource.path);
+                }
             }
             return new LanceConn({
                 path: lance_path


### PR DESCRIPTION
### Describe the Problem
This PR adds support for vector operations for NC in bucketspacefs.


### Explain the Changes

```shell
$ aws --no-verify-ssl --region us-east-1 --endpoint "https://localhost:14443" s3vectors create-vector-bucket --vector-bucket-name test
/opt/homebrew/Cellar/awscli/2.34.9/libexec/lib/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(

$ aws --no-verify-ssl --region us-east-1 --endpoint "https://localhost:14443" s3vectors list-vector-buckets
/opt/homebrew/Cellar/awscli/2.34.9/libexec/lib/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
{
    "vectorBuckets": [
        {
            "vectorBucketName": "test",
            "creationTime": "2026-03-16T13:51:20.721000+05:30"
        }
    ]
}

$ aws --no-verify-ssl --region us-east-1 --endpoint "https://localhost:14443" s3vectors create-index --vector-bucket-name test --index-name test-idx --data-type float32 --dimension 4 --distance-metric euclidean
/opt/homebrew/Cellar/awscli/2.34.9/libexec/lib/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(

$ aws --no-verify-ssl --region us-east-1 --endpoint "https://localhost:14443" s3vectors get-index --vector-bucket-name test --index-name test-idx
/opt/homebrew/Cellar/awscli/2.34.9/libexec/lib/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
{
    "index": {
        "vectorBucketName": "test",
        "indexName": "test-idx",
        "creationTime": "2026-03-16T13:55:38.913000+05:30",
        "dimension": 4,
        "distanceMetric": "euclidean"
    }
}

$ aws --no-verify-ssl --region us-east-1 --endpoint "https://localhost:14443" s3vectors list-indexes --vector-bucket-name test
/opt/homebrew/Cellar/awscli/2.34.9/libexec/lib/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
{
    "indexes": [
        {
            "vectorBucketName": "test",
            "indexName": "test-idx",
            "creationTime": "2026-03-16T13:55:38.913000+05:30"
        }
    ]
}

$ aws --no-verify-ssl --region us-east-1 --endpoint "https://localhost:14443" s3vectors delete-index --vector-bucket-name test --index-name test-idx
/opt/homebrew/Cellar/awscli/2.34.9/libexec/lib/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
```

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for persistent vector buckets and indices: create, retrieve, list (prefix + pagination), and delete with underlying storage and config persistence.

* **Behavioral Improvements**
  * Enforced ownership and authorization, rejects duplicates, prevents deleting non-empty buckets, and defaults vector engine to "lance" when omitted; namespace header made optional when system path is configured.

* **Tests**
  * Comprehensive end-to-end tests covering lifecycle, permissions, listing, pagination, and conditional native-engine operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->