### PR TITLE
NC | Adding minimal support to STS

### DIFF
--- a/config.js
+++ b/config.js
@@ -1068,7 +1068,7 @@ config.NSFS_NC_STORAGE_BACKEND = '';
 config.ENDPOINT_PORT = Number(process.env.ENDPOINT_PORT) || 6001;
 config.ENDPOINT_SSL_PORT = Number(process.env.ENDPOINT_SSL_PORT) || 6443;
 // Remove the NSFS condition when NSFS starts to support STS.
-config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || (process.env.NC_NSFS_NO_DB_ENV === 'true' ? -1 : 7443);
+config.ENDPOINT_SSL_STS_PORT = Number(process.env.ENDPOINT_SSL_STS_PORT) || 7443;
 // Remove the NC NSFS condition when NC NSFS starts to support IAM.
 config.ENDPOINT_SSL_IAM_PORT = Number(process.env.ENDPOINT_SSL_IAM_PORT) || (process.env.NC_NSFS_NO_DB_ENV === 'true' ? -1 : 13443);
 config.ENDPOINT_SSL_VECTOR_PORT = Number(process.env.ENDPOINT_SSL_VECTOR_PORT) || 14443;

--- a/src/cmd/nsfs.js
+++ b/src/cmd/nsfs.js
@@ -40,6 +40,7 @@ const endpoint_stats_collector = require('../sdk/endpoint_stats_collector');
 //const { RPC_BUFFERS } = require('../rpc');
 const AccountSDK = require('../sdk/account_sdk');
 const NsfsObjectSDK = require('../sdk/nsfs_object_sdk');
+const StsSDK = require('../sdk/sts_sdk');
 const AccountSpaceFS = require('../sdk/accountspace_fs');
 const NoobaaEvent = require('../manage_nsfs/manage_nsfs_events_utils').NoobaaEvent;
 const { set_debug_level } = require('../manage_nsfs/manage_nsfs_cli_utils');
@@ -69,34 +70,34 @@ Arguments:
 const OPTIONS = `
 Options:
 
-    --http_port <port>          (default 6001)      Set the S3 endpoint listening HTTP port to serve.
-    --https_port <port>         (default 6443)      Set the S3 endpoint listening HTTPS port to serve.
-    --https_port_sts <port>     (default -1)        Set the S3 endpoint listening HTTPS port for STS.
-    --https_port_iam <port>     (default -1)        Set the endpoint listening HTTPS port for IAM.
-    --https_port_vector <port>  (default -1)        Set the endpoint listening HTTPS port for IAM.
-    --http_metrics_port <port>      (default 7004)    Set the metrics listening HTTP port for prometheus.
-    --https_metrics_port <port>     (default 9443)    Set the metrics listening HTTPS port for prometheus.
-    --forks <n>                     (default none)  Forks spread incoming requests (config.ENDPOINT_FORKS used if flag is not provided).
-    --debug <level>                 (default 0)     Increase debug level.
+    --http_port <port>          (default 6001)       Set the S3 endpoint listening HTTP port to serve.
+    --https_port <port>         (default 6443)       Set the S3 endpoint listening HTTPS port to serve.
+    --https_port_sts <port>     (default 7443)       Set the S3 endpoint listening HTTPS port for STS.
+    --https_port_iam <port>     (default -1)         Set the endpoint listening HTTPS port for IAM.
+    --https_port_vector <port>  (default 14443)      Set the endpoint listening HTTPS port for Vector.
+    --http_metrics_port <port>  (default 7004)       Set the metrics listening HTTP port for prometheus.
+    --https_metrics_port <port> (default 9443)       Set the metrics listening HTTPS port for prometheus.
+    --forks <n>                 (default none)       Forks spread incoming requests (config.ENDPOINT_FORKS used if flag is not provided).
+    --debug <level>             (default 0)          Increase debug level.
 
     ## single user mode
 
-    --simple <boolean>   (default false)        Starts a single user/fs mode
-    --uid <uid>          (default as process)   Send requests to the Filesystem with uid.
-    --gid <gid>          (default as process)   Send requests to the Filesystem with gid.
-    --access_key <key>      (default none)      Authenticate incoming requests for this access key only (default is no auth).
-    --secret_key <key>      (default none)      The secret key pair for the access key.
+    --simple <boolean>          (default false)      Starts a single user/fs mode
+    --uid <uid>                 (default as process) Send requests to the Filesystem with uid.
+    --gid <gid>                 (default as process) Send requests to the Filesystem with gid.
+    --access_key <key>          (default none)       Authenticate incoming requests for this access key only (default is no auth).
+    --secret_key <key>          (default none)       The secret key pair for the access key.
 
     ## multi user mode
 
-    --config_root <dir>     (default ${config.NSFS_NC_DEFAULT_CONF_DIR})    Configuration files for Noobaa standalon NSFS. It includes config files for environment variables(<config_root>/.env), 
-                                                            local configuration(<config_root>/config-local.js), authentication (<config_root>/accounts/<access-key>.json) and 
-                                                            bucket schema (<config_root>/buckets/<bucket-name>.json).
+    --config_root <dir> (default ${config.NSFS_NC_DEFAULT_CONF_DIR}) Configuration files for Noobaa standalon NSFS. It includes config files for environment variables(<config_root>/.env), 
+                                                     local configuration(<config_root>/config-local.js), authentication (<config_root>/accounts/<access-key>.json) and 
+                                                     bucket schema (<config_root>/buckets/<bucket-name>.json).
 
     ## features
 
-    --backend <fs>          (default none)      Use custom backend fs to CEPH_FS 'GPFS', 'NFSv4').
-    --versioning <mode>   (default DISABLED)    Set versioning mode to DISABLED | ENABLED | SUSPENDED.
+    --backend <fs>              (default none)       Use custom backend fs to CEPH_FS 'GPFS', 'NFSv4').
+    --versioning <mode>         (default DISABLED)   Set versioning mode to DISABLED | ENABLED | SUSPENDED.
 
 `;
 
