### PR TITLE
CI | Adding --skipApiVersionCheck for BLOB MOCK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -654,13 +654,16 @@ endef
 
 #############
 # BLOB MOCK #
+# When @azure/storage-blob defaults to a newer REST API than Azurite implements, pass
+# --skipApiVersionCheck to azurite-blob so blob mock tests keep working until Azurite adds it
+# (https://github.com/Azure/Azurite/issues/2623).
 #############
 
 define run_blob_mock
   @echo "\033[1;34mStarting blob mock server if RUN_BLOB_MOCK=$(RUN_BLOB_MOCK) is true.\033[0m"
 	@ if [ $(RUN_BLOB_MOCK) = true ]; then \
 		echo "\033[1;34mRunning Blob mock.\033[0m"; \
-		$(CONTAINER_ENGINE) run -p 10000:10000 -d --network noobaa-net --name blob-mock-$(GIT_COMMIT)-$(NAME_POSTFIX) mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0; \
+		$(CONTAINER_ENGINE) run -p 10000:10000 -d --network noobaa-net --name blob-mock-$(GIT_COMMIT)-$(NAME_POSTFIX) mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck; \
 	fi
 	@echo "\033[1;32mBlob mock server done.\033[0m"
 endef

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@aws-sdk/s3-request-presigner": "3.1019.0",
         "@azure/identity": "4.13.1",
         "@azure/monitor-query-logs": "1.0.0",
-        "@azure/storage-blob": "12.29.1",
+        "@azure/storage-blob": "12.31.0",
         "@datadog/sketches-js": "2.1.1",
         "@google-cloud/storage": "7.19.0",
         "@smithy/node-http-handler": "4.5.0",
@@ -1502,9 +1502,9 @@
       }
     },
     "node_modules/@azure/storage-blob": {
-      "version": "12.29.1",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.29.1.tgz",
-      "integrity": "sha512-7ktyY0rfTM0vo7HvtK6E3UvYnI9qfd6Oz6z/+92VhGRveWng3kJwMKeUpqmW/NmwcDNbxHpSlldG+vsUnRFnBg==",
+      "version": "12.31.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
+      "integrity": "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -1518,7 +1518,7 @@
         "@azure/core-util": "^1.11.0",
         "@azure/core-xml": "^1.4.5",
         "@azure/logger": "^1.1.4",
-        "@azure/storage-common": "^12.1.1",
+        "@azure/storage-common": "^12.3.0",
         "events": "^3.0.0",
         "tslib": "^2.8.1"
       },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@aws-sdk/s3-request-presigner": "3.1019.0",
     "@azure/identity": "4.13.1",
     "@azure/monitor-query-logs": "1.0.0",
-    "@azure/storage-blob": "12.29.1",
+    "@azure/storage-blob": "12.31.0",
     "@datadog/sketches-js": "2.1.1",
     "@google-cloud/storage": "7.19.0",
     "@lancedb/lancedb": "0.27.1",


### PR DESCRIPTION
### Explain the Changes
CI | Adding --skipApiVersionCheck for BLOB MOCK
The Ci IS failing due to https://github.com/Azure/Azurite/issues/2623 when upgrading the `@azure/storage-blob` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Azure Storage Blob library to v12.31.0 for improved blob storage operations and compatibility.
  * Improved local mock blob storage startup to tolerate REST API version mismatch, enhancing reliability of development and testing environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->