### PR TITLE
S3 owner mismatch acl vs versions

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2258,8 +2258,17 @@ class NamespaceFS {
     for example, if the user tries to interact with an object that does not exist, the operation would fail as expected with NoSuchObject.
     */
     async get_object_acl(params, object_sdk) {
-        await this.read_object_md(params, object_sdk);
-        return s3_utils.DEFAULT_OBJECT_ACL;
+        const obj = await this.read_object_md(params, object_sdk);
+
+        // fetch the object owner / default owner
+        const owner = s3_utils.get_object_owner(obj) || await s3_utils.get_default_object_owner(params.bucket, object_sdk);
+
+        // clone DEFAULT_OBJECT_ACL to response since it is a frozen object and we need to update the owner and grantee info in the response
+        return {
+            ...s3_utils.DEFAULT_OBJECT_ACL,
+            owner,
+            access_control_list: s3_utils.DEFAULT_OBJECT_ACL.access_control_list.map(acl => ({...acl, Grantee: { ...acl.Grantee, ID: owner.ID, DisplayName: owner.DisplayName}}))
+        };
     }
 
     async put_object_acl(params, object_sdk) {

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2289,8 +2289,20 @@ class NamespaceFS {
     for example, if the user tries to interact with an object that does not exist, the operation would fail as expected with NoSuchObject.
     */
     async get_object_acl(params, object_sdk) {
-        await this.read_object_md(params, object_sdk);
-        return s3_utils.DEFAULT_OBJECT_ACL;
+        const obj = await this.read_object_md(params, object_sdk);
+
+        // fetch the object owner / default owner
+        const owner = s3_utils.get_object_owner(obj) || await s3_utils.get_default_object_owner(params.bucket, object_sdk);
+
+        // clone DEFAULT_OBJECT_ACL to response since it is a frozen object and we need to update the owner and grantee info in the response
+        return {
+            ...s3_utils.DEFAULT_OBJECT_ACL,
+            owner,
+            access_control_list: s3_utils.DEFAULT_OBJECT_ACL.access_control_list.map(acl => ({
+                ...acl,
+                Grantee: { ...acl.Grantee, ID: owner.ID, DisplayName: owner.DisplayName },
+            }))
+        };
     }
 
     async put_object_acl(params, object_sdk) {

--- a/src/test/external_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_black_list.txt
+++ b/src/test/external_tests/ceph_s3_tests/s3-tests-lists/nsfs_s3_tests_black_list.txt
@@ -85,6 +85,7 @@ s3tests_boto3/functional/test_s3.py::test_bucket_list_unordered
 s3tests_boto3/functional/test_s3.py::test_bucket_listv2_unordered
 s3tests_boto3/functional/test_s3.py::test_bucket_listv2_continuationtoken
 s3tests_boto3/functional/test_s3.py::test_bucket_listv2_startafter_unreadable
+# remove after https://github.com/ceph/s3-tests/issues/738 is resolved
 s3tests_boto3/functional/test_s3.py::test_bucket_list_return_data_versioning
 s3tests_boto3/functional/test_s3.py::test_bucket_list_objects_anonymous
 s3tests_boto3/functional/test_s3.py::test_bucket_listv2_objects_anonymous


### PR DESCRIPTION
### Describe the Problem
get-object-acl was returning default owner details while list-object-versions was returning correct owner details. Hence, there was a discrepency between the two.

### Explain the Changes
1. fetched owner details and replaced default object acl with the owner details

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. s3api get-object-acl --bucket version-bucket --key o1
2. s3api list-object-versions --bucket version-bucket

Check that both of these commands should return same owner details

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ACL responses now include the resolved object owner and update access control entries to reflect that owner instead of returning a static default.

* **Tests**
  * Added a comment to the S3 test blacklist marking a temporary exclusion; the test remains excluded pending upstream issue resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->