### PR TITLE
CI | Fix the Validate-package-lock.yaml test

### DIFF
--- a/.github/workflows/Validate-package-lock.yaml
+++ b/.github/workflows/Validate-package-lock.yaml
@@ -19,9 +19,11 @@ jobs:
 
       - name: Validate PR package-lock.json preserves base branch resolved and integrity
         run: |
-            # For every package path that exists in both the merge-base branch and the PR head lockfile:
-            # if the base entry has resolved and integrity, the PR entry must have the same values.
+            # For every package path that exists in both the base branch and the PR head lockfile:
+            # if the base entry has resolved and integrity (non-link), the PR entry must also have both fields set (non-null).
+            # Values are not compared; only presence of resolved and integrity on the PR is checked.
             RED='\033[0;31m'
+            GREEN='\033[0;32m'
             NC='\033[0m'
             BASE_REF="${{ github.base_ref }}"
             PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -32,46 +34,63 @@ jobs:
             git fetch origin "pull/${PR_NUMBER}/head" --depth=1
             git show FETCH_HEAD:package-lock.json > package-lock-pr-head.json
 
+            base_pkg_count=$(jq '[.packages | keys[] | select(. != "")] | length' package-lock-base.json)
+            pr_pkg_count=$(jq '[.packages | keys[] | select(. != "")] | length' package-lock-pr-head.json)
+
             jq -n \
               --slurpfile base package-lock-base.json \
               --slurpfile pr package-lock-pr-head.json \
               '
               ($base[0].packages // {}) as $A |
               ($pr[0].packages // {}) as $B |
+              (
+                [($A | keys[] | select(. != "")) as $k |
+                  select(
+                    ($B | has($k)) and
+                    ($A[$k].link != true) and
+                    (($A[$k] | .resolved != null) and ($A[$k] | .integrity != null)) and
+                    (($B[$k] | .resolved != null) and ($B[$k] | .integrity != null))
+                  ) | $k
+                ]
+              ) as $both_pinned |
               {
+                both_pinned_count: ($both_pinned | length),
                 diverged:
                   [($A | keys[] | select(. != "")) as $k |
                     select(
                       ($B | has($k)) and
                       ($A[$k].link != true) and
                       (($A[$k] | .resolved != null) and ($A[$k] | .integrity != null)) and
-                      (
-                        (($B[$k] | .resolved == null) or ($B[$k] | .integrity == null)) or
-                        (
-                          (($B[$k] | .resolved != null) and ($B[$k] | .integrity != null)) and
-                          (
-                            (($B[$k] | .resolved) != ($A[$k] | .resolved)) or
-                            (($B[$k] | .integrity) != ($A[$k] | .integrity))
-                          )
-                        )
-                      )
+                      (($B[$k] | .resolved == null) or ($B[$k] | .integrity == null))
                     ) | $k
                   ]
               }
             ' > package_lock_base_compare_report.json
 
             diverged_count=$(jq '.diverged | length' package_lock_base_compare_report.json)
+            both_pinned_count=$(jq '.both_pinned_count' package_lock_base_compare_report.json)
 
             if [ "${diverged_count}" -gt 0 ]; then
-              echo -e "${RED}package-lock.json on the PR branch must preserve resolved and integrity from the base branch (${BASE_REF}) for every shared package path where the base has both.${NC}"
+              echo "Shared registry package paths with resolved and integrity in both base (${BASE_REF}) and PR head: ${both_pinned_count}"
+              # Base has fewer package paths than PR (e.g. new dependencies on the PR): do not fail this step.
+              if [ "${base_pkg_count}" -lt "${pr_pkg_count}" ]; then
+                echo -e "${GREEN}Base (${BASE_REF}) has fewer package-lock package paths (${base_pkg_count}) than PR head (${pr_pkg_count}); not failing resolved/integrity check.${NC}"
+                exit 0
+              fi
+              echo -e "${RED}package-lock.json on the PR branch must have resolved and integrity set (non-null) for every shared package path where the base (${BASE_REF}) has both (values are not compared).${NC}"
+              echo -e "${RED}Lockfile package path counts: base branch (${BASE_REF})=${base_pkg_count}, PR head=${pr_pkg_count}, paths missing resolved or integrity on PR=${diverged_count}${NC}"
+              echo -e "${RED}Package paths missing resolved or integrity on PR (while base has both):${NC}"
+              jq -r '.diverged[]' package_lock_base_compare_report.json | while IFS= read -r path; do
+                echo "  ${path}"
+              done
               echo "for more details: https://github.com/npm/cli/issues/4263"
-              echo "To fix this, run: npm cache clean --force ; rm -rf node_modules ; rm -rf package-lock.json"
-              echo "and then run: npm install"
+              echo -e "${GREEN}To fix this, run: npm cache clean --force ; rm -rf node_modules ; rm -rf package-lock.json${NC}"
+              echo -e "${GREEN}and then run: npm install${NC}"
               echo "Regenerate the lockfile locally (same Node as .nvmrc), commit, and re-run."
               exit 1
             fi
 
-            echo "Base branch (${BASE_REF}) vs PR head: resolved and integrity match for all shared registry entries."
+            echo -e "${GREEN}Base branch (${BASE_REF}) vs PR head: for every shared path where base has resolved and integrity, PR has both fields set.${NC}"
 
       - name: Backup the current package-lock.json
         run: | 


### PR DESCRIPTION
### Explain the Changes
- `Validate PR package-lock.json preserves base branch resolved and integrity` was failing when the content of the fields was changed and not null, but it would only fail on null


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package-lock validation workflow to correctly handle pull requests that add new dependencies without triggering false failure reports.

* **Chores**
  * Enhanced validation reporting with improved metrics, output messaging, and more accurate package integrity field presence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->