### PR TITLE
enable dedup indexer

### DIFF
--- a/config.js
+++ b/config.js
@@ -457,11 +457,13 @@ config.CHUNK_CODER_EC_IS_DEFAULT = false;
 
 // DEDUP
 config.MIN_CHUNK_AGE_FOR_DEDUP = 60 * 60 * 1000; // 1 hour
+// Minimum chunk size in bytes to perform a dedup lookup. 0 means no threshold (lookup always runs).
+config.DEDUP_MIN_CHUNK_SIZE_FOR_DEDUP = 0;
 
 //////////////////////////
 // DEDUP INDEXER CONFIG //
 //////////////////////////
-config.DEDUP_INDEXER_ENABLED = false;
+config.DEDUP_INDEXER_ENABLED = true;
 config.DEDUP_INDEXER_BATCH_SIZE = 200;
 config.DEDUP_INDEXER_BATCH_DELAY = 1000;
 config.DEDUP_INDEXER_ERROR_DELAY = 10 * 1000;

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -85,7 +85,10 @@ class GetMapping {
         if (!config.DEDUP_ENABLED) return;
         await Promise.all(Object.values(this.chunks_per_bucket).map(async chunks => {
             const bucket = chunks[0].bucket;
-            const dedup_keys = chunks.map(chunk => chunk.digest_b64).filter(Boolean);
+            const dedup_keys = chunks
+                .filter(chunk => !config.DEDUP_MIN_CHUNK_SIZE_FOR_DEDUP || chunk.size >= config.DEDUP_MIN_CHUNK_SIZE_FOR_DEDUP)
+                .map(chunk => chunk.digest_b64)
+                .filter(Boolean);
 
             if (!dedup_keys.length) return;
             dbg.log0('GetMapping.find_dups: found keys', dedup_keys.length);

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2210]*/
+/*eslint max-lines: ["error", 2230]*/
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -1804,24 +1804,31 @@ class MDStore {
             .then(([total_count, sample_count]) => (sample_count ? sample_count : total_count));
     }
 
-    iterate_indexed_chunks(limit, marker) {
-        return this._chunks.find({
-                dedup_key: marker ? { $lt: marker, $exists: true } : { $exists: true }
-            }, {
-                projection: {
-                    _id: 1,
-                    dedup_key: 1
-                },
-                sort: {
-                    dedup_key: -1
-                },
-                limit: limit,
-            })
-
-            .then(chunks => ({
-                chunk_ids: db_client.instance().uniq_ids(chunks, '_id'),
-                marker: chunks.length ? chunks[chunks.length - 1].dedup_key : null,
-            }));
+    /**
+     * @param {number} limit - Max number of chunks to return per page
+     * @param {string|null} marker - Last dedup_key from the previous page, or null to start from the beginning
+     * @returns {Promise<{ chunk_ids: nb.ID[], marker: string|null }>}
+     */
+    async iterate_indexed_chunks(limit, marker) {
+        const marker_clause = marker ? `AND data->>'dedup_key' < $1` : '';
+        const limit_param = marker ? '$2' : '$1';
+        const query = `SELECT _id, data->>'dedup_key' AS dedup_key
+             FROM ${this._chunks.name}
+             WHERE data ? 'dedup_key'
+             ${marker_clause}
+             ORDER BY data->>'dedup_key' DESC
+             LIMIT ${limit_param}`;
+        const values = marker ? [marker, limit] : [limit];
+        try {
+            const res = await db_client.instance().executeSQL(query, values);
+            return {
+                chunk_ids: res.rows.map(row => db_client.instance().parse_object_id(row._id)),
+                marker: (res.rows.length >= limit) ? res.rows[res.rows.length - 1].dedup_key : null,
+            };
+        } catch (err) {
+            dbg.error('iterate_indexed_chunks: failed', err);
+            throw err;
+        }
     }
 
     find_deleted_chunks(max_delete_time, limit) {

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -661,17 +661,188 @@ mocha.describe('md_store', function() {
     });
 
     mocha.describe('dedup-index', function() {
-        mocha.it('get_dedup_index_size()', async function() {
+
+        mocha.it('get_dedup_index_size() returns without throwing', async function() {
             return md_store.get_dedup_index_size();
         });
 
-        mocha.it('get_aprox_dedup_keys_number()', async function() {
-            return md_store.get_aprox_dedup_keys_number();
+        mocha.it('get_aprox_dedup_keys_number() returns a non-negative number', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const count = await md_store.get_aprox_dedup_keys_number();
+            assert(typeof count === 'number' && count >= 0, `expected non-negative number, got ${count}`);
         });
 
-        mocha.it('iterate_indexed_chunks()', async function() {
-            return md_store.iterate_indexed_chunks(5);
+        mocha.it('iterate_indexed_chunks() skips chunks without dedup_key (count check)', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const isolated_store = new MDStore(`_test_dedup_count_${Date.now().toString(36)}`);
+            const sys = isolated_store.make_md_id();
+            // Insert 2 chunks: one with dedup_key and one without
+            await isolated_store.insert_chunks([
+                { _id: isolated_store.make_md_id(), system: sys, size: 10, frag_size: 10, dedup_key: Buffer.from('count_test_key') },
+                { _id: isolated_store.make_md_id(), system: sys, size: 10, frag_size: 10 },
+            ]);
+            // The function uses Postgres table-stat estimates which may return 0 for a brand-new table
+            // (reltuples is only updated by ANALYZE).  Just verify it doesn't throw and returns a number.
+            const count = await isolated_store.get_aprox_dedup_keys_number();
+            assert(typeof count === 'number' && count >= 0, `expected non-negative number, got ${count}`);
+            // More importantly: iterate_indexed_chunks must find only the chunk that has a dedup_key
+            const res = await isolated_store.iterate_indexed_chunks(10, null);
+            assert.strictEqual(res.chunk_ids.length, 1, 'only the chunk with dedup_key should be indexed');
         });
+
+        mocha.it('iterate_indexed_chunks() returns empty when no dedup_key chunks exist', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const isolated_store = new MDStore(`_test_dedup_empty_${Date.now().toString(36)}`);
+            const sys = isolated_store.make_md_id();
+            // Insert a chunk WITHOUT dedup_key to create the table, then verify iteration returns nothing
+            await isolated_store.insert_chunks([{
+                _id: isolated_store.make_md_id(),
+                system: sys,
+                size: 10,
+                frag_size: 10,
+            }]);
+            const res = await isolated_store.iterate_indexed_chunks(10, null);
+            assert.strictEqual(res.chunk_ids.length, 0);
+            assert.strictEqual(res.marker, null);
+        });
+
+        mocha.it('iterate_indexed_chunks() returns only chunks that have a dedup_key set', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const isolated_store = new MDStore(`_test_dedup_filter_${Date.now().toString(36)}`);
+            const sys = isolated_store.make_md_id();
+            const with_key = {
+                _id: isolated_store.make_md_id(),
+                system: sys,
+                size: 10,
+                frag_size: 10,
+                dedup_key: Buffer.from('dedup_filter_key'),
+            };
+            const without_key = {
+                _id: isolated_store.make_md_id(),
+                system: sys,
+                size: 10,
+                frag_size: 10,
+            };
+            await isolated_store.insert_chunks([with_key, without_key]);
+            const res = await isolated_store.iterate_indexed_chunks(100, null);
+            assert.strictEqual(res.chunk_ids.length, 1);
+            assert.strictEqual(res.chunk_ids[0].toString(), with_key._id.toString());
+        });
+
+        mocha.it('iterate_indexed_chunks() returns IDs as proper ObjectIDs with getTimestamp()', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const isolated_store = new MDStore(`_test_dedup_objid_${Date.now().toString(36)}`);
+            const sys = isolated_store.make_md_id();
+            const chunk = {
+                _id: isolated_store.make_md_id(),
+                system: sys,
+                size: 10,
+                frag_size: 10,
+                dedup_key: Buffer.from('objid_test_key'),
+            };
+            await isolated_store.insert_chunks([chunk]);
+            const res = await isolated_store.iterate_indexed_chunks(10, null);
+            assert.strictEqual(res.chunk_ids.length, 1);
+            const id = res.chunk_ids[0];
+            assert(typeof id.getTimestamp === 'function', 'expected returned ID to be a MongoDB ObjectID with getTimestamp()');
+            const ts = id.getTimestamp();
+            assert(ts instanceof Date, 'expected getTimestamp() to return a Date');
+        });
+
+        mocha.it('iterate_indexed_chunks() returns chunks in descending dedup_key order', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const isolated_store = new MDStore(`_test_dedup_order_${Date.now().toString(36)}`);
+            const sys = isolated_store.make_md_id();
+            // 'key_1'→a2V5XzE=, 'key_2'→a2V5XzI=, 'key_3'→a2V5XzM= — ascending in base64 text order
+            const key_low = Buffer.from('key_1');
+            const key_mid = Buffer.from('key_2');
+            const key_high = Buffer.from('key_3');
+            await isolated_store.insert_chunks([
+                { _id: isolated_store.make_md_id(), system: sys, size: 10, frag_size: 10, dedup_key: key_low },
+                { _id: isolated_store.make_md_id(), system: sys, size: 10, frag_size: 10, dedup_key: key_mid },
+                { _id: isolated_store.make_md_id(), system: sys, size: 10, frag_size: 10, dedup_key: key_high },
+            ]);
+            // Fetch one chunk at a time and verify descending order via the marker
+            const first = await isolated_store.iterate_indexed_chunks(1, null);
+            assert.strictEqual(first.chunk_ids.length, 1);
+            assert.strictEqual(first.marker, key_high.toString('base64'), 'first result should be the highest key');
+
+            const second = await isolated_store.iterate_indexed_chunks(1, first.marker);
+            assert.strictEqual(second.chunk_ids.length, 1);
+            assert.strictEqual(second.marker, key_mid.toString('base64'), 'second result should be the middle key');
+
+            const third = await isolated_store.iterate_indexed_chunks(1, second.marker);
+            assert.strictEqual(third.chunk_ids.length, 1);
+            // limit=1 with 1 row → rows.length >= limit → non-null marker pointing at the lowest key
+            assert.strictEqual(third.marker, key_low.toString('base64'), 'third result should be the lowest key');
+
+            const done = await isolated_store.iterate_indexed_chunks(1, third.marker);
+            assert.strictEqual(done.chunk_ids.length, 0);
+            assert.strictEqual(done.marker, null, 'after exhausting all chunks the marker should be null');
+        });
+
+        mocha.it('iterate_indexed_chunks() respects the limit parameter', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const isolated_store = new MDStore(`_test_dedup_limit_${Date.now().toString(36)}`);
+            const sys = isolated_store.make_md_id();
+            const chunks = ['key_a', 'key_b', 'key_c', 'key_d', 'key_e'].map(k => ({
+                _id: isolated_store.make_md_id(),
+                system: sys,
+                size: 10,
+                frag_size: 10,
+                dedup_key: Buffer.from(k),
+            }));
+            await isolated_store.insert_chunks(chunks);
+            const res = await isolated_store.iterate_indexed_chunks(3, null);
+            assert.strictEqual(res.chunk_ids.length, 3);
+            assert(res.marker !== null, 'expected a non-null marker when more results exist');
+        });
+
+        mocha.it('iterate_indexed_chunks() paginates correctly through all chunks using marker', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const isolated_store = new MDStore(`_test_dedup_page_${Date.now().toString(36)}`);
+            const sys = isolated_store.make_md_id();
+            const total = 5;
+            const chunks = Array.from({ length: total }, (_unused, i) => ({
+                _id: isolated_store.make_md_id(),
+                system: sys,
+                size: 10,
+                frag_size: 10,
+                dedup_key: Buffer.from(`page_key_${String(i).padStart(3, '0')}`),
+            }));
+            await isolated_store.insert_chunks(chunks);
+
+            const collected_ids = [];
+            let marker = null;
+            do {
+                const res = await isolated_store.iterate_indexed_chunks(2, marker);
+                collected_ids.push(...res.chunk_ids.map(id => id.toString()));
+                marker = res.marker;
+            } while (marker !== null);
+
+            assert.strictEqual(collected_ids.length, total, `expected ${total} total chunks across all pages`);
+            // no duplicates
+            assert.strictEqual(new Set(collected_ids).size, total, 'expected no duplicate IDs across pages');
+        });
+
+        mocha.it('iterate_indexed_chunks() returns null marker on final page', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const isolated_store = new MDStore(`_test_dedup_final_${Date.now().toString(36)}`);
+            const sys = isolated_store.make_md_id();
+            const chunk = {
+                _id: isolated_store.make_md_id(),
+                system: sys,
+                size: 10,
+                frag_size: 10,
+                dedup_key: Buffer.from('only_one_key'),
+            };
+            await isolated_store.insert_chunks([chunk]);
+            // limit=10 with only 1 chunk → final page
+            const res = await isolated_store.iterate_indexed_chunks(10, null);
+            assert.strictEqual(res.chunk_ids.length, 1);
+            assert.strictEqual(res.marker, null, 'expected null marker on the final page');
+        });
+
     });
 
 });


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deduplication indexer is now enabled by default, improving chunk deduplication performance automatically.
  * Added configurable minimum chunk size threshold for deduplication processing, enabling control over filtering behavior.

* **Chores**
  * Optimized database backend operations for indexed chunk pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->