### PR TITLE
vectors - create vector bucket - use account's default resource if it's nsfs

### DIFF
--- a/src/endpoint/vector/ops/vector_bucket_create.js
+++ b/src/endpoint/vector/ops/vector_bucket_create.js
@@ -3,6 +3,7 @@
 //const config = require('../../../../config');
 const dbg = require('../../../util/debug_module')(__filename);
 const config = require('../../../../config');
+const system_store = require('../../../server/system_services/system_store').get_instance();
 
 const { VectorError } = require('../vector_errors');
 
@@ -13,9 +14,19 @@ async function post_vector_bucket(req, res) {
 
     dbg.log0("post_vector_bucket body =", req.body, ", headers =", req.headers);
 
-    const ns_name = req.headers[config.VECTORS_NSR_HEADER];
+    let ns_name = req.headers[config.VECTORS_NSR_HEADER];
     const subpath = req.headers[config.NSFS_CUSTOM_BUCKET_PATH_HTTP_HEADER];
     const vector_db_type = req.headers[config.VECTORS_DB_TYPE_HEADER] || 'lance';
+
+    //if ns was not explicitly given in header, try account's default resource
+    if (!ns_name) {
+        const default_resource_name = req.object_sdk?.requesting_account.default_resource;
+        const default_resource = system_store?.data?.systems[0]?.namespace_resources_by_name[default_resource_name];
+        //only nsfs resources are applicable
+        if (default_resource && default_resource.nsfs_config) {
+            ns_name = default_resource_name;
+        }
+    }
 
     // NS header is mandatory for containerized, optional for NC NSFS
     if (!ns_name && !req.object_sdk.nsfs_config_root) {

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -32,6 +32,7 @@ mocha.describe('vectors_ops', function() {
     let created_vector_indices;
     let created_vector_buckets;
     const nsr = 'nsr';
+    let admin_account_info;
 
     mocha.before(async function() {
         const self = this;
@@ -44,12 +45,15 @@ mocha.describe('vectors_ops', function() {
             }
             await fs.mkdir(path.join(TMP_PATH, 'lance'), { recursive: true });
         }
-        const account_info = await rpc_client.account.read_account({ email: EMAIL });
+        admin_account_info = await rpc_client.account.read_account({ email: EMAIL });
+
+        console.log("admin_account_info =", admin_account_info);
+
         client_params = {
             endpoint: coretest.get_https_address_vectors(),
             credentials: {
-                accessKeyId: account_info.access_keys[0].access_key.unwrap(),
-                secretAccessKey: account_info.access_keys[0].secret_key.unwrap(),
+                accessKeyId: admin_account_info.access_keys[0].access_key.unwrap(),
+                secretAccessKey: admin_account_info.access_keys[0].secret_key.unwrap(),
             },
             region: config.DEFAULT_REGION,
             requestHandler: new NodeHttpHandler({
@@ -1344,6 +1348,63 @@ mocha.describe('vectors_ops', function() {
 
             vectors.pop();
             compare_vectors(response.vectors, vectors, false);
+        });
+
+        mocha.it('should create a vector bucket (default resource)', async function() {
+
+            //make an account with a default NSR
+            const email = "account2@noobaa.com";
+            const nsfs_account_config = admin_account_info.nsfs_account_config || {
+                uid: 1,
+                gid: 1,
+                new_buckets_path: path.join(TMP_PATH, 'lance'),
+                nsfs_only: false
+            };
+            await rpc_client.account.create_account({
+                name: "account2",
+                password: "account2",
+                email,
+                s3_access: true,
+                allow_bucket_creation: true,
+                has_login: true,
+                default_resource: nsr,
+                nsfs_account_config: nsfs_account_config
+            });
+
+            //make an s3 client without NSR header
+            const account_info = await rpc_client.account.read_account({ email });
+            client_params = {
+                endpoint: coretest.get_https_address_vectors(),
+                credentials: {
+                    accessKeyId: account_info.access_keys[0].access_key.unwrap(),
+                    secretAccessKey: account_info.access_keys[0].secret_key.unwrap(),
+                },
+                region: config.DEFAULT_REGION,
+                requestHandler: new NodeHttpHandler({
+                    httpsAgent: new https.Agent({ rejectUnauthorized: false }) // disable SSL certificate validation
+                }),
+            };
+            const s3_vectors_client_no_header = new s3vectors.S3VectorsClient(client_params);
+
+            //create bucket should work
+            await create_vector_bucket(s3_vectors_client_no_header, created_vector_buckets, vector_bucket_name1);
+
+            //need policy to explicitly allow vector bucket deletion
+            const policy = {
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: '*',
+                    Action: 's3vectors:*',
+                    Resource: `arn:aws:s3vectors:::${vector_bucket_name1}`,
+                }],
+            };
+
+            const command = new s3vectors.PutVectorBucketPolicyCommand({
+                vectorBucketName: vector_bucket_name1,
+                policy: JSON.stringify(policy),
+            });
+            await send(s3_vectors_client_no_header, command);
         });
 
     });


### PR DESCRIPTION
### Describe the Problem
Creating a vector bucket via s3 requires an NSFS resource.
This adds the option to default to account's default resource.

### Explain the Changes
1. If ns header is not present, default to account's default resource (if it's NSFS).

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
-Assuming PVC is available in cluster.
-Create an NSFS Namespacestore:
apiVersion: noobaa.io/v1alpha1
kind: NamespaceStore
metadata:
  name: **nsfs-nss**
  namespace: <ns>
  labels:
    app: noobaa
  finalizers: noobaa.io/finalizer
spec:
  type: **nsfs**
  nsfs:
    pvcName: <pvc>
    subpath: <subpath>

(Wait for pvc to be mounted in endpoints)

-Create a new MCG account that uses the NSFS NSS by default:
noobaa account create nsfs-account --allow_bucket_create=True --default_resource **nsfs-nss** --gid 1234 --new_buckets_path / --nsfs_account_config=True --nsfs_only=False --uid 5678  -n <ns>

-Set AWS key to new account:
NOOBAA_SECRET_KEY=$(kubectl get secret noobaa-account-nsfs-account -n vectors -o json | jq -r '.data.AWS_SECRET_ACCESS_KEY|@base64d')
NOOBAA_ACCESS_KEY=$(kubectl get secret noobaa-account-nsfs-account -n vectors -o json | jq -r '.data.AWS_ACCESS_KEY_ID|@base64d')

-alias and port-forwarding:
kubectl port-forward -n <ns> service/vectors 14443:443 &
alias s3v='AWS_ACCESS_KEY_ID=$NOOBAA_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$NOOBAA_SECRET_KEY aws --endpoint https://localhost:14443 --no-verify-ssl s3vectors'

-create new vector bucket
s3v create-vector-bucket --vector-bucket-name vecbuc1

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vector bucket namespace resolution now falls back to account defaults when header is absent.
  * Vector operation error responses now use the standardized vector error message (previous behavior of preserving original error text changed).

* **Known Issues**
  * Vector bucket deletion is currently broken due to a request-handling mismatch.

* **Tests**
  * Several vector integration tests disabled; a new integration scenario added for header-less bucket creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->