### PR TITLE
Improve performance of S3 delete-objects API for non-versioned buckets

### DIFF
--- a/config.js
+++ b/config.js
@@ -1251,6 +1251,13 @@ config.VECTORS_NSR_HEADER = 'x-noobaa-nsr';
 config.VECTORS_DB_TYPE_HEADER = 'x-noobaa-db-type';
 config.VECTORS_CACHE_DURATION = 1000;
 
+/////////////////////////
+///  OBJECT_SERVICES  ///
+/////////////////////////
+
+config.DELETE_OBJECTS_BATCH_SIZE = 1000;
+
+
 /////////////////////
 //                 //
 //    OVERRIDES    //

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -7,7 +7,8 @@ const COMMON_CONSTANTS = {
       ENABLED: 'ENABLED',
       SUSPENDED: 'SUSPENDED',
       DISABLED: "DISABLED"
-    }
+    },
+    VERSION_NULL: 'null'
   }
 };
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -781,6 +781,7 @@ interface BulkOpResult {
 interface DBSequence {
     seqname(): string;
     nextsequence(): Promise<number>;
+    nextNsequences(n: number): Promise<{ start: number; end: number}>;
 }
 
 interface sqlResult<T> {

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2500]*/
+/*eslint max-lines: ["error", 2600]*/
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -703,6 +703,14 @@ class MDStore {
      */
     async alloc_object_version_seq() {
         return this._sequences.nextsequence();
+    }
+
+    /**
+     * @param {number} n
+     * @returns {Promise<{start: number, end: number}>}
+     */
+    async alloc_next_n_object_version_seq(n) {
+        return this._sequences.nextNsequences(n);
     }
 
     /**
@@ -2340,6 +2348,24 @@ class MDStore {
 
     get_unordered_bulk_op_on_objects() {
         return this._objects.initializeUnorderedBulkOp();
+    }
+
+    async delete_objects_by_keys({ bucket_id, keys }) {
+        if (!keys || !keys.length) return [];
+        const now = new Date().toISOString();
+        const query = `
+        UPDATE ${this._objects.name}
+        SET data = jsonb_set(data, '{deleted}', to_jsonb($1::text), true)
+        WHERE
+            data->>'bucket' = $2
+            AND data->>'key' = ANY($3)
+            AND (data->'version_past' IS NULL OR data->'version_past' = 'null'::jsonb)
+            AND (data->'deleted' IS NULL OR data->'deleted' = 'null'::jsonb)
+            AND (data->'upload_started' IS NULL OR data->'upload_started' = 'null'::jsonb)
+        RETURNING *;`;
+        const params = [now, bucket_id, keys];
+        const result = await db_client.instance().executeSQL(query, params, { preferred_pool: this._postgres_pool });
+        return result.rows;
     }
 }
 

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -2476,3 +2476,9 @@ exports.get_object_legal_hold = get_object_legal_hold;
 exports.put_object_retention = put_object_retention;
 exports.get_object_retention = get_object_retention;
 exports.calc_retention = calc_retention;
+
+if (process.env.NODE_ENV === 'test') {
+    exports.__testing = {
+        update_bulk_delete_results
+    };
+}

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2500]*/
+/*eslint max-lines: ["error", 2600]*/
 'use strict';
 
 require('../../util/fips');
@@ -1088,10 +1088,6 @@ async function delete_object(req) {
         await _delete_object_version(req) :
         await _delete_object_only_key(req);
 
-    if (req.is_bulk_update) {
-        return (obj ? { obj_md: obj } : {});
-    }
-
     if (obj) {
         dbg.log1(`${obj.key} was deleted by ${req.account && req.account.email.unwrap()}`);
     }
@@ -1108,9 +1104,73 @@ async function delete_multiple_objects(req) {
     dbg.log1('delete_multiple_objects: keys =', req.rpc_params.objects);
     throw_if_maintenance(req);
     load_bucket(req, { include_deleting: true });
+    const objects = req.rpc_params.objects;
+
+    const results = [];
+    results.length = objects.length;
+
+    // if bucket versioning is disabled, optimize the DB operations
+    if (req.bucket.versioning === CONSTANTS.S3.VERSIONING.DISABLED) {
+        dbg.log1('Optimizing delete for non versioned bucket');
+
+        const keys = [];
+        const object_index_map = Object.create(null);
+        let valid_objects_count = 0;
+
+        objects.forEach((obj, idx) => {
+            if (object_index_map[obj.key]) {
+                object_index_map[obj.key].push(idx);
+                valid_objects_count += 1;
+                return;
+            }
+
+            if (obj.version_id && obj.version_id !== CONSTANTS.S3.VERSION_NULL) {
+                // For a bucket with versioning disabled, only null version can be specified for an object
+                return;
+            }
+            keys.push(obj.key);
+            object_index_map[obj.key] = [idx];
+            valid_objects_count += 1;
+        });
+
+        try {
+            if (keys.length) {
+                const objs = [];
+                const batch_size = config.DELETE_OBJECTS_BATCH_SIZE;
+                const batch_count = Math.ceil(keys.length / batch_size);
+                const batches = Array.from({ length: batch_count }, (v, i) =>
+                    keys.slice(i * batch_size, i * batch_size + batch_size)
+                );
+
+                for (const batch of batches) {
+                    const batch_objs = await MDStore.instance().delete_objects_by_keys({ bucket_id: String(req.bucket._id), keys: batch });
+                    objs.push(...batch_objs);
+                }
+                await update_bulk_delete_results(objs, object_index_map, results, valid_objects_count);
+            }
+
+            // in case object is not found, map empty result with object sequence as delete is idempotent
+            for (let i = 0; i < results.length; i++) {
+                if (!results[i]) {
+                    results[i] = {
+                        seq: await MDStore.instance().alloc_object_version_seq()
+                    };
+                }
+            }
+        } catch (e) {
+            dbg.error("error executing bulk delete for non-versioned bucket", e);
+            for (let i = 0; i < results.length; i++) {
+                results[i] = {
+                    err_code: 'InternalError',
+                    err_message: e.message || 'InternalError'
+                };
+            }
+        }
+        return results;
+    }
+
     // group objects by key to run different keys concurrently but same keys sequentially.
     // we keep indexes to the requested objects list to return the results in the same order.
-    const objects = req.rpc_params.objects;
     const group_by_key = {};
     for (let i = 0; i < objects.length; ++i) {
         const obj = objects[i];
@@ -1120,16 +1180,6 @@ async function delete_multiple_objects(req) {
             group_by_key[obj.key] = group;
         }
         group.push(i);
-    }
-    const results = [];
-    const objects_to_del = [];
-    results.length = objects.length;
-    objects_to_del.length = objects.length;
-
-    // If bucket versioning is disabled, optimize the DB updates to objectmds
-    if (req.bucket.versioning === CONSTANTS.S3.VERSIONING.DISABLED) {
-        req.is_bulk_update = true;
-        dbg.log0('Optimizing delete for non versioned bucket');
     }
 
     await Promise.all(Object.keys(group_by_key).map(async key => {
@@ -1155,18 +1205,9 @@ async function delete_multiple_objects(req) {
                 };
 
             }
-
-            if (req.is_bulk_update) {
-                objects_to_del[index] = res;
-                continue;
-            }
             results[index] = res;
         }
     }));
-
-    if (req.is_bulk_update) {
-        await execute_bulk_update(req, objects_to_del, results);
-    }
 
     return results;
 }
@@ -2106,9 +2147,6 @@ async function _delete_object_version(req) {
         if (obj.delete_marker) dbg.error('versioning disabled bucket null objects should not have delete_markers', obj);
         // 2, 3, 8
 
-        if (req.is_bulk_update) {
-            return { obj };
-        }
         await MDStore.instance().remove_object_and_unset_latest(obj);
         return { obj, reply: _get_delete_obj_reply(obj) };
     }
@@ -2170,9 +2208,7 @@ async function _delete_object_only_key(req) {
         if (!obj) return { reply: {} };
         if (obj.delete_marker) dbg.error('versioning disabled bucket null objects should not have delete_markers', obj);
         // 2, 3, 8
-        if (req.is_bulk_update) {
-            return { obj };
-        }
+
         await MDStore.instance().remove_object_and_unset_latest(obj);
         return { obj, reply: _get_delete_obj_reply(obj) };
     }
@@ -2370,57 +2406,21 @@ function _sort_parts_by_seq(a, b) {
     return a.seq - b.seq;
 }
 
-async function execute_bulk_update(req, objects, results) {
-    let bulk;
-    const now = new Date();
-    let to_update = false;
-
-    for (const [idx, obj] of objects.entries()) {
-        // If object not found in objectmds, assign empty result or validation errors if any
-        const obj_md = obj?.obj_md;
-
-        if (!obj_md) {
-            results[idx] = obj ?? {};
-            continue;
-        }
-
-        if (!to_update) {
-            to_update = true;
-            bulk = MDStore.instance().get_unordered_bulk_op_on_objects();
-        }
-
-        const filter = {
-            _id: obj_md._id,
-            deleted: null
-        };
-
-        const payload = {
-            $set: {
-                version_past: true,
-                deleted: now
-            }
-        };
-
-        bulk.find(filter).updateOne(payload);
-
-        dbg.log1(`${obj_md.key} was deleted by ${req.account && req.account.email.unwrap()}`);
-        const reply = _get_delete_obj_reply(obj_md);
-        reply.seq = await MDStore.instance().alloc_object_version_seq();
-        results[idx] = reply;
-    }
-
-    // return if there are no actual objects to delete
-    if (!to_update) {
+async function update_bulk_delete_results(objects, object_index_map, results, objects_count) {
+    if (!objects.length) {
         return;
     }
 
-    // Execute the bulk operations
-    dbg.log0('Performing bulk updates for batch delete');
-    const bulk_results = await bulk.execute();
-
-    if (!bulk_results.ok) {
-        throw new RpcError('INTERNAL_ERROR',
-            `failed to perform bulk_delete operation. error encountered is ${bulk_results.err}`);
+    const obj_seqs = await MDStore.instance().alloc_next_n_object_version_seq(objects_count);
+    let seq = obj_seqs.start;
+    for (const { data: obj_md } of objects) {
+        const indices = object_index_map[obj_md.key];
+        for (const j of indices) {
+            const reply = _get_delete_obj_reply(obj_md);
+            reply.seq = seq <= obj_seqs.end ? seq : await MDStore.instance().alloc_object_version_seq();
+            seq += 1;
+            results[j] = reply;
+        }
     }
 }
 

--- a/src/test/unit_tests/internal/test_object_server.test.js
+++ b/src/test/unit_tests/internal/test_object_server.test.js
@@ -1,0 +1,545 @@
+/* Copyright (C) 2026 NooBaa */
+/* eslint max-lines-per-function: ['error', 700] */
+
+'use strict';
+
+const config = require('../../../../config');
+const CONSTANTS = require('../../../common/constants');
+const SensitiveString = require('../../../util/sensitive_string');
+const system_utils = require('../../../server/utils/system_utils');
+const { MDStore } = require('../../../server/object_services/md_store');
+const object_server = require('../../../server/object_services/object_server');
+
+describe('object_server - delete_multiple_objects', () => {
+
+    let mock_req;
+    let mdstore_instance_stub;
+    let delete_objects_by_keys_stub;
+    let alloc_object_version_seq_stub;
+    let alloc_next_n_object_version_seq_stub;
+
+    beforeEach(() => {
+        mdstore_instance_stub = {
+            delete_objects_by_keys: jest.fn(),
+            alloc_object_version_seq: jest.fn(),
+            alloc_next_n_object_version_seq: jest.fn(),
+            make_md_id: jest.fn(),
+            get_object_version_id: jest.fn().mockReturnValue('v123')
+        };
+
+        jest.spyOn(MDStore, 'instance').mockReturnValue(mdstore_instance_stub);
+
+        jest.spyOn(system_utils, 'system_in_maintenance').mockReturnValue(false);
+
+        delete_objects_by_keys_stub = mdstore_instance_stub.delete_objects_by_keys;
+
+        alloc_object_version_seq_stub = mdstore_instance_stub.alloc_object_version_seq;
+
+        alloc_next_n_object_version_seq_stub = mdstore_instance_stub.alloc_next_n_object_version_seq;
+
+        mock_req = {
+            system: {
+                _id: 'system_id_123',
+                buckets_by_name: {
+                    'test-bucket': {
+                        _id: 'bucket_id_123',
+                        name: 'test-bucket',
+                        versioning: CONSTANTS.S3.VERSIONING.DISABLED
+                    }
+                }
+            },
+            rpc_params: {
+                bucket: new SensitiveString('test-bucket'),
+                objects: []
+            },
+            bucket: null
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('Non-versioned bucket (VERSIONING.DISABLED)', () => {
+
+        test('should successfully delete multiple objects', async () => {
+            const objects = [
+                { key: 'file1.txt' },
+                { key: 'file2.txt' },
+                { key: 'file3.txt' }
+            ];
+
+            mock_req.rpc_params.objects = objects;
+
+            const deleted_objs = [
+                { data: { key: 'file1.txt', _id: 'obj1' } },
+                { data: { key: 'file2.txt', _id: 'obj2' } },
+                { data: { key: 'file3.txt', _id: 'obj3' } }
+            ];
+
+            delete_objects_by_keys_stub.mockResolvedValue(deleted_objs);
+
+            alloc_next_n_object_version_seq_stub
+                .mockResolvedValue({
+                    start: 1,
+                    end: 3
+                });
+
+            const results = await object_server.delete_multiple_objects(mock_req);
+
+            expect(results).toHaveLength(3);
+
+            expect(results[0]).toHaveProperty('seq');
+            expect(results[1]).toHaveProperty('seq');
+            expect(results[2]).toHaveProperty('seq');
+
+            expect(delete_objects_by_keys_stub).toHaveBeenCalledTimes(1);
+        });
+
+        test('should handle duplicate keys in request', async () => {
+            const objects = [
+                { key: 'file1.txt' },
+                { key: 'file1.txt' },
+                { key: 'file2.txt' }
+            ];
+
+            mock_req.rpc_params.objects = objects;
+
+            const deleted_objs = [
+                { data: { key: 'file1.txt', _id: 'obj1' } },
+                { data: { key: 'file2.txt', _id: 'obj2' } }
+            ];
+
+            delete_objects_by_keys_stub.mockResolvedValue(deleted_objs);
+
+            alloc_next_n_object_version_seq_stub
+                .mockResolvedValue({
+                    start: 1,
+                    end: 3
+                });
+
+            const results = await object_server.delete_multiple_objects(mock_req);
+
+            expect(results).toHaveLength(3);
+
+            expect(results[0]).toHaveProperty('seq');
+            expect(results[1]).toHaveProperty('seq');
+            expect(results[2]).toHaveProperty('seq');
+        });
+
+        test('should filter out non-null version_id for non-versioned bucket', async () => {
+            const objects = [
+                { key: 'file1.txt', version_id: 'v123' },
+                { key: 'file2.txt' },
+                { key: 'file3.txt', version_id: CONSTANTS.S3.VERSION_NULL }
+            ];
+
+            mock_req.rpc_params.objects = objects;
+
+            const deleted_objs = [
+                { data: { key: 'file2.txt', _id: 'obj2' } },
+                { data: { key: 'file3.txt', _id: 'obj3' } }
+            ];
+
+            delete_objects_by_keys_stub.mockResolvedValue(deleted_objs);
+
+            alloc_next_n_object_version_seq_stub
+                .mockResolvedValue({
+                    start: 1,
+                    end: 2
+                });
+
+            alloc_object_version_seq_stub.mockResolvedValue(100);
+
+            const results = await object_server.delete_multiple_objects(mock_req);
+
+            expect(results).toHaveLength(3);
+
+            expect(results[0]).toHaveProperty('seq');
+            expect(results[1]).toHaveProperty('seq');
+            expect(results[2]).toHaveProperty('seq');
+        });
+
+        test('should handle objects not found in DB', async () => {
+            const objects = [
+                { key: 'file1.txt' },
+                { key: 'file2.txt' },
+                { key: 'file3.txt' }
+            ];
+
+            mock_req.rpc_params.objects = objects;
+
+            const deleted_objs = [
+                { data: { key: 'file1.txt', _id: 'obj1' } },
+                { data: { key: 'file3.txt', _id: 'obj3' } }
+            ];
+
+            delete_objects_by_keys_stub.mockResolvedValue(deleted_objs);
+
+            alloc_next_n_object_version_seq_stub
+                .mockResolvedValue({
+                    start: 1,
+                    end: 2
+                });
+
+            alloc_object_version_seq_stub.mockResolvedValue(100);
+
+            const results = await object_server.delete_multiple_objects(mock_req);
+
+            expect(results).toHaveLength(3);
+
+            expect(results[0]).toHaveProperty('seq');
+            expect(results[1]).toHaveProperty('seq');
+            expect(results[2]).toHaveProperty('seq');
+
+            expect(alloc_object_version_seq_stub).toHaveBeenCalledTimes(1);
+        });
+
+        test('should handle batch processing for large number of objects', async () => {
+            const batch_size =
+                config.DELETE_OBJECTS_BATCH_SIZE || 100;
+
+            const num_objects =
+                batch_size * 2 + 50;
+
+            const objects = Array.from(
+                { length: num_objects },
+                (_, i) => ({
+                    key: `file${i}.txt`
+                })
+            );
+
+            mock_req.rpc_params.objects = objects;
+
+            const deleted_objs = objects.map((obj, i) => ({
+                data: {
+                    key: obj.key,
+                    _id: `obj${i}`
+                }
+            }));
+
+            delete_objects_by_keys_stub
+                .mockResolvedValueOnce(
+                    deleted_objs.slice(0, batch_size)
+                )
+                .mockResolvedValueOnce(
+                    deleted_objs.slice(
+                        batch_size,
+                        batch_size * 2
+                    )
+                )
+                .mockResolvedValueOnce(
+                    deleted_objs.slice(batch_size * 2)
+                );
+
+            alloc_next_n_object_version_seq_stub
+                .mockResolvedValue({
+                    start: 1,
+                    end: num_objects
+                });
+
+            const results = await object_server.delete_multiple_objects(mock_req);
+
+            expect(results).toHaveLength(num_objects);
+
+            expect(delete_objects_by_keys_stub).toHaveBeenCalledTimes(3);
+        });
+
+        test('should handle errors during delete and return InternalError', async () => {
+            const objects = [
+                { key: 'file1.txt' },
+                { key: 'file2.txt' }
+            ];
+
+            mock_req.rpc_params.objects = objects;
+
+            delete_objects_by_keys_stub
+                .mockRejectedValue(
+                    new Error('Database connection failed')
+                );
+
+            const results = await object_server.delete_multiple_objects(mock_req);
+
+            expect(results).toHaveLength(2);
+
+            expect(results[0]).toHaveProperty(
+                'err_code',
+                'InternalError'
+            );
+
+            expect(results[0]).toHaveProperty(
+                'err_message',
+                'Database connection failed'
+            );
+
+            expect(results[1]).toHaveProperty(
+                'err_code',
+                'InternalError'
+            );
+        });
+
+        test('should handle empty objects array', async () => {
+            mock_req.rpc_params.objects = [];
+
+            const results =
+                await object_server.delete_multiple_objects(mock_req);
+
+            expect(results).toHaveLength(0);
+
+            expect(delete_objects_by_keys_stub).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe('object_server - update_bulk_delete_results', () => {
+
+    let mdstore_instance_stub;
+    let alloc_next_n_object_version_seq_stub;
+    let alloc_object_version_seq_stub;
+
+    beforeEach(() => {
+        mdstore_instance_stub = {
+            alloc_next_n_object_version_seq: jest.fn(),
+            alloc_object_version_seq: jest.fn(),
+            get_object_version_id: jest.fn()
+                .mockReturnValue('v123')
+        };
+
+        jest.spyOn(MDStore, 'instance')
+            .mockReturnValue(mdstore_instance_stub);
+
+        jest.spyOn(system_utils, 'system_in_maintenance')
+            .mockReturnValue(false);
+
+        alloc_next_n_object_version_seq_stub = mdstore_instance_stub.alloc_next_n_object_version_seq;
+
+        alloc_object_version_seq_stub = mdstore_instance_stub.alloc_object_version_seq;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('should update results with sequential version numbers', async () => {
+
+        const objects = [
+            { data: { key: 'file1.txt', _id: 'obj1' } },
+            { data: { key: 'file2.txt', _id: 'obj2' } },
+            { data: { key: 'file3.txt', _id: 'obj3' } }
+        ];
+
+        const object_index_map = {
+            'file1.txt': [0],
+            'file2.txt': [1],
+            'file3.txt': [2]
+        };
+
+        const results = new Array(3);
+
+        alloc_next_n_object_version_seq_stub
+            .mockResolvedValue({
+                start: 100,
+                end: 102
+            });
+
+        await object_server.__testing
+            .update_bulk_delete_results(
+                objects,
+                object_index_map,
+                results,
+                3
+            );
+
+        expect(results[0]).toHaveProperty('seq', 100);
+
+        expect(results[0])
+            .toHaveProperty(
+                'deleted_version_id',
+                'v123'
+            );
+
+        expect(results[1]).toHaveProperty('seq', 101);
+
+        expect(results[2]).toHaveProperty('seq', 102);
+
+        expect(alloc_next_n_object_version_seq_stub).toHaveBeenCalledTimes(1);
+
+        expect(alloc_next_n_object_version_seq_stub).toHaveBeenCalledWith(3);
+    });
+
+    test('should handle duplicate keys with multiple indices', async () => {
+        const objects = [
+            { data: { key: 'file1.txt', _id: 'obj1' } }
+        ];
+
+        const object_index_map = {
+            'file1.txt': [0, 1, 2]
+        };
+
+        const results = new Array(3);
+
+        alloc_next_n_object_version_seq_stub
+            .mockResolvedValue({
+                start: 100,
+                end: 102
+            });
+
+        await object_server.__testing
+            .update_bulk_delete_results(
+                objects,
+                object_index_map,
+                results,
+                3
+            );
+
+        expect(results[0]).toHaveProperty('seq', 100);
+
+        expect(results[1]).toHaveProperty('seq', 101);
+
+        expect(results[2]).toHaveProperty('seq', 102);
+
+        expect(results[0])
+            .toHaveProperty(
+                'deleted_version_id',
+                'v123'
+            );
+
+        expect(results[1])
+            .toHaveProperty(
+                'deleted_version_id',
+                'v123'
+            );
+
+        expect(results[2])
+            .toHaveProperty(
+                'deleted_version_id',
+                'v123'
+            );
+    });
+
+    test('should allocate individual seq when exceeding allocated range', async () => {
+        const objects = [
+            { data: { key: 'file1.txt', _id: 'obj1' } },
+            { data: { key: 'file2.txt', _id: 'obj2' } }
+        ];
+
+        const object_index_map = {
+            'file1.txt': [0],
+            'file2.txt': [1]
+        };
+
+        const results = new Array(2);
+
+        alloc_next_n_object_version_seq_stub
+            .mockResolvedValue({
+                start: 100,
+                end: 100
+            });
+
+        alloc_object_version_seq_stub.mockResolvedValue(200);
+
+        await object_server.__testing
+            .update_bulk_delete_results(
+                objects,
+                object_index_map,
+                results,
+                2
+            );
+
+        expect(results[0]).toHaveProperty('seq', 100);
+
+        expect(results[1]).toHaveProperty('seq', 200);
+
+        expect(alloc_object_version_seq_stub).toHaveBeenCalledTimes(1);
+    });
+
+    test('should handle empty objects array', async () => {
+        await object_server.__testing
+            .update_bulk_delete_results(
+                [],
+                {},
+                [],
+                0
+            );
+
+        expect(alloc_next_n_object_version_seq_stub).not.toHaveBeenCalled();
+
+        expect(alloc_object_version_seq_stub).not.toHaveBeenCalled();
+    });
+
+    test('should handle objects with delete_marker flag', async () => {
+        const objects = [
+            {
+                data: {
+                    key: 'file1.txt',
+                    _id: 'obj1',
+                    delete_marker: true
+                }
+            }
+        ];
+
+        const object_index_map = {
+            'file1.txt': [0]
+        };
+
+        const results = new Array(1);
+
+        alloc_next_n_object_version_seq_stub
+            .mockResolvedValue({
+                start: 100,
+                end: 100
+            });
+
+        await object_server.__testing
+            .update_bulk_delete_results(
+                objects,
+                object_index_map,
+                results,
+                1
+            );
+
+        expect(results[0]).toHaveProperty('seq', 100);
+
+        expect(results[0])
+            .toHaveProperty(
+                'deleted_delete_marker',
+                true
+            );
+    });
+
+    test('should process multiple objects with mixed indices', async () => {
+        const objects = [
+            { data: { key: 'file1.txt', _id: 'obj1' } },
+            { data: { key: 'file2.txt', _id: 'obj2' } }
+        ];
+
+        const object_index_map = {
+            'file1.txt': [0, 2],
+            'file2.txt': [1, 3]
+        };
+
+        const results = new Array(4);
+
+        alloc_next_n_object_version_seq_stub
+            .mockResolvedValue({
+                start: 100,
+                end: 103
+            });
+
+        await object_server.__testing
+            .update_bulk_delete_results(
+                objects,
+                object_index_map,
+                results,
+                4
+            );
+
+        expect(results[0]).toHaveProperty('seq', 100);
+
+        expect(results[1]).toHaveProperty('seq', 102);
+
+        expect(results[2]).toHaveProperty('seq', 101);
+
+        expect(results[3]).toHaveProperty('seq', 103);
+    });
+});

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -610,6 +610,37 @@ class PostgresSequence {
         const res = await _do_query(this.get_pool(), q, 0);
         return Number.parseInt(res.rows[0].nextval, 10);
     }
+
+    async nextNsequences(n) {
+        if (n <= 0) {
+            return { start: 0, end: 0 };
+        }
+
+        if (this.init_promise) await this.init_promise;
+        const conn_pool = await this.get_pool();
+
+        try {
+            await _do_query(conn_pool, { text: 'BEGIN' }, 0);
+            const query =
+                `WITH vals AS (
+                SELECT nextval('${this.seqname()}') AS val
+                FROM generate_series(1, ${n})
+            )
+            SELECT min(val) AS start, max(val) AS end
+            FROM vals;`;
+            const res = await _do_query(conn_pool, { text: query }, 0);
+            await _do_query(conn_pool, { text: 'COMMIT' }, 0);
+
+            return {
+                start: Number.parseInt(res.rows[0].start, 10),
+                end: Number.parseInt(res.rows[0].end, 10)
+            };
+        } catch (e) {
+            dbg.error("error allocating sequences", e);
+            await _do_query(conn_pool, { text: 'ROLLBACK' }, 0);
+            return { start: 0, end: 0 };
+        }
+    }
 }
 
 // TODO: Hint for the index is ignored


### PR DESCRIPTION
### Describe the Problem
### Note: Applicable for buckets with versioning disabled only
1. S3 delete-objects issues separate DB calls to fetch each object_md from postgres for each object. This is performed in a `Promise.all` block, so we would have high number of concurrent calls to the DB (max objects allowed in request is 1000) which will choke the DB pool and excert a high load on the DB. 

2. We generate sequence numbers for each object in the request (irrespective of the object deletion status), so this also adds another DB call per object.

### Explain the Changes
1. Update the objects in a single transaction. Filter out keys with versions specified other than `null` before issuing the update.
2. Allocate the required number of version sequence numbers in a single query using CTE per group by keeping track of object count.
3. Remove `check_md_conditions` as the request structure doesn't support it here: [`src/api/object_api.js`](https://github.com/noobaa/noobaa-core/blob/69d5a2185409f3061a5869b4186c0d2300806d0b/src/api/object_api.js#L651)

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8750
6. https://redhat.atlassian.net/browse/DFBUGS-5182

### Testing Instructions:

Note:
Optimizing the DB update to object_md (soft delete) was already done as part of this PR: #9389 which is now outdated.


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced bulk delete with per-item version validation, per-item sequencing, and idempotent replies.
  * Ability to reserve contiguous sequence ranges for object/version IDs.
  * New canonical "null" version value and configurable bulk-delete batch size.
  * Bulk delete by keys for faster multi-object removals.

* **Refactor**
  * Consolidated delete and bulk-update flows for more consistent ordering and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->