### PR TITLE
Fix InternalError on concurrent PUT uploads to the same key

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2210]*/
+/*eslint max-lines: ["error", 2220]*/
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -10,7 +10,6 @@ const moment = require('moment');
 const mongodb = require('mongodb');
 const mime = require('mime-types');
 
-const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
 const db_client = require('../../util/db_client');
 const { decode_json } = require('../../util/postgres_client.js');
@@ -105,6 +104,10 @@ class MDStore {
 
     is_valid_md_id(id_str) {
         return mongodb.ObjectId.isValid(id_str);
+    }
+
+    is_err_duplicate_key(err) {
+        return db_client.instance().is_err_duplicate_key(err);
     }
 
     /////////////
@@ -469,7 +472,7 @@ class MDStore {
         if (!res.ok || res.nMatched !== 2 || res.nModified !== 2) {
             dbg.error('remove_object_move_latest: partial bulk update',
                 _.clone(res), old_latest_obj, new_latest_obj);
-            throw new Error('remove_object_move_latest: partial bulk update');
+            throw res.err || new Error('remove_object_move_latest: partial bulk update');
         }
     }
 
@@ -505,7 +508,7 @@ class MDStore {
         if (!res.ok || res.nMatched !== 1 || res.nModified !== 1 || res.nInserted !== 1) {
             dbg.error('insert_object_delete_marker_move_latest: partial bulk update',
                 _.clone(res), obj, delete_marker);
-            throw new Error('insert_object_delete_marker_move_latest: partial bulk update');
+            throw res.err || new Error('insert_object_delete_marker_move_latest: partial bulk update');
         }
         return delete_marker;
     }
@@ -533,7 +536,7 @@ class MDStore {
         if (!res.ok || res.nMatched !== 2 || res.nModified !== 2) {
             dbg.error('complete_object_upload_latest_mark_remove_current: partial bulk update',
                 _.clone(res), unmark_obj, put_obj, set_updates, unset_updates);
-            throw new Error('complete_object_upload_latest_mark_remove_current: partial bulk update');
+            throw res.err || new Error('complete_object_upload_latest_mark_remove_current: partial bulk update');
         }
     }
 
@@ -571,7 +574,7 @@ class MDStore {
         if (!res.ok || res.nMatched !== number_of_queries || res.nModified !== number_of_queries) {
             dbg.error('complete_object_upload_latest_mark_remove_current_and_delete: partial bulk update',
                 _.clone(res), unmark_obj, put_obj, set_updates, unset_updates);
-            throw new Error('complete_object_upload_latest_mark_remove_current_and_delete: partial bulk update');
+            throw res.err || new Error('complete_object_upload_latest_mark_remove_current_and_delete: partial bulk update');
         }
     }
 
@@ -1446,13 +1449,19 @@ class MDStore {
         return this._parts.find({ obj: { $eq: obj._id, $exists: true }, deleted: null });
     }
 
-    update_parts_in_bulk(parts_updates) {
+    async update_parts_in_bulk(parts_updates) {
         const bulk = this._parts.initializeUnorderedBulkOp();
         for (const update of parts_updates) {
             bulk.find({ _id: update._id })
                 .updateOne(compact_updates(update.set_updates, update.unset_updates));
         }
-        return bulk.length ? bulk.execute() : P.resolve();
+        const res = await bulk.execute();
+        if (res.err) {
+            dbg.error('update_parts_in_bulk: error',
+                _.clone(res), parts_updates);
+            throw res.err;
+        }
+        return res;
     }
 
     delete_parts_of_object(obj) {

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -445,7 +445,18 @@ async function complete_object_upload(req) {
         set_updates.last_modified_time = new Date(req.rpc_params.last_modified_time);
     }
 
-    await _put_object_handle_latest({ req, put_obj: obj, set_updates, unset_updates });
+
+    // retry on duplicate key error to handle a race condition between two concurrent PUT requests to the same key
+    const put_obj_attempts = 3;
+    await P.retry({
+        func: async () => {
+            await _put_object_handle_latest({ req, put_obj: obj, set_updates, unset_updates });
+        },
+        attempts: put_obj_attempts,
+        delay_ms: 50,
+        should_retry_func: err => MDStore.instance().is_err_duplicate_key(err),
+        error_logger: err => dbg.warn('got duplicate key error in _put_object_handle_latest. retrying... bucket=', req.bucket.name, 'key=', obj.key, 'err=', err)
+    });
 
     const took_ms = set_updates.create_time.getTime() - obj._id.getTimestamp().getTime();
     const upload_duration = time_utils.format_time_duration(took_ms);

--- a/src/test/unit_tests/util_functions_tests/test_promise_utils.js
+++ b/src/test/unit_tests/util_functions_tests/test_promise_utils.js
@@ -90,6 +90,155 @@ mocha.describe('promise utils', function() {
         });
     });
 
+    mocha.describe('P.retry', function() {
+
+        mocha.it('should resolve on first attempt when func succeeds', async function() {
+            const result = await P.retry({
+                attempts: 3,
+                delay_ms: 0,
+                func: async () => 'ok',
+            });
+            assert.strictEqual(result, 'ok');
+        });
+
+        mocha.it('should retry and resolve when func fails then succeeds', async function() {
+            let call_count = 0;
+            const result = await P.retry({
+                attempts: 3,
+                delay_ms: 0,
+                func: async () => {
+                    call_count += 1;
+                    if (call_count < 3) throw new Error(`fail #${call_count}`);
+                    return 'recovered';
+                },
+            });
+            assert.strictEqual(result, 'recovered');
+            assert.strictEqual(call_count, 3);
+        });
+
+        mocha.it('should throw after all attempts are exhausted', async function() {
+            let call_count = 0;
+            await assert.rejects(
+                () => P.retry({
+                    attempts: 3,
+                    delay_ms: 0,
+                    func: async () => {
+                        call_count += 1;
+                        throw new Error(`fail #${call_count}`);
+                    },
+                }),
+                err => err.message === 'fail #3'
+            );
+            assert.strictEqual(call_count, 3);
+        });
+
+        mocha.it('should retry when should_retry_func returns true', async function() {
+            let call_count = 0;
+            const result = await P.retry({
+                attempts: 3,
+                delay_ms: 0,
+                func: async () => {
+                    call_count += 1;
+                    if (call_count === 1) {
+                        const err = new Error('retryable');
+                        err.code = 'RETRY_ME';
+                        throw err;
+                    }
+                    return 'ok';
+                },
+                should_retry_func: err => err.code === 'RETRY_ME',
+            });
+            assert.strictEqual(result, 'ok');
+            assert.strictEqual(call_count, 2);
+        });
+
+        mocha.it('should stop immediately when should_retry_func returns false', async function() {
+            let call_count = 0;
+            await assert.rejects(
+                () => P.retry({
+                    attempts: 5,
+                    delay_ms: 0,
+                    func: async () => {
+                        call_count += 1;
+                        throw new Error('non-retryable');
+                    },
+                    should_retry_func: () => false,
+                }),
+                err => err.message === 'non-retryable'
+            );
+            assert.strictEqual(call_count, 1);
+        });
+
+        mocha.it('should not retry when error has DO_NOT_RETRY flag', async function() {
+            let call_count = 0;
+            await assert.rejects(
+                () => P.retry({
+                    attempts: 5,
+                    delay_ms: 0,
+                    func: async () => {
+                        call_count += 1;
+                        const err = new Error('permanent');
+                        err.DO_NOT_RETRY = true;
+                        throw err;
+                    },
+                }),
+                err => err.message === 'permanent'
+            );
+            assert.strictEqual(call_count, 1);
+        });
+
+        mocha.it('should call error_logger on each retried error', async function() {
+            const logged_errors = [];
+            let call_count = 0;
+            await P.retry({
+                attempts: 3,
+                delay_ms: 0,
+                func: async () => {
+                    call_count += 1;
+                    if (call_count < 3) throw new Error(`fail #${call_count}`);
+                    return 'ok';
+                },
+                error_logger: err => logged_errors.push(err.message),
+            });
+            assert.deepStrictEqual(logged_errors, ['fail #1', 'fail #2']);
+        });
+
+        mocha.it('should pass remaining attempts to func', async function() {
+            const seen_attempts = [];
+            await assert.rejects(
+                () => P.retry({
+                    attempts: 3,
+                    delay_ms: 0,
+                    func: async remaining => {
+                        seen_attempts.push(remaining);
+                        throw new Error('fail');
+                    },
+                }),
+            );
+            assert.deepStrictEqual(seen_attempts, [3, 2, 1]);
+        });
+
+        mocha.it('should delay between retries when delay_ms is set', async function() {
+            const start = process.hrtime.bigint();
+            let call_count = 0;
+            await P.retry({
+                attempts: 2,
+                delay_ms: 50,
+                func: async () => {
+                    call_count += 1;
+                    if (call_count < 2) throw new Error('fail');
+                    return 'ok';
+                },
+            });
+            const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
+            // expected elapsed time is taking into account some inaccuracy after observing a failure with elapsed_ms=49.5
+            const expected_elapsed_ms = 40;
+            assert.strictEqual(call_count, 2);
+            assert.ok(elapsed_ms >= expected_elapsed_ms, `expected >= ${expected_elapsed_ms}ms (1 delay of 50ms - 10ms inaccuracy delta) but took ${elapsed_ms.toFixed(1)}ms`);
+        });
+
+    });
+
     mocha.describe('P.defer', function() {
         mocha.it('resolves immediately', /** @this {Mocha.Context} */ async function() {
             const defer = new Defer();

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -406,7 +406,7 @@ class BulkOp {
 
     async execute() {
         let ok = false;
-        let errmsg;
+        let pg_error;
         let nInserted = 0;
         let nMatched = 0;
         let nModified = 0;
@@ -433,7 +433,7 @@ class BulkOp {
             await this.transaction.commit();
             ok = true;
         } catch (err) {
-            errmsg = err;
+            pg_error = err;
             dbg.error('PgTransaction execute error', err);
             if (should_rollback) await this.transaction.rollback();
         } finally {
@@ -441,7 +441,7 @@ class BulkOp {
         }
 
         return {
-            err: errmsg,
+            err: pg_error,
             ok,
             nInserted,
             nMatched,
@@ -456,15 +456,15 @@ class BulkOp {
             getUpsertedIds: not_implemented,
             getWriteConcernError: _.noop,
             getWriteErrorAt: i => (ok ? undefined : {
-                code: errmsg.code,
+                code: pg_error.code,
                 index: i,
-                errmsg: errmsg.message
+                errmsg: pg_error.message
             }),
             getWriteErrorCount: () => (ok ? 0 : this.queries.length),
             getWriteErrors: () => (ok ? [] : _.times(this.queries.length, i => ({
-                code: errmsg.code,
+                code: pg_error.code,
                 index: i,
-                errmsg: errmsg.message
+                errmsg: pg_error.message
             }))),
             hasWriteErrors: () => !ok
 

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -28,7 +28,7 @@ function delay_unblocking(delay_ms) {
 
 /**
  * Simple array items mapping to async calls per item.
- * 
+ *
  * @template K
  * @template V
  * @param {Array<K>} arr
@@ -41,10 +41,10 @@ async function map(arr, func) {
 
 /**
  * Map with limited concurrency.
- * 
+ *
  * @template K
  * @template V
- * @param {number} concurrency 
+ * @param {number} concurrency
  * @param {Array<K>} arr
  * @param {(key:K, index?:number) => Promise<V>} func
  * @returns {Promise<Array<V>>}
@@ -56,7 +56,7 @@ async function map_with_concurrency(concurrency, arr, func) {
 
 /**
  * map_one_by_one iterates the array and maps its values one by one.
- * 
+ *
  * @template K
  * @template V
  * @param {Array<K>} arr
@@ -76,7 +76,7 @@ async function map_one_by_one(arr, func) {
 /**
  * @see https://stackoverflow.com/questions/48011353/how-to-unwrap-type-of-a-promise
  * @template T
- * @typedef {T extends PromiseLike<infer U> 
+ * @typedef {T extends PromiseLike<infer U>
  *  ? { 0:P.Unwrap<U>; 1:U }[T extends PromiseLike<any> ? 0 : 1]
  *  : T
  * } P.Unwrap;
@@ -85,13 +85,13 @@ async function map_one_by_one(arr, func) {
 /**
  * Return a new object with the same properties of obj
  * after awaiting all its values, concurrently.
- * 
+ *
  * Example:
  *          const { buckets, accounts } = await P.map_props({
  *              buckets: this.load_buckets(),
  *              accounts: this.load_accounts(),
  *          });
- * 
+ *
  * @template T
  * @param {T} obj
  * @returns {Promise<{[K in keyof T]: P.Unwrap<T[K]>}>}
@@ -110,7 +110,7 @@ async function map_props(obj) {
  * any returns the result of the first promise to resolve.
  * first promise to succeed will resolve the entire call and we're done.
  * but if all are settled without anyone resolving, we call reject.
- * 
+ *
  * @template K
  * @template V
  * @param {Array<K>} arr
@@ -135,8 +135,8 @@ const default_create_timeout_err = () => new TimeoutError();
 
 /**
  * When millis is undefined we do NOT set a timeout, and return the provided promise as is.
- * This allows to use it for optional timeout params: P.timeout(options.timeout, promise) 
- * 
+ * This allows to use it for optional timeout params: P.timeout(options.timeout, promise)
+ *
  * @template T
  * @param {number|undefined} millis when millis is undefined promise is returned as is
  * @param {Promise<T>} promise
@@ -148,7 +148,7 @@ async function timeout(millis, promise, create_timeout_err = default_create_time
     if (typeof millis === 'undefined') return promise;
     return new Promise((resolve, reject) => {
         let timer = setTimeout(() => {
-            // wish we could let the promise know so it could save some redundant work 
+            // wish we could let the promise know so it could save some redundant work
             reject(create_timeout_err());
         }, millis);
         if (timer.unref) timer.unref(); // browsers don't have unref
@@ -172,11 +172,12 @@ async function timeout(millis, promise, create_timeout_err = default_create_time
  *  attempts: number, // number of attempts. can be Infinity.
  *  delay_ms: number, // number of milliseconds between retries
  *  func: (attemtpts:number) => Promise<T>, // passing remaining attempts just fyi
+ *  should_retry_func?: (err:Error) => boolean, // function to determine if the error should be retried. Otherwise, the error is thrown
  *  error_logger?: (err:Error) => void,
  * }} params
  * @returns {Promise<T>}
  */
-async function retry({ attempts, delay_ms, func, error_logger }) {
+async function retry({ attempts, delay_ms, func, error_logger, should_retry_func }) {
     for (;;) {
         try {
             // call func and catch errors,
@@ -187,17 +188,18 @@ async function retry({ attempts, delay_ms, func, error_logger }) {
             return res;
 
         } catch (err) {
-
             // check attempts
             attempts -= 1;
-            if (attempts <= 0 || err.DO_NOT_RETRY) {
+            if (attempts <= 0 || err.DO_NOT_RETRY || (should_retry_func && !should_retry_func(err))) {
                 throw err;
             }
 
             if (error_logger) error_logger(err);
 
             // delay and retry next attempt
-            await delay(delay_ms);
+            if (delay_ms) {
+                await delay(delay_ms);
+            }
         }
     }
 }


### PR DESCRIPTION
### Describe the Problem
Concurrent PUT uploads to the same bucket and key fail with `InternalError`. When two PUT requests target the same object key simultaneously, both call `find_object_null_version` which returns `null` for each (no existing completed object yet), so both enter the `update_object_by_id` code path to promote their upload to "latest". The first UPDATE succeeds and satisfies the `latest_version_index` unique partial index (`bucket, key` where `version_past=null`). The second UPDATE then violates that same unique constraint (Postgres error code `23505`), which was not handled and propagated as an unrecoverable `InternalError`. The same race can also occur on the bulk path (`complete_object_upload_latest_mark_remove_current_and_delete`) when both requests find an existing object and attempt the mark-and-replace transaction concurrently. S3 allows concurrent uploads to the same key — the resulting object content is undefined when the data differs between uploads, but the operation must not fail.

### Explain the Changes

The changes in this PR are meant to reduce the probability of getting an InternalError by introducing retries in case of duplicate key errors. This does not completely eliminate the problem, which can still occur if there is an unreasonably high number of concurrent uploads to the same key. 

1. **Retry logic in `complete_object_upload`** (`object_server.js`): Wrapped `_put_object_handle_latest` in `P.retry` (up to 3 attempts, 50ms delay) with `should_retry_func` that only retries on duplicate key errors. On retry, `_put_object_handle_latest` re-queries `find_object_null_version` and sees the state left by the winning transaction, taking the correct code path for the updated state.
2. **`should_retry_func` parameter for `P.retry`** (`promise.js`): Added an optional callback to selectively decide whether an error should trigger a retry. Non-matching errors are thrown immediately without consuming retry attempts. Also added a guard to skip `delay()` when `delay_ms` is `0`.
3. **Error propagation in md_store bulk operations** (`md_store.js`): Changed `throw new Error(...)` to `throw res.err || new Error(...)` in `remove_object_move_latest`, `insert_object_delete_marker_move_latest`, `complete_object_upload_latest_mark_remove_current`, and `complete_object_upload_latest_mark_remove_current_and_delete` so the original Postgres error (with `.code`) is preserved for retry logic inspection.
4. **`update_parts_in_bulk` error handling** (`md_store.js`): Made the function `async`, execute the bulk op with `await`, and throw `res.err` when present instead of silently returning a failed result.
5. **`MDStore.is_err_duplicate_key()`** (`md_store.js`): Added a convenience method that delegates to `db_client.instance().is_err_duplicate_key(err)`, keeping the error-detection logic close to the store layer.
6. **Rename `errmsg` → `pg_error`** (`postgres_client.js`): Renamed the catch variable in `BulkOp.execute()` for clarity — it holds a full Error object, not a string message.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6548

### Testing Instructions:

1. Run the unit tests that exercise `P.retry`:  
   `npm run mocha` (full harness loads `src/test/unit_tests/util_functions_tests/test_promise_utils.js`), or run that file directly with mocha after `npm run build` if your environment requires the native addon for loading `promise.js`.
2. The **`P.retry`** suite in `src/test/unit_tests/util_functions_tests/test_promise_utils.js` covers:
   - Success on first attempt.
   - Multiple failures then success (retry until recovery).
   - Exhaustion of attempts when errors persist.
   - **`should_retry_func`**: retries when it returns true; stops after one attempt when it returns false.
   - **`DO_NOT_RETRY`**: no retry when the error carries that flag.
   - **`error_logger`**: invoked for errors that lead to a retry.
   - **`func(attempts)`**: remaining attempts passed through as documented.
   - **`delay_ms`**: when non-zero, elapsed wall time is at least one delay interval between attempts (single-delay scenario).
3. To reproduce the original bug manually: run two concurrent `aws s3 cp` commands to the same bucket/key against a NooBaa endpoint backed by Postgres — this creates a race that, without this fix, can yield `InternalError`. Timing-dependent; not consistently reproducible.


- [ ] Doc added/updated
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bulk-write failures and duplicate-key conflicts to surface the underlying database error and reduce silent failures.
  * Added automatic retry for object uploads that encounter duplicate-key conflicts (up to 3 attempts with short backoff).
  * Made database write-error reporting more consistent across operations.

* **Tests**
  * Added comprehensive tests covering retry behavior, conditional retrying, error handling, logging, and delay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->