### PR TITLE
Add MGMT to TLS configurable servers

### DIFF
--- a/config.js
+++ b/config.js
@@ -78,11 +78,11 @@ config.VECTOR_SERVICE_CERT_PATH = '/etc/vector-secret';
 config.MGMT_SERVICE_CERT_PATH = '/etc/mgmt-secret';
 config.EXTERNAL_DB_SERVICE_CERT_PATH = '/etc/external-db-secret';
 
-// add noobaa-mgmt or others in the future if needed ?
 config.TLS_CONFIGURABLE_SERVERS = [
     'S3',
     'STS',
     'IAM',
+    'MGMT',
     'METRICS',
     'VECTOR'
 ];

--- a/src/server/web_server.js
+++ b/src/server/web_server.js
@@ -90,10 +90,14 @@ async function main() {
         await P.ninvoke(http_server, 'listen', http_port);
 
         const ssl_cert_info = await ssl_utils.get_ssl_cert_info('MGMT');
-        const https_server = https.createServer({ ...ssl_cert_info.cert, honorCipherOrder: true }, app);
+        const ssl_options = { ...ssl_cert_info.cert, honorCipherOrder: true };
+        ssl_utils.apply_tls_config(ssl_options, 'MGMT');
+        const https_server = https.createServer(ssl_options, app);
         ssl_cert_info.on('update', updated_cert_info => {
             dbg.log0("Setting updated MGMT ssl certs for web server.");
-            https_server.setSecureContext({...updated_cert_info.cert, honorCipherOrder: true });
+            const updated_ssl_options = { ...updated_cert_info.cert, honorCipherOrder: true };
+            ssl_utils.apply_tls_config(updated_ssl_options, 'MGMT');
+            https_server.setSecureContext(updated_ssl_options);
         });
         server_rpc.rpc.register_ws_transport(https_server);
         await P.ninvoke(https_server, 'listen', https_port);

--- a/src/test/unit_tests/tls/test_tls_apply_config.js
+++ b/src/test/unit_tests/tls/test_tls_apply_config.js
@@ -5,7 +5,6 @@
 const mocha = require('mocha');
 const assert = require('assert');
 const https = require('https');
-const tls = require('tls');
 
 const config = require('../../../../config');
 const ssl_utils = require('../../../util/ssl_utils');
@@ -21,7 +20,7 @@ mocha.describe('apply_tls_config', function() {
         config.TLS_MIN_VERSION = '';
         config.TLS_CIPHERS = '';
         config.TLS_GROUPS = '';
-        config.TLS_CONFIGURABLE_SERVERS = ['S3', 'STS', 'IAM'];
+        config.TLS_CONFIGURABLE_SERVERS = ['S3', 'STS', 'IAM', 'MGMT'];
     });
 
     mocha.afterEach(function() {
@@ -135,6 +134,8 @@ mocha.describe('apply_tls_config', function() {
         ssl_utils.apply_tls_config(sts_options, 'STS');
         const iam_options = {};
         ssl_utils.apply_tls_config(iam_options, 'IAM');
+        const mgmt_options = {};
+        ssl_utils.apply_tls_config(mgmt_options, 'MGMT');
 
         const expected = {
             minVersion: config.TLS_MIN_VERSION,
@@ -144,6 +145,7 @@ mocha.describe('apply_tls_config', function() {
         validate_configurable_tls_option_fields(s3_options, expected);
         validate_configurable_tls_option_fields(sts_options, expected);
         validate_configurable_tls_option_fields(iam_options, expected);
+        validate_configurable_tls_option_fields(mgmt_options, expected);
     });
 
     mocha.it('should preserve existing ssl_options properties', function() {
@@ -162,10 +164,24 @@ mocha.describe('apply_tls_config', function() {
         });
     });
 
-    mocha.it('should skip TLS config for non-enabled service (MGMT)', function() {
+    mocha.it('should apply TLS config for MGMT server', function() {
+        config.TLS_MIN_VERSION = 'TLSv1.3';
+        config.TLS_CIPHERS = 'TLS_AES_256_GCM_SHA384';
+        config.TLS_GROUPS = 'X25519';
+        const options = { key: 'k', cert: 'c', honorCipherOrder: true };
+        ssl_utils.apply_tls_config(options, 'MGMT');
+        validate_configurable_tls_option_fields(options, {
+            minVersion: 'TLSv1.3',
+            ciphers: 'TLS_AES_256_GCM_SHA384',
+            ecdhCurve: 'X25519'
+        });
+        assert.strictEqual(options.honorCipherOrder, true);
+    });
+
+    mocha.it('should skip TLS config for non-enabled service (FORK_HEALTH)', function() {
         config.TLS_MIN_VERSION = 'TLSv1.3';
         const options = {};
-        ssl_utils.apply_tls_config(options, 'MGMT');
+        ssl_utils.apply_tls_config(options, 'FORK_HEALTH');
         assert.strictEqual(options.minVersion, undefined);
     });
 });
@@ -194,12 +210,13 @@ mocha.describe('create_https_server with TLS config', function() {
      * protocol, cipher, and ephemeral key info. The server is closed after the request.
      * @param {Object} client_options - TLS options passed to https.request
      * @param {Object} [cert_options] - options passed to nb_native().x509()
+     * @param {string} [service] - service name passed to create_https_server (default: 'S3')
      * @returns {Promise<{protocol: string, cipher: Object, ephemeral: Object}>}
      */
-    async function create_tls_server_and_connect(client_options, cert_options) {
+    async function create_tls_server_and_connect(client_options, cert_options, service = 'S3') {
         const ssl_cert = nb_native().x509({ dns: 'localhost', ...cert_options });
         const server = await ssl_utils.create_https_server(
-            { cert: ssl_cert }, true, (req, res) => res.end('ok'), 'S3'
+            { cert: ssl_cert }, true, (req, res) => res.end('ok'), service
         );
         try {
             await new Promise((resolve, reject) => {
@@ -234,14 +251,12 @@ mocha.describe('create_https_server with TLS config', function() {
     }
 
     mocha.it('should negotiate TLS 1.3 when minVersion is TLSv1.3', async function() {
-        if (tls.DEFAULT_MAX_VERSION !== 'TLSv1.3') return;
         config.TLS_MIN_VERSION = 'TLSv1.3';
         const result = await create_tls_server_and_connect({ minVersion: 'TLSv1.3' });
         assert.strictEqual(result.protocol, 'TLSv1.3');
     });
 
     mocha.it('should reject TLS 1.2 client when server minimum is TLS 1.3', async function() {
-        if (tls.DEFAULT_MAX_VERSION !== 'TLSv1.3') return;
         config.TLS_MIN_VERSION = 'TLSv1.3';
         await assert.rejects(
             () => create_tls_server_and_connect({ maxVersion: 'TLSv1.2' }),
@@ -275,13 +290,39 @@ mocha.describe('create_https_server with TLS config', function() {
     });*/
 
     mocha.it('should enforce all TLS options combined', async function() {
-        if (tls.DEFAULT_MAX_VERSION !== 'TLSv1.3') return;
         config.TLS_MIN_VERSION = 'TLSv1.3';
         config.TLS_CIPHERS = 'TLS_AES_256_GCM_SHA384';
         config.TLS_GROUPS = 'X25519';
         const result = await create_tls_server_and_connect({ minVersion: 'TLSv1.3' });
         assert.strictEqual(result.protocol, 'TLSv1.3');
         assert.strictEqual(result.cipher.name, 'TLS_AES_256_GCM_SHA384');
+    });
+
+    mocha.it('MGMT server should negotiate TLS 1.3 when minVersion is TLSv1.3', async function() {
+        config.TLS_MIN_VERSION = 'TLSv1.3';
+        const result = await create_tls_server_and_connect({ minVersion: 'TLSv1.3' }, undefined, 'MGMT');
+        assert.strictEqual(result.protocol, 'TLSv1.3');
+    });
+
+    mocha.it('MGMT server should reject TLS 1.2 client when server minimum is TLS 1.3', async function() {
+        config.TLS_MIN_VERSION = 'TLSv1.3';
+        await assert.rejects(
+            () => create_tls_server_and_connect({ maxVersion: 'TLSv1.2' }, undefined, 'MGMT'),
+            /TLSV1_ALERT_PROTOCOL_VERSION|ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION|tlsv1 alert protocol version|handshake failure/i
+        );
+    });
+
+    mocha.it('MGMT server should enforce specific cipher suite', async function() {
+        config.TLS_CIPHERS = 'ECDHE-RSA-AES128-GCM-SHA256';
+        const result = await create_tls_server_and_connect({ maxVersion: 'TLSv1.2' }, undefined, 'MGMT');
+        assert.strictEqual(result.cipher.name, 'ECDHE-RSA-AES128-GCM-SHA256');
+    });
+
+    mocha.it('MGMT server should enforce group P-256 via ecdhCurve', async function() {
+        config.TLS_GROUPS = 'P-256';
+        const result = await create_tls_server_and_connect({}, undefined, 'MGMT');
+        assert.strictEqual(result.ephemeral.type, 'ECDH');
+        assert.strictEqual(result.ephemeral.name, 'prime256v1');
     });
 });
 

--- a/src/test/unit_tests/tls/test_tls_ciphers.js
+++ b/src/test/unit_tests/tls/test_tls_ciphers.js
@@ -67,11 +67,12 @@ function generate_ecdsa_cert() {
  * Starts an HTTPS server using the provided ECDSA certificate via
  * ssl_utils.create_https_server, listening on a random port.
  * @param {{key: string, cert: string}} ecdsa_cert
+ * @param {string} [service] - service name passed to create_https_server (default: 'S3')
  * @returns {Promise<{server: import('https').Server, port: number}>}
  */
-async function start_ecdsa_server(ecdsa_cert) {
+async function start_ecdsa_server(ecdsa_cert, service = 'S3') {
     const server = await ssl_utils.create_https_server(
-        { cert: ecdsa_cert }, true, (req, res) => res.end('ok'), 'S3'
+        { cert: ecdsa_cert }, true, (req, res) => res.end('ok'), service
     );
     await new Promise((resolve, reject) => {
         server.on('error', reject);
@@ -83,70 +84,75 @@ async function start_ecdsa_server(ecdsa_cert) {
 mocha.describe('TLS cipher negotiation', function() {
 
     const saved_ciphers = config.TLS_CIPHERS;
+    const ecdsa_cert = generate_ecdsa_cert();
 
     mocha.afterEach(function() {
         config.TLS_CIPHERS = saved_ciphers;
     });
 
-    mocha.describe('TLS 1.3 ciphers', function() {
+    for (const service of config.TLS_CONFIGURABLE_SERVERS) {
 
-        for (const cipher_name of TLS13_CIPHERS) {
-            mocha.it(`should negotiate ${cipher_name}`, async function() {
-                config.TLS_CIPHERS = cipher_name;
-                const { server, port } = await start_endpoint_https_server('S3');
-                try {
-                    const res = await make_tls_request(port, { ciphers: cipher_name });
-                    assert.strictEqual(res.cipher.name, cipher_name);
-                } catch (err) {
-                    assert.fail(`Unexpected error negotiating ${cipher_name}: ${err.message}`);
-                } finally {
-                    server.close();
-                }
-            });
-        }
-    });
+        mocha.describe(`${service} service`, function() {
 
-    mocha.describe('ECDHE-RSA ciphers', function() {
+            mocha.describe('TLS 1.3 ciphers', function() {
 
-        for (const cipher_name of ECDHE_RSA_CIPHERS) {
-            mocha.it(`should negotiate ${cipher_name}`, async function() {
-                config.TLS_CIPHERS = cipher_name;
-                const { server, port } = await start_endpoint_https_server('S3');
-                try {
-                    const res = await make_tls_request(port, {
-                        maxVersion: 'TLSv1.2',
-                        ciphers: cipher_name,
+                for (const cipher_name of TLS13_CIPHERS) {
+                    mocha.it(`should negotiate ${cipher_name}`, async function() {
+                        config.TLS_CIPHERS = cipher_name;
+                        const { server, port } = await start_endpoint_https_server(service);
+                        try {
+                            const res = await make_tls_request(port, { ciphers: cipher_name });
+                            assert.strictEqual(res.cipher.name, cipher_name);
+                        } catch (err) {
+                            assert.fail(`Unexpected error negotiating ${cipher_name}: ${err.message}`);
+                        } finally {
+                            server.close();
+                        }
                     });
-                    assert.strictEqual(res.cipher.name, cipher_name);
-                } catch (err) {
-                    assert.fail(`Unexpected error negotiating ${cipher_name}: ${err.message}`);
-                } finally {
-                    server.close();
                 }
             });
-        }
-    });
 
-    mocha.describe('ECDHE-ECDSA ciphers', function() {
+            mocha.describe('ECDHE-RSA ciphers', function() {
 
-        const ecdsa_cert = generate_ecdsa_cert();
-
-        for (const cipher_name of ECDHE_ECDSA_CIPHERS) {
-            mocha.it(`should negotiate ${cipher_name}`, async function() {
-                config.TLS_CIPHERS = cipher_name;
-                const { server, port } = await start_ecdsa_server(ecdsa_cert);
-                try {
-                    const res = await make_tls_request(port, {
-                        maxVersion: 'TLSv1.2',
-                        ciphers: cipher_name,
+                for (const cipher_name of ECDHE_RSA_CIPHERS) {
+                    mocha.it(`should negotiate ${cipher_name}`, async function() {
+                        config.TLS_CIPHERS = cipher_name;
+                        const { server, port } = await start_endpoint_https_server(service);
+                        try {
+                            const res = await make_tls_request(port, {
+                                maxVersion: 'TLSv1.2',
+                                ciphers: cipher_name,
+                            });
+                            assert.strictEqual(res.cipher.name, cipher_name);
+                        } catch (err) {
+                            assert.fail(`Unexpected error negotiating ${cipher_name}: ${err.message}`);
+                        } finally {
+                            server.close();
+                        }
                     });
-                    assert.strictEqual(res.cipher.name, cipher_name);
-                } catch (err) {
-                    assert.fail(`Unexpected error negotiating ${cipher_name}: ${err.message}`);
-                } finally {
-                    server.close();
                 }
             });
-        }
-    });
+
+            mocha.describe('ECDHE-ECDSA ciphers', function() {
+
+                for (const cipher_name of ECDHE_ECDSA_CIPHERS) {
+                    mocha.it(`should negotiate ${cipher_name}`, async function() {
+                        config.TLS_CIPHERS = cipher_name;
+                        const { server, port } = await start_ecdsa_server(ecdsa_cert, service);
+                        try {
+                            const res = await make_tls_request(port, {
+                                maxVersion: 'TLSv1.2',
+                                ciphers: cipher_name,
+                            });
+                            assert.strictEqual(res.cipher.name, cipher_name);
+                        } catch (err) {
+                            assert.fail(`Unexpected error negotiating ${cipher_name}: ${err.message}`);
+                        } finally {
+                            server.close();
+                        }
+                    });
+                }
+            });
+        });
+    }
 });

--- a/src/test/unit_tests/tls/test_tls_groups.js
+++ b/src/test/unit_tests/tls/test_tls_groups.js
@@ -33,49 +33,54 @@ mocha.describe('TLS group negotiation', function() {
         config.TLS_GROUPS = saved_groups;
     });
 
-    mocha.describe('standard ECDH groups', function() {
+    for (const service of config.TLS_CONFIGURABLE_SERVERS) {
 
-        for (const group of STANDARD_GROUPS) {
-            mocha.it(`should negotiate group ${group}`, async function() {
-                config.TLS_GROUPS = group;
-                const { server, port } = await start_endpoint_https_server('S3');
-                try {
-                    const res = await make_tls_request(port);
-                    assert.strictEqual(res.ephemeral.type, 'ECDH');
-                    // Node.js getEphemeralKeyInfo() reports secp256r1 as 'prime256v1' (ANSI name),
-                    // all other groups use the same name as the OpenSSL group name.
-                    const expected_name = group === 'secp256r1' ? 'prime256v1' : group;
-                    assert.strictEqual(res.ephemeral.name, expected_name);
-                } catch (err) {
-                    assert.fail(`Unexpected error negotiating group ${group}: ${err.message}`);
-                } finally {
-                    server.close();
+        mocha.describe(`${service} service`, function() {
+
+            mocha.describe('standard ECDH groups', function() {
+
+                for (const group of STANDARD_GROUPS) {
+                    mocha.it(`should negotiate group ${group}`, async function() {
+                        config.TLS_GROUPS = group;
+                        const { server, port } = await start_endpoint_https_server(service);
+                        try {
+                            const res = await make_tls_request(port);
+                            assert.strictEqual(res.ephemeral.type, 'ECDH');
+                            // Node.js getEphemeralKeyInfo() reports secp256r1 as 'prime256v1' (ANSI name),
+                            // all other groups use the same name as the OpenSSL group name.
+                            const expected_name = group === 'secp256r1' ? 'prime256v1' : group;
+                            assert.strictEqual(res.ephemeral.name, expected_name);
+                        } catch (err) {
+                            assert.fail(`Unexpected error negotiating group ${group}: ${err.message}`);
+                        } finally {
+                            server.close();
+                        }
+                    });
                 }
             });
-        }
-    });
 
-    mocha.describe('PQC/hybrid groups', function() {
+            mocha.describe('PQC/hybrid groups', function() {
 
-        for (const group of PQC_GROUPS) {
-            mocha.it(`should negotiate group ${group}`, async function() {
-                config.TLS_GROUPS = group;
-
-                const { server, port } = await start_endpoint_https_server('S3');
-                try {
-                    const negotiated = await make_openssl_request(port, group);
-                    assert.ok(
-                        negotiated.includes(group),
-                        `Expected negotiated group to contain ${group} but got: ${negotiated}`
-                    );
-                } catch (err) {
-                    assert.fail(`Failed to negotiate PQC group ${group}: ${err.message}`);
-                } finally {
-                    server.close();
+                for (const group of PQC_GROUPS) {
+                    mocha.it(`should negotiate group ${group}`, async function() {
+                        config.TLS_GROUPS = group;
+                        const { server, port } = await start_endpoint_https_server(service);
+                        try {
+                            const negotiated = await make_openssl_request(port, group);
+                            assert.ok(
+                                negotiated.includes(group),
+                                `Expected negotiated group to contain ${group} but got: ${negotiated}`
+                            );
+                        } catch (err) {
+                            assert.fail(`Failed to negotiate PQC group ${group}: ${err.message}`);
+                        } finally {
+                            server.close();
+                        }
+                    });
                 }
             });
-        }
-    });
+        });
+    }
 });
 
 /**


### PR DESCRIPTION
### Explain the Changes
1. Added MGMT service to the TLS configurable servers list (because it has a route + exposes user metrics)
2. Added apply_tls_config() call before createServer() in web_server.js in order to set the custom ssl options. 
3. Added MGMT TLS configuration tests
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. auto -`node_modules/.bin/_mocha src/test/unit_tests/tls/test_tls_apply_config.js \
                         src/test/unit_tests/tls/test_tls_ciphers.js \
                         src/test/unit_tests/tls/test_tls_groups.js \
                         src/test/unit_tests/tls/test_tls_min_version.js
`
2. Manual - mentioned in https://github.com/noobaa/noobaa-operator/pull/1897

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MGMT server type now supports configurable TLS settings, matching other server types in the system.

* **Improvements**
  * Standardized TLS configuration handling by centralizing certificate context setup, ensuring consistent application of security parameters across all configurable servers.

* **Tests**
  * Extended TLS unit tests to verify MGMT server configuration and security parameter enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->