### PR TITLE
rdma fix the localAddress to ipv4 by unwrapping (::ffff:ipv4) + 2 small tool fixes

### DIFF
--- a/src/deploy/elbencho-rdma-build.sh
+++ b/src/deploy/elbencho-rdma-build.sh
@@ -92,8 +92,9 @@ fi
     git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git aws-sdk-cpp-rdma
     cd aws-sdk-cpp-rdma
 
-    # echo "Switching to tag v1.11.718 ..."
-    # git checkout 1.11.718
+    echo "Switching to tag v1.11.794 ..."
+    git checkout 1.11.794
+    # git checkout 1.11.718  ## this was the last tested version
 
     # Replacing crt libs with aws-c-s3-rdma versions ...
     cd crt/aws-crt-cpp/crt

--- a/src/tools/s3perf.js
+++ b/src/tools/s3perf.js
@@ -106,9 +106,21 @@ http.globalAgent.keepAlive = true;
 // @ts-ignore
 https.globalAgent.keepAlive = true;
 
+/** @typedef {import("@smithy/types").EndpointV2} EndpointV2 */
+/** @type {EndpointV2[]} */
+const endpoints = (argv.endpoint?.split(',') || []).map(s => ({ url: new URL(s) }));
+let endpoints_round_robin = 0;
+
+/** @returns {Promise<EndpointV2>} */
+async function endpoint_provider() {
+    const ep = endpoints[endpoints_round_robin];
+    endpoints_round_robin = (endpoints_round_robin + 1) % endpoints.length;
+    return ep;
+}
+
 /** @type {import('@aws-sdk/client-s3').S3ClientConfig} */
 const s3_config = {
-    endpoint: argv.endpoint,
+    endpoint: argv.endpoint && endpoint_provider,
     region: argv.region || 'us-east-1',
     forcePathStyle: true,
     credentials: (argv.access_key && argv.secret_key) ? {
@@ -495,10 +507,11 @@ Upload Flags:
   --part_concur <num>   multipart concurrency
   --exact_key <key>     use this key for all operations
 General S3 Flags:
-  --endpoint <host>     (default is localhost)
-  --access_key <key>    (default is env.AWS_ACCESS_KEY_ID || 123)
-  --secret_key <key>    (default is env.AWS_SECRET_ACCESS_KEY || abc)
-  --bucket <name>       (default is "first.bucket")
+  --endpoint <url,...>  (default is env.AWS_ENDPOINT_URL,
+                        use comma to use multiple endpoints with round robin)
+  --access_key <key>    (default is env.AWS_ACCESS_KEY_ID)
+  --secret_key <key>    (default is env.AWS_SECRET_ACCESS_KEY)
+  --bucket <name>
   --prefix <prefix>     (default is s3perf/<size><size_units>)
   --checksum            (default is false) Calculate checksums on data. slower.
   --verbose             (default is false) Print more info.

--- a/src/util/rdma_utils.js
+++ b/src/util/rdma_utils.js
@@ -3,6 +3,7 @@
 
 const dbg = require('./debug_module')(__filename);
 const config = require('../../config');
+const net_utils = require('./net_utils');
 const http_utils = require('./http_utils');
 const nb_native = require('./nb_native');
 const { S3 } = require('@aws-sdk/client-s3');
@@ -88,7 +89,7 @@ function parse_rdma_info(req) {
         const rdma_info = parse_cuobj_token(rdma_token);
         // save the server RDMA interface ip which received the request, 
         // for choosing routing in multi interface setup with separated fabrics
-        rdma_info.ip = req.socket?.localAddress || '';
+        rdma_info.ip = net_utils.unwrap_ipv6(req.socket?.localAddress || '');
         return rdma_info;
     }
 


### PR DESCRIPTION
### Describe the Problem
When `config.S3_RDMA_SERVER_IPS` is empty, we use the localAddress of the S3 request for the server RDMA IP. However, this IP might be ipv6 wrapped - `::ffff:ipv4` which we need to unwrap to be used for RDMA server IP.


### Explain the Changes
1. unwrap the localAddress of the request to be able to use it in this case that the config is not provided.
2. s3perf - add option to specify multiple endpoints with round robin (comma separated).
3. small fix for the elbencho rmda build flow.


### Issues: Fixed #xxx / Gap #xxx
1. NA

### Testing Instructions:
1. use config.S3_RDMA_SERVER_IPS = []


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 performance tester accepts multiple endpoints and distributes requests across them via round-robin.

* **Improvements**
  * Normalized RDMA server IP handling for more reliable connection routing.
  * Updated RDMA build to a newer tested version for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->