### PR TITLE
Refactor - moved executeSQL to PostgresClient class

### DIFF
--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -753,6 +753,8 @@ interface DBClient {
     check_entity_not_deleted(doc: object, entity: string): object;
     check_update_one(res: object, entity: string): void;
     make_object_diff(current: object, prev: object): object;
+
+    executeSQL<T>(query: string, params: Array<any>, options?: { query_name?: string, preferred_pool?: string }): Promise<sqlResult<T>>;
 }
 
 interface DBSequence {
@@ -789,7 +791,6 @@ interface DBCollection {
 
     validate(doc: object, warn?: 'warn'): object;
 
-    executeSQL<T>(query: string, params: Array<any>, options?: { query_name?: string, preferred_pool?: string }): Promise<sqlResult<T>>;
     name: any;
     schema: any;
 }

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -35,41 +35,41 @@ const sql_and_conditions = (...conditions) => conditions.filter(Boolean).join(' 
 class MDStore {
 
     constructor(test_suffix = '') {
-        const postgres_pool = 'md';
+        this._postgres_pool = 'md';
 
         this._objects = db_client.instance().define_collection({
             name: 'objectmds' + test_suffix,
             schema: object_md_schema,
             db_indexes: object_md_indexes,
-            postgres_pool,
+            postgres_pool: this._postgres_pool,
         });
         this._multiparts = db_client.instance().define_collection({
             name: 'objectmultiparts' + test_suffix,
             schema: object_multipart_schema,
             db_indexes: object_multipart_indexes,
-            postgres_pool,
+            postgres_pool: this._postgres_pool,
         });
         this._parts = db_client.instance().define_collection({
             name: 'objectparts' + test_suffix,
             schema: object_part_schema,
             db_indexes: object_part_indexes,
-            postgres_pool,
+            postgres_pool: this._postgres_pool,
         });
         this._chunks = db_client.instance().define_collection({
             name: 'datachunks' + test_suffix,
             schema: data_chunk_schema,
             db_indexes: data_chunk_indexes,
-            postgres_pool,
+            postgres_pool: this._postgres_pool,
         });
         this._blocks = db_client.instance().define_collection({
             name: 'datablocks' + test_suffix,
             schema: data_block_schema,
             db_indexes: data_block_indexes,
-            postgres_pool,
+            postgres_pool: this._postgres_pool,
         });
         this._sequences = db_client.instance().define_sequence({
             name: 'mdsequences' + test_suffix,
-            postgres_pool,
+            postgres_pool: this._postgres_pool,
         });
     }
 
@@ -318,7 +318,7 @@ class MDStore {
                 )};`;
 
         dbg.log1('[remove_pending_multiparts] generated query:', query);
-        const result = await this._objects.executeSQL(query, [new Date()]);
+        const result = await db_client.instance().executeSQL(query, [new Date()], { preferred_pool: this._postgres_pool });
         return result.rowCount;
     }
 
@@ -394,7 +394,7 @@ class MDStore {
             );`;
 
         dbg.log1('[remove_noncurrent_versions] generated query:', query);
-        const result = await this._objects.executeSQL(query, [new Date()]);
+        const result = await db_client.instance().executeSQL(query, [new Date()], { preferred_pool: this._postgres_pool });
         return result.rowCount;
     }
 
@@ -454,7 +454,7 @@ class MDStore {
         );`;
 
         dbg.log1('[delete_orphaned_delete_marker] generated query:', query);
-        const result = await this._objects.executeSQL(query, []);
+        const result = await db_client.instance().executeSQL(query, [], { preferred_pool: this._postgres_pool });
         return result.rowCount;
     }
 
@@ -766,7 +766,7 @@ class MDStore {
                 SELECT rows._id FROM rows
             )`;
         query += return_results ? ' RETURNING *;' : ';';
-        const result = await this._objects.executeSQL(query, params);
+        const result = await db_client.instance().executeSQL(query, params, { preferred_pool: this._postgres_pool });
         return return_results ? result.rows : [];
     }
 
