### PR TITLE
Fix: GCP namespaced bucket downloads failing with ECONNRESET

### DIFF
--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -191,7 +191,7 @@ class NamespaceGCP {
             read_stream.on('response', () => {
                 let count = 1;
                 const count_stream = stream_utils.get_tap_stream(data => {
-                    this.stats_collector.update_namespace_write_stats({
+                    this.stats?.update_namespace_read_stats({
                         namespace_resource_id: this.namespace_resource_id,
                         bucket_name: params.bucket,
                         size: data.length,


### PR DESCRIPTION
### Describe the Problem
Downloads from GCP-backed namespace buckets fail with `ECONNRESET` errors. The issue occurs when the first data chunk arrives from GCP - the code attempts to access `this.stats_collector` which doesn't exist (constructor sets `this.stats`), causing a `TypeError` that aborts the connection. Additionally, the code incorrectly calls `update_namespace_write_stats()` for a read operation.

### Explain the Changes
1. Changed from  `this.stats_collector.update_namespace_write_stats()` to `this.stats?.update_namespace_read_stats()` in `namespace_gcp.js`.

### Issues: Fixed #xxx / Gap #xxx
1.  Gap: https://github.com/noobaa/noobaa-core/pull/7503
2.  Issue Fixed: https://github.com/noobaa/noobaa-operator/issues/1831

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected statistics tracking so object read operations are recorded as reads rather than being miscategorized as writes, improving metric accuracy.
  * Made stats updates conditional on the stats subsystem being present to prevent errors or failed reporting when stats are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->