### PR TITLE
vectors - list vectors - add segments and nextToken

### DIFF
--- a/src/endpoint/vector/ops/vector_list_vectors.js
+++ b/src/endpoint/vector/ops/vector_list_vectors.js
@@ -1,6 +1,10 @@
 /* Copyright (C) 2025 NooBaa */
 'use strict';
-//const config = require('../../../../config');
+
+const _ = require('lodash');
+
+const { VectorError } = require('../vector_errors');
+
 const dbg = require('../../../util/debug_module')(__filename);
 
 /**
@@ -10,17 +14,84 @@ async function post_list_vectors(req, res) {
 
     dbg.log0("post_list_vectors body = ", req.body);
 
+    const fieldList = [];
+
+    const next_token = req.body.nextToken;
+    if (!next_token_sanity_check(next_token)) {
+        fieldList.push({path: 'nextToken', message: "Bad nextToken"});
+    }
+
+    const segment_count = req.body.segmentCount;
+    const segment_index = req.body.segmentIndex;
+    const segment_validation_error = segment_validate(segment_count, segment_index);
+    if (segment_validation_error) {
+        fieldList.push(segment_validation_error);
+    }
+
+    const max_results = req.body.maxResults || 500;
+    const max_results_validation_error_msg = max_result_validate(max_results);
+    if (max_results_validation_error_msg) {
+        fieldList.push({path: 'maxResults', message: max_results_validation_error_msg});
+    }
+
+
+    if (fieldList.length > 0) {
+        //validation failed
+        throw new VectorError({
+            code: VectorError.ValidationException.code,
+            http_code: VectorError.ValidationException.http_code,
+            message: VectorError.ValidationException.message,
+            fieldList,
+        });
+    }
+
     const list = await req.vector_sdk.list_vectors({
         vector_bucket_name: req.body.vectorBucketName,
         vector_index_name: req.body.indexName,
-        max_results: req.body.maxResults,
+        max_results,
         return_data: req.body.returnData,
         return_metadata: req.body.returnMetadata,
+        segment_count,
+        segment_index,
+        next_token,
     });
 
     dbg.log0("post_list_vectors list =", list);
 
     return list;
+}
+
+function max_result_validate(max_results) {
+    if (!Number.isInteger(max_results)) return "Must be integer.";
+    if (max_results > 1000) return "Can't be more than 1000.";
+    if (max_results < 1) return "Must be at least 1.";
+}
+
+function segment_validate(count, index) {
+    if (_.isNil(count) && _.isNil(index)) return; //no segments, nothing to do.
+    if (_.isNil(count)) return {path: "segmentCount", message: "Missing"};
+    if (_.isNil(index)) return {path: "segmentIndex", message: "Missing"};
+    if (!Number.isInteger(count)) return {path: "segmentCount", message: "Must be an integer."};
+    if (!Number.isInteger(index)) return {path: "segmentIndex", message: "Must be an integer."};
+    if (count <= 0) return {path: "segmentCount", message: "Must be greater than zero."};
+    if (index < 0) return {path: "segmentIndex", message: "Cannot be negative."};
+    if (index >= count) return {path: "segmentIndex", message: "Must be less than segmentCount."};
+}
+
+//validate next_token is of the form number_number
+function next_token_sanity_check(next_token) {
+    if (!next_token) return true;
+    const delim = next_token.indexOf('_');
+    if (delim === -1) return false;
+    const split = next_token.split('_');
+    if (split.length !== 2) return false;
+    if (split[0] === '' || split[1] === '') return false;
+    const start = Number(split[0]);
+    const end = Number(split[1]);
+    if (Number.isNaN(start) || Number.isNaN(end)) return false;
+    if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < 0) return false;
+    if (start >= end) return false;
+    return true;
 }
 
 exports.handler = post_list_vectors;

--- a/src/endpoint/vector/vector_errors.js
+++ b/src/endpoint/vector/vector_errors.js
@@ -13,6 +13,7 @@ const error_type_enum = {
  *      message: string, 
  *      http_code?: number,
  *      type?: string,
+ *      fieldList?: {path: string, message:string}[]
  * }} VectorErrorSpec
  */
 
