### PR TITLE
vectors - build - skip building lance for ppc64 without optionalDependencies

### DIFF
--- a/src/deploy/NVA_build/Base.Dockerfile
+++ b/src/deploy/NVA_build/Base.Dockerfile
@@ -3,6 +3,7 @@ FROM noobaa-builder AS noobaa-base
 # By default we build the image with s3select support, but can be overridden
 ARG BUILD_S3SELECT=1
 ARG BUILD_S3SELECT_PARQUET=0
+ARG TARGETPLATFORM
 
 ######################################################################
 # Layers:
@@ -11,6 +12,10 @@ ARG BUILD_S3SELECT_PARQUET=0
 #   Cache: Rebuild when there is new package.json or package-lock.json
 ######################################################################
 COPY ./package*.json ./
+
+RUN if [ "$TARGETPLATFORM" = "linux/ppc64le" ]; then \
+	sed -i '/lance/d' package.json; fi
+
 RUN npm install --omit=dev && \
     npm cache clean --force && \
     rm -rf node_modules/node-rdkafka/deps/librdkafka/examples/ && \

--- a/src/endpoint/vector/vector_rest.js
+++ b/src/endpoint/vector/vector_rest.js
@@ -7,6 +7,7 @@ const VectorSDK = require('../../sdk/vector_sdk');
 const js_utils = require('../../util/js_utils');
 const http_utils = require('../../util/http_utils');
 const signature_utils = require('../../util/signature_utils');
+const lance = js_utils.require_optional('@lancedb/lancedb');
 
 const VECTOR_MAX_BODY_LEN = 4 * 1024 * 1024; //TODO - validate
 
@@ -57,6 +58,14 @@ async function vector_rest(req, res) {
 }
 
 async function handle_request(req, res) {
+
+    if (!lance) {
+        throw new VectorError({
+            code: "NotAvailable",
+            message: "Vector API is not available in this server.",
+            http_code: 501,
+        });
+    }
 
     http_utils.set_amz_headers(req, res);
 


### PR DESCRIPTION
### Describe the Problem
Lance npm package doesn't support ppc64, and downstream build doesn't support optionalDependencies.
As a workaround, delete lance dependency for ppe64 from package.json.

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vector API now returns a proper HTTP 501 error when the service is unavailable, instead of failing silently.
  * Improved platform-specific build handling to ensure consistent installation across different system architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->