### PR TITLE
vectors - bg delete, reindex

### DIFF
--- a/config.js
+++ b/config.js
@@ -1254,6 +1254,10 @@ config.S3_RDMA_BYTES_HDR = 'x-amz-rdma-bytes-transferred';
 config.VECTORS_NSR_HEADER = 'x-noobaa-nsr';
 config.VECTORS_DB_TYPE_HEADER = 'x-noobaa-db-type';
 config.VECTORS_CACHE_DURATION = 1000;
+config.REINDEX_VECTOR_BUCKETS = true;
+config.REINDEX_VECTOR_BUCKETS_DELAY = 60 * 60 * 1000; // 1 hour default delay
+//after how many row changes (insert and deletion) to reindex a vector index
+config.VECTOR_INDEX_ROWS_REINDEX = 10000;
 
 /////////////////////////
 ///  OBJECT_SERVICES  ///

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1215,6 +1215,26 @@ module.exports = {
                 system: ['admin', 'user']
             }
         },
+
+        update_rows_since_index: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['vector_bucket_name', 'vector_index_name', 'op', 'value'],
+                properties: {
+                    vector_bucket_name: { wrapper: SensitiveString },
+                    vector_index_name: { wrapper: SensitiveString },
+                    op: {
+                        enum: ['SET', 'ADD'],
+                        type: 'string'
+                    },
+                    value: {type: 'integer'},
+                }
+            },
+            auth: {
+                system: ['admin']
+            }
+        }
     },
 
     definitions: {

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -46,6 +46,7 @@ const { get_notification_logger } = require('../util/notifications_util');
 const ldap_client = require('../util/ldap_client');
 const { is_nc_environment } = require('../nc/nc_utils');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
+const { VectorBucketsReindexer } = require('../server/bg_services/vector_buckets_reindexer');
 
 const cluster = /** @type {import('node:cluster').Cluster} */ (
     /** @type {unknown} */
@@ -255,6 +256,13 @@ async function main(options = {}) {
             background_scheduler.register_bg_worker(new SemaphoreMonitor({
                 name: 'semaphore_monitor',
                 object_io: object_io,
+            }));
+        }
+
+        if (internal_rpc_client && config.REINDEX_VECTOR_BUCKETS) {
+            background_scheduler.register_bg_worker(new VectorBucketsReindexer({
+                name: 'Vector_buckets_reindexer',
+                client: internal_rpc_client,
             }));
         }
 

--- a/src/endpoint/endpoint.js
+++ b/src/endpoint/endpoint.js
@@ -259,10 +259,11 @@ async function main(options = {}) {
             }));
         }
 
-        if (internal_rpc_client && config.REINDEX_VECTOR_BUCKETS) {
+        if ((internal_rpc_client || options.nsfs_config_root) && config.REINDEX_VECTOR_BUCKETS) {
             background_scheduler.register_bg_worker(new VectorBucketsReindexer({
                 name: 'Vector_buckets_reindexer',
                 client: internal_rpc_client,
+                nsfs_config_root: options.nsfs_config_root
             }));
         }
 

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -1465,6 +1465,10 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         });
     }
 
+    async add_rows_since_reindex(/*{vector_bucket_name, vector_index_name, delta}*/) {
+        //TODO
+    }
+
     //////////////////////////////
     // VECTOR BUCKET POLICY     //
     //////////////////////////////

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -1377,6 +1377,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 metadata_configuration,
                 owner_account: owner_account_id,
                 creation_time: Date.now(),
+                rows_since_index: 0,
             };
 
             await this.config_fs.create_vector_index_config_file(vector_bucket_name, vector_index);
@@ -1397,6 +1398,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
                 metadata_configuration: vi.metadata_configuration,
                 owner_account: { id: vi.owner_account },
                 creation_time: vi.creation_time,
+                rows_since_index: vi.rows_since_index,
             };
         } catch (err) {
             if (err.code === 'ENOENT') {
@@ -1465,8 +1467,28 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         });
     }
 
