### PR TITLE
Added support for bucket error objects num metrics when target is unreachable

### DIFF
--- a/src/server/bg_services/log_replication_scanner.js
+++ b/src/server/bg_services/log_replication_scanner.js
@@ -72,12 +72,8 @@ class LogReplicationScanner {
                 const rule_id = rule.rule_id;
 
                 const { src_bucket, dst_bucket } = replication_utils.find_src_and_dst_buckets(rule.destination_bucket, replication_id);
-                if (!src_bucket || !dst_bucket) {
-                    dbg.error('log_replication_scanner: can not find src_bucket or dst_bucket object', src_bucket, dst_bucket);
-                    // mark target bucket as unreachable (uses bucket id since bucket was deleted/not found)
-                    if (src_bucket && !dst_bucket) {
-                        replication_utils.update_replication_target_status(src_bucket.name, String(rule.destination_bucket), false);
-                    }
+                if (!src_bucket) {
+                    dbg.error('log_replication_scanner: src_bucket not found for replication_id:', replication_id);
                     return;
                 }
 
@@ -90,14 +86,38 @@ class LogReplicationScanner {
                 );
                 if (!candidates.items || !candidates.done) return;
 
+                const total = Object.keys(candidates.items).length;
+                if (!dst_bucket) {
+                    dbg.error('log_replication_scanner: destination_bucket not found:', rule.destination_bucket, 'for replication_id:', replication_id);
+                    replication_utils.update_replication_target_status(src_bucket.name, String(rule.destination_bucket), false);
+                    replication_utils.update_replication_prom_report(src_bucket.name, replication_id, {}, {
+                        bucket_last_cycle_total_objects_num: total,
+                        bucket_last_cycle_replicated_objects_num: 0,
+                        bucket_last_cycle_error_objects_num: total,
+                    });
+                    return;
+                }
+
                 dbg.log1('log_replication_scanner: candidates: ', candidates.items);
 
                 const sync_versions = rule.sync_versions || false;
 
                 const sync_deletions = rule.sync_deletions || false;
 
-                await this.process_candidates(
-                    src_bucket, dst_bucket, candidates.items, sync_versions, sync_deletions, rule_id, replication_id);
+                try {
+                    await this.process_candidates(
+                        src_bucket, dst_bucket, candidates.items, sync_versions, sync_deletions, rule_id, replication_id);
+                } catch (err) {
+                    dbg.error('log_replication_scanner: failed to process candidates, target may be unreachable:',
+                        src_bucket.name, dst_bucket.name, err);
+                    replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, false);
+                    replication_utils.update_replication_prom_report(src_bucket.name, replication_id, {}, {
+                        bucket_last_cycle_total_objects_num: total,
+                        bucket_last_cycle_replicated_objects_num: 0,
+                        bucket_last_cycle_error_objects_num: total,
+                    });
+                    throw err;
+                }
 
                 // Commit will save the continuation token for the next scan
                 // This needs to be done only after the candidates were processed.
@@ -310,10 +330,10 @@ class LogReplicationScanner {
             keys_diff_map,
         );
         dbg.log2('log_replication_scanner: scan copy_objects: ', keys_diff_map);
-        // in case of log-based replication there is no need for the src_cont_token, hance the undefined.
-        const replication_status = replication_utils.get_rule_status(rule_id, undefined, keys_diff_map, copy_res);
+        // in case of log-based replication there is no need for the src_cont_token, hence the undefined.
+        const {rule_status, bucket_status} = replication_utils.get_rule_and_bucket_status(rule_id, undefined, keys_diff_map, copy_res);
 
-        replication_utils.update_replication_prom_report(src_bucket_name, replication_id, replication_status);
+        replication_utils.update_replication_prom_report(src_bucket_name, replication_id, rule_status, bucket_status);
     }
 
     async delete_objects(bucket_name, keys) {

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -73,6 +73,8 @@ class ReplicationScanner {
                 // mark target bucket as unreachable (uses bucket id since bucket was deleted/not found)
                 if (src_bucket && !dst_bucket) {
                     replication_utils.update_replication_target_status(src_bucket.name, String(rule.destination_bucket), false);
+                    replication_utils.report_failed_replication_cycle(src_bucket.name, replication_id,
+                        rule.rule_id, _.get(src_bucket, 'storage_stats.objects_count', 0));
                 }
                 return;
             }
@@ -114,6 +116,8 @@ class ReplicationScanner {
                 dbg.error('replication_scanner: failed to get buckets diff, target may be unreachable:',
                     src_bucket.name, dst_bucket.name, err);
                 replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, false);
+                replication_utils.report_failed_replication_cycle(src_bucket.name, replication_id,
+                    rule.rule_id, _.get(src_bucket, 'storage_stats.objects_count', 0));
                 throw err;
             }
 

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -86,6 +86,26 @@ function update_replication_prom_report(bucket_name, replication_policy_id, rule
     core_report.set_replication_status(last_cycle_status);
 }
 
