### PR TITLE
Add error handler to the Azure stream to catch AbortError update if

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -248,13 +248,13 @@ class NamespaceBlob {
                     this.container,
                     inspect(_.omit(params, 'object_md.ns')),
                     'callback res');
+                if (!res.readableStreamBody) throw new Error('NamespaceBlob.read_object_stream: download response is invalid');
                 // Add error handler to the Azure stream to catch AbortError
-                res.readableStreamBody?.on('error', stream_err => {
+                res.readableStreamBody.on('error', stream_err => {
                     dbg.error('NamespaceBlob.read_object_stream: Azure stream error:', stream_err.name, stream_err.message);
                     // Destroy count_stream with error - properly cleans up and propagates error
                     count_stream.destroy(stream_err);
                 });
-                if (!res.readableStreamBody) throw new Error('NamespaceBlob.read_object_stream: download response is invalid');
                 return resolve(res.readableStreamBody.pipe(count_stream));
             }).catch(err => {
                     this._translate_error_code(err);


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1.  Add error handler to the Azure stream to catch AbortError update if

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blob stream handling by validating stream availability earlier in the process, enabling faster error detection when stream data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->