### PR TITLE
NC | ignore undefined messages for starting forks health server

### DIFF
--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -596,9 +596,19 @@ function fork_main_handler(req, res) {
 /**
  * fork_message_request_handler is used to handle messages from the primary process.
  * the primary process sends a message with the designated port to start the fork server.
+ * Only process messages that contain health_port - the primary also sends other message types
+ * (io_stats, op_stats, etc.) and processing those would incorrectly start duplicate servers.
  * @param {Object} msg
  */
 async function fork_message_request_handler(msg) {
+    if (msg.health_port === undefined) {
+        dbg.warn('Received message without health_port, ignoring', msg);
+        return;
+    }
+    // DONT_DISABLE_FORK_MESSAGE_HANDLER is a debugging flag in case we want to keep the message listener to log unknown messages
+    if (!process.env.DONT_DISABLE_FORK_MESSAGE_HANDLER || process.env.DONT_DISABLE_FORK_MESSAGE_HANDLER !== 'true') {
+        process.off('message', fork_message_request_handler); // stop listening after we started the server
+    }
     await http_utils.start_https_server(msg.health_port,
         SERVICES_TYPES_ENUM.FORK_HEALTH,
         fork_main_handler,
@@ -610,5 +620,6 @@ exports.main = main;
 exports.create_endpoint_handler = create_endpoint_handler;
 exports.create_init_request_sdk = create_init_request_sdk;
 exports.endpoint_fork_id_handler = endpoint_fork_id_handler;
+exports.fork_message_request_handler = fork_message_request_handler;
 
 if (require.main === module) main();

--- a/src/test/integration_tests/nc/test_nc_with_a_couple_of_forks.js
+++ b/src/test/integration_tests/nc/test_nc_with_a_couple_of_forks.js
@@ -15,6 +15,9 @@ const { NSFSHealth } = require('../../../manage_nsfs/health');
 const { ConfigFS } = require('../../../sdk/config_fs');
 const config = require('../../../../config');
 const ManageCLIResponse = require('../../../manage_nsfs/manage_nsfs_cli_responses').ManageCLIResponse;
+const endpoint = require('../../../endpoint/endpoint');
+const sinon = require('sinon');
+const http_utils = require('../../../util/http_utils');
 
 const coretest = require_coretest();
 const setup_options = { forks: 2, debug: 5 };
@@ -313,6 +316,56 @@ const s3_uid6001 = generate_s3_client(access_details.access_key,
             const res = await health.nc_nsfs_health();
             assert.strictEqual(res.status, 'OK');
             assert.strictEqual(res.checks.endpoint.endpoint_state.total_fork_count, 2, 'There should be 2 forks in the health response');
+        });
+
+        mocha.it('fork_message_request_handler ignores messages without health_port', async function() {
+            // Simulates messages that workers may receive (e.g. stats) which lack health_port.
+            // The handler should return early and not start duplicate fork health servers.
+            // This test does not require the NC server to be running.
+            const start_https_stub = sinon.stub(http_utils, 'start_https_server').resolves();
+            try {
+                const messages_without_health_port = [
+                    {},
+                    { io_stats: { read_count: 1 } },
+                    { op_stats: { get_object: { count: 1 } } },
+                    { iam_stats: { list_users: { count: 1 } } },
+                    { fs_workers_stats: { read: { count: 1 } } },
+                    { nsfs_config_root: '/some/path' },
+                    { ready_to_start_fork_server: true }
+                ];
+                const message_with_health_port = {health_port: 19999, nsfs_config_root: config_root};
+                for (const msg of messages_without_health_port) {
+                    await endpoint.fork_message_request_handler(msg);
+                }
+                assert.strictEqual(start_https_stub.callCount, 0,
+                    'start_https_server should not be called for messages without health_port');
+                await endpoint.fork_message_request_handler(message_with_health_port);
+                assert.strictEqual(start_https_stub.callCount, 1,
+                    'start_https_server should be called for messages with health_port');
+            } finally {
+                start_https_stub.restore();
+            }
+        });
+
+        mocha.it('fork_message_request_handler removes message listener after first valid message', async function() {
+            // After processing a valid health_port message, the handler removes itself to prevent
+            // duplicate server starts. This test does not require the NC server to be running.
+            process.on('message', endpoint.fork_message_request_handler);
+            const listener_count_after_add = process.listenerCount('message');
+
+            const start_https_stub = sinon.stub(http_utils, 'start_https_server').resolves();
+            try {
+                await endpoint.fork_message_request_handler({
+                    health_port: 19999,
+                    nsfs_config_root: config_root
+                });
+                const listener_count_after_remove = process.listenerCount('message');
+                assert.strictEqual(listener_count_after_remove, listener_count_after_add - 1,
+                    'Expected message listener to be removed after successful fork server start');
+            } finally {
+                start_https_stub.restore();
+                process.off('message', endpoint.fork_message_request_handler);
+            }
         });
     });
 });


### PR DESCRIPTION
### Describe the Problem
Fork health ports kept being opened repeatedly in customer environment. Logs showed many "Starting FORK_HEALTH server on HTTPS port undefined" messages and a MaxListenersExceededWarning on CertInfo due to too many update listeners.

The worker registers process.on('message', fork_message_request_handler) for all messages from the primary, but the handler treated every message as a fork health config and always tried to start a server with msg.health_port. Unknown messages that do not contain health_port caused the handler to start servers with port undefined and to add many listeners to the shared CertInfo emitter.

### Explain the Changes
1. Guard for messages without health_port – At the start of fork_message_request_handler, return early when msg.health_port === undefined and log a warning, so only valid fork health config messages are handled.

2. Remove listener after successful start – After successfully starting the fork health server, call process.off('message', fork_message_request_handler) so the listener is removed and duplicate servers are not started if more messages arrive later.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `NC_CORETEST=true node ./node_modules/mocha/bin/mocha src/test/integration_tests/nc/test_nc_with_a_couple_of_forks.js`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved fork startup: secure health servers now start automatically when a valid health port is provided; invalid startup messages are ignored with a warning and redundant message listeners are removed after successful startup.
* **Tests**
  * Added integration tests covering health-server initialization, handling of missing health-port messages, and listener cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->