### PR TITLE
vectors - get vector bucket op

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -980,9 +980,9 @@ module.exports = {
             params: {
                 type: 'object',
                 // TODO: in the future we might want to add more parameters like vector_db_type and namespace_resource
-                required: ['name'],
+                required: ['vector_bucket_name'],
                 properties: {
-                    name: { wrapper: SensitiveString },
+                    vector_bucket_name: { wrapper: SensitiveString },
                     vector_db_type: { $ref: 'common_api#/definitions/vector_db_type' },
                     namespace_resource: { $ref: '#/definitions/namespace_resource_config'},
                     bucket_claim: { $ref: 'common_api#/definitions/bucket_claim' }
@@ -996,13 +996,31 @@ module.exports = {
             }
         },
 
+        get_vector_bucket: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['vector_bucket_name'],
+                properties: {
+                    vector_bucket_name: { wrapper: SensitiveString },
+                }
+            },
+            reply: {
+                $ref: '#/definitions/vector_bucket_info'
+            },
+            auth: {
+                system: ['admin', 'user']
+            }
+        },
+
+
         delete_vector_bucket: {
             method: 'POST',
             params: {
                 type: 'object',
-                required: ['name'],
+                required: ['vector_bucket_name'],
                 properties: {
-                    name: { wrapper: SensitiveString },
+                    vector_bucket_name: { wrapper: SensitiveString },
                 }
             },
             auth: {

--- a/src/endpoint/vector/ops/vector_bucket_create.js
+++ b/src/endpoint/vector/ops/vector_bucket_create.js
@@ -11,7 +11,7 @@ async function post_vector_bucket(req, res) {
     dbg.log0("post_vector_bucket body =", req.body);
 
     const vector_bucket_name = req.body.vectorBucketName;
-    await req.vector_sdk.create_vector_bucket({ name: vector_bucket_name });
+    await req.vector_sdk.create_vector_bucket({ vector_bucket_name });
 }
 
 exports.handler = post_vector_bucket;

--- a/src/endpoint/vector/ops/vector_bucket_delete.js
+++ b/src/endpoint/vector/ops/vector_bucket_delete.js
@@ -11,7 +11,7 @@ async function post_delete_vector_bucket(req, res) {
 
     const vector_bucket_name = req.body.vectorBucketName;
 
-    await req.vector_sdk.delete_vector_bucket({ name: vector_bucket_name});
+    await req.vector_sdk.delete_vector_bucket({ vector_bucket_name});
 }
 
 exports.handler = post_delete_vector_bucket;

--- a/src/endpoint/vector/ops/vector_bucket_get.js
+++ b/src/endpoint/vector/ops/vector_bucket_get.js
@@ -1,0 +1,25 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+const dbg = require('../../../util/debug_module')(__filename);
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_GetVectorBucket.html
+ */
+async function post_get_vector_bucket(req, res) {
+
+    dbg.log0("post_get_vector_bucket body =", req.body);
+
+    const vector_bucket_name = req.body.vectorBucketName;
+
+    const vb = await req.vector_sdk.get_vector_bucket({ vector_bucket_name});
+
+    return {
+        vectorBucket: {
+            vectorBucketName: vb.name,
+            creationTime: vb.creation_time / 1000,
+        }
+    };
+}
+
+exports.handler = post_get_vector_bucket;
+

--- a/src/endpoint/vector/vector_rest.js
+++ b/src/endpoint/vector/vector_rest.js
@@ -39,7 +39,9 @@ const RPC_ERRORS_TO_VECTOR = Object.freeze({ //TODO - validate
 
 const VECTOR_OPS = js_utils.deep_freeze({
     CreateVectorBucket: require('./ops/vector_bucket_create'),
+    GetVectorBucket: require('./ops/vector_bucket_get'),
     DeleteVectorBucket: require('./ops/vector_bucket_delete'),
+    ListVectorBuckets: require('./ops/vector_list_vector_buckets'),
     CreateIndex: require('./ops/vector_index_create'),
     GetIndex: require('./ops/vector_index_get'),
     ListIndexes: require('./ops/vector_index_list'),
@@ -47,7 +49,6 @@ const VECTOR_OPS = js_utils.deep_freeze({
     PutVectors: require('./ops/vector_put_vectors'),
     ListVectors: require('./ops/vector_list_vectors'),
     QueryVectors: require('./ops/vector_query_vectors'),
-    ListVectorBuckets: require('./ops/vector_list_vector_buckets'),
     DeleteVectors: require('./ops/vector_delete_vectors'),
     PutVectorBucketPolicy: require('./ops/vector_put_vector_bucket_policy'),
     GetVectorBucketPolicy: require('./ops/vector_get_vector_bucket_policy'),

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -338,6 +338,11 @@ class BucketSpaceNB {
         return resp;
     }
 
+    async get_vector_bucket(params) {
+        const resp = await this.rpc_client.bucket.get_vector_bucket(params);
+        return resp;
+    }
+
     async list_vector_buckets(params) {
         const resp = await this.rpc_client.bucket.list_vector_buckets(params);
         return resp;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -910,7 +910,8 @@ interface BucketSpace {
     put_public_access_block({ bucket_name, public_access_block }): Promise<any>;
     delete_public_access_block({ bucket_name }): Promise<any>;
 
-    create_vector_bucket({vector_bucket_name}) : Promise<any>;
+    create_vector_bucket(params: object) : Promise<any>;
+    get_vector_bucket({vector_bucket_name}) : Promise<any>;
     delete_vector_bucket({vector_bucket_name}) : Promise<any>;
     list_vector_buckets({max_results, prefix, next_token}) : Promise<any>;
 

--- a/src/sdk/vector_sdk.js
+++ b/src/sdk/vector_sdk.js
@@ -34,6 +34,11 @@ class VectorSDK {
         await vector_utils.create_vector_bucket(params);
     }
 
+    async get_vector_bucket(params) {
+        const bs = this._get_bucketspace();
+        return await bs.get_vector_bucket(params);
+    }
+
     async delete_vector_bucket(params) {
         const bs = this._get_bucketspace();
         await bs.delete_vector_bucket(params);

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1529,15 +1529,15 @@ async function delete_public_access_block(req) {
 
 // UTILS //////////////////////////////////////////////////////////
 
-function validate_bucket_creation(req, buckets_by_name) {
-    if (req.rpc_params.name.unwrap().length < 3 ||
-        req.rpc_params.name.unwrap().length > 63 ||
-        net.isIP(req.rpc_params.name.unwrap()) ||
-        !VALID_BUCKET_NAME_REGEXP.test(req.rpc_params.name.unwrap())) {
+function validate_bucket_creation(req, buckets_by_name, name = req.rpc_params.name) {
+    if (name.unwrap().length < 3 ||
+        name.unwrap().length > 63 ||
+        net.isIP(name.unwrap()) ||
+        !VALID_BUCKET_NAME_REGEXP.test(name.unwrap())) {
         throw new RpcError('INVALID_BUCKET_NAME');
     }
     buckets_by_name = buckets_by_name || req.system.buckets_by_name;
-    const bucket = buckets_by_name && buckets_by_name[req.rpc_params.name.unwrap()];
+    const bucket = buckets_by_name && buckets_by_name[name.unwrap()];
 
     if (bucket) {
         if (system_store.has_same_id(bucket.owner_account, req.account)) {
@@ -2199,9 +2199,9 @@ async function _get_s3_client(connection) {
 }
 
 async function create_vector_bucket(req) {
-    return vector_bucket_semaphore.surround_key(String(req.rpc_params.name), async () => {
+    return vector_bucket_semaphore.surround_key(String(req.rpc_params.vector_bucket_name), async () => {
         req.load_auth();
-        validate_bucket_creation(req, req.system.vector_buckets_by_name);
+        validate_bucket_creation(req, req.system.vector_buckets_by_name, req.rpc_params.vector_bucket_name);
 
         const changes = {
             insert: {},
@@ -2216,7 +2216,8 @@ async function create_vector_bucket(req) {
         }
         // TODO - req.rpc_params should contain namespace_resource, db_types etc 
         const vector_bucket_params = resolve_namespace_resource(req);
-        const vector_bucket = new_vector_bucket_defaults(req.rpc_params.name, req.system._id, account_id, vector_bucket_params);
+        const vector_bucket = new_vector_bucket_defaults(req.rpc_params.vector_bucket_name,
+            req.system._id, account_id, vector_bucket_params);
         changes.insert.vector_buckets = [vector_bucket];
 
         Dispatcher.instance().activity({
@@ -2235,11 +2236,17 @@ async function create_vector_bucket(req) {
     });
 }
 
+async function get_vector_bucket(req) {
+    dbg.log0("get_vector_bucket req.rpc_params =", req.rpc_params);
+    const vector_bucket = find_vector_bucket(req, req.rpc_params.vector_bucket_name);
+    const vector_bucket_info = get_vector_bucket_info(vector_bucket);
+    return vector_bucket_info;
+}
 
 async function delete_vector_bucket(req) {
-    return vector_bucket_semaphore.surround_key(String(req.rpc_params.name), async () => {
+    return vector_bucket_semaphore.surround_key(String(req.rpc_params.vector_bucket_name), async () => {
         req.load_auth();
-        const vector_bucket = find_vector_bucket(req);
+        const vector_bucket = find_vector_bucket(req, req.rpc_params.vector_bucket_name);
         //don't delete a vector bucket that contains an index
         if (vector_bucket.vector_indices_by_name &&
             Object.keys(vector_bucket.vector_indices_by_name).length > 0) {
@@ -2332,7 +2339,7 @@ async function list_vector_buckets(req) {
     return await list_vector_objects(req, system_store.data.vector_buckets, get_vector_bucket_info);
 }
 
-function find_vector_bucket(req, vector_bucket_name = req.rpc_params.name) {
+function find_vector_bucket(req, vector_bucket_name = req.rpc_params.vector_bucket_name) {
     dbg.log0("vector_bucket_name = ", vector_bucket_name, ", unw =", vector_bucket_name.unwrap());
     const vector_bucket = req.system.vector_buckets_by_name && req.system.vector_buckets_by_name[vector_bucket_name.unwrap()];
     if (!vector_bucket) {
@@ -2598,6 +2605,7 @@ exports.delete_public_access_block = delete_public_access_block;
 
 //vector buckets
 exports.create_vector_bucket = create_vector_bucket;
+exports.get_vector_bucket = get_vector_bucket;
 exports.delete_vector_bucket = delete_vector_bucket;
 exports.list_vector_buckets = list_vector_buckets;
 
@@ -2606,10 +2614,7 @@ exports.put_vector_bucket_policy = put_vector_bucket_policy;
 exports.get_vector_bucket_policy = get_vector_bucket_policy;
 exports.delete_vector_bucket_policy = delete_vector_bucket_policy;
 
-//vectors
-exports.create_vector_bucket = create_vector_bucket;
-exports.delete_vector_bucket = delete_vector_bucket;
-exports.list_vector_buckets = list_vector_buckets;
+//vector indices
 exports.create_vector_index = create_vector_index;
 exports.get_vector_index = get_vector_index;
 exports.list_vector_indices = list_vector_indices;

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -107,6 +107,19 @@ mocha.describe('vectors_ops', function() {
             });
         });
 
+        mocha.it('should get a vector bucket', async function() {
+            const beforeTs = Date.now();
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+            const afterTs = Date.now();
+
+            const get_commnad = new s3vectors.GetVectorBucketCommand({
+                vectorBucketName: vector_bucket_name1,
+            });
+            const response = await send(s3_vectors_client, get_commnad);
+
+            validate_vector_bucket(response.vectorBucket, vector_bucket_name1, beforeTs, afterTs);
+        });
+
         mocha.it('should list vector buckets', async function() {
             const beforeTs = Date.now();
             await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
@@ -117,7 +130,6 @@ mocha.describe('vectors_ops', function() {
 
             validate_vector_bucket(response.vectorBuckets[0], vector_bucket_name1, beforeTs, afterTs);
         });
-
 
         mocha.it('should delete a vector bucket', async function() {
             await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -300,17 +300,17 @@ async function create_fs_db(path = '/tmp/lance') {
     return db;
 }
 
-async function create_vector_bucket({name}) {
-    dbg.log0("create_vector_bucket name = ", name);
+async function create_vector_bucket({vector_bucket_name}) {
+    dbg.log0("create_vector_bucket name = ", vector_bucket_name);
     const vc = await getVectorConn();
     await vc.create_vector_bucket();
     dbg.log0("create_vector_bucket done");
 }
 
-async function delete_vector_bucket({name}) {
-    dbg.log0("delete_vector_bucket name = ", name);
+async function delete_vector_bucket({vector_bucket_name}) {
+    dbg.log0("delete_vector_bucket name = ", vector_bucket_name);
     const vc = await getVectorConn();
-    await vc.delete_vector_bucket(name);
+    await vc.delete_vector_bucket(vector_bucket_name);
     dbg.log0("delete_vector_bucket done");
 }
 


### PR DESCRIPTION
### Describe the Problem
Vectors API describe a get vector bucket op, which we are missing.

### Explain the Changes
1. Implement missing op.
2. Align vector_bucket_name param

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_GetVectorBucket.html


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Get Vector Bucket endpoint to retrieve bucket metadata.

* **Refactor**
  * Standardized vector-bucket parameter name to "vector_bucket_name" across APIs, server handlers, and utilities.

* **SDK**
  * Added get_vector_bucket support in the SDK surface.

* **Tests**
  * Added an integration test validating the GetVectorBucket operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->