### PR TITLE
[S3Vectors] Supporting bucket policies - Part II - FS APIs

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1428,6 +1428,7 @@ module.exports = {
                 namespace_resource: { $ref: '#/definitions/namespace_resource_config'},
                 bucket_claim: { $ref: 'common_api#/definitions/bucket_claim' },
                 tags: { $ref: 'common_api#/definitions/tagging' },
+                vector_policy: { $ref: 'common_api#/definitions/bucket_policy'},
             }
         },
 

--- a/src/endpoint/vector/ops/vector_put_vector_bucket_policy.js
+++ b/src/endpoint/vector/ops/vector_put_vector_bucket_policy.js
@@ -29,23 +29,11 @@ async function put_vector_bucket_policy(req, res) {
             policy,
         });
     } catch (error) {
-        if (error.rpc_code === 'MALFORMED_POLICY') {
+        if (error.rpc_code === 'MALFORMED_POLICY' ||
+            error.rpc_code === 'INVALID_SCHEMA' ||
+            error.rpc_code === 'INVALID_SCHEMA_PARAMS') {
             const err = new VectorError(VectorError.ValidationException);
-            err.message = error.message || 'Policy was not well formed or did not validate against the published schema';
-            const detail = error.rpc_data && error.rpc_data.detail;
-            err.fieldList = [{
-                path: 'policy',
-                message: error.message + (detail ? ': ' + detail : ''),
-            }];
-            throw err;
-        }
-        if (error.rpc_code === 'INVALID_SCHEMA' || error.rpc_code === 'INVALID_SCHEMA_PARAMS') {
-            const err = new VectorError(VectorError.ValidationException);
-            err.message = 'Policy was not well formed or did not validate against the published schema';
-            err.fieldList = [{
-                path: 'policy',
-                message: 'Policy was not well formed or did not validate against the published schema',
-            }];
+            err.message = 'The provided policy is malformed or invalid';
             throw err;
         }
         throw error;

--- a/src/endpoint/vector/vector_errors.js
+++ b/src/endpoint/vector/vector_errors.js
@@ -9,11 +9,11 @@ const error_type_enum = {
 
 /**
  * @typedef {{
- *      code: string, 
- *      message: string, 
+ *      code: string,
+ *      message: string,
  *      http_code?: number,
  *      type?: string,
- *      fieldList?: {path: string, message:string}[]
+ *      fieldList?: {path: string, message:string}[],
  * }} VectorErrorSpec
  */
 

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -1247,6 +1247,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 creation_time: vb.creation_time,
                 vector_db_type: vb.vector_db_type,
                 path: vb.path,
+                vector_policy: vb.vector_policy,
             };
         } catch (err) {
             if (err.code === 'ENOENT') {
@@ -1461,6 +1462,46 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         return bucket_semaphore.surround_key(String(vector_bucket_name), async () => {
             await this.config_fs.delete_vector_index_config_file(vector_bucket_name, vector_index_name);
         });
+    }
+
+    //////////////////////////////
+    // VECTOR BUCKET POLICY     //
+    //////////////////////////////
+
+    async put_vector_bucket_policy(params) {
+        try {
+            const { name, policy } = params;
+            dbg.log0('BucketSpaceFS.put_vector_bucket_policy:', name, policy);
+            const vector_bucket = await this.config_fs.get_vector_bucket_by_name(name);
+            await access_policy_utils.validate_vector_bucket_policy(policy, name, []);
+            vector_bucket.vector_policy = policy;
+            await this.config_fs.update_vector_bucket_config_file(vector_bucket);
+        } catch (err) {
+            throw translate_error_codes(err, entity_enum.BUCKET);
+        }
+    }
+
+    async get_vector_bucket_policy(params) {
+        try {
+            const { name } = params;
+            dbg.log0('BucketSpaceFS.get_vector_bucket_policy:', name);
+            const vector_bucket = await this.config_fs.get_vector_bucket_by_name(name);
+            return { policy: vector_bucket.vector_policy };
+        } catch (err) {
+            throw translate_error_codes(err, entity_enum.BUCKET);
+        }
+    }
+
+    async delete_vector_bucket_policy(params) {
+        try {
+            const { name } = params;
+            dbg.log0('BucketSpaceFS.delete_vector_bucket_policy:', name);
+            const vector_bucket = await this.config_fs.get_vector_bucket_by_name(name);
+            delete vector_bucket.vector_policy;
+            await this.config_fs.update_vector_bucket_config_file(vector_bucket);
+        } catch (err) {
+            throw translate_error_codes(err, entity_enum.BUCKET);
+        }
     }
 }
 

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -1178,6 +1178,18 @@ class ConfigFS {
     }
 
     /**
+     * update_vector_bucket_config_file updates a vector bucket config file in place
+     * @param {Object} data - full vector bucket config; must include `name` (bucket name string)
+     * @returns {Promise<void>}
+     */
+    async update_vector_bucket_config_file(data) {
+        await this._throw_if_config_dir_locked();
+        const string_data = JSON.stringify(_.omitBy(data, _.isUndefined));
+        const vb_path = this.get_vector_bucket_path_by_name(data.name);
+        await native_fs_utils.update_config_file(this.fs_context, this.vector_buckets_dir_path, vb_path, string_data);
+    }
+
+    /**
      * delete_vector_bucket_config_file deletes a vector bucket config file
      * @param {string} vector_bucket_name
      * @returns {Promise<void>}

--- a/src/server/system_services/schemas/nsfs_vector_bucket_schema.js
+++ b/src/server/system_services/schemas/nsfs_vector_bucket_schema.js
@@ -1,0 +1,30 @@
+/* Copyright (C) 2025 NooBaa */
+'use strict';
+
+module.exports = {
+    $id: 'nsfs_vector_bucket_schema',
+    type: 'object',
+    required: [
+        '_id',
+        'name',
+        'owner_account',
+        'creation_date',
+    ],
+    properties: {
+        _id: {
+            type: 'string',
+        },
+        name: {
+            type: 'string',
+        },
+        owner_account: {
+            type: 'string',
+        },
+        creation_date: {
+            type: 'string',
+        },
+        vector_policy: {
+            $ref: 'common_api#/definitions/bucket_policy',
+        },
+    }
+};

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -3,9 +3,17 @@
 /* eslint-disable max-lines-per-function */
 
 'use strict';
-// setup coretest first to prepare the env
-const coretest = require('../../../utils/coretest/coretest');
-coretest.setup({ pools_to_create: [coretest.POOL_LIST[1]] });
+// Use require_coretest() so NC runs (nc_index) load nc_coretest; container runs load coretest.js.
+const { require_coretest, is_nc_coretest, TMP_PATH } = require('../../../system_tests/test_utils');
+const fs = require('fs').promises;
+const coretest = require_coretest();
+let setup_options;
+if (is_nc_coretest) {
+    setup_options = { should_run_vectors: true, should_run_iam: true, debug: 5 };
+} else {
+    setup_options = { pools_to_create: [coretest.POOL_LIST[1]] };
+}
+coretest.setup(setup_options);
 const config = require('../../../../../config');
 const s3vectors = require('@aws-sdk/client-s3vectors');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
@@ -14,7 +22,6 @@ const assert = require('assert');
 const https = require('https');
 const path = require('path');
 const { rpc_client, EMAIL } = coretest;
-const { TMP_PATH } = require('./../../../system_tests/test_utils');
 
 mocha.describe('vectors_ops', function() {
 
@@ -28,7 +35,15 @@ mocha.describe('vectors_ops', function() {
 
     mocha.before(async function() {
         const self = this;
-        self.timeout(2000);
+        self.timeout(is_nc_coretest ? 120000 : 60000);
+        if (is_nc_coretest) {
+            const current = coretest.get_current_setup_options();
+            if (!current.should_run_vectors) {
+                await coretest.stop_nsfs_process();
+                await coretest.start_nsfs_process(setup_options);
+            }
+            await fs.mkdir(path.join(TMP_PATH, 'lance'), { recursive: true });
+        }
         const account_info = await rpc_client.account.read_account({ email: EMAIL });
         client_params = {
             endpoint: coretest.get_https_address_vectors(),
@@ -517,11 +532,8 @@ mocha.describe('vectors_ops', function() {
                 await s3_vectors_client.send(put_cmd);
                 assert.fail('Expected error for malformed policy');
             } catch (err) {
-                console.error('Received expected error for malformed policy:', err);
                 assert.strictEqual(err.name, 'ValidationException');
-                assert.ok(err.fieldList, 'Expected fieldList in validation error');
-                assert.ok(err.fieldList.length > 0, 'Expected at least one entry in fieldList');
-                assert.strictEqual(err.fieldList[0].path, 'policy');
+                assert.ok(err.message, 'Expected validation error message');
             }
         });
 

--- a/src/test/utils/coretest/nc_coretest.js
+++ b/src/test/utils/coretest/nc_coretest.js
@@ -50,9 +50,11 @@ const PASSWORD = NC_CORETEST;
 const http_port = 6001;
 const https_port = 6443;
 const https_port_iam = 7005;
+const https_port_vectors = 7006;
 const http_address = `http://localhost:${http_port}`;
 const https_address = `https://localhost:${https_port}`;
 const https_address_iam = `https://localhost:${https_port_iam}`;
+const https_address_vectors = `https://localhost:${https_port_vectors}`;
 
 const FIRST_BUCKET = 'first.bucket';
 const NC_CORETEST_STORAGE_PATH = p.join(TMP_PATH, 'nc_coretest_storage_root_path/');
@@ -113,8 +115,8 @@ function setup(setup_options = {}) {
  */
 async function start_nsfs_process(setup_options) {
     console.log(`in start_nsfs_process - variables values: _setup ${_setup} _nsfs_process ${_nsfs_process}`);
-    const { forks, debug, should_run_iam, http_server_port } = setup_options;
-    console.log(`setup_options: forks ${forks} debug ${debug} should_run_iam ${should_run_iam}`);
+    const { forks, debug, should_run_iam, should_run_vectors, http_server_port } = setup_options;
+    console.log(`setup_options: forks ${forks} debug ${debug} should_run_iam ${should_run_iam} should_run_vectors ${should_run_vectors}`);
     if (_nsfs_process) return;
     await announce('start nsfs script');
     const logStream = fs.createWriteStream('nsfs_integration_test_log.txt', { flags: 'a' });
@@ -131,6 +133,10 @@ async function start_nsfs_process(setup_options) {
     if (should_run_iam && https_port_iam) {
         arguments_for_command.push('--https_port_iam');
         arguments_for_command.push(`${https_port_iam}`);
+    }
+    if (should_run_vectors && https_port_vectors) {
+        arguments_for_command.push('--https_port_vector');
+        arguments_for_command.push(`${https_port_vectors}`);
     }
     if (http_server_port) {
         arguments_for_command.push('--http_port');
@@ -291,6 +297,14 @@ function get_https_address() {
  */
 function get_https_address_iam() {
     return https_address_iam;
+}
+
+/**
+ * get_https_address_vectors return nc coretest https_address_vectors variable
+ * @returns {string}
+ */
+function get_https_address_vectors() {
+    return https_address_vectors;
 }
 
 ///////////////////////////////////
@@ -564,6 +578,7 @@ exports.rpc_client = rpc_cli_funcs_to_manage_nsfs_cli_cmds;
 exports.get_http_address = get_http_address;
 exports.get_https_address = get_https_address;
 exports.get_https_address_iam = get_https_address_iam;
+exports.get_https_address_vectors = get_https_address_vectors;
 exports.get_admin_mock_account_details = get_admin_mock_account_details;
 exports.NC_CORETEST_CONFIG_DIR_PATH = NC_CORETEST_CONFIG_DIR_PATH;
 exports.NC_CORETEST_CONFIG_FS = NC_CORETEST_CONFIG_FS;

--- a/src/test/utils/index/nc_index.js
+++ b/src/test/utils/index/nc_index.js
@@ -3,7 +3,8 @@
 
 
 const coretest = require('../coretest/nc_coretest');
-coretest.setup();
+// Vectors / IAM integration tests expect nsfs started with the extra HTTPS ports.
+coretest.setup({ should_run_vectors: true, should_run_iam: true, debug: 5 });
 
 require('../../unit_tests/nsfs/test_namespace_fs');
 require('../../unit_tests/api/s3/test_ns_list_objects');
@@ -25,6 +26,8 @@ require('../../integration_tests/nc/lifecycle/test_nc_lifecycle_expiration');
 require('../../integration_tests/api/s3/test_chunked_upload');
 require('../../integration_tests/api/s3/test_s3_worm.js');
 
+// running with vectors port
+require('../../integration_tests/api/vectors/test_vectors_ops'); // please notice that we use a different setup
 // running with iam port
 require('../../integration_tests/api/iam/test_iam_basic_integration'); // please notice that we use a different setup
 // running with a couple of forks - please notice and add only relevant tests here


### PR DESCRIPTION
### Describe the Problem
Adding the missing API for NB to support vector bucket policy - and the needed tests
Again, no actual authorisation - just the APIs

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage vector bucket policies: create/update, retrieve, and delete policies.
  * Vector policy now appears in vector bucket details.

* **Bug Fixes**
  * Unified and simplified validation error messages for vector policy operations.

* **Tests**
  * Integration tests and test harness updated to run and validate vector operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->