@@ -1121,11 +1121,13 @@ class MDStore {
      */
     async find_deleted_objects(max_delete_time, limit) {
         const query_limit = limit || 1000;
-        const query = `SELECT _id 
+        const query = `SELECT _id
         FROM ${this._objects.name}
-        WHERE (to_ts(data->>'deleted')<to_ts($1) and data ? 'deleted' and data ? 'reclaimed') 
+        WHERE (to_ts(data->>'deleted')<to_ts($1) and data ? 'deleted' and data ? 'reclaimed')
         LIMIT ${query_limit};`;
-        const result = await this._objects.executeSQL(query, [new Date(max_delete_time).toISOString()], {preferred_pool: 'read_only'});
+        const result = await db_client.instance().executeSQL(query, [new Date(max_delete_time).toISOString()], {
+            preferred_pool: 'read_only',
+        });
         return db_client.instance().uniq_ids(result.rows, '_id');
     }
 
@@ -1563,7 +1565,7 @@ class MDStore {
         const values = [`${bucket.system._id}`, `${bucket._id}`, dedup_keys];
 
         try {
-            const res = await this._chunks.executeSQL(query, values);
+            const res = await db_client.instance().executeSQL(query, values, { preferred_pool: this._postgres_pool });
 
             const chunks_map = new Map();
             const all_blocks = [];
@@ -1952,7 +1954,7 @@ class MDStore {
                 OFFSET 0
             ) d
         `;
-        const res = await this._blocks.executeSQL(query, [chunk_ids]);
+        const res = await db_client.instance().executeSQL(query, [chunk_ids], { preferred_pool: this._postgres_pool });
         const blocks = res.rows.map(row => decode_json(this._blocks.schema, row.data));
 
         const blocks_by_chunk = _.groupBy(blocks, 'chunk');

--- a/src/util/db_client.js
+++ b/src/util/db_client.js
@@ -46,6 +46,7 @@ class NoneDBClient extends EventEmitter {
     check_entity_not_deleted(doc, entity) { return doc; }
     check_update_one(res, entity) { return this.noop(); }
     make_object_diff(current, prev) { return this.noop(); }
+    async executeSQL() { return { rows: [], rowCount: 0 }; }
     define_gridfs(params) {
         return {
             gridfs() { return this.noop(); }

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -689,43 +689,6 @@ class PostgresTable {
         return _do_query(client || this.get_pool(), q, 0);
     }
 
-    /**
-     * executeSQL takes a raw SQL query and params and runs it against
-     * the database. If `query_name` is passed then it prepares a
-     * statement on the first execution while the further executions
-     * will re-utilize the prepared statement (pre-parsed).
-     *
-     * @template T
-     *
-     * @param {string} query
-     * @param {Array<any>} params
-     * @param {{
-     *  query_name?: string,
-     *  preferred_pool?: string,
-     * }} [options = {}]
-     *
-     * @returns {Promise<import('pg').QueryResult<T>>}
-     */
-    async executeSQL(query, params, options = {}) {
-        /** @type {Pool} */
-        const pool = this.get_pool(options.preferred_pool);
-        const client = await pool.connect();
-
-        const q = {
-            text: query,
-            values: params,
-        };
-
-        if (options.query_name) {
-            q.name = options.query_name;
-        }
-
-        const res = await _do_query(client, q, 0);
-        client.release();
-
-        return res;
-    }
-
     get_id(data) {
         return get_id(data);
     }
@@ -1359,6 +1322,55 @@ class PostgresClient extends EventEmitter {
 
     get_pool(name = 'default') {
         return this.pools[name].instance;
+    }
+
+    /**
+     * Resolve pool for raw SQL. If `preferred_pool` is missing or unavailable,
+     * falls back to the `default` pool (same name as {@link PostgresClient#get_pool}).
+     *
+     * @param {string} [preferred_pool='default']
+     * @returns {import('pg').Pool}
+     */
+    _get_pool_for_sql(preferred_pool = 'default') {
+        const pool = this.get_pool(preferred_pool);
+        if (!pool) {
+            if (preferred_pool && preferred_pool !== 'default') {
+                return this._get_pool_for_sql('default');
+            }
+            throw new Error(`The postgres clients pool ${preferred_pool} disconnected`);
+        }
+        return pool;
+    }
+
+    /**
+     * Raw SQL against the DB. Uses `preferred_pool` when set; defaults to `default`.
+     * If that pool is unavailable, falls back to the `default` pool.
+     *
+     * @template T
+     * @param {string} query
+     * @param {Array<any>} params
+     * @param {{
+     *   query_name?: string,
+     *   preferred_pool?: string,
+     * }} [options={}]
+     * @returns {Promise<import('pg').QueryResult<T>>}
+     */
+    async executeSQL(query, params, options = {}) {
+        const { query_name, preferred_pool = 'default' } = options;
+        const pool = this._get_pool_for_sql(preferred_pool);
+
+        const q = {
+            text: query,
+            values: params,
+        };
+
+        if (query_name) {
+            q.name = query_name;
+        }
+
+        const res = await _do_query(pool, q, 0);
+
+        return res;
     }
 
     constructor(params) {


### PR DESCRIPTION
### Explain the Changes
1. moved `executeSQL` from `PostgresTable` to `PostgresClient`
2. `executeSQL` accepts general SQL queries that can be unrelated to the actual table that it was being called on. make more sense as a general `PostgresClient` method.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized SQL execution through the database client for more consistent pool usage.
  * Improved pool resolution with fallbacks for more reliable query routing.
  * Added safe no-op behavior when no database is configured to prevent failures in DB-less environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->