### PR TITLE
vectors - require lance should be optional

### DIFF
--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -6,7 +6,8 @@ const config = require('../../config');
 const path = require('path');
 const LRUCache = require('./lru_cache');
 const system_store = require('../server/system_services/system_store').get_instance();
-const lance = require('@lancedb/lancedb');
+const js_utils = require('../util/js_utils');
+const lance = js_utils.require_optional('@lancedb/lancedb');
 
 class VectorConn {
     constructor(connOpts) {
@@ -18,6 +19,10 @@ class VectorConn {
 class LanceConn extends VectorConn {
 
     constructor(connOpts) {
+        if (!lance) {
+            throw new Error("LanceDB package is not available.");
+        }
+
         super(connOpts);
         this.tables = new Map();
     }


### PR DESCRIPTION
### Describe the Problem
Noobaa can't start if lance is not present, fails on ppc64.

### Explain the Changes
1. Change require to require_optional.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6299

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved handling of an optional database integration so import failures are deferred until the integration is actually used.
  * If the optional database package is not installed, the app now reports a clear runtime error when attempting to connect instead of failing on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->