### PR TITLE
Fix default CA to be based on system certs instead of none

### DIFF
--- a/src/test/unit_tests/util_functions_tests/test_http_utils.cert.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_http_utils.cert.test.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const tls = require('tls');
 const https = require('https');
 const { execSync } = require('child_process');
 const http_utils = require('../../../util/http_utils');
@@ -98,6 +99,64 @@ describe('http_utils - certificate loading and HTTPS connections', () => {
             // We can't directly test this without reloading the module, but we can verify the paths
             expect(default_internal).toBe('/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt');
             expect(default_external).toBe('/etc/ocp-injected-ca-bundle/ca-bundle.crt');
+        });
+
+        // Mirrors https.Agent `ca` construction in src/util/http_utils.js — keep in sync if that code changes.
+        it('https CA bundle is tls.getCACertificates("default") then internal/external PEMs when both files exist', () => {
+            const internal_pem =
+                '-----BEGIN CERTIFICATE-----\ninternal-test-ca\n-----END CERTIFICATE-----\n';
+            const external_pem =
+                '-----BEGIN CERTIFICATE-----\nexternal-test-ca\n-----END CERTIFICATE-----\n';
+            const internal_path = path.join(__dirname, 'test_internal_ca_default_bundle.crt');
+            const external_path = path.join(__dirname, 'test_external_ca_default_bundle.crt');
+
+            const prev_internal = process.env.INTERNAL_CA_CERTS;
+            const prev_external = process.env.EXTERNAL_CA_CERTS;
+
+            try {
+                fs.writeFileSync(internal_path, internal_pem, 'utf8');
+                fs.writeFileSync(external_path, external_pem, 'utf8');
+
+                jest.isolateModules(() => {
+                    process.env.INTERNAL_CA_CERTS = internal_path;
+                    process.env.EXTERNAL_CA_CERTS = external_path;
+                    require('../../../util/http_utils');
+                });
+
+                const ca = (() => {
+                    const custom_certs = [
+                        fs_utils.try_read_file_sync(internal_path),
+                        fs_utils.try_read_file_sync(external_path),
+                    ].filter(Boolean);
+                    return custom_certs.length ? [
+                        ...tls.getCACertificates('default'),
+                        ...custom_certs,
+                    ] : undefined;
+                })();
+
+                const default_cas = tls.getCACertificates('default');
+                expect(ca).toBeDefined();
+                expect(Array.isArray(ca)).toBe(true);
+                expect(ca.length).toBe(default_cas.length + 2);
+                for (let i = 0; i < default_cas.length; i += 1) {
+                    expect(ca[i]).toBe(default_cas[i]);
+                }
+                expect(ca[default_cas.length]).toBe(internal_pem);
+                expect(ca[default_cas.length + 1]).toBe(external_pem);
+            } finally {
+                if (fs.existsSync(internal_path)) fs.unlinkSync(internal_path);
+                if (fs.existsSync(external_path)) fs.unlinkSync(external_path);
+                if (prev_internal === undefined) {
+                    delete process.env.INTERNAL_CA_CERTS;
+                } else {
+                    process.env.INTERNAL_CA_CERTS = prev_internal;
+                }
+                if (prev_external === undefined) {
+                    delete process.env.EXTERNAL_CA_CERTS;
+                } else {
+                    process.env.EXTERNAL_CA_CERTS = prev_external;
+                }
+            }
         });
 
     });

--- a/src/test/unit_tests/util_functions_tests/test_http_utils.cert.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_http_utils.cert.test.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const tls = require('tls');
 const https = require('https');
 const { execSync } = require('child_process');
 const http_utils = require('../../../util/http_utils');