+// used by scan-based replication (only) to update metrics when target is unreachable and diff cannot be computed
+function report_failed_replication_cycle(bucket_name, replication_id, rule_id, total) {
+    const core_report = prom_reporting.get_core_report();
+    if (!core_report._metrics) return;
+    const name = bucket_name instanceof SensitiveString ? bucket_name.unwrap() : bucket_name;
+    // per replication_id metrics
+    delete core_report._metrics.replication_status.hashMap[String(replication_id)];
+    core_report._metrics.replication_status.set({ last_cycle_rule_id: rule_id, bucket_name: name, replication_id }, Date.now());
+    core_report._metrics.replication_last_cycle_writes_size.set({ replication_id }, 0);
+    core_report._metrics.replication_last_cycle_writes_num.set({ replication_id }, 0);
+    core_report._metrics.replication_last_cycle_error_writes_size.set({ replication_id }, 0);
+    core_report._metrics.replication_last_cycle_error_writes_num.inc({ replication_id }, 1);
+    // per bucket metrics
+    core_report._metrics.bucket_last_cycle_total_objects_num.set({ bucket_name: name }, total);
+    core_report._metrics.bucket_last_cycle_replicated_objects_num.set({ bucket_name: name }, 0);
+    core_report._metrics.bucket_last_cycle_error_objects_num.inc({ bucket_name: name }, 1);
+    dbg.log0('report_failed_replication_cycle: updated error metrics bucket:', name,
+        'replication_id:', replication_id, 'rule_id:', rule_id, 'total:', total);
+}
+
 function update_replication_target_status(source_bucket, target_bucket, is_reachable) {
     const core_report = prom_reporting.get_core_report();
     const src_name = source_bucket instanceof SensitiveString ? source_bucket.unwrap() : source_bucket;
@@ -206,6 +226,7 @@ async function delete_objects(scanner_semaphore, client, bucket_name, keys) {
 // EXPORTS
 exports.get_rule_and_bucket_status = get_rule_and_bucket_status;
 exports.update_replication_prom_report = update_replication_prom_report;
+exports.report_failed_replication_cycle = report_failed_replication_cycle;
 exports.update_replication_target_status = update_replication_target_status;
 exports.get_object_md = get_object_md;
 exports.find_src_and_dst_buckets = find_src_and_dst_buckets;


### PR DESCRIPTION
### Describe the Problem
When the target bucket is unreachable (network disconnection or deletion), the replication cycle aborts early and the bucket-level cycle metrics (`bucket_last_cycle_total_objects_num`, `bucket_last_cycle_replicated_objects_num`, `bucket_last_cycle_error_objects_num`) are never updated, leaving stale values from the last successful cycle.

### Explain the Changes
1. For log-based replication, moved candidate fetching before the target bucket check and report the candidate count as errors when the target is unreachable or missing.
2. Fixed pre-existing bug where copy_objects called non-existent `get_rule_status` instead of `get_rule_and_bucket_status` with missing bucket_status argument.
3. For scan-based replication, added `report_failed_replication_cycle()` that updates all replication metrics when the target is unreachable - sets `bucket_last_cycle_total_objects_num` to `storage_stats.objects_count`, `replicated to 0`, and `increments error counts by 1 per failed cycle`.

<img width="1716" height="908" alt="Screenshot from 2026-04-01 20-14-00" src="https://github.com/user-attachments/assets/a91d8601-cf16-4b2a-bb21-048d1cb1682e" />


### Issues: Fixed #xxx / Gap #xxx
1. JIRA: https://redhat.atlassian.net/browse/DFBUGS-3827

### Testing Instructions:
1. Put replication policy for buckets (src-bucket and dst-bucket).
2. Somehow make target bucket unreachable for dst-bucket (example delete the target bucket for dst-bucket namespacestore).
3. Check replication bg_worker metrics for multiple replication cycles, verify if error metrics are increasing by 1 when target is unreachable:
`$ JWT_TOKEN=$(kubectl get secret/noobaa-metrics-auth-secret -o jsonpath={.data.metrics_token} | base64 -d)`
`$ kubectl exec -it noobaa-core-0 -- curl -k -H "Authorization: Bearer ${JWT_TOKEN}" http://localhost:8080/metrics/bg_workers`


Note: Try similar steps for both scan and log based.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Differentiate missing source vs destination buckets: missing sources stop processing without changing metrics; missing destinations mark targets unreachable and record failed replication cycles with totals, zero replicated, and errors equal to total.
  * Ensure errors during candidate processing or bucket-diffing update replication metrics to reflect failed cycles before surfacing the error.

* **New Features**
  * Added explicit reporting for failed replication cycles to improve operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->