### PR TITLE
Add bucket claim owner fix

### DIFF
--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -77,7 +77,9 @@ async function create_account(req) {
             if (bucket_claim_owner) {
                 const creator_roles = req.account.roles_by_system[req.system._id];
                 if (creator_roles.includes('operator')) { // Not allowed to create claim owner outside of the operator
-                    account.bucket_claim_owner = req.system.buckets_by_name[bucket_claim_owner.unwrap()]._id;
+                    const bucket_by_claim_owner = req.system.buckets_by_name[bucket_claim_owner.unwrap()] ||
+                        req.system.vector_buckets_by_name[bucket_claim_owner.unwrap()];
+                    account.bucket_claim_owner = bucket_by_claim_owner._id;
                 } else {
                     dbg.warn('None operator user was trying to set a bucket-claim-owner for account', req.account);
                 }


### PR DESCRIPTION
### Explain the Changes
1. Added a fix for create_account API needed for creating vector OBCs.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced account creation to support both standard and vector bucket types when operators assign bucket claim owners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->