@@ -261,6 +262,10 @@ async function main(argv = minimist(process.argv.slice(2))) {
             init_request_sdk: (req, res) => {
                 req.object_sdk = new NsfsObjectSDK(fs_root, fs_config, account, versioning, nsfs_config_root, system_data);
                 req.account_sdk = new NsfsAccountSDK(fs_root, fs_config, account, nsfs_config_root);
+                const sts_bucketspace = nsfs_config_root ?
+                    new BucketSpaceFS({ config_root: nsfs_config_root }, endpoint_stats_collector.instance()) :
+                    new BucketSpaceSimpleFS({ fs_root });
+                req.sts_sdk = new StsSDK(null, null, sts_bucketspace);
             }
         });
         if (config.ALLOW_HTTP) {

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -5,7 +5,7 @@ const cloud_utils = require('../util/cloud_utils');
 const dbg = require('../util/debug_module')(__filename);
 const { RpcError } = require('../rpc');
 const signature_utils = require('../util/signature_utils');
-const { account_cache } = require('./object_sdk');
+const { account_cache, dn_cache } = require('./object_sdk');
 const BucketSpaceNB = require('./bucketspace_nb');
 const jwt = require('jsonwebtoken');
 const ldap_client = require('../util/ldap_client');
@@ -22,7 +22,7 @@ class StsSDK {
 
     set_auth_token(auth_token) {
         this.auth_token = auth_token;
-        this.rpc_client.options.auth_token = auth_token;
+        if (this.rpc_client) this.rpc_client.options.auth_token = auth_token;
     }
 
     get_auth_token() {
@@ -44,10 +44,22 @@ class StsSDK {
                 bucketspace: this._get_bucketspace(),
                 access_key: token.access_key,
             });
+            if (this.requesting_account?.nsfs_account_config?.distinguished_name) {
+                const distinguished_name = this.requesting_account.nsfs_account_config.distinguished_name.unwrap();
+                const user = await dn_cache.get_with_cache({
+                    bucketspace: this._get_bucketspace(),
+                    distinguished_name,
+                });
+                this.requesting_account.nsfs_account_config.uid = user.uid;
+                this.requesting_account.nsfs_account_config.gid = user.gid;
+            }
         } catch (error) {
-            dbg.error('authorize_request_account error:', error);
+            dbg.error('load_requesting_account error:', error);
             if (error.rpc_code === 'NO_SUCH_ACCOUNT') {
                 throw new RpcError('INVALID_ACCESS_KEY_ID', `Account with access_key not found`);
+            }
+            if (error.rpc_code === 'NO_SUCH_USER') {
+                throw new RpcError('UNAUTHORIZED', `Distinguished name associated with access_key not found`);
             }
             throw error;
         }
@@ -103,6 +115,7 @@ class StsSDK {
         } else {
             dbg.warn('get_assumed_ldap_user: No LDAP JWT secret found, failing back to decoding');
             web_token = jwt.decode(req.body.web_identity_token);
+            if (!web_token) throw new RpcError('INVALID_WEB_IDENTITY_TOKEN', 'jwt malformed');
         }
         if (!web_token.user) {
             throw new RpcError('INVALID_WEB_IDENTITY_TOKEN', 'Missing a required claim: user');

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -107,6 +107,9 @@ module.exports = {
         },
         default_connection: {
             type: 'string'
-        }
+        },
+        role_config: {
+            $ref: 'common_api#/definitions/role_config'
+        },
     }
 };


