### PR TITLE
Vectors - LanceDb table index for vectors and filterable MD fields

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1053,8 +1053,8 @@ module.exports = {
                     dimension: {
                         type: 'integer',
                         minimum: 1,
-                    }
-                    //TODO - non filterable MD keys
+                    },
+                    metadata_configuration: { $ref: 'common_api#/definitions/metadata_configuration' },
                 }
             },
             reply: {

--- a/src/endpoint/vector/ops/vector_index_create.js
+++ b/src/endpoint/vector/ops/vector_index_create.js
@@ -14,12 +14,19 @@ async function post_create_index(req, res) {
     const vector_bucket_name = req.body.vectorBucketName;
     const dimension = req.body.dimension;
     const distance_metric = req.body.distanceMetric;
+    let metadata_configuration;
+    if (req.body.metadataConfiguration) {
+        metadata_configuration = {
+            non_filterable_metadata_keys: req.body.metadataConfiguration?.nonFilterableMetadataKeys
+        };
+    }
 
     await req.vector_sdk.create_vector_index({
         vector_index_name,
         vector_bucket_name,
         dimension,
-        distance_metric
+        distance_metric,
+        metadata_configuration
     });
 }
 

--- a/src/endpoint/vector/ops/vector_index_get.js
+++ b/src/endpoint/vector/ops/vector_index_get.js
@@ -26,6 +26,7 @@ async function post_get_index(req, res) {
             dataType: vector_index_info.data_type,
             distanceMetric: vector_index_info.distance_metric,
             creationTime: vector_index_info.creation_time / 1000,
+            metadataConfiguration: vector_index_info.metadata_configuration,
         }
     };
 }

--- a/src/sdk/vector_sdk.js
+++ b/src/sdk/vector_sdk.js
@@ -1,6 +1,8 @@
 /* Copyright (C) 2026 NooBaa */
 'use strict';
 
