### PR TITLE
[5.19 backport] Fixing CA certs to use defaults in case they exist

### DIFF
--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -20,6 +20,7 @@ const config = require('../../config');
 const xml_utils = require('./xml_utils');
 const jwt_utils = require('./jwt_utils');
 const net_utils = require('./net_utils');
+const fs_utils = require('./fs_utils');
 const time_utils = require('./time_utils');
 const cloud_utils = require('./cloud_utils');
 const ssl_utils = require('../util/ssl_utils');
@@ -37,9 +38,17 @@ const CONTENT_TYPE_APP_JSON = 'application/json';
 const CONTENT_TYPE_APP_XML = 'application/xml';
 const CONTENT_TYPE_APP_FORM_URLENCODED = 'application/x-www-form-urlencoded';
 
-const { HTTP_PROXY, HTTPS_PROXY, NO_PROXY, NODE_EXTRA_CA_CERTS } = process.env;
+const INTERNAL_CA_CERTS = process.env.INTERNAL_CA_CERTS || '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt';
+const EXTERNAL_CA_CERTS = process.env.EXTERNAL_CA_CERTS || '/etc/ocp-injected-ca-bundle/ca-bundle.crt';
+
+const { HTTP_PROXY, HTTPS_PROXY, NO_PROXY } = process.env;
 const http_agent = new http.Agent();
-const https_agent = new https.Agent();
+const https_agent = new https.Agent({
+    ca: (ca => (ca.length ? ca : undefined))([
+        fs_utils.try_read_file_sync(INTERNAL_CA_CERTS),
+        fs_utils.try_read_file_sync(EXTERNAL_CA_CERTS),
+    ].filter(Boolean))
+});
 const unsecured_https_agent = new https.Agent({ rejectUnauthorized: false });
 const http_proxy_agent = HTTP_PROXY ?
     new HttpProxyAgent(HTTP_PROXY) : null;
@@ -465,9 +474,15 @@ function get_unsecured_agent(endpoint) {
     const is_aws_address = cloud_utils.is_aws_endpoint(endpoint);
     const hostname = url.parse(endpoint) ? url.parse(endpoint).hostname : endpoint;
     const is_localhost = _.isString(hostname) && hostname.toLowerCase() === 'localhost';
-    return _get_http_agent(endpoint, is_localhost || (!is_aws_address && _.isEmpty(NODE_EXTRA_CA_CERTS)));
+    return _get_http_agent(endpoint, is_localhost || (!is_aws_address && _.isEmpty(https_agent.options.ca)));
 }
 
+/**
+ * 
+ * @param {string} endpoint 
+ * @param {boolean} request_unsecured 
+ * @returns {https.Agent | http.Agent | HttpsProxyAgent | HttpProxyAgent}
+ */
 function _get_http_agent(endpoint, request_unsecured) {
     const { protocol, hostname } = url.parse(endpoint);
     const should_proxy_by_hostname = should_proxy(hostname);


### PR DESCRIPTION
(cherry picked from commit 50c16047278806dceb2f33f52fa235da2fbb039c) (cherry picked from commit e57519c489c418b8a7b1f8587c2f5b9ff413c09a) (cherry picked from commit 070a1769574e726c87c1fa293e4dc4bf3f365af9)

### Describe the Problem


### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://redhat.atlassian.net/browse/DFBUGS-5942 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