-    async add_rows_since_reindex(/*{vector_bucket_name, vector_index_name, delta}*/) {
-        //TODO
+    async add_rows_since_reindex({ vector_bucket_name, vector_index_name, delta }) {
+        dbg.log0("vector_bucket_name =", vector_bucket_name);
+        dbg.log0("vector_index_name =", vector_index_name);
+        dbg.log0("String(vector_bucket_name) =", String(vector_bucket_name));
+        dbg.log0("String(vector_index_name) =", String(vector_index_name));
+        return bucket_semaphore.surround_key(String(vector_bucket_name), async () => {
+            const vi = await this.config_fs.get_vector_index_by_name(vector_bucket_name.unwrap(), vector_index_name.unwrap());
+            if (!vi) {
+                throw new RpcError('NO_SUCH_BUCKET', 'No such vector index: ' + vector_index_name.unwrap());
+            }
+
+            const current_rows = vi.rows_since_index || 0;
+            const new_rows = current_rows + delta;
+
+            // Update the vector index with the new value
+            const updated_vi = {
+                ...vi,
+                rows_since_index: new_rows
+            };
+
+            await this.config_fs.update_vector_index_config_file(updated_vi);
+        });
     }
 
     //////////////////////////////

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -373,6 +373,16 @@ class BucketSpaceNB {
         return resp;
     }
 
+    async add_rows_since_reindex({vector_bucket_name, vector_index_name, delta}) {
+        const resp = await this.rpc_client.bucket.update_rows_since_index({
+            vector_bucket_name,
+            vector_index_name,
+            op: 'ADD',
+            value: delta
+        });
+        return resp;
+    }
+
     //////////////////////////////
     // VECTOR BUCKET POLICY     //
     //////////////////////////////

--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -1264,6 +1264,19 @@ class ConfigFS {
     }
 
     /**
+     * update_vector_index_config_file updates a vector index config file in place
+     * @param {Object} data - full vector index config
+     * @returns {Promise<void>}
+     */
+    async update_vector_index_config_file(data) {
+        await this._throw_if_config_dir_locked();
+        const string_data = JSON.stringify(_.omitBy(data, _.isUndefined));
+        const indexes_dir = this.get_vector_indexes_dir_for_bucket(data.vector_bucket);
+        const vi_path = this.get_vector_index_path(data.vector_bucket, data.name);
+        await native_fs_utils.update_config_file(this.fs_context, indexes_dir, vi_path, string_data);
+    }
+
+    /**
      * delete_vector_index_config_file deletes a vector index config file
      * @param {string} vector_bucket_name
      * @param {string} vector_index_name

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -944,6 +944,7 @@ interface BucketSpace {
     get_vector_index({ vector_bucket_name, vector_index_name }): Promise<any>;
     list_vector_indices({ vector_bucket_name, max_results, prefix, next_token }): Promise<any>;
     delete_vector_index({ vector_bucket_name, vector_index_name }): Promise<any>;
+    add_rows_since_reindex({vector_bucket_name, vector_index_name, delta}): Promise<any>;
 }
 
 /**********************************************************

--- a/src/sdk/vector_sdk.js
+++ b/src/sdk/vector_sdk.js
@@ -118,7 +118,13 @@ class VectorSDK {
     //////////////////////////
 
     async put_vectors(params) {
-        return await vector_utils.put_vectors(this.req.vector_bucket, this.req.vector_index, params.vectors);
+        const bs = this._get_bucketspace();
+        await vector_utils.put_vectors(this.req.vector_bucket, this.req.vector_index, params.vectors);
+        await bs.add_rows_since_reindex({
+            vector_bucket_name: this.req.vector_bucket.name,
+            vector_index_name: this.req.vector_index.name,
+            delta: params.vectors.length
+        });
     }
 
     async list_vectors(params) {
@@ -130,7 +136,13 @@ class VectorSDK {
     }
 
     async delete_vectors(params) {
+        const bs = this._get_bucketspace();
         await vector_utils.delete_vectors(this.req.vector_bucket, this.req.vector_index, params.keys);
+        await bs.add_rows_since_reindex({
+            vector_bucket_name: this.req.vector_bucket.name,
+            vector_index_name: this.req.vector_index.name,
+            delta: params.keys.length
+        });
     }
 
     async query_vectors(params) {

--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -131,37 +131,48 @@ async function clean_replication_store(last_date_to_remove) {
 async function clean_system_store(last_date_to_remove) {
     const total_accounts_count = await system_store.count_total_docs('accounts');
     const total_buckets_count = await system_store.count_total_docs('buckets');
+    const total_vector_buckets_count = await system_store.count_total_docs('vector_buckets');
+    const total_vector_indices_count = await system_store.count_total_docs('vector_indices');
     const total_pools_count = await system_store.count_total_docs('pools');
     if ((total_accounts_count < config.DB_CLEANER_MAX_TOTAL_DOCS) &&
         (total_buckets_count < config.DB_CLEANER_MAX_TOTAL_DOCS) &&
+        (total_vector_buckets_count < config.DB_CLEANER_MAX_TOTAL_DOCS) &&
+        (total_vector_indices_count < config.DB_CLEANER_MAX_TOTAL_DOCS) &&
         (total_pools_count < config.DB_CLEANER_MAX_TOTAL_DOCS)) {
         dbg.log0(`DB_CLEANER: found less than ${config.DB_CLEANER_MAX_TOTAL_DOCS} docs in system-store 
-        ${total_accounts_count} accounts, ${total_buckets_count} buckets, ${total_pools_count} pools - Skipping...`);
+        ${total_accounts_count} accounts, ${total_buckets_count} buckets, ${total_vector_buckets_count} vector bucket, 
+        ${total_vector_indices_count} vector indices, ${total_pools_count} pools - Skipping...`);
         return;
     }
     dbg.log0('DB_CLEANER: checking system_store for documents deleted before', new Date(last_date_to_remove));
-    const [accounts, buckets, pools] = await P.all([
+    const [accounts, buckets, vector_buckets, vector_indices, pools] = await P.all([
         system_store.find_deleted_docs('accounts', last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT),
         system_store.find_deleted_docs('buckets', last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT),
+        system_store.find_deleted_docs('vector_buckets', last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT),
+        system_store.find_deleted_docs('vector_indices', last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT),
         system_store.find_deleted_docs('pools', last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT)
     ]);
     dbg.log2('DB_CLEANER: list accounts:', accounts);
     dbg.log2('DB_CLEANER: list buckets:', buckets);
+    dbg.log2('DB_CLEANER: list vector_buckets:', vector_buckets);
+    dbg.log2('DB_CLEANER: list vector_indices:', vector_indices);
     dbg.log2('DB_CLEANER: list pools:', pools);
     const filtered_buckets = buckets.filter(async bucket =>
         !(await MDStore.instance().has_any_objects_for_bucket_including_deleted(bucket)));
     const filtered_pools = pools.filter(async pool =>
         !(await nodes_store.has_any_nodes_for_pool(pool)));
-    if (accounts.length || filtered_buckets.length || filtered_pools.length) {
+    if (accounts.length || filtered_buckets.length || filtered_pools.length || vector_buckets.length || vector_indices.length) {
         await system_store.make_changes({
             db_delete: {
                 accounts: accounts,
                 buckets: filtered_buckets,
+                vector_buckets: vector_buckets,
+                vector_indices: vector_indices,
                 pools: filtered_pools
             }
         });
     }
-    dbg.log0(`DB_CLEANER: removed ${accounts.length + filtered_buckets.length + filtered_pools.length} documents from system-store`);
+    dbg.log0(`DB_CLEANER: removed ${accounts.length + filtered_buckets.length + filtered_pools.length + vector_buckets.length + vector_indices.length} documents from system-store`);
 }
 
 // EXPORTS

--- a/src/server/bg_services/vector_buckets_reindexer.js
+++ b/src/server/bg_services/vector_buckets_reindexer.js
@@ -1,0 +1,69 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const dbg = require('../../util/debug_module')(__filename);
+const config = require('../../../config');
+const auth_server = require('../common_services/auth_server');
+const system_store = require('../system_services/system_store').get_instance();
+const vector_utils = require('../../util/vectors_util');
+
+
+class VectorBucketsReindexer {
+    constructor({client, name}) {
+        this.name = name;
+        this.client = client;
+    }
+
+    async run_batch() {
+        dbg.log0('Vector Bucket Reindexer: BEGIN');
+        if (!system_store.is_finished_initial_load) {
+            dbg.log0('waiting for system store to load');
+            return;
+        }
+        if (!system_store.data.systems[0]) {
+            dbg.log0('system does not exist, skipping');
+            return;
+        }
+
+        if (!system_store.data.vector_indices) {
+            dbg.log0("Vector Bucket Reindexer: no vector indices.");
+            return config.REINDEX_VECTOR_BUCKETS_DELAY;
+        }
+
+        for (const vi of system_store.data.vector_indices) {
+            dbg.log0("vi.name =", vi.name, ", vi.rows_since_index =", vi.rows_since_index);
+
+            if (vi.rows_since_index > config.VECTOR_INDEX_ROWS_REINDEX) {
+
+                try {
+                    await this.client.bucket.update_rows_since_index({
+                        vector_bucket_name: vi.vector_bucket.name,
+                        vector_index_name: vi.name,
+                        op: 'SET',
+                        value: 0
+                    }, {
+                        auth_token: auth_server.make_auth_token({
+                            system_id: system_store.data.systems[0]._id,
+                            account_id: system_store.data.systems[0].owner._id,
+                            role: 'admin'
+                        })
+                    });
+
+                    vector_utils.reindex(vi.vector_bucket, vi).catch(e =>
+                         dbg.error("Failed to reindex", vi.name, ", e =", e)
+                    );
+                } catch (e) {
+                    //swallow errors, continue to next vi
+                    dbg.error("Failed to reindex", vi.name, ", e =", e);
+                }
+            }
+        }
+
+        dbg.log0('Vector Bucket Reindexer: END. ');
+
+        return config.REINDEX_VECTOR_BUCKETS_DELAY;
+    }
+}
+
+// EXPORTS
+exports.VectorBucketsReindexer = VectorBucketsReindexer;

--- a/src/server/bg_services/vector_buckets_reindexer.js
+++ b/src/server/bg_services/vector_buckets_reindexer.js
@@ -6,36 +6,72 @@ const config = require('../../../config');
 const auth_server = require('../common_services/auth_server');
 const system_store = require('../system_services/system_store').get_instance();
 const vector_utils = require('../../util/vectors_util');
-
+const { get_process_fs_context } = require('../../util/native_fs_utils');
+const { ConfigFS } = require('../../sdk/config_fs');
+const SensitiveString = require('../../util/sensitive_string');
 
 class VectorBucketsReindexer {
-    constructor({client, name}) {
+    constructor({client, nsfs_config_root, name}) {
         this.name = name;
-        this.client = client;
+        this.client = client; //containerized env
+        if (nsfs_config_root) { //NC env
+            const fs_context = get_process_fs_context(
+            config.NSFS_NC_CONFIG_DIR_BACKEND,
+            config.NSFS_WARN_THRESHOLD_MS,
+            );
+
+            this.config_fs = new ConfigFS(nsfs_config_root, config.NSFS_NC_CONFIG_DIR_BACKEND, fs_context);
+        }
     }
 
     async run_batch() {
         dbg.log0('Vector Bucket Reindexer: BEGIN');
-        if (!system_store.is_finished_initial_load) {
-            dbg.log0('waiting for system store to load');
-            return;
+        if (this.client) {
+            if (!system_store.is_finished_initial_load) {
+                dbg.log0('waiting for system store to load');
+                return;
+            }
+            if (!system_store.data.systems[0]) {
+                dbg.log0('system does not exist, skipping');
+                return;
+            }
+
+            if (!system_store.data.vector_indices) {
+                dbg.log0("Vector Bucket Reindexer: no vector indices.");
+                return config.REINDEX_VECTOR_BUCKETS_DELAY;
+            }
+
+            for (const vi of system_store.data.vector_indices) {
+                await this.handle_single_vi(vi);
+            }
+        } else {
+            const vb_names = await this.config_fs.list_vector_buckets();
+            for (const vb_name of vb_names) {
+                const vb = await this.config_fs.get_vector_bucket_by_name(vb_name);
+                //vector utils expects name to be SensitiveString
+                vb.name = new SensitiveString(vb_name);
+                const vi_names = await this.config_fs.list_vector_indexes(vb_name);
+                for (const vi_name of vi_names) {
+                    const vi = await this.config_fs.get_vector_index_by_name(vb_name, vi_name);
+                    vi.name = new SensitiveString(vi_name);
+                    await this.handle_single_vi(vi, vb);
+                }
+            }
         }
-        if (!system_store.data.systems[0]) {
-            dbg.log0('system does not exist, skipping');
-            return;
-        }
 
-        if (!system_store.data.vector_indices) {
-            dbg.log0("Vector Bucket Reindexer: no vector indices.");
-            return config.REINDEX_VECTOR_BUCKETS_DELAY;
-        }
+        dbg.log0('Vector Bucket Reindexer: END. ');
 
-        for (const vi of system_store.data.vector_indices) {
-            dbg.log0("vi.name =", vi.name, ", vi.rows_since_index =", vi.rows_since_index);
+        return config.REINDEX_VECTOR_BUCKETS_DELAY;
+    }
 
-            if (vi.rows_since_index > config.VECTOR_INDEX_ROWS_REINDEX) {
+    async handle_single_vi(vi, vb) {
 
-                try {
+        dbg.log0("vi.name =", vi.name, ", vi.rows_since_index =", vi.rows_since_index);
+
+        if (vi.rows_since_index > config.VECTOR_INDEX_ROWS_REINDEX) {
+
+            try {
+                if (this.client) {
                     await this.client.bucket.update_rows_since_index({
                         vector_bucket_name: vi.vector_bucket.name,
                         vector_index_name: vi.name,
@@ -48,20 +84,19 @@ class VectorBucketsReindexer {
                             role: 'admin'
                         })
                     });
-
-                    vector_utils.reindex(vi.vector_bucket, vi).catch(e =>
-                         dbg.error("Failed to reindex", vi.name, ", e =", e)
-                    );
-                } catch (e) {
-                    //swallow errors, continue to next vi
-                    dbg.error("Failed to reindex", vi.name, ", e =", e);
+                } else {
+                    vi.rows_since_index = 0;
+                    await this.config_fs.update_vector_index_config_file(vi);
                 }
+
+                vector_utils.reindex(vb || vi.vector_bucket, vi).catch(e =>
+                        dbg.error("Failed to reindex", vi.name, ", e =", e)
+                );
+            } catch (e) {
+                //swallow errors, continue to next vi
+                dbg.error("Failed to reindex", vi.name, ", e =", e);
             }
         }
-
-        dbg.log0('Vector Bucket Reindexer: END. ');
-
-        return config.REINDEX_VECTOR_BUCKETS_DELAY;
     }
 }
 

--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -1,6 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+/* eslint-disable max-statements */
+
 // load .env file before any other modules so that it will contain
 // all the arguments even when the modules are loading.
 require('../util/dotenv').load();

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -103,7 +103,8 @@ function new_vector_index_defaults(name, system_id, owner_account_id, params = {
         system: system_id,
         owner_account: owner_account_id,
         creation_time: Date.now(),
-        tags: []
+        tags: [],
+        rows_since_index: 0
     };
     return defaults;
 }
@@ -2553,6 +2554,28 @@ async function delete_vector_index(req) {
     return vector_index_info;
 }
 
+async function update_rows_since_index(req) {
+    dbg.log0("update_rows_since_index req.rpc_params =", req.rpc_params);
+    const vector_index = find_vector_index(req, req.rpc_params.vector_bucket_name, req.rpc_params.vector_index_name);
+    const change = {
+        update: {
+            vector_indices: [{
+                _id: vector_index._id,
+            }]
+        }
+    };
+
+    if (req.rpc_params.op === 'SET') {
+        change.update.vector_indices[0].rows_since_index = req.rpc_params.value;
+    } else {
+        change.update.vector_indices[0].$inc = {
+            rows_since_index: req.rpc_params.value
+        };
+    }
+
+    await system_store.make_changes(change);
+}
+
 // EXPORTS
 exports.new_bucket_defaults = new_bucket_defaults;
 exports.get_bucket_info = get_bucket_info;
@@ -2630,3 +2653,4 @@ exports.create_vector_index = create_vector_index;
 exports.get_vector_index = get_vector_index;
 exports.list_vector_indices = list_vector_indices;
 exports.delete_vector_index = delete_vector_index;
+exports.update_rows_since_index = update_rows_since_index;

--- a/src/server/system_services/schemas/vector_index_schema.js
+++ b/src/server/system_services/schemas/vector_index_schema.js
@@ -49,6 +49,10 @@ module.exports = {
         tags: {
             $ref: 'common_api#/definitions/tagging',
         },
+        rows_since_index: {
+            type: 'integer',
+            minimum: 0
+        },
         deleted: {
             date: true
         },

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -297,6 +297,13 @@ class LanceConn extends VectorConn {
         return res;
     }
 
+    async reindex(vector_bucket, vector_index) {
+        dbg.log0("reindex vector_bucket =", vector_bucket.name.unwrap(), ", vector_index =", vector_index.name.unwrap());
+        const table_name = vector_bucket.name.unwrap() + "_" + vector_index.name.unwrap();
+        const table = await this.get_table(table_name);
+        await table.createIndex('vector', {replace: true});
+    }
+
     _lance_to_aws(lance_vector, return_metadata, return_distance) {
         const aws_vector = {
             key: lance_vector.id,
@@ -370,8 +377,10 @@ async function new_vector_conn(vector_bucket) {
                 lance_path = vector_bucket.path;
             } else {
                 // Containerized - resolve via system_store namespace resource
-                dbg.log0("vector_bucket.namespace_resource =", vector_bucket.namespace_resource);
-                const nsr = system_store.data.systems[0].namespace_resources_by_name[vector_bucket.namespace_resource.resource];
+                //for vc from system store, nsr is already an object.
+                //for vc from sdk info, lookup nsr name in sysem store.namespace_resources_by_name
+                const nsr = typeof vector_bucket.namespace_resource.resource === 'object' ? vector_bucket.namespace_resource.resource :
+                    system_store.data.systems[0].namespace_resources_by_name[vector_bucket.namespace_resource.resource];
                 lance_path = nsr.nsfs_config.fs_root_path;
                 if (vector_bucket.namespace_resource.path) {
                     lance_path = path.join(lance_path, vector_bucket.namespace_resource.path);
@@ -467,6 +476,12 @@ function next_token_sanity_check(next_token) {
     return true;
 }
 
+async function reindex(vector_bucket, vector_index) {
+    dbg.log0("reindex vector_bucket =", vector_bucket.name, ", vector_index =", vector_index.name);
+    const vc = await getVectorConn(vector_bucket);
+    await vc.reindex(vector_bucket, vector_index);
+}
+
 exports.delete_vector_bucket = delete_vector_bucket;
 exports.create_vector_index = create_vector_index;
 exports.delete_vector_index = delete_vector_index;
@@ -476,3 +491,4 @@ exports.query_vectors = query_vectors;
 exports.get_vectors = get_vectors;
 exports.delete_vectors = delete_vectors;
 exports.next_token_sanity_check = next_token_sanity_check;
+exports.reindex = reindex;


### PR DESCRIPTION
### Describe the Problem
Background maintenance for vectors for containerized.

### Explain the Changes
1. DB cleaner should clean deleted vector buckets and indices.
2. Vector index's vector index should be re-created after enough changes.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable automatic reindexing for vector indexes (enable/disable, delay, threshold).
  * Background reindex scheduler that detects over-threshold indexes and runs reindexes.
  * API/SDK hooks to report and update "rows since index"; vector put/delete now contribute to this tracking.
  * Vector index creation initializes a rows-since-index counter; integrated reindex operation for the vector backend.

* **Bug Fixes / Maintenance**
  * System-store cleanup now includes vector-related collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->