### PR TITLE
Fix native build on Mac M1 (arm64)

### DIFF
--- a/docs/dev_guide/node_rdkafka_macos_apple_silicon.md
+++ b/docs/dev_guide/node_rdkafka_macos_apple_silicon.md
@@ -1,0 +1,79 @@
+# Installing `node-rdkafka` on macOS (Apple Silicon)
+
+`node-rdkafka` builds native code (librdkafka via `node-gyp`). On Apple Silicon (M1/M2/M3), the build can fail if **OpenSSL** is resolved from the **wrong Homebrew prefix** (Intel `/usr/local` vs ARM64 `/opt/homebrew`), which mixes **x86_64** libraries with an **arm64** link.
+
+## Symptoms
+
+- Link step fails with `required architecture 'arm64'` while OpenSSL paths point at `/usr/local/Cellar/openssl@3/...`
+- Warnings such as: `ignoring file '.../libssl.dylib': found architecture 'x86_64', required architecture 'arm64'`
+- Followed by many **undefined symbols** for OpenSSL (`_SSL_*`, `_X509_*`, `_EVP_*`, etc.)
+
+## Root cause
+
+The linker builds **arm64** objects but picks up **Intel** `libssl` / `libcrypto` from legacy Homebrew under `/usr/local`. Those `.dylib` files are ignored, so OpenSSL symbols are never resolved.
+
+Common reasons `pkg-config` or the build still sees Intel OpenSSL:
+
+- `PKG_CONFIG_PATH` lists `/usr/local/...` before `/opt/homebrew/...`
+- Shell exports (`LDFLAGS`, `CPPFLAGS`, `OPENSSL_*`) pointing at `/usr/local`
+
+## Prerequisites
+
+- [Homebrew](https://brew.sh/) for **Apple Silicon** (install path should be `/opt/homebrew`, not `/usr/local` for the main ARM prefix)
+- OpenSSL 3: `brew install openssl@3`
+- Build tools: Xcode Command Line Tools (and whatever we already needs for `node-gyp`)
+
+## Verify your toolchain
+
+Run in the same terminal you use for `npm install`:
+
+```bash
+which pkg-config
+# Expect: /opt/homebrew/bin/pkg-config
+
+file "$(brew --prefix openssl@3)/lib/libssl.dylib"
+# Expect: Mach-O ... arm64
+
+pkg-config --cflags --libs openssl
+# Expect paths under /opt/homebrew, not /usr/local
+```
+
+If `pkg-config --cflags --libs openssl` mentions `/usr/local`, fix `PKG_CONFIG_PATH` or remove Intel entries before installing (see below).
+
+## Fix: point the build at ARM64 OpenSSL
+
+In the shell where you run `npm`, force Homebrew’s ARM64 OpenSSL:
+
+```bash
+export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"
+export LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib"
+```
+
+Optionally pin `pkg-config` to the same prefix if needed:
+
+```bash
+export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@3/lib/pkgconfig:${PKG_CONFIG_PATH}"
+```
+
+Then reinstall the native module (from the repo root):
+
+```bash
+rm -rf node_modules/node-rdkafka
+npm install node-rdkafka
+```
+
+Or a full reinstall: `rm -rf node_modules ; npm install`) as appropriate for your workflow.
+
+## Optional checks
+
+```bash
+echo "$PKG_CONFIG_PATH"
+env | grep -i openssl
+```
+
+Clear or override any variable that still references `/usr/local/Cellar/openssl` before building.
+
+## References
+
+- [node-rdkafka](https://www.npmjs.com/package/node-rdkafka) (native addon, uses bundled librdkafka build)
+- Homebrew [openssl@3](https://formulae.brew.sh/formula/openssl@3)

--- a/src/native/nb_native.gyp
+++ b/src/native/nb_native.gyp
@@ -4,7 +4,7 @@
 
     'target_defaults': {
         'conditions' : [
-            [ 'OS=="mac"', {
+            [ 'OS=="mac" and node_arch=="x64"', {
                 'xcode_settings': {
                      'OTHER_CFLAGS': ['-DUSE_SSSE3', '-msse4.1'],
                 },

--- a/src/native/third_party/isa-l.gyp
+++ b/src/native/third_party/isa-l.gyp
@@ -50,7 +50,7 @@
                     'isa-l/crc/crc32_gzip_refl_by16_10.asm',
                 ]
             }],
-            ['node_arch=="arm64"', {
+            ['node_arch=="arm64" and OS=="linux"', {
                 'sources': [
                     'isa-l/crc/aarch64/crc_multibinary_arm.S',
                     'isa-l/crc/aarch64/crc_aarch64_dispatcher.c',
@@ -143,7 +143,7 @@
                         'isa-l/erasure_code/gf_5vect_mad_avx512.asm',
                         'isa-l/erasure_code/gf_6vect_mad_avx512.asm',
                    ]}],
-                ['node_arch=="arm64"', {
+                ['node_arch=="arm64" and OS=="linux"', {
                     'sources': [
                         'isa-l/erasure_code/aarch64/ec_aarch64_highlevel_func.c',
                         'isa-l/erasure_code/aarch64/ec_aarch64_dispatcher.c',
@@ -183,7 +183,7 @@
                         'isa-l_crypto/rolling_hash/rolling_hash2_multibinary.asm',
                     ],
                 }],
-                ['node_arch=="arm64"', {
+                ['node_arch=="arm64" and OS=="linux"', {
                     'sources': [
                         'isa-l_crypto/rolling_hash/aarch64/rolling_hash2_aarch64_multibinary.S',
                         'isa-l_crypto/rolling_hash/aarch64/rolling_hash2_aarch64_dispatcher.c',
@@ -229,7 +229,7 @@
                         'isa-l_crypto/md5_mb/md5_ctx_avx512.c',
                      ]}
                 ],
-                ['node_arch=="arm64"', {
+                ['node_arch=="arm64" and OS=="linux"', {
                     'sources': [
                         'isa-l_crypto/md5_mb/aarch64/md5_ctx_aarch64_asimd.c',
                         'isa-l_crypto/md5_mb/aarch64/md5_mb_aarch64_dispatcher.c',
@@ -287,7 +287,7 @@
                 'isa-l_crypto/sha1_mb/sha1_mb_mgr_submit_sse_ni.asm',
                 'isa-l_crypto/sha1_mb/sha1_mb_mgr_flush_sse_ni.asm',
                 'isa-l_crypto/sha1_mb/sha1_mb_mgr_flush_avx512_ni.asm',
-            ]}, 'node_arch=="arm64"', {'sources': [
+            ]}, 'node_arch=="arm64" and OS=="linux"', {'sources': [
                 'isa-l_crypto/sha1_mb/aarch64/sha1_mb_multibinary.S',
                 'isa-l_crypto/sha1_mb/aarch64/sha1_ctx_ce.c',
                 'isa-l_crypto/sha1_mb/aarch64/sha1_mb_x1_ce.S',
@@ -342,7 +342,7 @@
                 'isa-l_crypto/sha256_mb/sha256_mb_mgr_flush_sse_ni.asm',
                 'isa-l_crypto/sha256_mb/sha256_mb_mgr_flush_avx512_ni.asm',
             ]}],
-            ['node_arch=="arm64"', {'sources': [
+            ['node_arch=="arm64" and OS=="linux"', {'sources': [
                 'isa-l_crypto/sha256_mb/aarch64/sha256_mb_multibinary.S',
                 'isa-l_crypto/sha256_mb/aarch64/sha256_mb_aarch64_dispatcher.c',
                 'isa-l_crypto/sha256_mb/aarch64/sha256_ctx_ce.c',
@@ -392,7 +392,7 @@
                 'isa-l_crypto/sha512_mb/sha512_mb_mgr_flush_avx512.asm',
                 'isa-l_crypto/sha512_mb/sha512_mb_x8_avx512.asm',
             ]}],
-            ['node_arch=="arm64"', {'sources': [
+            ['node_arch=="arm64" and OS=="linux"', {'sources': [
                 'isa-l_crypto/sha512_mb/aarch64/sha512_mb_multibinary.S',
                 'isa-l_crypto/sha512_mb/aarch64/sha512_mb_aarch64_dispatcher.c',
                 'isa-l_crypto/sha512_mb/aarch64/sha512_ctx_ce.c',


### PR DESCRIPTION
### Describe the Problem
1. Local build on Mac M1 is failing 

### Explain the Changes
- Fix native build on macOS M1 (arm64)
- Add instructions on how to build node-rdkafaka on Mac M1

### Testing Instructions:
1. Build on Mac M1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for macOS Apple Silicon installation issues, covering dependency resolution problems, diagnostic procedures, root cause explanations, and configuration instructions.

* **Chores**
  * Updated native build configuration to improve architecture-specific compilation support, with refined handling of ARM64 and x64 builds across multiple operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->