### PR TITLE
Added a fix to resolve destination bucket name for replication target unreachable metrics

### DIFF
--- a/src/server/bg_services/log_replication_scanner.js
+++ b/src/server/bg_services/log_replication_scanner.js
@@ -89,7 +89,8 @@ class LogReplicationScanner {
                 const total = Object.keys(candidates.items).length;
                 if (!dst_bucket) {
                     dbg.error('log_replication_scanner: destination_bucket not found:', rule.destination_bucket, 'for replication_id:', replication_id);
-                    replication_utils.update_replication_target_status(src_bucket.name, String(rule.destination_bucket), false);
+                    const dst_bucket_name = await replication_utils.resolve_destination_bucket_name(rule.destination_bucket);
+                    replication_utils.update_replication_target_status(src_bucket.name, dst_bucket_name, false);
                     replication_utils.update_replication_prom_report(src_bucket.name, replication_id, {}, {
                         bucket_last_cycle_total_objects_num: total,
                         bucket_last_cycle_replicated_objects_num: 0,

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -70,9 +70,10 @@ class ReplicationScanner {
             const { src_bucket, dst_bucket } = replication_utils.find_src_and_dst_buckets(rule.destination_bucket, replication_id);
             if (!src_bucket || !dst_bucket) {
                 dbg.error('replication_scanner: can not find src_bucket or dst_bucket object', src_bucket, dst_bucket);
-                // mark target bucket as unreachable (uses bucket id since bucket was deleted/not found)
+                // mark target bucket as unreachable (resolve display name from id while bucket row still exists)
                 if (src_bucket && !dst_bucket) {
-                    replication_utils.update_replication_target_status(src_bucket.name, String(rule.destination_bucket), false);
+                    const dst_bucket_name = await replication_utils.resolve_destination_bucket_name(rule.destination_bucket);
+                    replication_utils.update_replication_target_status(src_bucket.name, dst_bucket_name, false);
                     replication_utils.report_failed_replication_cycle(src_bucket.name, replication_id,
                         rule.rule_id, _.get(src_bucket, 'storage_stats.objects_count', 0));
                 }

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -113,6 +113,38 @@ function update_replication_target_status(source_bucket, target_bucket, is_reach
     core_report.set_replication_target_status(src_name, dst_name, is_reachable);
 }
 
+// remove the `-deleting-<timestamp>` suffix noobaa appends while a bucket is being deleted
+function strip_deleting_bucket_suffix(name) {
+    const s = name instanceof SensitiveString ? name.unwrap() : name;
+    if (!s) return '';
+    const m = String(s).match(/^(.*)-deleting-\d+$/);
+    return m ? m[1] : String(s);
+}
+
+// turn a bucket document into a plain string name suitable for metrics labels (unwrap + deleting rename)
+function bucket_name_for_metrics(bucket) {
+    if (!bucket?.name) return '';
+    if (bucket.deleting) return strip_deleting_bucket_suffix(bucket.name);
+    return bucket.name instanceof SensitiveString ? bucket.name.unwrap() : String(bucket.name);
+}
+
+// resolve a destination bucket id to a display name via system_store, then soft-deleted db rows
+async function resolve_destination_bucket_name(dst_bucket_id) {
+    const id = dst_bucket_id?.valueOf ? dst_bucket_id.valueOf() : dst_bucket_id;
+    try {
+        const bucket = system_store.data.get_by_id(id);
+        if (bucket?.name) return bucket_name_for_metrics(bucket);
+
+        const res = await system_store.data.get_by_id_include_deleted(id, 'buckets');
+        if (res?.record?.name) return bucket_name_for_metrics(res.record);
+        dbg.warn('resolve_destination_bucket_name: bucket not found for id:', id);
+    } catch (err) {
+        dbg.warn('resolve_destination_bucket_name failed:', id, err);
+    }
+    // worst-case: no row for this id (stale ref, e.g. bucket removed and recreated with a new _id); labels still need a non-empty string
+    return String(id);
+}
+
 /**
  * @param {any} bucket_name
  * @param {string} key
@@ -228,6 +260,7 @@ exports.get_rule_and_bucket_status = get_rule_and_bucket_status;
 exports.update_replication_prom_report = update_replication_prom_report;
 exports.report_failed_replication_cycle = report_failed_replication_cycle;
 exports.update_replication_target_status = update_replication_target_status;
+exports.resolve_destination_bucket_name = resolve_destination_bucket_name;
 exports.get_object_md = get_object_md;
 exports.find_src_and_dst_buckets = find_src_and_dst_buckets;
 exports.get_copy_type = get_copy_type;


### PR DESCRIPTION
### Describe the Problem
Replication rules store destination_bucket as an internal bucket `ObjectId`. Scanners normally resolve this to `dst_bucket.name`, but when the destination bucket isn’t visible in `system_store` bucket list (often during deletion/reclaim), the code fell back to `String(rule.destination_bucket)`. That prints the ObjectId hex, so `replication_target_status / NooBaaReplicationTargetUnreachable` showed `target_bucket` as a hash-like id instead of the configured bucket name, making alerts hard to act on.

### Explain the Changes
1. Added `resolve_destination_bucket_name()` to map the destination id to a human-readable name via `get_by_id / get_by_id_include_deleted`, and strip transient `*-deleting-<ts>` suffixes when present.
2. Updated `replication_scanner.js` and `log_replication_scanner.js` to use it in the missing destination bucket path instead of stringifying the ObjectId.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: https://redhat.atlassian.net/browse/DFBUGS-6380

### Testing Instructions:
1.  Create two obc and set bucket replication, then copy some objects to src bucket.
2.  Check if replication is working fine, then delete the destination obc.
3.  Verify if the destination bucket is printed as bucket name instead of hash id using below steps in prometheus dashboard for local installation.

`prometheus dashboard flow:

0) Prereqs: kubectl and helm work against your cluster. Set once:
export NS=default

1) Add Helm repo
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm repo update

2) Install or upgrade kube-prometheus-stack (match NooBaa labels):
helm upgrade prometheus prometheus-community/kube-prometheus-stack --install --namespace $NS --create-namespace --set prometheus.prometheusSpec.serviceMonitorSelector.matchLabels.app=noobaa --set prometheus.prometheusSpec.ruleSelector.matchLabels.prometheus=k8s --set prometheus.prometheusSpec.ruleSelector.matchLabels.role=alert-rules

Check it applied:
helm -n $NS get values prometheus
kubectl -n $NS get prometheus -o yaml | grep -A30 serviceMonitorSelector

3) Fix TLS on NooBaa ServiceMonitors (minimal tlsConfig)
Replace tlsConfig so there is no caFile, no ca: {}, no cert: {} — only skip-verify and SNI:

kubectl -n "$NS" patch servicemonitor noobaa-mgmt-service-monitor --type=json -p='[
  {"op":"replace","path":"/spec/endpoints/0/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}},
  {"op":"replace","path":"/spec/endpoints/1/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}},
  {"op":"replace","path":"/spec/endpoints/2/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}}
]'
kubectl -n "$NS" patch servicemonitor s3-service-monitor --type=json -p='[
  {"op":"replace","path":"/spec/endpoints/0/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"s3.'"$NS"'.svc"}}
]'

4) Verify scraping and metrics
POD=$(kubectl -n $NS get pods -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090/api/v1/query?query=up%7Bjob%3D%22s3%22%7D'
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090/api/v1/query?query=up%7Bjob%3D%22noobaa-mgmt%22%7D'
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090//api/v1/query?query=NooBaa_num_buckets'

5) Prometheus UI port-forward
kubectl port-forward -n $NS pod/prometheus-prometheus-kube-prometheus-prometheus-0 9090:9090
Open http://127.0.0.1:9090 — Graph, Status → Targets, Alerts, Rules.

6) What to expect (so you’re not surprised)
Core system metrics (NooBaa_num_buckets, etc.) usually show under job=noobaa-mgmt.
Endpoint metrics (NooBaa_Endpoint_*) show under job=s3 on :9443.
Replication metrics only appear after replication is configured and scanners update them.`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replication reports now resolve and display destination bucket names instead of raw IDs.
  * Display names are normalized for deleted/terminating buckets so metrics and statuses are clearer.
  * Failure and target-status reports include resolved bucket display names for improved diagnostics and reporting consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->