### PR TITLE
Add error handler to the Azure stream to catch AbortError

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -248,6 +248,12 @@ class NamespaceBlob {
                     this.container,
                     inspect(_.omit(params, 'object_md.ns')),
                     'callback res');
+                // Add error handler to the Azure stream to catch AbortError
+                res.readableStreamBody?.on('error', stream_err => {
+                    dbg.error('NamespaceBlob.read_object_stream: Azure stream error:', stream_err.name, stream_err.message);
+                    // Destroy count_stream with error - properly cleans up and propagates error
+                    count_stream.destroy(stream_err);
+                });
                 if (!res.readableStreamBody) throw new Error('NamespaceBlob.read_object_stream: download response is invalid');
                 return resolve(res.readableStreamBody.pipe(count_stream));
             }).catch(err => {


### PR DESCRIPTION
### Describe the Problem

In ODF 4.16.21, noobaa-endpoint pods backed by Azure Blob Storage are entering a CrashLoopBackOff. When the underlying network connection to Azure is interrupted mid-stream (likely due to timeouts or throttling), the @azure/storage-blob SDK throws an AbortError. NooBaa fails to catch this exception, resulting in an uncaughtException that fatally panics the Node.js process.

### Explain the Changes
1. Add error handler to the Azure stream to catch AbortError

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-5838

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blob download reliability: errors from the storage stream are now caught, logged (error name and message), and propagated into the existing failure path so download failures are consistently detected and cause the operation to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->