+const _ = require('lodash');
+
 const vector_utils = require("../util/vectors_util");
 
 class VectorSDK {
@@ -75,6 +77,7 @@ class VectorSDK {
     //////////////////////////
 
     async put_vectors(params) {
+        params.vector_index = await this.get_vector_index(_.pick(params, 'vector_bucket_name', 'vector_index_name'));
         return await vector_utils.put_vectors(params);
     }
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -2329,7 +2329,6 @@ async function list_vector_objects(req, unsorted_system_collection, get_info_fun
 
 async function list_vector_buckets(req) {
     dbg.log0("list_vector_buckets req.rpc_params =", req.rpc_params);
-
     return await list_vector_objects(req, system_store.data.vector_buckets, get_vector_bucket_info);
 }
 

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -99,6 +99,14 @@ mocha.describe('vectors_ops', function() {
             await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
         });
 
+        mocha.it('should create a vector bucket (non-filterable)', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1, {
+                metadataConfiguration: {
+                    nonFilterableMetadataKeys: [ "field_name" ]
+                }
+            });
+        });
+
         mocha.it('should list vector buckets', async function() {
             const beforeTs = Date.now();
             await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
@@ -539,9 +547,10 @@ mocha.describe('vectors_ops', function() {
     });
 });
 
-async function create_vector_bucket(client, create_vector_buckets, name) {
+async function create_vector_bucket(client, create_vector_buckets, name, extra_params = {}) {
     const params = {
-        vectorBucketName: name
+        vectorBucketName: name,
+        ...extra_params
     };
     const command = new s3vectors.CreateVectorBucketCommand(params);
     await send(client, command);

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -60,11 +60,11 @@ class LanceConn extends VectorConn {
 
     }
 
-    async put_vectors(vector_bucket, vector_index, vectors, is_retry = false) {
+    async put_vectors(vector_bucket_name, vector_index, vectors, is_retry = false) {
 
-        dbg.log0("put_vectors vector_bucket =", vector_bucket, ", vector_index =", vector_index, ", vectors =", vectors);
+        dbg.log0("put_vectors vector_bucket =", vector_bucket_name, ", vector_index =", vector_index.name, ", vectors =", vectors);
         //note underscore is not allowed in vector bucket name
-        const table_name = vector_bucket + "_" + vector_index;
+        const table_name = vector_bucket_name + "_" + vector_index.name;
 
         let lance_vectors;
         if (is_retry) {
@@ -92,17 +92,29 @@ class LanceConn extends VectorConn {
         } else {
             dbg.log0("put_vectors create table");
             try {
-                table = await this.lance.createTable(table_name, lance_vectors);
+                table = await this._create_table(table_name, lance_vectors, vector_index);
             } catch (e) {
                 //can happen for two concurrent inserts
                 if (e.message.indexOf("has already been declared") > -1 && !is_retry) {
-                    return await this.put_vectors(table_name, lance_vectors, true);
+                    return await this.put_vectors(table_name, vector_index, lance_vectors, true);
                 } else {
                     dbg.error("Failed to create table ", table_name, e);
                     throw e;
                 }
             }
             this.tables.set(table_name, table);
+        }
+
+        try {
+            await table.createIndex('vector', {replace: false});
+        } catch (err) {
+            //swallow 'not enougn rows', try again on next put_vectors
+            if (!err.message.includes('Not enough rows') && !err.message.include("already exists")) {
+                //failed to create vector index. revert so retry is possible.
+                dbg.error("Failed to create vector index for", table_name, ", err =", err);
+                this.lance.dropTable(table_name);
+                throw err;
+            }
         }
     }
 
@@ -212,6 +224,32 @@ class LanceConn extends VectorConn {
         }
         return table;
     }
+
+    async _create_table(name, vectors, vector_index) {
+        const table = await this.lance.createTable(name, vectors);
+
+        const non_filterable_metadata_keys = vector_index?.metadata_configuration?.non_filterable_metadata_keys || [];
+        //schema is implicitly defined by the first inserted vectors, get md fields from a vector
+        const keys = Object.keys(vectors[0]);
+
+        for (const key of keys) {
+            //skip 'vector' field
+            if (key === 'vector') continue;
+            //skip non-filterable metadata keys (ie, fields which user explicitly asked not to index)
+            if (non_filterable_metadata_keys.indexOf(key) > -1) continue;
+            //md field is searchable and should be indexed:
+            try {
+                await table.createIndex(key);
+            } catch (err) {
+                //revert so retry is possible
+                dbg.error("Failed to created index for", key, ", err =", err);
+                this.lance.dropTable(name);
+                throw err;
+            }
+        }
+
+        return table;
+    }
 }
 
 //temporary static lance connection to work with
@@ -288,10 +326,10 @@ async function delete_vector_index({vector_bucket_name, vector_index_name}) {
     await vc.delete_vector_index(vector_bucket_name, vector_index_name);
 }
 
-async function put_vectors({vector_bucket_name, vector_index_name, vectors}) {
-    dbg.log0("put_vectors vector_bucket_name =", vector_bucket_name, ", vector_index_name =", vector_index_name, ", vectors =", vectors);
+async function put_vectors({vector_bucket_name, vector_index, vectors}) {
+    dbg.log0("put_vectors vector_bucket_name =", vector_bucket_name, ", vector_index.name =", vector_index.name, ", vectors =", vectors);
     const vc = await getVectorConn();
-    await vc.put_vectors(vector_bucket_name, vector_index_name, vectors);
+    await vc.put_vectors(vector_bucket_name, vector_index, vectors);
     dbg.log0("put_vectors done");
 }
 


### PR DESCRIPTION
### Describe the Problem
User is expected to query vectors and filter by (filterable) MD fields.
This requires creating indexes in the LanceDb table.

### Explain the Changes
1. Create a vector index
2. Create an index for each filterable MD field.

### Issues: Fixed #xxx / Gap #xxx
1. Auto reindexing after table has enough row changes (additions/deletion)

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector index creation now accepts a metadata configuration to mark metadata fields as non-filterable and returns that configuration when fetching an index.
  * Uploads now use the full index metadata so non-filterable keys are respected; table/index creation is more robust and tolerates "not enough rows" for vector index setup.

* **Tests**
  * Integration test added to verify index creation with non-filterable metadata keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->