### PR DESCRIPTION
### Describe the Problem
support running STS flows on top of NC (for NC LDAP support)

### Explain the Changes
1. updated STS_SDK - we will maybe split to NsfsStsSdk in the future
2. added role_config to nsfs_account_schema
3. enabled sts port by default

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Create an account using manage_nsfs: 
`NSFS_NC_CONF_DIR='/Users/jackyalbo/nc-config-dir' node src/cmd/manage_nsfs account add --name jacky --uid 100 --gid 200`
2. As for now we can't create a user with role config, so edit the identity.json: `vi /Users/jackyalbo/nc-config-dir/identities/69ede9225426ae2fe35a20ac/identity.json`
3. Add role_config: 
```
{"_id":"69ede9225426ae2fe35a20ac","name":"jacky","email":"jacky","creation_date":"2026-04-26T10:29:54.442Z","access_keys":[{"access_key":"q9lG44z9vyxpLvXAXU7W","encrypted_secret_key":"fB60kaS3yQTlAM92gNTB8pQjWomSRlrASMaDI3CYE21m+UJhfUFoxA=="}],"nsfs_account_config":{"uid":100,"gid":200},"role_config":{"role_name":"ldap_users", "assume_role_policy":{"statement":[{"effect":"allow","action":["sts:*"],"principal":["*"]}]}},"allow_bucket_creation":false,"master_key_id":"69ede916e46cdd0f4a3a614b"}
```
4. run LDAP in docker: `docker run --rm --privileged -p 636:636 ghcr.io/ldapjs/docker-test-openldap/openldap:latest`
5. Edit ldap_config: sudo vi /etc/noobaa-server/ldap_config
6.  Adapt to the LDAP Docker: 
```
{
  "uri": "ldap://127.0.0.1:636",
  "admin": "cn=admin,dc=planetexpress,dc=com",
  "secret": "GoodNewsEveryone",
  "search_dn": "ou=people,dc=planetexpress,dc=com",
  "dn_attribute": "uid",
  "search_base": "dc=example,dc=com",
  "search_scope": "sub"
}
```
7. run nsfs: `sudo node src/cmd/nsfs.js --debug 5`
9. run sts assume-role-with-web-identity:
```
aws sts assume-role-with-web-identity --endpoint https://127.0.0.1:7443 --role-arn arn:aws:sts::q9lG44z9vyxpLvXAXU7W:role/ldap_users --role-session-name fry1 --web-identity-token eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJ1c2VyIjoiZnJ5IiwicGFzc3dvcmQiOiJmcnkiLCJ0eXBlIjoibGRhcCIsImlhdCI6MTc1NTQzMzkxOX0. --no-verify-ssl
{
    "Credentials": {
        "AccessKeyId": "10Zj3lYmHDd23G8Bc8Oy",
        "SecretAccessKey": "l2R359gQpG7qzr4IkIbaaKv1F04iXgGXTMzGPq2A",
        "SessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3Nfa2V5IjoiMTBaajNsWW1IRGQyM0c4QmM4T3kiLCJzZWNyZXRfa2V5IjoibDJSMzU5Z1FwRzdxenI0SWtJYmFhS3YxRjA0aVhnR1hUTXpHUHEyQSIsImFzc3VtZWRfcm9sZV9hY2Nlc3Nfa2V5IjoicTlsRzQ0ejl2eXhwTHZYQVhVN1ciLCJpYXQiOjE3Nzc0NzgyNDgsImV4cCI6MTc3NzQ4MTg0OH0.Gfed6hAoVIrAUZTK6wIO6eLmk05TryAegFI8RjD2zN4",
        "Expiration": "2026-04-29T16:57:28+00:00"
    },
    "AssumedRoleUser": {
        "AssumedRoleId": "q9lG44z9vyxpLvXAXU7W:fry1",
        "Arn": "arn:aws:sts::q9lG44z9vyxpLvXAXU7W:assumed-role/ldap_users/fry1"
    },
    "SourceIdentity": "cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com"
}
```
The WIT is an encoded JWT that holds both the LDAP user and password:
```
{
  "user": "fry",
  "password": "fry",
  "type": "ldap",
  "iat": 1755433919
}
```



- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request STS bucket-space selection for improved storage handling.
  * Added role configuration support for accounts.

* **Bug Fixes**
  * More robust auth-token handling and clearer error translation for account operations.
  * Stricter JWT validation with explicit error on malformed identity tokens.

* **Chores**
  * Updated default HTTPS ports for STS and vector services to secure defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->