### PR TITLE
Avoid object stats updates on read for a single tier

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -705,15 +705,22 @@ async function read_object_mapping(req) {
     const chunks = await map_reader.read_object_mapping(obj, start, end, location_info);
     const object_md = get_object_info(obj);
 
-    // update the object read stats and the chunks hit date
-    const date_now = new Date();
-    MDStore.instance().update_object_by_id(
-        obj._id, { 'stats.last_read': date_now },
-        undefined, { 'stats.reads': 1 }
-    );
-    MDStore.instance().update_chunks_by_ids(
-        chunks.map(chunk => chunk._id), { tier_lru: date_now }
-    );
+
+    // only update the object read stats if the bucket has more than one tier
+    if ((req.bucket.tiering?.tiers?.length || 0) > 1) {
+        // update the object read stats and the chunks hit date
+        // TODO: coalesce multiple updates into a single operation to reduce the number of DB updates
+        const date_now = new Date();
+        Promise.all([
+            MDStore.instance().update_object_by_id(
+                obj._id, { 'stats.last_read': date_now },
+                undefined, { 'stats.reads': 1 }
+            ),
+            MDStore.instance().update_chunks_by_ids(
+                chunks.map(chunk => chunk._id), { tier_lru: date_now }
+            ),
+        ]).catch(err => dbg.error('read_object_mapping: error updating object read stats and chunks tier_lru. bucket=', req.bucket.name, 'key=', obj.key, 'obj_id=', obj._id, 'err=', err));
+    }
 
     return {
         object_md,


### PR DESCRIPTION
### Describe the Problem
The tier_lru is used only for the tiering bg workers and is used when there is more than one tier. Performing these updates on every read increases the load and WAL pressure on the DB.


### Explain the Changes
- For now, perform these updates only if the bucket policy has more than one tier.
- In the future, we should consider coalescing these updates into a single transaction to reduce the load for tiering use cases.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8851

### Testing Instructions:
1. Can be checked by inspecting the DB. 
2. After reading an object, in psql, look for the objectmd and related chunks, and make sure the `stats` and `tier_lru` are not updated.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced unnecessary read-tracking for buckets with a single storage tier; for multi-tier buckets, read timestamps/counts and chunk access timestamps are still recorded, now updated concurrently to improve efficiency, with failures logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->