### PR TITLE
NC | don't copy home dir on useradd

### DIFF
--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -319,7 +319,7 @@ async function create_fs_user_by_platform(new_user, new_password, uid, gid) {
     } else {
         const create_group_cmd = `groupadd -g ${gid} ${new_user}`;
         await os_utils.exec(create_group_cmd, { return_stdout: true });
-        const create_user_cmd = `useradd -c ${new_user} -m ${new_user} -p $(openssl passwd -1 ${new_password}) -u ${uid} -g ${gid} `;
+        const create_user_cmd = `useradd -c ${new_user} ${new_user} -p $(openssl passwd -1 ${new_password}) -u ${uid} -g ${gid} `;
         await os_utils.exec(create_user_cmd, { return_stdout: true });
     }
 }
@@ -336,7 +336,15 @@ async function delete_fs_user_by_platform(name) {
         await os_utils.exec(delete_user_home_cmd, { return_stdout: true });
     } else {
         const delete_user_cmd = `userdel -r ${name}`;
-        await os_utils.exec(delete_user_cmd, { return_stdout: true });
+        try {
+            await os_utils.exec(delete_user_cmd, { return_stdout: true });
+        } catch (err) {
+            // don't throw error if user doesn't exist
+            // error code 6 is "specified user doesn't exist"
+            if (err.code !== 6) {
+                throw err;
+            }
+        }
     }
 }
 

--- a/src/test/unit_tests/nsfs/test_nsfs_access.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_access.js
@@ -179,6 +179,13 @@ mocha.describe('dynamic supplemental groups - get_fs_context flow', function() {
         config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = dynamic_supplemental_groups_enabled_backup;
     });
 
+    mocha.it('test delete user by platform doesnt throw if user does not exist', async function() {
+        if (process.platform === 'darwin') {
+            this.skip(); // eslint-disable-line no-invalid-this
+        }
+        await test_utils.delete_fs_user_by_platform("non_existing_user");
+    });
+
     mocha.it('get_fs_context with uid/gid and dynamic enabled - supplemental groups resolved, readdir succeeds', async function() {
         const nsfs_account_config = { uid: NON_ROOT4_UID, gid: NON_ROOT4_GID };
         const fs_context = await native_fs_utils.get_fs_context(nsfs_account_config, '');


### PR DESCRIPTION
### Describe the Problem
when creating new users using useradd linux copies files in /etc/skel dir to the new user homedir (see https://man7.org/linux/man-pages/man7/hier.7.html). on github actions ubuntu enviornment this folder is very large. and this process can take over 30 seconds. (see `https://github.com/actions/runner-images/issues/13048`) 
this causes some tests to intermittently timeout in CI

### Explain the Changes
1. since we only test new users for permission checks and don't actually need a home folder for them. remove the `-m` option which creates the home folder based on the skel file
2. don't throw when deleting new user fails because it didn't exist

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of test utilities for user account management operations.
  * Enhanced error handling in test environment setup to gracefully handle edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->