@@ -21,13 +22,13 @@ class VectorError extends Error {
     /**
      * @param {VectorErrorSpec} error_spec
      */
-    constructor({ code, message, http_code, type }) {
+    constructor({ code, message, http_code, type, fieldList = undefined }) {
         super(message);
         this.code = code;
         this.http_code = http_code;
         this.type = type;
         /** @type {Array<{path: string, message: string}>|undefined} */
-        this.fieldList = undefined;
+        this.fieldList = fieldList;
     }
 
     reply() {

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -1,5 +1,6 @@
 /* Copyright (C) 2025 NooBaa */
 /* eslint-disable no-invalid-this */
+/* eslint-disable max-lines-per-function */
 
 'use strict';
 // setup coretest first to prepare the env
@@ -205,6 +206,147 @@ mocha.describe('vectors_ops', function() {
 
             compare_vectors(response.vectors, vectors, true);
         });
+
+        mocha.it('should list vectors (next_token, max_results)', async function() {
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
+
+            const vectors = [
+                {
+                    key: "vector_id_1",
+                    data: {float32: [0.1, 0.2, 0.3]},
+                },
+                {
+                    key: "vector_id_2",
+                    data: {float32: [0.4, 0.5, 0.6]},
+                }
+            ];
+
+            const put_commnad = new s3vectors.PutVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                vectors
+            });
+            await send(s3_vectors_client, put_commnad);
+
+            const list_commnad = new s3vectors.ListVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                maxResults: 1,
+            });
+            let response = await send(s3_vectors_client, list_commnad);
+
+            compare_vectors(response.vectors, [vectors[0]], true);
+            assert.strictEqual(response.nextToken, "1_2");
+
+            list_commnad.input.nextToken = response.nextToken;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[1]], true);
+            assert(!response.nextToken);
+        });
+
+        mocha.it('should list vectors (segment)', async function() {
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
+
+            const vectors = [];
+
+            for (let i = 0; i < 10; ++i) {
+                vectors.push({
+                    key: "vector_id_" + i,
+                    data: {float32: [0.1, 0.2, 0.3]},
+                });
+            }
+
+            const put_commnad = new s3vectors.PutVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                vectors
+            });
+            await send(s3_vectors_client, put_commnad);
+
+            const list_commnad = new s3vectors.ListVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                segmentCount: 3,
+                segmentIndex: 0
+            });
+            let response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[0], vectors[1], vectors[2]], true);
+            assert(!response.nextToken);
+
+            list_commnad.input.segmentIndex = 1;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[3], vectors[4], vectors[5]], true);
+            assert(!response.nextToken);
+
+            list_commnad.input.segmentIndex = 2;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[6], vectors[7], vectors[8], vectors[9]], true);
+            assert(!response.nextToken);
+        });
+
+        mocha.it('should list vectors (segment, max_results)', async function() {
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
+
+            const vectors = [];
+
+            for (let i = 0; i < 11; ++i) {
+                vectors.push({
+                    key: "vector_id_" + i,
+                    data: {float32: [0.1, 0.2, 0.3]},
+                });
+            }
+
+            const put_commnad = new s3vectors.PutVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                vectors
+            });
+            await send(s3_vectors_client, put_commnad);
+
+            const list_commnad = new s3vectors.ListVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                segmentCount: 3,
+                segmentIndex: 0,
+                maxResults: 2,
+            });
+
+            let response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[0], vectors[1]], true);
+            assert.strictEqual(response.nextToken, "2_3");
+            list_commnad.input.nextToken = response.nextToken;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[2]], true);
+            assert(!response.nextToken);
+
+            list_commnad.input.segmentIndex = 1;
+            delete list_commnad.input.nextToken;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[3], vectors[4]], true);
+            assert.strictEqual(response.nextToken, "5_6");
+            list_commnad.input.nextToken = response.nextToken;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[5]], true);
+            assert(!response.nextToken);
+
+            list_commnad.input.segmentIndex = 2;
+            delete list_commnad.input.nextToken;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[6], vectors[7]], true);
+            assert.strictEqual(response.nextToken, "8_11");
+            list_commnad.input.nextToken = response.nextToken;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[8], vectors[9]], true);
+            assert.strictEqual(response.nextToken, "10_11");
+            list_commnad.input.nextToken = response.nextToken;
+            response = await send(s3_vectors_client, list_commnad);
+            compare_vectors(response.vectors, [vectors[10]], true);
+            assert(!response.nextToken);
+        });
+
 
         mocha.it('should query vectors (no md, no filter)', async function() {
             await create_vector_index(s3_vectors_client, created_vector_buckets,

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -106,21 +106,50 @@ class LanceConn extends VectorConn {
         }
     }
 
-    async list_vectors(vector_bucket, vector_index, limit) {
-        dbg.log0("list_vectors vector_bucket =", vector_bucket, ", vector_index =", vector_index, ", limit =", limit);
-        const table_name = vector_bucket + "_" + vector_index;
+    async list_vectors(params) {
+        //dbg.log0("list_vectors vector_bucket =", vector_bucket, ", vector_index =", vector_index, ", limit =", limit);
+        dbg.log0("lance list vectors params =", params);
+        const table_name = params.vector_bucket_name + "_" + params.vector_index_name;
 
         const table = await this.get_table(table_name);
         //TODO - check if(!table)
+
+        //determine this request place in the table
+        if (!params.next_token) {
+            //if there's no next_token, we're either in a segmented list_vector op or not segmented
+            //for not-segmented, create a default dummy segment which will include all rows
+            params.segment_count = params.segment_count || 1;
+            params.segment_index = params.segment_index || 0;
+            //now that we definitely have a segment, calc it's start and end for the given index
+            const rows = await table.countRows();
+            const segment = Math.floor(rows / params.segment_count); //total number of rows in a segment
+            const start = segment * params.segment_index;
+            //the last will pick up the remainder
+            const end = (params.segment_index + 1 === params.segment_count) ? rows : (segment * (params.segment_index + 1));
+            //continue as if we have next_token
+            dbg.log0("rows = ", rows, ", segment = ", segment, ", start = ", start, ", end =", end);
+            params.next_token = start + "_" + end;
+        }
+
+        //next_token syntax is currentOffset_endOfSegment
+        const next_token_parts = params.next_token.split('_');
+        const offset = Number(next_token_parts[0]);
+        const end = Number(next_token_parts[1]);
+        dbg.log0("lance list vectors offset =", offset, ", end =", end);
+
         const query = table.query();
-        if (limit) query.limit(limit);
-        //TODO - this won't work for large tables.
-        //support aws segments/tokens?
+        query.offset(offset);
+        //limit can't get us over end
+        const limit = offset + params.max_results >= end ? end - offset : params.max_results;
+        query.limit(limit);
         const lance_res = await query.toArray();
         dbg.log0("list_vectors lance_res =", lance_res);
         const aws_vectors = Array.from(lance_res, lance_vector => this._lance_to_aws(lance_vector));
         dbg.log0("list_vectors aws_vectors =", aws_vectors);
-        return {vectors: aws_vectors};
+        return {
+            vectors: aws_vectors,
+            //if there are more results in the segment, return the new next_token
+            nextToken: offset + limit >= end ? undefined : (offset + limit) + "_" + end};
     }
 
     async query_vectors(vector_bucket, vector_index, query_vector, limit, return_metadata, return_distance) {
@@ -170,12 +199,15 @@ class LanceConn extends VectorConn {
     }
 
     async get_table(name) {
+        dbg.log0("get_table name =", name);
         let table = this.tables.get(name);
         if (table) return table;
+        dbg.log0("not in tables name =", name);
         try {
             table = await this.lance.openTable(name);
             this.tables.set(name, table);
         } catch (e) {
+            dbg.log0("e = ", e);
             //ignore errors, at least for now
         }
         return table;
@@ -263,10 +295,11 @@ async function put_vectors({vector_bucket_name, vector_index_name, vectors}) {
     dbg.log0("put_vectors done");
 }
 
-async function list_vectors({vector_bucket_name, vector_index_name, max_results}) {
-    dbg.log0("list_vectors vector_bucket_name =", vector_bucket_name, ", vector_index_name =", vector_index_name, ", max_results =", max_results);
+async function list_vectors(params) {
+    dbg.log0("list_vectors params =", params);
+
     const vc = await getVectorConn();
-    return await vc.list_vectors(vector_bucket_name, vector_index_name, max_results);
+    return await vc.list_vectors(params);
 }
 
 async function query_vectors({vector_bucket_name, vector_index_name, query_vector, topk, return_metadata, return_distance}) {


### PR DESCRIPTION
### Describe the Problem
Allow object (vector buckets, vector indices, vectors) to be listed in several independent s3 op invocations.

### Explain the Changes
1. Implement nextToken and segment params.
2. For db objects (vector bucket and indices), skip to nextToken and return from there.
3. For vector segments, split up the table and use lance table.offset to get to next staring point.

### Issues: Fixed #xxx / Gap #xxx
1. nextToken and segments params were ignored.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector listing: pagination (maxResults now defaults to 500), segmentation (segmentCount/segmentIndex), and combined paged-segment retrieval; responses include nextToken until a segment is exhausted.

* **Bug Fixes**
  * Validation added for nextToken, segmentCount, and segmentIndex; malformed inputs return structured validation errors with field-level details.

* **Tests**
  * Integration tests added for pagination, segmentation, and combined paged-segment flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->