@@ -98,6 +99,85 @@ describe('http_utils - certificate loading and HTTPS connections', () => {
             // We can't directly test this without reloading the module, but we can verify the paths
             expect(default_internal).toBe('/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt');
             expect(default_external).toBe('/etc/ocp-injected-ca-bundle/ca-bundle.crt');
+        });
+
+        it('https CA bundle uses internal/external PEMs when external bundle exists (no system defaults)', () => {
+            const internal_pem =
+                '-----BEGIN CERTIFICATE-----\ninternal-test-ca\n-----END CERTIFICATE-----\n';
+            const external_pem =
+                '-----BEGIN CERTIFICATE-----\nexternal-test-ca\n-----END CERTIFICATE-----\n';
+            const internal_path = path.join(__dirname, 'test_internal_ca_default_bundle.crt');
+            const external_path = path.join(__dirname, 'test_external_ca_default_bundle.crt');
+
+            const prev_internal = process.env.INTERNAL_CA_CERTS;
+            const prev_external = process.env.EXTERNAL_CA_CERTS;
+
+            try {
+                fs.writeFileSync(internal_path, internal_pem, 'utf8');
+                fs.writeFileSync(external_path, external_pem, 'utf8');
+
+                let ca;
+                jest.isolateModules(() => {
+                    process.env.INTERNAL_CA_CERTS = internal_path;
+                    process.env.EXTERNAL_CA_CERTS = external_path;
+                    const isolated_http_utils = require('../../../util/http_utils');
+                    ca = isolated_http_utils.get_default_agent('https://example.com').options.ca;
+                });
+
+                expect(ca).toEqual([internal_pem, external_pem]);
+            } finally {
+                if (fs.existsSync(internal_path)) fs.unlinkSync(internal_path);
+                if (fs.existsSync(external_path)) fs.unlinkSync(external_path);
+                if (prev_internal === undefined) {
+                    delete process.env.INTERNAL_CA_CERTS;
+                } else {
+                    process.env.INTERNAL_CA_CERTS = prev_internal;
+                }
+                if (prev_external === undefined) {
+                    delete process.env.EXTERNAL_CA_CERTS;
+                } else {
+                    process.env.EXTERNAL_CA_CERTS = prev_external;
+                }
+            }
+        });
+
+        it('https CA bundle falls back to tls.getCACertificates("default") when external bundle is empty', () => {
+            const internal_pem =
+                '-----BEGIN CERTIFICATE-----\ninternal-test-ca\n-----END CERTIFICATE-----\n';
+            const internal_path = path.join(__dirname, 'test_internal_ca_fallback_bundle.crt');
+            const external_path = path.join(__dirname, 'test_external_ca_missing_bundle.crt');
+
+            const prev_internal = process.env.INTERNAL_CA_CERTS;
+            const prev_external = process.env.EXTERNAL_CA_CERTS;
+
+            try {
+                fs.writeFileSync(internal_path, internal_pem, 'utf8');
+
+                let ca;
+                jest.isolateModules(() => {
+                    process.env.INTERNAL_CA_CERTS = internal_path;
+                    process.env.EXTERNAL_CA_CERTS = external_path;
+                    const isolated_http_utils = require('../../../util/http_utils');
+                    ca = isolated_http_utils.get_default_agent('https://example.com').options.ca;
+                });
+
+                expect(ca).toEqual([
+                    ...tls.getCACertificates('default'),
+                    internal_pem,
+                ]);
+            } finally {
+                if (fs.existsSync(internal_path)) fs.unlinkSync(internal_path);
+                if (prev_internal === undefined) {
+                    delete process.env.INTERNAL_CA_CERTS;
+                } else {
+                    process.env.INTERNAL_CA_CERTS = prev_internal;
+                }
+                if (prev_external === undefined) {
+                    delete process.env.EXTERNAL_CA_CERTS;
+                } else {
+                    process.env.EXTERNAL_CA_CERTS = prev_external;
+                }
+            }
         });
 
     });

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -7,6 +7,7 @@ const util = require('util');
 const net = require('net');
 const url = require('url');
 const http = require('http');
+const tls = require('tls');
 const https = require('https');
 const crypto = require('crypto');
 const xml2js = require('xml2js');
@@ -44,10 +45,16 @@ const EXTERNAL_CA_CERTS = process.env.EXTERNAL_CA_CERTS || '/etc/ocp-injected-ca
 const { HTTP_PROXY, HTTPS_PROXY, NO_PROXY } = process.env;
 const http_agent = new http.Agent();
 const https_agent = new https.Agent({
-    ca: (ca => (ca.length ? ca : undefined))([
-        fs_utils.try_read_file_sync(INTERNAL_CA_CERTS),
-        fs_utils.try_read_file_sync(EXTERNAL_CA_CERTS),
-    ].filter(Boolean))
+    ca: (() => {
+        const custom_certs = [
+            fs_utils.try_read_file_sync(INTERNAL_CA_CERTS),
+            fs_utils.try_read_file_sync(EXTERNAL_CA_CERTS),
+        ].filter(Boolean);
+        return custom_certs.length ? [
+            ...tls.getCACertificates('default'),
+            ...custom_certs,
+        ] : undefined;
+    })()
 });
 const unsecured_https_agent = new https.Agent({ rejectUnauthorized: false });
 const http_proxy_agent = HTTP_PROXY ?

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -7,6 +7,7 @@ const util = require('util');
 const net = require('net');
 const url = require('url');
 const http = require('http');
+const tls = require('tls');
 const https = require('https');
 const crypto = require('crypto');
 const xml2js = require('xml2js');
@@ -43,10 +44,25 @@ const { HTTP_PROXY, HTTPS_PROXY, NO_PROXY } = process.env;
 const http_agent = new http.Agent({ keepAlive: true });
 const https_agent = new https.Agent({
     keepAlive: true,
-    ca: (ca => (ca.length ? ca : undefined))([
-        fs_utils.try_read_file_sync(INTERNAL_CA_CERTS),
-        fs_utils.try_read_file_sync(EXTERNAL_CA_CERTS),
-    ].filter(Boolean))
+    ca: (() => {
+        const internal_cert = fs_utils.try_read_file_sync(INTERNAL_CA_CERTS);
+        const external_cert = fs_utils.try_read_file_sync(EXTERNAL_CA_CERTS);
+        // OCP-injected external bundle already includes public CAs.
+        if (external_cert) {
+            return [internal_cert, external_cert].filter(Boolean);
+        }
+        // External missing but internal present: keep system trust + service CA.
+        // Setting only the internal cert would replace Node's default CA store.
+        if (internal_cert) {
+            return [
+                ...tls.getCACertificates('default'),
+                internal_cert,
+            ];
+        }
+        // No custom CAs — leave undefined so Node uses implicit defaults and
+        // get_unsecured_agent still treats non-AWS endpoints as unsecured.
+        return undefined;
+    })()
 });
 const unsecured_https_agent = new https.Agent({ rejectUnauthorized: false, keepAlive: true });
 


### PR DESCRIPTION
### Describe the Problem
When, for some reason, OCP failed to inject the CA list to our pods, noobaa-core/endpoint would start with an empty list of CAs instead of the system defaults - this fix is supposed to fix this.

### Explain the Changes
1. base ca list on the system default instead of empty list

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTPS certificate validation by updating how trusted CA certificates are assembled. When internal and external CA bundles are available, they’re combined; when the external bundle is missing or empty, the app retains system trust and adds the internal CA (when present).
* **Tests**
  * Added unit tests covering trusted CA bundle construction for both “both bundles present” and “external bundle missing/empty” scenarios, including certificate file and environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->