### PR TITLE
combine db querries for get command

### DIFF
--- a/config.js
+++ b/config.js
@@ -682,6 +682,11 @@ config.REMOTE_NOOAA_NAMESPACE = `remote-${config.KUBE_APP_LABEL}`;
 // FILES RELATED             //
 ///////////////////////////////
 config.INLINE_MAX_SIZE = 4096;
+// Maximum number of parts to prefetch in a single DB round-trip alongside read_object_md.
+// Matches the number of parts that read_object_stream fetches per range-aligned window
+// (IO_OBJECT_RANGE_ALIGN / CHUNK_SPLIT_AVG_CHUNK). Objects with more parts fall back to
+// the standard read_object_mapping RPC.
+config.MAPPINGS_PREFETCH_NUM_PARTS = config.IO_OBJECT_RANGE_ALIGN / config.CHUNK_SPLIT_AVG_CHUNK;
 
 ///////////////////////////////
 // CACHE (ACCOUNT, BUCKET)   //

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -472,16 +472,20 @@ module.exports = {
                     bucket: { $ref: 'common_api#/definitions/bucket_name' },
                     key: { type: 'string' },
                     obj_id: { objectid: true },
+                    size: { type: 'integer' },
                     start: { type: 'integer' },
                     end: { type: 'integer' },
                     location_info: { $ref: 'common_api#/definitions/location_info' },
+                    prefetched_chunks: {
+                        type: 'array',
+                        items: { $ref: '#/definitions/chunk_info' },
+                    },
                 },
             },
             reply: {
                 type: 'object',
-                required: ['object_md', 'chunks'],
+                required: ['chunks'],
                 properties: {
-                    object_md: { $ref: '#/definitions/object_info' },
                     chunks: {
                         type: 'array',
                         items: { $ref: '#/definitions/chunk_info' },
@@ -571,6 +575,7 @@ module.exports = {
                     key: { type: 'string' },
                     md_conditions: { $ref: '#/definitions/md_conditions' },
                     encryption: { $ref: 'common_api#/definitions/object_encryption' },
+                    should_prefetch_mappings: { type: 'boolean' },
                     adminfo: {
                         type: 'object',
                         properties: {
@@ -1567,6 +1572,10 @@ module.exports = {
                 object_owner: {
                     type: 'object',
                     properties: {}
+                },
+                prefetched_mappings: {
+                    type: 'array',
+                    items: { $ref: '#/definitions/chunk_info' }
                 },
             }
         },

--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -42,6 +42,9 @@ async function get_object(req, res) {
     if (part_number) {
         md_params.part_number = part_number;
     }
+    if (!part_number) {
+        md_params.should_prefetch_mappings = true;
+    }
 
     const object_md = await req.object_sdk.read_object_md(md_params);
 

--- a/src/sdk/map_client.js
+++ b/src/sdk/map_client.js
@@ -89,6 +89,7 @@ class MapClient {
      * @param {Partial<nb.ObjectInfo>} [props.object_md]
      * @param {number} [props.read_start]
      * @param {number} [props.read_end]
+     * @param {nb.ChunkInfo[]} [props.prefetched_chunks]
      * @param {nb.LocationInfo} [props.location_info]
      * @param {nb.Tier} [props.move_to_tier]
      * @param {boolean} [props.check_dups]
@@ -103,6 +104,7 @@ class MapClient {
         this.object_md = props.object_md;
         this.read_start = props.read_start;
         this.read_end = props.read_end;
+        this.prefetched_chunks = props.prefetched_chunks;
         this.location_info = props.location_info;
         this.move_to_tier = props.move_to_tier;
         this.check_dups = Boolean(props.check_dups);
@@ -390,9 +392,11 @@ class MapClient {
             obj_id: this.object_md.obj_id,
             bucket: this.object_md.bucket,
             key: this.object_md.key,
+            size: this.object_md.size,
             start: this.read_start,
             end: this.read_end,
             location_info: this.location_info,
+            prefetched_chunks: this.prefetched_chunks,
         });
         return res.chunks.map(chunk_info => {
             // TODO: Maybe move this to map_reader?

--- a/src/sdk/namespace_cache.js
+++ b/src/sdk/namespace_cache.js
@@ -102,8 +102,12 @@ class NamespaceCache {
     }
 
     async _get_cached_range_parts_info(params, object_sdk) {
-        const read_mapping_params = _.pick(params, ['bucket', 'key', 'obj_id']);
-        read_mapping_params.obj_id = params.object_md.obj_id;
+        const read_mapping_params = {
+            bucket: params.bucket,
+            key: params.key,
+            obj_id: params.object_md.obj_id,
+            size: params.object_md.size,
+        };
         const object_mapping = await object_sdk.rpc_client.object.read_object_mapping(read_mapping_params);
         const parts = [];
         for (const chunk of object_mapping.chunks) {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -457,6 +457,7 @@ interface ObjectInfo {
     capacity_size?: number;
     num_multiparts?: number;
     first_range_data?: Buffer;
+    prefetched_mappings?: ChunkInfo[];
     content_length?: number;
     content_range?: string;
     ns?: Namespace;

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -62,6 +62,7 @@ Object.isFrozen(RpcError); // otherwise unused
  * @property {number} [end]
  * @property {number} [watermark]
  * @property {function} [missing_part_getter]
+ * @property {nb.ChunkInfo[]} [prefetched_chunks]
  *
  * @typedef {Object} CachedRead
  * @property {nb.ObjectInfo} object_md
@@ -603,14 +604,16 @@ class ObjectIO {
                 reader.push(null);
                 return;
             }
-
-            const io_sem_size = _get_io_semaphore_size(requested_end - reader.pos);
+            const { chunks: prefetched_chunks, effective_end } =
+               _take_prefetched_chunks_for_range(params.object_md, reader.pos, requested_end);
+            const io_sem_size = _get_io_semaphore_size(effective_end - reader.pos);
             this._io_buffers_sem.surround_count(io_sem_size, async () => {
                 try {
                     const buffers = await this.read_object({
                         ...params,
                         start: reader.pos,
-                        end: requested_end,
+                        end: effective_end,
+                        prefetched_chunks,
                     });
                     if (buffers && buffers.length) {
                         for (const buffer of buffers) {
@@ -701,6 +704,7 @@ class ObjectIO {
             object_md: params.object_md,
             read_start: params.start,
             read_end: params.end,
+            prefetched_chunks: params.prefetched_chunks,
             location_info: this.location_info,
             rpc_client: params.client,
             verification_mode: this._verification_mode,
@@ -878,6 +882,35 @@ function slice_buffers_in_range(chunks, start, end) {
     return buffers;
 }
 
+/**
+ * Filters prefetched chunk mappings to those overlapping [read_start, read_end) and
+ * clears object_md.prefetched_mappings once all entries are consumed.
+ * Returns the filtered chunks and the effective end the caller should use for the read range.
+ * When matching mappings exist, effective_end is coverage_end capped to read_end.
+ * When there are no mappings or none match, chunks is undefined and effective_end is read_end
+ * so the normal DB path is used.
+ * @param {Partial<nb.ObjectInfo>} object_md
+ * @param {number} read_start - current stream position
+ * @param {number} read_end - watermark-based requested end
+ * @returns {{ chunks: nb.ChunkInfo[] | undefined, effective_end: number }}
+ */
+function _take_prefetched_chunks_for_range(object_md, read_start, read_end) {
+    const { prefetched_mappings } = object_md;
+    if (!prefetched_mappings || !prefetched_mappings.length) return { chunks: undefined, effective_end: read_end };
+
+    let coverage_end = read_start;
+    const chunks = prefetched_mappings.filter(chunk_info => {
+        const part = chunk_info.parts?.[0];
+        if (!part || part.end <= read_start || part.start >= read_end) return false;
+        if (part.end > coverage_end) coverage_end = part.end;
+        return true;
+    });
+
+    object_md.prefetched_mappings = undefined;
+
+    if (!chunks.length) return { chunks: undefined, effective_end: read_end };
+    return { chunks, effective_end: Math.min(coverage_end, read_end) };
+}
 function _get_io_semaphore_size(size) {
     // TODO: Currently we have a gap regarding chunked uploads
     // We assume that the chunked upload will take 1MB

--- a/src/server/object_services/map_reader.js
+++ b/src/server/object_services/map_reader.js
@@ -12,8 +12,48 @@ const MDStore = require('./md_store').MDStore;
 const map_server = require('./map_server');
 const db_client = require('../../util/db_client');
 const { ChunkDB } = require('./map_db_types');
+const { ChunkAPI } = require('../../sdk/map_api_types');
 const server_rpc = require('../server_rpc');
 const auth_server = require('../common_services/auth_server');
+const system_store = require('../system_services/system_store').get_instance();
+
+
+/**
+ * Builds prepared ChunkDB instances from pre-fetched parts and chunks_db rows.
+ * Groups each part with its matching chunk and calls prepare_chunks to resolve
+ * block locations before returning.
+ *
+ * @param {nb.PartSchemaDB[]} parts
+ * @param {nb.ChunkSchemaDB[]} chunks_db
+ * @returns {Promise<nb.Chunk[]>}
+ */
+async function assemble_chunks_from_parts(parts, chunks_db) {
+    const chunks_db_by_id = _.keyBy(chunks_db, '_id');
+    const chunks = parts.map(part =>
+        new ChunkDB({ ...chunks_db_by_id[part.chunk.toHexString()], parts: [part] })
+    );
+    await map_server.prepare_chunks({ chunks });
+    return chunks;
+}
+
+/**
+ * Fetch parts and chunks by range, build and return ChunkDB array.
+ * @param {nb.ID} obj_id
+ * @param {{ start: number, end: number }} rng
+ * @param {(a: any, b: any) => number} sorter
+ * @returns {Promise<nb.Chunk[]>}
+ */
+async function read_parts_mapping_postgres(obj_id, rng, sorter) {
+    const { parts, chunks_db } = await MDStore.instance().find_parts_chunks_blocks_by_range({
+        obj_id,
+        start_gte: rng.start - config.MAX_OBJECT_PART_SIZE,
+        start_lt: rng.end,
+        end_gt: rng.start,
+        sorter,
+    });
+    if (parts.length === 0) return [];
+    return assemble_chunks_from_parts(parts, chunks_db);
+}
 
 /**
  *
@@ -27,13 +67,30 @@ const auth_server = require('../common_services/auth_server');
  * @param {number} [start]
  * @param {number} [end]
  * @param {nb.LocationInfo} [location_info]
+ * @param {nb.ChunkInfo[]} [prefetched_chunks_info]
  * @returns {Promise<nb.Chunk[]>}
  */
-async function read_object_mapping(obj, start, end, location_info) {
+async function read_object_mapping(obj, start, end, location_info, prefetched_chunks_info) {
     // check for empty range
     const rng = sanitize_object_range(obj, start, end);
     if (!rng) return [];
 
+    let chunks;
+    if (config.DB_TYPE === 'postgres') {
+        // Combined query: parts + chunks + blocks in one round-trip.
+        // If pre-fetched chunk data was passed from read_object_md, use it to skip the DB
+        const sorter = location_info ? _block_sorter_local(location_info) : _block_sorter_basic;
+        if (prefetched_chunks_info && prefetched_chunks_info.length) {
+            chunks = prefetched_chunks_info.map(chunk_info => new ChunkAPI(chunk_info, system_store));
+        } else {
+            chunks = await read_parts_mapping_postgres(obj._id, rng, sorter);
+        }
+        if (chunks.length === 0) return [];
+        if (await update_chunks_on_read(chunks, location_info)) {
+            chunks = await read_parts_mapping_postgres(obj._id, rng, sorter);
+        }
+        return chunks;
+    }
     // find parts intersecting the [start,end) range
     const parts = await MDStore.instance().find_parts_by_start_range({
         obj_id: obj._id,
@@ -47,9 +104,7 @@ async function read_object_mapping(obj, start, end, location_info) {
     });
 
     if (parts.length === 0) return [];
-
-    let chunks = await read_parts_mapping(parts, location_info);
-
+    chunks = await read_parts_mapping(parts, location_info);
     if (await update_chunks_on_read(chunks, location_info)) {
         chunks = await read_parts_mapping(parts, location_info);
     }
@@ -230,6 +285,7 @@ function _block_sorter_local(location_info) {
 }
 
 // EXPORTS
+exports.assemble_chunks_from_parts = assemble_chunks_from_parts;
 exports.read_object_mapping = read_object_mapping;
 exports.read_object_mapping_admin = read_object_mapping_admin;
 exports.read_node_mapping = read_node_mapping;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2220]*/
+/*eslint max-lines: ["error", 2400]*/
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -1938,6 +1938,116 @@ class MDStore {
     }
 
     /**
+     * Combined query: fetch parts, chunks, and blocks in one round-trip.
+     * Replaces find_parts_by_start_range + find_chunks_by_ids + load_blocks_for_chunks.
+     *
+     * @param {Object} params
+     * @param {nb.ID} params.obj_id
+     * @param {number} params.start_gte
+     * @param {number} params.start_lt
+     * @param {number} params.end_gt
+     * @param {(a: any, b: any) => number} [params.sorter] block sort function
+     * @returns {Promise<{ parts: nb.PartSchemaDB[], chunks_db: nb.ChunkSchemaDB[] }>}
+     */
+    async find_parts_chunks_blocks_by_range({ obj_id, start_gte, start_lt, end_gt, sorter }) {
+        const query = `
+            SELECT
+                jsonb_agg(
+                    jsonb_build_object(
+                        'part', p.data,
+                        'chunk', c.data,
+                        'blocks', (
+                            SELECT jsonb_agg(b.data)
+                            FROM ${this._blocks.name} b
+                            WHERE b.data->>'chunk' = c.data->>'_id'
+                                AND b.data ? 'chunk'
+                                AND (b.data->'deleted' IS NULL OR b.data->'deleted' = 'null'::jsonb)
+                        )
+                    )
+                    ORDER BY (p.data->>'start')::bigint ASC
+                ) AS mapping
+            FROM ${this._parts.name} p
+            JOIN ${this._chunks.name} c ON c.data->>'_id' = p.data->>'chunk'
+                AND (c.data->'deleted' IS NULL OR c.data->'deleted' = 'null'::jsonb)
+            WHERE p.data->>'obj' = $1
+                AND p.data ? 'obj'
+                AND (p.data->'deleted' IS NULL OR p.data->'deleted' = 'null'::jsonb)
+                AND (p.data->'uncommitted' IS NULL OR p.data->'uncommitted' = 'null'::jsonb)
+                AND (p.data->>'start')::bigint >= $2
+                AND (p.data->>'start')::bigint < $3
+                AND (p.data->>'end')::bigint > $4
+        `;
+        const values = [String(obj_id), start_gte, start_lt, end_gt];
+        const res = await db_client.instance().executeSQL(query, values, { preferred_pool: this._postgres_pool });
+        return _parse_mapping(res.rows[0]?.mapping, sorter);
+    }
+
+    /**
+     * Single-query path: fetch object metadata and the first max_parts parts with
+     * their chunks and blocks in one round-trip. Replaces a read_object_md call
+     * followed by find_parts_chunks_blocks_by_range for the common GET case.
+     * Returns null if the object is not found.
+     *
+     * @param {string} bucket_id
+     * @param {string} key
+     * @param {number} max_parts
+     * @param {(a: any, b: any) => number} [sorter]
+     * @returns {Promise<{ obj: nb.ObjectMD, parts: nb.PartSchemaDB[], chunks_db: nb.ChunkSchemaDB[] }|null>}
+     */
+    async find_object_with_mapping_by_key(bucket_id, key, max_parts, sorter) {
+        const query = `
+            WITH obj AS (
+                SELECT o._id, o.data
+                FROM ${this._objects.name} o
+                WHERE o.data->>'bucket' = $1
+                    AND o.data->>'key' = $2
+                    AND (o.data->'deleted' IS NULL OR o.data->'deleted' = 'null'::jsonb)
+                    AND (o.data->'upload_started' IS NULL OR o.data->'upload_started' = 'null'::jsonb)
+                    AND (o.data->'version_past' IS NULL OR o.data->'version_past' = 'null'::jsonb)
+                LIMIT 1
+            ),
+            parts AS (
+                SELECT p.data
+                FROM obj
+                JOIN ${this._parts.name} p ON p.data->>'obj' = obj._id
+                    AND p.data ? 'obj'
+                    AND (p.data->'deleted' IS NULL OR p.data->'deleted' = 'null'::jsonb)
+                    AND (p.data->'uncommitted' IS NULL OR p.data->'uncommitted' = 'null'::jsonb)
+                ORDER BY (p.data->>'start')::bigint ASC
+                LIMIT $3
+            )
+            SELECT
+                obj.data AS obj_data,
+                jsonb_agg(
+                    jsonb_build_object(
+                        'part', parts.data,
+                        'chunk', c.data,
+                        'blocks', (
+                            SELECT jsonb_agg(b.data)
+                            FROM ${this._blocks.name} b
+                            WHERE b.data->>'chunk' = c.data->>'_id'
+                                AND b.data ? 'chunk'
+                                AND (b.data->'deleted' IS NULL OR b.data->'deleted' = 'null'::jsonb)
+                        )
+                    )
+                    ORDER BY (parts.data->>'start')::bigint ASC
+                ) FILTER (WHERE parts.data IS NOT NULL) AS mapping
+            FROM obj
+            LEFT JOIN parts ON true
+            LEFT JOIN ${this._chunks.name} c ON c.data->>'_id' = parts.data->>'chunk'
+                AND (c.data->'deleted' IS NULL OR c.data->'deleted' = 'null'::jsonb)
+            GROUP BY obj._id, obj.data
+        `;
+        const values = [`${bucket_id}`, key, max_parts];
+        const res = await db_client.instance().executeSQL(query, values, { preferred_pool: this._postgres_pool });
+        if (!res.rows.length) return null;
+        const row = res.rows[0];
+        const obj = decode_json(object_md_schema, row.obj_data);
+        const { parts, chunks_db } = _parse_mapping(row.mapping, sorter);
+        return { obj, parts, chunks_db };
+    }
+
+    /**
      * @param {nb.ChunkSchemaDB[]} chunks
      * @param {?(a: any, b: any) => number} [sorter]
      * @return {Promise<void>}
@@ -2144,6 +2254,34 @@ class MDStore {
 }
 
 MDStore._instance = undefined;
+
+/**
+ * Parse the mapping array returned by the jsonb_agg queries.
+ * Each entry contains one part with its chunk and a pre-aggregated blocks array.
+ * Attaches decoded blocks to their respective frags, applying the optional sorter.
+ *
+ * @param {Object[]|null} mapping
+ * @param {(a: any, b: any) => number} [sorter]
+ * @returns {{ parts: nb.PartSchemaDB[], chunks_db: nb.ChunkSchemaDB[] }}
+ */
+function _parse_mapping(mapping, sorter) {
+    const parts = [];
+    const chunks_db = [];
+    for (const entry of mapping || []) {
+        const part = decode_json(object_part_schema, entry.part);
+        const chunk = decode_json(data_chunk_schema, entry.chunk);
+        const blocks = (entry.blocks || []).map(b => decode_json(data_block_schema, b));
+        const blocks_by_frag = _.groupBy(blocks, b => b.frag.toHexString());
+        for (const frag of chunk.frags) {
+            let frag_blocks = blocks_by_frag[frag._id.toHexString()] || [];
+            if (sorter) frag_blocks = frag_blocks.sort(sorter);
+            frag.blocks = frag_blocks;
+        }
+        parts.push(part);
+        chunks_db.push(chunk);
+    }
+    return { parts, chunks_db };
+}
 
 function compact(obj) {
     return _.omitBy(obj, _.isUndefined);

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2300]*/
+/*eslint max-lines: ["error", 2400]*/
 'use strict';
 
 require('../../util/fips');
@@ -704,17 +704,21 @@ async function copy_object_mapping(req) {
  *
  */
 async function read_object_mapping(req) {
-    const { start, end, location_info } = req.rpc_params;
+    const { obj_id, key, size, start, end, location_info, prefetched_chunks } = req.rpc_params;
 
-    const obj = await find_object_md(req);
+    load_bucket(req);
+    const obj = {
+        _id: MDStore.instance().make_md_id(obj_id),
+        key,
+        size,
+    };
 
     // Check if the requesting account is authorized to read the object
     if (!await req.has_s3_bucket_permission(req.bucket, 's3:GetObject', '/' + obj.key, undefined)) {
         throw new RpcError('UNAUTHORIZED', 'requesting account is not authorized to read the object');
     }
 
-    const chunks = await map_reader.read_object_mapping(obj, start, end, location_info);
-    const object_md = get_object_info(obj);
+    const chunks = await map_reader.read_object_mapping(obj, start, end, location_info, prefetched_chunks);
 
 
     // only update the object read stats if the bucket has more than one tier
@@ -734,7 +738,6 @@ async function read_object_mapping(req) {
     }
 
     return {
-        object_md,
         chunks: chunks.map(chunk => chunk.to_api()),
     };
 }
@@ -815,14 +818,34 @@ function _convert_rpc_params_to_bucket_policy_req(rpc_params) {
  */
 async function read_object_md(req) {
     dbg.log1('object_server.read_object_md:', req.rpc_params);
-    const { bucket, key, md_conditions, adminfo, encryption, version_id } = req.rpc_params;
+    const { bucket, key, md_conditions, adminfo, encryption, version_id, should_prefetch_mappings } = req.rpc_params;
 
     if (adminfo && req.role !== 'admin') {
         throw new RpcError('UNAUTHORIZED', 'read_object_md: role should be admin');
     }
 
     const req_query = _convert_rpc_params_to_bucket_policy_req(req.rpc_params);
-    const obj = await find_object_md(req);
+
+    // Fast path: fetch obj + parts + chunks + blocks in a single DB round-trip.
+    // Only used when should_prefetch_mappings is set and there is no version or obj_id pinning
+    // (which would require different lookup logic).
+    let obj;
+    let prefetched_parts;
+    let prefetched_chunks_db;
+    if (should_prefetch_mappings && !version_id && !req.rpc_params.obj_id && config.DB_TYPE === 'postgres') {
+        load_bucket(req);
+        const bucket_id = String(req.bucket._id);
+        const result = await MDStore.instance().find_object_with_mapping_by_key(
+            bucket_id, key, config.MAPPINGS_PREFETCH_NUM_PARTS
+        );
+        if (!result) throw new RpcError('NO_SUCH_OBJECT', `object not found key=${key}`);
+        obj = result.obj;
+        prefetched_parts = result.parts;
+        prefetched_chunks_db = result.chunks_db;
+        check_object_mode(req, obj, 'NO_SUCH_OBJECT');
+    } else {
+        obj = await find_object_md(req);
+    }
 
     // Check if the requesting account is authorized to read the object
     const action = version_id ? 's3:GetObjectVersion' : 's3:GetObject';
@@ -865,6 +888,15 @@ async function read_object_md(req) {
                     }
                 }
             }
+        }
+    }
+
+    if (should_prefetch_mappings && prefetched_parts) {
+        try {
+            const chunks = await map_reader.assemble_chunks_from_parts(prefetched_parts, prefetched_chunks_db);
+            info.prefetched_mappings = chunks.map(c => c.to_api());
+        } catch (err) {
+            dbg.warn('read_object_md: failed to build prefetched mappings', err);
         }
     }
 

--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
@@ -1325,6 +1325,7 @@ mocha.describe('s3_bucket_policy', function() {
             bucket: BKT,
             key: KEY,
             obj_id: MDStore.instance().make_md_id(cross_test_store.obj.obj_id),
+            size: cross_test_store.obj.size,
         }), 'requesting account is not authorized to read the object');
     });
 
@@ -1351,6 +1352,7 @@ mocha.describe('s3_bucket_policy', function() {
             bucket: BKT,
             key: KEY,
             obj_id: MDStore.instance().make_md_id(cross_test_store.obj.obj_id),
+            size: cross_test_store.obj.size,
         });
     });
 
@@ -1378,6 +1380,7 @@ mocha.describe('s3_bucket_policy', function() {
             bucket: BKT,
             key: KEY,
             obj_id: MDStore.instance().make_md_id(cross_test_store.obj.obj_id),
+            size: cross_test_store.obj.size,
         });
     });
 

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -660,6 +660,182 @@ mocha.describe('md_store', function() {
         });
     });
 
+    mocha.describe('parts and blocks mapping queries', function() {
+
+        const frag_id = md_store.make_md_id();
+        const map_bucket_id = md_store.make_md_id();
+        const map_obj = {
+            _id: md_store.make_md_id(),
+            system: system_id,
+            bucket: map_bucket_id,
+            key: 'map-test-key-' + Date.now().toString(36),
+            create_time: new Date(),
+            content_type: 'application/octet-stream',
+        };
+        const map_chunk = {
+            _id: md_store.make_md_id(),
+            system: system_id,
+            bucket: map_bucket_id,
+            size: 100,
+            frag_size: 100,
+            frags: [{ _id: frag_id }],
+        };
+        const map_part = {
+            _id: md_store.make_md_id(),
+            system: system_id,
+            bucket: map_bucket_id,
+            obj: map_obj._id,
+            chunk: map_chunk._id,
+            start: 0,
+            end: 100,
+            seq: 0,
+        };
+        const map_block = {
+            _id: md_store.make_md_id(),
+            system: system_id,
+            bucket: map_bucket_id,
+            node: md_store.make_md_id(),
+            chunk: map_chunk._id,
+            frag: frag_id,
+            size: 100,
+        };
+
+        mocha.before(async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            await md_store.insert_object(map_obj);
+            await md_store.insert_chunks([map_chunk]);
+            await md_store.insert_parts([map_part]);
+            await md_store.insert_blocks([map_block]);
+        });
+
+        mocha.it('find_object_with_mapping_by_key - basic case', async function() {
+            const result = await md_store.find_object_with_mapping_by_key(
+                String(map_bucket_id), map_obj.key, 10
+            );
+            assert(result !== null, 'expected non-null result');
+            assert.strictEqual(String(result.obj._id), String(map_obj._id));
+            assert.strictEqual(result.parts.length, 1);
+            assert.strictEqual(result.chunks_db.length, 1);
+            assert.strictEqual(String(result.parts[0].chunk), String(map_chunk._id));
+            const frag = result.chunks_db[0].frags[0];
+            assert(frag.blocks.length >= 1, 'expected block to be populated in frag');
+            assert.strictEqual(String(frag.blocks[0].chunk), String(map_chunk._id));
+        });
+
+        mocha.it('find_object_with_mapping_by_key - key not found returns null', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const result = await md_store.find_object_with_mapping_by_key(
+                String(map_bucket_id), 'nonexistent-key-' + Date.now(), 10
+            );
+            assert.strictEqual(result, null);
+        });
+
+        mocha.it('find_object_with_mapping_by_key - deleted object excluded', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const del_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                key: 'deleted-map-key-' + Date.now().toString(36),
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(del_obj);
+            await md_store.update_object_by_id(del_obj._id, { deleted: new Date() });
+            const result = await md_store.find_object_with_mapping_by_key(
+                String(map_bucket_id), del_obj.key, 10
+            );
+            assert.strictEqual(result, null);
+        });
+
+        mocha.it('find_object_with_mapping_by_key - zero-part object returns obj with empty parts', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const zero_part_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                key: 'zero-part-' + Date.now().toString(36),
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(zero_part_obj);
+            const result = await md_store.find_object_with_mapping_by_key(
+                String(map_bucket_id), zero_part_obj.key, 10
+            );
+            assert(result !== null, 'expected non-null result for existing zero-part object');
+            assert.strictEqual(String(result.obj._id), String(zero_part_obj._id));
+            assert.strictEqual(result.parts.length, 0, 'expected empty parts array');
+            assert.strictEqual(result.chunks_db.length, 0, 'expected empty chunks_db array');
+        });
+
+        mocha.it('find_object_with_mapping_by_key - respects max_parts limit', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const limited_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                key: 'limited-parts-' + Date.now().toString(36),
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(limited_obj);
+            const limited_chunks = [0, 1, 2].map(() => ({
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                size: 10,
+                frag_size: 10,
+                frags: [{ _id: md_store.make_md_id() }],
+            }));
+            await md_store.insert_chunks(limited_chunks);
+            const limited_parts = limited_chunks.map((c, i) => ({
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                obj: limited_obj._id,
+                chunk: c._id,
+                start: i * 10,
+                end: (i + 1) * 10,
+                seq: i,
+            }));
+            await md_store.insert_parts(limited_parts);
+            const result = await md_store.find_object_with_mapping_by_key(
+                String(map_bucket_id), limited_obj.key, 1
+            );
+            assert(result !== null, 'expected non-null result');
+            assert.strictEqual(result.parts.length, 1, 'expected only 1 part due to max_parts limit');
+            assert.strictEqual(Number(result.parts[0].start), 0, 'expected first (lowest-start) part');
+        });
+
+        mocha.it('find_parts_chunks_blocks_by_range - returns parts and blocks in range', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const result = await md_store.find_parts_chunks_blocks_by_range({
+                obj_id: map_part.obj,
+                start_gte: 0,
+                start_lt: 100,
+                end_gt: 0,
+            });
+            assert.strictEqual(result.parts.length, 1);
+            assert.strictEqual(result.chunks_db.length, 1);
+            assert.strictEqual(String(result.parts[0].chunk), String(map_chunk._id));
+            assert(result.chunks_db[0].frags[0].blocks.length >= 1, 'expected blocks populated in frag');
+        });
+
+        mocha.it('find_parts_chunks_blocks_by_range - parts outside range excluded', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const result = await md_store.find_parts_chunks_blocks_by_range({
+                obj_id: map_part.obj,
+                start_gte: 200,
+                start_lt: 300,
+                end_gt: 200,
+            });
+            assert.strictEqual(result.parts.length, 0);
+            assert.strictEqual(result.chunks_db.length, 0);
+        });
+
+    });
+
+
     mocha.describe('dedup-index', function() {
         mocha.it('get_dedup_index_size()', async function() {
             return md_store.get_dedup_index_size();

--- a/src/test/integration_tests/internal/test_map_builder.js
+++ b/src/test/integration_tests/internal/test_map_builder.js
@@ -280,7 +280,10 @@ mocha.describe('map_builder', function() {
          * @param {BuilderObject} obj
          */
         async function assert_fully_built(obj) {
-            const chunks = await map_reader.read_object_mapping({ _id: MDStore.instance().make_md_id(obj.obj_id) });
+            const chunks = await map_reader.read_object_mapping({
+                _id: MDStore.instance().make_md_id(obj.obj_id),
+                size: obj.size,
+            });
             _.forEach(chunks, chunk => {
                 chunk.frags.forEach(frag => {
                     assert.strictEqual(frag.allocations.length, 0);

--- a/src/test/integration_tests/internal/test_object_io.js
+++ b/src/test/integration_tests/internal/test_object_io.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines-per-function: ["error", 600]*/
+/*eslint max-lines-per-function: ["error", 700]*/
 'use strict';
 
 // setup coretest first to prepare the env
@@ -257,6 +257,106 @@ coretest.describe_mapper_test_case({
             cached_parts: [],
             read_range: { start: 220, end: 240 }
         });
+    });
+
+    mocha.it('read_object_md with should_prefetch_mappings populates prefetched_mappings', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        const size = 61;
+        const data = generator.update(Buffer.alloc(size));
+        const key = `${KEY}-inline-${key_counter}`;
+        key_counter += 1;
+        await object_io.upload_object({
+            client: rpc_client,
+            bucket,
+            key,
+            size,
+            content_type: 'application/octet-stream',
+            source_stream: readable_buffer(data),
+        });
+        const object_md = await rpc_client.object.read_object_md({ bucket, key, should_prefetch_mappings: true });
+        assert(Array.isArray(object_md.prefetched_mappings) && object_md.prefetched_mappings.length > 0,
+            'expected prefetched_mappings to be a non-empty array');
+        assert.strictEqual(object_md.first_range_data, undefined, 'expected first_range_data to be absent');
+        // Verify the object data reads back correctly. When prefetched_mappings covers the full range
+        // they are forwarded through the read_object_mapping RPC to skip the DB round-trip.
+        const read_buf = await object_io.read_entire_object({ client: rpc_client, object_md });
+        assert.strictEqual(read_buf.length, data.length);
+        for (let i = 0; i < data.length; i++) {
+            assert.strictEqual(read_buf[i], data[i], `data mismatch at byte ${i}`);
+        }
+        await rpc_client.object.delete_object({ bucket, key });
+    });
+
+    mocha.it('read_object_md without should_prefetch_mappings does not populate prefetched_mappings', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        const size = 61;
+        const data = generator.update(Buffer.alloc(size));
+        const key = `${KEY}-no-inline-${key_counter}`;
+        key_counter += 1;
+        await object_io.upload_object({
+            client: rpc_client,
+            bucket,
+            key,
+            size,
+            content_type: 'application/octet-stream',
+            source_stream: readable_buffer(data),
+        });
+        const object_md = await rpc_client.object.read_object_md({ bucket, key });
+        assert.strictEqual(object_md.prefetched_mappings, undefined, 'expected prefetched_mappings to be absent');
+        assert.strictEqual(object_md.first_range_data, undefined, 'expected first_range_data to be absent');
+        await rpc_client.object.delete_object({ bucket, key });
+    });
+
+    mocha.it('read_object_md with should_prefetch_mappings on multi-part object provides partial prefetched_mappings', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        // Use multipart upload so the object has exactly (config.MAPPINGS_PREFETCH_NUM_PARTS + 1) NooBaa
+        // objectparts. Each upload_multipart call produces one objectpart, so with MAPPINGS_PREFETCH_NUM_PARTS=1
+        // only the first part is prefetched, guaranteeing prefetched_mappings cover less than the full object.
+        const num_parts = config.MAPPINGS_PREFETCH_NUM_PARTS + 1;
+        const part_size = 61;
+        const size = num_parts * part_size;
+        const content_type = 'application/octet-stream';
+        const key = `${KEY}-multi-inline-${key_counter}`;
+        key_counter += 1;
+        const data = generator.update(Buffer.alloc(size));
+
+        const { obj_id } = await rpc_client.object.create_object_upload({ bucket, key, content_type });
+        const multiparts = [];
+        for (let i = 0; i < num_parts; i++) {
+            const mp = await object_io.upload_multipart({
+                client: rpc_client,
+                obj_id,
+                bucket,
+                key,
+                num: i + 1,
+                size: part_size,
+                source_stream: readable_buffer(data.slice(i * part_size, (i + 1) * part_size)),
+            });
+            multiparts.push(mp);
+        }
+        await rpc_client.object.complete_object_upload({
+            obj_id, bucket, key,
+            multiparts: multiparts.map((mp, i) => ({ num: i + 1, etag: mp.etag })),
+        });
+
+        const object_md = await rpc_client.object.read_object_md({ bucket, key, should_prefetch_mappings: true });
+
+        // prefetched_mappings must be present but cover only the first MAPPINGS_PREFETCH_NUM_PARTS parts, not the full object
+        assert(Array.isArray(object_md.prefetched_mappings) && object_md.prefetched_mappings.length > 0,
+            'expected prefetched_mappings to be a non-empty array');
+        assert.strictEqual(object_md.prefetched_mappings.length, config.MAPPINGS_PREFETCH_NUM_PARTS,
+            `expected exactly ${config.MAPPINGS_PREFETCH_NUM_PARTS} prefetched mapping(s)`);
+        const last_prefetched_part = object_md.prefetched_mappings[object_md.prefetched_mappings.length - 1].parts?.[0];
+        assert(last_prefetched_part && last_prefetched_part.end < size,
+            `expected prefetched_mappings to cover less than the full object (last part end=${last_prefetched_part?.end}, size=${size})`);
+
+        // Full read must still return the complete original data
+        const read_buf = await object_io.read_entire_object({ client: rpc_client, object_md });
+        assert.strictEqual(read_buf.length, size);
+        for (let i = 0; i < size; i++) {
+            assert.strictEqual(read_buf[i], data[i], `full read mismatch at byte ${i}`);
+        }
+        await rpc_client.object.delete_object({ bucket, key });
     });
 
     async function upload_and_verify(size) {

--- a/src/test/utils/object_api_functions.js
+++ b/src/test/utils/object_api_functions.js
@@ -29,6 +29,7 @@ class ObjectAPIFunctions {
     async getObjectMDPartsInfo(params) {
         const md = await this.getObjectMD(params);
         params.obj_id = md.obj_id;
+        params.size = md.size;
         const object_mapping = await this._client.object.read_object_mapping(params);
         const parts = [];
         for (const chunk of object_mapping.chunks) {


### PR DESCRIPTION
### Describe the Problem

1. During the GET command on the PostgreSQL path, parts, chunks, and blocks were fetched in three separate DB queries, adding redundant round-trips for every object read.
2. For qualifying GET requests (non-folder, non-part-number), fetching object metadata and then streaming its blocks required multiple sequential DB queries and RPC calls, making small object reads unnecessarily slow.
3.The can_use_get_inline decision was computed inside namespace_s3.js rather than at the request entry point, so other namespaces couldn't benefit from it.

### Explain the Changes
1. Added find_parts_chunks_blocks_by_range() to md_store.js — a PostgreSQL-specific combined query that fetches parts, chunks, and aggregated blocks in a single round-trip using jsonb_agg.
2. Added find_object_with_mapping_by_key() to md_store.js — a PostgreSQL-specific query that fetches the object row together with its first INLINE_NUM_PARTS parts, chunks, and blocks in one round-trip. read_object_md in object_server.js uses this when can_use_get_inline is set, then reads the block data via MapClient and returns it as first_range_data in the response. s3_get_object can then serve small objects (or write the leading bytes of larger objects) without a separate streaming call
3. Moved the can_use_get_inline = true assignment from namespace_s3.js to s3_get_object.js so it is set once at the request entry point for all namespaces. namespace_s3 now reads it from params.can_use_get_inline instead of computing it locally.
4. reuse object_md from s3_get_object in read_object_mapping instead of calling read_object_md again. other paths that uses this function such as from namespace_context will still call get_object_md as before. also don't return object_md as it is never used


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional inline metadata prefetching returns initial bytes and inline chunk info with object metadata to accelerate eligible reads.
  * New configuration to control inline-read eligibility by part count.

* **Improvements**
  * GET object flow and SDK favor inline-prefetched data to reduce latency for eligible reads.
  * SDK read_object_md is now asynchronous (returns a Promise).

* **Tests**
  * Added integration tests covering inline prefetching and mapping queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->