### PR TITLE
Replace `morgan` with a native code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "moment-timezone": "0.6.1",
         "mongo-query-to-postgres-jsonb": "0.2.17",
         "mongodb": "3.7.4",
-        "morgan": "1.10.1",
         "nan": "2.26.2",
         "node-addon-api": "8.7.0",
         "node-rdkafka": "3.6.1",
@@ -5393,24 +5392,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/basic-auth/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -10059,34 +10040,6 @@
         "snappy": {
           "optional": true
         }
-      }
-    },
-    "node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
-      "license": "MIT",
-      "dependencies": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "moment-timezone": "0.6.1",
     "mongo-query-to-postgres-jsonb": "0.2.17",
     "mongodb": "3.7.4",
-    "morgan": "1.10.1",
     "nan": "2.26.2",
     "node-addon-api": "8.7.0",
     "node-rdkafka": "3.6.1",

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -18,7 +18,7 @@ const http = require('http');
 const https = require('https');
 const express = require('express');
 const express_compress = require('compression');
-const express_morgan_logger = require('morgan');
+const express_request_logger = require('../util/express_request_logger');
 const express_proxy = require('express-http-proxy');
 const P = require('../util/promise');
 const ssl_utils = require('../util/ssl_utils');
@@ -111,7 +111,7 @@ function setup_web_server_app(app) {
 
     // copied from s3rver. not sure why. but copy.
     app.disable('x-powered-by');
-    app.use(express_morgan_logger(dev_mode ? 'dev' : 'combined'));
+    app.use(express_request_logger(dev_mode ? 'dev' : 'combined'));
     app.use(https_redirect_handler);
     app.use(express_compress());
 

--- a/src/util/express_request_logger.js
+++ b/src/util/express_request_logger.js
@@ -1,0 +1,86 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+/**
+ * Returns an Apache CLF UTC timestamp for log lines.
+ * @returns {string}
+ */
+function get_log_date() {
+    const now = new Date();
+    const month_names = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const day = String(now.getUTCDate()).padStart(2, '0');
+    const month = month_names[now.getUTCMonth()];
+    const year = now.getUTCFullYear();
+    const hours = String(now.getUTCHours()).padStart(2, '0');
+    const minutes = String(now.getUTCMinutes()).padStart(2, '0');
+    const seconds = String(now.getUTCSeconds()).padStart(2, '0');
+    return `[${day}/${month}/${year}:${hours}:${minutes}:${seconds} +0000]`;
+}
+
+/**
+ * Builds a line in combined access-log style.
+ * @param {import('http').IncomingMessage} req
+ * @param {import('http').ServerResponse} res
+ * @param {number} duration_ms
+ * @returns {string}
+ */
+function format_combined(req, res, duration_ms) {
+    const remote_addr = req.ip || req.socket?.remoteAddress || '-';
+    const remote_user = '-';
+    const log_date = get_log_date();
+    const method = req.method || '-';
+    const url = req.originalUrl || req.url || '-';
+    const http_version = req.httpVersion || '1.1';
+    const status_code = res.statusCode || 0;
+    const content_length = res.getHeader('content-length') || '-';
+    const referrer = req.get?.('referer') || req.headers.referer || req.headers.referrer || '-';
+    const user_agent = req.headers['user-agent'] || '-';
+
+    return `${remote_addr} - ${remote_user} ${log_date} "${method} ${url} HTTP/${http_version}" ${status_code} ${content_length} "${referrer}" "${user_agent}" ${duration_ms.toFixed(3)} ms`;
+}
+
+/**
+ * Builds a line in short dev access-log style.
+ * @param {import('http').IncomingMessage} req
+ * @param {import('http').ServerResponse} res
+ * @param {number} duration_ms
+ * @returns {string}
+ */
+function format_dev(req, res, duration_ms) {
+    const method = req.method || '-';
+    const url = req.originalUrl || req.url || '-';
+    const status_code = res.statusCode || 0;
+    return `${method} ${url} ${status_code} ${duration_ms.toFixed(3)} ms`;
+}
+
+/**
+ * Returns an express request logger middleware.
+ * Supports the "dev" and "combined" formats.
+ * @param {string} format
+ * @returns {(req: import('http').IncomingMessage, res: import('http').ServerResponse, next: Function) => void}
+ */
+function express_request_logger(format) {
+    const format_name = format === 'dev' ? 'dev' : 'combined';
+
+    return function log_request(req, res, next) {
+        const start_time = process.hrtime.bigint();
+        let logged = false;
+
+        const emit_log_line = () => {
+            if (logged) return;
+            logged = true;
+            const end_time = process.hrtime.bigint();
+            const duration_ms = Number(end_time - start_time) / 1e6;
+            const line = format_name === 'dev' ?
+                format_dev(req, res, duration_ms) :
+                format_combined(req, res, duration_ms);
+            process.stdout.write(`${line}\n`);
+        };
+
+        res.once('finish', emit_log_line);
+        res.once('close', emit_log_line);
+        next();
+    };
+}
+
+module.exports = express_request_logger;


### PR DESCRIPTION
### Explain the Changes
- Replace `morgan` with a native code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced the external HTTP request-logging library with an internal request logger and removed the external dependency; logging behavior, formats, and middleware ordering are preserved. Access logs now include request durations and are emitted by the internal implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->