### PR TITLE
Added mode in stats_api for partial bucket status

### DIFF
--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -769,6 +769,9 @@ module.exports = {
                             bucket_name: {
                                 type: 'string'
                             },
+                            mode: {
+                                $ref: 'common_api#/definitions/bucket_mode'
+                            },
                             quota_size_percent: {
                                 type: 'number'
                             },
@@ -820,6 +823,9 @@ module.exports = {
                         properties: {
                             bucket_name: {
                                 type: 'string'
+                            },
+                            mode: {
+                                $ref: 'common_api#/definitions/bucket_mode'
                             },
                             is_healthy: {
                                 type: 'boolean'

--- a/src/test/integration_tests/internal/test_system_servers.js
+++ b/src/test/integration_tests/internal/test_system_servers.js
@@ -586,6 +586,7 @@ mocha.describe('system_servers', function() {
         await rpc_client.stats.get_nodes_stats({});
         await rpc_client.stats.get_ops_stats({});
         await rpc_client.stats.get_all_stats({});
+        await rpc_client.stats.get_partial_stats({});
     });
 
     ////////////


### PR DESCRIPTION
### Describe the Problem
`get_partial_stats` returns `mode` in buckets_stats.buckets[] and namespace_buckets_stats.namespace_buckets[], but stats_api schema disallowed it (additionalProperties: false), causing invalid_schma failures.

### Explain the Changes
1. Updated `stats_api.js` to include mode in both bucket stats item schemas, typed as `common_api#/definitions/bucket_mode`.

### Issues: Fixed #xxx / Gap #xxx
1. JIRA: https://redhat.atlassian.net/browse/RHSTOR-7732
2.  Gap: #9386 

### Testing Instructions:
1.  Start postgress container:
`$ docker run -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=noobaa quay.io/sclorg/postgresql-15-c9s`
3. Run tests (on another terminal):
`$  node ./node_modules/mocha/bin/mocha.js src/test/integration_tests/internal/test_system_servers.js`


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bucket statistics responses now include a new "mode" property for both standard and namespace bucket stats, exposing additional bucket metadata without changing existing behavior.

* **Tests**
  * Integration tests updated to exercise the partial stats path and validate the expanded stats responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->