### PR TITLE
NC | fix lifecycle test date calculation

### DIFF
--- a/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
@@ -2201,7 +2201,7 @@ async function create_object(object_sdk, bucket, key, size, is_old, tagging) {
  */
 async function update_version_xattr(bucket, key, version_id) {
     const older_time = new Date();
-    older_time.setDate(yesterday.getDate() - 5); // 5 days ago
+    older_time.setDate(older_time.getDate() - 5); // 5 days ago
 
     const target_path = path.join(root_path, bucket, path.dirname(key), '.versions', `${path.basename(key)}_${version_id}`);
     const file = await nb_native().fs.open(config_fs.fs_context, target_path, config.NSFS_OPEN_READ_MODE,


### PR DESCRIPTION
### Describe the Problem
JS setDate only updates the day of the month while keeping the month unchanged.
Due to a mistake, older_time’s day was calculated relative to yesterday instead of relative to older_time itself.

This leads to issues on the 1st of the month: since “yesterday” is the 31st of the previous month, calling setDate ends up setting the date to the end of the current month instead. effectively pushing the timestamp into the future.

### Explain the Changes
1. use older_time instead of yesterday

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect timestamp source used when recording noncurrent version timestamps, ensuring lifecycle age/retention checks reference the correct date.
  * This improves the accuracy of version lifecycle evaluations and reduces incorrect retention or expiration decisions for versioned objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->